### PR TITLE
fix(updater): Trigger safe launch-time update checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,7 @@ dependencies = [
  "chrono",
  "clap",
  "directories",
+ "fs4",
  "futures-util",
  "notify-rust",
  "reqwest",
@@ -673,6 +674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2783,6 +2794,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/README.md
+++ b/README.md
@@ -339,8 +339,9 @@ The build and update flow is:
 The package installs a companion service named `codex-update-manager`.
 
 - It runs as a `systemd --user` service.
-- The launcher starts it in best-effort mode on first app launch.
-- It checks the upstream `Codex.dmg` on startup and every 6 hours.
+- The launcher starts it in best-effort mode on app launch.
+- Each app launch also triggers a non-blocking `check-now`; the updater skips that request if another check, rebuild, or install is already active.
+- It checks the upstream `Codex.dmg` on daemon startup and every 6 hours.
 - When a new DMG is detected, it rebuilds a local native package using `/opt/codex-desktop/update-builder`.
 - If the app is open, the update waits until Electron exits.
 - When the app is closed, the updater uses `pkexec` only for the final native-package install step.
@@ -386,7 +387,7 @@ The installer replaces the macOS Electron with a Linux build and recompiles the 
 The extracted app expects a local webview origin on `localhost:5175`, so the launcher starts `python3 -m http.server 5175` from `content/webview/`, waits for the socket to become reachable, and only then launches Electron.
 The launcher now also verifies that `http://127.0.0.1:5175/index.html` contains the expected Codex startup markers before Electron launches, so a port collision or incomplete extracted webview fails fast in `launcher.log` instead of hanging on the splash screen.
 
-Native-package-only launcher behavior such as desktop-entry hints and `codex-update-manager` session bootstrapping lives in `packaging/linux/codex-packaged-runtime.sh`, which the generated launcher loads only when present inside a packaged install.
+Native-package-only launcher behavior such as desktop-entry hints, `codex-update-manager` session bootstrapping, and the background launch-time update check lives in `packaging/linux/codex-packaged-runtime.sh`, which the generated launcher loads only when present inside a packaged install.
 
 The current evaluation for a future Rust replacement for the local webview server lives in `docs/webview-server-evaluation.md`.
 

--- a/packaging/linux/codex-packaged-runtime.sh
+++ b/packaging/linux/codex-packaged-runtime.sh
@@ -32,10 +32,29 @@ codex_packaged_runtime_prelaunch() {
     fi
 
     if systemctl --user is-enabled codex-update-manager.service >/dev/null 2>&1; then
-        systemctl --user restart codex-update-manager.service >/dev/null 2>&1 || true
+        systemctl --user start codex-update-manager.service >/dev/null 2>&1 || true
     else
         systemctl --user enable --now codex-update-manager.service >/dev/null 2>&1 || true
     fi
+
+    codex_packaged_runtime_trigger_update_check
+}
+
+codex_packaged_runtime_trigger_update_check() {
+    if ! command -v codex-update-manager >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if command -v systemd-run >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
+        systemd-run --user \
+            --unit=codex-update-manager-launch-check \
+            --collect \
+            --quiet \
+            /usr/bin/codex-update-manager check-now >/dev/null 2>&1 || true
+        return 0
+    fi
+
+    nohup codex-update-manager check-now >/dev/null 2>&1 &
 }
 
 codex_packaged_runtime_export_env() {

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -10,12 +10,18 @@ DESKTOP_TEMPLATE="$REPO_DIR/packaging/linux/codex-desktop.desktop"
 SERVICE_TEMPLATE="$REPO_DIR/packaging/linux/codex-update-manager.service"
 USER_SERVICE_HELPER_TEMPLATE="$REPO_DIR/packaging/linux/codex-update-manager-user-service.sh"
 ICON_SOURCE="$REPO_DIR/assets/codex.png"
+PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
+PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
 UPDATE_BUILDER_ROOT_PLACEHOLDER="__UPDATE_BUILDER_ROOT__"
+
+# Keep the installed update-builder payload aligned with the other package formats.
+# shellcheck source=scripts/lib/package-common.sh
+. "$REPO_DIR/scripts/lib/package-common.sh"
 
 info()  { echo "[INFO] $*" >&2; }
 error() { echo "[ERROR] $*" >&2; exit 1; }
@@ -66,6 +72,7 @@ main() {
     [ -f "$UPDATER_SERVICE_SOURCE" ] || error "Missing updater service template: $UPDATER_SERVICE_SOURCE"
     [ -f "$USER_SERVICE_HELPER_TEMPLATE" ] || error "Missing updater user service helper: $USER_SERVICE_HELPER_TEMPLATE"
     [ -f "$ICON_SOURCE" ] || error "Missing icon: $ICON_SOURCE"
+    [ -f "$PACKAGED_RUNTIME_SOURCE" ] || error "Missing packaged launcher runtime helper: $PACKAGED_RUNTIME_SOURCE"
     command -v rpmbuild >/dev/null 2>&1 || error "rpmbuild is required (install rpm-build)"
 
     ensure_updater_binary
@@ -82,37 +89,9 @@ main() {
     trap "rm -rf '$build_root'" EXIT
 
     local staging_root="$build_root/STAGING"
-    local update_builder_dir="$staging_root/opt/$PACKAGE_NAME/update-builder"
 
-    mkdir -p \
-        "$staging_root/opt/$PACKAGE_NAME" \
-        "$staging_root/usr/bin" \
-        "$staging_root/usr/lib/systemd/user" \
-        "$staging_root/usr/share/applications" \
-        "$staging_root/usr/share/icons/hicolor/256x256/apps"
-
-    cp -a "$APP_DIR/." "$staging_root/opt/$PACKAGE_NAME/"
-    cp "$DESKTOP_TEMPLATE" "$staging_root/usr/share/applications/$PACKAGE_NAME.desktop"
-    cp "$ICON_SOURCE" "$staging_root/usr/share/icons/hicolor/256x256/apps/$PACKAGE_NAME.png"
-    cp "$UPDATER_BINARY_SOURCE" "$staging_root/usr/bin/codex-update-manager"
-    chmod 0755 "$staging_root/usr/bin/codex-update-manager"
-    cp "$UPDATER_SERVICE_SOURCE" "$staging_root/usr/lib/systemd/user/codex-update-manager.service"
-    chmod 0644 "$staging_root/usr/lib/systemd/user/codex-update-manager.service"
-
-    mkdir -p \
-        "$update_builder_dir/scripts" \
-        "$update_builder_dir/packaging/linux" \
-        "$update_builder_dir/assets"
-    cp "$REPO_DIR/install.sh" "$update_builder_dir/install.sh"
-    cp "$REPO_DIR/scripts/build-rpm.sh" "$update_builder_dir/scripts/build-rpm.sh"
-    cp "$REPO_DIR/scripts/build-deb.sh" "$update_builder_dir/scripts/build-deb.sh"
-    cp "$REPO_DIR/packaging/linux/codex-desktop.spec" "$update_builder_dir/packaging/linux/codex-desktop.spec"
-    cp "$REPO_DIR/packaging/linux/control" "$update_builder_dir/packaging/linux/control"
-    cp "$REPO_DIR/packaging/linux/codex-desktop.desktop" "$update_builder_dir/packaging/linux/codex-desktop.desktop"
-    cp "$USER_SERVICE_HELPER_TEMPLATE" \
-        "$update_builder_dir/packaging/linux/codex-update-manager-user-service.sh"
-    cp "$UPDATER_SERVICE_SOURCE" "$update_builder_dir/packaging/linux/codex-update-manager.service"
-    cp "$REPO_DIR/assets/codex.png" "$update_builder_dir/assets/codex.png"
+    stage_common_package_files "$staging_root"
+    stage_update_builder_bundle "$staging_root"
 
     cat > "$staging_root/usr/bin/$PACKAGE_NAME" <<SCRIPT
 #!/bin/bash

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -204,6 +204,11 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/install.sh" "--disable-gpu-sandbox"
     assert_contains "$REPO_DIR/install.sh" "PACKAGED_RUNTIME_HELPER"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "CHROME_DESKTOP"
+    assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager-launch-check"
+    assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now"
+    assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "restart codex-update-manager.service"
+    assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
+    assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "BAMF_DESKTOP_FILE_HINT"
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -175,9 +175,12 @@ test_missing_input_failure() {
     info "Checking missing-input failure path"
     local workspace="$TMP_DIR/missing"
     local bin_dir="$workspace/bin"
+    local rpm_app_dir="$workspace/rpm-app"
+    local rpm_log="$workspace/rpm-missing-runtime.log"
 
     mkdir -p "$workspace"
     make_stub_bin_dir "$bin_dir"
+    make_fake_app "$rpm_app_dir"
     cat > "$bin_dir/dpkg" <<'SCRIPT'
 #!/bin/bash
 echo amd64
@@ -191,6 +194,11 @@ SCRIPT
     if PATH="$bin_dir:$PATH" APP_DIR_OVERRIDE="$workspace/does-not-exist" PKG_ROOT_OVERRIDE="$workspace/deb-root" "$REPO_DIR/scripts/build-deb.sh" >/dev/null 2>&1; then
         fail "build-deb.sh should fail when APP_DIR is missing"
     fi
+
+    if APP_DIR_OVERRIDE="$rpm_app_dir" PACKAGED_RUNTIME_SOURCE="$workspace/does-not-exist.sh" "$REPO_DIR/scripts/build-rpm.sh" >"$rpm_log" 2>&1; then
+        fail "build-rpm.sh should fail when PACKAGED_RUNTIME_SOURCE is missing"
+    fi
+    assert_contains "$rpm_log" "Missing packaged launcher runtime helper"
 }
 
 test_launcher_template_sanity() {

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4.44", features = ["clock", "serde"] }
 clap = { version = "4.6.0", features = ["derive"] }
 directories = "6.0.0"
 futures-util = "0.3.32"
+fs4 = "0.13.1"
 notify-rust = "4.14.0"
 reqwest = { version = "0.13.2", default-features = false, features = ["http2", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -12,7 +12,11 @@ use crate::{
 use anyhow::{Context, Result};
 use chrono::Utc;
 use reqwest::Client;
-use std::path::Path;
+use std::{
+    fs::{self, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+};
 use tokio::time::{self, Duration};
 use tracing::{error, info, warn};
 
@@ -103,6 +107,49 @@ fn summarize_command_output(output: &[u8]) -> Option<String> {
     let mut lines = text.lines().rev().take(3).collect::<Vec<_>>();
     lines.reverse();
     Some(lines.join(" | "))
+}
+
+struct CheckLock {
+    path: PathBuf,
+}
+
+impl Drop for CheckLock {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.path) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                warn!(?error, path = %self.path.display(), "failed to remove check lock");
+            }
+        }
+    }
+}
+
+fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
+    let lock_path = paths.state_dir.join("check.lock");
+    match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+    {
+        Ok(mut file) => {
+            writeln!(file, "{}", std::process::id())
+                .with_context(|| format!("Failed to write {}", lock_path.display()))?;
+            Ok(Some(CheckLock { path: lock_path }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            info!("skipping upstream check because another check is already active");
+            Ok(None)
+        }
+        Err(error) => {
+            Err(error).with_context(|| format!("Failed to create {}", lock_path.display()))
+        }
+    }
+}
+
+fn update_install_is_pending(status: &UpdateStatus) -> bool {
+    matches!(
+        status,
+        UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit | UpdateStatus::Installing
+    )
 }
 
 async fn run_daemon(
@@ -223,13 +270,14 @@ async fn run_check_cycle(
 ) -> Result<()> {
     let retrying_failed_update = state.status == UpdateStatus::Failed;
 
-    if matches!(
-        state.status,
-        UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit | UpdateStatus::Installing
-    ) {
+    if update_install_is_pending(&state.status) {
         info!("skipping upstream check because an update is already pending");
         return Ok(());
     }
+
+    let Some(_check_lock) = try_acquire_check_lock(paths)? else {
+        return Ok(());
+    };
 
     let client = Client::builder().build()?;
 
@@ -429,10 +477,14 @@ fn compare_generated_versions(left: &str, right: &str) -> Option<std::cmp::Order
 }
 
 fn parse_generated_version(version: &str) -> Option<Vec<u32>> {
-    let base = version
+    let without_metadata = version
         .split_once('+')
         .map(|(prefix, _)| prefix)
         .unwrap_or(version);
+    let base = without_metadata
+        .split_once('-')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(without_metadata);
     let mut parts = Vec::new();
     for segment in base.split('.') {
         parts.push(segment.parse::<u32>().ok()?);
@@ -634,12 +686,53 @@ mod tests {
             app_executable_path: temp.path().join("not-running-electron"),
         };
 
+        for status in [
+            UpdateStatus::ReadyToInstall,
+            UpdateStatus::WaitingForAppExit,
+            UpdateStatus::Installing,
+        ] {
+            let mut state = PersistedState::new(true);
+            state.status = status.clone();
+
+            run_check_cycle(&config, &mut state, &paths).await?;
+
+            assert_eq!(state.status, status);
+            assert_eq!(state.last_check_at, None);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_check_cycle_skips_when_check_lock_exists() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+        std::fs::write(paths.state_dir.join("check.lock"), b"12345")?;
+
+        let config = RuntimeConfig {
+            dmg_url: "https://invalid.example/Codex.dmg".to_string(),
+            initial_check_delay_seconds: 1,
+            check_interval_hours: 6,
+            auto_install_on_app_exit: true,
+            notifications: false,
+            workspace_root: temp.path().join("cache"),
+            builder_bundle_root: temp.path().join("builder"),
+            app_executable_path: temp.path().join("not-running-electron"),
+        };
+
         let mut state = PersistedState::new(true);
-        state.status = UpdateStatus::ReadyToInstall;
 
         run_check_cycle(&config, &mut state, &paths).await?;
 
-        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert_eq!(state.status, UpdateStatus::Idle);
         assert_eq!(state.last_check_at, None);
         Ok(())
     }
@@ -732,6 +825,17 @@ mod tests {
         assert_eq!(
             compare_generated_versions("2026.04.01.035152", "2026.03.27.025604+1086e799"),
             Some(std::cmp::Ordering::Greater)
+        );
+    }
+
+    #[test]
+    fn generated_versions_ignore_package_release_suffixes() {
+        assert_eq!(
+            compare_generated_versions(
+                "2026.04.25.054929-90dd7716x11.fc43",
+                "2026.04.25.054929+90dd7716",
+            ),
+            Some(std::cmp::Ordering::Equal)
         );
     }
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -11,11 +11,12 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use chrono::Utc;
+use fs4::fs_std::FileExt;
 use reqwest::Client;
 use std::{
     fs::{self, OpenOptions},
-    io::Write,
-    path::{Path, PathBuf},
+    io::{Seek, SeekFrom, Write},
+    path::Path,
 };
 use tokio::time::{self, Duration};
 use tracing::{error, info, warn};
@@ -110,39 +111,38 @@ fn summarize_command_output(output: &[u8]) -> Option<String> {
 }
 
 struct CheckLock {
-    path: PathBuf,
-}
-
-impl Drop for CheckLock {
-    fn drop(&mut self) {
-        if let Err(error) = fs::remove_file(&self.path) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                warn!(?error, path = %self.path.display(), "failed to remove check lock");
-            }
-        }
-    }
+    _file: fs::File,
 }
 
 fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
     let lock_path = paths.state_dir.join("check.lock");
-    match OpenOptions::new()
+    let mut file = OpenOptions::new()
+        .read(true)
         .write(true)
-        .create_new(true)
+        .create(true)
+        .truncate(false)
         .open(&lock_path)
-    {
-        Ok(mut file) => {
-            writeln!(file, "{}", std::process::id())
-                .with_context(|| format!("Failed to write {}", lock_path.display()))?;
-            Ok(Some(CheckLock { path: lock_path }))
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+        .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+
+    match file.try_lock_exclusive() {
+        Ok(true) => {}
+        Ok(false) => {
             info!("skipping upstream check because another check is already active");
-            Ok(None)
+            return Ok(None);
         }
         Err(error) => {
-            Err(error).with_context(|| format!("Failed to create {}", lock_path.display()))
+            return Err(error).with_context(|| format!("Failed to lock {}", lock_path.display()));
         }
     }
+
+    file.set_len(0)
+        .with_context(|| format!("Failed to truncate {}", lock_path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("Failed to seek {}", lock_path.display()))?;
+    writeln!(file, "{}", std::process::id())
+        .with_context(|| format!("Failed to write {}", lock_path.display()))?;
+
+    Ok(Some(CheckLock { _file: file }))
 }
 
 fn update_install_is_pending(status: &UpdateStatus) -> bool {
@@ -703,8 +703,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn run_check_cycle_skips_when_check_lock_exists() -> Result<()> {
+    #[test]
+    fn check_lock_file_without_kernel_lock_does_not_block_acquire() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let paths = RuntimePaths {
             config_file: temp.path().join("config/config.toml"),
@@ -715,25 +715,42 @@ mod tests {
             config_dir: temp.path().join("config"),
         };
         paths.ensure_dirs()?;
-        std::fs::write(paths.state_dir.join("check.lock"), b"12345")?;
+        let lock_path = paths.state_dir.join("check.lock");
+        std::fs::write(&lock_path, b"stale-pid")?;
 
-        let config = RuntimeConfig {
-            dmg_url: "https://invalid.example/Codex.dmg".to_string(),
-            initial_check_delay_seconds: 1,
-            check_interval_hours: 6,
-            auto_install_on_app_exit: true,
-            notifications: false,
-            workspace_root: temp.path().join("cache"),
-            builder_bundle_root: temp.path().join("builder"),
-            app_executable_path: temp.path().join("not-running-electron"),
+        let lock = try_acquire_check_lock(&paths)?;
+
+        assert!(lock.is_some());
+        assert_eq!(
+            std::fs::read_to_string(&lock_path)?.trim(),
+            std::process::id().to_string()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn held_check_lock_blocks_second_acquire_until_drop() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
         };
+        paths.ensure_dirs()?;
 
-        let mut state = PersistedState::new(true);
+        let first_lock = try_acquire_check_lock(&paths)?;
+        let second_lock = try_acquire_check_lock(&paths)?;
 
-        run_check_cycle(&config, &mut state, &paths).await?;
+        assert!(first_lock.is_some());
+        assert!(second_lock.is_none());
 
-        assert_eq!(state.status, UpdateStatus::Idle);
-        assert_eq!(state.last_check_at, None);
+        drop(first_lock);
+        let reacquired_lock = try_acquire_check_lock(&paths)?;
+
+        assert!(reacquired_lock.is_some());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- start the packaged updater service without restarting it on every app launch, then trigger a non-blocking launch-time `check-now`
- serialize updater checks with a state-directory lock so daemon, periodic, and launch-triggered checks do not duplicate downloads/builds
- align RPM staging with the shared package payload so RPM installs include `.codex-linux/codex-packaged-runtime.sh` and the full update-builder bundle
- compare generated update versions after stripping RPM release suffixes, so interrupted installs can recover when the candidate is already installed

## Why
While validating the Fedora RPM install path, the updater could download and rebuild a candidate but RPM installs missed files that the packaged runtime and update-builder expected. App-launch service restarts could also interrupt an active updater build. This keeps launch checks best-effort and non-blocking while letting the updater skip duplicate live checks safely.

## Testing
- `bash -n packaging/linux/codex-packaged-runtime.sh scripts/build-rpm.sh tests/scripts_smoke.sh`
- `cargo test -p codex-update-manager` (65 passed)
- `cargo build --release -p codex-update-manager`
- `PACKAGE_VERSION=2026.04.25.054929+prcheck APP_DIR_OVERRIDE=<path-to-extracted-codex-app> ./scripts/build-rpm.sh`
- `rpm -qlp dist/codex-desktop-2026.04.25.054929-prcheck.x86_64.rpm | rg '/opt/codex-desktop/(\.codex-linux/codex-packaged-runtime\.sh|update-builder/(packaging/linux/codex-packaged-runtime\.sh|scripts/patch-linux-window-ui\.js|scripts/lib/package-common\.sh))'`

Known unrelated checks:
- `bash tests/scripts_smoke.sh` reaches the Debian/RPM packaging and launcher marker checks, then fails in the existing `test_linux_translucent_sidebar_default_patch_smoke` fixture.
- `cargo fmt --check` fails on pre-existing formatting in `updater/src/codex_cli.rs` and `updater/src/state.rs`; this PR does not touch those files.
