### PR TITLE
[codex] Fix updater builder linux-features staging

### DIFF
--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -14,7 +14,7 @@ use std::{
 use tokio::process::Command;
 use tracing::info;
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 13] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 14] = [
     ("Cargo.toml", "Cargo.toml"),
     ("Cargo.lock", "Cargo.lock"),
     ("computer-use-linux", "computer-use-linux"),
@@ -34,6 +34,7 @@ const REQUIRED_BUNDLE_FILES: [(&str, &str); 13] = [
     ("scripts/lib", "scripts/lib"),
     ("packaging/linux", "packaging/linux"),
     ("assets/codex.png", "assets/codex.png"),
+    ("linux-features", "linux-features"),
 ];
 const OPTIONAL_BUNDLE_FILES: [(&str, &str); 3] = [
     ("scripts/build-rpm.sh", "scripts/build-rpm.sh"),
@@ -491,6 +492,19 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         Ok(())
     }
 
+    fn write_fake_linux_features_bundle(root: &Path) -> Result<()> {
+        fs::create_dir_all(root.join("linux-features/example-feature"))?;
+        fs::write(
+            root.join("linux-features/features.example.json"),
+            b"{\"enabled\":[]}\n",
+        )?;
+        fs::write(
+            root.join("linux-features/example-feature/feature.json"),
+            b"{\"id\":\"example-feature\"}\n",
+        )?;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn builds_update_with_fake_bundle() -> Result<()> {
         let temp = tempdir()?;
@@ -503,6 +517,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         fs::create_dir_all(bundle_root.join("packaging/linux"))?;
         fs::create_dir_all(bundle_root.join("assets"))?;
         write_fake_computer_use_bundle(&bundle_root)?;
+        write_fake_linux_features_bundle(&bundle_root)?;
         fs::write(
             bundle_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
@@ -650,6 +665,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .workspace_dir
             .join("builder/scripts/patches/registry.js")
             .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("builder/linux-features/features.example.json")
+            .exists());
         assert!(
             is_native_package_file(&artifacts.package_path),
             "expected a native package (.deb, .rpm, or .pkg.tar.zst), got {}",
@@ -670,6 +689,7 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         fs::create_dir_all(source_root.join("packaging/linux"))?;
         fs::create_dir_all(source_root.join("assets"))?;
         write_fake_computer_use_bundle(&source_root)?;
+        write_fake_linux_features_bundle(&source_root)?;
         fs::write(source_root.join("install.sh"), b"#!/bin/bash\n")?;
         fs::write(
             source_root.join("launcher/start.sh.template"),
@@ -718,6 +738,9 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .exists());
         assert!(destination_root
             .join("scripts/lib/node-runtime.sh")
+            .exists());
+        assert!(destination_root
+            .join("linux-features/features.example.json")
             .exists());
         assert!(!destination_root.join("scripts/build-rpm.sh").exists());
         assert!(!destination_root.join("scripts/build-pacman.sh").exists());


### PR DESCRIPTION
## Summary

- add `linux-features/` to the updater builder bundle allowlist
- extend the updater builder tests so copied workspaces must include `linux-features/features.example.json`

## Root Cause

The package staging step now includes `linux-features/`, but the updater's Rust-side workspace copy allowlist did not include that directory. Packaged auto-update rebuilds could therefore fail when `scripts/build-*.sh` tried to stage the next update-builder bundle.

Fixes #156.

## Validation

- `cargo fmt --check`
- `cargo test -p codex-update-manager builder`
- `git diff --check`