### PR TITLE
Fix Browser Use node_repl fallback install

### DIFF
--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -79,17 +79,38 @@ stage_linux_computer_use_plugin() {
     return 0
 }
 
-is_elf_executable() {
+is_host_linux_elf_executable() {
     local file="$1"
-    python3 - "$file" <<'PY'
+    python3 - "$file" "$ARCH" <<'PY'
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1])
+arch = sys.argv[2]
+expected_machine = {
+    "x86_64": 62,
+    "aarch64": 183,
+    "armv7l": 40,
+    "armv6l": 40,
+    "armhf": 40,
+}.get(arch)
+if expected_machine is None:
+    sys.exit(1)
+
 try:
-    sys.exit(0 if path.read_bytes()[:4] == b"\x7fELF" else 1)
+    header = path.read_bytes()[:20]
 except OSError:
     sys.exit(1)
+
+if len(header) < 20 or header[:4] != b"\x7fELF":
+    sys.exit(1)
+
+is_little_endian = header[5] == 1
+if not is_little_endian:
+    sys.exit(1)
+
+machine = int.from_bytes(header[18:20], "little")
+sys.exit(0 if machine == expected_machine else 1)
 PY
 }
 
@@ -103,12 +124,101 @@ install_linux_executable_resource() {
         return 1
     fi
 
-    if ! is_elf_executable "$source"; then
-        warn "Browser Use $label is not a Linux executable; skipping"
+    if ! is_host_linux_elf_executable "$source"; then
+        warn "Browser Use $label is not a Linux executable for $ARCH; skipping"
         return 1
     fi
 
     install -m 0755 "$source" "$destination"
+}
+
+browser_use_node_repl_runtime_url() {
+    case "$ARCH" in
+        x86_64)
+            echo "${CODEX_BROWSER_USE_NODE_REPL_RUNTIME_URL:-https://persistent.oaistatic.com/codex-primary-runtime/26.426.12240/codex-primary-runtime-linux-x64-26.426.12240.tar.xz}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+browser_use_node_repl_runtime_sha256() {
+    case "$ARCH" in
+        x86_64)
+            echo "${CODEX_BROWSER_USE_NODE_REPL_RUNTIME_SHA256:-db5624eb6efa36b66ec6f6dd0488cefb966e49636862aab6209a4336c1ca90c4}"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+install_node_repl_from_primary_runtime_archive() {
+    local destination="$1"
+    local url
+    local expected_sha
+    local cache_dir
+    local archive
+    local extract_dir
+    local source
+
+    if ! url="$(browser_use_node_repl_runtime_url)"; then
+        warn "Browser Use node_repl primary-runtime fallback is unavailable for $ARCH"
+        return 1
+    fi
+    expected_sha="$(browser_use_node_repl_runtime_sha256)"
+
+    cache_dir="${CODEX_BROWSER_USE_RUNTIME_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/codex-desktop/browser-use}"
+    archive="$cache_dir/$(basename "$url")"
+    extract_dir="$WORK_DIR/browser-use-node-repl-runtime"
+    source="$extract_dir/codex-primary-runtime/dependencies/bin/node_repl"
+
+    mkdir -p "$cache_dir" "$extract_dir"
+    if [ ! -f "$archive" ]; then
+        info "Downloading Browser Use node_repl fallback runtime..."
+        if ! curl -L --fail --progress-bar -o "$archive.part" "$url"; then
+            rm -f "$archive.part"
+            warn "Failed to download Browser Use node_repl fallback runtime"
+            return 1
+        fi
+        mv "$archive.part" "$archive"
+    else
+        info "Using cached Browser Use node_repl fallback runtime: $archive"
+    fi
+
+    if ! printf '%s  %s\n' "$expected_sha" "$archive" | sha256sum -c - >/dev/null 2>&1; then
+        rm -f "$archive"
+        warn "Browser Use node_repl fallback runtime checksum mismatch; removed cached archive"
+        return 1
+    fi
+
+    if ! tar -xJf "$archive" -C "$extract_dir" codex-primary-runtime/dependencies/bin/node_repl; then
+        warn "Failed to extract Browser Use node_repl from fallback runtime"
+        return 1
+    fi
+
+    install_linux_executable_resource "$source" "$destination" "node_repl fallback runtime"
+}
+
+install_browser_use_node_repl_resource() {
+    local upstream_source="$1"
+    local destination="$2"
+    local source
+
+    for source in \
+        "${CODEX_LINUX_NODE_REPL_SOURCE:-}" \
+        "${CODEX_NODE_REPL_PATH:-}" \
+        "${XDG_CACHE_HOME:-$HOME/.cache}/codex-runtimes/codex-primary-runtime/dependencies/bin/node_repl" \
+        "$upstream_source"
+    do
+        [ -n "$source" ] || continue
+        if install_linux_executable_resource "$source" "$destination" "node_repl runtime"; then
+            return 0
+        fi
+    done
+
+    install_node_repl_from_primary_runtime_archive "$destination"
 }
 
 remove_macos_sidecar_files() {
@@ -203,8 +313,7 @@ install_bundled_plugin_resources() {
     write_bundled_plugins_marketplace "$source_marketplace" "$bundled_plugins_dir/.agents/plugins/marketplace.json" "$include_browser" "$include_computer_use"
 
     install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" || true
-    install_linux_executable_resource "$upstream_resources/node_repl" "$resources_dir/node_repl" "node_repl runtime" || true
+    install_browser_use_node_repl_resource "$upstream_resources/node_repl" "$resources_dir/node_repl" || true
 
     info "Linux-safe bundled plugins installed"
 }
-

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -47,6 +47,17 @@ assert_occurrence_count() {
     [ "$actual" = "$expected" ] || fail "Expected '$pattern' to appear $expected times in $path, found $actual"
 }
 
+make_fake_browser_use_upstream_app() {
+    local app_dir="$1"
+    local resources_dir="$app_dir/Contents/Resources"
+    mkdir -p \
+        "$resources_dir/plugins/openai-bundled/.agents/plugins" \
+        "$resources_dir/plugins/openai-bundled/plugins/browser-use"
+    cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
+{"plugins":[{"name":"browser-use","source":{"source":"local","path":"./plugins/browser-use"},"policy":{"installation":"AVAILABLE"}}]}
+JSON
+}
+
 make_fake_app() {
     local app_dir="$1"
     mkdir -p "$app_dir"
@@ -534,6 +545,61 @@ test_side_by_side_launcher_identity() {
     ln -s "$app_dir/start.sh" "$bin_dir/codex-cua-lab"
     XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" "$bin_dir/codex-cua-lab" --help >"$symlink_help_log"
     assert_contains "$symlink_help_log" "Launches the Codex CUA Lab app."
+}
+
+test_browser_use_node_repl_fallback_runtime() {
+    info "Checking Browser Use node_repl fallback runtime"
+    if [ "$(uname -m)" != "x86_64" ]; then
+        info "Skipping x86_64-only Browser Use fallback runtime test"
+        return 0
+    fi
+
+    local workspace="$TMP_DIR/browser-use-node-repl-fallback"
+    local app_dir="$workspace/Codex.app"
+    local install_dir="$workspace/install"
+    local archive_root="$workspace/archive-root"
+    local archive="$workspace/runtime.tar.xz"
+    local output_log="$workspace/output.log"
+    local archive_sha
+
+    mkdir -p "$workspace" "$install_dir/resources" "$archive_root/codex-primary-runtime/dependencies/bin"
+    make_fake_browser_use_upstream_app "$app_dir"
+
+    # Simulate the current upstream DMG shape: node_repl exists, but it is not a Linux ELF.
+    printf '\xfe\xed\xfa\xcf' > "$app_dir/Contents/Resources/node_repl"
+    chmod +x "$app_dir/Contents/Resources/node_repl"
+
+    cp /bin/true "$archive_root/codex-primary-runtime/dependencies/bin/node_repl"
+    chmod 0755 "$archive_root/codex-primary-runtime/dependencies/bin/node_repl"
+    tar -cJf "$archive" -C "$archive_root" codex-primary-runtime
+    archive_sha="$(sha256sum "$archive" | awk '{print $1}')"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="$(uname -m)"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        XDG_CACHE_HOME="$workspace/xdg-cache"
+        CODEX_NODE_REPL_PATH=
+        CODEX_LINUX_NODE_REPL_SOURCE=
+        CODEX_BROWSER_USE_RUNTIME_CACHE_DIR="$workspace/cache"
+        CODEX_BROWSER_USE_NODE_REPL_RUNTIME_URL="file://$archive"
+        CODEX_BROWSER_USE_NODE_REPL_RUNTIME_SHA256="$archive_sha"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$install_dir/resources/node_repl"
+    cmp -s /bin/true "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
+    assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
+    assert_contains "$output_log" "Downloading Browser Use node_repl fallback runtime"
 }
 
 make_fake_extracted_asar() {
@@ -1586,6 +1652,7 @@ main() {
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata
+    test_browser_use_node_repl_fallback_runtime
     test_launcher_template_sanity
     test_side_by_side_launcher_identity
     test_linux_file_manager_patch_smoke


### PR DESCRIPTION
## Summary

- reject upstream Browser Use `node` / `node_repl` binaries unless they are Linux ELF executables for the current host architecture
- restore the old `node_repl` behavior on `x86_64` by downloading a pinned official `codex-primary-runtime` archive and extracting only `dependencies/bin/node_repl`
- add smoke coverage for the fallback path without downloading the real runtime archive during tests

## Validation

- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh`
- `./tests/scripts_smoke.sh`
- `cargo test -p codex-update-manager`