### PR TITLE
fix: include patch script in updater rebuild bundle

### DIFF
--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -74,6 +74,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/build-deb.sh" "$update_builder_root/scripts/build-deb.sh"
     cp "$REPO_DIR/scripts/build-rpm.sh" "$update_builder_root/scripts/build-rpm.sh"
     cp "$REPO_DIR/scripts/build-pacman.sh" "$update_builder_root/scripts/build-pacman.sh"
+    cp "$REPO_DIR/scripts/patch-linux-window-ui.js" "$update_builder_root/scripts/patch-linux-window-ui.js"
     cp "$REPO_DIR/scripts/lib/package-common.sh" "$update_builder_root/scripts/lib/package-common.sh"
     cp "$REPO_DIR/packaging/linux/control" "$update_builder_root/packaging/linux/control"
     cp "$REPO_DIR/packaging/linux/codex-desktop.spec" "$update_builder_root/packaging/linux/codex-desktop.spec"

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -14,9 +14,13 @@ use std::{
 use tokio::process::Command;
 use tracing::info;
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 5] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 6] = [
     ("install.sh", "install.sh"),
     ("scripts/build-deb.sh", "scripts/build-deb.sh"),
+    (
+        "scripts/patch-linux-window-ui.js",
+        "scripts/patch-linux-window-ui.js",
+    ),
     (
         "scripts/lib/package-common.sh",
         "scripts/lib/package-common.sh",
@@ -455,6 +459,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             FakePackageOutput::Pacman,
         )?;
         fs::write(
+            bundle_root.join("scripts/patch-linux-window-ui.js"),
+            b"console.log('patched');\n",
+        )?;
+        fs::write(
             bundle_root.join("scripts/lib/package-common.sh"),
             b"#!/bin/bash\n",
         )?;
@@ -514,6 +522,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         fs::write(source_root.join("install.sh"), b"#!/bin/bash\n")?;
         fs::write(source_root.join("scripts/build-deb.sh"), b"#!/bin/bash\n")?;
         fs::write(
+            source_root.join("scripts/patch-linux-window-ui.js"),
+            b"console.log('patched');\n",
+        )?;
+        fs::write(
             source_root.join("scripts/lib/package-common.sh"),
             b"#!/bin/bash\n",
         )?;
@@ -530,6 +542,9 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         copy_builder_bundle(&source_root, &destination_root)?;
 
         assert!(destination_root.join("scripts/build-deb.sh").exists());
+        assert!(destination_root
+            .join("scripts/patch-linux-window-ui.js")
+            .exists());
         assert!(!destination_root.join("scripts/build-rpm.sh").exists());
         assert!(!destination_root.join("scripts/build-pacman.sh").exists());
         Ok(())


### PR DESCRIPTION
## Summary

This is a follow-up patch to the merged Arch/pacman support.

It fixes the updater rebuild bundle so native Arch auto-updates can complete on an installed system.

## Root Cause

`install.sh` invokes `scripts/patch-linux-window-ui.js` during local rebuilds, but the packaged `update-builder` bundle did not include that script.

The updater's Rust-side bundle copy logic also did not treat that script as required, so rebuild workspaces created by the installed updater were missing it as well.

That caused local update rebuilds to fail at `Patching Linux window behavior...` with `MODULE_NOT_FOUND`, leaving the updater in `failed`.

## Changes

- include `scripts/patch-linux-window-ui.js` in the packaged update-builder bundle
- require and copy the same script in `updater/src/builder.rs`
- extend builder tests so missing required rebuild assets are caught earlier

## Validation

- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager`
- `bash -n install.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/install-deps.sh scripts/lib/package-common.sh`
- verified real updater rebuild on Arch reaches `waiting_for_app_exit`
- verified rebuilt pacman artifact contains:
  - `/usr/bin/codex-update-manager`
  - `/opt/codex-desktop/update-builder/scripts/patch-linux-window-ui.js`
