### PR TITLE
[codex] Fix Copilot reasoning effort defaults for new chats

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -1275,6 +1275,129 @@ function applyLinuxComputerUseInstallFlowPatch(currentSource) {
   return currentSource;
 }
 
+function applyCopilotReasoningEffortSettingsPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const copilotDefaultsPatchMarker = "copilot-default-reasoning-effort`),codexCopilotModelValue=";
+  const copilotDefaultsRegex =
+    /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{data:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(`copilot-default-model`\),([A-Za-z_$][\w$]*)=\6\?\?\4\.defaultModel,([A-Za-z_$][\w$]*);return \2\[0\]!==\7\|\|\2\[1\]!==\9\?\(\10=\{model:\9,reasoningEffort:`medium`,profile:null,isLoading:\7\},\2\[0\]=\7,\2\[1\]=\9,\2\[2\]=\10\):\10=\2\[2\],\10\}/;
+  if (patchedSource.includes(copilotDefaultsPatchMarker)) {
+    // Already patched.
+  } else if (copilotDefaultsRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      copilotDefaultsRegex,
+      (
+        _match,
+        functionName,
+        memoVar,
+        cacheModuleVar,
+        defaultsVar,
+        defaultsHookVar,
+        savedModelVar,
+        modelLoadingVar,
+        persistedStateHookVar,
+        _modelValueVar,
+        resultVar,
+      ) =>
+        `function ${functionName}(){let ${memoVar}=(0,${cacheModuleVar}.c)(5),${defaultsVar}=${defaultsHookVar}(),{data:${savedModelVar},isLoading:${modelLoadingVar}}=${persistedStateHookVar}(\`copilot-default-model\`),{data:codexCopilotReasoningEffort,isLoading:codexCopilotReasoningEffortLoading}=${persistedStateHookVar}(\`copilot-default-reasoning-effort\`),codexCopilotModelValue=${savedModelVar}??${defaultsVar}.defaultModel,codexCopilotReasoningEffortValue=codexCopilotReasoningEffort??\`medium\`,${resultVar};return ${memoVar}[0]!==${modelLoadingVar}||${memoVar}[1]!==codexCopilotReasoningEffortLoading||${memoVar}[2]!==codexCopilotModelValue||${memoVar}[3]!==codexCopilotReasoningEffortValue?(${resultVar}={model:codexCopilotModelValue,reasoningEffort:codexCopilotReasoningEffortValue,profile:null,isLoading:${modelLoadingVar}||codexCopilotReasoningEffortLoading},${memoVar}[0]=${modelLoadingVar},${memoVar}[1]=codexCopilotReasoningEffortLoading,${memoVar}[2]=codexCopilotModelValue,${memoVar}[3]=codexCopilotReasoningEffortValue,${memoVar}[4]=${resultVar}):${resultVar}=${memoVar}[4],${resultVar}}`,
+    );
+  } else if (patchedSource.includes("copilot-default-model")) {
+    console.warn(
+      "WARN: Could not find Copilot default model reader — skipping Copilot reasoning effort default patch",
+    );
+  }
+
+  const copilotSavePatchMarker = "copilot-default-reasoning-effort`,";
+  const copilotSaveRegex =
+    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)return;/;
+  if (patchedSource.includes(copilotSavePatchMarker)) {
+    // Already patched.
+  } else if (copilotSaveRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      copilotSaveRegex,
+      (
+        _match,
+        updateConversationVar,
+        modelArgVar,
+        effortArgVar,
+        isCopilotVar,
+        persistStateVar,
+        stateScopeVar,
+        loggerVar,
+        configVar,
+        hostReadyVar,
+      ) =>
+        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar}),${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})return;`,
+    );
+  } else if (patchedSource.includes("copilot-default-model")) {
+    console.warn(
+      "WARN: Could not find Copilot default model writer — skipping Copilot reasoning effort persistence patch",
+    );
+  }
+
+  return patchedSource;
+}
+
+function applyCopilotReasoningEffortModelListPatch(currentSource) {
+  const copilotReasoningFilterRegex =
+    /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([A-Za-z_$][\w$]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
+
+  if (!copilotReasoningFilterRegex.test(currentSource)) {
+    if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
+      console.warn(
+        "WARN: Could not find Copilot model reasoning effort filter — skipping Copilot reasoning effort model list patch",
+      );
+    }
+    return currentSource;
+  }
+
+  return currentSource.replace(
+    copilotReasoningFilterRegex,
+    (_, _authMethodVar, modelVar) => `[...${modelVar}.supportedReasoningEfforts]`,
+  );
+}
+
+function applyCopilotReasoningEffortUiPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const reasoningDropdownPatch = "disabled:!1,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`";
+  const reasoningDropdownRegex =
+    /disabled:([A-Za-z_$][\w$]*),RightIcon:([A-Za-z_$][\w$]*)===([A-Za-z_$][\w$]*)\?rg:void 0,onSelect:\(\)=>\{([A-Za-z_$][\w$]*)\.get\(bh\)\.log\(\{eventName:`codex_composer_reasoning_effort_changed`/;
+  if (patchedSource.includes(reasoningDropdownPatch)) {
+    // Already patched.
+  } else if (reasoningDropdownRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      reasoningDropdownRegex,
+      (
+        _match,
+        _disabledVar,
+        effortVar,
+        selectedEffortVar,
+        scopeVar,
+      ) =>
+        `disabled:!1,RightIcon:${effortVar}===${selectedEffortVar}?rg:void 0,onSelect:()=>{${scopeVar}.get(bh).log({eventName:\`codex_composer_reasoning_effort_changed\``,
+    );
+  } else if (patchedSource.includes("codex_composer_reasoning_effort_changed")) {
+    console.warn(
+      "WARN: Could not find reasoning effort dropdown disabled state — skipping Copilot reasoning effort dropdown patch",
+    );
+  }
+
+  const slashCommandNeedle = "let w=s&&f&&!p,T;";
+  const slashCommandPatch = "let w=s&&f,T;";
+  if (patchedSource.includes(slashCommandPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(slashCommandNeedle)) {
+    patchedSource = patchedSource.replace(slashCommandNeedle, slashCommandPatch);
+  } else if (patchedSource.includes("composer.reasoningSlashCommand.title")) {
+    console.warn(
+      "WARN: Could not find reasoning slash command enabled state — skipping Copilot reasoning slash command patch",
+    );
+  }
+
+  return patchedSource;
+}
+
 function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   const approvalPatch =
     "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
@@ -1901,6 +2024,24 @@ function patchExtractedApp(extractedDir, options = {}) {
       applyLinuxOpaqueWindowsDefaultPatch,
       `WARN: Could not find resolved theme bundle in ${path.join(extractedDir, "webview", "assets")} — skipping translucent sidebar default patch`,
     ],
+    [
+      "copilot-reasoning-effort-settings",
+      /^use-model-settings-.*\.js$/,
+      applyCopilotReasoningEffortSettingsPatch,
+      `WARN: Could not find model settings bundle in ${path.join(extractedDir, "webview", "assets")} — skipping Copilot reasoning effort settings patch`,
+    ],
+    [
+      "copilot-reasoning-effort-model-list",
+      /^font-settings-.*\.js$/,
+      applyCopilotReasoningEffortModelListPatch,
+      `WARN: Could not find font settings bundle in ${path.join(extractedDir, "webview", "assets")} — skipping Copilot reasoning effort model list patch`,
+    ],
+    [
+      "copilot-reasoning-effort-ui",
+      /^index-.*\.js$/,
+      applyCopilotReasoningEffortUiPatch,
+      `WARN: Could not find webview index bundle in ${path.join(extractedDir, "webview", "assets")} — skipping Copilot reasoning effort UI patch`,
+    ],
   ]) {
     const { value: result, warnings } = captureWarnings(() =>
       patchAssetFiles(extractedDir, pattern, patchFn, warning),
@@ -2016,6 +2157,9 @@ module.exports = {
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
   applyLinuxComputerUseInstallFlowPatch,
+  applyCopilotReasoningEffortModelListPatch,
+  applyCopilotReasoningEffortSettingsPatch,
+  applyCopilotReasoningEffortUiPatch,
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -15,6 +15,9 @@ const {
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
+  applyCopilotReasoningEffortModelListPatch,
+  applyCopilotReasoningEffortSettingsPatch,
+  applyCopilotReasoningEffortUiPatch,
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
@@ -109,6 +112,24 @@ function computerUseRendererAvailabilityBundleFixture() {
 
 function computerUseInstallFlowBundleFixture() {
   return "function Qe({forceReloadPlugins:e,hostId:t}){let ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled,[L,R]=(0,Z.useState)({});return re}";
+}
+
+function copilotReasoningEffortSettingsFixture() {
+  return [
+    "function bwe(){let e=(0,Y.c)(3),t=wr(),{data:n,isLoading:r}=or(`copilot-default-model`),i=n??t.defaultModel,a;return e[0]!==r||e[1]!==i?(a={model:i,reasoningEffort:`medium`,profile:null,isLoading:r},e[0]=r,e[1]=i,e[2]=a):a=e[2],a}",
+    "function $9(e=null){let t=j(fe),m=a?.authMethod===`copilot`,g=(0,q.useCallback)(async(t,n)=>!1,[]),c={profile:null},i=!0,r=`local`,s=`/tmp`,v=()=>{},y=()=>{};return{setModelAndReasoningEffort:(0,q.useCallback)(async(e,n)=>{try{if(await g(e,n))return;if(m){Jn(t,`copilot-default-model`,e);return}if(h.info(`Setting default model and reasoning effort`,{safe:{newModel:e,newEffort:n,profile:c.profile}}),!i)return;await Gt(`set-default-model-config-for-host`,{hostId:r,model:e,reasoningEffort:n,profile:c.profile}),await v(),await t.query.fetch(Ss,{hostId:r,cwd:s})}catch(e){y(e)}},[m,g,c.profile,v,i,r,t,y,s])}}",
+  ].join("");
+}
+
+function copilotReasoningEffortModelListFixture() {
+  return "function Ge(){let s=`copilot`,d={};return e.forEach(e=>{let t=s===`copilot`?[e.supportedReasoningEfforts.find(Ue)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];d.models.push({...e,supportedReasoningEfforts:t})})}";
+}
+
+function copilotReasoningEffortUiFixture() {
+  return [
+    "function qU(){let E=o?.authMethod===`copilot`,D=ZH(T,f.model),O=QH(f.reasoningEffort,D),le=D.map(e=>{let{reasoningEffort:t}=e;return(0,$.jsx)(jm.Item,{\"data-reasoning-selected\":t===O?`true`:void 0,disabled:E,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`,metadata:{reasoning_effort:t}}),p(f.model,t),H()},children:(0,$.jsx)(nM,{effort:t})},t)})}",
+    "function bY(e){let p=o?.authMethod===`copilot`;let w=s&&f&&!p,T;return{enabled:w,dependencies:T}}",
+  ].join("");
 }
 
 function currentLaunchActionBundleFixture() {
@@ -759,6 +780,46 @@ test("allows Computer Use install flow on Linux", () => {
     patched,
     /re=!ne\.isLoading&&ne\.enabled\|\|navigator\.userAgent\.includes\(`Linux`\)/,
   );
+});
+
+test("persists Copilot reasoning effort with the default Copilot model", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortSettingsPatch,
+    copilotReasoningEffortSettingsFixture(),
+  );
+
+  assert.match(patched, /or\(`copilot-default-reasoning-effort`\)/);
+  assert.match(patched, /reasoningEffort:codexCopilotReasoningEffortValue/);
+  assert.match(patched, /isLoading:r\|\|codexCopilotReasoningEffortLoading/);
+  assert.match(
+    patched,
+    /Jn\(t,`copilot-default-model`,e\),Jn\(t,`copilot-default-reasoning-effort`,n\);return/,
+  );
+  assert.doesNotMatch(patched, /reasoningEffort:`medium`,profile:null,isLoading:r/);
+  assert.doesNotMatch(patched, /Jn\(t,`copilot-default-model`,e\);return/);
+});
+
+test("keeps all model reasoning efforts available for Copilot auth", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortModelListPatch,
+    copilotReasoningEffortModelListFixture(),
+  );
+
+  assert.match(patched, /let t=\[\.\.\.e\.supportedReasoningEfforts\]/);
+  assert.doesNotMatch(patched, /s===`copilot`\?\[/);
+  assert.doesNotMatch(patched, /description:`medium effort`/);
+});
+
+test("allows Copilot auth to change reasoning effort from the UI", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortUiPatch,
+    copilotReasoningEffortUiFixture(),
+  );
+
+  assert.match(patched, /disabled:!1,RightIcon:t===O\?rg:void 0/);
+  assert.match(patched, /let w=s&&f,T;/);
+  assert.doesNotMatch(patched, /disabled:E,RightIcon:t===O\?rg:void 0/);
+  assert.doesNotMatch(patched, /let w=s&&f&&!p,T;/);
 });
 
 test("auto-approves the app-provided Browser Use node_repl bridge", () => {


### PR DESCRIPTION
## Summary

Fixes the Linux webview patching path that left the Intelligence / reasoning effort selector stuck for new chats when the app is using Copilot auth.

The visible symptom was project-specific: a new chat could open with the reasoning effort stuck on the last/default effort for that project, for example `medium` in one project and `low` in another. Existing threads were less affected because the conversation-specific path can still call `set-model-and-reasoning-for-next-turn`; the broken path was the new-chat/default-model path.

## Root cause

The current upstream webview bundle has a separate Copilot settings path:

- the Copilot default reader only loads `copilot-default-model`
- that same reader hardcodes `reasoningEffort: "medium"`
- the Copilot save branch writes `copilot-default-model` and returns before saving the selected effort
- the model list code collapses Copilot-supported reasoning efforts down to a single `medium` option
- the UI disables reasoning effort entries, and the `/reasoning` command, when `authMethod === "copilot"`

I also checked the suspected stale-route path. The current route atom returns no conversation target for `home` / `new-thread-panel`, so this does not look like a stale `conversationId` being passed into the composer from that route state.

## What changed

The ASAR patcher now patches the relevant webview chunks instead of modifying generated `codex-app/` output directly:

- `use-model-settings-*.js`
  - read `copilot-default-reasoning-effort` next to `copilot-default-model`
  - include the effort key in loading/memoized state
  - persist `copilot-default-reasoning-effort` when saving Copilot defaults
- `font-settings-*.js`
  - keep the full `supportedReasoningEfforts` list for Copilot models instead of forcing only `medium`
- `index-*.js`
  - keep reasoning effort dropdown entries enabled for Copilot auth
  - keep the `/reasoning` command enabled when the normal model/effort prerequisites are present

The new patches follow the existing fail-soft style in `scripts/patch-linux-window-ui.js`: if the upstream minified bundle shape drifts, the installer logs a warning and keeps going.

## Why this is a PR instead of a separate issue

I checked the contribution guidance and searched existing issues/PRs for `reasoning effort`, `intelligence`, and `copilot`. I did not find a matching report. Since this is a focused bug fix with tests and only touches the source-of-truth patcher plus its test file, opening the PR directly seems more useful than creating an issue first and duplicating the same context.

## Source-of-truth files edited

- `scripts/patch-linux-window-ui.js`
- `scripts/patch-linux-window-ui.test.js`

No generated `codex-app/` assets were committed.

## Validation

Ran locally:

```bash
node --test scripts/patch-linux-window-ui.test.js
node --check scripts/patch-linux-window-ui.js
node --check scripts/patch-linux-window-ui.test.js
bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh
git diff --check
```

The targeted patcher test suite passes with `56` tests.

I did not run full package builds (`build-deb`, `build-rpm`, `build-pacman`) because this change only alters ASAR patch matching and test coverage, not package layout or maintainer scripts.