### PR TITLE
Fix install when upstream marketplace omits chrome plugin

### DIFF
--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -682,10 +682,22 @@ if (includeBrowser) {
 
 if (includeChrome) {
   const chrome = sourcePlugins.find((plugin) => plugin.name === "chrome");
-  if (chrome == null) {
-    throw new Error("Bundled marketplace does not contain chrome plugin");
+  if (chrome != null) {
+    plugins.push(chrome);
+  } else {
+    plugins.push({
+      name: "chrome",
+      source: {
+        source: "local",
+        path: "./plugins/chrome",
+      },
+      policy: {
+        installation: "AVAILABLE",
+        authentication: "ON_INSTALL",
+      },
+      category: "Productivity",
+    });
   }
-  plugins.push(chrome);
 }
 
 if (includeComputerUse) {

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -685,8 +685,34 @@ if (includeChrome) {
   if (chrome != null) {
     plugins.push(chrome);
   } else {
+    let name = "chrome";
+    let category = "Productivity";
+    const stagedManifestPath = path.join(
+      path.dirname(destinationPath),
+      "..",
+      "..",
+      "plugins",
+      "chrome",
+      ".codex-plugin",
+      "plugin.json",
+    );
+    try {
+      const manifest = JSON.parse(fs.readFileSync(stagedManifestPath, "utf8"));
+      if (typeof manifest.name === "string" && manifest.name.length > 0) {
+        name = manifest.name;
+      }
+      const manifestCategory =
+        manifest && manifest.interface ? manifest.interface.category : undefined;
+      if (typeof manifestCategory === "string" && manifestCategory.length > 0) {
+        category = manifestCategory;
+      }
+    } catch (_err) {
+      // Fall through to defaults when the staged plugin manifest is
+      // missing or malformed — stage_chrome_plugin_from_upstream only
+      // existence-checks plugin.json, so it can still be unparseable here.
+    }
     plugins.push({
-      name: "chrome",
+      name,
       source: {
         source: "local",
         path: "./plugins/chrome",
@@ -695,7 +721,7 @@ if (includeChrome) {
         installation: "AVAILABLE",
         authentication: "ON_INSTALL",
       },
-      category: "Productivity",
+      category,
     });
   }
 }

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1198,6 +1198,54 @@ test_chrome_plugin_staging() {
     assert_contains "$output_log" "Chrome plugin staged from upstream DMG"
 }
 
+test_chrome_marketplace_fallback_synthesis() {
+    info "Checking Chrome marketplace fallback synthesis when upstream omits chrome"
+    local workspace="$TMP_DIR/chrome-marketplace-fallback"
+    local app_dir="$workspace/Codex.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_chrome_upstream_app "$app_dir"
+
+    # Upstream marketplace.json lists no chrome entry — exercises the
+    # synthesized-fallback path in write_bundled_plugins_marketplace.
+    cat > "$app_dir/Contents/Resources/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
+{"plugins":[{"name":"browser-use","source":{"source":"local","path":"./plugins/browser-use"},"policy":{"installation":"AVAILABLE"}}]}
+JSON
+
+    # Distinctive name + category prove the synthesized entry actually
+    # reads the staged plugin.json rather than reusing hardcoded values.
+    cat > "$app_dir/Contents/Resources/plugins/openai-bundled/plugins/chrome/.codex-plugin/plugin.json" <<'JSON'
+{"name":"chrome-fallback-test","version":"9.9.9","interface":{"category":"FallbackCategory"}}
+JSON
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$marketplace"
+    assert_contains "$marketplace" '"name": "chrome-fallback-test"'
+    assert_contains "$marketplace" '"category": "FallbackCategory"'
+    assert_contains "$marketplace" '"path": "./plugins/chrome"'
+    assert_contains "$marketplace" '"installation": "AVAILABLE"'
+    assert_contains "$marketplace" '"authentication": "ON_INSTALL"'
+    assert_not_contains "$marketplace" "Bundled marketplace does not contain chrome plugin"
+}
+
 test_chrome_native_host_manifest_writer() {
     info "Checking Chrome native host manifest writer"
     local workspace="$TMP_DIR/chrome-native-host-manifest"
@@ -2464,6 +2512,7 @@ main() {
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility
     test_chrome_plugin_staging
+    test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_template_sanity
     test_side_by_side_launcher_identity


### PR DESCRIPTION
## Summary

- Upstream `Codex.dmg` no longer lists the `chrome` plugin in `plugins/openai-bundled/.agents/plugins/marketplace.json`, but the plugin directory is still shipped under `plugins/openai-bundled/plugins/chrome/`. `install.sh` was staging the directory successfully and then throwing in `write_bundled_plugins_marketplace` (`scripts/lib/bundled-plugins.sh`) because the source registry has no `name === "chrome"` entry, blocking the whole install with `Error: Bundled marketplace does not contain chrome plugin`.
- Mirror the existing `computer-use` handling in the same function: when the upstream marketplace omits chrome, synthesize a local-source entry. `name` and `category` are read from the staged chrome plugin's `.codex-plugin/plugin.json`, with a try/catch falling through to `"chrome"` / `"Productivity"` defaults if that manifest is missing or malformed. `source.path` and `policy` stay hardcoded because they are marketplace-registration concerns (where the plugin sits in the staged tree, and what policy this installer applies) rather than plugin-manifest concerns. The fallback silently goes unused if upstream re-adds the entry, so the change is forward-compatible.

## Test plan

- [x] `TMPDIR="$HOME/.cache/codex-desktop/tmp" ./install.sh` against the current upstream DMG completes — previously failed at this step.
- [x] Generated `codex-app/resources/plugins/openai-bundled/.agents/plugins/marketplace.json` contains all three of `browser-use`, `chrome`, and `computer-use`.
- [x] New `test_chrome_marketplace_fallback_synthesis` in `tests/scripts_smoke.sh`: with the upstream marketplace stripped of its chrome entry and the staged `plugin.json` containing distinctive `name="chrome-fallback-test"` / `category="FallbackCategory"` values, the resulting marketplace.json contains exactly those values — proving the synthesized entry reads `plugin.json` rather than reusing defaults.
- [x] Forward-compat (isolated): when fed a `marketplace.json` that does contain a chrome entry, the function uses the upstream entry verbatim and does not fall through to the synthesized path.
- [x] Defensive fallback (isolated): when the staged `plugin.json` is malformed JSON, the synthesized entry falls through to hardcoded `chrome` / `Productivity` rather than throwing.
- [x] Pre-fix simulation reproduces the original `Error: Bundled marketplace does not contain chrome plugin` throw on the same input, confirming the patch is what removes the failure.
- [ ] Manual launch of the resulting app and confirmation that the Chrome plugin appears in the in-app plugin list (recommend a maintainer with an end-to-end setup verify this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)