### PR TITLE
feat(computer-use): add Linux AT-SPI actions and window targeting

### DIFF
--- a/computer-use-linux/src/atspi_tree.rs
+++ b/computer-use-linux/src/atspi_tree.rs
@@ -8,12 +8,17 @@ use atspi::{
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::VecDeque;
-use zbus::{names::UniqueName, zvariant::ObjectPath};
+use zbus::{
+    fdo::DBusProxy,
+    names::{BusName, UniqueName},
+    zvariant::ObjectPath,
+};
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct AccessibleAppSummary {
     pub object_ref: String,
     pub name: Option<String>,
+    pub pid: Option<u32>,
     pub role: String,
     pub child_count: i32,
     pub bounds: Option<Bounds>,
@@ -76,11 +81,12 @@ pub enum ValueSetInvocation {
 pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSummary>> {
     let conn = connect().await?;
     let roots = registry_children(&conn).await?;
+    let dbus = DBusProxy::new(conn.connection()).await.ok();
     let mut apps = Vec::new();
 
     for object_ref in roots.into_iter().take(limit) {
         if let Ok(proxy) = conn.object_as_accessible(&object_ref).await {
-            apps.push(read_app_summary(&proxy, &object_ref).await);
+            apps.push(read_app_summary(&proxy, &object_ref, dbus.as_ref()).await);
         }
     }
 
@@ -89,12 +95,14 @@ pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSumma
 
 pub async fn snapshot_tree(
     app_name_or_bundle_identifier: Option<&str>,
+    target_pid: Option<u32>,
     max_nodes: usize,
     max_depth: u32,
 ) -> Result<Vec<AccessibilityNode>> {
     let conn = connect().await?;
     let roots = registry_children(&conn).await?;
-    let selected_roots = select_roots(&conn, roots, app_name_or_bundle_identifier).await;
+    let selected_roots =
+        select_roots(&conn, roots, app_name_or_bundle_identifier, target_pid).await;
     let mut nodes = Vec::new();
     let mut queue = VecDeque::new();
 
@@ -226,18 +234,53 @@ async fn select_roots(
     conn: &AccessibilityConnection,
     roots: Vec<ObjectRefOwned>,
     app_name_or_bundle_identifier: Option<&str>,
+    target_pid: Option<u32>,
 ) -> Vec<ObjectRefOwned> {
-    let Some(needle) = app_name_or_bundle_identifier
+    let needle = app_name_or_bundle_identifier
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(|value| value.to_ascii_lowercase())
-    else {
-        return roots;
+        .map(|value| value.to_ascii_lowercase());
+    let dbus = DBusProxy::new(conn.connection()).await.ok();
+    let mut remaining = roots;
+
+    if let Some(target_pid) = target_pid {
+        let mut pid_and_filter_matches = Vec::new();
+        let mut pid_matches = Vec::new();
+        let mut non_pid_matches = Vec::new();
+
+        for object_ref in remaining {
+            if object_ref_pid(dbus.as_ref(), &object_ref).await == Some(target_pid) {
+                if let Some(needle) = needle.as_deref() {
+                    if root_matches(conn, &object_ref, needle).await {
+                        pid_and_filter_matches.push(object_ref);
+                    } else {
+                        pid_matches.push(object_ref);
+                    }
+                } else {
+                    pid_matches.push(object_ref);
+                }
+            } else {
+                non_pid_matches.push(object_ref);
+            }
+        }
+
+        if !pid_and_filter_matches.is_empty() {
+            return pid_and_filter_matches;
+        }
+        if !pid_matches.is_empty() {
+            return pid_matches;
+        }
+
+        remaining = non_pid_matches;
+    }
+
+    let Some(needle) = needle.as_deref() else {
+        return remaining;
     };
 
     let mut selected = Vec::new();
-    for object_ref in roots {
-        if root_matches(conn, &object_ref, &needle).await {
+    for object_ref in remaining {
+        if root_matches(conn, &object_ref, needle).await {
             selected.push(object_ref);
         }
     }
@@ -288,10 +331,12 @@ async fn proxy_matches(
 async fn read_app_summary(
     proxy: &AccessibleProxy<'_>,
     object_ref: &ObjectRefOwned,
+    dbus: Option<&DBusProxy<'_>>,
 ) -> AccessibleAppSummary {
     AccessibleAppSummary {
         object_ref: object_ref_id(object_ref),
         name: optional_string(proxy.name().await.ok()),
+        pid: object_ref_pid(dbus, object_ref).await,
         role: role_name(proxy).await,
         child_count: proxy.child_count().await.unwrap_or_default(),
         bounds: bounds(proxy).await,
@@ -338,6 +383,12 @@ async fn role_name(proxy: &AccessibleProxy<'_>) -> String {
 
 async fn bounds(proxy: &AccessibleProxy<'_>) -> Option<Bounds> {
     bounds_from_proxies(proxy.proxies().await.ok().as_ref(), proxy).await
+}
+
+async fn object_ref_pid(dbus: Option<&DBusProxy<'_>>, object_ref: &ObjectRefOwned) -> Option<u32> {
+    let dbus = dbus?;
+    let bus_name = BusName::try_from(object_ref.name_as_str()?.to_string()).ok()?;
+    dbus.get_connection_unix_process_id(bus_name).await.ok()
 }
 
 async fn bounds_from_proxies(

--- a/computer-use-linux/src/atspi_tree.rs
+++ b/computer-use-linux/src/atspi_tree.rs
@@ -1,13 +1,14 @@
 use crate::diagnostics::hydrate_session_bus_env;
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use atspi::{
     connection::P2P,
     proxy::{accessible::AccessibleProxy, proxy_ext::ProxyExt},
-    AccessibilityConnection, CoordType, ObjectRefOwned,
+    AccessibilityConnection, CoordType, ObjectRef, ObjectRefOwned,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::collections::VecDeque;
+use zbus::{names::UniqueName, zvariant::ObjectPath};
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct AccessibleAppSummary {
@@ -29,6 +30,9 @@ pub struct AccessibilityNode {
     pub description: Option<String>,
     pub child_count: i32,
     pub bounds: Option<Bounds>,
+    pub actions: Vec<AccessibilityAction>,
+    pub value: Option<AccessibilityValue>,
+    pub supports_editable_text: bool,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -37,6 +41,36 @@ pub struct Bounds {
     pub y: i32,
     pub width: i32,
     pub height: i32,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AccessibilityAction {
+    pub index: i32,
+    pub name: String,
+    pub description: String,
+    pub keybinding: String,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AccessibilityValue {
+    pub current: f64,
+    pub minimum: f64,
+    pub maximum: f64,
+    pub minimum_increment: f64,
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ActionInvocation {
+    pub action_index: i32,
+    pub action_name: Option<String>,
+    pub ok: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum ValueSetInvocation {
+    Numeric { value: f64 },
+    EditableText,
 }
 
 pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSummary>> {
@@ -91,6 +125,84 @@ pub async fn snapshot_tree(
     }
 
     Ok(nodes)
+}
+
+pub async fn perform_action(
+    object_ref_id: &str,
+    requested_action: Option<&str>,
+) -> Result<ActionInvocation> {
+    let conn = connect().await?;
+    let object_ref = object_ref_from_id(object_ref_id)?;
+    let proxy = conn
+        .object_as_accessible(&object_ref)
+        .await
+        .with_context(|| format!("failed to open AT-SPI object {object_ref_id}"))?;
+    let action = proxy
+        .proxies()
+        .await?
+        .action()
+        .await
+        .context("element does not expose the AT-SPI Action interface")?;
+    let actions = action.get_actions().await.unwrap_or_default();
+    let action_index = select_action_index(&actions, requested_action)?;
+    let action_name = actions
+        .get(action_index as usize)
+        .map(|action| action.name.clone());
+    let ok = action
+        .do_action(action_index)
+        .await
+        .with_context(|| format!("failed to invoke AT-SPI action {action_index}"))?;
+
+    Ok(ActionInvocation {
+        action_index,
+        action_name,
+        ok,
+    })
+}
+
+pub async fn set_element_value(object_ref_id: &str, value: &str) -> Result<ValueSetInvocation> {
+    let conn = connect().await?;
+    let object_ref = object_ref_from_id(object_ref_id)?;
+    let proxy = conn
+        .object_as_accessible(&object_ref)
+        .await
+        .with_context(|| format!("failed to open AT-SPI object {object_ref_id}"))?;
+    let proxies = proxy.proxies().await?;
+
+    if let Ok(numeric_value) = value.parse::<f64>() {
+        if let Ok(value_proxy) = proxies.value().await {
+            value_proxy
+                .set_current_value(numeric_value)
+                .await
+                .with_context(|| {
+                    format!("failed to set AT-SPI numeric value to {numeric_value}")
+                })?;
+            return Ok(ValueSetInvocation::Numeric {
+                value: numeric_value,
+            });
+        }
+    }
+
+    if let Ok(editable_text) = proxies.editable_text().await {
+        let ok = editable_text
+            .set_text_contents(value)
+            .await
+            .context("failed to set AT-SPI editable text contents")?;
+        if ok {
+            return Ok(ValueSetInvocation::EditableText);
+        }
+        return Err(anyhow!("AT-SPI EditableText rejected the new contents"));
+    }
+
+    if value.parse::<f64>().is_err() && proxies.value().await.is_ok() {
+        return Err(anyhow!(
+            "element exposes the AT-SPI Value interface, but the requested value is not numeric"
+        ));
+    }
+
+    Err(anyhow!(
+        "element does not expose AT-SPI Value or EditableText interfaces"
+    ))
 }
 
 async fn connect() -> Result<AccessibilityConnection> {
@@ -193,6 +305,8 @@ async fn read_node(
     parent_index: Option<u32>,
     depth: u32,
 ) -> AccessibilityNode {
+    let proxies = proxy.proxies().await.ok();
+
     AccessibilityNode {
         index,
         parent_index,
@@ -202,7 +316,10 @@ async fn read_node(
         name: optional_string(proxy.name().await.ok()),
         description: optional_string(proxy.description().await.ok()),
         child_count: proxy.child_count().await.unwrap_or_default(),
-        bounds: bounds(proxy).await,
+        bounds: bounds_from_proxies(proxies.as_ref(), proxy).await,
+        actions: actions_from_proxies(proxies.as_ref()).await,
+        value: value_from_proxies(proxies.as_ref()).await,
+        supports_editable_text: supports_editable_text(proxies.as_ref()).await,
     }
 }
 
@@ -220,7 +337,20 @@ async fn role_name(proxy: &AccessibleProxy<'_>) -> String {
 }
 
 async fn bounds(proxy: &AccessibleProxy<'_>) -> Option<Bounds> {
-    let proxies = proxy.proxies().await.ok()?;
+    bounds_from_proxies(proxy.proxies().await.ok().as_ref(), proxy).await
+}
+
+async fn bounds_from_proxies(
+    proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>,
+    proxy: &AccessibleProxy<'_>,
+) -> Option<Bounds> {
+    let owned_proxies;
+    let proxies = if let Some(proxies) = proxies {
+        proxies
+    } else {
+        owned_proxies = proxy.proxies().await.ok()?;
+        &owned_proxies
+    };
     let component = proxies.component().await.ok()?;
     let (x, y, width, height) = component.get_extents(CoordType::Screen).await.ok()?;
     Some(Bounds {
@@ -231,10 +361,115 @@ async fn bounds(proxy: &AccessibleProxy<'_>) -> Option<Bounds> {
     })
 }
 
+async fn actions_from_proxies(
+    proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>,
+) -> Vec<AccessibilityAction> {
+    let Some(proxies) = proxies else {
+        return Vec::new();
+    };
+    let Ok(action_proxy) = proxies.action().await else {
+        return Vec::new();
+    };
+
+    action_proxy
+        .get_actions()
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+        .map(|(index, action)| AccessibilityAction {
+            index: index as i32,
+            name: action.name,
+            description: action.description,
+            keybinding: action.keybinding,
+        })
+        .collect()
+}
+
+async fn value_from_proxies(
+    proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>,
+) -> Option<AccessibilityValue> {
+    let value = proxies?.value().await.ok()?;
+    Some(AccessibilityValue {
+        current: value.current_value().await.ok()?,
+        minimum: value.minimum_value().await.ok()?,
+        maximum: value.maximum_value().await.ok()?,
+        minimum_increment: value.minimum_increment().await.ok()?,
+        text: optional_string(value.text().await.ok()),
+    })
+}
+
+async fn supports_editable_text(proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>) -> bool {
+    let Some(proxies) = proxies else {
+        return false;
+    };
+    proxies.editable_text().await.is_ok()
+}
+
+fn select_action_index(actions: &[atspi::Action], requested_action: Option<&str>) -> Result<i32> {
+    if actions.is_empty() {
+        return Err(anyhow!("element exposes no AT-SPI actions"));
+    }
+
+    if let Some(requested_action) = requested_action
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let requested_action = requested_action.to_ascii_lowercase();
+        if let Some((index, _)) = actions.iter().enumerate().find(|(_, action)| {
+            action.name.to_ascii_lowercase() == requested_action
+                || action.description.to_ascii_lowercase() == requested_action
+        }) {
+            return Ok(index as i32);
+        }
+
+        if let Ok(index) = requested_action.parse::<usize>() {
+            if index < actions.len() {
+                return Ok(index as i32);
+            }
+        }
+
+        return Err(anyhow!(
+            "requested AT-SPI action was not found; available actions: {}",
+            actions
+                .iter()
+                .map(|action| action.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+
+    Ok(if actions.len() > 1 { 1 } else { 0 })
+}
+
 fn optional_string(value: Option<String>) -> Option<String> {
     value
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+}
+
+fn object_ref_from_id(object_ref_id: &str) -> Result<ObjectRefOwned> {
+    let (name, path) = split_object_ref_id(object_ref_id)?;
+    let name = UniqueName::try_from(name.to_string())
+        .with_context(|| format!("invalid AT-SPI bus name in object ref {object_ref_id}"))?;
+    let path = ObjectPath::try_from(path.to_string())
+        .with_context(|| format!("invalid AT-SPI object path in object ref {object_ref_id}"))?;
+    Ok(ObjectRef::new_owned(name, path))
+}
+
+fn split_object_ref_id(object_ref_id: &str) -> Result<(&str, &str)> {
+    let Some(path_start) = object_ref_id.find('/') else {
+        return Err(anyhow!(
+            "invalid AT-SPI object ref '{object_ref_id}'; expected ':bus/path'"
+        ));
+    };
+    let (name, path) = object_ref_id.split_at(path_start);
+    if name.is_empty() || path.is_empty() {
+        return Err(anyhow!(
+            "invalid AT-SPI object ref '{object_ref_id}'; expected ':bus/path'"
+        ));
+    }
+    Ok((name, path))
 }
 
 fn object_ref_id(object_ref: &ObjectRefOwned) -> String {
@@ -243,4 +478,53 @@ fn object_ref_id(object_ref: &ObjectRefOwned) -> String {
         object_ref.name_as_str().unwrap_or(""),
         object_ref.path_as_str()
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_object_ref_id_separates_bus_name_and_path() {
+        let (name, path) = split_object_ref_id(":1.42/org/a11y/atspi/accessible/7").unwrap();
+
+        assert_eq!(name, ":1.42");
+        assert_eq!(path, "/org/a11y/atspi/accessible/7");
+    }
+
+    #[test]
+    fn select_action_index_uses_named_action() {
+        let actions = vec![
+            atspi::Action {
+                name: "click".to_string(),
+                description: "Clicks".to_string(),
+                keybinding: String::new(),
+            },
+            atspi::Action {
+                name: "show-menu".to_string(),
+                description: "Shows menu".to_string(),
+                keybinding: String::new(),
+            },
+        ];
+
+        assert_eq!(select_action_index(&actions, Some("show-menu")).unwrap(), 1);
+    }
+
+    #[test]
+    fn select_action_index_defaults_to_secondary_when_available() {
+        let actions = vec![
+            atspi::Action {
+                name: "click".to_string(),
+                description: String::new(),
+                keybinding: String::new(),
+            },
+            atspi::Action {
+                name: "show-menu".to_string(),
+                description: String::new(),
+                keybinding: String::new(),
+            },
+        ];
+
+        assert_eq!(select_action_index(&actions, None).unwrap(), 1);
+    }
 }

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         Some("state") => {
             let app_name_or_bundle_identifier = std::env::args().nth(2);
             let nodes =
-                atspi_tree::snapshot_tree(app_name_or_bundle_identifier.as_deref(), 120, 12)
+                atspi_tree::snapshot_tree(app_name_or_bundle_identifier.as_deref(), None, 120, 12)
                     .await?;
             println!(
                 "{}",

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -171,24 +171,9 @@ impl ComputerUseLinux {
         let max_nodes = params.max_nodes.unwrap_or(120).clamp(1, 500);
         let max_depth = params.max_depth.unwrap_or(12).min(12);
         let include_screenshot = params.include_screenshot.unwrap_or(true);
-        let app_filter = params
-            .app_name_or_bundle_identifier
-            .as_deref()
-            .or_else(|| {
-                window_context
-                    .as_ref()
-                    .and_then(|window| window.app_id.as_deref())
-            })
-            .or_else(|| {
-                window_context
-                    .as_ref()
-                    .and_then(|window| window.wm_class.as_deref())
-            })
-            .or_else(|| {
-                window_context
-                    .as_ref()
-                    .and_then(|window| window.title.as_deref())
-            });
+        let app_filter = self
+            .resolve_accessibility_app_filter(&params, window_context.as_ref())
+            .await;
         let (screenshot, screenshot_error) = if include_screenshot {
             match capture_screenshot().await {
                 Ok(capture) => (Some(capture), None),
@@ -199,7 +184,8 @@ impl ComputerUseLinux {
         };
         let (accessibility_tree, accessibility_error) =
             if diagnostics.readiness.can_build_accessibility_tree {
-                match snapshot_tree(app_filter, max_nodes, max_depth).await {
+                let target_pid = window_context.as_ref().and_then(|window| window.pid);
+                match snapshot_tree(app_filter.as_deref(), target_pid, max_nodes, max_depth).await {
                     Ok(nodes) => (nodes, None),
                     Err(error) => (Vec::new(), Some(error.to_string())),
                 }
@@ -1038,6 +1024,31 @@ impl ComputerUseLinux {
         }
     }
 
+    async fn resolve_accessibility_app_filter(
+        &self,
+        params: &GetAppStateParams,
+        window_context: Option<&WindowInfo>,
+    ) -> Option<String> {
+        if let Some(explicit) = trimmed_nonempty(params.app_name_or_bundle_identifier.as_deref()) {
+            return Some(explicit.to_string());
+        }
+
+        let target_pid = window_context.and_then(|window| window.pid).or(params.pid);
+        let candidates = accessibility_filter_candidates(window_context);
+
+        if let Some(target_pid) = target_pid {
+            if let Ok(apps) = list_accessible_apps(200).await {
+                if let Some(object_ref) =
+                    select_accessibility_object_ref(&apps, target_pid, &candidates)
+                {
+                    return Some(object_ref);
+                }
+            }
+        }
+
+        candidates.into_iter().next()
+    }
+
     async fn focus_target_for_input(
         &self,
         target: &WindowTarget,
@@ -1153,6 +1164,76 @@ impl ComputerUseLinux {
                 )
             })
     }
+}
+
+fn select_accessibility_object_ref(
+    apps: &[AccessibleAppSummary],
+    target_pid: u32,
+    candidates: &[String],
+) -> Option<String> {
+    let mut pid_matches = apps.iter().filter(|app| app.pid == Some(target_pid));
+    let first = pid_matches.next()?;
+    let second = pid_matches.next();
+
+    if second.is_none() {
+        return Some(first.object_ref.clone());
+    }
+
+    let lowered_candidates = candidates
+        .iter()
+        .map(|candidate| candidate.to_ascii_lowercase())
+        .collect::<Vec<_>>();
+
+    apps.iter()
+        .filter(|app| app.pid == Some(target_pid))
+        .find(|app| {
+            let name = app.name.as_deref().unwrap_or_default().to_ascii_lowercase();
+            lowered_candidates
+                .iter()
+                .any(|candidate| !candidate.is_empty() && name.contains(candidate))
+        })
+        .map(|app| app.object_ref.clone())
+        .or_else(|| Some(first.object_ref.clone()))
+}
+
+fn accessibility_filter_candidates(window_context: Option<&WindowInfo>) -> Vec<String> {
+    let Some(window) = window_context else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    push_candidate(&mut candidates, window.title.as_deref());
+    push_candidate(&mut candidates, window.wm_class.as_deref());
+
+    if let Some(app_id) = trimmed_nonempty(window.app_id.as_deref()) {
+        if !app_id.starts_with("window:") {
+            push_candidate(&mut candidates, Some(app_id));
+            if let Some(stripped) = app_id.strip_suffix(".desktop") {
+                push_candidate(&mut candidates, Some(stripped));
+                let normalized = stripped.replace(['-', '_', '.'], " ");
+                push_candidate(&mut candidates, Some(normalized.as_str()));
+            } else {
+                let normalized = app_id.replace(['-', '_', '.'], " ");
+                push_candidate(&mut candidates, Some(normalized.as_str()));
+            }
+        }
+    }
+
+    candidates
+}
+
+fn push_candidate(candidates: &mut Vec<String>, value: Option<&str>) {
+    let Some(value) = trimmed_nonempty(value) else {
+        return;
+    };
+
+    if !candidates.iter().any(|candidate| candidate == value) {
+        candidates.push(value.to_string());
+    }
+}
+
+fn trimmed_nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
 }
 
 fn action_result(
@@ -1520,6 +1601,7 @@ fn looks_like_desktop_app(name: &str, command: &str) -> bool {
 mod tests {
     use super::*;
     use crate::atspi_tree::Bounds;
+    use crate::windows::WindowBounds;
 
     fn node(index: u32, bounds: Option<Bounds>) -> AccessibilityNode {
         AccessibilityNode {
@@ -1536,6 +1618,89 @@ mod tests {
             value: None,
             supports_editable_text: false,
         }
+    }
+
+    fn window_info(
+        window_id: u64,
+        title: Option<&str>,
+        app_id: Option<&str>,
+        wm_class: Option<&str>,
+        pid: Option<u32>,
+    ) -> WindowInfo {
+        WindowInfo {
+            window_id,
+            title: title.map(str::to_string),
+            app_id: app_id.map(str::to_string),
+            wm_class: wm_class.map(str::to_string),
+            pid,
+            bounds: Some(WindowBounds {
+                x: Some(10),
+                y: Some(20),
+                width: 800,
+                height: 600,
+            }),
+            workspace: Some(0),
+            focused: false,
+            hidden: false,
+            client_type: Some("wayland".to_string()),
+            backend: GNOME_SHELL_EXTENSION_BACKEND.to_string(),
+            terminal: None,
+        }
+    }
+
+    #[test]
+    fn accessibility_filter_candidates_prefer_title_and_skip_synthetic_app_id() {
+        let window = window_info(
+            42,
+            Some("CU ATSPI GTK Test"),
+            Some("window:46"),
+            Some("cu_atspi_gtk_test.py"),
+            Some(2914326),
+        );
+
+        let candidates = accessibility_filter_candidates(Some(&window));
+
+        assert_eq!(
+            candidates,
+            vec![
+                "CU ATSPI GTK Test".to_string(),
+                "cu_atspi_gtk_test.py".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn select_accessibility_object_ref_prefers_exact_pid_match() {
+        let apps = vec![
+            AccessibleAppSummary {
+                object_ref: ":1.31/org/a11y/atspi/accessible/root".to_string(),
+                name: Some("electron".to_string()),
+                pid: Some(2774076),
+                role: "application".to_string(),
+                child_count: 1,
+                bounds: None,
+            },
+            AccessibleAppSummary {
+                object_ref: ":1.64/org/a11y/atspi/accessible/root".to_string(),
+                name: Some("cu_atspi_gtk_test.py".to_string()),
+                pid: Some(2914326),
+                role: "application".to_string(),
+                child_count: 1,
+                bounds: None,
+            },
+        ];
+
+        let object_ref = select_accessibility_object_ref(
+            &apps,
+            2914326,
+            &[
+                "CU ATSPI GTK Test".to_string(),
+                "cu_atspi_gtk_test.py".to_string(),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(object_ref, ":1.64/org/a11y/atspi/accessible/root");
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -1,5 +1,6 @@
 use crate::atspi_tree::{
-    list_accessible_apps, snapshot_tree, AccessibilityNode, AccessibleAppSummary,
+    list_accessible_apps, perform_action, set_element_value, snapshot_tree, AccessibilityNode,
+    AccessibleAppSummary, ValueSetInvocation,
 };
 use crate::diagnostics::{doctor_report, setup_accessibility_report, DoctorReport, SetupReport};
 use crate::gnome_extension::{setup_window_targeting_report, WindowTargetingSetupReport};
@@ -211,7 +212,9 @@ impl ComputerUseLinux {
                     ),
                 )
             };
-        self.cache_nodes(&accessibility_tree);
+        if accessibility_error.is_none() {
+            self.cache_nodes(&accessibility_tree);
+        }
         let mut message = if let Some(error) = &accessibility_error {
             format!("MCP registration is working, but AT-SPI tree extraction failed: {error}")
         } else if let Some(capture) = &screenshot {
@@ -338,27 +341,111 @@ impl ComputerUseLinux {
         name = "perform_secondary_action",
         description = "Invoke a secondary accessibility action exposed by an element."
     )]
-    fn perform_secondary_action(
+    async fn perform_secondary_action(
         &self,
         Parameters(params): Parameters<SecondaryActionParams>,
     ) -> Json<ActionOutput> {
-        Json(not_implemented(
-            "perform_secondary_action",
-            Some(serde_json::json!(params)),
-            "AT-SPI secondary actions need the element action cache and are not wired yet.",
-        ))
+        let received = Some(serde_json::json!(params.clone()));
+        let object_ref = match self
+            .resolve_object_ref(params.element_index, params.element_identifier.as_deref())
+        {
+            Ok(object_ref) => object_ref,
+            Err(message) => {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "perform_secondary_action".to_string(),
+                    message,
+                    received,
+                });
+            }
+        };
+
+        match perform_action(&object_ref, params.action.as_deref()).await {
+            Ok(invocation) => Json(ActionOutput {
+                ok: invocation.ok,
+                implemented: true,
+                action: "perform_secondary_action".to_string(),
+                message: if invocation.ok {
+                    format!(
+                        "AT-SPI action {} ({}) invoked.",
+                        invocation.action_index,
+                        invocation
+                            .action_name
+                            .as_deref()
+                            .filter(|name| !name.is_empty())
+                            .unwrap_or("unnamed")
+                    )
+                } else {
+                    format!(
+                        "AT-SPI action {} ({}) returned false.",
+                        invocation.action_index,
+                        invocation
+                            .action_name
+                            .as_deref()
+                            .filter(|name| !name.is_empty())
+                            .unwrap_or("unnamed")
+                    )
+                },
+                received,
+            }),
+            Err(error) => Json(ActionOutput {
+                ok: false,
+                implemented: true,
+                action: "perform_secondary_action".to_string(),
+                message: error.to_string(),
+                received,
+            }),
+        }
     }
 
     #[tool(
         name = "set_value",
         description = "Set the value of a settable accessibility element."
     )]
-    fn set_value(&self, Parameters(params): Parameters<SetValueParams>) -> Json<ActionOutput> {
-        Json(not_implemented(
-            "set_value",
-            Some(serde_json::json!(params)),
-            "AT-SPI value setting needs the element value cache and is not wired yet.",
-        ))
+    async fn set_value(
+        &self,
+        Parameters(params): Parameters<SetValueParams>,
+    ) -> Json<ActionOutput> {
+        let received = Some(serde_json::json!(params.clone()));
+        let object_ref = match self
+            .resolve_object_ref(params.element_index, params.element_identifier.as_deref())
+        {
+            Ok(object_ref) => object_ref,
+            Err(message) => {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "set_value".to_string(),
+                    message,
+                    received,
+                });
+            }
+        };
+
+        match set_element_value(&object_ref, &params.value).await {
+            Ok(ValueSetInvocation::Numeric { value }) => Json(ActionOutput {
+                ok: true,
+                implemented: true,
+                action: "set_value".to_string(),
+                message: format!("AT-SPI numeric value set to {value}."),
+                received,
+            }),
+            Ok(ValueSetInvocation::EditableText) => Json(ActionOutput {
+                ok: true,
+                implemented: true,
+                action: "set_value".to_string(),
+                message: "AT-SPI editable text contents set.".to_string(),
+                received,
+            }),
+            Err(error) => Json(ActionOutput {
+                ok: false,
+                implemented: true,
+                action: "set_value".to_string(),
+                message: error.to_string(),
+                received,
+            }),
+        }
     }
 
     #[tool(
@@ -593,7 +680,7 @@ impl ComputerUseLinux {
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -1033,19 +1120,38 @@ impl ComputerUseLinux {
         }
         Some((bounds.x + bounds.width / 2, bounds.y + bounds.height / 2))
     }
-}
 
-fn not_implemented(
-    action: &str,
-    received: Option<serde_json::Value>,
-    message: &str,
-) -> ActionOutput {
-    ActionOutput {
-        ok: false,
-        implemented: false,
-        action: action.to_string(),
-        message: message.to_string(),
-        received,
+    fn resolve_object_ref(
+        &self,
+        element_index: Option<u32>,
+        element_identifier: Option<&str>,
+    ) -> std::result::Result<String, String> {
+        if let Some(element_identifier) = element_identifier
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(element_identifier.to_string());
+        }
+
+        let Some(element_index) = element_index else {
+            return Err(
+                "Pass element_index from the latest get_app_state result or element_identifier."
+                    .to_string(),
+            );
+        };
+
+        let cached = self.last_nodes.lock().map_err(|_| {
+            "Could not read cached accessibility nodes. Call get_app_state and retry.".to_string()
+        })?;
+        cached
+            .iter()
+            .find(|node| node.index == element_index)
+            .map(|node| node.object_ref.clone())
+            .ok_or_else(|| {
+                format!(
+                    "No cached accessibility node for element_index {element_index}. Call get_app_state first."
+                )
+            })
     }
 }
 
@@ -1426,6 +1532,9 @@ mod tests {
             description: None,
             child_count: 0,
             bounds,
+            actions: Vec::new(),
+            value: None,
+            supports_editable_text: false,
         }
     }
 
@@ -1571,5 +1680,27 @@ mod tests {
             key_sequence("Super"),
             Some(vec!["125:1".to_string(), "125:0".to_string()])
         );
+    }
+
+    #[test]
+    fn element_identifier_overrides_cached_object_ref() {
+        let backend = ComputerUseLinux::default();
+        backend.cache_nodes(&[node(7, None)]);
+
+        let object_ref = backend
+            .resolve_object_ref(Some(7), Some(":1.99/org/a11y/atspi/accessible/3"))
+            .unwrap();
+
+        assert_eq!(object_ref, ":1.99/org/a11y/atspi/accessible/3");
+    }
+
+    #[test]
+    fn element_index_resolves_to_cached_object_ref() {
+        let backend = ComputerUseLinux::default();
+        backend.cache_nodes(&[node(7, None)]);
+
+        let object_ref = backend.resolve_object_ref(Some(7), None).unwrap();
+
+        assert_eq!(object_ref, ":1.7/org/a11y/atspi/accessible/7");
     }
 }


### PR DESCRIPTION
## Summary
- add Linux AT-SPI action and editable-value support to the Computer Use backend
- resolve `element_index` back to cached AT-SPI object refs so `set_value` and actions can target real nodes
- prefer exact PID/window-root matching when resolving AT-SPI trees for `get_app_state(window_id=...)` and `get_app_state(pid=...)`

## Validation
- `cargo fmt --all --check`
- `cargo test --manifest-path computer-use-linux/Cargo.toml`
- `cargo clippy --manifest-path computer-use-linux/Cargo.toml --all-targets -- -D warnings`

## Notes
- this keeps the local-only Linux Computer Use UI opt-in work out of the PR
- follow-up ergonomics/readback improvements can stay separate
