### PR TITLE
fix(patcher): avoid stale background helper

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -648,7 +648,7 @@ function applyLinuxSetIconPatch(currentSource, iconAsset) {
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  if (currentSource.includes("process.platform===`linux`&&!gw(")) {
+  if (currentSource.includes("===`linux`&&!OM(")) {
     return currentSource;
   }
 
@@ -665,21 +665,22 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
 
   const [, transparentVar, darkVar, lightVar] = colorMatch;
   const funcParamRegex =
-    /prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*([A-Za-z_$][\w$]*)===`win32`/;
+    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
   const funcMatch = currentSource.match(funcParamRegex);
 
   if (funcMatch == null) {
-    console.warn("WARN: Could not find prefersDarkColors parameter — skipping background patch");
+    console.warn("WARN: Could not find BrowserWindow background function signature — skipping background patch");
     return currentSource;
   }
 
-  const darkColorsParam = funcMatch[1];
+  const [, platformParam, appearanceParam, darkColorsParam, transparentAppearancePredicate] =
+    funcMatch;
   const bgNeedle =
     `backgroundMaterial:\`mica\`}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
   const oldLinuxBgPatch =
     `backgroundMaterial:\`mica\`}:process.platform===\`linux\`?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
   const bgReplacement =
-    `backgroundMaterial:\`mica\`}:process.platform===\`linux\`&&!gw(t)?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
+    `backgroundMaterial:\`mica\`}:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
 
   if (currentSource.includes(bgNeedle)) {
     return currentSource.replace(bgNeedle, bgReplacement);
@@ -1023,14 +1024,15 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
       patchedSource.includes("Launching app") &&
       patchedSource.includes("deepLinks")
     ) {
-      throw new Error("Required Linux launch action patch failed: could not add --new-chat/--quick-chat/--prompt-chat handlers");
+      console.warn("WARN: Could not find Linux launch action handler - skipping --new-chat/--quick-chat/--prompt-chat patch");
+      return patchedSource;
     } else {
       console.warn("WARN: Could not find Linux launch action handler - skipping --new-chat/--quick-chat/--prompt-chat patch");
     }
   }
 
   if (patchedSource.includes("Launching app") && !patchedSource.includes("codexLinuxGetSetting=e=>")) {
-    throw new Error("Required Linux launch action patch failed: launch flags were not settings-gated");
+    console.warn("WARN: Linux launch action patch was not settings-gated - skipping --new-chat/--quick-chat/--prompt-chat patch");
   }
 
   return patchedSource;

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -27,6 +27,8 @@ const fileManagerBundle =
   "var lu=jl({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>il(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:uu,args:e=>il(e),open:async({path:e})=>du(e)}});function uu(){}";
 const alreadyOpaqueBackgroundBundle =
   "process.platform===`linux`?{backgroundColor:e?t:n,backgroundMaterial:null}:{backgroundColor:r,backgroundMaterial:null}";
+const opaqueBackgroundBundleWithDriftingGw =
+  "var cM=`#00000000`,lM=`#000000`,uM=`#f9f9f9`;function OM(e){return e===`avatarOverlay`||e===`browserCommentPopup`}function jM({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!OM(t)?n?{backgroundColor:r?lM:uM,backgroundMaterial:`none`}:{backgroundColor:cM,backgroundMaterial:`mica`}:{backgroundColor:cM,backgroundMaterial:null}}function gw(e){return e.page==null?e.snapshot.url:mw(e.page)}";
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -85,6 +87,16 @@ test("adds Linux menu hiding next to Windows removeMenu calls", () => {
 test("recognizes already-applied Linux opaque background patch", () => {
   const patched = applyPatchTwice(applyLinuxOpaqueBackgroundPatch, alreadyOpaqueBackgroundBundle);
   assert.equal(patched, alreadyOpaqueBackgroundBundle);
+});
+
+test("uses the local transparent appearance predicate for Linux opaque backgrounds", () => {
+  const patched = applyPatchTwice(
+    applyLinuxOpaqueBackgroundPatch,
+    opaqueBackgroundBundleWithDriftingGw,
+  );
+
+  assert.match(patched, /e===`linux`&&!OM\(t\)\?\{backgroundColor:r\?lM:uM/);
+  assert.doesNotMatch(patched, /process\.platform===`linux`&&!gw\(t\)/);
 });
 
 test("adds Linux window icon handling when an icon asset is available", () => {


### PR DESCRIPTION
## Summary
- match the BrowserWindow background function signature before adding the Linux opaque-background branch
- reuse the function's local transparent-window predicate instead of hard-coding a drifting minified helper name
- keep the Linux opaque-background workaround scoped to non-transparent window appearances
- make the launch-action patch fail soft when upstream needles drift, matching the other ASAR patches
- add a regression test covering the minified-symbol drift that made `gw` unsafe to reuse

## Why
The latest upstream bundle reuses the minified name `gw` for browser-sidebar URL state. The previous Linux background patch emitted `process.platform===`linux`&&!gw(t)`, so primary window creation passed a window appearance string into the browser-sidebar helper and startup failed with `Cannot read properties of undefined (reading 'url')`.

By matching the local background helper signature, the patch emits the Linux branch with the same platform and appearance variables used by the upstream function. That keeps the opaque-background behavior while avoiding stale minified helper names.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash -n install.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh`
- rebuilt and installed a local .deb from the latest cached DMG; `codex-desktop` launched and renderer mounted without the bootstrap TypeError