### PR TITLE
fix(nix): update Codex.dmg hash to match current upstream binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-uSOeP7IozPh54EKyPyRwQ1xTwfL8lIStWS27ibg7ir8=";
+          hash = "sha256-T8rTXalt/FvnKvbHNovItKryOQdoCy9d3Rs2crD0L0U=";
         };
 
         electronLibs = with pkgs; [


### PR DESCRIPTION
## Summary

The file at `https://persistent.oaistatic.com/codex-app-prod/Codex.dmg` has been updated upstream, causing `nix build` and `nix run` to fail with a hash mismatch.

**Old hash:** `sha256-uSOeP7IozPh54EKyPyRwQ1xTwfL8lIStWS27ibg7ir8=`
**New hash:** `sha256-T8rTXalt/FvnKvbHNovItKryOQdoCy9d3Rs2crD0L0U=`

## Error

```
error: hash mismatch in fixed-output derivation '/nix/store/m65lig6r6kmcz85vsdfmrmsmjy6kl8ji-Codex.dmg.drv':
         specified: sha256-uSOeP7IozPh54EKyPyRwQ1xTwfL8lIStWS27ibg7ir8=
            got:    sha256-T8rTXalt/FvnKvbHNovItKryOQdoCy9d3Rs2crD0L0U=
```

Fixes #36