### PR TITLE
Fix Fedora RPM bundled binary dependency scanning

### DIFF
--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -4,7 +4,8 @@ Release:        __RPM_RELEASE__%{?dist}
 Summary:        Codex Desktop for Linux
 License:        Proprietary
 ExclusiveArch:  __ARCH__
-%global __requires_exclude_from ^/opt/__PACKAGE_NAME__/(resources|update-builder)/node-runtime/.*$
+%global __requires_exclude_from ^/opt/__PACKAGE_NAME__/.*$
+%global __provides_exclude_from ^/opt/__PACKAGE_NAME__/.*$
 
 Requires:       python3, /usr/bin/7z, polkit, curl, unzip, gcc-c++, make
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm


### PR DESCRIPTION
## Summary

Prevents Fedora RPM packaging from generating invalid dependencies from bundled application binaries under `/opt/codex-desktop`.

## User-Visible Behavior

Fedora users can install the generated RPM without bogus unresolved dependencies such as:

```text
libc++_shared.so
libc.musl-x86_64.so.1
liblog.so
libstdc++.so.6(CXXABI_ARM_1.3.3)
libgcc_s.so.1(GCC_3.5)
```

## Root Cause

RPM auto dependency/provides scanning was inspecting bundled Electron, Node, and plugin runtime files under /opt/codex-desktop. Some of those files are private bundled artifacts or foreign-runtime binaries, so Fedora tried to resolve them as system package dependencies.

## Changes

- Broaden RPM auto-requires exclusion to all files under /opt/codex-desktop.
- Add matching auto-provides exclusion for the same packaged app payload.
- Keep the existing explicit Fedora Requires: list as the source of system package dependencies.

## Validation

Ran:

```
rpmspec -P ... packaging/linux/codex-desktop.spec
```

Also verified during local RPM validation that the rebuilt package no longer declares the bogus bundled-library requirements that blocked installation.
