### PR TITLE
Fix GNOME dock grouping for Codex Desktop

### DIFF
--- a/packaging/linux/codex-desktop.desktop
+++ b/packaging/linux/codex-desktop.desktop
@@ -8,8 +8,8 @@ Type=Application
 Categories=Development;
 MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;
 StartupNotify=true
-StartupWMClass=codex-desktop
-X-GNOME-WMClass=codex-desktop
+StartupWMClass=Codex
+X-GNOME-WMClass=Codex
 Actions=CheckForUpdates;InstallReadyUpdate;
 
 [Desktop Action CheckForUpdates]

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -199,6 +199,8 @@ SCRIPT
     assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "CHROME_DESKTOP=codex-cua-lab.desktop"
     assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "/usr/bin/codex-cua-lab %u"
     assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
+    assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "StartupWMClass=Codex"
+    assert_contains "$pkg_root/usr/share/applications/codex-cua-lab.desktop" "X-GNOME-WMClass=Codex"
     assert_contains "$pkg_root/opt/codex-cua-lab/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-cua-lab.desktop"'
 }
 
@@ -556,6 +558,8 @@ PY
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "BAMF_DESKTOP_FILE_HINT"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "/usr/bin/codex-desktop %u"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "StartupWMClass=Codex"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "X-GNOME-WMClass=Codex"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "Actions=CheckForUpdates;InstallReadyUpdate;"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "codex-update-manager check-now"
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "codex-update-manager install-ready"


### PR DESCRIPTION
Fixes #108.

GNOME groups running windows by matching the desktop entry StartupWMClass with the actual window class. Upstream Codex sets the app name to "Codex", which can produce WM_CLASS=Codex on Linux. Our packaged desktop entry used StartupWMClass=codex-desktop, so Ubuntu GNOME could treat the running app as unrelated to the pinned launcher and show a second generic icon.

This updates the desktop entry to match the observed upstream window class.

Tested:
- bash tests/scripts_smoke.sh