### PR TITLE
feat: add user-local desktop integration helper bundle

### DIFF
--- a/contrib/user-local-install/README.md
+++ b/contrib/user-local-install/README.md
@@ -5,7 +5,8 @@ This folder packages a user-local install layout for `codex-desktop-linux`.
 It adds:
 
 - a stable install root under `~/.local/opt/codex-desktop-linux`
-- launch/check/update/version commands under `~/.local/bin`
+- self-contained maintenance scripts under `~/.local/opt/codex-desktop-linux/bin`
+- thin launch/check/update/version wrappers under `~/.local/bin`
 - a desktop entry under `~/.local/share/applications`
 - an icon extracted from the local `Codex.dmg`
 - metadata tracking for the wrapper repo and cached `Codex.dmg`
@@ -13,13 +14,11 @@ It adds:
 
 ## Files
 
-The package is laid out as files relative to `$HOME`:
+The package is laid out as reusable payload files. The installer copies them into:
 
-- `files/.local/bin/codex-desktop`
-- `files/.local/bin/codex-desktop-check-update`
-- `files/.local/bin/codex-desktop-update`
-- `files/.local/bin/codex-desktop-version`
-- `files/.local/lib/codex-desktop-linux/common.sh`
+- `~/.local/opt/codex-desktop-linux/bin/`
+- `~/.local/opt/codex-desktop-linux/lib/codex-desktop-linux/`
+- `~/.local/bin/` wrappers
 - `files/.local/share/applications/codex-desktop.desktop`
 - `files/.config/systemd/user/codex-desktop-update.service`
 - `files/.config/systemd/user/codex-desktop-update.timer`
@@ -28,16 +27,17 @@ The package is laid out as files relative to `$HOME`:
 
 If installing manually, copy the files to:
 
-- `~/.local/bin/`
-- `~/.local/lib/codex-desktop-linux/`
+- `~/.local/opt/codex-desktop-linux/bin/`
+- `~/.local/opt/codex-desktop-linux/lib/codex-desktop-linux/`
+- `~/.local/bin/` wrappers that exec into `~/.local/opt/codex-desktop-linux/bin/`
 - `~/.local/share/applications/`
 - `~/.config/systemd/user/`
 
-The main wrapper repository itself should live at:
+The preferred git checkout location is:
 
-- `~/.local/opt/codex-desktop-linux`
+- `~/workspace/codex-desktop-linux`
 
-That is the path assumed by the helper scripts.
+The installed maintenance scripts record the repo path in user state and use that checkout for `git pull`, while rebuilding runtime assets into `~/.local/opt/codex-desktop-linux` via `CODEX_INSTALL_ROOT` / `CODEX_INSTALL_DIR`.
 
 ## Install
 
@@ -49,12 +49,13 @@ From the repository root:
 
 The installer:
 
-1. copies the helper files into the user-local locations
-2. makes the scripts executable
-3. reloads the user `systemd` daemon if available
-4. enables the weekly timer if the user bus is reachable
-5. refreshes desktop metadata if available
-6. records local metadata and extracts the icon if `Codex.dmg` already exists
+1. copies standalone helper scripts into `~/.local/opt/codex-desktop-linux`
+2. installs thin wrappers into `~/.local/bin`
+3. makes the scripts executable
+4. reloads the user `systemd` daemon if available
+5. enables the weekly timer if the user bus is reachable
+6. refreshes desktop metadata if available
+7. records local metadata and extracts the icon if `Codex.dmg` already exists
 
 ## Commands
 
@@ -71,4 +72,5 @@ codex-desktop-version
 
 - The icon is not committed as a binary asset here. It is generated locally from `Codex.dmg`.
 - The helper scripts track both upstream wrapper changes and upstream `Codex.dmg` headers.
+- The helper scripts are copied into `~/.local/opt` and do not run from the git checkout directly.
 - The weekly timer runs `codex-desktop-update --quiet`.

--- a/contrib/user-local-install/README.md
+++ b/contrib/user-local-install/README.md
@@ -1,0 +1,74 @@
+# User-Local Desktop Integration
+
+This folder packages a user-local install layout for `codex-desktop-linux`.
+
+It adds:
+
+- a stable install root under `~/.local/opt/codex-desktop-linux`
+- launch/check/update/version commands under `~/.local/bin`
+- a desktop entry under `~/.local/share/applications`
+- an icon extracted from the local `Codex.dmg`
+- metadata tracking for the wrapper repo and cached `Codex.dmg`
+- a weekly `systemd --user` timer for unattended update checks and rebuilds
+
+## Files
+
+The package is laid out as files relative to `$HOME`:
+
+- `files/.local/bin/codex-desktop`
+- `files/.local/bin/codex-desktop-check-update`
+- `files/.local/bin/codex-desktop-update`
+- `files/.local/bin/codex-desktop-version`
+- `files/.local/lib/codex-desktop-linux/common.sh`
+- `files/.local/share/applications/codex-desktop.desktop`
+- `files/.config/systemd/user/codex-desktop-update.service`
+- `files/.config/systemd/user/codex-desktop-update.timer`
+
+## Expected Placement
+
+If installing manually, copy the files to:
+
+- `~/.local/bin/`
+- `~/.local/lib/codex-desktop-linux/`
+- `~/.local/share/applications/`
+- `~/.config/systemd/user/`
+
+The main wrapper repository itself should live at:
+
+- `~/.local/opt/codex-desktop-linux`
+
+That is the path assumed by the helper scripts.
+
+## Install
+
+From the repository root:
+
+```bash
+./contrib/user-local-install/install-user-local.sh
+```
+
+The installer:
+
+1. copies the helper files into the user-local locations
+2. makes the scripts executable
+3. reloads the user `systemd` daemon if available
+4. enables the weekly timer if the user bus is reachable
+5. refreshes desktop metadata if available
+6. records local metadata and extracts the icon if `Codex.dmg` already exists
+
+## Commands
+
+After installation:
+
+```bash
+codex-desktop
+codex-desktop-check-update
+codex-desktop-update
+codex-desktop-version
+```
+
+## Notes
+
+- The icon is not committed as a binary asset here. It is generated locally from `Codex.dmg`.
+- The helper scripts track both upstream wrapper changes and upstream `Codex.dmg` headers.
+- The weekly timer runs `codex-desktop-update --quiet`.

--- a/contrib/user-local-install/README.md
+++ b/contrib/user-local-install/README.md
@@ -10,7 +10,7 @@ It adds:
 - a desktop entry under `~/.local/share/applications`
 - an icon extracted from the local `Codex.dmg`
 - metadata tracking for the wrapper repo and cached `Codex.dmg`
-- a weekly `systemd --user` timer for unattended update checks and rebuilds
+- an optional weekly `systemd --user` timer for unattended update checks and rebuilds (opt-in)
 
 ## Files
 
@@ -47,15 +47,22 @@ From the repository root:
 ./contrib/user-local-install/install-user-local.sh
 ```
 
+To also enable the weekly auto-update timer, pass `--enable-timer`:
+
+```bash
+./contrib/user-local-install/install-user-local.sh --enable-timer
+```
+
 The installer:
 
 1. copies standalone helper scripts into `~/.local/opt/codex-desktop-linux`
 2. installs thin wrappers into `~/.local/bin`
-3. makes the scripts executable
-4. reloads the user `systemd` daemon if available
-5. enables the weekly timer if the user bus is reachable
-6. refreshes desktop metadata if available
-7. records local metadata and extracts the icon if `Codex.dmg` already exists
+3. copies systemd unit files to `~/.config/systemd/user/`
+4. makes the scripts executable
+5. reloads the user `systemd` daemon if available
+6. enables the weekly timer only if `--enable-timer` was passed
+7. refreshes desktop metadata if available
+8. records local metadata and extracts the icon if `Codex.dmg` already exists
 
 ## Commands
 
@@ -73,4 +80,4 @@ codex-desktop-version
 - The icon is not committed as a binary asset here. It is generated locally from `Codex.dmg`.
 - The helper scripts track both upstream wrapper changes and upstream `Codex.dmg` headers.
 - The helper scripts are copied into `~/.local/opt` and do not run from the git checkout directly.
-- The weekly timer runs `codex-desktop-update --quiet`.
+- The weekly timer runs `codex-desktop-update --quiet`. It is opt-in: pass `--enable-timer` to `install-user-local.sh` to activate it, or run `systemctl --user enable --now codex-desktop-update.timer` manually after install.

--- a/contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.service
+++ b/contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Update Codex desktop Linux wrapper
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/bin/codex-desktop-update --quiet

--- a/contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.timer
+++ b/contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly update for Codex desktop Linux wrapper
+
+[Timer]
+OnCalendar=Sun 05:00
+Persistent=true
+Unit=codex-desktop-update.service
+
+[Install]
+WantedBy=timers.target

--- a/contrib/user-local-install/files/.local/bin/codex-desktop
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR="${HOME}/.local/opt/codex-desktop-linux/codex-app"
+OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
+APP_DIR="${OPT_ROOT}/codex-app"
 exec "${APP_DIR}/start.sh" "$@"

--- a/contrib/user-local-install/files/.local/bin/codex-desktop
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR="${HOME}/.local/opt/codex-desktop-linux/codex-app"
+exec "${APP_DIR}/start.sh" "$@"

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-check-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-check-update
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+
+ensure_layout
+load_metadata
+
+local_head="$(current_repo_head)"
+remote_head=""
+dmg_headers=""
+
+if ! remote_head="$(remote_repo_head 2>/dev/null)"; then
+    echo "Could not query wrapper repo upstream."
+    exit 1
+fi
+
+if ! dmg_headers="$(remote_dmg_headers 2>/dev/null)"; then
+    echo "Could not query Codex.dmg headers."
+    exit 1
+fi
+
+remote_etag="$(header_value "$dmg_headers" "etag")"
+remote_last_modified="$(header_value "$dmg_headers" "last-modified")"
+remote_content_length="$(header_value "$dmg_headers" "content-length")"
+
+repo_changed=0
+dmg_changed=0
+
+if [ "$local_head" != "$remote_head" ]; then
+    repo_changed=1
+fi
+
+if [ "${DMG_ETAG-}" != "$remote_etag" ] || [ "${DMG_LAST_MODIFIED-}" != "$remote_last_modified" ] || [ "${DMG_CONTENT_LENGTH-}" != "$remote_content_length" ]; then
+    dmg_changed=1
+fi
+
+echo "Install root: $REPO_DIR"
+echo "Wrapper repo local:  $local_head"
+echo "Wrapper repo remote: $remote_head"
+echo "Cached DMG etag:     ${DMG_ETAG-untracked}"
+echo "Remote DMG etag:     ${remote_etag:-unknown}"
+echo "Cached DMG modified: ${DMG_LAST_MODIFIED-untracked}"
+echo "Remote DMG modified: ${remote_last_modified:-unknown}"
+
+if [ "$repo_changed" -eq 0 ] && [ "$dmg_changed" -eq 0 ]; then
+    echo "Status: up to date"
+    exit 0
+fi
+
+echo "Status: update available"
+if [ "$repo_changed" -eq 1 ]; then
+    echo "Reason: wrapper repo changed"
+fi
+if [ "$dmg_changed" -eq 1 ]; then
+    echo "Reason: Codex.dmg changed"
+fi
+exit 10

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-check-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-check-update
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+source "${HOME}/.local/opt/codex-desktop-linux/lib/codex-desktop-linux/common.sh"
 
 ensure_layout
+load_install_config
 load_metadata
 
 local_head="$(current_repo_head)"
@@ -35,7 +36,8 @@ if [ "${DMG_ETAG-}" != "$remote_etag" ] || [ "${DMG_LAST_MODIFIED-}" != "$remote
     dmg_changed=1
 fi
 
-echo "Install root: $REPO_DIR"
+echo "Install root: $OPT_ROOT"
+echo "Repo root:    $REPO_DIR"
 echo "Wrapper repo local:  $local_head"
 echo "Wrapper repo remote: $remote_head"
 echo "Cached DMG etag:     ${DMG_ETAG-untracked}"

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-update
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+source "${HOME}/.local/opt/codex-desktop-linux/lib/codex-desktop-linux/common.sh"
 
 ensure_layout
+load_install_config
 load_metadata
 
 quiet=0
@@ -79,6 +80,12 @@ fi
 if [ "$repo_changed" -eq 1 ]; then
     log "Pulling wrapper updates..."
     git -C "$REPO_DIR" pull --ff-only
+    if [ -x "$REPO_DIR/contrib/user-local-install/install-user-local.sh" ]; then
+        log "Refreshing installed helper scripts..."
+        "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --from-update
+        load_install_config
+        load_metadata
+    fi
 fi
 
 if [ "$dmg_changed" -eq 1 ]; then
@@ -89,7 +96,7 @@ fi
 log "Rebuilding wrapper..."
 (
     cd "$REPO_DIR"
-    ./install.sh
+    CODEX_INSTALL_ROOT="$OPT_ROOT" CODEX_INSTALL_DIR="$APP_DIR" ./install.sh
 )
 
 extract_icon

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-update
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+
+ensure_layout
+load_metadata
+
+quiet=0
+force=0
+record_only=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --quiet)
+            quiet=1
+            ;;
+        --force)
+            force=1
+            ;;
+        --record-only)
+            record_only=1
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+log() {
+    if [ "$quiet" -eq 0 ]; then
+        echo "$@"
+    fi
+}
+
+if [ "$record_only" -eq 1 ]; then
+    extract_icon
+    record_metadata
+    log "Metadata refreshed."
+    exit 0
+fi
+
+local_head="$(current_repo_head)"
+remote_head=""
+dmg_headers=""
+
+if ! remote_head="$(remote_repo_head 2>/dev/null)"; then
+    echo "Could not query wrapper repo upstream." >&2
+    exit 1
+fi
+
+if ! dmg_headers="$(remote_dmg_headers 2>/dev/null)"; then
+    echo "Could not query Codex.dmg headers." >&2
+    exit 1
+fi
+
+remote_etag="$(header_value "$dmg_headers" "etag")"
+remote_last_modified="$(header_value "$dmg_headers" "last-modified")"
+remote_content_length="$(header_value "$dmg_headers" "content-length")"
+
+repo_changed=0
+dmg_changed=0
+
+if [ "$local_head" != "$remote_head" ]; then
+    repo_changed=1
+fi
+
+if [ "$force" -eq 1 ] || [ "${DMG_ETAG-}" != "$remote_etag" ] || [ "${DMG_LAST_MODIFIED-}" != "$remote_last_modified" ] || [ "${DMG_CONTENT_LENGTH-}" != "$remote_content_length" ]; then
+    dmg_changed=1
+fi
+
+if [ "$repo_changed" -eq 0 ] && [ "$dmg_changed" -eq 0 ] && [ "$force" -eq 0 ]; then
+    log "Codex desktop wrapper is already up to date."
+    exit 0
+fi
+
+if [ "$repo_changed" -eq 1 ]; then
+    log "Pulling wrapper updates..."
+    git -C "$REPO_DIR" pull --ff-only
+fi
+
+if [ "$dmg_changed" -eq 1 ]; then
+    log "Refreshing cached Codex.dmg..."
+    rm -f "$DMG_FILE"
+fi
+
+log "Rebuilding wrapper..."
+(
+    cd "$REPO_DIR"
+    ./install.sh
+)
+
+extract_icon
+record_metadata
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "${XDG_DATA_HOME}/applications" >/dev/null 2>&1 || true
+fi
+
+log "Update complete."

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-version
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-version
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+
+ensure_layout
+load_metadata
+
+if [ ! -f "$METADATA_FILE" ]; then
+    echo "No metadata recorded yet. Run: codex-desktop-update --record-only"
+    exit 1
+fi
+
+echo "Install root:      $REPO_DIR"
+echo "Build time:        ${BUILD_TIME-unknown}"
+echo "Wrapper repo:      ${REPO_HEAD-unknown}"
+echo "Repo origin:       ${REPO_ORIGIN-unknown}"
+echo "DMG sha256:        ${DMG_SHA256-unknown}"
+echo "DMG size:          ${DMG_SIZE-unknown}"
+echo "DMG etag:          ${DMG_ETAG-unknown}"
+echo "DMG modified:      ${DMG_LAST_MODIFIED-unknown}"
+echo "Electron version:  ${ELECTRON_VERSION-unknown}"
+echo "Launcher:          ${HOME}/.local/bin/codex-desktop"

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-version
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-version
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+source "${HOME}/.local/opt/codex-desktop-linux/lib/codex-desktop-linux/common.sh"
 
 ensure_layout
+load_install_config
 load_metadata
 
 if [ ! -f "$METADATA_FILE" ]; then
@@ -11,7 +12,8 @@ if [ ! -f "$METADATA_FILE" ]; then
     exit 1
 fi
 
-echo "Install root:      $REPO_DIR"
+echo "Install root:      $OPT_ROOT"
+echo "Repo root:         ${REPO_DIR-unknown}"
 echo "Build time:        ${BUILD_TIME-unknown}"
 echo "Wrapper repo:      ${REPO_HEAD-unknown}"
 echo "Repo origin:       ${REPO_ORIGIN-unknown}"
@@ -21,3 +23,4 @@ echo "DMG etag:          ${DMG_ETAG-unknown}"
 echo "DMG modified:      ${DMG_LAST_MODIFIED-unknown}"
 echo "Electron version:  ${ELECTRON_VERSION-unknown}"
 echo "Launcher:          ${HOME}/.local/bin/codex-desktop"
+echo "Manager bin:       ${OPT_ROOT}/bin"

--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_DIR="${HOME}/.local/opt/codex-desktop-linux"
-APP_DIR="${REPO_DIR}/codex-app"
-DMG_FILE="${REPO_DIR}/Codex.dmg"
+OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
+APP_DIR="${OPT_ROOT}/codex-app"
+DMG_FILE="${OPT_ROOT}/Codex.dmg"
 DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
@@ -12,11 +12,23 @@ XDG_STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
 STATE_DIR="${XDG_STATE_HOME}/codex-desktop-linux"
 LOG_DIR="${STATE_DIR}/logs"
 METADATA_FILE="${STATE_DIR}/metadata.env"
+INSTALL_CONFIG_FILE="${STATE_DIR}/install.env"
 ICON_PATH="${XDG_DATA_HOME}/icons/hicolor/512x512/apps/codex-desktop.png"
 DESKTOP_FILE="${XDG_DATA_HOME}/applications/codex-desktop.desktop"
 
+REPO_DIR_DEFAULT="${HOME}/workspace/codex-desktop-linux"
+REPO_DIR="$REPO_DIR_DEFAULT"
+
 ensure_layout() {
     mkdir -p "$STATE_DIR" "$LOG_DIR" "$(dirname "$ICON_PATH")" "$(dirname "$DESKTOP_FILE")"
+}
+
+load_install_config() {
+    if [ -f "$INSTALL_CONFIG_FILE" ]; then
+        # shellcheck disable=SC1090
+        source "$INSTALL_CONFIG_FILE"
+    fi
+    REPO_DIR="${REPO_DIR:-$REPO_DIR_DEFAULT}"
 }
 
 load_metadata() {
@@ -69,10 +81,16 @@ PY
 
 record_metadata() {
     ensure_layout
+    load_install_config
 
     local repo_head dmg_sha256 dmg_size electron_version dmg_headers dmg_etag dmg_last_modified dmg_content_length build_time repo_origin
-    repo_head="$(current_repo_head)"
-    repo_origin="$(git -C "$REPO_DIR" remote get-url origin)"
+    if [ -d "$REPO_DIR/.git" ]; then
+        repo_head="$(current_repo_head)"
+        repo_origin="$(git -C "$REPO_DIR" remote get-url origin)"
+    else
+        repo_head="unavailable"
+        repo_origin="unavailable"
+    fi
     dmg_sha256="$(sha256sum "$DMG_FILE" | awk '{ print $1 }')"
     dmg_size="$(stat -c '%s' "$DMG_FILE")"
     electron_version="$(cat "$APP_DIR/version")"
@@ -95,5 +113,7 @@ record_metadata() {
         write_kv ELECTRON_VERSION "$electron_version"
         write_kv APP_DIR "$APP_DIR"
         write_kv ICON_PATH "$ICON_PATH"
+        write_kv OPT_ROOT "$OPT_ROOT"
+        write_kv REPO_DIR "$REPO_DIR"
     } > "$METADATA_FILE"
 }

--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${HOME}/.local/opt/codex-desktop-linux"
+APP_DIR="${REPO_DIR}/codex-app"
+DMG_FILE="${REPO_DIR}/Codex.dmg"
+DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+
+XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"
+
+STATE_DIR="${XDG_STATE_HOME}/codex-desktop-linux"
+LOG_DIR="${STATE_DIR}/logs"
+METADATA_FILE="${STATE_DIR}/metadata.env"
+ICON_PATH="${XDG_DATA_HOME}/icons/hicolor/512x512/apps/codex-desktop.png"
+DESKTOP_FILE="${XDG_DATA_HOME}/applications/codex-desktop.desktop"
+
+ensure_layout() {
+    mkdir -p "$STATE_DIR" "$LOG_DIR" "$(dirname "$ICON_PATH")" "$(dirname "$DESKTOP_FILE")"
+}
+
+load_metadata() {
+    if [ -f "$METADATA_FILE" ]; then
+        # shellcheck disable=SC1090
+        source "$METADATA_FILE"
+    fi
+}
+
+write_kv() {
+    printf '%s=%q\n' "$1" "${2-}"
+}
+
+current_repo_head() {
+    git -C "$REPO_DIR" rev-parse HEAD
+}
+
+remote_repo_head() {
+    git -C "$REPO_DIR" ls-remote origin HEAD | awk 'NR==1 { print $1 }'
+}
+
+remote_dmg_headers() {
+    curl -fsSIL "$DMG_URL" | tr -d '\r'
+}
+
+header_value() {
+    local headers="$1"
+    local name="$2"
+    printf '%s\n' "$headers" | awk -F': ' -v target="$name" 'tolower($1) == tolower(target) { print $2; exit }'
+}
+
+extract_icon() {
+    ensure_layout
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    7z e -y "$DMG_FILE" "Codex Installer/Codex.app/Contents/Resources/electron.icns" "-o${tmp_dir}" >/dev/null
+    python3 - "$tmp_dir/electron.icns" "$ICON_PATH" <<'PY'
+from PIL import Image
+import sys
+
+source_path, target_path = sys.argv[1], sys.argv[2]
+with Image.open(source_path) as img:
+    img.load()
+    img.thumbnail((512, 512))
+    img.save(target_path, format="PNG")
+PY
+}
+
+record_metadata() {
+    ensure_layout
+
+    local repo_head dmg_sha256 dmg_size electron_version dmg_headers dmg_etag dmg_last_modified dmg_content_length build_time repo_origin
+    repo_head="$(current_repo_head)"
+    repo_origin="$(git -C "$REPO_DIR" remote get-url origin)"
+    dmg_sha256="$(sha256sum "$DMG_FILE" | awk '{ print $1 }')"
+    dmg_size="$(stat -c '%s' "$DMG_FILE")"
+    electron_version="$(cat "$APP_DIR/version")"
+    build_time="$(date -Iseconds)"
+
+    dmg_headers="$(remote_dmg_headers 2>/dev/null || true)"
+    dmg_etag="$(header_value "$dmg_headers" "etag")"
+    dmg_last_modified="$(header_value "$dmg_headers" "last-modified")"
+    dmg_content_length="$(header_value "$dmg_headers" "content-length")"
+
+    {
+        write_kv BUILD_TIME "$build_time"
+        write_kv REPO_ORIGIN "$repo_origin"
+        write_kv REPO_HEAD "$repo_head"
+        write_kv DMG_SHA256 "$dmg_sha256"
+        write_kv DMG_SIZE "$dmg_size"
+        write_kv DMG_ETAG "$dmg_etag"
+        write_kv DMG_LAST_MODIFIED "$dmg_last_modified"
+        write_kv DMG_CONTENT_LENGTH "$dmg_content_length"
+        write_kv ELECTRON_VERSION "$electron_version"
+        write_kv APP_DIR "$APP_DIR"
+        write_kv ICON_PATH "$ICON_PATH"
+    } > "$METADATA_FILE"
+}

--- a/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop
+++ b/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Codex Desktop
+Comment=OpenAI Codex desktop wrapper for Linux
+Exec=@HOME@/.local/bin/codex-desktop %U
+TryExec=@HOME@/.local/bin/codex-desktop
+Terminal=false
+Categories=Development;IDE;
+Keywords=codex;openai;ai;coding;
+StartupNotify=true
+StartupWMClass=codex-desktop
+Icon=codex-desktop

--- a/contrib/user-local-install/install-user-local.sh
+++ b/contrib/user-local-install/install-user-local.sh
@@ -3,6 +3,25 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FILES_DIR="${SCRIPT_DIR}/files"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
+OPT_BIN_DIR="${OPT_ROOT}/bin"
+OPT_LIB_DIR="${OPT_ROOT}/lib/codex-desktop-linux"
+STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
+FROM_UPDATE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --from-update)
+            FROM_UPDATE=1
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
 
 copy_file() {
     local src="$1"
@@ -11,27 +30,56 @@ copy_file() {
     cp "$src" "$dst"
 }
 
-copy_tree() {
-    local root="$1"
-    local rel
-    while IFS= read -r rel; do
-        if [ "$rel" = "./.local/share/applications/codex-desktop.desktop" ]; then
-            mkdir -p "${HOME}/.local/share/applications"
-            sed "s|@HOME@|${HOME}|g" "${root}/${rel}" > "${HOME}/${rel#./}"
-            continue
-        fi
-        copy_file "${root}/${rel}" "${HOME}/${rel#./}"
-    done < <(cd "$root" && find . -type f | sort)
+install_manager_files() {
+    mkdir -p "$OPT_BIN_DIR" "$OPT_LIB_DIR" "${HOME}/.local/share/applications" "${HOME}/.local/bin" "$STATE_DIR"
+
+    copy_file "${FILES_DIR}/.local/lib/codex-desktop-linux/common.sh" "${OPT_LIB_DIR}/common.sh"
+    copy_file "${FILES_DIR}/.local/bin/codex-desktop" "${OPT_BIN_DIR}/codex-desktop"
+    copy_file "${FILES_DIR}/.local/bin/codex-desktop-check-update" "${OPT_BIN_DIR}/codex-desktop-check-update"
+    copy_file "${FILES_DIR}/.local/bin/codex-desktop-update" "${OPT_BIN_DIR}/codex-desktop-update"
+    copy_file "${FILES_DIR}/.local/bin/codex-desktop-version" "${OPT_BIN_DIR}/codex-desktop-version"
+
+    cat > "${HOME}/.local/bin/codex-desktop" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${HOME}/.local/opt/codex-desktop-linux/bin/codex-desktop" "$@"
+EOF
+    cat > "${HOME}/.local/bin/codex-desktop-check-update" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${HOME}/.local/opt/codex-desktop-linux/bin/codex-desktop-check-update" "$@"
+EOF
+    cat > "${HOME}/.local/bin/codex-desktop-update" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${HOME}/.local/opt/codex-desktop-linux/bin/codex-desktop-update" "$@"
+EOF
+    cat > "${HOME}/.local/bin/codex-desktop-version" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec "${HOME}/.local/opt/codex-desktop-linux/bin/codex-desktop-version" "$@"
+EOF
+
+    sed "s|@HOME@|${HOME}|g" "${FILES_DIR}/.local/share/applications/codex-desktop.desktop" > "${HOME}/.local/share/applications/codex-desktop.desktop"
+
+    cat > "${STATE_DIR}/install.env" <<EOF
+REPO_DIR=$(printf '%q' "$REPO_ROOT")
+OPT_ROOT=$(printf '%q' "$OPT_ROOT")
+EOF
+
+    chmod +x \
+        "${OPT_BIN_DIR}/codex-desktop" \
+        "${OPT_BIN_DIR}/codex-desktop-check-update" \
+        "${OPT_BIN_DIR}/codex-desktop-update" \
+        "${OPT_BIN_DIR}/codex-desktop-version" \
+        "${OPT_LIB_DIR}/common.sh" \
+        "${HOME}/.local/bin/codex-desktop" \
+        "${HOME}/.local/bin/codex-desktop-check-update" \
+        "${HOME}/.local/bin/codex-desktop-update" \
+        "${HOME}/.local/bin/codex-desktop-version"
 }
 
-copy_tree "$FILES_DIR"
-
-chmod +x \
-    "${HOME}/.local/bin/codex-desktop" \
-    "${HOME}/.local/bin/codex-desktop-check-update" \
-    "${HOME}/.local/bin/codex-desktop-update" \
-    "${HOME}/.local/bin/codex-desktop-version" \
-    "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+install_manager_files
 
 if command -v systemctl >/dev/null 2>&1; then
     systemctl --user daemon-reload >/dev/null 2>&1 || true
@@ -46,4 +94,6 @@ if [ -x "${HOME}/.local/bin/codex-desktop-update" ]; then
     "${HOME}/.local/bin/codex-desktop-update" --record-only >/dev/null 2>&1 || true
 fi
 
-echo "Installed user-local Codex desktop integration."
+if [ "$FROM_UPDATE" -eq 0 ]; then
+    echo "Installed user-local Codex desktop integration."
+fi

--- a/contrib/user-local-install/install-user-local.sh
+++ b/contrib/user-local-install/install-user-local.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FILES_DIR="${SCRIPT_DIR}/files"
+
+copy_file() {
+    local src="$1"
+    local dst="$2"
+    mkdir -p "$(dirname "$dst")"
+    cp "$src" "$dst"
+}
+
+copy_tree() {
+    local root="$1"
+    local rel
+    while IFS= read -r rel; do
+        if [ "$rel" = "./.local/share/applications/codex-desktop.desktop" ]; then
+            mkdir -p "${HOME}/.local/share/applications"
+            sed "s|@HOME@|${HOME}|g" "${root}/${rel}" > "${HOME}/${rel#./}"
+            continue
+        fi
+        copy_file "${root}/${rel}" "${HOME}/${rel#./}"
+    done < <(cd "$root" && find . -type f | sort)
+}
+
+copy_tree "$FILES_DIR"
+
+chmod +x \
+    "${HOME}/.local/bin/codex-desktop" \
+    "${HOME}/.local/bin/codex-desktop-check-update" \
+    "${HOME}/.local/bin/codex-desktop-update" \
+    "${HOME}/.local/bin/codex-desktop-version" \
+    "${HOME}/.local/lib/codex-desktop-linux/common.sh"
+
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    systemctl --user enable --now codex-desktop-update.timer >/dev/null 2>&1 || true
+fi
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "${HOME}/.local/share/applications" >/dev/null 2>&1 || true
+fi
+
+if [ -x "${HOME}/.local/bin/codex-desktop-update" ]; then
+    "${HOME}/.local/bin/codex-desktop-update" --record-only >/dev/null 2>&1 || true
+fi
+
+echo "Installed user-local Codex desktop integration."

--- a/contrib/user-local-install/install-user-local.sh
+++ b/contrib/user-local-install/install-user-local.sh
@@ -9,11 +9,15 @@ OPT_BIN_DIR="${OPT_ROOT}/bin"
 OPT_LIB_DIR="${OPT_ROOT}/lib/codex-desktop-linux"
 STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
 FROM_UPDATE=0
+ENABLE_TIMER=0
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --from-update)
             FROM_UPDATE=1
+            ;;
+        --enable-timer)
+            ENABLE_TIMER=1
             ;;
         *)
             echo "Unknown option: $1" >&2
@@ -31,7 +35,8 @@ copy_file() {
 }
 
 install_manager_files() {
-    mkdir -p "$OPT_BIN_DIR" "$OPT_LIB_DIR" "${HOME}/.local/share/applications" "${HOME}/.local/bin" "$STATE_DIR"
+    local systemd_user_dir="${XDG_CONFIG_HOME:-${HOME}/.config}/systemd/user"
+    mkdir -p "$OPT_BIN_DIR" "$OPT_LIB_DIR" "${HOME}/.local/share/applications" "${HOME}/.local/bin" "$STATE_DIR" "$systemd_user_dir"
 
     copy_file "${FILES_DIR}/.local/lib/codex-desktop-linux/common.sh" "${OPT_LIB_DIR}/common.sh"
     copy_file "${FILES_DIR}/.local/bin/codex-desktop" "${OPT_BIN_DIR}/codex-desktop"
@@ -62,6 +67,9 @@ EOF
 
     sed "s|@HOME@|${HOME}|g" "${FILES_DIR}/.local/share/applications/codex-desktop.desktop" > "${HOME}/.local/share/applications/codex-desktop.desktop"
 
+    copy_file "${FILES_DIR}/.config/systemd/user/codex-desktop-update.service" "${systemd_user_dir}/codex-desktop-update.service"
+    copy_file "${FILES_DIR}/.config/systemd/user/codex-desktop-update.timer" "${systemd_user_dir}/codex-desktop-update.timer"
+
     cat > "${STATE_DIR}/install.env" <<EOF
 REPO_DIR=$(printf '%q' "$REPO_ROOT")
 OPT_ROOT=$(printf '%q' "$OPT_ROOT")
@@ -83,7 +91,9 @@ install_manager_files
 
 if command -v systemctl >/dev/null 2>&1; then
     systemctl --user daemon-reload >/dev/null 2>&1 || true
-    systemctl --user enable --now codex-desktop-update.timer >/dev/null 2>&1 || true
+    if [ "$ENABLE_TIMER" -eq 1 ]; then
+        systemctl --user enable --now codex-desktop-update.timer >/dev/null 2>&1 || true
+    fi
 fi
 
 if command -v update-desktop-database >/dev/null 2>&1; then

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,8 @@ set -Eeuo pipefail
 # ============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-INSTALL_DIR="${CODEX_INSTALL_DIR:-$SCRIPT_DIR/codex-app}"
+INSTALL_ROOT="${CODEX_INSTALL_ROOT:-$SCRIPT_DIR}"
+INSTALL_DIR="${CODEX_INSTALL_DIR:-$INSTALL_ROOT/codex-app}"
 ELECTRON_VERSION="40.0.0"
 WORK_DIR="$(mktemp -d)"
 ARCH="$(uname -m)"

--- a/install.sh
+++ b/install.sh
@@ -267,6 +267,9 @@ patch_asar() {
     # Build native modules in clean environment and copy back
     build_native_modules "$WORK_DIR/app-extracted"
 
+    info "Patching Linux window behavior..."
+    node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" "$WORK_DIR/app-extracted"
+
     # Repack
     info "Repacking app.asar..."
     cd "$WORK_DIR"
@@ -475,6 +478,7 @@ if [ -z "${CODEX_CLI_PATH:-}" ]; then
     CODEX_CLI_PATH="$(find_codex_cli || true)"
     export CODEX_CLI_PATH
 fi
+export CHROME_DESKTOP="${CHROME_DESKTOP:-codex-desktop.desktop}"
 
 if [ -z "$CODEX_CLI_PATH" ]; then
     notify_error "Codex CLI not found. Install with: npm i -g @openai/codex"
@@ -489,8 +493,8 @@ cd "$SCRIPT_DIR"
 echo "$$" > "$APP_PID_FILE"
 exec "$SCRIPT_DIR/electron" \
     --no-sandbox \
-    --class=Codex \
-    --app-id=Codex \
+    --class=codex-desktop \
+    --app-id=codex-desktop \
     --ozone-platform-hint=auto \
     --disable-gpu-sandbox \
     --disable-gpu-compositing \

--- a/packaging/linux/codex-desktop.desktop
+++ b/packaging/linux/codex-desktop.desktop
@@ -7,5 +7,5 @@ Terminal=false
 Type=Application
 Categories=Development;
 StartupNotify=true
-StartupWMClass=Codex
-X-GNOME-WMClass=Codex
+StartupWMClass=codex-desktop
+X-GNOME-WMClass=codex-desktop

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -16,7 +16,8 @@ const iconAsset = fs
   .find((name) => /^app-.*\.png$/.test(name));
 
 if (!iconAsset) {
-  throw new Error(`Could not find app icon asset in ${assetsDir}`);
+  console.warn(`WARN: Could not find app icon asset in ${assetsDir} — skipping all UI patches`);
+  process.exit(0);
 }
 
 const buildDir = path.join(extractedDir, ".vite", "build");
@@ -25,7 +26,8 @@ const mainBundle = fs
   .find((name) => /^main(?:-[^.]+)?\.js$/.test(name));
 
 if (!mainBundle) {
-  throw new Error(`Could not find main bundle in ${buildDir}`);
+  console.warn(`WARN: Could not find main bundle in ${buildDir} — skipping all UI patches`);
+  process.exit(0);
 }
 
 const target = path.join(buildDir, mainBundle);

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -43,7 +43,7 @@ const windowOptionsReplacement =
 if (source.includes(windowOptionsNeedle)) {
   source = source.replace(windowOptionsNeedle, windowOptionsReplacement);
 } else if (!source.includes(iconPathNeedle)) {
-  throw new Error("Could not find BrowserWindow autoHideMenuBar snippet");
+  console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
 }
 
 const menuNeedle = "process.platform===`win32`&&D.removeMenu(),";
@@ -53,7 +53,7 @@ const menuReplacement = `${menuPatch}${menuNeedle}`;
 if (source.includes(menuNeedle) && !source.includes(menuPatch)) {
   source = source.replace(menuNeedle, menuReplacement);
 } else if (!source.includes(menuPatch)) {
-  throw new Error("Could not find window menu visibility snippet");
+  console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
 }
 
 const setIconNeedle =
@@ -64,7 +64,7 @@ const setIconPatch =
 if (source.includes(setIconNeedle) && !source.includes("&&D.setIcon(")) {
   source = source.replace(setIconNeedle, setIconPatch);
 } else if (!source.includes("&&D.setIcon(")) {
-  throw new Error("Could not find window setIcon insertion point");
+  console.warn("WARN: Could not find window setIcon insertion point — skipping setIcon patch");
 }
 
 fs.writeFileSync(target, source, "utf8");

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const extractedDir = process.argv[2];
+
+if (!extractedDir) {
+  console.error("Usage: patch-linux-window-ui.js <extracted-app-asar-dir>");
+  process.exit(1);
+}
+
+const assetsDir = path.join(extractedDir, "webview", "assets");
+const iconAsset = fs
+  .readdirSync(assetsDir)
+  .find((name) => /^app-.*\.png$/.test(name));
+
+if (!iconAsset) {
+  throw new Error(`Could not find app icon asset in ${assetsDir}`);
+}
+
+const buildDir = path.join(extractedDir, ".vite", "build");
+const mainBundle = fs
+  .readdirSync(buildDir)
+  .find((name) => /^main(?:-[^.]+)?\.js$/.test(name));
+
+if (!mainBundle) {
+  throw new Error(`Could not find main bundle in ${buildDir}`);
+}
+
+const target = path.join(buildDir, mainBundle);
+let source = fs.readFileSync(target, "utf8");
+const packageJsonPath = path.join(extractedDir, "package.json");
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+
+const windowOptionsNeedle =
+  "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+const iconPathNeedle =
+  `icon:t.join(process.resourcesPath,\`..\`,\`content\`,\`webview\`,\`assets\`,\`${iconAsset}\`)`;
+const windowOptionsReplacement =
+  `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
+
+if (source.includes(windowOptionsNeedle)) {
+  source = source.replace(windowOptionsNeedle, windowOptionsReplacement);
+} else if (!source.includes(iconPathNeedle)) {
+  throw new Error("Could not find BrowserWindow autoHideMenuBar snippet");
+}
+
+const menuNeedle = "process.platform===`win32`&&D.removeMenu(),";
+const menuPatch = "process.platform===`linux`&&D.setMenuBarVisibility(!1),";
+const menuReplacement = `${menuPatch}${menuNeedle}`;
+
+if (source.includes(menuNeedle) && !source.includes(menuPatch)) {
+  source = source.replace(menuNeedle, menuReplacement);
+} else if (!source.includes(menuPatch)) {
+  throw new Error("Could not find window menu visibility snippet");
+}
+
+const setIconNeedle =
+  ")}),D.once(`ready-to-show`,()=>{";
+const setIconPatch =
+  `)}),process.platform===\`linux\`&&D.setIcon(t.join(process.resourcesPath,\`..\`,\`content\`,\`webview\`,\`assets\`,\`${iconAsset}\`)),D.once(\`ready-to-show\`,()=>{`;
+
+if (source.includes(setIconNeedle) && !source.includes("&&D.setIcon(")) {
+  source = source.replace(setIconNeedle, setIconPatch);
+} else if (!source.includes("&&D.setIcon(")) {
+  throw new Error("Could not find window setIcon insertion point");
+}
+
+fs.writeFileSync(target, source, "utf8");
+
+if (packageJson.desktopName !== "codex-desktop.desktop") {
+  packageJson.desktopName = "codex-desktop.desktop";
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+}
+
+console.log("Patched Linux window icon and menu behavior:", {
+  target,
+  mainBundle,
+  iconAsset,
+  desktopName: packageJson.desktopName,
+});


### PR DESCRIPTION
Title: feat: add user-local desktop integration helper bundle

Body:

## Summary

This adds an optional `contrib/user-local-install` bundle for users who want to treat `codex-desktop-linux` like a managed desktop app instead of a one-off build folder.

The bundle includes:

- `~/.local/opt/codex-desktop-linux` as the stable repo/install location
- `~/.local/bin/codex-desktop` launcher
- `codex-desktop-check-update`, `codex-desktop-update`, and `codex-desktop-version` helper commands
- a `.desktop` launcher under `~/.local/share/applications`
- icon extraction from the local `Codex.dmg`
- metadata tracking for both the wrapper repo and the upstream `Codex.dmg`
- a weekly `systemd --user` timer for unattended update checks/rebuilds

## Why

The current installer works well for initial setup, but users may reasonably want:

- a meaningful install location outside `Downloads`
- a menu entry
- a stable launcher command
- a simple way to check/update versions later
- basic automation for keeping the wrapper current

This keeps that logic isolated in `contrib/` so the main installer stays simple.

## Included files

- `contrib/user-local-install/README.md`
- `contrib/user-local-install/install-user-local.sh`
- `contrib/user-local-install/files/.local/bin/codex-desktop`
- `contrib/user-local-install/files/.local/bin/codex-desktop-check-update`
- `contrib/user-local-install/files/.local/bin/codex-desktop-update`
- `contrib/user-local-install/files/.local/bin/codex-desktop-version`
- `contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh`
- `contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop`
- `contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.service`
- `contrib/user-local-install/files/.config/systemd/user/codex-desktop-update.timer`

## Notes

- This is additive only.
- The icon is generated locally from `Codex.dmg` rather than committed as a binary asset.
- The desktop entry is templated during install so it resolves to the current user's home path cleanly.
