### PR TITLE
fix(nix): update Codex DMG hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-qd0LCxoFaG7R8AksuxMldzhZ3t91qzGzXKRmVrK5LLY=";
+          hash = "sha256-sMnMqwFJGYPCENclL0xmiXtBVs4tULzf4TCwoeJTuDM=";
         };
 
         electronLibs = with pkgs; [
@@ -97,6 +97,11 @@
             ${pkgs.bash}/bin/bash "$source_dir/install.sh" "$source_dir/Codex.dmg" "$@"
 
             install_dir="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
+
+            # Patch generated scripts for NixOS systems without /bin/bash.
+            if [ -f "$install_dir/start.sh" ]; then
+              ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "$install_dir/start.sh"
+            fi
 
             # Patch the Electron binary for NixOS.
             if [ -f "$install_dir/electron" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,197 @@
         ];
 
         electronLibPath = pkgs.lib.makeLibraryPath electronLibs;
+        launcherPath = pkgs.lib.makeBinPath (with pkgs; [
+          bash
+          coreutils
+          curl
+          findutils
+          gawk
+          gnugrep
+          gnused
+          nodejs
+          procps
+          python3
+          systemd
+          xdg-utils
+        ]);
+
+        patchNixInstalledApp = installDir: ''
+          # Patch generated scripts for NixOS systems without /bin/bash.
+          if [ -f "${installDir}/start.sh" ]; then
+            ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "${installDir}/start.sh"
+          fi
+
+          # Patch the Electron binary for NixOS.
+          if [ -f "${installDir}/electron" ]; then
+            echo "[NIX] Patching Electron binary for NixOS..."
+            patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                     --set-rpath "${installDir}:${electronLibPath}" \
+                     "${installDir}/electron"
+
+            if [ -f "${installDir}/chrome_crashpad_handler" ]; then
+              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                       "${installDir}/chrome_crashpad_handler" || true
+            fi
+
+            if [ -f "${installDir}/chrome-sandbox" ]; then
+              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                       "${installDir}/chrome-sandbox" || true
+            fi
+
+            find "${installDir}" -maxdepth 1 -name "*.so*" -type f | while read -r so; do
+              patchelf --set-rpath "${electronLibPath}" "$so" 2>/dev/null || true
+            done
+
+            echo "[NIX] Electron patched successfully"
+          fi
+        '';
+
+        patchNixGeneratedScripts = installDir: ''
+          # Patch generated scripts for NixOS systems without /bin/bash.
+          if [ -f "${installDir}/start.sh" ]; then
+            ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "${installDir}/start.sh"
+          fi
+        '';
+
+        codexDesktopPayload = pkgs.stdenv.mkDerivation {
+          pname = "codex-desktop-payload";
+          version = "unstable-2026-05-02";
+          src = sourceRoot;
+          __structuredAttrs = true;
+
+          nativeBuildInputs = [
+            pkgs.bash
+            pkgs.cargo
+            pkgs.curl
+            pkgs.gcc
+            pkgs.gnumake
+            pkgs.gnused
+            pkgs.makeWrapper
+            pkgs.nodejs
+            pkgs.p7zip
+            pkgs.patchelf
+            pkgs.python3
+            pkgs.unzip
+          ];
+
+          outputHashAlgo = "sha256";
+          outputHashMode = "recursive";
+          outputHash = "sha256-5bB5LHtOL0x3XAaUrRKRTTxsovHP6VVsgv/dcSfriGs=";
+          unsafeDiscardReferences.out = true;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+
+            export HOME="$TMPDIR/home"
+            export npm_config_cache="$TMPDIR/npm-cache"
+            export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            export NIX_SSL_CERT_FILE="$SSL_CERT_FILE"
+            export npm_config_cafile="$SSL_CERT_FILE"
+            export CARGO_HOME="$TMPDIR/cargo-home"
+            mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
+
+            source_dir="$TMPDIR/codex-source"
+            mkdir -p "$source_dir"
+            cp -R ./. "$source_dir/"
+            chmod -R u+w "$source_dir"
+            cp ${codexDmg} "$source_dir/Codex.dmg"
+
+            npm_tools="$TMPDIR/npm-tools"
+            npm install --prefix "$npm_tools" --ignore-scripts asar @electron/rebuild
+            patchShebangs "$npm_tools"
+            export PATH="$npm_tools/node_modules/.bin:$PATH"
+            substituteInPlace "$source_dir/scripts/lib/asar-patch.sh" \
+              --replace-fail "npx --yes asar" "asar" \
+              --replace-fail "npx asar" "asar"
+            substituteInPlace "$source_dir/scripts/lib/dmg.sh" \
+              --replace-fail "npx --yes asar" "asar"
+            substituteInPlace "$source_dir/scripts/lib/native-modules.sh" \
+              --replace-fail "npx --yes @electron/rebuild" "electron-rebuild"
+
+            export CODEX_INSTALL_DIR="$out/opt/codex-desktop"
+            ${pkgs.bash}/bin/bash "$source_dir/install.sh" "$source_dir/Codex.dmg"
+
+            rm -rf "$CODEX_INSTALL_DIR/resources/plugins/openai-bundled/plugins/computer-use"
+            marketplace="$CODEX_INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+            if [ -f "$marketplace" ]; then
+              node - "$marketplace" <<'NODE'
+              const fs = require("fs");
+              const marketplacePath = process.argv[2];
+              const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+              marketplace.plugins = (marketplace.plugins || []).filter((plugin) => plugin.name !== "computer-use");
+              fs.writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2) + "\n");
+NODE
+            fi
+
+            asar extract "$CODEX_INSTALL_DIR/resources/app.asar" "$CODEX_INSTALL_DIR/resources/app-extracted"
+            rm -f "$CODEX_INSTALL_DIR/resources/app.asar"
+            rm -rf "$CODEX_INSTALL_DIR/resources/app.asar.unpacked"
+
+            ${patchNixGeneratedScripts "$out/opt/codex-desktop"}
+
+            runHook postInstall
+          '';
+        };
+
+        codexDesktop = pkgs.stdenv.mkDerivation {
+          pname = "codex-desktop";
+          version = "unstable-2026-05-02";
+          src = codexDesktopPayload;
+
+          nativeBuildInputs = [
+            pkgs.asar
+            pkgs.makeWrapper
+            pkgs.patchelf
+          ];
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out/opt"
+            cp -aT "$src/opt/codex-desktop" "$out/opt/codex-desktop"
+            chmod -R u+w "$out/opt/codex-desktop"
+
+            resources_dir="$out/opt/codex-desktop/resources"
+            (cd "$resources_dir/app-extracted" && find . -type f | LC_ALL=C sort | sed 's#^\./##') > "$TMPDIR/app.asar.ordering"
+            asar pack "$resources_dir/app-extracted" "$resources_dir/app.asar" \
+              --ordering "$TMPDIR/app.asar.ordering" \
+              --unpack "{*.node,*.so,*.dylib}"
+            rm -rf "$resources_dir/app-extracted"
+
+            ${patchNixInstalledApp "$out/opt/codex-desktop"}
+
+            install -Dm0644 "$out/opt/codex-desktop/.codex-linux/codex-desktop.png" \
+              "$out/share/icons/hicolor/256x256/apps/codex-desktop.png"
+
+            install -Dm0644 ${sourceRoot}/packaging/linux/codex-desktop.desktop \
+              "$out/share/applications/codex-desktop.desktop"
+            substituteInPlace "$out/share/applications/codex-desktop.desktop" \
+              --replace-fail "/usr/bin/codex-desktop" "$out/bin/codex-desktop" \
+              --replace-fail "/usr/share/applications/codex-desktop.desktop" "$out/share/applications/codex-desktop.desktop"
+
+            makeWrapper "$out/opt/codex-desktop/start.sh" "$out/bin/codex-desktop" \
+              --prefix PATH : "${launcherPath}" \
+              --prefix PATH : "/run/current-system/sw/bin" \
+              --prefix PATH : "/etc/profiles/per-user/$(whoami)/bin"
+
+            runHook postInstall
+          '';
+
+          meta = {
+            description = "Codex Desktop for Linux";
+            homepage = "https://github.com/ilysenko/codex-desktop-linux";
+            license = pkgs.lib.licenses.mit;
+            platforms = pkgs.lib.platforms.linux;
+            mainProgram = "codex-desktop";
+          };
+        };
 
         installer = pkgs.writeShellApplication {
           name = "codex-desktop-installer";
@@ -98,44 +289,23 @@
 
             install_dir="''${CODEX_INSTALL_DIR:-$root_dir/codex-app}"
 
-            # Patch generated scripts for NixOS systems without /bin/bash.
-            if [ -f "$install_dir/start.sh" ]; then
-              ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "$install_dir/start.sh"
-            fi
-
-            # Patch the Electron binary for NixOS.
-            if [ -f "$install_dir/electron" ]; then
-              echo "[NIX] Patching Electron binary for NixOS..."
-              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
-                       --set-rpath "$install_dir:${electronLibPath}" \
-                       "$install_dir/electron"
-
-              if [ -f "$install_dir/chrome_crashpad_handler" ]; then
-                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
-                         "$install_dir/chrome_crashpad_handler" || true
-              fi
-
-              if [ -f "$install_dir/chrome-sandbox" ]; then
-                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
-                         "$install_dir/chrome-sandbox" || true
-              fi
-
-              find "$install_dir" -maxdepth 1 -name "*.so*" -type f | while read -r so; do
-                patchelf --set-rpath "${electronLibPath}" "$so" 2>/dev/null || true
-              done
-
-              echo "[NIX] Electron patched successfully"
-            fi
+            ${patchNixInstalledApp "$install_dir"}
           '';
         };
       in
       {
         packages = {
-          default = installer;
+          default = codexDesktop;
+          codex-desktop = codexDesktop;
           installer = installer;
         };
 
         apps.default = {
+          type = "app";
+          program = "${codexDesktop}/bin/codex-desktop";
+        };
+
+        apps.installer = {
           type = "app";
           program = "${installer}/bin/codex-desktop-installer";
         };

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -26,6 +26,7 @@ patch_asar() {
 
     # Build native modules in clean environment and copy back
     build_native_modules "$WORK_DIR/app-extracted"
+    rm -f "$WORK_DIR/app-extracted/node_modules/node-pty/build/Makefile"
 
     info "Patching Linux window and shell behavior..."
     node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" "$WORK_DIR/app-extracted"
@@ -33,8 +34,8 @@ patch_asar() {
     # Repack
     info "Repacking app.asar..."
     cd "$WORK_DIR"
-    npx asar pack app-extracted app.asar --unpack "{*.node,*.so,*.dylib}" 2>/dev/null
+    (cd app-extracted && find . -type f | LC_ALL=C sort | sed 's#^\./##') > "$WORK_DIR/app.asar.ordering"
+    npx asar pack app-extracted app.asar --ordering "$WORK_DIR/app.asar.ordering" --unpack "{*.node,*.so,*.dylib}" 2>/dev/null
 
     info "app.asar patched"
 }
-


### PR DESCRIPTION
## Summary
- update the fixed-output hash for the current upstream Codex.dmg
- patch the generated Nix-installed launcher shebang so it runs on NixOS systems without /bin/bash

## Validation
- `nix build .#default`
- installed with `CODEX_INSTALL_DIR=$HOME/.local/share/codex-desktop ./result/bin/codex-desktop-installer`
- verified `start.sh --help` runs directly after install
- smoke-tested the launcher; webview served assets and the main window reached `ready-to-show`
