### PR TITLE
Harden updater packaging runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The current working flow is:
 - `~/.local/state/codex-update-manager/service.log`
   Updater service log.
 - `~/.cache/codex-update-manager/`
-  Downloaded DMGs, rebuild workspaces, staged package artifacts, and build logs.
+  Downloaded DMGs, rebuild workspaces, staged package artifacts, and build logs. Successful rebuilds prune older workspaces and keep the current workspace plus the newest previous one.
 
 Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, prefer updating `install.sh` and then regenerating the app.
 
@@ -104,15 +104,17 @@ Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, p
 - Privilege boundary:
   The updater runs unprivileged. It only escalates at install time via `pkexec /usr/bin/codex-update-manager install-deb --path <deb>`, `install-rpm --path <rpm>`, or `install-pacman --path <pkg.tar.zst>`.
 - Failed privileged installs:
-  A failed or cancelled `pkexec` install now stays in `Failed` and does not auto-retry every reconcile cycle. Check `service.log`, fix the root cause, and retry by waiting for the next rebuild or rebuilding a newer package.
+  A failed, cancelled, or timed-out `pkexec` install now stays in `Failed` and does not auto-retry every reconcile cycle. Check `service.log`, fix the root cause, and retry by waiting for the next rebuild or rebuilding a newer package.
 - Interrupted installs:
   If updater state is left in `Installing` after a crash, restart, or interrupted privileged flow, the daemon now recovers that state automatically instead of staying stuck and skipping future upstream checks.
+- Launch-time update checks:
+  The packaged runtime starts `codex-update-manager.service` in best-effort mode on app launch, but it skips the transient `codex-update-manager-launch-check` unit when the user daemon is already active. The daemon owns initial and periodic checks once it is running.
 - Package removal:
   Debian and RPM removal now make a best-effort attempt to stop and disable `codex-update-manager.service` for active user sessions. If a user manager is unavailable, manual cleanup is still `systemctl --user disable --now codex-update-manager.service`.
 
 ## Crate Versioning
 
-- Current updater crate version: `0.4.2`
+- Current updater crate version: `0.4.3`
 - Bump `patch` for fixes, docs, and maintenance-only updates.
 - Bump `minor` for compatible feature additions.
 - Bump `major` for incompatible CLI, persisted-state, or install-flow changes.
@@ -206,6 +208,8 @@ The native packages currently install:
 - icon under `/usr/share/icons/hicolor/256x256/apps/codex-desktop.png`
 
 The Debian builder uses `dpkg-deb --root-owner-group` so package ownership is correct.
+
+The native builders and post-install hooks normalize staged `/opt` and `/usr` payload permissions after copying generated app files, so package artifacts and upgrades do not preserve group-writable modes from a developer checkout.
 
 The RPM builder stages the same app and updater payload into an RPM buildroot before invoking `rpmbuild`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.3] - 2026-04-28
+
+### Changed
+
+- The packaged launcher now leaves stale update checks to the already-running user daemon instead of starting a duplicate launch-time `check-now` unit.
+- The RPM builder now uses the shared native-packaging launcher helper instead of duplicating package stub logic.
+- Native package builders and post-install hooks now normalize installed payload permissions after staging generated app files.
+
+### Fixed
+
+- Prefer user-local Codex CLI installs such as `~/.npm-global/bin/codex` before stale system-wide CLI binaries when a GUI launcher has a reduced `PATH`.
+- Validate executable permissions before using updater builder scripts, Node toolchain binaries, and resolved Codex CLI candidates.
+- Bound privileged updater installs with a timeout and prune stale rebuild workspaces after a successful local package build.
+
 ## [0.4.2] - 2026-04-23
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run [OpenAI Codex Desktop](https://openai.com/codex/) on Linux.
 
 The official Codex Desktop app is macOS-only. This project converts the upstream macOS `Codex.dmg` into a runnable Linux Electron app, packages it as `.deb`, `.rpm`, or pacman artifacts, and includes a local updater that rebuilds future Linux packages from newer upstream DMGs.
 
-`codex-update-manager` current crate version: `0.4.2`
+`codex-update-manager` current crate version: `0.4.3`
 
 SemVer policy for the crate:
 
@@ -373,14 +373,15 @@ The package installs a companion service named `codex-update-manager`.
 
 - It runs as a `systemd --user` service.
 - The launcher starts it in best-effort mode on app launch.
-- Each app launch also triggers a background `check-now --if-stale`; the updater skips that request when the last successful upstream check is still fresh or another check, rebuild, or install is already active.
+- If the service is not already active, the launcher also triggers a background `check-now --if-stale`; otherwise the running daemon owns startup and periodic checks.
 - It checks the upstream `Codex.dmg` on daemon startup and every 6 hours.
 - When a new DMG is detected, it rebuilds a local native package using `/opt/codex-desktop/update-builder`.
+- Successful rebuilds retain the current workspace plus the newest previous workspace and prune older updater workspaces from `~/.cache/codex-update-manager/workspaces`.
 - If the app is open, the update waits until Electron exits.
 - When the app is closed, the updater uses `pkexec` only for the final native-package install step.
 - On Arch, that final install step is `pacman -U --noconfirm` against the locally rebuilt `.pkg.tar.zst`, not `git pull`.
 - On openSUSE, that final install step is `zypper --non-interactive --no-gpg-checks install` against the locally rebuilt `.rpm` (the package is unsigned because it is built locally).
-- If a privileged install fails or is dismissed, the updater stays in `failed` instead of re-prompting every 15 seconds.
+- If a privileged install fails, is dismissed, or times out, the updater stays in `failed` instead of re-prompting every 15 seconds.
 - If an `Installing` state is interrupted by a crash or restart, the updater now recovers that state automatically instead of getting stuck and skipping all future upstream checks.
 - Before Electron launches, the launcher only resolves a usable Codex CLI path. If the CLI is missing and the launcher was started from an interactive terminal, it prompts before attempting an automatic install. The updater CLI preflight then runs in the background by default so npm registry checks and follow-up updates do not block the first window.
 - That CLI preflight is best-effort: it uses a 1-hour cooldown for registry checks, falls back to `npm install -g --prefix ~/.local` if a global install fails, and keeps the app launch on the current CLI when the automatic refresh does not succeed. Set `CODEX_SYNC_CLI_PREFLIGHT=1` to restore the old synchronous preflight behavior for debugging.

--- a/packaging/linux/codex-desktop.install
+++ b/packaging/linux/codex-desktop.install
@@ -9,6 +9,7 @@ post_install() {
         update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
     fi
     if [ -f "$SERVICE_HELPER" ]; then
+        codex_normalize_package_permissions || true
         codex_ensure_user_service_running || true
     fi
 }

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -40,6 +40,7 @@ fi
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
+    codex_normalize_package_permissions || true
     codex_ensure_user_service_running || true
 fi
 

--- a/packaging/linux/codex-packaged-runtime.sh
+++ b/packaging/linux/codex-packaged-runtime.sh
@@ -49,6 +49,11 @@ codex_packaged_runtime_trigger_update_check() {
         return 0
     fi
 
+    if command -v systemctl >/dev/null 2>&1 &&
+        systemctl --user is-active --quiet codex-update-manager.service >/dev/null 2>&1; then
+        return 0
+    fi
+
     if command -v systemd-run >/dev/null 2>&1 && systemctl --user show-environment >/dev/null 2>&1; then
         systemd-run --user \
             --unit=codex-update-manager-launch-check \

--- a/packaging/linux/codex-update-manager-user-service.sh
+++ b/packaging/linux/codex-update-manager-user-service.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 SERVICE_NAME="${SERVICE_NAME:-codex-update-manager.service}"
+PACKAGE_ROOT="${CODEX_DESKTOP_PACKAGE_ROOT:-/opt/codex-desktop}"
 
 codex_foreach_user_manager() {
     if ! command -v runuser >/dev/null 2>&1 || ! command -v systemctl >/dev/null 2>&1; then
@@ -82,4 +83,23 @@ codex_cleanup_one_user_service() {
 
     codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" "$action" "$SERVICE_NAME" || true
     codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" daemon-reload || true
+}
+
+codex_normalize_package_permissions() {
+    [ -d "$PACKAGE_ROOT" ] || return 0
+
+    chmod 0755 "$PACKAGE_ROOT" || true
+    find "$PACKAGE_ROOT" -type d -exec chmod 0755 {} + 2>/dev/null || true
+    find "$PACKAGE_ROOT" -type f -perm /022 -exec chmod go-w {} + 2>/dev/null || true
+
+    chmod 0755 \
+        "$PACKAGE_ROOT/start.sh" \
+        /usr/bin/codex-desktop \
+        /usr/bin/codex-update-manager 2>/dev/null || true
+
+    chmod 0644 \
+        "$PACKAGE_ROOT/.codex-linux/codex-packaged-runtime.sh" \
+        /usr/lib/systemd/user/codex-update-manager.service \
+        /usr/share/applications/codex-desktop.desktop \
+        /usr/share/icons/hicolor/256x256/apps/codex-desktop.png 2>/dev/null || true
 }

--- a/packaging/linux/codex-update-manager.postinst
+++ b/packaging/linux/codex-update-manager.postinst
@@ -5,6 +5,7 @@ SERVICE_HELPER="/opt/codex-desktop/update-builder/packaging/linux/codex-update-m
 if [ -f "$SERVICE_HELPER" ]; then
     # shellcheck source=/opt/codex-desktop/update-builder/packaging/linux/codex-update-manager-user-service.sh
     . "$SERVICE_HELPER"
+    codex_normalize_package_permissions || true
     codex_ensure_user_service_running || true
 fi
 

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -63,6 +63,7 @@ main() {
     stage_common_package_files "$PKG_ROOT"
     stage_update_builder_bundle "$PKG_ROOT"
     write_launcher_stub "$PKG_ROOT"
+    normalize_package_permissions "$PKG_ROOT"
 
     sed \
         -e "s/__VERSION__/$PACKAGE_VERSION/g" \

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -65,6 +65,7 @@ main() {
 	stage_common_package_files "$staging_root"
 	stage_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
+	normalize_package_permissions "$staging_root"
 
 	sed \
 		-e "s/__PACKAGE_NAME__/$PACKAGE_NAME/g" \

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -48,22 +48,6 @@ rpm_version_parts() {
     RPM_RELEASE="$hash"
 }
 
-ensure_updater_binary() {
-    if [ -x "$UPDATER_BINARY_SOURCE" ]; then
-        return
-    fi
-
-    [ -f "$REPO_DIR/Cargo.toml" ] || error "Missing updater binary: $UPDATER_BINARY_SOURCE"
-    command -v cargo >/dev/null 2>&1 || error "cargo is required to build codex-update-manager.
-Install the Rust toolchain:
-  bash scripts/install-deps.sh        # auto-installs via rustup
-  # or manually: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-
-    info "Building codex-update-manager release binary"
-    cargo build --release -p codex-update-manager >&2
-    [ -x "$UPDATER_BINARY_SOURCE" ] || error "Failed to build updater binary: $UPDATER_BINARY_SOURCE"
-}
-
 main() {
     [ -d "$APP_DIR" ] || error "Missing app directory: $APP_DIR. Run ./install.sh first."
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
@@ -93,11 +77,8 @@ main() {
     stage_common_package_files "$staging_root"
     stage_update_builder_bundle "$staging_root"
 
-    cat > "$staging_root/usr/bin/$PACKAGE_NAME" <<SCRIPT
-#!/bin/bash
-exec /opt/$PACKAGE_NAME/start.sh "\$@"
-SCRIPT
-    chmod 0755 "$staging_root/usr/bin/$PACKAGE_NAME"
+    write_launcher_stub "$staging_root"
+    normalize_package_permissions "$staging_root"
 
     local spec_file="$build_root/codex-desktop.spec"
     sed \

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -130,3 +130,20 @@ exec /opt/$PACKAGE_NAME/start.sh "\$@"
 SCRIPT
     chmod 0755 "$root/usr/bin/$PACKAGE_NAME"
 }
+
+normalize_package_permissions() {
+    local root="$1"
+    local path
+
+    chmod 0755 "$root"
+
+    for path in "$root/opt" "$root/usr"; do
+        if [ -d "$path" ]; then
+            chmod -R u+rwX,go+rX,go-w "$path"
+        fi
+    done
+
+    [ -x "$root/opt/$PACKAGE_NAME/start.sh" ] && chmod 0755 "$root/opt/$PACKAGE_NAME/start.sh"
+    [ -x "$root/usr/bin/$PACKAGE_NAME" ] && chmod 0755 "$root/usr/bin/$PACKAGE_NAME"
+    [ -x "$root/usr/bin/codex-update-manager" ] && chmod 0755 "$root/usr/bin/codex-update-manager"
+}

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -17,11 +17,16 @@ use std::{
     fs::{self, OpenOptions},
     io::{Seek, SeekFrom, Write},
     path::Path,
+    process::Output,
 };
-use tokio::time::{self, Duration};
+use tokio::{
+    process::Command,
+    time::{self, Duration},
+};
 use tracing::{error, info, warn};
 
 const RECONCILE_INTERVAL_SECONDS: u64 = 15;
+const PRIVILEGED_INSTALL_TIMEOUT_SECONDS: u64 = 300;
 const CLI_MISSING_NOTIFICATION_EVENT: &str = "cli_missing";
 
 /// Runs the updater command-line entrypoint.
@@ -670,9 +675,24 @@ async fn trigger_install(
     );
 
     let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
-    let output = install::pkexec_command(&current_exe, package_path)
-        .output()
-        .context("Failed to launch pkexec for update installation")?;
+    let output = match run_privileged_install_command(
+        &current_exe,
+        package_path,
+        Duration::from_secs(PRIVILEGED_INSTALL_TIMEOUT_SECONDS),
+    )
+    .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            error!(?error, "privileged install did not complete");
+            mark_failed_and_persist(state, paths, error.to_string())?;
+            let _ = notify::send(
+                "Codex update failed",
+                "The privileged package install did not finish. Check the updater log for details.",
+            );
+            return Err(error);
+        }
+    };
     let status = output.status;
 
     if status.success() {
@@ -767,6 +787,37 @@ fn defer_install_until_next_app_exit(
     persist_state(paths, state)
 }
 
+async fn run_privileged_install_command(
+    current_exe: &Path,
+    package_path: &Path,
+    timeout_duration: Duration,
+) -> Result<Output> {
+    let (updater_binary, subcommand) =
+        install::privileged_install_command_parts(current_exe, package_path);
+    let mut command = Command::new("pkexec");
+    command
+        .arg("--disable-internal-agent")
+        .arg(updater_binary)
+        .arg(subcommand)
+        .arg("--path")
+        .arg(package_path);
+    run_command_with_timeout(command, timeout_duration).await
+}
+
+async fn run_command_with_timeout(
+    mut command: Command,
+    timeout_duration: Duration,
+) -> Result<Output> {
+    command.kill_on_drop(true);
+    match time::timeout(timeout_duration, command.output()).await {
+        Ok(output) => output.context("Failed to execute privileged install command"),
+        Err(_) => anyhow::bail!(
+            "Privileged install timed out after {} seconds",
+            timeout_duration.as_secs()
+        ),
+    }
+}
+
 fn notify_failure(
     config: &RuntimeConfig,
     state: &mut PersistedState,
@@ -809,6 +860,18 @@ mod tests {
 
         state.last_successful_check_at = Some(Utc::now() - ChronoDuration::hours(7));
         assert!(!upstream_check_is_fresh(&config, &state));
+    }
+
+    #[tokio::test]
+    async fn privileged_install_command_timeout_returns_error() {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("sleep 5");
+
+        let error = run_command_with_timeout(command, Duration::from_millis(20))
+            .await
+            .expect_err("command should time out");
+
+        assert!(error.to_string().contains("timed out"));
     }
 
     #[tokio::test]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -6,13 +6,16 @@ use crate::{
     state::{ArtifactPaths, PersistedState, UpdateStatus},
 };
 use anyhow::{Context, Result};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     ffi::OsString,
     fs,
     path::{Path, PathBuf},
+    time::SystemTime,
 };
 use tokio::process::Command;
-use tracing::info;
+use tracing::{info, warn};
 
 const REQUIRED_BUNDLE_FILES: [(&str, &str); 6] = [
     ("install.sh", "install.sh"),
@@ -41,6 +44,7 @@ const PACMAN_PACKAGE_SUFFIXES: &[&str] = &[
     ".pkg.tar.lz4",
     ".pkg.tar.lz5",
 ];
+const MAX_RETAINED_WORKSPACES: usize = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Paths to the temporary workspace and generated package produced by a rebuild.
@@ -65,6 +69,10 @@ pub async fn build_update(
     state.save(&paths.state_file)?;
 
     copy_builder_bundle(&config.builder_bundle_root, &workspace.bundle_dir)?;
+    ensure_executable(
+        &workspace.bundle_dir.join("install.sh"),
+        "builder install script",
+    )?;
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
@@ -83,6 +91,7 @@ pub async fn build_update(
     state.save(&paths.state_file)?;
 
     let build_script = package_build_script(&workspace.bundle_dir);
+    ensure_executable(&build_script, "native package build script")?;
     run_and_log(
         Command::new(&build_script)
             .env("PACKAGE_VERSION", candidate_version)
@@ -111,6 +120,13 @@ pub async fn build_update(
     };
     state.save(&paths.state_file)?;
     info!(candidate_version, package = %package_path.display(), "local update build ready");
+    if let Err(error) = prune_old_workspaces(
+        &config.workspace_root,
+        &workspace.workspace_dir,
+        MAX_RETAINED_WORKSPACES,
+    ) {
+        warn!(?error, "failed to prune old updater workspaces");
+    }
 
     Ok(BuildArtifacts {
         workspace_dir: workspace.workspace_dir,
@@ -264,6 +280,56 @@ fn find_package_in(dist_dir: &Path) -> Result<PathBuf> {
     )
 }
 
+fn prune_old_workspaces(
+    workspace_root: &Path,
+    keep_workspace: &Path,
+    max_retained: usize,
+) -> Result<()> {
+    if max_retained == 0 {
+        return Ok(());
+    }
+
+    let workspaces_dir = workspace_root.join("workspaces");
+    if !workspaces_dir.exists() {
+        return Ok(());
+    }
+
+    let keep_workspace = keep_workspace
+        .canonicalize()
+        .unwrap_or_else(|_| keep_workspace.to_path_buf());
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(&workspaces_dir)
+        .with_context(|| format!("Failed to read {}", workspaces_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+
+        let path = entry.path();
+        let canonical_path = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if canonical_path == keep_workspace {
+            continue;
+        }
+
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        candidates.push((modified, path));
+    }
+
+    candidates.sort_by(|left, right| right.0.cmp(&left.0));
+    for (_, path) in candidates.into_iter().skip(max_retained.saturating_sub(1)) {
+        fs::remove_dir_all(&path).with_context(|| {
+            format!("Failed to remove old updater workspace {}", path.display())
+        })?;
+        info!(workspace = %path.display(), "removed old updater workspace");
+    }
+
+    Ok(())
+}
+
 fn is_native_package_file(path: &Path) -> bool {
     let name = path
         .file_name()
@@ -329,7 +395,28 @@ fn collect_nvm_bin_dirs(nvm_root: &Path) -> Vec<PathBuf> {
 fn is_node_toolchain_dir(path: &Path) -> bool {
     ["node", "npm", "npx"]
         .into_iter()
-        .all(|binary| path.join(binary).is_file())
+        .all(|binary| is_executable(&path.join(binary)))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn ensure_executable(path: &Path, label: &str) -> Result<()> {
+    if is_executable(path) {
+        return Ok(());
+    }
+
+    anyhow::bail!("{label} is missing or not executable: {}", path.display())
 }
 
 async fn run_and_log(command: &mut Command, log_path: &Path) -> Result<()> {
@@ -403,6 +490,16 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         Ok(())
     }
 
+    fn write_executable_file(path: &Path, contents: &[u8]) -> Result<()> {
+        fs::write(path, contents)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+        }
+        Ok(())
+    }
+
     #[tokio::test]
     async fn builds_update_with_fake_bundle() -> Result<()> {
         let temp = tempdir()?;
@@ -429,23 +526,15 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
             bundle_root.join("packaging/linux/codex-update-manager.service"),
             "[Unit]\nDescription=Codex Update Manager\n",
         )?;
-        fs::write(
-            bundle_root.join("install.sh"),
-            r#"#!/bin/bash
+        write_executable_file(
+            &bundle_root.join("install.sh"),
+            br#"#!/bin/bash
 set -euo pipefail
 mkdir -p "${CODEX_INSTALL_DIR}"
 echo launcher > "${CODEX_INSTALL_DIR}/start.sh"
 chmod +x "${CODEX_INSTALL_DIR}/start.sh"
 "#,
         )?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(
-                bundle_root.join("install.sh"),
-                fs::Permissions::from_mode(0o755),
-            )?;
-        }
 
         write_fake_build_script(
             &bundle_root.join("scripts/build-deb.sh"),
@@ -564,6 +653,50 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
     }
 
     #[test]
+    fn prunes_old_workspaces_but_keeps_current() -> Result<()> {
+        let temp = tempdir()?;
+        let workspace_root = temp.path().join("cache");
+        let workspaces_dir = workspace_root.join("workspaces");
+        let current = workspaces_dir.join("current");
+        let old_a = workspaces_dir.join("old-a");
+        let old_b = workspaces_dir.join("old-b");
+
+        for workspace in [&current, &old_a, &old_b] {
+            fs::create_dir_all(workspace)?;
+            fs::write(workspace.join("marker"), b"workspace")?;
+        }
+
+        prune_old_workspaces(&workspace_root, &current, 1)?;
+
+        assert!(current.exists());
+        assert!(!old_a.exists());
+        assert!(!old_b.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn workspace_pruning_retains_only_configured_count() -> Result<()> {
+        let temp = tempdir()?;
+        let workspace_root = temp.path().join("cache");
+        let workspaces_dir = workspace_root.join("workspaces");
+        let current = workspaces_dir.join("current");
+        let old_a = workspaces_dir.join("old-a");
+        let old_b = workspaces_dir.join("old-b");
+
+        for workspace in [&current, &old_a, &old_b] {
+            fs::create_dir_all(workspace)?;
+            fs::write(workspace.join("marker"), b"workspace")?;
+        }
+
+        prune_old_workspaces(&workspace_root, &current, 2)?;
+
+        let retained_count = fs::read_dir(&workspaces_dir)?.count();
+        assert_eq!(retained_count, 2);
+        assert!(current.exists());
+        Ok(())
+    }
+
+    #[test]
     fn finds_pacman_package_in_dist_dir() -> Result<()> {
         let temp = tempdir()?;
         let pkg_path = temp
@@ -587,13 +720,25 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         fs::create_dir_all(&version_bin)?;
         for dir in [&current_bin, &version_bin] {
             for binary in ["node", "npm", "npx"] {
-                fs::write(dir.join(binary), b"bin")?;
+                write_executable_file(&dir.join(binary), b"bin")?;
             }
         }
 
         let directories = collect_nvm_bin_dirs(&nvm_root);
         assert_eq!(directories.first(), Some(&current_bin));
         assert!(directories.contains(&version_bin));
+        Ok(())
+    }
+
+    #[test]
+    fn executable_check_requires_execute_permission() -> Result<()> {
+        let temp = tempdir()?;
+        let script = temp.path().join("script.sh");
+        fs::write(&script, b"#!/bin/sh\n")?;
+
+        assert!(!is_executable(&script));
+        write_executable_file(&script, b"#!/bin/sh\n")?;
+        assert!(is_executable(&script));
         Ok(())
     }
 }

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::{Duration, Utc};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     ffi::OsString,
     fs,
@@ -235,11 +237,10 @@ fn resolve_cli_path(explicit_path: Option<&Path>) -> Option<PathBuf> {
         }
     }
 
-    find_in_path("codex", &command_path_env()).or_else(|| {
-        known_cli_locations()
-            .into_iter()
-            .find(|path| is_executable(path))
-    })
+    known_cli_locations()
+        .into_iter()
+        .find(|path| is_executable(path))
+        .or_else(|| find_in_path("codex", &command_path_env()))
 }
 
 fn known_cli_locations() -> Vec<PathBuf> {
@@ -255,6 +256,7 @@ fn known_cli_locations() -> Vec<PathBuf> {
             versioned_paths.reverse();
             candidates.extend(versioned_paths);
         }
+        candidates.push(home.join(".npm-global/bin/codex"));
         candidates.push(home.join(".local/share/pnpm/codex"));
         candidates.push(home.join(".local/bin/codex"));
     }
@@ -264,14 +266,11 @@ fn known_cli_locations() -> Vec<PathBuf> {
 }
 
 fn requested_cli_path(state: &PersistedState) -> Option<PathBuf> {
-    state
-        .cli_path
-        .clone()
-        .or_else(|| {
-            std::env::var_os("CODEX_CLI_PATH")
-                .filter(|value| !value.is_empty())
-                .map(PathBuf::from)
-        })
+    state.cli_path.clone().or_else(|| {
+        std::env::var_os("CODEX_CLI_PATH")
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    })
 }
 
 fn should_skip_latest_version_check(
@@ -548,15 +547,23 @@ fn command_path_env() -> OsString {
 }
 
 fn preferred_node_bin_dirs() -> Vec<PathBuf> {
+    let mut directories = Vec::new();
+
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        let npm_global_bin = home.join(".npm-global/bin");
+        if node_toolchain_dir(&npm_global_bin) {
+            directories.push(npm_global_bin);
+        }
+    }
+
     let nvm_root = std::env::var_os("NVM_DIR")
         .map(PathBuf::from)
         .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".nvm")));
 
     let Some(nvm_root) = nvm_root else {
-        return Vec::new();
+        return directories;
     };
 
-    let mut directories = Vec::new();
     let current_bin = nvm_root.join("versions/node/current/bin");
     if node_toolchain_dir(&current_bin) {
         directories.push(current_bin);
@@ -579,9 +586,18 @@ fn preferred_node_bin_dirs() -> Vec<PathBuf> {
 fn node_toolchain_dir(path: &Path) -> bool {
     ["node", "npm", "npx"]
         .into_iter()
-        .all(|binary| path.join(binary).is_file())
+        .all(|binary| is_executable(&path.join(binary)))
 }
 
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    let Ok(metadata) = fs::metadata(path) else {
+        return false;
+    };
+    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
 fn is_executable(path: &Path) -> bool {
     path.is_file()
 }
@@ -601,6 +617,14 @@ mod tests {
         fs::write(path, contents)?;
         let mut permissions = fs::metadata(path)?.permissions();
         permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+        Ok(())
+    }
+
+    fn write_plain_file(path: &Path, contents: &str) -> Result<()> {
+        fs::write(path, contents)?;
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o644);
         fs::set_permissions(path, permissions)?;
         Ok(())
     }
@@ -632,6 +656,53 @@ mod tests {
     #[test]
     fn ignores_non_version_text() {
         assert_eq!(extract_version("Codex CLI"), None);
+    }
+
+    #[test]
+    fn executable_check_requires_execute_permission() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("codex");
+
+        write_plain_file(&path, "#!/bin/sh\n")?;
+        assert!(!is_executable(&path));
+
+        write_executable_script(&path, "#!/bin/sh\n")?;
+        assert!(is_executable(&path));
+        Ok(())
+    }
+
+    #[test]
+    fn find_in_path_rejects_non_executable_entries() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("codex");
+        write_plain_file(&path, "#!/bin/sh\n")?;
+
+        let path_env = std::env::join_paths([temp.path()])?;
+        assert_eq!(find_in_path("codex", &path_env), None);
+
+        write_executable_script(&path, "#!/bin/sh\n")?;
+        assert_eq!(
+            find_in_path("codex", &path_env).as_deref(),
+            Some(path.as_path())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn node_toolchain_dir_requires_executable_tools() -> Result<()> {
+        let temp = tempdir()?;
+        let bin = temp.path().join("bin");
+        fs::create_dir_all(&bin)?;
+        for tool in ["node", "npm", "npx"] {
+            write_plain_file(&bin.join(tool), "#!/bin/sh\n")?;
+        }
+        assert!(!node_toolchain_dir(&bin));
+
+        for tool in ["node", "npm", "npx"] {
+            write_executable_script(&bin.join(tool), "#!/bin/sh\n")?;
+        }
+        assert!(node_toolchain_dir(&bin));
+        Ok(())
     }
 
     #[test]

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -253,14 +253,24 @@ pub fn install_pacman(path: &Path) -> Result<()> {
     run_install(&mut command).context("pacman -U failed")
 }
 
-/// Builds the `pkexec` command used for privileged package installation.
-pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
+/// Returns the updater binary and install subcommand used for a privileged package install.
+pub fn privileged_install_command_parts(
+    current_exe: &Path,
+    package_path: &Path,
+) -> (PathBuf, &'static str) {
     let updater_binary = updater_binary_for_privileged_install(current_exe);
     let subcommand = match PackageKind::from_path(package_path) {
         PackageKind::Rpm => "install-rpm",
         PackageKind::Deb => "install-deb",
         PackageKind::Pacman => "install-pacman",
     };
+    (updater_binary, subcommand)
+}
+
+/// Builds the `pkexec` command used for privileged package installation.
+#[cfg(test)]
+pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
+    let (updater_binary, subcommand) = privileged_install_command_parts(current_exe, package_path);
     let mut command = Command::new("pkexec");
     command
         .arg("--disable-internal-agent")


### PR DESCRIPTION
## Summary
- prevent packaged app launches from starting a duplicate launch-time update check when the user daemon is already active
- wrap privileged package installs with a timeout while preserving upstream polkit auth-deferral behavior for permission-denied/cancelled prompts
- prune stale updater rebuild workspaces after successful builds
- normalize package payload permissions during build and post-install upgrades
- prefer executable user-local Codex CLI candidates and validate updater builder script/tool permissions

## Upstream interaction
- rebased on current `main` after the polkit install changes
- keeps `pkexec --disable-internal-agent` from upstream and applies the timeout around that command path

## Validation
- `bash -n scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/lib/package-common.sh packaging/linux/codex-packaged-runtime.sh`
- `sh -n packaging/linux/codex-update-manager.postinst packaging/linux/codex-update-manager.prerm packaging/linux/codex-update-manager.postrm packaging/linux/codex-update-manager-user-service.sh packaging/linux/codex-desktop.install`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager -- --test-threads=1` -> 83 passed, 0 failed
- `git diff --check`
- `git merge-tree upstream/main origin/codex/updater-package-runtime` -> clean