### PR TITLE
Add Linux auto-update mechanism and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,30 @@
 
 Run [OpenAI Codex Desktop](https://openai.com/codex/) on Linux.
 
+> **Fork of [ilysenko/codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux)** — the original project by [@ilysenko](https://github.com/ilysenko) that pioneered running Codex Desktop on Linux. This fork adds an automatic update mechanism and several installer improvements.
+
 The official Codex Desktop app is macOS-only. This project provides an automated installer that converts the macOS `.dmg` into a working Linux application.
+
+## What's new in this fork
+
+### Linux Auto-Updater
+
+The original installer removes the macOS-only Sparkle update framework, leaving the app with no way to check for or install updates on Linux. This fork adds a self-contained update mechanism (`linux-updater.js`) that:
+
+- **Checks the official appcast feed** (`appcast.xml`) for new builds, comparing `<sparkle:version>` against the local `codexBuildNumber`
+- **Patches the "Check for Updates" menu** so it actually works instead of showing "Updates Unavailable"
+- **Runs background checks every 15 minutes**, matching the Sparkle interval on macOS
+- **Notifies the renderer** via the same IPC messages the app already handles (`app-update-ready-changed`)
+- **Handles the "Install Update" button** from the UI — intercepts the `install-app-update` message that was previously silently ignored on Linux
+- **Install flow**: prompts the user, deletes the cached DMG (so it re-downloads), runs `install.sh --force` detached, then relaunches the app
+
+The updater is injected into `app.asar` during installation and loaded before the app bundle via a `require()` prepended to the Vite entry point. It only activates on Linux (`process.platform === "linux"` guard).
+
+### Installer improvements
+
+- **Automatic updater injection** during `patch_asar()` — copies `linux-updater.js` into the build and patches `main.js`
+- **Exports `CODEX_LINUX_INSTALLER_PATH`** in the generated `start.sh` so the updater can locate `install.sh` at runtime
+- **Idempotent** — re-running `install.sh` re-injects the updater each time, so updates survive reinstalls
 
 ## How it works
 
@@ -12,8 +35,9 @@ The installer:
 2. Extracts `app.asar` (the Electron app bundle)
 3. Rebuilds native Node.js modules (`node-pty`, `better-sqlite3`) for Linux
 4. Removes macOS-only modules (`sparkle` auto-updater)
-5. Downloads Linux Electron (same version as the app — v40)
-6. Repacks everything and creates a launch script
+5. **Injects the Linux update mechanism** (`linux-updater.js`)
+6. Downloads Linux Electron (same version as the app — v40)
+7. Repacks everything and creates a launch script
 
 ## Prerequisites
 
@@ -46,18 +70,14 @@ npm i -g @openai/codex
 
 ## Installation
 
-### Option A: Auto-download DMG
-
 ```bash
-git clone https://github.com/ilysenko/codex-desktop-linux.git
+git clone https://github.com/green2grey/codex-desktop-linux.git
 cd codex-desktop-linux
 chmod +x install.sh
 ./install.sh
 ```
 
-### Option B: Provide your own DMG
-
-Download `Codex.dmg` from [openai.com/codex](https://openai.com/codex/), then:
+Or provide your own DMG:
 
 ```bash
 ./install.sh /path/to/Codex.dmg
@@ -83,6 +103,20 @@ echo 'alias codex-desktop="~/codex-desktop-linux/codex-app/start.sh"' >> ~/.bash
 CODEX_INSTALL_DIR=/opt/codex ./install.sh
 ```
 
+### Updating
+
+The app checks for updates automatically in the background. You can also check manually via the app menu: **Check for Updates...**
+
+When an update is available, the app will prompt you to install it. This runs `install.sh --force` automatically, re-downloads the DMG, and relaunches the app.
+
+To update manually:
+
+```bash
+cd codex-desktop-linux
+rm Codex.dmg          # force re-download
+./install.sh --force
+```
+
 ## How it works (technical details)
 
 The macOS Codex app is an Electron application. The core code (`app.asar`) is platform-independent JavaScript, but it bundles:
@@ -90,9 +124,18 @@ The macOS Codex app is an Electron application. The core code (`app.asar`) is pl
 - **Native modules** compiled for macOS (`node-pty` for terminal emulation, `better-sqlite3` for local storage, `sparkle` for auto-updates)
 - **Electron binary** for macOS
 
-The installer replaces the macOS Electron with a Linux build and recompiles the native modules using `@electron/rebuild`. The `sparkle` module (macOS-only auto-updater) is removed since it has no Linux equivalent.
+The installer replaces the macOS Electron with a Linux build and recompiles the native modules using `@electron/rebuild`. The `sparkle` module (macOS-only auto-updater) is removed and replaced with `linux-updater.js`.
 
 A small Python HTTP server is used as a workaround: when `app.isPackaged` is `false` (which happens with extracted builds), the app tries to connect to a Vite dev server on `localhost:5175`. The HTTP server serves the static webview files on that port.
+
+### Update mechanism details
+
+`linux-updater.js` is a CommonJS module injected into `.vite/build/` inside `app.asar`. It's loaded via `require("./linux-updater.js")` prepended to `main.js` (the Vite entry point). It runs in the Electron main process and:
+
+- Monkey-patches `ipcMain.handle` to intercept `install-app-update` messages
+- Monkey-patches `Menu.setApplicationMenu` to fix the "Check for Updates" menu item
+- Registers the `codex_desktop:check-for-updates` IPC handler (never registered on Linux in the original app)
+- Uses the same IPC channels and message types the renderer already understands
 
 ## Troubleshooting
 
@@ -103,6 +146,11 @@ A small Python HTTP server is used as a workaround: when `app.isPackaged` is `fa
 | `CODEX_CLI_PATH` error | Install CLI: `npm i -g @openai/codex` |
 | GPU/rendering issues | Try: `./codex-app/start.sh --disable-gpu` |
 | Sandbox errors | The `--no-sandbox` flag is already set in `start.sh` |
+| "Updates Unavailable" in menu | Re-run `./install.sh --force` to re-inject the updater |
+
+## Attribution
+
+This is a fork of [ilysenko/codex-desktop-linux](https://github.com/ilysenko/codex-desktop-linux). All credit for the original installer goes to [@ilysenko](https://github.com/ilysenko).
 
 ## Disclaimer
 

--- a/install.sh
+++ b/install.sh
@@ -320,7 +320,15 @@ if [ -d "$WEBVIEW_DIR" ] && [ "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
 fi
 
 export CODEX_CLI_PATH="${CODEX_CLI_PATH:-$(which codex 2>/dev/null || true)}"
-export CODEX_LINUX_INSTALLER_PATH="$SCRIPT_DIR/../install.sh"
+SCRIPT
+
+    # Bake the absolute installer path at install time (not inside the
+    # single-quoted heredoc) so custom CODEX_INSTALL_DIR works correctly.
+    local real_installer_path
+    real_installer_path="$(cd "$SCRIPT_DIR" && realpath install.sh)"
+    echo "export CODEX_LINUX_INSTALLER_PATH=\"$real_installer_path\"" >> "$INSTALL_DIR/start.sh"
+
+    cat >> "$INSTALL_DIR/start.sh" << 'SCRIPT'
 
 if [ -z "$CODEX_CLI_PATH" ]; then
     echo "Error: Codex CLI not found. Install with: npm i -g @openai/codex" >&2

--- a/linux-updater.js
+++ b/linux-updater.js
@@ -1,0 +1,287 @@
+// linux-updater.js — Linux update mechanism for Codex Desktop
+// Injected into app.asar by install.sh, loaded via require() in main.js
+// Provides: update checking, IPC handling, menu patching, background checks
+
+"use strict";
+
+if (process.platform !== "linux") {
+  // Only activate on Linux — on macOS, Sparkle handles updates
+  return;
+}
+
+const { app, ipcMain, dialog, Menu, BrowserWindow } = require("electron");
+const https = require("https");
+const { execFile } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const APPCAST_URL =
+  "https://persistent.oaistatic.com/codex-app-prod/appcast.xml";
+const CHECK_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+
+let currentBuildNumber = null;
+let updateAvailable = false;
+let latestRemoteBuild = null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getInstallerPath() {
+  // Prefer the env var exported by start.sh
+  if (process.env.CODEX_LINUX_INSTALLER_PATH) {
+    return process.env.CODEX_LINUX_INSTALLER_PATH;
+  }
+  // Fallback: assume install.sh is two levels up from the app directory
+  const appDir = path.dirname(app.getAppPath());
+  return path.resolve(appDir, "..", "..", "install.sh");
+}
+
+function getCurrentBuildNumber() {
+  if (currentBuildNumber !== null) return currentBuildNumber;
+  try {
+    const pkgPath = path.join(app.getAppPath(), "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    currentBuildNumber = parseInt(pkg.codexBuildNumber, 10) || 0;
+  } catch (_e) {
+    currentBuildNumber = 0;
+  }
+  return currentBuildNumber;
+}
+
+function fetchAppcast() {
+  return new Promise((resolve, reject) => {
+    https
+      .get(APPCAST_URL, { timeout: 15000 }, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`Appcast HTTP ${res.statusCode}`));
+          res.resume();
+          return;
+        }
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve(data));
+      })
+      .on("error", reject);
+  });
+}
+
+function parseRemoteBuild(xml) {
+  // Look for <sparkle:version>NNN</sparkle:version>
+  const match = xml.match(/<sparkle:version>(\d+)<\/sparkle:version>/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Core update check
+// ---------------------------------------------------------------------------
+
+async function checkForUpdates(opts) {
+  const silent = opts && opts.silent;
+  const local = getCurrentBuildNumber();
+
+  let xml;
+  try {
+    xml = await fetchAppcast();
+  } catch (err) {
+    if (!silent) {
+      dialog.showMessageBox({
+        type: "error",
+        title: "Update Check Failed",
+        message: `Could not reach the update server.\n\n${err.message}`,
+      });
+    }
+    return { isUpdateAvailable: false };
+  }
+
+  const remote = parseRemoteBuild(xml);
+  if (remote === null) {
+    if (!silent) {
+      dialog.showMessageBox({
+        type: "error",
+        title: "Update Check Failed",
+        message: "Could not parse the update feed.",
+      });
+    }
+    return { isUpdateAvailable: false };
+  }
+
+  latestRemoteBuild = remote;
+
+  if (remote > local) {
+    updateAvailable = true;
+    notifyRendererUpdateReady();
+    if (!silent) {
+      promptInstallUpdate(local, remote);
+    }
+    return { isUpdateAvailable: true };
+  }
+
+  if (!silent) {
+    dialog.showMessageBox({
+      type: "info",
+      title: "No Updates Available",
+      message: `You are running the latest version (build ${local}).`,
+    });
+  }
+  return { isUpdateAvailable: false };
+}
+
+// ---------------------------------------------------------------------------
+// Notify renderer
+// ---------------------------------------------------------------------------
+
+function notifyRendererUpdateReady() {
+  for (const win of BrowserWindow.getAllWindows()) {
+    try {
+      win.webContents.send("codex_desktop:message-for-view", {
+        type: "app-update-ready-changed",
+        isUpdateReady: true,
+      });
+    } catch (_e) {
+      // Window might be destroyed
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Install flow
+// ---------------------------------------------------------------------------
+
+function promptInstallUpdate(local, remote) {
+  const installerPath = getInstallerPath();
+  const installerExists = fs.existsSync(installerPath);
+
+  dialog
+    .showMessageBox({
+      type: "info",
+      title: "Update Available",
+      message: `A new version is available (build ${remote}, current: ${local}).`,
+      detail: installerExists
+        ? "Would you like to install the update now? The app will restart."
+        : `Update available, but installer not found at:\n${installerPath}\n\nPlease re-run install.sh manually.`,
+      buttons: installerExists
+        ? ["Install & Restart", "Later"]
+        : ["OK"],
+      defaultId: 0,
+    })
+    .then(({ response }) => {
+      if (installerExists && response === 0) {
+        runInstaller(installerPath);
+      }
+    });
+}
+
+function runInstaller(installerPath) {
+  // Delete cached DMG so it re-downloads the new version
+  const dmgPath = path.resolve(path.dirname(installerPath), "Codex.dmg");
+  try {
+    fs.unlinkSync(dmgPath);
+  } catch (_e) {
+    // May not exist
+  }
+
+  // Run install.sh --force detached
+  const child = execFile("bash", [installerPath, "--force"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+
+  // Relaunch after a short delay to let the installer start
+  setTimeout(() => {
+    app.relaunch();
+    app.exit(0);
+  }, 1000);
+}
+
+// ---------------------------------------------------------------------------
+// IPC: register codex_desktop:check-for-updates handler
+// ---------------------------------------------------------------------------
+
+// This handler is never registered on Linux because Ice.initialize() returns
+// early when enableSparkle is false. We register it ourselves.
+app.whenReady().then(() => {
+  try {
+    ipcMain.handle("codex_desktop:check-for-updates", async () => {
+      return checkForUpdates({ silent: false });
+    });
+  } catch (_e) {
+    // Handler may already be registered in some future version
+  }
+});
+
+// ---------------------------------------------------------------------------
+// IPC: intercept install-app-update from renderer
+// ---------------------------------------------------------------------------
+
+const originalHandle = ipcMain.handle.bind(ipcMain);
+ipcMain.handle = function patchedHandle(channel, handler) {
+  if (channel === "codex_desktop:message-from-view") {
+    // Wrap the handler to intercept install-app-update messages
+    const wrappedHandler = async (event, message) => {
+      if (message && message.type === "install-app-update") {
+        const installerPath = getInstallerPath();
+        if (fs.existsSync(installerPath)) {
+          runInstaller(installerPath);
+        } else {
+          dialog.showMessageBox({
+            type: "error",
+            title: "Update Failed",
+            message: `Installer not found at:\n${installerPath}\n\nPlease re-run install.sh manually.`,
+          });
+        }
+        return;
+      }
+      // Pass through to original handler
+      return handler(event, message);
+    };
+    return originalHandle(channel, wrappedHandler);
+  }
+  return originalHandle(channel, handler);
+};
+
+// ---------------------------------------------------------------------------
+// Menu: patch "Check for Updates" menu item
+// ---------------------------------------------------------------------------
+
+const originalSetAppMenu = Menu.setApplicationMenu.bind(Menu);
+Menu.setApplicationMenu = function patchedSetApplicationMenu(menu) {
+  if (menu) {
+    patchMenuItems(menu.items);
+  }
+  return originalSetAppMenu(menu);
+};
+
+function patchMenuItems(items) {
+  if (!items) return;
+  for (const item of items) {
+    if (
+      item.label &&
+      item.label.toLowerCase().includes("check for update")
+    ) {
+      item.enabled = true;
+      item.click = () => {
+        checkForUpdates({ silent: false });
+      };
+    }
+    if (item.submenu && item.submenu.items) {
+      patchMenuItems(item.submenu.items);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Background update checks (every 15 minutes)
+// ---------------------------------------------------------------------------
+
+app.whenReady().then(() => {
+  // Initial check after a short delay (let the app finish loading)
+  setTimeout(() => {
+    checkForUpdates({ silent: true });
+  }, 30000); // 30 seconds after launch
+
+  setInterval(() => {
+    checkForUpdates({ silent: true });
+  }, CHECK_INTERVAL_MS);
+});


### PR DESCRIPTION
- Add linux-updater.js: self-contained update module that checks the official appcast feed, patches the Check for Updates menu, runs background checks every 15 minutes, and handles install-app-update IPC messages by running install.sh --force and relaunching
- Modify install.sh patch_asar() to inject linux-updater.js into the app.asar build and prepend require() to main.js entry point
- Modify start.sh generation to export CODEX_LINUX_INSTALLER_PATH
- Update README with fork attribution, changelog, and updater docs