### PR TITLE
Support Bun-installed Codex CLI

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -528,6 +528,7 @@ find_codex_cli() {
 
     local candidate
     for candidate in \
+        "$HOME/.bun/bin/codex" \
         "$HOME/.nvm/versions/node/current/bin/codex" \
         "$HOME/.nvm/versions/node"/*/bin/codex \
         "$HOME/.local/share/pnpm/codex" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -483,6 +483,8 @@ if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_bo
     raise SystemExit("second-instance handoff must skip CLI lookup")
 if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip missing-CLI failure")
+if '"$HOME/.bun/bin/codex"' not in source:
+    raise SystemExit("CLI lookup must include bun global install path")
 if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
 if "running_app_is_active" not in stop_body or "Preserving webview server" not in stop_body:


### PR DESCRIPTION
## Summary

- Add `~/.bun/bin/codex` to the launcher’s Codex CLI discovery paths
- Add smoke-test coverage so Bun global installs stay supported

## User-visible behavior

Users who installed the Codex CLI through Bun can launch Codex Desktop without setting `CODEX_CLI_PATH` manually, as long as the CLI exists at Bun’s global bin path.

## Validation

- `bash tests/scripts_smoke.sh`
