### PR TITLE
Add KWin window targeting backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Anything systemd-based should work for the optional auto-updater service (`syste
 | Linux tray + warm-start handoff | ✅ always | Single-instance lock, second-instance window focus |
 | GUI install prompts (`kdialog` / `zenity`) | ✅ if installed | Falls back to interactive terminal prompt |
 | Linux browser annotations | ✅ always | Stored-anchor screenshots, isolated marker rendering |
-| Linux Computer Use | ⚠️ opt-in | Linux Computer Use backend with screen capture, accessibility, and input synthesis. The MCP server registers by default; the in-app UI surface is enabled at your discretion — see "Enabling Computer Use UI" below. Validated on Ubuntu/GNOME. |
+| Linux Computer Use | ⚠️ opt-in | Linux Computer Use backend with screen capture, accessibility, window targeting, and input synthesis. The MCP server registers by default; the in-app UI surface is enabled at your discretion — see "Enabling Computer Use UI" below. Validated on Ubuntu/GNOME and KDE Plasma/KWin. |
 | Server-gated features (e.g. `gpt-5.5`) | 🟡 server-side | OpenAI rolls per-account, not project-controlled. Building a fresh package does not unlock these. |
 
 ## Before you install
@@ -84,6 +84,7 @@ Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control d
 
 - **App listing & accessibility tree** — via AT-SPI bus (`org.a11y.Bus`)
 - **Screenshot capture** — primary path through GNOME Shell DBus, fallback through XDG Desktop Portal (`org.freedesktop.portal.Screenshot`)
+- **Window listing & focusing** — via the Codex GNOME Shell extension, GNOME Shell introspection, KWin/Plasma DBus scripting, or Hyprland `hyprctl`
 - **Input synthesis** — keys, text, click, scroll, drag — through `ydotool` with `ydotoold` daemon
 
 ### Runtime dependencies
@@ -121,12 +122,13 @@ The plugin exposes a `doctor` tool. Once Computer Use is visible in the Codex UI
 
 > Check whether Linux Computer Use is ready
 
-The response is a structured report covering AT-SPI bus availability, GNOME Shell version, Desktop Portal interfaces, `ydotool` / `ydotoold` / `/dev/uinput`, and a top-level readiness verdict. You can also invoke the backend binary directly:
+The response is a structured report covering AT-SPI bus availability, GNOME Shell version, KWin/Plasma windowing support, Desktop Portal interfaces, `ydotool` / `ydotoold` / `/dev/uinput`, and a top-level readiness verdict. You can also invoke the backend binary directly:
 
 ```bash
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux doctor
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux setup    # enables GNOME accessibility
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux apps     # lists running apps via AT-SPI
+./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux windows  # lists targetable windows
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux state Codex
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux screenshot
 ```

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -64,6 +64,7 @@ pub struct AccessibilityReport {
 pub struct WindowingReport {
     pub gnome_shell_introspect: Check,
     pub codex_gnome_shell_extension: Check,
+    pub kwin: Check,
     pub hyprland: Check,
     pub can_list_windows: bool,
     pub can_focus_apps: bool,
@@ -356,9 +357,10 @@ fn windowing_report() -> WindowingReport {
         "com.openai.Codex.WindowControl.ListWindows",
         &[],
     );
+    let kwin = kwin_windowing_check();
     let hyprland = hyprland_windowing_check();
     let can_list_windows =
-        gnome_shell_introspect.ok || codex_gnome_shell_extension.ok || hyprland.ok;
+        gnome_shell_introspect.ok || codex_gnome_shell_extension.ok || kwin.ok || hyprland.ok;
     let gnome_focus_apps = gdbus_introspect_contains(
         "org.gnome.Shell",
         "/org/gnome/Shell",
@@ -366,28 +368,51 @@ fn windowing_report() -> WindowingReport {
         "FocusApp",
     )
     .ok;
-    let can_focus_apps = gnome_focus_apps || hyprland.ok;
-    let can_focus_windows = codex_gnome_shell_extension.ok || hyprland.ok;
+    let can_focus_apps = gnome_focus_apps || kwin.ok || hyprland.ok;
+    let can_focus_windows = codex_gnome_shell_extension.ok || kwin.ok || hyprland.ok;
     let note = if can_list_windows {
-        if hyprland.ok {
+        if kwin.ok {
+            "A KWin/Plasma window backend is available for list_windows, focused_window, and targeted input verification."
+        } else if hyprland.ok {
             "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
         } else {
             "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
         }
     } else {
-        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On Hyprland, ensure hyprctl is available in the session."
+        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting and WindowsRunner on the session bus. On Hyprland, ensure hyprctl is available in the session."
     }
     .to_string();
 
     WindowingReport {
         gnome_shell_introspect,
         codex_gnome_shell_extension,
+        kwin,
         hyprland,
         can_list_windows,
         can_focus_apps,
         can_focus_windows,
         note,
     }
+}
+
+fn kwin_windowing_check() -> Check {
+    let scripting = gdbus_introspect_contains(
+        "org.kde.KWin",
+        "/Scripting",
+        "org.kde.kwin.Scripting",
+        "loadScript",
+    );
+    if !scripting.ok {
+        return Check::fail(format!("KWin scripting unavailable: {}", scripting.detail));
+    }
+
+    let runner =
+        gdbus_introspect_contains("org.kde.KWin", "/WindowsRunner", "org.kde.krunner1", "Run");
+    if !runner.ok {
+        return Check::fail(format!("KWin WindowsRunner unavailable: {}", runner.detail));
+    }
+
+    Check::ok("KWin scripting and WindowsRunner are available on the session bus")
 }
 
 fn hyprland_windowing_check() -> Check {
@@ -474,7 +499,7 @@ fn readiness_report(
         "Run setup_accessibility to enable GNOME accessibility before element-aware actions."
             .to_string()
     } else if !can_query_windows {
-        "Enable a supported window backend before using targeted keyboard input: GNOME Shell Introspect, the Codex GNOME Shell extension, or Hyprland hyprctl.".to_string()
+        "Enable a supported window backend before using targeted keyboard input: GNOME Shell Introspect, the Codex GNOME Shell extension, KWin/Plasma DBus scripting, or Hyprland hyprctl.".to_string()
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
@@ -707,6 +732,7 @@ mod tests {
             } else {
                 Check::fail("missing")
             },
+            kwin: Check::fail("not a KWin session"),
             hyprland: Check::fail("not a Hyprland session"),
             can_list_windows,
             can_focus_apps: true,
@@ -785,6 +811,24 @@ mod tests {
             .blockers
             .iter()
             .any(|blocker| blocker.contains("Exact window activation")));
+    }
+
+    #[test]
+    fn readiness_treats_kwin_as_full_window_backend() {
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let mut windowing = windowing_report(false, false);
+        windowing.kwin = Check::ok("KWin scripting and WindowsRunner are available");
+        windowing.can_list_windows = true;
+        windowing.can_focus_apps = true;
+        windowing.can_focus_windows = true;
+        let input = input_report(true);
+
+        let readiness = readiness_report(&accessibility, &windowing, &input);
+
+        assert!(readiness.can_query_windows);
+        assert!(readiness.can_focus_apps);
+        assert!(readiness.can_focus_windows);
+        assert!(readiness.blockers.is_empty());
     }
 
     #[test]

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
                 Err(error) => {
                     let error = format!("{error:#}");
                     serde_json::json!({
-                        "backend": windows::GNOME_SHELL_INTROSPECT_BACKEND,
+                        "backend": "unavailable",
                         "windows": [],
                         "error": error,
                         "permissions_hint": windows::window_permission_hint(&error),

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -13,7 +13,7 @@ use crate::screenshot::{capture_screenshot, ScreenshotCapture};
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
     window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
-    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
+    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND, HYPRLAND_BACKEND, KWIN_BACKEND,
 };
 use anyhow::Result;
 use rmcp::{
@@ -103,7 +103,7 @@ impl ComputerUseLinux {
                     error: None,
                     permissions_hint: None,
                     message:
-                        "Focused window query completed through the available GNOME window backend."
+                        "Focused window query completed through the available compositor window backend."
                             .to_string(),
                 })
             }
@@ -671,7 +671,7 @@ impl ComputerUseLinux {
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus GNOME Shell windows when org.gnome.Shell.Introspect or the Codex GNOME Shell extension permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through GNOME Shell, KWin/Plasma, or Hyprland when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -1783,6 +1783,10 @@ async fn window_list_output() -> ListWindowsOutput {
             let backend = window_backend(windows.iter());
             let note = if backend == GNOME_SHELL_EXTENSION_BACKEND {
                 "Window list came from the Codex GNOME Shell extension. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
+            } else if backend == KWIN_BACKEND {
+                "Window list came from KWin/Plasma DBus scripting. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
+            } else if backend == HYPRLAND_BACKEND {
+                "Window list came from Hyprland hyprctl. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
             } else {
                 "Window list came from GNOME Shell Introspect. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
             };

--- a/computer-use-linux/src/windows.rs
+++ b/computer-use-linux/src/windows.rs
@@ -3,18 +3,34 @@ use crate::terminal::{enrich_terminal_windows, TerminalWindowContext};
 use anyhow::{bail, Context, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, process::Command, time::Duration};
-use tokio::time::sleep;
+use std::{
+    collections::HashMap,
+    fs::{self, OpenOptions},
+    io::Write,
+    process::Command,
+    sync::mpsc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::time::{sleep, timeout};
 use zbus::{zvariant::OwnedValue, Proxy};
 
 pub const GNOME_SHELL_INTROSPECT_BACKEND: &str = "gnome-shell-introspect";
 pub const GNOME_SHELL_EXTENSION_BACKEND: &str = "gnome-shell-extension";
+pub const KWIN_BACKEND: &str = "kwin";
 pub const HYPRLAND_BACKEND: &str = "hyprland";
 pub const GNOME_SHELL_EXTENSION_SERVICE: &str = "com.openai.Codex.WindowControl";
 pub const GNOME_SHELL_EXTENSION_OBJECT_PATH: &str = "/com/openai/Codex/WindowControl";
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a GNOME window list backend. Targeted window input requires session-bus access plus either GNOME Shell Introspect permission or the Codex GNOME Shell extension backend. Run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, KWin/Plasma DBus scripting, or Hyprland hyprctl. On GNOME, run setup_window_targeting to install the extension backend.";
 const FOCUS_VERIFY_ATTEMPTS: usize = 6;
 const FOCUS_VERIFY_DELAY: Duration = Duration::from_millis(50);
+const KWIN_SCRIPT_TIMEOUT: Duration = Duration::from_secs(2);
+const KWIN_SCRIPTING_SERVICE: &str = "org.kde.KWin";
+const KWIN_SCRIPTING_OBJECT_PATH: &str = "/Scripting";
+const KWIN_SCRIPTING_INTERFACE: &str = "org.kde.kwin.Scripting";
+const KWIN_WINDOWS_RUNNER_OBJECT_PATH: &str = "/WindowsRunner";
+const KWIN_WINDOWS_RUNNER_INTERFACE: &str = "org.kde.krunner1";
+const KWIN_CALLBACK_OBJECT_PATH_PREFIX: &str = "/com/openai/Codex/KWinWindowQuery";
+const KWIN_CALLBACK_INTERFACE: &str = "com.openai.Codex.KWinWindowQuery";
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct WindowInfo {
@@ -124,11 +140,14 @@ pub async fn list_windows() -> Result<Vec<WindowInfo>> {
         Ok(windows) => Ok(windows),
         Err(extension_error) => match list_gnome_shell_introspect_windows().await {
             Ok(windows) => Ok(windows),
-            Err(introspect_error) => match list_hyprland_windows() {
+            Err(introspect_error) => match list_kwin_windows().await {
                 Ok(windows) => Ok(windows),
-                Err(hyprland_error) => Err(anyhow::anyhow!(
-                    "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}; Hyprland failed: {hyprland_error:#}"
-                )),
+                Err(kwin_error) => match list_hyprland_windows() {
+                    Ok(windows) => Ok(windows),
+                    Err(hyprland_error) => Err(anyhow::anyhow!(
+                        "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}; KWin failed: {kwin_error:#}; Hyprland failed: {hyprland_error:#}"
+                    )),
+                },
             },
         },
     }
@@ -203,6 +222,13 @@ fn parse_hyprland_clients(json: &str) -> Result<Vec<WindowInfo>> {
     Ok(windows)
 }
 
+async fn list_kwin_windows() -> Result<Vec<WindowInfo>> {
+    let json = call_kwin_window_script().await?;
+    let mut windows = parse_kwin_windows(&json)?;
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
 pub async fn focused_window() -> Result<Option<WindowInfo>> {
     current_focused_window().await
 }
@@ -218,6 +244,8 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
 
     if requested_window.backend == HYPRLAND_BACKEND {
         activate_hyprland_window(requested_window.window_id)?;
+    } else if requested_window.backend == KWIN_BACKEND {
+        activate_kwin_window(requested_window.window_id).await?;
     } else if requested_window.backend == GNOME_SHELL_EXTENSION_BACKEND {
         activate_extension_window(requested_window.window_id).await?;
     } else {
@@ -254,10 +282,11 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
 fn ensure_backend_can_focus_target(target: &WindowTarget, window: &WindowInfo) -> Result<()> {
     if target.requires_exact_focus()
         && window.backend != GNOME_SHELL_EXTENSION_BACKEND
+        && window.backend != KWIN_BACKEND
         && window.backend != HYPRLAND_BACKEND
     {
         bail!(
-            "Exact window targeting requires the Codex GNOME Shell extension or Hyprland backend; {} can list the matched window but cannot activate a specific window safely.",
+            "Exact window targeting requires the Codex GNOME Shell extension, KWin, or Hyprland backend; {} can list the matched window but cannot activate a specific window safely.",
             window.backend
         );
     }
@@ -573,6 +602,475 @@ fn activate_hyprland_window(window_id: u64) -> Result<()> {
             "hyprctl dispatch focuswindow {address} failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         );
+    }
+}
+
+async fn activate_kwin_window(window_id: u64) -> Result<()> {
+    let uuid = kwin_uuid_for_window_id(window_id).await?.with_context(|| {
+        format!("No KWin window matched window_id {window_id} during activation")
+    })?;
+    let match_id = kwin_windows_runner_match_id(&uuid);
+
+    hydrate_session_bus_env();
+
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let proxy = Proxy::new(
+        &connection,
+        KWIN_SCRIPTING_SERVICE,
+        KWIN_WINDOWS_RUNNER_OBJECT_PATH,
+        KWIN_WINDOWS_RUNNER_INTERFACE,
+    )
+    .await
+    .context("failed to create KWin WindowsRunner proxy")?;
+    let _: () = proxy
+        .call("Run", &(match_id.as_str(), ""))
+        .await
+        .with_context(|| format!("KWin WindowsRunner Run failed for {match_id}"))?;
+    Ok(())
+}
+
+async fn kwin_uuid_for_window_id(window_id: u64) -> Result<Option<String>> {
+    let json = call_kwin_window_script().await?;
+    let snapshot = parse_kwin_snapshot(&json)?;
+    Ok(snapshot.windows.into_iter().find_map(|window| {
+        let uuid = window.kwin_uuid()?;
+        (kwin_window_id_from_uuid(&uuid) == window_id).then_some(uuid)
+    }))
+}
+
+async fn call_kwin_window_script() -> Result<String> {
+    hydrate_session_bus_env();
+
+    let connection = zbus::Connection::session()
+        .await
+        .context("failed to connect to session bus")?;
+    let unique_name = connection
+        .unique_name()
+        .context("session bus did not assign a unique name")?
+        .to_string();
+    let plugin_name = temporary_kwin_plugin_name();
+    let callback_object_path = format!("{KWIN_CALLBACK_OBJECT_PATH_PREFIX}/{plugin_name}");
+    let (sender, receiver) = mpsc::channel();
+    connection
+        .object_server()
+        .at(callback_object_path.as_str(), KwinWindowCallback { sender })
+        .await
+        .context("failed to register temporary KWin callback object")?;
+
+    let mut script_path = None;
+    let mut loaded_script = false;
+    let result = async {
+        let path = write_kwin_window_script(&unique_name, &callback_object_path, &plugin_name)?;
+        script_path = Some(path.clone());
+        let scripting_proxy = Proxy::new(
+            &connection,
+            KWIN_SCRIPTING_SERVICE,
+            KWIN_SCRIPTING_OBJECT_PATH,
+            KWIN_SCRIPTING_INTERFACE,
+        )
+        .await
+        .context("failed to create KWin scripting proxy")?;
+
+        // Plasma 6 can return 0 here even when isScriptLoaded reports success;
+        // the callback below is the authoritative completion signal.
+        let _script_id: i32 = scripting_proxy
+            .call(
+                "loadScript",
+                &(path.to_string_lossy().as_ref(), plugin_name.as_str()),
+            )
+            .await
+            .context("KWin loadScript failed")?;
+        loaded_script = true;
+
+        let _: () = scripting_proxy
+            .call("start", &())
+            .await
+            .context("KWin start failed after loading the temporary window query script")?;
+
+        timeout(KWIN_SCRIPT_TIMEOUT, async move {
+            loop {
+                match receiver.try_recv() {
+                    Ok(json) => return Ok(json),
+                    Err(mpsc::TryRecvError::Disconnected) => {
+                        bail!("KWin window query callback disconnected before returning data");
+                    }
+                    Err(mpsc::TryRecvError::Empty) => sleep(Duration::from_millis(20)).await,
+                }
+            }
+        })
+        .await
+        .context("KWin temporary window query script did not return data before timeout")?
+    }
+    .await;
+
+    if loaded_script {
+        if let Ok(scripting_proxy) = Proxy::new(
+            &connection,
+            KWIN_SCRIPTING_SERVICE,
+            KWIN_SCRIPTING_OBJECT_PATH,
+            KWIN_SCRIPTING_INTERFACE,
+        )
+        .await
+        {
+            let _: Result<bool, _> = scripting_proxy
+                .call("unloadScript", &(plugin_name.as_str()))
+                .await;
+        }
+    }
+    let _: Result<bool, _> = connection
+        .object_server()
+        .remove::<KwinWindowCallback, _>(callback_object_path.as_str())
+        .await;
+    if let Some(script_path) = script_path {
+        let _ = fs::remove_file(script_path);
+    }
+
+    result
+}
+
+struct KwinWindowCallback {
+    sender: mpsc::Sender<String>,
+}
+
+#[zbus::interface(name = "com.openai.Codex.KWinWindowQuery")]
+impl KwinWindowCallback {
+    fn receive_windows(&self, json: &str) -> zbus::fdo::Result<()> {
+        self.sender
+            .send(json.to_string())
+            .map_err(|error| zbus::fdo::Error::Failed(error.to_string()))
+    }
+}
+
+fn temporary_kwin_plugin_name() -> String {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("codex_kwin_window_query_{pid}_{nanos}")
+}
+
+fn write_kwin_window_script(
+    service_name: &str,
+    callback_object_path: &str,
+    plugin_name: &str,
+) -> Result<std::path::PathBuf> {
+    let service_name = serde_json::to_string(service_name)?;
+    let object_path = serde_json::to_string(callback_object_path)?;
+    let interface = serde_json::to_string(KWIN_CALLBACK_INTERFACE)?;
+    let plugin_name_json = serde_json::to_string(plugin_name)?;
+    let script = format!(
+        r#"(function() {{
+    var serviceName = {service_name};
+    var objectPath = {object_path};
+    var iface = {interface};
+    var pluginName = {plugin_name_json};
+
+    function read(obj, key) {{
+        try {{
+            if (obj === null || obj === undefined) {{
+                return null;
+            }}
+            var value = obj[key];
+            if (typeof value === "function") {{
+                return null;
+            }}
+            return serialize(value);
+        }} catch (error) {{
+            return null;
+        }}
+    }}
+
+    function serialize(value) {{
+        if (value === null || value === undefined) {{
+            return null;
+        }}
+        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {{
+            return value;
+        }}
+        if (Array.isArray(value)) {{
+            return value.map(serialize);
+        }}
+        try {{
+            if (typeof value.toString === "function") {{
+                return value.toString();
+            }}
+        }} catch (error) {{}}
+        return null;
+    }}
+
+    function geometry(window) {{
+        var frame = null;
+        try {{
+            frame = window.frameGeometry;
+        }} catch (error) {{}}
+        var x = read(window, "x");
+        var y = read(window, "y");
+        var width = read(window, "width");
+        var height = read(window, "height");
+        return {{
+            x: x !== null ? x : read(frame, "x"),
+            y: y !== null ? y : read(frame, "y"),
+            width: width !== null ? width : read(frame, "width"),
+            height: height !== null ? height : read(frame, "height")
+        }};
+    }}
+
+    function firstDesktop(window) {{
+        var desktops = read(window, "desktops");
+        if (!Array.isArray(desktops) || desktops.length === 0) {{
+            return null;
+        }}
+        var first = desktops[0];
+        var parsed = parseInt(first, 10);
+        return isFinite(parsed) ? parsed : null;
+    }}
+
+    function clientType(window) {{
+        if (read(window, "waylandClient")) {{
+            return "wayland";
+        }}
+        if (read(window, "x11Client")) {{
+            return "x11";
+        }}
+        return null;
+    }}
+
+    var activeWindow = null;
+    try {{
+        activeWindow = workspace.activeWindow;
+    }} catch (error) {{}}
+    var windows = workspace.windowList().map(function(window) {{
+        var geo = geometry(window);
+        return {{
+            uuid: read(window, "uuid"),
+            internalId: read(window, "internalId"),
+            caption: read(window, "caption"),
+            desktopFile: read(window, "desktopFile"),
+            resourceClass: read(window, "resourceClass"),
+            resourceName: read(window, "resourceName"),
+            windowClass: read(window, "windowClass"),
+            pid: read(window, "pid"),
+            x: geo.x,
+            y: geo.y,
+            width: geo.width,
+            height: geo.height,
+            workspace: firstDesktop(window),
+            minimized: read(window, "minimized"),
+            active: read(window, "active") || window === activeWindow,
+            clientType: clientType(window),
+            normalWindow: read(window, "normalWindow"),
+            desktopWindow: read(window, "desktopWindow"),
+            skipTaskbar: read(window, "skipTaskbar"),
+            dock: read(window, "dock")
+        }};
+    }});
+
+    callDBus(serviceName, objectPath, iface, "ReceiveWindows", JSON.stringify({{
+        backend: "kwin",
+        pluginName: pluginName,
+        windows: windows
+    }}));
+}})();
+"#
+    );
+    for attempt in 0..4 {
+        let filename = if attempt == 0 {
+            format!("{plugin_name}.js")
+        } else {
+            format!("{plugin_name}-{attempt}.js")
+        };
+        let path = std::env::temp_dir().join(filename);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                if let Err(error) = file.write_all(script.as_bytes()) {
+                    let _ = fs::remove_file(&path);
+                    return Err(error).with_context(|| {
+                        format!("failed to write temporary KWin script {}", path.display())
+                    });
+                }
+                return Ok(path);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to create temporary KWin script {}", path.display())
+                });
+            }
+        }
+    }
+
+    bail!("failed to create a unique temporary KWin script path for {plugin_name}")
+}
+
+fn parse_kwin_windows(json: &str) -> Result<Vec<WindowInfo>> {
+    let snapshot = parse_kwin_snapshot(json)?;
+    let mut windows = snapshot
+        .windows
+        .into_iter()
+        .filter(|window| !json_value_as_bool(window.desktop_window.as_ref()).unwrap_or(false))
+        .filter(|window| !json_value_as_bool(window.dock.as_ref()).unwrap_or(false))
+        .filter(|window| !json_value_as_bool(window.skip_taskbar.as_ref()).unwrap_or(false))
+        .filter(|window| json_value_as_bool(window.normal_window.as_ref()).unwrap_or(true))
+        .map(WindowInfo::try_from)
+        .collect::<Result<Vec<_>>>()?;
+    windows.sort_by_key(|window| window.window_id);
+    Ok(windows)
+}
+
+fn parse_kwin_snapshot(json: &str) -> Result<KwinWindowSnapshot> {
+    serde_json::from_str(json).context("failed to parse KWin temporary script output")
+}
+
+#[derive(Debug, Deserialize)]
+struct KwinWindowSnapshot {
+    windows: Vec<KwinRawWindow>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KwinRawWindow {
+    uuid: Option<String>,
+    internal_id: Option<String>,
+    caption: Option<String>,
+    desktop_file: Option<String>,
+    resource_class: Option<String>,
+    resource_name: Option<String>,
+    window_class: Option<String>,
+    pid: Option<serde_json::Value>,
+    x: Option<serde_json::Value>,
+    y: Option<serde_json::Value>,
+    width: Option<serde_json::Value>,
+    height: Option<serde_json::Value>,
+    workspace: Option<serde_json::Value>,
+    minimized: Option<serde_json::Value>,
+    active: Option<serde_json::Value>,
+    client_type: Option<String>,
+    normal_window: Option<serde_json::Value>,
+    desktop_window: Option<serde_json::Value>,
+    skip_taskbar: Option<serde_json::Value>,
+    dock: Option<serde_json::Value>,
+}
+
+impl KwinRawWindow {
+    fn kwin_uuid(&self) -> Option<String> {
+        self.uuid
+            .as_deref()
+            .or(self.internal_id.as_deref())
+            .and_then(normalize_kwin_uuid)
+    }
+}
+
+impl TryFrom<KwinRawWindow> for WindowInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(window: KwinRawWindow) -> Result<Self> {
+        let uuid = window
+            .kwin_uuid()
+            .context("KWin window did not include uuid or internalId")?;
+        let width = json_value_as_u32(window.width.as_ref());
+        let height = json_value_as_u32(window.height.as_ref());
+        let bounds = width.zip(height).map(|(width, height)| WindowBounds {
+            x: json_value_as_i32(window.x.as_ref()),
+            y: json_value_as_i32(window.y.as_ref()),
+            width,
+            height,
+        });
+        let app_id = clean_string(window.desktop_file.as_deref())
+            .or_else(|| clean_string(window.resource_class.as_deref()));
+        let wm_class = clean_string(window.resource_class.as_deref())
+            .or_else(|| clean_string(window.window_class.as_deref()))
+            .or_else(|| clean_string(window.resource_name.as_deref()));
+        let client_type = clean_string(window.client_type.as_deref());
+
+        Ok(WindowInfo {
+            window_id: kwin_window_id_from_uuid(&uuid),
+            title: clean_string(window.caption.as_deref()),
+            app_id,
+            wm_class,
+            pid: json_value_as_u32(window.pid.as_ref()),
+            bounds,
+            workspace: json_value_as_i32(window.workspace.as_ref()),
+            focused: json_value_as_bool(window.active.as_ref()).unwrap_or(false),
+            hidden: json_value_as_bool(window.minimized.as_ref()).unwrap_or(false),
+            client_type,
+            backend: KWIN_BACKEND.to_string(),
+            terminal: None,
+        })
+    }
+}
+
+fn kwin_window_id_from_uuid(uuid: &str) -> u64 {
+    let normalized = normalize_kwin_uuid(uuid).unwrap_or_else(|| uuid.trim().to_ascii_lowercase());
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in normalized.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn kwin_windows_runner_match_id(uuid: &str) -> String {
+    format!("0_{}", kwin_uuid_with_braces(uuid))
+}
+
+fn kwin_uuid_with_braces(uuid: &str) -> String {
+    let normalized = normalize_kwin_uuid(uuid).unwrap_or_else(|| uuid.trim().to_string());
+    format!("{{{normalized}}}")
+}
+
+fn normalize_kwin_uuid(uuid: &str) -> Option<String> {
+    let value = uuid
+        .trim()
+        .trim_start_matches('{')
+        .trim_end_matches('}')
+        .trim()
+        .to_ascii_lowercase();
+    (!value.is_empty()).then_some(value)
+}
+
+fn clean_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "null")
+        .map(ToOwned::to_owned)
+}
+
+fn json_value_as_bool(value: Option<&serde_json::Value>) -> Option<bool> {
+    match value? {
+        serde_json::Value::Bool(value) => Some(*value),
+        serde_json::Value::String(value) => match value.to_ascii_lowercase().as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn json_value_as_u32(value: Option<&serde_json::Value>) -> Option<u32> {
+    let value = json_value_as_f64(value)?;
+    if !value.is_finite() || value < 0.0 || value > u32::MAX as f64 {
+        return None;
+    }
+    Some(value.round() as u32)
+}
+
+fn json_value_as_i32(value: Option<&serde_json::Value>) -> Option<i32> {
+    let value = json_value_as_f64(value)?;
+    if !value.is_finite() || value < i32::MIN as f64 || value > i32::MAX as f64 {
+        return None;
+    }
+    Some(value.round() as i32)
+}
+
+fn json_value_as_f64(value: Option<&serde_json::Value>) -> Option<f64> {
+    match value? {
+        serde_json::Value::Number(value) => value.as_f64(),
+        serde_json::Value::String(value) => value.parse::<f64>().ok(),
+        _ => None,
     }
 }
 
@@ -1114,9 +1612,89 @@ mod tests {
     }
 
     #[test]
+    fn parses_kwin_windows_as_window_info() {
+        let uuid = "b4dfacf8-a559-43c9-8b1f-ecd5cfd78359";
+        let windows_json = r#"{
+          "backend": "kwin",
+          "windows": [
+            {
+              "uuid": "{b4dfacf8-a559-43c9-8b1f-ecd5cfd78359}",
+              "caption": "Codex",
+              "desktopFile": "codex-desktop",
+              "resourceClass": "codex-desktop",
+              "resourceName": "codex",
+              "pid": 68986,
+              "x": 10,
+              "y": 48,
+              "width": 1200,
+              "height": 800,
+              "workspace": 1,
+              "minimized": false,
+              "active": true,
+              "clientType": "wayland",
+              "normalWindow": true,
+              "desktopWindow": false,
+              "dock": false
+            },
+            {
+              "uuid": "{11111111-2222-3333-4444-555555555555}",
+              "caption": "Desktop",
+              "desktopWindow": true
+            }
+          ]
+        }"#;
+
+        let windows = parse_kwin_windows(windows_json).unwrap();
+
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].window_id, kwin_window_id_from_uuid(uuid));
+        assert_eq!(windows[0].title.as_deref(), Some("Codex"));
+        assert_eq!(windows[0].app_id.as_deref(), Some("codex-desktop"));
+        assert_eq!(windows[0].wm_class.as_deref(), Some("codex-desktop"));
+        assert_eq!(windows[0].pid, Some(68986));
+        assert_eq!(windows[0].bounds.as_ref().unwrap().x, Some(10));
+        assert_eq!(windows[0].bounds.as_ref().unwrap().height, 800);
+        assert_eq!(windows[0].workspace, Some(1));
+        assert!(windows[0].focused);
+        assert!(!windows[0].hidden);
+        assert_eq!(windows[0].client_type.as_deref(), Some("wayland"));
+        assert_eq!(windows[0].backend, KWIN_BACKEND);
+    }
+
+    #[test]
+    fn kwin_window_ids_are_stable_across_uuid_formats() {
+        let bare = "b4dfacf8-a559-43c9-8b1f-ecd5cfd78359";
+        let braced_upper = "{B4DFACF8-A559-43C9-8B1F-ECD5CFD78359}";
+
+        assert_eq!(
+            kwin_window_id_from_uuid(bare),
+            kwin_window_id_from_uuid(braced_upper)
+        );
+        assert_eq!(
+            kwin_windows_runner_match_id(bare),
+            "0_{b4dfacf8-a559-43c9-8b1f-ecd5cfd78359}"
+        );
+    }
+
+    #[test]
     fn hyprland_backend_can_exact_focus_targets() {
         let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
         window.backend = HYPRLAND_BACKEND.to_string();
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                title: Some("Codex".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn kwin_backend_can_exact_focus_targets() {
+        let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
+        window.backend = KWIN_BACKEND.to_string();
 
         ensure_backend_can_focus_target(
             &WindowTarget {


### PR DESCRIPTION
## Summary

Adds a KWin/Plasma window backend for Linux Computer Use.

KDE Plasma Wayland sessions currently pass the MCP, AT-SPI, portal, and ydotool checks, but still report window targeting as unavailable because the Linux backend only knows how to query GNOME and Hyprland windows. This adds an optional `kwin` backend that uses the KWin session bus APIs already available in Plasma.

## User-Visible Behavior

On KDE Plasma Wayland, `codex-computer-use-linux doctor` can now report:

```text
windowing.kwin.ok: true
can_list_windows: true
can_focus_apps: true
can_focus_windows: true
readiness.can_query_windows: true
```

`list_windows`, `focused_window`, and targeted input verification can use KWin when GNOME backends are unavailable and Hyprland is not present.

## Changes

- Add a `kwin` window backend after GNOME Shell backends and before Hyprland fallback.
- Query KWin windows with a temporary KWin script loaded over DBus, returning the window snapshot through a short-lived DBus callback object.
- Map KWin window properties into `WindowInfo`, including title, app id, class, pid, bounds, minimized state, and focus state.
- Derive stable `u64` window ids from KWin UUIDs and resolve those UUIDs again when activating a window.
- Activate KWin windows through `/WindowsRunner` using the matching KWin window UUID.
- Update doctor diagnostics/readiness, Computer Use MCP instructions, CLI output, and README Computer Use documentation to mention KWin/Plasma.
- Add unit coverage for KWin parsing, stable IDs, exact-focus support, and readiness.

## Source of Truth Files Edited

- `computer-use-linux/src/windows.rs`
- `computer-use-linux/src/diagnostics.rs`
- `computer-use-linux/src/server.rs`
- `computer-use-linux/src/main.rs`
- `README.md`

No generated `codex-app/` or `dist/` artifacts are edited.

## Validation

Ran:

```text
cargo fmt -p codex-computer-use-linux
cargo check -p codex-computer-use-linux
cargo test -p codex-computer-use-linux
cargo run -p codex-computer-use-linux -- windows
cargo run -p codex-computer-use-linux -- doctor
```

Results:

```text
cargo test: 69 passed
windows: backend "kwin" on a KDE Plasma Wayland session
doctor: kwin.ok=true, can_list_windows=true, can_focus_apps=true, can_focus_windows=true, blockers=[]
```

I also tested activation through KWin WindowsRunner and verified that a fresh window query reports the activated window as focused.

## Environment / Limitations

Validated locally on KDE Plasma Wayland with KWin 6.4.5. Existing GNOME and Hyprland behavior should remain unchanged because KWin is an optional fallback backend and fails cleanly if the KWin DBus APIs are unavailable.

## Notes

This does not add any external KDE tooling dependency such as `kdotool`, `wmctrl`, or `xdotool`. The backend uses KWin DBus scripting and WindowsRunner.

On Plasma 6.4.5, `loadScript` can return `0` even when the script is loaded successfully, so the implementation treats the callback response as the completion signal instead of relying on the returned script id.
