### PR TITLE
Add manual rollback to the last known-good package

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ sed -n '1,160p' ~/.local/state/codex-update-manager/state.json
 sed -n '1,160p' ~/.local/state/codex-update-manager/service.log
 ```
 
+If a rebuilt update installs but the previous retained package was better, close
+Codex Desktop and run:
+
+```bash
+codex-update-manager rollback
+```
+
+Rollback uses the last retained known-good package and refuses to run when no
+rollback package is available.
+
 Runtime files live in standard XDG locations:
 
 ```text

--- a/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy
+++ b/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy
@@ -42,4 +42,40 @@
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">install-pacman</annotate>
   </action>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.rollback-deb">
+    <description>Roll back a Codex Desktop update</description>
+    <message>Authentication is required to roll back the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-rollback-deb</annotate>
+  </action>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.rollback-rpm">
+    <description>Roll back a Codex Desktop update</description>
+    <message>Authentication is required to roll back the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-rollback-rpm</annotate>
+  </action>
+
+  <action id="com.github.ilysenko.codex-desktop-linux.update.rollback-pacman">
+    <description>Roll back a Codex Desktop update</description>
+    <message>Authentication is required to roll back the Codex Desktop update.</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/codex-update-manager</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv1">install-rollback-pacman</annotate>
+  </action>
 </policyconfig>

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{Cli, Commands},
     codex_cli,
     config::{RuntimeConfig, RuntimePaths},
-    install, liveness, logging, notify,
+    install, install_rollback, liveness, logging, notify, rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
     upstream,
 };
@@ -65,9 +65,13 @@ pub async fn run(cli: Cli) -> Result<()> {
         } => run_prompt_install_cli(&mut state, &paths, cli_path, print_path),
         Commands::Status { json } => run_status(&mut state, &paths, json),
         Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
+        Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
         Commands::InstallDeb { path } => install::install_deb(&path),
         Commands::InstallRpm { path } => install::install_rpm(&path),
         Commands::InstallPacman { path } => install::install_pacman(&path),
+        Commands::InstallRollbackDeb { path } => install_rollback::install_deb(&path),
+        Commands::InstallRollbackRpm { path } => install_rollback::install_rpm(&path),
+        Commands::InstallRollbackPacman { path } => install_rollback::install_pacman(&path),
     }
 }
 
@@ -276,6 +280,17 @@ fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> R
         println!(
             "candidate_version: {}",
             state.candidate_version.as_deref().unwrap_or("none")
+        );
+        println!(
+            "last_known_good_version: {}",
+            state.last_known_good_version.as_deref().unwrap_or("none")
+        );
+        println!(
+            "rollback_blocked_candidate_version: {}",
+            state
+                .rollback_blocked_candidate_version
+                .as_deref()
+                .unwrap_or("none")
         );
         println!("cli_status: {:?}", state.cli_status);
         println!(
@@ -488,6 +503,11 @@ async fn run_check_cycle(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
+    if update_install_is_pending(&state.status) {
+        info!("skipping upstream check because an update is already pending");
+        return Ok(());
+    }
+
     if let Err(error) = codex_cli::reconcile_if_present(state, paths) {
         warn!(
             ?error,
@@ -496,11 +516,6 @@ async fn run_check_cycle(
     }
 
     let retrying_failed_update = state.status == UpdateStatus::Failed;
-
-    if update_install_is_pending(&state.status) {
-        info!("skipping upstream check because an update is already pending");
-        return Ok(());
-    }
 
     let Some(_check_lock) = try_acquire_check_lock(paths)? else {
         return Ok(());
@@ -535,6 +550,26 @@ async fn run_check_cycle(
         let downloaded =
             upstream::download_dmg(&client, &config.dmg_url, &downloads_dir, Utc::now()).await?;
 
+        if state
+            .rollback_blocked_candidate_version
+            .as_deref()
+            .is_some_and(|blocked| {
+                installed_version_matches_candidate(blocked, &downloaded.candidate_version)
+            })
+        {
+            state.status = UpdateStatus::Idle;
+            state.error_message = Some(format!(
+                "Candidate {} was rolled back and will not be reinstalled automatically",
+                downloaded.candidate_version
+            ));
+            persist_state(paths, state)?;
+            info!(
+                candidate_version = %downloaded.candidate_version,
+                "skipping candidate blocked by rollback"
+            );
+            return Ok(());
+        }
+
         if state.dmg_sha256.as_deref() == Some(downloaded.sha256.as_str())
             && !retrying_failed_update
         {
@@ -545,6 +580,7 @@ async fn run_check_cycle(
             return Ok(());
         }
 
+        rollback::record_current_package_as_known_good(state);
         state.status = UpdateStatus::UpdateDetected;
         state.candidate_version = Some(downloaded.candidate_version);
         state.dmg_sha256 = Some(downloaded.sha256);
@@ -1020,6 +1056,7 @@ async fn trigger_install(
         state.status = UpdateStatus::Installed;
         state.installed_version = install::installed_package_version();
         state.candidate_version = None;
+        state.rollback_blocked_candidate_version = None;
         state.error_message = None;
         state.notified_events.clear();
         persist_state(paths, state)?;

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -122,6 +122,7 @@ pub async fn build_update(
         dmg_path: Some(dmg_path.to_path_buf()),
         workspace_dir: Some(workspace.workspace_dir.clone()),
         package_path: Some(package_path.clone()),
+        rollback_package_path: state.artifact_paths.rollback_package_path.clone(),
     };
     state.save(&paths.state_file)?;
     info!(candidate_version, package = %package_path.display(), "local update build ready");

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -39,6 +39,8 @@ pub enum Commands {
     },
     /// Install the already rebuilt update package, if one is ready.
     InstallReady,
+    /// Roll back to the last retained known-good package.
+    Rollback,
     /// Install a Debian package (.deb) with elevated privileges.
     InstallDeb {
         #[arg(long)]
@@ -51,6 +53,21 @@ pub enum Commands {
     },
     /// Install a pacman package (.pkg.tar.zst) with elevated privileges.
     InstallPacman {
+        #[arg(long)]
+        path: PathBuf,
+    },
+    /// Install a Debian package as an explicit rollback with elevated privileges.
+    InstallRollbackDeb {
+        #[arg(long)]
+        path: PathBuf,
+    },
+    /// Install an RPM package as an explicit rollback with elevated privileges.
+    InstallRollbackRpm {
+        #[arg(long)]
+        path: PathBuf,
+    },
+    /// Install a pacman package as an explicit rollback with elevated privileges.
+    InstallRollbackPacman {
         #[arg(long)]
         path: PathBuf,
     },

--- a/updater/src/install_rollback.rs
+++ b/updater/src/install_rollback.rs
@@ -1,0 +1,284 @@
+//! Explicit rollback package installation helpers.
+
+use crate::install::PackageKind;
+use anyhow::{Context, Result};
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const INSTALLED_UPDATER_BINARY: &str = "/usr/bin/codex-update-manager";
+const APT_CANDIDATES: &[&str] = &["/usr/bin/apt", "/bin/apt"];
+const DNF_CANDIDATES: &[&str] = &["/usr/bin/dnf", "/bin/dnf", "/usr/bin/dnf5", "/bin/dnf5"];
+const DPKG_CANDIDATES: &[&str] = &["/usr/bin/dpkg", "/bin/dpkg"];
+const RPM_CANDIDATES: &[&str] = &["/usr/bin/rpm", "/bin/rpm"];
+const ZYPPER_CANDIDATES: &[&str] = &["/usr/bin/zypper", "/bin/zypper"];
+const PACMAN_CANDIDATES: &[&str] = &["/usr/bin/pacman", "/bin/pacman"];
+
+pub fn install_deb(path: &Path) -> Result<()> {
+    anyhow::ensure!(
+        path.exists(),
+        "Debian rollback package not found: {}",
+        path.display()
+    );
+
+    if program_exists(APT_CANDIDATES, "apt") {
+        let mut command = apt_command(path)?;
+        run_install(&mut command).context("apt rollback install failed")?;
+        return Ok(());
+    }
+
+    let mut command = dpkg_command(path);
+    run_install(&mut command).context("dpkg rollback install failed")
+}
+
+pub fn install_rpm(path: &Path) -> Result<()> {
+    anyhow::ensure!(
+        path.exists(),
+        "RPM rollback package not found: {}",
+        path.display()
+    );
+
+    if program_exists(DNF_CANDIDATES, "dnf") || program_exists(DNF_CANDIDATES, "dnf5") {
+        let mut command = dnf_command(path)?;
+        run_install(&mut command).context("dnf rollback install failed")?;
+        return Ok(());
+    }
+
+    if program_exists(ZYPPER_CANDIDATES, "zypper") {
+        let mut command = zypper_command(path)?;
+        run_install(&mut command).context("zypper rollback install failed")?;
+        return Ok(());
+    }
+
+    let mut command = rpm_command(path);
+    run_install(&mut command).context("rpm rollback install failed")
+}
+
+pub fn install_pacman(path: &Path) -> Result<()> {
+    anyhow::ensure!(
+        path.exists(),
+        "Pacman rollback package not found: {}",
+        path.display()
+    );
+
+    let mut command = pacman_command(path);
+    run_install(&mut command).context("pacman rollback install failed")
+}
+
+pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
+    let updater_binary = updater_binary_for_privileged_install(current_exe);
+    let subcommand = match PackageKind::from_path(package_path) {
+        PackageKind::Rpm => "install-rollback-rpm",
+        PackageKind::Deb => "install-rollback-deb",
+        PackageKind::Pacman => "install-rollback-pacman",
+    };
+    let mut command = Command::new("pkexec");
+    command
+        .arg("--disable-internal-agent")
+        .arg(updater_binary)
+        .arg(subcommand)
+        .arg("--path")
+        .arg(package_path);
+    command
+}
+
+fn run_install(command: &mut Command) -> Result<()> {
+    let status = command
+        .status()
+        .context("Failed to execute rollback installation command")?;
+    anyhow::ensure!(
+        status.success(),
+        "rollback installation command exited with {status}"
+    );
+    Ok(())
+}
+
+fn apt_command(path: &Path) -> Result<Command> {
+    let parent = package_parent(path, "apt rollback")?;
+    let file_name = package_file_name(path, "apt rollback")?;
+    let mut command = Command::new(program_path(APT_CANDIDATES, "apt"));
+    command
+        .current_dir(parent)
+        .args(["install", "-y", "--allow-downgrades"])
+        .arg(format!("./{file_name}"));
+    Ok(command)
+}
+
+fn dpkg_command(path: &Path) -> Command {
+    let mut command = Command::new(program_path(DPKG_CANDIDATES, "dpkg"));
+    command.arg("-i").arg(path.as_os_str());
+    command
+}
+
+fn dnf_command(path: &Path) -> Result<Command> {
+    command_in_parent(&program_path(DNF_CANDIDATES, "dnf"), path, "downgrade")
+}
+
+fn zypper_command(path: &Path) -> Result<Command> {
+    let parent = package_parent(path, "zypper rollback")?;
+    let file_name = package_file_name(path, "zypper rollback")?;
+    let mut command = Command::new(program_path(ZYPPER_CANDIDATES, "zypper"));
+    command
+        .current_dir(parent)
+        .args([
+            "--non-interactive",
+            "--no-gpg-checks",
+            "install",
+            "--oldpackage",
+            "-y",
+        ])
+        .arg(format!("./{file_name}"));
+    Ok(command)
+}
+
+fn rpm_command(path: &Path) -> Command {
+    let mut command = Command::new(program_path(RPM_CANDIDATES, "rpm"));
+    command.args(["-Uvh", "--oldpackage"]).arg(path.as_os_str());
+    command
+}
+
+fn pacman_command(path: &Path) -> Command {
+    let mut command = Command::new(program_path(PACMAN_CANDIDATES, "pacman"));
+    command.args(["-U", "--noconfirm"]).arg(path.as_os_str());
+    command
+}
+
+fn command_in_parent(program: &Path, path: &Path, verb: &str) -> Result<Command> {
+    let program_name = program
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("package manager");
+    let parent = package_parent(path, program_name)?;
+    let file_name = package_file_name(path, program_name)?;
+
+    let mut command = Command::new(program);
+    command
+        .current_dir(parent)
+        .arg(verb)
+        .arg("-y")
+        .arg(format!("./{file_name}"));
+    Ok(command)
+}
+
+fn package_parent<'a>(path: &'a Path, label: &str) -> Result<&'a Path> {
+    path.parent()
+        .with_context(|| format!("{label} package path has no parent directory"))
+}
+
+fn package_file_name(path: &Path, label: &str) -> Result<String> {
+    Ok(path
+        .file_name()
+        .with_context(|| format!("{label} package path has no file name"))?
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn updater_binary_for_privileged_install(current_exe: &Path) -> PathBuf {
+    let installed = PathBuf::from(INSTALLED_UPDATER_BINARY);
+    if installed.is_file() {
+        installed
+    } else {
+        current_exe.to_path_buf()
+    }
+}
+
+fn program_path(candidates: &[&str], fallback: &str) -> PathBuf {
+    candidates
+        .iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+        .unwrap_or_else(|| PathBuf::from(fallback))
+}
+
+fn program_exists(candidates: &[&str], name: &str) -> bool {
+    candidates.iter().map(Path::new).any(|path| path.is_file()) || command_exists(name)
+}
+
+fn command_exists(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|path| {
+            std::env::split_paths(&path).any(|entry| {
+                let candidate: PathBuf = entry.join(name);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_local_apt_rollback_command() -> Result<()> {
+        let command = apt_command(Path::new("/tmp/build/codex.deb"))?;
+        assert!(command.get_program().to_string_lossy().ends_with("apt"));
+        assert_eq!(
+            command
+                .get_args()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["install", "-y", "--allow-downgrades", "./codex.deb"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn builds_local_dnf_rollback_command() -> Result<()> {
+        let command = dnf_command(Path::new("/tmp/build/codex.rpm"))?;
+        let program = command.get_program().to_string_lossy();
+        assert!(program.ends_with("dnf") || program.ends_with("dnf5"));
+        assert_eq!(
+            command
+                .get_args()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec!["downgrade", "-y", "./codex.rpm"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn builds_local_zypper_rollback_command() -> Result<()> {
+        let command = zypper_command(Path::new("/tmp/build/codex.rpm"))?;
+        assert!(command.get_program().to_string_lossy().ends_with("zypper"));
+        assert_eq!(
+            command
+                .get_args()
+                .map(|value| value.to_string_lossy().into_owned())
+                .collect::<Vec<_>>(),
+            vec![
+                "--non-interactive",
+                "--no-gpg-checks",
+                "install",
+                "--oldpackage",
+                "-y",
+                "./codex.rpm"
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn builds_pkexec_command_for_privileged_rollback() {
+        let command = pkexec_command(
+            Path::new("/usr/bin/codex-update-manager"),
+            Path::new("/tmp/update.rpm"),
+        );
+        let args: Vec<_> = command
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "--disable-internal-agent",
+                "/usr/bin/codex-update-manager",
+                "install-rollback-rpm",
+                "--path",
+                "/tmp/update.rpm"
+            ]
+        );
+    }
+}

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -6,9 +6,11 @@ mod cli;
 mod codex_cli;
 mod config;
 mod install;
+mod install_rollback;
 mod liveness;
 mod logging;
 mod notify;
+mod rollback;
 mod state;
 #[cfg(test)]
 mod test_util;

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -1,0 +1,197 @@
+//! Manual rollback support for the local update manager.
+
+use crate::{
+    config::{RuntimeConfig, RuntimePaths},
+    install, install_rollback, liveness, notify,
+    state::{PersistedState, UpdateStatus},
+};
+use anyhow::{Context, Result};
+use std::path::Path;
+use tracing::error;
+
+/// Retains the currently installed package as the rollback target, when known.
+pub fn record_current_package_as_known_good(state: &mut PersistedState) {
+    if state.installed_version == "unknown" {
+        return;
+    }
+
+    if state.candidate_version.is_some() {
+        return;
+    }
+
+    let Some(package_path) = state.artifact_paths.package_path.as_ref() else {
+        return;
+    };
+
+    if !package_path.exists() {
+        return;
+    }
+
+    state.last_known_good_version = Some(state.installed_version.clone());
+    state.artifact_paths.rollback_package_path = Some(package_path.clone());
+}
+
+/// Runs a user-requested rollback to the last retained known-good package.
+pub async fn run(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    if liveness::is_app_running(config)? {
+        println!("Codex Desktop is running. Close it before rollback.");
+        return Ok(());
+    }
+
+    let Some(package_path) = state.artifact_paths.rollback_package_path.clone() else {
+        println!("No rollback package is available.");
+        return Ok(());
+    };
+
+    if !package_path.exists() {
+        state.mark_failed(format!(
+            "Rollback package is missing: {}",
+            package_path.display()
+        ));
+        state.save(&paths.state_file)?;
+        println!("Rollback package is missing: {}", package_path.display());
+        return Ok(());
+    }
+
+    trigger_rollback(state, paths, &package_path).await
+}
+
+async fn trigger_rollback(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    package_path: &Path,
+) -> Result<()> {
+    let blocked_candidate = if state.installed_version == "unknown" {
+        state.candidate_version.clone()
+    } else {
+        Some(state.installed_version.clone())
+    };
+
+    state.status = UpdateStatus::Installing;
+    state.error_message = None;
+    state.save(&paths.state_file)?;
+
+    let _ = notify::send(
+        "Rolling back Codex Desktop",
+        "Installing the last retained known-good package.",
+    );
+
+    let current_exe = std::env::current_exe().context("Failed to resolve updater binary path")?;
+    let output = install_rollback::pkexec_command(&current_exe, package_path)
+        .output()
+        .context("Failed to launch pkexec for rollback")?;
+    let status = output.status;
+
+    if status.success() {
+        state.status = UpdateStatus::Installed;
+        state.installed_version = install::installed_package_version();
+        state.candidate_version = None;
+        state.rollback_blocked_candidate_version = blocked_candidate;
+        state.error_message = None;
+        state.notified_events.clear();
+        state.save(&paths.state_file)?;
+        println!("Rolled back Codex Desktop to {}.", state.installed_version);
+        return Ok(());
+    }
+
+    let stdout = summarize_command_output(&output.stdout);
+    let stderr = summarize_command_output(&output.stderr);
+    error!(
+        status = %status,
+        stdout = stdout.as_deref().unwrap_or(""),
+        stderr = stderr.as_deref().unwrap_or(""),
+        "privileged rollback failed"
+    );
+
+    let mut message = format!("Privileged rollback exited with status {status}");
+    if let Some(stderr) = stderr {
+        message.push_str(": ");
+        message.push_str(&stderr);
+    }
+
+    state.mark_failed(message.clone());
+    state.save(&paths.state_file)?;
+    let _ = notify::send(
+        "Codex rollback failed",
+        "The previous package could not be installed. Check the updater log for details.",
+    );
+    Err(anyhow::anyhow!(message))
+}
+
+fn summarize_command_output(output: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(output).trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{ArtifactPaths, PersistedState};
+    use anyhow::Result;
+
+    #[test]
+    fn records_existing_current_package_as_known_good() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let package_path = temp.path().join("codex.deb");
+        std::fs::write(&package_path, b"deb")?;
+
+        let mut state = PersistedState::new(true);
+        state.installed_version = "2026.04.20.120000".to_string();
+        state.artifact_paths = ArtifactPaths {
+            dmg_path: None,
+            workspace_dir: None,
+            package_path: Some(package_path.clone()),
+            rollback_package_path: None,
+        };
+
+        record_current_package_as_known_good(&mut state);
+
+        assert_eq!(
+            state.last_known_good_version.as_deref(),
+            Some("2026.04.20.120000")
+        );
+        assert_eq!(
+            state.artifact_paths.rollback_package_path,
+            Some(package_path)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_missing_current_package() {
+        let mut state = PersistedState::new(true);
+        state.installed_version = "2026.04.20.120000".to_string();
+        state.artifact_paths.package_path = Some(std::path::PathBuf::from("/missing/codex.deb"));
+
+        record_current_package_as_known_good(&mut state);
+
+        assert_eq!(state.last_known_good_version, None);
+        assert_eq!(state.artifact_paths.rollback_package_path, None);
+    }
+
+    #[test]
+    fn ignores_pending_candidate_package() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let package_path = temp.path().join("candidate.deb");
+        std::fs::write(&package_path, b"deb")?;
+
+        let mut state = PersistedState::new(true);
+        state.installed_version = "2026.04.20.120000".to_string();
+        state.candidate_version = Some("2026.04.21.120000+badcafe0".to_string());
+        state.artifact_paths.package_path = Some(package_path);
+
+        record_current_package_as_known_good(&mut state);
+
+        assert_eq!(state.last_known_good_version, None);
+        assert_eq!(state.artifact_paths.rollback_package_path, None);
+        Ok(())
+    }
+}

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -87,12 +87,12 @@ async fn trigger_rollback(
     let status = output.status;
 
     if status.success() {
-        state.status = UpdateStatus::Installed;
-        state.installed_version = install::installed_package_version();
-        state.candidate_version = None;
-        state.rollback_blocked_candidate_version = blocked_candidate;
-        state.error_message = None;
-        state.notified_events.clear();
+        apply_successful_rollback_state(
+            state,
+            install::installed_package_version(),
+            package_path,
+            blocked_candidate,
+        );
         state.save(&paths.state_file)?;
         println!("Rolled back Codex Desktop to {}.", state.installed_version);
         return Ok(());
@@ -129,6 +129,23 @@ fn summarize_command_output(output: &[u8]) -> Option<String> {
     } else {
         Some(text)
     }
+}
+
+fn apply_successful_rollback_state(
+    state: &mut PersistedState,
+    installed_version: String,
+    package_path: &Path,
+    blocked_candidate: Option<String>,
+) {
+    state.status = UpdateStatus::Installed;
+    state.installed_version = installed_version.clone();
+    state.candidate_version = None;
+    state.artifact_paths.package_path = Some(package_path.to_path_buf());
+    state.artifact_paths.rollback_package_path = Some(package_path.to_path_buf());
+    state.last_known_good_version = Some(installed_version);
+    state.rollback_blocked_candidate_version = blocked_candidate;
+    state.error_message = None;
+    state.notified_events.clear();
 }
 
 #[cfg(test)]
@@ -192,6 +209,53 @@ mod tests {
 
         assert_eq!(state.last_known_good_version, None);
         assert_eq!(state.artifact_paths.rollback_package_path, None);
+        Ok(())
+    }
+
+    #[test]
+    fn successful_rollback_repoints_package_paths_to_installed_package() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let update_path = temp.path().join("candidate.rpm");
+        let rollback_path = temp.path().join("known-good.rpm");
+        std::fs::write(&update_path, b"new")?;
+        std::fs::write(&rollback_path, b"old")?;
+
+        let mut state = PersistedState::new(true);
+        state.installed_version = "2026.05.04.131500".to_string();
+        state.candidate_version = Some("2026.05.04.131500+badcafe0".to_string());
+        state.status = UpdateStatus::Installing;
+        state.artifact_paths = ArtifactPaths {
+            dmg_path: None,
+            workspace_dir: None,
+            package_path: Some(update_path),
+            rollback_package_path: Some(rollback_path.clone()),
+        };
+
+        apply_successful_rollback_state(
+            &mut state,
+            "2026.05.02.120000".to_string(),
+            &rollback_path,
+            Some("2026.05.04.131500".to_string()),
+        );
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(
+            state.artifact_paths.package_path.as_deref(),
+            Some(rollback_path.as_path())
+        );
+        assert_eq!(
+            state.artifact_paths.rollback_package_path.as_deref(),
+            Some(rollback_path.as_path())
+        );
+        assert_eq!(
+            state.last_known_good_version.as_deref(),
+            Some("2026.05.02.120000")
+        );
+        assert_eq!(
+            state.rollback_blocked_candidate_version.as_deref(),
+            Some("2026.05.04.131500")
+        );
         Ok(())
     }
 }

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -58,6 +58,8 @@ pub struct ArtifactPaths {
     /// files.
     #[serde(rename = "deb_path")]
     pub package_path: Option<PathBuf>,
+    #[serde(default)]
+    pub rollback_package_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -74,6 +76,10 @@ pub struct PersistedState {
     pub error_message: Option<String>,
     pub notified_events: BTreeSet<String>,
     pub auto_install_on_app_exit: bool,
+    #[serde(default)]
+    pub last_known_good_version: Option<String>,
+    #[serde(default)]
+    pub rollback_blocked_candidate_version: Option<String>,
     #[serde(default)]
     pub cli_path: Option<PathBuf>,
     #[serde(default)]
@@ -107,6 +113,8 @@ impl PersistedState {
             error_message: None,
             notified_events: BTreeSet::new(),
             auto_install_on_app_exit,
+            last_known_good_version: None,
+            rollback_blocked_candidate_version: None,
             cli_path: None,
             cli_installed_version: None,
             cli_latest_version: None,
@@ -298,6 +306,7 @@ mod tests {
             dmg_path: None,
             workspace_dir: None,
             package_path: Some(std::path::PathBuf::from("/tmp/codex.rpm")),
+            rollback_package_path: None,
         };
         let json = serde_json::to_string(&paths).expect("should serialise");
         assert!(


### PR DESCRIPTION
Adds a manual rollback command for the update manager so a user can return to the last retained known-good native package after a broken rebuilt update.

Changed:
- add `codex-update-manager rollback`
- retain the previous known-good package path when preparing the next update
- add explicit privileged rollback install paths for DEB, RPM, and pacman
- add separate polkit actions for rollback
- block automatic reinstall of the candidate that was just rolled back
- document the manual rollback command in README

Rollback process:
1. Close Codex Desktop.
2. Run `codex-update-manager rollback`.
3. Authenticate when polkit asks.
4. Wait for the native package manager to reinstall the retained previous package.
5. Start Codex Desktop normally.

Validation:
- `cargo fmt --check`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-update-manager rollback`
- `cargo test -p codex-update-manager -- --skip upstream::tests::downloads_dmg_and_hashes_contents --skip upstream::tests::fetches_remote_metadata_from_head`
- `make rpm PACKAGE_VERSION=2026.05.04.131500.rollbacktest2`
- real Fedora RPM E2E: installed test package, ran `/usr/bin/codex-update-manager rollback`, confirmed package returned to `2026.05.02.120000-trayfix.fc43`, then launched `/opt/codex-desktop/start.sh`
- `git diff --check`

Limits:
- real E2E was done for RPM on Fedora only
- DEB and pacman rollback paths are covered by command construction tests, not live package installs
- this is manual rollback only; no automatic health check or automatic rollback is included

Follow-up refactor suggestion:
- split updater orchestration into focused modules: check cycle, pending install recovery, privileged install dispatch, rollback state, CLI preflight, and status rendering
- keep package-manager-specific install and rollback command construction separate from app orchestration
- keep state compatibility tests close to `state.rs`, especially for fields written before a downgrade
