### PR TITLE
Feat/add cosmic computer use support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ The current working flow is:
 - `scripts/lib/webview-install.sh`
   Webview asset extraction and final `codex-app/` install layout.
 - `scripts/lib/bundled-plugins.sh`
-  Linux Computer Use backend build, plugin staging, and bundled-plugin marketplace generation.
+  Linux Computer Use backend build, COSMIC helper build, plugin staging, and bundled-plugin marketplace generation.
 - `scripts/build-deb.sh`
   Builds the `.deb` from the already-generated `codex-app/`.
 - `scripts/build-rpm.sh`
@@ -68,6 +68,8 @@ The current working flow is:
   Source of truth for the updater crate version and dependency policy.
 - `computer-use-linux/`
   Rust crate implementing the Linux Computer Use MCP backend (`codex-computer-use-linux` binary). Talks AT-SPI to read accessibility trees, captures screenshots through GNOME Shell DBus or XDG Desktop Portal, and synthesizes input via `ydotool`. Runs as a subprocess of Codex Electron when the bundled plugin is registered.
+- `computer-use-linux/src/bin/codex-computer-use-cosmic.rs`
+  COSMIC Wayland helper binary used by the Linux Computer Use backend for compositor-native window enumeration and activation on COSMIC sessions.
 - `plugins/openai-bundled/plugins/computer-use/`
   Bundled plugin manifest for Linux Computer Use (`.codex-plugin/plugin.json` + `.mcp.json`). Author and license fields here must stay consistent with the repo's MIT license — they live alongside the runtime resources installed under `/opt/codex-desktop/resources/plugins/openai-bundled/`.
 - `packaging/linux/codex-update-manager-user-service.sh`
@@ -121,6 +123,8 @@ Do not assume `codex-app/` is pristine. If behavior differs from `install.sh`, p
   - **Default-on:** `applyLinuxComputerUsePluginGatePatch` flips the bundled-plugin manifest from `darwin`-only to `darwin || linux` and adds `installWhenMissing: true` so the MCP plugin auto-registers. Pure platform-port glue — no Statsig involvement, no behavioural override; it has shipped on by default since the project's first release.
   - **Opt-in:** `applyLinuxComputerUseFeaturePatch`, `applyLinuxComputerUseRendererAvailabilityPatch`, and `applyLinuxComputerUseInstallFlowPatch` together unlock the Codex Desktop UI controls. The install-flow patch in particular falls back to `navigator.userAgent.includes("Linux")` as an OR-clause against the `computer_use` Statsig flag, which is why it is deliberately not on by default. The orchestrator (`patchMainBundleSource` / `patchExtractedApp`) calls `isComputerUseUiEnabled()` once per build; the helper returns `true` when `process.env.CODEX_LINUX_ENABLE_COMPUTER_USE_UI === "1"` OR `~/.config/codex-desktop/settings.json` contains `"codex-linux-computer-use-ui-enabled": true`. The settings-flag fallback exists so the auto-updater (a `systemd --user` service that does not inherit interactive shell env) can keep applying the UI patches across rebuilds without the user re-exporting an env var on every login.
   - **Out of scope:** OpenAI per-account Statsig rollouts that gate other features (`gpt-5.5` model rollout is the recurring example). Those are decided server-side per account and there is nothing in the local install that controls them.
+- Linux Computer Use window backends:
+  GNOME uses `org.gnome.Shell.Introspect` for listing plus the bundled `codex-window-control@openai.com` GNOME Shell extension for exact activation. COSMIC Wayland uses the bundled `codex-computer-use-cosmic` helper, which talks directly to the compositor's COSMIC toplevel Wayland protocols. When neither backend is available, Computer Use still supports screenshots, AT-SPI, and global `ydotool` input, but not verified window-targeted keyboard input.
 - Linux settings persistence:
   `applyLinuxSettingsPersistencePatch` inserts `codexLinuxPersistSettingsState(...)` so the keybinds-settings page toggles (system tray, warm start, compact prompt window) are mirrored to `~/.config/codex-desktop/settings.json`, where `linux_setting_enabled` in `install.sh` reads them. The patch is fail-soft: if the upstream `Yb` state-file marker or `set-global-state` IPC handler isn't present, the patch logs a warning and skips, leaving keybinds toggles in-memory only.
 - Linux warm-start handoff:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,17 +452,20 @@ dependencies = [
 
 [[package]]
 name = "codex-computer-use-linux"
-version = "0.1.0"
+version = "0.1.2-linux-alpha1"
 dependencies = [
  "anyhow",
  "atspi",
  "base64",
+ "cosmic-protocols",
  "futures-util",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -535,6 +538,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cosmic-protocols"
+version = "0.2.0"
+source = "git+https://github.com/pop-os/cosmic-protocols?rev=160b086#160b086abe03cd34a8a375d7fbe47b24308d1f38"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -673,6 +689,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -1578,6 +1600,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -2830,6 +2858,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-computer-use-linux"
-version = "0.1.0"
+version = "0.1.2-linux-alpha1"
 edition = "2021"
 
 [[bin]]
@@ -11,10 +11,13 @@ path = "src/main.rs"
 anyhow = "1.0.102"
 atspi = { version = "0.29.0", features = ["tokio"] }
 base64 = "0.22.1"
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = ["client"] }
 futures-util = "0.3.32"
 rmcp = { version = "1.5.0", features = ["transport-io"] }
 schemars = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.51.1", features = ["macros", "rt", "time"] }
+wayland-client = "0.31.11"
+wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
 zbus = "5.14.0"

--- a/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
+++ b/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
@@ -99,7 +99,8 @@ struct AppData {
     toplevel_info: Option<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1>,
     toplevel_manager: Option<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1>,
     seats: Vec<wl_seat::WlSeat>,
-    capabilities: Vec<WEnum<zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1>>,
+    capabilities:
+        Vec<WEnum<zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1>>,
     records: Vec<ToplevelRecord>,
     by_foreign_id: HashMap<u32, usize>,
     by_cosmic_id: HashMap<u32, usize>,
@@ -180,11 +181,7 @@ fn collect_windows() -> Result<Vec<WindowInfo>> {
 
 fn focused_window() -> Result<Option<WindowInfo>> {
     let snapshot = Snapshot::collect()?;
-    if let Some(window) = snapshot
-        .windows()
-        .into_iter()
-        .find(|window| window.focused)
-    {
+    if let Some(window) = snapshot.windows().into_iter().find(|window| window.focused) {
         clear_activation_state();
         return Ok(Some(window));
     }
@@ -242,17 +239,25 @@ impl Snapshot {
         globals.contents().with_list(|entries| {
             for global in entries {
                 if global.interface == "wl_seat" {
-                    snapshot.app_data.seats.push(
-                        globals
-                            .registry()
-                            .bind::<wl_seat::WlSeat, _, _>(global.name, global.version.min(9), &qh, ()),
-                    );
+                    snapshot
+                        .app_data
+                        .seats
+                        .push(globals.registry().bind::<wl_seat::WlSeat, _, _>(
+                            global.name,
+                            global.version.min(9),
+                            &qh,
+                            (),
+                        ));
                 }
             }
         });
         if snapshot.app_data.toplevel_info.is_some() {
             let _ = globals
-                .bind::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(&qh, 1..=1, ())
+                .bind::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(
+                    &qh,
+                    1..=1,
+                    (),
+                )
                 .ok();
         }
         snapshot.prime()?;
@@ -355,17 +360,22 @@ impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for AppData {
                 "zcosmic_toplevel_info_v1" => {
                     app_data.toplevel_info = Some(
                         registry.bind::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(
-                            name, 3, qh, (),
+                            name,
+                            3,
+                            qh,
+                            (),
                         ),
                     );
                 }
                 "zcosmic_toplevel_manager_v1" => {
                     app_data.toplevel_manager = Some(
-                        registry.bind::<
-                            zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1,
-                            _,
-                            _,
-                        >(name, 4, qh, ()),
+                        registry
+                            .bind::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(
+                                name,
+                                4,
+                                qh,
+                                (),
+                            ),
                     );
                 }
                 "wl_seat" => {
@@ -402,7 +412,9 @@ impl Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, ()> for Ap
                         .insert(cosmic.id().protocol_id(), app_data.records.len());
                     record.cosmic = Some(cosmic);
                 }
-                app_data.by_foreign_id.insert(foreign_id, app_data.records.len());
+                app_data
+                    .by_foreign_id
+                    .insert(foreign_id, app_data.records.len());
                 app_data.records.push(record);
             }
             ext_foreign_toplevel_list_v1::Event::Finished => {}
@@ -428,7 +440,11 @@ impl Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()> fo
         _conn: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        let Some(index) = app_data.by_foreign_id.get(&handle.id().protocol_id()).copied() else {
+        let Some(index) = app_data
+            .by_foreign_id
+            .get(&handle.id().protocol_id())
+            .copied()
+        else {
             return;
         };
         let record = &mut app_data.records[index];
@@ -481,7 +497,11 @@ impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppDa
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        let Some(index) = app_data.by_cosmic_id.get(&handle.id().protocol_id()).copied() else {
+        let Some(index) = app_data
+            .by_cosmic_id
+            .get(&handle.id().protocol_id())
+            .copied()
+        else {
             return;
         };
         let record = &mut app_data.records[index];

--- a/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
+++ b/computer-use-linux/src/bin/codex-computer-use-cosmic.rs
@@ -1,0 +1,660 @@
+use anyhow::{anyhow, bail, Context, Result};
+use cosmic_protocols::{
+    toplevel_info::v1::client::{zcosmic_toplevel_handle_v1, zcosmic_toplevel_info_v1},
+    toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use wayland_client::{
+    event_created_child,
+    globals::{registry_queue_init, GlobalListContents},
+    protocol::{wl_registry, wl_seat},
+    Connection, Dispatch, Proxy, QueueHandle, WEnum,
+};
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
+    ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,
+};
+
+const HELP: &str = "codex-computer-use-cosmic\n\nUsage:\n  codex-computer-use-cosmic probe\n  codex-computer-use-cosmic list-windows\n  codex-computer-use-cosmic focused-window\n  codex-computer-use-cosmic activate-window --window-id <id>";
+const BACKEND: &str = "cosmic-wayland";
+const ACTIVATION_STATE_TTL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WindowInfo {
+    window_id: u64,
+    title: Option<String>,
+    app_id: Option<String>,
+    wm_class: Option<String>,
+    pid: Option<u32>,
+    bounds: Option<WindowBounds>,
+    workspace: Option<i32>,
+    focused: bool,
+    hidden: bool,
+    client_type: Option<String>,
+    backend: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WindowBounds {
+    x: Option<i32>,
+    y: Option<i32>,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ProbeOutput {
+    ok: bool,
+    can_list_windows: bool,
+    can_activate_windows: bool,
+    detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ActivationOutput {
+    ok: bool,
+    detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ActivationState {
+    window_id: u64,
+    timestamp_ms: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ToplevelRecord {
+    foreign: Option<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1>,
+    cosmic: Option<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>,
+    identifier: Option<String>,
+    title: Option<String>,
+    app_id: Option<String>,
+    focused: bool,
+    hidden: bool,
+}
+
+impl ToplevelRecord {
+    fn to_window(&self) -> Option<WindowInfo> {
+        let identifier = self.identifier.as_deref()?;
+        Some(WindowInfo {
+            window_id: stable_window_id(identifier),
+            title: self.title.clone().filter(|value| !value.trim().is_empty()),
+            app_id: self.app_id.clone().filter(|value| !value.trim().is_empty()),
+            wm_class: None,
+            pid: None,
+            bounds: None,
+            workspace: None,
+            focused: self.focused,
+            hidden: self.hidden,
+            client_type: Some("wayland".to_string()),
+            backend: BACKEND.to_string(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct AppData {
+    toplevel_info: Option<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1>,
+    toplevel_manager: Option<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1>,
+    seats: Vec<wl_seat::WlSeat>,
+    capabilities: Vec<WEnum<zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1>>,
+    records: Vec<ToplevelRecord>,
+    by_foreign_id: HashMap<u32, usize>,
+    by_cosmic_id: HashMap<u32, usize>,
+}
+
+fn main() -> Result<()> {
+    match Command::parse(std::env::args().skip(1).collect())? {
+        Command::Probe => print_json(&probe()?),
+        Command::ListWindows => print_json(&collect_windows()?),
+        Command::FocusedWindow => print_json(&focused_window()?),
+        Command::ActivateWindow { window_id } => print_json(&activate_window(window_id)?),
+    }
+}
+
+#[derive(Debug)]
+enum Command {
+    Probe,
+    ListWindows,
+    FocusedWindow,
+    ActivateWindow { window_id: u64 },
+}
+
+impl Command {
+    fn parse(args: Vec<String>) -> Result<Self> {
+        match args.as_slice() {
+            [command] if command == "probe" => Ok(Self::Probe),
+            [command] if command == "list-windows" => Ok(Self::ListWindows),
+            [command] if command == "focused-window" => Ok(Self::FocusedWindow),
+            [command, flag, value] if command == "activate-window" && flag == "--window-id" => {
+                Ok(Self::ActivateWindow {
+                    window_id: value
+                        .parse::<u64>()
+                        .with_context(|| format!("invalid window id {value}"))?,
+                })
+            }
+            [command] if command == "--help" || command == "-h" => {
+                println!("{HELP}");
+                std::process::exit(0);
+            }
+            [] => {
+                println!("{HELP}");
+                std::process::exit(0);
+            }
+            _ => bail!("unknown arguments. Expected one of: probe, list-windows, focused-window, activate-window --window-id <id>"),
+        }
+    }
+}
+
+fn probe() -> Result<ProbeOutput> {
+    let snapshot = Snapshot::collect()?;
+    let windows = snapshot.windows();
+    let can_activate = snapshot.can_activate_windows();
+    Ok(ProbeOutput {
+        ok: !windows.is_empty(),
+        can_list_windows: !windows.is_empty(),
+        can_activate_windows: can_activate,
+        detail: if !windows.is_empty() {
+            if can_activate {
+                format!(
+                    "COSMIC foreign toplevel listing is available and activation is supported for {} window(s).",
+                    windows.len()
+                )
+            } else {
+                format!(
+                    "COSMIC foreign toplevel listing is available for {} window(s), but activation support is incomplete.",
+                    windows.len()
+                )
+            }
+        } else {
+            "COSMIC foreign toplevel listing is unavailable in this session.".to_string()
+        },
+    })
+}
+
+fn collect_windows() -> Result<Vec<WindowInfo>> {
+    Ok(Snapshot::collect()?.windows())
+}
+
+fn focused_window() -> Result<Option<WindowInfo>> {
+    let snapshot = Snapshot::collect()?;
+    if let Some(window) = snapshot
+        .windows()
+        .into_iter()
+        .find(|window| window.focused)
+    {
+        clear_activation_state();
+        return Ok(Some(window));
+    }
+
+    let Some(state) = read_activation_state() else {
+        return Ok(None);
+    };
+
+    if state_is_stale(&state) {
+        clear_activation_state();
+        return Ok(None);
+    }
+
+    let mut window = snapshot
+        .windows()
+        .into_iter()
+        .find(|window| window.window_id == state.window_id);
+    if let Some(window) = window.as_mut() {
+        window.focused = true;
+    }
+    Ok(window)
+}
+
+fn activate_window(window_id: u64) -> Result<ActivationOutput> {
+    let mut snapshot = Snapshot::collect()?;
+    snapshot.activate(window_id)?;
+    write_activation_state(window_id)?;
+    Ok(ActivationOutput {
+        ok: true,
+        detail: format!("Requested COSMIC activation for window_id {window_id}."),
+    })
+}
+
+struct Snapshot {
+    event_queue: wayland_client::EventQueue<AppData>,
+    app_data: AppData,
+}
+
+impl Snapshot {
+    fn collect() -> Result<Self> {
+        let conn = Connection::connect_to_env().context("failed to connect to Wayland display")?;
+        let (globals, event_queue) =
+            registry_queue_init(&conn).context("failed to initialize Wayland registry queue")?;
+        let mut snapshot = Self {
+            event_queue,
+            app_data: AppData::default(),
+        };
+        let qh = snapshot.event_queue.handle();
+        snapshot.app_data.toplevel_info = globals
+            .bind::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(&qh, 1..=3, ())
+            .ok();
+        snapshot.app_data.toplevel_manager = globals
+            .bind::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(&qh, 1..=4, ())
+            .ok();
+        globals.contents().with_list(|entries| {
+            for global in entries {
+                if global.interface == "wl_seat" {
+                    snapshot.app_data.seats.push(
+                        globals
+                            .registry()
+                            .bind::<wl_seat::WlSeat, _, _>(global.name, global.version.min(9), &qh, ()),
+                    );
+                }
+            }
+        });
+        if snapshot.app_data.toplevel_info.is_some() {
+            let _ = globals
+                .bind::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(&qh, 1..=1, ())
+                .ok();
+        }
+        snapshot.prime()?;
+        Ok(snapshot)
+    }
+
+    fn prime(&mut self) -> Result<()> {
+        for _ in 0..4 {
+            self.event_queue
+                .roundtrip(&mut self.app_data)
+                .context("Wayland roundtrip failed")?;
+        }
+        Ok(())
+    }
+
+    fn windows(&self) -> Vec<WindowInfo> {
+        self.app_data
+            .records
+            .iter()
+            .filter_map(ToplevelRecord::to_window)
+            .collect()
+    }
+
+    fn can_activate_windows(&self) -> bool {
+        !self.app_data.seats.is_empty()
+            && self.app_data.toplevel_manager.is_some()
+            && self.app_data.records.iter().any(|record| record.cosmic.is_some())
+            && self.app_data.capabilities.iter().any(|capability| {
+                matches!(
+                    capability,
+                    WEnum::Value(
+                        zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1::Activate
+                    )
+                )
+            })
+    }
+
+    fn activate(&mut self, window_id: u64) -> Result<()> {
+        if !self.can_activate_windows() {
+            bail!("COSMIC activation capability is unavailable");
+        }
+        let seat = self
+            .app_data
+            .seats
+            .first()
+            .cloned()
+            .ok_or_else(|| anyhow!("no wl_seat available for activation"))?;
+        let record = self
+            .app_data
+            .records
+            .iter()
+            .find(|record| {
+                record
+                    .identifier
+                    .as_deref()
+                    .is_some_and(|id| stable_window_id(id) == window_id)
+            })
+            .ok_or_else(|| anyhow!("no COSMIC toplevel matched window_id {window_id}"))?;
+        let cosmic = record
+            .cosmic
+            .as_ref()
+            .ok_or_else(|| anyhow!("matched window has no COSMIC activation handle"))?;
+        let manager = self
+            .app_data
+            .toplevel_manager
+            .as_ref()
+            .ok_or_else(|| anyhow!("COSMIC toplevel management protocol not advertised"))?;
+        manager.activate(cosmic, &seat);
+        self.event_queue
+            .roundtrip(&mut self.app_data)
+            .context("Wayland roundtrip after activation failed")?;
+        Ok(())
+    }
+}
+
+impl Dispatch<wl_registry::WlRegistry, GlobalListContents> for AppData {
+    fn event(
+        app_data: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version: _,
+        } = event
+        {
+            match interface.as_str() {
+                "ext_foreign_toplevel_list_v1" => {
+                    registry.bind::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(
+                        name,
+                        1,
+                        qh,
+                        (),
+                    );
+                }
+                "zcosmic_toplevel_info_v1" => {
+                    app_data.toplevel_info = Some(
+                        registry.bind::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(
+                            name, 3, qh, (),
+                        ),
+                    );
+                }
+                "zcosmic_toplevel_manager_v1" => {
+                    app_data.toplevel_manager = Some(
+                        registry.bind::<
+                            zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1,
+                            _,
+                            _,
+                        >(name, 4, qh, ()),
+                    );
+                }
+                "wl_seat" => {
+                    app_data
+                        .seats
+                        .push(registry.bind::<wl_seat::WlSeat, _, _>(name, 9, qh, ()));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        _list: &ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        event: ext_foreign_toplevel_list_v1::Event,
+        _: &(),
+        _conn: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_foreign_toplevel_list_v1::Event::Toplevel { toplevel } => {
+                let foreign_id = toplevel.id().protocol_id();
+                let mut record = ToplevelRecord {
+                    foreign: Some(toplevel.clone()),
+                    ..Default::default()
+                };
+                if let Some(info) = app_data.toplevel_info.as_ref() {
+                    let cosmic = info.get_cosmic_toplevel(&toplevel, qh, ());
+                    app_data
+                        .by_cosmic_id
+                        .insert(cosmic.id().protocol_id(), app_data.records.len());
+                    record.cosmic = Some(cosmic);
+                }
+                app_data.by_foreign_id.insert(foreign_id, app_data.records.len());
+                app_data.records.push(record);
+            }
+            ext_foreign_toplevel_list_v1::Event::Finished => {}
+            _ => unreachable!(),
+        }
+    }
+
+    event_created_child!(
+        AppData,
+        ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        [
+            ext_foreign_toplevel_list_v1::EVT_TOPLEVEL_OPCODE => (ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()),
+        ]
+    );
+}
+
+impl Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        handle: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        event: ext_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        let Some(index) = app_data.by_foreign_id.get(&handle.id().protocol_id()).copied() else {
+            return;
+        };
+        let record = &mut app_data.records[index];
+        match event {
+            ext_foreign_toplevel_handle_v1::Event::Identifier { identifier } => {
+                record.identifier = Some(identifier);
+            }
+            ext_foreign_toplevel_handle_v1::Event::Title { title } => {
+                record.title = Some(title);
+            }
+            ext_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
+                record.app_id = Some(app_id);
+            }
+            ext_foreign_toplevel_handle_v1::Event::Done => {}
+            ext_foreign_toplevel_handle_v1::Event::Closed => {
+                app_data.records[index].foreign = None;
+                app_data.records[index].cosmic = None;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, ()> for AppData {
+    fn event(
+        _app_data: &mut Self,
+        _info: &zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1,
+        _event: zcosmic_toplevel_info_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+
+    event_created_child!(
+        AppData,
+        zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1,
+        [
+            zcosmic_toplevel_info_v1::EVT_TOPLEVEL_OPCODE => (zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()),
+        ]
+    );
+}
+
+impl Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        handle: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        event: zcosmic_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some(index) = app_data.by_cosmic_id.get(&handle.id().protocol_id()).copied() else {
+            return;
+        };
+        let record = &mut app_data.records[index];
+        match event {
+            zcosmic_toplevel_handle_v1::Event::State { state } => {
+                record.focused = false;
+                record.hidden = false;
+                for value in state.chunks_exact(4) {
+                    if let Ok(parsed) = zcosmic_toplevel_handle_v1::State::try_from(
+                        u32::from_ne_bytes(value.try_into().unwrap()),
+                    ) {
+                        if parsed == zcosmic_toplevel_handle_v1::State::Activated {
+                            record.focused = true;
+                        }
+                        if parsed == zcosmic_toplevel_handle_v1::State::Minimized {
+                            record.hidden = true;
+                        }
+                    }
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::Geometry { .. }
+            | zcosmic_toplevel_handle_v1::Event::OutputEnter { .. }
+            | zcosmic_toplevel_handle_v1::Event::OutputLeave { .. }
+            | zcosmic_toplevel_handle_v1::Event::WorkspaceEnter { .. }
+            | zcosmic_toplevel_handle_v1::Event::WorkspaceLeave { .. }
+            | zcosmic_toplevel_handle_v1::Event::ExtWorkspaceEnter { .. }
+            | zcosmic_toplevel_handle_v1::Event::ExtWorkspaceLeave { .. }
+            | zcosmic_toplevel_handle_v1::Event::Title { .. }
+            | zcosmic_toplevel_handle_v1::Event::AppId { .. }
+            | zcosmic_toplevel_handle_v1::Event::Done
+            | zcosmic_toplevel_handle_v1::Event::Closed => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, ()> for AppData {
+    fn event(
+        app_data: &mut Self,
+        _manager: &zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1,
+        event: zcosmic_toplevel_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            zcosmic_toplevel_manager_v1::Event::Capabilities { capabilities } => {
+                app_data.capabilities = capabilities
+                    .chunks(4)
+                    .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
+                    .collect();
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<wl_seat::WlSeat, ()> for AppData {
+    fn event(
+        _app_data: &mut Self,
+        _seat: &wl_seat::WlSeat,
+        _event: wl_seat::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+fn stable_window_id(identifier: &str) -> u64 {
+    fnv1a_64(identifier.as_bytes())
+}
+
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).context("failed to serialize JSON output")?
+    );
+    Ok(())
+}
+
+fn activation_state_path() -> PathBuf {
+    if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+        PathBuf::from(runtime_dir).join("codex-computer-use-cosmic-last-activation.json")
+    } else {
+        std::env::temp_dir().join("codex-computer-use-cosmic-last-activation.json")
+    }
+}
+
+fn write_activation_state(window_id: u64) -> Result<()> {
+    let state = ActivationState {
+        window_id,
+        timestamp_ms: now_timestamp_ms()?,
+    };
+    let path = activation_state_path();
+    let json = serde_json::to_vec(&state).context("failed to serialize activation state")?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("failed to write activation state to {}", path.display()))
+}
+
+fn read_activation_state() -> Option<ActivationState> {
+    let path = activation_state_path();
+    let contents = std::fs::read(&path).ok()?;
+    serde_json::from_slice(&contents).ok()
+}
+
+fn clear_activation_state() {
+    let _ = std::fs::remove_file(activation_state_path());
+}
+
+fn state_is_stale(state: &ActivationState) -> bool {
+    let Ok(now_ms) = now_timestamp_ms() else {
+        return false;
+    };
+    now_ms.saturating_sub(state.timestamp_ms) > ACTIVATION_STATE_TTL.as_millis() as u64
+}
+
+fn now_timestamp_ms() -> Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before UNIX_EPOCH")?
+        .as_millis() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_activate_window_args_requires_numeric_id() {
+        let error = Command::parse(vec![
+            "activate-window".to_string(),
+            "--window-id".to_string(),
+            "nope".to_string(),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("invalid window id"));
+    }
+
+    #[test]
+    fn stable_window_id_is_stable() {
+        assert_eq!(stable_window_id("window-1"), stable_window_id("window-1"));
+    }
+
+    #[test]
+    fn activation_state_expires_after_ttl() {
+        let state = ActivationState {
+            window_id: 7,
+            timestamp_ms: now_timestamp_ms().unwrap()
+                - (ACTIVATION_STATE_TTL.as_millis() as u64 + 1),
+        };
+
+        assert!(state_is_stale(&state));
+    }
+
+    #[test]
+    fn activation_state_is_fresh_within_ttl() {
+        let state = ActivationState {
+            window_id: 7,
+            timestamp_ms: now_timestamp_ms().unwrap(),
+        };
+
+        assert!(!state_is_stale(&state));
+    }
+}

--- a/computer-use-linux/src/cosmic_helper.rs
+++ b/computer-use-linux/src/cosmic_helper.rs
@@ -6,7 +6,6 @@ use std::{
     process::Command,
 };
 
-pub const COSMIC_BACKEND: &str = "cosmic-wayland";
 pub const COSMIC_HELPER_BINARY: &str = "codex-computer-use-cosmic";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/computer-use-linux/src/cosmic_helper.rs
+++ b/computer-use-linux/src/cosmic_helper.rs
@@ -139,4 +139,3 @@ fn is_executable(path: &Path) -> bool {
         })
         .unwrap_or(false)
 }
-

--- a/computer-use-linux/src/cosmic_helper.rs
+++ b/computer-use-linux/src/cosmic_helper.rs
@@ -1,0 +1,142 @@
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::{
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub const COSMIC_BACKEND: &str = "cosmic-wayland";
+pub const COSMIC_HELPER_BINARY: &str = "codex-computer-use-cosmic";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CosmicHelperProbe {
+    pub ok: bool,
+    pub can_list_windows: bool,
+    pub can_activate_windows: bool,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CosmicHelperActivation {
+    pub ok: bool,
+    pub detail: String,
+}
+
+pub fn resolve_helper_binary() -> Result<PathBuf> {
+    if let Some(path) = env::var("CODEX_COMPUTER_USE_COSMIC_HELPER")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Ok(path);
+        }
+    }
+
+    if let Ok(current_exe) = env::current_exe() {
+        let sibling = current_exe.with_file_name(COSMIC_HELPER_BINARY);
+        if sibling.exists() {
+            return Ok(sibling);
+        }
+    }
+
+    if let Some(path) = command_path(COSMIC_HELPER_BINARY) {
+        return Ok(path);
+    }
+
+    bail!("COSMIC helper binary {COSMIC_HELPER_BINARY} not found")
+}
+
+pub fn probe() -> Result<CosmicHelperProbe> {
+    run_json_command(["probe"])
+}
+
+pub fn list_windows_json() -> Result<String> {
+    run_text_command(["list-windows"])
+}
+
+pub fn focused_window_json() -> Result<String> {
+    run_text_command(["focused-window"])
+}
+
+pub fn activate_window(window_id: u64) -> Result<CosmicHelperActivation> {
+    run_json_command(["activate-window", "--window-id", &window_id.to_string()])
+}
+
+fn run_json_command<T, I, S>(args: I) -> Result<T>
+where
+    T: for<'de> Deserialize<'de>,
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let output = run_command(args)?;
+    serde_json::from_str(&output)
+        .with_context(|| format!("failed to parse {COSMIC_HELPER_BINARY} JSON output"))
+}
+
+fn run_text_command<I, S>(args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    run_command(args)
+}
+
+fn run_command<I, S>(args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let helper = resolve_helper_binary()?;
+    let args = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .collect::<Vec<_>>();
+    let output = Command::new(&helper)
+        .args(&args)
+        .output()
+        .with_context(|| format!("failed to run {}", helper.display()))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if !stderr.is_empty() { stderr } else { stdout };
+        bail!(
+            "{} {} failed{}",
+            helper.display(),
+            args.join(" "),
+            if detail.is_empty() {
+                String::new()
+            } else {
+                format!(": {detail}")
+            }
+        );
+    }
+    String::from_utf8(output.stdout)
+        .map(|text| text.trim().to_string())
+        .context("helper output was not valid UTF-8")
+}
+
+fn command_path(binary: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    env::split_paths(&path)
+        .map(|entry| entry.join(binary))
+        .find(|candidate| candidate.is_file() && is_executable(candidate))
+}
+
+fn is_executable(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|metadata| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                metadata.permissions().mode() & 0o111 != 0
+            }
+            #[cfg(not(unix))]
+            {
+                metadata.is_file()
+            }
+        })
+        .unwrap_or(false)
+}
+

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -1,3 +1,4 @@
+use crate::cosmic_helper;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::{
@@ -64,6 +65,7 @@ pub struct AccessibilityReport {
 pub struct WindowingReport {
     pub gnome_shell_introspect: Check,
     pub codex_gnome_shell_extension: Check,
+    pub cosmic_helper: Check,
     pub kwin: Check,
     pub hyprland: Check,
     pub can_list_windows: bool,
@@ -130,9 +132,9 @@ pub fn doctor_report() -> DoctorReport {
     let platform = platform_report();
     let portals = portal_report();
     let accessibility = accessibility_report();
-    let windowing = windowing_report();
+    let windowing = windowing_report(&platform);
     let input = input_report();
-    let readiness = readiness_report(&accessibility, &windowing, &input);
+    let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
 
     DoctorReport {
         platform,
@@ -344,7 +346,7 @@ fn accessibility_report() -> AccessibilityReport {
     }
 }
 
-fn windowing_report() -> WindowingReport {
+fn windowing_report(platform: &PlatformReport) -> WindowingReport {
     let gnome_shell_introspect = gdbus_call_check(
         "org.gnome.Shell",
         "/org/gnome/Shell/Introspect",
@@ -357,10 +359,14 @@ fn windowing_report() -> WindowingReport {
         "com.openai.Codex.WindowControl.ListWindows",
         &[],
     );
+    let cosmic_helper = cosmic_windowing_check();
     let kwin = kwin_windowing_check();
     let hyprland = hyprland_windowing_check();
-    let can_list_windows =
-        gnome_shell_introspect.ok || codex_gnome_shell_extension.ok || kwin.ok || hyprland.ok;
+    let can_list_windows = gnome_shell_introspect.ok
+        || codex_gnome_shell_extension.ok
+        || cosmic_helper.ok
+        || kwin.ok
+        || hyprland.ok;
     let gnome_focus_apps = gdbus_introspect_contains(
         "org.gnome.Shell",
         "/org/gnome/Shell",
@@ -368,10 +374,12 @@ fn windowing_report() -> WindowingReport {
         "FocusApp",
     )
     .ok;
-    let can_focus_apps = gnome_focus_apps || kwin.ok || hyprland.ok;
-    let can_focus_windows = codex_gnome_shell_extension.ok || kwin.ok || hyprland.ok;
+    let can_focus_apps = gnome_focus_apps || cosmic_helper.ok || kwin.ok || hyprland.ok;
+    let can_focus_windows = codex_gnome_shell_extension.ok || cosmic_helper.ok || kwin.ok || hyprland.ok;
     let note = if can_list_windows {
-        if kwin.ok {
+        if cosmic_helper.ok && is_cosmic_wayland_platform(platform) {
+            "A COSMIC Wayland window backend is available for list_windows, focused_window, and targeted input verification."
+        } else if kwin.ok {
             "A KWin/Plasma window backend is available for list_windows, focused_window, and targeted input verification."
         } else if hyprland.ok {
             "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
@@ -379,19 +387,28 @@ fn windowing_report() -> WindowingReport {
             "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
         }
     } else {
-        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session."
+        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On COSMIC, ensure the bundled COSMIC helper is present and can connect to the session. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session."
     }
     .to_string();
 
     WindowingReport {
         gnome_shell_introspect,
         codex_gnome_shell_extension,
+        cosmic_helper,
         kwin,
         hyprland,
         can_list_windows,
         can_focus_apps,
         can_focus_windows,
         note,
+    }
+}
+
+fn cosmic_windowing_check() -> Check {
+    match cosmic_helper::probe() {
+        Ok(probe) if probe.ok => Check::ok(probe.detail),
+        Ok(probe) => Check::fail(probe.detail),
+        Err(error) => Check::fail(error.to_string()),
     }
 }
 
@@ -449,6 +466,7 @@ fn input_report() -> InputReport {
 }
 
 fn readiness_report(
+    platform: &PlatformReport,
     accessibility: &AccessibilityReport,
     windowing: &WindowingReport,
     input: &InputReport,
@@ -469,10 +487,12 @@ fn readiness_report(
     }
 
     if !can_query_windows {
-        blockers.push(
+        blockers.push(if is_cosmic_wayland_platform(platform) {
+            "COSMIC Wayland window introspection is unavailable; targeted window focus and verification will be disabled.".to_string()
+        } else {
             "Window introspection is unavailable; targeted window focus and verification will be disabled."
-                .to_string(),
-        );
+                .to_string()
+        });
     }
 
     if can_query_windows && !can_focus_windows {
@@ -493,7 +513,7 @@ fn readiness_report(
         "Run setup_accessibility to enable GNOME accessibility before element-aware actions."
             .to_string()
     } else if !can_query_windows {
-        "Enable a supported window backend before using targeted keyboard input: GNOME Shell Introspect, the Codex GNOME Shell extension, KWin/Plasma DBus scripting, or Hyprland hyprctl.".to_string()
+        "Enable a supported window backend before using targeted keyboard input: GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, or Hyprland hyprctl.".to_string()
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
@@ -513,6 +533,14 @@ fn readiness_report(
         recommended_next_step,
         blockers,
     }
+}
+
+fn is_cosmic_wayland_platform(platform: &PlatformReport) -> bool {
+    platform
+        .xdg_current_desktop
+        .as_deref()
+        .is_some_and(|desktop| desktop.to_ascii_lowercase().contains("cosmic"))
+        && platform.xdg_session_type.as_deref() == Some("wayland")
 }
 
 fn can_build_accessibility_tree(accessibility: &AccessibilityReport) -> bool {
@@ -702,6 +730,21 @@ fn run_command(command: &str, args: &[&str], with_session_bus: bool) -> Check {
 mod tests {
     use super::*;
 
+    fn platform_report() -> PlatformReport {
+        PlatformReport {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            desktop_session: None,
+            xdg_session_type: Some("wayland".to_string()),
+            xdg_current_desktop: Some("GNOME".to_string()),
+            wayland_display: Some("wayland-0".to_string()),
+            display: Some(":0".to_string()),
+            dbus_session_bus_address: Some("unix:path=/run/user/1000/bus".to_string()),
+            xdg_runtime_dir: Some("/run/user/1000".to_string()),
+            gnome_shell_version: Check::ok("GNOME Shell 46.0"),
+        }
+    }
+
     fn accessibility_report(
         at_spi_bus: Check,
         toolkit_accessibility: Check,
@@ -726,6 +769,7 @@ mod tests {
             } else {
                 Check::fail("missing")
             },
+            cosmic_helper: Check::fail("missing"),
             kwin: Check::fail("not a KWin session"),
             hyprland: Check::fail("not a Hyprland session"),
             can_list_windows,
@@ -790,11 +834,12 @@ mod tests {
 
     #[test]
     fn readiness_requires_exact_window_focus_for_targeted_input() {
+        let platform = platform_report();
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
         let windowing = windowing_report(true, false);
         let input = input_report(true);
 
-        let readiness = readiness_report(&accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
 
         assert!(readiness.can_query_windows);
         assert!(!readiness.can_focus_windows);
@@ -809,6 +854,7 @@ mod tests {
 
     #[test]
     fn readiness_treats_kwin_as_full_window_backend() {
+        let platform = platform_report();
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
         let mut windowing = windowing_report(false, false);
         windowing.kwin = Check::ok("KWin scripting is available");
@@ -817,7 +863,7 @@ mod tests {
         windowing.can_focus_windows = true;
         let input = input_report(true);
 
-        let readiness = readiness_report(&accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
 
         assert!(readiness.can_query_windows);
         assert!(readiness.can_focus_apps);
@@ -827,11 +873,12 @@ mod tests {
 
     #[test]
     fn readiness_message_mentions_generic_window_targeting() {
+        let platform = platform_report();
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
         let windowing = windowing_report(true, true);
         let input = input_report(true);
 
-        let readiness = readiness_report(&accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
 
         assert!(readiness.blockers.is_empty());
         assert!(readiness
@@ -841,5 +888,21 @@ mod tests {
         assert!(!readiness
             .recommended_next_step
             .contains("GNOME window targeting"));
+    }
+
+    #[test]
+    fn readiness_reports_cosmic_window_blocker_on_cosmic() {
+        let mut platform = platform_report();
+        platform.xdg_current_desktop = Some("COSMIC".to_string());
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(false, false);
+        let input = input_report(true);
+
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+
+        assert!(readiness
+            .blockers
+            .iter()
+            .any(|blocker| blocker.contains("COSMIC Wayland window introspection")));
     }
 }

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -375,7 +375,8 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
     )
     .ok;
     let can_focus_apps = gnome_focus_apps || cosmic_helper.ok || kwin.ok || hyprland.ok;
-    let can_focus_windows = codex_gnome_shell_extension.ok || cosmic_helper.ok || kwin.ok || hyprland.ok;
+    let can_focus_windows =
+        codex_gnome_shell_extension.ok || cosmic_helper.ok || kwin.ok || hyprland.ok;
     let note = if can_list_windows {
         if cosmic_helper.ok && is_cosmic_wayland_platform(platform) {
             "A COSMIC Wayland window backend is available for list_windows, focused_window, and targeted input verification."

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -1,4 +1,5 @@
 mod atspi_tree;
+mod cosmic_helper;
 mod diagnostics;
 mod gnome_extension;
 mod remote_desktop;

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -12,9 +12,8 @@ use crate::remote_desktop::{
 use crate::screenshot::{capture_screenshot, ScreenshotCapture};
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
-    window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
-    COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, KWIN_BACKEND,
+    window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget, COSMIC_WAYLAND_BACKEND,
+    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND, HYPRLAND_BACKEND, KWIN_BACKEND,
 };
 use anyhow::Result;
 use rmcp::{

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -13,7 +13,8 @@ use crate::screenshot::{capture_screenshot, ScreenshotCapture};
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
     window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
-    GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND, HYPRLAND_BACKEND, KWIN_BACKEND,
+    COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
+    HYPRLAND_BACKEND, KWIN_BACKEND,
 };
 use anyhow::Result;
 use rmcp::{
@@ -1783,6 +1784,8 @@ async fn window_list_output() -> ListWindowsOutput {
             let backend = window_backend(windows.iter());
             let note = if backend == GNOME_SHELL_EXTENSION_BACKEND {
                 "Window list came from the Codex GNOME Shell extension. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
+            } else if backend == COSMIC_WAYLAND_BACKEND {
+                "Window list came from the COSMIC Wayland helper. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
             } else if backend == KWIN_BACKEND {
                 "Window list came from KWin/Plasma DBus scripting. Terminal windows may include best-effort PTY and active-process context when the process tree is readable."
             } else if backend == HYPRLAND_BACKEND {

--- a/computer-use-linux/src/windows.rs
+++ b/computer-use-linux/src/windows.rs
@@ -1,3 +1,4 @@
+use crate::cosmic_helper;
 use crate::diagnostics::hydrate_session_bus_env;
 use crate::terminal::{enrich_terminal_windows, TerminalWindowContext};
 use anyhow::{bail, Context, Result};
@@ -16,11 +17,12 @@ use zbus::{zvariant::OwnedValue, Proxy};
 
 pub const GNOME_SHELL_INTROSPECT_BACKEND: &str = "gnome-shell-introspect";
 pub const GNOME_SHELL_EXTENSION_BACKEND: &str = "gnome-shell-extension";
+pub const COSMIC_WAYLAND_BACKEND: &str = "cosmic-wayland";
 pub const KWIN_BACKEND: &str = "kwin";
 pub const HYPRLAND_BACKEND: &str = "hyprland";
 pub const GNOME_SHELL_EXTENSION_SERVICE: &str = "com.openai.Codex.WindowControl";
 pub const GNOME_SHELL_EXTENSION_OBJECT_PATH: &str = "/com/openai/Codex/WindowControl";
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, KWin/Plasma DBus scripting, or Hyprland hyprctl. On GNOME, run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, or Hyprland hyprctl. On GNOME, run setup_window_targeting to install the extension backend.";
 const FOCUS_VERIFY_ATTEMPTS: usize = 6;
 const FOCUS_VERIFY_DELAY: Duration = Duration::from_millis(50);
 const KWIN_SCRIPT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -138,13 +140,16 @@ pub async fn list_windows() -> Result<Vec<WindowInfo>> {
         Ok(windows) => Ok(windows),
         Err(extension_error) => match list_gnome_shell_introspect_windows().await {
             Ok(windows) => Ok(windows),
-            Err(introspect_error) => match list_kwin_windows().await {
+            Err(introspect_error) => match list_cosmic_helper_windows() {
                 Ok(windows) => Ok(windows),
-                Err(kwin_error) => match list_hyprland_windows() {
+                Err(cosmic_error) => match list_kwin_windows().await {
                     Ok(windows) => Ok(windows),
-                    Err(hyprland_error) => Err(anyhow::anyhow!(
-                        "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}; KWin failed: {kwin_error:#}; Hyprland failed: {hyprland_error:#}"
-                    )),
+                    Err(kwin_error) => match list_hyprland_windows() {
+                        Ok(windows) => Ok(windows),
+                        Err(hyprland_error) => Err(anyhow::anyhow!(
+                            "Codex GNOME Shell extension failed: {extension_error:#}; GNOME Shell Introspect failed: {introspect_error:#}; COSMIC helper failed: {cosmic_error:#}; KWin failed: {kwin_error:#}; Hyprland failed: {hyprland_error:#}"
+                        )),
+                    },
                 },
             },
         },
@@ -189,6 +194,28 @@ pub async fn list_extension_windows() -> Result<Vec<WindowInfo>> {
     windows.sort_by_key(|window| window.window_id);
     enrich_terminal_windows(&mut windows);
     Ok(windows)
+}
+
+fn list_cosmic_helper_windows() -> Result<Vec<WindowInfo>> {
+    let json = cosmic_helper::list_windows_json()?;
+    let mut windows: Vec<WindowInfo> =
+        serde_json::from_str(&json).context("COSMIC helper returned invalid list-windows JSON")?;
+    for window in &mut windows {
+        window.backend = COSMIC_WAYLAND_BACKEND.to_string();
+    }
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+fn focused_cosmic_helper_window() -> Result<Option<WindowInfo>> {
+    let json = cosmic_helper::focused_window_json()?;
+    let mut window: Option<WindowInfo> = serde_json::from_str(&json)
+        .context("COSMIC helper returned invalid focused-window JSON")?;
+    if let Some(window) = window.as_mut() {
+        window.backend = COSMIC_WAYLAND_BACKEND.to_string();
+    }
+    Ok(window)
 }
 
 fn list_hyprland_windows() -> Result<Vec<WindowInfo>> {
@@ -244,6 +271,11 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
         activate_hyprland_window(requested_window.window_id)?;
     } else if requested_window.backend == KWIN_BACKEND {
         activate_kwin_window(requested_window.window_id).await?;
+    } else if requested_window.backend == COSMIC_WAYLAND_BACKEND {
+        let activation = cosmic_helper::activate_window(requested_window.window_id)?;
+        if !activation.ok {
+            bail!("COSMIC helper refused activation: {}", activation.detail);
+        }
     } else if requested_window.backend == GNOME_SHELL_EXTENSION_BACKEND {
         activate_extension_window(requested_window.window_id).await?;
     } else {
@@ -280,11 +312,12 @@ pub async fn focus_window_target(target: &WindowTarget) -> Result<WindowFocusRes
 fn ensure_backend_can_focus_target(target: &WindowTarget, window: &WindowInfo) -> Result<()> {
     if target.requires_exact_focus()
         && window.backend != GNOME_SHELL_EXTENSION_BACKEND
+        && window.backend != COSMIC_WAYLAND_BACKEND
         && window.backend != KWIN_BACKEND
         && window.backend != HYPRLAND_BACKEND
     {
         bail!(
-            "Exact window targeting requires the Codex GNOME Shell extension, KWin, or Hyprland backend; {} can list the matched window but cannot activate a specific window safely.",
+            "Exact window targeting requires the Codex GNOME Shell extension, COSMIC helper, KWin, or Hyprland backend; {} can list the matched window but cannot activate a specific window safely.",
             window.backend
         );
     }
@@ -292,6 +325,12 @@ fn ensure_backend_can_focus_target(target: &WindowTarget, window: &WindowInfo) -
 }
 
 async fn current_focused_window() -> Result<Option<WindowInfo>> {
+    if let Ok(window) = focused_cosmic_helper_window() {
+        if window.is_some() {
+            return Ok(window);
+        }
+    }
+
     Ok(list_windows()
         .await?
         .into_iter()
@@ -1565,6 +1604,21 @@ mod tests {
         ensure_backend_can_focus_target(
             &WindowTarget {
                 app_id: Some("com.mitchellh.ghostty.desktop".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn cosmic_backend_can_exact_focus_targets() {
+        let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
+        window.backend = COSMIC_WAYLAND_BACKEND.to_string();
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                title: Some("Codex".to_string()),
                 ..Default::default()
             },
             &window,

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -291,7 +291,7 @@ prepend_managed_node_runtime_to_path() {
     export CODEX_MANAGED_NODE_RUNTIME_DIR="$SCRIPT_DIR/resources/node-runtime"
 }
 
-browser_use_plugin_version() {
+bundled_plugin_version() {
     local plugin_json="$1"
 
     python3 - "$plugin_json" <<'PY'
@@ -338,7 +338,7 @@ sync_browser_use_bundled_plugin_cache() {
             echo "Browser Use bundled marketplace sync failed; continuing with existing marketplace cache."
     fi
 
-    version="$(browser_use_plugin_version "$plugin_json" 2>/dev/null || true)"
+    version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
 
     cache_root="$codex_home/plugins/cache/openai-bundled/browser-use"
@@ -362,6 +362,67 @@ sync_browser_use_bundled_plugin_cache() {
     else
         rm -rf "$tmp_plugin"
         echo "Browser Use plugin cache sync failed; continuing with existing cache."
+    fi
+}
+
+sync_computer_use_bundled_plugin_cache() {
+    local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/computer-use"
+    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+    local plugin_json="$source_plugin/.codex-plugin/plugin.json"
+    local source_backend="$source_plugin/bin/codex-computer-use-linux"
+    local source_cosmic_helper="$source_plugin/bin/codex-computer-use-cosmic"
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local version
+    local cache_root
+    local cache_plugin
+    local cache_backend
+    local cache_cosmic_helper
+    local cache_parent
+    local tmp_plugin
+    local marketplace_root
+    local marketplace_plugins_dir
+
+    [ -f "$plugin_json" ] || return 0
+    [ -f "$source_backend" ] || return 0
+    [ -f "$source_cosmic_helper" ] || return 0
+
+    marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
+    marketplace_plugins_dir="$marketplace_root/.agents/plugins"
+    if [ -f "$source_marketplace" ]; then
+        mkdir -p "$marketplace_plugins_dir"
+        rm -f "$marketplace_plugins_dir/marketplace.json"
+        cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
+            chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
+            echo "Computer Use bundled marketplace sync failed; continuing with existing marketplace cache."
+    fi
+
+    version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
+    [ -n "$version" ] || return 0
+
+    cache_root="$codex_home/plugins/cache/openai-bundled/computer-use"
+    cache_plugin="$cache_root/$version"
+    cache_backend="$cache_plugin/bin/codex-computer-use-linux"
+    cache_cosmic_helper="$cache_plugin/bin/codex-computer-use-cosmic"
+
+    if [ -f "$cache_backend" ] && [ -f "$cache_cosmic_helper" ] && \
+        cmp -s "$source_backend" "$cache_backend" && \
+        cmp -s "$source_cosmic_helper" "$cache_cosmic_helper"; then
+        return 0
+    fi
+
+    cache_parent="$(dirname "$cache_plugin")"
+    tmp_plugin="$cache_parent/.computer-use-$version.tmp.$$"
+    rm -rf "$tmp_plugin"
+    mkdir -p "$cache_parent"
+
+    if cp -R "$source_plugin" "$tmp_plugin"; then
+        find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
+        rm -rf "$cache_plugin"
+        mv "$tmp_plugin" "$cache_plugin"
+        echo "Computer Use plugin cache synced from bundled resources: $cache_plugin"
+    else
+        rm -rf "$tmp_plugin"
+        echo "Computer Use plugin cache sync failed; continuing with existing cache."
     fi
 }
 
@@ -1243,6 +1304,7 @@ fi
 export_packaged_runtime_env
 if needs_cold_start; then
     sync_browser_use_bundled_plugin_cache
+    sync_computer_use_bundled_plugin_cache
 fi
 resolve_browser_use_runtime_env
 

--- a/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
+++ b/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "computer-use",
-  "version": "0.1.1-linux-alpha1",
+  "version": "0.1.2-linux-alpha1",
   "description": "Control desktop apps on Linux from Codex through Computer Use.",
   "author": {
     "name": "avifenesh"
@@ -13,6 +13,7 @@
     "linux",
     "wayland",
     "gnome",
+    "cosmic",
     "accessibility"
   ],
   "mcpServers": "./.mcp.json",

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -22,6 +22,7 @@ find_cargo_for_linux_computer_use() {
 build_linux_computer_use_backend() {
     local crate_dir="$SCRIPT_DIR/computer-use-linux"
     local backend_binary="$SCRIPT_DIR/target/release/codex-computer-use-linux"
+    local cosmic_helper_binary="$SCRIPT_DIR/target/release/codex-computer-use-cosmic"
     local cargo_cmd=""
 
     if [ ! -d "$crate_dir" ]; then
@@ -45,13 +46,20 @@ build_linux_computer_use_backend() {
         return 1
     }
 
-    echo "$backend_binary"
+    [ -x "$cosmic_helper_binary" ] || {
+        warn "Linux Computer Use COSMIC helper binary missing after build: $cosmic_helper_binary"
+        return 1
+    }
+
+    printf '%s\n%s\n' "$backend_binary" "$cosmic_helper_binary"
 }
 
 stage_linux_computer_use_plugin() {
     local target_plugins="$1"
     local plugin_template="$SCRIPT_DIR/plugins/openai-bundled/plugins/computer-use"
+    local build_outputs=""
     local backend_binary=""
+    local cosmic_helper_binary=""
     local target_plugin="$target_plugins/computer-use"
 
     if [ ! -d "$plugin_template" ]; then
@@ -59,16 +67,20 @@ stage_linux_computer_use_plugin() {
         return 1
     fi
 
-    if ! backend_binary="$(build_linux_computer_use_backend)"; then
+    if ! build_outputs="$(build_linux_computer_use_backend)"; then
         return 1
     fi
+    backend_binary="$(printf '%s\n' "$build_outputs" | sed -n '1p')"
+    cosmic_helper_binary="$(printf '%s\n' "$build_outputs" | sed -n '2p')"
 
     rm -rf "$target_plugin"
     mkdir -p "$target_plugin"
     cp -R "$plugin_template/." "$target_plugin/"
     mkdir -p "$target_plugin/bin"
     cp "$backend_binary" "$target_plugin/bin/codex-computer-use-linux"
+    cp "$cosmic_helper_binary" "$target_plugin/bin/codex-computer-use-cosmic"
     chmod 0755 "$target_plugin/bin/codex-computer-use-linux"
+    chmod 0755 "$target_plugin/bin/codex-computer-use-cosmic"
 
     if [ -f "$ICON_SOURCE" ]; then
         mkdir -p "$target_plugin/assets"


### PR DESCRIPTION
This pull request adds support for the COSMIC Wayland desktop environment as a window backend in the `codex-computer-use-linux` project. It introduces a new `cosmic_helper` module to detect and interact with the COSMIC session, updates diagnostics and readiness reporting to include COSMIC-specific checks and messages, and enhances window listing and focus capabilities for COSMIC Wayland users.

**COSMIC Wayland backend integration:**

* Added the `cosmic_helper` module, which detects and interacts with the COSMIC Wayland session using a bundled helper binary, and provides functions for probing, listing windows, and activating windows. (`computer-use-linux/src/cosmic_helper.rs`)
* Updated the window backend detection and reporting logic to include COSMIC Wayland, with new messages and checks in diagnostics and readiness reporting. (`computer-use-linux/src/diagnostics.rs`, `computer-use-linux/src/server.rs`) 

**Dependency and version updates:**

* Added new dependencies for COSMIC Wayland support: `cosmic-protocols`, `wayland-client`, and `wayland-protocols`. Updated the crate version to `0.1.2-linux-alpha1`. (`computer-use-linux/Cargo.toml`) [

These changes enable targeted window operations and diagnostics for COSMIC Wayland users, improving compatibility and user experience on this desktop environment.