### PR TITLE
[codex] Fix Linux patch drift for current Codex bundle

### DIFF
--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -130,14 +130,23 @@ install_linux_executable_resource() {
     local source="$1"
     local destination="$2"
     local label="$3"
+    local log_level="${4:-warn}"
 
     if [ ! -f "$source" ]; then
-        warn "Browser Use $label not found in upstream resources; skipping"
+        if [ "$log_level" = "info" ]; then
+            info "Browser Use $label not found in upstream resources; skipping"
+        else
+            warn "Browser Use $label not found in upstream resources; skipping"
+        fi
         return 1
     fi
 
     if ! is_host_linux_elf_executable "$source"; then
-        warn "Browser Use $label is not a Linux executable for $ARCH; skipping"
+        if [ "$log_level" = "info" ]; then
+            info "Browser Use $label is not a Linux executable for $ARCH; skipping"
+        else
+            warn "Browser Use $label is not a Linux executable for $ARCH; skipping"
+        fi
         return 1
     fi
 
@@ -220,15 +229,22 @@ install_browser_use_node_repl_resource() {
 
     for source in \
         "${CODEX_LINUX_NODE_REPL_SOURCE:-}" \
-        "${CODEX_NODE_REPL_PATH:-}" \
-        "${XDG_CACHE_HOME:-$HOME/.cache}/codex-runtimes/codex-primary-runtime/dependencies/bin/node_repl" \
-        "$upstream_source"
+        "${CODEX_NODE_REPL_PATH:-}"
     do
         [ -n "$source" ] || continue
         if install_linux_executable_resource "$source" "$destination" "node_repl runtime"; then
             return 0
         fi
     done
+
+    source="${XDG_CACHE_HOME:-$HOME/.cache}/codex-runtimes/codex-primary-runtime/dependencies/bin/node_repl"
+    if [ -f "$source" ] && install_linux_executable_resource "$source" "$destination" "node_repl runtime"; then
+        return 0
+    fi
+
+    if [ -n "$upstream_source" ] && install_linux_executable_resource "$upstream_source" "$destination" "node_repl runtime" "info"; then
+        return 0
+    fi
 
     install_node_repl_from_primary_runtime_archive "$destination"
 }
@@ -519,7 +535,7 @@ install_bundled_plugin_resources() {
 
     write_bundled_plugins_marketplace "$source_marketplace" "$bundled_plugins_dir/.agents/plugins/marketplace.json" "$include_browser" "$include_chrome" "$include_computer_use"
 
-    install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" || true
+    install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" "info" || true
     install_browser_use_node_repl_resource "$upstream_resources/node_repl" "$resources_dir/node_repl" || true
 
     info "Linux-safe bundled plugins installed"

--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -28,13 +28,97 @@ function buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
   const showUpdateMessage =
     electronVar == null
       ? "async function codexLinuxShowUpdateMessage(){}"
-      : `async function codexLinuxShowUpdateMessage(e,n){try{await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:[\`OK\`],defaultId:0,noLink:!0,message:e,detail:n})}catch{}}`;
+      : `async function codexLinuxShowUpdateMessage(codexLinuxMessage,codexLinuxDetail){try{await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:[\`OK\`],defaultId:0,noLink:!0,message:codexLinuxMessage,detail:codexLinuxDetail})}catch{}}`;
   const installAfterQuit = buildInstallAfterQuitSource(childProcessVar);
   const quitForUpdate = buildQuitForUpdateSource(electronVar, true);
   return `function codexLinuxUpdateStatePath(){let e=process.env.XDG_STATE_HOME||process.env.HOME&&(0,${pathVar}.join)(process.env.HOME,\`.local\`,\`state\`);return e?(0,${pathVar}.join)(e,\`codex-update-manager\`,\`state.json\`):null}function codexLinuxReadUpdateState(){let e=codexLinuxUpdateStatePath();if(!e||!${fsVar}.existsSync(e))return null;try{let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}catch{return null}}function codexLinuxUpdateLifecycleState(e){switch(e){case\`ready_to_install\`:case\`waiting_for_app_exit\`:return\`ready\`;case\`installing\`:return\`installing\`;case\`checking_upstream\`:case\`update_detected\`:case\`downloading_dmg\`:case\`preparing_workspace\`:case\`patching_app\`:case\`building_package\`:return\`checking\`;default:return\`idle\`}}function codexLinuxUpdateManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}${showUpdateMessage}${installAfterQuit}${quitForUpdate}function codexLinuxRunUpdateManager(e){return new Promise((t,n)=>{${childProcessVar}.execFile(codexLinuxUpdateManagerPath(),e,{encoding:\`utf8\`,windowsHide:!0},(e,r,i)=>{if(e){e.stdout=r,e.stderr=i,n(e);return}t({stdout:r??\`\`,stderr:i??\`\`})})})}`;
 }
 
+function buildBootstrapBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
+  return `${buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};function codexLinuxCreatePackageUpdateManager(e){let t=!1,n=\`idle\`,r=null,i=()=>{try{let e=codexLinuxReadUpdateState(),r=e?.status;t=r===\`ready_to_install\`||r===\`waiting_for_app_exit\`,n=codexLinuxUpdateLifecycleState(r);return e}catch{return null}},a=()=>{try{e.send({type:\`app-update-ready-changed\`,isUpdateReady:t}),e.send({type:\`app-update-lifecycle-state-changed\`,lifecycleState:n}),e.send({type:\`app-update-install-progress-changed\`,installProgressPercent:r})}catch{}};i();let o=()=>{e.allowQuit?.();codexLinuxQuitForUpdate()};return{manager:{getIsUpdateReady:()=>t,getUpdateLifecycleState:()=>n,getInstallProgressPercent:()=>r,checkForUpdates:async()=>{n=\`checking\`,a();try{await codexLinuxRunUpdateManager([\`check-now\`]),i(),a()}catch(e){n=t?\`ready\`:\`idle\`,a();throw e}},installUpdatesIfAvailable:async()=>{i();if(!t)return;r=0,n=\`installing\`,a();try{let e=await codexLinuxRunUpdateManager([\`install-ready\`]),s=i();if(s?.status===\`waiting_for_app_exit\`){r=null,n=\`ready\`,a(),o();return}r=null,a(),e.stdout?.includes(\`already installed\`)?await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`The ready update is already installed.\`):e.stdout?.includes(\`No Codex Desktop update is ready\`)&&await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`There is no rebuilt update waiting to install.\`)}catch(e){r=null,n=t?\`ready\`:\`idle\`,a();throw e}}},quitForUpdate:o,refresh:()=>{i(),a()}}}`;
+}
+
+function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
+  if (
+    !currentSource.includes("setSparkleBridgeHandlers") ||
+    !currentSource.includes("sparkleManager:") ||
+    !currentSource.includes("onInstallUpdatesRequested")
+  ) {
+    return currentSource;
+  }
+
+  const childProcessVar =
+    requireName(currentSource, "node:child_process") ?? requireName(currentSource, "child_process");
+  const electronVar = requireName(currentSource, "electron") ?? requireName(currentSource, "node:electron");
+  const fsVar = requireName(currentSource, "node:fs") ?? requireName(currentSource, "fs");
+  const pathVar = requireName(currentSource, "node:path") ?? requireName(currentSource, "path");
+  if (childProcessVar == null || fsVar == null || pathVar == null) {
+    console.warn("WARN: Could not find updater bridge module bindings - skipping Linux updater bridge patch");
+    return currentSource;
+  }
+
+  let patchedSource = currentSource;
+  if (!patchedSource.includes("function codexLinuxCreatePackageUpdateManager(")) {
+    if (!patchedSource.includes("state:`disabled`")) {
+      return currentSource;
+    }
+    const bootstrapNeedle = "var rK={enabled:!1,running:!1,state:`disabled`};";
+    if (!patchedSource.includes(bootstrapNeedle)) {
+      console.warn("WARN: Could not find current updater bridge insertion point - skipping Linux updater bridge patch");
+      return currentSource;
+    }
+    patchedSource = patchedSource.replace(
+      bootstrapNeedle,
+      `${buildBootstrapBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};${bootstrapNeedle}`,
+    );
+  }
+
+  const destructureRegex =
+    /let\{startedAtMs:([A-Za-z_$][\w$]*),buildFlavor:([A-Za-z_$][\w$]*),desktopSentry:([A-Za-z_$][\w$]*),sparkleManager:([A-Za-z_$][\w$]*),setSparkleBridgeHandlers:([A-Za-z_$][\w$]*),setSecondInstanceArgsHandler:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(\),/;
+  const destructureMatch = patchedSource.match(destructureRegex);
+  const sparkleVar = destructureMatch?.[4] ?? null;
+  const setSparkleBridgeHandlersVar = destructureMatch?.[5] ?? null;
+  if (sparkleVar == null) {
+    console.warn("WARN: Could not identify current sparkleManager binding - skipping Linux updater bridge patch");
+    return currentSource;
+  }
+  const bridgeHandlersStart = setSparkleBridgeHandlersVar == null
+    ? -1
+    : patchedSource.indexOf(`${setSparkleBridgeHandlersVar}({`, destructureMatch.index ?? 0);
+  const bridgeHandlersSlice = bridgeHandlersStart === -1
+    ? ""
+    : patchedSource.slice(bridgeHandlersStart, bridgeHandlersStart + 1500);
+  const messageDispatcherVar = bridgeHandlersSlice.match(
+    /([A-Za-z_$][\w$]*)\.sendMessageToAllRegisteredWindows\(\{type:`app-update-ready-changed`/,
+  )?.[1] ?? null;
+  if (messageDispatcherVar == null) {
+    console.warn("WARN: Could not identify current updater window message dispatcher - skipping Linux updater bridge patch");
+    return currentSource;
+  }
+
+  if (!patchedSource.includes("codexLinuxPackageUpdateBridge=process.platform===`linux`")) {
+    const bridgeRegex =
+      /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)=\(\)=>\{\1\.allowQuitTemporarilyForUpdateInstall\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\};/;
+    const bridgeMatch = patchedSource.match(bridgeRegex);
+    if (bridgeMatch == null) {
+      console.warn("WARN: Could not find current updater callback bridge - skipping Linux updater bridge patch");
+      return currentSource;
+    }
+    const [, quitControllerVar, quitFactoryVar, quitFnVar, electronBindingVar] = bridgeMatch;
+    const replacement =
+      `let ${quitControllerVar}=${quitFactoryVar}(),${quitFnVar}=()=>{${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),${electronBindingVar}.app.quit()},codexLinuxPackageUpdateBridge=process.platform===\`linux\`?codexLinuxCreatePackageUpdateManager({allowQuit:()=>${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),send:e=>${messageDispatcherVar}.sendMessageToAllRegisteredWindows(e)}):null;codexLinuxPackageUpdateBridge!=null&&(${sparkleVar}=codexLinuxPackageUpdateBridge.manager,${quitFnVar}=codexLinuxPackageUpdateBridge.quitForUpdate,setInterval(()=>codexLinuxPackageUpdateBridge.refresh(),3e4).unref?.());`;
+    patchedSource = patchedSource.replace(bridgeRegex, replacement);
+  }
+
+  return patchedSource;
+}
+
 function applyLinuxAppUpdaterBridgePatch(currentSource) {
+  const currentBootstrapPatched = applyCurrentBootstrapUpdaterBridgePatch(currentSource);
+  if (currentBootstrapPatched !== currentSource) {
+    return currentBootstrapPatched;
+  }
+
   if (!currentSource.includes("var tD=class{") || !currentSource.includes("initializeMacSparkle")) {
     return currentSource;
   }
@@ -124,19 +208,22 @@ function applyLinuxAppUpdaterBridgePatch(currentSource) {
 }
 
 function applyLinuxAppUpdaterMenuPatch(currentSource) {
-  const menuNeedle = "d=t.C.shouldIncludeSparkle(a,process.platform,process.env)";
-  const menuPatch = "d=t.C.shouldIncludeSparkle(a,process.platform,process.env)||process.platform===`linux`";
+  const menuNeedles = [
+    "d=t.C.shouldIncludeSparkle(a,process.platform,process.env)",
+    "d=t.T.shouldIncludeSparkle(a,process.platform,process.env)",
+  ];
 
-  if (currentSource.includes(menuPatch)) {
+  if (/d=t\.[A-Za-z_$][\w$]*\.shouldIncludeSparkle\(a,process\.platform,process\.env\)\|\|process\.platform===`linux`/.test(currentSource)) {
     return currentSource;
   }
-  if (!currentSource.includes(menuNeedle)) {
+  const menuNeedle = menuNeedles.find((needle) => currentSource.includes(needle));
+  if (menuNeedle == null) {
     if (currentSource.includes("enableSparkle") && currentSource.includes("shouldIncludeSparkle")) {
       console.warn("WARN: Could not find update menu feature gate - skipping Linux update menu patch");
     }
     return currentSource;
   }
-  return currentSource.replace(menuNeedle, menuPatch);
+  return currentSource.replace(menuNeedle, `${menuNeedle}||process.platform===\`linux\``);
 }
 
 function patchLinuxAppUpdaterBridge(extractedDir) {

--- a/scripts/lib/patch-chrome-plugin.js
+++ b/scripts/lib/patch-chrome-plugin.js
@@ -53,13 +53,15 @@ function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText =
     return;
   }
 
-  const oldText = oldTexts.find((candidate) => source.includes(candidate));
-  if (!oldText) {
+  const match = oldTexts
+    .map((candidate) => typeof candidate === "string" ? { oldText: candidate, newText } : candidate)
+    .find((candidate) => source.includes(candidate.oldText));
+  if (!match) {
     warn(`${path.basename(filePath)} missing patch target for ${label}`);
     return;
   }
 
-  fs.writeFileSync(filePath, source.replace(oldText, newText), "utf8");
+  fs.writeFileSync(filePath, source.replace(match.oldText, match.newText ?? newText), "utf8");
   console.log(`Patched ${path.basename(filePath)}: ${label}`);
 }
 
@@ -241,15 +243,20 @@ ${linuxNativeHostManifestFallback}
   },
 ]);
 
-patchFile(path.join(scriptsDir, "browser-client.mjs"), [
-  {
-    label: "Linux Chrome profile path",
-    oldText:
-      'var Tc=GF(VF(),WF()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":"Library/Application Support/Google/Chrome");',
-    newText:
-      'var Tc=GF(VF(),WF()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":WF()==="linux"?".config/google-chrome":"Library/Application Support/Google/Chrome");',
-  },
-]);
+patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
+  label: "Linux Chrome profile path",
+  oldTexts: [
+    {
+      oldText: 'var Tc=GF(VF(),WF()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":"Library/Application Support/Google/Chrome");',
+      newText: 'var Tc=GF(VF(),WF()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":WF()==="linux"?".config/google-chrome":"Library/Application Support/Google/Chrome");',
+    },
+    {
+      oldText: 'var Ic=eO(tO(),rO()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":"Library/Application Support/Google/Chrome");',
+      newText: 'var Ic=eO(tO(),rO()==="win32"?"AppData\\\\Local\\\\Google\\\\Chrome\\\\User Data":rO()==="linux"?".config/google-chrome":"Library/Application Support/Google/Chrome");',
+    },
+  ],
+  alreadyText: '".config/google-chrome"',
+});
 
 patchFile(path.join(scriptsDir, "installed-browsers.js"), [
   {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -204,6 +204,19 @@ function appUpdaterBundleFixture() {
   ].join("");
 }
 
+function currentBootstrapUpdaterBundleFixture() {
+  return [
+    "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`),u=require(`node:child_process`);",
+    "c({onUpdateReadyChanged:e=>{a.sendMessageToAllRegisteredWindows({type:`app-update-ready-changed`,isUpdateReady:e})}});",
+    "var rK={enabled:!1,running:!1,state:`disabled`};",
+    "async function iK(){",
+    "let{startedAtMs:r,buildFlavor:a,desktopSentry:o,sparkleManager:s,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=t.x(),d=t.T.shouldIncludeSparkle(a,process.platform,process.env);",
+    "let M=oG({});let ee=pB(),te=()=>{ee.allowQuitTemporarilyForUpdateInstall(),n.app.quit()};",
+    "c({onInstallProgressChanged:e=>{E&&M.sendMessageToAllRegisteredWindows({type:`app-update-install-progress-changed`,installProgressPercent:e})},onUpdateReadyChanged:e=>{M.sendMessageToAllRegisteredWindows({type:`app-update-ready-changed`,isUpdateReady:e})},onUpdateLifecycleStateChanged:e=>{M.sendMessageToAllRegisteredWindows({type:`app-update-lifecycle-state-changed`,lifecycleState:e})},onInstallUpdatesRequested:()=>{te()},isTrustedIpcEvent:N});",
+    "}",
+  ].join("");
+}
+
 function avatarOverlayBundleFixture() {
   return [
     "var rV=`/avatar-overlay`,zB={width:356,height:320},oV={width:112,height:121},sV={width:276,height:131};",
@@ -753,7 +766,7 @@ test("adds Linux package updater behind the existing app updater manager", () =>
   assert.match(patched, /function codexLinuxReadUpdateState\(\)/);
   assert.match(patched, /function codexLinuxUpdateLifecycleState\(e\)/);
   assert.match(patched, /function codexLinuxUpdateManagerPath\(\)/);
-  assert.match(patched, /async function codexLinuxShowUpdateMessage\(e,n\)/);
+  assert.match(patched, /async function codexLinuxShowUpdateMessage\(codexLinuxMessage,codexLinuxDetail\)/);
   assert.match(patched, /function codexLinuxInstallAfterQuit\(\)/);
   assert.match(patched, /function codexLinuxQuitForUpdate\(\)/);
   assert.match(patched, /t\.dialog\?\.showMessageBox\(\{type:`info`/);
@@ -779,6 +792,17 @@ test("adds Linux package updater behind the existing app updater manager", () =>
   assert.doesNotMatch(patched, /this\.options\.onInstallUpdatesRequested\?\.\(\)/);
   assert.match(patched, /n\.stdout\?\.includes\(`already installed`\)\?await codexLinuxShowUpdateMessage/);
   assert.match(patched, /if\(t\?\.status===`waiting_for_app_exit`\)/);
+});
+
+test("adds Linux package updater to current bootstrap updater wiring", () => {
+  const patched = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, currentBootstrapUpdaterBundleFixture());
+
+  assert.match(patched, /function codexLinuxCreatePackageUpdateManager\(/);
+  assert.match(patched, /codexLinuxPackageUpdateBridge=process\.platform===`linux`/);
+  assert.match(patched, /send:e=>M\.sendMessageToAllRegisteredWindows\(e\)/);
+  assert.doesNotMatch(patched, /send:e=>a\.sendMessageToAllRegisteredWindows\(e\)/);
+  assert.match(patched, /s=codexLinuxPackageUpdateBridge\.manager/);
+  assert.match(patched, /te=codexLinuxPackageUpdateBridge\.quitForUpdate/);
 });
 
 test("migrates an already-patched Linux updater bridge to quit before install", () => {
@@ -1433,10 +1457,6 @@ test("patchExtractedApp records a structured patch report", () => {
       ].join(""),
     );
     fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
-    fs.writeFileSync(
-      path.join(assetsDir, "code-theme-test.js"),
-      "opaqueWindows:e?.opaqueWindows??n.opaqueWindows,semanticColors:",
-    );
     fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
 
     const report = createPatchReport();
@@ -1446,7 +1466,6 @@ test("patchExtractedApp records a structured patch report", () => {
     assert.equal(report.iconAsset, "app-test.png");
     assert.equal(report.desktopName, "codex-desktop.desktop");
     assert.ok(report.patches.some((patch) => patch.name === "main-process-ui" && patch.status === "applied"));
-    assert.ok(report.patches.some((patch) => patch.name === "opaque-window-default-code-theme" && patch.status === "applied"));
     assert.ok(report.patches.some((patch) => patch.name === "keybinds-settings" && patch.status === "skipped-optional"));
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -16,13 +16,39 @@ const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
 function buildKeybindsSettingsSource({
   chunkAsset,
   reactAsset,
+  reactExportName = "t",
   jsxRuntimeAsset,
   vscodeApiAsset,
   hotkeySettingsAsset,
   toggleAsset,
   settingsRowAsset,
-  settingsLayoutAsset,
+  settingsPageAsset,
+  settingsPageExportName = "t",
+  settingsSectionAsset,
+  settingsSectionExportName = "r",
+  settingsGroupAsset,
+  settingsGroupExportName = "n",
 }) {
+  const reactImport = reactAsset === jsxRuntimeAsset
+    ? `import{${reactExportName} as __reactFactory,t as __jsxFactory}from"./${jsxRuntimeAsset}";`
+    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";`;
+  const defaultShortcuts = {
+    newThread: "CmdOrCtrl+N",
+    quickChat: "CmdOrCtrl+Shift+K",
+    newThreadAlt: "CmdOrCtrl+Shift+N",
+    openFolder: "CmdOrCtrl+O",
+    settings: "CmdOrCtrl+,",
+    openCommandMenu: "CmdOrCtrl+K",
+    openCommandMenuAlt: "CmdOrCtrl+Shift+P",
+    searchChats: "CmdOrCtrl+Shift+F",
+    searchFiles: "CmdOrCtrl+P",
+    findInThread: "CmdOrCtrl+F",
+    toggleSidebar: "CmdOrCtrl+B",
+    toggleTerminal: "Ctrl+`",
+    toggleFileTreePanel: "CmdOrCtrl+Shift+E",
+    toggleBrowserPanel: "CmdOrCtrl+Shift+B",
+    toggleDiffPanel: "CmdOrCtrl+Shift+D",
+  };
   const keybindGroups = [
     {
       title: "Core",
@@ -87,7 +113,7 @@ function buildKeybindsSettingsSource({
     },
   ];
 
-  return `import{s as __toESM}from"./${chunkAsset}";import{t as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";import{n as __post,rn as DEFAULT_SHORTCUTS}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{r as SettingsSection,n as SettingsGroup,t as SettingsPage}from"./${settingsLayoutAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
+  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{n as __post}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},DEFAULT_SHORTCUTS=${JSON.stringify(defaultShortcuts)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
 }
 
 function resolveKeybindsSettingsAsset(extractedDir) {
@@ -96,9 +122,14 @@ function resolveKeybindsSettingsAsset(extractedDir) {
     throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
   }
 
-  const reactAsset = findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
-  const chunkAsset = findImportedAsset(webviewAssetsDir, reactAsset, "React shared chunk asset");
   const jsxRuntimeAsset = findRequiredWebviewAsset(webviewAssetsDir, /^jsx-runtime-.*\.js$/, "react.transitional.element", "JSX runtime asset");
+  const jsxRuntimeSource = fs.readFileSync(path.join(webviewAssetsDir, jsxRuntimeAsset), "utf8");
+  const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
+  const reactAsset = jsxExportsReactFactory
+    ? jsxRuntimeAsset
+    : findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
+  const reactExportName = jsxExportsReactFactory ? "n" : "t";
+  const chunkAsset = findImportedAsset(webviewAssetsDir, reactAsset, "React shared chunk asset");
   const vscodeApiAsset = findRequiredWebviewAsset(webviewAssetsDir, /^vscode-api-.*\.js$/, "vscode://codex", "VS Code API asset");
   const hotkeySettingsAsset = findRequiredWebviewAsset(
     webviewAssetsDir,
@@ -114,6 +145,14 @@ function resolveKeybindsSettingsAsset(extractedDir) {
     null,
     "settings content layout asset",
   );
+  const settingsGroupCandidate = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^settings-group-.*\.js$/.test(name))
+    .sort()[0] ?? null;
+  const settingsSurfaceCandidate = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^settings-surface-.*\.js$/.test(name))
+    .sort()[0] ?? null;
   const filePath = path.join(webviewAssetsDir, keybindsSettingsAsset);
 
   return {
@@ -121,12 +160,18 @@ function resolveKeybindsSettingsAsset(extractedDir) {
     source: buildKeybindsSettingsSource({
       chunkAsset,
       reactAsset,
+      reactExportName,
       jsxRuntimeAsset,
       vscodeApiAsset,
       hotkeySettingsAsset,
       toggleAsset,
       settingsRowAsset,
-      settingsLayoutAsset,
+      settingsPageAsset: settingsLayoutAsset,
+      settingsPageExportName: "t",
+      settingsSectionAsset: settingsGroupCandidate ?? settingsLayoutAsset,
+      settingsSectionExportName: settingsGroupCandidate == null ? "r" : "t",
+      settingsGroupAsset: settingsSurfaceCandidate ?? settingsLayoutAsset,
+      settingsGroupExportName: settingsSurfaceCandidate == null ? "n" : "t",
     }),
   };
 }
@@ -156,7 +201,34 @@ function collectRequiredAssetPatches(extractedDir, filenamePattern, patchFn, des
   });
 }
 
+function hasNativeKeyboardShortcutsSettings(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    return false;
+  }
+
+  const hasSettingsRoute = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^settings-sections-.*\.js$/.test(name))
+    .some((name) => fs.readFileSync(path.join(webviewAssetsDir, name), "utf8").includes("slug:`keyboard-shortcuts`"));
+  if (!hasSettingsRoute) {
+    return false;
+  }
+
+  return fs
+    .readdirSync(webviewAssetsDir)
+    .some((name) => /^keyboard-shortcuts-settings-.*\.js$/.test(name));
+}
+
 function patchKeybindsSettingsAssets(extractedDir) {
+  if (hasNativeKeyboardShortcutsSettings(extractedDir)) {
+    return {
+      matched: true,
+      changed: 0,
+      reason: "upstream keyboard shortcuts settings are present",
+    };
+  }
+
   try {
     const keybindsAsset = resolveKeybindsSettingsAsset(extractedDir);
     const keybindsAssetExists = fs.existsSync(keybindsAsset.filePath);

--- a/scripts/patches/launch-actions.js
+++ b/scripts/patches/launch-actions.js
@@ -23,35 +23,40 @@ function applyLinuxSettingsPersistencePatch(currentSource) {
 
   if (
     !patchedSource.includes('"set-global-state"') &&
-    !patchedSource.includes("var Yb=`.codex-global-state.json`;")
+    !patchedSource.includes(".codex-global-state.json")
   ) {
     return patchedSource;
   }
 
   if (!patchedSource.includes("function codexLinuxPersistSettingsState(")) {
-    const stateFileNeedle = "var Yb=`.codex-global-state.json`;";
-    const stateFilePatch =
-      `var Yb=\`.codex-global-state.json\`;function codexLinuxSettingsPath(){let e=process.env.XDG_CONFIG_HOME||process.env.HOME&&i.join(process.env.HOME,\`.config\`);return e?i.join(e,\`codex-desktop\`,\`settings.json\`):null}function codexLinuxReadSettingsFile(){let e=codexLinuxSettingsPath();if(!e||!o.existsSync(e))return{};try{let t=o.readFileSync(e,\`utf8\`),n=JSON.parse(t);return n&&typeof n===\`object\`&&!Array.isArray(n)?n:{}}catch(e){return{}}}function codexLinuxPersistSettingsState(e,t){if(process.platform!==\`linux\`||![${Object.values(linuxSettingsKeys).map((key) => `\`${key}\``).join(",")}].includes(e))return;try{let n=codexLinuxSettingsPath();if(!n)return;let r=codexLinuxReadSettingsFile();t===void 0?delete r[e]:r[e]=t,o.mkdirSync(i.dirname(n),{recursive:!0,mode:448}),o.writeFileSync(n,JSON.stringify(r,null,2)+\`\\n\`,\`utf8\`)}catch(e){}}`;
-    if (!patchedSource.includes(stateFileNeedle)) {
+    const stateFileRegex = /var ([A-Za-z_$][\w$]*)=`\.codex-global-state\.json`;/;
+    const stateFileMatch = patchedSource.match(stateFileRegex);
+    const pathVar = inferModuleAlias(patchedSource, "node:path");
+    const fsVar = inferModuleAlias(patchedSource, "node:fs");
+    if (stateFileMatch == null || pathVar == null || fsVar == null) {
       console.warn("WARN: Could not find Linux settings state file marker — skipping settings persistence patch");
       return patchedSource;
     }
-    patchedSource = patchedSource.replace(stateFileNeedle, stateFilePatch);
+    const stateFilePatch =
+      `var ${stateFileMatch[1]}=\`.codex-global-state.json\`;function codexLinuxSettingsPath(){let e=process.env.XDG_CONFIG_HOME||process.env.HOME&&${pathVar}.join(process.env.HOME,\`.config\`);return e?${pathVar}.join(e,\`codex-desktop\`,\`settings.json\`):null}function codexLinuxReadSettingsFile(){let e=codexLinuxSettingsPath();if(!e||!${fsVar}.existsSync(e))return{};try{let t=${fsVar}.readFileSync(e,\`utf8\`),n=JSON.parse(t);return n&&typeof n===\`object\`&&!Array.isArray(n)?n:{}}catch(e){return{}}}function codexLinuxPersistSettingsState(e,t){if(process.platform!==\`linux\`||![${Object.values(linuxSettingsKeys).map((key) => `\`${key}\``).join(",")}].includes(e))return;try{let n=codexLinuxSettingsPath();if(!n)return;let r=codexLinuxReadSettingsFile();t===void 0?delete r[e]:r[e]=t,${fsVar}.mkdirSync(${pathVar}.dirname(n),{recursive:!0,mode:448}),${fsVar}.writeFileSync(n,JSON.stringify(r,null,2)+\`\\n\`,\`utf8\`)}catch(e){}}`;
+    patchedSource = patchedSource.replace(stateFileRegex, stateFilePatch);
   }
 
-  const setGlobalStateNeedle =
-    '"set-global-state":async({key:t,value:n,origin:r})=>(this.globalState.set(t,n),t===e.Tt.REMOTE_PROJECTS&&r.send(H,{type:`workspace-root-options-updated`}),{success:!0})';
-  const setGlobalStatePatch =
-    '"set-global-state":async({key:t,value:n,origin:r})=>(this.globalState.set(t,n),codexLinuxPersistSettingsState(t,n),t===e.Tt.REMOTE_PROJECTS&&r.send(H,{type:`workspace-root-options-updated`}),{success:!0})';
-  if (patchedSource.includes(setGlobalStatePatch)) {
+  if (/"set-global-state":async\(\{key:[A-Za-z_$][\w$]*,value:[A-Za-z_$][\w$]*,origin:[A-Za-z_$][\w$]*\}\)=>\(this\.globalState\.set\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\),codexLinuxPersistSettingsState\(/.test(patchedSource)) {
     return patchedSource;
   }
-  if (!patchedSource.includes(setGlobalStateNeedle)) {
+  const setGlobalStateRegex =
+    /"set-global-state":async\(\{key:([A-Za-z_$][\w$]*),value:([A-Za-z_$][\w$]*),origin:([A-Za-z_$][\w$]*)\}\)=>\(this\.globalState\.set\(\1,\2\),/;
+  if (!setGlobalStateRegex.test(patchedSource)) {
     console.warn("WARN: Could not find Linux set-global-state needle — skipping settings persistence hook");
     return patchedSource;
   }
 
-  return patchedSource.replace(setGlobalStateNeedle, setGlobalStatePatch);
+  return patchedSource.replace(
+    setGlobalStateRegex,
+    (_match, keyVar, valueVar, originVar) =>
+      `"set-global-state":async({key:${keyVar},value:${valueVar},origin:${originVar}})=>(this.globalState.set(${keyVar},${valueVar}),codexLinuxPersistSettingsState(${keyVar},${valueVar}),`,
+  );
 }
 
 function applyLinuxTrayCloseSettingPatch(currentSource) {
@@ -212,6 +217,83 @@ function applySemanticLinuxLaunchActionArgsPatch(currentSource) {
   return currentSource;
 }
 
+function applyCurrentSemanticLinuxLaunchActionArgsPatch(currentSource) {
+  const handlerRegex =
+    /([A-Za-z_$][\w$]*)\(e=>\{let ([A-Za-z_$][\w$]*)=[^;{}]+;if\(([A-Za-z_$][\w$]*)\.deepLinks\.queueProcessArgs\(e\)\)\{\2&&([A-Za-z_$][\w$]*)\(\);return\}if\(\2\)\{\4\(\);return\}\4\(\)\}\);let ([A-Za-z_$][\w$]*)=async\(e,t\)=>\{/g;
+  let match;
+  while ((match = handlerRegex.exec(currentSource)) != null) {
+    const [, setterVar, , deepLinksVar, fallbackFn, openerFn] = match;
+    const openerBraceIndex = match.index + match[0].length - 1;
+    const openerLetIndex = openerBraceIndex - `let ${openerFn}=async(e,t)=>`.length;
+    const openerEnd = findMatchingBrace(currentSource, openerBraceIndex);
+    if (openerEnd === -1) {
+      continue;
+    }
+
+    const separator = currentSource[openerEnd + 1];
+    if (separator !== ";" && separator !== ",") {
+      continue;
+    }
+
+    const openerText = currentSource.slice(openerLetIndex, openerEnd + 1);
+    const openerVars = openerText.match(
+      /([A-Za-z_$][\w$]*)\.hotkeyWindowLifecycleManager\.hide\(\);let ([A-Za-z_$][\w$]*)=\1\.getPrimaryWindow\(([^)]+)\),([A-Za-z_$][\w$]*)=\2\?\?await \1\.createFreshLocalWindow\(e\);/,
+    );
+    if (openerVars == null) {
+      continue;
+    }
+
+    const [, windowManagerVar, currentWindowVar, hostExpr, createdWindowVar] = openerVars;
+    const routeVar = openerText.match(/([A-Za-z_$][\w$]*)\.navigateToRoute\([A-Za-z_$][\w$]*,e\)/)?.[1];
+    const focusFn = openerText.match(new RegExp(`,([A-Za-z_$][\\w$]*)\\(${escapeRegExp(createdWindowVar)}\\)\\)\\}$`))?.[1];
+    if (routeVar == null || focusFn == null) {
+      continue;
+    }
+
+    const prefix = currentSource.slice(Math.max(0, match.index - HANDLER_PREFIX_LOOKBACK), match.index);
+    const globalStateExpr = findLinuxGlobalStateExpression(prefix);
+    const reporterVar = findLastRegexMatch(
+      prefix,
+      /([A-Za-z_$][\w$]*)\.reportNonFatal\(e instanceof Error\?e:`Failed to open window on second instance`/g,
+    )?.[1] ?? findLastRegexMatch(prefix, /([A-Za-z_$][\w$]*)=\{reportNonFatal/g)?.[1];
+    const disposableVar = findDisposableVar(prefix);
+    const pathVar = inferModuleAlias(currentSource, "node:path");
+    const fsVar = inferModuleAlias(currentSource, "node:fs");
+    const netVar = inferModuleAlias(currentSource, "node:net");
+    if (globalStateExpr == null || reporterVar == null || disposableVar == null || pathVar == null || fsVar == null || netVar == null) {
+      continue;
+    }
+
+    const notificationVar = openerText.match(
+      /([A-Za-z_$][\w$]*)\.desktopNotificationManager\.dismissByNavigationPath\(e\)/,
+    )?.[1] ?? null;
+    const replacement = buildSemanticLinuxLaunchActionPatch({
+      setterVar,
+      deepLinksVar,
+      fallbackFn,
+      openerFn,
+      windowManagerVar,
+      hostExpr: hostExpr.trim(),
+      currentWindowVar,
+      createdWindowVar,
+      routeVar,
+      focusFn,
+      notificationVar,
+      globalStateExpr,
+      reporterVar,
+      disposableVar,
+      pathVar,
+      fsVar,
+      netVar,
+      appVar: null,
+    });
+    const suffix = separator === "," ? "let " : "";
+    return currentSource.slice(0, match.index) + replacement + suffix + currentSource.slice(openerEnd + 2);
+  }
+
+  return currentSource;
+}
+
 function applyLinuxLaunchActionArgsPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -282,7 +364,10 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
     patchedSource.includes("codexLinuxGetHotkeyWindowController=()=>") &&
     patchedSource.includes("codexLinuxPrewarmHotkeyWindow=()=>") &&
     patchedSource.includes("codexLinuxStartLaunchActionSocket=()=>") &&
-    patchedSource.includes("n.app.on(`before-quit`,codexLinuxBeforeQuitHandler)") &&
+    (
+      patchedSource.includes("n.app.on(`before-quit`,codexLinuxBeforeQuitHandler)") ||
+      /process\.platform===`linux`&&codexLinuxStartLaunchActionSocket\(\);[A-Za-z_$][\w$]*\(e=>\{codexLinuxHandleLaunchActionArgsFallback\(e,\(\)=>\{[A-Za-z_$][\w$]*\(\)\}\)\}\)/.test(patchedSource)
+    ) &&
     !patchedSource.includes("codexLinuxOpenNewChat")
   ) {
     return patchedSource;
@@ -310,6 +395,10 @@ function applyLinuxLaunchActionArgsPatch(currentSource) {
     const semanticLaunchActionPatch = applySemanticLinuxLaunchActionArgsPatch(patchedSource);
     if (semanticLaunchActionPatch !== patchedSource) {
       return semanticLaunchActionPatch;
+    }
+    const currentSemanticLaunchActionPatch = applyCurrentSemanticLinuxLaunchActionArgsPatch(patchedSource);
+    if (currentSemanticLaunchActionPatch !== patchedSource) {
+      return currentSemanticLaunchActionPatch;
     }
 
     const existingLinuxLaunchActionBlock = patchedSource.match(

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -280,7 +280,10 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  if (currentSource.includes("===`linux`&&!OM(")) {
+  if (
+    currentSource.includes("===`linux`&&!OM(") ||
+    /===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(currentSource)
+  ) {
     return currentSource;
   }
 
@@ -883,15 +886,22 @@ function applyLinuxGitOriginsSourceFallbackPatch(currentSource) {
   if (currentSource.includes(exactNeedle)) {
     return currentSource.replace(exactNeedle, exactReplacement);
   }
+  const currentExactNeedle =
+    "if(o==null){if(e.Gt(r))throw Error(`Missing git operation source for ${r}`);return l()}return t.Gt({source:o,requestKind:r},l)";
+  const currentExactReplacement =
+    `if(o==null){if(e.Gt(r)){if(r===\`git-origins\`)return t.Gt({source:\`${fallbackSource}\`,requestKind:r},l);throw Error(\`Missing git operation source for \${r}\`)}return l()}return t.Gt({source:o,requestKind:r},l)`;
+  if (currentSource.includes(currentExactNeedle)) {
+    return currentSource.replace(currentExactNeedle, currentExactReplacement);
+  }
 
   const dynamicRegex =
-    /if\(([A-Za-z_$][\w$]*)==null\)\{if\(([A-Za-z_$][\w$]*)\.qt\(([A-Za-z_$][\w$]*)\)\)throw Error\(`Missing git operation source for \$\{\3\}`\);return ([A-Za-z_$][\w$]*)\(\)\}return ([A-Za-z_$][\w$]*)\.Gt\(\{source:\1,requestKind:\3\},\4\)/;
+    /if\(([A-Za-z_$][\w$]*)==null\)\{if\(([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\)throw Error\(`Missing git operation source for \$\{\4\}`\);return ([A-Za-z_$][\w$]*)\(\)\}return ([A-Za-z_$][\w$]*)\.Gt\(\{source:\1,requestKind:\4\},\5\)/;
   const dynamicMatch = currentSource.match(dynamicRegex);
   if (dynamicMatch != null) {
-    const [, sourceVar, gitGuardVar, requestKindVar, callVar, operationContextVar] = dynamicMatch;
+    const [, sourceVar, gitGuardVar, guardFn, requestKindVar, callVar, operationContextVar] = dynamicMatch;
     return currentSource.replace(
       dynamicRegex,
-      `if(${sourceVar}==null){if(${gitGuardVar}.qt(${requestKindVar})){if(${requestKindVar}===\`git-origins\`)return ${operationContextVar}.Gt({source:\`${fallbackSource}\`,requestKind:${requestKindVar}},${callVar});throw Error(\`Missing git operation source for \${${requestKindVar}}\`)}return ${callVar}()}return ${operationContextVar}.Gt({source:${sourceVar},requestKind:${requestKindVar}},${callVar})`,
+      `if(${sourceVar}==null){if(${gitGuardVar}.${guardFn}(${requestKindVar})){if(${requestKindVar}===\`git-origins\`)return ${operationContextVar}.Gt({source:\`${fallbackSource}\`,requestKind:${requestKindVar}},${callVar});throw Error(\`Missing git operation source for \${${requestKindVar}}\`)}return ${callVar}()}return ${operationContextVar}.Gt({source:${sourceVar},requestKind:${requestKindVar}},${callVar})`,
     );
   }
 

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -201,14 +201,6 @@ const WEBVIEW_ASSET_PATCHES = [
     skipDescription: "app sunset gate patch",
   },
   {
-    name: "opaque-window-default-code-theme",
-    ciPolicy: OPTIONAL,
-    pattern: /^code-theme-.*\.js$/,
-    apply: applyLinuxOpaqueWindowsDefaultPatch,
-    missingDescription: "code theme bundle",
-    skipDescription: "translucent sidebar default patch",
-  },
-  {
     name: "opaque-window-default-general-settings",
     ciPolicy: OPTIONAL,
     pattern: /^general-settings-.*\.js$/,

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -92,10 +92,25 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
     "if(M&&j?.anchor.kind===`element`){he=md(j.anchor),_e=void 0}";
   if (patchedSource.includes(storedAnchorScreenshotPatch)) {
     // Already patched.
+  } else if (
+    /if\([A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*\?\.anchor\.kind===`element`\)\{[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.anchor\),[A-Za-z_$][\w$]*=void 0\}/.test(patchedSource)
+  ) {
+    // Already patched with the current upstream symbol names.
   } else if (patchedSource.includes(liveElementScreenshotNeedle)) {
     patchedSource = patchedSource.replace(liveElementScreenshotNeedle, storedAnchorScreenshotPatch);
   } else {
-    console.warn("WARN: Could not find browser annotation screenshot element highlight — skipping screenshot anchor patch");
+    const currentElementScreenshotRegex =
+      /if\(([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)\?\.anchor\.kind===`element`\)\{let e=[^;{}]+?\?\?null,t=e==null\?null:[A-Za-z_$][\w$]*\(e\);([A-Za-z_$][\w$]*)=t\?\.rect\?\?([A-Za-z_$][\w$]*)\(\2\.anchor\),([A-Za-z_$][\w$]*)=t\?\.borderRadius\}/;
+    const currentElementScreenshotMatch = patchedSource.match(currentElementScreenshotRegex);
+    if (currentElementScreenshotMatch != null) {
+      const [, screenshotModeVar, selectedCommentVar, rectVar, anchorRectFn, radiusVar] = currentElementScreenshotMatch;
+      patchedSource = patchedSource.replace(
+        currentElementScreenshotRegex,
+        `if(${screenshotModeVar}&&${selectedCommentVar}?.anchor.kind===\`element\`){${rectVar}=${anchorRectFn}(${selectedCommentVar}.anchor),${radiusVar}=void 0}`,
+      );
+    } else {
+      console.warn("WARN: Could not find browser annotation screenshot element highlight — skipping screenshot anchor patch");
+    }
   }
 
   const allMarkersInScreenshotNeedle =
@@ -104,10 +119,20 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
     "de=u?.target.mode===`create`?ce.find(e=>Sd(e.anchor,u.anchor.value))??null:null,fe=M?ue:!M&&de!=null?ce.filter(e=>e.id!==de.id):ce,";
   if (patchedSource.includes(selectedMarkerInScreenshotPatch)) {
     // Already patched.
+  } else if (/=\([A-Za-z_$][\w$]*\?[A-Za-z_$][\w$]*:![A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*!=null\?[A-Za-z_$][\w$]*\.filter\(e=>e\.id!==[A-Za-z_$][\w$]*\.id\):[A-Za-z_$][\w$]*\)\.flatMap/.test(patchedSource)) {
+    // Already patched with the current upstream symbol names.
   } else if (patchedSource.includes(allMarkersInScreenshotNeedle)) {
     patchedSource = patchedSource.replace(allMarkersInScreenshotNeedle, selectedMarkerInScreenshotPatch);
   } else {
-    console.warn("WARN: Could not find browser annotation screenshot markers — skipping screenshot marker patch");
+    const currentMarkersNeedle = "be=(!ge&&ye!=null?A.filter(e=>e.id!==ye.id):A).flatMap";
+    const currentMarkersPatch = "be=(ge?he:!ge&&ye!=null?A.filter(e=>e.id!==ye.id):A).flatMap";
+    if (patchedSource.includes(currentMarkersPatch)) {
+      // Already patched.
+    } else if (patchedSource.includes(currentMarkersNeedle)) {
+      patchedSource = patchedSource.replace(currentMarkersNeedle, currentMarkersPatch);
+    } else {
+      console.warn("WARN: Could not find browser annotation screenshot markers — skipping screenshot marker patch");
+    }
   }
 
   return patchedSource;

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -709,6 +709,7 @@ test_browser_use_node_repl_fallback_runtime() {
     cmp -s /bin/true "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
     assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
+    assert_not_contains "$output_log" "WARN.*Browser Use node_repl runtime is not a Linux executable"
     assert_contains "$output_log" "Downloading Browser Use node_repl fallback runtime"
 }
 


### PR DESCRIPTION
## Summary

This PR updates the Linux ASAR and bundled-plugin patchers for the current upstream Codex Desktop bundle shape.

The fresh install path had drifted after upstream changes, which made several Linux patches log warnings or skip their targets even though the app still built. This change refreshes those matchers and removes obsolete patch work that no longer has a matching upstream asset.

## What changed

- Updated updater menu and Linux update bridge patching for the current bootstrap/updater wiring.
- Refreshed Linux settings persistence and launch-action patching for the current minified main bundle shape.
- Updated git-origins fallback, browser annotation screenshot, and Chrome profile path patching.
- Treated the upstream keyboard shortcuts settings page as already present instead of trying to inject the old Linux keybinds page.
- Removed the obsolete `code-theme-*` translucent-sidebar asset patch target.
- Downgraded expected macOS-only Browser Use runtime resource skips from warnings to informational logs while still using the Linux fallback runtime.
- Added regression coverage for the current updater bootstrap wiring so the Linux bridge uses the correct window message dispatcher.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `tests/scripts_smoke.sh`
- `bash -n scripts/lib/*.sh`
- `node --check scripts/lib/linux-update-bridge-patch.js`
- `node --check scripts/patches/keybinds-settings.js`
- `git diff --check`
- `CODEX_PATCH_REPORT_JSON=/tmp/codex-fresh-install-patch-report.json CODEX_LINUX_ENABLE_COMPUTER_USE_UI=1 ./install.sh --fresh`

The fresh install now completes without the previous Linux patch drift warnings. The remaining `better-sqlite3@12.9.0` warning is the existing Electron compatibility warning, not a skipped Linux patch.