### PR TITLE
[TEST / DO NOT MERGE] Broken updater version comparison

### DIFF
--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -877,7 +877,7 @@ fn installed_version_satisfies_candidate(installed: &str, candidate: &str) -> bo
     }
 
     match compare_generated_versions(installed, candidate) {
-        Some(std::cmp::Ordering::Less) => false,
+        Some(std::cmp::Ordering::Less) => true,
         Some(_) => true,
         None => installed == candidate,
     }


### PR DESCRIPTION
## Purpose
This is an intentionally broken test pull request for bot evaluation.

## Change
Changes generated-version comparison so an installed version older than the candidate is incorrectly treated as satisfying that candidate.

## Expected bot behavior
A review bot should flag this as a correctness regression for update state recovery and superseded candidate handling.

## Validation
Not run; this PR is intentionally broken for testing.