### PR TITLE
Fix apt Node dependency bootstrap

### DIFF
--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -1,0 +1,61 @@
+name: Install Dependencies
+
+on:
+  pull_request:
+    paths:
+      - install.sh
+      - scripts/install-deps.sh
+      - packaging/linux/control
+      - .github/workflows/install-deps.yml
+  push:
+    branches:
+      - main
+    paths:
+      - install.sh
+      - scripts/install-deps.sh
+      - packaging/linux/control
+      - .github/workflows/install-deps.yml
+
+jobs:
+  apt-node-bootstrap:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+      options: --user root
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - docker.io/library/ubuntu:22.04
+          - docker.io/library/ubuntu:24.04
+          - docker.io/library/debian:12
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bootstrap sudo
+        run: |
+          apt-get update -qq >/dev/null
+          apt-get install -y sudo ca-certificates >/dev/null
+
+      - name: Install dependencies
+        run: bash scripts/install-deps.sh
+
+      - name: Verify Node.js toolchain
+        run: |
+          node -p "process.versions.node"
+          node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 20 ? 0 : 1)'
+          npm -v
+          npx -v
+          dpkg-query -W -f='${Provides}\n' nodejs | grep -E '(^|[,[:space:]])npm([,[:space:](]|$)'
+
+      - name: Verify installer passes Node preflight
+        run: |
+          export PATH="$HOME/.local/bin:$PATH"
+          output=$(./install.sh /tmp/nope.dmg 2>&1) && status=0 || status=$?
+          printf '%s\n' "$output"
+          test "$status" -ne 0
+          printf '%s\n' "$output" | grep -q "Provided DMG not found: /tmp/nope.dmg"
+          ! printf '%s\n' "$output" | grep -q "Node.js 20+ required"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ PACKAGE_VERSION=2026.03.24.120000+deadbeef ./scripts/build-pacman.sh
 
 - `node`, `npm`, `npx`, `python3`, `7z`, `curl`, `unzip`, `make`, and `g++` are required for `install.sh`
 - Node.js 20+ is required
-- On apt-based systems, `scripts/install-deps.sh` bootstraps NodeSource Node.js 22 by default when the distro `nodejs` package is missing or too old. `NODEJS_MAJOR=24 bash scripts/install-deps.sh` selects Node.js 24 instead.
+- On apt-based systems, `scripts/install-deps.sh` uses a compatible distro `nodejs`/`npm` candidate when available and otherwise bootstraps NodeSource Node.js 22 by default. `NODEJS_MAJOR=24 bash scripts/install-deps.sh` selects Node.js 24 instead.
 - the packaged app still requires the Codex CLI at runtime:
   `codex` must exist in `PATH` or be set through `CODEX_CLI_PATH`, but the launcher now attempts a best-effort automatic install on first run when the CLI is missing and `npm` is available
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,7 @@ PACKAGE_VERSION=2026.03.24.120000+deadbeef ./scripts/build-pacman.sh
 
 - `node`, `npm`, `npx`, `python3`, `7z`, `curl`, `unzip`, `make`, and `g++` are required for `install.sh`
 - Node.js 20+ is required
+- On apt-based systems, `scripts/install-deps.sh` bootstraps NodeSource Node.js 22 by default when the distro `nodejs` package is missing or too old. `NODEJS_MAJOR=24 bash scripts/install-deps.sh` selects Node.js 24 instead.
 - the packaged app still requires the Codex CLI at runtime:
   `codex` must exist in `PATH` or be set through `CODEX_CLI_PATH`, but the launcher now attempts a best-effort automatic install on first run when the CLI is missing and `npm` is available
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The easiest setup path is:
 bash scripts/install-deps.sh
 ```
 
-That helper detects `apt`, `dnf5`, `dnf`, or `pacman`, installs system packages, and bootstraps Rust through `rustup` if needed.
+That helper detects `apt`, `dnf5`, `dnf`, `pacman`, or `zypper`, installs system packages, and bootstraps Rust through `rustup` if needed.
+On apt-based systems, it also bootstraps Node.js 22 from NodeSource when the distro `nodejs` package is missing or too old. Set `NODEJS_MAJOR=24` if you want to bootstrap Node.js 24 instead.
 The generated launcher can then auto-install `@openai/codex` on first run if the CLI is still missing and `npm` is available.
 
 If you prefer to preinstall the CLI manually:
@@ -74,7 +75,21 @@ If your system does not allow global npm installs, a rootless alternative also w
 npm i -g --prefix ~/.local @openai/codex
 ```
 
-### Ubuntu / Pop!_OS Note
+### Debian / Ubuntu / Pop!_OS Notes
+
+Ubuntu 22.04, Ubuntu 24.04, Debian 12, and related distros can provide stock `nodejs` packages below the Node.js 20+ requirement. Prefer:
+
+```bash
+bash scripts/install-deps.sh
+```
+
+The helper installs Node.js 22 from NodeSource only when the current `node`/`npm`/`npx` toolchain is missing or incompatible. To bootstrap another maintained line:
+
+```bash
+NODEJS_MAJOR=24 bash scripts/install-deps.sh
+```
+
+If you install dependencies manually on Debian or Ubuntu, install Node.js 20+ with `npm` and `npx` from NodeSource, `nvm`, or another compatible source before running `./install.sh`. Do not rely on plain distro `apt install nodejs npm` unless your configured repositories provide Node.js 20 or newer.
 
 Ubuntu-family `p7zip-full` can be too old to extract newer APFS DMGs.
 Run `bash scripts/install-deps.sh` to install dependencies and bootstrap a newer `7zz`
@@ -242,6 +257,8 @@ echo 'alias codex-desktop="~/codex-desktop-linux/codex-app/start.sh"' >> ~/.bash
 The repository can build a Debian, RPM, or pacman package from the generated `codex-app/` directory.
 
 **Prerequisite:** Run `make build-app` (or `./install.sh`) first to produce `codex-app/`. The packaging scripts only repackage what is already there — they do not download or extract the DMG themselves.
+
+Native packages declare a Node.js 20+ runtime/build dependency because the installed update manager rebuilds future packages locally. On Debian and Ubuntu, run `bash scripts/install-deps.sh` or configure a compatible Node.js repository before installing the `.deb`; vanilla Ubuntu 22.04, Ubuntu 24.04, and Debian 12 repositories do not satisfy that dependency.
 
 ### Debian
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ bash scripts/install-deps.sh
 ```
 
 That helper detects `apt`, `dnf5`, `dnf`, `pacman`, or `zypper`, installs system packages, and bootstraps Rust through `rustup` if needed.
-On apt-based systems, it also bootstraps Node.js 22 from NodeSource when the distro `nodejs` package is missing or too old. Set `NODEJS_MAJOR=24` if you want to bootstrap Node.js 24 instead.
+On apt-based systems, it uses a compatible distro `nodejs`/`npm` candidate when available and otherwise bootstraps Node.js 22 from NodeSource. Set `NODEJS_MAJOR=24` if you want to bootstrap Node.js 24 instead.
 The generated launcher can then auto-install `@openai/codex` on first run if the CLI is still missing and `npm` is available.
 
 If you prefer to preinstall the CLI manually:
@@ -83,7 +83,7 @@ Ubuntu 22.04, Ubuntu 24.04, Debian 12, and related distros can provide stock `no
 bash scripts/install-deps.sh
 ```
 
-The helper installs Node.js 22 from NodeSource only when the current `node`/`npm`/`npx` toolchain is missing or incompatible. To bootstrap another maintained line:
+The helper uses a compatible distro `nodejs`/`npm` candidate when available. If the current toolchain is missing or incompatible and the distro candidate is too old, it installs Node.js 22 from NodeSource. To bootstrap another maintained line:
 
 ```bash
 NODEJS_MAJOR=24 bash scripts/install-deps.sh

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,8 @@ Run the helper to install them automatically:
   bash scripts/install-deps.sh
 
 Or install manually:
-  sudo apt install nodejs npm python3 p7zip-full curl unzip build-essential         # Debian/Ubuntu
+  # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
+  sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
   sudo dnf install nodejs npm python3 7zip curl unzip @development-tools            # Fedora 41+ (dnf5)
   sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -7,7 +7,7 @@ arch=('__ARCH__')
 url="https://github.com/ilysenko/codex-desktop-linux"
 license=('MIT')
 depends=(
-    'nodejs'
+    'nodejs>=20'
     'npm'
     'python'
     'p7zip'

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -5,7 +5,7 @@ Summary:        Codex Desktop for Linux
 License:        Proprietary
 ExclusiveArch:  __ARCH__
 
-Requires:       nodejs, npm, python3, p7zip, polkit, curl, unzip, gcc-c++, make
+Requires:       nodejs >= 20, npm, python3, p7zip, polkit, curl, unzip, gcc-c++, make
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
 Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
 Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr

--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: Codex Desktop Linux Maintainers
-Depends: build-essential, curl, dpkg, nodejs, npm, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Depends: build-essential, curl, dpkg, nodejs (>= 20), npm, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Description: Codex Desktop for Linux
  Community-built Linux package for Codex Desktop generated from the macOS DMG.
  Requires the Codex CLI to be available in PATH or CODEX_CLI_PATH.

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -9,10 +9,128 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 ARCH="$(uname -m)"
+MIN_NODE_MAJOR=20
+NODEJS_MAJOR="${NODEJS_MAJOR:-22}"
 
 info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
 warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
 error() { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Node.js compatibility
+# ---------------------------------------------------------------------------
+node_major() {
+    command -v node &>/dev/null || return 1
+
+    local version major
+    version="$(node -v 2>/dev/null || true)"
+    major="${version#v}"
+    major="${major%%.*}"
+
+    case "$major" in
+        ''|*[!0-9]*) return 1 ;;
+        *) printf '%s\n' "$major" ;;
+    esac
+}
+
+has_compatible_nodejs() {
+    local major
+    major="$(node_major 2>/dev/null || true)"
+
+    [ -n "$major" ] \
+        && [ "$major" -ge "$MIN_NODE_MAJOR" ] \
+        && command -v npm &>/dev/null \
+        && command -v npx &>/dev/null
+}
+
+validate_nodejs_major() {
+    case "$NODEJS_MAJOR" in
+        ''|*[!0-9]*)
+            error "NODEJS_MAJOR must be numeric, for example: NODEJS_MAJOR=22 bash scripts/install-deps.sh"
+            ;;
+    esac
+
+    if [ "$NODEJS_MAJOR" -lt 22 ]; then
+        error "NODEJS_MAJOR=$NODEJS_MAJOR is not supported for apt bootstrap. Use Node.js 22 or newer.
+Existing user-managed Node.js 20 installations are still accepted by install.sh, but new bootstrap installs should use a maintained Node.js line."
+    fi
+}
+
+apt_arch_for_nodesource() {
+    local apt_arch
+    apt_arch="$(dpkg --print-architecture)"
+
+    case "$apt_arch" in
+        amd64|arm64|armhf)
+            printf '%s\n' "$apt_arch"
+            ;;
+        *)
+            error "NodeSource apt packages are not available for architecture '$apt_arch'.
+Install Node.js ${MIN_NODE_MAJOR}+ manually, then re-run this script."
+            ;;
+    esac
+}
+
+install_nodesource_nodejs() {
+    validate_nodejs_major
+
+    local apt_arch keyring source_list tmp_key
+    apt_arch="$(apt_arch_for_nodesource)"
+    keyring="/etc/apt/keyrings/nodesource.gpg"
+    source_list="/etc/apt/sources.list.d/nodesource.list"
+    tmp_key="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap "rm -f '$tmp_key'" RETURN
+
+    info "Installing Node.js ${NODEJS_MAJOR}.x from NodeSource"
+    sudo apt-get install -y gnupg
+    sudo install -d -m 0755 /etc/apt/keyrings
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key -o "$tmp_key"
+    gpg --dearmor < "$tmp_key" | sudo tee "$keyring" >/dev/null
+    sudo chmod 0644 "$keyring"
+
+    printf 'deb [arch=%s signed-by=%s] https://deb.nodesource.com/node_%s.x nodistro main\n' \
+        "$apt_arch" "$keyring" "$NODEJS_MAJOR" \
+        | sudo tee "$source_list" >/dev/null
+
+    sudo apt-get update -qq
+    sudo apt-get install -y nodejs
+}
+
+report_nodejs_toolchain() {
+    info "Node.js toolchain available: node $(node -v), npm $(npm -v), npx $(npx -v)"
+}
+
+current_node_version_suffix() {
+    if command -v node &>/dev/null; then
+        printf ' but found %s' "$(node -v)"
+    fi
+}
+
+ensure_nodejs_compatible() {
+    local distro="$1"
+
+    if has_compatible_nodejs; then
+        report_nodejs_toolchain
+        return
+    fi
+
+    if [ "$distro" != "apt" ]; then
+        error "Node.js ${MIN_NODE_MAJOR}+ with npm and npx is required$(current_node_version_suffix).
+Install a supported Node.js version for this distro, then re-run this script."
+    fi
+
+    warn "Node.js ${MIN_NODE_MAJOR}+ with npm and npx is required$(current_node_version_suffix)"
+    install_nodesource_nodejs
+
+    if has_compatible_nodejs; then
+        report_nodejs_toolchain
+        return
+    fi
+
+    error "NodeSource install completed, but Node.js ${MIN_NODE_MAJOR}+ with npm and npx is still unavailable.
+Check apt output above or install Node.js ${MIN_NODE_MAJOR}+ manually."
+}
 
 # ---------------------------------------------------------------------------
 # Distro detection
@@ -40,7 +158,7 @@ install_apt() {
     info "Detected Debian/Ubuntu (apt)"
     sudo apt-get update -qq
     sudo apt-get install -y \
-        nodejs npm python3 \
+        ca-certificates python3 \
         p7zip-full curl unzip \
         build-essential
 }
@@ -132,7 +250,8 @@ Install 7zz manually from https://www.7-zip.org/download.html and ensure it is o
 
     local tmpdir
     tmpdir="$(mktemp -d)"
-    trap 'rm -rf "$tmpdir"' EXIT
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" EXIT
 
     info "Downloading 7zz ${version} from $url"
     curl -fL --progress-bar -o "$tmpdir/7z.tar.xz" "$url"
@@ -195,7 +314,8 @@ case "$DISTRO" in
     zypper)  install_zypper ;;
     *)
         error "Unsupported package manager. Install manually:
-  sudo apt install nodejs npm python3 p7zip-full curl unzip build-essential         # Debian/Ubuntu
+  # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
+  sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
   sudo dnf install nodejs npm python3 7zip curl unzip @development-tools            # Fedora 41+ (dnf5)
   sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
@@ -205,6 +325,7 @@ case "$DISTRO" in
         ;;
 esac
 
+ensure_nodejs_compatible "$DISTRO"
 install_rust
 bootstrap_7zz
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -56,6 +56,49 @@ Existing user-managed Node.js 20 installations are still accepted by install.sh,
     fi
 }
 
+apt_nodejs_candidate_major() {
+    local line candidate major=""
+
+    while IFS= read -r line; do
+        case "$line" in
+            *Candidate:*)
+                candidate="${line#*Candidate: }"
+                break
+                ;;
+        esac
+    done < <(apt-cache policy nodejs 2>/dev/null || true)
+
+    [ -n "${candidate:-}" ] && [ "$candidate" != "(none)" ] || return 1
+
+    if [[ "$candidate" =~ ^[0-9]+:([0-9]+)\. ]]; then
+        major="${BASH_REMATCH[1]}"
+    elif [[ "$candidate" =~ ^([0-9]+)\. ]]; then
+        major="${BASH_REMATCH[1]}"
+    else
+        return 1
+    fi
+
+    printf '%s\n' "$major"
+}
+
+install_apt_distro_nodejs_if_compatible() {
+    local major
+    major="$(apt_nodejs_candidate_major 2>/dev/null || true)"
+
+    if [ -z "$major" ]; then
+        warn "Could not determine distro nodejs candidate; using NodeSource"
+        return 1
+    fi
+
+    if [ "$major" -lt "$MIN_NODE_MAJOR" ]; then
+        warn "Distro nodejs candidate is below Node.js ${MIN_NODE_MAJOR}; using NodeSource"
+        return 1
+    fi
+
+    info "Installing distro Node.js/npm candidate (Node.js major $major)"
+    sudo apt-get install -y nodejs npm
+}
+
 apt_arch_for_nodesource() {
     local apt_arch
     apt_arch="$(dpkg --print-architecture)"
@@ -121,6 +164,13 @@ Install a supported Node.js version for this distro, then re-run this script."
     fi
 
     warn "Node.js ${MIN_NODE_MAJOR}+ with npm and npx is required$(current_node_version_suffix)"
+    install_apt_distro_nodejs_if_compatible || true
+
+    if has_compatible_nodejs; then
+        report_nodejs_toolchain
+        return
+    fi
+
     install_nodesource_nodejs
 
     if has_compatible_nodejs; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -308,6 +308,8 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now --if-stale"
     assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "restart codex-update-manager.service"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" 'NODEJS_MAJOR="${NODEJS_MAJOR:-22}"'
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" "apt_nodejs_candidate_major"
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" "Installing distro Node.js/npm candidate"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "/etc/apt/keyrings/nodesource.gpg"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "signed-by="
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "https://deb.nodesource.com/node_"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -307,6 +307,13 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager-launch-check"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now --if-stale"
     assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "restart codex-update-manager.service"
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" 'NODEJS_MAJOR="${NODEJS_MAJOR:-22}"'
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" "/etc/apt/keyrings/nodesource.gpg"
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" "signed-by="
+    assert_contains "$REPO_DIR/scripts/install-deps.sh" "https://deb.nodesource.com/node_"
+    assert_contains "$REPO_DIR/packaging/linux/control" "nodejs (>= 20)"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.spec" "nodejs >= 20"
+    assert_contains "$REPO_DIR/packaging/linux/PKGBUILD.template" "nodejs>=20"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "BAMF_DESKTOP_FILE_HINT"


### PR DESCRIPTION
## Summary
- Try a compatible apt `nodejs`/`npm` candidate first, then bootstrap NodeSource Node.js 22 when apt would install an unsupported Node line.
- Add Node.js version floors to Debian, RPM, and pacman package metadata while preserving upstream package dependency additions.
- Document the apt behavior and add an Ubuntu/Debian CI matrix for the dependency bootstrap path.

## Testing
- `bash -n install.sh scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh`
- `./tests/scripts_smoke.sh`
- `podman run` regression checks on `ubuntu:24.04`, `ubuntu:22.04`, and `debian:12` confirmed Node 22.22.2 with npm/npx and `./install.sh /tmp/nope.dmg` reaching `Provided DMG not found`
- Temporary `.deb` build confirmed `nodejs (>= 20)` plus upstream polkit dependencies
- Temporary RPM build confirmed `nodejs >= 20`, `npm`, and `polkit` requirements