### PR TITLE
troubles when `/tmp` mounted with `noexec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ Existing `nvm`, asdf, Volta, NodeSource, or nodejs.org tarball installs are stil
 
 The Codex CLI is still required at runtime, but the first launch can install or update `@openai/codex` automatically using the bundled managed `npm`. You can also pre-install and manage the CLI yourself if you prefer.
 
+On some systems (e.g. hardened Linux setups), `/tmp` may be mounted with `noexec`, preventing the rust installer and bundled Node.js runtime from executing.
+
+Workaround:
+
+```bash
+mkdir -p ~/tmp/codex-work ~/tmp/codex-cache
+
+export TMPDIR=~/tmp/codex-work
+export XDG_CACHE_HOME=~/tmp/codex-cache
+
+# run install steps in this shell
+```
+
 ## Quick install
 
 The fastest path: install deps, build the local app, build the native package, install it.


### PR DESCRIPTION
I had /tmp mounted with noexec flag (part of OS hardening), which caused a number of problems.

First rust install failed, but managed to do it by hand, then node.js didn't want to work.
In the end overriding temp dir temporarily fixed the issue start to end.