### PR TITLE
Add Linux keybind settings and launch controls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,8 @@ Options:
 
 Environment variables:
   CODEX_INSTALL_DIR   Override the install directory (default: ./codex-app)
+  CODEX_INSTALL_ALLOW_RUNNING=1
+                      Allow overwriting INSTALL_DIR while Codex is running
 
 After install, launch with:
   ./codex-app/start.sh
@@ -94,6 +96,79 @@ parse_args() {
         esac
         shift
     done
+}
+
+canonical_path() {
+    realpath -m "$1"
+}
+
+pid_is_current_user() {
+    local pid="$1"
+    local uid
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [ -d "/proc/$pid" ] || return 1
+    uid="$(awk '/^Uid:/ {print $2}' "/proc/$pid/status" 2>/dev/null || true)"
+    [ "$uid" = "$(id -u)" ]
+}
+
+pid_matches_install_target() {
+    local pid="$1"
+    local expected="$2"
+    local actual
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    [ -d "/proc/$pid" ] || return 1
+    pid_is_current_user "$pid" || return 1
+    actual="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+    [ -n "$actual" ] || return 1
+    [ "$actual" = "$(canonical_path "$expected")" ]
+}
+
+find_running_install_target_pid() {
+    local electron_path="$INSTALL_DIR/electron"
+    local app_pid_file="${XDG_STATE_HOME:-$HOME/.local/state}/codex-desktop/app.pid"
+    local pid
+    local proc_exe
+
+    [ -e "$electron_path" ] || return 1
+
+    if [ -f "$app_pid_file" ]; then
+        pid="$(cat "$app_pid_file" 2>/dev/null || true)"
+        if pid_matches_install_target "$pid" "$electron_path"; then
+            echo "$pid"
+            return 0
+        fi
+    fi
+
+    for proc_exe in /proc/[0-9]*/exe; do
+        [ -e "$proc_exe" ] || continue
+        pid="${proc_exe#/proc/}"
+        pid="${pid%/exe}"
+        if pid_matches_install_target "$pid" "$electron_path"; then
+            echo "$pid"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+assert_install_target_not_running() {
+    local pid
+
+    if [ "${CODEX_INSTALL_ALLOW_RUNNING:-0}" = "1" ]; then
+        warn "CODEX_INSTALL_ALLOW_RUNNING=1 set; installer may overwrite a running Codex app"
+        return 0
+    fi
+
+    if pid="$(find_running_install_target_pid)"; then
+        error "Codex Desktop is currently running from $INSTALL_DIR (pid $pid).
+Close that app before rebuilding this install directory, or build into a separate path:
+  CODEX_INSTALL_DIR=/tmp/codex-app-build ./install.sh
+
+Set CODEX_INSTALL_ALLOW_RUNNING=1 only if you intentionally want to overwrite a running app."
+    fi
 }
 
 prepare_install() {
@@ -490,21 +565,34 @@ create_start_script() {
 #!/bin/bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_PATH="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE_PATH" ]; do
+    SOURCE_DIR="$(cd -P "$(dirname "$SOURCE_PATH")" && pwd)"
+    SOURCE_PATH="$(readlink "$SOURCE_PATH")"
+    [[ "$SOURCE_PATH" != /* ]] && SOURCE_PATH="$SOURCE_DIR/$SOURCE_PATH"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE_PATH")" && pwd)"
 WEBVIEW_DIR="$SCRIPT_DIR/content/webview"
 LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/codex-desktop"
 LOG_FILE="$LOG_DIR/launcher.log"
+APP_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/codex-desktop"
+APP_SETTINGS_FILE="$APP_CONFIG_DIR/settings.json"
 APP_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/codex-desktop"
 APP_PID_FILE="$APP_STATE_DIR/app.pid"
 WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
+LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/codex-desktop"
+LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
 APP_NOTIFICATION_ICON_NAME="codex-desktop"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
 APP_NOTIFICATION_ICON_SYSTEM="/usr/share/icons/hicolor/256x256/apps/$APP_NOTIFICATION_ICON_NAME.png"
 APP_NOTIFICATION_ICON_REPO="$SCRIPT_DIR/../assets/codex.png"
 
-mkdir -p "$LOG_DIR" "$APP_STATE_DIR"
+mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
+chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
+export CODEX_DESKTOP_LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_SOCKET"
 STARTED_WEBVIEW_PID=""
+ADOPTED_WEBVIEW_PID=""
 ELECTRON_PID=""
 RUNNING_APP_PID=""
 WARM_START=0
@@ -517,6 +605,10 @@ Launches the Codex Desktop app.
 
 Options:
   -h, --help                  Show this help message and exit
+  --new-chat                  Open the main window on a new chat
+  --quick-chat                Open a projectless quick chat
+  --prompt-chat               Show the compact prompt for a new chat
+  --hotkey-window             Alias for --prompt-chat
   --disable-gpu               Completely disable GPU acceleration
   --disable-gpu-compositing   Disable GPU compositing (fixes flickering)
   --ozone-platform=x11        Force X11/XWayland explicitly
@@ -548,6 +640,37 @@ log_phase() {
     local elapsed_ms
     elapsed_ms="$(($(now_ms) - LAUNCHER_START_MS))"
     echo "[$(date -Is)] launcher_phase=$phase elapsedMs=$elapsed_ms"
+}
+
+linux_setting_enabled() {
+    local key="$1"
+    local default_value="${2:-1}"
+
+    python3 - "$APP_SETTINGS_FILE" "$key" "$default_value" <<'PY'
+import json
+import sys
+
+settings_path, key, default_value = sys.argv[1:4]
+enabled = default_value == "1"
+
+try:
+    with open(settings_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if isinstance(data, dict) and key in data:
+        value = data[key]
+        if isinstance(value, bool):
+            enabled = value
+        elif isinstance(value, (int, float)):
+            enabled = value != 0
+        elif isinstance(value, str):
+            enabled = value.strip().lower() not in {"0", "false", "no", "off"}
+except FileNotFoundError:
+    pass
+except (OSError, json.JSONDecodeError):
+    pass
+
+raise SystemExit(0 if enabled else 1)
+PY
 }
 
 load_packaged_runtime_helper() {
@@ -788,12 +911,60 @@ find_running_app_pid() {
     return 1
 }
 
+running_app_is_active() {
+    [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"
+}
+
+using_second_instance_handoff() {
+    [ "$WARM_START" -eq 0 ] && running_app_is_active
+}
+
+needs_cold_start() {
+    [ "$WARM_START" -eq 0 ] && ! using_second_instance_handoff
+}
+
 detect_warm_start() {
     if RUNNING_APP_PID="$(find_running_app_pid)"; then
-        WARM_START=1
         echo "$RUNNING_APP_PID" > "$APP_PID_FILE"
+        if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then
+            WARM_START=0
+            echo "Warm-start handoff disabled by $APP_SETTINGS_FILE"
+            echo "Detected running Codex Desktop pid=$RUNNING_APP_PID; preserving liveness marker for second-instance handoff"
+            return 0
+        fi
+
+        WARM_START=1
         echo "Detected running Codex Desktop pid=$RUNNING_APP_PID; using warm-start handoff"
+        return 0
     fi
+
+    if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then
+        WARM_START=0
+        echo "Warm-start handoff disabled by $APP_SETTINGS_FILE"
+    fi
+}
+
+send_warm_start_launch_action() {
+    [ "$WARM_START" -eq 1 ] || return 1
+    [ -S "$LAUNCH_ACTION_SOCKET" ] || return 1
+
+    python3 - "$LAUNCH_ACTION_SOCKET" "$@" <<'PY'
+import json
+import socket
+import sys
+
+socket_path = sys.argv[1]
+argv = sys.argv[2:]
+payload = json.dumps({"argv": argv}, separators=(",", ":")).encode("utf-8") + b"\n"
+
+client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+client.settimeout(1.0)
+try:
+    client.connect(socket_path)
+    client.sendall(payload)
+finally:
+    client.close()
+PY
 }
 
 wait_for_webview_server() {
@@ -853,6 +1024,11 @@ stop_owned_webview_server() {
         pid="$(cat "$WEBVIEW_PID_FILE" 2>/dev/null || true)"
     fi
 
+    if running_app_is_active && [ -n "$pid" ] && pid_is_webview_server "$pid"; then
+        echo "Preserving webview server pid=$pid owned by running Codex Desktop pid=$RUNNING_APP_PID"
+        return 0
+    fi
+
     if [ -n "$pid" ] && pid_is_webview_server "$pid"; then
         echo "Stopping owned webview server pid=$pid"
         kill "$pid" 2>/dev/null || true
@@ -905,14 +1081,24 @@ adopt_existing_webview_server() {
     local pid
 
     if pid="$(owned_webview_server_pid)"; then
-        STARTED_WEBVIEW_PID="$pid"
+        if running_app_is_active; then
+            ADOPTED_WEBVIEW_PID="$pid"
+            echo "Reusing webview server pid=$pid owned by running Codex Desktop pid=$RUNNING_APP_PID"
+        else
+            STARTED_WEBVIEW_PID="$pid"
+        fi
         return 0
     fi
 
     if pid="$(discover_webview_server_pid)"; then
-        STARTED_WEBVIEW_PID="$pid"
         echo "$pid" > "$WEBVIEW_PID_FILE"
-        echo "Adopted existing webview server pid=$pid dir=$WEBVIEW_DIR"
+        if running_app_is_active; then
+            ADOPTED_WEBVIEW_PID="$pid"
+            echo "Reusing webview server pid=$pid owned by running Codex Desktop pid=$RUNNING_APP_PID"
+        else
+            STARTED_WEBVIEW_PID="$pid"
+            echo "Adopted existing webview server pid=$pid dir=$WEBVIEW_DIR"
+        fi
         return 0
     fi
 
@@ -924,10 +1110,17 @@ ensure_webview_server() {
         return 0
     fi
 
-    if adopt_existing_webview_server && verify_webview_origin "http://127.0.0.1:5175/index.html" >/dev/null 2>&1; then
-        echo "Reusing existing verified webview server on :5175"
-        log_phase "webview_reused"
-        return 0
+    if adopt_existing_webview_server; then
+        if verify_webview_origin "http://127.0.0.1:5175/index.html" >/dev/null 2>&1; then
+            echo "Reusing existing verified webview server on :5175"
+            log_phase "webview_reused"
+            return 0
+        fi
+
+        if running_app_is_active; then
+            notify_error "Codex Desktop webview server is already running for pid $RUNNING_APP_PID, but origin validation failed. Keeping the live app untouched."
+            exit 1
+        fi
     fi
 
     if verify_webview_origin "http://127.0.0.1:5175/index.html" >/dev/null 2>&1; then
@@ -1047,7 +1240,11 @@ launch_electron() {
         --enable-features=WaylandWindowDecorations \
         "$@" &
     ELECTRON_PID=$!
-    echo "$ELECTRON_PID" > "$APP_PID_FILE"
+    if [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"; then
+        echo "Preserving Codex Desktop pid=$RUNNING_APP_PID liveness marker for second-instance handoff"
+    else
+        echo "$ELECTRON_PID" > "$APP_PID_FILE"
+    fi
     log_phase "electron_spawned"
 
     set +e
@@ -1062,7 +1259,18 @@ clear_stale_pid_file
 detect_warm_start
 trap cleanup_launcher EXIT
 
-if [ "$WARM_START" -eq 0 ]; then
+if send_warm_start_launch_action "$@"; then
+    echo "Sent launch args over warm-start IPC"
+    log_phase "warm_start_ipc_sent"
+    exit 0
+elif [ "$WARM_START" -eq 1 ]; then
+    echo "Warm-start IPC unavailable; falling back to Electron second-instance handoff"
+fi
+
+if using_second_instance_handoff; then
+    echo "Detected running Codex Desktop pid=$RUNNING_APP_PID; using Electron second-instance handoff"
+    log_phase "second_instance_handoff_ready"
+elif needs_cold_start; then
     run_packaged_runtime_prelaunch
     log_phase "packaged_prelaunch"
     ensure_webview_server
@@ -1071,14 +1279,14 @@ else
     log_phase "warm_start_ready"
 fi
 
-if [ "$WARM_START" -eq 0 ] && [ -z "${CODEX_CLI_PATH:-}" ]; then
+if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then
     CODEX_CLI_PATH="$(find_codex_cli || true)"
     export CODEX_CLI_PATH
     log_phase "cli_lookup"
 fi
 export CHROME_DESKTOP="${CHROME_DESKTOP:-codex-desktop.desktop}"
 
-if [ "$WARM_START" -eq 0 ] && [ -z "$CODEX_CLI_PATH" ]; then
+if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then
     if prompt_install_missing_cli; then
         if ! run_cli_preflight 1; then
             notify_error "Codex CLI automatic installation failed. Install with: npm i -g @openai/codex or npm i -g --prefix ~/.local @openai/codex"
@@ -1087,12 +1295,12 @@ if [ "$WARM_START" -eq 0 ] && [ -z "$CODEX_CLI_PATH" ]; then
     fi
 fi
 
-if [ "$WARM_START" -eq 0 ] && [ -z "$CODEX_CLI_PATH" ]; then
+if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then
     notify_error "Codex CLI not found. Install with: npm i -g @openai/codex or npm i -g --prefix ~/.local @openai/codex"
     exit 1
 fi
 
-if [ "$WARM_START" -eq 0 ]; then
+if needs_cold_start; then
     if [ "${CODEX_SYNC_CLI_PREFLIGHT:-0}" = "1" ]; then
         run_cli_preflight 0
         log_phase "cli_preflight_sync"
@@ -1129,6 +1337,7 @@ main() {
 
     parse_args "$@"
     check_deps
+    assert_install_target_not_running
     prepare_install
 
     local dmg_path=""

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -24,6 +24,15 @@ function findIconAsset(extractedDir) {
   return readDirectoryNames(assetsDir).find((name) => /^app-.*\.png$/.test(name)) ?? null;
 }
 
+const keybindsSettingsAsset = "keybinds-settings-linux.js";
+const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
+
+const linuxSettingsKeys = {
+  promptWindow: "codex-linux-prompt-window-enabled",
+  systemTray: "codex-linux-system-tray-enabled",
+  warmStart: "codex-linux-warm-start-enabled",
+};
+
 function patchAssetFiles(extractedDir, filenamePattern, patchFn, missingWarnMessage) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -51,6 +60,388 @@ function patchAssetFiles(extractedDir, filenamePattern, patchFn, missingWarnMess
       fs.writeFileSync(filePath, patchedSource, "utf8");
     }
   }
+}
+
+function readWebviewAsset(webviewAssetsDir, assetName) {
+  return fs.readFileSync(path.join(webviewAssetsDir, assetName), "utf8");
+}
+
+function findRequiredWebviewAsset(webviewAssetsDir, filenamePattern, marker, description) {
+  if (!fs.existsSync(webviewAssetsDir)) {
+    throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => filenamePattern.test(name))
+    .sort();
+  const matches = marker == null
+    ? candidates
+    : candidates.filter((name) => readWebviewAsset(webviewAssetsDir, name).includes(marker));
+
+  if (matches.length === 0) {
+    throw new Error(`Required Keybinds settings patch failed: could not find ${description}`);
+  }
+
+  return matches[0];
+}
+
+function findImportedAsset(webviewAssetsDir, importerAsset, description) {
+  const importedAsset = readWebviewAsset(webviewAssetsDir, importerAsset).match(/from"\.\/([^"]+)"/)?.[1];
+  if (!importedAsset || !fs.existsSync(path.join(webviewAssetsDir, importedAsset))) {
+    throw new Error(`Required Keybinds settings patch failed: could not find ${description}`);
+  }
+  return importedAsset;
+}
+
+function buildKeybindsSettingsSource({
+  chunkAsset,
+  reactAsset,
+  jsxRuntimeAsset,
+  vscodeApiAsset,
+  hotkeySettingsAsset,
+  toggleAsset,
+  settingsRowAsset,
+  settingsLayoutAsset,
+}) {
+  const keybindGroups = [
+    {
+      title: "Core",
+      actions: [
+        { id: "newThread", label: "New chat", description: "Start a new chat." },
+        { id: "quickChat", label: "Quick chat", description: "Open a quick chat window." },
+        { id: "newThreadAlt", label: "New chat alternate", description: "Alternate shortcut for a new chat." },
+        { id: "openFolder", label: "Open folder", description: "Open a workspace folder." },
+        { id: "settings", label: "Settings", description: "Open settings." },
+        { id: "openCommandMenu", label: "Command menu", description: "Open the command menu." },
+        { id: "openCommandMenuAlt", label: "Command menu alternate", description: "Alternate shortcut for the command menu." },
+        { id: "searchChats", label: "Search chats", description: "Search existing chats." },
+        { id: "searchFiles", label: "Search files", description: "Search files in the current workspace." },
+        { id: "newWindow", label: "New window", description: "Open a new app window." },
+      ],
+    },
+    {
+      title: "Thread",
+      actions: [
+        { id: "findInThread", label: "Find in thread", description: "Search inside the current thread." },
+        { id: "copyConversationPath", label: "Copy conversation path", description: "Copy the current conversation path." },
+        { id: "toggleThreadPin", label: "Toggle thread pin", description: "Pin or unpin the current thread." },
+        { id: "renameThread", label: "Rename thread", description: "Rename the current thread." },
+        { id: "archiveThread", label: "Archive thread", description: "Archive the current thread." },
+        { id: "copyWorkingDirectory", label: "Copy working directory", description: "Copy the current working directory." },
+        { id: "copySessionId", label: "Copy session ID", description: "Copy the current session ID." },
+        { id: "copyDeeplink", label: "Copy deeplink", description: "Copy a deeplink for the current thread." },
+        { id: "previousThread", label: "Previous thread", description: "Move to the previous thread." },
+        { id: "nextThread", label: "Next thread", description: "Move to the next thread." },
+        { id: "thread1", label: "Thread 1", description: "Jump to thread slot 1." },
+        { id: "thread2", label: "Thread 2", description: "Jump to thread slot 2." },
+        { id: "thread3", label: "Thread 3", description: "Jump to thread slot 3." },
+        { id: "thread4", label: "Thread 4", description: "Jump to thread slot 4." },
+        { id: "thread5", label: "Thread 5", description: "Jump to thread slot 5." },
+        { id: "thread6", label: "Thread 6", description: "Jump to thread slot 6." },
+        { id: "thread7", label: "Thread 7", description: "Jump to thread slot 7." },
+        { id: "thread8", label: "Thread 8", description: "Jump to thread slot 8." },
+        { id: "thread9", label: "Thread 9", description: "Jump to thread slot 9." },
+      ],
+    },
+    {
+      title: "Panels",
+      actions: [
+        { id: "toggleSidebar", label: "Toggle sidebar", description: "Show or hide the sidebar." },
+        { id: "toggleTerminal", label: "Toggle terminal", description: "Show or hide the terminal." },
+        { id: "toggleFileTreePanel", label: "Toggle file tree", description: "Show or hide the file tree." },
+        { id: "openBrowserTab", label: "Open browser tab", description: "Open a browser tab." },
+        { id: "reloadBrowserPage", label: "Reload browser page", description: "Reload the active browser page." },
+        { id: "hardReloadBrowserPage", label: "Hard reload browser page", description: "Hard reload the active browser page." },
+        { id: "toggleBrowserPanel", label: "Toggle browser panel", description: "Show or hide the browser panel." },
+        { id: "toggleDiffPanel", label: "Toggle review panel", description: "Show or hide the review panel." },
+        { id: "openThreadOverlay", label: "Open thread switcher", description: "Open the thread switcher." },
+        { id: "openAvatarOverlay", label: "Open account menu", description: "Open the account menu." },
+      ],
+    },
+    {
+      title: "System",
+      actions: [
+        { id: "toggleTraceRecording", label: "Toggle trace recording", description: "Start or stop trace recording." },
+        { id: "dictation", label: "Dictation", description: "Start dictation." },
+      ],
+    },
+  ];
+
+  return `import{s as __toESM}from"./${chunkAsset}";import{t as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";import{n as __post,rn as DEFAULT_SHORTCUTS}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{r as SettingsSection,n as SettingsGroup,t as SettingsPage}from"./${settingsLayoutAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
+}
+
+function resolveKeybindsSettingsAsset(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
+  }
+
+  const reactAsset = findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
+  const chunkAsset = findImportedAsset(webviewAssetsDir, reactAsset, "React shared chunk asset");
+  const jsxRuntimeAsset = findRequiredWebviewAsset(webviewAssetsDir, /^jsx-runtime-.*\.js$/, "react.transitional.element", "JSX runtime asset");
+  const vscodeApiAsset = findRequiredWebviewAsset(webviewAssetsDir, /^vscode-api-.*\.js$/, "vscode://codex", "VS Code API asset");
+  const hotkeySettingsAsset = findRequiredWebviewAsset(
+    webviewAssetsDir,
+    /^general-settings-.*\.js$/,
+    "hotkey-window-hotkey-state",
+    "hotkey settings asset",
+  );
+  const toggleAsset = findRequiredWebviewAsset(webviewAssetsDir, /^toggle-.*\.js$/, null, "toggle asset");
+  const settingsRowAsset = findRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset");
+  const settingsLayoutAsset = findRequiredWebviewAsset(
+    webviewAssetsDir,
+    /^settings-content-layout-.*\.js$/,
+    null,
+    "settings content layout asset",
+  );
+  const filePath = path.join(webviewAssetsDir, keybindsSettingsAsset);
+
+  return {
+    filePath,
+    source: buildKeybindsSettingsSource({
+      chunkAsset,
+      reactAsset,
+      jsxRuntimeAsset,
+      vscodeApiAsset,
+      hotkeySettingsAsset,
+      toggleAsset,
+      settingsRowAsset,
+      settingsLayoutAsset,
+    }),
+  };
+}
+
+function collectRequiredAssetPatches(extractedDir, filenamePattern, patchFn, description) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => filenamePattern.test(name))
+    .sort();
+  if (candidates.length === 0) {
+    throw new Error(`Required Keybinds settings patch failed: could not find ${description}`);
+  }
+
+  return candidates.map((candidate) => {
+    const filePath = path.join(webviewAssetsDir, candidate);
+    const currentSource = fs.readFileSync(filePath, "utf8");
+    return {
+      filePath,
+      currentSource,
+      patchedSource: patchFn(currentSource),
+    };
+  });
+}
+
+function patchKeybindsSettingsAssets(extractedDir) {
+  try {
+    const keybindsAsset = resolveKeybindsSettingsAsset(extractedDir);
+    const patches = [
+      ...collectRequiredAssetPatches(
+        extractedDir,
+        /^settings-sections-.*\.js$/,
+        applyKeybindsSettingsSectionsPatch,
+        "settings sections bundle",
+      ),
+      ...collectRequiredAssetPatches(
+        extractedDir,
+        /^settings-shared-.*\.js$/,
+        applyKeybindsSettingsSharedPatch,
+        "settings shared bundle",
+      ),
+      ...collectRequiredAssetPatches(
+        extractedDir,
+        /^index-.*\.js$/,
+        applyKeybindsSettingsIndexPatch,
+        "webview index bundle",
+      ),
+    ];
+
+    fs.writeFileSync(keybindsAsset.filePath, keybindsAsset.source, "utf8");
+    for (const patch of patches) {
+      if (patch.patchedSource !== patch.currentSource) {
+        fs.writeFileSync(patch.filePath, patch.patchedSource, "utf8");
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`WARN: Keybinds settings patch skipped: ${message}`);
+  }
+}
+
+function applyKeybindsSettingsSectionsPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (patchedSource.includes("slug:`keybinds`")) {
+    return patchedSource;
+  }
+
+  const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
+  const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`keybinds`},";
+  if (patchedSource.includes(sectionsNeedle)) {
+    return patchedSource.replace(sectionsNeedle, sectionsPatch);
+  }
+
+  const currentNeedle = "n=[{slug:e},{slug:`appearance`}";
+  if (patchedSource.includes(currentNeedle)) {
+    return patchedSource.replace(currentNeedle, "n=[{slug:e},{slug:`keybinds`},{slug:`appearance`}");
+  }
+
+  const literalNeedle = "n=[{slug:`general-settings`},{slug:`appearance`}";
+  if (patchedSource.includes(literalNeedle)) {
+    return patchedSource.replace(literalNeedle, "n=[{slug:`general-settings`},{slug:`keybinds`},{slug:`appearance`}");
+  }
+
+  throw new Error("Required Keybinds settings patch failed: could not add keybinds settings section");
+}
+
+function applyKeybindsSettingsSharedPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!patchedSource.includes("settings.nav.keybinds")) {
+    const navNeedle =
+      '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},';
+    const navPatch =
+      '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},keybinds:{id:`settings.nav.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`},';
+    if (!patchedSource.includes(navNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds nav label");
+    }
+    patchedSource = patchedSource.replace(navNeedle, navPatch);
+  }
+
+  if (!patchedSource.includes("settings.section.keybinds")) {
+    const sectionNeedle =
+      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}";
+    const sectionPatch =
+      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`keybinds`:{return (0,d.jsx)(n,{id:`settings.section.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`})}";
+    if (!patchedSource.includes(sectionNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds section title");
+    }
+    patchedSource = patchedSource.replace(sectionNeedle, sectionPatch);
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxKeybindOverridesRuntimePatch(currentSource) {
+  const runtimePatch = `;function codexLinuxKeybindOverridesRuntime(){try{if(typeof window=="undefined")return;let storageKey=${JSON.stringify(linuxKeybindOverridesKey)},defaultMap=typeof Ct=="object"&&Ct?Ct:{},overrides={};function loadOverrides(){try{let value=JSON.parse(localStorage.getItem(storageKey)||"{}");overrides=value&&typeof value=="object"&&!Array.isArray(value)?value:{}}catch{overrides={}}}function isShortcutCaptureTarget(event){let target=event.target;return target instanceof Element&&target.closest("[data-codex-keybind-input]")!=null}function normalizeKeyName(key){let map={Space:" ",Esc:"Escape",Up:"ArrowUp",Down:"ArrowDown",Left:"ArrowLeft",Right:"ArrowRight",Plus:"+",Comma:",",Period:".",Slash:"/"};return map[key]??(/^.$/.test(key)?key.toUpperCase():key)}function parseAccelerator(accelerator){if(typeof accelerator!="string"||accelerator.trim().length===0)return null;let isMac=/Mac/.test(navigator.platform||""),parts=accelerator.split("+").map(part=>part.trim()).filter(Boolean),parsed={ctrl:false,alt:false,shift:false,meta:false,key:null};for(let part of parts){switch(part){case"CmdOrCtrl":isMac?parsed.meta=true:parsed.ctrl=true;break;case"Command":case"Cmd":case"Meta":case"Super":case"Win":parsed.meta=true;break;case"Control":case"Ctrl":parsed.ctrl=true;break;case"Alt":case"Option":parsed.alt=true;break;case"Shift":parsed.shift=true;break;default:parsed.key=normalizeKeyName(part);break}}return parsed.key?parsed:null}function matches(event,parsed){return event.ctrlKey===parsed.ctrl&&event.altKey===parsed.alt&&event.shiftKey===parsed.shift&&event.metaKey===parsed.meta&&normalizeKeyName(event.key)===parsed.key}function dispatchHost(message){if(typeof E=="object"&&E&&typeof E.dispatchHostMessage=="function"){E.dispatchHostMessage(message);return true}return false}function dispatchElectron(type,params={}){if(typeof E=="object"&&E&&typeof E.dispatchMessage=="function"){E.dispatchMessage(type,params);return true}return false}let hostActionTypes={newThread:"new-chat",quickChat:"new-quick-chat",newThreadAlt:"new-chat",toggleSidebar:"toggle-sidebar",toggleTerminal:"toggle-terminal",toggleBrowserPanel:"toggle-browser-panel",toggleDiffPanel:"toggle-diff-panel",findInThread:"find-in-thread",navigateBack:"navigate-back",navigateForward:"navigate-forward",previousThread:"previous-thread",nextThread:"next-thread",copyConversationPath:"copy-conversation-path",toggleThreadPin:"toggle-thread-pin",renameThread:"rename-thread",archiveThread:"archive-thread",copyWorkingDirectory:"copy-working-directory",copySessionId:"copy-session-id",copyDeeplink:"copy-deeplink",toggleFileTreePanel:"toggle-file-tree-panel"};function runAction(id){if(/^thread[1-9]$/.test(id))return dispatchHost({type:"go-to-thread-index",index:Number(id.slice(6))-1});switch(id){case"openCommandMenu":case"openCommandMenuAlt":return dispatchHost({type:"command-menu",query:""});case"searchChats":return dispatchHost({type:"chat-search-command-menu"});case"searchFiles":return dispatchHost({type:"file-search-command-menu"});case"openFolder":return dispatchElectron("electron-create-new-workspace-root-option",{});case"settings":return dispatchElectron("show-settings",{section:"general-settings"});case"openBrowserTab":return dispatchHost({type:"browser-sidebar-command",command:{type:"new-tab"}});case"reloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"reload"}});case"hardReloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"hard-reload"}});case"dictation":return dispatchElectron("global-dictation-start",{});default:return hostActionTypes[id]?dispatchHost({type:hostActionTypes[id]}):false}}loadOverrides();window.addEventListener("storage",event=>{event.key===storageKey&&loadOverrides()});window.addEventListener("codex-linux-keybind-overrides-changed",loadOverrides);window.addEventListener("keydown",event=>{if(event.defaultPrevented||event.repeat||isShortcutCaptureTarget(event))return;for(let[id,accelerator]of Object.entries(overrides)){if(typeof accelerator!="string"||accelerator.trim().length===0||accelerator.trim()===(defaultMap[id]||""))continue;let parsed=parseAccelerator(accelerator);if(parsed&&matches(event,parsed)&&runAction(id)){event.preventDefault();event.stopPropagation();break}}},true)}catch{}}codexLinuxKeybindOverridesRuntime();`;
+
+  const runtimeMarker = ";function codexLinuxKeybindOverridesRuntime()";
+  const existingRuntimeIndex = currentSource.indexOf(runtimeMarker);
+  if (existingRuntimeIndex !== -1) {
+    return `${currentSource.slice(0, existingRuntimeIndex).trimEnd()}\n${runtimePatch}`;
+  }
+
+  return `${currentSource}\n${runtimePatch}`;
+}
+
+function applyKeybindsSettingsIndexPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (
+    !patchedSource.includes("var c_e=") &&
+    !patchedSource.includes("Xge=") &&
+    !patchedSource.includes("Zge=")
+  ) {
+    return patchedSource;
+  }
+
+  if (!patchedSource.includes(`${keybindsSettingsAsset}`)) {
+    const routeNeedle = 'var c_e={"general-settings":';
+    const routePatch = `var c_e={keybinds:(0,Z.lazy)(()=>s(()=>import(\`./${keybindsSettingsAsset}\`),[],import.meta.url)),"general-settings":`;
+    if (!patchedSource.includes(routeNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds route");
+    }
+    patchedSource = patchedSource.replace(routeNeedle, routePatch);
+  }
+
+  if (!patchedSource.includes("keybinds:xh")) {
+    const iconNeedle = 'Xge={"general-settings":xh,';
+    const iconPatch = 'Xge={keybinds:xh,"general-settings":xh,';
+    if (!patchedSource.includes(iconNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds icon");
+    }
+    patchedSource = patchedSource.replace(iconNeedle, iconPatch);
+  }
+
+  if (!patchedSource.includes("Zge=[`general-settings`,`keybinds`")) {
+    const orderNeedle = "Zge=[`general-settings`,`appearance`";
+    const orderPatch = "Zge=[`general-settings`,`keybinds`,`appearance`";
+    if (!patchedSource.includes(orderNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds nav order");
+    }
+    patchedSource = patchedSource.replace(orderNeedle, orderPatch);
+  }
+
+  if (!patchedSource.includes("slugs:[`general-settings`,`keybinds`")) {
+    const groupNeedle = "slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]";
+    const groupPatch = "slugs:[`general-settings`,`keybinds`,`appearance`,`connections`,`git-settings`,`usage`]";
+    if (!patchedSource.includes(groupNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds nav group");
+    }
+    patchedSource = patchedSource.replace(groupNeedle, groupPatch);
+  }
+
+  if (!patchedSource.includes("case`keybinds`:return l===`electron`")) {
+    const visibilityNeedle =
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;";
+    const visibilityPatch =
+      "case`keybinds`:return l===`electron`;case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;";
+    if (!patchedSource.includes(visibilityNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add keybinds visibility");
+    }
+    patchedSource = patchedSource.replace(visibilityNeedle, visibilityPatch);
+  }
+
+  if (!patchedSource.includes("case`keybinds`:k=!1;break bb0;")) {
+    const redirectNeedle =
+      "case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;";
+    const redirectPatch =
+      "case`keybinds`:k=!1;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;";
+    if (patchedSource.includes(redirectNeedle)) {
+      patchedSource = patchedSource.replace(redirectNeedle, redirectPatch);
+    }
+  }
+
+  return applyLinuxKeybindOverridesRuntimePatch(patchedSource);
+}
+
+function applyLinuxSettingsPersistencePatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (
+    !patchedSource.includes('"set-global-state"') &&
+    !patchedSource.includes("var Yb=`.codex-global-state.json`;")
+  ) {
+    return patchedSource;
+  }
+
+  if (!patchedSource.includes("function codexLinuxPersistSettingsState(")) {
+    const stateFileNeedle = "var Yb=`.codex-global-state.json`;";
+    const stateFilePatch =
+      `var Yb=\`.codex-global-state.json\`;function codexLinuxSettingsPath(){let e=process.env.XDG_CONFIG_HOME||process.env.HOME&&i.join(process.env.HOME,\`.config\`);return e?i.join(e,\`codex-desktop\`,\`settings.json\`):null}function codexLinuxReadSettingsFile(){let e=codexLinuxSettingsPath();if(!e||!o.existsSync(e))return{};try{let t=o.readFileSync(e,\`utf8\`),n=JSON.parse(t);return n&&typeof n===\`object\`&&!Array.isArray(n)?n:{}}catch(e){return{}}}function codexLinuxPersistSettingsState(e,t){if(process.platform!==\`linux\`||![${Object.values(linuxSettingsKeys).map((key) => `\`${key}\``).join(",")}].includes(e))return;try{let n=codexLinuxSettingsPath();if(!n)return;let r=codexLinuxReadSettingsFile();t===void 0?delete r[e]:r[e]=t,o.mkdirSync(i.dirname(n),{recursive:!0,mode:448}),o.writeFileSync(n,JSON.stringify(r,null,2)+\`\\n\`,\`utf8\`)}catch(e){}}`;
+    if (!patchedSource.includes(stateFileNeedle)) {
+      throw new Error("Required Linux settings patch failed: could not add settings persistence helpers");
+    }
+    patchedSource = patchedSource.replace(stateFileNeedle, stateFilePatch);
+  }
+
+  const setGlobalStateNeedle =
+    '"set-global-state":async({key:t,value:n,origin:r})=>(this.globalState.set(t,n),t===e.Tt.REMOTE_PROJECTS&&r.send(H,{type:`workspace-root-options-updated`}),{success:!0})';
+  const setGlobalStatePatch =
+    '"set-global-state":async({key:t,value:n,origin:r})=>(this.globalState.set(t,n),codexLinuxPersistSettingsState(t,n),t===e.Tt.REMOTE_PROJECTS&&r.send(H,{type:`workspace-root-options-updated`}),{success:!0})';
+  if (patchedSource.includes(setGlobalStatePatch)) {
+    return patchedSource;
+  }
+  if (!patchedSource.includes(setGlobalStateNeedle)) {
+    throw new Error("Required Linux settings patch failed: could not synchronize launcher settings");
+  }
+
+  return patchedSource.replace(setGlobalStateNeedle, setGlobalStatePatch);
 }
 
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
@@ -421,9 +812,12 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   }
 
   const trayStartupNeedle = "E&&oe();";
-  const trayStartupPatch = "(E||process.platform===`linux`)&&oe();";
+  const previousTrayStartupPatch = "(E||process.platform===`linux`)&&oe();";
+  const trayStartupPatch = "(E||process.platform===`linux`&&codexLinuxIsTrayEnabled())&&oe();";
   if (patchedSource.includes(trayStartupPatch)) {
     // Already patched.
+  } else if (patchedSource.includes(previousTrayStartupPatch)) {
+    patchedSource = patchedSource.replace(previousTrayStartupPatch, trayStartupPatch);
   } else if (patchedSource.includes(trayStartupNeedle)) {
     patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
   } else {
@@ -493,6 +887,155 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxTrayCloseSettingPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const closeGateNeedle = "canHideLastLocalWindowToTray:()=>O,disposables:k";
+  const closeGatePatch =
+    `canHideLastLocalWindowToTray:()=>O&&(process.platform!==\`linux\`||M.globalState.get(\`${linuxSettingsKeys.systemTray}\`)!==!1),disposables:k`;
+
+  if (patchedSource.includes(closeGatePatch)) {
+    return patchedSource;
+  }
+
+  if (patchedSource.includes(closeGateNeedle)) {
+    return patchedSource.replace(closeGateNeedle, closeGatePatch);
+  }
+
+  if (patchedSource.includes("canHideLastLocalWindowToTray") && patchedSource.includes("Launching app")) {
+    throw new Error("Required Linux tray settings patch failed: could not gate close-to-tray behavior");
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxLaunchActionArgsPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const launchActionNeedle =
+    "let codexLinuxSecondInstanceHandler=(e,t)=>{R.deepLinks.queueProcessArgs(t)||ie()};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},oe=async()=>{";
+  const oldLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHandleLaunchActionArgs=async e=>Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{R.deepLinks.queueProcessArgs(t)||ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{R.deepLinks.queueProcessArgs(e)||ie()})});let oe=async()=>{";
+  const deepLinkFirstLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHandleLaunchActionArgs=async e=>Array.isArray(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const deepLinkAwareExistingWindowLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===`string`&&(e.startsWith(`codex://`)||e.startsWith(`codex-browser-sidebar://`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const openHomeHotkeyWindowLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxShowHotkeyWindow=async()=>{let e=P.hotkeyWindowLifecycleManager;typeof e.openHome===`function`?await e.openHome():typeof e.show===`function`?await e.show():await P.ensureHostWindow(z)},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===`string`&&(e.startsWith(`codex://`)||e.startsWith(`codex-browser-sidebar://`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&(e.includes(`--prompt-chat`)||e.includes(`--hotkey-window`))?(await codexLinuxShowHotkeyWindow(),!0):Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const socketHotkeyWindowLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxShowHotkeyWindow=async()=>{let e=P.hotkeyWindowLifecycleManager;typeof e.openHome===`function`?await e.openHome():typeof e.show===`function`?await e.show():await P.ensureHostWindow(z)},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===`string`&&(e.startsWith(`codex://`)||e.startsWith(`codex-browser-sidebar://`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&(e.includes(`--prompt-chat`)||e.includes(`--hotkey-window`))?(await codexLinuxShowHotkeyWindow(),!0):Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxStartLaunchActionSocket=()=>{let e=process.env.CODEX_DESKTOP_LAUNCH_ACTION_SOCKET?.trim();if(process.platform!==`linux`||!e)return;try{o.mkdirSync(i.default.dirname(e),{recursive:!0,mode:448}),o.rmSync(e,{force:!0});let t=u.default.createServer(t=>{let n=``,r=!1,i=()=>{if(r)return;r=!0;let i=[];try{let e=JSON.parse(n.trim());Array.isArray(e.argv)&&(i=e.argv.filter(e=>typeof e===`string`))}catch(e){t.end?.(`error\\n`);return}codexLinuxHandleLaunchActionArgs(i).then(e=>e?void 0:ie()).then(()=>{t.end?.(`ok\\n`)}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action socket`,{kind:`linux-launch-action-socket-failed`}),t.end?.(`error\\n`)})};t.setEncoding?.(`utf8`),t.on(`data`,e=>{n+=e,n.includes(`\\n`)?i():n.length>65536&&t.destroy()}),t.on(`end`,i)});t.on(`error`,e=>{g.reportNonFatal(e instanceof Error?e:`Failed Linux launch action socket`,{kind:`linux-launch-action-socket-error`})}),t.listen(e),k.add(()=>{t.close(),o.rmSync(e,{force:!0})})}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to start Linux launch action socket`,{kind:`linux-launch-action-socket-start-failed`})}},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(codexLinuxStartLaunchActionSocket(),n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const hotkeyWindowLaunchActionPatch = socketHotkeyWindowLaunchActionPatch
+    .replace(
+      "let ae=async(e,t)=>{",
+      `let codexLinuxGetSetting=e=>process.platform!==\`linux\`||M.globalState.get(e)!==!1,codexLinuxIsTrayEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.systemTray}\`),codexLinuxIsWarmStartEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.warmStart}\`),codexLinuxIsPromptWindowEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.promptWindow}\`),ae=async(e,t)=>{`,
+    )
+    .replace(
+      "codexLinuxShowHotkeyWindow=async()=>{let e=P.hotkeyWindowLifecycleManager;typeof e.openHome===`function`?await e.openHome():typeof e.show===`function`?await e.show():await P.ensureHostWindow(z)}",
+      "codexLinuxGetHotkeyWindowController=()=>typeof P.hotkeyWindowLifecycleManager.ensureHotkeyWindowController===`function`?P.hotkeyWindowLifecycleManager.ensureHotkeyWindowController():P.hotkeyWindowLifecycleManager,codexLinuxShowHotkeyWindow=async()=>{let e=codexLinuxGetHotkeyWindowController();typeof e.openHome===`function`?await e.openHome():typeof e.show===`function`?await e.show():await P.ensureHostWindow(z)}",
+    )
+    .replace(
+      "Array.isArray(e)&&(e.includes(`--prompt-chat`)||e.includes(`--hotkey-window`))?(await codexLinuxShowHotkeyWindow(),!0)",
+      "Array.isArray(e)&&(e.includes(`--prompt-chat`)||e.includes(`--hotkey-window`))?(codexLinuxIsPromptWindowEnabled()?(await codexLinuxShowHotkeyWindow(),!0):!1)",
+    )
+    .replace(
+      "if(process.platform!==`linux`||!e)return;",
+      "if(process.platform!==`linux`||!e||!codexLinuxIsWarmStartEnabled())return;",
+    )
+    .replace(
+      "codexLinuxStartLaunchActionSocket=()=>{",
+      "codexLinuxPrewarmHotkeyWindow=()=>{try{let e=codexLinuxGetHotkeyWindowController();typeof e.prewarm===`function`&&e.prewarm()}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to prewarm Linux hotkey window`,{kind:`linux-hotkey-window-prewarm-failed`})}},codexLinuxStartLaunchActionSocket=()=>{",
+    )
+    .replace(
+      "codexLinuxPrewarmHotkeyWindow=()=>{try{",
+      "codexLinuxPrewarmHotkeyWindow=()=>{if(!codexLinuxIsPromptWindowEnabled())return;try{",
+    );
+  const showBasedHotkeyWindowLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxShowHotkeyWindow=async()=>{P.hotkeyWindowLifecycleManager.show()||await P.ensureHostWindow(z)},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(z),t=e??await P.createFreshLocalWindow(`/`);t!=null&&(P.windowManager.sendMessageToWindow(t,{type:`new-quick-chat`}),re(t))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===`string`&&(e.startsWith(`codex://`)||e.startsWith(`codex-browser-sidebar://`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&(e.includes(`--prompt-chat`)||e.includes(`--hotkey-window`))?(await codexLinuxShowHotkeyWindow(),!0):Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await ae(`/`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const freshWindowLaunchActionPatch =
+    "let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},codexLinuxOpenNewChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=await P.createFreshLocalWindow(`/`);e!=null&&re(e)},codexLinuxOpenQuickChat=async()=>{P.hotkeyWindowLifecycleManager.hide();let e=await P.createFreshLocalWindow(`/`);e!=null&&(P.windowManager.sendMessageToWindow(e,{type:`new-quick-chat`}),re(e))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===`string`&&(e.startsWith(`codex://`)||e.startsWith(`codex-browser-sidebar://`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&R.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&e.includes(`--quick-chat`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(`--new-chat`)?(await codexLinuxOpenNewChat(),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{g.reportNonFatal(e instanceof Error?e:`Failed to handle Linux launch action`,{kind:`linux-launch-action-failed`}),t()})},codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{ie()})};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{ie()})});let oe=async()=>{";
+  const launchActionPatch =
+    hotkeyWindowLaunchActionPatch;
+
+  if (
+    patchedSource.includes("codexLinuxGetSetting=e=>") &&
+    patchedSource.includes("codexLinuxGetHotkeyWindowController=()=>") &&
+    patchedSource.includes("codexLinuxPrewarmHotkeyWindow=()=>") &&
+    patchedSource.includes("codexLinuxStartLaunchActionSocket=()=>") &&
+    !patchedSource.includes("codexLinuxOpenNewChat")
+  ) {
+    return patchedSource;
+  }
+
+  if (patchedSource.includes(oldLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(oldLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(deepLinkFirstLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(deepLinkFirstLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(deepLinkAwareExistingWindowLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(deepLinkAwareExistingWindowLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(openHomeHotkeyWindowLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(openHomeHotkeyWindowLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(socketHotkeyWindowLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(socketHotkeyWindowLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(showBasedHotkeyWindowLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(showBasedHotkeyWindowLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(freshWindowLaunchActionPatch)) {
+    patchedSource = patchedSource.replace(freshWindowLaunchActionPatch, launchActionPatch);
+  } else if (patchedSource.includes(launchActionNeedle)) {
+    patchedSource = patchedSource.replace(launchActionNeedle, launchActionPatch);
+  } else {
+    const existingLinuxLaunchActionBlock = patchedSource.match(
+      /let ae=async\(e,t\)=>\{P\.hotkeyWindowLifecycleManager\.hide\(\);.*?;let oe=async\(\)=>\{/,
+    )?.[0];
+    if (existingLinuxLaunchActionBlock?.includes("codexLinuxHandleLaunchActionArgs")) {
+      patchedSource = patchedSource.replace(existingLinuxLaunchActionBlock, launchActionPatch);
+    } else if (
+      patchedSource.includes("Launching app") &&
+      patchedSource.includes("deepLinks")
+    ) {
+      throw new Error("Required Linux launch action patch failed: could not add --new-chat/--quick-chat/--prompt-chat handlers");
+    } else {
+      console.warn("WARN: Could not find Linux launch action handler - skipping --new-chat/--quick-chat/--prompt-chat patch");
+    }
+  }
+
+  if (patchedSource.includes("Launching app") && !patchedSource.includes("codexLinuxGetSetting=e=>")) {
+    throw new Error("Required Linux launch action patch failed: launch flags were not settings-gated");
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxHotkeyWindowPrewarmPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!patchedSource.includes("codexLinuxPrewarmHotkeyWindow=()=>")) {
+    return patchedSource;
+  }
+
+  const startupPrewarmPatch =
+    "process.platform===`linux`&&codexLinuxPrewarmHotkeyWindow(),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()";
+
+  if (patchedSource.includes(startupPrewarmPatch)) {
+    return patchedSource;
+  }
+
+  const startupPrewarmNeedle =
+    "w(`local window ensured`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()";
+
+  if (patchedSource.includes(startupPrewarmNeedle)) {
+    patchedSource = patchedSource.replace(startupPrewarmNeedle, `w(\`local window ensured\`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),${startupPrewarmPatch}`);
+  } else if (
+    patchedSource.includes("process.platform===`linux`&&codexLinuxPrewarmHotkeyWindow(),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()")
+  ) {
+    // Already patched by an older run.
+  } else {
+    console.warn("WARN: Could not find Linux hotkey window prewarm insertion point — skipping startup prewarm patch");
+  }
+
+  return patchedSource;
+}
+
+
 function patchMainBundleSource(source, iconAsset) {
   let patched = source;
   const iconPathExpression =
@@ -504,6 +1047,10 @@ function patchMainBundleSource(source, iconAsset) {
   patched = applyLinuxFileManagerPatch(patched);
   patched = applyLinuxTrayPatch(patched, iconPathExpression);
   patched = applyLinuxSingleInstancePatch(patched);
+  patched = applyLinuxTrayCloseSettingPatch(patched);
+  patched = applyLinuxSettingsPersistencePatch(patched);
+  patched = applyLinuxLaunchActionArgsPatch(patched);
+  patched = applyLinuxHotkeyWindowPrewarmPatch(patched);
   return patched;
 }
 
@@ -603,6 +1150,7 @@ function patchExtractedApp(extractedDir) {
       "assets",
     )} — skipping translucent sidebar default patch`,
   );
+  patchKeybindsSettingsAssets(extractedDir);
 
   const desktopName = patchPackageJson(extractedDir);
   console.log("Patched Linux window, shell, and appearance behavior:", {
@@ -630,15 +1178,24 @@ if (require.main === module) {
 
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
+  applyKeybindsSettingsIndexPatch,
+  applyKeybindsSettingsSectionsPatch,
+  applyKeybindsSettingsSharedPatch,
   applyLinuxFileManagerPatch,
+  applyLinuxHotkeyWindowPrewarmPatch,
+  applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSetIconPatch,
   applyLinuxSingleInstancePatch,
+  applyLinuxSettingsPersistencePatch,
+  applyLinuxTrayCloseSettingPatch,
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
   patchCommentPreloadBundle,
+  patchKeybindsSettingsAssets,
   patchExtractedApp,
   patchMainBundleSource,
+  resolveKeybindsSettingsAsset,
 };

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -133,7 +133,7 @@ test("adds Linux tray support including the platform guard", () => {
     /process\.platform===`linux`&&this\.setLinuxTrayContextMenu\(\),this\.tray\.on\(`click`/,
   );
   assert.match(patched, /if\(process\.platform===`linux`\)return;e\.once\(`menu-will-show`/);
-  assert.match(patched, /\(E\|\|process\.platform===`linux`\)&&oe\(\);/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&oe\(\);/);
 });
 
 test("adds Linux single-instance lock and second-instance handoff", () => {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -290,6 +290,58 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/install.sh" "discover_webview_server_pid"
     assert_contains "$REPO_DIR/install.sh" "Adopted existing webview server"
     assert_contains "$REPO_DIR/install.sh" "detect_warm_start"
+    assert_contains "$REPO_DIR/install.sh" "send_warm_start_launch_action"
+    assert_contains "$REPO_DIR/install.sh" "CODEX_DESKTOP_LAUNCH_ACTION_SOCKET"
+    assert_contains "$REPO_DIR/install.sh" "APP_SETTINGS_FILE"
+    assert_contains "$REPO_DIR/install.sh" "linux_setting_enabled"
+    assert_contains "$REPO_DIR/install.sh" "codex-linux-warm-start-enabled"
+    assert_contains "$REPO_DIR/install.sh" "ADOPTED_WEBVIEW_PID"
+    assert_contains "$REPO_DIR/install.sh" "Reusing webview server pid="
+    python3 - "$REPO_DIR/install.sh" <<'PY'
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+detect_body = source.split("detect_warm_start() {", 1)[1].split("send_warm_start_launch_action() {", 1)[0]
+launch_body = source.split("launch_electron() {", 1)[1].split("load_packaged_runtime_helper", 1)[0]
+runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_electron", 1)[0]
+stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
+adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("ensure_webview_server() {", 1)[0]
+ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
+if 'if RUNNING_APP_PID="$(find_running_app_pid)"; then' not in detect_body:
+    raise SystemExit("detect_warm_start must record a running app even when warm start is disabled")
+if not re.search(r'if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then.*?return 0', detect_body, re.S):
+    raise SystemExit("detect_warm_start must not fail when warm start is disabled")
+if "preserving liveness marker for second-instance handoff" not in detect_body:
+    raise SystemExit("detect_warm_start must preserve the live app liveness marker")
+if 'pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"' not in launch_body:
+    raise SystemExit("launch_electron must not overwrite APP_PID_FILE for second-instance handoff")
+if 'echo "$ELECTRON_PID" > "$APP_PID_FILE"' not in launch_body:
+    raise SystemExit("launch_electron must still write APP_PID_FILE for normal cold launches")
+if "using_second_instance_handoff" not in source or "needs_cold_start" not in source:
+    raise SystemExit("launcher must have an explicit second-instance handoff mode")
+if "second_instance_handoff_ready" not in runtime_body:
+    raise SystemExit("second-instance handoff must skip cold-start setup")
+if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
+    raise SystemExit("second-instance handoff must skip CLI lookup")
+if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
+    raise SystemExit("second-instance handoff must skip missing-CLI failure")
+if "if needs_cold_start;" not in runtime_body:
+    raise SystemExit("second-instance handoff must skip CLI preflight")
+if "running_app_is_active" not in stop_body or "Preserving webview server" not in stop_body:
+    raise SystemExit("stop_owned_webview_server must not stop the live app webview server")
+if 'ADOPTED_WEBVIEW_PID="$pid"' not in adopt_body:
+    raise SystemExit("adopt_existing_webview_server must not mark a running app server as started by this launcher")
+if 'STARTED_WEBVIEW_PID="$pid"' not in adopt_body:
+    raise SystemExit("adopt_existing_webview_server must still own orphaned servers when no live app is running")
+if "running_app_is_active" not in adopt_body:
+    raise SystemExit("adopt_existing_webview_server must detect live-app reuse before cleanup")
+if "if adopt_existing_webview_server; then" not in ensure_body:
+    raise SystemExit("ensure_webview_server must split adoption from origin verification")
+if "Keeping the live app untouched" not in ensure_body:
+    raise SystemExit("ensure_webview_server must not stop a live app server when validation fails")
+PY
+    assert_contains "$REPO_DIR/install.sh" "warm_start_ipc_sent"
     assert_contains "$REPO_DIR/install.sh" "launcher_phase"
     assert_contains "$REPO_DIR/install.sh" "CODEX_SYNC_CLI_PREFLIGHT"
     assert_contains "$REPO_DIR/install.sh" "wait_for_webview_server"
@@ -300,6 +352,10 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/install.sh" "--ozone-platform-hint=auto"
     assert_contains "$REPO_DIR/install.sh" "--disable-gpu-sandbox"
     assert_contains "$REPO_DIR/install.sh" "PACKAGED_RUNTIME_HELPER"
+    assert_contains "$REPO_DIR/install.sh" "CODEX_INSTALL_ALLOW_RUNNING"
+    assert_contains "$REPO_DIR/install.sh" "assert_install_target_not_running"
+    assert_contains "$REPO_DIR/install.sh" "find_running_install_target_pid"
+    assert_contains "$REPO_DIR/install.sh" "Codex Desktop is currently running from"
     assert_contains "$REPO_DIR/install.sh" "prompt_install_missing_cli"
     assert_contains "$REPO_DIR/install.sh" "Install it now? \\[Y/n\\]"
     assert_contains "$REPO_DIR/install.sh" "is_interactive_terminal"
@@ -329,6 +385,14 @@ make_fake_extracted_asar() {
 
     mkdir -p "$root/webview/assets" "$root/.vite/build"
     printf 'png' > "$root/webview/assets/app-test.png"
+    printf 'export{s as t};\n' > "$root/webview/assets/chunk-test.js"
+    printf 'import{t as e}from"./chunk-test.js";Symbol.for(`react.transitional.element`);export{e as t};\n' > "$root/webview/assets/react-test.js"
+    printf 'import{t as e}from"./chunk-test.js";Symbol.for(`react.transitional.element`);export{e as t};\n' > "$root/webview/assets/jsx-runtime-test.js"
+    printf 'let marker=`vscode://codex`;async function n(){return{}}export{n};\n' > "$root/webview/assets/vscode-api-test.js"
+    printf 'let marker=`hotkey-window-hotkey-state`;function i(){}export{i};\n' > "$root/webview/assets/general-settings-hotkey-test.js"
+    printf 'function t(){}export{t};\n' > "$root/webview/assets/toggle-test.js"
+    printf 'function n(){}export{n};\n' > "$root/webview/assets/settings-row-test.js"
+    printf 'function r(){}function n(){}function t(){}export{r,n,t};\n' > "$root/webview/assets/settings-content-layout-test.js"
     if [ -n "$settings_body" ]; then
         printf '%s\n' "$settings_body" > "$root/webview/assets/general-settings-test.js"
     fi
@@ -429,7 +493,7 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate'
     assert_contains "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`'
     assert_contains "$extracted/.vite/build/main-test.js" 'this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.()'
-    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`)&&oe();'
+    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`&&codexLinuxIsTrayEnabled())&&oe();'
     assert_not_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)'
     assert_not_contains "$output_log" 'WARN: Could not find tray'
 
@@ -443,7 +507,162 @@ JS
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.setLinuxTrayContextMenu?.()' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&oe' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&codexLinuxIsTrayEnabled())&&oe' '1'
+}
+
+test_keybinds_settings_tab_patch_smoke() {
+    info "Checking Keybinds settings tab patch behavior"
+    local workspace="$TMP_DIR/keybinds-settings-patch"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let t={join(){}};let a={existsSync(){return true},statSync(){return {isFile(){return false}}}};let n={shell:{openPath(){return ""},showItemInFolder(){}}};...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
+
+    cat > "$extracted/webview/assets/settings-sections-test.js" <<'JS'
+var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`appearance`},{slug:`git-settings`},{slug:`connections`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:t},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}],r=t;export{n,t as r,e as t};
+JS
+    cat > "$extracted/webview/assets/settings-shared-test.js" <<'JS'
+import{t as d}from"./jsx-runtime-ebkFq_df.js";var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},appearance:{id:`settings.nav.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`appearance`:{let e;return t[1]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`}),t[1]=e):e=t[1],e}case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
+JS
+    cat > "$extracted/webview/assets/index-test.js" <<'JS'
+var Xge={"general-settings":xh,appearance:Pf,agent:gU},H7={},Zge=[`general-settings`,`appearance`,`agent`,`personalization`,`mcp-settings`,`connections`,`git-settings`,`local-environments`,`worktrees`,`browser-use`,`computer-use`,`data-controls`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];function n_e(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:case`agent`:case`personalization`:case`mcp-settings`:return!0}};if(O)bb0:switch(D.slug){case`usage`:k=g;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;}}function s_e(e){let{slug:n}=e,r=c_e[n];return (0,$.jsx)(r,{})}var c_e={"general-settings":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DZbwMmWz.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([4]),import.meta.url)),appearance:(0,Z.lazy)(()=>s(()=>import(`./appearance-settings-D4xYjo5o.js`).then(e=>({default:e.AppearanceSettings})),__vite__mapDeps([56]),import.meta.url)),agent:(0,Z.lazy)(()=>Promise.resolve({default:l_e}))};
+JS
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_file_exists "$extracted/webview/assets/keybinds-settings-linux.js"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "function KeybindsSettings"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "HotkeyWindowHotkeyRow"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "DEFAULT_SHORTCUTS"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-keybind-overrides"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "function ShortcutInput"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "data-codex-keybind-input"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "newThread"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "openFolder"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "toggleTerminal"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "toggleDiffPanel"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "thread9"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-system-tray-enabled"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-warm-start-enabled"
+    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-prompt-window-enabled"
+    assert_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`'
+    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.nav.keybinds"
+    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.section.keybinds"
+    assert_contains "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js"
+    assert_contains "$extracted/webview/assets/index-test.js" "keybinds:xh"
+    assert_contains "$extracted/webview/assets/index-test.js" 'Zge=\[`general-settings`,`keybinds`'
+    assert_contains "$extracted/webview/assets/index-test.js" 'slugs:\[`general-settings`,`keybinds`'
+    assert_contains "$extracted/webview/assets/index-test.js" 'case`keybinds`:return l===`electron`'
+    assert_contains "$extracted/webview/assets/index-test.js" "codexLinuxKeybindOverridesRuntime"
+    assert_contains "$extracted/webview/assets/index-test.js" "codex-linux-keybind-overrides"
+    assert_contains "$extracted/webview/assets/index-test.js" "go-to-thread-index"
+    assert_contains "$extracted/webview/assets/index-test.js" "newThreadAlt"
+    assert_contains "$extracted/webview/assets/index-test.js" "new-chat"
+    assert_contains "$extracted/webview/assets/index-test.js" "toggle-terminal"
+    assert_contains "$extracted/webview/assets/index-test.js" "toggle-diff-panel"
+    assert_contains "$extracted/webview/assets/index-test.js" "isShortcutCaptureTarget"
+    assert_contains "$extracted/webview/assets/index-test.js" "data-codex-keybind-input"
+    assert_not_contains "$extracted/webview/assets/index-test.js" "isEditableTarget(event))return"
+    assert_not_contains "$extracted/webview/assets/index-test.js" "ac(id)"
+
+    node - "$extracted/webview/assets/index-test.js" <<'NODE'
+const fs = require("fs");
+const vm = require("vm");
+const file = process.argv[2];
+const source = fs.readFileSync(file, "utf8");
+const marker = ";function codexLinuxKeybindOverridesRuntime()";
+const start = source.indexOf(marker);
+if (start === -1) throw new Error("missing runtime patch");
+const runtime = source
+  .slice(start)
+  .replace("codexLinuxKeybindOverridesRuntime();", "globalThis.codexLinuxKeybindOverridesRuntime=codexLinuxKeybindOverridesRuntime;");
+const listeners = {};
+const calls = [];
+class FakeElement {
+  constructor(isKeybindInput = false) {
+    this.isKeybindInput = isKeybindInput;
+  }
+  closest(selector) {
+    return selector === "[data-codex-keybind-input]" && this.isKeybindInput ? this : null;
+  }
+}
+const context = {
+  window: { addEventListener: (event, fn) => (listeners[event] ??= []).push(fn) },
+  Element: FakeElement,
+  navigator: { platform: "Linux x86_64" },
+  localStorage: { getItem: () => JSON.stringify({ toggleFileTreePanel: "Ctrl+E" }) },
+  Ct: { toggleFileTreePanel: "Command+Shift+E" },
+  E: {
+    dispatchHostMessage: (message) => calls.push(message),
+    dispatchMessage: () => {},
+  },
+  globalThis: null,
+};
+context.globalThis = context;
+vm.runInNewContext(runtime, context);
+context.codexLinuxKeybindOverridesRuntime();
+const makeEvent = (target) => ({
+  defaultPrevented: false,
+  repeat: false,
+  target,
+  ctrlKey: true,
+  altKey: false,
+  shiftKey: false,
+  metaKey: false,
+  key: "e",
+  preventDefault() {
+    this.defaultPrevented = true;
+  },
+  stopPropagation() {
+    this.stopped = true;
+  },
+});
+const composerEvent = makeEvent(new FakeElement(false));
+listeners.keydown[0](composerEvent);
+if (calls.length !== 1 || calls[0].type !== "toggle-file-tree-panel" || !composerEvent.defaultPrevented) {
+  throw new Error("Ctrl+E override did not dispatch from composer-like target");
+}
+const keybindInputEvent = makeEvent(new FakeElement(true));
+listeners.keydown[0](keybindInputEvent);
+if (calls.length !== 1 || keybindInputEvent.defaultPrevented) {
+  throw new Error("keybind capture input should not dispatch runtime override");
+}
+NODE
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`' '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.nav.keybinds" '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.section.keybinds" '1'
+    assert_occurrence_count "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js" '1'
+    assert_occurrence_count "$extracted/webview/assets/index-test.js" "keybinds:xh" '1'
+    assert_occurrence_count "$extracted/webview/assets/index-test.js" "function codexLinuxKeybindOverridesRuntime" '1'
+}
+
+test_keybinds_settings_patch_warns_on_bundle_shape_miss() {
+    info "Checking Keybinds settings bundle-shape warning"
+    local workspace="$TMP_DIR/keybinds-settings-shape-warning"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let t={join(){}};let a={existsSync(){return true},statSync(){return {isFile(){return false}}}};let n={shell:{openPath(){return ""},showItemInFolder(){}}};...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
+    rm "$extracted/webview/assets/settings-row-test.js"
+    cat > "$extracted/webview/assets/settings-sections-test.js" <<'JS'
+var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`appearance`}],r=t;export{n,t as r,e as t};
+JS
+    cat > "$extracted/webview/assets/settings-shared-test.js" <<'JS'
+var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
+JS
+    cat > "$extracted/webview/assets/index-test.js" <<'JS'
+var Xge={"general-settings":xh,appearance:Pf},H7={},Zge=[`general-settings`,`appearance`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];function n_e(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:return!0}};if(O)bb0:switch(D.slug){case`appearance`:case`general-settings`:k=!1;break bb0;}}var c_e={"general-settings":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DZbwMmWz.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([4]),import.meta.url))};
+JS
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_contains "$output_log" "WARN: Keybinds settings patch skipped"
+    assert_contains "$output_log" "could not find settings row asset"
+    [ ! -f "$extracted/webview/assets/keybinds-settings-linux.js" ] || fail "Keybinds asset should not be written when bundle shape is missing"
+    assert_not_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`'
+    assert_not_contains "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js"
 }
 
 test_browser_annotation_screenshot_patch_smoke() {
@@ -478,9 +697,11 @@ test_linux_single_instance_patch_smoke() {
 
     mkdir -p "$workspace"
     bundle_body="$(cat <<'JS'
-let n={app:{whenReady(){},quit(){},requestSingleInstanceLock(){},on(){},off(){}}};
-let t={Er(){return {info(){}}},jn:class{add(){}}};
-async function uT(){let k=new t.jn;t.Er().info(`Launching app`,{safe:{agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();let R={deepLinks:{queueProcessArgs(){return false}}},P={hotkeyWindowLifecycleManager:{hide(){}},getPrimaryWindow(){return null},createFreshLocalWindow(){return null}},g={reportNonFatal(){}},l=()=>{},re=e=>{e.isMinimized()&&e.restore(),e.show(),e.focus()},ie=async()=>{try{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(`local`)??await P.createFreshLocalWindow(`/`);if(e==null)return;re(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=async()=>{}}
+let S=globalThis.__codexSmoke;
+let n={app:{whenReady(){return Promise.resolve()},quit(){S.quitCount++},requestSingleInstanceLock(){S.lockCount++;return true},on(e,t){S.appHandlers[e]=t},off(e,t){S.offHandlers[e]=t}}};
+let t={Er(){return {info(){}}},jn:class{add(e){S.disposables.push(e)}}};
+let i={default:{dirname(e){S.dirnameCalls.push(e);return `/tmp`}}},o={mkdirSync(...e){S.mkdirSyncCalls.push(e)},rmSync(...e){S.rmSyncCalls.push(e)}},u={default:{createServer(e){S.createServerCalls++;S.socketConnectionHandler=e;return S.socketServer}}};
+async function uT(){let k=new t.jn;t.Er().info(`Launching app`,{safe:{agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();let w=(...e)=>{S.traceCalls.push(e)},M={globalState:S.globalState,repoRoot:`/tmp/codex-smoke`},z=`local`,R={deepLinks:{queueProcessArgs(e){S.queueArgs.push(e);return Array.isArray(e)&&e.some(e=>{let t=String(e);return t.startsWith(`codex://`)||t.startsWith(`codex-browser-sidebar://`)})},flushPendingDeepLinks(){S.flushPendingDeepLinksCalls++;return Promise.resolve()}},navigateToRoute(e,t){S.navigateCalls.push({windowId:e.id,path:t})}},P={windowManager:{sendMessageToWindow(e,t){S.messages.push({windowId:e.id,message:t})}},hotkeyWindowLifecycleManager:{hide(){S.hideCalls++},show(){S.showCalls++;return S.hotkeyWindowShowResult},ensureHotkeyWindowController(){S.ensureHotkeyWindowControllerCalls++;return S.hotkeyWindowController}},getPrimaryWindow(){return S.primaryWindow},createFreshLocalWindow(e){S.createFreshLocalWindowCalls.push(e);return S.createdWindow},ensureHostWindow(e){S.ensureHostWindowCalls.push(e);return S.primaryWindow??S.createdWindow}},g={reportNonFatal(e,t){S.errors.push({error:String(e),meta:t})}},l=e=>{S.initialHandler=e},re=e=>{S.focusCalls.push(e.id);e.isMinimized()&&e.restore(),e.show(),e.focus()},ie=async()=>{S.ieCalls++;try{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow(`local`)??await P.createFreshLocalWindow(`/`);if(e==null)return;re(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(z),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},oe=async()=>{S.trayStartupCalls++};let E=process.platform===`win32`;E&&oe();let me=await P.ensureHostWindow(z);me&&re(me),w(`local window ensured`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()}
 JS
 )"
     make_fake_extracted_asar "$extracted" "$bundle_body"
@@ -488,10 +709,517 @@ JS
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!n.app.requestSingleInstanceLock()'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxSecondInstanceHandler'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxHandleLaunchActionArgs'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--new-chat`)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--quick-chat`)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--prompt-chat`)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--hotkey-window`)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxHasDeepLink'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxShowHotkeyWindow'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxGetHotkeyWindowController'
+    assert_contains "$extracted/.vite/build/main-test.js" 'ensureHotkeyWindowController'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxPrewarmHotkeyWindow'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxStartLaunchActionSocket'
+    assert_contains "$extracted/.vite/build/main-test.js" 'CODEX_DESKTOP_LAUNCH_ACTION_SOCKET'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.openHome'
+    assert_contains "$extracted/.vite/build/main-test.js" 'e.prewarm'
+    assert_contains "$extracted/.vite/build/main-test.js" 'type:`new-quick-chat`'
+
+    node - "$extracted/.vite/build/main-test.js" <<'NODE'
+const fs = require("fs");
+const vm = require("vm");
+
+const source = fs.readFileSync(process.argv[2], "utf8");
+let state = makeState();
+
+function makeState(settings = {}) {
+  const next = {
+    appHandlers: Object.create(null),
+    offHandlers: Object.create(null),
+    disposables: [],
+    initialHandler: null,
+    lockCount: 0,
+    quitCount: 0,
+    globalStateGetKeys: [],
+    linuxSettings: {
+      promptChatEnabled: true,
+      warmStartEnabled: true,
+      trayEnabled: true,
+      ...settings,
+    },
+  };
+
+  next.globalState = {
+    get(key) {
+      next.globalStateGetKeys.push(String(key));
+      return linuxSettingForKey(next, key);
+    },
+  };
+
+  return next;
+}
+
+function linuxSettingsAtom(settings) {
+  return {
+    "settings.keybinds.promptChatEnabled": settings.promptChatEnabled,
+    "settings.keybinds.promptChat": settings.promptChatEnabled,
+    "settings.keybinds.hotkeyWindowEnabled": settings.promptChatEnabled,
+    "settings.keybinds.warmStartEnabled": settings.warmStartEnabled,
+    "settings.keybinds.warmStart": settings.warmStartEnabled,
+    "settings.keybinds.launchActionSocketEnabled": settings.warmStartEnabled,
+    "settings.keybinds.trayEnabled": settings.trayEnabled,
+    "settings.keybinds.tray": settings.trayEnabled,
+    "settings.linux.promptChatEnabled": settings.promptChatEnabled,
+    "settings.linux.warmStartEnabled": settings.warmStartEnabled,
+    "settings.linux.trayEnabled": settings.trayEnabled,
+  };
+}
+
+function linuxSettingForKey(next, key) {
+  const keyText = String(key).toLowerCase();
+  const settings = next.linuxSettings;
+
+  if (keyText.includes("persisted") || keyText === "electron-persisted-atom-state") {
+    return linuxSettingsAtom(settings);
+  }
+
+  if (keyText.includes("keybind") && !keyText.includes("prompt") && !keyText.includes("hotkey") && !keyText.includes("warm") && !keyText.includes("launch") && !keyText.includes("socket") && !keyText.includes("tray")) {
+    return {
+      promptChatEnabled: settings.promptChatEnabled,
+      hotkeyWindowEnabled: settings.promptChatEnabled,
+      warmStartEnabled: settings.warmStartEnabled,
+      launchActionSocketEnabled: settings.warmStartEnabled,
+      trayEnabled: settings.trayEnabled,
+    };
+  }
+
+  if (keyText.includes("prompt") || keyText.includes("hotkey")) {
+    return settings.promptChatEnabled;
+  }
+
+  if (keyText.includes("warm") || keyText.includes("socket") || keyText.includes("launch")) {
+    return settings.warmStartEnabled;
+  }
+
+  if (keyText.includes("tray")) {
+    return settings.trayEnabled;
+  }
+
+  return null;
+}
+
+function makeWindow(id) {
+  return {
+    id,
+    isMinimized() {
+      state.windowCalls.push(`${id}:isMinimized`);
+      return false;
+    },
+    isVisible() {
+      state.windowCalls.push(`${id}:isVisible`);
+      return true;
+    },
+    restore() {
+      state.windowCalls.push(`${id}:restore`);
+    },
+    show() {
+      state.windowCalls.push(`${id}:show`);
+    },
+    focus() {
+      state.windowCalls.push(`${id}:focus`);
+    },
+  };
+}
+
+function resetCalls() {
+  const existingCreateServerCalls = state.createServerCalls ?? 0;
+  const existingSocketConnectionHandler = state.socketConnectionHandler ?? null;
+  const existingSocketListenCalls = state.socketListenCalls ?? [];
+  const existingSocketServerHandlers = state.socketServerHandlers ?? Object.create(null);
+  state.queueArgs = [];
+  state.navigateCalls = [];
+  state.messages = [];
+  state.hideCalls = 0;
+  state.showCalls = 0;
+  state.controllerShowCalls = 0;
+  state.hotkeyWindowShowResult = true;
+  state.openHomeCalls = 0;
+  state.hotkeyWindowOpenHomeResult = undefined;
+  state.prewarmCalls = 0;
+  state.prewarmThrows = false;
+  state.ensureHotkeyWindowControllerCalls = 0;
+  state.hotkeyWindowController = {
+    show() {
+      state.controllerShowCalls++;
+      return state.hotkeyWindowShowResult;
+    },
+    openHome() {
+      state.openHomeCalls++;
+      return state.hotkeyWindowOpenHomeResult;
+    },
+    prewarm() {
+      state.prewarmCalls++;
+      if (state.prewarmThrows) {
+        throw new Error("prewarm failed");
+      }
+    },
+  };
+  state.ensureHostWindowCalls = [];
+  state.createFreshLocalWindowCalls = [];
+  state.focusCalls = [];
+  state.windowCalls = [];
+  state.errors = [];
+  state.ieCalls = 0;
+  state.traceCalls = [];
+  state.flushPendingDeepLinksCalls = 0;
+  state.trayStartupCalls = 0;
+  state.primaryWindow = null;
+  state.createdWindow = makeWindow("created");
+  state.dirnameCalls = [];
+  state.mkdirSyncCalls = [];
+  state.rmSyncCalls = [];
+  state.createServerCalls = existingCreateServerCalls;
+  state.socketConnectionHandler = existingSocketConnectionHandler;
+  state.socketListenCalls = existingSocketListenCalls;
+  state.socketCloseCalls = 0;
+  state.socketServer = {
+    listen(path) {
+      state.socketListenCalls.push(path);
+    },
+    close() {
+      state.socketCloseCalls += 1;
+    },
+    on(event, handler) {
+      state.socketServerHandlers[event] = handler;
+      return this;
+    },
+  };
+  state.socketServerHandlers = existingSocketServerHandlers;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function flushAsyncHandlers() {
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "/tmp/codex-smoke.sock" }) {
+  state = makeState(settings);
+  resetCalls();
+  state.primary = makeWindow("primary");
+
+  const context = {
+    console,
+    process: { platform: "linux", env },
+    __codexSmoke: state,
+  };
+  context.globalThis = context;
+
+  vm.runInNewContext(`${source}\nglobalThis.__codexSmokeRun = uT;`, context, {
+    filename: "main-test.js",
+  });
+
+  await context.__codexSmokeRun();
+  return context;
+}
+
+(async () => {
+  await boot();
+  assert(typeof state.appHandlers["second-instance"] === "function", "second-instance handler was not registered");
+  assert(typeof state.initialHandler === "function", "initial argv handler was not registered");
+  assert(state.createServerCalls === 1, "warm-start launch action socket server was not created");
+  assert(state.socketListenCalls.length === 1 && state.socketListenCalls[0] === "/tmp/codex-smoke.sock", "warm-start launch action socket did not listen on the configured path");
+  assert(typeof state.socketConnectionHandler === "function", "warm-start launch action socket connection handler was not registered");
+  assert(state.mkdirSyncCalls.length === 1, "warm-start launch action socket should create its parent runtime directory");
+  assert(state.rmSyncCalls.length === 1 && state.rmSyncCalls[0][0] === "/tmp/codex-smoke.sock", "warm-start launch action socket should remove a stale socket before listening");
+  assert(state.prewarmCalls === 1, "startup should prewarm the compact hotkey prompt window");
+  assert(state.ensureHotkeyWindowControllerCalls === 1, "startup prewarm should use the real hotkey window controller");
+  assert(state.flushPendingDeepLinksCalls === 1, "startup should still flush pending deeplinks after prewarm");
+  assert(state.trayStartupCalls === 1, "startup should initialize the Linux tray when the tray gate is enabled");
+
+  async function runSecondInstance(args) {
+    state.appHandlers["second-instance"]({}, args);
+    await flushAsyncHandlers();
+  }
+
+  async function runInitialArgs(args) {
+    state.initialHandler(args);
+    await flushAsyncHandlers();
+  }
+
+  function makeSocket() {
+    const handlers = Object.create(null);
+    return {
+      destroyed: false,
+      encoding: null,
+      outputs: [],
+      setEncoding(encoding) {
+        this.encoding = encoding;
+      },
+      on(event, handler) {
+        handlers[event] = handler;
+        return this;
+      },
+      emit(event, payload) {
+        if (handlers[event]) {
+          handlers[event](payload);
+        }
+      },
+      end(output) {
+        this.outputs.push(output);
+      },
+      destroy() {
+        this.destroyed = true;
+      },
+    };
+  }
+
+  async function runSocketArgs(args) {
+    const socket = makeSocket();
+    state.socketConnectionHandler(socket);
+    socket.emit("data", `${JSON.stringify({ argv: args })}\n`);
+    await flushAsyncHandlers();
+    return socket;
+  }
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--new-chat"]);
+  assert(state.queueArgs.length === 0, "--new-chat without a deeplink should not be consumed by deeplink routing");
+  assert(state.createFreshLocalWindowCalls.length === 0, "--new-chat should reuse the warm primary window");
+  assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "--new-chat should focus the warm primary window");
+  assert(state.navigateCalls.length === 1 && state.navigateCalls[0].path === "/", "--new-chat should navigate the warm primary window to /");
+  assert(state.messages.length === 0, "--new-chat should not send a quick-chat message");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--quick-chat"]);
+  assert(state.queueArgs.length === 0, "--quick-chat without a deeplink should not be consumed by deeplink routing");
+  assert(state.createFreshLocalWindowCalls.length === 0, "--quick-chat should reuse the warm primary window");
+  assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "--quick-chat should focus the warm primary window");
+  assert(state.messages.length === 1 && state.messages[0].windowId === "primary" && state.messages[0].message.type === "new-quick-chat", "--quick-chat should send new-quick-chat to the warm primary window");
+  assert(state.navigateCalls.length === 0, "--quick-chat should not navigate by route");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--prompt-chat"]);
+  assert(state.queueArgs.length === 0, "--prompt-chat without a deeplink should not be consumed by deeplink routing");
+  assert(state.openHomeCalls === 1, "--prompt-chat should open the compact hotkey prompt on the new-chat home surface");
+  assert(state.ensureHotkeyWindowControllerCalls === 1, "--prompt-chat should use the real hotkey window controller");
+  assert(state.showCalls === 0, "--prompt-chat should not reopen the last hotkey surface");
+  assert(state.controllerShowCalls === 0, "--prompt-chat should not call the controller show fallback");
+  assert(state.ensureHostWindowCalls.length === 0, "--prompt-chat should not open the main window when the hotkey prompt shows");
+  assert(state.hideCalls === 0, "--prompt-chat should not hide the hotkey window before showing it");
+  assert(state.focusCalls.length === 0, "--prompt-chat should not focus the main window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--hotkey-window"]);
+  assert(state.openHomeCalls === 1, "--hotkey-window should open the compact hotkey prompt on the new-chat home surface");
+  assert(state.ensureHotkeyWindowControllerCalls === 1, "--hotkey-window should use the real hotkey window controller");
+  assert(state.ensureHostWindowCalls.length === 0, "--hotkey-window should not open the main window when the compact prompt shows");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  let socket = await runSocketArgs(["codex-desktop", "--prompt-chat"]);
+  assert(socket.outputs[0] === "ok\n", "warm-start socket should acknowledge handled prompt args");
+  assert(state.openHomeCalls === 1, "warm-start socket should open the compact prompt on the new-chat home surface");
+  assert(state.ensureHotkeyWindowControllerCalls === 1, "warm-start socket prompt should use the real hotkey window controller");
+  assert(state.focusCalls.length === 0, "warm-start socket prompt should not focus the main window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  socket = await runSocketArgs(["codex://thread/abc", "--prompt-chat"]);
+  assert(socket.outputs[0] === "ok\n", "warm-start socket should acknowledge deeplink args");
+  assert(state.queueArgs.length === 1, "warm-start socket should check deeplinks before prompt flags");
+  assert(state.openHomeCalls === 0, "warm-start socket should not open the prompt when a deeplink is present");
+
+  resetCalls();
+  socket = await runSocketArgs(["codex-desktop"]);
+  assert(socket.outputs[0] === "ok\n", "warm-start socket should acknowledge fallback focus args");
+  assert(state.ieCalls === 1, "warm-start socket should use the focus fallback for args without launch flags");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex://thread/abc", "--quick-chat"]);
+  assert(state.queueArgs.length === 1, "deeplink+flag should check deeplinks");
+  assert(state.messages.length === 0, "deeplink+flag should not open quick chat");
+  assert(state.navigateCalls.length === 0, "deeplink+flag should not navigate to /");
+  assert(state.ieCalls === 0, "deeplink+flag should not fall back to focus");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-browser-sidebar://open", "--quick-chat"]);
+  assert(state.queueArgs.length === 1, "browser-sidebar deeplink+flag should check deeplinks");
+  assert(state.messages.length === 0, "browser-sidebar deeplink+flag should not open quick chat");
+  assert(state.navigateCalls.length === 0, "browser-sidebar deeplink+flag should not navigate to /");
+  assert(state.ieCalls === 0, "browser-sidebar deeplink+flag should not fall back to focus");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex://thread/abc", "--prompt-chat"]);
+  assert(state.queueArgs.length === 1, "deeplink+prompt flag should check deeplinks first");
+  assert(state.openHomeCalls === 0, "deeplink+prompt flag should not open the compact prompt");
+  assert(state.showCalls === 0, "deeplink+prompt flag should not show the compact prompt");
+  assert(state.ensureHostWindowCalls.length === 0, "deeplink+prompt flag should not fall back to the host window");
+
+  resetCalls();
+  await runSecondInstance(["codex-desktop"]);
+  assert(state.queueArgs.length === 0, "no-flag args without a deeplink should not be consumed by deeplink routing");
+  assert(state.ieCalls === 1, "no-flag args should use the focus fallback");
+  assert(state.createFreshLocalWindowCalls.length === 1 && state.createFreshLocalWindowCalls[0] === "/", "fallback should create the default window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runInitialArgs(["codex-desktop", "--quick-chat"]);
+  assert(state.createFreshLocalWindowCalls.length === 0, "initial argv handler should reuse an existing primary window");
+  assert(state.messages.length === 1 && state.messages[0].windowId === "primary" && state.messages[0].message.type === "new-quick-chat", "initial argv handler should open quick chat in the existing primary window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runInitialArgs(["codex-desktop", "--prompt-chat"]);
+  assert(state.openHomeCalls === 1, "initial argv handler should open the compact prompt on the new-chat home surface");
+  assert(state.ensureHotkeyWindowControllerCalls === 1, "initial argv handler should use the real hotkey window controller");
+  assert(state.showCalls === 0, "initial argv handler should not reopen the last hotkey surface");
+  assert(state.ensureHostWindowCalls.length === 0, "initial argv handler should not open the main window when the compact prompt shows");
+
+  resetCalls();
+  await runInitialArgs(["codex-desktop", "--quick-chat"]);
+  assert(state.createFreshLocalWindowCalls.length === 1 && state.createFreshLocalWindowCalls[0] === "/", "initial argv handler should create a window when no primary exists");
+  assert(state.messages.length === 1 && state.messages[0].windowId === "created" && state.messages[0].message.type === "new-quick-chat", "initial argv handler should open quick chat in the created window when no primary exists");
+
+  await boot({ promptChatEnabled: false });
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex://thread/abc", "--prompt-chat"]);
+  assert(state.queueArgs.length === 1, "deeplink priority should still win when the prompt-chat gate is disabled");
+  assert(state.openHomeCalls === 0, "disabled prompt-chat gate should not open the compact prompt for deeplink args");
+  assert(state.ieCalls === 0, "deeplink args should not fall back to main-window focus when the prompt-chat gate is disabled");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--prompt-chat"]);
+  assert(state.queueArgs.length === 0, "disabled prompt-chat args without a deeplink should not be consumed by deeplink routing");
+  assert(state.openHomeCalls === 0, "disabled prompt-chat gate should not open the compact prompt");
+  assert(state.ensureHotkeyWindowControllerCalls === 0, "disabled prompt-chat gate should not create the hotkey window controller");
+  assert(state.ieCalls === 1, "disabled prompt-chat gate should fall back to main-window focus");
+  assert(state.focusCalls.length === 1 && state.focusCalls[0] === "primary", "disabled prompt-chat fallback should focus the warm primary window");
+
+  resetCalls();
+  state.primaryWindow = state.primary;
+  await runSecondInstance(["codex-desktop", "--hotkey-window"]);
+  assert(state.openHomeCalls === 0, "disabled prompt-chat gate should also block --hotkey-window prompt opening");
+  assert(state.ensureHotkeyWindowControllerCalls === 0, "disabled prompt-chat gate should not create a controller for --hotkey-window");
+  assert(state.ieCalls === 1, "disabled --hotkey-window should fall back to main-window focus");
+
+  await boot({ warmStartEnabled: false }, { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "/tmp/codex-disabled.sock" });
+  assert(state.createServerCalls === 0, "disabled warm-start gate should not create the launch-action socket server");
+  assert(state.socketListenCalls.length === 0, "disabled warm-start gate should not listen on the launch-action socket");
+  assert(state.socketConnectionHandler == null, "disabled warm-start gate should not register a socket connection handler");
+
+  await boot({ trayEnabled: false });
+  assert(state.trayStartupCalls === 0, "disabled tray gate should not start the Linux tray during startup");
+})().catch((error) => {
+  console.error(error.stack || error);
+  process.exit(1);
+});
+NODE
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_occurrence_count "$extracted/.vite/build/main-test.js" '!n.app.requestSingleInstanceLock()' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxSecondInstanceHandler' '3'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxHandleLaunchActionArgs=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'e.includes(`--new-chat`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'e.includes(`--quick-chat`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'e.includes(`--prompt-chat`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'e.includes(`--hotkey-window`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxShowHotkeyWindow=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxGetHotkeyWindowController=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxPrewarmHotkeyWindow=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxStartLaunchActionSocket=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxOpenQuickChat=' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxPrewarmHotkeyWindow()' '1'
+
+    node - "$REPO_DIR" "$extracted" "$workspace" <<'NODE'
+const childProcess = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoDir = process.argv[2];
+const baseExtracted = process.argv[3];
+const workspace = process.argv[4];
+const patcher = path.join(repoDir, "scripts", "patch-linux-window-ui.js");
+const patcherSource = fs.readFileSync(patcher, "utf8");
+const mainBundlePath = path.join(".vite", "build", "main-test.js");
+const baseMainPath = path.join(baseExtracted, mainBundlePath);
+const currentSource = fs.readFileSync(baseMainPath, "utf8");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function extractConst(name) {
+  const match = patcherSource.match(new RegExp(`const ${name} =\\n    "((?:\\\\.|[^"])*)";`));
+  assert(match, `Could not extract ${name}`);
+  return JSON.parse(`"${match[1]}"`);
+}
+
+function extractCurrentLaunchActionPatch(source) {
+  const match = source.match(/let (?:codexLinuxGetSetting=.*?,)?ae=async\(e,t\)=>\{P\.hotkeyWindowLifecycleManager\.hide\(\);.*?;let oe=async\(\)=>\{/);
+  assert(match, "Could not extract current launch-action patch from smoke bundle");
+  return match[0];
+}
+
+const currentPatch = extractCurrentLaunchActionPatch(currentSource);
+const startupPrewarmNeedle = "codexLinuxPrewarmHotkeyWindow(),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()";
+const startupPrewarmPattern = /codexLinuxPrewarmHotkeyWindow\(\).*?await R\.deepLinks\.flushPendingDeepLinks\(\)/;
+const variants = [
+  ["old-flags-first", extractConst("oldLaunchActionPatch")],
+  ["deep-link-first-all-args", extractConst("deepLinkFirstLaunchActionPatch")],
+  ["warm-start-without-hotkey", extractConst("deepLinkAwareExistingWindowLaunchActionPatch")],
+  ["open-home-without-socket", extractConst("openHomeHotkeyWindowLaunchActionPatch")],
+  ["socket-without-controller-prewarm", extractConst("socketHotkeyWindowLaunchActionPatch")],
+  ["show-based-hotkey-window", extractConst("showBasedHotkeyWindowLaunchActionPatch")],
+  ["fresh-window", extractConst("freshWindowLaunchActionPatch")],
+];
+
+assert(currentSource.includes(currentPatch), "Base smoke bundle does not contain the current launch-action patch");
+
+for (const [name, variant] of variants) {
+  const variantDir = path.join(workspace, `upgrade-${name}`);
+  fs.cpSync(baseExtracted, variantDir, { recursive: true });
+  const variantMainPath = path.join(variantDir, mainBundlePath);
+  const variantSource = currentSource
+    .replace(currentPatch, variant)
+    .replace(`process.platform===\`linux\`&&${startupPrewarmNeedle}`, "A=Date.now(),await R.deepLinks.flushPendingDeepLinks()")
+    .replace(startupPrewarmNeedle, "A=Date.now(),await R.deepLinks.flushPendingDeepLinks()");
+  fs.writeFileSync(variantMainPath, variantSource, "utf8");
+  childProcess.execFileSync(process.execPath, [patcher, variantDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const upgraded = fs.readFileSync(variantMainPath, "utf8");
+  assert(upgraded.includes(currentPatch), `${name} variant did not upgrade to the current launch-action handler`);
+  assert(upgraded.includes("codexLinuxGetHotkeyWindowController="), `${name} variant did not include the hotkey controller accessor`);
+  assert(upgraded.includes("ensureHotkeyWindowController"), `${name} variant did not use the real hotkey window controller`);
+  assert(upgraded.includes("codexLinuxPrewarmHotkeyWindow="), `${name} variant did not include the hotkey prompt prewarm helper`);
+  assert(startupPrewarmPattern.test(upgraded), `${name} variant did not include startup hotkey prompt prewarming`);
+  assert(upgraded.includes("codexLinuxStartLaunchActionSocket="), `${name} variant did not include the fast warm-start socket handler`);
+  assert(upgraded.includes("o.mkdirSync(i.default.dirname(e)"), `${name} variant used the wrong fs namespace for the socket directory`);
+  assert(!upgraded.includes("o.default.mkdirSync"), `${name} variant kept the broken fs.default socket setup`);
+  assert(!upgraded.includes("let e=P.hotkeyWindowLifecycleManager;typeof e.openHome"), `${name} variant kept the fake lifecycle-manager openHome path`);
+  assert(!upgraded.includes("P.hotkeyWindowLifecycleManager.prewarm?.()"), `${name} variant kept the fake lifecycle-manager prewarm path`);
+  assert(!upgraded.includes("P.hotkeyWindowLifecycleManager.show()||await P.ensureHostWindow(z)"), `${name} variant kept the show-based hotkey handler`);
+  assert(!upgraded.includes("codexLinuxOpenNewChat="), `${name} variant kept the fresh-window handler`);
+  assert(!upgraded.includes("Array.isArray(e)&&R.deepLinks.queueProcessArgs(e)?!0"), `${name} variant kept broad deeplink routing`);
+}
+NODE
 }
 
 test_linux_file_manager_patch_fails_soft() {
@@ -518,6 +1246,8 @@ main() {
     test_launcher_template_sanity
     test_linux_file_manager_patch_smoke
     test_linux_translucent_sidebar_default_patch_smoke
+    test_keybinds_settings_tab_patch_smoke
+    test_keybinds_settings_patch_warns_on_bundle_shape_miss
     test_linux_tray_patch_smoke
     test_browser_annotation_screenshot_patch_smoke
     test_linux_single_instance_patch_smoke


### PR DESCRIPTION
## Summary
- add a Linux Keybinds settings page with editable app shortcut overrides
- persist Linux desktop controls for tray, warm start, and compact prompt behavior
- improve launcher warm-start/webview handling and add smoke coverage for the patcher/runtime paths

## Tests
- node --check scripts/patch-linux-window-ui.js
- bash -n install.sh
- bash -n tests/scripts_smoke.sh
- ./tests/scripts_smoke.sh