### PR TITLE
fix(updater): Include webview server in builder bundle

### DIFF
--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -270,6 +270,7 @@ run_deb_job() {
     assert_contains_file /tmp/deb-contents.txt './usr/bin/codex-update-manager'
     assert_contains_file /tmp/deb-contents.txt './usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/install.sh'
+    assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     append_summary "Debian Package Validation" \
@@ -296,6 +297,7 @@ run_rpm_job() {
     assert_contains_file /tmp/rpm-contents.txt '/usr/bin/codex-update-manager'
     assert_contains_file /tmp/rpm-contents.txt '/usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/install.sh'
+    assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     append_summary "RPM Package Validation" \
@@ -323,6 +325,7 @@ run_pacman_job() {
     assert_contains_file /tmp/pacman-contents.txt 'usr/bin/codex-update-manager'
     assert_contains_file /tmp/pacman-contents.txt 'usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/install.sh'
+    assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     append_summary "Pacman Package Validation" \

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -14,7 +14,7 @@ use std::{
 use tokio::process::Command;
 use tracing::info;
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 14] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 15] = [
     ("Cargo.toml", "Cargo.toml"),
     ("Cargo.lock", "Cargo.lock"),
     ("computer-use-linux", "computer-use-linux"),
@@ -25,6 +25,7 @@ const REQUIRED_BUNDLE_FILES: [(&str, &str); 14] = [
     ),
     ("install.sh", "install.sh"),
     ("launcher/start.sh.template", "launcher/start.sh.template"),
+    ("launcher/webview-server.py", "launcher/webview-server.py"),
     ("scripts/build-deb.sh", "scripts/build-deb.sh"),
     (
         "scripts/patch-linux-window-ui.js",
@@ -522,6 +523,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
             bundle_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
         )?;
+        fs::write(
+            bundle_root.join("launcher/webview-server.py"),
+            b"# fake webview server\n",
+        )?;
         fs::write(bundle_root.join("assets/codex.png"), b"png")?;
         fs::write(
             bundle_root.join("packaging/linux/control"),
@@ -659,6 +664,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .exists());
         assert!(artifacts
             .workspace_dir
+            .join("builder/launcher/webview-server.py")
+            .exists());
+        assert!(artifacts
+            .workspace_dir
             .join("builder/scripts/lib/node-runtime.sh")
             .exists());
         assert!(artifacts
@@ -695,6 +704,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             source_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
         )?;
+        fs::write(
+            source_root.join("launcher/webview-server.py"),
+            b"# fake webview server\n",
+        )?;
         fs::write(source_root.join("scripts/build-deb.sh"), b"#!/bin/bash\n")?;
         fs::write(
             source_root.join("scripts/patch-linux-window-ui.js"),
@@ -728,6 +741,7 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
         assert!(destination_root
             .join("scripts/patch-linux-window-ui.js")
             .exists());
+        assert!(destination_root.join("launcher/webview-server.py").exists());
         assert!(destination_root
             .join("scripts/patches/registry.js")
             .exists());


### PR DESCRIPTION
## Summary
- Include `launcher/webview-server.py` in the packaged updater builder bundle.
- Cover that file in updater builder bundle-copy tests.
- Assert the file is present in deb/rpm/pacman package-content CI checks.

## Why
The packaged update-builder runs the current `install.sh`, which now copies `launcher/webview-server.py` while creating the generated launcher support files. If the packaged builder omits that file, local updater rebuilds fail even though manual repo rebuilds work.

## Validation
- `cargo fmt --check -p codex-update-manager`
- `cargo test -p codex-update-manager builder::tests`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `bash -n scripts/ci/container-entrypoint.sh`
- `git diff --check`
- `make rpm PACKAGE_VERSION=2026.05.14.123500.autoupdatefix`
- `rpm -qlp dist/codex-desktop-2026.05.14.123500.autoupdatefix-1.x86_64.rpm | rg '/opt/codex-desktop/update-builder/launcher/webview-server.py|/opt/codex-desktop/update-builder/install.sh|/usr/bin/codex-update-manager'`
