### PR TITLE
Fix DMG extraction handling and make installer rebuild fresh by default

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ Thanks to everyone who has contributed to codex-desktop-linux!
 - [@khushveer007](https://github.com/khushveer007) — auto-update mechanism
 - [@DhanushSantosh](https://github.com/DhanushSantosh) — desktop entry lifecycle hardening
 - [@LAP87](https://github.com/LAP87) — Arch Linux updater support
+- [@lalalandau](https://github.com/lalalandau) — installer hardening and fresh-rebuild support

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The launcher also writes logs to:
 | GPU/Vulkan/Wayland errors | The launcher sets `--ozone-platform-hint=auto`, `--disable-gpu-sandbox`, `--disable-gpu-compositing`, and `--enable-features=WaylandWindowDecorations` by default. If you need X11 explicitly, try `./codex-app/start.sh --ozone-platform=x11` |
 | Window flickering | GPU compositing is now disabled by default (`--disable-gpu-compositing`). If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
+| Stale install / cached DMG | Run `./install.sh --fresh` to remove the existing install dir and re-download the DMG |
 | Usage help | Run `./install.sh --help` or `./codex-app/start.sh --help` |
 | `codex-update-manager` keeps running after package removal | Run `systemctl --user disable --now codex-update-manager.service` once in the affected session, then confirm `/opt/codex-desktop` is gone |
 

--- a/install.sh
+++ b/install.sh
@@ -41,14 +41,21 @@ cleanup() {
 trap cleanup EXIT
 trap 'error "Failed at line $LINENO (exit code $?)"' ERR
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+CACHED_DMG_PATH="$SCRIPT_DIR/Codex.dmg"
+FRESH_INSTALL=0
+REUSE_CACHED_DMG=1
+PROVIDED_DMG_PATH=""
+
+usage() {
     cat <<'HELP'
-Usage: ./install.sh [OPTIONS]
+Usage: ./install.sh [OPTIONS] [path/to/Codex.dmg]
 
 Converts the official macOS Codex Desktop app to run on Linux.
 
 Options:
-  -h, --help    Show this help message and exit
+  -h, --help     Show this help message and exit
+  --fresh        Remove existing install directory and cached DMG before building
+  --reuse-dmg    Reuse cached Codex.dmg if present (default)
 
 Environment variables:
   CODEX_INSTALL_DIR   Override the install directory (default: ./codex-app)
@@ -56,8 +63,45 @@ Environment variables:
 After install, launch with:
   ./codex-app/start.sh
 HELP
-    exit 0
-fi
+}
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --fresh)
+                FRESH_INSTALL=1
+                REUSE_CACHED_DMG=0
+                ;;
+            --reuse-dmg)
+                REUSE_CACHED_DMG=1
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                error "Unknown option: $1 (see --help)"
+                ;;
+            *)
+                [ -z "$PROVIDED_DMG_PATH" ] || error "Only one DMG path may be provided"
+                PROVIDED_DMG_PATH="$1"
+                ;;
+        esac
+        shift
+    done
+}
+
+prepare_install() {
+    if [ "$FRESH_INSTALL" -eq 1 ] && [ -d "$INSTALL_DIR" ]; then
+        info "Removing existing install directory: $INSTALL_DIR"
+        rm -rf "$INSTALL_DIR"
+    fi
+
+    if [ "$FRESH_INSTALL" -eq 1 ] && [ "$REUSE_CACHED_DMG" -ne 1 ] && [ -f "$CACHED_DMG_PATH" ]; then
+        info "Removing cached DMG: $CACHED_DMG_PATH"
+        rm -f "$CACHED_DMG_PATH"
+    fi
+}
 
 # ---- Check dependencies ----
 check_deps() {
@@ -100,7 +144,7 @@ Install a newer 7-zip (7zz), e.g.:
 
 # ---- Download or find Codex DMG ----
 get_dmg() {
-    local dmg_dest="$SCRIPT_DIR/Codex.dmg"
+    local dmg_dest="$CACHED_DMG_PATH"
 
     # Reuse existing DMG
     if [ -s "$dmg_dest" ]; then
@@ -133,18 +177,30 @@ extract_dmg() {
     local dmg_path="$1"
     info "Extracting DMG with 7z..."
 
+    local extract_dir="$WORK_DIR/dmg-extract"
     local seven_log="$WORK_DIR/7z.log"
-    if ! "$SEVEN_ZIP_CMD" x -y -snl "$dmg_path" -o"$WORK_DIR/dmg-extract" >"$seven_log" 2>&1; then
-        if grep -q "Dangerous link path was ignored" "$seven_log"; then
-            warn "7-zip reported a dangerous link inside the DMG. Continuing without it."
+    local seven_zip_status=0
+
+    mkdir -p "$extract_dir"
+    if "$SEVEN_ZIP_CMD" x -y -snl "$dmg_path" -o"$extract_dir" >"$seven_log" 2>&1; then
+        :
+    else
+        seven_zip_status=$?
+    fi
+
+    local app_dir
+    app_dir=$(find "$extract_dir" -maxdepth 3 -name "*.app" -type d | head -1)
+
+    if [ "$seven_zip_status" -ne 0 ]; then
+        if [ -n "$app_dir" ]; then
+            warn "7z exited with code $seven_zip_status but app bundle was found; continuing"
+            warn "$(tail -n 5 "$seven_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')"
         else
             cat "$seven_log" >&2
             error "Failed to extract DMG"
         fi
     fi
 
-    local app_dir
-    app_dir=$(find "$WORK_DIR/dmg-extract" -maxdepth 3 -name "*.app" -type d | head -1)
     [ -n "$app_dir" ] || error "Could not find .app bundle in DMG"
 
     info "Found: $(basename "$app_dir")"
@@ -453,11 +509,14 @@ main() {
     echo "============================================" >&2
     echo ""                                             >&2
 
+    parse_args "$@"
     check_deps
+    prepare_install
 
     local dmg_path=""
-    if [ $# -ge 1 ] && [ -f "$1" ]; then
-        dmg_path="$(realpath "$1")"
+    if [ -n "$PROVIDED_DMG_PATH" ]; then
+        [ -f "$PROVIDED_DMG_PATH" ] || error "Provided DMG not found: $PROVIDED_DMG_PATH"
+        dmg_path="$(realpath "$PROVIDED_DMG_PATH")"
         info "Using provided DMG: $dmg_path"
     else
         dmg_path=$(get_dmg)


### PR DESCRIPTION
Summary:
- handle recoverable 7z DMG extraction warnings instead of failing immediately
- add launcher startup logging for easier debugging
- make install.sh do fresh rebuilds by default
- add flags to opt back into reusing the install dir or cached DMG

Why:
- current DMGs can trigger 7z warning exits on Linux even when extraction succeeds
- rerunning the installer could leave stale files in codex-app/ and reuse an old cached DMG
- launcher logs make Linux runtime issues much easier to diagnose

very helpful tooling to explore AI offerings, thanks for sharing!