### PR TITLE
Fix Linux bundle patching for current Codex builds

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -925,18 +925,26 @@ function buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar }
   return `{installWhenMissing:!0,name:${nameExpr},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
 }
 
+function hasComputerUseLiteral(source) {
+  return /(?:`computer-use`|"computer-use"|'computer-use')/.test(source);
+}
+
+function isComputerUseNameExpr(nameExpr, computerUseNameVar) {
+  return /^(?:`computer-use`|"computer-use"|'computer-use')$/.test(nameExpr) || nameExpr === computerUseNameVar;
+}
+
 function applyLinuxComputerUsePluginGatePatch(currentSource) {
-  if (!currentSource.includes("`computer-use`")) {
+  if (!hasComputerUseLiteral(currentSource)) {
     return currentSource;
   }
 
-  const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=`computer-use`/)?.[1] ?? null;
+  const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=(?:`computer-use`|"computer-use"|'computer-use')/)?.[1] ?? null;
   const gateRegex =
-    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
+    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`|"computer-use"|'computer-use'),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
   let match;
   while ((match = gateRegex.exec(currentSource)) != null) {
     const [gateSource, installWhenMissing, nameExpr, paramsText, expression, migrateVar] = match;
-    if (nameExpr !== "`computer-use`" && nameExpr !== computerUseNameVar) {
+    if (!isComputerUseNameExpr(nameExpr, computerUseNameVar)) {
       continue;
     }
 
@@ -958,7 +966,7 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
     }
   }
 
-  if (currentSource.includes("`computer-use`") && currentSource.includes("computerUse")) {
+  if (hasComputerUseLiteral(currentSource) && currentSource.includes("computerUse")) {
     throw new Error("Required Linux Computer Use plugin gate patch failed: could not enable bundled Computer Use on Linux");
   }
 
@@ -998,11 +1006,10 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
 function applyLinuxTrayCloseSettingPatch(currentSource) {
   let patchedSource = currentSource;
 
-  if (
-    patchedSource.includes("canHideLastLocalWindowToTray:()=>") &&
-    patchedSource.includes("process.platform!==`linux`||") &&
-    patchedSource.includes(linuxSettingsKeys.systemTray)
-  ) {
+  const patchedCloseGateRegex = new RegExp(
+    `canHideLastLocalWindowToTray:\\(\\)=>[A-Za-z_$][\\w$]*&&\\(process\\.platform!==\`linux\`\\|\\|[^,{}]+\\.get\\(\`${escapeRegExp(linuxSettingsKeys.systemTray)}\`\\)!==!1\\),disposables:[A-Za-z_$][\\w$]*`,
+  );
+  if (patchedCloseGateRegex.test(patchedSource)) {
     return patchedSource;
   }
 

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -896,31 +896,49 @@ function applyLinuxSingleInstancePatch(currentSource) {
   return patchedSource;
 }
 
+function parseDestructuredParamAliases(paramsText) {
+  const aliases = Object.create(null);
+  for (const rawPart of paramsText.split(",")) {
+    const part = rawPart.trim();
+    const match = part.match(/^([A-Za-z_$][\w$]*)(?::([A-Za-z_$][\w$]*))?$/);
+    if (match != null) {
+      aliases[match[1]] = match[2] ?? match[1];
+    }
+  }
+  return aliases;
+}
+
+function buildComputerUseGate({ nameVar, featuresVar, platformVar, migrateVar }) {
+  return `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
+}
+
 function applyLinuxComputerUsePluginGatePatch(currentSource) {
-  const enabledGateRegex =
-    /\{installWhenMissing:!0,name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\(\3===`darwin`\|\|\3===`linux`\)&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
-  if (enabledGateRegex.test(currentSource)) {
-    return currentSource;
-  }
+  const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=`computer-use`/)?.[1] ?? null;
+  const gateRegex =
+    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
+  let match;
+  while ((match = gateRegex.exec(currentSource)) != null) {
+    const [gateSource, installWhenMissing, nameVar, paramsText, expression, migrateVar] = match;
+    if (computerUseNameVar != null && nameVar !== computerUseNameVar) {
+      continue;
+    }
 
-  const darwinOnlyGateRegex =
-    /\{(?:installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\3===`darwin`&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
-  if (darwinOnlyGateRegex.test(currentSource)) {
-    return currentSource.replace(
-      darwinOnlyGateRegex,
-      (_match, nameVar, featuresVar, platformVar, migrateVar) =>
-        `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`,
-    );
-  }
+    const aliases = parseDestructuredParamAliases(paramsText);
+    const featuresVar = aliases.features;
+    const platformVar = aliases.platform;
+    if (featuresVar == null || platformVar == null) {
+      continue;
+    }
 
-  const linuxGateWithoutInstallRegex =
-    /\{name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\(\3===`darwin`\|\|\3===`linux`\)&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
-  if (linuxGateWithoutInstallRegex.test(currentSource)) {
-    return currentSource.replace(
-      linuxGateWithoutInstallRegex,
-      (_match, nameVar, featuresVar, platformVar, migrateVar) =>
-        `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`,
-    );
+    const darwinOnlyExpression = `${platformVar}===\`darwin\`&&${featuresVar}.computerUse`;
+    const linuxExpression = `(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse`;
+    if (installWhenMissing != null && expression === linuxExpression) {
+      return currentSource;
+    }
+    if (expression === darwinOnlyExpression || expression === linuxExpression) {
+      const replacement = buildComputerUseGate({ nameVar, featuresVar, platformVar, migrateVar });
+      return `${currentSource.slice(0, match.index)}${replacement}${currentSource.slice(match.index + gateSource.length)}`;
+    }
   }
 
   if (currentSource.includes("`computer-use`") && currentSource.includes("computerUse")) {

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -733,8 +733,21 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     // Already patched.
   } else if (patchedSource.includes(closeToTrayNeedle)) {
     patchedSource = patchedSource.replace(closeToTrayNeedle, closeToTrayPatch);
+  } else if (/\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&[A-Za-z_$][\w$]*===`local`/.test(patchedSource)) {
+    // Already patched with a newer minifier's window variable.
   } else {
-    console.warn("WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch");
+    const closeToTrayRegex =
+      /if\(process\.platform===`win32`&&([A-Za-z_$][\w$]*)===`local`&&!this\.isAppQuitting&&this\.options\.canHideLastLocalWindowToTray\?\.\(\)===!0&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\.preventDefault\(\),([A-Za-z_$][\w$]*)\.hide\(\);return\}/;
+    const closeToTrayMatch = patchedSource.match(closeToTrayRegex);
+    if (closeToTrayMatch != null) {
+      const [, hostVar, hasOtherWindowVar, eventVar, windowVar] = closeToTrayMatch;
+      patchedSource = patchedSource.replace(
+        closeToTrayRegex,
+        `if((process.platform===\`win32\`||process.platform===\`linux\`)&&${hostVar}===\`local\`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!${hasOtherWindowVar}){${eventVar}.preventDefault(),${windowVar}.hide();return}`,
+      );
+    } else {
+      console.warn("WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch");
+    }
   }
 
   const trayContextMethodNeedle =
@@ -823,7 +836,27 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   } else if (patchedSource.includes(trayStartupNeedle)) {
     patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
   } else {
-    console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
+    const traySetupMatch = patchedSource.match(
+      /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await [A-Za-z_$][\w$]*\(\{buildFlavor:/,
+    );
+    const trayStartupRegex = traySetupMatch == null
+      ? null
+      : new RegExp(`([A-Za-z_$][\\w$]*)&&${traySetupMatch[1]}\\(\\);`);
+    const dynamicTrayStartupMatch = trayStartupRegex == null ? null : patchedSource.match(trayStartupRegex);
+    if (
+      traySetupMatch != null &&
+      patchedSource.includes(`process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetupMatch[1]}();`)
+    ) {
+      // Already patched with a newer minifier's tray setup identifier.
+    } else if (dynamicTrayStartupMatch != null) {
+      const isWindowsVar = dynamicTrayStartupMatch[1];
+      patchedSource = patchedSource.replace(
+        trayStartupRegex,
+        `(${isWindowsVar}||process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetupMatch[1]}();`,
+      );
+    } else {
+      console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
+    }
   }
 
   return patchedSource;
@@ -840,6 +873,8 @@ function applyLinuxSingleInstancePatch(currentSource) {
     // Already patched.
   } else if (patchedSource.includes(singleInstanceLockNeedle)) {
     patchedSource = patchedSource.replace(singleInstanceLockNeedle, singleInstanceLockPatch);
+  } else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
+    // Newer bundles take the single-instance lock in bootstrap.js and hand args into main here.
   } else {
     console.warn("WARN: Could not find startup handoff point — skipping Linux single-instance lock patch");
   }
@@ -852,6 +887,8 @@ function applyLinuxSingleInstancePatch(currentSource) {
     // Already patched.
   } else if (patchedSource.includes(secondInstanceHandlerNeedle)) {
     patchedSource = patchedSource.replace(secondInstanceHandlerNeedle, secondInstanceHandlerPatch);
+  } else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
+    // bootstrap.js owns the Electron second-instance event and calls this bundle's handler.
   } else {
     console.warn("WARN: Could not find second-instance handler — skipping Linux second-instance focus patch");
   }
@@ -860,29 +897,34 @@ function applyLinuxSingleInstancePatch(currentSource) {
 }
 
 function applyLinuxComputerUsePluginGatePatch(currentSource) {
-  const computerUseGateNeedle =
-    "{name:tn,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:wn}";
-  const computerUseLinuxGateNeedle =
-    "{name:tn,isEnabled:({features:e,platform:t})=>(t===`darwin`||t===`linux`)&&e.computerUse,migrate:wn}";
-  const computerUseGatePatch =
-    "{installWhenMissing:!0,name:tn,isEnabled:({features:e,platform:t})=>(t===`darwin`||t===`linux`)&&e.computerUse,migrate:wn}";
-
-  if (currentSource.includes(computerUseGatePatch)) {
+  const enabledGateRegex =
+    /\{installWhenMissing:!0,name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\(\3===`darwin`\|\|\3===`linux`\)&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
+  if (enabledGateRegex.test(currentSource)) {
     return currentSource;
   }
 
-  if (currentSource.includes(computerUseGateNeedle)) {
-    return currentSource.replace(computerUseGateNeedle, computerUseGatePatch);
-  }
-
-  if (currentSource.includes(computerUseLinuxGateNeedle)) {
-    return currentSource.replace(computerUseLinuxGateNeedle, computerUseGatePatch);
-  }
-
-  if (currentSource.includes("`computer-use`") && currentSource.includes("e.computerUse")) {
-    console.warn(
-      "WARN: Could not find Computer Use plugin platform gate — skipping Linux Computer Use gate patch",
+  const darwinOnlyGateRegex =
+    /\{(?:installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\3===`darwin`&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
+  if (darwinOnlyGateRegex.test(currentSource)) {
+    return currentSource.replace(
+      darwinOnlyGateRegex,
+      (_match, nameVar, featuresVar, platformVar, migrateVar) =>
+        `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`,
     );
+  }
+
+  const linuxGateWithoutInstallRegex =
+    /\{name:([A-Za-z_$][\w$]*),isEnabled:\(\{features:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)=>\(\3===`darwin`\|\|\3===`linux`\)&&\2\.computerUse,migrate:([A-Za-z_$][\w$]*)\}/;
+  if (linuxGateWithoutInstallRegex.test(currentSource)) {
+    return currentSource.replace(
+      linuxGateWithoutInstallRegex,
+      (_match, nameVar, featuresVar, platformVar, migrateVar) =>
+        `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`,
+    );
+  }
+
+  if (currentSource.includes("`computer-use`") && currentSource.includes("computerUse")) {
+    throw new Error("Required Linux Computer Use plugin gate patch failed: could not enable bundled Computer Use on Linux");
   }
 
   return currentSource;
@@ -921,16 +963,27 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
 function applyLinuxTrayCloseSettingPatch(currentSource) {
   let patchedSource = currentSource;
 
-  const closeGateNeedle = "canHideLastLocalWindowToTray:()=>O,disposables:k";
-  const closeGatePatch =
-    `canHideLastLocalWindowToTray:()=>O&&(process.platform!==\`linux\`||M.globalState.get(\`${linuxSettingsKeys.systemTray}\`)!==!1),disposables:k`;
-
-  if (patchedSource.includes(closeGatePatch)) {
+  if (
+    patchedSource.includes("canHideLastLocalWindowToTray:()=>") &&
+    patchedSource.includes("process.platform!==`linux`||") &&
+    patchedSource.includes(linuxSettingsKeys.systemTray)
+  ) {
     return patchedSource;
   }
 
-  if (patchedSource.includes(closeGateNeedle)) {
-    return patchedSource.replace(closeGateNeedle, closeGatePatch);
+  const closeGateRegex =
+    /canHideLastLocalWindowToTray:\(\)=>([A-Za-z_$][\w$]*),disposables:([A-Za-z_$][\w$]*)/;
+  const closeGateMatch = patchedSource.match(closeGateRegex);
+  if (closeGateMatch != null) {
+    const [, trayReadyVar, disposableVar] = closeGateMatch;
+    const prefix = patchedSource.slice(Math.max(0, closeGateMatch.index - 8000), closeGateMatch.index);
+    const globalStateExpr = findLinuxGlobalStateExpression(prefix);
+    if (globalStateExpr != null) {
+      return patchedSource.replace(
+        closeGateRegex,
+        `canHideLastLocalWindowToTray:()=>${trayReadyVar}&&(process.platform!==\`linux\`||${globalStateExpr}.get(\`${linuxSettingsKeys.systemTray}\`)!==!1),disposables:${disposableVar}`,
+      );
+    }
   }
 
   if (patchedSource.includes("canHideLastLocalWindowToTray") && patchedSource.includes("Launching app")) {
@@ -938,6 +991,193 @@ function applyLinuxTrayCloseSettingPatch(currentSource) {
   }
 
   return patchedSource;
+}
+
+function findMatchingBrace(source, openIndex) {
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let i = openIndex; i < source.length; i += 1) {
+    const char = source[i];
+    if (quote != null) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function findLastRegexMatch(source, regex) {
+  regex.lastIndex = 0;
+  let lastMatch = null;
+  let match;
+  while ((match = regex.exec(source)) != null) {
+    lastMatch = match;
+    if (match[0].length === 0) {
+      regex.lastIndex += 1;
+    }
+  }
+  return lastMatch;
+}
+
+function findLinuxGlobalStateExpression(prefix) {
+  const objectStateMatch = findLastRegexMatch(prefix, /(?:let|,)\s*([A-Za-z_$][\w$]*)=\{globalState:/g);
+  if (objectStateMatch != null) {
+    return `${objectStateMatch[1]}.globalState`;
+  }
+
+  const propertyStateMatch = findLastRegexMatch(prefix, /globalState:([A-Za-z_$][\w$]*)\.globalState/g);
+  if (propertyStateMatch != null) {
+    return `${propertyStateMatch[1]}.globalState`;
+  }
+
+  return null;
+}
+
+function buildSemanticLinuxLaunchActionPatch({
+  setterVar,
+  deepLinksVar,
+  fallbackFn,
+  openerFn,
+  windowManagerVar,
+  hostExpr,
+  currentWindowVar,
+  createdWindowVar,
+  routeVar,
+  focusFn,
+  notificationVar,
+  globalStateExpr,
+  reporterVar,
+  disposableVar,
+  pathVar,
+  fsVar,
+  netVar,
+  appVar,
+}) {
+  const notificationPrefix = notificationVar == null
+    ? ""
+    : `${notificationVar}.desktopNotificationManager.dismissByNavigationPath(e),`;
+  const directHandler = appVar == null
+    ? ""
+    : `,codexLinuxSecondInstanceHandler=(e,t)=>{codexLinuxHandleLaunchActionArgsFallback(t,()=>{${fallbackFn}()})}`;
+  const startup = appVar == null
+    ? `process.platform===\`linux\`&&codexLinuxStartLaunchActionSocket();${setterVar}(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{${fallbackFn}()})});`
+    : `process.platform===\`linux\`&&(codexLinuxStartLaunchActionSocket(),${appVar}.app.on(\`second-instance\`,codexLinuxSecondInstanceHandler),${disposableVar}.add(()=>{${appVar}.app.off(\`second-instance\`,codexLinuxSecondInstanceHandler)}));${setterVar}(e=>{codexLinuxHandleLaunchActionArgsFallback(e,()=>{${fallbackFn}()})});`;
+
+  return `let codexLinuxGetSetting=e=>process.platform!==\`linux\`||${globalStateExpr}.get(e)!==!1,codexLinuxIsTrayEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.systemTray}\`),codexLinuxIsWarmStartEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.warmStart}\`),codexLinuxIsPromptWindowEnabled=()=>codexLinuxGetSetting(\`${linuxSettingsKeys.promptWindow}\`),${openerFn}=async(e,t)=>{${windowManagerVar}.hotkeyWindowLifecycleManager.hide();let ${currentWindowVar}=${windowManagerVar}.getPrimaryWindow(${hostExpr}),${createdWindowVar}=${currentWindowVar}??await ${windowManagerVar}.createFreshLocalWindow(e);${createdWindowVar}!=null&&(${notificationPrefix}${currentWindowVar}!=null&&t.navigateExistingWindow&&${routeVar}.navigateToRoute(${createdWindowVar},e),${focusFn}(${createdWindowVar}))},codexLinuxGetHotkeyWindowController=()=>typeof ${windowManagerVar}.hotkeyWindowLifecycleManager.ensureHotkeyWindowController===\`function\`?${windowManagerVar}.hotkeyWindowLifecycleManager.ensureHotkeyWindowController():${windowManagerVar}.hotkeyWindowLifecycleManager,codexLinuxShowHotkeyWindow=async()=>{let e=codexLinuxGetHotkeyWindowController();typeof e.openHome===\`function\`?await e.openHome():typeof e.show===\`function\`?await e.show():await ${windowManagerVar}.ensureHostWindow(${hostExpr})},codexLinuxOpenQuickChat=async()=>{${windowManagerVar}.hotkeyWindowLifecycleManager.hide();let e=${windowManagerVar}.getPrimaryWindow(${hostExpr}),t=e??await ${windowManagerVar}.createFreshLocalWindow(\`/\`);t!=null&&(${windowManagerVar}.windowManager.sendMessageToWindow(t,{type:\`new-quick-chat\`}),${focusFn}(t))},codexLinuxHasDeepLink=e=>Array.isArray(e)&&e.some(e=>typeof e===\`string\`&&(e.startsWith(\`codex://\`)||e.startsWith(\`codex-browser-sidebar://\`))),codexLinuxHandleLaunchActionArgs=async e=>codexLinuxHasDeepLink(e)&&${deepLinksVar}.deepLinks.queueProcessArgs(e)?!0:Array.isArray(e)&&(e.includes(\`--prompt-chat\`)||e.includes(\`--hotkey-window\`))?(codexLinuxIsPromptWindowEnabled()?(await codexLinuxShowHotkeyWindow(),!0):!1):Array.isArray(e)&&e.includes(\`--quick-chat\`)?(await codexLinuxOpenQuickChat(),!0):Array.isArray(e)&&e.includes(\`--new-chat\`)?(await ${openerFn}(\`/\`,{navigateExistingWindow:!0}),!0):!1,codexLinuxHandleLaunchActionArgsFallback=(e,t)=>{codexLinuxHandleLaunchActionArgs(e).then(e=>{e||t()}).catch(e=>{${reporterVar}.reportNonFatal(e instanceof Error?e:\`Failed to handle Linux launch action\`,{kind:\`linux-launch-action-failed\`}),t()})},codexLinuxPrewarmHotkeyWindow=()=>{if(!codexLinuxIsPromptWindowEnabled())return;try{let e=codexLinuxGetHotkeyWindowController();typeof e.prewarm===\`function\`&&e.prewarm()}catch(e){${reporterVar}.reportNonFatal(e instanceof Error?e:\`Failed to prewarm Linux hotkey window\`,{kind:\`linux-hotkey-window-prewarm-failed\`})}},codexLinuxStartLaunchActionSocket=()=>{let e=process.env.CODEX_DESKTOP_LAUNCH_ACTION_SOCKET?.trim();if(process.platform!==\`linux\`||!e||!codexLinuxIsWarmStartEnabled())return;try{${fsVar}.mkdirSync(${pathVar}.default.dirname(e),{recursive:!0,mode:448}),${fsVar}.rmSync(e,{force:!0});let t=${netVar}.default.createServer(t=>{let n=\`\`,r=!1,i=()=>{if(r)return;r=!0;let i=[];try{let e=JSON.parse(n.trim());Array.isArray(e.argv)&&(i=e.argv.filter(e=>typeof e===\`string\`))}catch(e){t.end?.(\`error\\n\`);return}codexLinuxHandleLaunchActionArgs(i).then(e=>e?void 0:${fallbackFn}()).then(()=>{t.end?.(\`ok\\n\`)}).catch(e=>{${reporterVar}.reportNonFatal(e instanceof Error?e:\`Failed to handle Linux launch action socket\`,{kind:\`linux-launch-action-socket-failed\`}),t.end?.(\`error\\n\`)})};t.setEncoding?.(\`utf8\`),t.on(\`data\`,e=>{n+=e,n.includes(\`\\n\`)?i():n.length>65536&&t.destroy()}),t.on(\`end\`,i)});t.on(\`error\`,e=>{${reporterVar}.reportNonFatal(e instanceof Error?e:\`Failed Linux launch action socket\`,{kind:\`linux-launch-action-socket-error\`})}),t.listen(e),${disposableVar}.add(()=>{t.close(),${fsVar}.rmSync(e,{force:!0})})}catch(e){${reporterVar}.reportNonFatal(e instanceof Error?e:\`Failed to start Linux launch action socket\`,{kind:\`linux-launch-action-socket-start-failed\`})}}${directHandler};${startup}`;
+}
+
+function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
+  const handlerRegex =
+    /([A-Za-z_$][\w$]*)\(e=>\{([A-Za-z_$][\w$]*)\.deepLinks\.queueProcessArgs\(e\)\|\|([A-Za-z_$][\w$]*)\(\)\}\);let ([A-Za-z_$][\w$]*)=async\(e,t\)=>\{/g;
+  let match;
+  while ((match = handlerRegex.exec(currentSource)) != null) {
+    const [, setterVar, deepLinksVar, fallbackFn, openerFn] = match;
+    const openerLetIndex = currentSource.indexOf(`let ${openerFn}=async(e,t)=>{`, match.index);
+    if (openerLetIndex === -1) {
+      continue;
+    }
+
+    const openerBraceIndex = openerLetIndex + `let ${openerFn}=async(e,t)=>`.length;
+    const openerEnd = findMatchingBrace(currentSource, openerBraceIndex);
+    if (openerEnd === -1) {
+      continue;
+    }
+
+    const separator = currentSource[openerEnd + 1];
+    if (separator !== ";" && separator !== ",") {
+      continue;
+    }
+
+    const openerText = currentSource.slice(openerLetIndex, openerEnd + 1);
+    const openerVars = openerText.match(
+      /([A-Za-z_$][\w$]*)\.hotkeyWindowLifecycleManager\.hide\(\);let ([A-Za-z_$][\w$]*)=\1\.getPrimaryWindow\(([^)]+)\),([A-Za-z_$][\w$]*)=\2\?\?await \1\.createFreshLocalWindow\(e\);/,
+    );
+    if (openerVars == null) {
+      continue;
+    }
+
+    const [, windowManagerVar, currentWindowVar, hostExpr, createdWindowVar] = openerVars;
+    const routeVar = openerText.match(/([A-Za-z_$][\w$]*)\.navigateToRoute\([A-Za-z_$][\w$]*,e\)/)?.[1];
+    const focusFn = openerText.match(new RegExp(`,([A-Za-z_$][\\w$]*)\\(${createdWindowVar}\\)\\)\\}$`))?.[1];
+    if (routeVar == null || focusFn == null) {
+      continue;
+    }
+
+    const prefix = currentSource.slice(Math.max(0, match.index - 12000), match.index);
+    const globalStateExpr = findLinuxGlobalStateExpression(prefix);
+    const reporterVar = findLastRegexMatch(
+      prefix,
+      /([A-Za-z_$][\w$]*)\.reportNonFatal\(e instanceof Error\?e:`Failed to open window on second instance`/g,
+    )?.[1] ?? findLastRegexMatch(prefix, /([A-Za-z_$][\w$]*)=\{reportNonFatal/g)?.[1];
+    const disposableVar = findLastRegexMatch(prefix, /disposables:([A-Za-z_$][\w$]*)/g)?.[1]
+      ?? findLastRegexMatch(prefix, /([A-Za-z_$][\w$]*)=new [A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*;\1\.add\(/g)?.[1];
+    const pathVar = requireName(currentSource, "node:path");
+    const fsVar = requireName(currentSource, "node:fs");
+    const netVar = requireName(currentSource, "node:net");
+    if (globalStateExpr == null || reporterVar == null || disposableVar == null || pathVar == null || fsVar == null || netVar == null) {
+      continue;
+    }
+
+    let replaceStart = match.index;
+    let appVar = null;
+    const directStart = currentSource.lastIndexOf("let codexLinuxSecondInstanceHandler=", match.index);
+    if (directStart !== -1 && match.index - directStart < 1200) {
+      const directBlock = currentSource.slice(directStart, match.index);
+      const appMatch = directBlock.match(/([A-Za-z_$][\w$]*)\.app\.on\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
+      if (appMatch != null) {
+        replaceStart = directStart;
+        appVar = appMatch[1];
+      }
+    }
+
+    const notificationVar = openerText.match(
+      /([A-Za-z_$][\w$]*)\.desktopNotificationManager\.dismissByNavigationPath\(e\)/,
+    )?.[1] ?? null;
+    const replacement = buildSemanticLinuxLaunchActionPatch({
+      setterVar,
+      deepLinksVar,
+      fallbackFn,
+      openerFn,
+      windowManagerVar,
+      hostExpr: hostExpr.trim(),
+      currentWindowVar,
+      createdWindowVar,
+      routeVar,
+      focusFn,
+      notificationVar,
+      globalStateExpr,
+      reporterVar,
+      disposableVar,
+      pathVar,
+      fsVar,
+      netVar,
+      appVar,
+    });
+    const suffix = separator === "," ? "let " : "";
+    return currentSource.slice(0, replaceStart) + replacement + suffix + currentSource.slice(openerEnd + 2);
+  }
+
+  return currentSource;
 }
 
 function applyLinuxLaunchActionArgsPatch(currentSource) {
@@ -997,6 +1237,11 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
     return patchedSource;
   }
 
+  const semanticLaunchActionPatch = applySemanticLinuxLaunchActionArgsPatch(patchedSource);
+  if (semanticLaunchActionPatch !== patchedSource) {
+    return semanticLaunchActionPatch;
+  }
+
   if (patchedSource.includes(oldLaunchActionPatch)) {
     patchedSource = patchedSource.replace(oldLaunchActionPatch, launchActionPatch);
   } else if (patchedSource.includes(deepLinkFirstLaunchActionPatch)) {
@@ -1050,6 +1295,12 @@ function applyLinuxHotkeyWindowPrewarmPatch(currentSource) {
     return patchedSource;
   }
 
+  if (
+    /process\.platform===`linux`&&codexLinuxPrewarmHotkeyWindow\(\),[A-Za-z_$][\w$]*=Date\.now\(\),await [A-Za-z_$][\w$]*\.deepLinks\.flushPendingDeepLinks\(\)/.test(patchedSource)
+  ) {
+    return patchedSource;
+  }
+
   const startupPrewarmNeedle =
     "w(`local window ensured`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()";
 
@@ -1060,7 +1311,18 @@ function applyLinuxHotkeyWindowPrewarmPatch(currentSource) {
   ) {
     // Already patched by an older run.
   } else {
-    console.warn("WARN: Could not find Linux hotkey window prewarm insertion point — skipping startup prewarm patch");
+    const dynamicStartupPrewarmRegex =
+      /(w\(`local window ensured`,([A-Za-z_$][\w$]*),\{hostId:([A-Za-z_$][\w$]*),localWindowVisible:[^}]+\}\),)\2=Date\.now\(\),await ([A-Za-z_$][\w$]*)\.deepLinks\.flushPendingDeepLinks\(\)/;
+    const dynamicStartupPrewarmMatch = patchedSource.match(dynamicStartupPrewarmRegex);
+    if (dynamicStartupPrewarmMatch != null) {
+      const [, prefix, timeVar, , deepLinksVar] = dynamicStartupPrewarmMatch;
+      patchedSource = patchedSource.replace(
+        dynamicStartupPrewarmRegex,
+        `${prefix}process.platform===\`linux\`&&codexLinuxPrewarmHotkeyWindow(),${timeVar}=Date.now(),await ${deepLinksVar}.deepLinks.flushPendingDeepLinks()`,
+      );
+    } else {
+      console.warn("WARN: Could not find Linux hotkey window prewarm insertion point — skipping startup prewarm patch");
+    }
   }
 
   return patchedSource;

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -27,6 +27,15 @@ function findIconAsset(extractedDir) {
 const keybindsSettingsAsset = "keybinds-settings-linux.js";
 const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
 
+// Lookback/lookahead windows used when searching for the nearest minified
+// identifier or surrounding context around a regex anchor in the bundle.
+// Sized empirically to the typical distance between a feature's anchor and
+// the helper aliases it depends on.
+const TRAY_GUARD_LOOKAHEAD = 1200;
+const CLOSE_GATE_PREFIX_LOOKBACK = 8000;
+const HANDLER_PREFIX_LOOKBACK = 12000;
+const DIRECT_HANDLER_PROXIMITY = 1200;
+
 const linuxSettingsKeys = {
   promptWindow: "codex-linux-prompt-window-enabled",
   systemTray: "codex-linux-system-tray-enabled",
@@ -704,7 +713,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     // Already patched.
   } else if (
     trayGuardIndex !== -1 &&
-    patchedSource.slice(trayGuardIndex, trayGuardIndex + 1200).includes("new n.Tray")
+    patchedSource.slice(trayGuardIndex, trayGuardIndex + TRAY_GUARD_LOOKAHEAD).includes("new n.Tray")
   ) {
     patchedSource = patchedSource.replace(trayGuardNeedle, trayGuardPatch);
   } else {
@@ -908,18 +917,22 @@ function parseDestructuredParamAliases(paramsText) {
   return aliases;
 }
 
-function buildComputerUseGate({ nameVar, featuresVar, platformVar, migrateVar }) {
-  return `{installWhenMissing:!0,name:${nameVar},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
+function buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar }) {
+  return `{installWhenMissing:!0,name:${nameExpr},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
 }
 
 function applyLinuxComputerUsePluginGatePatch(currentSource) {
+  if (!currentSource.includes("`computer-use`")) {
+    return currentSource;
+  }
+
   const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=`computer-use`/)?.[1] ?? null;
   const gateRegex =
-    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
+    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
   let match;
   while ((match = gateRegex.exec(currentSource)) != null) {
-    const [gateSource, installWhenMissing, nameVar, paramsText, expression, migrateVar] = match;
-    if (computerUseNameVar != null && nameVar !== computerUseNameVar) {
+    const [gateSource, installWhenMissing, nameExpr, paramsText, expression, migrateVar] = match;
+    if (nameExpr !== "`computer-use`" && nameExpr !== computerUseNameVar) {
       continue;
     }
 
@@ -936,7 +949,7 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
       return currentSource;
     }
     if (expression === darwinOnlyExpression || expression === linuxExpression) {
-      const replacement = buildComputerUseGate({ nameVar, featuresVar, platformVar, migrateVar });
+      const replacement = buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar });
       return `${currentSource.slice(0, match.index)}${replacement}${currentSource.slice(match.index + gateSource.length)}`;
     }
   }
@@ -994,7 +1007,10 @@ function applyLinuxTrayCloseSettingPatch(currentSource) {
   const closeGateMatch = patchedSource.match(closeGateRegex);
   if (closeGateMatch != null) {
     const [, trayReadyVar, disposableVar] = closeGateMatch;
-    const prefix = patchedSource.slice(Math.max(0, closeGateMatch.index - 8000), closeGateMatch.index);
+    const prefix = patchedSource.slice(
+      Math.max(0, closeGateMatch.index - CLOSE_GATE_PREFIX_LOOKBACK),
+      closeGateMatch.index,
+    );
     const globalStateExpr = findLinuxGlobalStateExpression(prefix);
     if (globalStateExpr != null) {
       return patchedSource.replace(
@@ -1110,12 +1126,10 @@ function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
   let match;
   while ((match = handlerRegex.exec(currentSource)) != null) {
     const [, setterVar, deepLinksVar, fallbackFn, openerFn] = match;
-    const openerLetIndex = currentSource.indexOf(`let ${openerFn}=async(e,t)=>{`, match.index);
-    if (openerLetIndex === -1) {
-      continue;
-    }
-
-    const openerBraceIndex = openerLetIndex + `let ${openerFn}=async(e,t)=>`.length;
+    // handlerRegex ends with `let <openerFn>=async(e,t)=>{`, so the opening
+    // brace's position is determined directly by the match.
+    const openerBraceIndex = match.index + match[0].length - 1;
+    const openerLetIndex = openerBraceIndex - `let ${openerFn}=async(e,t)=>`.length;
     const openerEnd = findMatchingBrace(currentSource, openerBraceIndex);
     if (openerEnd === -1) {
       continue;
@@ -1141,7 +1155,7 @@ function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
       continue;
     }
 
-    const prefix = currentSource.slice(Math.max(0, match.index - 12000), match.index);
+    const prefix = currentSource.slice(Math.max(0, match.index - HANDLER_PREFIX_LOOKBACK), match.index);
     const globalStateExpr = findLinuxGlobalStateExpression(prefix);
     const reporterVar = findLastRegexMatch(
       prefix,
@@ -1159,7 +1173,7 @@ function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
     let replaceStart = match.index;
     let appVar = null;
     const directStart = currentSource.lastIndexOf("let codexLinuxSecondInstanceHandler=", match.index);
-    if (directStart !== -1 && match.index - directStart < 1200) {
+    if (directStart !== -1 && match.index - directStart < DIRECT_HANDLER_PROXIMITY) {
       const directBlock = currentSource.slice(directStart, match.index);
       const appMatch = directBlock.match(/([A-Za-z_$][\w$]*)\.app\.on\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
       if (appMatch != null) {
@@ -1255,11 +1269,8 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
     return patchedSource;
   }
 
-  const semanticLaunchActionPatch = applySemanticLinuxLaunchActionArgsPatch(patchedSource);
-  if (semanticLaunchActionPatch !== patchedSource) {
-    return semanticLaunchActionPatch;
-  }
-
+  // Try cheap exact-string legacy needles first; only fall through to the
+  // semantic regex+capture pass if no known shape matches.
   if (patchedSource.includes(oldLaunchActionPatch)) {
     patchedSource = patchedSource.replace(oldLaunchActionPatch, launchActionPatch);
   } else if (patchedSource.includes(deepLinkFirstLaunchActionPatch)) {
@@ -1277,6 +1288,11 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
   } else if (patchedSource.includes(launchActionNeedle)) {
     patchedSource = patchedSource.replace(launchActionNeedle, launchActionPatch);
   } else {
+    const semanticLaunchActionPatch = applySemanticLinuxLaunchActionArgsPatch(patchedSource);
+    if (semanticLaunchActionPatch !== patchedSource) {
+      return semanticLaunchActionPatch;
+    }
+
     const existingLinuxLaunchActionBlock = patchedSource.match(
       /let ae=async\(e,t\)=>\{P\.hotkeyWindowLifecycleManager\.hide\(\);.*?;let oe=async\(\)=>\{/,
     )?.[0];

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -742,11 +742,13 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     "if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}";
   const closeToTrayPatch =
     "if((process.platform===`win32`||process.platform===`linux`)&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}";
+  const patchedCloseToTrayRegex =
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&[A-Za-z_$][\w$]*===`local`&&!this\.isAppQuitting&&this\.options\.canHideLastLocalWindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
   if (patchedSource.includes(closeToTrayPatch)) {
     // Already patched.
   } else if (patchedSource.includes(closeToTrayNeedle)) {
     patchedSource = patchedSource.replace(closeToTrayNeedle, closeToTrayPatch);
-  } else if (/\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&[A-Za-z_$][\w$]*===`local`/.test(patchedSource)) {
+  } else if (patchedCloseToTrayRegex.test(patchedSource)) {
     // Already patched with a newer minifier's window variable.
   } else {
     const closeToTrayRegex =

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -519,6 +519,10 @@ function requireName(source, moduleName) {
   return match?.[1] ?? null;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function findCallBlock(source, marker) {
   const markerStart = source.indexOf(marker);
   if (markerStart === -1) {
@@ -850,7 +854,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     );
     const trayStartupRegex = traySetupMatch == null
       ? null
-      : new RegExp(`([A-Za-z_$][\\w$]*)&&${traySetupMatch[1]}\\(\\);`);
+      : new RegExp(`([A-Za-z_$][\\w$]*)&&${escapeRegExp(traySetupMatch[1])}\\(\\);`);
     const dynamicTrayStartupMatch = trayStartupRegex == null ? null : patchedSource.match(trayStartupRegex);
     if (
       traySetupMatch != null &&
@@ -1150,7 +1154,7 @@ function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
 
     const [, windowManagerVar, currentWindowVar, hostExpr, createdWindowVar] = openerVars;
     const routeVar = openerText.match(/([A-Za-z_$][\w$]*)\.navigateToRoute\([A-Za-z_$][\w$]*,e\)/)?.[1];
-    const focusFn = openerText.match(new RegExp(`,([A-Za-z_$][\\w$]*)\\(${createdWindowVar}\\)\\)\\}$`))?.[1];
+    const focusFn = openerText.match(new RegExp(`,([A-Za-z_$][\\w$]*)\\(${escapeRegExp(createdWindowVar)}\\)\\)\\}$`))?.[1];
     if (routeVar == null || focusFn == null) {
       continue;
     }

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -705,6 +705,43 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
   return currentSource;
 }
 
+function findNamedFunctionBody(source, functionName) {
+  const functionMatch = source.match(
+    new RegExp(`(?:async\\s+)?function\\s+${escapeRegExp(functionName)}\\([^)]*\\)\\{`),
+  );
+  if (functionMatch == null) {
+    return null;
+  }
+
+  const openIndex = functionMatch.index + functionMatch[0].length - 1;
+  const closeIndex = findMatchingBrace(source, openIndex);
+  return closeIndex === -1 ? null : source.slice(openIndex, closeIndex + 1);
+}
+
+function isTrayFactoryFunction(source, functionName) {
+  const body = findNamedFunctionBody(source, functionName);
+  return body != null && /new [A-Za-z_$][\w$]*\.Tray\(/.test(body);
+}
+
+function findDynamicTraySetup(source) {
+  const setupRegex =
+    /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await ([A-Za-z_$][\w$]*)\(\{buildFlavor:/g;
+  let match;
+  while ((match = setupRegex.exec(source)) != null) {
+    const [, setupFn, factoryFn] = match;
+    if (isTrayFactoryFunction(source, factoryFn)) {
+      return { setupFn, index: match.index };
+    }
+  }
+  return null;
+}
+
+function findDynamicTrayStartupCall(source, setupFn, startIndex) {
+  const startupRegex = new RegExp(`([A-Za-z_$][\\w$]*)&&${escapeRegExp(setupFn)}\\(\\);`, "g");
+  startupRegex.lastIndex = startIndex;
+  return startupRegex.exec(source);
+}
+
 function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   let patchedSource = currentSource;
 
@@ -851,24 +888,18 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   } else if (patchedSource.includes(trayStartupNeedle)) {
     patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
   } else {
-    const traySetupMatch = patchedSource.match(
-      /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await [A-Za-z_$][\w$]*\(\{buildFlavor:/,
-    );
-    const trayStartupRegex = traySetupMatch == null
+    const traySetup = findDynamicTraySetup(patchedSource);
+    const dynamicTrayStartupMatch = traySetup == null
       ? null
-      : new RegExp(`([A-Za-z_$][\\w$]*)&&${escapeRegExp(traySetupMatch[1])}\\(\\);`);
-    const dynamicTrayStartupMatch = trayStartupRegex == null ? null : patchedSource.match(trayStartupRegex);
+      : findDynamicTrayStartupCall(patchedSource, traySetup.setupFn, traySetup.index);
     if (
-      traySetupMatch != null &&
-      patchedSource.includes(`process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetupMatch[1]}();`)
+      traySetup != null &&
+      patchedSource.includes(`process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();`)
     ) {
       // Already patched with a newer minifier's tray setup identifier.
     } else if (dynamicTrayStartupMatch != null) {
       const isWindowsVar = dynamicTrayStartupMatch[1];
-      patchedSource = patchedSource.replace(
-        trayStartupRegex,
-        `(${isWindowsVar}||process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetupMatch[1]}();`,
-      );
+      patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
     } else {
       console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
     }
@@ -1096,11 +1127,11 @@ function findLastRegexMatch(source, regex) {
 
 function findLinuxGlobalStateExpression(prefix) {
   const objectStateMatch = findLastRegexMatch(prefix, /(?:let|,)\s*([A-Za-z_$][\w$]*)=\{globalState:/g);
-  if (objectStateMatch != null) {
+  const propertyStateMatch = findLastRegexMatch(prefix, /globalState:([A-Za-z_$][\w$]*)\.globalState/g);
+
+  if (objectStateMatch != null && (propertyStateMatch == null || objectStateMatch.index > propertyStateMatch.index)) {
     return `${objectStateMatch[1]}.globalState`;
   }
-
-  const propertyStateMatch = findLastRegexMatch(prefix, /globalState:([A-Za-z_$][\w$]*)\.globalState/g);
   if (propertyStateMatch != null) {
     return `${propertyStateMatch[1]}.globalState`;
   }

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -943,6 +943,8 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
   const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=(?:`computer-use`|"computer-use"|'computer-use')/)?.[1] ?? null;
   const gateRegex =
     /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`|"computer-use"|'computer-use'),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
+  let sawEnabledGate = false;
+  let sawUnpatchableGate = false;
   let match;
   while ((match = gateRegex.exec(currentSource)) != null) {
     const [gateSource, installWhenMissing, nameExpr, paramsText, expression, migrateVar] = match;
@@ -960,12 +962,18 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
     const darwinOnlyExpression = `${platformVar}===\`darwin\`&&${featuresVar}.computerUse`;
     const linuxExpression = `(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse`;
     if (installWhenMissing != null && expression === linuxExpression) {
-      return currentSource;
+      sawEnabledGate = true;
+      continue;
     }
     if (expression === darwinOnlyExpression || expression === linuxExpression) {
       const replacement = buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar });
       return `${currentSource.slice(0, match.index)}${replacement}${currentSource.slice(match.index + gateSource.length)}`;
     }
+    sawUnpatchableGate = true;
+  }
+
+  if (sawEnabledGate && !sawUnpatchableGate) {
+    return currentSource;
   }
 
   if (hasComputerUseLiteral(currentSource) && currentSource.includes("computerUse")) {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -233,6 +233,22 @@ test("gates current close-to-tray setting through the captured global state", ()
   assert.doesNotMatch(patched, /M\.globalState\.get/);
 });
 
+test("does not treat unrelated Linux setting references as close-to-tray patched", () => {
+  const source = [
+    "let j=KD({moduleDir:__dirname});",
+    "let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});",
+    "let codexLinuxGetSetting=e=>process.platform!==`linux`||j.globalState.get(`codex-linux-system-tray-enabled`)!==!1;",
+    "t.Mr().info(`Launching app`);",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
+
+  assert.match(
+    patched,
+    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
+  );
+});
+
 test("allows bundled Computer Use on Linux as well as macOS", () => {
   const patched = applyPatchTwice(
     applyLinuxComputerUsePluginGatePatch,
@@ -290,6 +306,22 @@ test("targets literal Computer Use gate names without patching unrelated descrip
     patched,
     /name:`computer-use`,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse,migrate:wn/,
   );
+});
+
+test("handles quoted Computer Use gate names", () => {
+  const boundNameSource = [
+    "var tn=\"computer-use\";",
+    "var $n=[{name:tn,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:wn}];",
+  ].join("");
+  const literalNameSource = "var $n=[{name:'computer-use',isEnabled:({platform:t,features:e})=>t===`darwin`&&e.computerUse,migrate:wn}];";
+
+  const patchedBoundName = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, boundNameSource);
+  const patchedLiteralName = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, literalNameSource);
+
+  assert.match(patchedBoundName, /installWhenMissing:!0,name:tn/);
+  assert.match(patchedBoundName, /\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/);
+  assert.match(patchedLiteralName, /installWhenMissing:!0,name:'computer-use'/);
+  assert.match(patchedLiteralName, /\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/);
 });
 
 test("patches the current Computer Use gate without touching the Windows-internal descriptor", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -246,6 +246,25 @@ test("adds installWhenMissing to an already Linux-enabled Computer Use gate", ()
   assert.equal((patched.match(/installWhenMissing:!0,name:tn/g) || []).length, 1);
 });
 
+test("handles reordered Computer Use gate destructuring", () => {
+  const darwinOnlySource = [
+    "var tn=`computer-use`;",
+    "var $n=[{name:tn,isEnabled:({platform:t,features:e})=>t===`darwin`&&e.computerUse,migrate:wn}];",
+  ].join("");
+  const alreadyLinuxEnabledSource = [
+    "var tn=`computer-use`;",
+    "var $n=[{installWhenMissing:!0,name:tn,isEnabled:({platform:t,features:e})=>(t===`darwin`||t===`linux`)&&e.computerUse,migrate:wn}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, darwinOnlySource);
+
+  assert.match(
+    patched,
+    /\{installWhenMissing:!0,name:tn,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse,migrate:wn\}/,
+  );
+  assert.equal(applyPatchTwice(applyLinuxComputerUsePluginGatePatch, alreadyLinuxEnabledSource), alreadyLinuxEnabledSource);
+});
+
 test("patches the current Computer Use gate without touching the Windows-internal descriptor", () => {
   const source = [
     "var Ye=`browser-use`,Xe=`chrome-internal`,Ze=`computer-use`,Qe=`latex-tectonic`;",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -169,6 +169,20 @@ test("adds Linux tray support for current minified window and startup identifier
   assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
 });
 
+test("scopes close-to-tray already-patched detection to the handler", () => {
+  const source = [
+    "let unrelated=(process.platform===`win32`||process.platform===`linux`)&&x===`local`;",
+    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
+
+  assert.match(
+    patched,
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&f===`local`&&!this\.isAppQuitting&&this\.options\.canHideLastLocalWindowToTray\?\.\(\)===!0&&!t\)\{e\.preventDefault\(\),j\.hide\(\);return\}/,
+  );
+});
+
 test("adds Linux single-instance lock and second-instance handoff", () => {
   const patched = applyPatchTwice(applyLinuxSingleInstancePatch, singleInstanceBundleFixture());
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -9,10 +9,13 @@ const test = require("node:test");
 const {
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxFileManagerPatch,
+  applyLinuxHotkeyWindowPrewarmPatch,
+  applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxSetIconPatch,
   applyLinuxSingleInstancePatch,
+  applyLinuxTrayCloseSettingPatch,
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
   patchMainBundleSource,
@@ -59,6 +62,13 @@ function computerUseGateBundleFixture() {
   return [
     "var Qt=`openai-bundled`,$t=`browser-use`,en=`chrome-internal`,tn=`computer-use`,nn=`latex-tectonic`;",
     "var $n=[{forceReload:!0,installWhenMissing:!0,name:$t,isEnabled:({features:e})=>e.browserAgentAvailable,migrate:cn},{name:en,isEnabled:({buildFlavor:e})=>rn(e)},{name:tn,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:wn},{name:nn,isEnabled:()=>!0}];",
+  ].join("");
+}
+
+function currentLaunchActionBundleFixture() {
+  return [
+    "const e={gr:e=>({default:e,...e})};let n=require(`electron`);let i=require(`node:path`);i=e.gr(i);let o=require(`node:fs`);o=e.gr(o);let f=require(`node:net`);f=e.gr(f);",
+    "async function CN(){let{setSecondInstanceArgsHandler:l}=t.y(),g={reportNonFatal(){}},k=new t.In;k.add(x);let j={globalState:{get(){return true}},repoRoot:`/tmp`,codexHome:`/tmp`},M={hotkeyWindowLifecycleManager:{hide(){},ensureHotkeyWindowController(){}},getPrimaryWindow(){},createFreshLocalWindow(){},ensureHostWindow(){},windowManager:{sendMessageToWindow(){}}},B=`local`,R={desktopNotificationManager:{dismissByNavigationPath(){}},getOrCreateContext(){},localHost:B},z={deepLinks:{queueProcessArgs(){},flushPendingDeepLinks(){}},navigateToRoute(){}};let A=Date.now(),w=()=>{},ae=e=>{e.isMinimized()&&e.restore(),e.show(),e.focus()},oe=async()=>{try{M.hotkeyWindowLifecycleManager.hide();let e=M.getPrimaryWindow(`local`)??await M.createFreshLocalWindow(`/`);if(e==null)return;ae(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{z.deepLinks.queueProcessArgs(e)||oe()});let se=async(e,t)=>{M.hotkeyWindowLifecycleManager.hide();let n=M.getPrimaryWindow(B),r=n??await M.createFreshLocalWindow(e);r!=null&&(R.desktopNotificationManager.dismissByNavigationPath(e),n!=null&&t.navigateExistingWindow&&z.navigateToRoute(r,e),ae(r))};let ce=async()=>{};E&&ce();let be=await M.ensureHostWindow(B);be&&ae(be),w(`local window ensured`,A,{hostId:B,localWindowVisible:be?.isVisible()??!1}),A=Date.now(),await z.deepLinks.flushPendingDeepLinks();}",
   ].join("");
 }
 
@@ -146,6 +156,19 @@ test("adds Linux tray support including the platform guard", () => {
   assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&oe\(\);/);
 });
 
+test("adds Linux tray support for current minified window and startup identifiers", () => {
+  const source = [
+    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
+    "let ce=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce();",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
+
+  assert.match(patched, /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&f===`local`/);
+  assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\(\);/);
+});
+
 test("adds Linux single-instance lock and second-instance handoff", () => {
   const patched = applyPatchTwice(applyLinuxSingleInstancePatch, singleInstanceBundleFixture());
 
@@ -154,6 +177,48 @@ test("adds Linux single-instance lock and second-instance handoff", () => {
   assert.match(patched, /codexLinuxSecondInstanceHandler/);
   assert.match(patched, /n\.app\.on\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
   assert.match(patched, /n\.app\.off\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
+});
+
+test("recognizes bootstrap-owned single-instance handoff in current bundles", () => {
+  const source = "let{setSecondInstanceArgsHandler:l}=t.y();l(e=>{z.deepLinks.queueProcessArgs(e)||oe()});";
+  const patched = applyPatchTwice(applyLinuxSingleInstancePatch, source);
+
+  assert.equal(patched, source);
+});
+
+test("adds Linux launch actions through current setSecondInstanceArgsHandler bundles", () => {
+  const launchPatched = applyPatchTwice(
+    applyLinuxLaunchActionArgsPatch,
+    currentLaunchActionBundleFixture(),
+  );
+  const prewarmPatched = applyPatchTwice(applyLinuxHotkeyWindowPrewarmPatch, launchPatched);
+
+  assert.match(launchPatched, /codexLinuxGetSetting=e=>process\.platform!==`linux`\|\|j\.globalState\.get\(e\)!==!1/);
+  assert.match(launchPatched, /codexLinuxStartLaunchActionSocket=\(\)=>/);
+  assert.match(launchPatched, /f\.default\.createServer/);
+  assert.match(launchPatched, /o\.mkdirSync\(i\.default\.dirname\(e\)/);
+  assert.match(launchPatched, /R\.desktopNotificationManager\.dismissByNavigationPath\(e\)/);
+  assert.match(launchPatched, /codexLinuxHasDeepLink\(e\)&&z\.deepLinks\.queueProcessArgs\(e\)/);
+  assert.match(launchPatched, /e\.includes\(`--prompt-chat`\)/);
+  assert.match(launchPatched, /e\.includes\(`--quick-chat`\)/);
+  assert.match(launchPatched, /e\.includes\(`--new-chat`\)/);
+  assert.match(launchPatched, /process\.platform===`linux`&&codexLinuxStartLaunchActionSocket\(\);l\(e=>/);
+  assert.doesNotMatch(launchPatched, /l\(e=>\{z\.deepLinks\.queueProcessArgs\(e\)\|\|oe\(\)\}\)/);
+  assert.match(
+    prewarmPatched,
+    /process\.platform===`linux`&&codexLinuxPrewarmHotkeyWindow\(\),A=Date\.now\(\),await z\.deepLinks\.flushPendingDeepLinks\(\)/,
+  );
+});
+
+test("gates current close-to-tray setting through the captured global state", () => {
+  const source = "let j=KD({moduleDir:__dirname});let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});t.Mr().info(`Launching app`);";
+  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
+
+  assert.match(
+    patched,
+    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
+  );
+  assert.doesNotMatch(patched, /M\.globalState\.get/);
 });
 
 test("allows bundled Computer Use on Linux as well as macOS", () => {
@@ -179,6 +244,26 @@ test("adds installWhenMissing to an already Linux-enabled Computer Use gate", ()
 
   assert.match(patched, /installWhenMissing:!0,name:tn/);
   assert.equal((patched.match(/installWhenMissing:!0,name:tn/g) || []).length, 1);
+});
+
+test("patches the current Computer Use gate without touching the Windows-internal descriptor", () => {
+  const source = [
+    "var Ye=`browser-use`,Xe=`chrome-internal`,Ze=`computer-use`,Qe=`latex-tectonic`;",
+    "var Dr=[{forceReload:!0,installWhenMissing:!0,name:Ye,isEnabled:({features:e})=>e.browserAgentAvailable,migrate:In},{forceReload:!0,name:Xe,isEnabled:({buildFlavor:e})=>Mn(e)},{name:Ze,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:Qn},{installWhenMissing:!0,name:Ze,isEnabled:({buildFlavor:e,features:n,platform:r})=>t.C.isInternal(e)&&r===`win32`&&n.computerUse},{name:Qe,isEnabled:()=>!0}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, source);
+
+  assert.match(patched, /name:Ze,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse,migrate:Qn/);
+  assert.match(patched, /t\.C\.isInternal\(e\)&&r===`win32`&&n\.computerUse/);
+  assert.equal((patched.match(/installWhenMissing:!0,name:Ze/g) || []).length, 2);
+});
+
+test("fails hard when the Computer Use gate is recognizable but unpatchable", () => {
+  assert.throws(
+    () => applyLinuxComputerUsePluginGatePatch("var tn=`computer-use`;var x=[{name:tn,isEnabled:({features:e,platform:t})=>isMac(t)&&e.computerUse,migrate:wn}];"),
+    /Required Linux Computer Use plugin gate patch failed/,
+  );
 });
 
 test("uses CODEX_APP_ID for Electron desktopName", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -265,6 +265,21 @@ test("handles reordered Computer Use gate destructuring", () => {
   assert.equal(applyPatchTwice(applyLinuxComputerUsePluginGatePatch, alreadyLinuxEnabledSource), alreadyLinuxEnabledSource);
 });
 
+test("targets literal Computer Use gate names without patching unrelated descriptors", () => {
+  const source = [
+    "var other=`other-plugin`;",
+    "var $n=[{name:other,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:on},{name:`computer-use`,isEnabled:({platform:t,features:e})=>t===`darwin`&&e.computerUse,migrate:wn}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, source);
+
+  assert.match(patched, /name:other,isEnabled:\(\{features:e,platform:t\}\)=>t===`darwin`&&e\.computerUse,migrate:on/);
+  assert.match(
+    patched,
+    /name:`computer-use`,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse,migrate:wn/,
+  );
+});
+
 test("patches the current Computer Use gate without touching the Windows-internal descriptor", () => {
   const source = [
     "var Ye=`browser-use`,Xe=`chrome-internal`,Ze=`computer-use`,Qe=`latex-tectonic`;",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -288,6 +288,22 @@ test("adds installWhenMissing to an already Linux-enabled Computer Use gate", ()
   assert.equal((patched.match(/installWhenMissing:!0,name:tn/g) || []).length, 1);
 });
 
+test("keeps scanning Computer Use gates after an already patched match", () => {
+  const source = [
+    "var tn=`computer-use`;",
+    "var $n=[{installWhenMissing:!0,name:tn,isEnabled:({features:e,platform:t})=>(t===`darwin`||t===`linux`)&&e.computerUse,migrate:on},{name:tn,isEnabled:({features:n,platform:r})=>r===`darwin`&&n.computerUse,migrate:wn}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, source);
+
+  assert.match(
+    patched,
+    /name:tn,isEnabled:\(\{features:n,platform:r\}\)=>\(r===`darwin`\|\|r===`linux`\)&&n\.computerUse,migrate:wn/,
+  );
+  assert.equal((patched.match(/installWhenMissing:!0,name:tn/g) || []).length, 2);
+  assert.doesNotMatch(patched, /r===`darwin`&&n\.computerUse/);
+});
+
 test("handles reordered Computer Use gate destructuring", () => {
   const darwinOnlySource = [
     "var tn=`computer-use`;",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -159,6 +159,7 @@ test("adds Linux tray support including the platform guard", () => {
 test("adds Linux tray support for current minified window and startup identifiers", () => {
   const source = [
     "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
+    "async function eN(e){let t=await Ww(e.buildFlavor,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
     "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
   ].join("");
 
@@ -166,6 +167,21 @@ test("adds Linux tray support for current minified window and startup identifier
 
   assert.match(patched, /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&f===`local`/);
   assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
+});
+
+test("scopes dynamic tray startup matching to the tray initializer", () => {
+  const source = [
+    "async function aa(e){return e.buildFlavor}",
+    "let startOther=async()=>{A=!0;try{await aa({buildFlavor:a})}catch(e){A=!1}};U&&startOther();",
+    "async function eN(e){let t=await Ww(e.buildFlavor,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
+    "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
+
+  assert.match(patched, /U&&startOther\(\);/);
+  assert.doesNotMatch(patched, /\(U\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&startOther\(\);/);
   assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
 });
 
@@ -261,6 +277,23 @@ test("does not treat unrelated Linux setting references as close-to-tray patched
     patched,
     /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
   );
+});
+
+test("chooses the nearest globalState alias for close-to-tray settings", () => {
+  const source = [
+    "let stale={globalState:{get(){return false}}};",
+    "let j=KD({moduleDir:__dirname});",
+    "let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});",
+    "t.Mr().info(`Launching app`);",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
+
+  assert.match(
+    patched,
+    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
+  );
+  assert.doesNotMatch(patched, /stale\.globalState\.get\(`codex-linux-system-tray-enabled`\)/);
 });
 
 test("allows bundled Computer Use on Linux as well as macOS", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -159,14 +159,14 @@ test("adds Linux tray support including the platform guard", () => {
 test("adds Linux tray support for current minified window and startup identifiers", () => {
   const source = [
     "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&f===`local`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
-    "let ce=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce();",
+    "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
 
   assert.match(patched, /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&f===`local`/);
   assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
-  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\(\);/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
 });
 
 test("adds Linux single-instance lock and second-instance handoff", () => {
@@ -208,6 +208,18 @@ test("adds Linux launch actions through current setSecondInstanceArgsHandler bun
     prewarmPatched,
     /process\.platform===`linux`&&codexLinuxPrewarmHotkeyWindow\(\),A=Date\.now\(\),await z\.deepLinks\.flushPendingDeepLinks\(\)/,
   );
+});
+
+test("adds Linux launch actions when captured window identifiers contain dollar signs", () => {
+  const source = currentLaunchActionBundleFixture().replace(
+    "let se=async(e,t)=>{M.hotkeyWindowLifecycleManager.hide();let n=M.getPrimaryWindow(B),r=n??await M.createFreshLocalWindow(e);r!=null&&(R.desktopNotificationManager.dismissByNavigationPath(e),n!=null&&t.navigateExistingWindow&&z.navigateToRoute(r,e),ae(r))};",
+    "let se=async(e,t)=>{M.hotkeyWindowLifecycleManager.hide();let n=M.getPrimaryWindow(B),r$=n??await M.createFreshLocalWindow(e);r$!=null&&(R.desktopNotificationManager.dismissByNavigationPath(e),n!=null&&t.navigateExistingWindow&&z.navigateToRoute(r$,e),ae(r$))};",
+  );
+
+  const patched = applyPatchTwice(applyLinuxLaunchActionArgsPatch, source);
+
+  assert.match(patched, /codexLinuxHandleLaunchActionArgs/);
+  assert.match(patched, /z\.navigateToRoute\(r\$,e\),ae\(r\$\)/);
 });
 
 test("gates current close-to-tray setting through the captured global state", () => {


### PR DESCRIPTION
## Summary
- Make the Linux bundle patcher recognize current Codex Desktop launch-action and bootstrap-owned single-instance shapes.
- Tighten Computer Use and tray patch matching so Linux support is applied without touching unrelated descriptors or handlers.
- Add regression coverage for reordered params, quoted plugin names, escaped minified identifiers, and close-to-tray idempotency.

Fixes #69.

## Validation
- `node --check scripts/patch-linux-window-ui.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `for script in install.sh scripts/lib/*.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh; do bash -n "$script"; done`
- `bash tests/scripts_smoke.sh`