### PR TITLE
[codex] Handle Computer Use UI asset drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1134,6 +1134,45 @@ test("missing icon asset skips only icon patches", () => {
   }
 });
 
+test("patchExtractedApp scans apps bundles for Computer Use availability when UI is enabled", () => {
+  withIsolatedHome(() => {
+    process.env[COMPUTER_USE_UI_ENV_VAR] = "1";
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-computer-use-apps-assets-test-"));
+    try {
+      const buildDir = path.join(tempRoot, ".vite", "build");
+      const assetsDir = path.join(tempRoot, "webview", "assets");
+      fs.mkdirSync(buildDir, { recursive: true });
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(buildDir, "main.js"),
+        [
+          mainBundlePrefix,
+          "process.platform===`win32`&&k.removeMenu(),",
+          alreadyOpaqueBackgroundBundle,
+          fileManagerBundle,
+          trayBundleFixture(),
+          singleInstanceBundleFixture(),
+        ].join(""),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, "apps-current.js"),
+        "function g(e){return e===`macOS`||e===`windows`}" +
+          "function _(e){let t=(0,d.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,{isLoading:o,platform:c}=u(),l=s(`1506311413`),f;t[0]===r?f=t[1]:(f={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=f);let p=h(f),m;t[2]===c?m=t[3]:(m=g(c),t[2]=c,t[3]=m);let _=a&&i&&l&&(o||m),v=_&&!o&&p.enabled&&!p.isLoading,y=_&&p.isLoading,b=_&&(o||p.isLoading),x;return x}",
+      );
+      fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
+
+      patchExtractedApp(tempRoot);
+
+      assert.match(
+        fs.readFileSync(path.join(assetsDir, "apps-current.js"), "utf8"),
+        /let _=a&&i&&\(c===`linux`\|\|l&&\(o\|\|m\)\),v=_&&!o&&\(c===`linux`\|\|p\.enabled\)&&!p\.isLoading/,
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 test("patchExtractedApp records a structured patch report", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-test-"));
   try {

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -199,7 +199,7 @@ const COMPUTER_USE_UI_ASSET_PATCHES = [
   {
     name: "linux-computer-use-ui-availability",
     ciPolicy: OPT_IN,
-    pattern: /^(use-model-settings|use-in-app-browser-use-availability)-.*\.js$/,
+    pattern: /^(use-model-settings|apps|use-in-app-browser-use-availability)-.*\.js$/,
     apply: applyLinuxComputerUseRendererAvailabilityPatch,
     missingDescription: "Computer Use availability bundle",
     skipDescription: "Linux Computer Use UI availability patch",


### PR DESCRIPTION
## Summary

- rebased on latest `main`
- narrowed this PR to only the remaining `apps-*` Computer Use availability asset scan
- added a focused `patchExtractedApp` regression test for `apps-current.js`

## What Changed

Latest `main` already includes the broader upstream drift fixes from the earlier version of this PR:

- `name:e.kn` bundled-plugin gate handling
- `use-in-app-browser-use-availability-*` scanning
- `plugins-availability-*` install-flow scanning
- current install-flow and availability patch shapes

This branch now only adds `apps-*` to the opt-in Computer Use UI availability asset scan:

```text
/^(use-model-settings|apps|use-in-app-browser-use-availability)-.*\.js$/
```

The availability logic itself is unchanged, including the existing `isHostLocal` behavior.

## Validation

```text
node --check scripts/patches/registry.js
node --check scripts/patch-linux-window-ui.test.js
git diff --check
node --test scripts/patch-linux-window-ui.test.js
```

Result:

```text
tests 62
pass 62
fail 0
```

Also ran Claude adversarial review in `code-vs-plan` mode. Verdict:

```text
VERDICT: APPROVED
```
