### PR TITLE
Support datagram ydotool sockets

### DIFF
--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -598,7 +598,7 @@ fn socket_connect_result(path: &Path) -> std::result::Result<(), String> {
     }
 
     match UnixStream::connect(path) {
-        Ok(_) => return Ok(()),
+        Ok(_) => Ok(()),
         Err(stream_error) => {
             match UnixDatagram::unbound().and_then(|socket| socket.connect(path)) {
                 Ok(()) => Ok(()),

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -8,7 +8,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     env, fs,
     fs::OpenOptions,
-    os::unix::net::UnixStream,
+    os::unix::net::{UnixDatagram, UnixStream},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -598,8 +598,18 @@ fn socket_connect_result(path: &Path) -> std::result::Result<(), String> {
     }
 
     match UnixStream::connect(path) {
-        Ok(_) => Ok(()),
-        Err(error) => Err(format!("{}: {error}", path.display())),
+        Ok(_) => return Ok(()),
+        Err(stream_error) => {
+            match UnixDatagram::unbound().and_then(|socket| socket.connect(path)) {
+                Ok(()) => Ok(()),
+                Err(datagram_error) => Err(format!(
+                    "{}: stream: {}; datagram: {}",
+                    path.display(),
+                    stream_error,
+                    datagram_error
+                )),
+            }
+        }
     }
 }
 
@@ -943,6 +953,25 @@ mod tests {
 
         assert!(check.ok, "{check:?}");
         drop(listener);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ydotool_socket_check_accepts_datagram_socket() {
+        let dir = std::env::temp_dir().join(format!(
+            "codex-computer-use-diagnostics-dgram-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp diagnostics dir");
+        let socket = dir.join("ydotool.sock");
+        let datagram =
+            std::os::unix::net::UnixDatagram::bind(&socket).expect("bind temp datagram socket");
+
+        let check = socket_connect_check(&socket);
+
+        assert!(check.ok, "{check:?}");
+        drop(datagram);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -1923,9 +1923,7 @@ fn ydotool_socket_candidates() -> Vec<PathBuf> {
 }
 
 fn connectable_ydotool_socket_from(candidates: Vec<PathBuf>) -> Option<PathBuf> {
-    candidates
-        .into_iter()
-        .find(|path| ydotool_socket_connects(path))
+    candidates.into_iter().find(ydotool_socket_connects)
 }
 
 fn ydotool_socket_connects(path: &PathBuf) -> bool {

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     env,
     io::Write,
-    os::unix::net::UnixStream,
+    os::unix::net::{UnixDatagram, UnixStream},
     path::PathBuf,
     process::{Command, Output, Stdio},
     sync::{Arc, Mutex},
@@ -1925,7 +1925,14 @@ fn ydotool_socket_candidates() -> Vec<PathBuf> {
 fn connectable_ydotool_socket_from(candidates: Vec<PathBuf>) -> Option<PathBuf> {
     candidates
         .into_iter()
-        .find(|path| UnixStream::connect(path).is_ok())
+        .find(|path| ydotool_socket_connects(path))
+}
+
+fn ydotool_socket_connects(path: &PathBuf) -> bool {
+    UnixStream::connect(path).is_ok()
+        || UnixDatagram::unbound()
+            .and_then(|socket| socket.connect(path))
+            .is_ok()
 }
 
 fn mouse_button_code(button: Option<&str>) -> String {
@@ -2695,6 +2702,28 @@ mod tests {
 
         assert_eq!(selected, usable_socket);
         drop(listener);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn ydotool_socket_selection_accepts_datagram_socket() {
+        let dir = std::env::temp_dir().join(format!(
+            "codex-computer-use-server-dgram-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp server dir");
+        let stale_socket = dir.join("stale.sock");
+        std::fs::write(&stale_socket, b"not a socket").expect("write stale socket placeholder");
+        let usable_socket = dir.join("usable.sock");
+        let datagram =
+            std::os::unix::net::UnixDatagram::bind(&usable_socket).expect("bind usable socket");
+
+        let selected = connectable_ydotool_socket_from(vec![stale_socket, usable_socket.clone()])
+            .expect("usable socket should be selected");
+
+        assert_eq!(selected, usable_socket);
+        drop(datagram);
         let _ = std::fs::remove_dir_all(&dir);
     }
 


### PR DESCRIPTION
## Summary
- Accept Unix datagram sockets when probing ydotoold sockets in diagnostics
- Use the same datagram-aware socket selection for runtime ydotool commands
- Add coverage for datagram sockets while preserving existing stream-socket behavior

## Why
Debian packages ydotoold with a Unix datagram socket at /run/user/UID/.ydotool_socket. The existing UnixStream-only probe reports this as Protocol wrong type for socket, so Linux Computer Use incorrectly reports ydotool input as unavailable even though ydotool itself can use the socket.

## Validation
- cargo fmt --all --check
- git diff --check
- cargo test -p codex-computer-use-linux
- Live Debian 13 check: codex-computer-use-linux doctor reports ydotool_socket connectable and can_send_development_input=true