### PR TITLE
fix(launcher): register connector URL schemes

### DIFF
--- a/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop
+++ b/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop
@@ -7,6 +7,7 @@ Exec=@HOME@/.local/bin/codex-desktop %U
 TryExec=@HOME@/.local/bin/codex-desktop
 Terminal=false
 Categories=Development;IDE;
+MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;
 Keywords=codex;openai;ai;coding;
 StartupNotify=true
 StartupWMClass=codex-desktop

--- a/install.sh
+++ b/install.sh
@@ -927,6 +927,40 @@ hydrate_graphical_session_env() {
     return 0
 }
 
+desktop_entry_exists() {
+    local desktop_name="$CODEX_LINUX_APP_ID.desktop"
+    local data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+    local data_dirs="${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+    local data_dir
+    local -a data_dirs_array
+
+    [ -f "$data_home/applications/$desktop_name" ] && return 0
+
+    IFS=: read -r -a data_dirs_array <<< "$data_dirs"
+    for data_dir in "${data_dirs_array[@]}"; do
+        [ -f "$data_dir/applications/$desktop_name" ] && return 0
+    done
+
+    return 1
+}
+
+register_url_scheme_handlers() {
+    command -v xdg-mime >/dev/null 2>&1 || return 0
+    desktop_entry_exists || return 0
+
+    local desktop_name="$CODEX_LINUX_APP_ID.desktop"
+    local scheme
+    local mime_type
+    local current_handler
+
+    for scheme in codex codex-browser-sidebar; do
+        mime_type="x-scheme-handler/$scheme"
+        current_handler="$(xdg-mime query default "$mime_type" 2>/dev/null || true)"
+        [ "$current_handler" = "$desktop_name" ] && continue
+        xdg-mime default "$desktop_name" "$mime_type" >/dev/null 2>&1 || true
+    done
+}
+
 linux_setting_enabled() {
     local key="$1"
     local default_value="${2:-1}"
@@ -1605,6 +1639,7 @@ launch_electron() {
 hydrate_graphical_session_env
 configure_side_by_side_app_env
 load_packaged_runtime_helper
+register_url_scheme_handlers
 clear_stale_pid_file
 detect_warm_start
 trap cleanup_launcher EXIT

--- a/packaging/linux/codex-desktop.desktop
+++ b/packaging/linux/codex-desktop.desktop
@@ -1,11 +1,12 @@
 [Desktop Entry]
 Name=Codex Desktop
 Comment=Run Codex Desktop on Linux
-Exec=env BAMF_DESKTOP_FILE_HINT=/usr/share/applications/codex-desktop.desktop CHROME_DESKTOP=codex-desktop.desktop /usr/bin/codex-desktop
+Exec=env BAMF_DESKTOP_FILE_HINT=/usr/share/applications/codex-desktop.desktop CHROME_DESKTOP=codex-desktop.desktop /usr/bin/codex-desktop %u
 Icon=codex-desktop
 Terminal=false
 Type=Application
 Categories=Development;
+MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;
 StartupNotify=true
 StartupWMClass=codex-desktop
 X-GNOME-WMClass=codex-desktop

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -178,7 +178,8 @@ SCRIPT
     assert_contains "$pkg_root/DEBIAN/control" "Package: codex-cua-lab"
     assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "Name=Codex CUA Lab"
     assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "CHROME_DESKTOP=codex-cua-lab.desktop"
-    assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "/usr/bin/codex-cua-lab"
+    assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "/usr/bin/codex-cua-lab %u"
+    assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
     assert_contains "$pkg_root/opt/codex-cua-lab/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-cua-lab.desktop"'
 }
 
@@ -353,6 +354,10 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/install.sh" "CODEX_DESKTOP_LAUNCH_ACTION_SOCKET"
     assert_contains "$REPO_DIR/install.sh" "APP_SETTINGS_FILE"
     assert_contains "$REPO_DIR/install.sh" "linux_setting_enabled"
+    assert_contains "$REPO_DIR/install.sh" "register_url_scheme_handlers"
+    assert_contains "$REPO_DIR/install.sh" "xdg-mime default"
+    assert_contains "$REPO_DIR/install.sh" "x-scheme-handler/"
+    assert_contains "$REPO_DIR/install.sh" "codex-browser-sidebar"
     assert_contains "$REPO_DIR/install.sh" "codex-linux-warm-start-enabled"
     assert_contains "$REPO_DIR/install.sh" "ADOPTED_WEBVIEW_PID"
     assert_contains "$REPO_DIR/install.sh" "Reusing webview server pid="
@@ -442,6 +447,10 @@ PY
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "BAMF_DESKTOP_FILE_HINT"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "/usr/bin/codex-desktop %u"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
+    assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop" "@HOME@/.local/bin/codex-desktop %U"
+    assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
 }
 
 test_side_by_side_launcher_identity() {


### PR DESCRIPTION
## Summary
- register packaged and user-local desktop entries as handlers for the codex URL schemes
- pass callback URLs through the packaged desktop Exec line with %u
- have the launcher keep the codex and codex-browser-sidebar XDG handlers aligned when a desktop entry is installed
- add smoke coverage for the desktop entries and launcher registration path

## Verification
- bash -n install.sh tests/scripts_smoke.sh
- desktop-file-validate packaging/linux/codex-desktop.desktop
- desktop-file-validate contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop
- git diff --check
- git diff --cached --check
- bash tests/scripts_smoke.sh