### PR TITLE
Add Hyprland window targeting backend

### DIFF
--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -64,6 +64,7 @@ pub struct AccessibilityReport {
 pub struct WindowingReport {
     pub gnome_shell_introspect: Check,
     pub codex_gnome_shell_extension: Check,
+    pub hyprland: Check,
     pub can_list_windows: bool,
     pub can_focus_apps: bool,
     pub can_focus_windows: bool,
@@ -355,29 +356,74 @@ fn windowing_report() -> WindowingReport {
         "com.openai.Codex.WindowControl.ListWindows",
         &[],
     );
-    let can_list_windows = gnome_shell_introspect.ok || codex_gnome_shell_extension.ok;
-    let can_focus_apps = gdbus_introspect_contains(
+    let hyprland = hyprland_windowing_check();
+    let can_list_windows =
+        gnome_shell_introspect.ok || codex_gnome_shell_extension.ok || hyprland.ok;
+    let gnome_focus_apps = gdbus_introspect_contains(
         "org.gnome.Shell",
         "/org/gnome/Shell",
         "org.gnome.Shell",
         "FocusApp",
     )
     .ok;
-    let can_focus_windows = codex_gnome_shell_extension.ok;
+    let can_focus_apps = gnome_focus_apps || hyprland.ok;
+    let can_focus_windows = codex_gnome_shell_extension.ok || hyprland.ok;
     let note = if can_list_windows {
-        "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
+        if hyprland.ok {
+            "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
+        } else {
+            "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
+        }
     } else {
-        "GNOME window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. Run setup_window_targeting to install the optional GNOME Shell extension backend."
+        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On Hyprland, ensure hyprctl is available in the session."
     }
     .to_string();
 
     WindowingReport {
         gnome_shell_introspect,
         codex_gnome_shell_extension,
+        hyprland,
         can_list_windows,
         can_focus_apps,
         can_focus_windows,
         note,
+    }
+}
+
+fn hyprland_windowing_check() -> Check {
+    let desktop = env::var("XDG_CURRENT_DESKTOP")
+        .or_else(|_| env::var("DESKTOP_SESSION"))
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if !desktop.contains("hyprland") {
+        return Check::fail("not a Hyprland session");
+    }
+
+    match Command::new("hyprctl").args(["clients", "-j"]).output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            match serde_json::from_str::<serde_json::Value>(&stdout) {
+                Ok(serde_json::Value::Array(clients)) => Check::ok(format!(
+                    "hyprctl clients -j returned {} clients",
+                    clients.len()
+                )),
+                Ok(_) => Check::fail("hyprctl clients -j did not return a JSON array"),
+                Err(error) => {
+                    Check::fail(format!("hyprctl clients -j returned invalid JSON: {error}"))
+                }
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let detail = if !stderr.is_empty() { stderr } else { stdout };
+            Check::fail(if detail.is_empty() {
+                format!("exit status {}", output.status)
+            } else {
+                detail
+            })
+        }
+        Err(error) => Check::fail(error.to_string()),
     }
 }
 
@@ -413,14 +459,14 @@ fn readiness_report(
 
     if !can_query_windows {
         blockers.push(
-            "GNOME Shell window introspection is unavailable; targeted window focus and verification will be disabled."
+            "Window introspection is unavailable; targeted window focus and verification will be disabled."
                 .to_string(),
         );
     }
 
     if can_query_windows && !can_focus_windows {
         blockers.push(
-            "Exact GNOME Shell window activation is unavailable; app-level focus may work, but window_id/title/terminal-targeted input cannot be verified."
+            "Exact window activation is unavailable; app-level focus may work, but window_id/title/terminal-targeted input cannot be verified."
                 .to_string(),
         );
     }
@@ -436,13 +482,13 @@ fn readiness_report(
         "Run setup_accessibility to enable GNOME accessibility before element-aware actions."
             .to_string()
     } else if !can_query_windows {
-        "Run setup_window_targeting to install the Codex GNOME Shell extension backend, or enable GNOME Shell window introspection before using targeted keyboard input.".to_string()
+        "Enable a supported window backend before using targeted keyboard input: GNOME Shell Introspect, the Codex GNOME Shell extension, or Hyprland hyprctl.".to_string()
     } else if !can_focus_windows {
-        "Run setup_window_targeting to install the Codex GNOME Shell extension backend before using exact window_id, title, or terminal-targeted input.".to_string()
+        "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
         "Install and start ydotoold if development input fallback is needed.".to_string()
     } else {
-        "Computer Use is ready: AT-SPI tree support, GNOME window targeting, and ydotool input fallback are available."
+        "Computer Use is ready: AT-SPI tree support, window targeting, and ydotool input fallback are available."
             .to_string()
     };
 
@@ -669,6 +715,7 @@ mod tests {
             } else {
                 Check::fail("missing")
             },
+            hyprland: Check::fail("not a Hyprland session"),
             can_list_windows,
             can_focus_apps: true,
             can_focus_windows,
@@ -741,15 +788,15 @@ mod tests {
         assert!(!readiness.can_focus_windows);
         assert!(readiness
             .recommended_next_step
-            .contains("setup_window_targeting"));
+            .contains("exact-focus window backend"));
         assert!(readiness
             .blockers
             .iter()
-            .any(|blocker| blocker.contains("Exact GNOME Shell window activation")));
+            .any(|blocker| blocker.contains("Exact window activation")));
     }
 
     #[test]
-    fn readiness_message_stays_within_pr1_scope() {
+    fn readiness_message_mentions_generic_window_targeting() {
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
         let windowing = windowing_report(true, true);
         let input = input_report(true);
@@ -760,6 +807,9 @@ mod tests {
         assert!(readiness
             .recommended_next_step
             .contains("AT-SPI tree support"));
-        assert!(!readiness.recommended_next_step.contains("action/value"));
+        assert!(readiness.recommended_next_step.contains("window targeting"));
+        assert!(!readiness
+            .recommended_next_step
+            .contains("GNOME window targeting"));
     }
 }

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -391,14 +391,6 @@ fn windowing_report() -> WindowingReport {
 }
 
 fn hyprland_windowing_check() -> Check {
-    let desktop = env::var("XDG_CURRENT_DESKTOP")
-        .or_else(|_| env::var("DESKTOP_SESSION"))
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if !desktop.contains("hyprland") {
-        return Check::fail("not a Hyprland session");
-    }
-
     match Command::new("hyprctl").args(["clients", "-j"]).output() {
         Ok(output) if output.status.success() => {
             let stdout = String::from_utf8_lossy(&output.stdout);

--- a/computer-use-linux/src/windows.rs
+++ b/computer-use-linux/src/windows.rs
@@ -587,7 +587,7 @@ struct HyprlandClient {
     #[serde(rename = "class")]
     class_name: Option<String>,
     title: Option<String>,
-    pid: Option<u32>,
+    pid: Option<i64>,
     xwayland: Option<bool>,
     #[serde(rename = "focusHistoryID")]
     focus_history_id: Option<i32>,
@@ -622,7 +622,7 @@ impl TryFrom<HyprlandClient> for WindowInfo {
             title: client.title,
             app_id: client.class_name.clone(),
             wm_class: client.class_name,
-            pid: client.pid,
+            pid: client.pid.and_then(|pid| u32::try_from(pid).ok()),
             bounds,
             workspace: client.workspace.and_then(|workspace| workspace.id),
             focused: client.focus_history_id == Some(0),
@@ -1079,12 +1079,25 @@ mod tests {
             "pid": 68986,
             "xwayland": false,
             "focusHistoryID": 0
+          },
+          {
+            "address": "0x559952c99aa0",
+            "mapped": true,
+            "hidden": false,
+            "at": [0, 0],
+            "size": [400, 300],
+            "workspace": {"id": 3, "name": "3"},
+            "class": "transient",
+            "title": "Transient",
+            "pid": -1,
+            "xwayland": false,
+            "focusHistoryID": 2
           }
         ]"#;
 
         let windows = parse_hyprland_clients(clients_json).unwrap();
 
-        assert_eq!(windows.len(), 2);
+        assert_eq!(windows.len(), 3);
         assert_eq!(windows[0].window_id, 0x559952b6db60);
         assert_eq!(windows[0].app_id.as_deref(), Some("brave-browser"));
         assert_eq!(windows[0].wm_class.as_deref(), Some("brave-browser"));
@@ -1097,6 +1110,7 @@ mod tests {
         assert_eq!(windows[0].client_type.as_deref(), Some("wayland"));
         assert_eq!(windows[0].backend, HYPRLAND_BACKEND);
         assert!(windows[1].focused);
+        assert_eq!(windows[2].pid, None);
     }
 
     #[test]

--- a/computer-use-linux/src/windows.rs
+++ b/computer-use-linux/src/windows.rs
@@ -3,12 +3,13 @@ use crate::terminal::{enrich_terminal_windows, TerminalWindowContext};
 use anyhow::{bail, Context, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, process::Command, time::Duration};
 use tokio::time::sleep;
 use zbus::{zvariant::OwnedValue, Proxy};
 
 pub const GNOME_SHELL_INTROSPECT_BACKEND: &str = "gnome-shell-introspect";
 pub const GNOME_SHELL_EXTENSION_BACKEND: &str = "gnome-shell-extension";
+pub const HYPRLAND_BACKEND: &str = "hyprland";
 pub const GNOME_SHELL_EXTENSION_SERVICE: &str = "com.openai.Codex.WindowControl";
 pub const GNOME_SHELL_EXTENSION_OBJECT_PATH: &str = "/com/openai/Codex/WindowControl";
 pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a GNOME window list backend. Targeted window input requires session-bus access plus either GNOME Shell Introspect permission or the Codex GNOME Shell extension backend. Run setup_window_targeting to install the extension backend.";
@@ -123,9 +124,12 @@ pub async fn list_windows() -> Result<Vec<WindowInfo>> {
         Ok(windows) => Ok(windows),
         Err(extension_error) => match list_gnome_shell_introspect_windows().await {
             Ok(windows) => Ok(windows),
-            Err(introspect_error) => Err(anyhow::anyhow!(
-                "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}"
-            )),
+            Err(introspect_error) => match list_hyprland_windows() {
+                Ok(windows) => Ok(windows),
+                Err(hyprland_error) => Err(anyhow::anyhow!(
+                    "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}; Hyprland failed: {hyprland_error:#}"
+                )),
+            },
         },
     }
 }
@@ -170,6 +174,35 @@ pub async fn list_extension_windows() -> Result<Vec<WindowInfo>> {
     Ok(windows)
 }
 
+fn list_hyprland_windows() -> Result<Vec<WindowInfo>> {
+    let output = Command::new("hyprctl")
+        .args(["clients", "-j"])
+        .output()
+        .context("failed to run hyprctl clients -j")?;
+    if !output.status.success() {
+        bail!(
+            "hyprctl clients -j failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    parse_hyprland_clients(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_hyprland_clients(json: &str) -> Result<Vec<WindowInfo>> {
+    let clients: Vec<HyprlandClient> =
+        serde_json::from_str(json).context("failed to parse hyprctl clients -j output")?;
+
+    let mut windows = clients
+        .into_iter()
+        .filter(|client| client.mapped.unwrap_or(true))
+        .map(WindowInfo::try_from)
+        .collect::<Result<Vec<_>>>()?;
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
 pub async fn focused_window() -> Result<Option<WindowInfo>> {
     current_focused_window().await
 }
@@ -183,7 +216,9 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
     let requested_window = resolve_window_target(&windows, target)?.clone();
     ensure_backend_can_focus_target(target, &requested_window)?;
 
-    if requested_window.backend == GNOME_SHELL_EXTENSION_BACKEND {
+    if requested_window.backend == HYPRLAND_BACKEND {
+        activate_hyprland_window(requested_window.window_id)?;
+    } else if requested_window.backend == GNOME_SHELL_EXTENSION_BACKEND {
         activate_extension_window(requested_window.window_id).await?;
     } else {
         let app_id = requested_window
@@ -217,9 +252,12 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
 }
 
 fn ensure_backend_can_focus_target(target: &WindowTarget, window: &WindowInfo) -> Result<()> {
-    if target.requires_exact_focus() && window.backend != GNOME_SHELL_EXTENSION_BACKEND {
+    if target.requires_exact_focus()
+        && window.backend != GNOME_SHELL_EXTENSION_BACKEND
+        && window.backend != HYPRLAND_BACKEND
+    {
         bail!(
-            "Exact window targeting requires the Codex GNOME Shell extension backend; {} can list the matched window but cannot activate a specific window safely.",
+            "Exact window targeting requires the Codex GNOME Shell extension or Hyprland backend; {} can list the matched window but cannot activate a specific window safely.",
             window.backend
         );
     }
@@ -520,6 +558,89 @@ async fn activate_extension_window(window_id: u64) -> Result<()> {
     } else {
         bail!("Codex GNOME Shell extension refused activation: {message}");
     }
+}
+
+fn activate_hyprland_window(window_id: u64) -> Result<()> {
+    let address = format!("address:0x{window_id:x}");
+    let output = Command::new("hyprctl")
+        .args(["dispatch", "focuswindow", &address])
+        .output()
+        .with_context(|| format!("failed to run hyprctl dispatch focuswindow {address}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!(
+            "hyprctl dispatch focuswindow {address} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct HyprlandClient {
+    address: String,
+    mapped: Option<bool>,
+    hidden: Option<bool>,
+    at: Option<[i32; 2]>,
+    size: Option<[u32; 2]>,
+    workspace: Option<HyprlandWorkspace>,
+    #[serde(rename = "class")]
+    class_name: Option<String>,
+    title: Option<String>,
+    pid: Option<u32>,
+    xwayland: Option<bool>,
+    #[serde(rename = "focusHistoryID")]
+    focus_history_id: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HyprlandWorkspace {
+    id: Option<i32>,
+}
+
+impl TryFrom<HyprlandClient> for WindowInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(client: HyprlandClient) -> Result<Self> {
+        let window_id = parse_hyprland_address(&client.address)?;
+        let bounds = client.size.map(|[width, height]| WindowBounds {
+            x: client.at.map(|[x, _]| x),
+            y: client.at.map(|[_, y]| y),
+            width,
+            height,
+        });
+        let client_type = client.xwayland.map(|xwayland| {
+            if xwayland {
+                "x11".to_string()
+            } else {
+                "wayland".to_string()
+            }
+        });
+
+        Ok(WindowInfo {
+            window_id,
+            title: client.title,
+            app_id: client.class_name.clone(),
+            wm_class: client.class_name,
+            pid: client.pid,
+            bounds,
+            workspace: client.workspace.and_then(|workspace| workspace.id),
+            focused: client.focus_history_id == Some(0),
+            hidden: client.hidden.unwrap_or(false),
+            client_type,
+            backend: HYPRLAND_BACKEND.to_string(),
+            terminal: None,
+        })
+    }
+}
+
+fn parse_hyprland_address(address: &str) -> Result<u64> {
+    let hex = address
+        .trim()
+        .strip_prefix("0x")
+        .context("Hyprland window address did not start with 0x")?;
+    u64::from_str_radix(hex, 16)
+        .with_context(|| format!("failed to parse Hyprland window address {address}"))
 }
 
 fn window_from_properties(window_id: u64, properties: &HashMap<String, OwnedValue>) -> WindowInfo {
@@ -928,6 +1049,69 @@ mod tests {
         );
 
         assert_eq!(hint.as_deref(), Some(WINDOW_PERMISSION_HINT));
+    }
+
+    #[test]
+    fn parses_hyprland_clients_as_window_info() {
+        let clients_json = r#"[
+          {
+            "address": "0x559952b6db60",
+            "mapped": true,
+            "hidden": false,
+            "at": [10, 48],
+            "size": [1900, 1022],
+            "workspace": {"id": 2, "name": "2"},
+            "class": "brave-browser",
+            "title": "Repo - Brave",
+            "pid": 24134,
+            "xwayland": false,
+            "focusHistoryID": 1
+          },
+          {
+            "address": "0x559952be43d0",
+            "mapped": true,
+            "hidden": false,
+            "at": [10, 48],
+            "size": [1900, 1022],
+            "workspace": {"id": 1, "name": "1"},
+            "class": "codex-desktop",
+            "title": "Codex",
+            "pid": 68986,
+            "xwayland": false,
+            "focusHistoryID": 0
+          }
+        ]"#;
+
+        let windows = parse_hyprland_clients(clients_json).unwrap();
+
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].window_id, 0x559952b6db60);
+        assert_eq!(windows[0].app_id.as_deref(), Some("brave-browser"));
+        assert_eq!(windows[0].wm_class.as_deref(), Some("brave-browser"));
+        assert_eq!(windows[0].title.as_deref(), Some("Repo - Brave"));
+        assert_eq!(windows[0].pid, Some(24134));
+        assert_eq!(windows[0].bounds.as_ref().unwrap().x, Some(10));
+        assert_eq!(windows[0].bounds.as_ref().unwrap().height, 1022);
+        assert_eq!(windows[0].workspace, Some(2));
+        assert!(!windows[0].focused);
+        assert_eq!(windows[0].client_type.as_deref(), Some("wayland"));
+        assert_eq!(windows[0].backend, HYPRLAND_BACKEND);
+        assert!(windows[1].focused);
+    }
+
+    #[test]
+    fn hyprland_backend_can_exact_focus_targets() {
+        let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
+        window.backend = HYPRLAND_BACKEND.to_string();
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                title: Some("Codex".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a Hyprland backend for Linux Computer Use window listing via `hyprctl clients -j`
- Support exact Hyprland window focus through `hyprctl dispatch focuswindow address:<addr>`
- Update doctor diagnostics/readiness to report Hyprland window targeting as fully available when `hyprctl` works

## Verification
- `cargo fmt -- --check`
- `cargo test -p codex-computer-use-linux`
- `cargo run -p codex-computer-use-linux -- windows` reports `backend: hyprland`
- Built app backend doctor reports `can_focus_windows: true` and no blockers on Hyprland