### PR TITLE
Bundle managed Node.js runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf codex-app dist
-          mkdir -p codex-app/content/webview
-          printf '%s\n' '#!/bin/bash' 'echo "codex desktop fixture"' > codex-app/start.sh
-          chmod +x codex-app/start.sh
-          printf '%s\n' '<!doctype html><title>Codex fixture</title>' > codex-app/content/webview/index.html
+          tests/fixtures/create-packaged-app-fixture.sh codex-app
 
       - name: Build Debian package
         run: PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-deb.sh
@@ -110,10 +107,7 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf codex-app dist
-          mkdir -p codex-app/content/webview
-          printf '%s\n' '#!/bin/bash' 'echo "codex desktop fixture"' > codex-app/start.sh
-          chmod +x codex-app/start.sh
-          printf '%s\n' '<!doctype html><title>Codex fixture</title>' > codex-app/content/webview/index.html
+          tests/fixtures/create-packaged-app-fixture.sh codex-app
 
       - name: Build RPM package
         run: PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-rpm.sh
@@ -159,10 +153,7 @@ jobs:
               runuser -u builder -- bash -lc '"'"'
                 set -euo pipefail
                 rm -rf codex-app dist
-                mkdir -p codex-app/content/webview
-                printf "%s\n" "#!/bin/bash" "echo \"codex desktop fixture\"" > codex-app/start.sh
-                chmod +x codex-app/start.sh
-                printf "%s\n" "<!doctype html><title>Codex fixture</title>" > codex-app/content/webview/index.html
+                tests/fixtures/create-packaged-app-fixture.sh codex-app
 
                 cargo build --release -p codex-update-manager
                 PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-pacman.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,9 +227,9 @@ PACKAGE_VERSION=2026.03.24.120000+deadbeef ./scripts/build-pacman.sh
 
 ## Runtime Expectations
 
-- `node`, `npm`, `npx`, `python3`, `7z`, `curl`, `unzip`, `make`, and `g++` are required for `install.sh`
-- Node.js 20+ is required
-- On apt-based systems, `scripts/install-deps.sh` uses a compatible distro `nodejs`/`npm` candidate when available and otherwise bootstraps NodeSource Node.js 22 by default. `NODEJS_MAJOR=24 bash scripts/install-deps.sh` selects Node.js 24 instead.
+- `python3`, `7z`, `curl`, `unzip`, `tar`, `make`, and `g++` are required for `install.sh`
+- `install.sh` downloads and installs a managed Linux Node.js runtime into `codex-app/resources/node-runtime`; that runtime provides `node`, `npm`, and `npx` for native module rebuilds, Browser Use, Codex CLI install/update flow, and local auto-update rebuilds.
+- On apt-based systems, `scripts/install-deps.sh` can still bootstrap NodeSource Node.js 22 for users who want a system Node.js. `NODEJS_MAJOR=24 bash scripts/install-deps.sh` selects Node.js 24 instead.
 - the packaged app still requires the Codex CLI at runtime:
   `codex` must exist in `PATH` or be set through `CODEX_CLI_PATH`, but the launcher now attempts a best-effort automatic install on first run when the CLI is missing and `npm` is available
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Linux Computer Use plugin now exposes accessibility actions and editable-value setting via a new `perform_action` MCP tool. `element_index` selections resolve back to cached AT-SPI object references so actions and value writes target the same node as a click.
 - UI-driven Linux app update flow: when an update is rebuilt and ready, the in-app updater control can request install. The app exits, the user service installs the package, and the launcher relaunches `/usr/bin/codex-desktop` after the update lands. Backed by a new `codex-update-manager install-ready` subcommand and a `scripts/rebuild-candidate.sh` helper packaged into the update-builder bundle.
 - NixOS launcher exposes Electron GL/EGL libraries and primary-runtime native libraries via `LD_LIBRARY_PATH`, so the bundled Python/Node payloads (Pillow, NumPy, sharp, canvas) load on stock NixOS.
+- The installer now bundles a managed Linux Node.js 22.22 runtime into `codex-app/resources/node-runtime`; packaged launches and local auto-update rebuilds use it before any system, nvm, asdf, or manually installed Node.js.
 
 ### Changed
 
 - `get_app_state(window_id=...)` and `get_app_state(pid=...)` prefer exact PID/window-root matching when resolving the AT-SPI tree.
 - `click(element_index=...)` falls back to the primary AT-SPI action when the element exposes no usable bounds.
 - `app.asar` repack is now reproducible: file ordering is sorted and `node-pty/build/Makefile` (which embeds absolute build paths) is removed before packing.
+- Native packages no longer hard-depend on distro `nodejs`/`npm`; the bundled managed Node.js runtime covers Codex CLI install/update flows, Browser Use, and updater rebuilds. This lets users with `nvm`, asdf, Volta, or nodejs.org tarball installs install the native package cleanly. Fixes #104.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,10 @@ Runtime files live in standard XDG locations:
 
 You need:
 
-- **Node.js 20+** with `npm` and `npx`
 - `python3`, `7z` (or `7zz`), `curl`, `unzip`, `make`, `g++`
 - **Rust toolchain** (`cargo`) for the `codex-update-manager` and `codex-computer-use-linux` crates
+
+The installer downloads a managed Linux Node.js runtime into `codex-app/resources/node-runtime` and uses it for `node`, `npm`, and `npx` during the build. Existing `nvm`, asdf, Volta, NodeSource, or nodejs.org tarball installs are still fine, but they are no longer required for this project.
 
 The easiest setup is the bundled bootstrap:
 
@@ -194,14 +195,12 @@ It auto-detects `apt`, `dnf5`, `dnf`, `pacman`, or `zypper`, installs system pac
 
 #### Apt-specific (Debian / Ubuntu / Pop!_OS / Mint)
 
-Stock `apt install nodejs` on Ubuntu 22.04, 24.04, and Debian 12 ships Node.js 18, which is too old. `install-deps.sh` first tries the distro `nodejs` candidate; if it's < Node 20 it bootstraps Node.js 22 from NodeSource:
+`install-deps.sh` can still bootstrap NodeSource Node.js for users who want a system Node.js, but the Codex Desktop build no longer requires distro `nodejs` / `npm` packages:
 
 ```bash
 bash scripts/install-deps.sh                       # bootstraps Node 22 if needed
 NODEJS_MAJOR=24 bash scripts/install-deps.sh       # bootstrap a different maintained line
 ```
-
-If you install dependencies manually on Debian or Ubuntu, install Node.js 20+ with `npm` and `npx` from NodeSource, `nvm`, or another compatible source before running `./install.sh`. Do not rely on plain distro `apt install nodejs npm` unless your repos provide Node.js 20 or newer.
 
 Ubuntu-family `p7zip-full` can be too old for newer APFS DMGs. `install-deps.sh` bootstraps `7zz` into `~/.local/bin` (set `SEVENZIP_SYSTEM_INSTALL=1` to install to `/usr/local/bin` instead).
 
@@ -209,18 +208,18 @@ Ubuntu-family `p7zip-full` can be too old for newer APFS DMGs. `install-deps.sh`
 
 ```bash
 # Fedora 41+
-sudo dnf install nodejs npm python3 7zip curl unzip @development-tools
+sudo dnf install python3 7zip curl unzip @development-tools
 
 # Fedora < 41
-sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip
+sudo dnf install python3 p7zip p7zip-plugins curl unzip
 sudo dnf groupinstall 'Development Tools'
 
 # openSUSE
-sudo zypper install nodejs-default npm-default python3 p7zip-full curl unzip
+sudo zypper install python3 p7zip-full curl unzip
 sudo zypper install -t pattern devel_basis
 
 # Arch / Manjaro
-sudo pacman -S --needed nodejs npm python p7zip curl unzip zstd base-devel
+sudo pacman -S --needed python p7zip curl unzip zstd base-devel
 
 # Rust toolchain (any distro)
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -277,7 +276,7 @@ Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish .
 
 The packaging scripts only repackage what's already in `codex-app/`. They do not download or extract the DMG themselves.
 
-Native packages declare `nodejs (>= 20)` because the bundled update manager rebuilds future packages locally. They also pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` so the privileged install flow works out of the box.
+Native packages bundle the managed Node.js runtime used by the launcher, Browser Use, Codex CLI install/update flow, and local auto-update rebuilds. They do not hard-depend on distro `nodejs` / `npm`, so installs also work when Node.js comes from `nvm`, asdf, Volta, or the nodejs.org tarball. Packages still pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` so the privileged install flow works out of the box.
 
 ### Updater service controls
 

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ ICON_SOURCE="$SCRIPT_DIR/assets/codex.png"
 
 # ---- Source library helpers ----
 . "$SCRIPT_DIR/scripts/lib/install-helpers.sh"
+. "$SCRIPT_DIR/scripts/lib/node-runtime.sh"
 . "$SCRIPT_DIR/scripts/lib/process-detection.sh"
 . "$SCRIPT_DIR/scripts/lib/dmg.sh"
 . "$SCRIPT_DIR/scripts/lib/native-modules.sh"
@@ -79,6 +80,9 @@ main() {
     if [ "$INSPECT_ONLY" -ne 1 ]; then
         assert_install_target_not_running
         prepare_install
+        ensure_managed_node_runtime "$INSTALL_DIR/resources/node-runtime"
+    else
+        ensure_managed_node_runtime "$WORK_DIR/node-runtime"
     fi
 
     local dmg_path=""

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -26,6 +26,7 @@ WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
 LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/$CODEX_LINUX_APP_ID"
 LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
+MANAGED_NODE_BIN_DIR="$SCRIPT_DIR/resources/node-runtime/bin"
 APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
 APP_NOTIFICATION_ICON_SYSTEM="/usr/share/icons/hicolor/256x256/apps/$APP_NOTIFICATION_ICON_NAME.png"
@@ -265,6 +266,16 @@ export_packaged_runtime_env() {
     fi
 }
 
+prepend_managed_node_runtime_to_path() {
+    [ -x "$MANAGED_NODE_BIN_DIR/node" ] || return 0
+
+    case ":$PATH:" in
+        *":$MANAGED_NODE_BIN_DIR:"*) ;;
+        *) export PATH="$MANAGED_NODE_BIN_DIR:$PATH" ;;
+    esac
+    export CODEX_MANAGED_NODE_RUNTIME_DIR="$SCRIPT_DIR/resources/node-runtime"
+}
+
 browser_use_plugin_version() {
     local plugin_json="$1"
 
@@ -332,12 +343,18 @@ resolve_browser_use_runtime_env() {
     fi
 
     if [ -z "${CODEX_BROWSER_USE_NODE_PATH:-}" ]; then
-        if [ -x "$SCRIPT_DIR/resources/node" ]; then
+        if [ -x "$MANAGED_NODE_BIN_DIR/node" ]; then
+            export CODEX_BROWSER_USE_NODE_PATH="$MANAGED_NODE_BIN_DIR/node"
+        elif [ -x "$SCRIPT_DIR/resources/node" ]; then
             export CODEX_BROWSER_USE_NODE_PATH="$SCRIPT_DIR/resources/node"
         elif command -v node >/dev/null 2>&1; then
             CODEX_BROWSER_USE_NODE_PATH="$(command -v node)"
             export CODEX_BROWSER_USE_NODE_PATH
         fi
+    fi
+
+    if [ -z "${NODE_REPL_NODE_PATH:-}" ] && [ -n "${CODEX_BROWSER_USE_NODE_PATH:-}" ]; then
+        export NODE_REPL_NODE_PATH="$CODEX_BROWSER_USE_NODE_PATH"
     fi
 
     if [ -z "${CODEX_NODE_REPL_PATH:-}" ]; then
@@ -1111,6 +1128,7 @@ launch_electron() {
 hydrate_graphical_session_env
 configure_side_by_side_app_env
 load_packaged_runtime_helper
+prepend_managed_node_runtime_to_path
 register_url_scheme_handlers
 clear_stale_pid_file
 detect_warm_start
@@ -1180,5 +1198,6 @@ fi
 resolve_browser_use_runtime_env
 
 echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
+echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"
 
 launch_electron "$@"

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -7,8 +7,6 @@ arch=('__ARCH__')
 url="https://github.com/ilysenko/codex-desktop-linux"
 license=('MIT')
 depends=(
-    'nodejs>=20'
-    'npm'
     'python'
     'p7zip'
     'polkit'
@@ -40,6 +38,8 @@ depends=(
     'pango'
 )
 optdepends=(
+    'nodejs>=22.22.0: optional override for the bundled managed Node.js runtime'
+    'npm: optional override for Codex CLI install/update flows'
     'zenity: GTK dialog fallback when the Codex CLI is missing'
     'kdialog: KDE dialog fallback when the Codex CLI is missing'
 )

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -5,7 +5,7 @@ Summary:        Codex Desktop for Linux
 License:        Proprietary
 ExclusiveArch:  __ARCH__
 
-Requires:       nodejs >= 20, npm, python3, p7zip, polkit, curl, unzip, gcc-c++, make
+Requires:       python3, p7zip, polkit, curl, unzip, gcc-c++, make
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
 Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
 Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr
@@ -16,7 +16,7 @@ Recommends:     zenity, kdialog
 Community-built Linux package for Codex Desktop generated from the macOS DMG.
 Requires the Codex CLI to be available in PATH or CODEX_CLI_PATH.
 Local auto-updates rebuild a Linux package from the upstream Codex.dmg and therefore
-require the local packaging toolchain listed in Requires.
+use the bundled managed Node.js runtime plus the local packaging toolchain listed in Requires.
 
 %install
 # Files are staged by build-rpm.sh outside of BUILDROOT and copied here.

--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,10 +4,10 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: Codex Desktop Linux Maintainers
-Depends: build-essential, curl, dpkg, nodejs (>= 20), npm, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Recommends: zenity, kdialog
 Description: Codex Desktop for Linux
  Community-built Linux package for Codex Desktop generated from the macOS DMG.
  Requires the Codex CLI to be available in PATH or CODEX_CLI_PATH.
   Local auto-updates rebuild a Linux package from the upstream Codex.dmg and therefore
-  require the local packaging toolchain listed in Depends.
+  use the bundled managed Node.js runtime plus the local packaging toolchain listed in Depends.

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -19,13 +19,12 @@ Run the helper to install them automatically:
   bash scripts/install-deps.sh
 
 Or install manually:
-  # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install nodejs npm python3 7zip curl unzip @development-tools            # Fedora 41+ (dnf5)
-  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
+  sudo dnf install python3 7zip curl unzip @development-tools                       # Fedora 41+ (dnf5)
+  sudo dnf install python3 p7zip p7zip-plugins curl unzip                           # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
-  sudo pacman -S nodejs npm python p7zip curl unzip zstd base-devel                 # Arch
-  sudo zypper install nodejs-default npm-default python3 p7zip-full curl unzip      # openSUSE
+  sudo pacman -S python p7zip curl unzip zstd base-devel                            # Arch
+  sudo zypper install python3 p7zip-full curl unzip                                 # openSUSE
     && sudo zypper install -t pattern devel_basis
 EOF
 }
@@ -149,17 +148,12 @@ prepare_install() {
 # ---- Check dependencies ----
 check_deps() {
     local missing=()
-    for cmd in node npm npx python3 7z curl unzip; do
+    for cmd in python3 7z curl unzip tar; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
     if [ ${#missing[@]} -ne 0 ]; then
         error "Missing dependencies: ${missing[*]}
 $(dependency_help)"
-    fi
-
-    NODE_MAJOR=$(node -v | cut -d. -f1 | tr -d v)
-    if [ "$NODE_MAJOR" -lt 20 ]; then
-        error "Node.js 20+ required (found $(node -v))"
     fi
 
     if ! command -v make &>/dev/null || ! command -v g++ &>/dev/null; then
@@ -185,5 +179,5 @@ If ~/.local/bin is not on your PATH, add it before re-running this script:
 Set SEVENZIP_SYSTEM_INSTALL=1 to install into /usr/local/bin instead."
     fi
 
-    info "All dependencies found (using $SEVEN_ZIP_CMD)"
+    info "All system dependencies found (using $SEVEN_ZIP_CMD)"
 }

--- a/scripts/lib/node-runtime.sh
+++ b/scripts/lib/node-runtime.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Managed Node.js runtime used by the installer, launcher, and update builder.
+#
+# Sourced by install.sh. Do not run directly.
+# shellcheck shell=bash
+
+MANAGED_NODE_VERSION="${CODEX_MANAGED_NODE_VERSION:-v22.22.2}"
+case "$MANAGED_NODE_VERSION" in
+    v*) ;;
+    *) MANAGED_NODE_VERSION="v$MANAGED_NODE_VERSION" ;;
+esac
+MANAGED_NODE_MIN_VERSION="22.22.0"
+MANAGED_NODE_MIN_MAJOR=22
+MANAGED_NODE_MIN_MINOR=22
+MANAGED_NODE_MIN_PATCH=0
+
+managed_node_arch() {
+    case "$ARCH" in
+        x86_64)  echo "x64" ;;
+        aarch64) echo "arm64" ;;
+        armv7l)  echo "armv7l" ;;
+        *)       error "Unsupported Node.js runtime architecture: $ARCH" ;;
+    esac
+}
+
+managed_node_archive_sha256() {
+    local node_arch="$1"
+
+    if [ -n "${CODEX_MANAGED_NODE_SHA256:-}" ]; then
+        echo "$CODEX_MANAGED_NODE_SHA256"
+        return
+    fi
+
+    case "$MANAGED_NODE_VERSION:$node_arch" in
+        v22.22.2:x64)   echo "88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a" ;;
+        v22.22.2:arm64) echo "e9e1930fd321a470e29bb68f30318bf58e3ecb4acb4f1533fb19c58328a091fe" ;;
+        v22.22.2:armv7l) echo "2ebc6746e517f345da340ec76a108203eb6c2365391eb525c0e0dd6135b0b9df" ;;
+        *)
+            error "No SHA256 configured for Node.js $MANAGED_NODE_VERSION linux-$node_arch.
+Set CODEX_MANAGED_NODE_SHA256 when overriding CODEX_MANAGED_NODE_VERSION or CODEX_MANAGED_NODE_URL."
+            ;;
+    esac
+}
+
+node_version_parts() {
+    local node_path="$1"
+    local version
+    local major
+    local minor
+    local patch
+
+    [ -x "$node_path" ] || return 1
+    version="$("$node_path" -v 2>/dev/null)" || return 1
+    major="${version#v}"
+    minor="${major#*.}"
+    patch="${minor#*.}"
+    major="${major%%.*}"
+    minor="${minor%%.*}"
+    patch="${patch%%.*}"
+
+    case "$major" in ""|*[!0-9]*) return 1 ;; esac
+    case "$minor" in ""|*[!0-9]*) return 1 ;; esac
+    case "$patch" in ""|*[!0-9]*) return 1 ;; esac
+
+    echo "$major $minor $patch"
+}
+
+node_runtime_compatible() {
+    local node_path="$1"
+    local major
+    local minor
+    local patch
+
+    read -r major minor patch < <(node_version_parts "$node_path") || return 1
+    if [ "$major" -gt "$MANAGED_NODE_MIN_MAJOR" ]; then
+        return 0
+    fi
+    if [ "$major" -lt "$MANAGED_NODE_MIN_MAJOR" ]; then
+        return 1
+    fi
+    if [ "$minor" -gt "$MANAGED_NODE_MIN_MINOR" ]; then
+        return 0
+    fi
+    if [ "$minor" -lt "$MANAGED_NODE_MIN_MINOR" ]; then
+        return 1
+    fi
+    [ "$patch" -ge "$MANAGED_NODE_MIN_PATCH" ]
+}
+
+node_toolchain_compatible() {
+    local runtime_dir="$1"
+
+    node_runtime_compatible "$runtime_dir/bin/node" \
+        && [ -x "$runtime_dir/bin/npm" ] \
+        && [ -x "$runtime_dir/bin/npx" ]
+}
+
+copy_node_runtime() {
+    local source_dir="$1"
+    local destination_dir="$2"
+    local tmp_dir
+
+    node_toolchain_compatible "$source_dir" || return 1
+
+    if [ "$(realpath -m "$source_dir")" = "$(realpath -m "$destination_dir")" ]; then
+        return 0
+    fi
+
+    tmp_dir="$(dirname "$destination_dir")/.node-runtime.tmp.$$"
+    rm -rf "$tmp_dir"
+    mkdir -p "$tmp_dir"
+    cp -a "$source_dir/." "$tmp_dir/"
+    rm -rf "$destination_dir"
+    mv "$tmp_dir" "$destination_dir"
+}
+
+managed_node_archive_url() {
+    local node_arch="$1"
+
+    if [ -n "${CODEX_MANAGED_NODE_URL:-}" ]; then
+        echo "$CODEX_MANAGED_NODE_URL"
+    else
+        echo "https://nodejs.org/dist/$MANAGED_NODE_VERSION/node-$MANAGED_NODE_VERSION-linux-$node_arch.tar.xz"
+    fi
+}
+
+download_managed_node_runtime() {
+    local destination_dir="$1"
+    local node_arch
+    local url
+    local expected_sha
+    local cache_dir
+    local archive
+    local extract_dir
+    local extracted_root
+
+    node_arch="$(managed_node_arch)"
+    url="$(managed_node_archive_url "$node_arch")"
+    expected_sha="$(managed_node_archive_sha256 "$node_arch")"
+    cache_dir="${CODEX_MANAGED_NODE_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/codex-desktop/node-runtime}"
+    archive="$cache_dir/$(basename "$url")"
+    extract_dir="$WORK_DIR/managed-node-runtime"
+    extracted_root="$extract_dir/node-$MANAGED_NODE_VERSION-linux-$node_arch"
+
+    mkdir -p "$cache_dir" "$extract_dir"
+    if [ ! -f "$archive" ]; then
+        info "Downloading managed Node.js $MANAGED_NODE_VERSION runtime..."
+        if ! curl -L --fail --progress-bar -o "$archive.part" "$url"; then
+            rm -f "$archive.part"
+            error "Failed to download managed Node.js runtime from $url"
+        fi
+        mv "$archive.part" "$archive"
+    else
+        info "Using cached managed Node.js runtime: $archive"
+    fi
+
+    if ! printf '%s  %s\n' "$expected_sha" "$archive" | sha256sum -c - >/dev/null 2>&1; then
+        rm -f "$archive"
+        error "Managed Node.js runtime checksum mismatch; removed cached archive"
+    fi
+
+    rm -rf "$extract_dir"
+    mkdir -p "$extract_dir"
+    tar -xJf "$archive" -C "$extract_dir"
+    [ -d "$extracted_root" ] || error "Managed Node.js archive did not contain expected directory: node-$MANAGED_NODE_VERSION-linux-$node_arch"
+    copy_node_runtime "$extracted_root" "$destination_dir" || error "Managed Node.js runtime is not compatible"
+}
+
+ensure_managed_node_runtime() {
+    local destination_dir="$1"
+    local source_dir
+
+    if node_toolchain_compatible "$destination_dir"; then
+        info "Managed Node.js runtime ready: $destination_dir"
+        export_managed_node_runtime "$destination_dir"
+        return 0
+    fi
+
+    for source_dir in \
+        "${CODEX_MANAGED_NODE_SOURCE:-}" \
+        "$SCRIPT_DIR/node-runtime" \
+        "$SCRIPT_DIR/resources/node-runtime" \
+        "$SCRIPT_DIR/../node-runtime"
+    do
+        [ -n "$source_dir" ] || continue
+        if copy_node_runtime "$source_dir" "$destination_dir"; then
+            info "Managed Node.js runtime copied from $source_dir"
+            export_managed_node_runtime "$destination_dir"
+            return 0
+        fi
+    done
+
+    download_managed_node_runtime "$destination_dir"
+    export_managed_node_runtime "$destination_dir"
+    info "Managed Node.js runtime ready: $destination_dir"
+}
+
+export_managed_node_runtime() {
+    local runtime_dir="$1"
+    local bin_dir="$runtime_dir/bin"
+
+    [ -x "$bin_dir/node" ] || error "Managed Node.js runtime is missing node: $bin_dir/node"
+    export PATH="$bin_dir:$PATH"
+    export CODEX_MANAGED_NODE_RUNTIME_DIR="$runtime_dir"
+}

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -121,6 +121,7 @@ stage_common_package_files() {
 stage_update_builder_bundle() {
     local root="$1"
     local update_builder_root="$root/opt/$PACKAGE_NAME/update-builder"
+    local node_runtime_source="$APP_DIR/resources/node-runtime"
 
     mkdir -p \
         "$update_builder_root/scripts" \
@@ -169,6 +170,11 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/packaging/linux/codex-update-manager.prerm" "$update_builder_root/packaging/linux/codex-update-manager.prerm"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.postrm" "$update_builder_root/packaging/linux/codex-update-manager.postrm"
     cp "$REPO_DIR/assets/codex.png" "$update_builder_root/assets/codex.png"
+    if [ -d "$node_runtime_source" ]; then
+        cp -a "$node_runtime_source" "$update_builder_root/node-runtime"
+    else
+        error "Missing managed Node.js runtime: $node_runtime_source. Run ./install.sh first."
+    fi
 }
 
 write_launcher_stub() {

--- a/tests/fixtures/create-packaged-app-fixture.sh
+++ b/tests/fixtures/create-packaged-app-fixture.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+app_dir="${1:-codex-app}"
+
+mkdir -p "$app_dir/content/webview" "$app_dir/resources/node-runtime/bin"
+
+printf '%s\n' '#!/bin/bash' 'echo "codex desktop fixture"' > "$app_dir/start.sh"
+chmod +x "$app_dir/start.sh"
+
+printf '%s\n' '<!doctype html><title>Codex fixture</title>' > "$app_dir/content/webview/index.html"
+
+for binary in node npm npx; do
+    cat > "$app_dir/resources/node-runtime/bin/$binary" <<'SCRIPT'
+#!/bin/bash
+case "$(basename "$0")" in
+    node) echo v22.22.2 ;;
+    *) echo 10.9.7 ;;
+esac
+SCRIPT
+    chmod +x "$app_dir/resources/node-runtime/bin/$binary"
+done

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -67,12 +67,22 @@ JS
 
 make_fake_app() {
     local app_dir="$1"
-    mkdir -p "$app_dir"
+    mkdir -p "$app_dir/resources/node-runtime/bin"
     cat > "$app_dir/start.sh" <<'SCRIPT'
 #!/bin/bash
 exit 0
 SCRIPT
     chmod +x "$app_dir/start.sh"
+    for binary in node npm npx; do
+        cat > "$app_dir/resources/node-runtime/bin/$binary" <<'SCRIPT'
+#!/bin/bash
+case "$(basename "$0")" in
+    node) echo v22.22.2 ;;
+    *) echo 10.9.7 ;;
+esac
+SCRIPT
+        chmod +x "$app_dir/resources/node-runtime/bin/$binary"
+    done
 }
 
 make_stub_bin_dir() {
@@ -141,11 +151,13 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-update-bridge-patch.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/patch-report.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/rebuild-report.sh"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/node-runtime/bin/node"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/computer-use-linux/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/updater/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/plugins/openai-bundled/plugins/computer-use/.mcp.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
+    assert_file_exists "$pkg_root/opt/codex-desktop/resources/node-runtime/bin/node"
 }
 
 test_deb_builder_respects_package_identity() {
@@ -380,6 +392,45 @@ PLIST
     [ "$(tail -n 1 "$output_log")" = "41.3.0" ] || fail "Expected fallback Electron version 41.3.0, got: $(cat "$output_log")"
 }
 
+test_managed_node_runtime_source_install() {
+    info "Checking managed Node.js runtime source install"
+    local workspace="$TMP_DIR/managed-node-runtime"
+    local source_dir="$workspace/source"
+    local install_dir="$workspace/install"
+
+    mkdir -p "$source_dir/bin" "$install_dir/resources"
+    for binary in node npm npx; do
+        cat > "$source_dir/bin/$binary" <<'SCRIPT'
+#!/bin/bash
+case "$(basename "$0")" in
+    node) echo v22.22.2 ;;
+    *) echo 10.9.7 ;;
+esac
+SCRIPT
+        chmod +x "$source_dir/bin/$binary"
+    done
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        CODEX_MANAGED_NODE_SOURCE="$source_dir"
+        mkdir -p "$WORK_DIR"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/node-runtime.sh"
+        ensure_managed_node_runtime "$install_dir/resources/node-runtime"
+        command -v node
+        node -v
+    ) > "$workspace/output.log" 2>&1
+
+    assert_file_exists "$install_dir/resources/node-runtime/bin/node"
+    assert_contains "$workspace/output.log" "$install_dir/resources/node-runtime/bin/node"
+    assert_contains "$workspace/output.log" "v22.22.2"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -503,9 +554,16 @@ PY
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "/etc/apt/keyrings/nodesource.gpg"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "signed-by="
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "https://deb.nodesource.com/node_"
-    assert_contains "$REPO_DIR/packaging/linux/control" "nodejs (>= 20)"
-    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.spec" "nodejs >= 20"
-    assert_contains "$REPO_DIR/packaging/linux/PKGBUILD.template" "nodejs>=20"
+    assert_not_contains "$REPO_DIR/packaging/linux/control" "Depends:.*nodejs"
+    assert_not_contains "$REPO_DIR/packaging/linux/control" "Depends:.*npm"
+    assert_not_contains "$REPO_DIR/packaging/linux/codex-desktop.spec" "Requires:.*nodejs"
+    assert_not_contains "$REPO_DIR/packaging/linux/codex-desktop.spec" "Requires:.*npm"
+    assert_not_contains "$REPO_DIR/packaging/linux/PKGBUILD.template" "'nodejs>=20'"
+    assert_contains "$REPO_DIR/packaging/linux/PKGBUILD.template" "optional override for the bundled managed Node.js runtime"
+    assert_contains "$REPO_DIR/scripts/lib/node-runtime.sh" "MANAGED_NODE_VERSION"
+    assert_contains "$REPO_DIR/scripts/lib/package-common.sh" "node-runtime"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "MANAGED_NODE_BIN_DIR"
+    assert_contains "$REPO_DIR/updater/src/builder.rs" "managed_node_bin_dirs"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "BAMF_DESKTOP_FILE_HINT"
@@ -1664,6 +1722,7 @@ main() {
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata
+    test_managed_node_runtime_source_install
     test_browser_use_node_repl_fallback_runtime
     test_launcher_template_sanity
     test_side_by_side_launcher_identity

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -67,22 +67,7 @@ JS
 
 make_fake_app() {
     local app_dir="$1"
-    mkdir -p "$app_dir/resources/node-runtime/bin"
-    cat > "$app_dir/start.sh" <<'SCRIPT'
-#!/bin/bash
-exit 0
-SCRIPT
-    chmod +x "$app_dir/start.sh"
-    for binary in node npm npx; do
-        cat > "$app_dir/resources/node-runtime/bin/$binary" <<'SCRIPT'
-#!/bin/bash
-case "$(basename "$0")" in
-    node) echo v22.22.2 ;;
-    *) echo 10.9.7 ;;
-esac
-SCRIPT
-        chmod +x "$app_dir/resources/node-runtime/bin/$binary"
-    done
+    "$REPO_DIR/tests/fixtures/create-packaged-app-fixture.sh" "$app_dir"
 }
 
 make_stub_bin_dir() {
@@ -562,6 +547,8 @@ PY
     assert_contains "$REPO_DIR/packaging/linux/PKGBUILD.template" "optional override for the bundled managed Node.js runtime"
     assert_contains "$REPO_DIR/scripts/lib/node-runtime.sh" "MANAGED_NODE_VERSION"
     assert_contains "$REPO_DIR/scripts/lib/package-common.sh" "node-runtime"
+    assert_contains "$REPO_DIR/tests/fixtures/create-packaged-app-fixture.sh" "resources/node-runtime/bin"
+    assert_contains "$REPO_DIR/.github/workflows/ci.yml" "tests/fixtures/create-packaged-app-fixture.sh codex-app"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "MANAGED_NODE_BIN_DIR"
     assert_contains "$REPO_DIR/updater/src/builder.rs" "managed_node_bin_dirs"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -68,7 +68,7 @@ pub async fn build_update(
     dmg_path: &Path,
 ) -> Result<BuildArtifacts> {
     let workspace = BuilderWorkspace::prepare(&config.workspace_root, candidate_version)?;
-    let build_path = build_command_path();
+    let build_path = build_command_path(&config.builder_bundle_root);
 
     state.status = UpdateStatus::PreparingWorkspace;
     state.artifact_paths.workspace_dir = Some(workspace.workspace_dir.clone());
@@ -82,6 +82,10 @@ pub async fn build_update(
         Command::new(workspace.bundle_dir.join("install.sh"))
             .arg(dmg_path)
             .env("CODEX_INSTALL_DIR", &workspace.app_dir)
+            .env(
+                "CODEX_MANAGED_NODE_SOURCE",
+                config.builder_bundle_root.join("node-runtime"),
+            )
             .env("PATH", &build_path)
             .current_dir(&workspace.bundle_dir),
         &workspace.install_log,
@@ -287,13 +291,23 @@ fn is_native_package_file(path: &Path) -> bool {
             .any(|suffix| name.ends_with(suffix))
 }
 
-fn build_command_path() -> OsString {
-    let mut entries = preferred_node_bin_dirs();
+fn build_command_path(builder_bundle_root: &Path) -> OsString {
+    let mut entries = managed_node_bin_dirs(builder_bundle_root);
+    entries.extend(preferred_node_bin_dirs());
     entries.extend(std::env::split_paths(
         &std::env::var_os("PATH").unwrap_or_default(),
     ));
     entries.extend(system_bin_dirs());
     std::env::join_paths(entries).unwrap_or_else(|_| std::env::var_os("PATH").unwrap_or_default())
+}
+
+fn managed_node_bin_dirs(builder_bundle_root: &Path) -> Vec<PathBuf> {
+    let bin_dir = builder_bundle_root.join("node-runtime/bin");
+    if is_node_toolchain_dir(&bin_dir) {
+        vec![bin_dir]
+    } else {
+        Vec::new()
+    }
 }
 
 fn system_bin_dirs() -> Vec<PathBuf> {
@@ -710,10 +724,25 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
 
     #[test]
     fn build_command_path_includes_system_dirs() {
-        let path = build_command_path();
+        let path = build_command_path(Path::new("/tmp/missing-codex-builder"));
         let directories = std::env::split_paths(&path).collect::<Vec<_>>();
 
         assert!(directories.iter().any(|dir| dir == Path::new("/usr/bin")));
         assert!(directories.iter().any(|dir| dir == Path::new("/bin")));
+    }
+
+    #[test]
+    fn build_command_path_prefers_packaged_managed_node_runtime() -> Result<()> {
+        let temp = tempdir()?;
+        let runtime_bin = temp.path().join("node-runtime/bin");
+        fs::create_dir_all(&runtime_bin)?;
+        for binary in ["node", "npm", "npx"] {
+            fs::write(runtime_bin.join(binary), b"bin")?;
+        }
+
+        let path = build_command_path(temp.path());
+        let directories = std::env::split_paths(&path).collect::<Vec<_>>();
+        assert_eq!(directories.first(), Some(&runtime_bin));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- bundle a verified managed Node.js 22.22.2 runtime into generated Linux app builds
- use the bundled runtime for launcher PATH, Browser Use, Codex CLI install/update flows, and updater rebuilds
- remove hard native-package dependencies on distro `nodejs` / `npm` so manual Node installs from nvm/asdf/Volta/nodejs.org do not break package installation

Fixes #104.

## Validation

- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager`
- `git diff --check`