### PR TITLE
fix: force --ozone-platform=x11 under ChromeOS Crostini Sommelier (#95)

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1033,6 +1033,27 @@ set_electron_defaults() {
         esac
         shift
     done
+
+    # ChromeOS / Crostini (Sommelier) auto-fallback to X11.
+    #
+    # On a Crostini Linux container the default Wayland session is provided by
+    # Sommelier (see SOMMELIER_VERSION/SOMMELIER_VM_IDENTIFIER, exported by
+    # cros-garcon for both terminal and app-menu launches). With the default
+    # Electron path (--ozone-platform-hint=auto) Electron picks the Wayland
+    # backend, reaches `window ready-to-show`, but the window never surfaces in
+    # the ChromeOS shell — leaving the launcher icon spinning indefinitely with
+    # no visible app. Forcing X11 (proxied by sommelier-x to ChromeOS) is the
+    # documented workaround. Skip this only when the operator explicitly chose
+    # a platform via --x11 / --wayland / --ozone-platform=*.
+    #
+    # See https://github.com/ilysenko/codex-desktop-linux/issues/95.
+    if [ -z "$ELECTRON_OZONE_PLATFORM" ] \
+        && [ "$ELECTRON_OZONE_HINT" = "auto" ] \
+        && [ -n "${SOMMELIER_VERSION:-}" ]; then
+        ELECTRON_OZONE_PLATFORM="x11"
+        ELECTRON_OZONE_HINT=""
+        echo "Detected Sommelier (SOMMELIER_VERSION=$SOMMELIER_VERSION); forcing --ozone-platform=x11 (Wayland windows are not visible under ChromeOS Crostini)"
+    fi
 }
 
 build_electron_launch_args() {

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -179,6 +179,16 @@ discover_graphical_env_from_processes() {
 
 hydrate_graphical_session_env() {
     if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then
+        # Display vars are already present, but the ChromeOS / Crostini
+        # auto-X11 fallback in set_electron_defaults also needs
+        # SOMMELIER_VERSION. On some app-launcher paths the spawned
+        # process inherits DISPLAY / WAYLAND_DISPLAY but not the Sommelier
+        # markers (those live only in the systemd --user manager env). Try
+        # one user-manager import in that case so the whitelisted
+        # SOMMELIER_VERSION / SOMMELIER_VM_IDENTIFIER get hydrated.
+        if [ -z "${SOMMELIER_VERSION:-}" ]; then
+            import_graphical_env_from_systemd_user >/dev/null 2>&1 || true
+        fi
         return 0
     fi
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -112,8 +112,13 @@ import_graphical_env_entry() {
 
     [ "$entry" != "$name" ] || return 0
 
+    # SOMMELIER_VERSION / SOMMELIER_VM_IDENTIFIER are imported here so the
+    # ChromeOS / Crostini auto-X11 fallback in set_electron_defaults sees
+    # them on app-launcher paths where they may only be present in the
+    # systemd --user manager environment (and not in the spawned process's
+    # initial env).
     case "$name" in
-        DISPLAY|WAYLAND_DISPLAY|XDG_SESSION_TYPE|XDG_CURRENT_DESKTOP|DBUS_SESSION_BUS_ADDRESS|XDG_RUNTIME_DIR|DESKTOP_SESSION|XAUTHORITY)
+        DISPLAY|WAYLAND_DISPLAY|XDG_SESSION_TYPE|XDG_CURRENT_DESKTOP|DBUS_SESSION_BUS_ADDRESS|XDG_RUNTIME_DIR|DESKTOP_SESSION|XAUTHORITY|SOMMELIER_VERSION|SOMMELIER_VM_IDENTIFIER)
             if [ -z "${!name:-}" ]; then
                 export "$entry"
             fi


### PR DESCRIPTION
## Summary

Fixes #95. On a ChromeOS Crostini Linux container the default Wayland session is provided by Sommelier. With Electron's default `--ozone-platform-hint=auto` path the window logs `ready-to-show` but never surfaces in the ChromeOS shell — both bare `codex-desktop` and ChromeOS app-menu launches just leave the launcher icon spinning. The reporter and I have both confirmed `--x11` (which Sommelier proxies to ChromeOS via XWayland) renders correctly.

This hooks the existing flag parser in `set_electron_defaults` so that, when the operator did **not** explicitly choose a platform (no `--x11` / `--wayland` / `--ozone-platform=*`), and `SOMMELIER_VERSION` is non-empty, we substitute `--ozone-platform=x11` and log a one-line note for visibility. Explicit user flags still win, so anyone wanting to test the native Wayland path can opt back in with `--wayland`.

## Why detect via `SOMMELIER_VERSION`

`SOMMELIER_VERSION` and `SOMMELIER_VM_IDENTIFIER` are exported by `cros-garcon` for both terminal sessions and app-menu launches inside Crostini, and they are not set in any other Linux session I'm aware of. They are also what the original report uses to identify the environment, so the detection is symmetric with how the issue was filed.

## Verified on

- Crostini Debian 12 (`bookworm`), Sommelier `0.20`
- `XDG_SESSION_TYPE=wayland`, `XDG_CURRENT_DESKTOP=X-Generic`
- codex-desktop `2026.05.04.231437` (built locally from this branch's parent commit)

| Scenario | Before | After |
|---|---|---|
| `codex-desktop` (terminal, no flags) | window not visible | window visible (auto x11) |
| ChromeOS app launcher click | spinner forever, no window | singleton handoff focuses existing window |
| `codex-desktop --x11` | window visible | window visible (no behavior change) |
| `codex-desktop --wayland` | (Wayland, but invisible) | Wayland honored (no auto-override) |
| `codex-desktop --safe-mode` | x11 + sw rendering | unchanged |

`launcher.log` excerpt after the patch:

```
Detected Sommelier (SOMMELIER_VERSION=0.20); forcing --ozone-platform=x11 (Wayland windows are not visible under ChromeOS Crostini)
Electron launch mode: ozone_platform=x11 ozone_hint=none gpu_enabled=1
```

## Smoke-tested

```bash
# synthetic prelude + template syntax
{ printf '#!/bin/bash\nset -euo pipefail\nCODEX_LINUX_APP_ID=codex-desktop\nCODEX_LINUX_APP_DISPLAY_NAME="Codex Desktop"\nCODEX_LINUX_WEBVIEW_PORT=5175\n'; cat launcher/start.sh.template; } > /tmp/start-test.sh
bash -n /tmp/start-test.sh   # OK

# upstream smoke tests
bash tests/scripts_smoke.sh  # All script smoke tests passed
```

## Test plan for the reviewer

- [ ] `bash -n install.sh launcher/start.sh.template` (syntax)
- [ ] `bash tests/scripts_smoke.sh` (existing smoke)
- [ ] On a non-Crostini Wayland host, confirm the auto-substitution is **not** triggered (no `SOMMELIER_VERSION` env)
- [ ] On Crostini, confirm app-menu launch surfaces a window without `--x11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)