### PR TITLE
Fix webview server race condition and Wayland/GPU errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ A small Python HTTP server is used as a workaround: when `app.isPackaged` is `fa
 | Problem | Solution |
 |---------|----------|
 | `Error: write EPIPE` | Make sure you're not piping the output — run `start.sh` directly |
-| Blank window | Check that port 5175 is not in use: `lsof -i :5175` |
+| Blank window | Check that port 5175 is not in use: `ss -tlnp \| grep 5175` |
+| `ERR_CONNECTION_REFUSED` on `:5175` | The webview HTTP server failed to start. Ensure `python3` works and port 5175 is free |
 | `CODEX_CLI_PATH` error | Install CLI: `npm i -g @openai/codex` |
-| GPU/rendering issues | Try: `./codex-app/start.sh --disable-gpu` |
+| GPU/Vulkan/Wayland errors | Electron flags `--ozone-platform-hint=auto` and `--disable-gpu-sandbox` are set by default. For X11, try: `./codex-app/start.sh --ozone-platform=x11` |
 | Sandbox errors | The `--no-sandbox` flag is already set in `start.sh` |
 
 ## Disclaimer


### PR DESCRIPTION
## Summary
- Fix `ERR_CONNECTION_REFUSED` on startup caused by Electron launching before the webview HTTP server is ready
- Fix Vulkan/Wayland GPU errors on Linux Wayland compositors

## Changes
- Use `nohup` for the python HTTP server to prevent signal-related process death
- Add a socket-based readiness check (up to 5s) before launching Electron
- Increase post-`pkill` sleep from 0.3s to 0.5s for reliable port release
- Add Electron flags for Wayland compatibility: `--ozone-platform-hint=auto`, `--disable-gpu-sandbox`, `--enable-features=WaylandWindowDecorations`
- Update troubleshooting table in README

## Test plan
- [ ] Run `./install.sh` and verify the generated `start.sh` contains the new readiness check and Electron flags
- [ ] Run `codex-app/start.sh` on a Wayland session and confirm the app loads without `ERR_CONNECTION_REFUSED`
- [ ] Run `codex-app/start.sh` on an X11 session and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)