### PR TITLE
Add Nix flake for NixOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ sudo dnf groupinstall 'Development Tools'
 sudo pacman -S nodejs npm python p7zip curl base-devel
 ```
 
+### NixOS
+
+A Nix flake is provided that handles all dependencies and patches Electron for NixOS:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux
+```
+
+This will build and install the app into `codex-app/` in the current directory. You can also enter a dev shell with all dependencies:
+
+```bash
+nix develop github:ilysenko/codex-desktop-linux
+```
+
 You also need the **Codex CLI**:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ This will build and install the app into `codex-app/` in the current directory. 
 nix develop github:ilysenko/codex-desktop-linux
 ```
 
+To add it to your NixOS system flake, add the input and include the installer package:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    codex-desktop.url = "github:ilysenko/codex-desktop-linux";
+  };
+
+  outputs = { nixpkgs, codex-desktop, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            codex-desktop.packages.${pkgs.system}.default
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+Then run the installer with `codex-desktop-installer` after rebuilding.
+
 You also need the **Codex CLI**:
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,141 @@
+{
+  description = "Codex Desktop for Linux installer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        codexDmg = pkgs.fetchurl {
+          url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
+          hash = "sha256-dGgr8Av/1MArxkpIxT8c/Ui2fexgpnWHywJPuSq82PY=";
+        };
+
+        electronLibs = with pkgs; [
+          glib
+          gtk3
+          pango
+          cairo
+          gdk-pixbuf
+          atk
+          at-spi2-atk
+          at-spi2-core
+          nss
+          nspr
+          dbus
+          cups
+          expat
+          libdrm
+          mesa
+          libgbm
+          alsa-lib
+          libX11
+          libXcomposite
+          libXdamage
+          libXext
+          libXfixes
+          libXrandr
+          libxcb
+          libxkbcommon
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libXtst
+          xorg.libXScrnSaver
+          libglvnd
+          systemd
+          wayland
+        ];
+
+        electronLibPath = pkgs.lib.makeLibraryPath electronLibs;
+
+        installer = pkgs.writeShellApplication {
+          name = "codex-desktop-installer";
+          runtimeInputs = [
+            pkgs.nodejs_20
+            pkgs.python3
+            pkgs.p7zip
+            pkgs.curl
+            pkgs.unzip
+            pkgs.gnumake
+            pkgs.gcc
+            pkgs.patchelf
+          ];
+          text = ''
+            set -euo pipefail
+
+            root_dir="$(pwd)"
+            workdir="$(mktemp -d)"
+            cleanup() {
+              rm -rf "$workdir"
+            }
+            trap cleanup EXIT
+
+            cp ${./install.sh} "$workdir/install.sh"
+            cp ${codexDmg} "$workdir/Codex.dmg"
+            chmod +x "$workdir/install.sh"
+
+            cd "$workdir"
+            export CODEX_INSTALL_DIR="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
+            "$workdir/install.sh" "$workdir/Codex.dmg" "$@"
+
+            install_dir="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
+
+            # Patch the Electron binary for NixOS
+            if [ -f "$install_dir/electron" ]; then
+              echo "[NIX] Patching Electron binary for NixOS..."
+              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                       --set-rpath "$install_dir:${electronLibPath}" \
+                       "$install_dir/electron"
+
+              # Also patch chrome_crashpad_handler if present
+              if [ -f "$install_dir/chrome_crashpad_handler" ]; then
+                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                         "$install_dir/chrome_crashpad_handler" || true
+              fi
+
+              # Also patch chrome-sandbox if present
+              if [ -f "$install_dir/chrome-sandbox" ]; then
+                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                         "$install_dir/chrome-sandbox" || true
+              fi
+
+              # Patch all .so files in the install dir
+              find "$install_dir" -maxdepth 1 -name "*.so*" -type f | while read -r so; do
+                patchelf --set-rpath "${electronLibPath}" "$so" 2>/dev/null || true
+              done
+
+              echo "[NIX] Electron patched successfully"
+            fi
+          '';
+        };
+      in
+      {
+        packages = {
+          default = installer;
+          installer = installer;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${installer}/bin/codex-desktop-installer";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.nodejs_20
+            pkgs.python3
+            pkgs.p7zip
+            pkgs.curl
+            pkgs.unzip
+            pkgs.gnumake
+            pkgs.gcc
+          ];
+        };
+      }
+    );
+}

--- a/install.sh
+++ b/install.sh
@@ -91,8 +91,11 @@ extract_dmg() {
     local dmg_path="$1"
     info "Extracting DMG with 7z..."
 
-    7z x -y "$dmg_path" -o"$WORK_DIR/dmg-extract" >&2 || \
-        error "Failed to extract DMG"
+    local rc=0
+    7z x -y "$dmg_path" -o"$WORK_DIR/dmg-extract" >&2 || rc=$?
+    if [ "$rc" -gt 2 ]; then
+        error "Failed to extract DMG (7z exit code $rc)"
+    fi
 
     local app_dir
     app_dir=$(find "$WORK_DIR/dmg-extract" -maxdepth 3 -name "*.app" -type d | head -1)


### PR DESCRIPTION
Adds a Nix flake that enables running the installer on NixOS with zero manual dependency management.


- `flake.nix` — Nix flake providing:
  - `nix run` app that downloads the DMG, runs `install.sh`, and patches the Electron binary for NixOS via `patchelf` (sets the dynamic linker and rpath for all required shared libraries)
  - `nix develop` shell with all build dependencies (nodejs, python3, p7zip, curl, gcc, etc.)
  - All Electron runtime library dependencies (GTK, Mesa, NSS, Wayland, X11, etc.)

- README update — NixOS section added under Prerequisites with `nix run` and `nix develop` usage

- install.sh fix — 7z exit codes 0–2 are treated as non-fatal (warnings/minor issues), only exit codes > 2 are errors. This prevents false failures on my machine

Usage

```bash
# One-command install on NixOS
nix run github:ilysenko/codex-desktop-linux

# Or enter a dev shell with all dependencies
nix develop github:ilysenko/codex-desktop-linux
```

Testing

Tested on NixOS 25.05 (x86_64). The flake patches the Electron binary, chrome_crashpad_handler, chrome-sandbox, and all bundled `.so` files.