### PR TITLE
Add opt-in Copilot reasoning effort feature

### DIFF
--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -24,12 +24,18 @@ Each feature directory should include:
 
 - `feature.json` — metadata and entrypoints
 - `README.md` — what it does, how to test it, and known risks
-- optional `patch.js` — exports `applyMainBundlePatch(source, context)`
+- optional `patch.js` — exports `applyMainBundlePatch(source, context)`, or
+  descriptor patches when `feature.json` uses `entrypoints.patchDescriptors`
 - optional `stage.sh` — install/build staging hook
 - optional `test.js` — self-contained tests for the feature
 
 `stage.sh` hooks run with `SCRIPT_DIR`, `INSTALL_DIR`, `WORK_DIR`, `ARCH`, and
 `CODEX_UPSTREAM_APP_DIR` in the environment.
+
+Descriptor patches use the same shape as `scripts/patches/core/**/patch.js`.
+They can target `main-bundle`, `webview-asset`, or `extracted-app` phases.
+Feature descriptor ids are namespaced as `feature:<feature-id>:<descriptor-id>`
+in patch reports and are optional by default.
 
 Feature self-tests live inside each feature directory. Run them with:
 

--- a/linux-features/copilot-reasoning-effort/README.md
+++ b/linux-features/copilot-reasoning-effort/README.md
@@ -1,0 +1,50 @@
+# Copilot Reasoning Effort Defaults
+
+This optional Linux feature patches Codex webview bundles so Copilot-auth
+sessions can persist and select reasoning effort defaults for new chats.
+
+By default, upstream Copilot-auth paths only read and write
+`copilot-default-model`, hardcode the loaded reasoning effort to `medium`, and
+collapse Copilot model reasoning effort choices to one `medium` entry. This
+feature keeps those changes local and opt-in instead of shipping them as a core
+Linux compatibility patch.
+
+Enable it by copying `linux-features/features.example.json` to
+`linux-features/features.json` and adding the feature id:
+
+```json
+{
+  "enabled": [
+    "copilot-reasoning-effort"
+  ]
+}
+```
+
+Then rerun the install or package build so the ASAR patch step can apply the
+feature to the generated app.
+
+## What It Patches
+
+- `use-model-settings-*.js` reads and writes
+  `copilot-default-reasoning-effort` next to `copilot-default-model`.
+- `font-settings-*.js` keeps the model's full `supportedReasoningEfforts` list
+  for Copilot auth instead of forcing only `medium`.
+- `index-*.js` keeps reasoning effort dropdown entries and the `/reasoning`
+  command enabled when the normal model and effort prerequisites are present.
+
+## Validation
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/copilot-reasoning-effort/test.js
+```
+
+Or run all feature tests with:
+
+```bash
+node --test linux-features/*/test.js
+```
+
+The patch is fail-soft. If the upstream minified bundle shape changes, the
+build logs a warning and leaves the affected bundle unchanged.

--- a/linux-features/copilot-reasoning-effort/feature.json
+++ b/linux-features/copilot-reasoning-effort/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "copilot-reasoning-effort",
+  "title": "Copilot Reasoning Effort Defaults",
+  "description": "Opt-in patch that lets Copilot-auth sessions persist and select reasoning effort defaults on Linux.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -65,7 +65,7 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
 
 function applyCopilotReasoningEffortModelListPatch(currentSource) {
   const copilotReasoningFilterRegex =
-    /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([A-Za-z_$][\w$]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
+    /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([^)]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
 
   if (!copilotReasoningFilterRegex.test(currentSource)) {
     if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
@@ -129,7 +129,7 @@ module.exports = {
       id: "settings",
       name: "copilot-reasoning-effort-settings",
       phase: "webview-asset",
-      pattern: /^use-model-settings-.*\.js$/,
+      pattern: /^(use-model-settings|use-collaboration-mode)-.*\.js$/,
       missingDescription: "model settings bundle",
       skipDescription: "Copilot reasoning effort settings patch",
       apply: applyCopilotReasoningEffortSettingsPatch,
@@ -138,7 +138,7 @@ module.exports = {
       id: "model-list",
       name: "copilot-reasoning-effort-model-list",
       phase: "webview-asset",
-      pattern: /^font-settings-.*\.js$/,
+      pattern: /^(font-settings|model-queries)-.*\.js$/,
       missingDescription: "font settings bundle",
       skipDescription: "Copilot reasoning effort model list patch",
       apply: applyCopilotReasoningEffortModelListPatch,

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -1,0 +1,159 @@
+"use strict";
+
+function applyCopilotReasoningEffortSettingsPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const copilotDefaultsPatchMarker = "copilot-default-reasoning-effort`),codexCopilotModelValue=";
+  const copilotDefaultsRegex =
+    /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{data:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(`copilot-default-model`\),([A-Za-z_$][\w$]*)=\6\?\?\4\.defaultModel,([A-Za-z_$][\w$]*);return \2\[0\]!==\7\|\|\2\[1\]!==\9\?\(\10=\{model:\9,reasoningEffort:`medium`,profile:null,isLoading:\7\},\2\[0\]=\7,\2\[1\]=\9,\2\[2\]=\10\):\10=\2\[2\],\10\}/;
+  if (patchedSource.includes(copilotDefaultsPatchMarker)) {
+    // Already patched.
+  } else if (copilotDefaultsRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      copilotDefaultsRegex,
+      (
+        _match,
+        functionName,
+        memoVar,
+        cacheModuleVar,
+        defaultsVar,
+        defaultsHookVar,
+        savedModelVar,
+        modelLoadingVar,
+        persistedStateHookVar,
+        _modelValueVar,
+        resultVar,
+      ) =>
+        `function ${functionName}(){let ${memoVar}=(0,${cacheModuleVar}.c)(5),${defaultsVar}=${defaultsHookVar}(),{data:${savedModelVar},isLoading:${modelLoadingVar}}=${persistedStateHookVar}(\`copilot-default-model\`),{data:codexCopilotReasoningEffort,isLoading:codexCopilotReasoningEffortLoading}=${persistedStateHookVar}(\`copilot-default-reasoning-effort\`),codexCopilotModelValue=${savedModelVar}??${defaultsVar}.defaultModel,codexCopilotReasoningEffortValue=codexCopilotReasoningEffort??\`medium\`,${resultVar};return ${memoVar}[0]!==${modelLoadingVar}||${memoVar}[1]!==codexCopilotReasoningEffortLoading||${memoVar}[2]!==codexCopilotModelValue||${memoVar}[3]!==codexCopilotReasoningEffortValue?(${resultVar}={model:codexCopilotModelValue,reasoningEffort:codexCopilotReasoningEffortValue,profile:null,isLoading:${modelLoadingVar}||codexCopilotReasoningEffortLoading},${memoVar}[0]=${modelLoadingVar},${memoVar}[1]=codexCopilotReasoningEffortLoading,${memoVar}[2]=codexCopilotModelValue,${memoVar}[3]=codexCopilotReasoningEffortValue,${memoVar}[4]=${resultVar}):${resultVar}=${memoVar}[4],${resultVar}}`,
+    );
+  } else if (patchedSource.includes("copilot-default-model")) {
+    console.warn(
+      "WARN: Could not find Copilot default model reader - skipping Copilot reasoning effort default patch",
+    );
+  }
+
+  const copilotSavePatchMarker = "copilot-default-reasoning-effort`,";
+  const copilotSaveRegex =
+    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)return;/;
+  if (patchedSource.includes(copilotSavePatchMarker)) {
+    // Already patched.
+  } else if (copilotSaveRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      copilotSaveRegex,
+      (
+        _match,
+        updateConversationVar,
+        modelArgVar,
+        effortArgVar,
+        isCopilotVar,
+        persistStateVar,
+        stateScopeVar,
+        loggerVar,
+        configVar,
+        hostReadyVar,
+      ) =>
+        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar}),${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})return;`,
+    );
+  } else if (patchedSource.includes("copilot-default-model")) {
+    console.warn(
+      "WARN: Could not find Copilot default model writer - skipping Copilot reasoning effort persistence patch",
+    );
+  }
+
+  return patchedSource;
+}
+
+function applyCopilotReasoningEffortModelListPatch(currentSource) {
+  const copilotReasoningFilterRegex =
+    /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([A-Za-z_$][\w$]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
+
+  if (!copilotReasoningFilterRegex.test(currentSource)) {
+    if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
+      console.warn(
+        "WARN: Could not find Copilot model reasoning effort filter - skipping Copilot reasoning effort model list patch",
+      );
+    }
+    return currentSource;
+  }
+
+  return currentSource.replace(
+    copilotReasoningFilterRegex,
+    (_, _authMethodVar, modelVar) => `[...${modelVar}.supportedReasoningEfforts]`,
+  );
+}
+
+function applyCopilotReasoningEffortUiPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  const reasoningDropdownPatch = "disabled:!1,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`";
+  const reasoningDropdownRegex =
+    /disabled:([A-Za-z_$][\w$]*),RightIcon:([A-Za-z_$][\w$]*)===([A-Za-z_$][\w$]*)\?rg:void 0,onSelect:\(\)=>\{([A-Za-z_$][\w$]*)\.get\(bh\)\.log\(\{eventName:`codex_composer_reasoning_effort_changed`/;
+  if (patchedSource.includes(reasoningDropdownPatch)) {
+    // Already patched.
+  } else if (reasoningDropdownRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      reasoningDropdownRegex,
+      (
+        _match,
+        _disabledVar,
+        effortVar,
+        selectedEffortVar,
+        scopeVar,
+      ) =>
+        `disabled:!1,RightIcon:${effortVar}===${selectedEffortVar}?rg:void 0,onSelect:()=>{${scopeVar}.get(bh).log({eventName:\`codex_composer_reasoning_effort_changed\``,
+    );
+  } else if (patchedSource.includes("codex_composer_reasoning_effort_changed")) {
+    console.warn(
+      "WARN: Could not find reasoning effort dropdown disabled state - skipping Copilot reasoning effort dropdown patch",
+    );
+  }
+
+  const slashCommandNeedle = "let w=s&&f&&!p,T;";
+  const slashCommandPatch = "let w=s&&f,T;";
+  if (patchedSource.includes(slashCommandPatch)) {
+    // Already patched.
+  } else if (patchedSource.includes(slashCommandNeedle)) {
+    patchedSource = patchedSource.replace(slashCommandNeedle, slashCommandPatch);
+  } else if (patchedSource.includes("composer.reasoningSlashCommand.title")) {
+    console.warn(
+      "WARN: Could not find reasoning slash command enabled state - skipping Copilot reasoning slash command patch",
+    );
+  }
+
+  return patchedSource;
+}
+
+module.exports = {
+  descriptors: [
+    {
+      id: "settings",
+      name: "copilot-reasoning-effort-settings",
+      phase: "webview-asset",
+      pattern: /^use-model-settings-.*\.js$/,
+      missingDescription: "model settings bundle",
+      skipDescription: "Copilot reasoning effort settings patch",
+      apply: applyCopilotReasoningEffortSettingsPatch,
+    },
+    {
+      id: "model-list",
+      name: "copilot-reasoning-effort-model-list",
+      phase: "webview-asset",
+      pattern: /^font-settings-.*\.js$/,
+      missingDescription: "font settings bundle",
+      skipDescription: "Copilot reasoning effort model list patch",
+      apply: applyCopilotReasoningEffortModelListPatch,
+    },
+    {
+      id: "ui",
+      name: "copilot-reasoning-effort-ui",
+      phase: "webview-asset",
+      pattern: /^index-.*\.js$/,
+      missingDescription: "webview index bundle",
+      skipDescription: "Copilot reasoning effort UI patch",
+      apply: applyCopilotReasoningEffortUiPatch,
+    },
+  ],
+  applyCopilotReasoningEffortModelListPatch,
+  applyCopilotReasoningEffortSettingsPatch,
+  applyCopilotReasoningEffortUiPatch,
+};

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -36,6 +36,10 @@ function copilotReasoningEffortModelListFixture() {
   return "function Ge(){let s=`copilot`,d={};return e.forEach(e=>{let t=s===`copilot`?[e.supportedReasoningEfforts.find(Ue)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];d.models.push({...e,supportedReasoningEfforts:t})})}";
 }
 
+function currentCopilotReasoningEffortModelListFixture() {
+  return "function Ge(){let t=`copilot`;return r.forEach(e=>{let n=t===`copilot`?[e.supportedReasoningEfforts.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];i.push({...e,supportedReasoningEfforts:n})})}";
+}
+
 function copilotReasoningEffortUiFixture() {
   return [
     "function qU(){let E=o?.authMethod===`copilot`,D=ZH(T,f.model),O=QH(f.reasoningEffort,D),le=D.map(e=>{let{reasoningEffort:t}=e;return(0,$.jsx)(jm.Item,{\"data-reasoning-selected\":t===O?`true`:void 0,disabled:E,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`,metadata:{reasoning_effort:t}}),p(f.model,t),H()},children:(0,$.jsx)(nM,{effort:t})},t)})}",
@@ -107,6 +111,17 @@ test("keeps all model reasoning efforts available for Copilot auth", () => {
   assert.doesNotMatch(patched, /description:`medium effort`/);
 });
 
+test("keeps all model reasoning efforts for current Copilot model query chunks", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortModelListPatch,
+    currentCopilotReasoningEffortModelListFixture(),
+  );
+
+  assert.match(patched, /let n=\[\.\.\.e\.supportedReasoningEfforts\]/);
+  assert.doesNotMatch(patched, /t===`copilot`\?\[/);
+  assert.doesNotMatch(patched, /description:`medium effort`/);
+});
+
 test("allows Copilot auth to change reasoning effort from the UI", () => {
   const patched = applyPatchTwice(
     applyCopilotReasoningEffortUiPatch,
@@ -150,8 +165,8 @@ test("enabled feature descriptors patch matching webview assets", () => {
 
   withTempFeatureConfig(["copilot-reasoning-effort"], () => {
     withTempDir((extractedDir) => {
-      writeAsset(extractedDir, "use-model-settings-fixture.js", copilotReasoningEffortSettingsFixture());
-      writeAsset(extractedDir, "font-settings-fixture.js", copilotReasoningEffortModelListFixture());
+      writeAsset(extractedDir, "use-collaboration-mode-fixture.js", copilotReasoningEffortSettingsFixture());
+      writeAsset(extractedDir, "model-queries-fixture.js", currentCopilotReasoningEffortModelListFixture());
       writeAsset(extractedDir, "index-fixture.js", copilotReasoningEffortUiFixture());
 
       const descriptors = normalizePatchDescriptors(
@@ -160,11 +175,11 @@ test("enabled feature descriptors patch matching webview assets", () => {
       applyWebviewAssetPatchDescriptors(extractedDir, descriptors, {}, null);
 
       assert.match(
-        readAsset(extractedDir, "use-model-settings-fixture.js"),
+        readAsset(extractedDir, "use-collaboration-mode-fixture.js"),
         /copilot-default-reasoning-effort/,
       );
       assert.match(
-        readAsset(extractedDir, "font-settings-fixture.js"),
+        readAsset(extractedDir, "model-queries-fixture.js"),
         /\[\.\.\.e\.supportedReasoningEfforts\]/,
       );
       assert.match(

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  applyWebviewAssetPatchDescriptors,
+  normalizePatchDescriptors,
+} = require("../../scripts/patches/engine.js");
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  applyCopilotReasoningEffortModelListPatch,
+  applyCopilotReasoningEffortSettingsPatch,
+  applyCopilotReasoningEffortUiPatch,
+} = require("./patch.js");
+
+function applyPatchTwice(patchFn, source) {
+  const patched = patchFn(source);
+  assert.equal(patchFn(patched), patched);
+  return patched;
+}
+
+function copilotReasoningEffortSettingsFixture() {
+  return [
+    "function bwe(){let e=(0,Y.c)(3),t=wr(),{data:n,isLoading:r}=or(`copilot-default-model`),i=n??t.defaultModel,a;return e[0]!==r||e[1]!==i?(a={model:i,reasoningEffort:`medium`,profile:null,isLoading:r},e[0]=r,e[1]=i,e[2]=a):a=e[2],a}",
+    "function $9(e=null){let t=j(fe),m=a?.authMethod===`copilot`,g=(0,q.useCallback)(async(t,n)=>!1,[]),c={profile:null},i=!0,r=`local`,s=`/tmp`,v=()=>{},y=()=>{};return{setModelAndReasoningEffort:(0,q.useCallback)(async(e,n)=>{try{if(await g(e,n))return;if(m){Jn(t,`copilot-default-model`,e);return}if(h.info(`Setting default model and reasoning effort`,{safe:{newModel:e,newEffort:n,profile:c.profile}}),!i)return;await Gt(`set-default-model-config-for-host`,{hostId:r,model:e,reasoningEffort:n,profile:c.profile}),await v(),await t.query.fetch(Ss,{hostId:r,cwd:s})}catch(e){y(e)}},[m,g,c.profile,v,i,r,t,y,s])}}",
+  ].join("");
+}
+
+function copilotReasoningEffortModelListFixture() {
+  return "function Ge(){let s=`copilot`,d={};return e.forEach(e=>{let t=s===`copilot`?[e.supportedReasoningEfforts.find(Ue)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];d.models.push({...e,supportedReasoningEfforts:t})})}";
+}
+
+function copilotReasoningEffortUiFixture() {
+  return [
+    "function qU(){let E=o?.authMethod===`copilot`,D=ZH(T,f.model),O=QH(f.reasoningEffort,D),le=D.map(e=>{let{reasoningEffort:t}=e;return(0,$.jsx)(jm.Item,{\"data-reasoning-selected\":t===O?`true`:void 0,disabled:E,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`,metadata:{reasoning_effort:t}}),p(f.model,t),H()},children:(0,$.jsx)(nM,{effort:t})},t)})}",
+    "function bY(e){let p=o?.authMethod===`copilot`;let w=s&&f&&!p,T;return{enabled:w,dependencies:T}}",
+  ].join("");
+}
+
+function withTempDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-copilot-reasoning-feature-"));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function withTempFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  return withTempDir((tmp) => {
+    process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tmp, "features.json");
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }, null, 2));
+    try {
+      return fn();
+    } finally {
+      if (originalConfig == null) {
+        delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+      } else {
+        process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+      }
+    }
+  });
+}
+
+function writeAsset(extractedDir, name, source) {
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, name), source);
+}
+
+function readAsset(extractedDir, name) {
+  return fs.readFileSync(path.join(extractedDir, "webview", "assets", name), "utf8");
+}
+
+test("persists Copilot reasoning effort with the default Copilot model", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortSettingsPatch,
+    copilotReasoningEffortSettingsFixture(),
+  );
+
+  assert.match(patched, /or\(`copilot-default-reasoning-effort`\)/);
+  assert.match(patched, /reasoningEffort:codexCopilotReasoningEffortValue/);
+  assert.match(patched, /isLoading:r\|\|codexCopilotReasoningEffortLoading/);
+  assert.match(
+    patched,
+    /Jn\(t,`copilot-default-model`,e\),Jn\(t,`copilot-default-reasoning-effort`,n\);return/,
+  );
+  assert.doesNotMatch(patched, /reasoningEffort:`medium`,profile:null,isLoading:r/);
+  assert.doesNotMatch(patched, /Jn\(t,`copilot-default-model`,e\);return/);
+});
+
+test("keeps all model reasoning efforts available for Copilot auth", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortModelListPatch,
+    copilotReasoningEffortModelListFixture(),
+  );
+
+  assert.match(patched, /let t=\[\.\.\.e\.supportedReasoningEfforts\]/);
+  assert.doesNotMatch(patched, /s===`copilot`\?\[/);
+  assert.doesNotMatch(patched, /description:`medium effort`/);
+});
+
+test("allows Copilot auth to change reasoning effort from the UI", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortUiPatch,
+    copilotReasoningEffortUiFixture(),
+  );
+
+  assert.match(patched, /disabled:!1,RightIcon:t===O\?rg:void 0/);
+  assert.match(patched, /let w=s&&f,T;/);
+  assert.doesNotMatch(patched, /disabled:E,RightIcon:t===O\?rg:void 0/);
+  assert.doesNotMatch(patched, /let w=s&&f&&!p,T;/);
+});
+
+test("feature descriptor loader exposes the Copilot webview asset patches only when enabled", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+
+  withTempFeatureConfig([], () => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withTempFeatureConfig(["copilot-reasoning-effort"], () => {
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+
+    assert.deepEqual(
+      descriptors.map((descriptor) => descriptor.id),
+      [
+        "feature:copilot-reasoning-effort:settings",
+        "feature:copilot-reasoning-effort:model-list",
+        "feature:copilot-reasoning-effort:ui",
+      ],
+    );
+    assert.deepEqual(
+      descriptors.map((descriptor) => descriptor.phase),
+      ["webview-asset", "webview-asset", "webview-asset"],
+    );
+    assert.ok(descriptors.every((descriptor) => descriptor.ciPolicy === "optional"));
+  });
+});
+
+test("enabled feature descriptors patch matching webview assets", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+
+  withTempFeatureConfig(["copilot-reasoning-effort"], () => {
+    withTempDir((extractedDir) => {
+      writeAsset(extractedDir, "use-model-settings-fixture.js", copilotReasoningEffortSettingsFixture());
+      writeAsset(extractedDir, "font-settings-fixture.js", copilotReasoningEffortModelListFixture());
+      writeAsset(extractedDir, "index-fixture.js", copilotReasoningEffortUiFixture());
+
+      const descriptors = normalizePatchDescriptors(
+        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+      );
+      applyWebviewAssetPatchDescriptors(extractedDir, descriptors, {}, null);
+
+      assert.match(
+        readAsset(extractedDir, "use-model-settings-fixture.js"),
+        /copilot-default-reasoning-effort/,
+      );
+      assert.match(
+        readAsset(extractedDir, "font-settings-fixture.js"),
+        /\[\.\.\.e\.supportedReasoningEfforts\]/,
+      );
+      assert.match(
+        readAsset(extractedDir, "index-fixture.js"),
+        /disabled:!1,RightIcon:t===O\?rg:void 0/,
+      );
+    });
+  });
+});

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -123,22 +123,121 @@ function resolveFeatureEntrypoint(feature, key) {
   return entrypoint;
 }
 
+function loadFeatureEntrypointModule(feature, key) {
+  const entrypoint = resolveFeatureEntrypoint(feature, key);
+  if (entrypoint == null) {
+    return null;
+  }
+
+  try {
+    return {
+      entrypoint,
+      moduleExports: require(entrypoint),
+    };
+  } catch (error) {
+    console.warn(`WARN: Could not load Linux feature '${feature.id}' ${key}: ${error.message}`);
+    return null;
+  }
+}
+
+function featureContext(context, feature) {
+  return { ...context, feature };
+}
+
+function prefixedFeaturePatchId(feature, descriptorId) {
+  return descriptorId.startsWith(`feature:${feature.id}`)
+    ? descriptorId
+    : `feature:${feature.id}:${descriptorId}`;
+}
+
+function wrapFeaturePatchDescriptor(feature, descriptor, sourcePath, index, featureIndex) {
+  if (descriptor == null || typeof descriptor !== "object") {
+    console.warn(`WARN: Linux feature '${feature.id}' patch descriptor ${index + 1} must be an object`);
+    return null;
+  }
+  if (typeof descriptor.apply !== "function") {
+    console.warn(`WARN: Linux feature '${feature.id}' patch descriptor ${index + 1} must export apply`);
+    return null;
+  }
+
+  const descriptorId = descriptor.id ?? descriptor.name;
+  if (typeof descriptorId !== "string" || descriptorId.length === 0) {
+    console.warn(`WARN: Linux feature '${feature.id}' patch descriptor ${index + 1} must have id or name`);
+    return null;
+  }
+
+  const wrapped = {
+    ...descriptor,
+    id: prefixedFeaturePatchId(feature, descriptorId),
+    ciPolicy: descriptor.ciPolicy ?? "optional",
+    order: descriptor.order ?? 20_000 + featureIndex * 100 + index * 10,
+    sourcePath,
+    apply: (target, context) => descriptor.apply(target, featureContext(context, feature)),
+  };
+
+  if (typeof descriptor.appliesTo === "function") {
+    wrapped.appliesTo = (context) => descriptor.appliesTo(featureContext(context, feature));
+  }
+  if (typeof descriptor.enabled === "function") {
+    wrapped.enabled = (context) => descriptor.enabled(featureContext(context, feature));
+  }
+  if (typeof descriptor.targetSummary === "function") {
+    wrapped.targetSummary = (context) => descriptor.targetSummary(featureContext(context, feature));
+  }
+  if (typeof descriptor.status === "function") {
+    wrapped.status = (result, warnings, context) =>
+      descriptor.status(result, warnings, featureContext(context, feature));
+  }
+
+  return wrapped;
+}
+
+function featurePatchDescriptorListFromExports(feature, moduleExports, sourcePath, featureIndex) {
+  const exported = moduleExports?.descriptors ??
+    moduleExports?.patches ??
+    moduleExports?.default ??
+    moduleExports;
+  if (exported == null) {
+    console.warn(`WARN: Linux feature '${feature.id}' patchDescriptors entrypoint must export descriptors`);
+    return [];
+  }
+
+  const descriptors = Array.isArray(exported) ? exported : [exported];
+  return descriptors
+    .map((descriptor, index) =>
+      wrapFeaturePatchDescriptor(feature, descriptor, sourcePath, index, featureIndex),
+    )
+    .filter(Boolean);
+}
+
+function loadLinuxFeaturePatchDescriptors(options = {}) {
+  const descriptors = [];
+  for (const [featureIndex, feature] of loadEnabledLinuxFeatures(options).entries()) {
+    const loaded = loadFeatureEntrypointModule(feature, "patchDescriptors");
+    if (loaded == null) {
+      continue;
+    }
+    descriptors.push(
+      ...featurePatchDescriptorListFromExports(
+        feature,
+        loaded.moduleExports,
+        loaded.entrypoint,
+        featureIndex,
+      ),
+    );
+  }
+  return descriptors;
+}
+
 function loadLinuxFeatureMainBundlePatches(options = {}) {
   const patches = [];
   for (const feature of loadEnabledLinuxFeatures(options)) {
-    const entrypoint = resolveFeatureEntrypoint(feature, "mainBundlePatch");
-    if (entrypoint == null) {
+    const loaded = loadFeatureEntrypointModule(feature, "mainBundlePatch");
+    if (loaded == null) {
       continue;
     }
 
-    let moduleExports;
-    try {
-      moduleExports = require(entrypoint);
-    } catch (error) {
-      console.warn(`WARN: Could not load Linux feature '${feature.id}' mainBundlePatch: ${error.message}`);
-      continue;
-    }
-
+    const moduleExports = loaded.moduleExports;
     const apply = moduleExports.applyMainBundlePatch ?? moduleExports.apply ?? moduleExports;
     if (typeof apply !== "function") {
       console.warn(`WARN: Linux feature '${feature.id}' mainBundlePatch must export a function`);
@@ -189,6 +288,7 @@ module.exports = {
   enabledLinuxFeatureIds,
   enabledLinuxFeatureStageHooks,
   loadEnabledLinuxFeatures,
+  loadLinuxFeaturePatchDescriptors,
   loadLinuxFeatureMainBundlePatches,
   linuxFeaturesConfigPath,
   linuxFeaturesRoot,

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -9,6 +9,7 @@ const {
   enabledLinuxFeatureIds,
   enabledLinuxFeatureStageHooks,
   loadEnabledLinuxFeatures,
+  loadLinuxFeaturePatchDescriptors,
   loadLinuxFeatureMainBundlePatches,
 } = require("./lib/linux-features.js");
 const {
@@ -177,6 +178,7 @@ module.exports = {
   legacyCorePatchDescriptors,
   linuxTargetSummary,
   loadEnabledLinuxFeatures,
+  loadLinuxFeaturePatchDescriptors,
   loadLinuxFeatureMainBundlePatches,
   normalizePatchDescriptors,
   parseOsRelease,

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -208,7 +208,7 @@ function applyWebviewAssetPatchDescriptors(extractedDir, descriptors, context, r
     const missingWarning = descriptor.missingWarning ??
       defaultWebviewMissingWarning(extractedDir, descriptor);
     const { value: result, warnings } = captureWarnings(() =>
-      patchAssetFiles(extractedDir, pattern, descriptor.apply, missingWarning),
+      patchAssetFiles(extractedDir, pattern, (source) => descriptor.apply(source, context), missingWarning),
     );
     recordAssetDescriptorPatch(report, descriptor, result, warnings, context);
   }

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -13,6 +13,7 @@ const {
 } = require("../lib/linux-target-context.js");
 const {
   loadLinuxFeatureMainBundlePatches,
+  loadLinuxFeaturePatchDescriptors,
 } = require("../lib/linux-features.js");
 const {
   findIconAsset,
@@ -52,16 +53,19 @@ function legacyCorePatchDescriptors(options = {}) {
   return corePatchDescriptors(options);
 }
 
-function featureMainBundleDescriptors() {
+function featurePatchDescriptors() {
   return normalizePatchDescriptors(
-    loadLinuxFeatureMainBundlePatches().map((patch, index) => ({
-      ...patch,
-      id: patch.id ?? patch.name,
-      name: patch.name ?? patch.id,
-      phase: "main-bundle",
-      order: 20_000 + index * 10,
-      ciPolicy: patch.ciPolicy ?? OPTIONAL,
-    })),
+    [
+      ...loadLinuxFeatureMainBundlePatches().map((patch, index) => ({
+        ...patch,
+        id: patch.id ?? patch.name,
+        name: patch.name ?? patch.id,
+        phase: "main-bundle",
+        order: 20_000 + index * 10,
+        ciPolicy: patch.ciPolicy ?? OPTIONAL,
+      })),
+      ...loadLinuxFeaturePatchDescriptors(),
+    ],
   );
 }
 
@@ -100,7 +104,7 @@ function mainBundlePatchDescriptors(context) {
   return normalizePatchDescriptors([
     ...corePatchDescriptors({ corePatchRoot: context.corePatchRoot })
       .filter((patch) => patch.phase === "main-bundle"),
-    ...featureMainBundleDescriptors(),
+    ...featurePatchDescriptors().filter((patch) => patch.phase === "main-bundle"),
   ]);
 }
 
@@ -115,7 +119,10 @@ function patchMainBundleSource(source, iconAsset, options = {}) {
 function patchExtractedApp(extractedDir, options = {}) {
   const report = options.report ?? null;
   const baseContext = createMainBundleContext(null, options);
-  const coreDescriptors = corePatchDescriptors({ corePatchRoot: options.corePatchRoot });
+  const patchDescriptors = normalizePatchDescriptors([
+    ...corePatchDescriptors({ corePatchRoot: options.corePatchRoot }),
+    ...featurePatchDescriptors(),
+  ]);
 
   setReportLinuxTarget(report, baseContext.linux);
 
@@ -163,21 +170,21 @@ function patchExtractedApp(extractedDir, options = {}) {
 
   applyExtractedAppPatchDescriptors(
     extractedDir,
-    coreDescriptors.filter((patch) => patch.order < EXTRACTED_APP_WEBVIEW_SPLIT_ORDER),
+    patchDescriptors.filter((patch) => patch.order < EXTRACTED_APP_WEBVIEW_SPLIT_ORDER),
     assetContext,
     report,
   );
 
   applyWebviewAssetPatchDescriptors(
     extractedDir,
-    coreDescriptors,
+    patchDescriptors,
     assetContext,
     report,
   );
 
   applyExtractedAppPatchDescriptors(
     extractedDir,
-    coreDescriptors.filter((patch) => patch.order >= EXTRACTED_APP_WEBVIEW_SPLIT_ORDER),
+    patchDescriptors.filter((patch) => patch.order >= EXTRACTED_APP_WEBVIEW_SPLIT_ORDER),
     assetContext,
     report,
   );
@@ -199,7 +206,7 @@ function allPatchPolicies(options = {}) {
       phase,
       appliesTo,
     })),
-    ...featureMainBundleDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
+    ...featurePatchDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
       name: name ?? id,
       ciPolicy,
       phase,
@@ -239,6 +246,7 @@ module.exports = {
   allPatchPolicies,
   corePatchDescriptors,
   createMainBundleContext,
+  featurePatchDescriptors,
   legacyCorePatchDescriptors,
   patchExtractedApp,
   patchMainBundleSource,


### PR DESCRIPTION
## Summary

Reworks the closed Copilot reasoning-effort fix from #127 as an opt-in `linux-features/` module, following the maintainer guidance to keep this kind of optional behavior out of the default Linux patch set.

The new `linux-features/copilot-reasoning-effort` feature is disabled by default and can be enabled locally through `linux-features/features.json` before rebuilding the app.

## What changed

- Added descriptor-style Linux feature patch loading so optional features can target `webview-asset` and `extracted-app` phases, not only the main bundle.
- Kept existing `mainBundlePatch` features compatible with the previous framework contract.
- Added `copilot-reasoning-effort` with feature metadata, README, fail-soft webview asset patches, and feature-local tests.
- Patched the same three Copilot-auth surfaces from #127 when the feature is enabled:
  - `use-model-settings-*.js` reads and writes `copilot-default-reasoning-effort` alongside `copilot-default-model`.
  - `font-settings-*.js` preserves the model's full `supportedReasoningEfforts` list for Copilot auth.
  - `index-*.js` keeps the reasoning effort dropdown and `/reasoning` command available when the normal model/effort prerequisites are present.

## Why

In #127, the behavior was implemented as core ASAR patching. The maintainer noted that the new `linux-features/` framework is the better home for this work:

> if you still want to use or maintain this Copilot reasoning-effort work on top of the latest `main`, you can now move it into a feature and enable it locally through `linux-features/features.json`.

This PR keeps the behavior available for users who need it while leaving default builds unchanged.

## Validation

- `node --test linux-features/copilot-reasoning-effort/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- targeted `node --check` on changed JS entrypoints