### PR TITLE
Speed up launcher startup checks

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -593,7 +593,13 @@ find_running_app_pid() {
         fi
     fi
 
+    return 1
+}
+
+discover_running_app_pid() {
+    local pid
     local proc_exe
+
     for proc_exe in /proc/[0-9]*/exe; do
         [ -e "$proc_exe" ] || continue
         pid="${proc_exe#/proc/}"
@@ -620,7 +626,7 @@ needs_cold_start() {
 }
 
 detect_warm_start() {
-    if RUNNING_APP_PID="$(find_running_app_pid)"; then
+    if RUNNING_APP_PID="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"; }; then
         echo "$RUNNING_APP_PID" > "$APP_PID_FILE"
         if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then
             WARM_START=0
@@ -660,6 +666,25 @@ try:
     client.sendall(payload)
 finally:
     client.close()
+PY
+}
+
+webview_origin_is_reachable() {
+    verify_webview_origin "$WEBVIEW_ORIGIN/index.html" >/dev/null 2>&1
+}
+
+webview_port_is_open() {
+    python3 - "$CODEX_LINUX_WEBVIEW_PORT" <<'PY' 2>/dev/null
+import socket
+import sys
+
+port = int(sys.argv[1])
+s = socket.socket()
+s.settimeout(0.2)
+try:
+    s.connect(("127.0.0.1", port))
+finally:
+    s.close()
 PY
 }
 
@@ -844,6 +869,12 @@ adopt_existing_webview_server() {
         return 0
     fi
 
+    return 1
+}
+
+adopt_discovered_webview_server() {
+    local pid
+
     if pid="$(discover_webview_server_pid)"; then
         echo "$pid" > "$WEBVIEW_PID_FILE"
         if running_app_is_active; then
@@ -865,7 +896,7 @@ ensure_webview_server() {
     fi
 
     if adopt_existing_webview_server; then
-        if verify_webview_origin "$WEBVIEW_ORIGIN/index.html" >/dev/null 2>&1; then
+        if webview_origin_is_reachable; then
             echo "Reusing existing verified webview server on :$CODEX_LINUX_WEBVIEW_PORT"
             log_phase "webview_reused"
             return 0
@@ -877,11 +908,31 @@ ensure_webview_server() {
         fi
     fi
 
-    stop_stale_webview_server
+    if webview_port_is_open && webview_origin_is_reachable; then
+        if adopt_discovered_webview_server; then
+            echo "Reusing existing verified webview server on :$CODEX_LINUX_WEBVIEW_PORT"
+            log_phase "webview_reused"
+            return 0
+        fi
 
-    if verify_webview_origin "$WEBVIEW_ORIGIN/index.html" >/dev/null 2>&1; then
         notify_error "$CODEX_LINUX_APP_DISPLAY_NAME webview port $CODEX_LINUX_WEBVIEW_PORT is already serving Codex content, but it is not owned by this launcher. Stop the other webview server and try again."
         exit 1
+    fi
+
+    if webview_port_is_open; then
+        stop_stale_webview_server
+        if webview_origin_is_reachable; then
+            if adopt_discovered_webview_server; then
+                echo "Reusing existing verified webview server on :$CODEX_LINUX_WEBVIEW_PORT"
+                log_phase "webview_reused"
+                return 0
+            fi
+        fi
+
+        if webview_port_is_open; then
+            notify_error "$CODEX_LINUX_APP_DISPLAY_NAME webview port $CODEX_LINUX_WEBVIEW_PORT is already in use. Stop the other process and try again."
+            exit 1
+        fi
     fi
 
     stop_owned_webview_server

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -420,8 +420,10 @@ runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_el
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("ensure_webview_server() {", 1)[0]
 ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
-if 'if RUNNING_APP_PID="$(find_running_app_pid)"; then' not in detect_body:
-    raise SystemExit("detect_warm_start must record a running app even when warm start is disabled")
+if 'RUNNING_APP_PID="$(find_running_app_pid)"' not in detect_body:
+    raise SystemExit("detect_warm_start must record a pid-file running app even when warm start is disabled")
+if '[ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"' not in detect_body:
+    raise SystemExit("detect_warm_start must only use the expensive running-app scan when the launch socket exists")
 if not re.search(r'if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then.*?return 0', detect_body, re.S):
     raise SystemExit("detect_warm_start must not fail when warm start is disabled")
 if "preserving liveness marker for second-instance handoff" not in detect_body:


### PR DESCRIPTION
## Summary
- avoid full `/proc` scans during the normal launcher cold-start path
- use the app and webview pid files as the fast path, and only fall back to process discovery when it is needed
- only run stale webview cleanup/discovery when the webview port is actually in use

## Why
On systems with many running processes, the launcher can spend several seconds walking `/proc` before Electron starts. Recent local logs showed startup reaching `electron_launch` after roughly 20 seconds, with most of the delay happening before the webview was ready.

This keeps the existing defensive behavior for second-instance handoff, occupied webview ports, and stale webview servers, but avoids paying those scans on the normal cold-start path.

## Validation
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh`
- `./tests/scripts_smoke.sh`
- `git diff --check`