### PR TITLE
fix(install): Detect Linux dependency profiles from os-release

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -190,8 +190,71 @@ Check apt output above or install Node.js ${MIN_NODE_MAJOR}+ manually."
 # ---------------------------------------------------------------------------
 # Distro detection
 # ---------------------------------------------------------------------------
+os_release_field() {
+    local field="$1"
+    local file line value
+
+    for file in ${OS_RELEASE_FILE:-} /etc/os-release /usr/lib/os-release; do
+        [ -n "$file" ] || continue
+        [ -r "$file" ] || continue
+        while IFS= read -r line; do
+            case "$line" in
+                "$field="*)
+                    value="${line#*=}"
+                    value="${value#\"}"
+                    value="${value%\"}"
+                    value="${value#\'}"
+                    value="${value%\'}"
+                    printf '%s\n' "${value,,}"
+                    return 0
+                    ;;
+            esac
+        done < "$file"
+    done
+
+    return 1
+}
+
+os_release_matches() {
+    local expected token
+    for expected in "$@"; do
+        [ "${OS_RELEASE_ID:-}" = "$expected" ] && return 0
+        for token in ${OS_RELEASE_ID_LIKE:-}; do
+            [ "$token" = "$expected" ] && return 0
+        done
+    done
+    return 1
+}
+
+os_release_version_major() {
+    local version="${OS_RELEASE_VERSION_ID:-}"
+    version="${version%%.*}"
+    case "$version" in
+        ''|*[!0-9]*) return 1 ;;
+        *) printf '%s\n' "$version" ;;
+    esac
+}
+
 detect_distro() {
-    if command -v apt-get &>/dev/null; then
+    if os_release_matches debian ubuntu linuxmint pop elementary zorin && command -v apt-get &>/dev/null; then
+        echo "apt"
+    elif os_release_matches arch archlinux manjaro endeavouros artix && command -v pacman &>/dev/null; then
+        echo "pacman"
+    elif os_release_matches opensuse suse sles && command -v zypper &>/dev/null; then
+        echo "zypper"
+    elif os_release_matches fedora rhel centos rocky almalinux ol; then
+        local major
+        major="$(os_release_version_major 2>/dev/null || true)"
+        if [ "${OS_RELEASE_ID:-}" = "fedora" ] && [ -n "$major" ] && [ "$major" -lt 41 ] && command -v dnf &>/dev/null; then
+            echo "dnf"
+        elif command -v dnf5 &>/dev/null; then
+            echo "dnf5"
+        elif command -v dnf &>/dev/null; then
+            echo "dnf"
+        else
+            echo "unknown"
+        fi
+    elif command -v apt-get &>/dev/null; then
         echo "apt"
     elif command -v dnf5 &>/dev/null; then
         echo "dnf5"
@@ -232,7 +295,7 @@ install_apt() {
 }
 
 install_dnf5() {
-    info "Detected Fedora 41+ (dnf5)"
+    info "Detected RPM-based distro (dnf5)"
     # dnf5: 7zip provides /usr/bin/7z; @development-tools is the group syntax
     sudo dnf install -y \
         python3 7zip curl unzip \
@@ -240,7 +303,7 @@ install_dnf5() {
 }
 
 install_dnf() {
-    info "Detected Fedora/RHEL (dnf)"
+    info "Detected RPM-based distro (dnf)"
     # Older dnf: 7z comes from p7zip + p7zip-plugins
     sudo dnf install -y \
         nodejs npm python3 \
@@ -394,7 +457,16 @@ install_rust() {
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
+OS_RELEASE_ID="$(os_release_field ID 2>/dev/null || true)"
+OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
+OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID 2>/dev/null || true)"
 DISTRO="$(detect_distro)"
+
+if [ "${DETECT_ONLY:-0}" = "1" ]; then
+    info "Detected dependency profile: $DISTRO"
+    info "os-release: ID=${OS_RELEASE_ID:-unknown} ID_LIKE=${OS_RELEASE_ID_LIKE:-unknown} VERSION_ID=${OS_RELEASE_VERSION_ID:-unknown}"
+    exit 0
+fi
 
 case "$DISTRO" in
     apt)     install_apt    ;;


### PR DESCRIPTION
Summary:
- Prefer os-release ID, ID_LIKE, and VERSION_ID when selecting the install-deps dependency profile.
- Keep package-manager command detection as the fallback for unusual systems.
- Add DETECT_ONLY=1 plus OS_RELEASE_FILE override so dependency-profile detection can be checked without installing packages.

Validation:
- bash -n scripts/install-deps.sh scripts/lib/install-helpers.sh
- bash tests/scripts_smoke.sh
- git diff --check
- Dry detection matrix: Fedora 40 -> dnf, Fedora 41 -> dnf5, Ubuntu -> apt, Arch -> pacman, openSUSE -> zypper, unknown with dnf5 -> dnf5.