### PR TITLE
[codex] fix Fedora package format detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,23 @@ PACMAN_GLOB := $(CURDIR)/dist/$(PACKAGE_NAME)-[0-9]*.pkg.tar.*
 .DEFAULT_GOAL := help
 
 NATIVE_PKG_FORMAT_CMD = format=""; \
+os_release_token_match() { \
+	local expected token; \
+	for token in $${ID:-} $${ID_LIKE:-}; do \
+		for expected in "$$@"; do \
+			if [ "$$token" = "$$expected" ]; then \
+				return 0; \
+			fi; \
+		done; \
+	done; \
+	return 1; \
+}; \
 if [ -r /etc/os-release ]; then . /etc/os-release; \
-	if command -v pacman >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (arch|archlinux|manjaro|endeavouros|artix) ]]; then \
+	if os_release_token_match arch archlinux manjaro endeavouros artix; then \
 		format="pacman"; \
-	elif command -v rpmbuild >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (fedora|rhel|centos|rocky|almalinux|ol|sles|suse|opensuse) ]]; then \
+	elif os_release_token_match fedora rhel centos rocky almalinux ol sles suse opensuse; then \
 		format="rpm"; \
-	elif command -v dpkg-deb >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (debian|ubuntu|linuxmint|pop|elementary|zorin) ]]; then \
+	elif os_release_token_match debian ubuntu linuxmint pop elementary zorin; then \
 		format="deb"; \
 	fi; \
 fi; \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,31 @@ PACMAN_GLOB := $(CURDIR)/dist/$(PACKAGE_NAME)-[0-9]*.pkg.tar.*
 
 .DEFAULT_GOAL := help
 
+NATIVE_PKG_FORMAT_CMD = format=""; \
+if [ -r /etc/os-release ]; then . /etc/os-release; \
+	if command -v pacman >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (arch|archlinux|manjaro|endeavouros|artix) ]]; then \
+		format="pacman"; \
+	elif command -v rpmbuild >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (fedora|rhel|centos|rocky|almalinux|ol|sles|suse|opensuse) ]]; then \
+		format="rpm"; \
+	elif command -v dpkg-deb >/dev/null 2>&1 && [[ " $${ID:-} $${ID_LIKE:-} " =~ (debian|ubuntu|linuxmint|pop|elementary|zorin) ]]; then \
+		format="deb"; \
+	fi; \
+fi; \
+if [ -z "$$format" ]; then \
+	if command -v pacman >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then \
+		format="pacman"; \
+	elif command -v rpmbuild >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then \
+		format="rpm"; \
+	elif command -v dpkg-deb >/dev/null 2>&1; then \
+		format="deb"; \
+	elif command -v rpmbuild >/dev/null 2>&1; then \
+		format="rpm"; \
+	elif command -v pacman >/dev/null 2>&1; then \
+		format="pacman"; \
+	fi; \
+fi; \
+printf '%s\n' "$$format"
+
 .PHONY: help check test build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman package install service-enable service-status clean-dist clean-state
 
 help:
@@ -144,12 +169,13 @@ pacman: build-updater
 
 package: build-updater
 	@echo "[make] Building native package (auto-detecting distro)"
-	@if command -v makepkg >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then \
+	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
+	if [ "$$format" = "pacman" ]; then \
 		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-pacman.sh; \
-	elif command -v dpkg-deb >/dev/null 2>&1; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-deb.sh; \
-	elif command -v rpmbuild >/dev/null 2>&1; then \
+	elif [ "$$format" = "rpm" ]; then \
 		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-rpm.sh; \
+	elif [ "$$format" = "deb" ]; then \
+		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-deb.sh; \
 	else \
 		echo "[make] No supported packaging tool found. Install dpkg-dev (Debian), rpm-build (Fedora), or pacman (Arch)." >&2; \
 		exit 1; \
@@ -157,34 +183,42 @@ package: build-updater
 
 install:
 	@echo "[make] Installing latest native package"
-	@if command -v pacman >/dev/null 2>&1 && ! command -v dpkg >/dev/null 2>&1; then \
+	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
+	if [ "$$format" = "pacman" ]; then \
 		pkg="$${PKG:-$$(ls -1 $(PACMAN_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
 		if [ -z "$$pkg" ]; then \
 			echo "[make] No pacman package found. Run 'make pacman' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$pkg"; \
 		sudo pacman -U --noconfirm "$$pkg"; \
-	elif command -v dpkg >/dev/null 2>&1; then \
-		deb="$${DEB:-$$(ls -1 $(DEB_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
-		if [ -z "$$deb" ]; then \
-			echo "[make] No Debian package found. Run 'make deb' first." >&2; exit 1; \
+	elif [ "$$format" = "rpm" ] && command -v dnf >/dev/null 2>&1; then \
+		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		if [ -z "$$rpm" ]; then \
+			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
-		echo "[make] Installing $$deb"; \
-		sudo dpkg -i "$$deb"; \
-	elif command -v zypper >/dev/null 2>&1; then \
+		echo "[make] Installing $$rpm"; \
+		sudo dnf install -y "$$rpm"; \
+	elif [ "$$format" = "rpm" ] && command -v zypper >/dev/null 2>&1; then \
 		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
 		if [ -z "$$rpm" ]; then \
 			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$rpm"; \
 		sudo zypper --non-interactive --no-gpg-checks install -y "$$rpm"; \
-	elif command -v rpm >/dev/null 2>&1; then \
+	elif [ "$$format" = "rpm" ]; then \
 		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
 		if [ -z "$$rpm" ]; then \
 			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$rpm"; \
 		sudo rpm -Uvh "$$rpm"; \
+	elif [ "$$format" = "deb" ]; then \
+		deb="$${DEB:-$$(ls -1 $(DEB_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		if [ -z "$$deb" ]; then \
+			echo "[make] No Debian package found. Run 'make deb' first." >&2; exit 1; \
+		fi; \
+		echo "[make] Installing $$deb"; \
+		sudo dpkg -i "$$deb"; \
 	else \
 		echo "[make] No supported package manager found (dpkg, rpm, zypper, or pacman)." >&2; exit 1; \
 	fi

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -74,16 +74,6 @@ fn detect_package_kind(
     rpm_installed: bool,
     os_release: Option<(String, String)>,
 ) -> PackageKind {
-    if pacman_installed {
-        return PackageKind::Pacman;
-    }
-    if deb_installed {
-        return PackageKind::Deb;
-    }
-    if rpm_installed {
-        return PackageKind::Rpm;
-    }
-
     if let Some((id, id_like)) = os_release {
         let fields = [id.as_str(), id_like.as_str()];
         if os_release_matches(
@@ -121,6 +111,16 @@ fn detect_package_kind(
         ) {
             return PackageKind::Rpm;
         }
+    }
+
+    if pacman_installed {
+        return PackageKind::Pacman;
+    }
+    if deb_installed {
+        return PackageKind::Deb;
+    }
+    if rpm_installed {
+        return PackageKind::Rpm;
     }
 
     if has_dpkg {
@@ -752,7 +752,7 @@ mod tests {
     }
 
     #[test]
-    fn detection_prefers_installed_pacman_package_even_if_rpm_exists() {
+    fn detection_prefers_arch_os_release_even_if_rpm_command_exists() {
         assert_eq!(
             detect_package_kind(
                 true,
@@ -764,6 +764,22 @@ mod tests {
                 Some(("arch".to_string(), "".to_string())),
             ),
             PackageKind::Pacman
+        );
+    }
+
+    #[test]
+    fn detection_prefers_fedora_os_release_even_if_deb_package_is_installed() {
+        assert_eq!(
+            detect_package_kind(
+                false,
+                true,
+                true,
+                false,
+                true,
+                false,
+                Some(("fedora".to_string(), "rhel".to_string())),
+            ),
+            PackageKind::Rpm
         );
     }
 


### PR DESCRIPTION
## Summary

This fixes package-format auto-detection on Fedora.

On Fedora systems that also have Debian tooling installed, the project could choose the Debian packaging path just because `dpkg` or `dpkg-deb` existed on the machine. That led `make package` to build a `.deb` instead of an `.rpm`, and `make install` to run `dpkg -i` instead of the native RPM install flow.

## Root cause

Package selection was giving too much weight to command availability and not enough weight to the actual host distribution.

That created two related problems:

- The shell-side Makefile logic could prefer DEB on Fedora if Debian tools were present.
- The Rust updater could also prefer the wrong package format if a package from another ecosystem had been installed previously.

## Fix

This change makes package detection distro-first.

- `Makefile` now checks `/etc/os-release` first and picks the native package format for the current distro.
- Fedora-family systems now prefer RPM, Debian-family systems prefer DEB, and Arch-family systems prefer pacman.
- `make install` now follows the same decision and uses the native package manager for the chosen format.
- On Fedora, that means using the RPM path with `dnf` instead of incorrectly routing through `dpkg`.
- `updater/src/install.rs` now mirrors the same distro-first logic so the updater stays aligned with the Makefile behavior.

## Why this matters

This prevents Fedora hosts from building or installing the wrong package format just because cross-distro tooling happens to be installed. It also prevents an already-installed `.deb` from teaching the updater to keep preferring Debian behavior on an RPM-based system.

## Validation

I verified the change with:

- `cargo test -p codex-update-manager detection_`
- `make -n package`
- `make -n install`

On this Fedora machine, the dry runs now resolve to the RPM build and install paths as intended.

## Notes

I did not use the full `cargo test -p codex-update-manager` suite as the primary validation signal for this PR because this environment still has unrelated CLI-path test failures around an existing `/usr/local/bin/codex`. Those failures are outside the scope of this packaging fix.
