### PR TITLE
[codex] Add no-updater package mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ APP_DIR := $(CURDIR)/codex-app
 NEXT_APP_DIR := $(CURDIR)/codex-app-next
 REBUILD_REPORT_DIR := $(CURDIR)/dist-next/rebuild
 PACKAGE_NAME := codex-desktop
+PACKAGE_WITH_UPDATER ?= 1
 DEV_APP_ID ?= codex-cua-lab
 DEV_APP_NAME ?= Codex CUA Lab
 DEV_APP_DIR ?= $(CURDIR)/$(DEV_APP_ID)-app
@@ -51,7 +52,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -84,6 +85,7 @@ help:
 	@printf '  %-18s %s\n' "DEV_APP_ID=..." "Override side-by-side test app id/bin (default: codex-cua-lab)"
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
 	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman"
+	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
 	@printf '  %-18s %s\n' "DEB=/path/file.deb" "Override the .deb used by make install"
 	@printf '  %-18s %s\n' "RPM=/path/file.rpm" "Override the .rpm used by make install"
 	@printf '  %-18s %s\n' "PKG=/path/file.pkg.tar.zst" "Override the pacman package used by make install"
@@ -114,6 +116,14 @@ test:
 build-updater:
 	@echo "[make] Building codex-update-manager (release)"
 	cargo build --release -p codex-update-manager
+
+maybe-build-updater:
+	@case "$(PACKAGE_WITH_UPDATER)" in \
+		0|false|False|FALSE|no|No|NO|off|Off|OFF) \
+			echo "[make] Skipping codex-update-manager build (PACKAGE_WITH_UPDATER=0)" ;; \
+		*) \
+			$(MAKE) build-updater ;; \
+	esac
 
 update: rebuild-install
 
@@ -166,27 +176,27 @@ run-dev-app:
 	@echo "[make] Launching side-by-side Electron app"
 	"$(DEV_APP_BIN)"
 
-deb: build-updater
+deb: maybe-build-updater
 	@echo "[make] Building Debian package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-deb.sh
+	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh
 
-rpm: build-updater
+rpm: maybe-build-updater
 	@echo "[make] Building RPM package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-rpm.sh
+	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh
 
-pacman: build-updater
+pacman: maybe-build-updater
 	@echo "[make] Building pacman package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-pacman.sh
+	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
 
-package: build-updater
+package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"
 	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
 	if [ "$$format" = "pacman" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-pacman.sh; \
+		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh; \
 	elif [ "$$format" = "rpm" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-rpm.sh; \
+		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh; \
 	elif [ "$$format" = "deb" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-deb.sh; \
+		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh; \
 	else \
 		echo "[make] No supported packaging tool found. Install dpkg-dev (Debian), rpm-build (Fedora), or pacman (Arch)." >&2; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ PACKAGE_WITH_UPDATER=0 make package
 make install
 ```
 
-That package omits `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, desktop updater actions, and launcher updater startup checks. The packaged launcher still exports desktop-entry hints for window/icon association, but it does not enable, start, or probe the updater.
+That package omits `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, desktop updater actions, and launcher updater startup checks. The packaged launcher still exports desktop-entry hints for window/icon association, but it does not enable, start, or probe the updater. Installing a no-updater package over a default package also stops and disables any existing `codex-update-manager.service` for active user managers.
 
 Manual updates should come from a checkout you have chosen to trust:
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Override the dev identity with `DEV_APP_ID`, `DEV_APP_NAME`, and `CODEX_WEBVIEW_
 
 ## Auto-update Manager
 
-The native package installs a companion `systemd --user` service named `codex-update-manager`.
+By default, the native package installs a companion `systemd --user` service named `codex-update-manager`.
 
 - It checks upstream `Codex.dmg` on daemon startup, every 6 hours, and in the background on app launch when stale.
 - When a new DMG is available, it rebuilds a local native package with `/opt/codex-desktop/update-builder`.
@@ -195,6 +195,26 @@ Runtime files live in standard XDG locations:
 ~/.cache/codex-update-manager/
 ~/.cache/codex-desktop/launcher.log
 ~/.local/state/codex-desktop/app.pid
+```
+
+### Manual-update packages
+
+For installs that must not include a resident updater, build the native package with:
+
+```bash
+PACKAGE_WITH_UPDATER=0 make package
+make install
+```
+
+That package omits `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, desktop updater actions, and launcher updater startup checks. The packaged launcher still exports desktop-entry hints for window/icon association, but it does not enable, start, or probe the updater.
+
+Manual updates should come from a checkout you have chosen to trust:
+
+```bash
+git pull --ff-only
+make build-app
+PACKAGE_WITH_UPDATER=0 make package
+make install
 ```
 
 ## Build from source / custom DMG
@@ -293,11 +313,11 @@ Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish .
 
 The packaging scripts only repackage what's already in `codex-app/`. They do not download or extract the DMG themselves.
 
-Native packages bundle the managed Node.js runtime and do not hard-depend on distro `nodejs` / `npm`. Packages still pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` for privileged update installs.
+Native packages bundle the managed Node.js runtime and do not hard-depend on distro `nodejs` / `npm`. Packages built with the default updater pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` for privileged update installs; `PACKAGE_WITH_UPDATER=0` packages do not install those updater-specific artifacts.
 
 ### Updater service controls
 
-After installing a native package:
+After installing a default native package with the updater enabled:
 
 ```bash
 make service-enable           # enable + start the systemd --user service
@@ -359,14 +379,14 @@ make clean-state
 5. It downloads the matching Linux Electron runtime (cached under `~/.cache/codex-desktop/electron/`)
 6. It writes the Linux launcher into `codex-app/start.sh` (body sourced from `launcher/start.sh.template`)
 7. `scripts/build-{deb,rpm,pacman}.sh` packages `codex-app/` into a native artifact
-8. The installed package provides `codex-update-manager` plus a `systemd --user` service unit
-9. The updater watches for newer upstream DMGs and rebuilds future Linux packages locally
+8. Default native packages provide `codex-update-manager` plus a `systemd --user` service unit
+9. The updater watches for newer upstream DMGs and rebuilds future Linux packages locally, unless the package was built with `PACKAGE_WITH_UPDATER=0`
 
 The installer replaces the macOS Electron binary with a Linux build, recompiles native modules, and removes macOS-only pieces such as `sparkle`.
 
 The launcher serves extracted webview assets from `content/webview/` on `127.0.0.1` (`5175` by default, `5176` for the dev app), validates the origin, then starts Electron. Warm-start launches hand off actions such as `--new-chat` over a Unix-domain socket instead of spawning a second app process.
 
-Native-package-only launcher behavior, such as desktop-entry hints and update-manager startup, lives in `packaging/linux/codex-packaged-runtime.sh`.
+Native-package-only launcher behavior, such as desktop-entry hints and default update-manager startup, lives in `packaging/linux/codex-packaged-runtime.sh`.
 
 The current evaluation for a future Rust replacement of the local webview server lives in `docs/webview-server-evaluation.md`.
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ PACKAGE_WITH_UPDATER=0 make package
 make install
 ```
 
-That package omits `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, desktop updater actions, and launcher updater startup checks. The packaged launcher still exports desktop-entry hints for window/icon association, but it does not enable, start, or probe the updater. Installing a no-updater package over a default package also stops and disables any existing `codex-update-manager.service` for active user managers.
+That package omits `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, desktop updater actions, and launcher updater startup checks. The packaged launcher still exports desktop-entry hints for window/icon association, but it does not enable, start, or probe the updater. Installing a no-updater package over a default package also stops and disables any existing `codex-update-manager.service` for active user managers and removes stale per-user enablement links for inactive users.
 
 Manual updates should come from a checkout you have chosen to trust:
 

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -58,6 +58,12 @@ if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
     codex_ensure_user_service_running || true
 fi
+%else
+CLEANUP_HELPER=/opt/__PACKAGE_NAME__/.codex-linux/codex-no-updater-transition-cleanup.sh
+if [ -f "$CLEANUP_HELPER" ]; then
+    . "$CLEANUP_HELPER"
+    codex_no_updater_cleanup_update_manager_service || true
+fi
 %endif
 
 %if __PACKAGE_WITH_UPDATER__
@@ -67,6 +73,13 @@ SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update
 if [ $1 -eq 0 ] && [ -f "$SERVICE_HELPER" ]; then
     codex_cleanup_user_service stop || true
     codex_cleanup_user_service disable || true
+fi
+%else
+%preun
+CLEANUP_HELPER=/opt/__PACKAGE_NAME__/.codex-linux/codex-no-updater-transition-cleanup.sh
+if [ -f "$CLEANUP_HELPER" ]; then
+    . "$CLEANUP_HELPER"
+    codex_no_updater_cleanup_update_manager_service || true
 fi
 %endif
 

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -7,7 +7,11 @@ ExclusiveArch:  __ARCH__
 %global __requires_exclude_from ^/opt/__PACKAGE_NAME__/.*$
 %global __provides_exclude_from ^/opt/__PACKAGE_NAME__/.*$
 
+%if __PACKAGE_WITH_UPDATER__
 Requires:       python3, /usr/bin/7z, polkit, curl, unzip, gcc-c++, make
+%else
+Requires:       python3, /usr/bin/7z, curl, unzip, gcc-c++, make
+%endif
 Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
 Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
 Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr
@@ -17,8 +21,12 @@ Recommends:     zenity, kdialog
 %description
 Community-built Linux package for Codex Desktop generated from the macOS DMG.
 Requires the Codex CLI to be available in PATH or CODEX_CLI_PATH.
+%if __PACKAGE_WITH_UPDATER__
 Local auto-updates rebuild a Linux package from the upstream Codex.dmg and therefore
 use the bundled managed Node.js runtime plus the local packaging toolchain listed in Requires.
+%else
+This package was built without codex-update-manager. Update manually from a trusted checkout.
+%endif
 
 %install
 # Files are staged by build-rpm.sh outside of BUILDROOT and copied here.
@@ -29,23 +37,30 @@ cp -a "__RPM_STAGING_DIR__/." "%{buildroot}/"
 %defattr(-,root,root,-)
 /opt/__PACKAGE_NAME__/
 /usr/bin/__PACKAGE_NAME__
+%if __PACKAGE_WITH_UPDATER__
 /usr/bin/codex-update-manager
 /usr/lib/systemd/user/codex-update-manager.service
+%endif
 /usr/share/applications/__PACKAGE_NAME__.desktop
 /usr/share/icons/hicolor/256x256/apps/__PACKAGE_NAME__.png
+%if __PACKAGE_WITH_UPDATER__
 /usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy
+%endif
 
 %post
 if command -v update-desktop-database >/dev/null 2>&1; then
     update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
 fi
 
+%if __PACKAGE_WITH_UPDATER__
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
     codex_ensure_user_service_running || true
 fi
+%endif
 
+%if __PACKAGE_WITH_UPDATER__
 %preun
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 [ -f "$SERVICE_HELPER" ] && . "$SERVICE_HELPER"
@@ -53,13 +68,16 @@ if [ $1 -eq 0 ] && [ -f "$SERVICE_HELPER" ]; then
     codex_cleanup_user_service stop || true
     codex_cleanup_user_service disable || true
 fi
+%endif
 
+%if __PACKAGE_WITH_UPDATER__
 %postun
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
     codex_reload_user_managers || true
 fi
+%endif
 
 %changelog
 * Thu Jan 01 2026 Codex Desktop Linux Maintainers <maintainers@codex-desktop-linux>

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -90,6 +90,9 @@ CONTROL
         cp "$PRERM_TEMPLATE" "$PKG_ROOT/DEBIAN/prerm"
         cp "$POSTRM_TEMPLATE" "$PKG_ROOT/DEBIAN/postrm"
         chmod 0755 "$PKG_ROOT/DEBIAN/postinst" "$PKG_ROOT/DEBIAN/prerm" "$PKG_ROOT/DEBIAN/postrm"
+    else
+        write_no_updater_deb_postinst "$PKG_ROOT/DEBIAN/postinst"
+        write_no_updater_deb_prerm "$PKG_ROOT/DEBIAN/prerm"
     fi
 
     mkdir -p "$DIST_DIR"

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -38,13 +38,17 @@ main() {
     ensure_app_layout
     ensure_file_exists "$CONTROL_TEMPLATE" "control template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
-    ensure_file_exists "$UPDATER_SERVICE_SOURCE" "updater service template"
-    ensure_file_exists "$USER_SERVICE_HELPER_TEMPLATE" "updater user service helper"
     ensure_file_exists "$ICON_SOURCE" "icon"
-    ensure_file_exists "$PRERM_TEMPLATE" "Debian prerm template"
-    ensure_file_exists "$POSTRM_TEMPLATE" "Debian postrm template"
-    ensure_file_exists "$POSTINST_TEMPLATE" "Debian postinst template"
-    ensure_file_exists "$PACKAGED_RUNTIME_SOURCE" "packaged launcher runtime helper"
+    if package_with_updater_enabled; then
+        ensure_file_exists "$UPDATER_SERVICE_SOURCE" "updater service template"
+        ensure_file_exists "$USER_SERVICE_HELPER_TEMPLATE" "updater user service helper"
+        ensure_file_exists "$PRERM_TEMPLATE" "Debian prerm template"
+        ensure_file_exists "$POSTRM_TEMPLATE" "Debian postrm template"
+        ensure_file_exists "$POSTINST_TEMPLATE" "Debian postinst template"
+        ensure_file_exists "$PACKAGED_RUNTIME_SOURCE" "packaged launcher runtime helper"
+    else
+        info "Building package without codex-update-manager (PACKAGE_WITH_UPDATER=0)"
+    fi
     command -v dpkg-deb >/dev/null 2>&1 || error "dpkg-deb is required"
     command -v dpkg >/dev/null 2>&1 || error "dpkg is required"
 
@@ -61,7 +65,7 @@ main() {
         "$PKG_ROOT/opt"
 
     stage_common_package_files "$PKG_ROOT"
-    stage_update_builder_bundle "$PKG_ROOT"
+    stage_optional_update_builder_bundle "$PKG_ROOT"
     write_launcher_stub "$PKG_ROOT"
 
     sed \
@@ -69,11 +73,24 @@ main() {
         -e "s/__VERSION__/$PACKAGE_VERSION/g" \
         -e "s/__ARCH__/$arch/g" \
         "$CONTROL_TEMPLATE" > "$PKG_ROOT/DEBIAN/control"
+    if ! package_with_updater_enabled; then
+        sed -i \
+            -e 's/pkexec | policykit-1, //g' \
+            -e 's/polkitd | policykit-1, //g' \
+            -e '/Local auto-updates rebuild a Linux package/d' \
+            -e '/use the bundled managed Node.js runtime plus the local packaging toolchain/d' \
+            "$PKG_ROOT/DEBIAN/control"
+        cat >> "$PKG_ROOT/DEBIAN/control" <<'CONTROL'
+ This package was built without codex-update-manager. Update manually from a trusted checkout.
+CONTROL
+    fi
     chmod 0644 "$PKG_ROOT/DEBIAN/control"
-    sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" "$POSTINST_TEMPLATE" > "$PKG_ROOT/DEBIAN/postinst"
-    cp "$PRERM_TEMPLATE" "$PKG_ROOT/DEBIAN/prerm"
-    cp "$POSTRM_TEMPLATE" "$PKG_ROOT/DEBIAN/postrm"
-    chmod 0755 "$PKG_ROOT/DEBIAN/postinst" "$PKG_ROOT/DEBIAN/prerm" "$PKG_ROOT/DEBIAN/postrm"
+    if package_with_updater_enabled; then
+        sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" "$POSTINST_TEMPLATE" > "$PKG_ROOT/DEBIAN/postinst"
+        cp "$PRERM_TEMPLATE" "$PKG_ROOT/DEBIAN/prerm"
+        cp "$POSTRM_TEMPLATE" "$PKG_ROOT/DEBIAN/postrm"
+        chmod 0755 "$PKG_ROOT/DEBIAN/postinst" "$PKG_ROOT/DEBIAN/prerm" "$PKG_ROOT/DEBIAN/postrm"
+    fi
 
     mkdir -p "$DIST_DIR"
     info "Building $output_file"

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -81,9 +81,9 @@ main() {
 		sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \
 			"$INSTALL_HOOKS" >"$build_root/${PACKAGE_NAME}.install"
 	else
+		write_no_updater_pacman_install_hooks "$build_root/${PACKAGE_NAME}.install"
 		sed -i \
 			-e "/'polkit'/d" \
-			-e '/^install=/d' \
 			"$build_root/PKGBUILD"
 	fi
 

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -37,12 +37,16 @@ pacman_version_parts() {
 main() {
 	ensure_app_layout
 	ensure_file_exists "$PKGBUILD_TEMPLATE" "PKGBUILD template"
-	ensure_file_exists "$INSTALL_HOOKS" "install hooks"
 	ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
-	ensure_file_exists "$UPDATER_SERVICE_SOURCE" "updater service template"
-	ensure_file_exists "$USER_SERVICE_HELPER_TEMPLATE" "updater user service helper"
 	ensure_file_exists "$ICON_SOURCE" "icon"
-	ensure_file_exists "$PACKAGED_RUNTIME_SOURCE" "packaged launcher runtime helper"
+	if package_with_updater_enabled; then
+		ensure_file_exists "$INSTALL_HOOKS" "install hooks"
+		ensure_file_exists "$UPDATER_SERVICE_SOURCE" "updater service template"
+		ensure_file_exists "$USER_SERVICE_HELPER_TEMPLATE" "updater user service helper"
+		ensure_file_exists "$PACKAGED_RUNTIME_SOURCE" "packaged launcher runtime helper"
+	else
+		info "Building package without codex-update-manager (PACKAGE_WITH_UPDATER=0)"
+	fi
 	command -v makepkg >/dev/null 2>&1 || error "makepkg is required (part of pacman)"
 
 	if [ "$(id -u)" -eq 0 ]; then
@@ -63,7 +67,7 @@ main() {
 	local staging_root="$build_root/staging"
 
 	stage_common_package_files "$staging_root"
-	stage_update_builder_bundle "$staging_root"
+	stage_optional_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
 
 	sed \
@@ -73,8 +77,15 @@ main() {
 		-e "s|__STAGING_DIR__|$staging_root|g" \
 		-e "s/__ARCH__/$arch/g" \
 		"$PKGBUILD_TEMPLATE" >"$build_root/PKGBUILD"
-	sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \
-		"$INSTALL_HOOKS" >"$build_root/${PACKAGE_NAME}.install"
+	if package_with_updater_enabled; then
+		sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \
+			"$INSTALL_HOOKS" >"$build_root/${PACKAGE_NAME}.install"
+	else
+		sed -i \
+			-e "/'polkit'/d" \
+			-e '/^install=/d' \
+			"$build_root/PKGBUILD"
+	fi
 
 	mkdir -p "$DIST_DIR"
 	info "Building ${PACKAGE_NAME}-${PACMAN_PKGVER}-${PACMAN_PKGREL}-${arch}.pkg.tar.zst"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -53,10 +53,14 @@ main() {
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
     [ -f "$SPEC_TEMPLATE" ] || error "Missing spec template: $SPEC_TEMPLATE"
     [ -f "$DESKTOP_TEMPLATE" ] || error "Missing desktop template: $DESKTOP_TEMPLATE"
-    [ -f "$UPDATER_SERVICE_SOURCE" ] || error "Missing updater service template: $UPDATER_SERVICE_SOURCE"
-    [ -f "$USER_SERVICE_HELPER_TEMPLATE" ] || error "Missing updater user service helper: $USER_SERVICE_HELPER_TEMPLATE"
     [ -f "$ICON_SOURCE" ] || error "Missing icon: $ICON_SOURCE"
-    [ -f "$PACKAGED_RUNTIME_SOURCE" ] || error "Missing packaged launcher runtime helper: $PACKAGED_RUNTIME_SOURCE"
+    if package_with_updater_enabled; then
+        [ -f "$UPDATER_SERVICE_SOURCE" ] || error "Missing updater service template: $UPDATER_SERVICE_SOURCE"
+        [ -f "$USER_SERVICE_HELPER_TEMPLATE" ] || error "Missing updater user service helper: $USER_SERVICE_HELPER_TEMPLATE"
+        [ -f "$PACKAGED_RUNTIME_SOURCE" ] || error "Missing packaged launcher runtime helper: $PACKAGED_RUNTIME_SOURCE"
+    else
+        info "Building package without codex-update-manager (PACKAGE_WITH_UPDATER=0)"
+    fi
     command -v rpmbuild >/dev/null 2>&1 || error "rpmbuild is required (install rpm-build)"
 
     ensure_updater_binary
@@ -75,7 +79,7 @@ main() {
     local staging_root="$build_root/STAGING"
 
     stage_common_package_files "$staging_root"
-    stage_update_builder_bundle "$staging_root"
+    stage_optional_update_builder_bundle "$staging_root"
 
     cat > "$staging_root/usr/bin/$PACKAGE_NAME" <<SCRIPT
 #!/bin/bash
@@ -90,6 +94,7 @@ SCRIPT
         -e "s/__RPM_RELEASE__/$rpm_rel/g" \
         -e "s|__RPM_STAGING_DIR__|$staging_root|g" \
         -e "s/__ARCH__/$arch/g" \
+        -e "s/__PACKAGE_WITH_UPDATER__/$(package_with_updater_enabled && echo 1 || echo 0)/g" \
         "$SPEC_TEMPLATE" > "$spec_file"
 
     local rpmbuild_dir="$build_root/rpmbuild"

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -290,11 +290,19 @@ run_deb_job() {
     local deb_no_updater_file
     deb_no_updater_file="$(package_file_or_fail 'codex-desktop_*.deb')"
     dpkg-deb -c "$deb_no_updater_file" | tee /tmp/deb-no-updater-contents.txt >/dev/null
+    rm -rf /tmp/deb-no-updater-control
+    mkdir -p /tmp/deb-no-updater-control
+    dpkg-deb -e "$deb_no_updater_file" /tmp/deb-no-updater-control
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/bin/codex-update-manager'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/lib/systemd/user/codex-update-manager.service'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/update-builder/'
     assert_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+    assert_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh'
+    assert_contains_file /tmp/deb-no-updater-control/postinst 'codex_no_updater_cleanup_update_manager_service'
+    assert_contains_file /tmp/deb-no-updater-control/prerm 'codex_no_updater_cleanup_update_manager_service'
+    assert_not_contains_file /tmp/deb-no-updater-control/postinst 'update-builder'
+    assert_not_contains_file /tmp/deb-no-updater-control/prerm 'update-builder'
 
     append_summary "Debian Package Validation" \
         "Built: \`$(basename "$deb_file")\`" \
@@ -333,11 +341,16 @@ run_rpm_job() {
     local rpm_no_updater_file
     rpm_no_updater_file="$(package_file_or_fail 'codex-desktop-*.rpm')"
     rpm -qlp "$rpm_no_updater_file" | tee /tmp/rpm-no-updater-contents.txt >/dev/null
+    rpm -qp --scripts "$rpm_no_updater_file" | tee /tmp/rpm-no-updater-scripts.txt >/dev/null
     assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/bin/codex-update-manager'
     assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/lib/systemd/user/codex-update-manager.service'
     assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
     assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/opt/codex-desktop/update-builder/'
     assert_contains_file /tmp/rpm-no-updater-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+    assert_contains_file /tmp/rpm-no-updater-contents.txt '/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh'
+    assert_contains_file /tmp/rpm-no-updater-scripts.txt 'codex_no_updater_cleanup_update_manager_service'
+    assert_not_contains_file /tmp/rpm-no-updater-scripts.txt 'update-builder'
+    assert_not_contains_file /tmp/rpm-no-updater-scripts.txt 'codex_ensure_user_service_running'
 
     append_summary "RPM Package Validation" \
         "Built: \`$(basename "$rpm_file")\`" \
@@ -377,11 +390,17 @@ run_pacman_job() {
     local pkg_no_updater_file
     pkg_no_updater_file="$(package_file_or_fail 'codex-desktop-*.pkg.tar.*')"
     pacman -Qlp "$pkg_no_updater_file" | tee /tmp/pacman-no-updater-contents.txt >/dev/null
+    tar -xOf "$pkg_no_updater_file" .INSTALL | tee /tmp/pacman-no-updater-install.txt >/dev/null
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/bin/codex-update-manager'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/lib/systemd/user/codex-update-manager.service'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/update-builder/'
     assert_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+    assert_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh'
+    assert_contains_file /tmp/pacman-no-updater-install.txt 'codex_no_updater_cleanup_update_manager_service'
+    assert_contains_file /tmp/pacman-no-updater-install.txt 'post_upgrade'
+    assert_contains_file /tmp/pacman-no-updater-install.txt 'pre_remove'
+    assert_not_contains_file /tmp/pacman-no-updater-install.txt 'update-builder'
 
     append_summary "Pacman Package Validation" \
         "Built: \`$(basename "$pkg_file")\`" \

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -205,6 +205,14 @@ assert_contains_file() {
     grep -q -- "$pattern" "$path" || error "Expected '$pattern' in $path"
 }
 
+assert_not_contains_file() {
+    local path="$1"
+    local pattern="$2"
+    if grep -q -- "$pattern" "$path"; then
+        error "Did not expect '$pattern' in $path"
+    fi
+}
+
 prepare_package_fixture() {
     rm -rf codex-app dist
     tests/fixtures/create-packaged-app-fixture.sh codex-app
@@ -273,9 +281,25 @@ run_deb_job() {
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
+    rm -rf dist
+    CARGO_TARGET_DIR="$target_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-deb.sh
+
+    local deb_no_updater_file
+    deb_no_updater_file="$(package_file_or_fail 'codex-desktop_*.deb')"
+    dpkg-deb -c "$deb_no_updater_file" | tee /tmp/deb-no-updater-contents.txt >/dev/null
+    assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/bin/codex-update-manager'
+    assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/lib/systemd/user/codex-update-manager.service'
+    assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
+    assert_not_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/update-builder/'
+    assert_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+
     append_summary "Debian Package Validation" \
         "Built: \`$(basename "$deb_file")\`" \
-        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper."
+        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
+        "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts."
 }
 
 run_rpm_job() {
@@ -300,9 +324,25 @@ run_rpm_job() {
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
+    rm -rf dist
+    CARGO_TARGET_DIR="$target_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-rpm.sh
+
+    local rpm_no_updater_file
+    rpm_no_updater_file="$(package_file_or_fail 'codex-desktop-*.rpm')"
+    rpm -qlp "$rpm_no_updater_file" | tee /tmp/rpm-no-updater-contents.txt >/dev/null
+    assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/bin/codex-update-manager'
+    assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/lib/systemd/user/codex-update-manager.service'
+    assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
+    assert_not_contains_file /tmp/rpm-no-updater-contents.txt '/opt/codex-desktop/update-builder/'
+    assert_contains_file /tmp/rpm-no-updater-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+
     append_summary "RPM Package Validation" \
         "Built: \`$(basename "$rpm_file")\`" \
-        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper."
+        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
+        "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts."
 }
 
 run_pacman_job() {
@@ -328,9 +368,25 @@ run_pacman_job() {
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
+    rm -rf dist
+    CARGO_TARGET_DIR="$target_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-pacman.sh
+
+    local pkg_no_updater_file
+    pkg_no_updater_file="$(package_file_or_fail 'codex-desktop-*.pkg.tar.*')"
+    pacman -Qlp "$pkg_no_updater_file" | tee /tmp/pacman-no-updater-contents.txt >/dev/null
+    assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/bin/codex-update-manager'
+    assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/lib/systemd/user/codex-update-manager.service'
+    assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
+    assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/update-builder/'
+    assert_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
+
     append_summary "Pacman Package Validation" \
         "Built: \`$(basename "$pkg_file")\`" \
-        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper."
+        "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
+        "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts."
 }
 
 run_install_deps_job_as_root() {

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -291,14 +291,18 @@ run_deb_job() {
     deb_no_updater_file="$(package_file_or_fail 'codex-desktop_*.deb')"
     dpkg-deb -c "$deb_no_updater_file" | tee /tmp/deb-no-updater-contents.txt >/dev/null
     rm -rf /tmp/deb-no-updater-control
-    mkdir -p /tmp/deb-no-updater-control
+    rm -rf /tmp/deb-no-updater-payload
+    mkdir -p /tmp/deb-no-updater-control /tmp/deb-no-updater-payload
     dpkg-deb -e "$deb_no_updater_file" /tmp/deb-no-updater-control
+    dpkg-deb -x "$deb_no_updater_file" /tmp/deb-no-updater-payload
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/bin/codex-update-manager'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/lib/systemd/user/codex-update-manager.service'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
     assert_not_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/update-builder/'
     assert_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
     assert_contains_file /tmp/deb-no-updater-contents.txt './opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh'
+    assert_contains_file /tmp/deb-no-updater-payload/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh 'codex_no_updater_cleanup_user_enablement_links'
+    assert_contains_file /tmp/deb-no-updater-payload/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh 'default.target.wants'
     assert_contains_file /tmp/deb-no-updater-control/postinst 'codex_no_updater_cleanup_update_manager_service'
     assert_contains_file /tmp/deb-no-updater-control/prerm 'codex_no_updater_cleanup_update_manager_service'
     assert_not_contains_file /tmp/deb-no-updater-control/postinst 'update-builder'
@@ -391,12 +395,15 @@ run_pacman_job() {
     pkg_no_updater_file="$(package_file_or_fail 'codex-desktop-*.pkg.tar.*')"
     pacman -Qlp "$pkg_no_updater_file" | tee /tmp/pacman-no-updater-contents.txt >/dev/null
     tar -xOf "$pkg_no_updater_file" .INSTALL | tee /tmp/pacman-no-updater-install.txt >/dev/null
+    tar -xOf "$pkg_no_updater_file" opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh | tee /tmp/pacman-no-updater-cleanup.txt >/dev/null
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/bin/codex-update-manager'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/lib/systemd/user/codex-update-manager.service'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy'
     assert_not_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/update-builder/'
     assert_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
     assert_contains_file /tmp/pacman-no-updater-contents.txt 'opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh'
+    assert_contains_file /tmp/pacman-no-updater-cleanup.txt 'codex_no_updater_cleanup_user_enablement_links'
+    assert_contains_file /tmp/pacman-no-updater-cleanup.txt 'default.target.wants'
     assert_contains_file /tmp/pacman-no-updater-install.txt 'codex_no_updater_cleanup_update_manager_service'
     assert_contains_file /tmp/pacman-no-updater-install.txt 'post_upgrade'
     assert_contains_file /tmp/pacman-no-updater-install.txt 'pre_remove'

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -92,6 +92,150 @@ SCRIPT
     chmod 0644 "$target"
 }
 
+render_no_updater_transition_cleanup_helper() {
+    local target="$1"
+
+    cat > "$target" <<'SCRIPT'
+#!/bin/sh
+
+SERVICE_NAME="${SERVICE_NAME:-codex-update-manager.service}"
+
+codex_no_updater_foreach_user_manager() {
+    if ! command -v runuser >/dev/null 2>&1 ||
+        ! command -v systemctl >/dev/null 2>&1 ||
+        ! command -v getent >/dev/null 2>&1; then
+        return
+    fi
+
+    for runtime_dir in /run/user/*; do
+        [ -d "$runtime_dir" ] || continue
+
+        uid="$(basename "$runtime_dir")"
+        case "$uid" in
+            ''|*[!0-9]*|0)
+                continue
+                ;;
+        esac
+
+        bus="$runtime_dir/bus"
+        [ -S "$bus" ] || continue
+
+        user_name="$(getent passwd "$uid" | cut -d: -f1 || true)"
+        [ -n "$user_name" ] || continue
+
+        "$@" "$user_name" "$runtime_dir" "$bus"
+    done
+}
+
+codex_no_updater_run_systemctl_user() {
+    user_name="$1"
+    runtime_dir="$2"
+    bus="$3"
+    shift 3
+
+    runuser -u "$user_name" -- env \
+        XDG_RUNTIME_DIR="$runtime_dir" \
+        DBUS_SESSION_BUS_ADDRESS="unix:path=$bus" \
+        systemctl --user "$@" >/dev/null 2>&1
+}
+
+codex_no_updater_cleanup_one_user_manager() {
+    user_name="$1"
+    runtime_dir="$2"
+    bus="$3"
+
+    codex_no_updater_run_systemctl_user "$user_name" "$runtime_dir" "$bus" stop "$SERVICE_NAME" || true
+    codex_no_updater_run_systemctl_user "$user_name" "$runtime_dir" "$bus" disable "$SERVICE_NAME" || true
+    codex_no_updater_run_systemctl_user "$user_name" "$runtime_dir" "$bus" daemon-reload || true
+}
+
+codex_no_updater_cleanup_update_manager_service() {
+    codex_no_updater_foreach_user_manager codex_no_updater_cleanup_one_user_manager
+}
+SCRIPT
+    chmod 0644 "$target"
+}
+
+write_no_updater_deb_postinst() {
+    local target="$1"
+    local package_name
+
+    package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+    cat > "$target" <<SCRIPT
+#!/bin/sh
+set -eu
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+fi
+
+CLEANUP_HELPER="/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh"
+if [ -f "\$CLEANUP_HELPER" ]; then
+    # shellcheck source=/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh
+    . "\$CLEANUP_HELPER"
+    codex_no_updater_cleanup_update_manager_service || true
+fi
+
+exit 0
+SCRIPT
+    chmod 0755 "$target"
+}
+
+write_no_updater_deb_prerm() {
+    local target="$1"
+    local package_name
+
+    package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+    cat > "$target" <<SCRIPT
+#!/bin/sh
+set -eu
+
+CLEANUP_HELPER="/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh"
+if [ -f "\$CLEANUP_HELPER" ]; then
+    # shellcheck source=/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh
+    . "\$CLEANUP_HELPER"
+    codex_no_updater_cleanup_update_manager_service || true
+fi
+
+exit 0
+SCRIPT
+    chmod 0755 "$target"
+}
+
+write_no_updater_pacman_install_hooks() {
+    local target="$1"
+    local package_name
+
+    package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+    cat > "$target" <<SCRIPT
+CLEANUP_HELPER="/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh"
+
+codex_no_updater_cleanup_if_present() {
+    if [ -f "\$CLEANUP_HELPER" ]; then
+        # shellcheck source=/opt/$package_name/.codex-linux/codex-no-updater-transition-cleanup.sh
+        . "\$CLEANUP_HELPER"
+        codex_no_updater_cleanup_update_manager_service || true
+    fi
+}
+
+post_install() {
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+    fi
+    codex_no_updater_cleanup_if_present
+}
+
+post_upgrade() {
+    post_install
+}
+
+pre_remove() {
+    codex_no_updater_cleanup_if_present
+}
+SCRIPT
+    chmod 0644 "$target"
+}
+
 updater_binary_is_stale() {
     local binary="$1"
 
@@ -182,6 +326,9 @@ stage_common_package_files() {
         chmod 0644 "$root/usr/lib/systemd/user/codex-update-manager.service"
         cp "$polkit_policy" "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
         chmod 0644 "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    else
+        render_no_updater_transition_cleanup_helper \
+            "$app_root/.codex-linux/codex-no-updater-transition-cleanup.sh"
     fi
     render_packaged_runtime_helper "$app_root/.codex-linux/codex-packaged-runtime.sh"
 }

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -24,11 +24,26 @@ sed_escape_replacement() {
     printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
 }
 
+package_with_updater_enabled() {
+    case "${PACKAGE_WITH_UPDATER:-1}" in
+        1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+            return 0
+            ;;
+        0|false|False|FALSE|no|No|NO|off|Off|OFF)
+            return 1
+            ;;
+        *)
+            error "PACKAGE_WITH_UPDATER must be 1 or 0"
+            ;;
+    esac
+}
+
 render_desktop_entry() {
     local target="$1"
     local package_name
     local display_name
     local comment
+    local rendered_target="$target.tmp"
 
     package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
     display_name="$(sed_escape_replacement "${PACKAGE_DISPLAY_NAME:-Codex Desktop}")"
@@ -38,7 +53,20 @@ render_desktop_entry() {
         -e "s/codex-desktop/$package_name/g" \
         -e "s/^Name=.*/Name=$display_name/g" \
         -e "s/^Comment=.*/Comment=$comment/g" \
-        "$DESKTOP_TEMPLATE" > "$target"
+        "$DESKTOP_TEMPLATE" > "$rendered_target"
+    if package_with_updater_enabled; then
+        mv "$rendered_target" "$target"
+    else
+        awk '
+            /^\[Desktop Action CheckForUpdates\]$/ { skip = 1; next }
+            /^\[Desktop Action InstallReadyUpdate\]$/ { skip = 1; next }
+            /^\[/ { skip = 0 }
+            skip { next }
+            /^Actions=/ { next }
+            { print }
+        ' "$rendered_target" > "$target"
+        rm -f "$rendered_target"
+    fi
     chmod 0644 "$target"
 }
 
@@ -47,6 +75,19 @@ render_packaged_runtime_helper() {
     local package_name
 
     package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+    if ! package_with_updater_enabled; then
+        cat > "$target" <<SCRIPT
+#!/bin/bash
+
+codex_packaged_runtime_export_env() {
+    export CHROME_DESKTOP="$package_name.desktop"
+    export BAMF_DESKTOP_FILE_HINT="/usr/share/applications/$package_name.desktop"
+}
+SCRIPT
+        chmod 0644 "$target"
+        return
+    fi
+
     sed -e "s/codex-desktop/$package_name/g" "$PACKAGED_RUNTIME_SOURCE" > "$target"
     chmod 0644 "$target"
 }
@@ -89,6 +130,10 @@ find_cargo_command() {
 ensure_updater_binary() {
     local cargo_cmd=""
 
+    if ! package_with_updater_enabled; then
+        return
+    fi
+
     if [ -x "$UPDATER_BINARY_SOURCE" ] && ! updater_binary_is_stale "$UPDATER_BINARY_SOURCE"; then
         return
     fi
@@ -109,15 +154,20 @@ stage_common_package_files() {
     local app_root="$root/opt/$PACKAGE_NAME"
     local polkit_policy="$REPO_DIR/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy"
 
-    ensure_file_exists "$polkit_policy" "polkit policy"
+    if package_with_updater_enabled; then
+        ensure_file_exists "$polkit_policy" "polkit policy"
+    fi
 
     mkdir -p \
         "$root/opt" \
         "$root/usr/bin" \
-        "$root/usr/lib/systemd/user" \
         "$root/usr/share/applications" \
-        "$root/usr/share/icons/hicolor/256x256/apps" \
-        "$root/usr/share/polkit-1/actions"
+        "$root/usr/share/icons/hicolor/256x256/apps"
+    if package_with_updater_enabled; then
+        mkdir -p \
+            "$root/usr/lib/systemd/user" \
+            "$root/usr/share/polkit-1/actions"
+    fi
 
     rm -rf "$app_root"
     cp -aT "$APP_DIR" "$app_root"
@@ -125,12 +175,14 @@ stage_common_package_files() {
     cp "$ICON_SOURCE" "$app_root/.codex-linux/$PACKAGE_NAME.png"
     render_desktop_entry "$root/usr/share/applications/$PACKAGE_NAME.desktop"
     cp "$ICON_SOURCE" "$root/usr/share/icons/hicolor/256x256/apps/$PACKAGE_NAME.png"
-    cp "$UPDATER_BINARY_SOURCE" "$root/usr/bin/codex-update-manager"
-    chmod 0755 "$root/usr/bin/codex-update-manager"
-    cp "$UPDATER_SERVICE_SOURCE" "$root/usr/lib/systemd/user/codex-update-manager.service"
-    chmod 0644 "$root/usr/lib/systemd/user/codex-update-manager.service"
-    cp "$polkit_policy" "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
-    chmod 0644 "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    if package_with_updater_enabled; then
+        cp "$UPDATER_BINARY_SOURCE" "$root/usr/bin/codex-update-manager"
+        chmod 0755 "$root/usr/bin/codex-update-manager"
+        cp "$UPDATER_SERVICE_SOURCE" "$root/usr/lib/systemd/user/codex-update-manager.service"
+        chmod 0644 "$root/usr/lib/systemd/user/codex-update-manager.service"
+        cp "$polkit_policy" "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+        chmod 0644 "$root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    fi
     render_packaged_runtime_helper "$app_root/.codex-linux/codex-packaged-runtime.sh"
 }
 
@@ -201,6 +253,14 @@ stage_update_builder_bundle() {
         cp -a "$node_runtime_source" "$update_builder_root/node-runtime"
     else
         error "Missing managed Node.js runtime: $node_runtime_source. Run ./install.sh first."
+    fi
+}
+
+stage_optional_update_builder_bundle() {
+    if package_with_updater_enabled; then
+        stage_update_builder_bundle "$@"
+    else
+        info "Skipping update-builder bundle (PACKAGE_WITH_UPDATER=0)"
     fi
 }
 

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -149,8 +149,32 @@ codex_no_updater_cleanup_one_user_manager() {
     codex_no_updater_run_systemctl_user "$user_name" "$runtime_dir" "$bus" daemon-reload || true
 }
 
+codex_no_updater_cleanup_user_enablement_links() {
+    if ! command -v getent >/dev/null 2>&1 || ! command -v runuser >/dev/null 2>&1; then
+        return
+    fi
+
+    getent passwd | while IFS=: read -r user_name _ uid _ _ home _; do
+        case "$uid" in
+            ''|*[!0-9]*|0)
+                continue
+                ;;
+        esac
+
+        [ -n "$home" ] || continue
+        [ "$home" != "/" ] || continue
+
+        wants_dir="$home/.config/systemd/user/default.target.wants"
+        service_link="$wants_dir/$SERVICE_NAME"
+        [ -L "$service_link" ] || continue
+
+        runuser -u "$user_name" -- rm -f "$service_link" >/dev/null 2>&1 || true
+    done
+}
+
 codex_no_updater_cleanup_update_manager_service() {
     codex_no_updater_foreach_user_manager codex_no_updater_cleanup_one_user_manager
+    codex_no_updater_cleanup_user_enablement_links
 }
 SCRIPT
     chmod 0644 "$target"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -268,13 +268,14 @@ SCRIPT
 
     assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+manual_amd64.deb"
     assert_file_exists "$pkg_root/usr/bin/codex-desktop"
+    assert_file_exists "$pkg_root/DEBIAN/postinst"
+    assert_file_exists "$pkg_root/DEBIAN/prerm"
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
+    assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh"
     assert_file_not_exists "$pkg_root/usr/bin/codex-update-manager"
     assert_file_not_exists "$pkg_root/usr/lib/systemd/user/codex-update-manager.service"
     assert_file_not_exists "$pkg_root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
     assert_file_not_exists "$pkg_root/opt/codex-desktop/update-builder"
-    assert_file_not_exists "$pkg_root/DEBIAN/postinst"
-    assert_file_not_exists "$pkg_root/DEBIAN/prerm"
     assert_file_not_exists "$pkg_root/DEBIAN/postrm"
     assert_not_contains "$pkg_root/DEBIAN/control" "pkexec"
     assert_not_contains "$pkg_root/DEBIAN/control" "polkit"
@@ -286,6 +287,14 @@ SCRIPT
     assert_not_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "systemctl"
     assert_not_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "codex-update-manager"
     assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-desktop.desktop"'
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "codex_no_updater_cleanup_update_manager_service"
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "stop \"\$SERVICE_NAME\""
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "disable \"\$SERVICE_NAME\""
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "daemon-reload"
+    assert_contains "$pkg_root/DEBIAN/postinst" "codex_no_updater_cleanup_update_manager_service"
+    assert_contains "$pkg_root/DEBIAN/prerm" "codex_no_updater_cleanup_update_manager_service"
+    assert_not_contains "$pkg_root/DEBIAN/postinst" "update-builder"
+    assert_not_contains "$pkg_root/DEBIAN/prerm" "update-builder"
 }
 
 test_rpm_builder_smoke() {
@@ -334,6 +343,58 @@ SCRIPT
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
+}
+
+test_pacman_builder_without_updater_transition_hook() {
+    info "Running no-updater pacman packaging hook smoke test"
+    if [ "$(id -u)" -eq 0 ]; then
+        info "Skipping pacman no-updater hook smoke test as root"
+        return
+    fi
+
+    local workspace="$TMP_DIR/pacman-no-updater"
+    local bin_dir="$workspace/bin"
+    local app_dir="$workspace/app"
+    local dist_dir="$workspace/dist"
+    local capture_dir="$workspace/capture"
+
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
+    make_stub_bin_dir "$bin_dir"
+    make_fake_app "$app_dir"
+
+    cat > "$bin_dir/makepkg" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+cp PKGBUILD "$CAPTURE_DIR/PKGBUILD"
+cp codex-desktop.install "$CAPTURE_DIR/codex-desktop.install"
+mkdir -p "$PKGDEST"
+touch "$PKGDEST/codex-desktop-2026.03.24.120000-1-x86_64.pkg.tar.zst"
+SCRIPT
+    cat > "$bin_dir/cargo" <<'SCRIPT'
+#!/usr/bin/env bash
+echo "cargo should not be called when PACKAGE_WITH_UPDATER=0" >&2
+exit 99
+SCRIPT
+    chmod +x "$bin_dir/makepkg" "$bin_dir/cargo"
+
+    PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="2026.03.24.120000+manual" \
+    bash "$REPO_DIR/scripts/build-pacman.sh"
+
+    assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-1-x86_64.pkg.tar.zst"
+    assert_file_exists "$capture_dir/PKGBUILD"
+    assert_file_exists "$capture_dir/codex-desktop.install"
+    assert_contains "$capture_dir/PKGBUILD" "install=codex-desktop.install"
+    assert_not_contains "$capture_dir/PKGBUILD" "'polkit'"
+    assert_contains "$capture_dir/codex-desktop.install" "codex_no_updater_cleanup_update_manager_service"
+    assert_contains "$capture_dir/codex-desktop.install" "post_upgrade"
+    assert_contains "$capture_dir/codex-desktop.install" "pre_remove"
+    assert_contains "$capture_dir/codex-desktop.install" "codex-no-updater-transition-cleanup.sh"
+    assert_not_contains "$capture_dir/codex-desktop.install" "update-builder"
 }
 
 test_missing_input_failure() {
@@ -2316,6 +2377,7 @@ main() {
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater
     test_rpm_builder_smoke
+    test_pacman_builder_without_updater_transition_hook
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default
     test_upstream_build_app_workflow_tracks_dmg_metadata

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -225,6 +225,69 @@ SCRIPT
     assert_contains "$pkg_root/opt/codex-cua-lab/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-cua-lab.desktop"'
 }
 
+test_deb_builder_without_updater() {
+    info "Running no-updater Debian packaging smoke test"
+    local workspace="$TMP_DIR/deb-no-updater"
+    local bin_dir="$workspace/bin"
+    local app_dir="$workspace/app"
+    local dist_dir="$workspace/dist"
+    local pkg_root="$workspace/deb-root"
+
+    mkdir -p "$workspace" "$dist_dir"
+    make_stub_bin_dir "$bin_dir"
+    make_fake_app "$app_dir"
+
+    cat > "$bin_dir/dpkg" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "--print-architecture" ]; then
+    echo amd64
+    exit 0
+fi
+exit 0
+SCRIPT
+    cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
+#!/usr/bin/env bash
+output="${@: -1}"
+mkdir -p "$(dirname "$output")"
+touch "$output"
+SCRIPT
+    cat > "$bin_dir/cargo" <<'SCRIPT'
+#!/usr/bin/env bash
+echo "cargo should not be called when PACKAGE_WITH_UPDATER=0" >&2
+exit 99
+SCRIPT
+    chmod +x "$bin_dir/dpkg" "$bin_dir/dpkg-deb" "$bin_dir/cargo"
+
+    PATH="$bin_dir:$PATH" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    PKG_ROOT_OVERRIDE="$pkg_root" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="2026.03.24.120000+manual" \
+    bash "$REPO_DIR/scripts/build-deb.sh"
+
+    assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+manual_amd64.deb"
+    assert_file_exists "$pkg_root/usr/bin/codex-desktop"
+    assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
+    assert_file_not_exists "$pkg_root/usr/bin/codex-update-manager"
+    assert_file_not_exists "$pkg_root/usr/lib/systemd/user/codex-update-manager.service"
+    assert_file_not_exists "$pkg_root/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    assert_file_not_exists "$pkg_root/opt/codex-desktop/update-builder"
+    assert_file_not_exists "$pkg_root/DEBIAN/postinst"
+    assert_file_not_exists "$pkg_root/DEBIAN/prerm"
+    assert_file_not_exists "$pkg_root/DEBIAN/postrm"
+    assert_not_contains "$pkg_root/DEBIAN/control" "pkexec"
+    assert_not_contains "$pkg_root/DEBIAN/control" "polkit"
+    assert_not_contains "$pkg_root/DEBIAN/control" "Local auto-updates"
+    assert_contains "$pkg_root/DEBIAN/control" "without codex-update-manager"
+    assert_not_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Actions=CheckForUpdates"
+    assert_not_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Desktop Action CheckForUpdates"
+    assert_not_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "codex-update-manager"
+    assert_not_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "systemctl"
+    assert_not_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "codex-update-manager"
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-desktop.desktop"'
+}
+
 test_rpm_builder_smoke() {
     info "Running RPM packaging smoke test"
     local workspace="$TMP_DIR/rpm"
@@ -2251,6 +2314,7 @@ main() {
     test_common_helper_sourcing
     test_deb_builder_smoke
     test_deb_builder_respects_package_identity
+    test_deb_builder_without_updater
     test_rpm_builder_smoke
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -291,10 +291,54 @@ SCRIPT
     assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "stop \"\$SERVICE_NAME\""
     assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "disable \"\$SERVICE_NAME\""
     assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "daemon-reload"
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "codex_no_updater_cleanup_user_enablement_links"
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "default.target.wants"
     assert_contains "$pkg_root/DEBIAN/postinst" "codex_no_updater_cleanup_update_manager_service"
     assert_contains "$pkg_root/DEBIAN/prerm" "codex_no_updater_cleanup_update_manager_service"
     assert_not_contains "$pkg_root/DEBIAN/postinst" "update-builder"
     assert_not_contains "$pkg_root/DEBIAN/prerm" "update-builder"
+}
+
+test_no_updater_cleanup_helper_removes_inactive_user_enablement() {
+    info "Checking no-updater inactive user service cleanup"
+    local workspace="$TMP_DIR/no-updater-cleanup"
+    local bin_dir="$workspace/bin"
+    local helper="$workspace/codex-no-updater-transition-cleanup.sh"
+    local fake_home="$workspace/home/codexuser"
+    local service_link="$fake_home/.config/systemd/user/default.target.wants/codex-update-manager.service"
+
+    mkdir -p "$bin_dir" "$(dirname "$service_link")"
+    ln -s /usr/lib/systemd/user/codex-update-manager.service "$service_link"
+
+    render_no_updater_transition_cleanup_helper "$helper"
+
+    cat > "$bin_dir/getent" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = "passwd" ]; then
+    printf 'codexuser:x:1000:1000::%s:/bin/sh\n' "$FAKE_HOME"
+fi
+SCRIPT
+    cat > "$bin_dir/runuser" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-u" ]; then
+    shift 2
+fi
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+exec "$@"
+SCRIPT
+    cat > "$bin_dir/systemctl" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+    chmod +x "$bin_dir/getent" "$bin_dir/runuser" "$bin_dir/systemctl"
+
+    PATH="$bin_dir:$PATH" FAKE_HOME="$fake_home" sh -c \
+        '. "$1"; codex_no_updater_cleanup_update_manager_service' \
+        _ "$helper"
+
+    assert_file_not_exists "$service_link"
 }
 
 test_rpm_builder_smoke() {
@@ -304,8 +348,9 @@ test_rpm_builder_smoke() {
     local app_dir="$workspace/app"
     local dist_dir="$workspace/dist"
     local updater_bin="$workspace/codex-update-manager"
+    local capture_dir="$workspace/capture"
 
-    mkdir -p "$workspace" "$dist_dir"
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
@@ -314,6 +359,7 @@ test_rpm_builder_smoke() {
     cat > "$bin_dir/rpmbuild" <<'SCRIPT'
 #!/usr/bin/env bash
 rpmdir=""
+spec_file="${@: -1}"
 while [ $# -gt 0 ]; do
     if [ "$1" = "--define" ]; then
         case "$2" in
@@ -325,6 +371,13 @@ while [ $# -gt 0 ]; do
     shift
 done
 [ -n "$rpmdir" ] || exit 1
+if [ -n "${CAPTURE_DIR:-}" ]; then
+    cp "$spec_file" "$CAPTURE_DIR/codex-desktop.spec"
+    staging_dir="$(sed -n 's|cp -a "\(.*\)/\." "%{buildroot}/"|\1|p' "$spec_file" | head -n 1)"
+    if [ -n "$staging_dir" ] && [ -d "$staging_dir" ]; then
+        cp -a "$staging_dir" "$CAPTURE_DIR/staging"
+    fi
+fi
 mkdir -p "$rpmdir/x86_64"
 touch "$rpmdir/x86_64/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
 SCRIPT
@@ -343,6 +396,28 @@ SCRIPT
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
+
+    rm -rf "$dist_dir" "$capture_dir"
+    mkdir -p "$dist_dir" "$capture_dir"
+
+    PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    PACKAGE_WITH_UPDATER=0 \
+    PACKAGE_VERSION="2026.03.24.120000+manual" \
+    bash "$REPO_DIR/scripts/build-rpm.sh"
+
+    assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-manual.x86_64.rpm"
+    assert_file_exists "$capture_dir/codex-desktop.spec"
+    assert_file_exists "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh"
+    assert_file_not_exists "$capture_dir/staging/usr/bin/codex-update-manager"
+    assert_file_not_exists "$capture_dir/staging/usr/lib/systemd/user/codex-update-manager.service"
+    assert_file_not_exists "$capture_dir/staging/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    assert_file_not_exists "$capture_dir/staging/opt/codex-desktop/update-builder"
+    assert_contains "$capture_dir/codex-desktop.spec" "%if 0"
+    assert_contains "$capture_dir/codex-desktop.spec" "codex_no_updater_cleanup_update_manager_service"
+    assert_contains "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "codex_no_updater_cleanup_user_enablement_links"
 }
 
 test_pacman_builder_without_updater_transition_hook() {
@@ -2376,6 +2451,7 @@ main() {
     test_deb_builder_smoke
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater
+    test_no_updater_cleanup_helper_removes_inactive_user_enablement
     test_rpm_builder_smoke
     test_pacman_builder_without_updater_transition_hook
     test_missing_input_failure


### PR DESCRIPTION
Fixes #159.

## Summary

- Add `PACKAGE_WITH_UPDATER=0` for `make deb`, `make rpm`, `make pacman`, and `make package`.
- Omit updater-specific package artifacts when disabled: `codex-update-manager`, the user service unit, updater polkit policy, `/opt/codex-desktop/update-builder`, updater desktop actions, and packaged-runtime updater startup checks.
- Add no-updater transition cleanup for DEB/RPM/Pacman upgrades from an updater-enabled package: stop/disable any existing `codex-update-manager.service` for active user managers, remove stale per-user enablement links for inactive users, and reload active user managers without depending on `update-builder`.
- Document the manual `git pull --ff-only` + rebuild + package workflow.
- Add smoke and package-content checks for the no-updater mode while preserving the existing default updater package path.

## User-visible behavior

Default packages keep the current automatic updater behavior. Users with stricter local policy can build and install a package with:

```bash
PACKAGE_WITH_UPDATER=0 make package
make install
```

Manual updates can then be driven from a trusted checkout:

```bash
git pull --ff-only
make build-app
PACKAGE_WITH_UPDATER=0 make package
make install
```

Installing a no-updater package over a default package also cleans up any already-running/enabled updater service for active user managers, and removes stale `default.target.wants/codex-update-manager.service` links for users who do not have an active user manager during the upgrade.

## Validation

- `bash -n scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/ci/container-entrypoint.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `PACKAGE_WITH_UPDATER=0 make deb` with a fake `cargo` first in `PATH`, verifying the updater build is skipped
- Real `dpkg-deb` no-updater archive inspection, verifying updater binary, service unit, polkit policy, and update-builder are absent, and postinst/prerm transition cleanup hooks are present
- Generated no-updater maintainer scripts pass `sh -n`
- Unit smoke covers no-updater RPM staging and script content
- Smoke covers inactive-user stale enablement link cleanup with fake `getent`/`runuser`
- `git diff --check`
