### PR TITLE
fix(updater): Use polkit for package installs

### DIFF
--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -11,6 +11,7 @@ depends=(
     'npm'
     'python'
     'p7zip'
+    'polkit'
     'curl'
     'unzip'
     'gcc'

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -5,7 +5,7 @@ Summary:        Codex Desktop for Linux
 License:        Proprietary
 ExclusiveArch:  __ARCH__
 
-Requires:       nodejs, npm, python3, p7zip, curl, unzip, gcc-c++, make
+Requires:       nodejs, npm, python3, p7zip, polkit, curl, unzip, gcc-c++, make
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
 Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
 Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr
@@ -30,6 +30,7 @@ cp -a "__RPM_STAGING_DIR__/." "%{buildroot}/"
 /usr/lib/systemd/user/codex-update-manager.service
 /usr/share/applications/__PACKAGE_NAME__.desktop
 /usr/share/icons/hicolor/256x256/apps/__PACKAGE_NAME__.png
+/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy
 
 %post
 if command -v update-desktop-database >/dev/null 2>&1; then
@@ -45,10 +46,8 @@ fi
 %preun
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 [ -f "$SERVICE_HELPER" ] && . "$SERVICE_HELPER"
-if [ -f "$SERVICE_HELPER" ]; then
-    codex_cleanup_user_service stop || true
-fi
 if [ $1 -eq 0 ] && [ -f "$SERVICE_HELPER" ]; then
+    codex_cleanup_user_service stop || true
     codex_cleanup_user_service disable || true
 fi
 

--- a/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy
+++ b/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/software/polkit/policyconfig-1.dtd">
+<policyconfig>
+  <vendor>Codex Desktop Linux</vendor>
+  <vendor_url>https://github.com/ilysenko/codex-desktop-linux</vendor_url>
+  <icon_name>codex-desktop</icon_name>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.install-deb">
+    <description>Install a Codex Desktop update</description>
+    <message>Authentication is required to install the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-deb</annotate>
+  </action>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.install-rpm">
+    <description>Install a Codex Desktop update</description>
+    <message>Authentication is required to install the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-rpm</annotate>
+  </action>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.install-pacman">
+    <description>Install a Codex Desktop update</description>
+    <message>Authentication is required to install the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-pacman</annotate>
+  </action>
+</policyconfig>

--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: Codex Desktop Linux Maintainers
-Depends: build-essential, curl, dpkg, nodejs, npm, p7zip-full, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Depends: build-essential, curl, dpkg, nodejs, npm, p7zip-full, pkexec, polkitd, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Description: Codex Desktop for Linux
  Community-built Linux package for Codex Desktop generated from the macOS DMG.
  Requires the Codex CLI to be available in PATH or CODEX_CLI_PATH.

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -60,13 +60,17 @@ Install the Rust toolchain:
 stage_common_package_files() {
     local root="$1"
     local app_root="$root/opt/$PACKAGE_NAME"
+    local polkit_policy="$REPO_DIR/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy"
+
+    ensure_file_exists "$polkit_policy" "polkit policy"
 
     mkdir -p \
         "$root/opt" \
         "$root/usr/bin" \
         "$root/usr/lib/systemd/user" \
         "$root/usr/share/applications" \
-        "$root/usr/share/icons/hicolor/256x256/apps"
+        "$root/usr/share/icons/hicolor/256x256/apps" \
+        "$root/usr/share/polkit-1/actions"
 
     rm -rf "$app_root"
     cp -aT "$APP_DIR" "$app_root"
@@ -78,6 +82,8 @@ stage_common_package_files() {
     chmod 0755 "$root/usr/bin/codex-update-manager"
     cp "$UPDATER_SERVICE_SOURCE" "$root/usr/lib/systemd/user/codex-update-manager.service"
     chmod 0644 "$root/usr/lib/systemd/user/codex-update-manager.service"
+    cp "$polkit_policy" "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    chmod 0644 "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
     cp "$PACKAGED_RUNTIME_SOURCE" "$app_root/.codex-linux/codex-packaged-runtime.sh"
     chmod 0644 "$app_root/.codex-linux/codex-packaged-runtime.sh"
 }
@@ -102,6 +108,8 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/packaging/linux/codex-desktop.spec" "$update_builder_root/packaging/linux/codex-desktop.spec"
     cp "$REPO_DIR/packaging/linux/codex-desktop.desktop" "$update_builder_root/packaging/linux/codex-desktop.desktop"
     cp "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "$update_builder_root/packaging/linux/codex-packaged-runtime.sh"
+    cp "$REPO_DIR/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy" \
+        "$update_builder_root/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy"
     cp "$REPO_DIR/packaging/linux/codex-update-manager-user-service.sh" \
         "$update_builder_root/packaging/linux/codex-update-manager-user-service.sh"
     cp "$REPO_DIR/packaging/linux/PKGBUILD.template" "$update_builder_root/packaging/linux/PKGBUILD.template"

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -388,6 +388,10 @@ async fn reconcile_pending_install(
 ) -> Result<()> {
     sync_runtime_state(config, state);
     recover_interrupted_install(state, paths)?;
+    if complete_pending_install_if_already_installed(state, paths)? {
+        let _ = maybe_notify_installed(state, paths, config.notifications);
+        return Ok(());
+    }
 
     match state.status {
         UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit => {
@@ -408,6 +412,7 @@ async fn reconcile_pending_install(
             }
 
             if liveness::is_app_running(config)? {
+                clear_install_auth_required_event(state, paths)?;
                 set_status(state, paths, UpdateStatus::WaitingForAppExit)?;
                 maybe_notify(
                     state,
@@ -417,6 +422,10 @@ async fn reconcile_pending_install(
                     "Codex Desktop update ready",
                     "An update is ready and will install after you close Codex Desktop.",
                 )?;
+                return Ok(());
+            }
+
+            if install_auth_retry_is_blocked(state) {
                 return Ok(());
             }
 
@@ -431,6 +440,32 @@ async fn reconcile_pending_install(
     }
 
     Ok(())
+}
+
+fn complete_pending_install_if_already_installed(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<bool> {
+    if !matches!(
+        state.status,
+        UpdateStatus::ReadyToInstall | UpdateStatus::WaitingForAppExit
+    ) {
+        return Ok(false);
+    }
+
+    if !state.candidate_version.as_deref().is_some_and(|candidate| {
+        installed_version_matches_candidate(&state.installed_version, candidate)
+    }) {
+        return Ok(false);
+    }
+
+    state.status = UpdateStatus::Installed;
+    state.candidate_version = None;
+    state.error_message = None;
+    state.notified_events.clear();
+    persist_state(paths, state)?;
+    info!("recovered pending install state because the candidate version is already installed");
+    Ok(true)
 }
 
 fn recover_interrupted_install(state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
@@ -487,6 +522,18 @@ fn installed_version_satisfies_candidate(installed: &str, candidate: &str) -> bo
     match compare_generated_versions(installed, candidate) {
         Some(std::cmp::Ordering::Less) => false,
         Some(_) => true,
+        None => installed == candidate,
+    }
+}
+
+fn installed_version_matches_candidate(installed: &str, candidate: &str) -> bool {
+    if installed == "unknown" {
+        return false;
+    }
+
+    match compare_generated_versions(installed, candidate) {
+        Some(std::cmp::Ordering::Equal) => true,
+        Some(_) => false,
         None => installed == candidate,
     }
 }
@@ -655,12 +702,69 @@ async fn trigger_install(
     }
 
     let error = anyhow::anyhow!(message);
+    if pkexec_authentication_was_not_obtained(&status) {
+        defer_install_until_next_app_exit(state, paths, error.to_string())?;
+        return Err(error);
+    }
+
     mark_failed_and_persist(state, paths, error.to_string())?;
     let _ = notify::send(
         "Codex update failed",
         "The package could not be installed. Check the updater log for details.",
     );
     Err(error)
+}
+
+fn pkexec_authentication_was_not_obtained(status: &std::process::ExitStatus) -> bool {
+    matches!(status.code(), Some(126 | 127))
+}
+
+fn install_auth_required_event_key(state: &PersistedState) -> Option<String> {
+    state
+        .candidate_version
+        .as_deref()
+        .map(|candidate| format!("install_auth_required:{candidate}"))
+}
+
+fn install_auth_retry_is_blocked(state: &PersistedState) -> bool {
+    install_auth_required_event_key(state)
+        .as_ref()
+        .is_some_and(|event_key| state.notified_events.contains(event_key))
+}
+
+fn clear_install_auth_required_event(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let Some(event_key) = install_auth_required_event_key(state) else {
+        return Ok(());
+    };
+
+    if state.notified_events.remove(&event_key) {
+        persist_state(paths, state)?;
+    }
+
+    Ok(())
+}
+
+fn defer_install_until_next_app_exit(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    message: String,
+) -> Result<()> {
+    state.status = UpdateStatus::ReadyToInstall;
+    state.error_message = Some(message);
+
+    if let Some(event_key) = install_auth_required_event_key(state) {
+        if state.notified_events.insert(event_key) {
+            let _ = notify::send(
+                "Codex update needs permission",
+                "The ready update will retry after the next app close. Approve the system authentication dialog to install it.",
+            );
+        }
+    }
+
+    persist_state(paths, state)
 }
 
 fn notify_failure(
@@ -924,6 +1028,104 @@ mod tests {
 
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
         assert_eq!(state.error_message, None);
+        Ok(())
+    }
+
+    #[test]
+    fn pkexec_authentication_failures_are_retryable() -> Result<()> {
+        for code in [126, 127] {
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(format!("exit {code}"))
+                .status()?;
+            assert!(pkexec_authentication_was_not_obtained(&status));
+        }
+
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("exit 1")
+            .status()?;
+        assert!(!pkexec_authentication_was_not_obtained(&status));
+        Ok(())
+    }
+
+    #[test]
+    fn install_auth_retry_block_is_scoped_to_candidate() {
+        let mut state = PersistedState::new(true);
+        state.candidate_version = Some("2026.04.28.082247+abcdef12".to_string());
+
+        assert!(!install_auth_retry_is_blocked(&state));
+
+        state
+            .notified_events
+            .insert("install_auth_required:2026.04.28.082247+abcdef12".to_string());
+        assert!(install_auth_retry_is_blocked(&state));
+
+        state.candidate_version = Some("2026.04.29.010203+abcdef12".to_string());
+        assert!(!install_auth_retry_is_blocked(&state));
+    }
+
+    #[test]
+    fn clear_install_auth_required_event_keeps_unrelated_notifications() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+
+        let mut state = PersistedState::new(true);
+        state.candidate_version = Some("2026.04.28.082247+abcdef12".to_string());
+        state
+            .notified_events
+            .insert("install_auth_required:2026.04.28.082247+abcdef12".to_string());
+        state
+            .notified_events
+            .insert("installed:2026.04.25.054929+12345678".to_string());
+
+        clear_install_auth_required_event(&mut state, &paths)?;
+
+        assert!(!install_auth_retry_is_blocked(&state));
+        assert!(state
+            .notified_events
+            .contains("installed:2026.04.25.054929+12345678"));
+        Ok(())
+    }
+
+    #[test]
+    fn pending_install_becomes_installed_when_candidate_is_already_present() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.installed_version = "2026.04.28.082247-abcdef12.fc43".to_string();
+        state.candidate_version = Some("2026.04.28.082247+abcdef12".to_string());
+        state.error_message = Some("authentication was not obtained".to_string());
+        state
+            .notified_events
+            .insert("install_auth_required:2026.04.28.082247+abcdef12".to_string());
+
+        assert!(complete_pending_install_if_already_installed(
+            &mut state, &paths
+        )?);
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.error_message, None);
+        assert!(state.notified_events.is_empty());
         Ok(())
     }
 

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -158,7 +158,7 @@ fn os_release_matches(fields: &[&str], expected: &[&str]) -> bool {
     fields.iter().any(|field| {
         field
             .split_whitespace()
-            .any(|token| expected.iter().any(|candidate| token == *candidate))
+            .any(|token| expected.contains(&token))
     })
 }
 
@@ -222,6 +222,7 @@ pub fn install_deb(path: &Path) -> Result<()> {
 /// Installs a rebuilt RPM package on the local machine.
 pub fn install_rpm(path: &Path) -> Result<()> {
     anyhow::ensure!(path.exists(), "RPM package not found: {}", path.display());
+    ensure_upgrade_path_rpm(path)?;
 
     if program_exists(DNF_CANDIDATES, "dnf") || program_exists(DNF_CANDIDATES, "dnf5") {
         let mut command = dnf_install_command(path)?;
@@ -262,6 +263,7 @@ pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
     };
     let mut command = Command::new("pkexec");
     command
+        .arg("--disable-internal-agent")
         .arg(updater_binary)
         .arg(subcommand)
         .arg("--path")
@@ -334,6 +336,20 @@ fn ensure_upgrade_path_pacman(path: &Path) -> Result<()> {
     let candidate = pacman_package_version(path)?;
     anyhow::ensure!(
         is_version_newer_pacman(&candidate, &installed)?,
+        "Refusing to install non-newer package version {candidate} over installed version {installed}"
+    );
+    Ok(())
+}
+
+fn ensure_upgrade_path_rpm(path: &Path) -> Result<()> {
+    let installed = installed_rpm_version();
+    if installed == "unknown" {
+        return Ok(());
+    }
+
+    let candidate = rpm_package_version(path)?;
+    anyhow::ensure!(
+        generated_package_version_is_newer(&candidate, &installed),
         "Refusing to install non-newer package version {candidate} over installed version {installed}"
     );
     Ok(())
@@ -442,6 +458,33 @@ fn deb_package_version(path: &Path) -> Result<String> {
     Ok(version)
 }
 
+fn rpm_package_version(path: &Path) -> Result<String> {
+    let output = Command::new(program_path(RPM_CANDIDATES, "rpm"))
+        .arg("-qp")
+        .arg("--queryformat")
+        .arg("%{VERSION}-%{RELEASE}")
+        .arg(path)
+        .output()
+        .context("Failed to inspect RPM package metadata")?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "rpm could not read the package version from {}",
+        path.display()
+    );
+
+    let version = String::from_utf8(output.stdout)
+        .context("rpm returned a non-UTF8 package version")?
+        .trim()
+        .to_string();
+    anyhow::ensure!(
+        !version.is_empty(),
+        "rpm returned an empty package version for {}",
+        path.display()
+    );
+    Ok(version)
+}
+
 fn is_version_newer(candidate: &str, installed: &str) -> Result<bool> {
     let status = Command::new(program_path(DPKG_CANDIDATES, "dpkg"))
         .args(["--compare-versions", candidate, "gt", installed])
@@ -489,6 +532,41 @@ fn is_version_newer_pacman(candidate: &str, installed: &str) -> Result<bool> {
         .parse::<i32>()
         .context("vercmp returned an invalid comparison value")?;
     Ok(comparison > 0)
+}
+
+fn generated_package_version_is_newer(candidate: &str, installed: &str) -> bool {
+    matches!(
+        compare_generated_package_versions(candidate, installed),
+        Some(std::cmp::Ordering::Greater)
+    )
+}
+
+fn compare_generated_package_versions(left: &str, right: &str) -> Option<std::cmp::Ordering> {
+    let left = parse_generated_package_version(left)?;
+    let right = parse_generated_package_version(right)?;
+    Some(left.cmp(&right))
+}
+
+fn parse_generated_package_version(version: &str) -> Option<Vec<u32>> {
+    let without_metadata = version
+        .split_once('+')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(version);
+    let base = without_metadata
+        .split_once('-')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(without_metadata);
+    let mut parts = Vec::new();
+
+    for segment in base.split('.') {
+        parts.push(segment.parse().ok()?);
+    }
+
+    if parts.len() < 3 || !(2000..=2100).contains(&parts[0]) {
+        return None;
+    }
+
+    Some(parts)
 }
 
 fn strip_pacman_package_suffix(file_name: &str) -> Option<&str> {
@@ -545,6 +623,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                "--disable-internal-agent",
                 "/usr/bin/codex-update-manager",
                 "install-deb",
                 "--path",
@@ -566,6 +645,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                "--disable-internal-agent",
                 "/usr/bin/codex-update-manager",
                 "install-rpm",
                 "--path",
@@ -760,6 +840,7 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                "--disable-internal-agent",
                 "/usr/bin/codex-update-manager",
                 "install-pacman",
                 "--path",
@@ -786,6 +867,34 @@ mod tests {
     }
 
     #[test]
+    fn compares_generated_package_versions_by_timestamp() {
+        assert!(generated_package_version_is_newer(
+            "2026.04.28.140000-abcdef12.fc43",
+            "2026.04.28.082247-12345678.fc43"
+        ));
+        assert!(!generated_package_version_is_newer(
+            "2026.04.28.082247-12345678.fc43",
+            "2026.04.28.140000-abcdef12.fc43"
+        ));
+        assert!(!generated_package_version_is_newer(
+            "2026.04.28.140000-abcdef12.fc43",
+            "2026.04.28.140000-abcdef12.fc43"
+        ));
+    }
+
+    #[test]
+    fn generated_package_version_comparison_rejects_non_generated_versions() {
+        assert_eq!(
+            compare_generated_package_versions("0.4.2", "2026.04.28.082247-12345678.fc43"),
+            None
+        );
+        assert!(!generated_package_version_is_newer(
+            "0.4.2",
+            "2026.04.28.082247-12345678.fc43"
+        ));
+    }
+
+    #[test]
     fn install_commands_require_a_file_name() {
         let deb_error = apt_install_command(Path::new("/")).expect_err("root is not a package");
         let rpm_error = dnf_install_command(Path::new("/")).expect_err("root is not a package");
@@ -794,7 +903,9 @@ mod tests {
 
         assert!(deb_error.to_string().contains("apt package path has no"));
         assert!(rpm_error.to_string().contains("dnf package path has no"));
-        assert!(zypper_error.to_string().contains("zypper package path has no"));
+        assert!(zypper_error
+            .to_string()
+            .contains("zypper package path has no"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ship a polkit action policy for the updater install subcommands and call `pkexec` with `--disable-internal-agent`, so package installs use the desktop authentication agent instead of falling back to a textual prompt
- keep cancelled or unavailable `pkexec` authentication retryable: the updater no longer marks the candidate as permanently failed, and it suppresses repeated prompts until the app has run again or a new candidate appears
- reject non-newer RPM packages before invoking DNF/Zypper, matching the existing DEB/pacman downgrade guard behavior for generated package versions
- keep the user updater service running during RPM upgrades by only stopping/disabling it from `%preun` on package erase
- include the polkit policy in both the installed package payload and the update-builder bundle, and add the required polkit dependencies for RPM/DEB/pacman packages

## Why
The updater needs a privileged package install step, but unattended service retries should not get stuck after a cancelled authentication prompt or repeatedly launch a text-based auth flow. RPM installs also needed the same non-newer package guard that DEB and pacman already had, and RPM upgrades should not stop the user updater service between package scriptlets.

## Testing
- `rustfmt --edition 2021 --check updater/src/app.rs updater/src/install.rs`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-update-manager` (76 passed)
- `cargo build --release -p codex-update-manager`
- `git diff --check`
- `bash -n scripts/lib/package-common.sh scripts/build-rpm.sh scripts/build-deb.sh scripts/build-pacman.sh`
- `python3 -m xml.etree.ElementTree packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy`
- built an RPM from the current branch and verified:
  - the policy is installed under `/usr/share/polkit-1/actions/`
  - the policy is included in the update-builder bundle
  - `/usr/bin/codex-update-manager` is included
  - `rpm -qpR` includes `polkit`
  - `%preun` only stops/disables the user service on erase
- live RPM validation on Fedora:
  - the polkit action registered through `pkaction`
  - `pkexec --disable-internal-agent codex-update-manager install-rpm --path <newer-rpm>` installed a newer test package
  - an older generated RPM version was rejected before DNF/Zypper
  - a fixed-to-fixed RPM upgrade kept `codex-update-manager.service` active

## Notes
- Full `cargo fmt --check` still reports existing formatting drift in `updater/src/codex_cli.rs` and `updater/src/state.rs`; this PR does not touch those files, so the targeted Rust format check above was used.
- DEB and pacman package builds were not run locally because the environment does not have `dpkg-deb` or `makepkg`; their shared shell staging path was syntax-checked, and the RPM build validated the shared policy staging.
