### PR TITLE
Enhance builder scripts and release version 0.7.0 with UI actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, p
 
 ## Crate Versioning
 
-- Current updater crate version: `0.6.2`
+- Current updater crate version: `0.7.0`
 - Bump `patch` for fixes, docs, and maintenance-only updates.
 - Bump `minor` for compatible feature additions.
 - Bump `major` for incompatible CLI, persisted-state, or install-flow changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-04
+
 ### Added
 
 - Linux Computer Use plugin now exposes accessibility actions and editable-value setting via a new `perform_action` MCP tool. `element_index` selections resolve back to cached AT-SPI object references so actions and value writes target the same node as a click.
@@ -25,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Linux quit now bypasses the close-to-tray gate so the app actually exits instead of getting trapped in the tray.
 - Keybinds settings index patch tolerates upstream minified variable-name drift; the route map is detected via a `(0,X.lazy)` lookahead instead of hard-coded `c_e` / `Xge` / `Zge` names.
 - NixOS-installed `start.sh` shebang is patched to a nix-store `bash` so the launcher actually runs on systems without `/bin/bash`.
+- Native packages now always stage `scripts/lib/node-runtime.sh` into `/opt/codex-desktop/update-builder`, so local auto-update rebuilds can source the managed Node runtime helper instead of failing before package generation.
 
 ## [0.6.2] - 2026-05-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ pacman -Qlp dist/codex-desktop-*.pkg.tar.zst | sed -n '1,40p'
 
 ## Versioning
 
-`codex-update-manager` current crate version: `0.6.2`
+`codex-update-manager` current crate version: `0.7.0`
 
 SemVer policy:
 

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -145,6 +145,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/rebuild-candidate.sh" "$update_builder_root/scripts/rebuild-candidate.sh"
     cp "$REPO_DIR/scripts/patch-linux-window-ui.js" "$update_builder_root/scripts/patch-linux-window-ui.js"
     cp "$REPO_DIR/scripts/lib/package-common.sh" "$update_builder_root/scripts/lib/package-common.sh"
+    cp "$REPO_DIR/scripts/lib/node-runtime.sh" "$update_builder_root/scripts/lib/node-runtime.sh"
     cp "$REPO_DIR/scripts/lib/install-helpers.sh" "$update_builder_root/scripts/lib/install-helpers.sh"
     cp "$REPO_DIR/scripts/lib/process-detection.sh" "$update_builder_root/scripts/lib/process-detection.sh"
     cp "$REPO_DIR/scripts/lib/dmg.sh" "$update_builder_root/scripts/lib/dmg.sh"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -133,6 +133,7 @@ SCRIPT
     assert_file_exists "$pkg_root/DEBIAN/prerm"
     assert_file_exists "$pkg_root/DEBIAN/postrm"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/package-common.sh"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/node-runtime.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-update-bridge-patch.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/patch-report.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/rebuild-report.sh"

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -578,6 +578,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             bundle_root.join("scripts/lib/package-common.sh"),
             b"#!/bin/bash\n",
         )?;
+        fs::write(
+            bundle_root.join("scripts/lib/node-runtime.sh"),
+            b"#!/bin/bash\n",
+        )?;
 
         let paths = RuntimePaths {
             config_file: temp.path().join("config/config.toml"),
@@ -618,6 +622,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .workspace_dir
             .join("builder/scripts/rebuild-candidate.sh")
             .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("builder/scripts/lib/node-runtime.sh")
+            .exists());
         assert!(
             is_native_package_file(&artifacts.package_path),
             "expected a native package (.deb, .rpm, or .pkg.tar.zst), got {}",
@@ -652,6 +660,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             b"#!/bin/bash\n",
         )?;
         fs::write(
+            source_root.join("scripts/lib/node-runtime.sh"),
+            b"#!/bin/bash\n",
+        )?;
+        fs::write(
             source_root.join("packaging/linux/control"),
             b"Package: codex\n",
         )?;
@@ -671,6 +683,9 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         assert!(destination_root.join("updater").exists());
         assert!(destination_root
             .join("plugins/openai-bundled/plugins/computer-use/.mcp.json")
+            .exists());
+        assert!(destination_root
+            .join("scripts/lib/node-runtime.sh")
             .exists());
         assert!(!destination_root.join("scripts/build-rpm.sh").exists());
         assert!(!destination_root.join("scripts/build-pacman.sh").exists());


### PR DESCRIPTION
This pull request upgrades the `codex-update-manager` crate to version `0.7.0` and ensures that native packages always include the `node-runtime.sh` helper script in the update builder bundle. 

**Versioning and Documentation Updates:**
* Bumped `codex-update-manager` crate version from `0.6.2` to `0.7.0` in `updater/Cargo.toml`, `README.md`, and `AGENTS.md`.
* Added a new `0.7.0` section to `CHANGELOG.md` describing the update and its features.

**Packaging Improvements:**
* Updated `scripts/lib/package-common.sh` to always copy `scripts/lib/node-runtime.sh` into the update builder bundle for native packages.
* Modified Rust packaging logic in `updater/src/builder.rs` to generate and verify the presence of `node-runtime.sh` in the bundle during build and tests. 

**Testing:**
* Added assertions in `tests/scripts_smoke.sh` to verify that `node-runtime.sh` is present in the staged package.