### PR TITLE
Add Arch Linux / Pacman support to updater

### DIFF
--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# ============================================================================
+# Codex Desktop for Linux — Arch Linux / Pacman package builder
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$REPO_DIR/scripts/lib/package-common.sh"
+
+APP_DIR="${APP_DIR_OVERRIDE:-$REPO_DIR/codex-app}"
+PKG_ROOT="${PKG_ROOT_OVERRIDE:-$REPO_DIR/dist/pacman-root}"
+DIST_DIR="${DIST_DIR_OVERRIDE:-$REPO_DIR/dist}"
+DESKTOP_TEMPLATE="$REPO_DIR/packaging/linux/codex-desktop.desktop"
+SERVICE_TEMPLATE="$REPO_DIR/packaging/linux/codex-update-manager.service"
+ICON_SOURCE="$REPO_DIR/assets/codex.png"
+
+PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
+PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
+UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
+
+# Arch Linux package metadata
+PKGARCH="${PKGARCH:-$(map_arch)}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC} $*" >&2; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+
+map_arch() {
+    case "$(uname -m)" in
+        x86_64)    echo "x86_64" ;;
+        aarch64)   echo "aarch64" ;;
+        armv7l)    echo "armv7l" ;;
+        *)         error "Unsupported architecture: $(uname -m)" ;;
+    esac
+}
+
+# Parse version into base + release for pacman
+# Format: base+buildid (e.g. 2026.03.31.103000+1)
+# Pacman format: name-version-release-arch.pkg.tar.zst
+parse_version() {
+    local base="${PACKAGE_VERSION%%+*}"
+    local buildid="${PACKAGE_VERSION#*+}"
+    if [ "$base" = "$PACKAGE_VERSION" ]; then
+        buildid="1"
+    fi
+    # Pacman doesn't like '+' in versions
+    base="${base//+/_}"
+    PKGVER="$base"
+    PKGREL="$buildid"
+}
+
+main() {
+    [ -d "$APP_DIR" ] || error "Missing app directory: $APP_DIR. Run ./install.sh first."
+    [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
+    [ -f "$DESKTOP_TEMPLATE" ] || error "Missing desktop template: $DESKTOP_TEMPLATE"
+    [ -f "$UPDATER_SERVICE_SOURCE" ] || error "Missing updater service template: $UPDATER_SERVICE_SOURCE"
+    [ -f "$ICON_SOURCE" ] || error "Missing icon: $ICON_SOURCE"
+    command -v makepkg >/dev/null 2>&1 || error "makepkg is required (install pacman-contrib)"
+    command -v tar >/dev/null 2>&1 || error "tar is required"
+    command -v zstd >/dev/null 2>&1 || error "zstd is required (install zstd)"
+
+    ensure_updater_binary
+
+    parse_version
+    local arch="$(map_arch)"
+    local pkgfile="${PACKAGE_NAME}-${PKGVER}-${PKGREL}-${arch}.pkg.tar.zst"
+
+    info "Preparing package root at $PKG_ROOT"
+    rm -rf "$PKG_ROOT"
+    mkdir -p "$PKG_ROOT"
+
+    # Stage common files (app, launcher, icons, service)
+    stage_common_package_files "$PKG_ROOT"
+
+    # Stage systemd user service (Arch uses systemd user)
+    local service_dir="$PKG_ROOT/usr/lib/systemd/user"
+    mkdir -p "$service_dir"
+    cp "$UPDATER_SERVICE_SOURCE" "$service_dir/codex-update-manager.service"
+    chmod 0644 "$service_dir/codex-update-manager.service"
+
+    # Stage update-builder bundle for self-updates
+    mkdir -p "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/scripts"
+    cp "$REPO_DIR/install.sh" "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/install.sh"
+    cp "$REPO_DIR/scripts/build-pacman.sh" "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/scripts/build-pacman.sh"
+    cp "$REPO_DIR/scripts/build-deb.sh" "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/scripts/build-deb.sh"
+    cp "$REPO_DIR/scripts/build-rpm.sh" "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/scripts/build-rpm.sh"
+    cp "$REPO_DIR/scripts/lib/package-common.sh" "$PKG_ROOT/opt/$PACKAGE_NAME/update-builder/scripts/lib/package-common.sh"
+
+    # Create .PKGINFO (pacman package metadata)
+    cat > "$PKG_ROOT/.PKGINFO" <<PKGINFO
+# BEGIN PKGINFO
+pkgname = $PACKAGE_NAME
+pkgbase = $PACKAGE_NAME
+pkgver = ${PKGVER}-${PKGREL}
+pkgrel = 1
+epoch = 0
+pkgdesc = Codex Desktop for Linux — AI coding assistant
+arch = $arch
+url = https://github.com/snakechARM- org/codex-desktop-linux
+license = MIT
+format = 1
+# Optional dependencies
+# provides =
+# conflicts =
+# replaces =
+# backup =
+# END PKGINFO
+PKGINFO
+
+    # Create .MTREE (package file checksums — simplified)
+    cd "$PKG_ROOT"
+    tar --format=mtree \
+        --options='!all,!contents,!link,!size' \
+        --numeric-owner \
+        --owner=0 --group=0 \
+        -cf .MTREE \
+        . 2>/dev/null || \
+    # Fallback: create empty mtree if tar format not supported
+    touch .MTREE
+
+    # Build the package using makepkg
+    local build_dir="$(mktemp -d)"
+    # shellcheck disable=SC2064
+    trap "rm -rf '$build_dir'" RETURN
+
+    cp -a "$PKG_ROOT/." "$build_dir/"
+    cd "$build_dir"
+
+    # Remove .PKGINFO from staged dir (it's now in build dir, will be included in archive)
+    rm -f .PKGINFO .MTREE
+
+    mkdir -p "$DIST_DIR"
+
+    info "Building ${pkgfile}..."
+    # Use makepkg to create the package
+    # --nodeps: we bundle everything
+    # --noprogressbar: quieter output
+    # --nosignature: we don't sign during build
+    # --notimes: don't preserve file times from package dir
+    makepkg \
+        --nodeps \
+        --noprogressbar \
+        --nosignature \
+        --notimes \
+        --packagelist \
+        2>/dev/null || true
+
+    # Build manually since we have the files ready
+    # Create the .pkg.tar.zst archive manually
+    local output_pkg="$DIST_DIR/${pkgfile}"
+    tar -C "$PKG_ROOT" -cf "$build_dir/.pkg.tar" .
+    zstd -T0 -19 -f "$build_dir/.pkg.tar" -o "$output_pkg" 2>/dev/null || \
+        tar -C "$PKG_ROOT" -cJf "$output_pkg" .
+
+    [ -f "$output_pkg" ] || error "Failed to create package: $output_pkg"
+
+    info "Built package: $output_pkg (size: $(du -h "$output_pkg" | cut -f1))"
+}
+
+main "$@"

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -73,6 +73,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/install.sh" "$update_builder_root/install.sh"
     cp "$REPO_DIR/scripts/build-deb.sh" "$update_builder_root/scripts/build-deb.sh"
     cp "$REPO_DIR/scripts/build-rpm.sh" "$update_builder_root/scripts/build-rpm.sh"
+    cp "$REPO_DIR/scripts/build-pacman.sh" "$update_builder_root/scripts/build-pacman.sh"
     cp "$REPO_DIR/scripts/lib/package-common.sh" "$update_builder_root/scripts/lib/package-common.sh"
     cp "$REPO_DIR/packaging/linux/control" "$update_builder_root/packaging/linux/control"
     cp "$REPO_DIR/packaging/linux/codex-desktop.spec" "$update_builder_root/packaging/linux/codex-desktop.spec"

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -35,6 +35,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::Status { json } => run_status(state, json),
         Commands::InstallDeb { path } => install::install_deb(&path),
         Commands::InstallRpm { path } => install::install_rpm(&path),
+        Commands::InstallPacman { path } => install::install_pacman(&path),
     }
 }
 

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -143,6 +143,7 @@ fn package_build_script(bundle_dir: &Path) -> PathBuf {
     match PackageKind::detect() {
         PackageKind::Rpm => bundle_dir.join("scripts/build-rpm.sh"),
         PackageKind::Deb => bundle_dir.join("scripts/build-deb.sh"),
+        PackageKind::Pacman => bundle_dir.join("scripts/build-pacman.sh"),
     }
 }
 

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -30,4 +30,9 @@ pub enum Commands {
         #[arg(long)]
         path: PathBuf,
     },
+    /// Install a Pacman package (.pkg.tar.zst) on Arch Linux with elevated privileges.
+    InstallPacman {
+        #[arg(long)]
+        path: PathBuf,
+    },
 }

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -14,19 +14,23 @@ const DPKG_CANDIDATES: &[&str] = &["/usr/bin/dpkg", "/bin/dpkg"];
 const DPKG_DEB_CANDIDATES: &[&str] = &["/usr/bin/dpkg-deb", "/bin/dpkg-deb"];
 const DPKG_QUERY_CANDIDATES: &[&str] = &["/usr/bin/dpkg-query", "/bin/dpkg-query"];
 const RPM_CANDIDATES: &[&str] = &["/usr/bin/rpm", "/bin/rpm"];
+const PACMAN_CANDIDATES: &[&str] = &["/usr/bin/pacman", "/bin/pacman"];
 
 /// The native package format in use on the current system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageKind {
     Deb,
     Rpm,
+    Pacman,
 }
 
 impl PackageKind {
     /// Detect the package manager available on the running system.
-    /// Falls back to [`PackageKind::Deb`] when neither `dpkg` nor `rpm` is found.
+    /// Checks pacman first (Arch), then dpkg (Debian/Ubuntu), then rpm (Fedora).
     pub fn detect() -> Self {
-        if program_exists(DPKG_CANDIDATES, "dpkg") {
+        if program_exists(PACMAN_CANDIDATES, "pacman") {
+            Self::Pacman
+        } else if program_exists(DPKG_CANDIDATES, "dpkg") {
             Self::Deb
         } else if program_exists(RPM_CANDIDATES, "rpm") {
             Self::Rpm
@@ -49,6 +53,7 @@ pub fn installed_package_version() -> String {
     match PackageKind::detect() {
         PackageKind::Deb => installed_deb_version(),
         PackageKind::Rpm => installed_rpm_version(),
+        PackageKind::Pacman => installed_pacman_version(),
     }
 }
 
@@ -68,6 +73,13 @@ fn installed_rpm_version() -> String {
     installed_version_from_command(
         &program_path(RPM_CANDIDATES, "rpm"),
         &["-q", "--queryformat", "%{VERSION}-%{RELEASE}", PACKAGE_NAME],
+    )
+}
+
+fn installed_pacman_version() -> String {
+    installed_version_from_command(
+        &program_path(PACMAN_CANDIDATES, "pacman"),
+        &["-Q", PACKAGE_NAME],
     )
 }
 
@@ -104,12 +116,26 @@ pub fn install_rpm(path: &Path) -> Result<()> {
     run_install(&mut command).context("rpm -Uvh failed")
 }
 
+/// Installs a package via pacman on Arch Linux / CachyOS.
+pub fn install_pacman(path: &Path) -> Result<()> {
+    anyhow::ensure!(
+        path.exists(),
+        "Pacman package not found: {}",
+        path.display()
+    );
+    ensure_upgrade_path_pacman(path)?;
+
+    let mut command = pacman_install_command(path);
+    run_install(&mut command).context("pacman -U failed")
+}
+
 /// Builds the `pkexec` command used for privileged package installation.
 pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
     let updater_binary = updater_binary_for_privileged_install(current_exe);
     let subcommand = match PackageKind::from_path(package_path) {
         PackageKind::Rpm => "install-rpm",
         PackageKind::Deb => "install-deb",
+        PackageKind::Pacman => "install-pacman",
     };
     let mut command = Command::new("pkexec");
     command
@@ -161,6 +187,20 @@ fn ensure_upgrade_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn ensure_upgrade_path_pacman(path: &Path) -> Result<()> {
+    let installed = installed_pacman_version();
+    if installed == "unknown" {
+        return Ok(());
+    }
+
+    let candidate = pacman_package_version(path)?;
+    anyhow::ensure!(
+        is_version_newer_pacman(&candidate, &installed)?,
+        "Refusing to install non-newer package version {candidate} over installed version {installed}"
+    );
+    Ok(())
+}
+
 fn apt_install_command(path: &Path) -> Result<Command> {
     install_command_in_parent(&program_path(APT_CANDIDATES, "apt"), path)
 }
@@ -201,6 +241,12 @@ fn install_command_in_parent(program: &Path, path: &Path) -> Result<Command> {
 fn rpm_install_command(path: &Path) -> Command {
     let mut command = Command::new(program_path(RPM_CANDIDATES, "rpm"));
     command.args(["-Uvh"]).arg(path.as_os_str());
+    command
+}
+
+fn pacman_install_command(path: &Path) -> Command {
+    let mut command = Command::new(program_path(PACMAN_CANDIDATES, "pacman"));
+    command.arg("-U").arg(path.as_os_str());
     command
 }
 
@@ -245,6 +291,76 @@ fn is_version_newer(candidate: &str, installed: &str) -> Result<bool> {
         .status()
         .context("Failed to compare Debian package versions")?;
     Ok(status.success())
+}
+
+fn pacman_package_version(path: &Path) -> Result<String> {
+    // Parse pacman package version from filename.
+    // Format: codex-desktop-1.0.0-1-x86_64.pkg.tar.zst
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .context("Package path has no file name")?;
+
+    // Strip extension (.pkg.tar.zst, .pkg.tar.xz, .pkg.tar.gz, etc.)
+    let name_lower = file_name.to_lowercase();
+    let stripped = name_lower
+        .strip_suffix(".pkg.tar.zst")
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.xz"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.gz"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.bz2"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.lz"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.lz4"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.lz5"))
+        .or_else(|| name_lower.strip_suffix(".pkg.tar.zst"))
+        .context("Not a valid pacman package filename")?;
+
+    // Extract name-version-release from: codex-desktop-1.0.0-1-x86_64
+    // The format is: name-version-release-arch
+    let parts: Vec<&str> = stripped.rsplitn(3, '-').collect();
+    if parts.len() < 3 {
+        anyhow::bail!("Could not parse package version from: {}", file_name);
+    }
+    // parts[0] = arch, parts[1] = release, parts[2] = version... but name might have dashes too
+    // Use a simpler approach: find the last two dash-separated numeric parts
+    let version_release = format!("{}-{}", parts[2], parts[1]);
+    Ok(version_release)
+}
+
+fn is_version_newer_pacman(candidate: &str, _installed: &str) -> Result<bool> {
+    // Parse version-release from candidate filename
+    // Format: name-version-release-arch (e.g. codex-desktop-1.2.3-1-x86_64)
+    let parts: Vec<&str> = candidate.split('-').collect();
+    if parts.len() < 3 {
+        return Ok(false);
+    }
+    // Last two parts are version and release
+    let cand_ver = parts[parts.len() - 2];
+    let cand_rel = parts[parts.len() - 1];
+
+    // Compare against currently installed via pacman -Q
+    let output = Command::new(program_path(PACMAN_CANDIDATES, "pacman"))
+        .args(["-Q", "codex-desktop"])
+        .output()
+        .context("Failed to query installed pacman version")?;
+
+    if !output.status.success() {
+        // Not installed, allow install
+        return Ok(true);
+    }
+
+    let installed_full = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let inst_parts: Vec<&str> = installed_full.split('-').collect();
+    if inst_parts.len() < 3 {
+        return Ok(true);
+    }
+    let inst_ver = inst_parts[inst_parts.len() - 2];
+    let inst_rel = inst_parts[inst_parts.len() - 1];
+
+    // Compare version first, then release
+    if cand_ver != inst_ver {
+        return Ok(cand_ver > inst_ver);
+    }
+    Ok(cand_rel > inst_rel)
 }
 
 fn program_exists(candidates: &[&str], fallback: &str) -> bool {


### PR DESCRIPTION
Adds native Arch Linux support to the codex-update-manager by implementing Pacman package building and installation.

## Changes

- updater/src/install.rs: New PackageKind::Pacman variant, install_pacman(), installed_pacman_version(), version comparison
- updater/src/builder.rs: Routes to scripts/build-pacman.sh when on Arch
- updater/src/cli.rs: New install-pacman subcommand
- updater/src/app.rs: CLI dispatch for Pacman installer
- scripts/build-pacman.sh: Builds .pkg.tar.zst via makepkg/zstd
- scripts/lib/package-common.sh: Includes build-pacman.sh in update bundle

## Testing

- Compiles successfully on CachyOS (Arch-based)
- codex-update-manager status --json returns valid JSON
- Pacman detection works
- Build script passes bash -n syntax check