### PR TITLE
feat(computer-use): compact Linux AT-SPI state readback

### DIFF
--- a/computer-use-linux/src/atspi_tree.rs
+++ b/computer-use-linux/src/atspi_tree.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context, Result};
 use atspi::{
     connection::P2P,
     proxy::{accessible::AccessibleProxy, proxy_ext::ProxyExt},
-    AccessibilityConnection, CoordType, ObjectRef, ObjectRefOwned,
+    AccessibilityConnection, CoordType, ObjectRef, ObjectRefOwned, StateSet,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -35,8 +35,10 @@ pub struct AccessibilityNode {
     pub description: Option<String>,
     pub child_count: i32,
     pub bounds: Option<Bounds>,
+    pub states: Vec<String>,
     pub actions: Vec<AccessibilityAction>,
     pub value: Option<AccessibilityValue>,
+    pub text: Option<AccessibilityText>,
     pub supports_editable_text: bool,
 }
 
@@ -65,6 +67,21 @@ pub struct AccessibilityValue {
     pub text: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AccessibilityText {
+    pub character_count: i32,
+    pub caret_offset: Option<i32>,
+    pub content: Option<String>,
+    pub truncated: bool,
+    pub selections: Vec<AccessibilityTextSelection>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct AccessibilityTextSelection {
+    pub start_offset: i32,
+    pub end_offset: i32,
+}
+
 #[derive(Debug, Clone)]
 pub struct ActionInvocation {
     pub action_index: i32,
@@ -77,6 +94,9 @@ pub enum ValueSetInvocation {
     Numeric { value: f64 },
     EditableText,
 }
+
+const MAX_TEXT_READBACK_CHARS: i32 = 4096;
+const MAX_TEXT_SELECTIONS: i32 = 8;
 
 pub async fn list_accessible_apps(limit: usize) -> Result<Vec<AccessibleAppSummary>> {
     let conn = connect().await?;
@@ -362,8 +382,10 @@ async fn read_node(
         description: optional_string(proxy.description().await.ok()),
         child_count: proxy.child_count().await.unwrap_or_default(),
         bounds: bounds_from_proxies(proxies.as_ref(), proxy).await,
+        states: states_from_proxy(proxy).await,
         actions: actions_from_proxies(proxies.as_ref()).await,
         value: value_from_proxies(proxies.as_ref()).await,
+        text: text_from_proxies(proxies.as_ref()).await,
         supports_editable_text: supports_editable_text(proxies.as_ref()).await,
     }
 }
@@ -437,6 +459,14 @@ async fn actions_from_proxies(
         .collect()
 }
 
+async fn states_from_proxy(proxy: &AccessibleProxy<'_>) -> Vec<String> {
+    proxy
+        .get_state()
+        .await
+        .map(state_labels)
+        .unwrap_or_default()
+}
+
 async fn value_from_proxies(
     proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>,
 ) -> Option<AccessibilityValue> {
@@ -450,11 +480,51 @@ async fn value_from_proxies(
     })
 }
 
+async fn text_from_proxies(
+    proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>,
+) -> Option<AccessibilityText> {
+    let text = proxies?.text().await.ok()?;
+    let character_count = text.character_count().await.ok()?.max(0);
+    let caret_offset = text.caret_offset().await.ok();
+    let capped_count = character_count.min(MAX_TEXT_READBACK_CHARS);
+    let content = if capped_count > 0 {
+        optional_string(text.get_text(0, capped_count).await.ok())
+    } else {
+        None
+    };
+    let selection_count = text
+        .get_nselections()
+        .await
+        .unwrap_or_default()
+        .clamp(0, MAX_TEXT_SELECTIONS);
+    let mut selections = Vec::new();
+    for index in 0..selection_count {
+        if let Ok((start_offset, end_offset)) = text.get_selection(index).await {
+            selections.push(AccessibilityTextSelection {
+                start_offset,
+                end_offset,
+            });
+        }
+    }
+
+    Some(AccessibilityText {
+        character_count,
+        caret_offset,
+        content,
+        truncated: character_count > MAX_TEXT_READBACK_CHARS,
+        selections,
+    })
+}
+
 async fn supports_editable_text(proxies: Option<&atspi::proxy::proxy_ext::Proxies<'_>>) -> bool {
     let Some(proxies) = proxies else {
         return false;
     };
     proxies.editable_text().await.is_ok()
+}
+
+fn state_labels(state_set: StateSet) -> Vec<String> {
+    state_set.iter().map(|state| state.to_string()).collect()
 }
 
 fn select_action_index(actions: &[atspi::Action], requested_action: Option<&str>) -> Result<i32> {
@@ -577,5 +647,12 @@ mod tests {
         ];
 
         assert_eq!(select_action_index(&actions, None).unwrap(), 1);
+    }
+
+    #[test]
+    fn state_labels_serialize_in_bit_order() {
+        let labels = state_labels(StateSet::new(atspi::State::Focused | atspi::State::Checked));
+
+        assert_eq!(labels, vec!["checked".to_string(), "focused".to_string()]);
     }
 }

--- a/computer-use-linux/src/atspi_tree.rs
+++ b/computer-use-linux/src/atspi_tree.rs
@@ -426,12 +426,22 @@ async fn bounds_from_proxies(
     };
     let component = proxies.component().await.ok()?;
     let (x, y, width, height) = component.get_extents(CoordType::Screen).await.ok()?;
-    Some(Bounds {
+    normalize_bounds(Bounds {
         x,
         y,
         width,
         height,
     })
+}
+
+fn normalize_bounds(bounds: Bounds) -> Option<Bounds> {
+    if bounds.width <= 0 || bounds.height <= 0 {
+        return None;
+    }
+    if bounds.x <= i32::MIN / 2 || bounds.y <= i32::MIN / 2 {
+        return None;
+    }
+    Some(bounds)
 }
 
 async fn actions_from_proxies(

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -255,7 +255,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "click",
-        description = "Click an element by index or pixel coordinates from screenshot."
+        description = "Click an element by index, semantic selector, or pixel coordinates from screenshot."
     )]
     async fn click(&self, Parameters(params): Parameters<ClickParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
@@ -377,7 +377,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "perform_action",
-        description = "Invoke an accessibility action exposed by an element. Defaults to the primary action unless action is provided."
+        description = "Invoke an accessibility action exposed by an element selected by index, identifier, or semantic selector. Defaults to the primary action unless action is provided."
     )]
     async fn perform_action(
         &self,
@@ -389,16 +389,19 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "set_value",
-        description = "Set the value of a settable accessibility element."
+        description = "Set the value of a settable accessibility element selected by index, identifier, or semantic selector."
     )]
     async fn set_value(
         &self,
         Parameters(params): Parameters<SetValueParams>,
     ) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
-        let object_ref = match self
-            .resolve_object_ref(params.element_index, params.element_identifier.as_deref())
-        {
+        let object_ref = match self.resolve_object_ref(
+            params.element_index,
+            params.element_identifier.as_deref(),
+            &params.selector(),
+            ElementResolvePurpose::SetValue,
+        ) {
             Ok(object_ref) => object_ref,
             Err(message) => {
                 return Json(ActionOutput {
@@ -668,7 +671,7 @@ impl ComputerUseLinux {
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate, element-index click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -825,10 +828,18 @@ struct GetAppStateOutput {
     message: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 struct ClickParams {
     #[serde(default)]
     element_index: Option<u32>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    states: Vec<String>,
     #[serde(default)]
     x: Option<i32>,
     #[serde(default)]
@@ -839,23 +850,72 @@ struct ClickParams {
     click_count: Option<u32>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+impl ClickParams {
+    fn selector(&self) -> ElementSelector<'_> {
+        ElementSelector {
+            role: self.role.as_deref(),
+            name: self.name.as_deref(),
+            text: self.text.as_deref(),
+            states: &self.states,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 struct ActionParams {
     #[serde(default)]
     element_index: Option<u32>,
     #[serde(default)]
     element_identifier: Option<String>,
     #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    states: Vec<String>,
+    #[serde(default)]
     action: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+impl ActionParams {
+    fn selector(&self) -> ElementSelector<'_> {
+        ElementSelector {
+            role: self.role.as_deref(),
+            name: self.name.as_deref(),
+            text: self.text.as_deref(),
+            states: &self.states,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
 struct SetValueParams {
     #[serde(default)]
     element_index: Option<u32>,
     #[serde(default)]
     element_identifier: Option<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    states: Vec<String>,
     value: String,
+}
+
+impl SetValueParams {
+    fn selector(&self) -> ElementSelector<'_> {
+        ElementSelector {
+            role: self.role.as_deref(),
+            name: self.name.as_deref(),
+            text: self.text.as_deref(),
+            states: &self.states,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -1120,34 +1180,28 @@ impl ComputerUseLinux {
             return Ok(ClickTarget::Coordinates(x, y));
         }
 
-        let Some(element_index) = params.element_index else {
-            return Err(
-                "Pass x/y coordinates or an element_index from the latest get_app_state result."
-                    .to_string(),
-            );
-        };
+        let selector = params.selector();
+        let node = self.resolve_cached_node(
+            params.element_index,
+            &selector,
+            ElementResolvePurpose::Click,
+        )?;
 
-        if let Some((x, y)) = self.center_for_cached_node(element_index) {
+        if let Some((x, y)) = node.bounds.as_ref().and_then(bounds_center) {
             return Ok(ClickTarget::Coordinates(x, y));
         }
 
         if !is_plain_left_click(params.button.as_deref(), params.click_count) {
             return Err(format!(
-                "No clickable bounds cached for element_index {element_index}. Call get_app_state first and choose a node with positive width and height."
+                "No clickable bounds cached for element_index {}. Call get_app_state first and choose a node with positive width and height.",
+                node.index
             ));
         }
 
-        let cached = self.last_nodes.lock().map_err(|_| {
-            "Could not read cached accessibility nodes. Call get_app_state and retry.".to_string()
-        })?;
-        let Some(node) = cached.iter().find(|node| node.index == element_index) else {
-            return Err(format!(
-                "No cached accessibility node for element_index {element_index}. Call get_app_state first."
-            ));
-        };
         let Some(action_name) = primary_action_name(node.actions.as_slice()) else {
             return Err(format!(
-                "No clickable bounds cached for element_index {element_index}, and the element exposes no primary AT-SPI action."
+                "No clickable bounds cached for element_index {}, and the element exposes no primary AT-SPI action.",
+                node.index
             ));
         };
         Ok(ClickTarget::PrimaryAction {
@@ -1166,6 +1220,8 @@ impl ComputerUseLinux {
         &self,
         element_index: Option<u32>,
         element_identifier: Option<&str>,
+        selector: &ElementSelector<'_>,
+        purpose: ElementResolvePurpose,
     ) -> std::result::Result<String, String> {
         if let Some(element_identifier) = element_identifier
             .map(str::trim)
@@ -1174,25 +1230,40 @@ impl ComputerUseLinux {
             return Ok(element_identifier.to_string());
         }
 
-        let Some(element_index) = element_index else {
-            return Err(
-                "Pass element_index from the latest get_app_state result or element_identifier."
-                    .to_string(),
-            );
-        };
+        self.resolve_cached_node(element_index, selector, purpose)
+            .map(|node| node.object_ref)
+    }
 
+    fn resolve_cached_node(
+        &self,
+        element_index: Option<u32>,
+        selector: &ElementSelector<'_>,
+        purpose: ElementResolvePurpose,
+    ) -> std::result::Result<AccessibilityNode, String> {
         let cached = self.last_nodes.lock().map_err(|_| {
             "Could not read cached accessibility nodes. Call get_app_state and retry.".to_string()
         })?;
-        cached
-            .iter()
-            .find(|node| node.index == element_index)
-            .map(|node| node.object_ref.clone())
-            .ok_or_else(|| {
-                format!(
-                    "No cached accessibility node for element_index {element_index}. Call get_app_state first."
-                )
-            })
+
+        if let Some(element_index) = element_index {
+            return cached
+                .iter()
+                .find(|node| node.index == element_index)
+                .cloned()
+                .ok_or_else(|| {
+                    format!(
+                        "No cached accessibility node for element_index {element_index}. Call get_app_state first."
+                    )
+                });
+        }
+
+        if selector.is_empty() {
+            return Err(
+                "Pass element_index, element_identifier, or a semantic selector such as role/name/text/states from the latest get_app_state result."
+                    .to_string(),
+            );
+        }
+
+        resolve_semantic_node(cached.as_slice(), selector, purpose)
     }
 
     async fn perform_element_action(
@@ -1201,9 +1272,12 @@ impl ComputerUseLinux {
         requested_action: Option<&str>,
     ) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params.clone()));
-        let object_ref = match self
-            .resolve_object_ref(params.element_index, params.element_identifier.as_deref())
-        {
+        let object_ref = match self.resolve_object_ref(
+            params.element_index,
+            params.element_identifier.as_deref(),
+            &params.selector(),
+            ElementResolvePurpose::Action,
+        ) {
             Ok(object_ref) => object_ref,
             Err(message) => {
                 return Json(ActionOutput {
@@ -1262,6 +1336,204 @@ enum ClickTarget {
         object_ref: String,
         action_name: Option<String>,
     },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ElementResolvePurpose {
+    Click,
+    Action,
+    SetValue,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ElementSelector<'a> {
+    role: Option<&'a str>,
+    name: Option<&'a str>,
+    text: Option<&'a str>,
+    states: &'a [String],
+}
+
+impl ElementSelector<'_> {
+    fn is_empty(&self) -> bool {
+        [self.role, self.name, self.text]
+            .into_iter()
+            .all(|value| value.map(str::trim).is_none_or(str::is_empty))
+            && self.states.iter().all(|value| value.trim().is_empty())
+    }
+}
+
+fn resolve_semantic_node(
+    nodes: &[AccessibilityNode],
+    selector: &ElementSelector<'_>,
+    purpose: ElementResolvePurpose,
+) -> std::result::Result<AccessibilityNode, String> {
+    let mut matches = nodes
+        .iter()
+        .filter(|node| node_matches_selector(node, selector))
+        .collect::<Vec<_>>();
+
+    if matches.is_empty() {
+        return Err(format!(
+            "No cached accessibility node matched semantic selector {}. Call get_app_state first or pass element_index.",
+            describe_selector(selector)
+        ));
+    }
+
+    if let Some(node) =
+        unique_preferred_node(&matches, |node| node_matches_resolve_purpose(node, purpose))
+    {
+        return Ok(node.clone());
+    }
+
+    let useful_matches = matches
+        .iter()
+        .copied()
+        .filter(|node| node_matches_resolve_purpose(node, purpose))
+        .collect::<Vec<_>>();
+    if !useful_matches.is_empty() {
+        matches = useful_matches;
+    }
+
+    if let Some(node) = unique_preferred_node(&matches, node_is_showing) {
+        return Ok(node.clone());
+    }
+
+    let visible_matches = matches
+        .iter()
+        .copied()
+        .filter(|node| node_is_showing(node))
+        .collect::<Vec<_>>();
+    if !visible_matches.is_empty() {
+        matches = visible_matches;
+    }
+
+    if matches.len() == 1 {
+        return Ok(matches[0].clone());
+    }
+
+    Err(format!(
+        "Semantic selector {} matched multiple cached nodes: {}. Pass element_index or add more selector fields.",
+        describe_selector(selector),
+        describe_matching_nodes(&matches),
+    ))
+}
+
+fn unique_preferred_node<'a>(
+    nodes: &[&'a AccessibilityNode],
+    predicate: impl Fn(&AccessibilityNode) -> bool,
+) -> Option<&'a AccessibilityNode> {
+    let mut matches = nodes.iter().copied().filter(|node| predicate(node));
+    let first = matches.next()?;
+    matches.next().is_none().then_some(first)
+}
+
+fn node_matches_selector(node: &AccessibilityNode, selector: &ElementSelector<'_>) -> bool {
+    selector
+        .role
+        .is_none_or(|role| normalized_contains(Some(node.role.as_str()), role))
+        && selector
+            .name
+            .is_none_or(|name| normalized_contains(node.name.as_deref(), name))
+        && selector.text.is_none_or(|text| {
+            normalized_contains(
+                node.text
+                    .as_ref()
+                    .and_then(|value| value.content.as_deref()),
+                text,
+            ) || normalized_contains(node.name.as_deref(), text)
+                || normalized_contains(node.description.as_deref(), text)
+        })
+        && selector
+            .states
+            .iter()
+            .filter(|state| !state.trim().is_empty())
+            .all(|state| {
+                node.states
+                    .iter()
+                    .any(|node_state| normalized_equals(node_state, state))
+            })
+}
+
+fn node_matches_resolve_purpose(node: &AccessibilityNode, purpose: ElementResolvePurpose) -> bool {
+    match purpose {
+        ElementResolvePurpose::Click => {
+            node.bounds.as_ref().and_then(bounds_center).is_some()
+                || primary_action_name(&node.actions).is_some()
+        }
+        ElementResolvePurpose::Action => !node.actions.is_empty(),
+        ElementResolvePurpose::SetValue => node.supports_editable_text || node.value.is_some(),
+    }
+}
+
+fn node_is_showing(node: &AccessibilityNode) -> bool {
+    node.states
+        .iter()
+        .any(|state| normalized_equals(state, "showing"))
+        && node
+            .states
+            .iter()
+            .any(|state| normalized_equals(state, "visible"))
+}
+
+fn normalized_equals(actual: &str, expected: &str) -> bool {
+    normalize_text(actual) == normalize_text(expected)
+}
+
+fn normalized_contains(actual: Option<&str>, expected: &str) -> bool {
+    let expected = normalize_text(expected);
+    !expected.is_empty()
+        && actual
+            .map(normalize_text)
+            .is_some_and(|actual| actual.contains(&expected))
+}
+
+fn normalize_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+fn describe_selector(selector: &ElementSelector<'_>) -> String {
+    let mut parts = Vec::new();
+    if let Some(role) = selector.role.map(str::trim).filter(|role| !role.is_empty()) {
+        parts.push(format!("role={role:?}"));
+    }
+    if let Some(name) = selector.name.map(str::trim).filter(|name| !name.is_empty()) {
+        parts.push(format!("name={name:?}"));
+    }
+    if let Some(text) = selector.text.map(str::trim).filter(|text| !text.is_empty()) {
+        parts.push(format!("text={text:?}"));
+    }
+    let states = selector
+        .states
+        .iter()
+        .map(|state| state.trim())
+        .filter(|state| !state.is_empty())
+        .collect::<Vec<_>>();
+    if !states.is_empty() {
+        parts.push(format!("states={states:?}"));
+    }
+    if parts.is_empty() {
+        "<empty>".to_string()
+    } else {
+        parts.join(", ")
+    }
+}
+
+fn describe_matching_nodes(nodes: &[&AccessibilityNode]) -> String {
+    nodes
+        .iter()
+        .take(8)
+        .map(|node| {
+            format!(
+                "element_index {} role={:?} name={:?}",
+                node.index, node.role, node.name
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
 }
 
 fn is_plain_left_click(button: Option<&str>, click_count: Option<u32>) -> bool {
@@ -1845,6 +2117,15 @@ mod tests {
         }
     }
 
+    fn click_action() -> AccessibilityAction {
+        AccessibilityAction {
+            index: 0,
+            name: "Click".to_string(),
+            description: "Clicks the element".to_string(),
+            keybinding: String::new(),
+        }
+    }
+
     fn window_info(
         window_id: u64,
         title: Option<&str>,
@@ -2213,10 +2494,7 @@ mod tests {
         let target = backend
             .resolve_click_target(&ClickParams {
                 element_index: Some(7),
-                x: None,
-                y: None,
-                button: None,
-                click_count: None,
+                ..Default::default()
             })
             .unwrap();
 
@@ -2256,10 +2534,7 @@ mod tests {
         let target = backend
             .resolve_click_target(&ClickParams {
                 element_index: Some(7),
-                x: None,
-                y: None,
-                button: None,
-                click_count: None,
+                ..Default::default()
             })
             .unwrap();
 
@@ -2294,10 +2569,8 @@ mod tests {
         let error = backend
             .resolve_click_target(&ClickParams {
                 element_index: Some(7),
-                x: None,
-                y: None,
                 button: Some("right".to_string()),
-                click_count: None,
+                ..Default::default()
             })
             .unwrap_err();
 
@@ -2375,7 +2648,12 @@ mod tests {
         backend.cache_nodes(&[node(7, None)]);
 
         let object_ref = backend
-            .resolve_object_ref(Some(7), Some(":1.99/org/a11y/atspi/accessible/3"))
+            .resolve_object_ref(
+                Some(7),
+                Some(":1.99/org/a11y/atspi/accessible/3"),
+                &ElementSelector::default(),
+                ElementResolvePurpose::Action,
+            )
             .unwrap();
 
         assert_eq!(object_ref, ":1.99/org/a11y/atspi/accessible/3");
@@ -2386,8 +2664,146 @@ mod tests {
         let backend = ComputerUseLinux::default();
         backend.cache_nodes(&[node(7, None)]);
 
-        let object_ref = backend.resolve_object_ref(Some(7), None).unwrap();
+        let object_ref = backend
+            .resolve_object_ref(
+                Some(7),
+                None,
+                &ElementSelector::default(),
+                ElementResolvePurpose::Action,
+            )
+            .unwrap();
 
         assert_eq!(object_ref, ":1.7/org/a11y/atspi/accessible/7");
+    }
+
+    #[test]
+    fn semantic_selector_resolves_unique_cached_node_by_role_and_name() {
+        let backend = ComputerUseLinux::default();
+        let mut search_entry = node(7, None);
+        search_entry.role = "entry".to_string();
+        search_entry.name = Some("Search files".to_string());
+        search_entry.supports_editable_text = true;
+        backend.cache_nodes(&[search_entry]);
+
+        let object_ref = backend
+            .resolve_object_ref(
+                None,
+                None,
+                &ElementSelector {
+                    role: Some("entry"),
+                    name: Some("search"),
+                    ..Default::default()
+                },
+                ElementResolvePurpose::SetValue,
+            )
+            .unwrap();
+
+        assert_eq!(object_ref, ":1.7/org/a11y/atspi/accessible/7");
+    }
+
+    #[test]
+    fn semantic_selector_prefers_actionable_match() {
+        let backend = ComputerUseLinux::default();
+        let mut label = node(4, None);
+        label.role = "label".to_string();
+        label.name = Some("Close".to_string());
+        let mut button = node_with_actions(7, None, vec![click_action()]);
+        button.role = "push button".to_string();
+        button.name = Some("Close".to_string());
+        backend.cache_nodes(&[label, button]);
+
+        let object_ref = backend
+            .resolve_object_ref(
+                None,
+                None,
+                &ElementSelector {
+                    name: Some("close"),
+                    ..Default::default()
+                },
+                ElementResolvePurpose::Action,
+            )
+            .unwrap();
+
+        assert_eq!(object_ref, ":1.7/org/a11y/atspi/accessible/7");
+    }
+
+    #[test]
+    fn semantic_selector_prefers_editable_match() {
+        let backend = ComputerUseLinux::default();
+        let mut label = node(4, None);
+        label.role = "label".to_string();
+        label.name = Some("Search".to_string());
+        let mut entry = node(7, None);
+        entry.role = "entry".to_string();
+        entry.name = Some("Search".to_string());
+        entry.supports_editable_text = true;
+        backend.cache_nodes(&[label, entry]);
+
+        let object_ref = backend
+            .resolve_object_ref(
+                None,
+                None,
+                &ElementSelector {
+                    name: Some("search"),
+                    ..Default::default()
+                },
+                ElementResolvePurpose::SetValue,
+            )
+            .unwrap();
+
+        assert_eq!(object_ref, ":1.7/org/a11y/atspi/accessible/7");
+    }
+
+    #[test]
+    fn semantic_selector_reports_ambiguous_matches() {
+        let backend = ComputerUseLinux::default();
+        let mut first = node_with_actions(7, None, vec![click_action()]);
+        first.name = Some("Close".to_string());
+        let mut second = node_with_actions(9, None, vec![click_action()]);
+        second.name = Some("Close".to_string());
+        backend.cache_nodes(&[first, second]);
+
+        let error = backend
+            .resolve_object_ref(
+                None,
+                None,
+                &ElementSelector {
+                    name: Some("close"),
+                    ..Default::default()
+                },
+                ElementResolvePurpose::Action,
+            )
+            .unwrap_err();
+
+        assert!(error.contains("matched multiple cached nodes"));
+        assert!(error.contains("element_index 7"));
+        assert!(error.contains("element_index 9"));
+    }
+
+    #[test]
+    fn semantic_click_selector_resolves_coordinates() {
+        let backend = ComputerUseLinux::default();
+        let mut button = node_with_actions(
+            7,
+            Some(Bounds {
+                x: 10,
+                y: 20,
+                width: 100,
+                height: 40,
+            }),
+            vec![click_action()],
+        );
+        button.name = Some("Run".to_string());
+        backend.cache_nodes(&[button]);
+
+        let target = backend
+            .resolve_click_target(&ClickParams {
+                role: Some("button".to_string()),
+                name: Some("run".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert!(matches!(target, ClickTarget::Coordinates(60, 40)));
     }
 }

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -1734,8 +1734,10 @@ mod tests {
             description: None,
             child_count: 0,
             bounds,
+            states: Vec::new(),
             actions,
             value: None,
+            text: None,
             supports_editable_text: false,
         }
     }

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -183,16 +183,20 @@ impl ComputerUseLinux {
         } else {
             (None, None)
         };
-        let (accessibility_tree, accessibility_error) =
+        let (accessibility_tree, accessibility_tree_raw_count, accessibility_error) =
             if diagnostics.readiness.can_build_accessibility_tree {
                 let target_pid = window_context.as_ref().and_then(|window| window.pid);
                 match snapshot_tree(app_filter.as_deref(), target_pid, max_nodes, max_depth).await {
-                    Ok(nodes) => (nodes, None),
-                    Err(error) => (Vec::new(), Some(error.to_string())),
+                    Ok(nodes) => {
+                        let raw_count = nodes.len();
+                        (compact_accessibility_tree(nodes), raw_count, None)
+                    }
+                    Err(error) => (Vec::new(), 0, Some(error.to_string())),
                 }
             } else {
                 (
                     Vec::new(),
+                    0,
                     Some(
                         "GNOME accessibility is disabled; call setup_accessibility first."
                             .to_string(),
@@ -206,19 +210,22 @@ impl ComputerUseLinux {
             format!("MCP registration is working, but AT-SPI tree extraction failed: {error}")
         } else if let Some(capture) = &screenshot {
             format!(
-                "MCP registration, screenshot capture, and AT-SPI tree extraction are working. Captured {} accessibility nodes and a screenshot through {}.",
+                "MCP registration, screenshot capture, and AT-SPI tree extraction are working. Captured {} accessibility nodes (compacted from {}) and a screenshot through {}.",
                 accessibility_tree.len(),
+                accessibility_tree_raw_count,
                 capture.source
             )
         } else if let Some(error) = &screenshot_error {
             format!(
-                "MCP registration and AT-SPI tree extraction are working. Captured {} accessibility nodes. Screenshot capture failed: {error}",
-                accessibility_tree.len()
+                "MCP registration and AT-SPI tree extraction are working. Captured {} accessibility nodes (compacted from {}). Screenshot capture failed: {error}",
+                accessibility_tree.len(),
+                accessibility_tree_raw_count,
             )
         } else {
             format!(
-                "MCP registration and AT-SPI tree extraction are working. Captured {} accessibility nodes. Screenshot capture was not requested.",
-                accessibility_tree.len()
+                "MCP registration and AT-SPI tree extraction are working. Captured {} accessibility nodes (compacted from {}). Screenshot capture was not requested.",
+                accessibility_tree.len(),
+                accessibility_tree_raw_count,
             )
         };
         if let Some(window) = &window_context {
@@ -239,6 +246,7 @@ impl ComputerUseLinux {
             screenshot,
             screenshot_error,
             accessibility_tree,
+            accessibility_tree_raw_count,
             accessibility_error,
             diagnostics,
             message,
@@ -811,6 +819,7 @@ struct GetAppStateOutput {
     screenshot: Option<ScreenshotCapture>,
     screenshot_error: Option<String>,
     accessibility_tree: Vec<AccessibilityNode>,
+    accessibility_tree_raw_count: usize,
     accessibility_error: Option<String>,
     diagnostics: DoctorReport,
     message: String,
@@ -1276,6 +1285,100 @@ fn bounds_center(bounds: &Bounds) -> Option<(i32, i32)> {
         bounds.x.checked_add(bounds.width / 2)?,
         bounds.y.checked_add(bounds.height / 2)?,
     ))
+}
+
+fn compact_accessibility_tree(nodes: Vec<AccessibilityNode>) -> Vec<AccessibilityNode> {
+    if nodes.is_empty() {
+        return nodes;
+    }
+
+    let keep = nodes
+        .iter()
+        .map(should_keep_accessibility_node)
+        .collect::<Vec<_>>();
+    let mut old_to_new = vec![None; nodes.len()];
+    let mut compacted = Vec::new();
+
+    for (old_index, node) in nodes.iter().enumerate() {
+        if !keep[old_index] {
+            continue;
+        }
+
+        let mut compacted_node = node.clone();
+        compacted_node.index = compacted.len() as u32;
+        compacted_node.parent_index = nearest_kept_parent(&keep, &nodes, old_index);
+        old_to_new[old_index] = Some(compacted_node.index);
+        compacted.push(compacted_node);
+    }
+
+    for node in &mut compacted {
+        node.parent_index = node
+            .parent_index
+            .and_then(|old_parent| old_to_new.get(old_parent as usize).copied().flatten());
+    }
+
+    let child_counts = compacted.iter().filter_map(|node| node.parent_index).fold(
+        vec![0_i32; compacted.len()],
+        |mut counts, parent_index| {
+            counts[parent_index as usize] += 1;
+            counts
+        },
+    );
+
+    for (index, node) in compacted.iter_mut().enumerate() {
+        node.child_count = child_counts[index];
+    }
+
+    compacted
+}
+
+fn nearest_kept_parent(
+    keep: &[bool],
+    nodes: &[AccessibilityNode],
+    old_index: usize,
+) -> Option<u32> {
+    let mut parent = nodes[old_index].parent_index;
+    while let Some(parent_index) = parent {
+        let parent_usize = parent_index as usize;
+        if keep.get(parent_usize).copied().unwrap_or(false) {
+            return Some(parent_index);
+        }
+        parent = nodes.get(parent_usize).and_then(|node| node.parent_index);
+    }
+    None
+}
+
+fn should_keep_accessibility_node(node: &AccessibilityNode) -> bool {
+    if node.depth <= 1 {
+        return true;
+    }
+
+    if is_actionable_accessibility_node(node) || has_meaningful_node_copy(node) {
+        return true;
+    }
+
+    matches!(
+        node.role.as_str(),
+        "page tab" | "menu item" | "menu" | "list item" | "tree item"
+    ) && !is_sentinel_or_missing_bounds(node.bounds.as_ref())
+}
+
+fn is_actionable_accessibility_node(node: &AccessibilityNode) -> bool {
+    !node.actions.is_empty() || node.supports_editable_text || node.value.is_some()
+}
+
+fn has_meaningful_node_copy(node: &AccessibilityNode) -> bool {
+    has_non_empty_text(node.name.as_deref())
+        || has_non_empty_text(node.description.as_deref())
+        || has_non_empty_text(node.text.as_ref().and_then(|text| text.content.as_deref()))
+}
+
+fn has_non_empty_text(value: Option<&str>) -> bool {
+    value.map(str::trim).is_some_and(|value| !value.is_empty())
+}
+
+fn is_sentinel_or_missing_bounds(bounds: Option<&Bounds>) -> bool {
+    bounds.is_none()
 }
 
 fn select_accessibility_object_ref(
@@ -1823,6 +1926,171 @@ mod tests {
         .unwrap();
 
         assert_eq!(object_ref, ":1.64/org/a11y/atspi/accessible/root");
+    }
+
+    #[test]
+    fn compact_accessibility_tree_reparents_actionable_descendants() {
+        let nodes = vec![
+            AccessibilityNode {
+                index: 0,
+                parent_index: None,
+                depth: 0,
+                object_ref: ":1.0/root".to_string(),
+                role: "application".to_string(),
+                name: Some("demo-app".to_string()),
+                description: None,
+                child_count: 1,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 1,
+                parent_index: Some(0),
+                depth: 1,
+                object_ref: ":1.1/frame".to_string(),
+                role: "frame".to_string(),
+                name: Some("Demo Frame".to_string()),
+                description: None,
+                child_count: 1,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 2,
+                parent_index: Some(1),
+                depth: 2,
+                object_ref: ":1.2/filler".to_string(),
+                role: "filler".to_string(),
+                name: None,
+                description: None,
+                child_count: 1,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 3,
+                parent_index: Some(2),
+                depth: 3,
+                object_ref: ":1.3/button".to_string(),
+                role: "button".to_string(),
+                name: Some("Run".to_string()),
+                description: None,
+                child_count: 0,
+                bounds: Some(Bounds {
+                    x: 10,
+                    y: 20,
+                    width: 100,
+                    height: 40,
+                }),
+                states: Vec::new(),
+                actions: vec![AccessibilityAction {
+                    index: 0,
+                    name: "Click".to_string(),
+                    description: "Clicks the button".to_string(),
+                    keybinding: String::new(),
+                }],
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+        ];
+
+        let compacted = compact_accessibility_tree(nodes);
+
+        assert_eq!(compacted.len(), 3);
+        assert_eq!(compacted[0].role, "application");
+        assert_eq!(compacted[1].role, "frame");
+        assert_eq!(compacted[2].role, "button");
+        assert_eq!(compacted[2].parent_index, Some(1));
+        assert_eq!(compacted[1].child_count, 1);
+    }
+
+    #[test]
+    fn compact_accessibility_tree_drops_structural_noise() {
+        let nodes = vec![
+            AccessibilityNode {
+                index: 0,
+                parent_index: None,
+                depth: 0,
+                object_ref: ":1.0/root".to_string(),
+                role: "application".to_string(),
+                name: Some("demo-app".to_string()),
+                description: None,
+                child_count: 2,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 1,
+                parent_index: Some(0),
+                depth: 1,
+                object_ref: ":1.1/frame".to_string(),
+                role: "frame".to_string(),
+                name: Some("Demo Frame".to_string()),
+                description: None,
+                child_count: 2,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 2,
+                parent_index: Some(1),
+                depth: 2,
+                object_ref: ":1.2/tab".to_string(),
+                role: "page tab".to_string(),
+                name: Some("Hidden".to_string()),
+                description: None,
+                child_count: 0,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+            AccessibilityNode {
+                index: 3,
+                parent_index: Some(1),
+                depth: 2,
+                object_ref: ":1.3/separator".to_string(),
+                role: "separator".to_string(),
+                name: None,
+                description: None,
+                child_count: 0,
+                bounds: None,
+                states: Vec::new(),
+                actions: Vec::new(),
+                value: None,
+                text: None,
+                supports_editable_text: false,
+            },
+        ];
+
+        let compacted = compact_accessibility_tree(nodes);
+
+        assert_eq!(compacted.len(), 3);
+        assert_eq!(compacted[2].role, "page tab");
+        assert_eq!(compacted[2].name.as_deref(), Some("Hidden"));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

This PR improves the Linux Computer Use AT-SPI readback path so `get_app_state` returns a smaller, more useful accessibility tree with richer state for the model to act on.

## What changed

- Include AT-SPI node state labels in `get_app_state` output.
- Include bounded text snapshots and caret/selection metadata for text-capable nodes.
- Normalize sentinel bounds earlier so hidden/offscreen nodes do not look clickable.
- Compact Linux accessibility trees before returning them to the model, preserving actionable and meaningful nodes while dropping structural filler.
- Reparent surviving nodes and expose the raw node count so the amount of compaction remains visible.

## Why

The Linux AT-SPI tree can be very noisy. Returning every filler/panel/separator makes the model spend context on nodes it cannot use, while missing state/text readback makes it harder to choose the right action. This keeps the actionable surface intact but makes `get_app_state` more useful for real desktop control.

## Validation

- `cargo fmt --all --check --manifest-path computer-use-linux/Cargo.toml`
- `cargo test --manifest-path computer-use-linux/Cargo.toml` (`58/58`)
- `cargo clippy --manifest-path computer-use-linux/Cargo.toml --all-targets -- -D warnings`
