### PR TITLE
feat(linux): improve tray and warm-start launch handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The package installs a companion service named `codex-update-manager`.
 
 - It runs as a `systemd --user` service.
 - The launcher starts it in best-effort mode on app launch.
-- Each app launch also triggers a non-blocking `check-now`; the updater skips that request if another check, rebuild, or install is already active.
+- Each app launch also triggers a background `check-now --if-stale`; the updater skips that request when the last successful upstream check is still fresh or another check, rebuild, or install is already active.
 - It checks the upstream `Codex.dmg` on daemon startup and every 6 hours.
 - When a new DMG is detected, it rebuilds a local native package using `/opt/codex-desktop/update-builder`.
 - If the app is open, the update waits until Electron exits.
@@ -368,8 +368,8 @@ The package installs a companion service named `codex-update-manager`.
 - On openSUSE, that final install step is `zypper --non-interactive --no-gpg-checks install` against the locally rebuilt `.rpm` (the package is unsigned because it is built locally).
 - If a privileged install fails or is dismissed, the updater stays in `failed` instead of re-prompting every 15 seconds.
 - If an `Installing` state is interrupted by a crash or restart, the updater now recovers that state automatically instead of getting stuck and skipping all future upstream checks.
-- Before Electron launches, the launcher asks the updater to verify the installed Codex CLI and update it if the npm package is newer.
-- That CLI preflight is best-effort: it uses a 1-hour cooldown for registry checks, falls back to `npm install -g --prefix ~/.local` if a global install fails, and warns instead of aborting app launch when the automatic refresh does not succeed.
+- Before Electron launches, the launcher only resolves a usable Codex CLI path. The updater CLI preflight runs in the background by default so npm registry checks and installs do not block the first window.
+- That CLI preflight is best-effort: it uses a 1-hour cooldown for registry checks, falls back to `npm install -g --prefix ~/.local` if a global install fails, and keeps the app launch on the current CLI when the automatic refresh does not succeed. Set `CODEX_SYNC_CLI_PREFLIGHT=1` to restore the old synchronous preflight behavior for debugging.
 
 Inspect the live service and runtime files with:
 
@@ -404,8 +404,8 @@ The macOS Codex app is an Electron application. The core code (`app.asar`) is pl
 
 The installer replaces the macOS Electron with a Linux build and recompiles the native modules using `@electron/rebuild`. The `sparkle` module is removed because it is macOS-only.
 
-The extracted app expects a local webview origin on `localhost:5175`, so the launcher starts `python3 -m http.server 5175` from `content/webview/`, waits for the socket to become reachable, and only then launches Electron.
-The launcher now also verifies that `http://127.0.0.1:5175/index.html` contains the expected Codex startup markers before Electron launches, so a port collision or incomplete extracted webview fails fast in `launcher.log` instead of hanging on the splash screen.
+The extracted app expects a local webview origin on `127.0.0.1:5175`, so the launcher starts `python3 -m http.server 5175 --bind 127.0.0.1` from `content/webview/`, waits for the socket to become reachable, and only then launches Electron. The launcher tracks the owned webview server PID under XDG state, rediscovers an orphaned server from the same `content/webview/` directory, and reuses an already verified server instead of killing every process that matches the port.
+The launcher also verifies that `http://127.0.0.1:5175/index.html` contains the expected Codex startup markers before cold-starting Electron, so a port collision or incomplete extracted webview fails fast in `launcher.log` instead of hanging on the splash screen. If an existing Electron process is detected, the launcher uses a warm-start handoff path and lets the app's single-instance handler focus the running window.
 
 Native-package-only launcher behavior such as desktop-entry hints, `codex-update-manager` session bootstrapping, and the background launch-time update check lives in `packaging/linux/codex-packaged-runtime.sh`, which the generated launcher loads only when present inside a packaged install.
 

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_ROOT="${CODEX_INSTALL_ROOT:-$SCRIPT_DIR}"
 INSTALL_DIR="${CODEX_INSTALL_DIR:-$INSTALL_ROOT/codex-app}"
-ELECTRON_VERSION="40.8.5"
+ELECTRON_VERSION="41.3.0"
 WORK_DIR="$(mktemp -d)"
 ARCH="$(uname -m)"
 ICON_SOURCE="$SCRIPT_DIR/assets/codex.png"
@@ -350,6 +350,7 @@ LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/codex-desktop"
 LOG_FILE="$LOG_DIR/launcher.log"
 APP_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/codex-desktop"
 APP_PID_FILE="$APP_STATE_DIR/app.pid"
+WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
 APP_NOTIFICATION_ICON_NAME="codex-desktop"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
@@ -357,6 +358,10 @@ APP_NOTIFICATION_ICON_SYSTEM="/usr/share/icons/hicolor/256x256/apps/$APP_NOTIFIC
 APP_NOTIFICATION_ICON_REPO="$SCRIPT_DIR/../assets/codex.png"
 
 mkdir -p "$LOG_DIR" "$APP_STATE_DIR"
+STARTED_WEBVIEW_PID=""
+ELECTRON_PID=""
+RUNNING_APP_PID=""
+WARM_START=0
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     cat <<'HELP'
@@ -380,6 +385,24 @@ fi
 exec >>"$LOG_FILE" 2>&1
 
 echo "[$(date -Is)] Starting Codex Desktop launcher"
+
+now_ms() {
+    local value
+    value="$(date +%s%3N 2>/dev/null || true)"
+    case "$value" in
+        *N*|"") echo "$(($(date +%s) * 1000))" ;;
+        *) echo "$value" ;;
+    esac
+}
+
+LAUNCHER_START_MS="$(now_ms)"
+
+log_phase() {
+    local phase="$1"
+    local elapsed_ms
+    elapsed_ms="$(($(now_ms) - LAUNCHER_START_MS))"
+    echo "[$(date -Is)] launcher_phase=$phase elapsedMs=$elapsed_ms"
+}
 
 load_packaged_runtime_helper() {
     if [ -f "$PACKAGED_RUNTIME_HELPER" ]; then
@@ -415,6 +438,18 @@ run_cli_preflight() {
         CODEX_CLI_PATH="$refreshed_path"
         export CODEX_CLI_PATH
     fi
+}
+
+run_cli_preflight_background() {
+    if ! command -v codex-update-manager >/dev/null 2>&1; then
+        return 0
+    fi
+
+    (
+        if ! codex-update-manager cli-preflight --cli-path "$CODEX_CLI_PATH" --print-path >/dev/null 2>&1; then
+            echo "Codex CLI background preflight failed. Continuing with the current CLI."
+        fi
+    ) &
 }
 
 resolve_notification_icon() {
@@ -482,6 +517,63 @@ notify_error() {
     fi
 }
 
+canonical_path() {
+    readlink -f "$1" 2>/dev/null || echo "$1"
+}
+
+pid_is_current_user() {
+    local pid="$1"
+    local uid
+
+    uid="$(awk '/^Uid:/ {print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    [ "$uid" = "$(id -u)" ]
+}
+
+pid_matches_executable() {
+    local pid="$1"
+    local expected="$2"
+    local actual
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [ -d "/proc/$pid" ] || return 1
+    pid_is_current_user "$pid" || return 1
+    actual="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+    [ "$actual" = "$(canonical_path "$expected")" ]
+}
+
+find_running_app_pid() {
+    local pid
+
+    if [ -f "$APP_PID_FILE" ]; then
+        pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
+        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+            echo "$pid"
+            return 0
+        fi
+    fi
+
+    local proc_exe
+    for proc_exe in /proc/[0-9]*/exe; do
+        [ -e "$proc_exe" ] || continue
+        pid="${proc_exe#/proc/}"
+        pid="${pid%/exe}"
+        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+            echo "$pid"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+detect_warm_start() {
+    if RUNNING_APP_PID="$(find_running_app_pid)"; then
+        WARM_START=1
+        echo "$RUNNING_APP_PID" > "$APP_PID_FILE"
+        echo "Detected running Codex Desktop pid=$RUNNING_APP_PID; using warm-start handoff"
+    fi
+}
+
 wait_for_webview_server() {
     echo "Waiting for webview server on :5175"
 
@@ -518,38 +610,124 @@ if missing:
 PY
 }
 
-clear_stale_pid_file() {
-    if [ ! -f "$APP_PID_FILE" ]; then
+pid_is_webview_server() {
+    local pid="$1"
+    local cmdline
+    local cwd
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [ -d "/proc/$pid" ] || return 1
+    pid_is_current_user "$pid" || return 1
+    cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    [[ "$cmdline" == *"http.server 5175"* ]] || return 1
+    cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+    [ "$cwd" = "$(canonical_path "$WEBVIEW_DIR")" ]
+}
+
+stop_owned_webview_server() {
+    local pid=""
+
+    if [ -f "$WEBVIEW_PID_FILE" ]; then
+        pid="$(cat "$WEBVIEW_PID_FILE" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$pid" ] && pid_is_webview_server "$pid"; then
+        echo "Stopping owned webview server pid=$pid"
+        kill "$pid" 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 0.05
+        done
+    fi
+
+    rm -f "$WEBVIEW_PID_FILE"
+}
+
+owned_webview_server_pid() {
+    local pid=""
+
+    if [ -f "$WEBVIEW_PID_FILE" ]; then
+        pid="$(cat "$WEBVIEW_PID_FILE" 2>/dev/null || true)"
+    fi
+
+    if [ -n "$pid" ] && pid_is_webview_server "$pid"; then
+        echo "$pid"
         return 0
     fi
 
-    local pid=""
-    pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
-    if [ -z "$pid" ] || ! kill -0 "$pid" 2>/dev/null; then
-        rm -f "$APP_PID_FILE"
+    if [ -n "$pid" ]; then
+        rm -f "$WEBVIEW_PID_FILE"
     fi
+
+    return 1
 }
 
-load_packaged_runtime_helper
-clear_stale_pid_file
-run_packaged_runtime_prelaunch
-pkill -f "http.server 5175" 2>/dev/null || true
-sleep 0.5
+discover_webview_server_pid() {
+    local proc_cmdline
+    local pid
 
-if [ -d "$WEBVIEW_DIR" ] && [ "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
+    for proc_cmdline in /proc/[0-9]*/cmdline; do
+        [ -e "$proc_cmdline" ] || continue
+        pid="${proc_cmdline#/proc/}"
+        pid="${pid%/cmdline}"
+        if pid_is_webview_server "$pid"; then
+            echo "$pid"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+adopt_existing_webview_server() {
+    local pid
+
+    if pid="$(owned_webview_server_pid)"; then
+        STARTED_WEBVIEW_PID="$pid"
+        return 0
+    fi
+
+    if pid="$(discover_webview_server_pid)"; then
+        STARTED_WEBVIEW_PID="$pid"
+        echo "$pid" > "$WEBVIEW_PID_FILE"
+        echo "Adopted existing webview server pid=$pid dir=$WEBVIEW_DIR"
+        return 0
+    fi
+
+    return 1
+}
+
+ensure_webview_server() {
+    if [ ! -d "$WEBVIEW_DIR" ] || [ ! "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
+        return 0
+    fi
+
+    if adopt_existing_webview_server && verify_webview_origin "http://127.0.0.1:5175/index.html" >/dev/null 2>&1; then
+        echo "Reusing existing verified webview server on :5175"
+        log_phase "webview_reused"
+        return 0
+    fi
+
+    if verify_webview_origin "http://127.0.0.1:5175/index.html" >/dev/null 2>&1; then
+        notify_error "Codex Desktop webview port 5175 is already serving Codex content, but it is not owned by this launcher. Stop the other webview server and try again."
+        exit 1
+    fi
+
+    stop_owned_webview_server
+
     cd "$WEBVIEW_DIR"
-    nohup python3 -m http.server 5175 &
-    HTTP_PID=$!
-    trap "kill $HTTP_PID 2>/dev/null" EXIT
+    python3 -m http.server 5175 --bind 127.0.0.1 &
+    STARTED_WEBVIEW_PID=$!
+    echo "$STARTED_WEBVIEW_PID" > "$WEBVIEW_PID_FILE"
 
-    echo "Started webview server pid=$HTTP_PID dir=$WEBVIEW_DIR"
+    echo "Started webview server pid=$STARTED_WEBVIEW_PID dir=$WEBVIEW_DIR"
 
     if ! wait_for_webview_server; then
         notify_error "Codex Desktop webview server did not become ready on port 5175. Check the launcher log for the embedded http.server output."
         exit 1
     fi
 
-    if ! kill -0 "$HTTP_PID" 2>/dev/null; then
+    if ! kill -0 "$STARTED_WEBVIEW_PID" 2>/dev/null; then
         notify_error "Codex Desktop webview server exited before Electron launch. Another process may already be using port 5175."
         exit 1
     fi
@@ -560,36 +738,114 @@ if [ -d "$WEBVIEW_DIR" ] && [ "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
     fi
 
     echo "Webview origin verified."
+    log_phase "webview_ready"
+}
+
+clear_stale_pid_file() {
+    if [ ! -f "$APP_PID_FILE" ]; then
+        return 0
+    fi
+
+    local pid=""
+    pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
+    if [ -z "$pid" ] || ! pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+        rm -f "$APP_PID_FILE"
+    fi
+}
+
+cleanup_launcher() {
+    if [ -n "${ELECTRON_PID:-}" ] && [ -f "$APP_PID_FILE" ]; then
+        local current_pid
+        current_pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
+        if [ "$current_pid" = "$ELECTRON_PID" ]; then
+            rm -f "$APP_PID_FILE"
+        fi
+    fi
+
+    if [ -n "${STARTED_WEBVIEW_PID:-}" ] && pid_is_webview_server "$STARTED_WEBVIEW_PID"; then
+        kill "$STARTED_WEBVIEW_PID" 2>/dev/null || true
+        rm -f "$WEBVIEW_PID_FILE"
+    fi
+}
+
+launch_electron() {
+    cd "$SCRIPT_DIR"
+    log_phase "electron_launch"
+
+    if [ "$WARM_START" -eq 1 ]; then
+        "$SCRIPT_DIR/electron" \
+            --no-sandbox \
+            --class=codex-desktop \
+            --app-id=codex-desktop \
+            --ozone-platform-hint=auto \
+            --disable-gpu-sandbox \
+            --disable-gpu-compositing \
+            --enable-features=WaylandWindowDecorations \
+            "$@"
+        return $?
+    fi
+
+    "$SCRIPT_DIR/electron" \
+        --no-sandbox \
+        --class=codex-desktop \
+        --app-id=codex-desktop \
+        --ozone-platform-hint=auto \
+        --disable-gpu-sandbox \
+        --disable-gpu-compositing \
+        --enable-features=WaylandWindowDecorations \
+        "$@" &
+    ELECTRON_PID=$!
+    echo "$ELECTRON_PID" > "$APP_PID_FILE"
+    log_phase "electron_spawned"
+
+    set +e
+    wait "$ELECTRON_PID"
+    local status=$?
+    set -e
+    return "$status"
+}
+
+load_packaged_runtime_helper
+clear_stale_pid_file
+detect_warm_start
+trap cleanup_launcher EXIT
+
+if [ "$WARM_START" -eq 0 ]; then
+    run_packaged_runtime_prelaunch
+    log_phase "packaged_prelaunch"
+    ensure_webview_server
+else
+    echo "Skipping packaged prelaunch and webview setup for warm start"
+    log_phase "warm_start_ready"
 fi
 
-if [ -z "${CODEX_CLI_PATH:-}" ]; then
+if [ "$WARM_START" -eq 0 ] && [ -z "${CODEX_CLI_PATH:-}" ]; then
     CODEX_CLI_PATH="$(find_codex_cli || true)"
     export CODEX_CLI_PATH
+    log_phase "cli_lookup"
 fi
 export CHROME_DESKTOP="${CHROME_DESKTOP:-codex-desktop.desktop}"
 
-if [ -z "$CODEX_CLI_PATH" ]; then
+if [ "$WARM_START" -eq 0 ] && [ -z "$CODEX_CLI_PATH" ]; then
     notify_error "Codex CLI not found. Install with: npm i -g @openai/codex or npm i -g --prefix ~/.local @openai/codex"
     exit 1
 fi
 
-run_cli_preflight
+if [ "$WARM_START" -eq 0 ]; then
+    if [ "${CODEX_SYNC_CLI_PREFLIGHT:-0}" = "1" ]; then
+        run_cli_preflight
+        log_phase "cli_preflight_sync"
+    else
+        run_cli_preflight_background
+        log_phase "cli_preflight_backgrounded"
+    fi
+fi
 
 export_packaged_runtime_env
 
-echo "Using CODEX_CLI_PATH=$CODEX_CLI_PATH"
+echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
 
-cd "$SCRIPT_DIR"
-echo "$$" > "$APP_PID_FILE"
-exec "$SCRIPT_DIR/electron" \
-    --no-sandbox \
-    --class=codex-desktop \
-    --app-id=codex-desktop \
-    --ozone-platform-hint=auto \
-    --disable-gpu-sandbox \
-    --disable-gpu-compositing \
-    --enable-features=WaylandWindowDecorations \
-    "$@"
+launch_electron "$@"
 SCRIPT
 
     chmod +x "$INSTALL_DIR/start.sh"

--- a/packaging/linux/codex-packaged-runtime.sh
+++ b/packaging/linux/codex-packaged-runtime.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 codex_packaged_runtime_prelaunch() {
+    codex_packaged_runtime_prelaunch_background >/dev/null 2>&1 &
+}
+
+codex_packaged_runtime_prelaunch_background() {
     if ! command -v systemctl >/dev/null 2>&1; then
         return 0
     fi
@@ -50,11 +54,11 @@ codex_packaged_runtime_trigger_update_check() {
             --unit=codex-update-manager-launch-check \
             --collect \
             --quiet \
-            /usr/bin/codex-update-manager check-now >/dev/null 2>&1 || true
+            /usr/bin/codex-update-manager check-now --if-stale >/dev/null 2>&1 || true
         return 0
     fi
 
-    nohup codex-update-manager check-now >/dev/null 2>&1 &
+    codex-update-manager check-now --if-stale >/dev/null 2>&1 || true
 }
 
 codex_packaged_runtime_export_env() {

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -63,23 +63,59 @@ function patchAssetFiles(filenamePattern, patchFn, missingWarnMessage) {
 }
 
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
+  let patchedSource = currentSource;
+
   const mergeNeedle = "opaqueWindows:e?.opaqueWindows??n.opaqueWindows,semanticColors:";
   const mergePatch =
     "opaqueWindows:e?.opaqueWindows??(typeof navigator<`u`&&((navigator.userAgentData?.platform??navigator.platform??navigator.userAgent).toLowerCase().includes(`linux`))?!0:n.opaqueWindows),semanticColors:";
 
-  if (currentSource.includes("opaqueWindows:e?.opaqueWindows??(typeof navigator<`u`&&")) {
-    return currentSource;
-  }
-
-  if (currentSource.includes(mergeNeedle)) {
-    return currentSource.replace(mergeNeedle, mergePatch);
-  }
-
-  if (currentSource.includes("opaqueWindows") && currentSource.includes("semanticColors")) {
+  if (patchedSource.includes("opaqueWindows:e?.opaqueWindows??(typeof navigator<`u`&&")) {
+    // Already patched.
+  } else if (patchedSource.includes(mergeNeedle)) {
+    patchedSource = patchedSource.replace(mergeNeedle, mergePatch);
+  } else if (patchedSource.includes("opaqueWindows") && patchedSource.includes("semanticColors")) {
     console.warn("WARN: Could not find Linux opaque window default insertion point — skipping settings default patch");
   }
 
-  return currentSource;
+  const settingsNeedle =
+    "let d=ot(r,e),f=at(e),p={codeThemeId:tt(a,e).id,theme:d},";
+  const settingsPatch =
+    "let d=ot(r,e);navigator.userAgent.includes(`Linux`)&&r?.opaqueWindows==null&&(d={...d,opaqueWindows:!0});let f=at(e),p={codeThemeId:tt(a,e).id,theme:d},";
+  if (patchedSource.includes("navigator.userAgent.includes(`Linux`)&&r?.opaqueWindows==null")) {
+    // Already patched.
+  } else if (patchedSource.includes(settingsNeedle)) {
+    patchedSource = patchedSource.replace(settingsNeedle, settingsPatch);
+  }
+
+  const currentSettingsNeedle = "setThemePatch:b,theme:x}=ne(t),S=$t(i,t),";
+  const currentSettingsPatch =
+    "setThemePatch:b,theme:x}=ne(t);navigator.userAgent.includes(`Linux`)&&x?.opaqueWindows==null&&(x={...x,opaqueWindows:!0});let S=$t(i,t),";
+  if (patchedSource.includes("navigator.userAgent.includes(`Linux`)&&x?.opaqueWindows==null")) {
+    // Already patched.
+  } else if (patchedSource.includes(currentSettingsNeedle)) {
+    patchedSource = patchedSource.replace(currentSettingsNeedle, currentSettingsPatch);
+  }
+
+  const runtimeNeedle =
+    "let T=o===`light`?C:w,E;if(T.opaqueWindows&&!XZ()){";
+  const runtimePatch =
+    "let T=o===`light`?C:w,E;document.documentElement.dataset.codexOs===`linux`&&((o===`light`?l:f)?.opaqueWindows==null&&(T={...T,opaqueWindows:!0}));if(T.opaqueWindows&&!XZ()){";
+  if (patchedSource.includes("document.documentElement.dataset.codexOs===`linux`&&((o===`light`?l:f)?.opaqueWindows==null")) {
+    // Already patched.
+  } else if (patchedSource.includes(runtimeNeedle)) {
+    patchedSource = patchedSource.replace(runtimeNeedle, runtimePatch);
+  }
+
+  const currentRuntimeNeedle = "let T=s===`light`?S:w,E;";
+  const currentRuntimePatch =
+    "let T=s===`light`?S:w,E;document.documentElement.dataset.codexOs===`linux`&&((s===`light`?u:p)?.opaqueWindows==null&&(T={...T,opaqueWindows:!0}));";
+  if (patchedSource.includes("document.documentElement.dataset.codexOs===`linux`&&((s===`light`?u:p)?.opaqueWindows==null")) {
+    // Already patched.
+  } else if (patchedSource.includes(currentRuntimeNeedle)) {
+    patchedSource = patchedSource.replace(currentRuntimeNeedle, currentRuntimePatch);
+  }
+
+  return patchedSource;
 }
 
 function applyLinuxFileManagerPatch(currentSource) {
@@ -137,6 +173,168 @@ function applyLinuxFileManagerPatch(currentSource) {
   ) {
     console.error("Failed to apply Linux File Manager Patch");
     return currentSource;
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxTrayPatch(currentSource, iconPathExpression) {
+  let patchedSource = currentSource;
+
+  const trayGuardNeedle =
+    "process.platform!==`win32`&&process.platform!==`darwin`?null:";
+  const trayGuardPatch =
+    "process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`?null:";
+  const trayGuardIndex = patchedSource.indexOf(trayGuardNeedle);
+  if (patchedSource.includes(trayGuardPatch)) {
+    // Already patched.
+  } else if (
+    trayGuardIndex !== -1 &&
+    patchedSource.slice(trayGuardIndex, trayGuardIndex + 1200).includes("new n.Tray")
+  ) {
+    patchedSource = patchedSource.replace(trayGuardNeedle, trayGuardPatch);
+  } else {
+    console.warn("WARN: Could not find tray platform guard — skipping Linux tray guard patch");
+  }
+
+  const trayIconNeedle =
+    "for(let e of o){let t=n.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await n.app.getFileIcon(process.execPath,{size:process.platform===`win32`?`small`:`normal`}),chronicleRunningIcon:null}}";
+  const trayIconPatch =
+    `for(let e of o){let t=n.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}if(process.platform===\`linux\`){let e=n.nativeImage.createFromPath(${iconPathExpression});if(!e.isEmpty())return{defaultIcon:e,chronicleRunningIcon:null}}return{defaultIcon:await n.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
+  if (patchedSource.includes(`nativeImage.createFromPath(${iconPathExpression})`)) {
+    // Already patched.
+  } else if (patchedSource.includes(trayIconNeedle)) {
+    patchedSource = patchedSource.replace(trayIconNeedle, trayIconPatch);
+  } else {
+    console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");
+  }
+
+  const closeToTrayNeedle =
+    "if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}";
+  const closeToTrayPatch =
+    "if((process.platform===`win32`||process.platform===`linux`)&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}";
+  if (patchedSource.includes(closeToTrayPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(closeToTrayNeedle)) {
+    patchedSource = patchedSource.replace(closeToTrayNeedle, closeToTrayPatch);
+  } else {
+    console.warn("WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch");
+  }
+
+  const trayContextMethodNeedle =
+    "trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(";
+  const trayContextMethodPatch =
+    "trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};setLinuxTrayContextMenu(){let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());this.tray.setContextMenu?.(e);return e}constructor(";
+  if (patchedSource.includes("setLinuxTrayContextMenu(){")) {
+    // Already patched.
+  } else if (patchedSource.includes(trayContextMethodNeedle)) {
+    patchedSource = patchedSource.replace(trayContextMethodNeedle, trayContextMethodPatch);
+  } else {
+    console.warn("WARN: Could not find tray controller fields — skipping Linux tray context menu method patch");
+  }
+
+  const trayClickNeedle =
+    "this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+  const trayClickPatchWithoutContextSetup =
+    "this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+  const trayClickPatch =
+    "process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+  const canSetLinuxTrayContextMenu = patchedSource.includes("setLinuxTrayContextMenu(){");
+  if (patchedSource.includes("process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`")) {
+    // Already patched.
+  } else if (patchedSource.includes(trayClickNeedle)) {
+    patchedSource = patchedSource.replace(
+      trayClickNeedle,
+      canSetLinuxTrayContextMenu ? trayClickPatch : trayClickPatchWithoutContextSetup,
+    );
+  } else if (canSetLinuxTrayContextMenu && patchedSource.includes(trayClickPatchWithoutContextSetup)) {
+    patchedSource = patchedSource.replace(trayClickPatchWithoutContextSetup, trayClickPatch);
+  } else {
+    console.warn("WARN: Could not find tray click handler — skipping Linux tray menu click patch");
+  }
+
+  const trayMenuBuildNeedle =
+    "openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());";
+  const trayMenuBuildPatch =
+    "openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());";
+  if (patchedSource.includes("let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?")) {
+    // Already patched.
+  } else if (patchedSource.includes(trayMenuBuildNeedle)) {
+    patchedSource = patchedSource.replace(trayMenuBuildNeedle, trayMenuBuildPatch);
+  } else {
+    console.warn("WARN: Could not find tray native menu builder — skipping Linux tray context menu builder patch");
+  }
+
+  const trayContextMenuNeedle =
+    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+  const trayContextMenuPatch =
+    "if(process.platform===`linux`)return;e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+  const oldLinuxPopupPatch =
+    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)}";
+  const badLinuxPopupPatch =
+    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),if(process.platform===`linux`)return;e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+  if (patchedSource.includes("if(process.platform===`linux`)return;e.once(`menu-will-show`")) {
+    // Already patched.
+  } else if (patchedSource.includes(badLinuxPopupPatch)) {
+    patchedSource = patchedSource.replace(badLinuxPopupPatch, trayContextMenuPatch);
+  } else if (patchedSource.includes(oldLinuxPopupPatch)) {
+    patchedSource = patchedSource.replace(oldLinuxPopupPatch, trayContextMenuPatch);
+  } else if (patchedSource.includes(trayContextMenuNeedle)) {
+    patchedSource = patchedSource.replace(trayContextMenuNeedle, trayContextMenuPatch);
+  } else {
+    console.warn("WARN: Could not find tray native menu popup — skipping Linux tray popup guard patch");
+  }
+
+  const trayMenuThreadsNeedle =
+    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return";
+  const trayMenuThreadsPatch =
+    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.();return";
+  if (patchedSource.includes("this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.()")) {
+    // Already patched.
+  } else if (patchedSource.includes(trayMenuThreadsNeedle)) {
+    patchedSource = patchedSource.replace(trayMenuThreadsNeedle, trayMenuThreadsPatch);
+  } else {
+    console.warn("WARN: Could not find tray menu thread update handler — skipping Linux tray context refresh patch");
+  }
+
+  const trayStartupNeedle = "E&&oe();";
+  const trayStartupPatch = "(E||process.platform===`linux`)&&oe();";
+  if (patchedSource.includes(trayStartupPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(trayStartupNeedle)) {
+    patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
+  } else {
+    console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxSingleInstancePatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const singleInstanceLockNeedle =
+    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady()";
+  const singleInstanceLockPatch =
+    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});if(process.platform===`linux`&&!n.app.requestSingleInstanceLock()){n.app.quit();return}let A=Date.now();await n.app.whenReady()";
+  if (patchedSource.includes("process.platform===`linux`&&!n.app.requestSingleInstanceLock()")) {
+    // Already patched.
+  } else if (patchedSource.includes(singleInstanceLockNeedle)) {
+    patchedSource = patchedSource.replace(singleInstanceLockNeedle, singleInstanceLockPatch);
+  } else {
+    console.warn("WARN: Could not find startup handoff point — skipping Linux single-instance lock patch");
+  }
+
+  const secondInstanceHandlerNeedle =
+    "l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
+  const secondInstanceHandlerPatch =
+    "let codexLinuxSecondInstanceHandler=(e,t)=>{R.deepLinks.queueProcessArgs(t)||ie()};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
+  if (patchedSource.includes("codexLinuxSecondInstanceHandler")) {
+    // Already patched.
+  } else if (patchedSource.includes(secondInstanceHandlerNeedle)) {
+    patchedSource = patchedSource.replace(secondInstanceHandlerNeedle, secondInstanceHandlerPatch);
+  } else {
+    console.warn("WARN: Could not find second-instance handler — skipping Linux second-instance focus patch");
   }
 
   return patchedSource;
@@ -213,6 +411,8 @@ if (colorMatch) {
 }
 
 source = applyLinuxFileManagerPatch(source);
+source = applyLinuxTrayPatch(source, iconPathExpression);
+source = applyLinuxSingleInstancePatch(source);
 
 fs.writeFileSync(target, source, "utf8");
 
@@ -220,6 +420,16 @@ patchAssetFiles(
   /^code-theme-.*\.js$/,
   applyLinuxOpaqueWindowsDefaultPatch,
   `WARN: Could not find code theme bundle in ${webviewAssetsDir} — skipping translucent sidebar default patch`,
+);
+patchAssetFiles(
+  /^general-settings-.*\.js$/,
+  applyLinuxOpaqueWindowsDefaultPatch,
+  `WARN: Could not find general settings bundle in ${webviewAssetsDir} — skipping translucent sidebar default patch`,
+);
+patchAssetFiles(
+  /^index-.*\.js$/,
+  applyLinuxOpaqueWindowsDefaultPatch,
+  `WARN: Could not find webview index bundle in ${webviewAssetsDir} — skipping translucent sidebar default patch`,
 );
 patchAssetFiles(
   /^use-resolved-theme-variant-.*\.js$/,
@@ -232,7 +442,7 @@ if (packageJson.desktopName !== "codex-desktop.desktop") {
   fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
 }
 
-console.log("Patched Linux window, shell, and appearance behavior:", {
+console.log("Patched Linux window, shell, tray, and appearance behavior:", {
   target,
   mainBundle,
   iconAsset,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -203,17 +203,25 @@ SCRIPT
 
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
-    assert_contains "$REPO_DIR/install.sh" "nohup python3 -m http.server 5175"
+    assert_contains "$REPO_DIR/install.sh" "python3 -m http.server 5175 --bind 127.0.0.1"
+    assert_contains "$REPO_DIR/install.sh" "WEBVIEW_PID_FILE"
+    assert_contains "$REPO_DIR/install.sh" "owned_webview_server_pid"
+    assert_contains "$REPO_DIR/install.sh" "discover_webview_server_pid"
+    assert_contains "$REPO_DIR/install.sh" "Adopted existing webview server"
+    assert_contains "$REPO_DIR/install.sh" "detect_warm_start"
+    assert_contains "$REPO_DIR/install.sh" "launcher_phase"
+    assert_contains "$REPO_DIR/install.sh" "CODEX_SYNC_CLI_PREFLIGHT"
     assert_contains "$REPO_DIR/install.sh" "wait_for_webview_server"
     assert_contains "$REPO_DIR/install.sh" "verify_webview_origin"
     assert_contains "$REPO_DIR/install.sh" "Webview origin verified."
+    assert_not_contains "$REPO_DIR/install.sh" "pkill -f \"http.server 5175\""
     assert_contains "$REPO_DIR/install.sh" "--app-id=codex-desktop"
     assert_contains "$REPO_DIR/install.sh" "--ozone-platform-hint=auto"
     assert_contains "$REPO_DIR/install.sh" "--disable-gpu-sandbox"
     assert_contains "$REPO_DIR/install.sh" "PACKAGED_RUNTIME_HELPER"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "CHROME_DESKTOP"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager-launch-check"
-    assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now"
+    assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now --if-stale"
     assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "restart codex-update-manager.service"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"
@@ -284,6 +292,94 @@ test_linux_translucent_sidebar_default_patch_smoke() {
     assert_occurrence_count "$extracted/webview/assets/index-test.js" 'dataset.codexOs===`linux`' '1'
 }
 
+test_linux_tray_patch_smoke() {
+    info "Checking Linux tray patch behavior"
+    local workspace="$TMP_DIR/tray-patch"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+    local bundle_body
+
+    mkdir -p "$workspace"
+    bundle_body="$(cat <<'JS'
+let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};
+let t={join(){},C:{Prod:`prod`},A(){}};
+let a={existsSync(){return true},statSync(){return {isFile(){return false}}}};
+let n={app:{isPackaged:true,getFileIcon(){},quit(){}},Menu:{buildFromTemplate(){return {once(){}}}},nativeImage:{createFromPath(){return {isEmpty(){return false}}}},shell:{openPath(){return ""},showItemInFolder(){}},Tray:function(){}};
+let i={join(){}};
+let k={hide(){},isDestroyed(){return false}};
+let f=`local`;
+...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{
+var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});
+function ca(){let e=1;return e}
+async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}
+function ua(e){return e}
+var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});
+async function Wa(e){return e}
+function Nw(e,n){return `icon`}
+async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let r=await Ww(e.buildFlavor,e.repoRoot),i=new n.Tray(r.defaultIcon);return i})()))}
+async function Ww(e,t){if(process.platform===`darwin`){return null}let r=process.platform===`win32`?`.ico`:`.png`,a=Nw(e,process.platform),o=[...n.app.isPackaged?[(0,i.join)(process.resourcesPath,`${a}${r}`)]:[],(0,i.join)(t,`electron`,`src`,`icons`,`${a}${r}`)];for(let e of o){let t=n.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await n.app.getFileIcon(process.execPath,{size:process.platform===`win32`?`small`:`normal`}),chronicleRunningIcon:null}}
+var pb=class{trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(){this.tray={on(){},setContextMenu(){},popUpContextMenu(){}};this.onTrayButtonClick=()=>{};this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}async handleMessage(e){switch(e.type){case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return}}openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}updateChronicleTrayIcon(){}getNativeTrayMenuItems(){return[]}}
+v&&k.on(`close`,e=>{this.persistPrimaryWindowBounds(k,f);let t=this.getPrimaryWindows(f).some(e=>e!==k);if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}if(process.platform===`darwin`&&!this.isAppQuitting&&!t){e.preventDefault(),k.hide()}});
+let E=process.platform===`win32`;
+let oe=async()=>{};
+let se=async e=>{};
+E&&oe();let ce=Hr({});
+JS
+)"
+    make_fake_extracted_asar "$extracted" "$bundle_body"
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`?null:'
+    assert_contains "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`)'
+    assert_contains "$extracted/.vite/build/main-test.js" '(process.platform===`win32`||process.platform===`linux`)&&f===`local`'
+    assert_contains "$extracted/.vite/build/main-test.js" 'setLinuxTrayContextMenu(){let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems())'
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`'
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()'
+    assert_contains "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate'
+    assert_contains "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`'
+    assert_contains "$extracted/.vite/build/main-test.js" 'this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.()'
+    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`)&&oe();'
+    assert_not_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)'
+    assert_not_contains "$output_log" 'WARN: Could not find tray'
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`linux`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&f===`local`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'setLinuxTrayContextMenu(){' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.setLinuxTrayContextMenu?.()' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&oe' '1'
+}
+
+test_linux_single_instance_patch_smoke() {
+    info "Checking Linux single-instance patch behavior"
+    local workspace="$TMP_DIR/single-instance-patch"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+    local bundle_body
+
+    mkdir -p "$workspace"
+    bundle_body="$(cat <<'JS'
+let n={app:{whenReady(){},quit(){},requestSingleInstanceLock(){},on(){},off(){}}};
+let t={Er(){return {info(){}}},jn:class{add(){}}};
+async function uT(){let k=new t.jn;t.Er().info(`Launching app`,{safe:{agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();let R={deepLinks:{queueProcessArgs(){return false}}},P={hotkeyWindowLifecycleManager:{hide(){}},getPrimaryWindow(){return null},createFreshLocalWindow(){return null}},g={reportNonFatal(){}},l=()=>{},re=e=>{e.isMinimized()&&e.restore(),e.show(),e.focus()},ie=async()=>{try{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(`local`)??await P.createFreshLocalWindow(`/`);if(e==null)return;re(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=async()=>{}}
+JS
+)"
+    make_fake_extracted_asar "$extracted" "$bundle_body"
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!n.app.requestSingleInstanceLock()'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxSecondInstanceHandler'
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" '!n.app.requestSingleInstanceLock()' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxSecondInstanceHandler' '3'
+}
+
 test_linux_file_manager_patch_fails_soft() {
     info "Checking Linux file manager patch fallback"
     local workspace="$TMP_DIR/file-manager-patch-fallback"
@@ -305,6 +401,8 @@ main() {
     test_launcher_template_sanity
     test_linux_file_manager_patch_smoke
     test_linux_translucent_sidebar_default_patch_smoke
+    test_linux_tray_patch_smoke
+    test_linux_single_instance_patch_smoke
     test_linux_file_manager_patch_fails_soft
     info "All script smoke tests passed"
 }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -10,7 +10,7 @@ use crate::{
     upstream,
 };
 use anyhow::{Context, Result};
-use chrono::Utc;
+use chrono::{Duration as ChronoDuration, Utc};
 use fs4::fs_std::FileExt;
 use reqwest::Client;
 use std::{
@@ -37,7 +37,9 @@ pub async fn run(cli: Cli) -> Result<()> {
 
     match cli.command {
         Commands::Daemon => run_daemon(&config, &mut state, &paths).await,
-        Commands::CheckNow => run_check_now(&config, &mut state, &paths).await,
+        Commands::CheckNow { if_stale } => {
+            run_check_now(&config, &mut state, &paths, if_stale).await
+        }
         Commands::CliPreflight {
             cli_path,
             print_path,
@@ -211,12 +213,26 @@ async fn run_check_now(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
+    if_stale: bool,
 ) -> Result<()> {
     sync_and_persist(config, state, paths)?;
     recover_interrupted_install(state, paths)?;
     maybe_notify_installed(state, paths, config.notifications)?;
+    if if_stale && upstream_check_is_fresh(config, state) {
+        info!("skipping check-now because the last successful upstream check is still fresh");
+        return reconcile_pending_install(config, state, paths).await;
+    }
     run_check_cycle(config, state, paths).await?;
     reconcile_pending_install(config, state, paths).await
+}
+
+fn upstream_check_is_fresh(config: &RuntimeConfig, state: &PersistedState) -> bool {
+    let Some(last_successful_check_at) = state.last_successful_check_at else {
+        return false;
+    };
+
+    let freshness_window = ChronoDuration::hours(config.check_interval_hours as i64);
+    Utc::now().signed_duration_since(last_successful_check_at) < freshness_window
 }
 
 fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> Result<()> {
@@ -616,6 +632,29 @@ fn notify_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn upstream_check_freshness_respects_configured_interval() {
+        let config = RuntimeConfig {
+            dmg_url: "https://example.com/Codex.dmg".to_string(),
+            initial_check_delay_seconds: 1,
+            check_interval_hours: 6,
+            auto_install_on_app_exit: true,
+            notifications: false,
+            workspace_root: std::path::PathBuf::from("/tmp/cache"),
+            builder_bundle_root: std::path::PathBuf::from("/tmp/builder"),
+            app_executable_path: std::path::PathBuf::from("/tmp/electron"),
+        };
+
+        let mut state = PersistedState::new(true);
+        assert!(!upstream_check_is_fresh(&config, &state));
+
+        state.last_successful_check_at = Some(Utc::now() - ChronoDuration::hours(1));
+        assert!(upstream_check_is_fresh(&config, &state));
+
+        state.last_successful_check_at = Some(Utc::now() - ChronoDuration::hours(7));
+        assert!(!upstream_check_is_fresh(&config, &state));
+    }
 
     #[tokio::test]
     async fn failed_state_with_existing_deb_stays_failed() -> Result<()> {

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -15,7 +15,10 @@ pub struct Cli {
 /// Top-level commands supported by the updater binary.
 pub enum Commands {
     Daemon,
-    CheckNow,
+    CheckNow {
+        #[arg(long, default_value_t = false)]
+        if_stale: bool,
+    },
     CliPreflight {
         #[arg(long)]
         cli_path: Option<PathBuf>,


### PR DESCRIPTION
## Summary
- enable Linux tray patching and single-instance warm-start handoff
- track, rediscover, and reuse verified webview servers on port 5175 instead of failing on orphaned launcher-owned servers
- make launch-time updater checks stale-aware and move CLI preflight to the background by default

## Validation
- bash -n install.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh packaging/linux/codex-packaged-runtime.sh tests/scripts_smoke.sh
- bash tests/scripts_smoke.sh
- cargo check -p codex-update-manager
- cargo test -p codex-update-manager