### PR TITLE
Fix Browser Use site_status allowlist fallback on Linux

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -265,6 +265,67 @@ export_packaged_runtime_env() {
     fi
 }
 
+browser_use_plugin_version() {
+    local plugin_json="$1"
+
+    python3 - "$plugin_json" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        version = json.load(handle).get("version")
+except (OSError, json.JSONDecodeError):
+    version = None
+
+if not isinstance(version, str) or not version.strip():
+    raise SystemExit(1)
+print(version.strip())
+PY
+}
+
+sync_browser_use_bundled_plugin_cache() {
+    local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser-use"
+    local plugin_json="$source_plugin/.codex-plugin/plugin.json"
+    local source_client="$source_plugin/scripts/browser-client.mjs"
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local version
+    local cache_root
+    local cache_plugin
+    local cache_client
+    local cache_parent
+    local tmp_plugin
+
+    [ -f "$plugin_json" ] || return 0
+    [ -f "$source_client" ] || return 0
+
+    version="$(browser_use_plugin_version "$plugin_json" 2>/dev/null || true)"
+    [ -n "$version" ] || return 0
+
+    cache_root="$codex_home/plugins/cache/openai-bundled/browser-use"
+    cache_plugin="$cache_root/$version"
+    cache_client="$cache_plugin/scripts/browser-client.mjs"
+
+    if [ -f "$cache_client" ] && cmp -s "$source_client" "$cache_client"; then
+        return 0
+    fi
+
+    cache_parent="$(dirname "$cache_plugin")"
+    tmp_plugin="$cache_parent/.browser-use-$version.tmp.$$"
+    rm -rf "$tmp_plugin"
+    mkdir -p "$cache_parent"
+
+    if cp -R "$source_plugin" "$tmp_plugin"; then
+        find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
+        rm -rf "$cache_plugin"
+        mv "$tmp_plugin" "$cache_plugin"
+        echo "Browser Use plugin cache synced from bundled resources: $cache_plugin"
+    else
+        rm -rf "$tmp_plugin"
+        echo "Browser Use plugin cache sync failed; continuing with existing cache."
+    fi
+}
+
 resolve_browser_use_runtime_env() {
     if [ -z "${CODEX_ELECTRON_RESOURCES_PATH:-}" ]; then
         export CODEX_ELECTRON_RESOURCES_PATH="$SCRIPT_DIR/resources"
@@ -1062,6 +1123,9 @@ if needs_cold_start; then
 fi
 
 export_packaged_runtime_env
+if needs_cold_start; then
+    sync_browser_use_bundled_plugin_cache
+fi
 resolve_browser_use_runtime_env
 
 echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -226,6 +226,72 @@ remove_macos_sidecar_files() {
     find "$root" -type f -name '*:com.apple.*' -delete
 }
 
+patch_browser_use_site_status_allowlist_fallback() {
+    local client="$1"
+
+    if grep -q "codexLinuxSiteStatusAllowlistFallback" "$client"; then
+        return 0
+    fi
+
+    python3 - "$client" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+needle = (
+    'async fetchBlocked(t){let n=await MT(t.endpoint,{method:"GET"});'
+    'if(!n.ok)throw new Error(Rt(`Browser Use cannot determine if ${t.displayUrl} is allowed. '
+    'Please try again later or use another source.`));let r=await n.json();return R7(r)}'
+)
+replacement = (
+    'async fetchBlocked(t){let n;try{n=await MT(t.endpoint,{method:"GET"})}catch(r){'
+    'if(String(t?.endpoint??"").includes("/aura/site_status")&&String(r?.message??r).includes("URL is not allowlisted"))return console.warn'
+    '("codexLinuxSiteStatusAllowlistFallback",t.endpoint),!1;throw r}'
+    'if(!n.ok)throw new Error(Rt(`Browser Use cannot determine if ${t.displayUrl} is allowed. '
+    'Please try again later or use another source.`));let r=await n.json();return R7(r)}'
+)
+if needle not in source:
+    print(
+        "WARN: Could not find Browser Use site_status allowlist fallback insertion point — leaving browser-client.mjs unchanged",
+        file=sys.stderr,
+    )
+    raise SystemExit(0)
+path.write_text(source.replace(needle, replacement, 1), encoding="utf-8")
+PY
+}
+
+stage_browser_use_plugin_from_upstream() {
+    local source_plugin="$1"
+    local target_plugins="$2"
+    local target_plugin="$target_plugins/browser-use"
+    local source_client="$source_plugin/scripts/browser-client.mjs"
+    local target_client="$target_plugin/scripts/browser-client.mjs"
+
+    if [ ! -d "$source_plugin" ]; then
+        warn "Browser Use bundled plugin resources not found in upstream app; skipping Browser Use"
+        return 1
+    fi
+
+    if [ ! -f "$source_plugin/.codex-plugin/plugin.json" ]; then
+        warn "Browser Use plugin manifest not found in upstream app; skipping Browser Use"
+        return 1
+    fi
+
+    if [ ! -f "$source_client" ]; then
+        warn "Browser Use browser-client.mjs not found in upstream app; skipping Browser Use"
+        return 1
+    fi
+
+    rm -rf "$target_plugin"
+    cp -R "$source_plugin" "$target_plugin"
+    remove_macos_sidecar_files "$target_plugin"
+    patch_browser_use_site_status_allowlist_fallback "$target_client"
+
+    info "Browser Use plugin staged from upstream DMG"
+    return 0
+}
+
 write_bundled_plugins_marketplace() {
     local source="$1"
     local destination="$2"
@@ -290,13 +356,8 @@ install_bundled_plugin_resources() {
 
     mkdir -p "$bundled_plugins_dir/plugins" "$bundled_plugins_dir/.agents/plugins"
 
-    if [ -d "$source_plugin" ]; then
-        rm -rf "$bundled_plugins_dir/plugins/browser-use"
-        cp -R "$source_plugin" "$bundled_plugins_dir/plugins/browser-use"
-        remove_macos_sidecar_files "$bundled_plugins_dir/plugins/browser-use"
+    if stage_browser_use_plugin_from_upstream "$source_plugin" "$bundled_plugins_dir/plugins"; then
         include_browser=1
-    else
-        warn "Browser Use bundled plugin resources not found in upstream app; skipping Browser Use"
     fi
 
     if stage_linux_computer_use_plugin "$bundled_plugins_dir/plugins"; then

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -1251,6 +1251,24 @@ function applyLinuxComputerUseInstallFlowPatch(currentSource) {
   return currentSource;
 }
 
+function applyBrowserUseNodeReplApprovalPatch(currentSource) {
+  const approvalPatch =
+    "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
+  if (currentSource.includes(approvalPatch)) {
+    return currentSource;
+  }
+
+  const needle = "startup_timeout_sec:120,env:{";
+  if (!currentSource.includes(needle)) {
+    console.warn(
+      "WARN: Could not find Browser Use node_repl config insertion point — skipping node_repl approval patch",
+    );
+    return currentSource;
+  }
+
+  return currentSource.replace(needle, approvalPatch);
+}
+
 function applyBrowserAnnotationScreenshotPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -1710,6 +1728,7 @@ function patchMainBundleSource(source, iconAsset) {
     patched = applyLinuxComputerUseFeaturePatch(patched);
   }
   patched = applyLinuxComputerUsePluginGatePatch(patched);
+  patched = applyBrowserUseNodeReplApprovalPatch(patched);
   patched = applyLinuxAppUpdaterMenuPatch(patched);
   patched = applyLinuxTrayCloseSettingPatch(patched);
   patched = applyLinuxSettingsPersistencePatch(patched);
@@ -1963,6 +1982,7 @@ module.exports = {
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
   applyLinuxComputerUseInstallFlowPatch,
+  applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
   patchLinuxAppUpdaterBridge,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -15,6 +15,7 @@ const {
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
+  applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
   applyLinuxFileManagerPatch,
@@ -692,6 +693,16 @@ test("allows Computer Use install flow on Linux", () => {
     patched,
     /re=!ne\.isLoading&&ne\.enabled\|\|navigator\.userAgent\.includes\(`Linux`\)/,
   );
+});
+
+test("auto-approves the app-provided Browser Use node_repl bridge", () => {
+  const source =
+    "return{[`mcp_servers.${pt}`]:{command:i.nodeReplPath,args:[],startup_timeout_sec:120,env:{[dt]:l,[ft]:i.nodePath}}}";
+
+  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
+
+  assert.match(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
+  assert.match(patched, /env:\{\[dt\]:l,\[ft\]:i\.nodePath/);
 });
 
 function withIsolatedHome(body) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -52,10 +52,17 @@ make_fake_browser_use_upstream_app() {
     local resources_dir="$app_dir/Contents/Resources"
     mkdir -p \
         "$resources_dir/plugins/openai-bundled/.agents/plugins" \
-        "$resources_dir/plugins/openai-bundled/plugins/browser-use"
+        "$resources_dir/plugins/openai-bundled/plugins/browser-use/.codex-plugin" \
+        "$resources_dir/plugins/openai-bundled/plugins/browser-use/scripts"
     cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
 {"plugins":[{"name":"browser-use","source":{"source":"local","path":"./plugins/browser-use"},"policy":{"installation":"AVAILABLE"}}]}
 JSON
+    cat > "$resources_dir/plugins/openai-bundled/plugins/browser-use/.codex-plugin/plugin.json" <<'JSON'
+{"name":"browser-use","version":"0.1.0-alpha1"}
+JSON
+    cat > "$resources_dir/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" <<'JS'
+class Wm{async fetchBlocked(t){let n=await MT(t.endpoint,{method:"GET"});if(!n.ok)throw new Error(Rt(`Browser Use cannot determine if ${t.displayUrl} is allowed. Please try again later or use another source.`));let r=await n.json();return R7(r)}}export function setupAtlasRuntime() {}
+JS
 }
 
 make_fake_app() {
@@ -479,6 +486,7 @@ PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_UPDATE_MANAGER_PATH"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "resolve_update_manager_path"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_browser_use_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Install it now? \\[Y/n\\]"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "is_interactive_terminal"
     assert_contains "$REPO_DIR/updater/src/app.rs" "kdialog"
@@ -597,7 +605,9 @@ test_browser_use_node_repl_fallback_runtime() {
     ) >"$output_log" 2>&1
 
     assert_file_exists "$install_dir/resources/node_repl"
+    assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs"
     cmp -s /bin/true "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
+    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
     assert_contains "$output_log" "Downloading Browser Use node_repl fallback runtime"
 }


### PR DESCRIPTION
## Summary
- stage the upstream Browser Use plugin into the Linux app resources and sync that bundled copy into the Codex plugin cache on cold start
- keep the app-provided Browser Use \`node_repl/js\` bridge approved so Browser Use commands do not repeatedly prompt for the internal JS transport
- patch the staged \`browser-client.mjs\` so a Linux \`nodeRepl.fetch\` allowlist failure for the ChatGPT \`/aura/site_status\` preflight falls back to the existing Browser Use approval flow

## Why
Recent Browser Use builds call \`https://chatgpt.com/backend-api/aura/site_status\` before the local Browser Use domain approval checks run. On Linux, the fallback \`node_repl\` runtime can reject that service request with \`URL is not allowlisted\`, which blocks external navigation before the user's Browser settings are considered.

This keeps the fallback narrow: it only handles \`URL is not allowlisted\` for \`/aura/site_status\`. Normal Browser Use approval settings, allowed domains, blocked domains, and history permissions still apply afterward.

## Validation
- \`bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh\`
- \`node --test scripts/patch-linux-window-ui.test.js\`
- \`./tests/scripts_smoke.sh\`
- \`git diff --check\`