### PR TITLE
Harden Linux desktop entry lifecycle and installer operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The app is installed into `codex-app/` next to the install script:
 codex-desktop-linux/codex-app/start.sh
 ```
 
+The installer also creates a desktop launcher at:
+
+```bash
+~/.local/share/applications/codex-desktop-linux.desktop
+```
+
 Or add an alias to your shell:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Remove the installed app and desktop integration:
 ```
 
 This also removes:
-- `~/.config/Codex`, `~/.cache/Codex`, and `~/.local/share/Codex`
 - Legacy launcher/icon leftovers from earlier installs
 
 To also remove the cached DMG in the repo root:
@@ -124,6 +123,14 @@ To also remove the cached DMG in the repo root:
 ```bash
 ./install.sh --uninstall --purge-cache
 ```
+
+To also remove Codex desktop user data directories:
+
+```bash
+./install.sh --uninstall --purge-user-data
+```
+
+`~/.codex` is not removed by uninstall.
 
 ## How it works (technical details)
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,14 @@ Remove the installed app and desktop integration:
 ```
 
 This also removes:
-- Cached DMG at `Codex.dmg` in the repo root
+- `~/.config/Codex`, `~/.cache/Codex`, and `~/.local/share/Codex`
 - Legacy launcher/icon leftovers from earlier installs
+
+To also remove the cached DMG in the repo root:
+
+```bash
+./install.sh --uninstall --purge-cache
+```
 
 ## How it works (technical details)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ echo 'alias codex-desktop="~/codex-desktop-linux/codex-app/start.sh"' >> ~/.bash
 CODEX_INSTALL_DIR=/opt/codex ./install.sh
 ```
 
+### Optional sandbox mode
+
+By default the launcher uses `--no-sandbox` for compatibility.
+
+To launch without that flag:
+
+```bash
+CODEX_DISABLE_SANDBOX=0 ./codex-app/start.sh
+```
+
+### Repair desktop integration
+
+Recreate launcher script, icon, and desktop entry without full reinstall:
+
+```bash
+./install.sh --repair-desktop
+```
+
+### Uninstall
+
+Remove the installed app and desktop integration:
+
+```bash
+./install.sh --uninstall
+```
+
 ## How it works (technical details)
 
 The macOS Codex app is an Electron application. The core code (`app.asar`) is platform-independent JavaScript, but it bundles:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Remove the installed app and desktop integration:
 ./install.sh --uninstall
 ```
 
+This also removes:
+- Cached DMG at `Codex.dmg` in the repo root
+- Legacy launcher/icon leftovers from earlier installs
+
 ## How it works (technical details)
 
 The macOS Codex app is an Electron application. The core code (`app.asar`) is platform-independent JavaScript, but it bundles:


### PR DESCRIPTION
## Summary
This PR delivers a full Linux desktop-integration hardening pass for the Codex Desktop installer and launcher flow, based on real runtime behavior validation under Linux desktop environments.

The update addresses two user-facing issues:
1. The launcher icon/process identity mismatch (window rebind to generic Electron icon after startup).
2. Incomplete uninstall/recovery behavior around desktop artifacts and install lifecycle actions.

## Problem and User Impact
The original installer converted the app bundle, but did not robustly own Linux desktop integration concerns (desktop entry generation, icon installation, window class matching, and lifecycle maintenance). This caused desktop environments to treat the launched app as a generic Electron instance in some cases, resulting in icon swapping and inconsistent launcher/taskbar behavior.

In addition, uninstall/repair workflows were minimal, making it harder to recover from stale local desktop metadata and previous install leftovers.

## Root Cause
- No first-class desktop-entry management existed initially.
- Window identity metadata (`StartupWMClass` and runtime class/name) was not aligned with what the desktop shell used to track the process.
- Launcher/runtime metadata and icon asset propagation were incomplete.
- Lifecycle commands for repair/uninstall and validation were missing.

## What Changed
### 1) Desktop launcher identity and icon integration
- Added managed desktop-entry creation in installer:
  - `~/.local/share/applications/codex-desktop-linux.desktop`
- Added icon installation under hicolor icon theme.
- Added desktop matching fields (`StartupWMClass`, `X-GNOME-WMClass`).
- Updated runtime launch to pass explicit class/name/icon args so desktop shell grouping is stable.

### 2) Installer validation and maintainability improvements
- Added installer self-validation hooks:
  - `shellcheck` (when present)
  - `desktop-file-validate` (when present)
- Added command modes:
  - `--repair-desktop`
  - `--uninstall`
  - `--help`
- Added configurable sandbox behavior via `CODEX_DISABLE_SANDBOX`.

### 3) Startup robustness
- Reworked webview static-server startup handling in `start.sh`:
  - PID-file based reuse/validation instead of broad process killing.
  - lock-dir based startup guard.
  - bound local server to `127.0.0.1`.

### 4) Uninstall semantics and safety
- Uninstall now targets install artifacts and legacy desktop leftovers reliably.
- DMG cache handling is explicit:
  - keep by default
  - remove only with `--purge-cache`
- User data handling is explicit:
  - keep by default
  - remove only with `--purge-user-data`
- `~/.codex` is intentionally not touched.

## Validation Performed
- Repeated installer execution end-to-end after changes.
- Verified generated desktop file contents and launcher script contents.
- Verified icon files are installed at expected paths.
- Verified command behavior:
  - `./install.sh --help`
  - `./install.sh --repair-desktop`
  - `./install.sh --uninstall`
  - `./install.sh --uninstall --purge-cache`
  - `./install.sh --uninstall --purge-user-data` (opt-in semantics)
- Shell syntax checks: `bash -n install.sh`.

## Notes
- Upstream repo permissions required fork-based branch push for this PR.
- PR includes all commits from this desktop-integration workstream.
