### PR TITLE
[codex] fix NixOS bundled browser startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 APP_DIR := $(CURDIR)/codex-app

--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@ PY
 
           outputHashAlgo = "sha256";
           outputHashMode = "recursive";
-          outputHash = "sha256-mKfNGjFA3qG8UnTnH9uk4nl+8t8x09B4yk98nDE2vK8=";
+          outputHash = "sha256-UnqbizEDTpNCH1tViVVAKpE8NPBRn5JMy0GfcAhswkw=";
           unsafeDiscardReferences.out = true;
 
           dontConfigure = true;

--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@ PY
 
           outputHashAlgo = "sha256";
           outputHashMode = "recursive";
-          outputHash = "sha256-6WGym+Z9glOZvfaimUYXVhnko8KmN5WBxSIXmG3ln5A=";
+          outputHash = "sha256-mKfNGjFA3qG8UnTnH9uk4nl+8t8x09B4yk98nDE2vK8=";
           unsafeDiscardReferences.out = true;
 
           dontConfigure = true;

--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@ PY
 
           outputHashAlgo = "sha256";
           outputHashMode = "recursive";
-          outputHash = "sha256-A4gRYx5hAJD5OoNog1DI0lDERt3Po1xyJcpib7dCX0M=";
+          outputHash = "sha256-6WGym+Z9glOZvfaimUYXVhnko8KmN5WBxSIXmG3ln5A=";
           unsafeDiscardReferences.out = true;
 
           dontConfigure = true;
@@ -215,6 +215,7 @@ PY
             export NIX_SSL_CERT_FILE="$SSL_CERT_FILE"
             export npm_config_cafile="$SSL_CERT_FILE"
             export CARGO_HOME="$TMPDIR/cargo-home"
+            export CARGO_BUILD_JOBS=1
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,7 @@ SCRIPT
 
     chmod +x "$INSTALL_DIR/start.sh"
     mkdir -p "$INSTALL_DIR/.codex-linux"
+    cp "$SCRIPT_DIR/launcher/webview-server.py" "$INSTALL_DIR/.codex-linux/webview-server.py"
     if [ -f "$ICON_SOURCE" ]; then
         cp "$ICON_SOURCE" "$INSTALL_DIR/.codex-linux/$CODEX_APP_ID.png"
     else

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -112,6 +112,53 @@ log_phase() {
     echo "[$(date -Is)] launcher_phase=$phase elapsedMs=$elapsed_ms"
 }
 
+make_tree_owner_writable() {
+    local path="$1"
+
+    [ -e "$path" ] || return 0
+    chmod -R u+rwX "$path" 2>/dev/null || true
+}
+
+remove_tree_if_exists() {
+    local path="$1"
+
+    [ -e "$path" ] || return 0
+    make_tree_owner_writable "$path"
+    rm -rf "$path"
+}
+
+fix_bundled_marketplace_tmp_permissions() {
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local marketplace_tmp_root="$codex_home/.tmp/bundled-marketplaces"
+
+    [ -d "$marketplace_tmp_root" ] || return 0
+    find "$marketplace_tmp_root" -type d -exec chmod u+rwx {} + 2>/dev/null || true
+    find "$marketplace_tmp_root" -type f -exec chmod u+rw {} + 2>/dev/null || true
+}
+
+clear_bundled_marketplace_tmp_cache() {
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local marketplace_tmp_root="$codex_home/.tmp/bundled-marketplaces"
+    local path
+
+    fix_bundled_marketplace_tmp_permissions
+    for path in "$marketplace_tmp_root"/openai-bundled "$marketplace_tmp_root"/openai-bundled.staging-*; do
+        [ -e "$path" ] || continue
+        remove_tree_if_exists "$path"
+    done
+}
+
+monitor_bundled_marketplace_tmp_permissions() {
+    (
+        local i=0
+        while [ "$i" -lt 300 ]; do
+            fix_bundled_marketplace_tmp_permissions
+            sleep 0.1
+            i=$((i + 1))
+        done
+    ) &
+}
+
 import_graphical_env_entry() {
     local entry="$1"
     local name="${entry%%=*}"
@@ -357,16 +404,17 @@ sync_browser_use_bundled_plugin_cache() {
 
     cache_parent="$(dirname "$cache_plugin")"
     tmp_plugin="$cache_parent/.browser-use-$version.tmp.$$"
-    rm -rf "$tmp_plugin"
+    remove_tree_if_exists "$tmp_plugin"
     mkdir -p "$cache_parent"
 
     if cp -R "$source_plugin" "$tmp_plugin"; then
+        make_tree_owner_writable "$tmp_plugin"
         find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-        rm -rf "$cache_plugin"
+        remove_tree_if_exists "$cache_plugin"
         mv "$tmp_plugin" "$cache_plugin"
         echo "Browser Use plugin cache synced from bundled resources: $cache_plugin"
     else
-        rm -rf "$tmp_plugin"
+        remove_tree_if_exists "$tmp_plugin"
         echo "Browser Use plugin cache sync failed; continuing with existing cache."
     fi
 }
@@ -523,23 +571,24 @@ sync_chrome_bundled_plugin_cache() {
     if [ "$needs_copy" -eq 1 ]; then
         cache_parent="$(dirname "$cache_plugin")"
         tmp_plugin="$cache_parent/.chrome-$version.tmp.$$"
-        rm -rf "$tmp_plugin"
+        remove_tree_if_exists "$tmp_plugin"
         mkdir -p "$cache_parent"
 
         if cp -R "$source_plugin" "$tmp_plugin"; then
+            make_tree_owner_writable "$tmp_plugin"
             find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-            rm -rf "$cache_plugin"
+            remove_tree_if_exists "$cache_plugin"
             mv "$tmp_plugin" "$cache_plugin"
             echo "Chrome plugin cache synced from bundled resources: $cache_plugin"
         else
-            rm -rf "$tmp_plugin"
+            remove_tree_if_exists "$tmp_plugin"
             echo "Chrome plugin cache sync failed; continuing with existing cache."
             return 0
         fi
     fi
 
     if [ -e "$cache_root/latest" ] && [ ! -L "$cache_root/latest" ]; then
-        rm -rf "$cache_root/latest"
+        remove_tree_if_exists "$cache_root/latest"
     fi
     ln -sfn "$version" "$cache_root/latest"
 
@@ -554,7 +603,7 @@ sync_chrome_bundled_plugin_cache() {
             echo "Chrome bundled marketplace sync failed; continuing with existing marketplace cache."
     fi
     if [ -e "$marketplace_plugin_link" ] && [ ! -L "$marketplace_plugin_link" ]; then
-        rm -rf "$marketplace_plugin_link"
+        remove_tree_if_exists "$marketplace_plugin_link"
     fi
     ln -sfn "$cache_root/latest" "$marketplace_plugin_link"
 
@@ -611,16 +660,17 @@ sync_computer_use_bundled_plugin_cache() {
 
     cache_parent="$(dirname "$cache_plugin")"
     tmp_plugin="$cache_parent/.computer-use-$version.tmp.$$"
-    rm -rf "$tmp_plugin"
+    remove_tree_if_exists "$tmp_plugin"
     mkdir -p "$cache_parent"
 
     if cp -R "$source_plugin" "$tmp_plugin"; then
+        make_tree_owner_writable "$tmp_plugin"
         find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-        rm -rf "$cache_plugin"
+        remove_tree_if_exists "$cache_plugin"
         mv "$tmp_plugin" "$cache_plugin"
         echo "Computer Use plugin cache synced from bundled resources: $cache_plugin"
     else
-        rm -rf "$tmp_plugin"
+        remove_tree_if_exists "$tmp_plugin"
         echo "Computer Use plugin cache sync failed; continuing with existing cache."
     fi
 }
@@ -1615,6 +1665,8 @@ configure_side_by_side_app_env
 load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
 register_url_scheme_handlers
+clear_bundled_marketplace_tmp_cache
+monitor_bundled_marketplace_tmp_permissions
 reconcile_runtime_state
 detect_warm_start
 trap cleanup_launcher EXIT

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1665,8 +1665,6 @@ configure_side_by_side_app_env
 load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
 register_url_scheme_handlers
-clear_bundled_marketplace_tmp_cache
-monitor_bundled_marketplace_tmp_permissions
 reconcile_runtime_state
 detect_warm_start
 trap cleanup_launcher EXIT
@@ -1730,6 +1728,10 @@ fi
 
 export_packaged_runtime_env
 if needs_cold_start; then
+    clear_bundled_marketplace_tmp_cache
+    # The runtime marketplace is populated asynchronously and can briefly
+    # recreate read-only plugin cache trees before the sync below replaces them.
+    monitor_bundled_marketplace_tmp_permissions
     sync_browser_use_bundled_plugin_cache
     sync_chrome_bundled_plugin_cache
     sync_computer_use_bundled_plugin_cache

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1047,7 +1047,7 @@ pid_has_webview_server_cmdline() {
     [ -d "/proc/$pid" ] || return 1
     pid_is_current_user "$pid" || return 1
     cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
-    [[ "$cmdline" == *"http.server $CODEX_LINUX_WEBVIEW_PORT"* ]]
+    [[ "$cmdline" == *"http.server $CODEX_LINUX_WEBVIEW_PORT"* || "$cmdline" == *"webview-server.py $CODEX_LINUX_WEBVIEW_PORT"* ]]
 }
 
 pid_is_webview_server() {
@@ -1244,7 +1244,7 @@ ensure_webview_server() {
     stop_owned_webview_server
 
     cd "$WEBVIEW_DIR"
-    python3 -m http.server "$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1 &
+    python3 "$SCRIPT_DIR/.codex-linux/webview-server.py" "$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1 &
     STARTED_WEBVIEW_PID=$!
     echo "$STARTED_WEBVIEW_PID" > "$WEBVIEW_PID_FILE"
 

--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import functools
+import http.server
+import sys
+
+
+port = int(sys.argv[1])
+bind = "127.0.0.1"
+if len(sys.argv) >= 4 and sys.argv[2] == "--bind":
+    bind = sys.argv[3]
+
+
+class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
+    def send_head(self):
+        for header in ("If-Modified-Since", "If-None-Match"):
+            if header in self.headers:
+                del self.headers[header]
+        return super().send_head()
+
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+        super().end_headers()
+
+
+handler = functools.partial(CodexWebviewHandler, directory=".")
+with http.server.ThreadingHTTPServer((bind, port), handler) as httpd:
+    httpd.serve_forever()

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -150,6 +150,7 @@ stage_update_builder_bundle() {
 
     cp "$REPO_DIR/install.sh" "$update_builder_root/install.sh"
     cp "$REPO_DIR/launcher/start.sh.template" "$update_builder_root/launcher/start.sh.template"
+    cp "$REPO_DIR/launcher/webview-server.py" "$update_builder_root/launcher/webview-server.py"
     cp "$REPO_DIR/Cargo.toml" "$update_builder_root/Cargo.toml"
     cp "$REPO_DIR/Cargo.lock" "$update_builder_root/Cargo.lock"
     cp -r "$REPO_DIR/computer-use-linux" "$update_builder_root/computer-use-linux"

--- a/tests/fixtures/create-packaged-app-fixture.sh
+++ b/tests/fixtures/create-packaged-app-fixture.sh
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 app_dir="${1:-codex-app}"
 
 mkdir -p "$app_dir/content/webview" "$app_dir/resources/node-runtime/bin"
 
-printf '%s\n' '#!/bin/bash' 'echo "codex desktop fixture"' > "$app_dir/start.sh"
+printf '%s\n' '#!/usr/bin/env bash' 'echo "codex desktop fixture"' > "$app_dir/start.sh"
 chmod +x "$app_dir/start.sh"
 
 printf '%s\n' '<!doctype html><title>Codex fixture</title>' > "$app_dir/content/webview/index.html"
 
 for binary in node npm npx; do
     cat > "$app_dir/resources/node-runtime/bin/$binary" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$(basename "$0")" in
     node) echo v22.22.2 ;;
     *) echo 10.9.7 ;;

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -496,6 +496,10 @@ if "using_second_instance_handoff" not in source or "needs_cold_start" not in so
     raise SystemExit("launcher must have an explicit second-instance handoff mode")
 if "second_instance_handoff_ready" not in runtime_body:
     raise SystemExit("second-instance handoff must skip cold-start setup")
+if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permissions\nreconcile_runtime_state" in runtime_body:
+    raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
+if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache', runtime_body, re.S):
+    raise SystemExit("bundled marketplace cleanup must run only on cold start immediately before plugin sync")
 if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI lookup")
 if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -72,7 +72,7 @@ JS
 
 make_fake_app() {
     local app_dir="$1"
-    "$REPO_DIR/tests/fixtures/create-packaged-app-fixture.sh" "$app_dir"
+    bash "$REPO_DIR/tests/fixtures/create-packaged-app-fixture.sh" "$app_dir"
 }
 
 make_stub_bin_dir() {
@@ -102,11 +102,11 @@ test_deb_builder_smoke() {
     mkdir -p "$workspace" "$dist_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
-    printf '#!/bin/bash\nexit 0\n' > "$updater_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
     chmod +x "$updater_bin"
 
     cat > "$bin_dir/dpkg" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$1" = "--print-architecture" ]; then
     echo amd64
     exit 0
@@ -114,13 +114,13 @@ fi
 exit 0
 SCRIPT
     cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 output="${@: -1}"
 mkdir -p "$(dirname "$output")"
 touch "$output"
 SCRIPT
     cat > "$bin_dir/cargo" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "cargo should not be called when UPDATER_BINARY_SOURCE exists" >&2
 exit 99
 SCRIPT
@@ -132,7 +132,7 @@ SCRIPT
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
-    "$REPO_DIR/scripts/build-deb.sh"
+    bash "$REPO_DIR/scripts/build-deb.sh"
 
     assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+deadbeef_amd64.deb"
     assert_file_exists "$pkg_root/DEBIAN/prerm"
@@ -171,11 +171,11 @@ test_deb_builder_respects_package_identity() {
     mkdir -p "$workspace" "$dist_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
-    printf '#!/bin/bash\nexit 0\n' > "$updater_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
     chmod +x "$updater_bin"
 
     cat > "$bin_dir/dpkg" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$1" = "--print-architecture" ]; then
     echo amd64
     exit 0
@@ -183,13 +183,13 @@ fi
 exit 0
 SCRIPT
     cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 output="${@: -1}"
 mkdir -p "$(dirname "$output")"
 touch "$output"
 SCRIPT
     cat > "$bin_dir/cargo" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "cargo should not be called when UPDATER_BINARY_SOURCE exists" >&2
 exit 99
 SCRIPT
@@ -203,7 +203,7 @@ SCRIPT
     PACKAGE_NAME="codex-cua-lab" \
     PACKAGE_DISPLAY_NAME="Codex CUA Lab" \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
-    "$REPO_DIR/scripts/build-deb.sh"
+    bash "$REPO_DIR/scripts/build-deb.sh"
 
     assert_file_exists "$dist_dir/codex-cua-lab_2026.03.24.120000+deadbeef_amd64.deb"
     assert_file_exists "$pkg_root/usr/bin/codex-cua-lab"
@@ -229,11 +229,11 @@ test_rpm_builder_smoke() {
     mkdir -p "$workspace" "$dist_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
-    printf '#!/bin/bash\nexit 0\n' > "$updater_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
     chmod +x "$updater_bin"
 
     cat > "$bin_dir/rpmbuild" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 rpmdir=""
 while [ $# -gt 0 ]; do
     if [ "$1" = "--define" ]; then
@@ -250,7 +250,7 @@ mkdir -p "$rpmdir/x86_64"
 touch "$rpmdir/x86_64/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
 SCRIPT
     cat > "$bin_dir/cargo" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 echo "cargo should not be called when UPDATER_BINARY_SOURCE exists" >&2
 exit 99
 SCRIPT
@@ -261,7 +261,7 @@ SCRIPT
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
-    "$REPO_DIR/scripts/build-rpm.sh"
+    bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
 }
@@ -277,20 +277,20 @@ test_missing_input_failure() {
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$rpm_app_dir"
     cat > "$bin_dir/dpkg" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 echo amd64
 SCRIPT
     cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 exit 0
 SCRIPT
     chmod +x "$bin_dir/dpkg" "$bin_dir/dpkg-deb"
 
-    if PATH="$bin_dir:$PATH" APP_DIR_OVERRIDE="$workspace/does-not-exist" PKG_ROOT_OVERRIDE="$workspace/deb-root" "$REPO_DIR/scripts/build-deb.sh" >/dev/null 2>&1; then
+    if PATH="$bin_dir:$PATH" APP_DIR_OVERRIDE="$workspace/does-not-exist" PKG_ROOT_OVERRIDE="$workspace/deb-root" bash "$REPO_DIR/scripts/build-deb.sh" >/dev/null 2>&1; then
         fail "build-deb.sh should fail when APP_DIR is missing"
     fi
 
-    if APP_DIR_OVERRIDE="$rpm_app_dir" PACKAGED_RUNTIME_SOURCE="$workspace/does-not-exist.sh" "$REPO_DIR/scripts/build-rpm.sh" >"$rpm_log" 2>&1; then
+    if APP_DIR_OVERRIDE="$rpm_app_dir" PACKAGED_RUNTIME_SOURCE="$workspace/does-not-exist.sh" bash "$REPO_DIR/scripts/build-rpm.sh" >"$rpm_log" 2>&1; then
         fail "build-rpm.sh should fail when PACKAGED_RUNTIME_SOURCE is missing"
     fi
     assert_contains "$rpm_log" "Missing packaged launcher runtime helper"
@@ -304,7 +304,7 @@ test_make_build_app_uses_installer_download_flow_by_default() {
     mkdir -p "$workspace"
 
     cat > "$workspace/install.sh" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 printf '%s\n' "$#" > "$TEST_INSTALL_LOG"
 if [ "$#" -gt 0 ]; then
@@ -404,7 +404,7 @@ test_managed_node_runtime_source_install() {
     mkdir -p "$source_dir/bin" "$install_dir/resources"
     for binary in node npm npx; do
         cat > "$source_dir/bin/$binary" <<'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
 case "$(basename "$0")" in
     node) echo v22.22.2 ;;
     *) echo 10.9.7 ;;
@@ -446,7 +446,11 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "better_sqlite3_build_version"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "CODEX_ELECTRON_CACHE_DIR"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "--continue-at -"
-    assert_contains "$REPO_DIR/launcher/start.sh.template" 'python3 -m http.server "$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1'
+    assert_file_exists "$REPO_DIR/launcher/webview-server.py"
+    assert_contains "$REPO_DIR/launcher/webview-server.py" "Cache-Control"
+    assert_contains "$REPO_DIR/launcher/webview-server.py" "If-Modified-Since"
+    assert_contains "$REPO_DIR/install.sh" "webview-server.py"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'python3 "$SCRIPT_DIR/.codex-linux/webview-server.py" "$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "WEBVIEW_PID_FILE"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "owned_webview_server_pid"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "discover_webview_server_pid"
@@ -535,7 +539,7 @@ source_path, output_path = sys.argv[1:3]
 source = open(source_path, encoding="utf-8").read()
 start = source.index("is_wsl_environment() {")
 end = source.index("configure_side_by_side_app_env() {")
-probe = "#!/bin/bash\n" + source[start:end] + r'''
+probe = "#!/usr/bin/env bash\n" + source[start:end] + r'''
 set -Eeuo pipefail
 
 CODEX_LINUX_APP_ID="${CODEX_LINUX_APP_ID:-codex-desktop}"
@@ -640,6 +644,9 @@ PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_browser_use_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_chrome_bundled_plugin_cache"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "make_tree_owner_writable"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "clear_bundled_marketplace_tmp_cache"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "monitor_bundled_marketplace_tmp_permissions"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-id.json"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/chromium/NativeMessagingHosts"
@@ -711,6 +718,7 @@ test_side_by_side_launcher_identity() {
     bash -c 'source "$1"; validate_app_identity; create_start_script' _ "$REPO_DIR/install.sh"
 
     assert_file_exists "$app_dir/start.sh"
+    assert_file_exists "$app_dir/.codex-linux/webview-server.py"
     assert_contains "$app_dir/start.sh" "CODEX_LINUX_APP_ID=codex-cua-lab"
     assert_contains "$app_dir/start.sh" "CODEX_LINUX_APP_DISPLAY_NAME=Codex\\\\ CUA\\\\ Lab"
     assert_contains "$app_dir/start.sh" 'CODEX_LINUX_WEBVIEW_PORT=${CODEX_WEBVIEW_PORT:-5176}'
@@ -724,12 +732,12 @@ test_side_by_side_launcher_identity() {
     assert_contains "$app_dir/start.sh" '--user-data-dir="${CODEX_ELECTRON_USER_DATA_DIR:-$APP_STATE_DIR/electron-user-data}"'
     assert_contains "$app_dir/start.sh" "--force-renderer-accessibility"
     assert_contains "$app_dir/start.sh" 'LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID"'
-    XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" "$app_dir/start.sh" --help >"$help_log"
+    XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" bash "$app_dir/start.sh" --help >"$help_log"
     assert_contains "$help_log" "Launches the Codex CUA Lab app."
     assert_contains "$help_log" "codex-cua-lab/launcher.log"
 
     ln -s "$app_dir/start.sh" "$bin_dir/codex-cua-lab"
-    XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" "$bin_dir/codex-cua-lab" --help >"$symlink_help_log"
+    XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" bash "$bin_dir/codex-cua-lab" --help >"$symlink_help_log"
     assert_contains "$symlink_help_log" "Launches the Codex CUA Lab app."
 }
 
@@ -747,6 +755,7 @@ test_browser_use_node_repl_fallback_runtime() {
     local archive="$workspace/runtime.tar.xz"
     local output_log="$workspace/output.log"
     local archive_sha
+    local true_bin
 
     mkdir -p "$workspace" "$install_dir/resources" "$archive_root/codex-primary-runtime/dependencies/bin"
     make_fake_browser_use_upstream_app "$app_dir"
@@ -755,7 +764,8 @@ test_browser_use_node_repl_fallback_runtime() {
     printf '\xfe\xed\xfa\xcf' > "$app_dir/Contents/Resources/node_repl"
     chmod +x "$app_dir/Contents/Resources/node_repl"
 
-    cp /bin/true "$archive_root/codex-primary-runtime/dependencies/bin/node_repl"
+    true_bin="$(type -P true)"
+    cp "$true_bin" "$archive_root/codex-primary-runtime/dependencies/bin/node_repl"
     chmod 0755 "$archive_root/codex-primary-runtime/dependencies/bin/node_repl"
     tar -cJf "$archive" -C "$archive_root" codex-primary-runtime
     archive_sha="$(sha256sum "$archive" | awk '{print $1}')"
@@ -790,7 +800,7 @@ test_browser_use_node_repl_fallback_runtime() {
 
     assert_file_exists "$install_dir/resources/node_repl"
     assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs"
-    cmp -s /bin/true "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
+    cmp -s "$true_bin" "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
     assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
     assert_not_contains "$output_log" "WARN.*Browser Use node_repl runtime is not a Linux executable"


### PR DESCRIPTION
## Summary

- serve the extracted webview through a tiny no-cache Python server so Electron cannot reuse an old `index.html` that points at removed hashed assets
- make bundled plugin cache replacement tolerant of read-only trees copied from Nix store resources
- clear and normalize bundled marketplace staging directories before app startup to avoid `EACCES` during plugin marketplace resolution
- limit Cargo build jobs in the Nix payload build and refresh the fixed-output hash
- make the smoke test harness runnable on systems without `/bin/bash`

## Why

The current Nix package can launch with stale webview assets or fail while app-server resolves bundled plugins because copied plugin directories can inherit read-only modes from packaged resources. On NixOS this showed up as missing UI assets, `EACCES` errors under `~/.codex/.tmp/bundled-marketplaces`, and bundled browser plugins not becoming available.

## Validation

- `bash tests/scripts_smoke.sh`
- `nix build .#packages.x86_64-linux.default --no-link`
- inspected the built package for `.codex-linux/webview-server.py`
- inspected the built bundled marketplace plugin list: `browser-use`, `chrome`
