### PR TITLE
[codex] Fix Linux Computer Use coordinate input

### DIFF
--- a/computer-use-linux/src/screenshot.rs
+++ b/computer-use-linux/src/screenshot.rs
@@ -20,6 +20,8 @@ pub struct ScreenshotCapture {
     pub mime_type: String,
     pub data_url: String,
     pub source: String,
+    pub width: u32,
+    pub height: u32,
 }
 
 pub async fn capture_screenshot() -> Result<ScreenshotCapture> {
@@ -155,13 +157,29 @@ async fn read_png_as_capture(path: PathBuf, source: &str) -> Result<ScreenshotCa
     if bytes.is_empty() {
         bail!("screenshot file was empty: {}", path.display());
     }
+    let (width, height) = png_dimensions(&bytes)?;
     let encoded = STANDARD.encode(bytes);
     let _ = fs::remove_file(path);
     Ok(ScreenshotCapture {
         mime_type: "image/png".to_string(),
         data_url: format!("data:image/png;base64,{encoded}"),
         source: source.to_string(),
+        width,
+        height,
     })
+}
+
+fn png_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
+    const PNG_SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if bytes.len() < 24 || &bytes[..8] != PNG_SIGNATURE || &bytes[12..16] != b"IHDR" {
+        bail!("screenshot file was not a valid PNG");
+    }
+    let width = u32::from_be_bytes(bytes[16..20].try_into().unwrap());
+    let height = u32::from_be_bytes(bytes[20..24].try_into().unwrap());
+    if width == 0 || height == 0 {
+        bail!("screenshot PNG had invalid dimensions {width}x{height}");
+    }
+    Ok((width, height))
 }
 
 fn file_uri_to_path(uri: &str) -> Result<PathBuf> {
@@ -230,5 +248,18 @@ mod tests {
         let token = request_token();
         assert!(token.starts_with("codex_"));
         assert!(token.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
+    }
+
+    #[test]
+    fn reads_png_dimensions_from_ihdr() {
+        let mut png = Vec::new();
+        png.extend_from_slice(b"\x89PNG\r\n\x1a\n");
+        png.extend_from_slice(&13_u32.to_be_bytes());
+        png.extend_from_slice(b"IHDR");
+        png.extend_from_slice(&3840_u32.to_be_bytes());
+        png.extend_from_slice(&1080_u32.to_be_bytes());
+        png.extend_from_slice(&[8, 6, 0, 0, 0]);
+
+        assert_eq!(png_dimensions(&png).unwrap(), (3840, 1080));
     }
 }

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -20,6 +20,7 @@ use std::{
 #[derive(Debug, Clone, Default)]
 pub struct ComputerUseLinux {
     last_nodes: Arc<Mutex<Vec<AccessibilityNode>>>,
+    last_screenshot_size: Arc<Mutex<Option<ScreenSize>>>,
 }
 
 #[tool_router]
@@ -72,7 +73,10 @@ impl ComputerUseLinux {
         let include_screenshot = params.include_screenshot.unwrap_or(true);
         let (screenshot, screenshot_error) = if include_screenshot {
             match capture_screenshot().await {
-                Ok(capture) => (Some(capture), None),
+                Ok(capture) => {
+                    self.cache_screenshot_size(capture.width, capture.height);
+                    (Some(capture), None)
+                }
                 Err(error) => (None, Some(error.to_string())),
             }
         } else {
@@ -154,6 +158,7 @@ impl ComputerUseLinux {
         };
         let button = mouse_button_code(params.button.as_deref());
         let click_count = params.click_count.unwrap_or(1).clamp(1, 10).to_string();
+        let (x, y) = self.to_ydotool_absolute_point(x, y);
         let result = run_ydotool_sequence(&[
             absolute_mousemove_args(x, y),
             vec![
@@ -231,14 +236,10 @@ impl ComputerUseLinux {
         };
         let mut sequence = Vec::new();
         if let Some((x, y)) = target_point {
+            let (x, y) = self.to_ydotool_absolute_point(x, y);
             sequence.push(absolute_mousemove_args(x, y));
         }
-        sequence.push(vec![
-            "mousemove".to_string(),
-            "--wheel".to_string(),
-            dx.to_string(),
-            dy.to_string(),
-        ]);
+        sequence.push(wheel_mousemove_args(dx, dy));
         let result = run_ydotool_sequence(&sequence);
         Json(action_result("scroll", result, received))
     }
@@ -249,10 +250,12 @@ impl ComputerUseLinux {
     )]
     fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
+        let (start_x, start_y) = self.to_ydotool_absolute_point(params.start_x, params.start_y);
+        let (end_x, end_y) = self.to_ydotool_absolute_point(params.end_x, params.end_y);
         let result = run_ydotool_sequence(&[
-            absolute_mousemove_args(params.start_x, params.start_y),
+            absolute_mousemove_args(start_x, start_y),
             vec!["click".to_string(), "0x40".to_string()],
-            absolute_mousemove_args(params.end_x, params.end_y),
+            absolute_mousemove_args(end_x, end_y),
             vec!["click".to_string(), "0x80".to_string()],
         ]);
         Json(action_result("drag", result, received))
@@ -410,6 +413,12 @@ struct TypeTextParams {
     text: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ScreenSize {
+    width: u32,
+    height: u32,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 struct ActionOutput {
     ok: bool,
@@ -439,6 +448,30 @@ impl ComputerUseLinux {
             cached.clear();
             cached.extend_from_slice(nodes);
         }
+    }
+
+    fn cache_screenshot_size(&self, width: u32, height: u32) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        if let Ok(mut cached) = self.last_screenshot_size.lock() {
+            *cached = Some(ScreenSize { width, height });
+        }
+    }
+
+    fn to_ydotool_absolute_point(&self, x: i32, y: i32) -> (i32, i32) {
+        let Some(size) = self
+            .last_screenshot_size
+            .lock()
+            .ok()
+            .and_then(|cached| *cached)
+        else {
+            return (x, y);
+        };
+        (
+            pixel_to_ydotool_absolute(x, size.width),
+            pixel_to_ydotool_absolute(y, size.height),
+        )
     }
 
     fn resolve_target_point(
@@ -485,6 +518,16 @@ impl ComputerUseLinux {
     }
 }
 
+fn pixel_to_ydotool_absolute(value: i32, extent: u32) -> i32 {
+    if extent <= 1 {
+        return value;
+    }
+    let max_pixel = extent as i32 - 1;
+    let clamped = value.clamp(0, max_pixel) as i64;
+    let max_pixel = max_pixel as i64;
+    ((clamped * 65_535 + max_pixel / 2) / max_pixel) as i32
+}
+
 fn action_result(
     action: &str,
     result: std::result::Result<Vec<Output>, String>,
@@ -515,6 +558,16 @@ fn absolute_mousemove_args(x: i32, y: i32) -> Vec<String> {
         "--".to_string(),
         x.to_string(),
         y.to_string(),
+    ]
+}
+
+fn wheel_mousemove_args(dx: i32, dy: i32) -> Vec<String> {
+    vec![
+        "mousemove".to_string(),
+        "--wheel".to_string(),
+        "--".to_string(),
+        dx.to_string(),
+        dy.to_string(),
     ]
 }
 
@@ -853,6 +906,28 @@ mod tests {
                 "300".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn wheel_mousemove_uses_coordinate_separator_for_negative_values() {
+        assert_eq!(
+            wheel_mousemove_args(0, -3),
+            vec![
+                "mousemove".to_string(),
+                "--wheel".to_string(),
+                "--".to_string(),
+                "0".to_string(),
+                "-3".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn screenshot_pixels_normalize_to_ydotool_absolute_space() {
+        let backend = ComputerUseLinux::default();
+        backend.cache_screenshot_size(3840, 1080);
+
+        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (26460, 56485));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cache screenshot dimensions from `get_app_state` captures and convert screenshot pixel coordinates into ydotool absolute coordinates for click, scroll target, and drag input
- add a `--` separator for wheel scroll deltas so negative values are not parsed as options
- add regression tests for PNG dimension extraction, coordinate normalization, and negative wheel deltas

## Why
During a fresh app restart test on Linux/GNOME, the Computer Use MCP transport loaded correctly and `doctor` was green, but direct input exposed two concrete runtime issues: screenshot pixels needed conversion before ydotool absolute input, and `mousemove --wheel 0 -3` failed because the negative delta was parsed as an option.

## Validation
- `cargo fmt -p codex-computer-use-linux`
- `cargo test -p codex-computer-use-linux`
- `git diff --check`
- live app smoke: after restart, app-exposed `mcp__computer_use__` tools loaded, `doctor` reported screenshot/AT-SPI/ydotool ready, click at the visible Codex prompt typed `cu2`, and the prompt was cleared without submitting
