### PR TITLE
feat(computer-use): add Linux window targeting

### DIFF
--- a/computer-use-linux/gnome-shell-extension/codex-window-control@openai.com/extension.js
+++ b/computer-use-linux/gnome-shell-extension/codex-window-control@openai.com/extension.js
@@ -1,0 +1,159 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+const SERVICE_NAME = 'com.openai.Codex.WindowControl';
+const OBJECT_PATH = '/com/openai/Codex/WindowControl';
+const BACKEND = 'gnome-shell-extension';
+
+const WINDOW_CONTROL_XML = `
+<node>
+  <interface name="${SERVICE_NAME}">
+    <method name="ListWindows">
+      <arg name="json" type="s" direction="out"/>
+    </method>
+    <method name="ActivateWindow">
+      <arg name="window_id" type="t" direction="in"/>
+      <arg name="ok" type="b" direction="out"/>
+      <arg name="message" type="s" direction="out"/>
+    </method>
+  </interface>
+</node>
+`;
+
+const WindowControlDBus = GObject.registerClass(
+class WindowControlDBus extends GObject.Object {
+    constructor() {
+        super();
+
+        this._dbusObject = Gio.DBusExportedObject.wrapJSObject(
+            WINDOW_CONTROL_XML, this);
+        this._dbusObject.export(Gio.DBus.session, OBJECT_PATH);
+        this._nameId = Gio.DBus.session.own_name(
+            SERVICE_NAME,
+            Gio.BusNameOwnerFlags.NONE,
+            null,
+            () => log(`Codex Window Control lost DBus name ${SERVICE_NAME}`));
+    }
+
+    destroy() {
+        if (this._nameId) {
+            Gio.DBus.session.unown_name(this._nameId);
+            this._nameId = 0;
+        }
+
+        this._dbusObject?.unexport();
+        this._dbusObject?.run_dispose();
+        this._dbusObject = null;
+    }
+
+    ListWindowsAsync(_params, invocation) {
+        this._returnJson(invocation, this._listWindows());
+    }
+
+    ActivateWindowAsync([windowId], invocation) {
+        const requestedId = Number(windowId);
+        const window = this._listMetaWindows().find(
+            candidate => Number(candidate.get_id()) === requestedId);
+
+        if (!window) {
+            invocation.return_value(new GLib.Variant('(bs)', [
+                false,
+                `No window matched window_id ${requestedId}`,
+            ]));
+            return;
+        }
+
+        try {
+            if (Main.overview.visible)
+                Main.overview.hide();
+
+            if (window.minimized && typeof window.unminimize === 'function')
+                window.unminimize();
+
+            Main.activateWindow(window, global.get_current_time());
+            invocation.return_value(new GLib.Variant('(bs)', [
+                true,
+                `Activated window_id ${requestedId}`,
+            ]));
+        } catch (error) {
+            invocation.return_value(new GLib.Variant('(bs)', [
+                false,
+                `Activation failed: ${error.message}`,
+            ]));
+        }
+    }
+
+    _returnJson(invocation, value) {
+        invocation.return_value(new GLib.Variant('(s)', [
+            JSON.stringify(value),
+        ]));
+    }
+
+    _listWindows() {
+        return this._listMetaWindows()
+            .map(window => this._windowInfo(window))
+            .filter(window => window !== null);
+    }
+
+    _listMetaWindows() {
+        return global.get_window_actors()
+            .map(actor => actor.meta_window)
+            .filter(window => window && !window.is_override_redirect?.())
+            .filter(window => window.get_window_type?.() !== Meta.WindowType.DESKTOP);
+    }
+
+    _windowInfo(window) {
+        if (!window)
+            return null;
+
+        const app = Shell.WindowTracker.get_default().get_window_app(window);
+        const rect = window.get_frame_rect();
+        const workspace = window.get_workspace?.();
+
+        return {
+            window_id: Number(window.get_id()),
+            title: window.get_title?.() ?? null,
+            app_id: app?.get_id?.() ?? null,
+            wm_class: window.get_wm_class?.() ?? null,
+            pid: window.get_pid?.() ?? null,
+            bounds: rect ? {
+                x: rect.x,
+                y: rect.y,
+                width: rect.width,
+                height: rect.height,
+            } : null,
+            workspace: workspace?.index?.() ?? null,
+            focused: global.display.focus_window === window && !Main.overview.visible,
+            hidden: window.minimized ?? false,
+            client_type: clientTypeName(window.get_client_type?.()),
+            backend: BACKEND,
+        };
+    }
+});
+
+function clientTypeName(value) {
+    if (value === undefined || value === null)
+        return null;
+    if (value === Meta.WindowClientType.WAYLAND)
+        return 'wayland';
+    if (value === Meta.WindowClientType.X11)
+        return 'x11';
+    return 'unknown';
+}
+
+export default class CodexWindowControlExtension extends Extension {
+    enable() {
+        this._dbusServer = new WindowControlDBus();
+    }
+
+    disable() {
+        this._dbusServer?.destroy();
+        this._dbusServer = null;
+    }
+}

--- a/computer-use-linux/gnome-shell-extension/codex-window-control@openai.com/metadata.json
+++ b/computer-use-linux/gnome-shell-extension/codex-window-control@openai.com/metadata.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "codex-window-control@openai.com",
+  "name": "Codex Window Control",
+  "description": "Local GNOME Shell window listing and focus bridge for Codex Computer Use on Linux.",
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
+  "version": 1
+}

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -1,16 +1,28 @@
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::{
-    env,
+    collections::HashMap,
+    env, fs,
     path::{Path, PathBuf},
     process::Command,
 };
+
+const DESKTOP_ENV_KEYS: &[&str] = &[
+    "DBUS_SESSION_BUS_ADDRESS",
+    "DESKTOP_SESSION",
+    "DISPLAY",
+    "WAYLAND_DISPLAY",
+    "XDG_CURRENT_DESKTOP",
+    "XDG_RUNTIME_DIR",
+    "XDG_SESSION_TYPE",
+];
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct DoctorReport {
     pub platform: PlatformReport,
     pub portals: PortalReport,
     pub accessibility: AccessibilityReport,
+    pub windowing: WindowingReport,
     pub input: InputReport,
     pub readiness: ReadinessReport,
 }
@@ -49,6 +61,16 @@ pub struct AccessibilityReport {
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct WindowingReport {
+    pub gnome_shell_introspect: Check,
+    pub codex_gnome_shell_extension: Check,
+    pub can_list_windows: bool,
+    pub can_focus_apps: bool,
+    pub can_focus_windows: bool,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct InputReport {
     pub ydotool: Check,
     pub ydotoold: Check,
@@ -60,6 +82,9 @@ pub struct InputReport {
 pub struct ReadinessReport {
     pub can_register_mcp_tools: bool,
     pub can_build_accessibility_tree: bool,
+    pub can_query_windows: bool,
+    pub can_focus_apps: bool,
+    pub can_focus_windows: bool,
     pub can_send_development_input: bool,
     pub recommended_next_step: String,
     pub blockers: Vec<String>,
@@ -103,19 +128,23 @@ pub fn doctor_report() -> DoctorReport {
     let platform = platform_report();
     let portals = portal_report();
     let accessibility = accessibility_report();
+    let windowing = windowing_report();
     let input = input_report();
-    let readiness = readiness_report(&accessibility, &input);
+    let readiness = readiness_report(&accessibility, &windowing, &input);
 
     DoctorReport {
         platform,
         portals,
         accessibility,
+        windowing,
         input,
         readiness,
     }
 }
 
 pub fn hydrate_session_bus_env() {
+    hydrate_desktop_env_from_process_tree();
+
     if env_var("XDG_RUNTIME_DIR").is_none() {
         if let Some(runtime) = xdg_runtime_dir() {
             if runtime.exists() {
@@ -135,6 +164,81 @@ pub fn hydrate_session_bus_env() {
             }
         }
     }
+}
+
+fn hydrate_desktop_env_from_process_tree() {
+    for process_env in desktop_process_environments() {
+        for key in DESKTOP_ENV_KEYS {
+            if env_var(key).is_some() {
+                continue;
+            }
+            if let Some(value) = process_env
+                .get(*key)
+                .filter(|value| !value.trim().is_empty())
+            {
+                env::set_var(key, value);
+            }
+        }
+
+        if DESKTOP_ENV_KEYS.iter().all(|key| env_var(key).is_some()) {
+            break;
+        }
+    }
+}
+
+fn desktop_process_environments() -> Vec<HashMap<String, String>> {
+    let mut environments = Vec::new();
+    let mut pid = parent_pid("self");
+
+    for _ in 0..8 {
+        let Some(current_pid) = pid else {
+            break;
+        };
+        if current_pid <= 1 {
+            break;
+        }
+
+        if let Some(process_env) = read_process_environ(current_pid) {
+            environments.push(process_env);
+        }
+        pid = parent_pid(&current_pid.to_string());
+    }
+
+    environments
+}
+
+fn parent_pid(pid: &str) -> Option<u32> {
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    parse_parent_pid(&status)
+}
+
+fn parse_parent_pid(status: &str) -> Option<u32> {
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix("PPid:")?.trim();
+        value.parse::<u32>().ok()
+    })
+}
+
+fn read_process_environ(pid: u32) -> Option<HashMap<String, String>> {
+    let bytes = fs::read(format!("/proc/{pid}/environ")).ok()?;
+    Some(parse_environ(&bytes))
+}
+
+fn parse_environ(bytes: &[u8]) -> HashMap<String, String> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter_map(|entry| {
+            if entry.is_empty() {
+                return None;
+            }
+            let split = entry.iter().position(|byte| *byte == b'=')?;
+            let (key, value) = entry.split_at(split);
+            let value = &value[1..];
+            let key = std::str::from_utf8(key).ok()?.to_string();
+            let value = std::str::from_utf8(value).ok()?.to_string();
+            Some((key, value))
+        })
+        .collect()
 }
 
 pub fn setup_accessibility_report() -> SetupReport {
@@ -238,6 +342,45 @@ fn accessibility_report() -> AccessibilityReport {
     }
 }
 
+fn windowing_report() -> WindowingReport {
+    let gnome_shell_introspect = gdbus_call_check(
+        "org.gnome.Shell",
+        "/org/gnome/Shell/Introspect",
+        "org.gnome.Shell.Introspect.GetWindows",
+        &[],
+    );
+    let codex_gnome_shell_extension = gdbus_call_check(
+        "com.openai.Codex.WindowControl",
+        "/com/openai/Codex/WindowControl",
+        "com.openai.Codex.WindowControl.ListWindows",
+        &[],
+    );
+    let can_list_windows = gnome_shell_introspect.ok || codex_gnome_shell_extension.ok;
+    let can_focus_apps = gdbus_introspect_contains(
+        "org.gnome.Shell",
+        "/org/gnome/Shell",
+        "org.gnome.Shell",
+        "FocusApp",
+    )
+    .ok;
+    let can_focus_windows = codex_gnome_shell_extension.ok;
+    let note = if can_list_windows {
+        "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
+    } else {
+        "GNOME window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. Run setup_window_targeting to install the optional GNOME Shell extension backend."
+    }
+    .to_string();
+
+    WindowingReport {
+        gnome_shell_introspect,
+        codex_gnome_shell_extension,
+        can_list_windows,
+        can_focus_apps,
+        can_focus_windows,
+        note,
+    }
+}
+
 fn input_report() -> InputReport {
     let socket = ydotool_socket_path();
     InputReport {
@@ -248,15 +391,36 @@ fn input_report() -> InputReport {
     }
 }
 
-fn readiness_report(accessibility: &AccessibilityReport, input: &InputReport) -> ReadinessReport {
+fn readiness_report(
+    accessibility: &AccessibilityReport,
+    windowing: &WindowingReport,
+    input: &InputReport,
+) -> ReadinessReport {
     let mut blockers = Vec::new();
     let can_build_accessibility_tree = can_build_accessibility_tree(accessibility);
+    let can_query_windows = windowing.can_list_windows;
+    let can_focus_apps = windowing.can_focus_apps;
+    let can_focus_windows = windowing.can_focus_windows;
     let can_send_development_input =
         input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok && input.uinput.ok;
 
     if !can_build_accessibility_tree {
         blockers.push(
             "GNOME accessibility is disabled; enable org.gnome.desktop.interface toolkit-accessibility for AT-SPI tree extraction."
+                .to_string(),
+        );
+    }
+
+    if !can_query_windows {
+        blockers.push(
+            "GNOME Shell window introspection is unavailable; targeted window focus and verification will be disabled."
+                .to_string(),
+        );
+    }
+
+    if can_query_windows && !can_focus_windows {
+        blockers.push(
+            "Exact GNOME Shell window activation is unavailable; app-level focus may work, but window_id/title/terminal-targeted input cannot be verified."
                 .to_string(),
         );
     }
@@ -271,15 +435,23 @@ fn readiness_report(accessibility: &AccessibilityReport, input: &InputReport) ->
     let recommended_next_step = if !can_build_accessibility_tree {
         "Run setup_accessibility to enable GNOME accessibility before element-aware actions."
             .to_string()
+    } else if !can_query_windows {
+        "Run setup_window_targeting to install the Codex GNOME Shell extension backend, or enable GNOME Shell window introspection before using targeted keyboard input.".to_string()
+    } else if !can_focus_windows {
+        "Run setup_window_targeting to install the Codex GNOME Shell extension backend before using exact window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
         "Install and start ydotoold if development input fallback is needed.".to_string()
     } else {
-        "Implement native AT-SPI action/value support for element-specific operations.".to_string()
+        "Computer Use is ready: AT-SPI tree support, GNOME window targeting, and ydotool input fallback are available."
+            .to_string()
     };
 
     ReadinessReport {
         can_register_mcp_tools: true,
         can_build_accessibility_tree,
+        can_query_windows,
+        can_focus_apps,
+        can_focus_windows,
         can_send_development_input,
         recommended_next_step,
         blockers,
@@ -287,8 +459,9 @@ fn readiness_report(accessibility: &AccessibilityReport, input: &InputReport) ->
 }
 
 fn can_build_accessibility_tree(accessibility: &AccessibilityReport) -> bool {
-    check_detail_contains_true(&accessibility.at_spi_enabled)
-        || check_detail_contains_true(&accessibility.toolkit_accessibility)
+    accessibility.at_spi_bus.ok
+        && (check_detail_contains_true(&accessibility.at_spi_enabled)
+            || check_detail_contains_true(&accessibility.toolkit_accessibility))
 }
 
 fn check_detail_contains_true(check: &Check) -> bool {
@@ -396,6 +569,34 @@ fn gdbus_call_check(destination: &str, object_path: &str, method: &str, args: &[
     command_check_with_session_bus("gdbus", &command_args)
 }
 
+fn gdbus_introspect_contains(
+    destination: &str,
+    object_path: &str,
+    interface: &str,
+    member: &str,
+) -> Check {
+    let check = command_check_with_session_bus(
+        "gdbus",
+        &[
+            "introspect",
+            "--session",
+            "--dest",
+            destination,
+            "--object-path",
+            object_path,
+        ],
+    );
+    if !check.ok {
+        return check;
+    }
+
+    if check.detail.contains(interface) && check.detail.contains(member) {
+        Check::ok(format!("{interface}.{member} is available"))
+    } else {
+        Check::fail(format!("{interface}.{member} was not advertised"))
+    }
+}
+
 fn command_check(command: &str, args: &[&str]) -> Check {
     run_command(command, args, false)
 }
@@ -437,5 +638,128 @@ fn run_command(command: &str, args: &[&str], with_session_bus: bool) -> Check {
             })
         }
         Err(error) => Check::fail(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn accessibility_report(
+        at_spi_bus: Check,
+        toolkit_accessibility: Check,
+    ) -> AccessibilityReport {
+        AccessibilityReport {
+            at_spi_bus,
+            toolkit_accessibility,
+            at_spi_enabled: Check::fail("(<false>,)"),
+            screen_reader_enabled: Check::fail("(<false>,)"),
+        }
+    }
+
+    fn windowing_report(can_list_windows: bool, can_focus_windows: bool) -> WindowingReport {
+        WindowingReport {
+            gnome_shell_introspect: if can_list_windows {
+                Check::ok("ok")
+            } else {
+                Check::fail("denied")
+            },
+            codex_gnome_shell_extension: if can_focus_windows {
+                Check::ok("ok")
+            } else {
+                Check::fail("missing")
+            },
+            can_list_windows,
+            can_focus_apps: true,
+            can_focus_windows,
+            note: String::new(),
+        }
+    }
+
+    fn input_report(can_send_input: bool) -> InputReport {
+        let check = if can_send_input {
+            Check::ok("ok")
+        } else {
+            Check::fail("missing")
+        };
+        InputReport {
+            ydotool: check.clone(),
+            ydotoold: check.clone(),
+            ydotool_socket: check.clone(),
+            uinput: check,
+        }
+    }
+
+    #[test]
+    fn accessibility_tree_requires_reachable_at_spi_bus() {
+        let report = accessibility_report(Check::fail("permission denied"), Check::ok("true"));
+
+        assert!(!can_build_accessibility_tree(&report));
+    }
+
+    #[test]
+    fn accessibility_tree_is_ready_when_bus_and_toolkit_are_ready() {
+        let report = accessibility_report(
+            Check::ok("('unix:path=/run/user/1000/at-spi/bus',)"),
+            Check::ok("true"),
+        );
+
+        assert!(can_build_accessibility_tree(&report));
+    }
+
+    #[test]
+    fn parses_parent_pid_from_proc_status() {
+        let status = "Name:\ttest\nPid:\t42\nPPid:\t7\n";
+
+        assert_eq!(parse_parent_pid(status), Some(7));
+    }
+
+    #[test]
+    fn parses_nul_separated_process_environment() {
+        let environment = parse_environ(
+            b"DISPLAY=:0\0WAYLAND_DISPLAY=wayland-0\0EMPTY=\0NO_EQUALS\0XDG_SESSION_TYPE=wayland\0",
+        );
+
+        assert_eq!(environment.get("DISPLAY").map(String::as_str), Some(":0"));
+        assert_eq!(
+            environment.get("WAYLAND_DISPLAY").map(String::as_str),
+            Some("wayland-0")
+        );
+        assert_eq!(environment.get("EMPTY").map(String::as_str), Some(""));
+        assert!(!environment.contains_key("NO_EQUALS"));
+    }
+
+    #[test]
+    fn readiness_requires_exact_window_focus_for_targeted_input() {
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, false);
+        let input = input_report(true);
+
+        let readiness = readiness_report(&accessibility, &windowing, &input);
+
+        assert!(readiness.can_query_windows);
+        assert!(!readiness.can_focus_windows);
+        assert!(readiness
+            .recommended_next_step
+            .contains("setup_window_targeting"));
+        assert!(readiness
+            .blockers
+            .iter()
+            .any(|blocker| blocker.contains("Exact GNOME Shell window activation")));
+    }
+
+    #[test]
+    fn readiness_message_stays_within_pr1_scope() {
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report(true);
+
+        let readiness = readiness_report(&accessibility, &windowing, &input);
+
+        assert!(readiness.blockers.is_empty());
+        assert!(readiness
+            .recommended_next_step
+            .contains("AT-SPI tree support"));
+        assert!(!readiness.recommended_next_step.contains("action/value"));
     }
 }

--- a/computer-use-linux/src/gnome_extension.rs
+++ b/computer-use-linux/src/gnome_extension.rs
@@ -1,0 +1,287 @@
+use crate::diagnostics::hydrate_session_bus_env;
+use crate::windows::{list_extension_windows, window_permission_hint, WindowInfo};
+use schemars::JsonSchema;
+use serde::Serialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub const UUID: &str = "codex-window-control@openai.com";
+const METADATA_JSON: &str =
+    include_str!("../gnome-shell-extension/codex-window-control@openai.com/metadata.json");
+const EXTENSION_JS: &str =
+    include_str!("../gnome-shell-extension/codex-window-control@openai.com/extension.js");
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct WindowTargetingSetupReport {
+    pub extension_dir: String,
+    pub wrote_files: bool,
+    pub enable_command: SetupCommandReport,
+    pub windows: Vec<WindowInfo>,
+    pub windows_error: Option<String>,
+    pub permissions_hint: Option<String>,
+    pub requires_shell_reload: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct SetupCommandReport {
+    pub ok: bool,
+    pub detail: String,
+}
+
+pub async fn setup_window_targeting_report() -> WindowTargetingSetupReport {
+    hydrate_session_bus_env();
+
+    let extension_dir = extension_dir();
+    let mut wrote_files = false;
+    let mut write_error = None;
+    match write_extension_files(&extension_dir) {
+        Ok(()) => wrote_files = true,
+        Err(error) => write_error = Some(error),
+    }
+
+    let enable_command = if let Some(error) = &write_error {
+        SetupCommandReport {
+            ok: false,
+            detail: format!("extension file write failed: {error}"),
+        }
+    } else {
+        run_gnome_extensions_enable()
+    };
+
+    let (windows, windows_error, permissions_hint) = match list_extension_windows().await {
+        Ok(windows) => (windows, None, None),
+        Err(error) => {
+            let error = format!("{error:#}");
+            let hint = window_permission_hint(&error);
+            (Vec::new(), Some(error), hint)
+        }
+    };
+
+    let requires_shell_reload = windows_error.is_some();
+    let message = if !wrote_files {
+        "Could not install the Codex GNOME Shell extension files.".to_string()
+    } else if !enable_command.ok {
+        "Codex GNOME Shell extension files were installed, but enabling the extension failed. Enable it with gnome-extensions after GNOME Shell sees the new extension."
+            .to_string()
+    } else if windows_error.is_none() {
+        "Codex GNOME Shell extension is active and window targeting is available.".to_string()
+    } else {
+        "Codex GNOME Shell extension files were installed and enable was requested, but GNOME Shell is not serving the window-control DBus API yet. Log out and back in, then retry setup_window_targeting."
+            .to_string()
+    };
+
+    WindowTargetingSetupReport {
+        extension_dir: extension_dir.display().to_string(),
+        wrote_files,
+        enable_command,
+        windows,
+        windows_error,
+        permissions_hint,
+        requires_shell_reload,
+        message,
+    }
+}
+
+fn write_extension_files(extension_dir: &Path) -> Result<(), String> {
+    fs::create_dir_all(extension_dir)
+        .map_err(|error| format!("failed to create {}: {error}", extension_dir.display()))?;
+    fs::write(extension_dir.join("metadata.json"), METADATA_JSON).map_err(|error| {
+        format!(
+            "failed to write {}: {error}",
+            extension_dir.join("metadata.json").display()
+        )
+    })?;
+    fs::write(extension_dir.join("extension.js"), EXTENSION_JS).map_err(|error| {
+        format!(
+            "failed to write {}: {error}",
+            extension_dir.join("extension.js").display()
+        )
+    })?;
+    Ok(())
+}
+
+fn run_gnome_extensions_enable() -> SetupCommandReport {
+    let mut command = Command::new("gnome-extensions");
+    command.args(["enable", UUID]);
+    add_session_env(&mut command);
+
+    let primary = match command.output() {
+        Ok(output) if output.status.success() => SetupCommandReport {
+            ok: true,
+            detail: output_detail(&output.stdout, &output.stderr, "gnome-extensions enable ok"),
+        },
+        Ok(output) => SetupCommandReport {
+            ok: false,
+            detail: output_detail(
+                &output.stdout,
+                &output.stderr,
+                &format!("gnome-extensions exited with {}", output.status),
+            ),
+        },
+        Err(error) => SetupCommandReport {
+            ok: false,
+            detail: format!("failed to run gnome-extensions: {error}"),
+        },
+    };
+    if primary.ok {
+        return primary;
+    }
+
+    let fallback = run_gsettings_enable_fallback();
+    if fallback.ok {
+        SetupCommandReport {
+            ok: true,
+            detail: format!(
+                "gnome-extensions enable failed: {}; {detail}",
+                primary.detail,
+                detail = fallback.detail
+            ),
+        }
+    } else {
+        SetupCommandReport {
+            ok: false,
+            detail: format!(
+                "gnome-extensions enable failed: {}; gsettings fallback failed: {}",
+                primary.detail, fallback.detail
+            ),
+        }
+    }
+}
+
+fn run_gsettings_enable_fallback() -> SetupCommandReport {
+    let mut get_command = Command::new("gsettings");
+    get_command.args(["get", "org.gnome.shell", "enabled-extensions"]);
+    add_session_env(&mut get_command);
+    let current = match get_command.output() {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        Ok(output) => {
+            return SetupCommandReport {
+                ok: false,
+                detail: output_detail(&output.stdout, &output.stderr, "gsettings get failed"),
+            }
+        }
+        Err(error) => {
+            return SetupCommandReport {
+                ok: false,
+                detail: format!("failed to run gsettings get: {error}"),
+            }
+        }
+    };
+
+    let Some(updated) = enabled_extensions_literal(&current) else {
+        return SetupCommandReport {
+            ok: false,
+            detail: format!("could not parse enabled-extensions value: {current}"),
+        };
+    };
+    if updated == current {
+        return SetupCommandReport {
+            ok: true,
+            detail: format!("{UUID} already present in org.gnome.shell enabled-extensions"),
+        };
+    }
+
+    let mut set_command = Command::new("gsettings");
+    set_command.args(["set", "org.gnome.shell", "enabled-extensions", &updated]);
+    add_session_env(&mut set_command);
+    match set_command.output() {
+        Ok(output) if output.status.success() => SetupCommandReport {
+            ok: true,
+            detail: format!(
+                "added {UUID} to org.gnome.shell enabled-extensions for the next GNOME Shell load"
+            ),
+        },
+        Ok(output) => SetupCommandReport {
+            ok: false,
+            detail: output_detail(&output.stdout, &output.stderr, "gsettings set failed"),
+        },
+        Err(error) => SetupCommandReport {
+            ok: false,
+            detail: format!("failed to run gsettings set: {error}"),
+        },
+    }
+}
+
+fn enabled_extensions_literal(current: &str) -> Option<String> {
+    let trimmed = current.trim();
+    let quoted = format!("'{UUID}'");
+    if trimmed.contains(&quoted) {
+        return Some(trimmed.to_string());
+    }
+
+    let list = if trimmed == "@as []" { "[]" } else { trimmed };
+    if list == "[]" {
+        return Some(format!("[{quoted}]"));
+    }
+
+    let prefix = list.strip_suffix(']')?;
+    Some(format!("{prefix}, {quoted}]"))
+}
+
+fn add_session_env(command: &mut Command) {
+    if let Some(address) = env::var("DBUS_SESSION_BUS_ADDRESS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        command.env("DBUS_SESSION_BUS_ADDRESS", address);
+    }
+    if let Some(runtime) = env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        command.env("XDG_RUNTIME_DIR", runtime);
+    }
+}
+
+fn output_detail(stdout: &[u8], stderr: &[u8], fallback: &str) -> String {
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr;
+    }
+    let stdout = String::from_utf8_lossy(stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return stdout;
+    }
+    fallback.to_string()
+}
+
+fn extension_dir() -> PathBuf {
+    let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home)
+        .join(".local/share/gnome-shell/extensions")
+        .join(UUID)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_extensions_literal_adds_uuid_to_existing_list() {
+        assert_eq!(
+            enabled_extensions_literal("['ubuntu-dock@ubuntu.com']").unwrap(),
+            "['ubuntu-dock@ubuntu.com', 'codex-window-control@openai.com']"
+        );
+    }
+
+    #[test]
+    fn enabled_extensions_literal_handles_empty_typed_array() {
+        assert_eq!(
+            enabled_extensions_literal("@as []").unwrap(),
+            "['codex-window-control@openai.com']"
+        );
+    }
+
+    #[test]
+    fn enabled_extensions_literal_is_idempotent() {
+        let value = "['codex-window-control@openai.com']";
+
+        assert_eq!(enabled_extensions_literal(value).unwrap(), value);
+    }
+}

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -1,7 +1,10 @@
 mod atspi_tree;
 mod diagnostics;
+mod gnome_extension;
 mod screenshot;
 mod server;
+mod terminal;
+mod windows;
 
 use anyhow::{Context, Result};
 
@@ -63,13 +66,49 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
+        Some("windows") => {
+            let report = match windows::list_windows().await {
+                Ok(windows) => {
+                    let backend = windows
+                        .first()
+                        .map(|window| window.backend.as_str())
+                        .unwrap_or(windows::GNOME_SHELL_INTROSPECT_BACKEND);
+                    serde_json::json!({
+                        "backend": backend,
+                        "windows": windows,
+                        "error": null,
+                        "permissions_hint": null,
+                    })
+                }
+                Err(error) => {
+                    let error = format!("{error:#}");
+                    serde_json::json!({
+                        "backend": windows::GNOME_SHELL_INTROSPECT_BACKEND,
+                        "windows": [],
+                        "error": error,
+                        "permissions_hint": windows::window_permission_hint(&error),
+                    })
+                }
+            };
+            println!("{}", serde_json::to_string_pretty(&report)?);
+            Ok(())
+        }
+        Some("setup-window-targeting") => {
+            let report = gnome_extension::setup_window_targeting_report().await;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&report)
+                    .context("failed to serialize window targeting setup report")?
+            );
+            Ok(())
+        }
         Some("--help") | Some("-h") => {
             print_help();
             Ok(())
         }
         Some(command) => {
             anyhow::bail!(
-                "unknown command '{command}'. Expected one of: mcp, doctor, setup, apps, state, screenshot"
+                "unknown command '{command}'. Expected one of: mcp, doctor, setup, apps, state, screenshot, windows, setup-window-targeting"
             );
         }
         None => {
@@ -81,6 +120,6 @@ async fn main() -> Result<()> {
 
 fn print_help() {
     println!(
-        "codex-computer-use-linux\n\nUsage:\n  codex-computer-use-linux mcp\n  codex-computer-use-linux doctor\n  codex-computer-use-linux setup\n  codex-computer-use-linux apps\n  codex-computer-use-linux state [APP_NAME]\n  codex-computer-use-linux screenshot"
+        "codex-computer-use-linux\n\nUsage:\n  codex-computer-use-linux mcp\n  codex-computer-use-linux doctor\n  codex-computer-use-linux setup\n  codex-computer-use-linux setup-window-targeting\n  codex-computer-use-linux apps\n  codex-computer-use-linux state [APP_NAME]\n  codex-computer-use-linux screenshot\n  codex-computer-use-linux windows"
     );
 }

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -2,7 +2,13 @@ use crate::atspi_tree::{
     list_accessible_apps, snapshot_tree, AccessibilityNode, AccessibleAppSummary,
 };
 use crate::diagnostics::{doctor_report, setup_accessibility_report, DoctorReport, SetupReport};
+use crate::gnome_extension::{setup_window_targeting_report, WindowTargetingSetupReport};
 use crate::screenshot::{capture_screenshot, ScreenshotCapture};
+use crate::windows::{
+    focus_window_target, focused_window, list_windows, resolve_window_target,
+    window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
+    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
+};
 use anyhow::Result;
 use rmcp::{
     handler::server::wrapper::{Json, Parameters},
@@ -42,6 +48,14 @@ impl ComputerUseLinux {
     }
 
     #[tool(
+        name = "setup_window_targeting",
+        description = "Install and enable the optional GNOME Shell extension used for exact window list/focus targeting when GNOME blocks native introspection."
+    )]
+    async fn setup_window_targeting(&self) -> Json<WindowTargetingSetupReport> {
+        Json(setup_window_targeting_report().await)
+    }
+
+    #[tool(
         name = "list_apps",
         description = "List running Linux desktop app candidates visible to the Computer Use backend."
     )]
@@ -60,6 +74,83 @@ impl ComputerUseLinux {
     }
 
     #[tool(
+        name = "list_windows",
+        description = "List compositor windows with title, app id, class, focus state, client type, and known bounds."
+    )]
+    async fn list_windows(&self) -> Json<ListWindowsOutput> {
+        Json(window_list_output().await)
+    }
+
+    #[tool(
+        name = "focused_window",
+        description = "Return the compositor window that currently has keyboard focus."
+    )]
+    async fn focused_window(&self) -> Json<FocusedWindowOutput> {
+        match focused_window().await {
+            Ok(window) => {
+                let backend = window_backend(window.as_ref().into_iter());
+                Json(FocusedWindowOutput {
+                    backend,
+                    focused_window: window,
+                    error: None,
+                    permissions_hint: None,
+                    message:
+                        "Focused window query completed through the available GNOME window backend."
+                            .to_string(),
+                })
+            }
+            Err(error) => {
+                let error = format!("{error:#}");
+                Json(FocusedWindowOutput {
+                    backend: GNOME_SHELL_INTROSPECT_BACKEND.to_string(),
+                    focused_window: None,
+                    permissions_hint: window_permission_hint(&error),
+                    error: Some(error),
+                    message: "Focused window query failed; targeted keyboard input is unavailable until window introspection works.".to_string(),
+                })
+            }
+        }
+    }
+
+    #[tool(
+        name = "activate_window",
+        description = "Focus a Linux desktop window by window_id, pid, app_id, wm_class, title, or terminal selectors when the compositor permits it."
+    )]
+    async fn activate_window(
+        &self,
+        Parameters(params): Parameters<ActivateWindowParams>,
+    ) -> Json<ActivateWindowOutput> {
+        let target = params.into_target();
+        let received = Some(serde_json::json!(target.clone()));
+        match focus_window_target(&target).await {
+            Ok(focus) => {
+                let ok = focus_satisfies_target(&focus, &target);
+                Json(ActivateWindowOutput {
+                    ok,
+                    implemented: true,
+                    backend: focus.backend.clone(),
+                    focus: Some(focus),
+                    error: None,
+                    permissions_hint: None,
+                    received,
+                })
+            }
+            Err(error) => {
+                let error = format!("{error:#}");
+                Json(ActivateWindowOutput {
+                    ok: false,
+                    implemented: true,
+                    backend: GNOME_SHELL_INTROSPECT_BACKEND.to_string(),
+                    focus: None,
+                    permissions_hint: window_permission_hint(&error),
+                    error: Some(error),
+                    received,
+                })
+            }
+        }
+    }
+
+    #[tool(
         name = "get_app_state",
         description = "Start an app use session if needed, then get screenshot and accessibility state for a Linux app."
     )]
@@ -68,9 +159,29 @@ impl ComputerUseLinux {
         Parameters(params): Parameters<GetAppStateParams>,
     ) -> Json<GetAppStateOutput> {
         let diagnostics = doctor_report();
+        let (window_context, window_error, window_permissions_hint) =
+            self.resolve_window_context(&params).await;
         let max_nodes = params.max_nodes.unwrap_or(120).clamp(1, 500);
         let max_depth = params.max_depth.unwrap_or(12).min(12);
         let include_screenshot = params.include_screenshot.unwrap_or(true);
+        let app_filter = params
+            .app_name_or_bundle_identifier
+            .as_deref()
+            .or_else(|| {
+                window_context
+                    .as_ref()
+                    .and_then(|window| window.app_id.as_deref())
+            })
+            .or_else(|| {
+                window_context
+                    .as_ref()
+                    .and_then(|window| window.wm_class.as_deref())
+            })
+            .or_else(|| {
+                window_context
+                    .as_ref()
+                    .and_then(|window| window.title.as_deref())
+            });
         let (screenshot, screenshot_error) = if include_screenshot {
             match capture_screenshot().await {
                 Ok(capture) => {
@@ -88,13 +199,7 @@ impl ComputerUseLinux {
         };
         let (accessibility_tree, accessibility_error) =
             if diagnostics.readiness.can_build_accessibility_tree {
-                match snapshot_tree(
-                    params.app_name_or_bundle_identifier.as_deref(),
-                    max_nodes,
-                    max_depth,
-                )
-                .await
-                {
+                match snapshot_tree(app_filter, max_nodes, max_depth).await {
                     Ok(nodes) => (nodes, None),
                     Err(error) => (Vec::new(), Some(error.to_string())),
                 }
@@ -108,7 +213,7 @@ impl ComputerUseLinux {
                 )
             };
         self.cache_nodes(&accessibility_tree);
-        let message = if let Some(error) = &accessibility_error {
+        let mut message = if let Some(error) = &accessibility_error {
             format!("MCP registration is working, but AT-SPI tree extraction failed: {error}")
         } else if let Some(capture) = &screenshot {
             format!(
@@ -127,9 +232,20 @@ impl ComputerUseLinux {
                 accessibility_tree.len()
             )
         };
+        if let Some(window) = &window_context {
+            message.push_str(&format!(
+                " Window target resolved to window_id {}.",
+                window.window_id
+            ));
+        } else if let Some(error) = &window_error {
+            message.push_str(&format!(" Window target resolution failed: {error}"));
+        }
 
         Json(GetAppStateOutput {
             app_name_or_bundle_identifier: params.app_name_or_bundle_identifier,
+            window_context,
+            window_error,
+            window_permissions_hint,
             backend: "linux-atspi".to_string(),
             screenshot,
             screenshot_error,
@@ -265,10 +381,25 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "press_key",
-        description = "Press a key or key-combination on the keyboard, including modifier and navigation keys."
+        description = "Press a key or key-combination on the keyboard, optionally after focusing a target window or terminal selector."
     )]
-    fn press_key(&self, Parameters(params): Parameters<PressKeyParams>) -> Json<ActionOutput> {
-        let received = Some(serde_json::json!(params));
+    async fn press_key(
+        &self,
+        Parameters(params): Parameters<PressKeyParams>,
+    ) -> Json<ActionOutput> {
+        let received = Some(serde_json::json!(params.clone()));
+        let focus = match self.focus_target_for_input(&params.window_target()).await {
+            Ok(focus) => focus,
+            Err(message) => {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "press_key".to_string(),
+                    message,
+                    received,
+                });
+            }
+        };
         let Some(key_events) = key_sequence(&params.key) else {
             return Json(ActionOutput {
                 ok: false,
@@ -281,25 +412,50 @@ impl ComputerUseLinux {
         let mut args = vec!["key".to_string()];
         args.extend(key_events);
         let result = run_ydotool(&args).map(|output| vec![output]);
-        Json(action_result("press_key", result, received))
+        Json(action_result_with_focus(
+            "press_key",
+            result,
+            received,
+            focus,
+        ))
     }
 
     #[tool(
         name = "type_text",
-        description = "Type literal text using keyboard input."
+        description = "Type literal text using keyboard input, optionally after focusing a target window or terminal selector."
     )]
-    fn type_text(&self, Parameters(params): Parameters<TypeTextParams>) -> Json<ActionOutput> {
-        let received = Some(serde_json::json!(params));
+    async fn type_text(
+        &self,
+        Parameters(params): Parameters<TypeTextParams>,
+    ) -> Json<ActionOutput> {
+        let received = Some(serde_json::json!(params.clone()));
+        let focus = match self.focus_target_for_input(&params.window_target()).await {
+            Ok(focus) => focus,
+            Err(message) => {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "type_text".to_string(),
+                    message,
+                    received,
+                });
+            }
+        };
         let result = run_ydotool(&["type".to_string(), "--".to_string(), params.text])
             .map(|output| vec![output]);
-        Json(action_result("type_text", result, received))
+        Json(action_result_with_focus(
+            "type_text",
+            result,
+            received,
+            focus,
+        ))
     }
 }
 
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees, and send coordinate, element-index click/scroll, key, text, and drag input through ydotool when ydotoold is available. Native AT-SPI actions are still in progress."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll, key, text, and drag input through ydotool when ydotoold is available. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -321,6 +477,73 @@ struct ListAppsOutput {
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
+struct ListWindowsOutput {
+    backend: String,
+    windows: Vec<WindowInfo>,
+    error: Option<String>,
+    permissions_hint: Option<String>,
+    note: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct FocusedWindowOutput {
+    backend: String,
+    focused_window: Option<WindowInfo>,
+    error: Option<String>,
+    permissions_hint: Option<String>,
+    message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+struct ActivateWindowParams {
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    terminal_pid: Option<u32>,
+    #[serde(default)]
+    terminal_command: Option<String>,
+    #[serde(default)]
+    terminal_cwd: Option<String>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+}
+
+impl ActivateWindowParams {
+    fn into_target(self) -> WindowTarget {
+        WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: self.tty,
+            terminal_pid: self.terminal_pid,
+            terminal_command: self.terminal_command,
+            terminal_cwd: self.terminal_cwd,
+            app_id: self.app_id,
+            wm_class: self.wm_class,
+            title: self.title,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+struct ActivateWindowOutput {
+    ok: bool,
+    implemented: bool,
+    backend: String,
+    focus: Option<WindowFocusResult>,
+    error: Option<String>,
+    permissions_hint: Option<String>,
+    received: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
 struct AppCandidate {
     name: String,
     pid: u32,
@@ -332,6 +555,24 @@ struct GetAppStateParams {
     #[serde(default)]
     app_name_or_bundle_identifier: Option<String>,
     #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    terminal_pid: Option<u32>,
+    #[serde(default)]
+    terminal_command: Option<String>,
+    #[serde(default)]
+    terminal_cwd: Option<String>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
     max_nodes: Option<usize>,
     #[serde(default)]
     max_depth: Option<u32>,
@@ -339,9 +580,28 @@ struct GetAppStateParams {
     include_screenshot: Option<bool>,
 }
 
+impl GetAppStateParams {
+    fn window_target(&self) -> WindowTarget {
+        WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: self.tty.clone(),
+            terminal_pid: self.terminal_pid,
+            terminal_command: self.terminal_command.clone(),
+            terminal_cwd: self.terminal_cwd.clone(),
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.title.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 struct GetAppStateOutput {
     app_name_or_bundle_identifier: Option<String>,
+    window_context: Option<WindowInfo>,
+    window_error: Option<String>,
+    window_permissions_hint: Option<String>,
     backend: String,
     screenshot: Option<ScreenshotCapture>,
     screenshot_error: Option<String>,
@@ -408,11 +668,79 @@ struct DragParams {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 struct PressKeyParams {
     key: String,
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    terminal_pid: Option<u32>,
+    #[serde(default)]
+    terminal_command: Option<String>,
+    #[serde(default)]
+    terminal_cwd: Option<String>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 struct TypeTextParams {
     text: String,
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    terminal_pid: Option<u32>,
+    #[serde(default)]
+    terminal_command: Option<String>,
+    #[serde(default)]
+    terminal_cwd: Option<String>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+}
+
+impl PressKeyParams {
+    fn window_target(&self) -> WindowTarget {
+        WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: self.tty.clone(),
+            terminal_pid: self.terminal_pid,
+            terminal_command: self.terminal_command.clone(),
+            terminal_cwd: self.terminal_cwd.clone(),
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.title.clone(),
+        }
+    }
+}
+
+impl TypeTextParams {
+    fn window_target(&self) -> WindowTarget {
+        WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: self.tty.clone(),
+            terminal_pid: self.terminal_pid,
+            terminal_command: self.terminal_command.clone(),
+            terminal_cwd: self.terminal_cwd.clone(),
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.title.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -430,21 +758,62 @@ struct ActionOutput {
     received: Option<serde_json::Value>,
 }
 
-fn not_implemented(
-    action: &str,
-    received: Option<serde_json::Value>,
-    message: &str,
-) -> ActionOutput {
-    ActionOutput {
-        ok: false,
-        implemented: false,
-        action: action.to_string(),
-        message: message.to_string(),
-        received,
-    }
-}
-
 impl ComputerUseLinux {
+    async fn resolve_window_context(
+        &self,
+        params: &GetAppStateParams,
+    ) -> (Option<WindowInfo>, Option<String>, Option<String>) {
+        let target = params.window_target();
+        if !target.has_target() {
+            return (None, None, None);
+        }
+
+        match list_windows().await {
+            Ok(windows) => match resolve_window_target(&windows, &target) {
+                Ok(window) => (Some(window.clone()), None, None),
+                Err(error) => (None, Some(format!("{error:#}")), None),
+            },
+            Err(error) => {
+                let error = format!("{error:#}");
+                let hint = window_permission_hint(&error);
+                (None, Some(error), hint)
+            }
+        }
+    }
+
+    async fn focus_target_for_input(
+        &self,
+        target: &WindowTarget,
+    ) -> std::result::Result<Option<WindowFocusResult>, String> {
+        if !target.has_target() {
+            return Ok(None);
+        }
+
+        let focus = focus_window_target(target).await.map_err(|error| {
+            let error = format!("{error:#}");
+            if let Some(hint) = window_permission_hint(&error) {
+                format!("Did not send input because the target window could not be focused: {error}. {hint}")
+            } else {
+                format!("Did not send input because the target window could not be focused: {error}")
+            }
+        })?;
+
+        if focus_satisfies_target(&focus, target) {
+            Ok(Some(focus))
+        } else {
+            let required = if target.requires_exact_focus() {
+                "exact target-window focus"
+            } else {
+                "app-level focus"
+            };
+            Err(format!(
+                "Did not send input because {required} verification failed after activating the target window. Focus result: requested window_id {}, focused window_id {:?}.",
+                focus.requested_window.window_id,
+                focus.focused_window.as_ref().map(|window| window.window_id)
+            ))
+        }
+    }
+
     fn cache_nodes(&self, nodes: &[AccessibilityNode]) {
         if let Ok(mut cached) = self.last_nodes.lock() {
             cached.clear();
@@ -527,6 +896,20 @@ impl ComputerUseLinux {
     }
 }
 
+fn not_implemented(
+    action: &str,
+    received: Option<serde_json::Value>,
+    message: &str,
+) -> ActionOutput {
+    ActionOutput {
+        ok: false,
+        implemented: false,
+        action: action.to_string(),
+        message: message.to_string(),
+        received,
+    }
+}
+
 fn pixel_to_ydotool_absolute(value: i32, extent: u32) -> i32 {
     if extent <= 1 {
         return value;
@@ -558,6 +941,75 @@ fn action_result(
             received,
         },
     }
+}
+
+fn action_result_with_focus(
+    action: &str,
+    result: std::result::Result<Vec<Output>, String>,
+    received: Option<serde_json::Value>,
+    focus: Option<WindowFocusResult>,
+) -> ActionOutput {
+    let mut output = action_result(action, result, received);
+    if output.ok {
+        if let Some(focus) = focus {
+            let verification = if focus.exact_window_focused {
+                "exact window-focus"
+            } else {
+                "app-level focus"
+            };
+            output.message = format!(
+                "{} Target window_id {} was focused with {verification} verification before input.",
+                output.message, focus.requested_window.window_id,
+            );
+        }
+    }
+    output
+}
+
+fn focus_satisfies_target(focus: &WindowFocusResult, target: &WindowTarget) -> bool {
+    if target.requires_exact_focus() {
+        focus.exact_window_focused
+    } else {
+        focus.exact_window_focused || focus.app_focused
+    }
+}
+
+async fn window_list_output() -> ListWindowsOutput {
+    match list_windows().await {
+        Ok(windows) => {
+            let backend = window_backend(windows.iter());
+            let note = if backend == GNOME_SHELL_EXTENSION_BACKEND {
+                "Window list came from the Codex GNOME Shell extension. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
+            } else {
+                "Window list came from GNOME Shell Introspect. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
+            };
+            ListWindowsOutput {
+                backend,
+                windows,
+                error: None,
+                permissions_hint: None,
+                note: note.to_string(),
+            }
+        }
+        Err(error) => {
+            let error = format!("{error:#}");
+            ListWindowsOutput {
+                backend: GNOME_SHELL_INTROSPECT_BACKEND.to_string(),
+                windows: Vec::new(),
+                permissions_hint: window_permission_hint(&error),
+                error: Some(error),
+                note: "Window listing failed, so targeted keyboard input cannot safely focus or verify a target window."
+                    .to_string(),
+            }
+        }
+    }
+}
+
+fn window_backend<'a>(windows: impl Iterator<Item = &'a WindowInfo>) -> String {
+    windows
+        .map(|window| window.backend.clone())
+        .next()
+        .unwrap_or_else(|| GNOME_SHELL_INTROSPECT_BACKEND.to_string())
 }
 
 fn absolute_mousemove_args(x: i32, y: i32) -> Vec<String> {

--- a/computer-use-linux/src/terminal.rs
+++ b/computer-use-linux/src/terminal.rs
@@ -1,0 +1,429 @@
+use crate::windows::WindowInfo;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fs,
+    path::PathBuf,
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct TerminalWindowContext {
+    pub tty: String,
+    pub root_process: TerminalProcess,
+    pub active_process: Option<TerminalProcess>,
+    pub process_count: usize,
+    pub confidence: String,
+    pub match_reason: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct TerminalProcess {
+    pub pid: u32,
+    pub command_name: String,
+    pub command_line: String,
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ProcessInfo {
+    pid: u32,
+    ppid: u32,
+    start_ticks: u64,
+    command_name: String,
+    command_line: String,
+    cwd: Option<String>,
+    tty_paths: Vec<String>,
+}
+
+pub fn enrich_terminal_windows(windows: &mut [WindowInfo]) {
+    let processes = read_process_table();
+    if processes.is_empty() {
+        return;
+    }
+    enrich_terminal_windows_with_processes(windows, &processes);
+}
+
+fn enrich_terminal_windows_with_processes(windows: &mut [WindowInfo], processes: &[ProcessInfo]) {
+    let mut windows_by_terminal_pid: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+    for (index, window) in windows.iter().enumerate() {
+        if !looks_like_terminal_window(window) {
+            continue;
+        }
+        if let Some(pid) = window.pid {
+            windows_by_terminal_pid.entry(pid).or_default().push(index);
+        }
+    }
+
+    if windows_by_terminal_pid.is_empty() {
+        return;
+    }
+
+    let by_pid = processes
+        .iter()
+        .map(|process| (process.pid, process))
+        .collect::<HashMap<_, _>>();
+
+    for (terminal_pid, mut window_indexes) in windows_by_terminal_pid {
+        let mut sessions = terminal_sessions_for_pid(terminal_pid, processes, &by_pid);
+        if sessions.is_empty() {
+            continue;
+        }
+
+        window_indexes.sort_by_key(|index| windows[*index].window_id);
+        sessions.sort_by_key(|session| session.root_start_ticks);
+
+        let confidence = if window_indexes.len() == 1 && sessions.len() == 1 {
+            Some((
+                "high",
+                "Only one terminal window and one PTY session share the terminal app PID.",
+            ))
+        } else if window_indexes.len() == sessions.len() {
+            Some((
+                "heuristic",
+                "Matched terminal windows to PTY sessions by shared terminal app PID and creation order.",
+            ))
+        } else {
+            None
+        };
+
+        let Some((confidence, reason)) = confidence else {
+            continue;
+        };
+
+        for (window_index, session) in window_indexes.into_iter().zip(sessions) {
+            windows[window_index].terminal = Some(TerminalWindowContext {
+                tty: session.tty,
+                root_process: process_summary(&session.root_process),
+                active_process: session.active_process.as_ref().map(process_summary),
+                process_count: session.process_count,
+                confidence: confidence.to_string(),
+                match_reason: reason.to_string(),
+            });
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TerminalSession {
+    tty: String,
+    root_process: ProcessInfo,
+    active_process: Option<ProcessInfo>,
+    process_count: usize,
+    root_start_ticks: u64,
+}
+
+fn terminal_sessions_for_pid(
+    terminal_pid: u32,
+    processes: &[ProcessInfo],
+    by_pid: &HashMap<u32, &ProcessInfo>,
+) -> Vec<TerminalSession> {
+    let mut grouped: BTreeMap<String, Vec<ProcessInfo>> = BTreeMap::new();
+    for process in processes {
+        if process.pid == terminal_pid || !is_descendant_of(process.pid, terminal_pid, by_pid) {
+            continue;
+        }
+        for tty in &process.tty_paths {
+            grouped
+                .entry(tty.clone())
+                .or_default()
+                .push(process.clone());
+        }
+    }
+
+    grouped
+        .into_iter()
+        .filter_map(|(tty, mut processes)| {
+            processes.sort_by_key(|process| {
+                (
+                    process_depth(process.pid, terminal_pid, by_pid),
+                    process.start_ticks,
+                    process.pid,
+                )
+            });
+            let root_process = processes.first()?.clone();
+            let active_process = active_terminal_process(&processes);
+            Some(TerminalSession {
+                tty,
+                root_start_ticks: root_process.start_ticks,
+                process_count: processes.len(),
+                root_process,
+                active_process,
+            })
+        })
+        .collect()
+}
+
+fn active_terminal_process(processes: &[ProcessInfo]) -> Option<ProcessInfo> {
+    let same_tty_parents = processes
+        .iter()
+        .map(|process| process.ppid)
+        .collect::<HashSet<_>>();
+    processes
+        .iter()
+        .filter(|process| !same_tty_parents.contains(&process.pid))
+        .max_by_key(|process| (process.start_ticks, process.pid))
+        .cloned()
+        .or_else(|| {
+            processes
+                .iter()
+                .max_by_key(|process| (process.start_ticks, process.pid))
+                .cloned()
+        })
+}
+
+fn process_summary(process: &ProcessInfo) -> TerminalProcess {
+    TerminalProcess {
+        pid: process.pid,
+        command_name: process.command_name.clone(),
+        command_line: process.command_line.clone(),
+        cwd: process.cwd.clone(),
+    }
+}
+
+fn is_descendant_of(pid: u32, ancestor_pid: u32, by_pid: &HashMap<u32, &ProcessInfo>) -> bool {
+    let mut current = pid;
+    for _ in 0..128 {
+        let Some(process) = by_pid.get(&current) else {
+            return false;
+        };
+        if process.ppid == ancestor_pid {
+            return true;
+        }
+        if process.ppid == 0 || process.ppid == current {
+            return false;
+        }
+        current = process.ppid;
+    }
+    false
+}
+
+fn process_depth(pid: u32, ancestor_pid: u32, by_pid: &HashMap<u32, &ProcessInfo>) -> usize {
+    let mut current = pid;
+    for depth in 0..128 {
+        let Some(process) = by_pid.get(&current) else {
+            return usize::MAX;
+        };
+        if process.ppid == ancestor_pid {
+            return depth;
+        }
+        if process.ppid == 0 || process.ppid == current {
+            return usize::MAX;
+        }
+        current = process.ppid;
+    }
+    usize::MAX
+}
+
+fn looks_like_terminal_window(window: &WindowInfo) -> bool {
+    let haystack = [
+        window.app_id.as_deref(),
+        window.wm_class.as_deref(),
+        window.title.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .to_ascii_lowercase();
+
+    [
+        "ghostty",
+        "gnome-terminal",
+        "org.gnome.terminal",
+        "ptyxis",
+        "org.gnome.ptyxis",
+        "kgx",
+        "konsole",
+        "kitty",
+        "alacritty",
+        "wezterm",
+        "xterm",
+    ]
+    .iter()
+    .any(|needle| haystack.contains(needle))
+}
+
+fn read_process_table() -> Vec<ProcessInfo> {
+    let Ok(entries) = fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_string_lossy().parse::<u32>().ok()?;
+            read_process_info(pid)
+        })
+        .collect()
+}
+
+fn read_process_info(pid: u32) -> Option<ProcessInfo> {
+    let (ppid, start_ticks) = parse_stat(pid)?;
+    let command_name = fs::read_to_string(format!("/proc/{pid}/comm"))
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| pid.to_string());
+    let command_line = read_command_line(pid).unwrap_or_else(|| command_name.clone());
+    let cwd = fs::read_link(format!("/proc/{pid}/cwd"))
+        .ok()
+        .map(path_to_string);
+    let tty_paths = read_tty_paths(pid);
+
+    Some(ProcessInfo {
+        pid,
+        ppid,
+        start_ticks,
+        command_name,
+        command_line,
+        cwd,
+        tty_paths,
+    })
+}
+
+fn parse_stat(pid: u32) -> Option<(u32, u64)> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_stat_contents(&stat)
+}
+
+fn parse_stat_contents(stat: &str) -> Option<(u32, u64)> {
+    let close_paren = stat.rfind(')')?;
+    let fields = stat
+        .get(close_paren + 2..)?
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    let ppid = fields.get(1)?.parse().ok()?;
+    let start_ticks = fields.get(19)?.parse().ok()?;
+    Some((ppid, start_ticks))
+}
+
+fn read_command_line(pid: u32) -> Option<String> {
+    let bytes = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    let parts = bytes
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .map(|part| String::from_utf8_lossy(part).into_owned())
+        .collect::<Vec<_>>();
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
+
+fn read_tty_paths(pid: u32) -> Vec<String> {
+    let Ok(entries) = fs::read_dir(format!("/proc/{pid}/fd")) else {
+        return Vec::new();
+    };
+    let mut paths = entries
+        .flatten()
+        .filter_map(|entry| fs::read_link(entry.path()).ok())
+        .filter_map(|path| {
+            let value = path_to_string(path);
+            value.starts_with("/dev/pts/").then_some(value)
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+fn path_to_string(path: PathBuf) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::windows::{WindowBounds, GNOME_SHELL_EXTENSION_BACKEND};
+
+    fn terminal_window(window_id: u64, pid: u32) -> WindowInfo {
+        WindowInfo {
+            window_id,
+            title: Some("Ghostty".to_string()),
+            app_id: Some("com.mitchellh.ghostty.desktop".to_string()),
+            wm_class: Some("com.mitchellh.ghostty".to_string()),
+            pid: Some(pid),
+            bounds: Some(WindowBounds {
+                x: Some(0),
+                y: Some(0),
+                width: 800,
+                height: 600,
+            }),
+            workspace: Some(0),
+            focused: false,
+            hidden: false,
+            client_type: Some("wayland".to_string()),
+            backend: GNOME_SHELL_EXTENSION_BACKEND.to_string(),
+            terminal: None,
+        }
+    }
+
+    fn process(
+        pid: u32,
+        ppid: u32,
+        start_ticks: u64,
+        command_name: &str,
+        tty: Option<&str>,
+    ) -> ProcessInfo {
+        ProcessInfo {
+            pid,
+            ppid,
+            start_ticks,
+            command_name: command_name.to_string(),
+            command_line: command_name.to_string(),
+            cwd: Some("/home/user".to_string()),
+            tty_paths: tty.into_iter().map(ToOwned::to_owned).collect(),
+        }
+    }
+
+    #[test]
+    fn assigns_terminal_sessions_by_window_and_pty_creation_order() {
+        let mut windows = vec![terminal_window(11, 100), terminal_window(12, 100)];
+        let processes = vec![
+            process(100, 1, 1, "ghostty", None),
+            process(200, 100, 10, "sh", Some("/dev/pts/0")),
+            process(201, 200, 11, "zsh", Some("/dev/pts/0")),
+            process(202, 201, 12, "claude", Some("/dev/pts/0")),
+            process(300, 100, 20, "sh", Some("/dev/pts/1")),
+            process(301, 300, 21, "zsh", Some("/dev/pts/1")),
+            process(302, 301, 22, "codex", Some("/dev/pts/1")),
+        ];
+
+        enrich_terminal_windows_with_processes(&mut windows, &processes);
+
+        let first = windows[0].terminal.as_ref().unwrap();
+        assert_eq!(first.tty, "/dev/pts/0");
+        assert_eq!(
+            first.active_process.as_ref().unwrap().command_name,
+            "claude"
+        );
+        assert_eq!(first.confidence, "heuristic");
+
+        let second = windows[1].terminal.as_ref().unwrap();
+        assert_eq!(second.tty, "/dev/pts/1");
+        assert_eq!(
+            second.active_process.as_ref().unwrap().command_name,
+            "codex"
+        );
+    }
+
+    #[test]
+    fn leaves_terminal_context_empty_when_window_session_counts_do_not_match() {
+        let mut windows = vec![terminal_window(11, 100), terminal_window(12, 100)];
+        let processes = vec![
+            process(100, 1, 1, "ghostty", None),
+            process(200, 100, 10, "sh", Some("/dev/pts/0")),
+            process(201, 200, 11, "zsh", Some("/dev/pts/0")),
+        ];
+
+        enrich_terminal_windows_with_processes(&mut windows, &processes);
+
+        assert!(windows.iter().all(|window| window.terminal.is_none()));
+    }
+
+    #[test]
+    fn parses_proc_stat_with_parenthesized_command() {
+        let stat =
+            "123 (cmd with spaces) S 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 12345 26";
+
+        assert_eq!(parse_stat_contents(stat), Some((7, 12345)));
+    }
+}

--- a/computer-use-linux/src/windows.rs
+++ b/computer-use-linux/src/windows.rs
@@ -1,0 +1,957 @@
+use crate::diagnostics::hydrate_session_bus_env;
+use crate::terminal::{enrich_terminal_windows, TerminalWindowContext};
+use anyhow::{bail, Context, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, time::Duration};
+use tokio::time::sleep;
+use zbus::{zvariant::OwnedValue, Proxy};
+
+pub const GNOME_SHELL_INTROSPECT_BACKEND: &str = "gnome-shell-introspect";
+pub const GNOME_SHELL_EXTENSION_BACKEND: &str = "gnome-shell-extension";
+pub const GNOME_SHELL_EXTENSION_SERVICE: &str = "com.openai.Codex.WindowControl";
+pub const GNOME_SHELL_EXTENSION_OBJECT_PATH: &str = "/com/openai/Codex/WindowControl";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a GNOME window list backend. Targeted window input requires session-bus access plus either GNOME Shell Introspect permission or the Codex GNOME Shell extension backend. Run setup_window_targeting to install the extension backend.";
+const FOCUS_VERIFY_ATTEMPTS: usize = 6;
+const FOCUS_VERIFY_DELAY: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct WindowInfo {
+    pub window_id: u64,
+    pub title: Option<String>,
+    pub app_id: Option<String>,
+    pub wm_class: Option<String>,
+    pub pid: Option<u32>,
+    pub bounds: Option<WindowBounds>,
+    pub workspace: Option<i32>,
+    pub focused: bool,
+    pub hidden: bool,
+    pub client_type: Option<String>,
+    pub backend: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<TerminalWindowContext>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct WindowBounds {
+    pub x: Option<i32>,
+    pub y: Option<i32>,
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+pub struct WindowTarget {
+    #[serde(default)]
+    pub window_id: Option<u64>,
+    #[serde(default)]
+    pub pid: Option<u32>,
+    #[serde(default)]
+    pub tty: Option<String>,
+    #[serde(default)]
+    pub terminal_pid: Option<u32>,
+    #[serde(default)]
+    pub terminal_command: Option<String>,
+    #[serde(default)]
+    pub terminal_cwd: Option<String>,
+    #[serde(default)]
+    pub app_id: Option<String>,
+    #[serde(default)]
+    pub wm_class: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct WindowFocusResult {
+    pub requested_window: WindowInfo,
+    pub focused_window: Option<WindowInfo>,
+    pub exact_window_focused: bool,
+    pub app_focused: bool,
+    pub backend: String,
+    pub note: String,
+}
+
+impl WindowTarget {
+    pub fn has_target(&self) -> bool {
+        self.window_id.is_some()
+            || self.pid.is_some()
+            || self.has_terminal_target()
+            || self
+                .app_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .wm_class
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .title
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    pub fn requires_exact_focus(&self) -> bool {
+        self.window_id.is_some()
+            || self.pid.is_some()
+            || self.has_terminal_target()
+            || self
+                .title
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+
+    fn has_terminal_target(&self) -> bool {
+        self.terminal_pid.is_some()
+            || self
+                .tty
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .terminal_command
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .terminal_cwd
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
+}
+
+pub async fn list_windows() -> Result<Vec<WindowInfo>> {
+    match list_extension_windows().await {
+        Ok(windows) => Ok(windows),
+        Err(extension_error) => match list_gnome_shell_introspect_windows().await {
+            Ok(windows) => Ok(windows),
+            Err(introspect_error) => Err(anyhow::anyhow!(
+                "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}"
+            )),
+        },
+    }
+}
+
+async fn list_gnome_shell_introspect_windows() -> Result<Vec<WindowInfo>> {
+    hydrate_session_bus_env();
+
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let proxy = Proxy::new(
+        &connection,
+        "org.gnome.Shell",
+        "/org/gnome/Shell/Introspect",
+        "org.gnome.Shell.Introspect",
+    )
+    .await
+    .context("failed to create GNOME Shell introspection proxy")?;
+    let windows: HashMap<u64, HashMap<String, OwnedValue>> = proxy
+        .call("GetWindows", &())
+        .await
+        .context("GNOME Shell GetWindows call failed")?;
+
+    let mut windows = windows
+        .into_iter()
+        .map(|(window_id, properties)| window_from_properties(window_id, &properties))
+        .collect::<Vec<_>>();
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub async fn list_extension_windows() -> Result<Vec<WindowInfo>> {
+    let json = call_extension_json("ListWindows").await?;
+    let mut windows: Vec<WindowInfo> =
+        serde_json::from_str(&json).context("Codex GNOME Shell extension returned invalid JSON")?;
+    for window in &mut windows {
+        window.backend = GNOME_SHELL_EXTENSION_BACKEND.to_string();
+    }
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub async fn focused_window() -> Result<Option<WindowInfo>> {
+    current_focused_window().await
+}
+
+pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusResult> {
+    if !target.has_target() {
+        bail!("Pass window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd to target a window.");
+    }
+
+    let windows = list_windows().await?;
+    let requested_window = resolve_window_target(&windows, target)?.clone();
+    ensure_backend_can_focus_target(target, &requested_window)?;
+
+    if requested_window.backend == GNOME_SHELL_EXTENSION_BACKEND {
+        activate_extension_window(requested_window.window_id).await?;
+    } else {
+        let app_id = requested_window
+            .app_id
+            .as_deref()
+            .or(target.app_id.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .context("GNOME Shell can only focus by app_id; the matched window has no app_id")?
+            .to_string();
+        focus_app(&app_id).await?;
+    }
+
+    let focused_window = wait_for_focused_window(&requested_window).await;
+    let exact_window_focused = focused_window
+        .as_ref()
+        .is_some_and(|window| window.window_id == requested_window.window_id);
+    let app_focused = focused_window
+        .as_ref()
+        .is_some_and(|window| same_optional_string(&window.app_id, &requested_window.app_id));
+
+    Ok(WindowFocusResult {
+        backend: requested_window.backend.clone(),
+        requested_window,
+        focused_window,
+        exact_window_focused,
+        app_focused,
+        note: "Computer Use activated the requested window through the available window backend, then verified focus through a fresh window query."
+            .to_string(),
+    })
+}
+
+fn ensure_backend_can_focus_target(target: &WindowTarget, window: &WindowInfo) -> Result<()> {
+    if target.requires_exact_focus() && window.backend != GNOME_SHELL_EXTENSION_BACKEND {
+        bail!(
+            "Exact window targeting requires the Codex GNOME Shell extension backend; {} can list the matched window but cannot activate a specific window safely.",
+            window.backend
+        );
+    }
+    Ok(())
+}
+
+async fn current_focused_window() -> Result<Option<WindowInfo>> {
+    Ok(list_windows()
+        .await?
+        .into_iter()
+        .find(|window| window.focused))
+}
+
+async fn wait_for_focused_window(requested_window: &WindowInfo) -> Option<WindowInfo> {
+    let mut last_focused_window = None;
+    for attempt in 0..FOCUS_VERIFY_ATTEMPTS {
+        if let Ok(focused_window) = current_focused_window().await {
+            if focused_window
+                .as_ref()
+                .is_some_and(|window| window.window_id == requested_window.window_id)
+            {
+                return focused_window;
+            }
+            if focused_window.is_some() {
+                last_focused_window = focused_window;
+            }
+        }
+
+        if attempt + 1 < FOCUS_VERIFY_ATTEMPTS {
+            sleep(FOCUS_VERIFY_DELAY).await;
+        }
+    }
+    last_focused_window
+}
+
+pub fn resolve_window_target<'a>(
+    windows: &'a [WindowInfo],
+    target: &WindowTarget,
+) -> Result<&'a WindowInfo> {
+    if let Some(window_id) = target.window_id {
+        return windows
+            .iter()
+            .find(|window| window.window_id == window_id)
+            .with_context(|| format!("No window matched window_id {window_id}."));
+    }
+
+    if target.has_terminal_target() {
+        let matches = windows
+            .iter()
+            .filter(|window| window_matches_terminal_target(window, target))
+            .filter(|window| target.pid.is_none_or(|pid| window.pid == Some(pid)))
+            .filter(|window| optional_exact_match(&window.app_id, target.app_id.as_deref()))
+            .filter(|window| optional_exact_match(&window.wm_class, target.wm_class.as_deref()))
+            .filter(|window| optional_title_match(&window.title, target.title.as_deref()))
+            .collect::<Vec<_>>();
+        return unique_window_match(matches, "terminal target");
+    }
+
+    if let Some(pid) = target.pid {
+        let matches = windows
+            .iter()
+            .filter(|window| window.pid == Some(pid))
+            .collect::<Vec<_>>();
+        return unique_window_match(matches, &format!("pid {pid}"));
+    }
+
+    if let Some(app_id) = normalized_target(target.app_id.as_deref()) {
+        if let Some(window) = windows.iter().find(|window| {
+            window
+                .app_id
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case(&app_id))
+        }) {
+            return Ok(window);
+        }
+        bail!("No window matched app_id {app_id}.");
+    }
+
+    if let Some(wm_class) = normalized_target(target.wm_class.as_deref()) {
+        if let Some(window) = windows.iter().find(|window| {
+            window
+                .wm_class
+                .as_deref()
+                .is_some_and(|value| value.eq_ignore_ascii_case(&wm_class))
+        }) {
+            return Ok(window);
+        }
+        bail!("No window matched wm_class {wm_class}.");
+    }
+
+    if let Some(title) = normalized_target(target.title.as_deref()) {
+        let title_lower = title.to_ascii_lowercase();
+        if let Some(window) = windows.iter().find(|window| {
+            window
+                .title
+                .as_deref()
+                .is_some_and(|value| value.to_ascii_lowercase().contains(&title_lower))
+        }) {
+            return Ok(window);
+        }
+        bail!("No window title contained {title}.");
+    }
+
+    bail!("Pass window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd to target a window.");
+}
+
+fn unique_window_match<'a>(
+    matches: Vec<&'a WindowInfo>,
+    description: &str,
+) -> Result<&'a WindowInfo> {
+    match matches.as_slice() {
+        [window] => Ok(*window),
+        [] => bail!("No window matched {description}."),
+        windows => {
+            let ids = windows
+                .iter()
+                .map(|window| window.window_id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "{description} matched multiple windows ({ids}); add window_id, tty, title, or terminal_command to disambiguate."
+            );
+        }
+    }
+}
+
+fn window_matches_terminal_target(window: &WindowInfo, target: &WindowTarget) -> bool {
+    let Some(terminal) = &window.terminal else {
+        return false;
+    };
+
+    if let Some(tty) = normalized_target(target.tty.as_deref()) {
+        if !tty_matches(&terminal.tty, &tty) {
+            return false;
+        }
+    }
+
+    if let Some(pid) = target.terminal_pid {
+        let active_pid = terminal.active_process.as_ref().map(|process| process.pid);
+        if active_pid != Some(pid) && terminal.root_process.pid != pid {
+            return false;
+        }
+    }
+
+    if let Some(command) = normalized_target(target.terminal_command.as_deref()) {
+        let command = command.to_ascii_lowercase();
+        let active_matches = terminal
+            .active_process
+            .as_ref()
+            .is_some_and(|process| terminal_process_matches_command(process, &command));
+        if !active_matches && !terminal_process_matches_command(&terminal.root_process, &command) {
+            return false;
+        }
+    }
+
+    if let Some(cwd) = normalized_target(target.terminal_cwd.as_deref()) {
+        let active_matches = terminal
+            .active_process
+            .as_ref()
+            .is_some_and(|process| terminal_process_matches_cwd(process, &cwd));
+        if !active_matches && !terminal_process_matches_cwd(&terminal.root_process, &cwd) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn terminal_process_matches_command(
+    process: &crate::terminal::TerminalProcess,
+    command_lower: &str,
+) -> bool {
+    process
+        .command_name
+        .to_ascii_lowercase()
+        .contains(command_lower)
+        || process
+            .command_line
+            .to_ascii_lowercase()
+            .contains(command_lower)
+}
+
+fn terminal_process_matches_cwd(process: &crate::terminal::TerminalProcess, cwd: &str) -> bool {
+    let requested = cwd.trim_end_matches('/');
+    process.cwd.as_deref().is_some_and(|value| {
+        let actual = value.trim_end_matches('/');
+        actual == requested
+            || (!requested.starts_with('/')
+                && actual
+                    .strip_suffix(requested)
+                    .is_some_and(|prefix| prefix.ends_with('/')))
+    })
+}
+
+fn tty_matches(actual: &str, requested: &str) -> bool {
+    actual == requested
+        || actual
+            .strip_prefix("/dev/")
+            .is_some_and(|value| value == requested)
+        || actual
+            .strip_prefix("/dev/pts/")
+            .is_some_and(|value| value == requested)
+}
+
+fn optional_exact_match(actual: &Option<String>, requested: Option<&str>) -> bool {
+    normalized_target(requested).is_none_or(|requested| {
+        actual
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case(&requested))
+    })
+}
+
+fn optional_title_match(actual: &Option<String>, requested: Option<&str>) -> bool {
+    normalized_target(requested).is_none_or(|requested| {
+        let requested = requested.to_ascii_lowercase();
+        actual
+            .as_deref()
+            .is_some_and(|value| value.to_ascii_lowercase().contains(&requested))
+    })
+}
+
+pub fn window_permission_hint(error: &str) -> Option<String> {
+    let lower = error.to_ascii_lowercase();
+    if lower.contains("accessdenied")
+        || lower.contains("access denied")
+        || lower.contains("not allowed")
+        || lower.contains("operation not permitted")
+        || lower.contains("failed to connect to session bus")
+    {
+        Some(WINDOW_PERMISSION_HINT.to_string())
+    } else {
+        None
+    }
+}
+
+async fn focus_app(app_id: &str) -> Result<()> {
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let proxy = Proxy::new(
+        &connection,
+        "org.gnome.Shell",
+        "/org/gnome/Shell",
+        "org.gnome.Shell",
+    )
+    .await
+    .context("failed to create GNOME Shell proxy")?;
+    let _: () = proxy
+        .call("FocusApp", &(app_id))
+        .await
+        .with_context(|| format!("GNOME Shell FocusApp failed for app_id {app_id}"))?;
+    Ok(())
+}
+
+async fn call_extension_json(method: &str) -> Result<String> {
+    hydrate_session_bus_env();
+
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let proxy = Proxy::new(
+        &connection,
+        GNOME_SHELL_EXTENSION_SERVICE,
+        GNOME_SHELL_EXTENSION_OBJECT_PATH,
+        GNOME_SHELL_EXTENSION_SERVICE,
+    )
+    .await
+    .context("failed to create Codex GNOME Shell extension proxy")?;
+    let json: String = proxy
+        .call(method, &())
+        .await
+        .with_context(|| format!("Codex GNOME Shell extension {method} call failed"))?;
+    Ok(json)
+}
+
+async fn activate_extension_window(window_id: u64) -> Result<()> {
+    hydrate_session_bus_env();
+
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let proxy = Proxy::new(
+        &connection,
+        GNOME_SHELL_EXTENSION_SERVICE,
+        GNOME_SHELL_EXTENSION_OBJECT_PATH,
+        GNOME_SHELL_EXTENSION_SERVICE,
+    )
+    .await
+    .context("failed to create Codex GNOME Shell extension proxy")?;
+    let (ok, message): (bool, String) = proxy
+        .call("ActivateWindow", &(window_id))
+        .await
+        .with_context(|| {
+            format!("Codex GNOME Shell extension ActivateWindow failed for {window_id}")
+        })?;
+    if ok {
+        Ok(())
+    } else {
+        bail!("Codex GNOME Shell extension refused activation: {message}");
+    }
+}
+
+fn window_from_properties(window_id: u64, properties: &HashMap<String, OwnedValue>) -> WindowInfo {
+    let width = get_u32(properties, "width");
+    let height = get_u32(properties, "height");
+    let bounds = width.zip(height).map(|(width, height)| WindowBounds {
+        x: get_i32(properties, "x"),
+        y: get_i32(properties, "y"),
+        width,
+        height,
+    });
+
+    WindowInfo {
+        window_id,
+        title: get_string(properties, "title"),
+        app_id: get_string(properties, "app-id"),
+        wm_class: get_string(properties, "wm-class"),
+        pid: get_u32(properties, "pid"),
+        bounds,
+        workspace: get_i32(properties, "workspace"),
+        focused: get_bool(properties, "has-focus").unwrap_or(false),
+        hidden: get_bool(properties, "is-hidden").unwrap_or(false),
+        client_type: get_u32(properties, "client-type").map(client_type_name),
+        backend: GNOME_SHELL_INTROSPECT_BACKEND.to_string(),
+        terminal: None,
+    }
+}
+
+fn get_string(properties: &HashMap<String, OwnedValue>, key: &str) -> Option<String> {
+    properties
+        .get(key)
+        .and_then(|value| <&str>::try_from(value).ok())
+        .map(ToOwned::to_owned)
+}
+
+fn get_bool(properties: &HashMap<String, OwnedValue>, key: &str) -> Option<bool> {
+    properties
+        .get(key)
+        .and_then(|value| bool::try_from(value).ok())
+}
+
+fn get_u32(properties: &HashMap<String, OwnedValue>, key: &str) -> Option<u32> {
+    properties
+        .get(key)
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn get_i32(properties: &HashMap<String, OwnedValue>, key: &str) -> Option<i32> {
+    properties.get(key).and_then(|value| {
+        i32::try_from(value).ok().or_else(|| {
+            u32::try_from(value)
+                .ok()
+                .and_then(|value| value.try_into().ok())
+        })
+    })
+}
+
+fn client_type_name(value: u32) -> String {
+    match value {
+        0 => "wayland",
+        1 => "x11",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn normalized_target(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn same_optional_string(left: &Option<String>, right: &Option<String>) -> bool {
+    match (left.as_deref(), right.as_deref()) {
+        (Some(left), Some(right)) => left.eq_ignore_ascii_case(right),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::terminal::{TerminalProcess, TerminalWindowContext};
+    use zbus::zvariant::Value;
+
+    fn owned_value(value: Value<'_>) -> OwnedValue {
+        OwnedValue::try_from(value).unwrap()
+    }
+
+    fn window(window_id: u64, title: &str, app_id: &str, wm_class: &str) -> WindowInfo {
+        WindowInfo {
+            window_id,
+            title: Some(title.to_string()),
+            app_id: Some(app_id.to_string()),
+            wm_class: Some(wm_class.to_string()),
+            pid: Some(window_id as u32 + 1000),
+            bounds: Some(WindowBounds {
+                x: None,
+                y: None,
+                width: 800,
+                height: 600,
+            }),
+            workspace: None,
+            focused: false,
+            hidden: false,
+            client_type: Some("wayland".to_string()),
+            backend: GNOME_SHELL_INTROSPECT_BACKEND.to_string(),
+            terminal: None,
+        }
+    }
+
+    fn terminal_window(
+        window_id: u64,
+        title: &str,
+        tty: &str,
+        active_pid: u32,
+        active_command: &str,
+        active_cwd: &str,
+    ) -> WindowInfo {
+        let mut window = window(
+            window_id,
+            title,
+            "com.mitchellh.ghostty.desktop",
+            "com.mitchellh.ghostty",
+        );
+        window.terminal = Some(TerminalWindowContext {
+            tty: tty.to_string(),
+            root_process: TerminalProcess {
+                pid: active_pid - 1,
+                command_name: "zsh".to_string(),
+                command_line: "zsh --login".to_string(),
+                cwd: Some("/home/avifenesh".to_string()),
+            },
+            active_process: Some(TerminalProcess {
+                pid: active_pid,
+                command_name: active_command.to_string(),
+                command_line: format!("{active_command} resume 123"),
+                cwd: Some(active_cwd.to_string()),
+            }),
+            process_count: 2,
+            confidence: "heuristic".to_string(),
+            match_reason: "test".to_string(),
+        });
+        window
+    }
+
+    #[test]
+    fn target_reports_when_any_selector_is_present() {
+        assert!(!WindowTarget::default().has_target());
+        assert!(WindowTarget {
+            title: Some("Ghostty".to_string()),
+            ..Default::default()
+        }
+        .has_target());
+        assert!(WindowTarget {
+            tty: Some("/dev/pts/1".to_string()),
+            ..Default::default()
+        }
+        .has_target());
+    }
+
+    #[test]
+    fn title_pid_and_window_id_targets_require_exact_focus() {
+        assert!(WindowTarget {
+            title: Some("Ghostty".to_string()),
+            ..Default::default()
+        }
+        .requires_exact_focus());
+        assert!(WindowTarget {
+            pid: Some(123),
+            ..Default::default()
+        }
+        .requires_exact_focus());
+        assert!(WindowTarget {
+            window_id: Some(123),
+            ..Default::default()
+        }
+        .requires_exact_focus());
+        assert!(WindowTarget {
+            terminal_command: Some("codex".to_string()),
+            ..Default::default()
+        }
+        .requires_exact_focus());
+        assert!(!WindowTarget {
+            app_id: Some("com.mitchellh.ghostty.desktop".to_string()),
+            ..Default::default()
+        }
+        .requires_exact_focus());
+    }
+
+    #[test]
+    fn exact_targets_require_extension_activation_backend() {
+        let window = window(
+            2,
+            "Ghostty",
+            "com.mitchellh.ghostty.desktop",
+            "com.mitchellh.ghostty",
+        );
+
+        let error = ensure_backend_can_focus_target(
+            &WindowTarget {
+                terminal_command: Some("codex".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("Exact window targeting requires"));
+    }
+
+    #[test]
+    fn app_targets_can_use_app_level_focus_backend() {
+        let window = window(
+            2,
+            "Ghostty",
+            "com.mitchellh.ghostty.desktop",
+            "com.mitchellh.ghostty",
+        );
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                app_id: Some("com.mitchellh.ghostty.desktop".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn resolves_target_by_window_id_first() {
+        let windows = vec![
+            window(1, "Codex", "codex.desktop", "Codex"),
+            window(2, "Ghostty", "com.mitchellh.ghostty.desktop", "Ghostty"),
+        ];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                window_id: Some(2),
+                title: Some("Codex".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, 2);
+    }
+
+    #[test]
+    fn pid_target_reports_ambiguous_matches() {
+        let mut first = window(1, "Ghostty One", "com.mitchellh.ghostty.desktop", "Ghostty");
+        let mut second = window(2, "Ghostty Two", "com.mitchellh.ghostty.desktop", "Ghostty");
+        first.pid = Some(300);
+        second.pid = Some(300);
+
+        let error = resolve_window_target(
+            &[first, second],
+            &WindowTarget {
+                pid: Some(300),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("pid 300 matched multiple windows"));
+    }
+
+    #[test]
+    fn resolves_target_by_title_substring_case_insensitive() {
+        let windows = vec![window(
+            2,
+            "avifenesh@host: ~/projects/codex",
+            "com.mitchellh.ghostty.desktop",
+            "Ghostty",
+        )];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                title: Some("PROJECTS/CODEX".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, 2);
+    }
+
+    #[test]
+    fn resolves_terminal_target_by_tty() {
+        let windows = vec![
+            terminal_window(1, "Claude", "/dev/pts/0", 101, "claude", "/tmp"),
+            terminal_window(2, "Codex", "/dev/pts/1", 201, "codex", "/home/avifenesh"),
+        ];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                tty: Some("pts/1".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, 2);
+    }
+
+    #[test]
+    fn resolves_terminal_target_by_active_command() {
+        let windows = vec![
+            terminal_window(1, "Claude", "/dev/pts/0", 101, "claude", "/tmp"),
+            terminal_window(2, "Codex", "/dev/pts/1", 201, "codex", "/home/avifenesh"),
+        ];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                terminal_command: Some("codex resume".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, 2);
+    }
+
+    #[test]
+    fn resolves_terminal_target_by_cwd_suffix() {
+        let windows = vec![
+            terminal_window(1, "Home", "/dev/pts/0", 101, "zsh", "/home/avifenesh"),
+            terminal_window(
+                2,
+                "Project",
+                "/dev/pts/1",
+                201,
+                "codex",
+                "/home/avifenesh/projects/codex-desktop-linux",
+            ),
+        ];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                terminal_cwd: Some("projects/codex-desktop-linux".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, 2);
+    }
+
+    #[test]
+    fn terminal_cwd_does_not_match_arbitrary_substrings() {
+        let windows = vec![terminal_window(
+            1,
+            "Project",
+            "/dev/pts/1",
+            201,
+            "codex",
+            "/home/avifenesh/projects/codex-desktop-linux",
+        )];
+
+        let error = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                terminal_cwd: Some("fenesh/proj".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("No window matched terminal target"));
+    }
+
+    #[test]
+    fn terminal_target_reports_ambiguous_matches() {
+        let windows = vec![
+            terminal_window(1, "One", "/dev/pts/0", 101, "zsh", "/home/avifenesh"),
+            terminal_window(2, "Two", "/dev/pts/1", 201, "zsh", "/home/avifenesh"),
+        ];
+
+        let error = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                terminal_command: Some("zsh".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("matched multiple windows"));
+    }
+
+    #[test]
+    fn maps_access_denied_errors_to_permission_hint() {
+        let hint = window_permission_hint(
+            "GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: GetWindows is not allowed",
+        );
+
+        assert_eq!(hint.as_deref(), Some(WINDOW_PERMISSION_HINT));
+    }
+
+    #[test]
+    fn extracts_known_window_properties() {
+        let properties = HashMap::from([
+            ("title".to_string(), owned_value(Value::from("Ghostty"))),
+            (
+                "app-id".to_string(),
+                owned_value(Value::from("com.mitchellh.ghostty.desktop")),
+            ),
+            ("wm-class".to_string(), owned_value(Value::from("Ghostty"))),
+            ("client-type".to_string(), owned_value(Value::from(0_u32))),
+            ("is-hidden".to_string(), owned_value(Value::from(false))),
+            ("has-focus".to_string(), owned_value(Value::from(true))),
+            ("width".to_string(), owned_value(Value::from(1200_u32))),
+            ("height".to_string(), owned_value(Value::from(800_u32))),
+        ]);
+
+        let info = window_from_properties(42, &properties);
+
+        assert_eq!(info.window_id, 42);
+        assert_eq!(info.title.as_deref(), Some("Ghostty"));
+        assert!(info.focused);
+        assert_eq!(info.client_type.as_deref(), Some("wayland"));
+        assert_eq!(info.bounds.unwrap().width, 1200);
+    }
+}


### PR DESCRIPTION
## Summary
- add Linux Computer Use tools for compositor window listing, focused-window lookup, and target activation
- add an optional GNOME Shell extension backend for exact window focus when native GNOME introspection is unavailable or insufficient
- wire window and terminal selectors into `get_app_state`, `press_key`, and `type_text`, with focus verification before targeted input
- add terminal PTY/process metadata for terminal windows and diagnostics/setup guidance for window targeting

## Why
Linux Computer Use could previously send keyboard input only to whatever already had focus. That made terminal workflows unsafe when several Ghostty windows or app windows were open, because the tool could not reliably identify, focus, and verify the intended target before typing.

## Impact
This keeps global input behavior available, but adds a safer targeted path: tools can enumerate compositor windows, resolve selectors such as `window_id`, `title`, `tty`, `terminal_pid`, `terminal_command`, and `terminal_cwd`, activate the matched window, and refuse targeted input when focus verification fails.

## Scope
This PR intentionally stays within the Linux Computer Use window-targeting layer. It does not include plugin UI/install-flow changes, generated desktop bundle artifacts, plugin version bumps, or AT-SPI action/value wiring.

## Testing
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `cargo test -p codex-computer-use-linux`
- `cargo build -p codex-computer-use-linux`
- `git diff --check`
