### PR TITLE
Improve Linux Computer Use fallback and input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,35 @@ sudo usermod -a -G input "$USER"
 
 On Ubuntu 24.04, the `ydotoold` package may install `/usr/bin/ydotoold` without a systemd unit. In that case, create or install a `ydotoold.service` unit before running `systemctl enable --now ydotoold`.
 
+If `doctor` reports `ydotoold` as running but `ydotool_socket` is `Permission denied`, the daemon is reachable only by root. This unit keeps the daemon privileged enough to open `/dev/uinput`, but makes the socket usable by desktop users in the `input` group:
+
+```ini
+[Unit]
+Description=ydotool daemon
+Documentation=man:ydotool(1)
+After=multi-user.target
+
+[Service]
+Type=simple
+Group=input
+UMask=0007
+ExecStartPre=/usr/bin/rm -f /tmp/.ydotool_socket
+ExecStart=/usr/bin/ydotoold
+ExecStartPost=/bin/sh -c 'for i in $(seq 1 50); do [ -S /tmp/.ydotool_socket ] && chgrp input /tmp/.ydotool_socket && chmod 0660 /tmp/.ydotool_socket && exit 0; sleep 0.1; done; exit 1'
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Save it as `/etc/systemd/system/ydotoold.service`, then run:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now ydotoold
+```
+
 A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway / Hyprland, or your distro's preferred portal backend for i3. GNOME ships a working portal by default.
 
 ### Verifying readiness
@@ -363,6 +392,7 @@ make clean-state
 | Stale install / cached DMG | `./install.sh --fresh` removes the existing install dir and re-downloads |
 | Computer Use plugin invisible in UI | Most likely the OpenAI per-account Statsig rollout (`computerUse` feature flag) hasn't been enabled for your account. Building / reinstalling does not change this |
 | Computer Use `doctor` reports `ydotool not running` | `sudo systemctl enable --now ydotoold` and add your user to the `input` group |
+| Computer Use `doctor` reports `ydotool_socket: Permission denied` | The daemon socket is root-only. Use the `ydotoold.service` example above so `/tmp/.ydotool_socket` becomes `root:input` with `0660` permissions |
 | `ConnectTimeoutError` for `www.electronjs.org` during `@electron/rebuild` | Re-run `make build-app`; the installer now uses `https://artifacts.electronjs.org/headers/dist` for Electron headers by default |
 | Computer Use AT-SPI tree empty | Run `codex-computer-use-linux setup` to flip GNOME accessibility on, then restart the target app |
 | `codex-update-manager` keeps running after package removal | `systemctl --user disable --now codex-update-manager.service` once in the affected session, then confirm `/opt/codex-desktop` is gone |

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -7,6 +7,8 @@ use serde::Serialize;
 use std::{
     collections::{BTreeMap, HashMap},
     env, fs,
+    fs::OpenOptions,
+    os::unix::net::UnixStream,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -409,12 +411,11 @@ fn check_from_backend_probe(probe: &registry::BackendProbe) -> Check {
 }
 
 fn input_report() -> InputReport {
-    let socket = ydotool_socket_path();
     InputReport {
         ydotool: command_path_check("ydotool"),
         ydotoold: process_check("ydotoold"),
-        ydotool_socket: path_check(&socket),
-        uinput: path_check(Path::new("/dev/uinput")),
+        ydotool_socket: ydotool_socket_check(),
+        uinput: read_write_path_check(Path::new("/dev/uinput")),
     }
 }
 
@@ -430,7 +431,7 @@ fn readiness_report(
     let can_focus_apps = windowing.can_focus_apps;
     let can_focus_windows = windowing.can_focus_windows;
     let can_send_development_input =
-        input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok && input.uinput.ok;
+        input.ydotool.ok && ((input.ydotoold.ok && input.ydotool_socket.ok) || input.uinput.ok);
 
     if !can_build_accessibility_tree {
         blockers.push(
@@ -457,7 +458,7 @@ fn readiness_report(
 
     if !can_send_development_input {
         blockers.push(
-            "Development input fallback is not fully available; ydotool, ydotoold, socket, and /dev/uinput are required."
+            "Development input fallback is unavailable; ydotool needs either a connectable ydotoold socket or read/write access to /dev/uinput."
                 .to_string(),
         );
     }
@@ -477,7 +478,7 @@ fn readiness_report(
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
-        "Install and start ydotoold if development input fallback is needed.".to_string()
+        "Fix ydotool input access: start ydotoold with a socket accessible to this desktop user, or allow direct read/write access to /dev/uinput.".to_string()
     } else {
         "Computer Use is ready: AT-SPI tree support, window targeting, and ydotool input fallback are available."
             .to_string()
@@ -537,24 +538,32 @@ fn dbus_session_address() -> Option<String> {
         })
 }
 
-fn ydotool_socket_path() -> PathBuf {
+fn ydotool_socket_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
     if let Some(value) = env_var("YDOTOOL_SOCKET") {
-        return PathBuf::from(value);
+        candidates.push(PathBuf::from(value));
     }
 
-    let runtime_socket = xdg_runtime_dir().map(|runtime| runtime.join(".ydotool_socket"));
-    let tmp_socket = PathBuf::from("/tmp/.ydotool_socket");
+    if let Some(runtime_socket) = xdg_runtime_dir().map(|runtime| runtime.join(".ydotool_socket")) {
+        candidates.push(runtime_socket);
+    }
+    candidates.push(PathBuf::from("/tmp/.ydotool_socket"));
+    candidates
+}
 
-    for candidate in [runtime_socket.as_ref(), Some(&tmp_socket)]
-        .into_iter()
-        .flatten()
-    {
-        if candidate.exists() {
-            return candidate.to_path_buf();
+fn ydotool_socket_check() -> Check {
+    let mut checked = Vec::new();
+    for candidate in ydotool_socket_candidates() {
+        match socket_connect_result(&candidate) {
+            Ok(()) => return Check::ok(format!("connectable: {}", candidate.display())),
+            Err(detail) => checked.push(detail),
         }
     }
 
-    runtime_socket.unwrap_or(tmp_socket)
+    Check::fail(format!(
+        "no connectable ydotool socket ({})",
+        checked.join("; ")
+    ))
 }
 
 fn user_id() -> Option<String> {
@@ -574,11 +583,33 @@ fn process_check(process_name: &str) -> Check {
     command_check("pgrep", &["-a", process_name])
 }
 
-fn path_check(path: &Path) -> Check {
-    if path.exists() {
-        Check::ok(path.display().to_string())
-    } else {
-        Check::fail(format!("missing: {}", path.display()))
+#[cfg(test)]
+fn socket_connect_check(path: &Path) -> Check {
+    match socket_connect_result(path) {
+        Ok(()) => Check::ok(format!("connectable: {}", path.display())),
+        Err(detail) => Check::fail(detail),
+    }
+}
+
+fn socket_connect_result(path: &Path) -> std::result::Result<(), String> {
+    if !path.exists() {
+        return Err(format!("missing: {}", path.display()));
+    }
+
+    match UnixStream::connect(path) {
+        Ok(_) => Ok(()),
+        Err(error) => Err(format!("{}: {error}", path.display())),
+    }
+}
+
+fn read_write_path_check(path: &Path) -> Check {
+    if !path.exists() {
+        return Check::fail(format!("missing: {}", path.display()));
+    }
+
+    match OpenOptions::new().read(true).write(true).open(path) {
+        Ok(_) => Check::ok(format!("read/write: {}", path.display())),
+        Err(error) => Check::fail(format!("{}: {error}", path.display())),
     }
 }
 
@@ -718,11 +749,20 @@ mod tests {
         } else {
             Check::fail("missing")
         };
+        input_report_parts(check.clone(), check.clone(), check.clone(), check)
+    }
+
+    fn input_report_parts(
+        ydotool: Check,
+        ydotoold: Check,
+        ydotool_socket: Check,
+        uinput: Check,
+    ) -> InputReport {
         InputReport {
-            ydotool: check.clone(),
-            ydotoold: check.clone(),
-            ydotool_socket: check.clone(),
-            uinput: check,
+            ydotool,
+            ydotoold,
+            ydotool_socket,
+            uinput,
         }
     }
 
@@ -821,6 +861,67 @@ mod tests {
         assert!(!readiness
             .recommended_next_step
             .contains("GNOME window targeting"));
+    }
+
+    #[test]
+    fn readiness_accepts_connectable_ydotool_socket_without_direct_uinput_access() {
+        let platform = platform_report();
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::ok("ydotool"),
+            Check::ok("ydotoold"),
+            Check::ok("connectable: /tmp/.ydotool_socket"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+
+        assert!(readiness.can_send_development_input);
+        assert!(readiness.blockers.is_empty());
+    }
+
+    #[test]
+    fn readiness_rejects_inaccessible_ydotool_paths() {
+        let platform = platform_report();
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::ok("ydotool"),
+            Check::ok("ydotoold"),
+            Check::fail("/tmp/.ydotool_socket: Permission denied"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+
+        assert!(!readiness.can_send_development_input);
+        assert!(readiness
+            .recommended_next_step
+            .contains("Fix ydotool input access"));
+        assert!(readiness
+            .blockers
+            .iter()
+            .any(|blocker| blocker.contains("connectable ydotoold socket")));
+    }
+
+    #[test]
+    fn ydotool_socket_check_requires_a_connectable_socket() {
+        let dir = std::env::temp_dir().join(format!(
+            "codex-computer-use-diagnostics-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp diagnostics dir");
+        let socket = dir.join("ydotool.sock");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&socket).expect("bind temp diagnostics socket");
+
+        let check = socket_connect_check(&socket);
+
+        assert!(check.ok, "{check:?}");
+        drop(listener);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -431,7 +431,7 @@ fn readiness_report(
     let can_focus_apps = windowing.can_focus_apps;
     let can_focus_windows = windowing.can_focus_windows;
     let can_send_development_input =
-        input.ydotool.ok && ((input.ydotoold.ok && input.ydotool_socket.ok) || input.uinput.ok);
+        input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok;
 
     if !can_build_accessibility_tree {
         blockers.push(
@@ -458,7 +458,7 @@ fn readiness_report(
 
     if !can_send_development_input {
         blockers.push(
-            "Development input fallback is unavailable; ydotool needs either a connectable ydotoold socket or read/write access to /dev/uinput."
+            "Development input fallback is unavailable; ydotool needs a running ydotoold daemon with a connectable ydotoold socket."
                 .to_string(),
         );
     }
@@ -478,7 +478,8 @@ fn readiness_report(
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
-        "Fix ydotool input access: start ydotoold with a socket accessible to this desktop user, or allow direct read/write access to /dev/uinput.".to_string()
+        "Fix ydotool input access: start ydotoold with a socket accessible to this desktop user."
+            .to_string()
     } else {
         "Computer Use is ready: AT-SPI tree support, window targeting, and ydotool input fallback are available."
             .to_string()
@@ -879,6 +880,27 @@ mod tests {
 
         assert!(readiness.can_send_development_input);
         assert!(readiness.blockers.is_empty());
+    }
+
+    #[test]
+    fn readiness_rejects_direct_uinput_without_connectable_ydotool_socket() {
+        let platform = platform_report();
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::ok("ydotool"),
+            Check::fail("ydotoold not running"),
+            Check::fail("no connectable ydotool socket"),
+            Check::ok("read/write: /dev/uinput"),
+        );
+
+        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+
+        assert!(!readiness.can_send_development_input);
+        assert!(readiness
+            .blockers
+            .iter()
+            .any(|blocker| blocker.contains("connectable ydotoold socket")));
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -25,8 +25,10 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use std::{
     env,
+    io::Write,
+    os::unix::net::UnixStream,
     path::PathBuf,
-    process::{Command, Output},
+    process::{Command, Output, Stdio},
     sync::{Arc, Mutex},
     thread,
     time::Duration,
@@ -476,6 +478,34 @@ impl ComputerUseLinux {
                 });
             }
         };
+
+        if let Some(scroll_key) = keyboard_scroll_key(direction) {
+            if let Ok(Some(focus)) = self
+                .focus_window_at_point_for_keyboard_scroll(target_point)
+                .await
+            {
+                let Some(args) = ydotool_key_args(scroll_key) else {
+                    return Json(ActionOutput {
+                        ok: false,
+                        implemented: true,
+                        action: "scroll".to_string(),
+                        message: format!("Unsupported keyboard scroll key: {scroll_key}"),
+                        received,
+                    });
+                };
+                let commands = (0..keyboard_scroll_pages(params.pages))
+                    .map(|_| args.clone())
+                    .collect::<Vec<_>>();
+                let result = run_ydotool_sequence(&commands);
+                return Json(action_result_with_focus(
+                    "scroll",
+                    result,
+                    received,
+                    Some(focus),
+                ));
+            }
+        }
+
         if let Some(session) = self.cached_portal_pointer_session() {
             match portal_scroll(&session, target_point, direction, units).await {
                 Ok(()) => {
@@ -617,18 +647,22 @@ impl ComputerUseLinux {
                 });
             }
         };
-        let Some(key_events) = key_sequence(&params.key) else {
-            return Json(ActionOutput {
-                ok: false,
-                implemented: true,
-                action: "press_key".to_string(),
-                message: "Unsupported key. Use names like Enter, Escape, Tab, ArrowLeft, Super, Ctrl+L, or a single US keyboard letter/digit.".to_string(),
-                received,
-            });
+        let result = if is_bare_space_key(&params.key) {
+            run_ydotool_type_text(" ").map(|output| vec![output])
+        } else {
+            let Some(key_events) = key_sequence(&params.key) else {
+                return Json(ActionOutput {
+                    ok: false,
+                    implemented: true,
+                    action: "press_key".to_string(),
+                    message: "Unsupported key. Use names like Enter, Escape, Tab, ArrowLeft, Super, Ctrl+L, or a single US keyboard letter/digit.".to_string(),
+                    received,
+                });
+            };
+            let mut args = vec!["key".to_string()];
+            args.extend(key_events);
+            run_ydotool(&args).map(|output| vec![output])
         };
-        let mut args = vec!["key".to_string()];
-        args.extend(key_events);
-        let result = run_ydotool(&args).map(|output| vec![output]);
         Json(action_result_with_focus(
             "press_key",
             result,
@@ -658,8 +692,7 @@ impl ComputerUseLinux {
                 });
             }
         };
-        let result = run_ydotool(&["type".to_string(), "--".to_string(), params.text])
-            .map(|output| vec![output]);
+        let result = run_ydotool_type_text(&params.text).map(|output| vec![output]);
         Json(action_result_with_focus(
             "type_text",
             result,
@@ -1144,6 +1177,30 @@ impl ComputerUseLinux {
                 focus.focused_window.as_ref().map(|window| window.window_id)
             ))
         }
+    }
+
+    async fn focus_window_at_point_for_keyboard_scroll(
+        &self,
+        target_point: Option<(i32, i32)>,
+    ) -> std::result::Result<Option<WindowFocusResult>, String> {
+        let Some(point) = target_point else {
+            return Ok(None);
+        };
+
+        let windows = list_windows().await.map_err(|error| format!("{error:#}"))?;
+        let Some(window) = window_at_point(&windows, point) else {
+            return Ok(None);
+        };
+
+        if window.backend != "kwin" {
+            return Ok(None);
+        }
+
+        self.focus_target_for_input(&WindowTarget {
+            window_id: Some(window.window_id),
+            ..Default::default()
+        })
+        .await
     }
 
     fn cache_nodes(&self, nodes: &[AccessibilityNode]) {
@@ -1822,6 +1879,12 @@ fn absolute_mousemove_args(x: i32, y: i32) -> Vec<String> {
     ]
 }
 
+fn ydotool_key_args(key: &str) -> Option<Vec<String>> {
+    let mut args = vec!["key".to_string()];
+    args.extend(key_sequence(key)?);
+    Some(args)
+}
+
 fn wheel_mousemove_args(dx: i32, dy: i32) -> Vec<String> {
     vec![
         "mousemove".to_string(),
@@ -1843,6 +1906,58 @@ fn run_ydotool_sequence(commands: &[Vec<String>]) -> std::result::Result<Vec<Out
     Ok(outputs)
 }
 
+fn keyboard_scroll_key(direction: ScrollDirection) -> Option<&'static str> {
+    match direction {
+        ScrollDirection::Up => Some("PageUp"),
+        ScrollDirection::Down => Some("PageDown"),
+        ScrollDirection::Left | ScrollDirection::Right => None,
+    }
+}
+
+fn keyboard_scroll_pages(pages: Option<f64>) -> usize {
+    pages.unwrap_or(1.0).abs().ceil().clamp(1.0, 20.0) as usize
+}
+
+fn window_at_point(windows: &[WindowInfo], point: (i32, i32)) -> Option<&WindowInfo> {
+    let matches = windows
+        .iter()
+        .filter(|window| !window.hidden)
+        .filter(|window| window_contains_point(window, point))
+        .collect::<Vec<_>>();
+
+    matches
+        .iter()
+        .copied()
+        .find(|window| window.focused)
+        .or_else(|| {
+            matches
+                .into_iter()
+                .min_by_key(|window| window_bounds_area(window).unwrap_or(u64::MAX))
+        })
+}
+
+fn window_contains_point(window: &WindowInfo, (x, y): (i32, i32)) -> bool {
+    let Some(bounds) = &window.bounds else {
+        return false;
+    };
+    let Some(left) = bounds.x else {
+        return false;
+    };
+    let Some(top) = bounds.y else {
+        return false;
+    };
+    let right = left.saturating_add(bounds.width as i32);
+    let bottom = top.saturating_add(bounds.height as i32);
+    x >= left && x < right && y >= top && y < bottom
+}
+
+fn window_bounds_area(window: &WindowInfo) -> Option<u64> {
+    window
+        .bounds
+        .as_ref()
+        .map(|bounds| bounds.width as u64 * bounds.height as u64)
+}
+
 fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
     let mut command = Command::new("ydotool");
     command.args(args);
@@ -1852,41 +1967,78 @@ fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
 
     match command.output() {
         Ok(output) if output.status.success() => Ok(output),
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            let detail = if stderr.is_empty() { stdout } else { stderr };
-            Err(if detail.is_empty() {
-                format!("ydotool exited with {}", output.status)
-            } else {
-                detail
-            })
+        Ok(output) => Err(ydotool_output_error(output)),
+        Err(error) => Err(format!("failed to run ydotool: {error}")),
+    }
+}
+
+fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String> {
+    let mut command = Command::new("ydotool");
+    command.args(["type", "--file", "-"]);
+    if let Some(socket) = ydotool_socket() {
+        command.env("YDOTOOL_SOCKET", socket);
+    }
+    command.stdin(Stdio::piped());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    match command.spawn() {
+        Ok(mut child) => {
+            if let Some(stdin) = child.stdin.as_mut() {
+                if let Err(error) = stdin.write_all(text.as_bytes()) {
+                    let _ = child.kill();
+                    return Err(format!("failed to write text to ydotool stdin: {error}"));
+                }
+            }
+            match child.wait_with_output() {
+                Ok(output) if output.status.success() => Ok(output),
+                Ok(output) => Err(ydotool_output_error(output)),
+                Err(error) => Err(format!("failed to wait for ydotool: {error}")),
+            }
         }
         Err(error) => Err(format!("failed to run ydotool: {error}")),
     }
 }
 
+fn ydotool_output_error(output: Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    if detail.is_empty() {
+        format!("ydotool exited with {}", output.status)
+    } else {
+        detail
+    }
+}
+
 fn ydotool_socket() -> Option<String> {
+    connectable_ydotool_socket_from(ydotool_socket_candidates())
+        .map(|path| path.display().to_string())
+}
+
+fn ydotool_socket_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
     if let Ok(socket) = env::var("YDOTOOL_SOCKET") {
-        if !socket.trim().is_empty() {
-            return Some(socket);
+        let socket = socket.trim();
+        if !socket.is_empty() {
+            candidates.push(PathBuf::from(socket));
         }
     }
+    if let Some(runtime) = env::var("XDG_RUNTIME_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| user_id().map(|uid| PathBuf::from(format!("/run/user/{uid}"))))
+    {
+        candidates.push(runtime.join(".ydotool_socket"));
+    }
+    candidates.push(PathBuf::from("/tmp/.ydotool_socket"));
+    candidates
+}
 
-    let candidates = [
-        env::var("XDG_RUNTIME_DIR")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| user_id().map(|uid| PathBuf::from(format!("/run/user/{uid}"))))
-            .map(|runtime| runtime.join(".ydotool_socket")),
-        Some(PathBuf::from("/tmp/.ydotool_socket")),
-    ];
-
+fn connectable_ydotool_socket_from(candidates: Vec<PathBuf>) -> Option<PathBuf> {
     candidates
         .into_iter()
-        .flatten()
-        .find(|path| path.exists())
-        .map(|path| path.display().to_string())
+        .find(|path| UnixStream::connect(path).is_ok())
 }
 
 fn mouse_button_code(button: Option<&str>) -> String {
@@ -1909,68 +2061,54 @@ fn key_sequence(key: &str) -> Option<Vec<String>> {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>();
     let (key_part, modifier_parts) = parts.split_last()?;
-    if modifier_parts.is_empty() {
-        if let Some(modifier) = modifier_keycode(key_part) {
-            return Some(vec![format!("{modifier}:1"), format!("{modifier}:0")]);
-        }
-    }
     let mut modifiers = Vec::new();
     for part in modifier_parts {
-        modifiers.push(modifier_keycode(part)?);
+        modifiers.push(modifier_key_name(part)?);
     }
-    let keycode = keycode(key_part)?;
+    let key = modifier_key_name(key_part).or_else(|| key_name(key_part))?;
 
-    let mut events = Vec::new();
-    for modifier in &modifiers {
-        events.push(format!("{modifier}:1"));
+    if modifiers.is_empty() {
+        return Some(vec![key]);
     }
-    events.push(format!("{keycode}:1"));
-    events.push(format!("{keycode}:0"));
-    for modifier in modifiers.iter().rev() {
-        events.push(format!("{modifier}:0"));
-    }
-    Some(events)
+
+    modifiers.push(key);
+    Some(vec![modifiers.join("+")])
 }
 
-fn modifier_keycode(key: &str) -> Option<u16> {
+fn is_bare_space_key(key: &str) -> bool {
+    matches!(normalize_key(key).as_str(), "space")
+}
+
+fn modifier_key_name(key: &str) -> Option<String> {
     match normalize_key(key).as_str() {
-        "ctrl" | "control" => Some(29),
-        "alt" | "option" => Some(56),
-        "shift" => Some(42),
-        "meta" | "super" | "cmd" | "command" => Some(125),
+        "ctrl" | "control" => Some("ctrl".to_string()),
+        "alt" | "option" => Some("alt".to_string()),
+        "shift" => Some("shift".to_string()),
+        "meta" | "super" | "cmd" | "command" => Some("super".to_string()),
         _ => None,
     }
 }
 
-fn keycode(key: &str) -> Option<u16> {
+fn key_name(key: &str) -> Option<String> {
     match normalize_key(key).as_str() {
-        "enter" | "return" => Some(28),
-        "escape" | "esc" => Some(1),
-        "tab" => Some(15),
-        "backspace" => Some(14),
-        "delete" | "del" => Some(111),
-        "space" => Some(57),
-        "home" => Some(102),
-        "end" => Some(107),
-        "pageup" | "page_up" => Some(104),
-        "pagedown" | "page_down" => Some(109),
-        "arrowleft" | "left" => Some(105),
-        "arrowright" | "right" => Some(106),
-        "arrowup" | "up" => Some(103),
-        "arrowdown" | "down" => Some(108),
-        "f1" => Some(59),
-        "f2" => Some(60),
-        "f3" => Some(61),
-        "f4" => Some(62),
-        "f5" => Some(63),
-        "f6" => Some(64),
-        "f7" => Some(65),
-        "f8" => Some(66),
-        "f9" => Some(67),
-        "f10" => Some(68),
-        "f11" => Some(87),
-        "f12" => Some(88),
-        value if value.len() == 1 => keycode_for_ascii(value.as_bytes()[0] as char),
+        "enter" | "return" => Some("enter".to_string()),
+        "escape" | "esc" => Some("esc".to_string()),
+        "tab" => Some("tab".to_string()),
+        "backspace" => Some("backspace".to_string()),
+        "delete" | "del" => Some("delete".to_string()),
+        "space" => Some("space".to_string()),
+        "home" => Some("home".to_string()),
+        "end" => Some("end".to_string()),
+        "pageup" | "page_up" => Some("pageup".to_string()),
+        "pagedown" | "page_down" => Some("pagedown".to_string()),
+        "arrowleft" | "left" => Some("left".to_string()),
+        "arrowright" | "right" => Some("right".to_string()),
+        "arrowup" | "up" => Some("up".to_string()),
+        "arrowdown" | "down" => Some("down".to_string()),
+        "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" => {
+            Some(normalize_key(key))
+        }
+        value if value.len() == 1 => key_name_for_ascii(value.as_bytes()[0] as char),
         _ => None,
     }
 }
@@ -1979,44 +2117,9 @@ fn normalize_key(key: &str) -> String {
     key.trim().to_ascii_lowercase().replace(['-', ' '], "")
 }
 
-fn keycode_for_ascii(value: char) -> Option<u16> {
+fn key_name_for_ascii(value: char) -> Option<String> {
     match value {
-        'a' => Some(30),
-        'b' => Some(48),
-        'c' => Some(46),
-        'd' => Some(32),
-        'e' => Some(18),
-        'f' => Some(33),
-        'g' => Some(34),
-        'h' => Some(35),
-        'i' => Some(23),
-        'j' => Some(36),
-        'k' => Some(37),
-        'l' => Some(38),
-        'm' => Some(50),
-        'n' => Some(49),
-        'o' => Some(24),
-        'p' => Some(25),
-        'q' => Some(16),
-        'r' => Some(19),
-        's' => Some(31),
-        't' => Some(20),
-        'u' => Some(22),
-        'v' => Some(47),
-        'w' => Some(17),
-        'x' => Some(45),
-        'y' => Some(21),
-        'z' => Some(44),
-        '1' => Some(2),
-        '2' => Some(3),
-        '3' => Some(4),
-        '4' => Some(5),
-        '5' => Some(6),
-        '6' => Some(7),
-        '7' => Some(8),
-        '8' => Some(9),
-        '9' => Some(10),
-        '0' => Some(11),
+        'a'..='z' | '0'..='9' => Some(value.to_string()),
         _ => None,
     }
 }
@@ -2617,26 +2720,112 @@ mod tests {
     }
 
     #[test]
+    fn keyboard_scroll_uses_page_keys_for_vertical_directions() {
+        assert_eq!(keyboard_scroll_key(ScrollDirection::Down), Some("PageDown"));
+        assert_eq!(keyboard_scroll_key(ScrollDirection::Up), Some("PageUp"));
+        assert_eq!(keyboard_scroll_key(ScrollDirection::Left), None);
+        assert_eq!(keyboard_scroll_pages(Some(2.2)), 3);
+        assert_eq!(keyboard_scroll_pages(Some(0.0)), 1);
+        assert_eq!(keyboard_scroll_pages(Some(100.0)), 20);
+    }
+
+    #[test]
+    fn window_at_point_prefers_focused_containing_window() {
+        let mut background =
+            window_info(1, Some("Background"), Some("app"), Some("app"), Some(100));
+        background.bounds = Some(WindowBounds {
+            x: Some(0),
+            y: Some(0),
+            width: 1000,
+            height: 1000,
+        });
+
+        let mut focused = window_info(2, Some("Kate"), Some("kate"), Some("kate"), Some(200));
+        focused.focused = true;
+        focused.bounds = Some(WindowBounds {
+            x: Some(100),
+            y: Some(100),
+            width: 500,
+            height: 500,
+        });
+
+        let windows = [background, focused];
+        let selected = window_at_point(&windows, (250, 250)).unwrap();
+
+        assert_eq!(selected.window_id, 2);
+    }
+
+    #[test]
+    fn window_at_point_ignores_hidden_and_out_of_bounds_windows() {
+        let mut hidden = window_info(1, Some("Hidden"), Some("app"), Some("app"), Some(100));
+        hidden.hidden = true;
+        hidden.bounds = Some(WindowBounds {
+            x: Some(0),
+            y: Some(0),
+            width: 1000,
+            height: 1000,
+        });
+
+        let visible = window_info(2, Some("Visible"), Some("app"), Some("app"), Some(200));
+
+        let windows = [hidden, visible];
+        assert!(window_at_point(&windows, (900, 900)).is_none());
+    }
+
+    #[test]
     fn key_sequence_presses_modifiers_around_key() {
         assert_eq!(
             key_sequence("Ctrl+Shift+P"),
-            Some(vec![
-                "29:1".to_string(),
-                "42:1".to_string(),
-                "25:1".to_string(),
-                "25:0".to_string(),
-                "42:0".to_string(),
-                "29:0".to_string(),
-            ])
+            Some(vec!["ctrl+shift+p".to_string()])
         );
     }
 
     #[test]
     fn key_sequence_presses_bare_modifier() {
+        assert_eq!(key_sequence("Super"), Some(vec!["super".to_string()]));
+    }
+
+    #[test]
+    fn key_sequence_uses_ydotool_key_names_for_navigation_keys() {
+        assert_eq!(key_sequence("Delete"), Some(vec!["delete".to_string()]));
         assert_eq!(
-            key_sequence("Super"),
-            Some(vec!["125:1".to_string(), "125:0".to_string()])
+            key_sequence("Ctrl+Home"),
+            Some(vec!["ctrl+home".to_string()])
         );
+        assert_eq!(
+            key_sequence("Shift+ArrowRight"),
+            Some(vec!["shift+right".to_string()])
+        );
+        assert_eq!(
+            ydotool_key_args("PageDown"),
+            Some(vec!["key".to_string(), "pagedown".to_string(),])
+        );
+    }
+
+    #[test]
+    fn bare_space_uses_text_input_path() {
+        assert!(is_bare_space_key("Space"));
+        assert!(!is_bare_space_key("Shift+Space"));
+    }
+
+    #[test]
+    fn ydotool_socket_selection_skips_unconnectable_candidates() {
+        let dir =
+            std::env::temp_dir().join(format!("codex-computer-use-server-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp server dir");
+        let stale_socket = dir.join("stale.sock");
+        std::fs::write(&stale_socket, b"not a socket").expect("write stale socket placeholder");
+        let usable_socket = dir.join("usable.sock");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&usable_socket).expect("bind usable socket");
+
+        let selected = connectable_ydotool_socket_from(vec![stale_socket, usable_socket.clone()])
+            .expect("usable socket should be selected");
+
+        assert_eq!(selected, usable_socket);
+        drop(listener);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -479,33 +479,6 @@ impl ComputerUseLinux {
             }
         };
 
-        if let Some(scroll_key) = keyboard_scroll_key(direction) {
-            if let Ok(Some(focus)) = self
-                .focus_window_at_point_for_keyboard_scroll(target_point)
-                .await
-            {
-                let Some(args) = ydotool_key_args(scroll_key) else {
-                    return Json(ActionOutput {
-                        ok: false,
-                        implemented: true,
-                        action: "scroll".to_string(),
-                        message: format!("Unsupported keyboard scroll key: {scroll_key}"),
-                        received,
-                    });
-                };
-                let commands = (0..keyboard_scroll_pages(params.pages))
-                    .map(|_| args.clone())
-                    .collect::<Vec<_>>();
-                let result = run_ydotool_sequence(&commands);
-                return Json(action_result_with_focus(
-                    "scroll",
-                    result,
-                    received,
-                    Some(focus),
-                ));
-            }
-        }
-
         if let Some(session) = self.cached_portal_pointer_session() {
             match portal_scroll(&session, target_point, direction, units).await {
                 Ok(()) => {
@@ -647,22 +620,18 @@ impl ComputerUseLinux {
                 });
             }
         };
-        let result = if is_bare_space_key(&params.key) {
-            run_ydotool_type_text(" ").map(|output| vec![output])
-        } else {
-            let Some(key_events) = key_sequence(&params.key) else {
-                return Json(ActionOutput {
-                    ok: false,
-                    implemented: true,
-                    action: "press_key".to_string(),
-                    message: "Unsupported key. Use names like Enter, Escape, Tab, ArrowLeft, Super, Ctrl+L, or a single US keyboard letter/digit.".to_string(),
-                    received,
-                });
-            };
-            let mut args = vec!["key".to_string()];
-            args.extend(key_events);
-            run_ydotool(&args).map(|output| vec![output])
+        let Some(key_events) = key_sequence(&params.key) else {
+            return Json(ActionOutput {
+                ok: false,
+                implemented: true,
+                action: "press_key".to_string(),
+                message: "Unsupported key. Use names like Enter, Escape, Tab, ArrowLeft, Super, Ctrl+L, or a single US keyboard letter/digit.".to_string(),
+                received,
+            });
         };
+        let mut args = vec!["key".to_string()];
+        args.extend(key_events);
+        let result = run_ydotool(&args).map(|output| vec![output]);
         Json(action_result_with_focus(
             "press_key",
             result,
@@ -1177,30 +1146,6 @@ impl ComputerUseLinux {
                 focus.focused_window.as_ref().map(|window| window.window_id)
             ))
         }
-    }
-
-    async fn focus_window_at_point_for_keyboard_scroll(
-        &self,
-        target_point: Option<(i32, i32)>,
-    ) -> std::result::Result<Option<WindowFocusResult>, String> {
-        let Some(point) = target_point else {
-            return Ok(None);
-        };
-
-        let windows = list_windows().await.map_err(|error| format!("{error:#}"))?;
-        let Some(window) = window_at_point(&windows, point) else {
-            return Ok(None);
-        };
-
-        if window.backend != "kwin" {
-            return Ok(None);
-        }
-
-        self.focus_target_for_input(&WindowTarget {
-            window_id: Some(window.window_id),
-            ..Default::default()
-        })
-        .await
     }
 
     fn cache_nodes(&self, nodes: &[AccessibilityNode]) {
@@ -1879,12 +1824,6 @@ fn absolute_mousemove_args(x: i32, y: i32) -> Vec<String> {
     ]
 }
 
-fn ydotool_key_args(key: &str) -> Option<Vec<String>> {
-    let mut args = vec!["key".to_string()];
-    args.extend(key_sequence(key)?);
-    Some(args)
-}
-
 fn wheel_mousemove_args(dx: i32, dy: i32) -> Vec<String> {
     vec![
         "mousemove".to_string(),
@@ -1904,58 +1843,6 @@ fn run_ydotool_sequence(commands: &[Vec<String>]) -> std::result::Result<Vec<Out
         }
     }
     Ok(outputs)
-}
-
-fn keyboard_scroll_key(direction: ScrollDirection) -> Option<&'static str> {
-    match direction {
-        ScrollDirection::Up => Some("PageUp"),
-        ScrollDirection::Down => Some("PageDown"),
-        ScrollDirection::Left | ScrollDirection::Right => None,
-    }
-}
-
-fn keyboard_scroll_pages(pages: Option<f64>) -> usize {
-    pages.unwrap_or(1.0).abs().ceil().clamp(1.0, 20.0) as usize
-}
-
-fn window_at_point(windows: &[WindowInfo], point: (i32, i32)) -> Option<&WindowInfo> {
-    let matches = windows
-        .iter()
-        .filter(|window| !window.hidden)
-        .filter(|window| window_contains_point(window, point))
-        .collect::<Vec<_>>();
-
-    matches
-        .iter()
-        .copied()
-        .find(|window| window.focused)
-        .or_else(|| {
-            matches
-                .into_iter()
-                .min_by_key(|window| window_bounds_area(window).unwrap_or(u64::MAX))
-        })
-}
-
-fn window_contains_point(window: &WindowInfo, (x, y): (i32, i32)) -> bool {
-    let Some(bounds) = &window.bounds else {
-        return false;
-    };
-    let Some(left) = bounds.x else {
-        return false;
-    };
-    let Some(top) = bounds.y else {
-        return false;
-    };
-    let right = left.saturating_add(bounds.width as i32);
-    let bottom = top.saturating_add(bounds.height as i32);
-    x >= left && x < right && y >= top && y < bottom
-}
-
-fn window_bounds_area(window: &WindowInfo) -> Option<u64> {
-    window
-        .bounds
-        .as_ref()
-        .map(|bounds| bounds.width as u64 * bounds.height as u64)
 }
 
 fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
@@ -2061,54 +1948,68 @@ fn key_sequence(key: &str) -> Option<Vec<String>> {
         .filter(|part| !part.is_empty())
         .collect::<Vec<_>>();
     let (key_part, modifier_parts) = parts.split_last()?;
+    if modifier_parts.is_empty() {
+        if let Some(modifier) = modifier_keycode(key_part) {
+            return Some(vec![format!("{modifier}:1"), format!("{modifier}:0")]);
+        }
+    }
     let mut modifiers = Vec::new();
     for part in modifier_parts {
-        modifiers.push(modifier_key_name(part)?);
+        modifiers.push(modifier_keycode(part)?);
     }
-    let key = modifier_key_name(key_part).or_else(|| key_name(key_part))?;
+    let keycode = keycode(key_part)?;
 
-    if modifiers.is_empty() {
-        return Some(vec![key]);
+    let mut events = Vec::new();
+    for modifier in &modifiers {
+        events.push(format!("{modifier}:1"));
     }
-
-    modifiers.push(key);
-    Some(vec![modifiers.join("+")])
+    events.push(format!("{keycode}:1"));
+    events.push(format!("{keycode}:0"));
+    for modifier in modifiers.iter().rev() {
+        events.push(format!("{modifier}:0"));
+    }
+    Some(events)
 }
 
-fn is_bare_space_key(key: &str) -> bool {
-    matches!(normalize_key(key).as_str(), "space")
-}
-
-fn modifier_key_name(key: &str) -> Option<String> {
+fn modifier_keycode(key: &str) -> Option<u16> {
     match normalize_key(key).as_str() {
-        "ctrl" | "control" => Some("ctrl".to_string()),
-        "alt" | "option" => Some("alt".to_string()),
-        "shift" => Some("shift".to_string()),
-        "meta" | "super" | "cmd" | "command" => Some("super".to_string()),
+        "ctrl" | "control" => Some(29),
+        "alt" | "option" => Some(56),
+        "shift" => Some(42),
+        "meta" | "super" | "cmd" | "command" => Some(125),
         _ => None,
     }
 }
 
-fn key_name(key: &str) -> Option<String> {
+fn keycode(key: &str) -> Option<u16> {
     match normalize_key(key).as_str() {
-        "enter" | "return" => Some("enter".to_string()),
-        "escape" | "esc" => Some("esc".to_string()),
-        "tab" => Some("tab".to_string()),
-        "backspace" => Some("backspace".to_string()),
-        "delete" | "del" => Some("delete".to_string()),
-        "space" => Some("space".to_string()),
-        "home" => Some("home".to_string()),
-        "end" => Some("end".to_string()),
-        "pageup" | "page_up" => Some("pageup".to_string()),
-        "pagedown" | "page_down" => Some("pagedown".to_string()),
-        "arrowleft" | "left" => Some("left".to_string()),
-        "arrowright" | "right" => Some("right".to_string()),
-        "arrowup" | "up" => Some("up".to_string()),
-        "arrowdown" | "down" => Some("down".to_string()),
-        "f1" | "f2" | "f3" | "f4" | "f5" | "f6" | "f7" | "f8" | "f9" | "f10" | "f11" | "f12" => {
-            Some(normalize_key(key))
-        }
-        value if value.len() == 1 => key_name_for_ascii(value.as_bytes()[0] as char),
+        "enter" | "return" => Some(28),
+        "escape" | "esc" => Some(1),
+        "tab" => Some(15),
+        "backspace" => Some(14),
+        "delete" | "del" => Some(111),
+        "space" => Some(57),
+        "home" => Some(102),
+        "end" => Some(107),
+        "pageup" | "page_up" => Some(104),
+        "pagedown" | "page_down" => Some(109),
+        "arrowleft" | "left" => Some(105),
+        "arrowright" | "right" => Some(106),
+        "arrowup" | "up" => Some(103),
+        "arrowdown" | "down" => Some(108),
+        "f1" => Some(59),
+        "f2" => Some(60),
+        "f3" => Some(61),
+        "f4" => Some(62),
+        "f5" => Some(63),
+        "f6" => Some(64),
+        "f7" => Some(65),
+        "f8" => Some(66),
+        "f9" => Some(67),
+        "f10" => Some(68),
+        "f11" => Some(87),
+        "f12" => Some(88),
+        value if value.len() == 1 => keycode_for_ascii(value.as_bytes()[0] as char),
         _ => None,
     }
 }
@@ -2117,9 +2018,44 @@ fn normalize_key(key: &str) -> String {
     key.trim().to_ascii_lowercase().replace(['-', ' '], "")
 }
 
-fn key_name_for_ascii(value: char) -> Option<String> {
+fn keycode_for_ascii(value: char) -> Option<u16> {
     match value {
-        'a'..='z' | '0'..='9' => Some(value.to_string()),
+        'a' => Some(30),
+        'b' => Some(48),
+        'c' => Some(46),
+        'd' => Some(32),
+        'e' => Some(18),
+        'f' => Some(33),
+        'g' => Some(34),
+        'h' => Some(35),
+        'i' => Some(23),
+        'j' => Some(36),
+        'k' => Some(37),
+        'l' => Some(38),
+        'm' => Some(50),
+        'n' => Some(49),
+        'o' => Some(24),
+        'p' => Some(25),
+        'q' => Some(16),
+        'r' => Some(19),
+        's' => Some(31),
+        't' => Some(20),
+        'u' => Some(22),
+        'v' => Some(47),
+        'w' => Some(17),
+        'x' => Some(45),
+        'y' => Some(21),
+        'z' => Some(44),
+        '1' => Some(2),
+        '2' => Some(3),
+        '3' => Some(4),
+        '4' => Some(5),
+        '5' => Some(6),
+        '6' => Some(7),
+        '7' => Some(8),
+        '8' => Some(9),
+        '9' => Some(10),
+        '0' => Some(11),
         _ => None,
     }
 }
@@ -2720,92 +2656,26 @@ mod tests {
     }
 
     #[test]
-    fn keyboard_scroll_uses_page_keys_for_vertical_directions() {
-        assert_eq!(keyboard_scroll_key(ScrollDirection::Down), Some("PageDown"));
-        assert_eq!(keyboard_scroll_key(ScrollDirection::Up), Some("PageUp"));
-        assert_eq!(keyboard_scroll_key(ScrollDirection::Left), None);
-        assert_eq!(keyboard_scroll_pages(Some(2.2)), 3);
-        assert_eq!(keyboard_scroll_pages(Some(0.0)), 1);
-        assert_eq!(keyboard_scroll_pages(Some(100.0)), 20);
-    }
-
-    #[test]
-    fn window_at_point_prefers_focused_containing_window() {
-        let mut background =
-            window_info(1, Some("Background"), Some("app"), Some("app"), Some(100));
-        background.bounds = Some(WindowBounds {
-            x: Some(0),
-            y: Some(0),
-            width: 1000,
-            height: 1000,
-        });
-
-        let mut focused = window_info(2, Some("Kate"), Some("kate"), Some("kate"), Some(200));
-        focused.focused = true;
-        focused.bounds = Some(WindowBounds {
-            x: Some(100),
-            y: Some(100),
-            width: 500,
-            height: 500,
-        });
-
-        let windows = [background, focused];
-        let selected = window_at_point(&windows, (250, 250)).unwrap();
-
-        assert_eq!(selected.window_id, 2);
-    }
-
-    #[test]
-    fn window_at_point_ignores_hidden_and_out_of_bounds_windows() {
-        let mut hidden = window_info(1, Some("Hidden"), Some("app"), Some("app"), Some(100));
-        hidden.hidden = true;
-        hidden.bounds = Some(WindowBounds {
-            x: Some(0),
-            y: Some(0),
-            width: 1000,
-            height: 1000,
-        });
-
-        let visible = window_info(2, Some("Visible"), Some("app"), Some("app"), Some(200));
-
-        let windows = [hidden, visible];
-        assert!(window_at_point(&windows, (900, 900)).is_none());
-    }
-
-    #[test]
     fn key_sequence_presses_modifiers_around_key() {
         assert_eq!(
             key_sequence("Ctrl+Shift+P"),
-            Some(vec!["ctrl+shift+p".to_string()])
+            Some(vec![
+                "29:1".to_string(),
+                "42:1".to_string(),
+                "25:1".to_string(),
+                "25:0".to_string(),
+                "42:0".to_string(),
+                "29:0".to_string(),
+            ])
         );
     }
 
     #[test]
     fn key_sequence_presses_bare_modifier() {
-        assert_eq!(key_sequence("Super"), Some(vec!["super".to_string()]));
-    }
-
-    #[test]
-    fn key_sequence_uses_ydotool_key_names_for_navigation_keys() {
-        assert_eq!(key_sequence("Delete"), Some(vec!["delete".to_string()]));
         assert_eq!(
-            key_sequence("Ctrl+Home"),
-            Some(vec!["ctrl+home".to_string()])
+            key_sequence("Super"),
+            Some(vec!["125:1".to_string(), "125:0".to_string()])
         );
-        assert_eq!(
-            key_sequence("Shift+ArrowRight"),
-            Some(vec!["shift+right".to_string()])
-        );
-        assert_eq!(
-            ydotool_key_args("PageDown"),
-            Some(vec!["key".to_string(), "pagedown".to_string(),])
-        );
-    }
-
-    #[test]
-    fn bare_space_uses_text_input_path() {
-        assert!(is_bare_space_key("Space"));
-        assert!(!is_bare_space_key("Shift+Space"));
     }
 
     #[test]

--- a/computer-use-linux/src/windowing/backends/i3.rs
+++ b/computer-use-linux/src/windowing/backends/i3.rs
@@ -192,7 +192,7 @@ fn i3_socket_path() -> Option<PathBuf> {
             Some((modified, entry.path()))
         })
         .collect::<Vec<_>>();
-    sockets.sort_by(|left, right| right.0.cmp(&left.0));
+    sockets.sort_by_key(|(modified, _)| std::cmp::Reverse(*modified));
     sockets.into_iter().map(|(_, path)| path).next()
 }
 

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -258,6 +258,32 @@ mod tests {
     }
 
     #[test]
+    fn resolves_large_window_id_after_json_number_rounding() {
+        let exact_window_id = 7_511_476_032_840_641_491;
+        let rounded_window_id = 7_511_476_032_840_642_000;
+        assert_ne!(exact_window_id, rounded_window_id);
+        assert_eq!(exact_window_id as f64, rounded_window_id as f64);
+
+        let windows = vec![window(
+            exact_window_id,
+            "Untitled — Kate",
+            "org.kde.kate",
+            "org.kde.kate",
+        )];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                window_id: Some(rounded_window_id),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, exact_window_id);
+    }
+
+    #[test]
     fn pid_target_reports_ambiguous_matches() {
         let mut first = window(1, "Ghostty One", "com.mitchellh.ghostty.desktop", "Ghostty");
         let mut second = window(2, "Ghostty Two", "com.mitchellh.ghostty.desktop", "Ghostty");

--- a/computer-use-linux/src/windowing/registry.rs
+++ b/computer-use-linux/src/windowing/registry.rs
@@ -118,17 +118,31 @@ pub fn backend_can_exact_focus(id: &str) -> bool {
 pub async fn list_windows() -> Result<Vec<WindowInfo>> {
     let mut errors = Vec::new();
     for backend in BACKEND_ORDER {
-        match list_windows_for(*backend).await {
-            Ok(windows) => return Ok(windows),
-            Err(error) => {
-                let label = descriptor(backend.id())
-                    .map(|item| item.failure_label)
-                    .unwrap_or(backend.id());
-                errors.push(format!("{label} failed: {error:#}"));
-            }
+        if let Some(windows) =
+            usable_backend_windows(*backend, list_windows_for(*backend).await, &mut errors)
+        {
+            return Ok(windows);
         }
     }
     Err(anyhow!(errors.join("; ")))
+}
+
+fn usable_backend_windows(
+    backend: BackendKind,
+    result: Result<Vec<WindowInfo>>,
+    errors: &mut Vec<String>,
+) -> Option<Vec<WindowInfo>> {
+    match result {
+        Ok(windows) if !windows.is_empty() => Some(windows),
+        Ok(_) => {
+            errors.push(format!("{} returned no windows", backend.failure_label()));
+            None
+        }
+        Err(error) => {
+            errors.push(format!("{} failed: {error:#}", backend.failure_label()));
+            None
+        }
+    }
 }
 
 async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
@@ -193,5 +207,73 @@ impl BackendKind {
             BackendKind::Hyprland => HYPRLAND_BACKEND,
             BackendKind::I3 => I3_BACKEND,
         }
+    }
+
+    fn failure_label(self) -> &'static str {
+        descriptor(self.id())
+            .map(|item| item.failure_label)
+            .unwrap_or(self.id())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::windowing::types::WindowBounds;
+
+    fn window(backend: &str) -> WindowInfo {
+        WindowInfo {
+            window_id: 1,
+            title: Some("Codex".to_string()),
+            app_id: Some("codex-desktop".to_string()),
+            wm_class: Some("codex-desktop".to_string()),
+            pid: Some(1234),
+            bounds: Some(WindowBounds {
+                x: Some(0),
+                y: Some(0),
+                width: 800,
+                height: 600,
+            }),
+            workspace: None,
+            focused: true,
+            hidden: false,
+            client_type: Some("wayland".to_string()),
+            backend: backend.to_string(),
+            terminal: None,
+        }
+    }
+
+    #[test]
+    fn skips_empty_backend_results_so_later_backends_can_answer() {
+        let mut errors = Vec::new();
+
+        assert!(
+            usable_backend_windows(BackendKind::GnomeIntrospect, Ok(Vec::new()), &mut errors,)
+                .is_none()
+        );
+
+        let windows = usable_backend_windows(
+            BackendKind::Kwin,
+            Ok(vec![window(KWIN_BACKEND)]),
+            &mut errors,
+        )
+        .expect("non-empty backend result should be accepted");
+
+        assert_eq!(windows[0].backend, KWIN_BACKEND);
+        assert_eq!(errors, vec!["GNOME Shell Introspect returned no windows"]);
+    }
+
+    #[test]
+    fn records_backend_failures_with_registry_labels() {
+        let mut errors = Vec::new();
+
+        assert!(usable_backend_windows(
+            BackendKind::Kwin,
+            Err(anyhow!("loadScript failed")),
+            &mut errors,
+        )
+        .is_none());
+
+        assert_eq!(errors, vec!["KWin failed: loadScript failed"]);
     }
 }

--- a/computer-use-linux/src/windowing/target.rs
+++ b/computer-use-linux/src/windowing/target.rs
@@ -1,6 +1,6 @@
 use crate::windowing::registry::{self, WINDOW_PERMISSION_HINT};
 use crate::windowing::types::{WindowFocusResult, WindowInfo, WindowTarget};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use tokio::time::{sleep, Duration};
 
 const FOCUS_VERIFY_ATTEMPTS: usize = 6;
@@ -95,10 +95,7 @@ pub fn resolve_window_target<'a>(
     target: &WindowTarget,
 ) -> Result<&'a WindowInfo> {
     if let Some(window_id) = target.window_id {
-        return windows
-            .iter()
-            .find(|window| window.window_id == window_id)
-            .with_context(|| format!("No window matched window_id {window_id}."));
+        return resolve_window_id_target(windows, window_id);
     }
 
     if target.has_terminal_target() {
@@ -159,6 +156,37 @@ pub fn resolve_window_target<'a>(
     }
 
     bail!("Pass window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd to target a window.");
+}
+
+fn resolve_window_id_target(windows: &[WindowInfo], window_id: u64) -> Result<&WindowInfo> {
+    if let Some(window) = windows.iter().find(|window| window.window_id == window_id) {
+        return Ok(window);
+    }
+
+    let matches = windows
+        .iter()
+        .filter(|window| window_id_matches_json_number(window.window_id, window_id))
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [window] => Ok(*window),
+        [] => Err(anyhow::anyhow!("No window matched window_id {window_id}.")),
+        windows => {
+            let ids = windows
+                .iter()
+                .map(|window| window.window_id.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "window_id {window_id} matched multiple windows after JSON number rounding ({ids}); add title, pid, app_id, or wm_class to disambiguate."
+            );
+        }
+    }
+}
+
+fn window_id_matches_json_number(actual: u64, requested: u64) -> bool {
+    const JS_SAFE_INTEGER_MAX: u64 = (1_u64 << 53) - 1;
+    (actual > JS_SAFE_INTEGER_MAX || requested > JS_SAFE_INTEGER_MAX)
+        && (actual as f64) == (requested as f64)
 }
 
 fn unique_window_match<'a>(

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -1313,15 +1313,22 @@ mod tests {
         };
         paths.ensure_dirs()?;
 
-        {
-            let first_lock = try_acquire_check_lock(&paths)?;
-            let second_lock = try_acquire_check_lock(&paths)?;
+        let first_lock =
+            try_acquire_check_lock(&paths)?.expect("first lock acquisition should succeed");
+        let second_lock = try_acquire_check_lock(&paths)?;
 
-            assert!(first_lock.is_some());
-            assert!(second_lock.is_none());
+        assert!(second_lock.is_none());
+        drop(second_lock);
+        drop(first_lock);
+
+        let mut reacquired_lock = None;
+        for _ in 0..20 {
+            reacquired_lock = try_acquire_check_lock(&paths)?;
+            if reacquired_lock.is_some() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
-
-        let reacquired_lock = try_acquire_check_lock(&paths)?;
 
         assert!(reacquired_lock.is_some());
         Ok(())
@@ -1555,6 +1562,8 @@ mod tests {
         let original_path = std::env::var_os("PATH");
         let original_home = std::env::var_os("HOME");
         let original_nvm_dir = std::env::var_os("NVM_DIR");
+        let original_skip_system_cli_lookup =
+            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
 
         std::env::remove_var("DISPLAY");
         std::env::remove_var("WAYLAND_DISPLAY");
@@ -1563,6 +1572,7 @@ mod tests {
         std::env::set_var("PATH", temp.path().join("missing-bin"));
         std::env::set_var("HOME", temp.path());
         std::env::remove_var("NVM_DIR");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
         let invalid_cli_path = temp.path().join("codex.txt");
         std::fs::write(&invalid_cli_path, b"not executable")?;
@@ -1606,6 +1616,11 @@ mod tests {
             std::env::set_var("NVM_DIR", value);
         } else {
             std::env::remove_var("NVM_DIR");
+        }
+        if let Some(value) = original_skip_system_cli_lookup {
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
         }
 
         assert_eq!(outcome, PromptInstallCliOutcome::NoBackend);

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -305,9 +305,23 @@ fn known_cli_locations() -> Vec<PathBuf> {
         candidates.push(home.join(".local/share/pnpm/codex"));
         candidates.push(home.join(".local/bin/codex"));
     }
-    candidates.push(PathBuf::from("/usr/local/bin/codex"));
-    candidates.push(PathBuf::from("/usr/bin/codex"));
+    if include_system_cli_locations() {
+        candidates.push(PathBuf::from("/usr/local/bin/codex"));
+        candidates.push(PathBuf::from("/usr/bin/codex"));
+    }
     candidates
+}
+
+fn include_system_cli_locations() -> bool {
+    #[cfg(test)]
+    {
+        std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP").is_none()
+    }
+
+    #[cfg(not(test))]
+    {
+        true
+    }
 }
 
 fn requested_cli_path(state: &PersistedState) -> Option<PathBuf> {
@@ -861,10 +875,13 @@ mod tests {
         let original_path = std::env::var_os("PATH");
         let original_nvm_dir = std::env::var_os("NVM_DIR");
         let original_codex_cli_path = std::env::var_os("CODEX_CLI_PATH");
+        let original_skip_system_cli_lookup =
+            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
         std::env::set_var("HOME", temp.path());
         std::env::set_var("PATH", temp.path().join("missing-bin"));
         std::env::remove_var("NVM_DIR");
         std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
         let missing_path = temp.path().join("missing-codex");
         let mut state = PersistedState::new(true);
@@ -894,6 +911,11 @@ mod tests {
         } else {
             std::env::remove_var("CODEX_CLI_PATH");
         }
+        if let Some(value) = original_skip_system_cli_lookup {
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        }
 
         assert_eq!(state.cli_path, None);
         assert_eq!(state.cli_installed_version, None);
@@ -916,10 +938,13 @@ mod tests {
         let original_path = std::env::var_os("PATH");
         let original_nvm_dir = std::env::var_os("NVM_DIR");
         let original_codex_cli_path = std::env::var_os("CODEX_CLI_PATH");
+        let original_skip_system_cli_lookup =
+            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
         std::env::set_var("HOME", temp.path());
         std::env::set_var("PATH", temp.path().join("missing-bin"));
         std::env::remove_var("NVM_DIR");
         std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
         let mut state = PersistedState::new(true);
         refresh_status(&mut state, &paths)?;
@@ -943,6 +968,11 @@ mod tests {
             std::env::set_var("CODEX_CLI_PATH", cli_path);
         } else {
             std::env::remove_var("CODEX_CLI_PATH");
+        }
+        if let Some(value) = original_skip_system_cli_lookup {
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
         }
 
         assert_eq!(state.cli_path, None);


### PR DESCRIPTION
Tightens the Linux Computer Use backend after the windowing refactor landed in #136, now focused on fallback and readiness robustness.

What changed:

- The window backend registry keeps trying later backends when an earlier backend returns an empty window list, instead of treating that empty result as final
- The i3 backend from #134 stays in the registry order, diagnostics, activation path, and tests after the rebase on current `main`
- Runtime ydotool setup now only exports `YDOTOOL_SOCKET` when the socket can actually be connected to, so stale socket files are skipped
- `doctor` reports ydotool socket connection failures with useful detail, including permission problems
- `can_send_development_input` now requires `ydotool`, a running `ydotoold`, and a connectable ydotoold socket, matching the current runtime path that still calls the `ydotool` CLI
- `/dev/uinput` stays in diagnostics as useful detail, but it no longer makes input readiness pass by itself
- `press_key` stays on raw `ydotool key` events such as `29:1 25:1 25:0 29:0`
- `type_text` sends literal text through stdin via `ydotool type --file -`, avoiding shell quoting issues without changing the `ydotool key` protocol
- Large KWin-generated `window_id` values tolerate JSON/JavaScript number rounding on the client side, while still preferring exact id matches first
- The flaky update-manager lock test was made less timing-sensitive, and CLI lookup tests no longer depend on a system-installed `codex`

What stayed out after review feedback:

- Symbolic `ydotool key` names are not part of this PR anymore
- The PageUp/PageDown keyboard-scroll fallback was removed from this PR; scroll remains on the existing portal path and ydotool wheel fallback for now

How this fits the #136 refactor:

- Backend ordering, fallback labels, and capability metadata stay in `computer-use-linux/src/windowing/registry.rs`
- Backend-specific i3 behavior remains in `computer-use-linux/src/windowing/backends/i3.rs`
- Target resolution, including the rounded large-window-id fallback, stays in `computer-use-linux/src/windowing/target.rs`
- Shared MCP input handling stays in `computer-use-linux/src/server.rs`, with diagnostics matching the runtime ydotool socket requirement

Validation run locally:

```bash
rtk git diff --check
rtk cargo fmt --check
rtk cargo clippy --workspace --all-targets -- -D warnings
rtk cargo test -p codex-computer-use-linux
rtk cargo test -p codex-update-manager
rtk cargo test --workspace --all-targets
```

All passed locally after the scope reduction.
