### PR TITLE
Fix Linux quit guard patch fallback

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -864,6 +864,10 @@ function applyLinuxQuitGuardPatch(currentSource) {
     return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
   }
 
+  if (patchedSource.includes("require(`electron`)")) {
+    return `${quitGuardSuffix}${patchedSource}`;
+  }
+
   if (patchedSource.includes("require(`electron`)") && patchedSource.includes("require(`node:path`)")) {
     console.warn("WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch");
   }

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -144,6 +144,18 @@ test("adds the Linux quit guard when electron/path/fs requires are split across 
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
 });
 
+test("adds the Linux quit guard when only the Electron require is recognizable", () => {
+  const source =
+    "const e=require(`./app-session.js`);let t=require(`electron`);class WindowManager{}";
+
+  const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
+
+  assert.match(patched, /^let codexLinuxQuitInProgress=!1/);
+  assert.match(patched, /codexLinuxMarkQuitInProgress=\(\)=>\{codexLinuxQuitInProgress=!0\}/);
+  assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
+  assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
+});
+
 test("adds Linux menu hiding next to Windows removeMenu calls", () => {
   const source = "process.platform===`win32`&&k.removeMenu(),k.on(`closed`,()=>{})";
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);


### PR DESCRIPTION
## Summary
- add a fallback path for injecting the Linux quit-state helper when the main bundle no longer matches the older `electron/path/fs` require pattern
- prevent close/tray patches from leaving unresolved `codexLinuxIsQuitInProgress()` references in the Electron main process
- add regression coverage for bundles where only the Electron require is recognizable

## Why
Current upstream bundles can skip the explicit quit-state insertion point while later Linux tray/close patches still insert calls to `codexLinuxIsQuitInProgress()`. That leaves the generated app with an undefined reference and crashes the main process when closing the window.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `./tests/scripts_smoke.sh`
- `git diff --check`