### PR TITLE
Improve Electron runtime launch robustness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, p
   `7z` can return a non-zero status for the `/Applications` symlink inside the DMG. This is currently treated as a warning if a `.app` bundle was still extracted successfully.
 - Launcher and `nvm`:
   GUI launchers often do not inherit the user's shell `PATH`. The generated `start.sh` explicitly searches for `codex`, including common `nvm` locations.
+- Electron runtime validation:
+  Validate downloaded Electron with `ELECTRON_RUN_AS_NODE=1 "$INSTALL_DIR/electron" -p 'process.versions.electron || ""'`; plain `electron --version` can launch the bundled app or report the embedded Node version and is not reliable.
 - CLI preflight:
   Before Electron launches, the generated launcher asks `codex-update-manager` to verify the installed Codex CLI, prompt to install it when it is missing, and update it if the npm package is newer. Terminal launches prompt inline; GUI launches prefer `kdialog` on KDE/Plasma, otherwise `zenity`, before falling back to an actionable desktop notification. Missing-CLI automatic installation is launcher-scoped: the daemon and `codex-update-manager status` report `cli_status: NotInstalled` and may notify, but they do not attempt installation on their own. The check is best-effort: it uses a 1-hour cooldown for npm registry lookups, caches local CLI version reads to keep startup light, falls back to `npm install -g --prefix ~/.local` if a global install fails, and warns instead of blocking app launch when the refresh attempt does not succeed.
 - ASAR patches are independent and fail-soft:

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -422,6 +422,8 @@ find_codex_cli() {
 
     local candidate
     for candidate in \
+        "$HOME/.npm-global/bin/codex" \
+        "$HOME/.npm-packages/bin/codex" \
         "$HOME/.nvm/versions/node/current/bin/codex" \
         "$HOME/.nvm/versions/node"/*/bin/codex \
         "$HOME/.local/share/pnpm/codex" \

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -104,7 +104,15 @@ download_electron() {
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
     unzip -qo "$WORK_DIR/electron.zip"
-    chmod 4755 "$INSTALL_DIR/chrome-sandbox" 2>/dev/null || true
+
+    local chrome_sandbox_path="$INSTALL_DIR/chrome-sandbox"
+    if [ -e "$chrome_sandbox_path" ]; then
+        if ! chmod 4755 "$chrome_sandbox_path"; then
+            warn "Failed to set setuid permissions on $chrome_sandbox_path"
+        fi
+    else
+        warn "Expected Electron sandbox binary not found at $chrome_sandbox_path"
+    fi
 
     local runtime_version
     runtime_version="$(ELECTRON_RUN_AS_NODE=1 "$INSTALL_DIR/electron" -p 'process.versions.electron || ""' 2>/dev/null || true)"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -104,7 +104,13 @@ download_electron() {
     mkdir -p "$INSTALL_DIR"
     cd "$INSTALL_DIR"
     unzip -qo "$WORK_DIR/electron.zip"
+    chmod 4755 "$INSTALL_DIR/chrome-sandbox" 2>/dev/null || true
+
+    local runtime_version
+    runtime_version="$(ELECTRON_RUN_AS_NODE=1 "$INSTALL_DIR/electron" -p 'process.versions.electron || ""' 2>/dev/null || true)"
+    if [ "$runtime_version" != "$ELECTRON_VERSION" ]; then
+        error "Downloaded runtime validation failed: expected Electron $ELECTRON_VERSION, got ${runtime_version:-not-electron}. Clear the Electron cache and rebuild."
+    fi
 
     info "Electron ready"
 }
-

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -105,6 +105,7 @@ stage_common_package_files() {
 
     rm -rf "$app_root"
     cp -aT "$APP_DIR" "$app_root"
+    chmod 4755 "$app_root/chrome-sandbox" 2>/dev/null || true
     mkdir -p "$app_root/.codex-linux"
     cp "$ICON_SOURCE" "$app_root/.codex-linux/$PACKAGE_NAME.png"
     render_desktop_entry "$root/usr/share/applications/$PACKAGE_NAME.desktop"


### PR DESCRIPTION
## Summary
- validate the downloaded Linux Electron runtime after extraction so a wrong runtime fails during build instead of launching broken
- set chrome-sandbox to 4755 both after runtime extraction and during native package staging
- include common npm global install prefixes in launcher CLI discovery for GUI sessions

## Testing
- bash -n scripts/lib/native-modules.sh
- bash -n scripts/lib/package-common.sh
- bash -n launcher/start.sh.template
- make build-app && make package
- verified rebuilt .deb contains setuid chrome-sandbox and Electron runtime reports 41.2.0 via ELECTRON_RUN_AS_NODE

Related to #74 and #75.