### PR TITLE
fix(updater): fix mixed-manager updater packaging

### DIFF
--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -20,8 +20,29 @@ ensure_app_layout() {
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
 }
 
+updater_binary_is_stale() {
+    local binary="$1"
+
+    [ -x "$binary" ] || return 0
+
+    local source
+    for source in "$REPO_DIR/Cargo.toml" "$REPO_DIR/Cargo.lock"; do
+        if [ -f "$source" ] && [ "$source" -nt "$binary" ]; then
+            return 0
+        fi
+    done
+
+    while IFS= read -r -d '' source; do
+        if [ "$source" -nt "$binary" ]; then
+            return 0
+        fi
+    done < <(find "$REPO_DIR/updater" -type f -print0 2>/dev/null)
+
+    return 1
+}
+
 ensure_updater_binary() {
-    if [ -x "$UPDATER_BINARY_SOURCE" ]; then
+    if [ -x "$UPDATER_BINARY_SOURCE" ] && ! updater_binary_is_stale "$UPDATER_BINARY_SOURCE"; then
         return
     fi
 

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use std::{
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -36,20 +37,15 @@ pub enum PackageKind {
 
 impl PackageKind {
     pub fn detect() -> Self {
-        if program_exists(PACMAN_CANDIDATES, "pacman")
-            && !program_exists(DPKG_CANDIDATES, "dpkg")
-            && !program_exists(RPM_CANDIDATES, "rpm")
-        {
-            Self::Pacman
-        } else if program_exists(DPKG_CANDIDATES, "dpkg") {
-            Self::Deb
-        } else if program_exists(RPM_CANDIDATES, "rpm") {
-            Self::Rpm
-        } else if program_exists(PACMAN_CANDIDATES, "pacman") {
-            Self::Pacman
-        } else {
-            Self::Deb
-        }
+        detect_package_kind(
+            program_exists(PACMAN_CANDIDATES, "pacman"),
+            program_exists(DPKG_CANDIDATES, "dpkg"),
+            program_exists(RPM_CANDIDATES, "rpm"),
+            installed_pacman_version() != "unknown",
+            installed_deb_version() != "unknown",
+            installed_rpm_version() != "unknown",
+            os_release_fields(),
+        )
     }
 
     pub fn from_path(path: &Path) -> Self {
@@ -66,6 +62,103 @@ impl PackageKind {
             _ => Self::Deb,
         }
     }
+}
+
+fn detect_package_kind(
+    has_pacman: bool,
+    has_dpkg: bool,
+    has_rpm: bool,
+    pacman_installed: bool,
+    deb_installed: bool,
+    rpm_installed: bool,
+    os_release: Option<(String, String)>,
+) -> PackageKind {
+    if pacman_installed {
+        return PackageKind::Pacman;
+    }
+    if deb_installed {
+        return PackageKind::Deb;
+    }
+    if rpm_installed {
+        return PackageKind::Rpm;
+    }
+
+    if let Some((id, id_like)) = os_release {
+        let fields = [id.as_str(), id_like.as_str()];
+        if os_release_matches(
+            &fields,
+            &["arch", "archlinux", "manjaro", "endeavouros", "artix"],
+        ) {
+            return PackageKind::Pacman;
+        }
+        if os_release_matches(
+            &fields,
+            &[
+                "debian",
+                "ubuntu",
+                "linuxmint",
+                "pop",
+                "elementary",
+                "zorin",
+            ],
+        ) {
+            return PackageKind::Deb;
+        }
+        if os_release_matches(
+            &fields,
+            &[
+                "fedora",
+                "rhel",
+                "centos",
+                "rocky",
+                "almalinux",
+                "ol",
+                "sles",
+                "suse",
+                "opensuse",
+            ],
+        ) {
+            return PackageKind::Rpm;
+        }
+    }
+
+    if has_dpkg {
+        PackageKind::Deb
+    } else if has_rpm {
+        PackageKind::Rpm
+    } else if has_pacman {
+        PackageKind::Pacman
+    } else {
+        PackageKind::Deb
+    }
+}
+
+fn os_release_fields() -> Option<(String, String)> {
+    let contents = fs::read_to_string("/etc/os-release").ok()?;
+    let mut id = String::new();
+    let mut id_like = String::new();
+
+    for line in contents.lines() {
+        if let Some(value) = line.strip_prefix("ID=") {
+            id = trim_os_release_value(value).to_ascii_lowercase();
+        } else if let Some(value) = line.strip_prefix("ID_LIKE=") {
+            id_like = trim_os_release_value(value).to_ascii_lowercase();
+        }
+    }
+
+    Some((id, id_like))
+}
+
+fn trim_os_release_value(value: &str) -> &str {
+    value.trim().trim_matches('"').trim_matches('\'')
+}
+
+fn os_release_matches(fields: &[&str], expected: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field
+            .split_whitespace()
+            .any(|token| expected.iter().any(|candidate| token == *candidate))
+    })
 }
 
 /// Returns the currently installed package version when available.
@@ -530,6 +623,82 @@ mod tests {
             )),
             PackageKind::Pacman
         );
+    }
+
+    #[test]
+    fn detection_prefers_installed_pacman_package_even_if_rpm_exists() {
+        assert_eq!(
+            detect_package_kind(
+                true,
+                false,
+                true,
+                true,
+                false,
+                false,
+                Some(("arch".to_string(), "".to_string())),
+            ),
+            PackageKind::Pacman
+        );
+    }
+
+    #[test]
+    fn detection_uses_arch_os_release_when_nothing_is_installed() {
+        assert_eq!(
+            detect_package_kind(
+                true,
+                false,
+                true,
+                false,
+                false,
+                false,
+                Some(("arch".to_string(), "".to_string())),
+            ),
+            PackageKind::Pacman
+        );
+    }
+
+    #[test]
+    fn detection_uses_debian_os_release_before_rpm_command_presence() {
+        assert_eq!(
+            detect_package_kind(
+                false,
+                true,
+                true,
+                false,
+                false,
+                false,
+                Some(("ubuntu".to_string(), "debian".to_string())),
+            ),
+            PackageKind::Deb
+        );
+    }
+
+    #[test]
+    fn detection_uses_rpm_os_release_before_pacman_command_presence() {
+        assert_eq!(
+            detect_package_kind(
+                true,
+                false,
+                true,
+                false,
+                false,
+                false,
+                Some(("fedora".to_string(), "rhel".to_string())),
+            ),
+            PackageKind::Rpm
+        );
+    }
+
+    #[test]
+    fn trims_quoted_os_release_values() {
+        assert_eq!(trim_os_release_value("\"arch\""), "arch");
+        assert_eq!(trim_os_release_value("'debian ubuntu'"), "debian ubuntu");
+    }
+
+    #[test]
+    fn matches_expected_os_release_tokens() {
+        assert!(os_release_matches(&["ubuntu debian", ""], &["debian"]));
+        assert!(!os_release_matches(&["ubuntu", ""], &["fedora"]));
     }
 
     #[test]


### PR DESCRIPTION
On Arch systems that also had rpm installed, PackageKind::detect() could fall through to the rpm path even when codex-desktop was actually installed via pacman. That made the updater rebuild .rpm artifacts, report the installed version as unknown, and fail the privileged install path on a working pacman install.

We also found that scripts/build-pacman.sh reused an existing target/release/codex-update-manager binary without checking whether the updater sources had changed, so rebuilding and reinstalling the pacman package could still ship the old updater binary.

Prefer the package manager that already owns codex-desktop, then fall back to /etc/os-release before raw command presence. Add regression tests for mixed package-manager systems, and rebuild the packaged updater binary whenever Cargo metadata or files under updater/ are newer than the existing release binary.

Co-Authored-By: Codex, gpt-5.4, xhigh.

Additional notes (not in commit message):

- Tested working on my Arch system which had this issue because rpm was installed too
- The new approach of course is of course useful for non-Arch systems too