### PR TITLE
Fix Computer Use patching for current upstream bundle

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -1045,9 +1045,12 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
 
   const trayStartupNeedle = "E&&oe();";
   const previousTrayStartupPatch = "(E||process.platform===`linux`)&&oe();";
-  const trayStartupPatch = "(E||process.platform===`linux`&&codexLinuxIsTrayEnabled())&&oe();";
+  const badTrayStartupPatch = "(E||process.platform===`linux`&&codexLinuxIsTrayEnabled())&&oe();";
+  const trayStartupPatch = "(E||process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe();";
   if (patchedSource.includes(trayStartupPatch)) {
     // Already patched.
+  } else if (patchedSource.includes(badTrayStartupPatch)) {
+    patchedSource = patchedSource.replace(badTrayStartupPatch, trayStartupPatch);
   } else if (patchedSource.includes(previousTrayStartupPatch)) {
     patchedSource = patchedSource.replace(previousTrayStartupPatch, trayStartupPatch);
   } else if (patchedSource.includes(trayStartupNeedle)) {
@@ -1059,12 +1062,20 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
       : findDynamicTrayStartupCall(patchedSource, traySetup.setupFn, traySetup.index);
     if (
       traySetup != null &&
-      patchedSource.includes(`process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();`)
+      patchedSource.includes(`process.platform===\`linux\`&&(typeof codexLinuxIsTrayEnabled!==\`function\`||codexLinuxIsTrayEnabled()))&&${traySetup.setupFn}();`)
     ) {
       // Already patched with a newer minifier's tray setup identifier.
+    } else if (
+      traySetup != null &&
+      patchedSource.includes(`process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();`)
+    ) {
+      patchedSource = patchedSource.replace(
+        `process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();`,
+        `process.platform===\`linux\`&&(typeof codexLinuxIsTrayEnabled!==\`function\`||codexLinuxIsTrayEnabled()))&&${traySetup.setupFn}();`,
+      );
     } else if (dynamicTrayStartupMatch != null) {
       const isWindowsVar = dynamicTrayStartupMatch[1];
-      patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||process.platform===\`linux\`&&codexLinuxIsTrayEnabled())&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
+      patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||process.platform===\`linux\`&&(typeof codexLinuxIsTrayEnabled!==\`function\`||codexLinuxIsTrayEnabled()))&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
     } else {
       console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
     }
@@ -1126,8 +1137,8 @@ function parseDestructuredParamAliases(paramsText) {
   return aliases;
 }
 
-function buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar }) {
-  return `{installWhenMissing:!0,name:${nameExpr},isEnabled:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
+function buildComputerUseGate({ availabilityKey, nameExpr, featuresVar, platformVar, migrateVar }) {
+  return `{installWhenMissing:!0,name:${nameExpr},${availabilityKey}:({features:${featuresVar},platform:${platformVar}})=>(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse,migrate:${migrateVar}}`;
 }
 
 function hasComputerUseLiteral(source) {
@@ -1145,12 +1156,12 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
 
   const computerUseNameVar = currentSource.match(/([A-Za-z_$][\w$]*)=(?:`computer-use`|"computer-use"|'computer-use')/)?.[1] ?? null;
   const gateRegex =
-    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`|"computer-use"|'computer-use'),isEnabled:\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
+    /\{(installWhenMissing:!0,)?name:([A-Za-z_$][\w$]*|`computer-use`|"computer-use"|'computer-use'),(isEnabled|isAvailable):\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}/g;
   let sawEnabledGate = false;
   let sawUnpatchableGate = false;
   let match;
   while ((match = gateRegex.exec(currentSource)) != null) {
-    const [gateSource, installWhenMissing, nameExpr, paramsText, expression, migrateVar] = match;
+    const [gateSource, installWhenMissing, nameExpr, availabilityKey, paramsText, expression, migrateVar] = match;
     if (!isComputerUseNameExpr(nameExpr, computerUseNameVar)) {
       continue;
     }
@@ -1169,7 +1180,7 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
       continue;
     }
     if (expression === darwinOnlyExpression || expression === linuxExpression) {
-      const replacement = buildComputerUseGate({ nameExpr, featuresVar, platformVar, migrateVar });
+      const replacement = buildComputerUseGate({ availabilityKey, nameExpr, featuresVar, platformVar, migrateVar });
       return `${currentSource.slice(0, match.index)}${replacement}${currentSource.slice(match.index + gateSource.length)}`;
     }
     sawUnpatchableGate = true;

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -278,7 +278,7 @@ test("adds Linux tray support including the platform guard", () => {
     patched,
     /this\.trayMenuThreads=e\.trayMenuThreads,process\.platform===`linux`&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.setLinuxTrayContextMenu\?\.\(\)/,
   );
-  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&oe\(\);/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/);
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {
@@ -296,7 +296,7 @@ test("adds Linux tray support for current minified window and startup identifier
     /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&f===`local`&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)/,
   );
   assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
-  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/);
 });
 
 test("scopes dynamic tray startup matching to the tray initializer", () => {
@@ -310,8 +310,8 @@ test("scopes dynamic tray startup matching to the tray initializer", () => {
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
 
   assert.match(patched, /U&&startOther\(\);/);
-  assert.doesNotMatch(patched, /\(U\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&startOther\(\);/);
-  assert.match(patched, /\(E\|\|process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)\)&&ce\$\(\);/);
+  assert.doesNotMatch(patched, /\(U\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&startOther\(\);/);
+  assert.match(patched, /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/);
 });
 
 test("scopes close-to-tray already-patched detection to the handler", () => {
@@ -477,6 +477,21 @@ test("allows bundled Computer Use on Linux as well as macOS", () => {
     /\{installWhenMissing:!0,name:tn,isEnabled:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/,
   );
   assert.doesNotMatch(patched, /t===`darwin`&&e\.computerUse/);
+});
+
+test("allows bundled Computer Use on Linux after availability gate rename", () => {
+  const source = [
+    "var lt=`browser-use`,ut=`chrome`,dt=`chrome-internal`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed,migrate:rr},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxComputerUsePluginGatePatch, source);
+
+  assert.match(
+    patched,
+    /\{installWhenMissing:!0,name:ft,isAvailable:\(\{features:e,platform:t\}\)=>\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse,migrate:vr\}/,
+  );
+  assert.doesNotMatch(patched, /name:ft,isAvailable:\(\{features:e,platform:t\}\)=>t===`darwin`&&e\.computerUse/);
 });
 
 test("adds Keybinds settings route after upstream minified variable drift", () => {


### PR DESCRIPTION
## Summary

Updates the ASAR patcher for the current upstream Codex Desktop bundle shape.

The current bundle can use `isAvailable` instead of `isEnabled` for the bundled Computer Use plugin gate. This caused the Linux Computer Use plugin gate patch to fail hard even though the bundle was otherwise recognizable.

This also makes Linux tray startup tolerate a missing `codexLinuxIsTrayEnabled` helper when the optional Linux settings patch is skipped.

## User-Visible Behavior

Linux builds against the current upstream DMG no longer fail with:

```text
Required Linux Computer Use plugin gate patch failed: could not enable bundled Computer Use on Linux
```

The generated app also no longer fails at startup with:

```
codexLinuxIsTrayEnabled is not defined
```

## Root Cause

The Computer Use plugin gate patch only matched isEnabled, but the current upstream bundle uses isAvailable.

The tray startup patch directly called codexLinuxIsTrayEnabled(), but that helper is introduced by another optional patch that can fail-soft when upstream bundle shapes drift.

## Changes

- Recognize both isEnabled and isAvailable in the Computer Use plugin gate patch.
- Preserve the upstream gate key when rebuilding the patched plugin descriptor.
- Make Linux tray startup default-safe if codexLinuxIsTrayEnabled is not defined.
- Add regression coverage for the isAvailable gate and updated tray startup expression.

## Validation

Ran:

```
node --check scripts/patch-linux-window-ui.js
node --check scripts/patch-linux-window-ui.test.js
node --test scripts/patch-linux-window-ui.test.js
```