### PR TITLE
Add Nix flake for NixOS support V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ sudo dnf groupinstall 'Development Tools'
 sudo pacman -S nodejs npm python p7zip curl base-devel
 ```
 
+### NixOS
+
+A Nix flake is provided that handles all dependencies and patches Electron for NixOS:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux
+```
+
+This will build and install the app into `codex-app/` in the current directory. You can also enter a dev shell with all dependencies:
+
+```bash
+nix develop github:ilysenko/codex-desktop-linux
+```
+
 You also need the **Codex CLI**:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ This will build and install the app into `codex-app/` in the current directory. 
 nix develop github:ilysenko/codex-desktop-linux
 ```
 
+To add it to your NixOS system flake, add the input and include the installer package:
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    codex-desktop.url = "github:ilysenko/codex-desktop-linux";
+  };
+
+  outputs = { nixpkgs, codex-desktop, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            codex-desktop.packages.${pkgs.system}.default
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+Then run the installer with `codex-desktop-installer` after rebuilding.
+
 You also need the **Codex CLI**:
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772773019,
+        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,141 @@
+{
+  description = "Codex Desktop for Linux installer";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+
+        codexDmg = pkgs.fetchurl {
+          url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
+          hash = "sha256-dGgr8Av/1MArxkpIxT8c/Ui2fexgpnWHywJPuSq82PY=";
+        };
+
+        electronLibs = with pkgs; [
+          glib
+          gtk3
+          pango
+          cairo
+          gdk-pixbuf
+          atk
+          at-spi2-atk
+          at-spi2-core
+          nss
+          nspr
+          dbus
+          cups
+          expat
+          libdrm
+          mesa
+          libgbm
+          alsa-lib
+          libX11
+          libXcomposite
+          libXdamage
+          libXext
+          libXfixes
+          libXrandr
+          libxcb
+          libxkbcommon
+          xorg.libXcursor
+          xorg.libXi
+          xorg.libXtst
+          xorg.libXScrnSaver
+          libglvnd
+          systemd
+          wayland
+        ];
+
+        electronLibPath = pkgs.lib.makeLibraryPath electronLibs;
+
+        installer = pkgs.writeShellApplication {
+          name = "codex-desktop-installer";
+          runtimeInputs = [
+            pkgs.nodejs_20
+            pkgs.python3
+            pkgs.p7zip
+            pkgs.curl
+            pkgs.unzip
+            pkgs.gnumake
+            pkgs.gcc
+            pkgs.patchelf
+          ];
+          text = ''
+            set -euo pipefail
+
+            root_dir="$(pwd)"
+            workdir="$(mktemp -d)"
+            cleanup() {
+              rm -rf "$workdir"
+            }
+            trap cleanup EXIT
+
+            cp ${./install.sh} "$workdir/install.sh"
+            cp ${codexDmg} "$workdir/Codex.dmg"
+            chmod +x "$workdir/install.sh"
+
+            cd "$workdir"
+            export CODEX_INSTALL_DIR="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
+            "$workdir/install.sh" "$workdir/Codex.dmg" "$@"
+
+            install_dir="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
+
+            # Patch the Electron binary for NixOS
+            if [ -f "$install_dir/electron" ]; then
+              echo "[NIX] Patching Electron binary for NixOS..."
+              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                       --set-rpath "$install_dir:${electronLibPath}" \
+                       "$install_dir/electron"
+
+              # Also patch chrome_crashpad_handler if present
+              if [ -f "$install_dir/chrome_crashpad_handler" ]; then
+                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                         "$install_dir/chrome_crashpad_handler" || true
+              fi
+
+              # Also patch chrome-sandbox if present
+              if [ -f "$install_dir/chrome-sandbox" ]; then
+                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                         "$install_dir/chrome-sandbox" || true
+              fi
+
+              # Patch all .so files in the install dir
+              find "$install_dir" -maxdepth 1 -name "*.so*" -type f | while read -r so; do
+                patchelf --set-rpath "${electronLibPath}" "$so" 2>/dev/null || true
+              done
+
+              echo "[NIX] Electron patched successfully"
+            fi
+          '';
+        };
+      in
+      {
+        packages = {
+          default = installer;
+          installer = installer;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${installer}/bin/codex-desktop-installer";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.nodejs_20
+            pkgs.python3
+            pkgs.p7zip
+            pkgs.curl
+            pkgs.unzip
+            pkgs.gnumake
+            pkgs.gcc
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-dGgr8Av/1MArxkpIxT8c/Ui2fexgpnWHywJPuSq82PY=";
+          hash = "sha256-4oKdhkRmwUbvnexeguuwfv+oRHhR3WYbUwewB9rpLDc=";
         };
 
         electronLibs = with pkgs; [
@@ -42,10 +42,10 @@
           libXrandr
           libxcb
           libxkbcommon
-          xorg.libXcursor
-          xorg.libXi
-          xorg.libXtst
-          xorg.libXScrnSaver
+          libxcursor
+          libxi
+          libxtst
+          libxscrnsaver
           libglvnd
           systemd
           wayland
@@ -56,7 +56,8 @@
         installer = pkgs.writeShellApplication {
           name = "codex-desktop-installer";
           runtimeInputs = [
-            pkgs.nodejs_20
+            pkgs.bash
+            pkgs.nodejs
             pkgs.python3
             pkgs.p7zip
             pkgs.curl
@@ -81,7 +82,7 @@
 
             cd "$workdir"
             export CODEX_INSTALL_DIR="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
-            "$workdir/install.sh" "$workdir/Codex.dmg" "$@"
+            ${pkgs.bash}/bin/bash "$workdir/install.sh" "$workdir/Codex.dmg" "$@"
 
             install_dir="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
 
@@ -127,7 +128,7 @@
 
         devShells.default = pkgs.mkShell {
           packages = [
-            pkgs.nodejs_20
+            pkgs.nodejs
             pkgs.python3
             pkgs.p7zip
             pkgs.curl

--- a/install.sh
+++ b/install.sh
@@ -91,8 +91,11 @@ extract_dmg() {
     local dmg_path="$1"
     info "Extracting DMG with 7z..."
 
-    7z x -y "$dmg_path" -o"$WORK_DIR/dmg-extract" >&2 || \
-        error "Failed to extract DMG"
+    local rc=0
+    7z x -y "$dmg_path" -o"$WORK_DIR/dmg-extract" >&2 || rc=$?
+    if [ "$rc" -gt 2 ]; then
+        error "Failed to extract DMG (7z exit code $rc)"
+    fi
 
     local app_dir
     app_dir=$(find "$WORK_DIR/dmg-extract" -maxdepth 3 -name "*.app" -type d | head -1)

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 # ============================================================================
@@ -222,7 +222,7 @@ install_app() {
 # ---- Create start script ----
 create_start_script() {
     cat > "$INSTALL_DIR/start.sh" << 'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 WEBVIEW_DIR="$SCRIPT_DIR/content/webview"
 
@@ -236,7 +236,7 @@ if [ -d "$WEBVIEW_DIR" ] && [ "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
     trap "kill $HTTP_PID 2>/dev/null" EXIT
 fi
 
-export CODEX_CLI_PATH="${CODEX_CLI_PATH:-$(which codex 2>/dev/null)}"
+export CODEX_CLI_PATH="${CODEX_CLI_PATH:-$(command -v codex 2>/dev/null)}"
 
 if [ -z "$CODEX_CLI_PATH" ]; then
     echo "Error: Codex CLI not found. Install with: npm i -g @openai/codex"


### PR DESCRIPTION
Follow-up to #7. I tested the previous branch on NixOS and fixed the stale Codex.dmg hash, deprecated nixpkgs xorg attrs, /bin/bash interpreter issues in the installer and generated launcher, and the nodejs-slim npm/npx failure so nix run completes successfully.