### PR TITLE
[codex] Add WSLg rendering launch profile

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -75,6 +75,12 @@ Options:
 Default launch keeps Electron GPU enabled and lets Electron choose the platform.
 Extra flags are passed directly to Electron.
 
+Environment:
+  CODEX_LINUX_RENDERING_MODE=auto|default|wslg
+                              Auto-detect WSLg, keep generic Linux defaults, or force the WSLg profile
+  CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0|1
+                              Override the launcher's default --disable-gpu-compositing decision
+
 Logs: ${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID/launcher.log
 HELP
     exit 0
@@ -1300,18 +1306,155 @@ reconcile_runtime_state() {
     fi
 }
 
+is_wsl_environment() {
+    if [ -n "${WSL_INTEROP:-}" ] || [ -n "${WSL_DISTRO_NAME:-}" ]; then
+        return 0
+    fi
+
+    grep -qiE "(microsoft|wsl)" /proc/sys/kernel/osrelease 2>/dev/null
+}
+
+is_wslg_session() {
+    is_wsl_environment || return 1
+
+    if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+        return 0
+    fi
+
+    [ -n "${DISPLAY:-}" ] && [ -e /mnt/wslg ]
+}
+
+normalize_linux_rendering_mode() {
+    case "${CODEX_LINUX_RENDERING_MODE:-auto}" in
+        auto|default|wslg)
+            echo "${CODEX_LINUX_RENDERING_MODE:-auto}"
+            ;;
+        *)
+            echo "Invalid CODEX_LINUX_RENDERING_MODE='${CODEX_LINUX_RENDERING_MODE:-}'; using auto" >&2
+            echo "auto"
+            ;;
+    esac
+}
+
+truthy_env_value() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+falsey_env_value() {
+    case "${1:-}" in
+        0|false|FALSE|no|NO|off|OFF) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+scan_electron_rendering_arg() {
+    case "$1" in
+        --ozone-platform|--ozone-platform=*|--ozone-platform-hint|--ozone-platform-hint=*)
+            ELECTRON_OZONE_SWITCH_IN_ARGS=1
+            ;;
+        --use-gl|--use-gl=*|--use-angle|--use-angle=*)
+            ELECTRON_GL_SWITCH_PROVIDED=1
+            ;;
+        --disable-gpu|--disable-gpu=*)
+            ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS=1
+            ;;
+        --disable-gpu-compositing|--disable-gpu-compositing=*)
+            ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED=1
+            ;;
+    esac
+}
+
+apply_electron_rendering_profile() {
+    local requested_mode
+    requested_mode="$(normalize_linux_rendering_mode)"
+
+    ELECTRON_RENDERING_MODE="$requested_mode"
+    ELECTRON_WSLG_DETECTED=0
+    if is_wslg_session; then
+        ELECTRON_WSLG_DETECTED=1
+    fi
+
+    case "$requested_mode" in
+        auto)
+            if [ "$ELECTRON_WSLG_DETECTED" -eq 1 ]; then
+                ELECTRON_RENDERING_MODE="wslg"
+            else
+                ELECTRON_RENDERING_MODE="default"
+            fi
+            ;;
+        default)
+            return 0
+            ;;
+    esac
+
+    [ "$ELECTRON_RENDERING_MODE" = "wslg" ] || return 0
+
+    if [ "$ELECTRON_PLATFORM_EXPLICIT" -eq 0 ] && [ "$ELECTRON_OZONE_SWITCH_IN_ARGS" -eq 0 ]; then
+        ELECTRON_OZONE_PLATFORM="x11"
+        ELECTRON_OZONE_HINT=""
+    fi
+
+    if [ "$ELECTRON_GL_SWITCH_PROVIDED" -eq 0 ] && [ "$ELECTRON_GPU_ENABLED" = "1" ] && [ "$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS" -eq 0 ]; then
+        ELECTRON_ARGS+=(--use-gl=angle)
+        ELECTRON_GL_SWITCH_PROVIDED=1
+        ELECTRON_GL_SWITCH_ADDED=1
+    fi
+}
+
+should_disable_gpu_compositing() {
+    if [ "$ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED" -eq 1 ]; then
+        return 0
+    fi
+
+    if [ -n "${CODEX_ELECTRON_DISABLE_GPU_COMPOSITING:-}" ]; then
+        if truthy_env_value "$CODEX_ELECTRON_DISABLE_GPU_COMPOSITING"; then
+            return 0
+        fi
+        if falsey_env_value "$CODEX_ELECTRON_DISABLE_GPU_COMPOSITING"; then
+            return 1
+        fi
+        echo "Invalid CODEX_ELECTRON_DISABLE_GPU_COMPOSITING='${CODEX_ELECTRON_DISABLE_GPU_COMPOSITING:-}'; using rendering profile default" >&2
+    fi
+
+    [ "$ELECTRON_RENDERING_MODE" != "wslg" ]
+}
+
 set_electron_defaults() {
     ELECTRON_OZONE_PLATFORM=""
     ELECTRON_OZONE_HINT="auto"
     ELECTRON_GPU_ENABLED=1
+    ELECTRON_RENDERING_MODE="default"
+    ELECTRON_WSLG_DETECTED=0
+    ELECTRON_PLATFORM_EXPLICIT=0
+    ELECTRON_OZONE_SWITCH_IN_ARGS=0
+    ELECTRON_GL_SWITCH_PROVIDED=0
+    ELECTRON_GL_SWITCH_ADDED=0
+    ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS=0
+    ELECTRON_GPU_COMPOSITING_DISABLED=0
+    ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED=0
     ELECTRON_ARGS=()
+    local passthrough=0
 
     while [ "$#" -gt 0 ]; do
+        if [ "$passthrough" -eq 1 ]; then
+            ELECTRON_ARGS+=("$1")
+            scan_electron_rendering_arg "$1"
+            shift
+            continue
+        fi
+
         case "$1" in
+            --)
+                passthrough=1
+                ;;
             --safe-mode)
                 ELECTRON_OZONE_PLATFORM="x11"
                 ELECTRON_OZONE_HINT=""
                 ELECTRON_GPU_ENABLED=0
+                ELECTRON_PLATFORM_EXPLICIT=1
                 ;;
             --disable-gpu)
                 ELECTRON_GPU_ENABLED=0
@@ -1322,21 +1465,26 @@ set_electron_defaults() {
             --x11)
                 ELECTRON_OZONE_PLATFORM="x11"
                 ELECTRON_OZONE_HINT=""
+                ELECTRON_PLATFORM_EXPLICIT=1
                 ;;
             --wayland)
                 ELECTRON_OZONE_PLATFORM="wayland"
                 ELECTRON_OZONE_HINT=""
+                ELECTRON_PLATFORM_EXPLICIT=1
                 ;;
             --ozone-platform=*)
                 ELECTRON_OZONE_PLATFORM="${1#--ozone-platform=}"
                 ELECTRON_OZONE_HINT=""
+                ELECTRON_PLATFORM_EXPLICIT=1
                 ;;
             --ozone-platform-hint=*)
                 ELECTRON_OZONE_HINT="${1#--ozone-platform-hint=}"
                 ELECTRON_OZONE_PLATFORM=""
+                ELECTRON_PLATFORM_EXPLICIT=1
                 ;;
             *)
                 ELECTRON_ARGS+=("$1")
+                scan_electron_rendering_arg "$1"
                 ;;
         esac
         shift
@@ -1362,6 +1510,8 @@ set_electron_defaults() {
         ELECTRON_OZONE_HINT=""
         echo "Detected Sommelier (SOMMELIER_VERSION=$SOMMELIER_VERSION); forcing --ozone-platform=x11 (Wayland windows are not visible under ChromeOS Crostini)"
     fi
+
+    apply_electron_rendering_profile
 }
 
 build_electron_launch_args() {
@@ -1371,8 +1521,14 @@ build_electron_launch_args() {
         --app-id="$CODEX_LINUX_APP_ID"
         --disable-dev-shm-usage
         --disable-gpu-sandbox
-        --disable-gpu-compositing
     )
+
+    if should_disable_gpu_compositing; then
+        ELECTRON_LAUNCH_ARGS+=(--disable-gpu-compositing)
+        ELECTRON_GPU_COMPOSITING_DISABLED=1
+    else
+        ELECTRON_GPU_COMPOSITING_DISABLED=0
+    fi
 
     if [ "$CODEX_LINUX_APP_ID" != "codex-desktop" ]; then
         ELECTRON_LAUNCH_ARGS+=(--user-data-dir="${CODEX_ELECTRON_USER_DATA_DIR:-$APP_STATE_DIR/electron-user-data}")
@@ -1382,7 +1538,7 @@ build_electron_launch_args() {
 
     if [ -n "$ELECTRON_OZONE_PLATFORM" ]; then
         ELECTRON_LAUNCH_ARGS+=(--ozone-platform="$ELECTRON_OZONE_PLATFORM")
-    elif [ -n "$ELECTRON_OZONE_HINT" ]; then
+    elif [ -n "$ELECTRON_OZONE_HINT" ] && [ "$ELECTRON_OZONE_SWITCH_IN_ARGS" -eq 0 ]; then
         ELECTRON_LAUNCH_ARGS+=(--ozone-platform-hint="$ELECTRON_OZONE_HINT")
     fi
 
@@ -1432,12 +1588,12 @@ launch_electron() {
     build_electron_launch_args
 
     if [ "$WARM_START" -eq 1 ]; then
-        echo "Electron warm-start handoff: pid=$RUNNING_APP_PID ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED"
+        echo "Electron warm-start handoff: pid=$RUNNING_APP_PID rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED"
         "$SCRIPT_DIR/electron" "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}"
         return $?
     fi
 
-    echo "Electron launch mode: ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED"
+    echo "Electron launch mode: rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED"
     "$SCRIPT_DIR/electron" "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}" &
     ELECTRON_PID=$!
     if [ -n "${RUNNING_APP_PID:-}" ] && pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -525,6 +525,90 @@ if 'clear_stale_pid_file' not in reconcile_body:
 if 'if [ -z "$webview_pid" ] || { ! pid_is_webview_server "$webview_pid" && ! pid_is_stale_webview_server "$webview_pid"; }; then' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must clear stale launcher webview ownership markers without touching valid orphaned servers")
 PY
+    local launcher_probe
+    local output
+    launcher_probe="$TMP_DIR/launcher-rendering-probe.sh"
+    python3 - "$REPO_DIR/launcher/start.sh.template" "$launcher_probe" <<'PY'
+import sys
+
+source_path, output_path = sys.argv[1:3]
+source = open(source_path, encoding="utf-8").read()
+start = source.index("is_wsl_environment() {")
+end = source.index("configure_side_by_side_app_env() {")
+probe = "#!/bin/bash\n" + source[start:end] + r'''
+set -Eeuo pipefail
+
+CODEX_LINUX_APP_ID="${CODEX_LINUX_APP_ID:-codex-desktop}"
+APP_STATE_DIR="${APP_STATE_DIR:-/tmp/codex-launcher-probe-state}"
+
+print_state() {
+    printf 'mode=%s wslg=%s ozone_platform=%s ozone_hint=%s gpu=%s gpu_arg=%s comp=%s gl_added=%s launch=' \
+        "$ELECTRON_RENDERING_MODE" \
+        "$ELECTRON_WSLG_DETECTED" \
+        "${ELECTRON_OZONE_PLATFORM:-}" \
+        "${ELECTRON_OZONE_HINT:-}" \
+        "$ELECTRON_GPU_ENABLED" \
+        "$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS" \
+        "$ELECTRON_GPU_COMPOSITING_DISABLED" \
+        "$ELECTRON_GL_SWITCH_ADDED"
+    for arg in "${ELECTRON_LAUNCH_ARGS[@]}"; do
+        printf '<%s>' "$arg"
+    done
+    printf ' electron='
+    for arg in "${ELECTRON_ARGS[@]}"; do
+        printf '<%s>' "$arg"
+    done
+    printf '\n'
+}
+
+case "${1:-}" in
+    probe)
+        shift
+        set_electron_defaults "$@"
+        build_electron_launch_args
+        print_state
+        ;;
+    *)
+        echo "Usage: $0 probe [launcher args...]" >&2
+        exit 2
+        ;;
+esac
+'''
+open(output_path, "w", encoding="utf-8").write(probe)
+PY
+    chmod +x "$launcher_probe"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe --x11 -- --use-gl=angle)"
+    [[ "$output" == *"electron=<--use-gl=angle>"* ]] || fail "launcher must pass Electron args after -- without the separator: $output"
+    [[ "$output" != *"electron=<--><--use-gl=angle>"* ]] || fail "launcher must not pass the -- separator to Electron: $output"
+    [[ "$output" == *"<--ozone-platform=x11>"* ]] || fail "launcher --x11 must still set the Electron ozone platform: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --ozone-platform=x11)"
+    [[ "$output" == *"electron=<--ozone-platform=x11>"* ]] || fail "pass-through ozone platform must reach Electron: $output"
+    [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "launcher must not add ozone hint when pass-through supplies an ozone platform: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe)"
+    [[ "$output" == *"mode=wslg"* && "$output" == *"comp=0"* && "$output" == *"gl_added=1"* ]] || fail "forced WSLg profile must disable GPU compositing default and add ANGLE: $output"
+    [[ "$output" == *"<--ozone-platform=x11>"* && "$output" == *"electron=<--use-gl=angle>"* ]] || fail "forced WSLg profile must use X11 and ANGLE by default: $output"
+    [[ "$output" != *"<--disable-gpu-compositing>"* ]] || fail "forced WSLg profile must not add disable-gpu-compositing by default: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe --wayland --use-gl=desktop)"
+    [[ "$output" == *"<--ozone-platform=wayland>"* && "$output" == *"electron=<--use-gl=desktop>"* ]] || fail "explicit rendering args must override WSLg defaults: $output"
+    [[ "$output" == *"gl_added=0"* && "$output" != *"<--use-gl=angle>"* ]] || fail "WSLg profile must not add ANGLE when a GL switch was supplied: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe -- --disable-gpu)"
+    [[ "$output" == *"gpu=1"* && "$output" == *"gpu_arg=1"* && "$output" == *"gl_added=0"* ]] || fail "pass-through --disable-gpu must suppress WSLg ANGLE without becoming a launcher GPU toggle: $output"
+    [[ "$output" == *"electron=<--disable-gpu>"* && "$output" != *"<--disable-features=Vulkan>"* ]] || fail "pass-through --disable-gpu must not add launcher-only Vulkan flags: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 "$launcher_probe" probe)"
+    [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 must force the compositor flag: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 "$launcher_probe" probe)"
+    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 must suppress the compositor flag: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" WSL_INTEROP=/tmp/codex-wsl WAYLAND_DISPLAY=wayland-0 "$launcher_probe" probe)"
+    [[ "$output" == *"mode=wslg"* && "$output" == *"wslg=1"* ]] || fail "auto rendering mode must detect WSLg from WSL and GUI markers: $output"
+
     assert_contains "$REPO_DIR/launcher/start.sh.template" "warm_start_ipc_sent"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "launcher_phase"
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'date +%s%N'


### PR DESCRIPTION
## Summary

- Add a WSLg-specific launcher rendering profile for Windows/WSL2 environments.
- Treat `--` as a real launcher/Electron separator so flags like `--use-gl=angle` reach Electron instead of being hidden behind the separator.
- Add env overrides for rendering mode and GPU compositing behavior, with expanded launch logging.

## Why

Issue #147 showed a blank/white WSLg startup window and follow-up GL tests used commands like `codex-desktop --x11 -- --use-gl=angle`. The launcher advertised that syntax but passed the literal `--` through to Electron, which prevents Chromium switches after it from being recognized. The WSLg profile keeps generic Linux defaults unchanged while giving WSLg a safer rendering path to try by default.

## Validation

- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js`