### PR TITLE
fix: avoid stale minified symbol in Linux window icon patch

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -37,14 +37,18 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
 
 const windowOptionsNeedle =
   "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+const iconPathExpression =
+  `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
 const iconPathNeedle =
+  `icon:${iconPathExpression}`;
+const legacyIconPathNeedle =
   `icon:t.join(process.resourcesPath,\`..\`,\`content\`,\`webview\`,\`assets\`,\`${iconAsset}\`)`;
 const windowOptionsReplacement =
   `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
 
 if (source.includes(windowOptionsNeedle)) {
   source = source.replace(windowOptionsNeedle, windowOptionsReplacement);
-} else if (!source.includes(iconPathNeedle)) {
+} else if (!source.includes(iconPathNeedle) && !source.includes(legacyIconPathNeedle)) {
   console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
 }
 
@@ -61,7 +65,7 @@ if (source.includes(menuNeedle) && !source.includes(menuPatch)) {
 const setIconNeedle =
   ")}),D.once(`ready-to-show`,()=>{";
 const setIconPatch =
-  `)}),process.platform===\`linux\`&&D.setIcon(t.join(process.resourcesPath,\`..\`,\`content\`,\`webview\`,\`assets\`,\`${iconAsset}\`)),D.once(\`ready-to-show\`,()=>{`;
+  `)}),process.platform===\`linux\`&&D.setIcon(${iconPathExpression}),D.once(\`ready-to-show\`,()=>{`;
 
 if (source.includes(setIconNeedle) && !source.includes("&&D.setIcon(")) {
   source = source.replace(setIconNeedle, setIconPatch);


### PR DESCRIPTION
Thanks for your awesome work on this!

Did my first install this morning, and not sure what's special about my system or the current binaries, but, immediately got an irrecoverable error on launch with `t.join is not a function`.

Anyway, I just set Codex on it and the fix seems simple enough... but I will note that I don't actually have any prior Electron experience, so would still appreciate some better human eyes on it :sweat_smile: 

Commit message follows:

Codex failed to start on Linux with "t.join is not a function" during make run-app because the generated startup patch injected t.join(process.resourcesPath, ...) into the upstream minified main Electron bundle.

In the current upstream build, t now refers to the Electron module rather than Node's path module, so BrowserWindow creation crashed before the app could finish launching.

- replace the injected Linux icon path with a stable process.resourcesPath + '/..../...' expression instead of relying on minified variable names
- accept either the new or legacy icon snippet when checking whether the BrowserWindow options patch is already present
- keep the change Linux-only so macOS and Windows continue to use the upstream behavior

Co-Authored-By: Codex, gpt-5.4, xhigh.