### PR TITLE
Fix layout-safe Linux type_text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "tokio",
  "wayland-client",
  "wayland-protocols",
+ "xkeysym",
  "zbus",
 ]
 
@@ -3417,6 +3418,12 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = "1.0.149"
 tokio = { version = "1.51.1", features = ["macros", "rt", "time"] }
 wayland-client = "0.31.11"
 wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
+xkeysym = "0.2.1"
 zbus = "5.14.0"

--- a/computer-use-linux/src/remote_desktop.rs
+++ b/computer-use-linux/src/remote_desktop.rs
@@ -2,6 +2,7 @@ use crate::diagnostics::hydrate_session_bus_env;
 use anyhow::{bail, Context, Result};
 use futures_util::StreamExt;
 use std::{collections::HashMap, time::Duration};
+use xkeysym::Keysym;
 use zbus::{
     proxy::SignalStream,
     zvariant::{OwnedObjectPath, OwnedValue, Value},
@@ -15,9 +16,13 @@ const PORTAL_SCREENCAST_INTERFACE: &str = "org.freedesktop.portal.ScreenCast";
 const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
+const DEVICE_KEYBOARD: u32 = 1;
 const DEVICE_POINTER: u32 = 2;
 const SOURCE_MONITOR: u32 = 1;
 const CURSOR_MODE_HIDDEN: u32 = 1;
+
+const KEY_RELEASED: u32 = 0;
+const KEY_PRESSED: u32 = 1;
 
 const POINTER_BUTTON_RELEASED: u32 = 0;
 const POINTER_BUTTON_PRESSED: u32 = 1;
@@ -38,6 +43,12 @@ pub struct PortalPointerSession {
     connection: Connection,
     session_handle: OwnedObjectPath,
     streams: Vec<PortalStream>,
+}
+
+#[derive(Clone)]
+pub struct PortalKeyboardSession {
+    connection: Connection,
+    session_handle: OwnedObjectPath,
 }
 
 #[derive(Debug, Clone)]
@@ -89,6 +100,41 @@ pub async fn start_portal_pointer_session() -> Result<PortalPointerSession> {
         session_handle,
         streams,
     })
+}
+
+pub async fn start_portal_keyboard_session() -> Result<PortalKeyboardSession> {
+    hydrate_session_bus_env();
+
+    let connection = Connection::session()
+        .await
+        .context("failed to connect to session bus for remote desktop portal")?;
+    let session_handle = create_remote_desktop_session(&connection).await?;
+    select_keyboard_devices(&connection, &session_handle).await?;
+    let (devices, _) = start_remote_desktop_session(&connection, &session_handle).await?;
+
+    if devices & DEVICE_KEYBOARD == 0 {
+        bail!("remote desktop portal session started without keyboard access");
+    }
+
+    Ok(PortalKeyboardSession {
+        connection,
+        session_handle,
+    })
+}
+
+pub fn keysyms_for_text(text: &str) -> Result<Vec<i32>> {
+    text.chars()
+        .map(|ch| {
+            let keysym = Keysym::from_char(ch);
+            if keysym == Keysym::NoSymbol {
+                bail!(
+                    "character U+{:04X} cannot be represented as an X11 keysym",
+                    ch as u32
+                );
+            }
+            i32::try_from(keysym.raw()).context("X11 keysym did not fit in D-Bus int32")
+        })
+        .collect()
 }
 
 pub async fn click(
@@ -179,6 +225,38 @@ pub async fn drag(
         POINTER_BUTTON_RELEASED,
     )
     .await
+}
+
+pub async fn type_text_with_keysyms(
+    session: &PortalKeyboardSession,
+    keysyms: &[i32],
+) -> Result<()> {
+    let proxy = remote_desktop_proxy(&session.connection).await?;
+    for keysym in keysyms {
+        notify_keyboard_keysym(&proxy, &session.session_handle, *keysym, KEY_PRESSED).await?;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        notify_keyboard_keysym(&proxy, &session.session_handle, *keysym, KEY_RELEASED).await?;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    Ok(())
+}
+
+pub async fn press_keycode_chord(
+    session: &PortalKeyboardSession,
+    modifiers: &[i32],
+    keycode: i32,
+) -> Result<()> {
+    let proxy = remote_desktop_proxy(&session.connection).await?;
+    for modifier in modifiers {
+        notify_keyboard_keycode(&proxy, &session.session_handle, *modifier, KEY_PRESSED).await?;
+    }
+    notify_keyboard_keycode(&proxy, &session.session_handle, keycode, KEY_PRESSED).await?;
+    tokio::time::sleep(Duration::from_millis(35)).await;
+    notify_keyboard_keycode(&proxy, &session.session_handle, keycode, KEY_RELEASED).await?;
+    for modifier in modifiers.iter().rev() {
+        notify_keyboard_keycode(&proxy, &session.session_handle, *modifier, KEY_RELEASED).await?;
+    }
+    Ok(())
 }
 
 impl PortalPointerSession {
@@ -278,15 +356,28 @@ async fn create_remote_desktop_session(connection: &Connection) -> Result<OwnedO
 }
 
 async fn select_pointer_devices(connection: &Connection, session: &OwnedObjectPath) -> Result<()> {
+    select_devices(connection, session, DEVICE_POINTER, "rd_devices").await
+}
+
+async fn select_keyboard_devices(connection: &Connection, session: &OwnedObjectPath) -> Result<()> {
+    select_devices(connection, session, DEVICE_KEYBOARD, "rd_keyboard_devices").await
+}
+
+async fn select_devices(
+    connection: &Connection,
+    session: &OwnedObjectPath,
+    device_types: u32,
+    request_prefix: &str,
+) -> Result<()> {
     let remote_proxy = remote_desktop_proxy(connection).await?;
     let (request_path, mut response_stream) =
-        portal_request_stream(connection, "rd_devices").await?;
+        portal_request_stream(connection, request_prefix).await?;
     let mut options: HashMap<&str, Value<'_>> = HashMap::new();
     options.insert(
         "handle_token",
         Value::from(last_path_component(&request_path)),
     );
-    options.insert("types", Value::from(DEVICE_POINTER));
+    options.insert("types", Value::from(device_types));
 
     let handle: OwnedObjectPath = remote_proxy
         .call("SelectDevices", &(session, options))
@@ -405,6 +496,34 @@ async fn notify_pointer_axis_discrete(
         )
         .await
         .context("RemoteDesktop NotifyPointerAxisDiscrete failed")?;
+    Ok(())
+}
+
+async fn notify_keyboard_keysym(
+    proxy: &Proxy<'_>,
+    session: &OwnedObjectPath,
+    keysym: i32,
+    state: u32,
+) -> Result<()> {
+    let options: HashMap<&str, Value<'_>> = HashMap::new();
+    let _: () = proxy
+        .call("NotifyKeyboardKeysym", &(session, options, keysym, state))
+        .await
+        .context("RemoteDesktop NotifyKeyboardKeysym failed")?;
+    Ok(())
+}
+
+async fn notify_keyboard_keycode(
+    proxy: &Proxy<'_>,
+    session: &OwnedObjectPath,
+    keycode: i32,
+    state: u32,
+) -> Result<()> {
+    let options: HashMap<&str, Value<'_>> = HashMap::new();
+    let _: () = proxy
+        .call("NotifyKeyboardKeycode", &(session, options, keycode, state))
+        .await
+        .context("RemoteDesktop NotifyKeyboardKeycode failed")?;
     Ok(())
 }
 
@@ -540,4 +659,58 @@ fn request_token(prefix: &str) -> String {
         _ => '_',
     })
     .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xkeysym::key;
+
+    #[test]
+    fn keysyms_for_url_text_round_trips_to_literal_characters() {
+        let text = "https://example.com:8080/page#anchor";
+        let keysyms = keysyms_for_text(text).expect("URL should map to keysyms");
+
+        let round_tripped = keysyms
+            .iter()
+            .map(|keysym| {
+                Keysym::new(*keysym as u32)
+                    .key_char()
+                    .expect("keysym should map back to a character")
+            })
+            .collect::<String>();
+
+        assert_eq!(round_tripped, text);
+    }
+
+    #[test]
+    fn keysyms_for_layout_sensitive_ascii_use_literal_symbols() {
+        assert_eq!(
+            keysyms_for_text(":#/?@").expect("symbols should map to keysyms"),
+            vec![
+                key::colon as i32,
+                key::numbersign as i32,
+                key::slash as i32,
+                key::question as i32,
+                key::at as i32,
+            ]
+        );
+    }
+
+    #[test]
+    fn keysyms_for_non_ascii_use_legacy_and_unicode_mapped_values() {
+        assert_eq!(
+            keysyms_for_text("ä€😉").expect("non-ASCII text should map to keysyms"),
+            vec![key::adiaeresis as i32, key::EuroSign as i32, 0x0101_F609]
+        );
+    }
+
+    #[test]
+    fn keysyms_for_text_rejects_unicode_non_symbols_before_input() {
+        let error = keysyms_for_text("\u{FDD0}")
+            .expect_err("Unicode non-characters should not be emitted through the portal")
+            .to_string();
+
+        assert!(error.contains("U+FDD0"));
+    }
 }

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -668,34 +668,31 @@ impl ComputerUseLinux {
             match self.ensure_portal_keyboard_session().await {
                 Ok(Some(session)) => {
                     match run_kde_clipboard_paste_text(&session, &params.text).await {
-                        Ok(()) => {
+                        Ok(message) => {
                             return Json(successful_action_with_focus(
                                 "type_text",
-                                "Action pasted through KDE clipboard integration.",
+                                &message,
                                 received,
                                 focus,
                             ));
                         }
                         Err(error) => {
-                            self.clear_portal_keyboard_session();
-                            return Json(action_result_with_focus(
-                                "type_text",
-                                Err(error),
-                                received,
-                                focus,
-                            ));
+                            if error.clear_portal_keyboard_session {
+                                self.clear_portal_keyboard_session();
+                            }
+                            if !error.can_fallback_to_ydotool {
+                                return Json(action_result_with_focus(
+                                    "type_text",
+                                    Err(error.message),
+                                    received,
+                                    focus,
+                                ));
+                            }
                         }
                     }
                 }
                 Ok(None) => {}
-                Err(error) => {
-                    return Json(action_result_with_focus(
-                        "type_text",
-                        Err(format!("{error:#}")),
-                        received,
-                        focus,
-                    ));
-                }
+                Err(_) => {}
             }
         }
         if self.should_prefer_portal_keyboard_backend() {
@@ -2039,29 +2036,58 @@ fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String> {
     }
 }
 
+const EVDEV_KEY_LEFTCTRL: i32 = 29;
+const EVDEV_KEY_V: i32 = 47;
+const KDE_CLIPBOARD_RESTORE_DELAY_MS: u64 = 500;
+
+#[derive(Debug)]
+struct KdeClipboardPasteError {
+    message: String,
+    can_fallback_to_ydotool: bool,
+    clear_portal_keyboard_session: bool,
+}
+
+impl KdeClipboardPasteError {
+    fn before_text_input(message: String) -> Self {
+        Self {
+            message,
+            can_fallback_to_ydotool: true,
+            clear_portal_keyboard_session: false,
+        }
+    }
+
+    fn after_portal_input(message: String) -> Self {
+        Self {
+            message,
+            can_fallback_to_ydotool: false,
+            clear_portal_keyboard_session: true,
+        }
+    }
+}
+
 async fn run_kde_clipboard_paste_text(
     session: &PortalKeyboardSession,
     text: &str,
-) -> std::result::Result<(), String> {
-    let previous = kde_clipboard_contents()?;
-    kde_set_clipboard_contents(text)?;
+) -> std::result::Result<String, KdeClipboardPasteError> {
+    let previous = kde_clipboard_contents().map_err(KdeClipboardPasteError::before_text_input)?;
+    kde_set_clipboard_contents(text).map_err(KdeClipboardPasteError::before_text_input)?;
 
-    let paste_result = press_keycode_chord(session, &[29], 47)
+    let paste_result = press_keycode_chord(session, &[EVDEV_KEY_LEFTCTRL], EVDEV_KEY_V)
         .await
         .map_err(|error| format!("{error:#}"));
 
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    tokio::time::sleep(Duration::from_millis(KDE_CLIPBOARD_RESTORE_DELAY_MS)).await;
     let restore_result = kde_set_clipboard_contents(&previous);
 
     match (paste_result, restore_result) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(error), Ok(_)) => Err(error),
-        (Ok(_), Err(restore_error)) => Err(format!(
-            "text was pasted, but previous KDE clipboard contents could not be restored: {restore_error}"
+        (Ok(_), Ok(_)) => Ok("Action pasted through KDE clipboard integration.".to_string()),
+        (Err(error), Ok(_)) => Err(KdeClipboardPasteError::after_portal_input(error)),
+        (Ok(_), Err(restore_error)) => Ok(format!(
+            "Action pasted through KDE clipboard integration. Warning: previous KDE clipboard contents could not be restored: {restore_error}"
         )),
-        (Err(error), Err(restore_error)) => Err(format!(
+        (Err(error), Err(restore_error)) => Err(KdeClipboardPasteError::after_portal_input(format!(
             "{error}; previous KDE clipboard contents could not be restored: {restore_error}"
-        )),
+        ))),
     }
 }
 

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -6,8 +6,10 @@ use crate::atspi_tree::{
 use crate::diagnostics::{doctor_report, setup_accessibility_report, DoctorReport, SetupReport};
 use crate::gnome_extension::{setup_window_targeting_report, WindowTargetingSetupReport};
 use crate::remote_desktop::{
-    click as portal_click, drag as portal_drag, scroll as portal_scroll,
-    start_portal_pointer_session, PointerButton, PortalPointerSession, ScrollDirection,
+    click as portal_click, drag as portal_drag, keysyms_for_text, press_keycode_chord,
+    scroll as portal_scroll, start_portal_keyboard_session, start_portal_pointer_session,
+    type_text_with_keysyms, PointerButton, PortalKeyboardSession, PortalPointerSession,
+    ScrollDirection,
 };
 use crate::screenshot::{capture_screenshot, ScreenshotCapture};
 use crate::windowing::registry;
@@ -38,6 +40,7 @@ use std::{
 pub struct ComputerUseLinux {
     last_nodes: Arc<Mutex<Vec<AccessibilityNode>>>,
     portal_pointer_session: Arc<Mutex<Option<PortalPointerSession>>>,
+    portal_keyboard_session: Arc<Mutex<Option<PortalKeyboardSession>>>,
 }
 
 #[tool_router]
@@ -661,6 +664,67 @@ impl ComputerUseLinux {
                 });
             }
         };
+        if self.should_prefer_kde_clipboard_text_backend() {
+            match self.ensure_portal_keyboard_session().await {
+                Ok(Some(session)) => {
+                    match run_kde_clipboard_paste_text(&session, &params.text).await {
+                        Ok(()) => {
+                            return Json(successful_action_with_focus(
+                                "type_text",
+                                "Action pasted through KDE clipboard integration.",
+                                received,
+                                focus,
+                            ));
+                        }
+                        Err(error) => {
+                            self.clear_portal_keyboard_session();
+                            return Json(action_result_with_focus(
+                                "type_text",
+                                Err(error),
+                                received,
+                                focus,
+                            ));
+                        }
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return Json(action_result_with_focus(
+                        "type_text",
+                        Err(format!("{error:#}")),
+                        received,
+                        focus,
+                    ));
+                }
+            }
+        }
+        if self.should_prefer_portal_keyboard_backend() {
+            if let Ok(keysyms) = keysyms_for_text(&params.text) {
+                match self.ensure_portal_keyboard_session().await {
+                    Ok(Some(session)) => match type_text_with_keysyms(&session, &keysyms).await {
+                        Ok(()) => {
+                            return Json(successful_action_with_focus(
+                                "type_text",
+                                "Action sent through the remote desktop portal.",
+                                received,
+                                focus,
+                            ));
+                        }
+                        Err(error) => {
+                            self.clear_portal_keyboard_session();
+                            return Json(action_result_with_focus(
+                                "type_text",
+                                Err(format!("{error:#}")),
+                                received,
+                                focus,
+                            ));
+                        }
+                    },
+                    Ok(None) => {}
+                    Err(_) => {}
+                }
+            }
+        }
         let result = run_ydotool_type_text(&params.text).map(|output| vec![output]);
         Json(action_result_with_focus(
             "type_text",
@@ -674,7 +738,7 @@ impl ComputerUseLinux {
 #[tool_handler(
     name = "codex-computer-use-linux",
     version = "0.1.0",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through registered Linux window backends when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available or through ydotool otherwise. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through registered Linux window backends when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available, and send layout-safe literal type_text through KDE clipboard integration on Plasma Wayland or through portal keysyms on other Wayland sessions before falling back to ydotool. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -1030,14 +1094,42 @@ struct ActionOutput {
 }
 
 impl ComputerUseLinux {
+    fn is_wayland_session(&self) -> bool {
+        crate::diagnostics::hydrate_session_bus_env();
+        env::var("XDG_SESSION_TYPE")
+            .ok()
+            .is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+    }
+
     fn should_prefer_portal_pointer_backend(&self) -> bool {
         env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_POINTER")
             .ok()
             .as_deref()
             != Some("1")
-            && env::var("XDG_SESSION_TYPE")
-                .ok()
-                .is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
+            && self.is_wayland_session()
+    }
+
+    fn should_prefer_portal_keyboard_backend(&self) -> bool {
+        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
+            .ok()
+            .as_deref()
+            != Some("1")
+            && self.is_wayland_session()
+            && !self.is_kde_wayland_session()
+    }
+
+    fn should_prefer_kde_clipboard_text_backend(&self) -> bool {
+        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
+            .ok()
+            .as_deref()
+            != Some("1")
+            && self.is_kde_wayland_session()
+    }
+
+    fn is_kde_wayland_session(&self) -> bool {
+        self.is_wayland_session()
+            && (env_contains("XDG_CURRENT_DESKTOP", "kde")
+                || env_contains("DESKTOP_SESSION", "plasma"))
     }
 
     fn cached_portal_pointer_session(&self) -> Option<PortalPointerSession> {
@@ -1053,6 +1145,19 @@ impl ComputerUseLinux {
         }
     }
 
+    fn cached_portal_keyboard_session(&self) -> Option<PortalKeyboardSession> {
+        self.portal_keyboard_session
+            .lock()
+            .ok()
+            .and_then(|cached| cached.clone())
+    }
+
+    fn clear_portal_keyboard_session(&self) {
+        if let Ok(mut cached) = self.portal_keyboard_session.lock() {
+            *cached = None;
+        }
+    }
+
     async fn ensure_portal_pointer_session(&self) -> Result<Option<PortalPointerSession>> {
         if !self.should_prefer_portal_pointer_backend() {
             return Ok(None);
@@ -1063,6 +1168,26 @@ impl ComputerUseLinux {
 
         let session = start_portal_pointer_session().await?;
         if let Ok(mut cached) = self.portal_pointer_session.lock() {
+            *cached = Some(session.clone());
+        }
+        Ok(Some(session))
+    }
+
+    async fn ensure_portal_keyboard_session(&self) -> Result<Option<PortalKeyboardSession>> {
+        if env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
+            .ok()
+            .as_deref()
+            == Some("1")
+            || !self.is_wayland_session()
+        {
+            return Ok(None);
+        }
+        if let Some(session) = self.cached_portal_keyboard_session() {
+            return Ok(Some(session));
+        }
+
+        let session = start_portal_keyboard_session().await?;
+        if let Ok(mut cached) = self.portal_keyboard_session.lock() {
             *cached = Some(session.clone());
         }
         Ok(Some(session))
@@ -1726,6 +1851,12 @@ fn trimmed_nonempty(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|value| !value.is_empty())
 }
 
+fn env_contains(key: &str, needle: &str) -> bool {
+    env::var(key)
+        .ok()
+        .is_some_and(|value| value.to_ascii_lowercase().contains(needle))
+}
+
 fn action_result(
     action: &str,
     result: std::result::Result<Vec<Output>, String>,
@@ -1755,7 +1886,28 @@ fn action_result_with_focus(
     received: Option<serde_json::Value>,
     focus: Option<WindowFocusResult>,
 ) -> ActionOutput {
-    let mut output = action_result(action, result, received);
+    with_focus_context(action_result(action, result, received), focus)
+}
+
+fn successful_action_with_focus(
+    action: &str,
+    message: &str,
+    received: Option<serde_json::Value>,
+    focus: Option<WindowFocusResult>,
+) -> ActionOutput {
+    with_focus_context(
+        ActionOutput {
+            ok: true,
+            implemented: true,
+            action: action.to_string(),
+            message: message.to_string(),
+            received,
+        },
+        focus,
+    )
+}
+
+fn with_focus_context(mut output: ActionOutput, focus: Option<WindowFocusResult>) -> ActionOutput {
     if output.ok {
         if let Some(focus) = focus {
             let verification = if focus.exact_window_focused {
@@ -1887,12 +2039,66 @@ fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String> {
     }
 }
 
+async fn run_kde_clipboard_paste_text(
+    session: &PortalKeyboardSession,
+    text: &str,
+) -> std::result::Result<(), String> {
+    let previous = kde_clipboard_contents()?;
+    kde_set_clipboard_contents(text)?;
+
+    let paste_result = press_keycode_chord(session, &[29], 47)
+        .await
+        .map_err(|error| format!("{error:#}"));
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let restore_result = kde_set_clipboard_contents(&previous);
+
+    match (paste_result, restore_result) {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(restore_error)) => Err(format!(
+            "text was pasted, but previous KDE clipboard contents could not be restored: {restore_error}"
+        )),
+        (Err(error), Err(restore_error)) => Err(format!(
+            "{error}; previous KDE clipboard contents could not be restored: {restore_error}"
+        )),
+    }
+}
+
+fn kde_clipboard_contents() -> std::result::Result<String, String> {
+    let output = run_qdbus6_klipper(&["getClipboardContents"])?;
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches('\n')
+        .to_string())
+}
+
+fn kde_set_clipboard_contents(text: &str) -> std::result::Result<Output, String> {
+    run_qdbus6_klipper(&["setClipboardContents", text])
+}
+
+fn run_qdbus6_klipper(args: &[&str]) -> std::result::Result<Output, String> {
+    let output = Command::new("qdbus6")
+        .args(["org.kde.klipper", "/klipper"])
+        .args(args)
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => Ok(output),
+        Ok(output) => Err(command_output_error("qdbus6", output)),
+        Err(error) => Err(format!("failed to run qdbus6: {error}")),
+    }
+}
+
 fn ydotool_output_error(output: Output) -> String {
+    command_output_error("ydotool", output)
+}
+
+fn command_output_error(command: &str, output: Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
     let detail = if stderr.is_empty() { stdout } else { stderr };
     if detail.is_empty() {
-        format!("ydotool exited with {}", output.status)
+        format!("{command} exited with {}", output.status)
     } else {
         detail
     }
@@ -2680,6 +2886,31 @@ mod tests {
         assert_eq!(
             key_sequence("Super"),
             Some(vec!["125:1".to_string(), "125:0".to_string()])
+        );
+    }
+
+    #[test]
+    fn key_sequence_keeps_shortcuts_and_navigation_on_raw_events() {
+        assert_eq!(
+            key_sequence("Ctrl+L"),
+            Some(vec![
+                "29:1".to_string(),
+                "38:1".to_string(),
+                "38:0".to_string(),
+                "29:0".to_string(),
+            ])
+        );
+        assert_eq!(
+            key_sequence("ArrowLeft"),
+            Some(vec!["105:1".to_string(), "105:0".to_string()])
+        );
+        assert_eq!(
+            key_sequence("Escape"),
+            Some(vec!["1:1".to_string(), "1:0".to_string()])
+        );
+        assert_eq!(
+            key_sequence("Enter"),
+            Some(vec!["28:1".to_string(), "28:0".to_string()])
         );
     }
 


### PR DESCRIPTION
## Summary
- Add a keyboard-capable XDG RemoteDesktop portal session for Linux Computer Use.
- Route literal `type_text` through layout-safe text paths on Wayland before falling back to `ydotool type --file -`.
- Keep `press_key` on the existing raw `ydotool key <keycode>:<pressed>` path.

Fixes #132.

## Why
`ydotool type` is layout-dependent, so non-US layouts can emit the wrong literal characters for strings containing symbols like `:`, `/`, `#`, `?`, and `@`.

The first Wayland path uses `NotifyKeyboardKeysym` so literal text is converted to X11 keysyms before dispatch. Local KDE Plasma validation showed KDE still layout-maps those keysyms under a German layout, so Plasma uses Klipper plus portal-delivered `Ctrl+V` to preserve exact text while still avoiding synthetic layout-dependent typing.

## Source of truth
- `computer-use-linux/src/remote_desktop.rs`
- `computer-use-linux/src/server.rs`
- `computer-use-linux/Cargo.toml`
- `Cargo.lock`

## User-visible behavior
- On Wayland, `type_text` tries a layout-safe portal-backed text path unless `CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD=1` is set.
- On KDE Plasma Wayland, `type_text` uses the KDE clipboard integration and restores the previous clipboard contents after paste.
- If portal permission/session setup fails before text is emitted, behavior falls back to the existing `ydotool` text path.
- `press_key`, keyboard scroll behavior, window backends, diagnostics readiness, and clipboard tool behavior are unchanged.

## Validation
- `rtk cargo fmt -p codex-computer-use-linux -- --check`
- `rtk cargo test -p codex-computer-use-linux`
- `rtk cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `rtk git diff --check`

## Manual validation
KDE Plasma 6 Wayland with active German keyboard layout:
- Opened a focused editable field.
- Verified pure `NotifyKeyboardKeysym` still produced layout-mapped output: `https_@@example.com_8080@page§anchor`.
- Verified the fixed Plasma path returned `Action pasted through KDE clipboard integration.`
- Verified the field contained exactly `https://example.com:8080/page#anchor`.