### PR TITLE
fix(nix): expose runtime libraries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,9 @@
           # Patch generated scripts for NixOS systems without /bin/bash.
           if [ -f "${installDir}/start.sh" ]; then
             ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "${installDir}/start.sh"
+            if ! grep -q "NixOS Electron library path" "${installDir}/start.sh"; then
+              ${pkgs.gnused}/bin/sed -i '2i# NixOS Electron library path for dlopen()ed GL/EGL libraries.\nexport LD_LIBRARY_PATH="${electronLibPath}:''${LD_LIBRARY_PATH:-}"' "${installDir}/start.sh"
+            fi
           fi
 
           # Patch the Electron binary for NixOS.
@@ -238,6 +241,7 @@ NODE
 
             makeWrapper "$out/opt/codex-desktop/start.sh" "$out/bin/codex-desktop" \
               --prefix PATH : "${launcherPath}" \
+              --prefix LD_LIBRARY_PATH : "${electronLibPath}" \
               --prefix PATH : "/run/current-system/sw/bin" \
               --prefix PATH : "/etc/profiles/per-user/$(whoami)/bin"
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,11 @@
         ];
 
         electronLibPath = pkgs.lib.makeLibraryPath electronLibs;
+        runtimeLibPath = pkgs.lib.makeLibraryPath (with pkgs; [
+          libxcrypt-legacy
+          stdenv.cc.cc.lib
+          zlib
+        ]);
         launcherPath = pkgs.lib.makeBinPath (with pkgs; [
           bash
           coreutils
@@ -81,7 +86,32 @@
           if [ -f "${installDir}/start.sh" ]; then
             ${pkgs.gnused}/bin/sed -i '1s|^#!/bin/bash$|#!${pkgs.bash}/bin/bash|' "${installDir}/start.sh"
             if ! grep -q "NixOS Electron library path" "${installDir}/start.sh"; then
-              ${pkgs.gnused}/bin/sed -i '2i# NixOS Electron library path for dlopen()ed GL/EGL libraries.\nexport LD_LIBRARY_PATH="${electronLibPath}:''${LD_LIBRARY_PATH:-}"' "${installDir}/start.sh"
+              ${pkgs.gnused}/bin/sed -i '2i# NixOS Electron library path for dlopen()ed GL/EGL libraries.\nexport LD_LIBRARY_PATH="${electronLibPath}:${runtimeLibPath}:''${LD_LIBRARY_PATH:-}"' "${installDir}/start.sh"
+            fi
+            if ! grep -q "codex_nixos_add_runtime_library_dirs" "${installDir}/start.sh"; then
+              ${pkgs.gnused}/bin/sed -i '/^set -euo pipefail$/a\
+\
+codex_nixos_add_runtime_library_dirs() {\
+    local cache_home="''${XDG_CACHE_HOME:-''${HOME:-}/.cache}"\
+    local runtime_root="''${CODEX_PRIMARY_RUNTIME_ROOT:-''${CODEX_RUNTIME_ROOT:-$cache_home/codex-runtimes/codex-primary-runtime}}"\
+    local dir\
+\
+    for dir in \\\
+        "$runtime_root/dependencies/python/lib" \\\
+        "$runtime_root/dependencies/python/lib/python3.12/site-packages/pillow.libs" \\\
+        "$runtime_root/dependencies/python/lib/python3.12/site-packages/numpy.libs" \\\
+        "$runtime_root/dependencies/node/node_modules/@img/sharp-libvips-linux-x64/lib" \\\
+        "$runtime_root/dependencies/node/node_modules/@img/sharp-linux-x64/lib" \\\
+        "$runtime_root/dependencies/node/node_modules/@napi-rs/canvas-linux-x64-gnu"; do\
+        if [ -d "$dir" ]; then\
+            LD_LIBRARY_PATH="$dir:''${LD_LIBRARY_PATH:-}"\
+        fi\
+    done\
+\
+    export LD_LIBRARY_PATH\
+}\
+\
+codex_nixos_add_runtime_library_dirs' "${installDir}/start.sh"
             fi
           fi
 
@@ -242,6 +272,7 @@ NODE
             makeWrapper "$out/opt/codex-desktop/start.sh" "$out/bin/codex-desktop" \
               --prefix PATH : "${launcherPath}" \
               --prefix LD_LIBRARY_PATH : "${electronLibPath}" \
+              --prefix LD_LIBRARY_PATH : "${runtimeLibPath}" \
               --prefix PATH : "/run/current-system/sw/bin" \
               --prefix PATH : "/etc/profiles/per-user/$(whoami)/bin"
 


### PR DESCRIPTION
PR #85 was merged before the follow-up runtime fixes landed on the branch, so this opens those fixes as a fresh PR.

This updates the Nix launcher to expose libraries that Electron and the downloaded primary runtime load dynamically at startup.

Changes:
- adds GL/EGL libraries to `LD_LIBRARY_PATH` for Electron startup
- adds core runtime libraries for the downloaded primary runtime (`libxcrypt-legacy`, C++ runtime, and zlib)
- adds dynamic library dirs from the downloaded Python, Pillow, NumPy, sharp, and canvas runtime payloads when present

Verification:
- `nix build .#codex-desktop`
- `result/bin/codex-desktop --help`
- checked the downloaded `~/.cache/codex-runtimes/codex-primary-runtime` ELF files under the launcher environment with `ldd`; no unresolved `not found` libraries remained
