### PR TITLE
[codex] Fix Linux updater bridge and Browser Use visibility

### DIFF
--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -16,6 +16,18 @@ function replaceInstallAfterQuitSource(source, childProcessVar) {
   return source.replace(pattern, buildInstallAfterQuitSource(childProcessVar));
 }
 
+function replaceAfter(source, anchor, search, replacement) {
+  const anchorIndex = source.indexOf(anchor);
+  if (anchorIndex === -1) {
+    return source;
+  }
+  const matchIndex = source.indexOf(search, anchorIndex);
+  if (matchIndex === -1) {
+    return source;
+  }
+  return source.slice(0, matchIndex) + replacement + source.slice(matchIndex + search.length);
+}
+
 function buildQuitForUpdateSource(electronVar, callInstallAfterQuit) {
   if (electronVar == null) {
     return "function codexLinuxQuitForUpdate(){codexLinuxInstallAfterQuit()}";
@@ -31,11 +43,104 @@ function buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
       : `async function codexLinuxShowUpdateMessage(codexLinuxMessage,codexLinuxDetail){try{await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:[\`OK\`],defaultId:0,noLink:!0,message:codexLinuxMessage,detail:codexLinuxDetail})}catch{}}`;
   const installAfterQuit = buildInstallAfterQuitSource(childProcessVar);
   const quitForUpdate = buildQuitForUpdateSource(electronVar, true);
-  return `function codexLinuxUpdateStatePath(){let e=process.env.XDG_STATE_HOME||process.env.HOME&&(0,${pathVar}.join)(process.env.HOME,\`.local\`,\`state\`);return e?(0,${pathVar}.join)(e,\`codex-update-manager\`,\`state.json\`):null}function codexLinuxReadUpdateState(){let e=codexLinuxUpdateStatePath();if(!e||!${fsVar}.existsSync(e))return null;try{let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}catch{return null}}function codexLinuxUpdateLifecycleState(e){switch(e){case\`ready_to_install\`:case\`waiting_for_app_exit\`:return\`ready\`;case\`installing\`:return\`installing\`;case\`checking_upstream\`:case\`update_detected\`:case\`downloading_dmg\`:case\`preparing_workspace\`:case\`patching_app\`:case\`building_package\`:return\`checking\`;default:return\`idle\`}}function codexLinuxUpdateManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}${showUpdateMessage}${installAfterQuit}${quitForUpdate}function codexLinuxRunUpdateManager(e){return new Promise((t,n)=>{${childProcessVar}.execFile(codexLinuxUpdateManagerPath(),e,{encoding:\`utf8\`,windowsHide:!0},(e,r,i)=>{if(e){e.stdout=r,e.stderr=i,n(e);return}t({stdout:r??\`\`,stderr:i??\`\`})})})}`;
+  return `function codexLinuxUpdateStatePath(){let e=process.env.XDG_STATE_HOME||process.env.HOME&&(0,${pathVar}.join)(process.env.HOME,\`.local\`,\`state\`);return e?(0,${pathVar}.join)(e,\`codex-update-manager\`,\`state.json\`):null}function codexLinuxReadUpdateState(){let e=codexLinuxUpdateStatePath();if(!e||!${fsVar}.existsSync(e))return null;try{let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}catch{return null}}function codexLinuxUpdateLifecycleState(e){switch(e){case\`ready_to_install\`:case\`waiting_for_app_exit\`:return\`ready\`;case\`installing\`:return\`installing\`;case\`checking_upstream\`:case\`update_detected\`:case\`downloading_dmg\`:case\`preparing_workspace\`:case\`patching_app\`:case\`building_package\`:return\`checking\`;default:return\`idle\`}}function codexLinuxUpdateManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}${showUpdateMessage}${installAfterQuit}${quitForUpdate}function codexLinuxRunUpdateManager(e){return new Promise((t,n)=>{${childProcessVar}.execFile(codexLinuxUpdateManagerPath(),e,{encoding:\`utf8\`,windowsHide:!0},(e,r,i)=>{if(e){e.stdout=r,e.stderr=i,n(e);return}t({stdout:r??\`\`,stderr:i??\`\`})})})}async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([\`--help\`])}async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}`;
+}
+
+function migrateLinuxUpdaterBridgeSource(source) {
+  let patchedSource = source.replace(
+    "async function codexLinuxRefreshUpdateState(){await codexLinuxRunUpdateManager([`status`,`--json`]);return codexLinuxReadUpdateState()}",
+    "async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}",
+  );
+  const probeSource =
+    "async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([`--help`])}";
+  const refreshSource =
+    "async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}";
+  if (
+    patchedSource.includes("function codexLinuxRunUpdateManager(") &&
+    patchedSource.includes(refreshSource) &&
+    !patchedSource.includes(probeSource)
+  ) {
+    patchedSource = patchedSource.replace(
+      refreshSource,
+      `${probeSource}${refreshSource}`,
+    );
+  }
+
+  const bootstrapNeedle = "function codexLinuxCreatePackageUpdateManager(";
+  const isBootstrapSource = patchedSource.includes(bootstrapNeedle);
+  if (
+    patchedSource.includes("function codexLinuxRunUpdateManager(") &&
+    isBootstrapSource &&
+    (!patchedSource.includes(probeSource) || !patchedSource.includes(refreshSource))
+  ) {
+    const helperSource =
+      `${patchedSource.includes(probeSource) ? "" : probeSource}` +
+      `${patchedSource.includes(refreshSource) ? "" : refreshSource}`;
+    patchedSource = patchedSource.replace(bootstrapNeedle, `${helperSource}${bootstrapNeedle}`);
+  }
+
+  patchedSource = patchedSource.replace(
+    "await codexLinuxRefreshUpdateState(),e()",
+    "await codexLinuxProbeUpdateManager(),e()",
+  );
+
+  const probeStateSource =
+    "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=";
+  const hasProbeState = () => patchedSource.includes("c=codexLinuxProbeUpdateManager().then(");
+  if (isBootstrapSource && !hasProbeState() && patchedSource.includes(probeSource)) {
+    patchedSource = replaceAfter(
+      patchedSource,
+      bootstrapNeedle,
+      "i(),codexLinuxRefreshUpdateState().then(()=>{i(),a()}).catch(()=>{});let o=",
+      probeStateSource,
+    );
+    patchedSource = replaceAfter(patchedSource, bootstrapNeedle, "i();let o=", probeStateSource);
+  }
+
+  if (!isBootstrapSource || !hasProbeState()) {
+    return patchedSource;
+  }
+
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "getIsUpdateReady:()=>t,getUpdateLifecycleState:()=>n,",
+    "getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:`idle`,",
+  );
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "checkForUpdates:async()=>{n=`checking`,a();try{",
+    "checkForUpdates:async()=>{if(!await c)return;n=`checking`,a();try{",
+  );
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "installUpdatesIfAvailable:async()=>{i();if(!t){a();return}",
+    "installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}",
+  );
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "installUpdatesIfAvailable:async()=>{i();if(!t)return;",
+    "installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}",
+  );
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "refresh:async()=>{try{await codexLinuxRefreshUpdateState()}catch{}i(),a()}",
+    "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
+  );
+  return replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "refresh:()=>{i(),a()}",
+    "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
+  );
 }
 
 function buildBootstrapBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
-  return `${buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};function codexLinuxCreatePackageUpdateManager(e){let t=!1,n=\`idle\`,r=null,i=()=>{try{let e=codexLinuxReadUpdateState(),r=e?.status;t=r===\`ready_to_install\`||r===\`waiting_for_app_exit\`,n=codexLinuxUpdateLifecycleState(r);return e}catch{return null}},a=()=>{try{e.send({type:\`app-update-ready-changed\`,isUpdateReady:t}),e.send({type:\`app-update-lifecycle-state-changed\`,lifecycleState:n}),e.send({type:\`app-update-install-progress-changed\`,installProgressPercent:r})}catch{}};i();let o=()=>{e.allowQuit?.();codexLinuxQuitForUpdate()};return{manager:{getIsUpdateReady:()=>t,getUpdateLifecycleState:()=>n,getInstallProgressPercent:()=>r,checkForUpdates:async()=>{n=\`checking\`,a();try{await codexLinuxRunUpdateManager([\`check-now\`]),i(),a()}catch(e){n=t?\`ready\`:\`idle\`,a();throw e}},installUpdatesIfAvailable:async()=>{i();if(!t)return;r=0,n=\`installing\`,a();try{let e=await codexLinuxRunUpdateManager([\`install-ready\`]),s=i();if(s?.status===\`waiting_for_app_exit\`){r=null,n=\`ready\`,a(),o();return}r=null,a(),e.stdout?.includes(\`already installed\`)?await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`The ready update is already installed.\`):e.stdout?.includes(\`No Codex Desktop update is ready\`)&&await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`There is no rebuilt update waiting to install.\`)}catch(e){r=null,n=t?\`ready\`:\`idle\`,a();throw e}}},quitForUpdate:o,refresh:()=>{i(),a()}}}`;
+  return `${buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};function codexLinuxCreatePackageUpdateManager(e){let t=!1,n=\`idle\`,r=null,i=()=>{try{let e=codexLinuxReadUpdateState(),r=e?.status;t=r===\`ready_to_install\`||r===\`waiting_for_app_exit\`,n=codexLinuxUpdateLifecycleState(r);return e}catch{return null}},a=()=>{try{e.send({type:\`app-update-ready-changed\`,isUpdateReady:t}),e.send({type:\`app-update-lifecycle-state-changed\`,lifecycleState:n}),e.send({type:\`app-update-install-progress-changed\`,installProgressPercent:r})}catch{}},s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=\`idle\`,a();return!1});let o=()=>{e.allowQuit?.();codexLinuxQuitForUpdate()};return{manager:{getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:\`idle\`,getInstallProgressPercent:()=>r,checkForUpdates:async()=>{if(!await c)return;n=\`checking\`,a();try{await codexLinuxRunUpdateManager([\`check-now\`]),i(),a()}catch(e){n=t?\`ready\`:\`idle\`,a();throw e}},installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}r=0,n=\`installing\`,a();try{let e=await codexLinuxRunUpdateManager([\`install-ready\`]),s=i();if(s?.status===\`waiting_for_app_exit\`){r=null,n=\`ready\`,a(),o();return}r=null,a(),e.stdout?.includes(\`already installed\`)?await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`The ready update is already installed.\`):e.stdout?.includes(\`No Codex Desktop update is ready\`)&&await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`There is no rebuilt update waiting to install.\`)}catch(e){r=null,n=t?\`ready\`:\`idle\`,a();throw e}}},quitForUpdate:o,refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=\`idle\`;a()}}}`;
 }
 
 function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
@@ -72,6 +177,8 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
       `${buildBootstrapBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};${bootstrapNeedle}`,
     );
   }
+
+  patchedSource = migrateLinuxUpdaterBridgeSource(patchedSource);
 
   const destructureRegex =
     /let\{startedAtMs:([A-Za-z_$][\w$]*),buildFlavor:([A-Za-z_$][\w$]*),desktopSentry:([A-Za-z_$][\w$]*),sparkleManager:([A-Za-z_$][\w$]*),setSparkleBridgeHandlers:([A-Za-z_$][\w$]*),setSecondInstanceArgsHandler:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(\),/;
@@ -196,7 +303,7 @@ function applyLinuxAppUpdaterBridgePatch(currentSource) {
   if (!patchedSource.includes("async initializeLinuxPackageUpdater(){")) {
     const methodNeedle = "async initializeWindowsUpdater(){";
     const methodPatch =
-      "async initializeLinuxPackageUpdater(){if(process.platform!==`linux`){this.lastUnavailableReason=`unsupported platform`;return}let e=()=>{let e=codexLinuxReadUpdateState(),t=e?.status;this.setUpdateReady(t===`ready_to_install`||t===`waiting_for_app_exit`),this.setUpdateLifecycleState(codexLinuxUpdateLifecycleState(t)),this.lastUnavailableReason=null;return e};try{await codexLinuxRunUpdateManager([`--help`]),e()}catch(e){this.lastUnavailableReason=e?.code===`ENOENT`?`codex-update-manager not found`:`codex-update-manager unavailable`,ZE().warning(`Linux updater unavailable`,{safe:{reason:this.lastUnavailableReason},sensitive:{error:e}});return}this.updater={checkForUpdates:async()=>{this.setUpdateLifecycleState(`checking`);try{await codexLinuxRunUpdateManager([`check-now`]),e()}catch(t){this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw t}},installUpdatesIfAvailable:async()=>{e();if(!this.isUpdateReady)return;this.setInstallProgressPercent(0),this.setUpdateLifecycleState(`installing`);try{let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();if(t?.status===`waiting_for_app_exit`){this.setInstallProgressPercent(null),codexLinuxQuitForUpdate();return}this.setInstallProgressPercent(null),n.stdout?.includes(`already installed`)?await codexLinuxShowUpdateMessage(`Codex Desktop update`,`The ready update is already installed.`):n.stdout?.includes(`No Codex Desktop update is ready`)&&await codexLinuxShowUpdateMessage(`Codex Desktop update`,`There is no rebuilt update waiting to install.`)}catch(e){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw e}}};let t=setInterval(()=>{try{e()}catch(e){ZE().warning(`Linux updater state refresh failed`,{safe:{},sensitive:{error:e}})}},3e4);t.unref?.()}";
+      "async initializeLinuxPackageUpdater(){if(process.platform!==`linux`){this.lastUnavailableReason=`unsupported platform`;return}let e=()=>{let e=codexLinuxReadUpdateState(),t=e?.status;this.setUpdateReady(t===`ready_to_install`||t===`waiting_for_app_exit`),this.setUpdateLifecycleState(codexLinuxUpdateLifecycleState(t)),this.lastUnavailableReason=null;return e};try{await codexLinuxProbeUpdateManager(),e()}catch(e){this.lastUnavailableReason=e?.code===`ENOENT`?`codex-update-manager not found`:`codex-update-manager unavailable`,ZE().warning(`Linux updater unavailable`,{safe:{reason:this.lastUnavailableReason},sensitive:{error:e}});return}this.updater={checkForUpdates:async()=>{this.setUpdateLifecycleState(`checking`);try{await codexLinuxRunUpdateManager([`check-now`]),e()}catch(t){this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw t}},installUpdatesIfAvailable:async()=>{e();if(!this.isUpdateReady)return;this.setInstallProgressPercent(0),this.setUpdateLifecycleState(`installing`);try{let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();if(t?.status===`waiting_for_app_exit`){this.setInstallProgressPercent(null),codexLinuxQuitForUpdate();return}this.setInstallProgressPercent(null),n.stdout?.includes(`already installed`)?await codexLinuxShowUpdateMessage(`Codex Desktop update`,`The ready update is already installed.`):n.stdout?.includes(`No Codex Desktop update is ready`)&&await codexLinuxShowUpdateMessage(`Codex Desktop update`,`There is no rebuilt update waiting to install.`)}catch(e){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw e}}};let t=setInterval(()=>{codexLinuxRefreshUpdateState().then(()=>e()).catch(e=>{ZE().warning(`Linux updater state refresh failed`,{safe:{},sensitive:{error:e}})})},3e4);t.unref?.()}";
     if (!patchedSource.includes(methodNeedle)) {
       console.warn("WARN: Could not find updater method insertion point - skipping Linux updater bridge patch");
       return currentSource;
@@ -204,7 +311,7 @@ function applyLinuxAppUpdaterBridgePatch(currentSource) {
     patchedSource = patchedSource.replace(methodNeedle, `${methodPatch}${methodNeedle}`);
   }
 
-  return patchedSource;
+  return migrateLinuxUpdaterBridgeSource(patchedSource);
 }
 
 function applyLinuxAppUpdaterMenuPatch(currentSource) {

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -42,6 +42,7 @@ const {
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,
@@ -122,6 +123,7 @@ module.exports = {
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseInstallFlowPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -17,6 +17,7 @@ const {
   applyLinuxComputerUseRendererAvailabilityPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
@@ -781,7 +782,12 @@ test("adds Linux package updater behind the existing app updater manager", () =>
   assert.match(patched, /t\.app\?\.quit\?\.\(\)/);
   assert.match(patched, /t\.app\?\.exit\?\.\(0\)/);
   assert.match(patched, /execFile\(codexLinuxUpdateManagerPath\(\),e/);
+  assert.match(patched, /async function codexLinuxProbeUpdateManager\(\)/);
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`--help`\]\)/);
+  assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)/);
+  assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
+  assert.doesNotMatch(patched, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
+  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\)/);
   assert.match(patched, /if\(!this\.options\.enableUpdater&&process\.platform!==`linux`\)/);
   assert.match(patched, /process\.platform===`linux`\?await this\.initializeLinuxPackageUpdater\(\)/);
   assert.match(patched, /async initializeLinuxPackageUpdater\(\)/);
@@ -794,6 +800,16 @@ test("adds Linux package updater behind the existing app updater manager", () =>
   assert.match(patched, /if\(t\?\.status===`waiting_for_app_exit`\)/);
 });
 
+test("does not run bootstrap probe-state migration on class-style updater bundles", () => {
+  const source = `function unrelated(){i();let o=1;return o}${appUpdaterBundleFixture()}`;
+  const patched = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, source);
+
+  assert.match(patched, /function unrelated\(\)\{i\(\);let o=1;return o\}/);
+  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\)/);
+  assert.doesNotMatch(patched, /let s=!1,c=codexLinuxProbeUpdateManager/);
+  assert.doesNotMatch(patched, /getIsUpdateReady:\(\)=>s&&t/);
+});
+
 test("adds Linux package updater to current bootstrap updater wiring", () => {
   const patched = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, currentBootstrapUpdaterBundleFixture());
 
@@ -803,6 +819,117 @@ test("adds Linux package updater to current bootstrap updater wiring", () => {
   assert.doesNotMatch(patched, /send:e=>a\.sendMessageToAllRegisteredWindows\(e\)/);
   assert.match(patched, /s=codexLinuxPackageUpdateBridge\.manager/);
   assert.match(patched, /te=codexLinuxPackageUpdateBridge\.quitForUpdate/);
+  assert.match(patched, /async function codexLinuxProbeUpdateManager\(\)/);
+  assert.match(patched, /codexLinuxRunUpdateManager\(\[`--help`\]\)/);
+  assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
+  assert.match(patched, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\);return!0\}\)/);
+  assert.match(patched, /getIsUpdateReady:\(\)=>s&&t/);
+  assert.match(patched, /checkForUpdates:async\(\)=>\{if\(!await c\)return;n=`checking`/);
+  assert.match(patched, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+  assert.match(patched, /refresh:async\(\)=>\{if\(await c\)\{try\{await codexLinuxRefreshUpdateState\(\)\}/);
+  assert.doesNotMatch(patched, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
+});
+
+test("migrates already-patched bootstrap updater bridge to probe before enabling UI", () => {
+  const patched = applyLinuxAppUpdaterBridgePatch(currentBootstrapUpdaterBundleFixture());
+  const oldPatched = patched
+    .replace(
+      "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
+      "i(),codexLinuxRefreshUpdateState().then(()=>{i(),a()}).catch(()=>{});let o=",
+    )
+    .replace(
+      "getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:`idle`,",
+      "getIsUpdateReady:()=>t,getUpdateLifecycleState:()=>n,",
+    )
+    .replace(
+      "checkForUpdates:async()=>{if(!await c)return;n=`checking`,a();try{",
+      "checkForUpdates:async()=>{n=`checking`,a();try{",
+    )
+    .replace(
+      "installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}",
+      "installUpdatesIfAvailable:async()=>{i();if(!t)return;",
+    )
+    .replace(
+      "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
+      "refresh:async()=>{try{await codexLinuxRefreshUpdateState()}catch{}i(),a()}",
+    );
+
+  const migrated = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, oldPatched);
+
+  assert.match(migrated, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\);return!0\}\)/);
+  assert.match(migrated, /getIsUpdateReady:\(\)=>s&&t/);
+  assert.match(migrated, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+});
+
+test("migrates previous bootstrap updater bridge without leaving undefined probe state", () => {
+  const patched = applyLinuxAppUpdaterBridgePatch(currentBootstrapUpdaterBundleFixture());
+  const oldPatched = patched
+    .replace(
+      "async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([`--help`])}",
+      "",
+    )
+    .replace(
+      "async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}",
+      "",
+    )
+    .replace(
+      ",s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
+      ";i();let o=",
+    )
+    .replace(
+      "getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:`idle`,",
+      "getIsUpdateReady:()=>t,getUpdateLifecycleState:()=>n,",
+    )
+    .replace(
+      "checkForUpdates:async()=>{if(!await c)return;n=`checking`,a();try{",
+      "checkForUpdates:async()=>{n=`checking`,a();try{",
+    )
+    .replace(
+      "installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}",
+      "installUpdatesIfAvailable:async()=>{i();if(!t)return;",
+    )
+    .replace(
+      "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
+      "refresh:()=>{i(),a()}",
+    );
+
+  assert.doesNotMatch(oldPatched, /codexLinuxProbeUpdateManager/);
+  assert.doesNotMatch(oldPatched, /codexLinuxRefreshUpdateState/);
+  assert.match(oldPatched, /i\(\);let o=/);
+
+  const migrated = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, oldPatched);
+
+  assert.match(migrated, /async function codexLinuxProbeUpdateManager\(\)\{await codexLinuxRunUpdateManager\(\[`--help`\]\)\}/);
+  assert.match(migrated, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
+  assert.match(migrated, /let s=!1,c=codexLinuxProbeUpdateManager\(\)\.then/);
+  assert.match(migrated, /getIsUpdateReady:\(\)=>s&&t/);
+  assert.match(migrated, /checkForUpdates:async\(\)=>\{if\(!await c\)return;n=`checking`/);
+  assert.match(migrated, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+  assert.match(migrated, /refresh:async\(\)=>\{if\(await c\)\{try\{await codexLinuxRefreshUpdateState\(\)\}/);
+});
+
+test("migrates already-patched Linux updater bridge to probe without mutating refresh", () => {
+  const patched = applyLinuxAppUpdaterBridgePatch(appUpdaterBundleFixture());
+  const oldPatched = patched
+    .replace(
+      "async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([`--help`])}",
+      "",
+    )
+    .replace(
+      "async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}",
+      "async function codexLinuxRefreshUpdateState(){await codexLinuxRunUpdateManager([`status`,`--json`]);return codexLinuxReadUpdateState()}",
+    )
+    .replace(
+      "await codexLinuxProbeUpdateManager(),e()",
+      "await codexLinuxRefreshUpdateState(),e()",
+    );
+
+  const migrated = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, oldPatched);
+
+  assert.match(migrated, /async function codexLinuxProbeUpdateManager\(\)\{await codexLinuxRunUpdateManager\(\[`--help`\]\)\}/);
+  assert.match(migrated, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
+  assert.match(migrated, /await codexLinuxProbeUpdateManager\(\),e\(\)/);
+  assert.doesNotMatch(migrated, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
 });
 
 test("migrates an already-patched Linux updater bridge to quit before install", () => {
@@ -1096,6 +1223,24 @@ test("auto-approves the app-provided Browser Use node_repl bridge", () => {
 
   assert.match(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
   assert.match(patched, /env:\{\[dt\]:l,\[ft\]:i\.nodePath/);
+});
+
+test("shows the Linux IAB panel after Browser Use creates or reuses a tab", () => {
+  const source =
+    "var CF=class{async createTabForBrowserUse(e){let t=this.getActiveBrowserUseTab(e,{assertCurrentPageAllowed:!1});if(t!=null)return await this.navigateTabToInitialPage(t),this.serializeTab(t);let n=this.getRequiredBrowserHost(e);n.setBrowserUseActive(!0,e.turnId);let r=await n.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:e.turnId}),i=this.updateTabForPage(r,n.routeKey);return SF().info(`IAB_LIFECYCLE iab createTab mapped page to tab`,{}),this.markBrowserUseCommandForTab(e,i),this.selectedTabIdsByRouteKey.set(n.routeKey,i.cdpTabId),this.serializeTab(i)}};";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseIabVisibleOnCreatePatch, source);
+
+  assert.match(
+    patched,
+    /this\.getRequiredBrowserHost\(e\)\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)/,
+  );
+  assert.match(patched, /n\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)/);
+  assert.match(patched, /codexLinuxBrowserUseAutoVisible/);
+  assert.match(
+    patched,
+    /return \(\(\)=>\{try\{n\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)\}/,
+  );
 });
 
 test("detects Chrome extension installation from Linux browser profiles", () => {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -783,6 +783,44 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   return currentSource.replace(needle, approvalPatch);
 }
 
+function applyLinuxBrowserUseIabVisibleOnCreatePatch(currentSource) {
+  const marker = "codexLinuxBrowserUseAutoVisible";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const visibilityExpr = (hostExpr, sessionExpr) =>
+    `(()=>{try{${hostExpr}.setBrowserVisibleForBrowserUse(!0,${sessionExpr}.turnId)}catch(__codexLinuxErr){console.warn("${marker}",__codexLinuxErr?.message??__codexLinuxErr)}})()`;
+  const createTabRegex =
+    /if\(([A-Za-z_$][\w$]*)!=null\)return await this\.navigateTabToInitialPage\(\1\),this\.serializeTab\(\1\);let ([A-Za-z_$][\w$]*)=this\.getRequiredBrowserHost\(([A-Za-z_$][\w$]*)\);\2\.setBrowserUseActive\(!0,\3\.turnId\);let ([A-Za-z_$][\w$]*)=await \2\.openPageForBrowserUse\(\{startingUrl:this\.initialPageUrl,turnId:\3\.turnId\}\),([A-Za-z_$][\w$]*)=this\.updateTabForPage\(\4,\2\.routeKey\);return/;
+  const match = currentSource.match(createTabRegex);
+  if (match == null) {
+    if (
+      currentSource.includes("createTabForBrowserUse") &&
+      currentSource.includes("openPageForBrowserUse")
+    ) {
+      console.warn(
+        "WARN: Could not find Browser Use IAB tab creation point — skipping Linux IAB visibility patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [needle, tabVar, hostVar, sessionVar, pageVar, tabInfoVar] = match;
+  const activeTabVisibility = visibilityExpr(
+    `this.getRequiredBrowserHost(${sessionVar})`,
+    sessionVar,
+  );
+  const newTabVisibility = visibilityExpr(hostVar, sessionVar);
+  const replacement =
+    `if(${tabVar}!=null)return await this.navigateTabToInitialPage(${tabVar}),${activeTabVisibility},this.serializeTab(${tabVar});` +
+    `let ${hostVar}=this.getRequiredBrowserHost(${sessionVar});${hostVar}.setBrowserUseActive(!0,${sessionVar}.turnId);` +
+    `let ${pageVar}=await ${hostVar}.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:${sessionVar}.turnId}),${tabInfoVar}=this.updateTabForPage(${pageVar},${hostVar}.routeKey);` +
+    `return ${newTabVisibility},`;
+
+  return currentSource.replace(needle, replacement);
+}
+
 function applyLinuxChromeExtensionStatusPatch(currentSource) {
   if (currentSource.includes("codexLinuxChromeProfileRoots")) {
     return currentSource;
@@ -918,6 +956,7 @@ function applyLinuxGitOriginsSourceFallbackPatch(currentSource) {
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -22,6 +22,7 @@ const {
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,
@@ -151,6 +152,11 @@ const MAIN_BUNDLE_PATCHES = [
     name: "browser-use-node-repl-approval",
     ciPolicy: OPTIONAL,
     apply: (source) => applyBrowserUseNodeReplApprovalPatch(source),
+  },
+  {
+    name: "linux-browser-use-iab-visible-on-create",
+    ciPolicy: OPTIONAL,
+    apply: (source) => applyLinuxBrowserUseIabVisibleOnCreatePatch(source),
   },
   {
     name: "linux-chrome-extension-status",

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -271,6 +271,7 @@ fn upstream_check_is_fresh(config: &RuntimeConfig, state: &PersistedState) -> bo
 
 fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> Result<()> {
     codex_cli::reconcile_if_present(state, paths)?;
+    complete_pending_install_if_already_installed(state, paths)?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(state)?);
@@ -712,7 +713,7 @@ async fn run_install_ready(
 
     if complete_pending_install_if_already_installed(state, paths)? {
         let _ = maybe_notify_installed(state, paths, config.notifications);
-        println!("Codex Desktop update is already installed.");
+        println!("Codex Desktop update is already installed or superseded.");
         return Ok(());
     }
 
@@ -797,18 +798,24 @@ fn complete_pending_install_if_already_installed(
         return Ok(false);
     }
 
-    if !state.candidate_version.as_deref().is_some_and(|candidate| {
-        installed_version_matches_candidate(&state.installed_version, candidate)
-    }) {
+    let Some(candidate_version) = state.candidate_version.clone().filter(|candidate| {
+        installed_version_satisfies_candidate(&state.installed_version, candidate)
+    }) else {
         return Ok(false);
-    }
+    };
+
+    let candidate_is_installed =
+        installed_version_matches_candidate(&state.installed_version, &candidate_version);
 
     state.status = UpdateStatus::Installed;
     state.candidate_version = None;
+    if !candidate_is_installed {
+        state.artifact_paths.package_path = None;
+    }
     state.error_message = None;
     state.notified_events.clear();
     persist_state(paths, state)?;
-    info!("recovered pending install state because the candidate version is already installed");
+    info!("recovered pending install state because the candidate version is already installed or superseded");
     Ok(true)
 }
 
@@ -817,11 +824,17 @@ fn recover_interrupted_install(state: &mut PersistedState, paths: &RuntimePaths)
         return Ok(());
     }
 
-    if state.candidate_version.as_deref().is_some_and(|candidate| {
+    if let Some(candidate_version) = state.candidate_version.clone().filter(|candidate| {
         installed_version_satisfies_candidate(&state.installed_version, candidate)
     }) {
+        let candidate_is_installed =
+            installed_version_matches_candidate(&state.installed_version, &candidate_version);
+
         state.status = UpdateStatus::Installed;
         state.candidate_version = None;
+        if !candidate_is_installed {
+            state.artifact_paths.package_path = None;
+        }
         state.error_message = None;
         state.notified_events.clear();
         persist_state(paths, state)?;
@@ -1223,7 +1236,7 @@ mod tests {
 
         let mut state = PersistedState::new(false);
         state.status = UpdateStatus::Failed;
-        state.candidate_version = Some("2026.03.25.010203+deadbeef".to_string());
+        state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.error_message = Some("previous failure".to_string());
         state.artifact_paths.package_path = Some(package_path);
 
@@ -1360,7 +1373,7 @@ mod tests {
 
         let mut state = PersistedState::new(true);
         state.status = UpdateStatus::ReadyToInstall;
-        state.candidate_version = Some("2026.03.25.010203+deadbeef".to_string());
+        state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(temp.path().join("missing/codex.deb"));
 
         reconcile_pending_install(&config, &mut state, &paths).await?;
@@ -1407,7 +1420,7 @@ mod tests {
 
         let mut state = PersistedState::new(true);
         state.status = UpdateStatus::ReadyToInstall;
-        state.candidate_version = Some("2026.03.25.010203+deadbeef".to_string());
+        state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(package_path);
 
         reconcile_pending_install(&config, &mut state, &paths).await?;
@@ -1451,11 +1464,11 @@ mod tests {
 
         let mut state = PersistedState::new(false);
         state.status = UpdateStatus::ReadyToInstall;
-        state.candidate_version = Some("2026.03.25.010203+deadbeef".to_string());
+        state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(package_path);
         state
             .notified_events
-            .insert("install_auth_required:2026.03.25.010203+deadbeef".to_string());
+            .insert("install_auth_required:2999.03.25.010203+deadbeef".to_string());
 
         run_install_ready(&config, &mut state, &paths).await?;
 
@@ -1490,7 +1503,7 @@ mod tests {
 
         let mut state = PersistedState::new(false);
         state.status = UpdateStatus::ReadyToInstall;
-        state.candidate_version = Some("2026.03.25.010203+deadbeef".to_string());
+        state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(temp.path().join("missing/codex.deb"));
 
         run_install_ready(&config, &mut state, &paths).await?;
@@ -1708,6 +1721,192 @@ mod tests {
     }
 
     #[test]
+    fn pending_install_is_cleared_when_installed_version_is_newer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.installed_version = "2026.05.01.010203-99999999.fc43".to_string();
+        state.candidate_version = Some("2026.04.28.082247+abcdef12".to_string());
+        state.error_message = Some("authentication was not obtained".to_string());
+        let superseded_package_path = temp.path().join("superseded.deb");
+        std::fs::write(&superseded_package_path, b"deb")?;
+        state.artifact_paths.package_path = Some(superseded_package_path);
+
+        assert!(complete_pending_install_if_already_installed(
+            &mut state, &paths
+        )?);
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.artifact_paths.package_path, None);
+        assert_eq!(state.error_message, None);
+        crate::rollback::record_current_package_as_known_good(&mut state);
+        assert_eq!(state.artifact_paths.rollback_package_path, None);
+        Ok(())
+    }
+
+    #[test]
+    fn status_clears_superseded_ready_update() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.installed_version = "2026.05.01.010203".to_string();
+        state.candidate_version = Some("2026.04.28.082247+abcdef12".to_string());
+        let superseded_package_path = temp.path().join("superseded-status.deb");
+        std::fs::write(&superseded_package_path, b"deb")?;
+        state.artifact_paths.package_path = Some(superseded_package_path);
+
+        let original_home = std::env::var_os("HOME");
+        let original_path = std::env::var_os("PATH");
+        let original_nvm_dir = std::env::var_os("NVM_DIR");
+        let original_codex_cli_path = std::env::var_os("CODEX_CLI_PATH");
+        let original_skip_system_cli_lookup =
+            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        std::env::set_var("HOME", temp.path());
+        std::env::set_var("PATH", temp.path().join("missing-bin"));
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+
+        let result = run_status(&mut state, &paths, true);
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        if let Some(nvm_dir) = original_nvm_dir {
+            std::env::set_var("NVM_DIR", nvm_dir);
+        } else {
+            std::env::remove_var("NVM_DIR");
+        }
+        if let Some(cli_path) = original_codex_cli_path {
+            std::env::set_var("CODEX_CLI_PATH", cli_path);
+        } else {
+            std::env::remove_var("CODEX_CLI_PATH");
+        }
+        if let Some(value) = original_skip_system_cli_lookup {
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        }
+
+        result?;
+
+        assert_eq!(state.status, UpdateStatus::Installed);
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.artifact_paths.package_path, None);
+        Ok(())
+    }
+
+    #[test]
+    fn status_preserves_cli_reconciliation_failure() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        let codex_path = bin_dir.join("codex");
+        fs::write(
+            &codex_path,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+        let mut permissions = fs::metadata(&codex_path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&codex_path, permissions)?;
+
+        let npm_path = bin_dir.join("npm");
+        fs::write(
+            &npm_path,
+            "#!/bin/sh\nif [ \"$1\" = \"view\" ] && [ \"$2\" = \"@openai/codex\" ] && [ \"$3\" = \"version\" ]; then\n  echo '0.42.1'\n  exit 0\nfi\nexit 1\n",
+        )?;
+        let mut permissions = fs::metadata(&npm_path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&npm_path, permissions)?;
+
+        let original_home = std::env::var_os("HOME");
+        let original_path = std::env::var_os("PATH");
+        let original_nvm_dir = std::env::var_os("NVM_DIR");
+        let original_codex_cli_path = std::env::var_os("CODEX_CLI_PATH");
+        let original_skip_system_cli_lookup =
+            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        std::env::set_var("HOME", temp.path());
+        std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(codex_path);
+        let result = run_status(&mut state, &paths, true);
+
+        if let Some(home) = original_home {
+            std::env::set_var("HOME", home);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(path) = original_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+        if let Some(nvm_dir) = original_nvm_dir {
+            std::env::set_var("NVM_DIR", nvm_dir);
+        } else {
+            std::env::remove_var("NVM_DIR");
+        }
+        if let Some(cli_path) = original_codex_cli_path {
+            std::env::set_var("CODEX_CLI_PATH", cli_path);
+        } else {
+            std::env::remove_var("CODEX_CLI_PATH");
+        }
+        if let Some(value) = original_skip_system_cli_lookup {
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        }
+
+        assert!(result.is_err());
+        assert_eq!(state.cli_status, CliStatus::Updating);
+        Ok(())
+    }
+
+    #[test]
     fn generated_versions_compare_by_timestamp_segments() {
         assert_eq!(
             compare_generated_versions("2026.04.01.035152", "2026.03.27.025604+1086e799"),
@@ -1763,6 +1962,7 @@ mod tests {
 
         assert_eq!(state.status, UpdateStatus::Installed);
         assert_eq!(state.candidate_version, None);
+        assert_eq!(state.artifact_paths.package_path, None);
         assert_eq!(state.error_message, None);
         Ok(())
     }


### PR DESCRIPTION
## Summary
- make the Linux updater bridge refresh state read-only and probe codex-update-manager before enabling updater UI
- clear superseded pending update artifacts so rollback cannot reuse stale packages
- show the in-app Browser panel when Browser Use creates or reuses a Linux IAB tab

## Root Cause
The Linux updater bridge could read status through a mutating updater command and migrations could affect the wrong bundle shape. Superseded update candidates also left stale package paths behind, which could later be mistaken for rollback targets. Browser Use could open an IAB tab without making the Browser panel visible on Linux.

## Validation
- node --check scripts/lib/linux-update-bridge-patch.js
- node --test scripts/patch-linux-window-ui.test.js
- cargo fmt --check
- cargo test -p codex-update-manager
- bash tests/scripts_smoke.sh
- git diff --check