### PR TITLE
Fix Linux Computer Use screenshot cleanup and stale caches

### DIFF
--- a/computer-use-linux/src/screenshot.rs
+++ b/computer-use-linux/src/screenshot.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::{
     collections::HashMap,
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use zbus::{
@@ -22,6 +22,12 @@ pub struct ScreenshotCapture {
     pub source: String,
     pub width: u32,
     pub height: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ScreenshotCleanup {
+    DeletePath(PathBuf),
+    Preserve,
 }
 
 pub async fn capture_screenshot() -> Result<ScreenshotCapture> {
@@ -54,16 +60,26 @@ async fn capture_with_gnome_shell() -> Result<ScreenshotCapture> {
     let filename = path
         .to_str()
         .context("temporary screenshot path is not valid UTF-8")?;
-    let (success, filename_used): (bool, String) = proxy
-        .call("Screenshot", &(false, false, filename))
-        .await
-        .context("GNOME Shell Screenshot call failed")?;
+    let result = proxy.call("Screenshot", &(false, false, filename)).await;
+    let (success, filename_used): (bool, String) = match result {
+        Ok(result) => result,
+        Err(error) => {
+            cleanup_gnome_requested_path(&path);
+            return Err(error).context("GNOME Shell Screenshot call failed");
+        }
+    };
 
     if !success {
+        cleanup_gnome_requested_path(&path);
         bail!("GNOME Shell reported screenshot failure");
     }
 
-    read_png_as_capture(PathBuf::from(filename_used), "gnome-shell").await
+    read_png_as_capture(
+        PathBuf::from(filename_used),
+        "gnome-shell",
+        ScreenshotCleanup::DeletePath(path),
+    )
+    .await
 }
 
 async fn capture_with_portal() -> Result<ScreenshotCapture> {
@@ -148,18 +164,29 @@ async fn capture_with_portal() -> Result<ScreenshotCapture> {
         .context("XDG portal screenshot uri was not a string")?;
     let path = file_uri_to_path(&uri)?;
 
-    read_png_as_capture(path, "xdg-desktop-portal").await
+    read_png_as_capture(path, "xdg-desktop-portal", ScreenshotCleanup::Preserve).await
 }
 
-async fn read_png_as_capture(path: PathBuf, source: &str) -> Result<ScreenshotCapture> {
-    let bytes = fs::read(&path)
+async fn read_png_as_capture(
+    path: PathBuf,
+    source: &str,
+    cleanup: ScreenshotCleanup,
+) -> Result<ScreenshotCapture> {
+    let result = read_png_as_capture_inner(&path, source);
+    if let ScreenshotCleanup::DeletePath(path) = cleanup {
+        let _ = fs::remove_file(path);
+    }
+    result
+}
+
+fn read_png_as_capture_inner(path: &Path, source: &str) -> Result<ScreenshotCapture> {
+    let bytes = fs::read(path)
         .with_context(|| format!("failed to read screenshot file {}", path.display()))?;
     if bytes.is_empty() {
         bail!("screenshot file was empty: {}", path.display());
     }
     let (width, height) = png_dimensions(&bytes)?;
     let encoded = STANDARD.encode(bytes);
-    let _ = fs::remove_file(path);
     Ok(ScreenshotCapture {
         mime_type: "image/png".to_string(),
         data_url: format!("data:image/png;base64,{encoded}"),
@@ -167,6 +194,10 @@ async fn read_png_as_capture(path: PathBuf, source: &str) -> Result<ScreenshotCa
         width,
         height,
     })
+}
+
+fn cleanup_gnome_requested_path(path: &Path) {
+    let _ = fs::remove_file(path);
 }
 
 fn png_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
@@ -235,6 +266,21 @@ fn unique_suffix() -> String {
 mod tests {
     use super::*;
 
+    fn test_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("codex-screenshot-test-{name}-{}", unique_suffix()))
+    }
+
+    fn valid_png(width: u32, height: u32) -> Vec<u8> {
+        let mut png = Vec::new();
+        png.extend_from_slice(b"\x89PNG\r\n\x1a\n");
+        png.extend_from_slice(&13_u32.to_be_bytes());
+        png.extend_from_slice(b"IHDR");
+        png.extend_from_slice(&width.to_be_bytes());
+        png.extend_from_slice(&height.to_be_bytes());
+        png.extend_from_slice(&[8, 6, 0, 0, 0]);
+        png
+    }
+
     #[test]
     fn decodes_file_uri_percent_escapes() {
         assert_eq!(
@@ -252,14 +298,109 @@ mod tests {
 
     #[test]
     fn reads_png_dimensions_from_ihdr() {
-        let mut png = Vec::new();
-        png.extend_from_slice(b"\x89PNG\r\n\x1a\n");
-        png.extend_from_slice(&13_u32.to_be_bytes());
-        png.extend_from_slice(b"IHDR");
-        png.extend_from_slice(&3840_u32.to_be_bytes());
-        png.extend_from_slice(&1080_u32.to_be_bytes());
-        png.extend_from_slice(&[8, 6, 0, 0, 0]);
+        let png = valid_png(3840, 1080);
 
         assert_eq!(png_dimensions(&png).unwrap(), (3840, 1080));
+    }
+
+    #[tokio::test]
+    async fn portal_capture_preserves_valid_returned_path() {
+        let path = test_path("portal-valid");
+        fs::write(&path, valid_png(1, 1)).unwrap();
+
+        let capture = read_png_as_capture(
+            path.clone(),
+            "xdg-desktop-portal",
+            ScreenshotCleanup::Preserve,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(capture.source, "xdg-desktop-portal");
+        assert!(path.exists());
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn portal_capture_preserves_invalid_returned_path() {
+        let path = test_path("portal-invalid");
+        fs::write(&path, b"").unwrap();
+
+        let error = read_png_as_capture(
+            path.clone(),
+            "xdg-desktop-portal",
+            ScreenshotCleanup::Preserve,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("screenshot file was empty"));
+        assert!(path.exists());
+        let _ = fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn gnome_capture_deletes_backend_temp_path_on_success() {
+        let path = test_path("gnome-valid");
+        fs::write(&path, valid_png(1, 1)).unwrap();
+
+        let capture = read_png_as_capture(
+            path.clone(),
+            "gnome-shell",
+            ScreenshotCleanup::DeletePath(path.clone()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(capture.source, "gnome-shell");
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn gnome_capture_deletes_backend_temp_path_on_parse_failure() {
+        let path = test_path("gnome-invalid");
+        fs::write(&path, b"").unwrap();
+
+        let error = read_png_as_capture(
+            path.clone(),
+            "gnome-shell",
+            ScreenshotCleanup::DeletePath(path.clone()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("screenshot file was empty"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn gnome_failure_cleanup_removes_requested_temp_path() {
+        let path = test_path("gnome-pre-read-failure");
+        fs::write(&path, b"partial").unwrap();
+
+        cleanup_gnome_requested_path(&path);
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn gnome_deletes_requested_temp_path_and_preserves_unexpected_returned_path() {
+        let requested = test_path("gnome-requested");
+        let returned = test_path("gnome-returned");
+        fs::write(&requested, b"partial").unwrap();
+        fs::write(&returned, valid_png(1, 1)).unwrap();
+
+        let capture = read_png_as_capture(
+            returned.clone(),
+            "gnome-shell",
+            ScreenshotCleanup::DeletePath(requested.clone()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(capture.source, "gnome-shell");
+        assert!(!requested.exists());
+        assert!(returned.exists());
+        let _ = fs::remove_file(returned);
     }
 }

--- a/computer-use-linux/src/screenshot.rs
+++ b/computer-use-linux/src/screenshot.rs
@@ -11,9 +11,13 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use zbus::{
+    message::{Message, Type as MessageType},
     zvariant::{OwnedObjectPath, OwnedValue, Value},
-    Proxy,
+    MatchRule, MessageStream, Proxy,
 };
+
+const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+const PORTAL_REQUEST_PATH_NAMESPACE: &str = "/org/freedesktop/portal/desktop/request";
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ScreenshotCapture {
@@ -86,30 +90,10 @@ async fn capture_with_portal() -> Result<ScreenshotCapture> {
     let connection = zbus::Connection::session()
         .await
         .context("failed to connect to session bus")?;
-    let unique_name = connection
-        .unique_name()
-        .context("session bus connection has no unique name")?;
     let token = request_token();
-    let request_path = format!(
-        "/org/freedesktop/portal/desktop/request/{}/{}",
-        unique_name
-            .as_str()
-            .trim_start_matches(':')
-            .replace('.', "_"),
-        token
-    );
-    let request_proxy = Proxy::new(
-        &connection,
-        "org.freedesktop.portal.Desktop",
-        request_path.as_str(),
-        "org.freedesktop.portal.Request",
-    )
-    .await
-    .context("failed to create XDG portal request proxy")?;
-    let mut response_stream = request_proxy
-        .receive_signal("Response")
-        .await
-        .context("failed to subscribe to XDG portal screenshot response")?;
+    // Some portals rewrite the request handle, so subscribe before calling Screenshot
+    // and filter by the returned handle instead of subscribing after the call.
+    let mut response_stream = portal_response_stream(&connection).await?;
 
     let portal_proxy = Proxy::new(
         &connection,
@@ -127,28 +111,12 @@ async fn capture_with_portal() -> Result<ScreenshotCapture> {
         .await
         .context("XDG portal Screenshot call failed")?;
 
-    if handle.as_str() != request_path {
-        response_stream = Proxy::new(
-            &connection,
-            "org.freedesktop.portal.Desktop",
-            handle.as_str(),
-            "org.freedesktop.portal.Request",
-        )
-        .await
-        .context("failed to create returned XDG portal request proxy")?
-        .receive_signal("Response")
-        .await
-        .context("failed to subscribe to returned XDG portal screenshot response")?;
-    }
-
-    let response = tokio::time::timeout(Duration::from_secs(20), response_stream.next())
-        .await
-        .context("timed out waiting for XDG portal screenshot response")?
-        .context("XDG portal screenshot response stream ended")?;
-    let (response_code, results): (u32, HashMap<String, OwnedValue>) = response
-        .body()
-        .deserialize()
-        .context("failed to decode XDG portal screenshot response")?;
+    let (response_code, results) = tokio::time::timeout(
+        Duration::from_secs(20),
+        wait_for_portal_response(&mut response_stream, handle.as_str()),
+    )
+    .await
+    .context("timed out waiting for XDG portal screenshot response")??;
 
     if response_code != 0 {
         bail!("XDG portal screenshot was denied or cancelled with response code {response_code}");
@@ -165,6 +133,48 @@ async fn capture_with_portal() -> Result<ScreenshotCapture> {
     let path = file_uri_to_path(&uri)?;
 
     read_png_as_capture(path, "xdg-desktop-portal", ScreenshotCleanup::Preserve).await
+}
+
+async fn portal_response_stream(connection: &zbus::Connection) -> Result<MessageStream> {
+    let response_rule = MatchRule::builder()
+        .msg_type(MessageType::Signal)
+        .interface(PORTAL_REQUEST_INTERFACE)?
+        .member("Response")?
+        .path_namespace(PORTAL_REQUEST_PATH_NAMESPACE)?
+        .build();
+
+    MessageStream::for_match_rule(response_rule, connection, None)
+        .await
+        .context("failed to subscribe to XDG portal screenshot responses")
+}
+
+async fn wait_for_portal_response(
+    response_stream: &mut MessageStream,
+    request_path: &str,
+) -> Result<(u32, HashMap<String, OwnedValue>)> {
+    loop {
+        let response = response_stream
+            .next()
+            .await
+            .context("XDG portal screenshot response stream ended")?
+            .context("XDG portal screenshot response stream failed")?;
+
+        if !portal_response_matches_path(&response, request_path) {
+            continue;
+        }
+
+        return response
+            .body()
+            .deserialize()
+            .context("failed to decode XDG portal screenshot response");
+    }
+}
+
+fn portal_response_matches_path(response: &Message, request_path: &str) -> bool {
+    response
+        .header()
+        .path()
+        .is_some_and(|path| path.as_str() == request_path)
 }
 
 async fn read_png_as_capture(

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -77,9 +77,13 @@ impl ComputerUseLinux {
                     self.cache_screenshot_size(capture.width, capture.height);
                     (Some(capture), None)
                 }
-                Err(error) => (None, Some(error.to_string())),
+                Err(error) => {
+                    self.clear_screenshot_size();
+                    (None, Some(error.to_string()))
+                }
             }
         } else {
+            self.clear_screenshot_size();
             (None, None)
         };
         let (accessibility_tree, accessibility_error) =
@@ -103,9 +107,7 @@ impl ComputerUseLinux {
                     ),
                 )
             };
-        if accessibility_error.is_none() {
-            self.cache_nodes(&accessibility_tree);
-        }
+        self.cache_nodes(&accessibility_tree);
         let message = if let Some(error) = &accessibility_error {
             format!("MCP registration is working, but AT-SPI tree extraction failed: {error}")
         } else if let Some(capture) = &screenshot {
@@ -452,10 +454,17 @@ impl ComputerUseLinux {
 
     fn cache_screenshot_size(&self, width: u32, height: u32) {
         if width == 0 || height == 0 {
+            self.clear_screenshot_size();
             return;
         }
         if let Ok(mut cached) = self.last_screenshot_size.lock() {
             *cached = Some(ScreenSize { width, height });
+        }
+    }
+
+    fn clear_screenshot_size(&self) {
+        if let Ok(mut cached) = self.last_screenshot_size.lock() {
+            *cached = None;
         }
     }
 
@@ -895,6 +904,27 @@ mod tests {
     }
 
     #[test]
+    fn empty_node_cache_clears_stale_element_index() {
+        let backend = ComputerUseLinux::default();
+        backend.cache_nodes(&[node(
+            7,
+            Some(Bounds {
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 40,
+            }),
+        )]);
+        backend.cache_nodes(&[]);
+
+        let error = backend
+            .resolve_target_point(None, None, Some(7))
+            .unwrap_err();
+
+        assert!(error.contains("No clickable bounds cached for element_index 7"));
+    }
+
+    #[test]
     fn absolute_mousemove_uses_coordinate_separator() {
         assert_eq!(
             absolute_mousemove_args(200, 300),
@@ -928,6 +958,21 @@ mod tests {
         backend.cache_screenshot_size(3840, 1080);
 
         assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (26460, 56485));
+    }
+
+    #[test]
+    fn screenshot_size_cache_can_be_cleared() {
+        let backend = ComputerUseLinux::default();
+        backend.cache_screenshot_size(3840, 1080);
+
+        backend.clear_screenshot_size();
+
+        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (1550, 930));
+
+        backend.cache_screenshot_size(3840, 1080);
+        backend.cache_screenshot_size(0, 1080);
+
+        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (1550, 930));
     }
 
     #[test]

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -132,6 +132,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/Cargo.toml" "$update_builder_root/Cargo.toml"
     cp "$REPO_DIR/Cargo.lock" "$update_builder_root/Cargo.lock"
     cp -r "$REPO_DIR/computer-use-linux" "$update_builder_root/computer-use-linux"
+    cp -r "$REPO_DIR/updater" "$update_builder_root/updater"
     mkdir -p "$update_builder_root/plugins/openai-bundled/plugins"
     cp -r "$REPO_DIR/plugins/openai-bundled/plugins/computer-use" \
         "$update_builder_root/plugins/openai-bundled/plugins/computer-use"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -122,6 +122,7 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/package-common.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/computer-use-linux/Cargo.toml"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/updater/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/plugins/openai-bundled/plugins/computer-use/.mcp.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
 }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -17,6 +17,7 @@ use std::{
     ffi::OsString,
     fs::{self, OpenOptions},
     io::{Seek, SeekFrom, Write},
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -429,12 +430,20 @@ fn command_in_path(name: &str) -> Option<PathBuf> {
     let path_env = std::env::var_os("PATH").unwrap_or_else(|| OsString::from(""));
     std::env::split_paths(&path_env).find_map(|entry| {
         let candidate = entry.join(name);
-        if candidate.is_file() {
+        if is_executable_file(&candidate) {
             Some(candidate)
         } else {
             None
         }
     })
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
 }
 
 fn run_kdialog_prompt() -> Result<bool> {
@@ -1236,6 +1245,26 @@ mod tests {
             .arg("exit 1")
             .status()?;
         assert!(!pkexec_authentication_was_not_obtained(&status));
+        Ok(())
+    }
+
+    #[test]
+    fn command_lookup_requires_executable_file() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let candidate = temp.path().join("zenity");
+        std::fs::write(&candidate, b"#!/bin/sh\n")?;
+
+        let mut permissions = std::fs::metadata(&candidate)?.permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&candidate, permissions)?;
+
+        assert!(!is_executable_file(&candidate));
+
+        let mut permissions = std::fs::metadata(&candidate)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&candidate, permissions)?;
+
+        assert!(is_executable_file(&candidate));
         Ok(())
     }
 

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -14,10 +14,11 @@ use std::{
 use tokio::process::Command;
 use tracing::info;
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 10] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 11] = [
     ("Cargo.toml", "Cargo.toml"),
     ("Cargo.lock", "Cargo.lock"),
     ("computer-use-linux", "computer-use-linux"),
+    ("updater", "updater"),
     (
         "plugins/openai-bundled/plugins/computer-use",
         "plugins/openai-bundled/plugins/computer-use",
@@ -426,7 +427,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
     }
 
     fn write_fake_computer_use_bundle(root: &Path) -> Result<()> {
-        fs::write(root.join("Cargo.toml"), b"[workspace]\nmembers = []\n")?;
+        fs::write(
+            root.join("Cargo.toml"),
+            b"[workspace]\nmembers = [\"computer-use-linux\", \"updater\"]\n",
+        )?;
         fs::write(root.join("Cargo.lock"), b"# fake lock\n")?;
         fs::create_dir_all(root.join("computer-use-linux/src"))?;
         fs::write(
@@ -437,6 +441,12 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
             root.join("computer-use-linux/src/main.rs"),
             b"fn main() {}\n",
         )?;
+        fs::create_dir_all(root.join("updater/src"))?;
+        fs::write(
+            root.join("updater/Cargo.toml"),
+            b"[package]\nname = \"codex-update-manager\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(root.join("updater/src/main.rs"), b"fn main() {}\n")?;
         fs::create_dir_all(root.join("plugins/openai-bundled/plugins/computer-use/.codex-plugin"))?;
         fs::write(
             root.join("plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json"),
@@ -623,6 +633,7 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .join("scripts/patch-linux-window-ui.js")
             .exists());
         assert!(destination_root.join("computer-use-linux").exists());
+        assert!(destination_root.join("updater").exists());
         assert!(destination_root
             .join("plugins/openai-bundled/plugins/computer-use/.mcp.json")
             .exists());


### PR DESCRIPTION
## Summary
- Preserve screenshot files returned by XDG Desktop Portal while cleaning only GNOME backend temp files owned by this backend.
- Subscribe to portal responses before requesting a screenshot so fast responses on rewritten handles are not missed.
- Clear stale Computer Use caches when fresh accessibility or screenshot state is unavailable, require executable dialog helpers, and include the updater crate in the staged update-builder bundle.

## Testing
- `cargo fmt --check -p codex-computer-use-linux -p codex-update-manager`
- `cargo clippy -p codex-computer-use-linux -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-computer-use-linux`
- `cargo test -p codex-update-manager`
- `bash -n scripts/lib/package-common.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`

@Leay15 @ilysenko, could you share feedback on this approach, especially the portal/GNOME screenshot ownership split and the update-builder bundle change?