### PR TITLE
Detect Electron version from app metadata

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -214,6 +214,66 @@ extract_dmg() {
     echo "$app_dir"
 }
 
+# ---- Detect Electron version from DMG ----
+sanitize_electron_version() {
+    local value="$1"
+    value="${value#v}"
+    value="${value#^}"
+    value="${value#~}"
+
+    if [[ "$value" =~ ^[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z]+)*$ ]]; then
+        echo "$value"
+        return 0
+    fi
+
+    return 1
+}
+
+detect_electron_version() {
+    local app_dir="$1"
+    local detected=""
+    local detected_version=""
+    local plist_file="$app_dir/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist"
+
+    if [ -f "$plist_file" ]; then
+        detected=$(python3 - "$plist_file" <<'PY' 2>/dev/null || true
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(plistlib.load(handle).get("CFBundleVersion", ""))
+PY
+)
+        if detected_version=$(sanitize_electron_version "$detected"); then
+            ELECTRON_VERSION="$detected_version"
+            info "Detected Electron version from DMG: $ELECTRON_VERSION"
+            return 0
+        elif [ -n "$detected" ]; then
+            warn "Ignoring invalid Electron version from DMG: $detected"
+        fi
+    fi
+
+    local resources_dir="$app_dir/Contents/Resources"
+    if [ -f "$resources_dir/app.asar" ]; then
+        detected=$(npx --yes asar extract-file "$resources_dir/app.asar" package.json 2>/dev/null |
+            node -e '
+const fs = require("node:fs");
+const pkg = JSON.parse(fs.readFileSync(0, "utf8"));
+process.stdout.write(String(pkg.devDependencies?.electron ?? pkg.dependencies?.electron ?? ""));
+' 2>/dev/null || true)
+        if detected_version=$(sanitize_electron_version "$detected"); then
+            ELECTRON_VERSION="$detected_version"
+            info "Detected Electron version from package.json: $ELECTRON_VERSION"
+            return 0
+        elif [ -n "$detected" ]; then
+            warn "Ignoring invalid Electron version from package.json: $detected"
+        fi
+    fi
+
+    warn "Could not auto-detect Electron version; using fallback $ELECTRON_VERSION"
+    return 0
+}
+
 # ---- Build native modules in a clean directory ----
 build_native_modules() {
     local app_extracted="$1"
@@ -935,6 +995,7 @@ main() {
     local app_dir
     app_dir=$(extract_dmg "$dmg_path")
 
+    detect_electron_version "$app_dir"
     patch_asar "$app_dir"
     download_electron
     extract_webview "$app_dir"
@@ -952,4 +1013,6 @@ main() {
     echo "============================================" >&2
 }
 
-main "$@"
+if [ "${CODEX_INSTALLER_SOURCE_ONLY:-0}" != "1" ]; then
+    main "$@"
+fi

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -227,6 +227,61 @@ SCRIPT
     [ -z "$second_line" ] || fail "Expected make build-app default DMG argument to be empty so install.sh falls back to reuse/download, got: $(cat "$install_log")"
 }
 
+test_installer_detects_electron_version_from_plist() {
+    info "Checking Electron version detection from app metadata"
+    local workspace="$TMP_DIR/electron-version"
+    local app_dir="$workspace/Codex.app"
+    local plist_dir="$app_dir/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$plist_dir"
+    cat > "$plist_dir/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleVersion</key>
+    <string>42.5.7</string>
+</dict>
+</plist>
+PLIST
+
+    CODEX_INSTALLER_SOURCE_ONLY=1 bash -c \
+        'source "$1"; detect_electron_version "$2"; printf "%s\n" "$ELECTRON_VERSION"' \
+        _ "$REPO_DIR/install.sh" "$app_dir" >"$output_log" 2>&1
+
+    assert_contains "$output_log" "Detected Electron version from DMG: 42.5.7"
+    [ "$(tail -n 1 "$output_log")" = "42.5.7" ] || fail "Expected detected Electron version 42.5.7, got: $(cat "$output_log")"
+}
+
+test_installer_keeps_electron_fallback_for_bad_metadata() {
+    info "Checking Electron version fallback for malformed metadata"
+    local workspace="$TMP_DIR/electron-version-fallback"
+    local app_dir="$workspace/Codex.app"
+    local plist_dir="$app_dir/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$plist_dir"
+    cat > "$plist_dir/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleVersion</key>
+    <string>not-a-version</string>
+</dict>
+</plist>
+PLIST
+
+    CODEX_INSTALLER_SOURCE_ONLY=1 bash -c \
+        'source "$1"; detect_electron_version "$2"; printf "%s\n" "$ELECTRON_VERSION"' \
+        _ "$REPO_DIR/install.sh" "$app_dir" >"$output_log" 2>&1
+
+    assert_contains "$output_log" "Ignoring invalid Electron version from DMG: not-a-version"
+    assert_contains "$output_log" "Could not auto-detect Electron version; using fallback 41.3.0"
+    [ "$(tail -n 1 "$output_log")" = "41.3.0" ] || fail "Expected fallback Electron version 41.3.0, got: $(cat "$output_log")"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" "python3 -m http.server 5175 --bind 127.0.0.1"
@@ -426,6 +481,8 @@ main() {
     test_rpm_builder_smoke
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default
+    test_installer_detects_electron_version_from_plist
+    test_installer_keeps_electron_fallback_for_bad_metadata
     test_launcher_template_sanity
     test_linux_file_manager_patch_smoke
     test_linux_translucent_sidebar_default_patch_smoke


### PR DESCRIPTION
## Summary
- Detect the Electron runtime version from the extracted Codex.app framework metadata before rebuilding native modules and downloading the Linux Electron runtime.
- Keep the pinned `41.3.0` fallback when metadata is missing or malformed, so fresh checkouts remain buildable.
- Add smoke coverage for valid app metadata and malformed metadata fallback behavior.

## Validation
- `bash -n install.sh`
- `bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh` -> All script smoke tests passed
- `git diff --check upstream/main...HEAD`
- `git merge-tree upstream/main HEAD` -> clean

## Notes
This is a focused re-cut of the Electron-version part of the earlier launcher draft. GPU-mode and CLI-path changes are intentionally left out for separate follow-ups.