### PR TITLE
[codex] Use modern 7zz for Nix builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - The Chrome native-messaging host now evicts stale browser clients when a newer Codex browser client connects, preventing old Node REPL sessions from repeatedly reattaching CDP and driving extension service-worker CPU.
 - The bundled Chrome plugin is now auto-installed during app startup, matching Browser Use, so the plugin page no longer falls back to an install button after restart when the Linux native host is already staged.
+- Nix builds, installer apps, and dev shells now use modern `7zz`, and the installer dependency check accepts `7zz` without requiring a separate legacy `7z` binary.
 
 ## [0.7.1] - 2026-05-06
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,7 @@ PY
             pkgs.gnused
             pkgs.makeWrapper
             pkgs.nodejs
-            pkgs.p7zip
+            pkgs._7zz
             pkgs.patchelf
             pkgs.python3
             pkgs.unzip
@@ -202,7 +202,7 @@ PY
 
           outputHashAlgo = "sha256";
           outputHashMode = "recursive";
-          outputHash = "sha256-am6vffCgLeArVmji3tcK5YhdU19fYT+pjO23Vv7rIzI=";
+          outputHash = "sha256-70GGJ1swnU3yywp+T7qO0ZzlmRcYHkV5uEngzuZ79TI=";
           unsafeDiscardReferences.out = true;
 
           dontConfigure = true;
@@ -344,7 +344,7 @@ NODE
             pkgs.bash
             pkgs.nodejs
             pkgs.python3
-            pkgs.p7zip
+            pkgs._7zz
             pkgs.curl
             pkgs.unzip
             pkgs.gnumake
@@ -400,7 +400,7 @@ NODE
           packages = [
             pkgs.nodejs
             pkgs.python3
-            pkgs.p7zip
+            pkgs._7zz
             pkgs.curl
             pkgs.unzip
             pkgs.gnumake

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -148,9 +148,12 @@ prepare_install() {
 # ---- Check dependencies ----
 check_deps() {
     local missing=()
-    for cmd in python3 7z curl unzip tar; do
+    for cmd in python3 curl unzip tar; do
         command -v "$cmd" &>/dev/null || missing+=("$cmd")
     done
+    if ! command -v 7zz &>/dev/null && ! command -v 7z &>/dev/null; then
+        missing+=("7z or 7zz")
+    fi
     if [ ${#missing[@]} -ne 0 ]; then
         error "Missing dependencies: ${missing[*]}
 $(dependency_help)"


### PR DESCRIPTION
## Summary

- use Nixpkgs' modern `7zz` package instead of legacy `p7zip` in the Nix payload build, installer app, and dev shell
- allow the installer dependency check to pass when `7zz` is available without a separate `7z` binary
- refresh the fixed-output payload hash after the Nix source change

## Why

The installer already prefers `7zz` because newer APFS DMGs require a modern 7-Zip. Nixpkgs' `_7zz` package only exposes the `7zz` binary, so the previous dependency check still failed before the installer could select it.

## Validation

- `nix develop .#default -c bash -lc 'set -e; command -v 7zz; if command -v 7z >/dev/null; then echo "unexpected 7z on PATH" >&2; exit 1; fi'`
- `nix build .#installer --no-link`
- `nix shell nixpkgs#{_7zz,python3,curl,unzip,gnutar,gnumake,gcc} --command bash -lc 'set -euo pipefail; tmp=$(mktemp -d); export SCRIPT_DIR=$PWD WORK_DIR=$tmp; source scripts/lib/install-helpers.sh; check_deps; rm -rf "$tmp"'`
- `nix build .#default --no-link`
