### PR TITLE
fix(computer-use): enable Linux UI gates and Wayland pointer input

### DIFF
--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -1,6 +1,7 @@
 mod atspi_tree;
 mod diagnostics;
 mod gnome_extension;
+mod remote_desktop;
 mod screenshot;
 mod server;
 mod terminal;

--- a/computer-use-linux/src/remote_desktop.rs
+++ b/computer-use-linux/src/remote_desktop.rs
@@ -1,0 +1,543 @@
+use crate::diagnostics::hydrate_session_bus_env;
+use anyhow::{bail, Context, Result};
+use futures_util::StreamExt;
+use std::{collections::HashMap, time::Duration};
+use zbus::{
+    proxy::SignalStream,
+    zvariant::{OwnedObjectPath, OwnedValue, Value},
+    Connection, Proxy,
+};
+
+const PORTAL_DESKTOP_SERVICE: &str = "org.freedesktop.portal.Desktop";
+const PORTAL_DESKTOP_PATH: &str = "/org/freedesktop/portal/desktop";
+const PORTAL_REMOTE_DESKTOP_INTERFACE: &str = "org.freedesktop.portal.RemoteDesktop";
+const PORTAL_SCREENCAST_INTERFACE: &str = "org.freedesktop.portal.ScreenCast";
+const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+const DEVICE_POINTER: u32 = 2;
+const SOURCE_MONITOR: u32 = 1;
+const CURSOR_MODE_HIDDEN: u32 = 1;
+
+const POINTER_BUTTON_RELEASED: u32 = 0;
+const POINTER_BUTTON_PRESSED: u32 = 1;
+
+const AXIS_VERTICAL: u32 = 0;
+const AXIS_HORIZONTAL: u32 = 1;
+
+const BTN_LEFT: i32 = 0x110;
+const BTN_RIGHT: i32 = 0x111;
+const BTN_MIDDLE: i32 = 0x112;
+const BTN_SIDE: i32 = 0x113;
+const BTN_EXTRA: i32 = 0x114;
+const BTN_FORWARD: i32 = 0x115;
+const BTN_BACK: i32 = 0x116;
+
+#[derive(Clone)]
+pub struct PortalPointerSession {
+    connection: Connection,
+    session_handle: OwnedObjectPath,
+    streams: Vec<PortalStream>,
+}
+
+#[derive(Debug, Clone)]
+struct PortalStream {
+    node_id: u32,
+    position: Option<(i32, i32)>,
+    size: Option<(i32, i32)>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PointerButton {
+    Left,
+    Right,
+    Middle,
+    Side,
+    Extra,
+    Forward,
+    Back,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+pub async fn start_portal_pointer_session() -> Result<PortalPointerSession> {
+    hydrate_session_bus_env();
+
+    let connection = Connection::session()
+        .await
+        .context("failed to connect to session bus for remote desktop portal")?;
+    let session_handle = create_remote_desktop_session(&connection).await?;
+    select_pointer_devices(&connection, &session_handle).await?;
+    select_monitor_sources(&connection, &session_handle).await?;
+    let (devices, streams) = start_remote_desktop_session(&connection, &session_handle).await?;
+
+    if devices & DEVICE_POINTER == 0 {
+        bail!("remote desktop portal session started without pointer access");
+    }
+    if streams.is_empty() {
+        bail!("remote desktop portal session started without any monitor streams");
+    }
+
+    Ok(PortalPointerSession {
+        connection,
+        session_handle,
+        streams,
+    })
+}
+
+pub async fn click(
+    session: &PortalPointerSession,
+    x: i32,
+    y: i32,
+    button: PointerButton,
+    click_count: u32,
+) -> Result<()> {
+    let proxy = remote_desktop_proxy(&session.connection).await?;
+    let (stream_id, x, y) = session.map_absolute_point(x, y)?;
+    notify_pointer_motion_absolute(&proxy, &session.session_handle, stream_id, x, y).await?;
+    for _ in 0..click_count.max(1) {
+        notify_pointer_button(
+            &proxy,
+            &session.session_handle,
+            button.evdev_code(),
+            POINTER_BUTTON_PRESSED,
+        )
+        .await?;
+        tokio::time::sleep(Duration::from_millis(35)).await;
+        notify_pointer_button(
+            &proxy,
+            &session.session_handle,
+            button.evdev_code(),
+            POINTER_BUTTON_RELEASED,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+pub async fn scroll(
+    session: &PortalPointerSession,
+    target_point: Option<(i32, i32)>,
+    direction: ScrollDirection,
+    steps: i32,
+) -> Result<()> {
+    let proxy = remote_desktop_proxy(&session.connection).await?;
+    if let Some((x, y)) = target_point {
+        let (stream_id, x, y) = session.map_absolute_point(x, y)?;
+        notify_pointer_motion_absolute(&proxy, &session.session_handle, stream_id, x, y).await?;
+    }
+
+    let (axis, steps) = match direction {
+        ScrollDirection::Up => (AXIS_VERTICAL, steps.max(1)),
+        ScrollDirection::Down => (AXIS_VERTICAL, -steps.max(1)),
+        ScrollDirection::Left => (AXIS_HORIZONTAL, steps.max(1)),
+        ScrollDirection::Right => (AXIS_HORIZONTAL, -steps.max(1)),
+    };
+
+    notify_pointer_axis_discrete(&proxy, &session.session_handle, axis, steps).await
+}
+
+pub async fn drag(
+    session: &PortalPointerSession,
+    start_x: i32,
+    start_y: i32,
+    end_x: i32,
+    end_y: i32,
+) -> Result<()> {
+    let proxy = remote_desktop_proxy(&session.connection).await?;
+    let (start_stream, start_x, start_y) = session.map_absolute_point(start_x, start_y)?;
+    notify_pointer_motion_absolute(
+        &proxy,
+        &session.session_handle,
+        start_stream,
+        start_x,
+        start_y,
+    )
+    .await?;
+    notify_pointer_button(
+        &proxy,
+        &session.session_handle,
+        BTN_LEFT,
+        POINTER_BUTTON_PRESSED,
+    )
+    .await?;
+    tokio::time::sleep(Duration::from_millis(35)).await;
+    let (end_stream, end_x, end_y) = session.map_absolute_point(end_x, end_y)?;
+    notify_pointer_motion_absolute(&proxy, &session.session_handle, end_stream, end_x, end_y)
+        .await?;
+    tokio::time::sleep(Duration::from_millis(35)).await;
+    notify_pointer_button(
+        &proxy,
+        &session.session_handle,
+        BTN_LEFT,
+        POINTER_BUTTON_RELEASED,
+    )
+    .await
+}
+
+impl PortalPointerSession {
+    fn map_absolute_point(&self, x: i32, y: i32) -> Result<(u32, f64, f64)> {
+        if let Some(stream) = self
+            .streams
+            .iter()
+            .find(|stream| stream.contains_global_point(x, y))
+        {
+            return Ok(stream.relative_point(x, y));
+        }
+
+        self.streams
+            .first()
+            .map(|stream| stream.relative_point(x, y))
+            .context("remote desktop portal session had no usable streams")
+    }
+}
+
+impl PortalStream {
+    fn contains_global_point(&self, x: i32, y: i32) -> bool {
+        let Some((stream_x, stream_y)) = self.position else {
+            return false;
+        };
+        let Some((width, height)) = self.size else {
+            return false;
+        };
+        x >= stream_x && y >= stream_y && x < stream_x + width && y < stream_y + height
+    }
+
+    fn relative_point(&self, x: i32, y: i32) -> (u32, f64, f64) {
+        let (stream_x, stream_y) = self.position.unwrap_or((0, 0));
+        let (width, height) = self.size.unwrap_or((i32::MAX, i32::MAX));
+        let rel_x = (x - stream_x).clamp(0, width.saturating_sub(1)) as f64;
+        let rel_y = (y - stream_y).clamp(0, height.saturating_sub(1)) as f64;
+        (self.node_id, rel_x, rel_y)
+    }
+}
+
+impl PointerButton {
+    pub fn from_name(name: Option<&str>) -> Self {
+        match name.unwrap_or("left").to_ascii_lowercase().as_str() {
+            "right" => Self::Right,
+            "middle" => Self::Middle,
+            "side" => Self::Side,
+            "extra" => Self::Extra,
+            "forward" => Self::Forward,
+            "back" => Self::Back,
+            _ => Self::Left,
+        }
+    }
+
+    fn evdev_code(self) -> i32 {
+        match self {
+            Self::Left => BTN_LEFT,
+            Self::Right => BTN_RIGHT,
+            Self::Middle => BTN_MIDDLE,
+            Self::Side => BTN_SIDE,
+            Self::Extra => BTN_EXTRA,
+            Self::Forward => BTN_FORWARD,
+            Self::Back => BTN_BACK,
+        }
+    }
+}
+
+async fn create_remote_desktop_session(connection: &Connection) -> Result<OwnedObjectPath> {
+    let remote_proxy = remote_desktop_proxy(connection).await?;
+    let (request_path, mut response_stream) =
+        portal_request_stream(connection, "rd_create").await?;
+    let session_token = request_token("rd_session");
+    let mut options: HashMap<&str, Value<'_>> = HashMap::new();
+    options.insert(
+        "handle_token",
+        Value::from(last_path_component(&request_path)),
+    );
+    options.insert("session_handle_token", Value::from(session_token.as_str()));
+
+    let handle: OwnedObjectPath = remote_proxy
+        .call("CreateSession", &(options))
+        .await
+        .context("RemoteDesktop CreateSession call failed")?;
+    let (response_code, results) =
+        await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
+    if response_code != 0 {
+        bail!("RemoteDesktop CreateSession denied or cancelled with response code {response_code}");
+    }
+
+    let session_handle: String = results
+        .get("session_handle")
+        .context("RemoteDesktop CreateSession response did not include session_handle")?
+        .try_clone()
+        .context("failed to clone session_handle")?
+        .try_into()
+        .context("RemoteDesktop session_handle was not a string")?;
+    OwnedObjectPath::try_from(session_handle)
+        .context("RemoteDesktop session_handle was not a valid object path")
+}
+
+async fn select_pointer_devices(connection: &Connection, session: &OwnedObjectPath) -> Result<()> {
+    let remote_proxy = remote_desktop_proxy(connection).await?;
+    let (request_path, mut response_stream) =
+        portal_request_stream(connection, "rd_devices").await?;
+    let mut options: HashMap<&str, Value<'_>> = HashMap::new();
+    options.insert(
+        "handle_token",
+        Value::from(last_path_component(&request_path)),
+    );
+    options.insert("types", Value::from(DEVICE_POINTER));
+
+    let handle: OwnedObjectPath = remote_proxy
+        .call("SelectDevices", &(session, options))
+        .await
+        .context("RemoteDesktop SelectDevices call failed")?;
+    let (response_code, _) =
+        await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
+    if response_code != 0 {
+        bail!("RemoteDesktop SelectDevices denied or cancelled with response code {response_code}");
+    }
+    Ok(())
+}
+
+async fn select_monitor_sources(connection: &Connection, session: &OwnedObjectPath) -> Result<()> {
+    let screencast_proxy = screencast_proxy(connection).await?;
+    let (request_path, mut response_stream) =
+        portal_request_stream(connection, "rd_sources").await?;
+    let mut options: HashMap<&str, Value<'_>> = HashMap::new();
+    options.insert(
+        "handle_token",
+        Value::from(last_path_component(&request_path)),
+    );
+    options.insert("types", Value::from(SOURCE_MONITOR));
+    options.insert("multiple", Value::from(false));
+    options.insert("cursor_mode", Value::from(CURSOR_MODE_HIDDEN));
+
+    let handle: OwnedObjectPath = screencast_proxy
+        .call("SelectSources", &(session, options))
+        .await
+        .context("ScreenCast SelectSources call failed for remote desktop session")?;
+    let (response_code, _) =
+        await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
+    if response_code != 0 {
+        bail!("ScreenCast SelectSources denied or cancelled with response code {response_code}");
+    }
+    Ok(())
+}
+
+async fn start_remote_desktop_session(
+    connection: &Connection,
+    session: &OwnedObjectPath,
+) -> Result<(u32, Vec<PortalStream>)> {
+    let remote_proxy = remote_desktop_proxy(connection).await?;
+    let (request_path, mut response_stream) = portal_request_stream(connection, "rd_start").await?;
+    let mut options: HashMap<&str, Value<'_>> = HashMap::new();
+    options.insert(
+        "handle_token",
+        Value::from(last_path_component(&request_path)),
+    );
+
+    let handle: OwnedObjectPath = remote_proxy
+        .call("Start", &(session, "", options))
+        .await
+        .context("RemoteDesktop Start call failed")?;
+    let (response_code, results) =
+        await_portal_response(connection, handle, &request_path, &mut response_stream).await?;
+    if response_code != 0 {
+        bail!("RemoteDesktop Start denied or cancelled with response code {response_code}");
+    }
+
+    let devices = results
+        .get("devices")
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or_default();
+    let streams = results
+        .get("streams")
+        .map(parse_streams)
+        .transpose()?
+        .unwrap_or_default();
+    Ok((devices, streams))
+}
+
+async fn notify_pointer_motion_absolute(
+    proxy: &Proxy<'_>,
+    session: &OwnedObjectPath,
+    stream_id: u32,
+    x: f64,
+    y: f64,
+) -> Result<()> {
+    let options: HashMap<&str, Value<'_>> = HashMap::new();
+    let _: () = proxy
+        .call(
+            "NotifyPointerMotionAbsolute",
+            &(session, options, stream_id, x, y),
+        )
+        .await
+        .context("RemoteDesktop NotifyPointerMotionAbsolute failed")?;
+    Ok(())
+}
+
+async fn notify_pointer_button(
+    proxy: &Proxy<'_>,
+    session: &OwnedObjectPath,
+    button: i32,
+    state: u32,
+) -> Result<()> {
+    let options: HashMap<&str, Value<'_>> = HashMap::new();
+    let _: () = proxy
+        .call("NotifyPointerButton", &(session, options, button, state))
+        .await
+        .context("RemoteDesktop NotifyPointerButton failed")?;
+    Ok(())
+}
+
+async fn notify_pointer_axis_discrete(
+    proxy: &Proxy<'_>,
+    session: &OwnedObjectPath,
+    axis: u32,
+    steps: i32,
+) -> Result<()> {
+    let options: HashMap<&str, Value<'_>> = HashMap::new();
+    let _: () = proxy
+        .call(
+            "NotifyPointerAxisDiscrete",
+            &(session, options, axis, steps),
+        )
+        .await
+        .context("RemoteDesktop NotifyPointerAxisDiscrete failed")?;
+    Ok(())
+}
+
+async fn remote_desktop_proxy(connection: &Connection) -> Result<Proxy<'_>> {
+    Proxy::new(
+        connection,
+        PORTAL_DESKTOP_SERVICE,
+        PORTAL_DESKTOP_PATH,
+        PORTAL_REMOTE_DESKTOP_INTERFACE,
+    )
+    .await
+    .context("failed to create RemoteDesktop portal proxy")
+}
+
+async fn screencast_proxy(connection: &Connection) -> Result<Proxy<'_>> {
+    Proxy::new(
+        connection,
+        PORTAL_DESKTOP_SERVICE,
+        PORTAL_DESKTOP_PATH,
+        PORTAL_SCREENCAST_INTERFACE,
+    )
+    .await
+    .context("failed to create ScreenCast portal proxy")
+}
+
+async fn portal_request_stream<'a>(
+    connection: &'a Connection,
+    prefix: &str,
+) -> Result<(String, SignalStream<'a>)> {
+    let unique_name = connection
+        .unique_name()
+        .context("session bus connection has no unique name")?;
+    let token = request_token(prefix);
+    let request_path = request_path(unique_name.as_str(), &token);
+    let request_proxy = Proxy::new(
+        connection,
+        PORTAL_DESKTOP_SERVICE,
+        request_path.as_str(),
+        PORTAL_REQUEST_INTERFACE,
+    )
+    .await
+    .context("failed to create portal request proxy")?;
+    let response_stream = request_proxy
+        .receive_signal("Response")
+        .await
+        .context("failed to subscribe to portal request response")?;
+    Ok((request_path, response_stream))
+}
+
+async fn await_portal_response(
+    connection: &Connection,
+    handle: OwnedObjectPath,
+    expected_request_path: &str,
+    response_stream: &mut SignalStream<'_>,
+) -> Result<(u32, HashMap<String, OwnedValue>)> {
+    if handle.as_str() != expected_request_path {
+        *response_stream = Proxy::new(
+            connection,
+            PORTAL_DESKTOP_SERVICE,
+            handle.as_str(),
+            PORTAL_REQUEST_INTERFACE,
+        )
+        .await
+        .context("failed to create returned portal request proxy")?
+        .receive_signal("Response")
+        .await
+        .context("failed to subscribe to returned portal response")?;
+    }
+
+    let response = tokio::time::timeout(REQUEST_TIMEOUT, response_stream.next())
+        .await
+        .context("timed out waiting for portal response")?
+        .context("portal response stream ended")?;
+    response
+        .body()
+        .deserialize()
+        .context("failed to decode portal response")
+}
+
+fn parse_streams(value: &OwnedValue) -> Result<Vec<PortalStream>> {
+    let streams: Vec<(u32, HashMap<String, OwnedValue>)> = value
+        .try_clone()
+        .context("failed to clone streams response")?
+        .try_into()
+        .context("portal streams response had unexpected type")?;
+    Ok(streams
+        .into_iter()
+        .map(|(node_id, properties)| PortalStream {
+            node_id,
+            position: get_pair_i32(&properties, "position"),
+            size: get_pair_i32(&properties, "size"),
+        })
+        .collect())
+}
+
+fn get_pair_i32(properties: &HashMap<String, OwnedValue>, key: &str) -> Option<(i32, i32)> {
+    properties.get(key).and_then(|value| {
+        value
+            .try_clone()
+            .ok()
+            .and_then(|owned| <(i32, i32)>::try_from(owned).ok())
+            .or_else(|| {
+                value
+                    .try_clone()
+                    .ok()
+                    .and_then(|owned| <(u32, u32)>::try_from(owned).ok())
+                    .map(|(left, right)| (left as i32, right as i32))
+            })
+    })
+}
+
+fn request_path(unique_name: &str, token: &str) -> String {
+    format!(
+        "/org/freedesktop/portal/desktop/request/{}/{}",
+        unique_name.trim_start_matches(':').replace('.', "_"),
+        token
+    )
+}
+
+fn last_path_component(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+fn request_token(prefix: &str) -> String {
+    format!(
+        "{prefix}_{}_{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+    )
+    .chars()
+    .map(|ch| match ch {
+        'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => ch,
+        _ => '_',
+    })
+    .collect()
+}

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -281,7 +281,7 @@ impl ComputerUseLinux {
                 x,
                 y,
                 PointerButton::from_name(params.button.as_deref()),
-                params.click_count.unwrap_or(1).clamp(1, 10) as u32,
+                params.click_count.unwrap_or(1).clamp(1, 10),
             )
             .await
             {
@@ -303,7 +303,7 @@ impl ComputerUseLinux {
                     x,
                     y,
                     PointerButton::from_name(params.button.as_deref()),
-                    params.click_count.unwrap_or(1).clamp(1, 10) as u32,
+                    params.click_count.unwrap_or(1).clamp(1, 10),
                 )
                 .await
                 {

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -3,6 +3,10 @@ use crate::atspi_tree::{
 };
 use crate::diagnostics::{doctor_report, setup_accessibility_report, DoctorReport, SetupReport};
 use crate::gnome_extension::{setup_window_targeting_report, WindowTargetingSetupReport};
+use crate::remote_desktop::{
+    click as portal_click, drag as portal_drag, scroll as portal_scroll,
+    start_portal_pointer_session, PointerButton, PortalPointerSession, ScrollDirection,
+};
 use crate::screenshot::{capture_screenshot, ScreenshotCapture};
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
@@ -21,12 +25,14 @@ use std::{
     path::PathBuf,
     process::{Command, Output},
     sync::{Arc, Mutex},
+    thread,
+    time::Duration,
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct ComputerUseLinux {
     last_nodes: Arc<Mutex<Vec<AccessibilityNode>>>,
-    last_screenshot_size: Arc<Mutex<Option<ScreenSize>>>,
+    portal_pointer_session: Arc<Mutex<Option<PortalPointerSession>>>,
 }
 
 #[tool_router]
@@ -184,17 +190,10 @@ impl ComputerUseLinux {
             });
         let (screenshot, screenshot_error) = if include_screenshot {
             match capture_screenshot().await {
-                Ok(capture) => {
-                    self.cache_screenshot_size(capture.width, capture.height);
-                    (Some(capture), None)
-                }
-                Err(error) => {
-                    self.clear_screenshot_size();
-                    (None, Some(error.to_string()))
-                }
+                Ok(capture) => (Some(capture), None),
+                Err(error) => (None, Some(error.to_string())),
             }
         } else {
-            self.clear_screenshot_size();
             (None, None)
         };
         let (accessibility_tree, accessibility_error) =
@@ -260,7 +259,7 @@ impl ComputerUseLinux {
         name = "click",
         description = "Click an element by index or pixel coordinates from screenshot."
     )]
-    fn click(&self, Parameters(params): Parameters<ClickParams>) -> Json<ActionOutput> {
+    async fn click(&self, Parameters(params): Parameters<ClickParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
         let (x, y) = match self.resolve_target_point(params.x, params.y, params.element_index) {
             Ok(point) => point,
@@ -276,7 +275,53 @@ impl ComputerUseLinux {
         };
         let button = mouse_button_code(params.button.as_deref());
         let click_count = params.click_count.unwrap_or(1).clamp(1, 10).to_string();
-        let (x, y) = self.to_ydotool_absolute_point(x, y);
+        if let Some(session) = self.cached_portal_pointer_session() {
+            match portal_click(
+                &session,
+                x,
+                y,
+                PointerButton::from_name(params.button.as_deref()),
+                params.click_count.unwrap_or(1).clamp(1, 10) as u32,
+            )
+            .await
+            {
+                Ok(()) => {
+                    return Json(ActionOutput {
+                        ok: true,
+                        implemented: true,
+                        action: "click".to_string(),
+                        message: "Action sent through the remote desktop portal.".to_string(),
+                        received,
+                    });
+                }
+                Err(_) => self.clear_portal_pointer_session(),
+            }
+        } else if self.should_prefer_portal_pointer_backend() {
+            match self.ensure_portal_pointer_session().await {
+                Ok(Some(session)) => match portal_click(
+                    &session,
+                    x,
+                    y,
+                    PointerButton::from_name(params.button.as_deref()),
+                    params.click_count.unwrap_or(1).clamp(1, 10) as u32,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        return Json(ActionOutput {
+                            ok: true,
+                            implemented: true,
+                            action: "click".to_string(),
+                            message: "Action sent through the remote desktop portal.".to_string(),
+                            received,
+                        });
+                    }
+                    Err(_) => self.clear_portal_pointer_session(),
+                },
+                Ok(None) => {}
+                Err(_) => {}
+            }
+        }
         let result = run_ydotool_sequence(&[
             absolute_mousemove_args(x, y),
             vec![
@@ -320,7 +365,7 @@ impl ComputerUseLinux {
         name = "scroll",
         description = "Scroll an element in a direction by a number of pages."
     )]
-    fn scroll(&self, Parameters(params): Parameters<ScrollParams>) -> Json<ActionOutput> {
+    async fn scroll(&self, Parameters(params): Parameters<ScrollParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
         let units = ((params.pages.unwrap_or(1.0).abs().max(0.1) * 5.0).round() as i32).max(1);
         let target_point =
@@ -336,6 +381,55 @@ impl ComputerUseLinux {
                     });
                 }
             };
+        let direction = match params.direction.to_ascii_lowercase().as_str() {
+            "up" => ScrollDirection::Up,
+            "down" => ScrollDirection::Down,
+            "left" => ScrollDirection::Left,
+            "right" => ScrollDirection::Right,
+            _ => {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "scroll".to_string(),
+                    message: "Unsupported scroll direction; expected up, down, left, or right."
+                        .to_string(),
+                    received,
+                });
+            }
+        };
+        if let Some(session) = self.cached_portal_pointer_session() {
+            match portal_scroll(&session, target_point, direction, units).await {
+                Ok(()) => {
+                    return Json(ActionOutput {
+                        ok: true,
+                        implemented: true,
+                        action: "scroll".to_string(),
+                        message: "Action sent through the remote desktop portal.".to_string(),
+                        received,
+                    });
+                }
+                Err(_) => self.clear_portal_pointer_session(),
+            }
+        } else if self.should_prefer_portal_pointer_backend() {
+            match self.ensure_portal_pointer_session().await {
+                Ok(Some(session)) => match portal_scroll(&session, target_point, direction, units)
+                    .await
+                {
+                    Ok(()) => {
+                        return Json(ActionOutput {
+                            ok: true,
+                            implemented: true,
+                            action: "scroll".to_string(),
+                            message: "Action sent through the remote desktop portal.".to_string(),
+                            received,
+                        });
+                    }
+                    Err(_) => self.clear_portal_pointer_session(),
+                },
+                Ok(None) => {}
+                Err(_) => {}
+            }
+        }
         let (dx, dy) = match params.direction.to_ascii_lowercase().as_str() {
             "up" => (0, units),
             "down" => (0, -units),
@@ -354,7 +448,6 @@ impl ComputerUseLinux {
         };
         let mut sequence = Vec::new();
         if let Some((x, y)) = target_point {
-            let (x, y) = self.to_ydotool_absolute_point(x, y);
             sequence.push(absolute_mousemove_args(x, y));
         }
         sequence.push(wheel_mousemove_args(dx, dy));
@@ -366,14 +459,59 @@ impl ComputerUseLinux {
         name = "drag",
         description = "Drag from one point to another using pixel coordinates."
     )]
-    fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
+    async fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
-        let (start_x, start_y) = self.to_ydotool_absolute_point(params.start_x, params.start_y);
-        let (end_x, end_y) = self.to_ydotool_absolute_point(params.end_x, params.end_y);
+        if let Some(session) = self.cached_portal_pointer_session() {
+            match portal_drag(
+                &session,
+                params.start_x,
+                params.start_y,
+                params.end_x,
+                params.end_y,
+            )
+            .await
+            {
+                Ok(()) => {
+                    return Json(ActionOutput {
+                        ok: true,
+                        implemented: true,
+                        action: "drag".to_string(),
+                        message: "Action sent through the remote desktop portal.".to_string(),
+                        received,
+                    });
+                }
+                Err(_) => self.clear_portal_pointer_session(),
+            }
+        } else if self.should_prefer_portal_pointer_backend() {
+            match self.ensure_portal_pointer_session().await {
+                Ok(Some(session)) => match portal_drag(
+                    &session,
+                    params.start_x,
+                    params.start_y,
+                    params.end_x,
+                    params.end_y,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        return Json(ActionOutput {
+                            ok: true,
+                            implemented: true,
+                            action: "drag".to_string(),
+                            message: "Action sent through the remote desktop portal.".to_string(),
+                            received,
+                        });
+                    }
+                    Err(_) => self.clear_portal_pointer_session(),
+                },
+                Ok(None) => {}
+                Err(_) => {}
+            }
+        }
         let result = run_ydotool_sequence(&[
-            absolute_mousemove_args(start_x, start_y),
+            absolute_mousemove_args(params.start_x, params.start_y),
             vec!["click".to_string(), "0x40".to_string()],
-            absolute_mousemove_args(end_x, end_y),
+            absolute_mousemove_args(params.end_x, params.end_y),
             vec!["click".to_string(), "0x80".to_string()],
         ]);
         Json(action_result("drag", result, received))
@@ -455,7 +593,7 @@ impl ComputerUseLinux {
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll, key, text, and drag input through ydotool when ydotoold is available. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -743,12 +881,6 @@ impl TypeTextParams {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct ScreenSize {
-    width: u32,
-    height: u32,
-}
-
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 struct ActionOutput {
     ok: bool,
@@ -759,6 +891,44 @@ struct ActionOutput {
 }
 
 impl ComputerUseLinux {
+    fn should_prefer_portal_pointer_backend(&self) -> bool {
+        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_POINTER")
+            .ok()
+            .as_deref()
+            != Some("1")
+            && env::var("XDG_SESSION_TYPE")
+                .ok()
+                .is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+    }
+
+    fn cached_portal_pointer_session(&self) -> Option<PortalPointerSession> {
+        self.portal_pointer_session
+            .lock()
+            .ok()
+            .and_then(|cached| cached.clone())
+    }
+
+    fn clear_portal_pointer_session(&self) {
+        if let Ok(mut cached) = self.portal_pointer_session.lock() {
+            *cached = None;
+        }
+    }
+
+    async fn ensure_portal_pointer_session(&self) -> Result<Option<PortalPointerSession>> {
+        if !self.should_prefer_portal_pointer_backend() {
+            return Ok(None);
+        }
+        if let Some(session) = self.cached_portal_pointer_session() {
+            return Ok(Some(session));
+        }
+
+        let session = start_portal_pointer_session().await?;
+        if let Ok(mut cached) = self.portal_pointer_session.lock() {
+            *cached = Some(session.clone());
+        }
+        Ok(Some(session))
+    }
+
     async fn resolve_window_context(
         &self,
         params: &GetAppStateParams,
@@ -821,37 +991,6 @@ impl ComputerUseLinux {
         }
     }
 
-    fn cache_screenshot_size(&self, width: u32, height: u32) {
-        if width == 0 || height == 0 {
-            self.clear_screenshot_size();
-            return;
-        }
-        if let Ok(mut cached) = self.last_screenshot_size.lock() {
-            *cached = Some(ScreenSize { width, height });
-        }
-    }
-
-    fn clear_screenshot_size(&self) {
-        if let Ok(mut cached) = self.last_screenshot_size.lock() {
-            *cached = None;
-        }
-    }
-
-    fn to_ydotool_absolute_point(&self, x: i32, y: i32) -> (i32, i32) {
-        let Some(size) = self
-            .last_screenshot_size
-            .lock()
-            .ok()
-            .and_then(|cached| *cached)
-        else {
-            return (x, y);
-        };
-        (
-            pixel_to_ydotool_absolute(x, size.width),
-            pixel_to_ydotool_absolute(y, size.height),
-        )
-    }
-
     fn resolve_target_point(
         &self,
         x: Option<i32>,
@@ -908,16 +1047,6 @@ fn not_implemented(
         message: message.to_string(),
         received,
     }
-}
-
-fn pixel_to_ydotool_absolute(value: i32, extent: u32) -> i32 {
-    if extent <= 1 {
-        return value;
-    }
-    let max_pixel = extent as i32 - 1;
-    let clamped = value.clamp(0, max_pixel) as i64;
-    let max_pixel = max_pixel as i64;
-    ((clamped * 65_535 + max_pixel / 2) / max_pixel) as i32
 }
 
 fn action_result(
@@ -1034,8 +1163,11 @@ fn wheel_mousemove_args(dx: i32, dy: i32) -> Vec<String> {
 
 fn run_ydotool_sequence(commands: &[Vec<String>]) -> std::result::Result<Vec<Output>, String> {
     let mut outputs = Vec::new();
-    for args in commands {
+    for (index, args) in commands.iter().enumerate() {
         outputs.push(run_ydotool(args)?);
+        if index + 1 < commands.len() {
+            thread::sleep(Duration::from_millis(35));
+        }
     }
     Ok(outputs)
 }
@@ -1405,26 +1537,17 @@ mod tests {
     }
 
     #[test]
-    fn screenshot_pixels_normalize_to_ydotool_absolute_space() {
-        let backend = ComputerUseLinux::default();
-        backend.cache_screenshot_size(3840, 1080);
-
-        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (26460, 56485));
-    }
-
-    #[test]
-    fn screenshot_size_cache_can_be_cleared() {
-        let backend = ComputerUseLinux::default();
-        backend.cache_screenshot_size(3840, 1080);
-
-        backend.clear_screenshot_size();
-
-        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (1550, 930));
-
-        backend.cache_screenshot_size(3840, 1080);
-        backend.cache_screenshot_size(0, 1080);
-
-        assert_eq!(backend.to_ydotool_absolute_point(1550, 930), (1550, 930));
+    fn pointer_actions_keep_pixel_coordinates_for_ydotool_absolute_moves() {
+        assert_eq!(
+            absolute_mousemove_args(1550, 930),
+            vec![
+                "mousemove".to_string(),
+                "--absolute".to_string(),
+                "--".to_string(),
+                "1550".to_string(),
+                "930".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
+++ b/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "computer-use",
-  "version": "0.1.0-linux-alpha1",
+  "version": "0.1.1-linux-alpha1",
   "description": "Control desktop apps on Linux from Codex through Computer Use.",
   "author": {
     "name": "avifenesh"

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -1015,6 +1015,95 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxComputerUseFeaturePatch(currentSource) {
+  const patchedFeaturePattern =
+    /function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,\{env:[A-Za-z_$][\w$]*=process\.env,platform:[A-Za-z_$][\w$]*=process\.platform\}=\{\}\)\{return [A-Za-z_$][\w$]*===`linux`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:/;
+  const windowsOnlyFeaturePattern =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{env:([A-Za-z_$][\w$]*)=process\.env,platform:([A-Za-z_$][\w$]*)=process\.platform\}=\{\}\)\{return \4!==`win32`\|\|\3\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?\2:\{\.\.\.\2,computerUse:!0,computerUseNodeRepl:!0\}\}/;
+
+  if (patchedFeaturePattern.test(currentSource)) {
+    return currentSource;
+  }
+
+  if (windowsOnlyFeaturePattern.test(currentSource)) {
+    return currentSource.replace(
+      windowsOnlyFeaturePattern,
+      (_, fnName, featuresVar, envVar, platformVar) =>
+        `function ${fnName}(${featuresVar},{env:${envVar}=process.env,platform:${platformVar}=process.platform}={}){return ${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}!==\`win32\`||${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==\`1\`?${featuresVar}:{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}}`,
+    );
+  }
+
+  if (currentSource.includes("CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE")) {
+    console.warn(
+      "WARN: Could not find Computer Use desktop feature gate — skipping Linux Computer Use feature patch",
+    );
+  }
+
+  return currentSource;
+}
+
+function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const platformPredicateNeedle = "function hae(e){return e===`macOS`||e===`windows`}";
+  const platformPredicatePatch =
+    "function hae(e){return e===`macOS`||e===`windows`||e===`linux`}";
+  if (patchedSource.includes(platformPredicatePatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(platformPredicateNeedle)) {
+    patchedSource = patchedSource.replace(platformPredicateNeedle, platformPredicatePatch);
+  }
+
+  const availabilityNeedle =
+    "let m=a&&i&&s===`electron`&&u&&(c||p),h=m&&!c&&f.enabled&&!f.isLoading,g=m&&f.isLoading,_=m&&(c||f.isLoading),v;";
+  const availabilityHostLocalLinuxPatch =
+    "let m=a&&i&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;";
+  const availabilityPatch =
+    "let m=a&&(i||l===`linux`)&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;";
+  if (patchedSource.includes(availabilityPatch)) {
+    return patchedSource;
+  }
+
+  if (patchedSource.includes(availabilityHostLocalLinuxPatch)) {
+    return patchedSource.replace(availabilityHostLocalLinuxPatch, availabilityPatch);
+  }
+
+  if (patchedSource.includes(availabilityNeedle)) {
+    return patchedSource.replace(availabilityNeedle, availabilityPatch);
+  }
+
+  if (currentSource.includes("featureName:`computer_use`") && currentSource.includes("isComputerUseAvailable")) {
+    console.warn(
+      "WARN: Could not find Computer Use renderer availability gate — skipping Linux Computer Use UI availability patch",
+    );
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxComputerUseInstallFlowPatch(currentSource) {
+  const availabilityNeedle =
+    "ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled,";
+  const availabilityPatch =
+    "ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled||navigator.userAgent.includes(`Linux`),";
+
+  if (currentSource.includes(availabilityPatch)) {
+    return currentSource;
+  }
+
+  if (currentSource.includes(availabilityNeedle)) {
+    return currentSource.replace(availabilityNeedle, availabilityPatch);
+  }
+
+  if (currentSource.includes("featureName:`computer_use`")) {
+    console.warn(
+      "WARN: Could not find Computer Use install flow gate — skipping Linux Computer Use install flow patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function applyBrowserAnnotationScreenshotPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -1428,6 +1517,7 @@ function patchMainBundleSource(source, iconAsset) {
   patched = applyLinuxFileManagerPatch(patched);
   patched = applyLinuxTrayPatch(patched, iconPathExpression);
   patched = applyLinuxSingleInstancePatch(patched);
+  patched = applyLinuxComputerUseFeaturePatch(patched);
   patched = applyLinuxComputerUsePluginGatePatch(patched);
   patched = applyLinuxTrayCloseSettingPatch(patched);
   patched = applyLinuxSettingsPersistencePatch(patched);
@@ -1541,6 +1631,26 @@ function patchExtractedApp(extractedDir) {
       "assets",
     )} — skipping translucent sidebar default patch`,
   );
+  patchAssetFiles(
+    extractedDir,
+    /^use-model-settings-.*\.js$/,
+    applyLinuxComputerUseRendererAvailabilityPatch,
+    `WARN: Could not find model settings bundle in ${path.join(
+      extractedDir,
+      "webview",
+      "assets",
+    )} — skipping Linux Computer Use UI availability patch`,
+  );
+  patchAssetFiles(
+    extractedDir,
+    /^use-plugin-install-flow-.*\.js$/,
+    applyLinuxComputerUseInstallFlowPatch,
+    `WARN: Could not find plugin install flow bundle in ${path.join(
+      extractedDir,
+      "webview",
+      "assets",
+    )} — skipping Linux Computer Use install flow patch`,
+  );
   patchKeybindsSettingsAssets(extractedDir);
 
   const desktopName = patchPackageJson(extractedDir);
@@ -1573,6 +1683,9 @@ module.exports = {
   applyKeybindsSettingsSectionsPatch,
   applyKeybindsSettingsSharedPatch,
   applyLinuxComputerUsePluginGatePatch,
+  applyLinuxComputerUseFeaturePatch,
+  applyLinuxComputerUseRendererAvailabilityPatch,
+  applyLinuxComputerUseInstallFlowPatch,
   applyLinuxFileManagerPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -7,7 +7,10 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  applyLinuxComputerUseFeaturePatch,
+  applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
+  applyLinuxComputerUseRendererAvailabilityPatch,
   applyLinuxFileManagerPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,
@@ -65,6 +68,22 @@ function computerUseGateBundleFixture() {
     "var Qt=`openai-bundled`,$t=`browser-use`,en=`chrome-internal`,tn=`computer-use`,nn=`latex-tectonic`;",
     "var $n=[{forceReload:!0,installWhenMissing:!0,name:$t,isEnabled:({features:e})=>e.browserAgentAvailable,migrate:cn},{name:en,isEnabled:({buildFlavor:e})=>rn(e)},{name:tn,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:wn},{name:nn,isEnabled:()=>!0}];",
   ].join("");
+}
+
+function computerUseFeatureBundleFixture() {
+  return "function me(e,{env:t=process.env,platform:n=process.platform}={}){return n!==`win32`||t.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`?e:{...e,computerUse:!0,computerUseNodeRepl:!0}}";
+}
+
+function computerUseRendererAvailabilityBundleFixture() {
+  return [
+    "function hae(e){return e===`macOS`||e===`windows`}",
+    "function LS(e){let t=(0,q.c)(10),{hostId:n,featureName:r,defaultEnabled:i}=e,a=i===void 0?!0:i,{data:o,isLoading:s}=N(Wa,n),c;t[0]===o?c=t[1]:(c=o===void 0?[]:o,t[0]=o,t[1]=c);let l=c,u;if(t[2]!==r||t[3]!==l){let e;t[5]===r?e=t[6]:(e=e=>e.name===r,t[5]=r,t[6]=e),u=l.find(e),t[2]=r,t[3]=l,t[4]=u}else u=t[4];let d=u?.enabled??a,f;return t[7]!==s||t[8]!==d?(f={enabled:d,isLoading:s},t[7]=s,t[8]=d,t[9]=f):f=t[9],f}",
+    "function RS(e){let t=(0,q.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,o=r===void 0?R:r,s=Kn(),{isLoading:c,platform:l}=Hr(),u=Vn(`1506311413`),d;t[0]===o?d=t[1]:(d={featureName:`computer_use`,hostId:o},t[0]=o,t[1]=d);let f=LS(d),p;t[2]===l?p=t[3]:(p=hae(l),t[2]=l,t[3]=p);let m=a&&i&&s===`electron`&&u&&(c||p),h=m&&!c&&f.enabled&&!f.isLoading,g=m&&f.isLoading,_=m&&(c||f.isLoading),v;return t[4]!==h||t[5]!==g||t[6]!==_?(v={available:h,isFetching:g,isLoading:_},t[4]=h,t[5]=g,t[6]=_,t[7]=v):v=t[7],v}",
+  ].join("");
+}
+
+function computerUseInstallFlowBundleFixture() {
+  return "function Qe({forceReloadPlugins:e,hostId:t}){let ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled,[L,R]=(0,Z.useState)({});return re}";
 }
 
 function currentLaunchActionBundleFixture() {
@@ -441,6 +460,44 @@ test("fails hard when the Computer Use gate is recognizable but unpatchable", ()
   assert.throws(
     () => applyLinuxComputerUsePluginGatePatch("var tn=`computer-use`;var x=[{name:tn,isEnabled:({features:e,platform:t})=>isMac(t)&&e.computerUse,migrate:wn}];"),
     /Required Linux Computer Use plugin gate patch failed/,
+  );
+});
+
+test("enables Computer Use desktop features on Linux", () => {
+  const patched = applyPatchTwice(
+    applyLinuxComputerUseFeaturePatch,
+    computerUseFeatureBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /return n===`linux`\?\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}:n!==`win32`\|\|t\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?e:\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}/,
+  );
+  assert.match(patched, /CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE/);
+});
+
+test("shows Computer Use plugin UI on Linux without the upstream rollout flag", () => {
+  const patched = applyPatchTwice(
+    applyLinuxComputerUseRendererAvailabilityPatch,
+    computerUseRendererAvailabilityBundleFixture(),
+  );
+
+  assert.match(patched, /function hae\(e\)\{return e===`macOS`\|\|e===`windows`\|\|e===`linux`\}/);
+  assert.match(
+    patched,
+    /let m=a&&\(i\|\|l===`linux`\)&&s===`electron`&&\(l===`linux`\|\|u&&\(c\|\|p\)\),h=m&&!c&&\(l===`linux`\|\|f\.enabled\)&&!f\.isLoading,g=m&&l!==`linux`&&f\.isLoading,_=m&&\(c\|\|l!==`linux`&&f\.isLoading\),v;/,
+  );
+});
+
+test("allows Computer Use install flow on Linux", () => {
+  const patched = applyPatchTwice(
+    applyLinuxComputerUseInstallFlowPatch,
+    computerUseInstallFlowBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /re=!ne\.isLoading&&ne\.enabled\|\|navigator\.userAgent\.includes\(`Linux`\)/,
   );
 });
 


### PR DESCRIPTION
## Summary
- fix Linux pointer input by preferring the Wayland remote desktop portal for click, scroll, and drag
- keep raw pixel coordinates for ydotool fallback instead of remapping screenshot pixels into 0..65535 absolute space
- enable the remaining Linux Computer Use desktop/UI/install gates in the app patcher

## What changed
- add `computer-use-linux/src/remote_desktop.rs` for `org.freedesktop.portal.RemoteDesktop` + `ScreenCast` pointer sessions
- update `click`, `scroll`, and `drag` in `computer-use-linux/src/server.rs` to use the portal on Wayland and fall back to ydotool otherwise
- add a small inter-command delay for ydotool pointer sequences
- bump the bundled plugin version to `0.1.1-linux-alpha1`
- patch the Electron app bundles so Linux enables Computer Use desktop features and shows the UI/install flow

## Validation
- `cargo check --manifest-path computer-use-linux/Cargo.toml`
- `cargo test --manifest-path computer-use-linux/Cargo.toml` (`44/44`)
- `cargo build --release --manifest-path computer-use-linux/Cargo.toml`
- `node --test scripts/patch-linux-window-ui.test.js` (`31/31`)

## Live verification
Tested locally on GNOME 50.1 / Wayland:
- the previous ydotool path could jump into the GNOME hot corner / overview because the fallback was using remapped absolute coordinates
- with the portal path warm, `click`, `scroll`, and `drag` produced real mouse event bytes inside a local Ghostty terminal instead of landing in the top-left overview corner
