### PR TITLE
Fix Keybinds settings patch after upstream bundle drift

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -430,39 +430,34 @@ function applyLinuxKeybindOverridesRuntimePatch(currentSource) {
 function applyKeybindsSettingsIndexPatch(currentSource) {
   let patchedSource = currentSource;
 
-  if (
-    !patchedSource.includes("var c_e=") &&
-    !patchedSource.includes("Xge=") &&
-    !patchedSource.includes("Zge=")
-  ) {
-    return patchedSource;
-  }
-
   if (!patchedSource.includes(`${keybindsSettingsAsset}`)) {
-    const routeNeedle = 'var c_e={"general-settings":';
-    const routePatch = `var c_e={keybinds:(0,Z.lazy)(()=>s(()=>import(\`./${keybindsSettingsAsset}\`),[],import.meta.url)),"general-settings":`;
-    if (!patchedSource.includes(routeNeedle)) {
+    const routePattern = /var ([A-Za-z_$][\w$]*)=\{"general-settings":(?=\(0,[A-Za-z_$][\w$]*\.lazy\))/;
+    if (!routePattern.test(patchedSource)) {
       throw new Error("Required Keybinds settings patch failed: could not add keybinds route");
     }
-    patchedSource = patchedSource.replace(routeNeedle, routePatch);
+    patchedSource = patchedSource.replace(
+      routePattern,
+      `var $1={keybinds:(0,Z.lazy)(()=>s(()=>import(\`./${keybindsSettingsAsset}\`),[],import.meta.url)),"general-settings":`,
+    );
   }
 
-  if (!patchedSource.includes("keybinds:xh")) {
-    const iconNeedle = 'Xge={"general-settings":xh,';
-    const iconPatch = 'Xge={keybinds:xh,"general-settings":xh,';
-    if (!patchedSource.includes(iconNeedle)) {
+  if (!/[,{]keybinds:[A-Za-z_$][\w$]*,"general-settings":/.test(patchedSource)) {
+    const iconPattern = /([A-Za-z_$][\w$]*=\{)"general-settings":([A-Za-z_$][\w$]*),/;
+    if (!iconPattern.test(patchedSource)) {
       throw new Error("Required Keybinds settings patch failed: could not add keybinds icon");
     }
-    patchedSource = patchedSource.replace(iconNeedle, iconPatch);
+    patchedSource = patchedSource.replace(
+      iconPattern,
+      (_match, prefix, icon) => `${prefix}keybinds:${icon},"general-settings":${icon},`,
+    );
   }
 
-  if (!patchedSource.includes("Zge=[`general-settings`,`keybinds`")) {
-    const orderNeedle = "Zge=[`general-settings`,`appearance`";
-    const orderPatch = "Zge=[`general-settings`,`keybinds`,`appearance`";
-    if (!patchedSource.includes(orderNeedle)) {
+  if (!/=\[`general-settings`,`keybinds`/.test(patchedSource)) {
+    const orderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)`appearance`/;
+    if (!orderPattern.test(patchedSource)) {
       throw new Error("Required Keybinds settings patch failed: could not add keybinds nav order");
     }
-    patchedSource = patchedSource.replace(orderNeedle, orderPatch);
+    patchedSource = patchedSource.replace(orderPattern, "$1`keybinds`,`appearance`");
   }
 
   if (!patchedSource.includes("slugs:[`general-settings`,`keybinds`")) {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -10,6 +10,7 @@ const test = require("node:test");
 const {
   COMPUTER_USE_UI_ENV_VAR,
   COMPUTER_USE_UI_SETTINGS_KEY,
+  applyKeybindsSettingsIndexPatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
@@ -99,6 +100,17 @@ function currentLaunchActionBundleFixture() {
   return [
     "const e={gr:e=>({default:e,...e})};let n=require(`electron`);let i=require(`node:path`);i=e.gr(i);let o=require(`node:fs`);o=e.gr(o);let f=require(`node:net`);f=e.gr(f);",
     "async function CN(){let{setSecondInstanceArgsHandler:l}=t.y(),g={reportNonFatal(){}},k=new t.In;k.add(x);let j={globalState:{get(){return true}},repoRoot:`/tmp`,codexHome:`/tmp`},M={hotkeyWindowLifecycleManager:{hide(){},ensureHotkeyWindowController(){}},getPrimaryWindow(){},createFreshLocalWindow(){},ensureHostWindow(){},windowManager:{sendMessageToWindow(){}}},B=`local`,R={desktopNotificationManager:{dismissByNavigationPath(){}},getOrCreateContext(){},localHost:B},z={deepLinks:{queueProcessArgs(){},flushPendingDeepLinks(){}},navigateToRoute(){}};let A=Date.now(),w=()=>{},ae=e=>{e.isMinimized()&&e.restore(),e.show(),e.focus()},oe=async()=>{try{M.hotkeyWindowLifecycleManager.hide();let e=M.getPrimaryWindow(`local`)??await M.createFreshLocalWindow(`/`);if(e==null)return;ae(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{z.deepLinks.queueProcessArgs(e)||oe()});let se=async(e,t)=>{M.hotkeyWindowLifecycleManager.hide();let n=M.getPrimaryWindow(B),r=n??await M.createFreshLocalWindow(e);r!=null&&(R.desktopNotificationManager.dismissByNavigationPath(e),n!=null&&t.navigateExistingWindow&&z.navigateToRoute(r,e),ae(r))};let ce=async()=>{};E&&ce();let be=await M.ensureHostWindow(B);be&&ae(be),w(`local window ensured`,A,{hostId:B,localWindowVisible:be?.isVisible()??!1}),A=Date.now(),await z.deepLinks.flushPendingDeepLinks();}",
+  ].join("");
+}
+
+function keybindsIndexBundleFixture() {
+  return [
+    "var Kge={\"general-settings\":xh,appearance:Pf,\"git-settings\":t1};",
+    "var i_e={\"general-settings\":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DsLl9t6Z.js`),[],import.meta.url)),appearance:(0,Z.lazy)(()=>s(()=>import(`./appearance.js`),[],import.meta.url))};",
+    "qge=[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`];",
+    "Jge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];",
+    "switch(e){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;}",
+    "switch(e){case`usage`:k=g;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;}",
   ].join("");
 }
 
@@ -423,6 +435,21 @@ test("allows bundled Computer Use on Linux as well as macOS", () => {
     /\{installWhenMissing:!0,name:tn,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/,
   );
   assert.doesNotMatch(patched, /t===`darwin`&&e\.computerUse/);
+});
+
+test("adds Keybinds settings route after upstream minified variable drift", () => {
+  const patched = applyPatchTwice(applyKeybindsSettingsIndexPatch, keybindsIndexBundleFixture());
+
+  assert.match(
+    patched,
+    /var i_e=\{keybinds:\(0,Z\.lazy\)\(\(\)=>s\(\(\)=>import\(`\.\/keybinds-settings-linux\.js`\)/,
+  );
+  assert.match(patched, /var Kge=\{keybinds:xh,"general-settings":xh,/);
+  assert.match(patched, /qge=\[`general-settings`,`keybinds`,`appearance`/);
+  assert.match(patched, /slugs:\[`general-settings`,`keybinds`,`appearance`/);
+  assert.match(patched, /case`keybinds`:return l===`electron`/);
+  assert.match(patched, /case`keybinds`:k=!1;break bb0;/);
+  assert.match(patched, /codexLinuxKeybindOverridesRuntime/);
 });
 
 test("adds Linux package updater behind the existing app updater manager", () => {


### PR DESCRIPTION
## Summary

- Make the Keybinds settings index patch tolerate upstream minified variable name drift
- Match the settings route/icon/nav structures instead of hard-coded `c_e` / `Xge` / `Zge` names
- Add regression coverage for the current upstream bundle shape

## Validation

- `node --check scripts/patch-linux-window-ui.js`
- `node --test scripts/patch-linux-window-ui.test.js`
