### PR TITLE
Add Linux Zed opener support

### DIFF
--- a/linux-features/zed-opener/README.md
+++ b/linux-features/zed-opener/README.md
@@ -1,0 +1,49 @@
+# Zed Opener
+
+Adds Zed as an opt-in Linux editor opener in Codex Desktop. The patch extends
+the upstream Zed opener block with a Linux platform entry and reuses the
+upstream `path:line:column` argument builder.
+
+This feature is opt-in. The loader reads enabled feature ids from the root
+config at `linux-features/features.json`, then loads this feature's manifest
+from `linux-features/zed-opener/feature.json`.
+
+To enable it locally, create the root config if needed:
+
+```bash
+cp linux-features/features.example.json linux-features/features.json
+```
+
+Then list `zed-opener` in `linux-features/features.json`:
+
+```json
+{
+  "enabled": [
+    "zed-opener"
+  ]
+}
+```
+
+The Linux opener detects these commands in `PATH`, in order:
+
+- `zed`
+- `zeditor`
+- `zedit`
+- `zed-cli`
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/zed-opener/test.js
+```
+
+To validate it against an extracted app bundle, enable `zed-opener` in a Linux
+features config and run:
+
+```bash
+node scripts/patch-linux-window-ui.js /path/to/extracted/app.asar
+```
+
+Known risk: the patch depends on the upstream minified Zed opener block. If
+that block changes shape, the feature fails soft and leaves the bundle
+unchanged.

--- a/linux-features/zed-opener/feature.json
+++ b/linux-features/zed-opener/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "zed-opener",
+  "title": "Zed Opener",
+  "description": "Adds Zed as an opt-in Linux editor opener when a supported Zed CLI binary is available.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "mainBundlePatch": "./patch.js"
+  }
+}

--- a/linux-features/zed-opener/patch.js
+++ b/linux-features/zed-opener/patch.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const {
+  escapeRegExp,
+  findMatchingBrace,
+} = require("../../scripts/patches/shared.js");
+
+const PATCH_NAME = "zed-opener feature patch";
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping ${PATCH_NAME}`);
+}
+
+function findZedOpenerBlock(source) {
+  const markerStart = source.indexOf("id:`zed`");
+  if (markerStart === -1) {
+    warn("Could not find Zed opener block");
+    return null;
+  }
+
+  const blockStart = Math.max(
+    source.lastIndexOf("var ", markerStart),
+    source.lastIndexOf("let ", markerStart),
+    source.lastIndexOf("const ", markerStart),
+  );
+  const objectStart = blockStart === -1 ? -1 : source.indexOf("{", blockStart);
+  const objectEnd = objectStart === -1 ? -1 : findMatchingBrace(source, objectStart);
+  if (blockStart === -1 || objectStart === -1 || objectEnd === -1) {
+    warn("Could not parse Zed opener block");
+    return null;
+  }
+
+  const blockEnd = source[objectEnd + 1] === ";" ? objectEnd + 2 : objectEnd + 1;
+  return {
+    start: blockStart,
+    end: blockEnd,
+    text: source.slice(blockStart, blockEnd),
+  };
+}
+
+function findZedPathLookupFunction(source, detectFn) {
+  const detectFunctionRegex = new RegExp(
+    `function ${escapeRegExp(detectFn)}\\(\\)\\{return ([A-Za-z_$][\\w$]*)\\(\\\`zed\\\`\\)`,
+  );
+  return source.match(detectFunctionRegex)?.[1] ?? null;
+}
+
+function applyMainBundlePatch(currentSource) {
+  const block = findZedOpenerBlock(currentSource);
+  if (block == null) {
+    return currentSource;
+  }
+  if (block.text.includes("linux:{")) {
+    return currentSource;
+  }
+
+  const argsFn = block.text.match(/\bargs:([A-Za-z_$][\w$]*)/)?.[1];
+  const detectFn = block.text.match(/\bdarwin:\{[^}]*\bdetect:([A-Za-z_$][\w$]*)/)?.[1];
+  if (argsFn == null || detectFn == null) {
+    warn("Could not identify Zed opener helpers");
+    return currentSource;
+  }
+
+  const pathLookupFn = findZedPathLookupFunction(currentSource, detectFn);
+  if (pathLookupFn == null) {
+    warn("Could not identify Zed path lookup helper");
+    return currentSource;
+  }
+
+  let insertionPoint = block.text.lastIndexOf("}}};");
+  if (insertionPoint === -1) {
+    insertionPoint = block.text.lastIndexOf("}}}");
+  }
+  if (insertionPoint === -1) {
+    warn("Could not find Zed opener insertion point");
+    return currentSource;
+  }
+
+  const linuxZed =
+    `,linux:{label:\`Zed\`,icon:\`apps/zed.png\`,kind:\`editor\`,detect:()=>${pathLookupFn}(\`zed\`)??${pathLookupFn}(\`zeditor\`)??${pathLookupFn}(\`zedit\`)??${pathLookupFn}(\`zed-cli\`),args:${argsFn}}`;
+  const patchedBlock =
+    block.text.slice(0, insertionPoint + 1) + linuxZed + block.text.slice(insertionPoint + 1);
+  const patchedSource =
+    currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
+  const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
+  if (
+    !patchedBlockCheck.includes("id:`zed`") ||
+    !patchedBlockCheck.includes("linux:{label:`Zed`") ||
+    !patchedBlockCheck.includes(`${pathLookupFn}(\`zeditor\`)`) ||
+    !patchedBlockCheck.includes(`args:${argsFn}`)
+  ) {
+    console.warn(`WARN: Failed to apply ${PATCH_NAME}`);
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
+module.exports = {
+  applyMainBundlePatch,
+};

--- a/linux-features/zed-opener/test.js
+++ b/linux-features/zed-opener/test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { applyMainBundlePatch } = require("./patch.js");
+const {
+  enabledLinuxFeatureIds,
+  loadLinuxFeatureMainBundlePatches,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  createPatchReport,
+  patchExtractedApp,
+  patchMainBundleSource,
+} = require("../../scripts/patch-linux-window-ui.js");
+
+const zedOpenerBundle =
+  "function Tw(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}function Rp(e){return e}var eT={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:tT,args:Tw,open:async({command:e,path:t,location:n})=>{await aT(e,t,n)}},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:nT,args:Tw}}};function tT(){return Rp(`zed`)??nC(`Zed`,`zed`)}function nT(){let e=Rp(`zed.exe`)??Rp(`zed`);return e}";
+
+function applyPatchTwice(patchFn, source, ...args) {
+  const patched = patchFn(source, ...args);
+  assert.equal(patchFn(patched, ...args), patched);
+  return patched;
+}
+
+function captureWarns(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function withTempFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const root = path.resolve(__dirname, "..");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-zed-feature-test-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }, null, 2));
+    return fn(root);
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function withLinuxFeatureRootEnv(root, fn) {
+  const originalRoot = process.env.CODEX_LINUX_FEATURES_ROOT;
+  process.env.CODEX_LINUX_FEATURES_ROOT = root;
+  try {
+    return fn();
+  } finally {
+    if (originalRoot == null) {
+      delete process.env.CODEX_LINUX_FEATURES_ROOT;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_ROOT = originalRoot;
+    }
+  }
+}
+
+test("Zed opener feature adds Linux editor support to the upstream opener block", () => {
+  const patched = applyPatchTwice(applyMainBundlePatch, zedOpenerBundle);
+
+  assert.match(patched, /linux:\{label:`Zed`,icon:`apps\/zed\.png`,kind:`editor`/);
+  assert.match(
+    patched,
+    /detect:\(\)=>Rp\(`zed`\)\?\?Rp\(`zeditor`\)\?\?Rp\(`zedit`\)\?\?Rp\(`zed-cli`\)/,
+  );
+  assert.match(patched, /args:Tw/);
+});
+
+test("Zed opener feature is a no-op when Linux support is already present", () => {
+  const patched = applyMainBundlePatch(zedOpenerBundle);
+
+  assert.equal(applyMainBundlePatch(patched), patched);
+});
+
+test("Zed opener feature fails soft when the opener block is missing", () => {
+  const { value, warnings } = captureWarns(() => applyMainBundlePatch("real codex bundle"));
+
+  assert.equal(value, "real codex bundle");
+  assert.match(warnings.join("\n"), /Could not find Zed opener block/);
+});
+
+test("Zed opener feature stays disabled until listed in features.json", () => {
+  withTempFeatureConfig([], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
+    assert.deepEqual(loadLinuxFeatureMainBundlePatches({ featuresRoot: root }), []);
+
+    withLinuxFeatureRootEnv(root, () => {
+      const { value: patched } = captureWarns(() => patchMainBundleSource(zedOpenerBundle, null));
+      assert.doesNotMatch(patched, /linux:\{label:`Zed`/);
+    });
+  });
+});
+
+test("Zed opener feature exposes its patch when enabled", () => {
+  withTempFeatureConfig(["zed-opener"], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["zed-opener"]);
+
+    const patches = loadLinuxFeatureMainBundlePatches({ featuresRoot: root });
+    assert.equal(patches.length, 1);
+    assert.equal(patches[0].name, "feature:zed-opener");
+    assert.match(patches[0].apply(zedOpenerBundle, {}), /linux:\{label:`Zed`/);
+  });
+});
+
+test("Zed opener feature participates in main bundle patching and patch reports", () => {
+  withTempFeatureConfig(["zed-opener"], (root) => {
+    withLinuxFeatureRootEnv(root, () => {
+      assert.match(
+        captureWarns(() => patchMainBundleSource(zedOpenerBundle, null)).value,
+        /linux:\{label:`Zed`/,
+      );
+
+      const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-zed-feature-app-"));
+      try {
+        const buildDir = path.join(tempApp, ".vite", "build");
+        const assetsDir = path.join(tempApp, "webview", "assets");
+        fs.mkdirSync(buildDir, { recursive: true });
+        fs.mkdirSync(assetsDir, { recursive: true });
+        fs.writeFileSync(path.join(buildDir, "main.js"), zedOpenerBundle);
+        fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
+
+        const report = createPatchReport();
+        captureWarns(() => patchExtractedApp(tempApp, { report }));
+
+        assert.match(fs.readFileSync(path.join(buildDir, "main.js"), "utf8"), /linux:\{label:`Zed`/);
+        assert.ok(
+          report.patches.some((patch) => patch.name === "feature:zed-opener" && patch.status === "applied"),
+        );
+      } finally {
+        fs.rmSync(tempApp, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Linux ASAR patch for the upstream Zed opener block
- detect common Linux Zed CLI names: `zed`, `zeditor`, `zedit`, and `zed-cli`
- register the patch in the main bundle pipeline and cover direct/full-bundle patching in tests

## User-visible behavior
- Linux builds can expose Zed as an editor opener when a supported Zed CLI binary is available on PATH
- Existing macOS and Windows Zed opener behavior is preserved

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --check scripts/patches/main-process.js`
- `node --check scripts/patches/registry.js`
- `node --check scripts/patch-linux-window-ui.js`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- live ASAR extraction check: `linux-zed-opener` applied once and reported `already-applied` on rerun

Full smoke tests and package builds were not run because this change is scoped to the JS ASAR patcher and its unit coverage.