### PR TITLE
fix Linux explicit quit and stale runtime recovery

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1082,6 +1082,31 @@ clear_stale_pid_file() {
     fi
 }
 
+reconcile_runtime_state() {
+    local live_app_pid=""
+    local webview_pid=""
+
+    if live_app_pid="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && live_app_pid="$(discover_running_app_pid)"; }; then
+        echo "$live_app_pid" > "$APP_PID_FILE"
+        return 0
+    fi
+
+    clear_stale_pid_file
+
+    if [ -e "$LAUNCH_ACTION_SOCKET" ]; then
+        rm -f "$LAUNCH_ACTION_SOCKET"
+    fi
+
+    if [ ! -f "$WEBVIEW_PID_FILE" ]; then
+        return 0
+    fi
+
+    webview_pid="$(cat "$WEBVIEW_PID_FILE" 2>/dev/null || true)"
+    if [ -z "$webview_pid" ] || { ! pid_is_webview_server "$webview_pid" && ! pid_is_stale_webview_server "$webview_pid"; }; then
+        rm -f "$WEBVIEW_PID_FILE"
+    fi
+}
+
 set_electron_defaults() {
     ELECTRON_OZONE_PLATFORM=""
     ELECTRON_OZONE_HINT="auto"
@@ -1241,7 +1266,7 @@ configure_side_by_side_app_env
 load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
 register_url_scheme_handlers
-clear_stale_pid_file
+reconcile_runtime_state
 detect_warm_start
 trap cleanup_launcher EXIT
 

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -36,6 +36,8 @@ const {
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxExplicitIpcQuitPatch,
+  applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,
@@ -115,6 +117,8 @@ module.exports = {
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
+  applyLinuxExplicitIpcQuitPatch,
+  applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxHotkeyWindowPrewarmPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -19,6 +19,8 @@ const {
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
+  applyLinuxExplicitIpcQuitPatch,
+  applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxQuitGuardPatch,
@@ -90,6 +92,13 @@ function singleInstanceBundleFixture() {
   return [
     "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();",
     "l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=",
+  ].join("");
+}
+
+function explicitQuitBundleFixture() {
+  return [
+    "var pb=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{n.app.quit()}}]}};",
+    "if(o.type===`quit-app`){n.app.quit();return}",
   ].join("");
 }
 
@@ -207,6 +216,54 @@ test("adds the Linux quit guard when only the Electron require is recognizable",
   assert.match(patched, /codexLinuxMarkQuitInProgress=\(\)=>\{codexLinuxQuitInProgress=!0\}/);
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
   assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
+});
+
+test("marks Linux quit-in-progress for the tray quit path", () => {
+  const source = `${mainBundlePrefix}${explicitQuitBundleFixture()}`;
+  const patched = applyPatchTwice(
+    applyLinuxExplicitTrayQuitPatch,
+    applyLinuxQuitGuardPatch(source),
+  );
+
+  assert.match(
+    patched,
+    /\{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\)\}\}/,
+  );
+});
+
+test("marks Linux quit-in-progress for the quit-app IPC path", () => {
+  const source = `${mainBundlePrefix}${explicitQuitBundleFixture()}`;
+  const patched = applyPatchTwice(
+    applyLinuxExplicitIpcQuitPatch,
+    applyLinuxQuitGuardPatch(source),
+  );
+
+  assert.match(
+    patched,
+    /if\(o\.type===`quit-app`\)\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\);return\}/,
+  );
+});
+
+test("supports explicit tray quit patching when minified aliases drift", () => {
+  const source =
+    "let x=require(`electron`);var q=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{x.app.quit()}}]}};if(m.type===`quit-app`){x.app.quit();return}";
+  const patched = applyPatchTwice(applyLinuxExplicitTrayQuitPatch, source);
+
+  assert.match(
+    patched,
+    /\{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),x\.app\.quit\(\)\}\}/,
+  );
+});
+
+test("supports explicit IPC quit patching when minified aliases drift", () => {
+  const source =
+    "let x=require(`electron`);var q=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{x.app.quit()}}]}};if(m.type===`quit-app`){x.app.quit();return}";
+  const patched = applyPatchTwice(applyLinuxExplicitIpcQuitPatch, source);
+
+  assert.match(
+    patched,
+    /if\(m\.type===`quit-app`\)\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),x\.app\.quit\(\);return\}/,
+  );
 });
 
 test("adds Linux menu hiding next to Windows removeMenu calls", () => {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -398,6 +398,64 @@ function applyLinuxQuitGuardPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxExplicitTrayQuitPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const quitMarkerExpression =
+    "typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
+
+  const trayQuitNeedle = "{label:rB(this.appName),click:()=>{n.app.quit()}}";
+  const trayQuitPatch =
+    `{label:rB(this.appName),click:()=>{${quitMarkerExpression}n.app.quit()}}`;
+  const trayQuitRegex =
+    /\{label:rB\(([^)]+)\),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/;
+  if (patchedSource.includes(trayQuitPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(trayQuitNeedle)) {
+    patchedSource = patchedSource.replace(trayQuitNeedle, trayQuitPatch);
+  } else if (trayQuitRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      trayQuitRegex,
+      (_match, appNameExpr, electronVar) =>
+        `{label:rB(${appNameExpr}),click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`,
+    );
+  } else if (
+    patchedSource.includes("getNativeTrayMenuItems(){") &&
+    (patchedSource.includes("label:rB(") || patchedSource.includes("role:`quit`"))
+  ) {
+    console.warn("WARN: Could not find tray quit menu handler — skipping Linux explicit tray quit patch");
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxExplicitIpcQuitPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const quitMarkerExpression =
+    "typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
+
+  const quitAppNeedle = "if(o.type===`quit-app`){n.app.quit();return}";
+  const quitAppPatch = `if(o.type===\`quit-app\`){${quitMarkerExpression}n.app.quit();return}`;
+  const quitAppRegex =
+    /if\(([A-Za-z_$][\w$]*)\.type===`quit-app`\)\{([A-Za-z_$][\w$]*)\.app\.quit\(\);return\}/;
+  if (patchedSource.includes(quitAppPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(quitAppNeedle)) {
+    patchedSource = patchedSource.replace(quitAppNeedle, quitAppPatch);
+  } else if (quitAppRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      quitAppRegex,
+      (_match, messageVar, electronVar) =>
+        `if(${messageVar}.type===\`quit-app\`){${quitMarkerExpression}${electronVar}.app.quit();return}`,
+    );
+  } else if (patchedSource.includes("type===`quit-app`")) {
+    console.warn("WARN: Could not find quit-app IPC handler — skipping Linux explicit quit-app patch");
+  }
+
+  return patchedSource;
+}
+
 function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   let patchedSource = currentSource;
 
@@ -678,6 +736,8 @@ function applyLinuxGitOriginsSourceFallbackPatch(currentSource) {
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxExplicitIpcQuitPatch,
+  applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -19,6 +19,8 @@ const {
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxExplicitIpcQuitPatch,
+  applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxMenuPatch,
@@ -67,6 +69,16 @@ const MAIN_BUNDLE_PATCHES = [
     name: "linux-quit-guard",
     ciPolicy: REQUIRED_UPSTREAM,
     apply: (source) => applyLinuxQuitGuardPatch(source),
+  },
+  {
+    name: "linux-explicit-tray-quit",
+    ciPolicy: REQUIRED_UPSTREAM,
+    apply: (source) => applyLinuxExplicitTrayQuitPatch(source),
+  },
+  {
+    name: "linux-explicit-ipc-quit",
+    ciPolicy: REQUIRED_UPSTREAM,
+    apply: (source) => applyLinuxExplicitIpcQuitPatch(source),
   },
   {
     name: "linux-window-options",

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -440,6 +440,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" "owned_webview_server_pid"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "discover_webview_server_pid"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Adopted existing webview server"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "reconcile_runtime_state"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "detect_warm_start"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "send_warm_start_launch_action"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_DESKTOP_LAUNCH_ACTION_SOCKET"
@@ -463,6 +464,7 @@ runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_el
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("ensure_webview_server() {", 1)[0]
 ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
+reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
 if 'RUNNING_APP_PID="$(find_running_app_pid)"' not in detect_body:
     raise SystemExit("detect_warm_start must record a pid-file running app even when warm start is disabled")
 if '[ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"' not in detect_body:
@@ -503,6 +505,14 @@ if "stop_stale_webview_server" not in ensure_body:
     raise SystemExit("ensure_webview_server must clear stale deleted webview servers before treating the port as foreign")
 if "Keeping the live app untouched" not in ensure_body:
     raise SystemExit("ensure_webview_server must not stop a live app server when validation fails")
+if 'if live_app_pid="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && live_app_pid="$(discover_running_app_pid)"; }; then' not in reconcile_body:
+    raise SystemExit("reconcile_runtime_state must preserve runtime markers when a live app still exists")
+if 'rm -f "$LAUNCH_ACTION_SOCKET"' not in reconcile_body:
+    raise SystemExit("reconcile_runtime_state must clear a stale launch-action socket when no live app exists")
+if 'clear_stale_pid_file' not in reconcile_body:
+    raise SystemExit("reconcile_runtime_state must still clear stale app.pid markers")
+if 'if [ -z "$webview_pid" ] || { ! pid_is_webview_server "$webview_pid" && ! pid_is_stale_webview_server "$webview_pid"; }; then' not in reconcile_body:
+    raise SystemExit("reconcile_runtime_state must clear stale launcher webview ownership markers without touching valid orphaned servers")
 PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "warm_start_ipc_sent"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "launcher_phase"
@@ -900,6 +910,92 @@ NODE
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe' '1'
+}
+
+test_linux_explicit_quit_patch_smoke() {
+    info "Checking Linux explicit quit patch behavior"
+    local workspace="$TMP_DIR/explicit-quit-patch"
+    local extracted="$workspace/extracted"
+    local output_log="$workspace/output.log"
+    local bundle_body
+
+    mkdir -p "$workspace"
+    bundle_body="$(cat <<'JS'
+let n=require(`electron`),i=require(`node:path`),a=require(`node:fs`);
+var pb=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{n.app.quit()}}]}};
+function qB(r,o){if(o.type===`quit-app`){n.app.quit();return}return o}
+JS
+)"
+    make_fake_extracted_asar "$extracted" "$bundle_body"
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_contains "$extracted/.vite/build/main-test.js" '{label:rB(this.appName),click:()=>{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit()}}'
+    assert_contains "$extracted/.vite/build/main-test.js" 'if(o.type===`quit-app`){typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit();return}'
+    assert_not_contains "$output_log" 'WARN: Could not find tray quit menu handler'
+    assert_not_contains "$output_log" 'WARN: Could not find quit-app IPC handler'
+
+    node - "$extracted/.vite/build/main-test.js" <<'NODE'
+const fs = require("fs");
+
+const source = fs.readFileSync(process.argv[2], "utf8");
+const traySnippet = source.match(/\{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\)\}\}/)?.[0];
+const quitAppSnippet = source.match(/if\(o\.type===`quit-app`\)\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\);return\}/)?.[0];
+if (!traySnippet || !quitAppSnippet) {
+  throw new Error("Could not extract explicit quit snippets");
+}
+
+function runTrayQuit({ withHelper = true } = {}) {
+  const state = { markCalls: 0, quitCalls: 0 };
+  const app = { quit() { state.quitCalls += 1; } };
+  const mark = withHelper ? () => { state.markCalls += 1; } : undefined;
+  const factory = new Function(
+    "n",
+    "rB",
+    "codexLinuxMarkQuitInProgress",
+    `return (${traySnippet}).click;`,
+  );
+  const click = factory({ app }, () => "Quit", mark);
+  click();
+  return state;
+}
+
+function runQuitApp({ withHelper = true } = {}) {
+  const state = { markCalls: 0, quitCalls: 0 };
+  const app = { quit() { state.quitCalls += 1; } };
+  const mark = withHelper ? () => { state.markCalls += 1; } : undefined;
+  const handler = new Function(
+    "n",
+    "codexLinuxMarkQuitInProgress",
+    "o",
+    `${quitAppSnippet};return null;`,
+  );
+  handler({ app }, mark, { type: "quit-app" });
+  return state;
+}
+
+let state = runTrayQuit();
+if (state.markCalls !== 1 || state.quitCalls !== 1) {
+  throw new Error("tray quit should mark quit-in-progress before quitting");
+}
+
+state = runQuitApp();
+if (state.markCalls !== 1 || state.quitCalls !== 1) {
+  throw new Error("quit-app IPC should mark quit-in-progress before quitting");
+}
+
+state = runTrayQuit({ withHelper: false });
+if (state.markCalls !== 0 || state.quitCalls !== 1) {
+  throw new Error("tray quit should still quit when the helper is unavailable");
+}
+
+state = runQuitApp({ withHelper: false });
+if (state.markCalls !== 0 || state.quitCalls !== 1) {
+  throw new Error("quit-app IPC should still quit when the helper is unavailable");
+}
+NODE
+
+    node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()' '2'
 }
 
 test_keybinds_settings_tab_patch_smoke() {
@@ -1766,6 +1862,7 @@ main() {
     test_keybinds_settings_tab_patch_smoke
     test_keybinds_settings_patch_warns_on_bundle_shape_miss
     test_linux_tray_patch_smoke
+    test_linux_explicit_quit_patch_smoke
     test_browser_annotation_screenshot_patch_smoke
     test_linux_single_instance_patch_smoke
     test_linux_computer_use_gate_patch_smoke


### PR DESCRIPTION
## Summary

This fixes two linked Linux shutdown issues:

- closing the main window and choosing background mode should keep Codex alive in the system tray
- choosing to fully quit from the tray or the app's explicit quit flow should exit the app completely
- after a failed quit or a forced kill, the next launch should recover cleanly instead of getting stuck behind stale runtime state

## Root cause

There were two separate failure modes on Linux:

1. The close-to-tray guard already knew how to keep the app alive in the background, but explicit quit paths were not reliably marking Linux quit-in-progress early enough. That let the window-close logic win in some full-exit flows, so the app stayed resident instead of exiting.
2. Launcher startup cleanup only removed a stale `app.pid`. If the app died badly, stale runtime markers like the launch-action socket or launcher-owned webview pid file could remain behind and interfere with relaunch.

## Fix

Main-process patcher:

- added a dedicated `linux-explicit-quit` patch immediately after `linux-quit-guard`
- patched the tray `Quit` menu item to call `codexLinuxMarkQuitInProgress()` before `app.quit()`
- patched the `quit-app` IPC path to do the same before `app.quit()`
- kept the existing close-to-tray behavior unchanged for normal background-mode window closes

Launcher:

- replaced the narrow startup `clear_stale_pid_file` call with `reconcile_runtime_state`
- preserve runtime markers when a real Electron main process is still alive
- clear stale `app.pid` when no live app exists
- remove a stale `launch-action.sock` when no live app exists
- clear stale launcher-owned `webview.pid` markers when they no longer point at a valid owned webview server

## Why this matters

On Linux, the expected behavior after this change is:

- closing the main window in background mode keeps Codex alive in the tray
- explicit quit from the tray fully exits the app
- explicit quit from the app's quit flow fully exits the app
- after a forced kill, the next launch starts normally instead of being blocked by stale runtime state

## Validation

I ran:

- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `make build-app`

I also verified the rebuilt payload directly:

- generated `codex-app/start.sh` contains the new `reconcile_runtime_state()` startup reconciliation
- rebuilt `app.asar` contains both explicit quit markers before `app.quit()` in the tray quit and `quit-app` paths

## Notes

This keeps the patch narrow in the hot Linux patcher surface:

- explicit quit is patched only at the concrete tray quit and `quit-app` call sites found in the current upstream bundle
- startup reconciliation only removes stale runtime markers when no live Electron app is actually running
