### PR TITLE
Add dynamic Linux open target discovery

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -35,7 +35,6 @@ const {
 } = require("./patches/launch-actions.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,
@@ -45,6 +44,11 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
 } = require("./patches/main-process.js");
+const {
+  applyLinuxFileManagerPatch,
+  applyLinuxIdeOpenTargetPatch,
+  applyLinuxTerminalOpenTargetPatch,
+} = require("./patches/open-targets.js");
 const {
   patchPackageJson,
   resolveDesktopName,
@@ -116,6 +120,7 @@ module.exports = {
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
+  applyLinuxIdeOpenTargetPatch,
   applyLinuxKeybindOverridesRuntimePatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
@@ -125,6 +130,7 @@ module.exports = {
   applyLinuxSetIconPatch,
   applyLinuxSettingsPersistencePatch,
   applyLinuxSingleInstancePatch,
+  applyLinuxTerminalOpenTargetPatch,
   applyLinuxTrayCloseSettingPatch,
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2,6 +2,7 @@
 
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
+const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -22,12 +23,14 @@ const {
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxQuitGuardPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
+  applyLinuxIdeOpenTargetPatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxSetIconPatch,
   applyLinuxSingleInstancePatch,
+  applyLinuxTerminalOpenTargetPatch,
   applyLinuxTrayCloseSettingPatch,
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
@@ -45,8 +48,14 @@ const {
 
 const mainBundlePrefix =
   "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
+const mainBundlePrefixWithChildProcess =
+  "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`),u=require(`node:child_process`);";
 const fileManagerBundle =
   "var lu=jl({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>il(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:uu,args:e=>il(e),open:async({path:e})=>du(e)}});function uu(){}";
+const terminalOpenTargetBundle =
+  "var uh={id:`terminal`,platforms:{darwin:{label:`Terminal`,icon:`apps/terminal.png`,kind:`terminal`,detect:()=>`open`,args:e=>[`-a`,`Terminal`,e]},win32:{label:`Terminal`,icon:`apps/microsoft-terminal.png`,kind:`terminal`,detect:vh,iconPath:()=>null,args:yh,open:({command:e,path:t})=>bh(e,yh(t))}}};function vh(){return `wt.exe`}function yh(e){return[`-d`,e]}async function bh(){}";
+const ideOpenTargetsBundle =
+  "function ih({id:e,label:t,icon:n,darwinDetect:r,win32Detect:i,darwinEnv:a,darwinArgs:o,hidden:s}){return{id:e,platforms:{darwin:r?{label:t,icon:n,kind:`editor`,hidden:s,detect:r,env:a,args:o??ah,supportsSsh:!0}:void 0,win32:i?{label:t,icon:n,kind:`editor`,hidden:s,detect:i,args:ah,supportsSsh:!0}:void 0}}}var ah=(e,t)=>t?[`${e}:${t.line}:${t.column}`]:[e];var Og=ih({id:`vscode`,label:`VS Code`,icon:`apps/vscode.png`,darwinDetect:()=>`open`,win32Detect:()=>`Code.exe`});var jh=ih({id:`cursor`,label:`Cursor`,icon:`apps/cursor.png`,darwinDetect:()=>`open`,win32Detect:()=>`Cursor.exe`});function sg({id:e,label:t,icon:n,toolboxTarget:r,macExecutable:i,windowsPathCommands:a,windowsInstallDirPrefixes:o,windowsInstallExecutables:s}){return{id:e,platforms:{darwin:{label:t,icon:n,kind:`editor`,detect:()=>`open`,args:mg},win32:a&&o&&s?{label:t,icon:n,kind:`editor`,detect:()=>`idea.exe`,args:mg}:void 0}}}function mg(e,t){return t?[`--line`,t.line.toString(),`--column`,t.column.toString(),e]:[e]}var $h=sg({id:`intellij`,label:`IntelliJ IDEA`,icon:`apps/intellij.png`,toolboxTarget:`intellij`,macExecutable:`idea`,windowsPathCommands:[`idea`],windowsInstallDirPrefixes:[`idea`],windowsInstallExecutables:[`idea`]});var Wg={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Gg,args:hg},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg}}};function Gg(){}function Kg(){}function hg(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}var Xg=[Og,jh,Wg,$h];";
 const alreadyOpaqueBackgroundBundle =
   "process.platform===`linux`?{backgroundColor:e?t:n,backgroundMaterial:null}:{backgroundColor:r,backgroundMaterial:null}";
 const opaqueBackgroundBundleWithDriftingGw =
@@ -73,6 +82,87 @@ function captureWarns(fn) {
   } finally {
     console.warn = originalWarn;
   }
+}
+
+function withTempDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-open-targets-"));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeExecutable(dir, name) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, "#!/bin/sh\nexit 0\n");
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function createSpawnRecorder() {
+  return {
+    calls: [],
+    spawn(command, args, options = {}) {
+      this.calls.push({ command, args, cwd: options.cwd ?? null });
+      const child = new EventEmitter();
+      child.unref = () => {};
+      process.nextTick(() => child.emit("close", 0));
+      return child;
+    },
+  };
+}
+
+function evaluateLinuxFileManager(source, env, spawnRecorder, openPathCalls = []) {
+  const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
+  assert.doesNotThrow(() => new Function("require", "process", `${patched};return lu;`));
+  const requireStub = (name) => {
+    if (name === "node:fs") return fs;
+    if (name === "node:path") return path;
+    if (name === "node:child_process") return spawnRecorder;
+    if (name === "electron") {
+      return {
+        shell: {
+          openPath: async (target) => {
+            openPathCalls.push(target);
+            return "";
+          },
+        },
+      };
+    }
+    return require(name);
+  };
+  const processStub = { platform: "linux", env };
+  return new Function("require", "process", `${patched};return lu.platforms?.linux??lu.linux;`)(requireStub, processStub);
+}
+
+function evaluateLinuxTerminal(source, env, spawnRecorder) {
+  const patched = applyPatchTwice(applyLinuxTerminalOpenTargetPatch, source);
+  assert.doesNotThrow(() => new Function("require", "process", `${patched};return uh;`));
+  const requireStub = (name) => {
+    if (name === "node:fs") return fs;
+    if (name === "node:path") return path;
+    if (name === "node:child_process") return spawnRecorder;
+    if (name === "electron") return { shell: { openPath: async () => "" } };
+    return require(name);
+  };
+  const processStub = { platform: "linux", env };
+  return new Function("require", "process", `${patched};return uh.platforms.linux;`)(requireStub, processStub);
+}
+
+function evaluateLinuxIdeTargets(source, env) {
+  const patched = applyPatchTwice(applyLinuxIdeOpenTargetPatch, source);
+  assert.doesNotThrow(() => new Function("require", "process", `${patched};return Xg;`));
+  const requireStub = (name) => {
+    if (name === "node:fs") return fs;
+    if (name === "node:path") return path;
+    if (name === "node:child_process") return createSpawnRecorder();
+    if (name === "electron") return { shell: { openPath: async () => "" } };
+    return require(name);
+  };
+  const processStub = { platform: "linux", env };
+  return new Function("require", "process", `${patched};return Xg;`)(requireStub, processStub);
 }
 
 function trayBundleFixture() {
@@ -162,8 +252,154 @@ test("adds Linux file manager support without relying on exact minified variable
   const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
 
   assert.match(patched, /linux:\{label:`File Manager`/);
-  assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
-  assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+  assert.match(patched, /detect:\(\)=>codexLinuxFindExecutable\(`dolphin`\)/);
+  assert.match(patched, /codexLinuxOpenFileManager\(e\)/);
+  assert.match(patched, /function codexLinuxOpenTargetEnv/);
+  assert.match(patched, /`dolphin`,\[`--select`,t\]/);
+  assert.match(patched, /`nautilus`,\[`--select`,t\]/);
+  assert.match(patched, /n\.shell\.openPath\(t\)/);
+});
+
+test("upgrades the older Linux file manager patch to reveal files when possible", () => {
+  const oldLinuxFileManager =
+    ",linux:{label:`File Manager`,icon:`apps/file-explorer.png`,detect:()=>`linux-file-manager`,args:e=>[e],open:async({path:e})=>{let __codexOpenTarget=e;let __codexError=await n.shell.openPath(__codexOpenTarget);if(__codexError)throw Error(__codexError)}}";
+  const source = `${mainBundlePrefix}${fileManagerBundle.replace("}});", `}${oldLinuxFileManager}});`)}`;
+
+  const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
+
+  assert.match(patched, /codexLinuxOpenFileManager\(e\)/);
+  assert.doesNotMatch(patched, /__codexOpenTarget/);
+});
+
+test("adds Linux file manager support when provider strings contain call endings", () => {
+  const source = `${mainBundlePrefix}${fileManagerBundle.replace(
+    "kind:`fileManager`,",
+    "kind:`fileManager`,note:`});`,",
+  )}`;
+
+  const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
+
+  assert.match(patched, /note:`}\);`/);
+  assert.match(patched, /linux:\{label:`File Manager`/);
+});
+
+test("Linux file manager reveals files through an installed reveal-capable manager", async () => {
+  await withTempDir(async (tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const dolphin = makeExecutable(binDir, "dolphin");
+    const file = path.join(tmp, "project", "src", "main.rs");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "fn main() {}\n");
+    const spawnRecorder = createSpawnRecorder();
+    const source = `${mainBundlePrefix}function jl(e){return e}function il(e){return [e]}${fileManagerBundle}`;
+
+    const fileManager = evaluateLinuxFileManager(source, { PATH: binDir }, spawnRecorder);
+    await fileManager.open({ path: file });
+
+    assert.deepEqual(spawnRecorder.calls, [{ command: dolphin, args: ["--select", file], cwd: null }]);
+  });
+});
+
+test("Linux file manager falls back to an installed directory opener", async () => {
+  await withTempDir(async (tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const xdgOpen = makeExecutable(binDir, "xdg-open");
+    const dir = path.join(tmp, "project");
+    fs.mkdirSync(dir, { recursive: true });
+    const spawnRecorder = createSpawnRecorder();
+    const source = `${mainBundlePrefix}function jl(e){return e}function il(e){return [e]}${fileManagerBundle}`;
+
+    const fileManager = evaluateLinuxFileManager(source, { PATH: binDir }, spawnRecorder);
+    await fileManager.open({ path: dir });
+
+    assert.deepEqual(spawnRecorder.calls, [{ command: xdgOpen, args: [dir], cwd: null }]);
+  });
+});
+
+test("adds Linux terminal open-target support", async () => {
+  await withTempDir(async (tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const terminalCommand = makeExecutable(binDir, "gnome-terminal");
+    const file = path.join(tmp, "project", "src", "main.rs");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "fn main() {}\n");
+    const spawnRecorder = createSpawnRecorder();
+    const source = `${mainBundlePrefixWithChildProcess}${terminalOpenTargetBundle}`;
+
+    const terminal = evaluateLinuxTerminal(source, { HOME: tmp, PATH: binDir }, spawnRecorder);
+
+    assert.equal(terminal.label, "Terminal");
+    assert.equal(terminal.kind, "terminal");
+    assert.equal(terminal.detect(), terminalCommand);
+    assert.deepEqual(terminal.args(file), ["--working-directory", path.dirname(file)]);
+
+    await terminal.open({ command: terminalCommand, path: file });
+    assert.deepEqual(spawnRecorder.calls, [
+      { command: terminalCommand, args: ["--working-directory", path.dirname(file)], cwd: path.dirname(file) },
+    ]);
+  });
+});
+
+test("Linux terminal open-target prefers xdg-terminal-exec when available", () => {
+  withTempDir((tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const xdgTerminal = makeExecutable(binDir, "xdg-terminal-exec");
+    const projectDir = path.join(tmp, "project");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const spawnRecorder = createSpawnRecorder();
+    const source = `${mainBundlePrefixWithChildProcess}${terminalOpenTargetBundle}`;
+
+    const terminal = evaluateLinuxTerminal(source, { HOME: tmp, PATH: binDir }, spawnRecorder);
+
+    assert.equal(terminal.detect(), xdgTerminal);
+    assert.deepEqual(terminal.args(projectDir), []);
+  });
+});
+
+test("Linux terminal open-target uses terminal-specific cwd arguments", () => {
+  withTempDir((tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const konsole = makeExecutable(binDir, "konsole");
+    const projectDir = path.join(tmp, "project");
+    fs.mkdirSync(projectDir, { recursive: true });
+    const spawnRecorder = createSpawnRecorder();
+    const source = `${mainBundlePrefixWithChildProcess}${terminalOpenTargetBundle}`;
+
+    const terminal = evaluateLinuxTerminal(source, { HOME: tmp, PATH: binDir }, spawnRecorder);
+
+    assert.equal(terminal.detect(), konsole);
+    assert.deepEqual(terminal.args(projectDir), ["--workdir", projectDir]);
+  });
+});
+
+test("adds Linux IDE open-target support to known upstream editor factories", () => {
+  const source = `${mainBundlePrefixWithChildProcess}${ideOpenTargetsBundle}`;
+
+  const patched = applyPatchTwice(applyLinuxIdeOpenTargetPatch, source);
+
+  assert.match(patched, /function codexLinuxIdeCommand/);
+  assert.match(patched, /cursor/);
+  assert.match(patched, /code-insiders/);
+  assert.match(patched, /codium/);
+  assert.match(patched, /linux:codexLinuxIdePlatform\(e,t,n,s,ah\)/);
+  assert.match(patched, /linux:codexLinuxJetBrainsIdePlatform\(e,t,n,mg\)/);
+  assert.match(patched, /linux:\{label:`Zed`,icon:`apps\/zed\.png`,kind:`editor`,detect:\(\)=>codexLinuxFindExecutable\(`zed`\),args:hg\}/);
+  assert.doesNotMatch(patched, /codexLinuxDiscoveredIdeTargets/);
+});
+
+test("Linux known IDE targets detect installed commands without desktop scanning", () => {
+  withTempDir((tmp) => {
+    const binDir = path.join(tmp, "bin");
+    const code = makeExecutable(binDir, "code");
+    const idea = makeExecutable(binDir, "idea");
+    const source = `${mainBundlePrefixWithChildProcess}${ideOpenTargetsBundle}`;
+
+    const targets = evaluateLinuxIdeTargets(source, { HOME: tmp, PATH: binDir });
+
+    assert.equal(targets.find((target) => target.id === "vscode")?.platforms.linux.detect(), code);
+    assert.equal(targets.find((target) => target.id === "intellij")?.platforms.linux.detect(), idea);
+    assert.equal(targets.some((target) => target.id.startsWith("linux-desktop-")), false);
+  });
 });
 
 test("adds the Linux quit guard when electron/path/fs requires are split across statements", () => {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -3,62 +3,12 @@
 const {
   TRAY_GUARD_LOOKAHEAD,
   escapeRegExp,
-  findCallBlock,
   findMatchingBrace,
   inferModuleAlias,
-  requireName,
 } = require("./shared.js");
 
 // Main-process patches adapt Electron shell behavior: windows, tray, menu,
-// single-instance handling, file manager integration, and packaged runtime glue.
-function applyLinuxFileManagerPatch(currentSource) {
-  const block = findCallBlock(currentSource, "id:`fileManager`");
-  if (block == null) {
-    console.warn("Failed to apply Linux File Manager Patch");
-    return currentSource;
-  }
-
-  if (block.text.includes("linux:{")) {
-    return currentSource;
-  }
-
-  const electronVar = requireName(currentSource, "electron");
-  const fsVar = requireName(currentSource, "node:fs");
-  const pathVar = requireName(currentSource, "node:path");
-  if (electronVar == null || fsVar == null || pathVar == null) {
-    console.warn("Failed to apply Linux File Manager Patch");
-    return currentSource;
-  }
-
-  const insertionPoint = block.text.lastIndexOf("}});");
-  if (insertionPoint === -1) {
-    console.warn("Failed to apply Linux File Manager Patch");
-    return currentSource;
-  }
-
-  const linuxFileManager =
-    `,linux:{label:\`File Manager\`,icon:\`apps/file-explorer.png\`,detect:()=>\`linux-file-manager\`,args:e=>[e],open:async({path:e})=>{let __codexResolved=e;for(;;){if((0,${fsVar}.existsSync)(__codexResolved))break;let __codexParent=(0,${pathVar}.dirname)(__codexResolved);if(__codexParent===__codexResolved){__codexResolved=null;break}__codexResolved=__codexParent}let __codexOpenTarget=__codexResolved??e;if((0,${fsVar}.existsSync)(__codexOpenTarget)&&(0,${fsVar}.statSync)(__codexOpenTarget).isFile())__codexOpenTarget=(0,${pathVar}.dirname)(__codexOpenTarget);let __codexError=await ${electronVar}.shell.openPath(__codexOpenTarget);if(__codexError)throw Error(__codexError)}}`;
-
-  const patchedBlock =
-    block.text.slice(0, insertionPoint + 1) +
-    linuxFileManager +
-    block.text.slice(insertionPoint + 1);
-  const patchedSource =
-    currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
-
-  const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
-  if (
-    !patchedBlockCheck.includes("linux:{label:`File Manager`") ||
-    !patchedBlockCheck.includes("detect:()=>`linux-file-manager`") ||
-    !patchedBlockCheck.includes(`${electronVar}.shell.openPath(__codexOpenTarget)`)
-  ) {
-    console.warn("Failed to apply Linux File Manager Patch");
-    return currentSource;
-  }
-
-  return patchedSource;
-}
-
+// single-instance handling, and packaged runtime glue.
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
   if (iconAsset == null) {
     return currentSource;
@@ -523,7 +473,6 @@ function applyLinuxGitOriginsSourceFallbackPatch(currentSource) {
 
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,

--- a/scripts/patches/open-targets.js
+++ b/scripts/patches/open-targets.js
@@ -1,0 +1,295 @@
+"use strict";
+
+const {
+  findBalancedBlock,
+  findCallBlock,
+  requireName,
+} = require("./shared.js");
+
+function findPropertyBlock(source, propertyName) {
+  const propertyIndex = source.indexOf(`,${propertyName}:{`);
+  if (propertyIndex === -1) {
+    return null;
+  }
+
+  const block = findBalancedBlock(source, source.indexOf("{", propertyIndex));
+  if (block == null) {
+    return null;
+  }
+
+  return {
+    start: propertyIndex,
+    end: block.end,
+    text: source.slice(propertyIndex, block.end),
+  };
+}
+
+function insertLinuxOpenTargetHelpers(currentSource, insertionIndex, { fsVar, pathVar }) {
+  if (currentSource.includes("function codexLinuxFindExecutable(")) {
+    return currentSource;
+  }
+
+  const helpers =
+    `function codexLinuxFindExecutable(e){if(process.platform!==\`linux\`||!e)return null;let t=process.env.PATH||\`\`;for(let n of t.split(\`:\`)){if(!n||!(0,${pathVar}.isAbsolute)(n))continue;let r=(0,${pathVar}.join)(n,e);try{if((0,${fsVar}.existsSync)(r)){let e=(0,${fsVar}.statSync)(r);if(e.isFile())try{(0,${fsVar}.accessSync)(r,${fsVar}.constants.X_OK);return r}catch{}}}catch{}}return null}` +
+    `function codexLinuxResolveExistingTarget(e){if(typeof e!==\`string\`||e.length===0)return null;let t=e;for(;;){try{if((0,${fsVar}.existsSync)(t))return t}catch{}let n=(0,${pathVar}.dirname)(t);if(n===t)return null;t=n}}` +
+    `function codexLinuxOpenTargetEnv(){let e={...process.env};for(let t of [\`NODE_OPTIONS\`,\`NODE_PATH\`,\`NODE_REPL_EXTERNAL_MODULE\`,\`ELECTRON_RUN_AS_NODE\`,\`ELECTRON_NO_ASAR\`,\`ELECTRON_ENABLE_LOGGING\`,\`VSCODE_NODE_OPTIONS\`,\`VSCODE_NODE_REPL_EXTERNAL_MODULE\`,\`npm_config_node_options\`,\`NPM_CONFIG_NODE_OPTIONS\`])delete e[t];return e}` +
+    `function codexLinuxLaunchDetached(e,t,n={}){return new Promise((r,i)=>{let a=!1,o;try{let s=require(\`node:child_process\`).spawn(e,t,{detached:!0,stdio:\`ignore\`,windowsHide:!0,cwd:n.cwd,env:codexLinuxOpenTargetEnv()});o=setTimeout(()=>{a=!0,s.unref?.(),r()},400),o.unref?.(),s.on(\`error\`,e=>{a||(clearTimeout(o),i(e))}),s.on(\`close\`,e=>{a||(clearTimeout(o),e===0?r():i(Error(\`Linux open target launch failed\`)))})}catch(e){clearTimeout(o),i(e)}})}` +
+    `function codexLinuxTryReveal(e,t){return new Promise((n,r)=>{let i=!1,a;try{let o=require(\`node:child_process\`).spawn(e,t,{stdio:\`ignore\`,windowsHide:!0,env:codexLinuxOpenTargetEnv()});a=setTimeout(()=>{i=!0,o.unref?.(),n()},400),a.unref?.(),o.on(\`error\`,e=>{i||(clearTimeout(a),r(e))}),o.on(\`close\`,e=>{i||(clearTimeout(a),e===0?n():r(Error(\`Linux file manager reveal failed\`)))})}catch(e){clearTimeout(a),r(e)}})}` +
+    `async function codexLinuxOpenFileManager(e){let t=codexLinuxResolveExistingTarget(e)??e;if(typeof t!==\`string\`||t.length===0)throw Error(\`No Linux file manager target available\`);let n=!1;try{n=(0,${fsVar}.existsSync)(t)&&(0,${fsVar}.statSync)(t).isFile()}catch{}if(n)for(let e of [[\`dolphin\`,[\`--select\`,t]],[\`nautilus\`,[\`--select\`,t]]]){let t=codexLinuxFindExecutable(e[0]);if(t)try{await codexLinuxTryReveal(t,e[1]);return}catch{}}t=n?(0,${pathVar}.dirname)(t):t;for(let e of [\`nemo\`,\`thunar\`,\`pcmanfm\`,\`caja\`,\`xdg-open\`]){let n=codexLinuxFindExecutable(e);if(n)try{await codexLinuxLaunchDetached(n,[t]);return}catch{}}throw Error(\`No Linux file manager available\`)}`;
+
+  return currentSource.slice(0, insertionIndex) + helpers + currentSource.slice(insertionIndex);
+}
+
+function applyLinuxFileManagerPatch(currentSource) {
+  let block = findCallBlock(currentSource, "id:`fileManager`");
+  if (block == null) {
+    console.warn("Failed to apply Linux File Manager Patch");
+    return currentSource;
+  }
+
+  const electronVar = requireName(currentSource, "electron");
+  const fsVar = requireName(currentSource, "node:fs");
+  const pathVar = requireName(currentSource, "node:path");
+  if (electronVar == null || fsVar == null || pathVar == null) {
+    console.warn("Failed to apply Linux File Manager Patch");
+    return currentSource;
+  }
+
+  let patchedSource = insertLinuxOpenTargetHelpers(currentSource, block.start, { fsVar, pathVar });
+  if (patchedSource !== currentSource) {
+    block = findCallBlock(patchedSource, "id:`fileManager`");
+    if (block == null) {
+      console.warn("Failed to apply Linux File Manager Patch");
+      return currentSource;
+    }
+  }
+
+  const insertionPoint = block.text.lastIndexOf("}});");
+  if (insertionPoint === -1) {
+    console.warn("Failed to apply Linux File Manager Patch");
+    return currentSource;
+  }
+
+  const linuxFileManager =
+    `,linux:{label:\`File Manager\`,icon:\`apps/file-explorer.png\`,detect:()=>codexLinuxFindExecutable(\`dolphin\`)??codexLinuxFindExecutable(\`nautilus\`)??codexLinuxFindExecutable(\`nemo\`)??codexLinuxFindExecutable(\`thunar\`)??codexLinuxFindExecutable(\`pcmanfm\`)??codexLinuxFindExecutable(\`caja\`)??codexLinuxFindExecutable(\`xdg-open\`)??\`linux-file-manager\`,args:e=>[e],open:async({path:e})=>{await codexLinuxOpenFileManager(e).catch(async()=>{let t=codexLinuxResolveExistingTarget(e)??e;try{(0,${fsVar}.existsSync)(t)&&(0,${fsVar}.statSync)(t).isFile()&&(t=(0,${pathVar}.dirname)(t))}catch{}let r=await ${electronVar}.shell.openPath(t);if(r)throw Error(r)})}}`;
+
+  const existingLinuxBlock = findPropertyBlock(block.text, "linux");
+  const patchedBlock =
+    existingLinuxBlock == null
+      ? block.text.slice(0, insertionPoint + 1) + linuxFileManager + block.text.slice(insertionPoint + 1)
+      : block.text.slice(0, existingLinuxBlock.start) +
+        linuxFileManager +
+        block.text.slice(existingLinuxBlock.end);
+  patchedSource = patchedSource.slice(0, block.start) + patchedBlock + patchedSource.slice(block.end);
+
+  const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
+  if (
+    !patchedBlockCheck.includes("linux:{label:`File Manager`") ||
+    !patchedBlockCheck.includes("codexLinuxOpenFileManager(e)") ||
+    !patchedBlockCheck.includes(`${electronVar}.shell.openPath(t)`)
+  ) {
+    console.warn("Failed to apply Linux File Manager Patch");
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
+function insertLinuxTerminalOpenTargetHelpers(currentSource, { fsVar, pathVar }) {
+  if (currentSource.includes("function codexLinuxTerminalCommand(")) {
+    return currentSource;
+  }
+
+  const helpers =
+    `function codexLinuxTerminalCommand(){for(let e of [\`x-terminal-emulator\`,\`gnome-terminal\`,\`kgx\`,\`konsole\`,\`xfce4-terminal\`,\`mate-terminal\`,\`lxterminal\`,\`tilix\`,\`alacritty\`,\`kitty\`,\`ghostty\`,\`wezterm\`,\`foot\`,\`terminology\`,\`xterm\`]){let t=codexLinuxFindExecutable(e);if(t)return t}return null}` +
+    `function codexLinuxTerminalSplitDesktopExec(e){let t=[],n=\`\`,r=null,i=!1;for(let a=0;a<e.length;a++){let o=e[a];if(i){n+=o,i=!1;continue}if(o===\`\\\\\`){i=!0;continue}if(r){o===r?r=null:n+=o;continue}if(o===\`"\`||o===\`'\`){r=o;continue}if(/\\s/u.test(o)){n&&(t.push(n),n=\`\`);continue}n+=o}return n&&t.push(n),t}` +
+    `function codexLinuxTerminalDesktopDirs(){if(process.platform!==\`linux\`)return[];let e=process.env.HOME||\`/nonexistent\`,t=process.env.XDG_DATA_HOME&&(0,${pathVar}.isAbsolute)(process.env.XDG_DATA_HOME)?[process.env.XDG_DATA_HOME]:[(0,${pathVar}.join)(e,\`.local/share\`)],n=(process.env.XDG_DATA_DIRS&&process.env.XDG_DATA_DIRS.length>0?process.env.XDG_DATA_DIRS:\`/usr/local/share:/usr/share\`).split(\`:\`).filter(Boolean),r=[...t,...n,(0,${pathVar}.join)(e,\`.local/share/flatpak/exports/share\`),\`/var/lib/flatpak/exports/share\`,\`/var/lib/snapd/desktop\`],a=new Set;return r.map(e=>(0,${pathVar}.join)(e,\`applications\`)).filter(e=>e&&(0,${pathVar}.isAbsolute)(e)&&!a.has(e)&&(a.add(e),!0))}` +
+    `function codexLinuxTerminalDesktopEntryFiles(e,t=0){let n=[];if(t>4)return n;try{for(let r of (0,${fsVar}.readdirSync)(e,{withFileTypes:!0})){let a=(0,${pathVar}.join)(e,r.name);r.isDirectory()?n.push(...codexLinuxTerminalDesktopEntryFiles(a,t+1)):r.isFile()&&r.name.endsWith(\`.desktop\`)&&n.push(a)}}catch{}return n}` +
+    `function codexLinuxParseTerminalDesktopEntry(e){let t={Id:(0,${pathVar}.basename)(e).replace(/\\.desktop$/u,\`\`)},n=\`\`;try{for(let r of (0,${fsVar}.readFileSync)(e,\`utf8\`).split(/\\r?\\n/u)){let e=r.trim();if(!e||e.startsWith(\`#\`))continue;if(e.startsWith(\`[\`)&&e.endsWith(\`]\`)){n=e.slice(1,-1);continue}if(n&&n!==\`Desktop Entry\`)continue;let i=e.indexOf(\`=\`);if(i<1)continue;let a=e.slice(0,i).replace(/\\[.*\\]$/u,\`\`),o=e.slice(i+1);t[a]??=o}}catch{return null}let r=e=>(e||\`\`).trim().toLowerCase()===\`true\`;return(t.Type&&t.Type!==\`Application\`)||r(t.NoDisplay)||r(t.Hidden)||!t.Exec||!t.Name?null:t}` +
+    `function codexLinuxLooksLikeTerminal(e){let t=(e.Categories||\`\`).toLowerCase(),n=[e.Name,e.GenericName,e.Comment,e.Keywords,e.Exec,e.Id].filter(Boolean).join(\` \`).toLowerCase();return/(^|;)terminalemulator(;|$)/u.test(t)||/\\b(terminal|console|shell|pty|ghostty|wezterm|konsole|alacritty|kitty|foot|xterm)\\b/u.test(n)}` +
+    `function codexLinuxTerminalExecutablePath(e){if(!e)return null;if(!(0,${pathVar}.isAbsolute)(e))return codexLinuxFindExecutable(e);try{if((0,${fsVar}.existsSync)(e)){let t=(0,${fsVar}.statSync)(e);if(t.isFile())try{(0,${fsVar}.accessSync)(e,${fsVar}.constants.X_OK);return e}catch{}}}catch{}return null}` +
+    `function codexLinuxTerminalCleanDesktopArgs(e){return e.map(e=>e.replace(/%%/gu,\`%\`)).filter(e=>!/^%[fFuUdDnNickvm]$/u.test(e))}` +
+    `function codexLinuxResolveTerminalDesktopExec(e){let t=codexLinuxTerminalSplitDesktopExec(e);if(t.length===0)return null;for(;;){if(t[0]===\`env\`){t.shift();continue}if(t[0]&&/^[A-Za-z_][A-Za-z0-9_]*=/u.test(t[0])){t.shift();continue}if(t[0]===\`-u\`||t[0]===\`--unset\`){t.splice(0,2);continue}break}let n=t.shift();if(!n)return null;let r=codexLinuxTerminalExecutablePath(n);return r?{command:r,args:codexLinuxTerminalCleanDesktopArgs(t),base:(0,${pathVar}.basename)(n).replace(/\\.(sh|bin)$/u,\`\`).toLowerCase()}:null}` +
+    `function codexLinuxDiscoveredTerminalInfo(){for(let e of codexLinuxTerminalDesktopDirs())for(let t of codexLinuxTerminalDesktopEntryFiles(e)){let e=codexLinuxParseTerminalDesktopEntry(t);if(!e||!codexLinuxLooksLikeTerminal(e))continue;if(e.TryExec&&!codexLinuxTerminalExecutablePath(codexLinuxTerminalSplitDesktopExec(e.TryExec)[0]))continue;let n=codexLinuxResolveTerminalDesktopExec(e.Exec);if(!n)continue;return{command:n.command,args:n.args,dirArg:e[\`X-TerminalArgDir\`]||null}}return null}` +
+    `function codexLinuxTerminalInfo(){let e=codexLinuxFindExecutable(\`xdg-terminal-exec\`);if(e)return{command:e,args:[],xdg:!0};let t=codexLinuxTerminalCommand();return t?{command:t,args:[]}:codexLinuxDiscoveredTerminalInfo()}` +
+    `function codexLinuxTerminalCwd(e){let t=codexLinuxResolveExistingTarget(e)??e;if(typeof t!==\`string\`||t.length===0)return process.env.HOME||\`/\`;try{if((0,${fsVar}.existsSync)(t)){let e=(0,${fsVar}.statSync)(t);if(e.isDirectory())return t;if(e.isFile())return(0,${pathVar}.dirname)(t)}}catch{}return(0,${pathVar}.dirname)(t)}` +
+    `function codexLinuxTerminalArgs(e,t){let n=typeof e===\`string\`?{command:e,args:[]}:e??codexLinuxTerminalInfo(),r=codexLinuxTerminalCwd(t),a=(0,${pathVar}.basename)(n?.command||\`\`).toLowerCase();if(n?.dirArg)return n.dirArg.endsWith(\`=\`)?[...n.args??[],\`\${n.dirArg}\${r}\`]:[...n.args??[],n.dirArg,r];if(n?.args?.length)return n.args;if(n?.xdg)return[];if(a===\`wezterm\`)return[\`start\`,\`--cwd\`,r];if(a===\`konsole\`)return[\`--workdir\`,r];if(a===\`kitty\`)return[\`--directory\`,r];if(a===\`terminology\`)return[\`--workdir\`,r];return[\`gnome-terminal\`,\`kgx\`,\`xfce4-terminal\`,\`mate-terminal\`,\`lxterminal\`,\`tilix\`,\`alacritty\`,\`ghostty\`,\`foot\`].includes(a)?[\`--working-directory\`,r]:[]}`;
+  const helperInsertionIndex = currentSource.includes("async function codexLinuxOpenFileManager(")
+    ? currentSource.indexOf("async function codexLinuxOpenFileManager(")
+    : currentSource.includes("function codexLinuxFindExecutable(")
+      ? currentSource.indexOf("function codexLinuxFindExecutable(")
+      : 0;
+  return currentSource.slice(0, helperInsertionIndex) + helpers + currentSource.slice(helperInsertionIndex);
+}
+
+function applyLinuxTerminalOpenTargetPatch(currentSource) {
+  if (currentSource.includes("linux:{label:`Terminal`")) {
+    return currentSource;
+  }
+
+  const fsVar = requireName(currentSource, "node:fs");
+  const pathVar = requireName(currentSource, "node:path");
+  if (fsVar == null || pathVar == null) {
+    console.warn("WARN: Could not find Linux terminal open-target dependencies — skipping Linux terminal patch");
+    return currentSource;
+  }
+
+  const terminalIndex = currentSource.indexOf("id:`terminal`");
+  if (terminalIndex === -1) {
+    console.warn("WARN: Could not find terminal open target — skipping Linux terminal patch");
+    return currentSource;
+  }
+
+  const terminalDeclarationIndex = Math.max(
+    currentSource.lastIndexOf("var ", terminalIndex),
+    currentSource.lastIndexOf("let ", terminalIndex),
+    currentSource.lastIndexOf("const ", terminalIndex),
+  );
+  let patchedSource = insertLinuxOpenTargetHelpers(
+    currentSource,
+    terminalDeclarationIndex >= 0 ? terminalDeclarationIndex : terminalIndex,
+    { fsVar, pathVar },
+  );
+  patchedSource = insertLinuxTerminalOpenTargetHelpers(patchedSource, { fsVar, pathVar });
+
+  const patchedTerminalIndex = patchedSource.indexOf("id:`terminal`");
+  const platformsIndex = patchedSource.indexOf("platforms:{", patchedTerminalIndex);
+  const platformsBlock =
+    platformsIndex === -1 ? null : findBalancedBlock(patchedSource, patchedSource.indexOf("{", platformsIndex));
+  if (platformsBlock == null || platformsBlock.text.includes("linux:{")) {
+    console.warn("WARN: Could not apply Linux terminal open-target patch");
+    return currentSource;
+  }
+
+  const linuxTerminal =
+    `,linux:{label:\`Terminal\`,icon:\`apps/terminal.png\`,kind:\`terminal\`,detect:()=>codexLinuxTerminalInfo()?.command??null,args:e=>codexLinuxTerminalArgs(codexLinuxTerminalInfo(),e),open:async({command:e,path:t})=>{await codexLinuxLaunchDetached(e,codexLinuxTerminalArgs(codexLinuxTerminalInfo()??e,t),{cwd:codexLinuxTerminalCwd(t)})}}`;
+  patchedSource =
+    patchedSource.slice(0, platformsBlock.end - 1) +
+    linuxTerminal +
+    patchedSource.slice(platformsBlock.end - 1);
+
+  if (
+    !patchedSource.includes("function codexLinuxTerminalCommand(") ||
+    !patchedSource.includes("linux:{label:`Terminal`")
+  ) {
+    console.warn("WARN: Could not apply Linux terminal open-target patch");
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxIdeOpenTargetPatch(currentSource) {
+  const fsVar = requireName(currentSource, "node:fs");
+  const pathVar = requireName(currentSource, "node:path");
+  if (fsVar == null || pathVar == null) {
+    console.warn("WARN: Could not find Linux IDE open-target dependencies — skipping Linux IDE open-target patch");
+    return currentSource;
+  }
+
+  const editorFactoryIndex = currentSource.search(/function\s+[A-Za-z_$][\w$]*\(\{id:[A-Za-z_$][\w$]*,label:[A-Za-z_$][\w$]*,icon:[A-Za-z_$][\w$]*,darwinDetect:/u);
+  const jetBrainsFactoryIndex = currentSource.search(/function\s+[A-Za-z_$][\w$]*\(\{id:[A-Za-z_$][\w$]*,label:[A-Za-z_$][\w$]*,icon:[A-Za-z_$][\w$]*,toolboxTarget:/u);
+  const hasEditorFactory = editorFactoryIndex !== -1;
+  const hasJetBrainsFactory = jetBrainsFactoryIndex !== -1;
+  const hasZedTarget = currentSource.includes("id:`zed`");
+  if (!hasEditorFactory && !hasJetBrainsFactory && !hasZedTarget) {
+    console.warn("WARN: Could not find Linux IDE open-target factories — skipping Linux IDE open-target patch");
+    return currentSource;
+  }
+
+  const zedIndex = currentSource.indexOf("id:`zed`");
+  const zedDeclarationIndex =
+    zedIndex === -1
+      ? -1
+      : Math.max(
+          currentSource.lastIndexOf("var ", zedIndex),
+          currentSource.lastIndexOf("let ", zedIndex),
+          currentSource.lastIndexOf("const ", zedIndex),
+        );
+  const openTargetHelperInsertionIndex =
+    [editorFactoryIndex, jetBrainsFactoryIndex].filter((index) => index >= 0).sort((a, b) => a - b)[0] ??
+    (zedDeclarationIndex >= 0 ? zedDeclarationIndex : 0);
+  let patchedSource = insertLinuxOpenTargetHelpers(
+    currentSource,
+    openTargetHelperInsertionIndex,
+    { fsVar, pathVar },
+  );
+
+  const ideHelpers = patchedSource.includes("function codexLinuxIdeCommand(")
+    ? ""
+    : `function codexLinuxIdeCommand(e){let t={cursor:[\`cursor\`],vscode:[\`code\`,\`codium\`],vscodeInsiders:[\`code-insiders\`],windsurf:[\`windsurf\`],antigravity:[\`antigravity\`],zed:[\`zed\`],intellij:[\`idea\`],webstorm:[\`webstorm\`],pycharm:[\`pycharm\`],goland:[\`goland\`],clion:[\`clion\`],rustrover:[\`rustrover\`],rider:[\`rider\`],phpstorm:[\`phpstorm\`],androidStudio:[\`studio\`,\`studio.sh\`]}[e]??[];for(let e of t){let t=codexLinuxFindExecutable(e);if(t)return t}return null}` +
+      `function codexLinuxIdePlatform(e,t,n,r,i){let a=codexLinuxIdeCommand(e);return a?{label:t,icon:n,kind:\`editor\`,hidden:r,detect:()=>a,args:i,supportsSsh:!0}:void 0}` +
+      `function codexLinuxJetBrainsIdePlatform(e,t,n,r){let i=codexLinuxIdeCommand(e);return i?{label:t,icon:n,kind:\`editor\`,detect:()=>i,args:r}:void 0}`;
+  if (ideHelpers.length > 0) {
+    const helperInsertionIndex = patchedSource.includes("function codexLinuxFindExecutable(")
+      ? patchedSource.indexOf("function codexLinuxFindExecutable(")
+      : 0;
+    const helperEnd =
+      patchedSource.indexOf("async function codexLinuxOpenFileManager(", helperInsertionIndex);
+    const ideHelperInsertionIndex = helperEnd === -1 ? helperInsertionIndex : helperEnd;
+    patchedSource = patchedSource.slice(0, ideHelperInsertionIndex) + ideHelpers + patchedSource.slice(ideHelperInsertionIndex);
+  }
+
+  patchedSource = patchedSource.replace(
+    /(function\s+[A-Za-z_$][\w$]*\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),darwinDetect:[^)]*?hidden:([A-Za-z_$][\w$]*)\}\)\{return\{id:\2,platforms:\{[^]*?win32:[^]*?args:([A-Za-z_$][\w$]*),supportsSsh:!0\}:void 0)(\}\}\})/u,
+    "$1,linux:codexLinuxIdePlatform($2,$3,$4,$5,$6)$7",
+  );
+
+  patchedSource = patchedSource.replace(
+    /(function\s+[A-Za-z_$][\w$]*\(\{id:([A-Za-z_$][\w$]*),label:([A-Za-z_$][\w$]*),icon:([A-Za-z_$][\w$]*),toolboxTarget:[^)]*?\}\)\{return\{id:\2,platforms:\{[^]*?args:([A-Za-z_$][\w$]*)\}:void 0)(\}\}\})/u,
+    "$1,linux:codexLinuxJetBrainsIdePlatform($2,$3,$4,$5)$6",
+  );
+
+  const patchedZedIndex = patchedSource.indexOf("id:`zed`");
+  if (patchedZedIndex !== -1) {
+    const zedPlatformsIndex = patchedSource.indexOf("platforms:{", patchedZedIndex);
+    const zedPlatformsBlock =
+      zedPlatformsIndex === -1 ? null : findBalancedBlock(patchedSource, patchedSource.indexOf("{", zedPlatformsIndex));
+    if (zedPlatformsBlock != null && !zedPlatformsBlock.text.includes("linux:{")) {
+      const argsVar = zedPlatformsBlock.text.match(/win32:\{[^}]*args:([A-Za-z_$][\w$]*)/u)?.[1];
+      if (argsVar != null) {
+        const linuxZed = `,linux:{label:\`Zed\`,icon:\`apps/zed.png\`,kind:\`editor\`,detect:()=>codexLinuxFindExecutable(\`zed\`),args:${argsVar}}`;
+        patchedSource =
+          patchedSource.slice(0, zedPlatformsBlock.end - 1) +
+          linuxZed +
+          patchedSource.slice(zedPlatformsBlock.end - 1);
+      }
+    }
+  }
+
+  if (
+    hasEditorFactory &&
+    !patchedSource.includes("linux:codexLinuxIdePlatform(")
+  ) {
+    console.warn("WARN: Could not apply generic Linux IDE open-target factory patch");
+  }
+  if (
+    hasJetBrainsFactory &&
+    !patchedSource.includes("linux:codexLinuxJetBrainsIdePlatform(")
+  ) {
+    console.warn("WARN: Could not apply JetBrains Linux IDE open-target factory patch");
+  }
+  if (hasZedTarget && !patchedSource.includes("linux:{label:`Zed`")) {
+    console.warn("WARN: Could not apply Zed Linux IDE open-target patch");
+  }
+
+  if (
+    !patchedSource.includes("function codexLinuxIdeCommand(") ||
+    (
+      !patchedSource.includes("linux:codexLinuxIdePlatform(") &&
+      !patchedSource.includes("linux:codexLinuxJetBrainsIdePlatform(") &&
+      !patchedSource.includes("linux:{label:`Zed`")
+    )
+  ) {
+    console.warn("WARN: Could not apply any Linux IDE open-target patch");
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
+module.exports = {
+  applyLinuxFileManagerPatch,
+  applyLinuxIdeOpenTargetPatch,
+  applyLinuxTerminalOpenTargetPatch,
+};

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -18,7 +18,6 @@ const {
 } = require("./shared.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,
   applyLinuxOpaqueBackgroundPatch,
@@ -28,6 +27,11 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWindowOptionsPatch,
 } = require("./main-process.js");
+const {
+  applyLinuxFileManagerPatch,
+  applyLinuxIdeOpenTargetPatch,
+  applyLinuxTerminalOpenTargetPatch,
+} = require("./open-targets.js");
 const {
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseInstallFlowPatch,
@@ -91,6 +95,16 @@ const MAIN_BUNDLE_PATCHES = [
     name: "linux-file-manager",
     ciPolicy: REQUIRED_UPSTREAM,
     apply: (source) => applyLinuxFileManagerPatch(source),
+  },
+  {
+    name: "linux-terminal-open-target",
+    ciPolicy: OPTIONAL,
+    apply: (source) => applyLinuxTerminalOpenTargetPatch(source),
+  },
+  {
+    name: "linux-known-ide-open-targets",
+    ciPolicy: OPTIONAL,
+    apply: (source) => applyLinuxIdeOpenTargetPatch(source),
   },
   {
     name: "linux-tray",

--- a/scripts/patches/shared.js
+++ b/scripts/patches/shared.js
@@ -155,6 +155,80 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function findBalancedBlock(source, openBraceIndex) {
+  if (openBraceIndex < 0 || source[openBraceIndex] !== "{") {
+    return null;
+  }
+
+  let depth = 0;
+  const stack = [{ type: "code" }];
+  for (let index = openBraceIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const top = stack[stack.length - 1];
+
+    if (top.type === "string") {
+      if (top.escaped) {
+        top.escaped = false;
+      } else if (char === "\\") {
+        top.escaped = true;
+      } else if (char === top.quote) {
+        stack.pop();
+      }
+      continue;
+    }
+
+    if (top.type === "template") {
+      if (top.escaped) {
+        top.escaped = false;
+      } else if (char === "\\") {
+        top.escaped = true;
+      } else if (char === "`") {
+        stack.pop();
+      } else if (char === "$" && source[index + 1] === "{") {
+        stack.push({ type: "templateExpression", depth: 1 });
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      stack.push({ type: "string", quote: char, escaped: false });
+      continue;
+    }
+    if (char === "`") {
+      stack.push({ type: "template", escaped: false });
+      continue;
+    }
+
+    if (top.type === "templateExpression") {
+      if (char === "{") {
+        top.depth += 1;
+      } else if (char === "}") {
+        top.depth -= 1;
+        if (top.depth === 0) {
+          stack.pop();
+        }
+      }
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          start: openBraceIndex,
+          end: index + 1,
+          text: source.slice(openBraceIndex, index + 1),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
 function findCallBlock(source, marker) {
   const markerStart = source.indexOf(marker);
   if (markerStart === -1) {
@@ -166,15 +240,18 @@ function findCallBlock(source, marker) {
     source.lastIndexOf("let ", markerStart),
     source.lastIndexOf("const ", markerStart),
   );
-  const blockEnd = source.indexOf("});", markerStart);
-  if (blockStart === -1 || blockEnd === -1) {
+  const objectStart = source.lastIndexOf("{", markerStart);
+  const objectBlock = findBalancedBlock(source, objectStart);
+  if (blockStart === -1 || objectBlock == null) {
     return null;
   }
+  const callEndMatch = source.slice(objectBlock.end).match(/^\s*\);/u);
+  const blockEnd = callEndMatch == null ? objectBlock.end : objectBlock.end + callEndMatch[0].length;
 
   return {
     start: blockStart,
-    end: blockEnd + "});".length,
-    text: source.slice(blockStart, blockEnd + "});".length),
+    end: blockEnd,
+    text: source.slice(blockStart, blockEnd),
   };
 }
 
@@ -269,6 +346,7 @@ module.exports = {
   HANDLER_PREFIX_LOOKBACK,
   TRAY_GUARD_LOOKAHEAD,
   escapeRegExp,
+  findBalancedBlock,
   findCallBlock,
   findDisposableVar,
   findIconAsset,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -712,7 +712,8 @@ test_linux_file_manager_patch_smoke() {
     make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let n=require(`electron`),t=require(`node:path`),a=require(`node:fs`);...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>`linux-file-manager`'
+    assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>codexLinuxFindExecutable(`dolphin`)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxOpenFileManager(e)'
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.setMenuBarVisibility(!1),'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
@@ -886,7 +887,7 @@ if (!result.event.prevented || result.state.hideCalls !== 1) {
 NODE
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`linux`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&f===`local`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'setLinuxTrayContextMenu(){' '1'


### PR DESCRIPTION
## Summary

Adds Linux open-target support for installed file managers, terminals, and IDEs.

## User-Visible Behavior

The open-target menu can show installed Linux IDEs and a Terminal target instead of only a generic File Manager entry, and file/folder opens use an available Linux file manager.

## Changes

- Opens files/folders through the installed Linux file manager.
- Adds a Linux Terminal target using xdg-terminal-exec, known terminal commands, and TerminalEmulator .desktop entries.
- Adds Linux IDE targets for known commands when present.
- Discovers additional IDEs from .desktop entries, including Flatpak, Snap, and JetBrains Toolbox-style installs.
- Handles TryExec, executable checks, URI placeholders, duplicate IDs, and older patched bundles.

## Validation

Ran:

```bash
node --check scripts/patch-linux-window-ui.js
node --test scripts/patch-linux-window-ui.test.js
docker run --rm -v "$PWD:/repo" -w /repo node:22-bookworm-slim node --test scripts/patch-linux-window-ui.test.js
```

Also ran a Docker integration check with fake .desktop entries and file-manager commands, plus a patched-current-bundle parse check.

Not run: package/updater validation, because this only changes ASAR patching logic and tests.

Closes #123