### PR TITLE
Fix/0.7.1 missing cargo path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, p
 
 ## Crate Versioning
 
-- Current updater crate version: `0.7.0`
+- Current updater crate version: `0.7.1`
 - Bump `patch` for fixes, docs, and maintenance-only updates.
 - Bump `minor` for compatible feature additions.
 - Bump `major` for incompatible CLI, persisted-state, or install-flow changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-06
+
+### Fixed
+
+- Local auto-update rebuilds and package builds now find the Rust toolchain reliably when `cargo` is installed via `rustup` under `~/.cargo/bin`, even if the `codex-update-manager` user service or packaging scripts inherit a reduced `PATH`.
+
+### Added
+
+- Regression coverage for the build-environment fix: updater path construction now has a unit test for `~/.cargo/bin`, and packaging helpers resolve `cargo` through the same fallback path used by Linux Computer Use staging.
+
 ## [0.7.0] - 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ pacman -Qlp dist/codex-desktop-*.pkg.tar.zst | sed -n '1,40p'
 
 ## Versioning
 
-`codex-update-manager` current crate version: `0.7.0`
+`codex-update-manager` current crate version: `0.7.1`
 
 SemVer policy:
 

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -48,24 +48,6 @@ rpm_version_parts() {
     RPM_RELEASE="$hash"
 }
 
-ensure_updater_binary() {
-    local cargo_cmd=""
-
-    if [ -x "$UPDATER_BINARY_SOURCE" ]; then
-        return
-    fi
-
-    [ -f "$REPO_DIR/Cargo.toml" ] || error "Missing updater binary: $UPDATER_BINARY_SOURCE"
-    cargo_cmd="$(find_cargo_command)" || error "cargo is required to build codex-update-manager.
-Install the Rust toolchain:
-  bash scripts/install-deps.sh        # auto-installs via rustup
-  # or manually: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
-
-    info "Building codex-update-manager release binary"
-    "$cargo_cmd" build --release -p codex-update-manager >&2
-    [ -x "$UPDATER_BINARY_SOURCE" ] || error "Failed to build updater binary: $UPDATER_BINARY_SOURCE"
-}
-
 main() {
     [ -d "$APP_DIR" ] || error "Missing app directory: $APP_DIR. Run ./install.sh first."
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -49,18 +49,20 @@ rpm_version_parts() {
 }
 
 ensure_updater_binary() {
+    local cargo_cmd=""
+
     if [ -x "$UPDATER_BINARY_SOURCE" ]; then
         return
     fi
 
     [ -f "$REPO_DIR/Cargo.toml" ] || error "Missing updater binary: $UPDATER_BINARY_SOURCE"
-    command -v cargo >/dev/null 2>&1 || error "cargo is required to build codex-update-manager.
+    cargo_cmd="$(find_cargo_command)" || error "cargo is required to build codex-update-manager.
 Install the Rust toolchain:
   bash scripts/install-deps.sh        # auto-installs via rustup
   # or manually: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
 
     info "Building codex-update-manager release binary"
-    cargo build --release -p codex-update-manager >&2
+    "$cargo_cmd" build --release -p codex-update-manager >&2
     [ -x "$UPDATER_BINARY_SOURCE" ] || error "Failed to build updater binary: $UPDATER_BINARY_SOURCE"
 }
 

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -72,19 +72,35 @@ updater_binary_is_stale() {
     return 1
 }
 
+find_cargo_command() {
+    if command -v cargo >/dev/null 2>&1; then
+        command -v cargo
+        return 0
+    fi
+
+    if [ -x "$HOME/.cargo/bin/cargo" ]; then
+        echo "$HOME/.cargo/bin/cargo"
+        return 0
+    fi
+
+    return 1
+}
+
 ensure_updater_binary() {
+    local cargo_cmd=""
+
     if [ -x "$UPDATER_BINARY_SOURCE" ] && ! updater_binary_is_stale "$UPDATER_BINARY_SOURCE"; then
         return
     fi
 
     [ -f "$REPO_DIR/Cargo.toml" ] || error "Missing updater binary: $UPDATER_BINARY_SOURCE"
-    command -v cargo >/dev/null 2>&1 || error "cargo is required to build codex-update-manager.
+    cargo_cmd="$(find_cargo_command)" || error "cargo is required to build codex-update-manager.
 Install the Rust toolchain:
   bash scripts/install-deps.sh        # auto-installs via rustup
   # or manually: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
 
     info "Building codex-update-manager release binary"
-    cargo build --release -p codex-update-manager >&2
+    "$cargo_cmd" build --release -p codex-update-manager >&2
     [ -x "$UPDATER_BINARY_SOURCE" ] || error "Failed to build updater binary: $UPDATER_BINARY_SOURCE"
 }
 

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -778,6 +778,7 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
 
     #[test]
     fn build_command_path_includes_cargo_bin_from_home() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
         let temp = tempdir()?;
         let home_dir = temp.path().join("home");
         let cargo_bin = home_dir.join(".cargo/bin");

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -295,6 +295,7 @@ fn is_native_package_file(path: &Path) -> bool {
 fn build_command_path(builder_bundle_root: &Path) -> OsString {
     let mut entries = managed_node_bin_dirs(builder_bundle_root);
     entries.extend(preferred_node_bin_dirs());
+    entries.extend(preferred_rust_bin_dirs());
     entries.extend(std::env::split_paths(
         &std::env::var_os("PATH").unwrap_or_default(),
     ));
@@ -335,6 +336,19 @@ fn preferred_node_bin_dirs() -> Vec<PathBuf> {
     };
 
     collect_nvm_bin_dirs(&nvm_root)
+}
+
+fn preferred_rust_bin_dirs() -> Vec<PathBuf> {
+    let Some(home) = std::env::var_os("HOME") else {
+        return Vec::new();
+    };
+
+    let cargo_bin = PathBuf::from(home).join(".cargo/bin");
+    if cargo_bin.join("cargo").is_file() {
+        vec![cargo_bin]
+    } else {
+        Vec::new()
+    }
 }
 
 fn collect_nvm_bin_dirs(nvm_root: &Path) -> Vec<PathBuf> {
@@ -759,6 +773,30 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         let path = build_command_path(temp.path());
         let directories = std::env::split_paths(&path).collect::<Vec<_>>();
         assert_eq!(directories.first(), Some(&runtime_bin));
+        Ok(())
+    }
+
+    #[test]
+    fn build_command_path_includes_cargo_bin_from_home() -> Result<()> {
+        let temp = tempdir()?;
+        let home_dir = temp.path().join("home");
+        let cargo_bin = home_dir.join(".cargo/bin");
+        fs::create_dir_all(&cargo_bin)?;
+        fs::write(cargo_bin.join("cargo"), b"bin")?;
+
+        let original_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", &home_dir);
+
+        let path = build_command_path(Path::new("/tmp/missing-codex-builder"));
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+
+        let directories = std::env::split_paths(&path).collect::<Vec<_>>();
+        assert!(directories.iter().any(|dir| dir == &cargo_bin));
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request updates the `codex-update-manager` to version 0.7.1 and addresses issues with reliably locating the Rust toolchain (`cargo`) in local auto-update and packaging scripts, especially when `cargo` is installed via `rustup` under `~/.cargo/bin`. It also adds regression test coverage for the new path resolution logic. The most important changes are:

**Build and Packaging Reliability:**

* Both `scripts/lib/package-common.sh` and `scripts/build-rpm.sh` now use a new `find_cargo_command` function to reliably locate `cargo`, falling back to `~/.cargo/bin/cargo` if it's not on the `PATH`. This ensures builds work even in reduced environment contexts. 

**Testing and Quality Assurance:**

* Added a unit test in `updater/src/builder.rs` to verify that `build_command_path` includes `~/.cargo/bin` when present, ensuring regression coverage for the new path logic.

**Documentation and Versioning:**

* Updated documentation and version references in `README.md`, `AGENTS.md`, `CHANGELOG.md`, and `Cargo.toml` to reflect the new version (0.7.1) and the build-environment improvements. 