### PR TITLE
fix(browser): Stabilize Linux browser annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The current evaluation for a future Rust replacement for the local webview serve
 | Stuck on the Codex logo splash | Check `~/.cache/codex-desktop/launcher.log`. If webview origin validation failed, another process is probably serving port `5175` or the extracted `content/webview/` bundle is incomplete |
 | `CODEX_CLI_PATH` error | Install the CLI with `npm i -g @openai/codex` or `npm i -g --prefix ~/.local @openai/codex` |
 | Electron hangs while the CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log`; the launcher now runs a best-effort CLI preflight and warns if the automatic refresh fails |
-| GPU/Vulkan/Wayland errors | The launcher sets `--ozone-platform-hint=auto`, `--disable-gpu-sandbox`, `--disable-gpu-compositing`, and `--enable-features=WaylandWindowDecorations` by default. If you need X11 explicitly, try `./codex-app/start.sh --ozone-platform=x11` |
+| GPU/Vulkan/Wayland errors | Under Wayland with `DISPLAY` available, the launcher uses `--ozone-platform=x11` for Electron window-positioning compatibility. Otherwise it uses `--ozone-platform-hint=auto`. GPU sandbox/compositing are disabled by default. |
 | Window flickering | GPU compositing is now disabled by default (`--disable-gpu-compositing`). If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | Run `./install.sh --fresh` to remove the existing install dir and re-download the DMG |

--- a/install.sh
+++ b/install.sh
@@ -398,6 +398,91 @@ install_app() {
     info "app.asar installed"
 }
 
+# ---- Install Browser Use bundled plugin resources ----
+is_elf_executable() {
+    local file="$1"
+    python3 - "$file" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+try:
+    sys.exit(0 if path.read_bytes()[:4] == b"\x7fELF" else 1)
+except OSError:
+    sys.exit(1)
+PY
+}
+
+install_linux_executable_resource() {
+    local source="$1"
+    local destination="$2"
+    local label="$3"
+
+    if [ ! -f "$source" ]; then
+        warn "Browser Use $label not found in upstream resources; skipping"
+        return 1
+    fi
+
+    if ! is_elf_executable "$source"; then
+        warn "Browser Use $label is not a Linux executable; skipping"
+        return 1
+    fi
+
+    install -m 0755 "$source" "$destination"
+}
+
+remove_macos_sidecar_files() {
+    local root="$1"
+    find "$root" -type f -name '*:com.apple.*' -delete
+}
+
+write_browser_use_marketplace() {
+    local source="$1"
+    local destination="$2"
+
+    node - "$source" "$destination" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const sourcePath = process.argv[2];
+const destinationPath = process.argv[3];
+const marketplace = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
+marketplace.plugins = (marketplace.plugins || []).filter((plugin) => plugin.name === "browser-use");
+
+if (marketplace.plugins.length !== 1) {
+  throw new Error("Bundled marketplace does not contain exactly one browser-use plugin");
+}
+
+fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+fs.writeFileSync(destinationPath, `${JSON.stringify(marketplace, null, 2)}\n`);
+NODE
+}
+
+install_browser_use_resources() {
+    local app_dir="$1"
+    local upstream_resources="$app_dir/Contents/Resources"
+    local source_marketplace="$upstream_resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+    local source_plugin="$upstream_resources/plugins/openai-bundled/plugins/browser-use"
+    local resources_dir="$INSTALL_DIR/resources"
+    local bundled_plugins_dir="$resources_dir/plugins/openai-bundled"
+
+    if [ ! -d "$source_plugin" ] || [ ! -f "$source_marketplace" ]; then
+        warn "Browser Use bundled plugin resources not found in upstream app; skipping"
+        return 0
+    fi
+
+    mkdir -p "$bundled_plugins_dir/plugins" "$bundled_plugins_dir/.agents/plugins"
+    rm -rf "$bundled_plugins_dir/plugins/browser-use"
+    cp -R "$source_plugin" "$bundled_plugins_dir/plugins/browser-use"
+    remove_macos_sidecar_files "$bundled_plugins_dir/plugins/browser-use"
+    write_browser_use_marketplace "$source_marketplace" "$bundled_plugins_dir/.agents/plugins/marketplace.json"
+
+    install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" || true
+    install_linux_executable_resource "$upstream_resources/node_repl" "$resources_dir/node_repl" "node_repl runtime" || true
+
+    info "Browser Use plugin resources installed"
+}
+
 # ---- Create start script ----
 create_start_script() {
     cat > "$INSTALL_DIR/start.sh" << 'SCRIPT'
@@ -433,7 +518,7 @@ Options:
   -h, --help                  Show this help message and exit
   --disable-gpu               Completely disable GPU acceleration
   --disable-gpu-compositing   Disable GPU compositing (fixes flickering)
-  --ozone-platform=x11        Force X11 instead of Wayland
+  --ozone-platform=x11        Force X11/XWayland explicitly
 
 Extra flags are passed directly to Electron.
 
@@ -480,6 +565,37 @@ run_packaged_runtime_prelaunch() {
 export_packaged_runtime_env() {
     if declare -F codex_packaged_runtime_export_env >/dev/null 2>&1; then
         codex_packaged_runtime_export_env
+    fi
+}
+
+resolve_browser_use_runtime_env() {
+    if [ -z "${CODEX_ELECTRON_RESOURCES_PATH:-}" ]; then
+        export CODEX_ELECTRON_RESOURCES_PATH="$SCRIPT_DIR/resources"
+    fi
+
+    if [ -z "${CODEX_BROWSER_USE_NODE_PATH:-}" ]; then
+        if [ -x "$SCRIPT_DIR/resources/node" ]; then
+            export CODEX_BROWSER_USE_NODE_PATH="$SCRIPT_DIR/resources/node"
+        elif command -v node >/dev/null 2>&1; then
+            CODEX_BROWSER_USE_NODE_PATH="$(command -v node)"
+            export CODEX_BROWSER_USE_NODE_PATH
+        fi
+    fi
+
+    if [ -z "${CODEX_NODE_REPL_PATH:-}" ]; then
+        codex_runtime_node_repl="${XDG_CACHE_HOME:-$HOME/.cache}/codex-runtimes/codex-primary-runtime/dependencies/bin/node_repl"
+        if [ -x "$SCRIPT_DIR/resources/node_repl" ]; then
+            export CODEX_NODE_REPL_PATH="$SCRIPT_DIR/resources/node_repl"
+        elif command -v node_repl >/dev/null 2>&1; then
+            CODEX_NODE_REPL_PATH="$(command -v node_repl)"
+            export CODEX_NODE_REPL_PATH
+        elif [ -x "$codex_runtime_node_repl" ]; then
+            export CODEX_NODE_REPL_PATH="$codex_runtime_node_repl"
+        fi
+    fi
+
+    if [ -z "${CODEX_NODE_REPL_PATH:-}" ]; then
+        echo "Browser Use node_repl runtime not found; in-app browser automation may be unavailable."
     fi
 }
 
@@ -858,6 +974,32 @@ clear_stale_pid_file() {
     fi
 }
 
+has_electron_flag() {
+    local flag_name="$1"
+    shift
+
+    local arg
+    for arg in "$@"; do
+        case "$arg" in
+            "$flag_name"|"$flag_name="*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+resolve_ozone_platform_args() {
+    OZONE_PLATFORM_ARGS=()
+    if has_electron_flag "--ozone-platform" "$@" || has_electron_flag "--ozone-platform-hint" "$@"; then
+        return 0
+    fi
+
+    if [ "${XDG_SESSION_TYPE:-}" = "wayland" ] && [ -n "${DISPLAY:-}" ]; then
+        OZONE_PLATFORM_ARGS=(--ozone-platform=x11)
+    else
+        OZONE_PLATFORM_ARGS=(--ozone-platform-hint=auto)
+    fi
+}
+
 cleanup_launcher() {
     if [ -n "${ELECTRON_PID:-}" ] && [ -f "$APP_PID_FILE" ]; then
         local current_pid
@@ -876,13 +1018,17 @@ cleanup_launcher() {
 launch_electron() {
     cd "$SCRIPT_DIR"
     log_phase "electron_launch"
+    resolve_ozone_platform_args "$@"
+    if [ "${OZONE_PLATFORM_ARGS[0]:-}" = "--ozone-platform=x11" ]; then
+        echo "Using --ozone-platform=x11 for Wayland window positioning compatibility"
+    fi
 
     if [ "$WARM_START" -eq 1 ]; then
         "$SCRIPT_DIR/electron" \
             --no-sandbox \
             --class=codex-desktop \
             --app-id=codex-desktop \
-            --ozone-platform-hint=auto \
+            "${OZONE_PLATFORM_ARGS[@]}" \
             --disable-gpu-sandbox \
             --disable-gpu-compositing \
             --enable-features=WaylandWindowDecorations \
@@ -894,7 +1040,7 @@ launch_electron() {
         --no-sandbox \
         --class=codex-desktop \
         --app-id=codex-desktop \
-        --ozone-platform-hint=auto \
+        "${OZONE_PLATFORM_ARGS[@]}" \
         --disable-gpu-sandbox \
         --disable-gpu-compositing \
         --enable-features=WaylandWindowDecorations \
@@ -956,6 +1102,7 @@ if [ "$WARM_START" -eq 0 ]; then
 fi
 
 export_packaged_runtime_env
+resolve_browser_use_runtime_env
 
 echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
 
@@ -1000,6 +1147,7 @@ main() {
     download_electron
     extract_webview "$app_dir"
     install_app
+    install_browser_use_resources "$app_dir"
     create_start_script
 
     if ! command -v codex &>/dev/null; then

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -255,7 +255,7 @@ function applyLinuxSetIconPatch(currentSource, iconAsset) {
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  if (currentSource.includes("process.platform===`linux`?{backgroundColor:")) {
+  if (currentSource.includes("process.platform===`linux`&&!gw(")) {
     return currentSource;
   }
 
@@ -283,11 +283,16 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
   const darkColorsParam = funcMatch[1];
   const bgNeedle =
     `backgroundMaterial:\`mica\`}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-  const bgReplacement =
+  const oldLinuxBgPatch =
     `backgroundMaterial:\`mica\`}:process.platform===\`linux\`?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
+  const bgReplacement =
+    `backgroundMaterial:\`mica\`}:process.platform===\`linux\`&&!gw(t)?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
 
   if (currentSource.includes(bgNeedle)) {
     return currentSource.replace(bgNeedle, bgReplacement);
+  }
+  if (currentSource.includes(oldLinuxBgPatch)) {
+    return currentSource.replace(oldLinuxBgPatch, bgReplacement);
   }
 
   console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
@@ -458,6 +463,36 @@ function applyLinuxSingleInstancePatch(currentSource) {
   return patchedSource;
 }
 
+function applyBrowserAnnotationScreenshotPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const liveElementScreenshotNeedle =
+    "if(M&&j?.anchor.kind===`element`){let e=qu(j,y.current)??null,t=e==null?null:rd(e);he=t?.rect??md(j.anchor),_e=t?.borderRadius}";
+  const storedAnchorScreenshotPatch =
+    "if(M&&j?.anchor.kind===`element`){he=md(j.anchor),_e=void 0}";
+  if (patchedSource.includes(storedAnchorScreenshotPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(liveElementScreenshotNeedle)) {
+    patchedSource = patchedSource.replace(liveElementScreenshotNeedle, storedAnchorScreenshotPatch);
+  } else {
+    console.warn("WARN: Could not find browser annotation screenshot element highlight — skipping screenshot anchor patch");
+  }
+
+  const allMarkersInScreenshotNeedle =
+    "de=u?.target.mode===`create`?ce.find(e=>Sd(e.anchor,u.anchor.value))??null:null,fe=!M&&de!=null?ce.filter(e=>e.id!==de.id):ce,";
+  const selectedMarkerInScreenshotPatch =
+    "de=u?.target.mode===`create`?ce.find(e=>Sd(e.anchor,u.anchor.value))??null:null,fe=M?ue:!M&&de!=null?ce.filter(e=>e.id!==de.id):ce,";
+  if (patchedSource.includes(selectedMarkerInScreenshotPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(allMarkersInScreenshotNeedle)) {
+    patchedSource = patchedSource.replace(allMarkersInScreenshotNeedle, selectedMarkerInScreenshotPatch);
+  } else {
+    console.warn("WARN: Could not find browser annotation screenshot markers — skipping screenshot marker patch");
+  }
+
+  return patchedSource;
+}
+
 function patchMainBundleSource(source, iconAsset) {
   let patched = source;
   const iconPathExpression =
@@ -486,6 +521,22 @@ function patchPackageJson(extractedDir) {
   return packageJson.desktopName;
 }
 
+function patchCommentPreloadBundle(extractedDir) {
+  const commentPreloadBundle = path.join(extractedDir, ".vite", "build", "comment-preload.js");
+  if (!fs.existsSync(commentPreloadBundle)) {
+    console.warn(
+      `WARN: Could not find comment preload bundle in ${path.dirname(commentPreloadBundle)} — skipping annotation screenshot patch`,
+    );
+    return;
+  }
+
+  const source = fs.readFileSync(commentPreloadBundle, "utf8");
+  const patchedSource = applyBrowserAnnotationScreenshotPatch(source);
+  if (patchedSource !== source) {
+    fs.writeFileSync(commentPreloadBundle, patchedSource, "utf8");
+  }
+}
+
 function patchExtractedApp(extractedDir) {
   const main = findMainBundle(extractedDir);
   if (main == null) {
@@ -509,6 +560,8 @@ function patchExtractedApp(extractedDir) {
       fs.writeFileSync(target, patchedSource, "utf8");
     }
   }
+
+  patchCommentPreloadBundle(extractedDir);
 
   patchAssetFiles(
     extractedDir,
@@ -576,6 +629,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  applyBrowserAnnotationScreenshotPatch,
   applyLinuxFileManagerPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,
@@ -584,6 +638,7 @@ module.exports = {
   applyLinuxSingleInstancePatch,
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
+  patchCommentPreloadBundle,
   patchExtractedApp,
   patchMainBundleSource,
 };

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -437,6 +437,29 @@ JS
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&oe' '1'
 }
 
+test_browser_annotation_screenshot_patch_smoke() {
+    info "Checking browser annotation screenshot patch behavior"
+    local workspace="$TMP_DIR/browser-annotation-patch"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let n=require(`electron`),t=require(`node:path`),a=require(`node:fs`);...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{})'
+    cat > "$extracted/.vite/build/comment-preload.js" <<'JS'
+if(M&&j?.anchor.kind===`element`){let e=qu(j,y.current)??null,t=e==null?null:rd(e);he=t?.rect??md(j.anchor),_e=t?.borderRadius}
+de=u?.target.mode===`create`?ce.find(e=>Sd(e.anchor,u.anchor.value))??null:null,fe=!M&&de!=null?ce.filter(e=>e.id!==de.id):ce,
+JS
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_contains "$extracted/.vite/build/comment-preload.js" 'if(M&&j?.anchor.kind===`element`){he=md(j.anchor),_e=void 0}'
+    assert_contains "$extracted/.vite/build/comment-preload.js" 'fe=M?ue:!M&&de!=null?ce.filter(e=>e.id!==de.id):ce,'
+    assert_not_contains "$extracted/.vite/build/comment-preload.js" 'qu(j,y.current)'
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/.vite/build/comment-preload.js" 'he=md(j.anchor)' '1'
+    assert_occurrence_count "$extracted/.vite/build/comment-preload.js" 'fe=M?ue' '1'
+}
+
 test_linux_single_instance_patch_smoke() {
     info "Checking Linux single-instance patch behavior"
     local workspace="$TMP_DIR/single-instance-patch"
@@ -487,6 +510,7 @@ main() {
     test_linux_file_manager_patch_smoke
     test_linux_translucent_sidebar_default_patch_smoke
     test_linux_tray_patch_smoke
+    test_browser_annotation_screenshot_patch_smoke
     test_linux_single_instance_patch_smoke
     test_linux_file_manager_patch_fails_soft
     info "All script smoke tests passed"


### PR DESCRIPTION
## Summary

- install the bundled Browser Use plugin resources and Linux runtime fallbacks for packaged installs
- default Wayland sessions with `DISPLAY` to `--ozone-platform=x11` unless the user supplied an ozone flag, so Electron popup positioning uses the XWayland path
- keep browser annotation popup windows transparent while preserving opaque Linux backgrounds for normal windows
- stabilize saved browser annotation screenshots by using the stored anchor geometry and rendering only the selected comment marker

## Scope notes

The Linux browser annotation bugs found during testing are fixed in the touched paths, but this is intentionally scoped to the browser annotation flow rather than a full browser audit. The relevant component surfaces are:

- `install.sh` for Browser Use resources and launcher/runtime setup
- `scripts/patch-linux-window-ui.js` for the extracted ASAR patches, especially `.vite/build/main-*.js` and `.vite/build/comment-preload.js`
- `tests/scripts_smoke.sh` for script-level regression coverage
- `README.md` for the Wayland launcher note

Current `origin/main` tray behavior is left unchanged.

## Verification

- `node --check scripts/patch-linux-window-ui.js`
- `bash -n install.sh`
- `bash -n codex-app/start.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- patched a real extracted `app.asar` copy and verified:
  - `comment-preload.js` contains the stored-anchor screenshot path
  - `comment-preload.js` renders only the selected marker in prepared screenshot mode
  - `main-*.js` keeps Linux opaque backgrounds off overlay windows
- manual in-app browser check on a Google results page: sign-in button, result row, search field, and image annotations all saved with the marker and outline on the selected target