### PR TITLE
fix(rpm): Align Fedora 44 dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,6 @@ bash scripts/install-deps.sh
 
 This project requires:
 
-- Node.js 20+ with `npm` and `npx`
 - `python3`
 - `7z` or `7zz`
 - `curl`
@@ -74,6 +73,8 @@ This project requires:
 - `make`
 - `g++`
 - Rust toolchain with `cargo`
+
+`install.sh` downloads a managed Node.js runtime for the build and packaged app. A system Node.js install is optional user tooling.
 
 If you are working on apt-based systems, prefer the bootstrap path in `scripts/install-deps.sh` so you get a compatible Node.js version.
 

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -4,8 +4,9 @@ Release:        __RPM_RELEASE__%{?dist}
 Summary:        Codex Desktop for Linux
 License:        Proprietary
 ExclusiveArch:  __ARCH__
+%global __requires_exclude_from ^/opt/__PACKAGE_NAME__/(resources|update-builder)/node-runtime/.*$
 
-Requires:       python3, p7zip, polkit, curl, unzip, gcc-c++, make
+Requires:       python3, /usr/bin/7z, polkit, curl, unzip, gcc-c++, make
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
 Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
 Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -158,9 +158,14 @@ ensure_nodejs_compatible() {
         return
     fi
 
+    if [ "$distro" = "dnf5" ]; then
+        info "Skipping system Node.js check; install.sh provides the managed Node.js runtime"
+        return
+    fi
+
     if [ "$distro" != "apt" ]; then
         error "Node.js ${MIN_NODE_MAJOR}+ with npm and npx is required$(current_node_version_suffix).
-Install a supported Node.js version for this distro, then re-run this script."
+Install a supported Node.js version for this distro, or use install.sh to download the managed runtime, then re-run this script."
     fi
 
     warn "Node.js ${MIN_NODE_MAJOR}+ with npm and npx is required$(current_node_version_suffix)"
@@ -230,8 +235,7 @@ install_dnf5() {
     info "Detected Fedora 41+ (dnf5)"
     # dnf5: 7zip provides /usr/bin/7z; @development-tools is the group syntax
     sudo dnf install -y \
-        nodejs npm python3 \
-        7zip curl unzip \
+        python3 7zip curl unzip \
         @development-tools
 }
 
@@ -402,7 +406,7 @@ case "$DISTRO" in
         error "Unsupported package manager. Install manually:
   # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install nodejs npm python3 7zip curl unzip @development-tools            # Fedora 41+ (dnf5)
+  sudo dnf install python3 7zip curl unzip @development-tools                       # Fedora 41+ (dnf5)
   sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S nodejs npm python p7zip curl unzip zstd base-devel                 # Arch

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -21,7 +21,7 @@ Run the helper to install them automatically:
 Or install manually:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
   sudo dnf install python3 7zip curl unzip @development-tools                       # Fedora 41+ (dnf5)
-  sudo dnf install python3 p7zip p7zip-plugins curl unzip                           # Fedora <41 (dnf)
+  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S python p7zip curl unzip zstd base-devel                            # Arch
   sudo zypper install python3 p7zip-full curl unzip                                 # openSUSE


### PR DESCRIPTION
## Summary
- replace the RPM p7zip package dependency with a /usr/bin/7z file dependency for Fedora 44
- exclude the bundled managed Node.js runtime from RPM auto-requires so bundled npm/corepack shebangs do not add a system Node.js dependency
- stop installing or requiring system nodejs/npm on the Fedora 41+ dnf5 dependency helper path
- update contributor dependency guidance to match the managed Node.js runtime

## Validation
- make build-app
- make rpm
- bash tests/scripts_smoke.sh
- bash -n scripts/install-deps.sh scripts/lib/install-helpers.sh scripts/build-rpm.sh
- git diff --check
- rpm -qpR dist/codex-desktop-2026.05.06.133549-1.x86_64.rpm
- rpm -qlp dist/codex-desktop-2026.05.06.133549-1.x86_64.rpm

## Notes
- Scope is limited to Fedora 41+/Fedora 44 RPM dependency handling and matching docs.
- Debian, Arch, openSUSE, package installation, and service state are unchanged.