### PR TITLE
[codex] Refresh all Nix fixed-output hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           bash -n scripts/build-deb.sh
           bash -n scripts/build-rpm.sh
           bash -n scripts/build-pacman.sh
+          bash -n scripts/ci/update-nix-hashes.sh
 
       - name: Check Rust formatting
         run: cargo fmt --check

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -1,8 +1,8 @@
-name: Update Codex.dmg hash
+name: Update Nix upstream hashes
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -11,42 +11,55 @@ permissions:
 jobs:
   update-hash:
     runs-on: ubuntu-latest
+    env:
+      NIX_CONFIG: experimental-features = nix-command flakes
     steps:
       - uses: actions/checkout@v4
 
       - uses: cachix/install-nix-action@v27
 
-      - name: Download upstream Codex.dmg
-        run: curl -fL --retry 3 -o /tmp/Codex.dmg https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+      - name: Refresh Nix fixed-output hashes
+        run: scripts/ci/update-nix-hashes.sh
 
-      - name: Compute SRI hash and update flake.nix
+      - name: Commit refreshed hashes
         run: |
           set -euo pipefail
 
-          NEW_HASH=$(nix hash file --sri --type sha256 /tmp/Codex.dmg)
-          echo "Upstream hash: $NEW_HASH"
-
-          if ! [[ "$NEW_HASH" =~ ^sha256-[A-Za-z0-9+/=]{44}$ ]]; then
-            echo "Refusing to proceed: computed hash '$NEW_HASH' is not a valid SRI sha256." >&2
-            exit 1
-          fi
-
-          CURRENT_HASH=$(grep -oP 'hash = "\Ksha256-[^"]+' flake.nix)
-          echo "Current hash:  $CURRENT_HASH"
-
-          if [ "$NEW_HASH" = "$CURRENT_HASH" ]; then
-            echo "Hash unchanged, nothing to do."
+          if git diff --quiet -- flake.nix; then
+            echo "Nix hashes unchanged, nothing to do."
             exit 0
           fi
 
-          sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"$NEW_HASH\";|" flake.nix
+          CODEX_DMG_HASH="$(python3 - <<'PY'
+from pathlib import Path
+import re
+
+text = Path("flake.nix").read_text()
+match = re.search(r'codexDmg = pkgs\.fetchurl \{.*?hash = "(sha256-[^"]+)";', text, re.S)
+if not match:
+    raise SystemExit("Could not find codexDmg hash")
+print(match.group(1))
+PY
+)"
+          PAYLOAD_HASH="$(python3 - <<'PY'
+from pathlib import Path
+import re
+
+text = Path("flake.nix").read_text()
+match = re.search(r'codexDesktopPayload = pkgs\.stdenv\.mkDerivation \{.*?outputHash = "(sha256-[^"]+)";', text, re.S)
+if not match:
+    raise SystemExit("Could not find codexDesktopPayload outputHash")
+print(match.group(1))
+PY
+)"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
           git add flake.nix
-          git commit -m "fix(nix): update Codex.dmg hash
+          git commit -m "fix(nix): update upstream Nix hashes
 
-          Upstream binary changed — refreshed SRI hash to $NEW_HASH.
+          Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH.
+          Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH.
 
           [skip ci]"
           git push origin main

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The first launch can auto-install the Codex CLI (`@openai/codex`) using the bund
 nix run github:ilysenko/codex-desktop-linux
 ```
 
-The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot keeps the upstream `Codex.dmg` SRI hash refreshed in `main` once per day. If you happen to try right after an upstream Codex release and hit `error: hash mismatch in fixed-output derivation`, wait up to a day for the bot and retry.
+The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot keeps the upstream `Codex.dmg` SRI hash and the recursive Nix payload `outputHash` refreshed in `main` every 2 hours. If you happen to try right after an upstream Codex release and hit `error: hash mismatch in fixed-output derivation`, wait for the next bot run and retry.
 
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
+UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
+BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
+VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
+
+validate_sri_hash() {
+    local hash="$1"
+    [[ "$hash" =~ ^sha256-[A-Za-z0-9+/=]{44}$ ]]
+}
+
+replace_flake_hash() {
+    local anchor="$1"
+    local key="$2"
+    local new_hash="$3"
+
+    python3 - "$FLAKE_FILE" "$anchor" "$key" "$new_hash" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+anchor = sys.argv[2]
+key = sys.argv[3]
+new_hash = sys.argv[4]
+
+lines = path.read_text().splitlines(keepends=True)
+in_block = False
+for index, line in enumerate(lines):
+    if anchor in line:
+        in_block = True
+        continue
+    if not in_block:
+        continue
+    if key in line:
+        lines[index] = re.sub(r'sha256-[^"]+', new_hash, line, count=1)
+        path.write_text("".join(lines))
+        raise SystemExit(0)
+    if line.strip() == "};":
+        break
+
+raise SystemExit(f"Could not find {key!r} after {anchor!r} in {path}")
+PY
+}
+
+read_flake_hash() {
+    local anchor="$1"
+    local key="$2"
+
+    python3 - "$FLAKE_FILE" "$anchor" "$key" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+anchor = sys.argv[2]
+key = sys.argv[3]
+
+in_block = False
+for line in path.read_text().splitlines():
+    if anchor in line:
+        in_block = True
+        continue
+    if not in_block:
+        continue
+    if key in line:
+        match = re.search(r'sha256-[^"]+', line)
+        if match:
+            print(match.group(0))
+            raise SystemExit(0)
+    if line.strip() == "};":
+        break
+
+raise SystemExit(f"Could not find {key!r} after {anchor!r} in {path}")
+PY
+}
+
+extract_got_sri_hash() {
+    local log_path="$1"
+
+    python3 - "$log_path" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text(errors="replace")
+text = re.sub(r"\x1b\[[0-9;]*m", "", text)
+matches = re.findall(r"got:\s*(sha256-[A-Za-z0-9+/=]{44})", text)
+if not matches:
+    raise SystemExit(1)
+print(matches[-1])
+PY
+}
+
+run_nix_build() {
+    local log_path="$1"
+    rm -f "$log_path"
+    set +e
+    nix build .#codex-desktop --no-link --print-build-logs 2>&1 | tee "$log_path"
+    local status="${PIPESTATUS[0]}"
+    set -e
+    return "$status"
+}
+
+mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
+curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+
+new_dmg_hash="$(nix hash file --sri --type sha256 "$UPSTREAM_DMG_PATH")"
+if ! validate_sri_hash "$new_dmg_hash"; then
+    echo "Refusing to proceed: computed DMG hash '$new_dmg_hash' is not a valid SRI sha256." >&2
+    exit 1
+fi
+
+current_dmg_hash="$(read_flake_hash "codexDmg = pkgs.fetchurl {" "hash = ")"
+echo "Current Codex.dmg hash:  $current_dmg_hash"
+echo "Upstream Codex.dmg hash: $new_dmg_hash"
+replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$new_dmg_hash"
+
+# Seed the Nix store so the build can reuse the DMG that was already downloaded
+# for hashing instead of fetching the same 300MB artifact again.
+nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
+
+if run_nix_build "$BUILD_LOG"; then
+    echo "Nix build succeeded with the current payload outputHash."
+    exit 0
+fi
+
+new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
+if [ -z "$new_payload_hash" ]; then
+    echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
+    exit 1
+fi
+
+if ! validate_sri_hash "$new_payload_hash"; then
+    echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
+    exit 1
+fi
+
+current_payload_hash="$(read_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = ")"
+echo "Current payload outputHash: $current_payload_hash"
+echo "Actual payload outputHash:  $new_payload_hash"
+replace_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = " "$new_payload_hash"
+
+run_nix_build "$VERIFY_LOG"
+echo "Nix build succeeded after refreshing the payload outputHash."


### PR DESCRIPTION
## Summary
- run the Nix upstream hash workflow every 2 hours
- refresh both the upstream Codex.dmg SRI hash and codexDesktopPayload recursive outputHash
- verify the refreshed payload hash by rerunning nix build before committing
- add CI syntax coverage for the new hash-refresh script and update the README timing note

## Why
The existing scheduled workflow only updated the fetchurl hash. After the Nix package gained a recursive fixed-output payload, upstream DMG or source changes can also require codexDesktopPayload.outputHash to move. This keeps the bot responsible for both values.

## Validation
- bash -n scripts/ci/update-nix-hashes.sh
- bash -n install.sh
- bash -n scripts/install-deps.sh
- bash -n scripts/build-deb.sh
- bash -n scripts/build-rpm.sh
- bash -n scripts/build-pacman.sh
- git diff --check

Note: I could not run the full Nix build locally because nix is not installed in this workspace; the workflow script itself performs that verification in GitHub Actions.