### PR TITLE
Add i3 window backend for Computer Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Anything systemd-based should work for the optional auto-updater service (`syste
 | Linux tray + warm-start handoff | ✅ always | Single-instance lock, second-instance window focus |
 | GUI install prompts (`kdialog` / `zenity`) | ✅ if installed | Falls back to interactive terminal prompt |
 | Linux browser annotations | ✅ always | Stored-anchor screenshots, isolated marker rendering |
-| Linux Computer Use | ⚠️ opt-in | Linux Computer Use backend with screen capture, accessibility, window targeting, and input synthesis. The MCP server registers by default; the in-app UI surface is enabled at your discretion — see "Enabling Computer Use UI" below. Validated on Ubuntu/GNOME and KDE Plasma/KWin. |
+| Linux Computer Use | ⚠️ opt-in | Linux Computer Use backend with screen capture, accessibility, window targeting, and input synthesis. The MCP server registers by default; the in-app UI surface is enabled at your discretion — see "Enabling Computer Use UI" below. Validated on Ubuntu/GNOME, KDE Plasma/KWin, Hyprland, and i3. |
 | Server-gated features (e.g. `gpt-5.5`) | 🟡 server-side | OpenAI rolls per-account, not project-controlled. Building a fresh package does not unlock these. |
 
 ## Before you install
@@ -84,7 +84,7 @@ Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control d
 
 - **App listing & accessibility tree** — via AT-SPI bus (`org.a11y.Bus`)
 - **Screenshot capture** — primary path through GNOME Shell DBus, fallback through XDG Desktop Portal (`org.freedesktop.portal.Screenshot`)
-- **Window listing & focusing** — via the Codex GNOME Shell extension, GNOME Shell introspection, KWin/Plasma DBus scripting, or Hyprland `hyprctl`
+- **Window listing & focusing** — via the Codex GNOME Shell extension, GNOME Shell introspection, KWin/Plasma DBus scripting, Hyprland `hyprctl`, or i3 `i3-msg`
 - **Input synthesis** — keys, text, click, scroll, drag — through `ydotool` with `ydotoold` daemon
 
 ### Runtime dependencies
@@ -114,7 +114,7 @@ sudo usermod -a -G input "$USER"
 
 On Ubuntu 24.04, the `ydotoold` package may install `/usr/bin/ydotoold` without a systemd unit. In that case, create or install a `ydotoold.service` unit before running `systemctl enable --now ydotoold`.
 
-A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway / Hyprland. GNOME ships a working portal by default.
+A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway / Hyprland, or your distro's preferred portal backend for i3. GNOME ships a working portal by default.
 
 ### Verifying readiness
 
@@ -122,7 +122,7 @@ The plugin exposes a `doctor` tool. Once Computer Use is visible in the Codex UI
 
 > Check whether Linux Computer Use is ready
 
-The response is a structured report covering AT-SPI bus availability, GNOME Shell version, KWin/Plasma windowing support, Desktop Portal interfaces, `ydotool` / `ydotoold` / `/dev/uinput`, and a top-level readiness verdict. You can also invoke the backend binary directly:
+The response is a structured report covering AT-SPI bus availability, GNOME Shell version, KWin/Plasma, Hyprland, and i3 windowing support, Desktop Portal interfaces, `ydotool` / `ydotoold` / `/dev/uinput`, and a top-level readiness verdict. You can also invoke the backend binary directly:
 
 ```bash
 ./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux doctor

--- a/computer-use-linux/src/windowing/backends/i3.rs
+++ b/computer-use-linux/src/windowing/backends/i3.rs
@@ -1,0 +1,307 @@
+use crate::terminal::enrich_terminal_windows;
+use crate::windowing::registry::BackendProbe;
+use crate::windowing::types::{WindowBounds, WindowInfo};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::{env, fs, os::unix::fs::FileTypeExt, path::PathBuf, process::Command};
+
+pub const I3_BACKEND: &str = "i3";
+
+pub fn probe() -> BackendProbe {
+    match i3_msg_command().args(["-t", "get_tree"]).output() {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let ok = matches!(
+                serde_json::from_str::<serde_json::Value>(&stdout),
+                Ok(serde_json::Value::Object(_))
+            );
+            BackendProbe {
+                id: I3_BACKEND,
+                ok,
+                can_list_windows: ok,
+                can_focus_apps: ok,
+                can_focus_windows: ok,
+                detail: if ok {
+                    "i3-msg get_tree returned a JSON tree".to_string()
+                } else {
+                    "i3-msg get_tree did not return a JSON object".to_string()
+                },
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            BackendProbe {
+                id: I3_BACKEND,
+                ok: false,
+                can_list_windows: false,
+                can_focus_apps: false,
+                can_focus_windows: false,
+                detail: if stderr.is_empty() { stdout } else { stderr },
+            }
+        }
+        Err(error) => BackendProbe {
+            id: I3_BACKEND,
+            ok: false,
+            can_list_windows: false,
+            can_focus_apps: false,
+            can_focus_windows: false,
+            detail: error.to_string(),
+        },
+    }
+}
+
+pub fn list_windows() -> Result<Vec<WindowInfo>> {
+    let output = i3_msg_command()
+        .args(["-t", "get_tree"])
+        .output()
+        .context("failed to run i3-msg -t get_tree")?;
+    if !output.status.success() {
+        bail!(
+            "i3-msg -t get_tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let mut windows = parse_i3_tree(&String::from_utf8_lossy(&output.stdout))?;
+    hydrate_i3_window_pids(&mut windows);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub(crate) fn parse_i3_tree(json: &str) -> Result<Vec<WindowInfo>> {
+    let root: I3Node =
+        serde_json::from_str(json).context("failed to parse i3-msg get_tree output")?;
+    let mut windows = Vec::new();
+    collect_i3_windows(&root, None, false, &mut windows);
+    windows.sort_by_key(|window| window.window_id);
+    Ok(windows)
+}
+
+pub fn activate_window(window_id: u64) -> Result<()> {
+    let selector = format!(r#"[id="0x{window_id:x}"] focus"#);
+    let output = i3_msg_command()
+        .arg(&selector)
+        .output()
+        .with_context(|| format!("failed to run i3-msg {selector}"))?;
+    if !output.status.success() {
+        bail!(
+            "i3-msg {selector} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let replies: Vec<I3CommandReply> =
+        serde_json::from_slice(&output.stdout).context("failed to parse i3-msg focus reply")?;
+    if replies.iter().all(|reply| reply.success) {
+        Ok(())
+    } else {
+        let details = replies
+            .into_iter()
+            .filter_map(|reply| reply.error)
+            .collect::<Vec<_>>()
+            .join("; ");
+        bail!(
+            "i3-msg {selector} did not focus the window: {}",
+            if details.is_empty() {
+                "unknown i3 failure"
+            } else {
+                details.as_str()
+            }
+        );
+    }
+}
+
+fn collect_i3_windows(
+    node: &I3Node,
+    workspace: Option<i32>,
+    in_dockarea: bool,
+    windows: &mut Vec<WindowInfo>,
+) {
+    let node_type = node.node_type.as_deref();
+    let current_workspace = if node_type == Some("workspace") {
+        node.num
+    } else {
+        workspace
+    };
+    let current_in_dockarea = in_dockarea || node_type == Some("dockarea");
+
+    if let Some(window) = node.to_window_info(current_workspace, current_in_dockarea) {
+        windows.push(window);
+    }
+
+    for child in &node.nodes {
+        collect_i3_windows(child, current_workspace, current_in_dockarea, windows);
+    }
+    for child in &node.floating_nodes {
+        collect_i3_windows(child, current_workspace, current_in_dockarea, windows);
+    }
+}
+
+fn hydrate_i3_window_pids(windows: &mut [WindowInfo]) {
+    for window in windows {
+        if window.pid.is_none() {
+            window.pid = i3_window_pid(window.window_id);
+        }
+    }
+}
+
+fn i3_window_pid(window_id: u64) -> Option<u32> {
+    let output = Command::new("xprop")
+        .args(["-id", &window_id.to_string(), "_NET_WM_PID"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    parse_xprop_pid(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub(crate) fn parse_xprop_pid(output: &str) -> Option<u32> {
+    output.split('=').nth(1)?.trim().parse::<u32>().ok()
+}
+
+fn i3_msg_command() -> Command {
+    let mut command = Command::new("i3-msg");
+    if let Some(socket_path) = i3_socket_path() {
+        command.arg("-s").arg(socket_path);
+    }
+    command
+}
+
+fn i3_socket_path() -> Option<PathBuf> {
+    if let Some(value) = env_var("I3SOCK") {
+        return Some(PathBuf::from(value));
+    }
+
+    let socket_dir = xdg_runtime_dir()?.join("i3");
+    let mut sockets = fs::read_dir(socket_dir)
+        .ok()?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_str()?;
+            if !file_name.starts_with("ipc-socket.") {
+                return None;
+            }
+            let metadata = entry.metadata().ok()?;
+            if !metadata.file_type().is_socket() {
+                return None;
+            }
+            let modified = metadata.modified().ok();
+            Some((modified, entry.path()))
+        })
+        .collect::<Vec<_>>();
+    sockets.sort_by(|left, right| right.0.cmp(&left.0));
+    sockets.into_iter().map(|(_, path)| path).next()
+}
+
+fn xdg_runtime_dir() -> Option<PathBuf> {
+    env_var("XDG_RUNTIME_DIR").map(PathBuf::from)
+}
+
+fn env_var(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn clean_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != "null")
+        .map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Deserialize)]
+struct I3CommandReply {
+    success: bool,
+    error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct I3Node {
+    #[serde(rename = "type")]
+    node_type: Option<String>,
+    name: Option<String>,
+    window: Option<u64>,
+    window_type: Option<String>,
+    window_properties: Option<I3WindowProperties>,
+    rect: Option<I3Rect>,
+    geometry: Option<I3Rect>,
+    #[serde(default)]
+    focused: bool,
+    #[serde(default)]
+    nodes: Vec<I3Node>,
+    #[serde(default)]
+    floating_nodes: Vec<I3Node>,
+    num: Option<i32>,
+    scratchpad_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct I3WindowProperties {
+    class: Option<String>,
+    instance: Option<String>,
+    title: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct I3Rect {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+impl I3Node {
+    fn to_window_info(&self, workspace: Option<i32>, in_dockarea: bool) -> Option<WindowInfo> {
+        if in_dockarea {
+            return None;
+        }
+        let window_id = self.window?;
+        if self.window_type.as_deref() == Some("dock") {
+            return None;
+        }
+
+        let properties = self.window_properties.as_ref();
+        let title = clean_string(
+            properties
+                .and_then(|properties| properties.title.as_deref())
+                .or(self.name.as_deref()),
+        );
+        let wm_class = clean_string(
+            properties
+                .and_then(|properties| properties.class.as_deref())
+                .or_else(|| properties.and_then(|properties| properties.instance.as_deref())),
+        );
+        let app_id = clean_string(
+            properties
+                .and_then(|properties| properties.instance.as_deref())
+                .or(wm_class.as_deref()),
+        );
+        let rect = self.rect.as_ref().or(self.geometry.as_ref());
+        let bounds = rect.map(|rect| WindowBounds {
+            x: Some(rect.x),
+            y: Some(rect.y),
+            width: rect.width,
+            height: rect.height,
+        });
+
+        Some(WindowInfo {
+            window_id,
+            title,
+            app_id,
+            wm_class,
+            pid: None,
+            bounds,
+            workspace,
+            focused: self.focused,
+            hidden: self.scratchpad_state.as_deref() == Some("fresh"),
+            client_type: Some("x11".to_string()),
+            backend: I3_BACKEND.to_string(),
+            terminal: None,
+        })
+    }
+}

--- a/computer-use-linux/src/windowing/backends/mod.rs
+++ b/computer-use-linux/src/windowing/backends/mod.rs
@@ -1,4 +1,5 @@
 pub mod cosmic;
 pub mod gnome;
 pub mod hyprland;
+pub mod i3;
 pub mod kwin;

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 #[allow(unused_imports)]
 pub use registry::{
     COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, KWIN_BACKEND, WINDOW_PERMISSION_HINT,
+    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, WINDOW_PERMISSION_HINT,
 };
 #[allow(unused_imports)]
 pub use target::{
@@ -20,6 +20,7 @@ pub use types::{WindowBounds, WindowFocusResult, WindowInfo, WindowTarget};
 mod tests {
     use super::backends::gnome::window_from_properties;
     use super::backends::hyprland::{parse_hyprland_clients, HYPRLAND_BACKEND};
+    use super::backends::i3::{parse_i3_tree, parse_xprop_pid, I3_BACKEND};
     use super::backends::kwin::{
         kwin_activate_script_source, kwin_window_id_from_uuid, parse_kwin_windows, KWIN_BACKEND,
     };
@@ -53,6 +54,7 @@ mod tests {
                 COSMIC_WAYLAND_BACKEND,
                 KWIN_BACKEND,
                 HYPRLAND_BACKEND,
+                I3_BACKEND,
             ]
         );
     }
@@ -209,6 +211,21 @@ mod tests {
     fn cosmic_backend_can_exact_focus_targets() {
         let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
         window.backend = COSMIC_WAYLAND_BACKEND.to_string();
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                title: Some("Codex".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn i3_backend_can_exact_focus_targets() {
+        let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
+        window.backend = I3_BACKEND.to_string();
 
         ensure_backend_can_focus_target(
             &WindowTarget {
@@ -458,6 +475,104 @@ mod tests {
         assert_eq!(windows[0].backend, HYPRLAND_BACKEND);
         assert!(windows[1].focused);
         assert_eq!(windows[2].pid, None);
+    }
+
+    #[test]
+    fn parses_i3_tree_as_window_info() {
+        let tree_json = r#"{
+          "type": "root",
+          "focused": false,
+          "window": null,
+          "nodes": [
+            {
+              "type": "output",
+              "focused": false,
+              "window": null,
+              "nodes": [
+                {
+                  "type": "dockarea",
+                  "focused": false,
+                  "window": null,
+                  "nodes": [
+                    {
+                      "type": "con",
+                      "focused": false,
+                      "window": 25165826,
+                      "window_type": "unknown",
+                      "name": "polybar",
+                      "window_properties": {
+                        "class": "Polybar",
+                        "instance": "polybar",
+                        "title": "polybar"
+                      },
+                      "rect": {"x": 0, "y": 0, "width": 2560, "height": 40}
+                    }
+                  ]
+                },
+                {
+                  "type": "workspace",
+                  "num": 2,
+                  "focused": false,
+                  "window": null,
+                  "nodes": [
+                    {
+                      "type": "con",
+                      "focused": true,
+                      "window": 67108868,
+                      "window_type": "normal",
+                      "name": "Codex",
+                      "window_properties": {
+                        "class": "Codex",
+                        "instance": "codex",
+                        "title": "Codex"
+                      },
+                      "rect": {"x": 0, "y": 782, "width": 2560, "height": 1440}
+                    }
+                  ],
+                  "floating_nodes": [
+                    {
+                      "type": "con",
+                      "focused": false,
+                      "window": 73400323,
+                      "window_type": "dialog",
+                      "name": "Save File",
+                      "window_properties": {
+                        "class": "zenity",
+                        "instance": "zenity",
+                        "title": "Save File"
+                      },
+                      "geometry": {"x": 100, "y": 120, "width": 600, "height": 400}
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }"#;
+
+        let windows = parse_i3_tree(tree_json).unwrap();
+
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].window_id, 67108868);
+        assert_eq!(windows[0].title.as_deref(), Some("Codex"));
+        assert_eq!(windows[0].app_id.as_deref(), Some("codex"));
+        assert_eq!(windows[0].wm_class.as_deref(), Some("Codex"));
+        assert_eq!(windows[0].workspace, Some(2));
+        assert!(windows[0].focused);
+        assert_eq!(windows[0].client_type.as_deref(), Some("x11"));
+        assert_eq!(windows[0].backend, I3_BACKEND);
+        assert_eq!(windows[0].bounds.as_ref().unwrap().x, Some(0));
+        assert_eq!(windows[1].title.as_deref(), Some("Save File"));
+        assert_eq!(windows[1].bounds.as_ref().unwrap().width, 600);
+    }
+
+    #[test]
+    fn parses_xprop_pid() {
+        assert_eq!(
+            parse_xprop_pid("_NET_WM_PID(CARDINAL) = 19313\n"),
+            Some(19313)
+        );
+        assert_eq!(parse_xprop_pid("_NET_WM_PID:  not found.\n"), None);
     }
 
     #[test]

--- a/computer-use-linux/src/windowing/registry.rs
+++ b/computer-use-linux/src/windowing/registry.rs
@@ -1,13 +1,14 @@
-use crate::windowing::backends::{cosmic, gnome, hyprland, kwin};
+use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin};
 use crate::windowing::types::WindowInfo;
 use anyhow::{anyhow, Result};
 
 pub use cosmic::COSMIC_WAYLAND_BACKEND;
 pub use gnome::{GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND};
 pub use hyprland::HYPRLAND_BACKEND;
+pub use i3::I3_BACKEND;
 pub use kwin::KWIN_BACKEND;
 
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, or Hyprland hyprctl. On GNOME, run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
 
 #[derive(Debug, Clone, Copy)]
 pub struct BackendDescriptor {
@@ -35,6 +36,7 @@ enum BackendKind {
     Cosmic,
     Kwin,
     Hyprland,
+    I3,
 }
 
 const BACKEND_ORDER: &[BackendKind] = &[
@@ -43,6 +45,7 @@ const BACKEND_ORDER: &[BackendKind] = &[
     BackendKind::Cosmic,
     BackendKind::Kwin,
     BackendKind::Hyprland,
+    BackendKind::I3,
 ];
 
 const DESCRIPTORS: &[BackendDescriptor] = &[
@@ -79,6 +82,13 @@ const DESCRIPTORS: &[BackendDescriptor] = &[
         failure_label: "Hyprland",
         list_note: "Window list came from Hyprland hyprctl. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
         missing_hint: "On Hyprland, ensure hyprctl is available in the session.",
+        can_exact_focus: true,
+    },
+    BackendDescriptor {
+        id: I3_BACKEND,
+        failure_label: "i3",
+        list_note: "Window list came from i3-msg. Terminal windows may include best-effort PTY and active-process context when xprop and the process tree are readable.",
+        missing_hint: "On i3, ensure i3-msg can reach the active i3 IPC socket.",
         can_exact_focus: true,
     },
 ];
@@ -128,6 +138,7 @@ async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
         BackendKind::Cosmic => cosmic::list_windows(),
         BackendKind::Kwin => kwin::list_windows().await,
         BackendKind::Hyprland => hyprland::list_windows(),
+        BackendKind::I3 => i3::list_windows(),
     }
 }
 
@@ -150,6 +161,7 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
         COSMIC_WAYLAND_BACKEND => cosmic::activate_window(window.window_id),
         KWIN_BACKEND => kwin::activate_window(window.window_id).await,
         HYPRLAND_BACKEND => hyprland::activate_window(window.window_id),
+        I3_BACKEND => i3::activate_window(window.window_id),
         backend => Err(anyhow!(
             "Unsupported window backend for activation: {backend}"
         )),
@@ -167,6 +179,7 @@ pub fn probe_backends() -> Vec<BackendProbe> {
         cosmic::probe(),
         kwin::probe(),
         hyprland::probe(),
+        i3::probe(),
     ]
 }
 
@@ -178,6 +191,7 @@ impl BackendKind {
             BackendKind::Cosmic => COSMIC_WAYLAND_BACKEND,
             BackendKind::Kwin => KWIN_BACKEND,
             BackendKind::Hyprland => HYPRLAND_BACKEND,
+            BackendKind::I3 => I3_BACKEND,
         }
     }
 }

--- a/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
+++ b/plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "computer-use",
-  "version": "0.1.2-linux-alpha1",
+  "version": "0.1.2-linux-alpha2",
   "description": "Control desktop apps on Linux from Codex through Computer Use.",
   "author": {
     "name": "avifenesh"


### PR DESCRIPTION
## Summary

- Add an i3 window backend for Linux Computer Use using `i3-msg`
- Parse i3 trees into targetable windows and hydrate X11 window PIDs with `xprop`
- Report i3 readiness in doctor output and update the Linux Computer Use docs
- Bump the bundled Computer Use plugin version so installs use a fresh cache entry

## User-visible behavior

On i3/X11, Linux Computer Use can now list windows, focus apps, and verify exact targeted window focus. The backend also resolves the i3 IPC socket directly from `I3SOCK` or `/run/user/$UID/i3/ipc-socket.*`, so it still works when the MCP process cannot use X auth to discover the socket.

## Files edited

- `computer-use-linux/src/windows.rs`
- `computer-use-linux/src/diagnostics.rs`
- `computer-use-linux/src/server.rs`
- `plugins/openai-bundled/plugins/computer-use/.codex-plugin/plugin.json`
- `README.md`
- `AGENTS.md`

## Validation

- `cargo fmt -p codex-computer-use-linux -- --check`
- `cargo check -p codex-computer-use-linux`
- `cargo test -p codex-computer-use-linux` - 74 passed
- Live `doctor` on i3/X11 after restarting the plugin reported no readiness blockers, with `can_query_windows`, `can_focus_apps`, and `can_focus_windows` all true
