### PR TITLE
Fix Electron 42 better-sqlite3 rebuild

### DIFF
--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -24,6 +24,92 @@ better_sqlite3_build_version() {
     echo "$detected_version"
 }
 
+patch_better_sqlite3_for_v8_external_pointer_api() {
+    local module_dir="$1"
+    local electron_major="${ELECTRON_VERSION%%.*}"
+
+    case "$electron_major" in
+        ""|*[!0-9]*) return 0 ;;
+    esac
+    [ "$electron_major" -ge 42 ] || return 0
+
+    [ -d "$module_dir" ] || error "better-sqlite3 source not found at $module_dir"
+
+    node - "$module_dir" <<'JS'
+const fs = require("fs");
+const path = require("path");
+
+const moduleDir = process.argv[2];
+const files = {
+  main: path.join(moduleDir, "src/better_sqlite3.cpp"),
+  helpers: path.join(moduleDir, "src/util/helpers.cpp"),
+  macros: path.join(moduleDir, "src/util/macros.cpp"),
+};
+
+for (const [name, file] of Object.entries(files)) {
+  if (!fs.existsSync(file)) {
+    throw new Error(`Missing better-sqlite3 ${name} source: ${file}`);
+  }
+}
+
+function replaceOnce(file, needle, replacement) {
+  const source = fs.readFileSync(file, "utf8");
+  if (source.includes(replacement)) {
+    return false;
+  }
+  if (!source.includes(needle)) {
+    throw new Error(`Could not find better-sqlite3 V8 external pointer patch needle in ${file}`);
+  }
+  fs.writeFileSync(file, source.replace(needle, replacement));
+  return true;
+}
+
+let patched = false;
+patched = replaceOnce(
+  files.main,
+  "v8::Local<v8::External> data = v8::External::New(isolate, addon);",
+  "v8::Local<v8::External> data = BETTER_SQLITE3_EXTERNAL_NEW(isolate, addon);",
+) || patched;
+
+patched = replaceOnce(
+  files.macros,
+  `#define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
+#define OnlyIsolate info.GetIsolate()
+#define OnlyContext isolate->GetCurrentContext()
+#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())`,
+  `#if defined(V8_MAJOR_VERSION) && V8_MAJOR_VERSION >= 14
+#define BETTER_SQLITE3_EXTERNAL_POINTER_TAG v8::kExternalPointerTypeTagDefault
+#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value), BETTER_SQLITE3_EXTERNAL_POINTER_TAG)
+#define BETTER_SQLITE3_EXTERNAL_VALUE(external) ((external)->Value(BETTER_SQLITE3_EXTERNAL_POINTER_TAG))
+#else
+#define BETTER_SQLITE3_EXTERNAL_NEW(isolate, value) v8::External::New((isolate), (value))
+#define BETTER_SQLITE3_EXTERNAL_VALUE(external) ((external)->Value())
+#endif
+
+#define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
+#define OnlyIsolate info.GetIsolate()
+#define OnlyContext isolate->GetCurrentContext()
+#define OnlyAddon static_cast<Addon*>(BETTER_SQLITE3_EXTERNAL_VALUE(info.Data().As<v8::External>()))`,
+) || patched;
+
+patched = replaceOnce(
+  files.helpers,
+  `\t\tfunc,
+\t\t0,
+\t\tdata`,
+  `\t\tfunc,
+\t\tnullptr,
+\t\tdata`,
+) || patched;
+
+if (patched) {
+  console.error("[INFO] Patched better-sqlite3 source for V8 external pointer API");
+} else {
+  console.error("[INFO] better-sqlite3 V8 external pointer source patch already applied");
+}
+JS
+}
+
 prune_native_module_build_artifacts() {
     local module_dir="$1"
     local build_dir="$module_dir/build"
@@ -64,6 +150,7 @@ build_native_modules() {
     info "Installing fresh sources from npm..."
     npm install "electron@$ELECTRON_VERSION" --save-dev --ignore-scripts 2>&1 >&2
     npm install "better-sqlite3@$bs3_build_ver" "node-pty@$npty_ver" --ignore-scripts 2>&1 >&2
+    patch_better_sqlite3_for_v8_external_pointer_api "$build_dir/node_modules/better-sqlite3"
 
     info "Compiling for Electron v$ELECTRON_VERSION (this takes ~1 min)..."
     info "Using Electron headers: $ELECTRON_HEADERS_URL"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -5,6 +5,9 @@
 # shellcheck shell=bash
 
 # ---- Build native modules in a clean directory ----
+ELECTRON_REBUILD_PACKAGE="@electron/rebuild@4.0.4"
+ELECTRON_REBUILD_NODE_ABI_PACKAGE="node-abi@^4.31.0"
+
 version_lt() {
     [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n 1)" = "$1" ]
 }
@@ -148,15 +151,21 @@ build_native_modules() {
     echo '{"private":true}' > package.json
 
     info "Installing fresh sources from npm..."
-    npm install "electron@$ELECTRON_VERSION" --save-dev --ignore-scripts 2>&1 >&2
+    npm install \
+        "electron@$ELECTRON_VERSION" \
+        "$ELECTRON_REBUILD_PACKAGE" \
+        "$ELECTRON_REBUILD_NODE_ABI_PACKAGE" \
+        --save-dev \
+        --ignore-scripts 2>&1 >&2
     npm install "better-sqlite3@$bs3_build_ver" "node-pty@$npty_ver" --ignore-scripts 2>&1 >&2
     patch_better_sqlite3_for_v8_external_pointer_api "$build_dir/node_modules/better-sqlite3"
 
     info "Compiling for Electron v$ELECTRON_VERSION (this takes ~1 min)..."
     info "Using Electron headers: $ELECTRON_HEADERS_URL"
+    [ -x "$build_dir/node_modules/.bin/electron-rebuild" ] || error "electron-rebuild binary not found in native build toolchain"
     npm_config_disturl="$ELECTRON_HEADERS_URL" \
     NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
-    npx --yes @electron/rebuild -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
+    "$build_dir/node_modules/.bin/electron-rebuild" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
 
     info "Native modules built successfully"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -640,6 +640,54 @@ SCRIPT
     assert_contains "$workspace/output.log" "v22.22.2"
 }
 
+test_better_sqlite3_electron_42_source_patch() {
+    info "Checking better-sqlite3 Electron 42 source patch"
+    local workspace="$TMP_DIR/better-sqlite3-electron-42"
+    local module_dir="$workspace/node_modules/better-sqlite3"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$module_dir/src/util"
+    cat > "$module_dir/src/better_sqlite3.cpp" <<'CPP'
+void init(v8::Isolate* isolate, Addon* addon) {
+	v8::Local<v8::External> data = v8::External::New(isolate, addon);
+}
+CPP
+    cat > "$module_dir/src/util/macros.cpp" <<'CPP'
+#define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
+#define OnlyIsolate info.GetIsolate()
+#define OnlyContext isolate->GetCurrentContext()
+#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())
+CPP
+    cat > "$module_dir/src/util/helpers.cpp" <<'CPP'
+void SetPrototypeGetter() {
+	recv->InstanceTemplate()->SetNativeDataProperty(
+		InternalizedFromLatin1(isolate, name),
+		func,
+		0,
+		data
+	);
+}
+CPP
+
+    (
+        ELECTRON_VERSION="42.0.1"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/native-modules.sh"
+        patch_better_sqlite3_for_v8_external_pointer_api "$module_dir"
+        patch_better_sqlite3_for_v8_external_pointer_api "$module_dir"
+    ) > "$output_log" 2>&1
+
+    assert_contains "$module_dir/src/better_sqlite3.cpp" "BETTER_SQLITE3_EXTERNAL_NEW(isolate, addon)"
+    assert_contains "$module_dir/src/util/macros.cpp" "BETTER_SQLITE3_EXTERNAL_POINTER_TAG"
+    assert_contains "$module_dir/src/util/macros.cpp" "BETTER_SQLITE3_EXTERNAL_VALUE(info.Data().As<v8::External>())"
+    assert_contains "$module_dir/src/util/helpers.cpp" "nullptr"
+    assert_contains "$output_log" "Patched better-sqlite3 source for V8 external pointer API"
+    assert_contains "$output_log" "already applied"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -650,6 +698,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/scripts/lib/rebuild-report.sh" "write_rebuild_report_json"
     assert_contains "$REPO_DIR/install.sh" "MIN_BETTER_SQLITE3_VERSION_FOR_ELECTRON_41=\"12.9.0\""
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "better_sqlite3_build_version"
+    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "patch_better_sqlite3_for_v8_external_pointer_api"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "prune_native_module_build_artifacts"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'find "$build_dir" -type f ! -name'
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'find "$module_dir" -type f -name'
@@ -2460,6 +2509,7 @@ main() {
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata
     test_managed_node_runtime_source_install
+    test_better_sqlite3_electron_42_source_patch
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -688,6 +688,109 @@ CPP
     assert_contains "$output_log" "already applied"
 }
 
+test_native_module_rebuild_uses_local_electron_rebuild_toolchain() {
+    info "Checking native module rebuild uses local Electron rebuild toolchain"
+    local workspace="$TMP_DIR/native-module-rebuild-toolchain"
+    local app_dir="$workspace/app-extracted"
+    local fake_bin="$workspace/bin"
+    local toolchain_log="$workspace/toolchain.log"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$app_dir/node_modules/better-sqlite3" "$app_dir/node_modules/node-pty" "$fake_bin"
+    printf '%s\n' '{"version":"12.9.0"}' > "$app_dir/node_modules/better-sqlite3/package.json"
+    printf '%s\n' '{"version":"1.1.0"}' > "$app_dir/node_modules/node-pty/package.json"
+
+    cat > "$fake_bin/npm" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'npm %s\n' "$*" >> "$NATIVE_TOOLCHAIN_LOG"
+args=" $* "
+
+case "$args" in
+    *" @electron/rebuild@4.0.4 "*)
+        mkdir -p node_modules/.bin
+        cat > node_modules/.bin/electron-rebuild <<'REBUILD'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'electron-rebuild %s\n' "$*" >> "$NATIVE_TOOLCHAIN_LOG"
+mkdir -p node_modules/better-sqlite3/build/Release node_modules/node-pty/build/Release
+: > node_modules/better-sqlite3/build/Release/better_sqlite3.node
+: > node_modules/node-pty/build/Release/pty.node
+REBUILD
+        chmod +x node_modules/.bin/electron-rebuild
+        ;;
+esac
+
+case "$args" in
+    *" better-sqlite3@12.9.0 "*)
+        mkdir -p node_modules/better-sqlite3/src/util
+        printf '%s\n' '{"version":"12.9.0"}' > node_modules/better-sqlite3/package.json
+        cat > node_modules/better-sqlite3/src/better_sqlite3.cpp <<'CPP'
+void init(v8::Isolate* isolate, Addon* addon) {
+	v8::Local<v8::External> data = v8::External::New(isolate, addon);
+}
+CPP
+        cat > node_modules/better-sqlite3/src/util/macros.cpp <<'CPP'
+#define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
+#define OnlyIsolate info.GetIsolate()
+#define OnlyContext isolate->GetCurrentContext()
+#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())
+CPP
+        cat > node_modules/better-sqlite3/src/util/helpers.cpp <<'CPP'
+void SetPrototypeGetter() {
+	recv->InstanceTemplate()->SetNativeDataProperty(
+		InternalizedFromLatin1(isolate, name),
+		func,
+		0,
+		data
+	);
+}
+CPP
+        ;;
+esac
+
+case "$args" in
+    *" node-pty@1.1.0 "*)
+        mkdir -p node_modules/node-pty
+        printf '%s\n' '{"version":"1.1.0"}' > node_modules/node-pty/package.json
+        ;;
+esac
+SCRIPT
+    chmod +x "$fake_bin/npm"
+
+    cat > "$fake_bin/npx" <<'SCRIPT'
+#!/usr/bin/env bash
+echo "npx should not be used for electron-rebuild" >&2
+exit 99
+SCRIPT
+    chmod +x "$fake_bin/npx"
+
+    (
+        PATH="$fake_bin:$PATH"
+        export PATH
+        NATIVE_TOOLCHAIN_LOG="$toolchain_log"
+        export NATIVE_TOOLCHAIN_LOG
+        WORK_DIR="$workspace/work"
+        ELECTRON_VERSION="42.0.1"
+        ELECTRON_HEADERS_URL="https://example.invalid/electron"
+        mkdir -p "$WORK_DIR"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/native-modules.sh"
+        build_native_modules "$app_dir"
+    ) > "$output_log" 2>&1
+
+    assert_contains "$toolchain_log" "@electron/rebuild@4.0.4"
+    assert_contains "$toolchain_log" "node-abi@^4.31.0"
+    assert_contains "$toolchain_log" "electron-rebuild -v 42.0.1 --force --dist-url https://example.invalid/electron"
+    assert_contains "$output_log" "Native modules built successfully"
+    assert_file_exists "$app_dir/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+    assert_file_exists "$app_dir/node_modules/node-pty/build/Release/pty.node"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -699,6 +802,10 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/install.sh" "MIN_BETTER_SQLITE3_VERSION_FOR_ELECTRON_41=\"12.9.0\""
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "better_sqlite3_build_version"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "patch_better_sqlite3_for_v8_external_pointer_api"
+    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "@electron/rebuild@4.0.4"
+    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "node-abi@^4.31.0"
+    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'node_modules/.bin/electron-rebuild'
+    assert_not_contains "$REPO_DIR/scripts/lib/native-modules.sh" "npx --yes @electron/rebuild"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "prune_native_module_build_artifacts"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'find "$build_dir" -type f ! -name'
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'find "$module_dir" -type f -name'
@@ -2510,6 +2617,7 @@ main() {
     test_installer_keeps_electron_fallback_for_bad_metadata
     test_managed_node_runtime_source_install
     test_better_sqlite3_electron_42_source_patch
+    test_native_module_rebuild_uses_local_electron_rebuild_toolchain
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility


### PR DESCRIPTION
Fixes #186.

## Summary

- Patch freshly installed `better-sqlite3` sources before native rebuilds when the detected Electron major is 42 or newer.
- Add V8 14-compatible wrappers for `v8::External::New()` / `Value()` and disambiguate the `SetNativeDataProperty()` no-setter argument.
- Add a smoke fixture that applies the source patch twice to cover both first-run and idempotent rebuild behavior.

## Root Cause

The current upstream DMG now ships Electron `42.0.1`, but its bundled `better-sqlite3@12.9.0` source still uses the old V8 external pointer API. The latest npm release, `better-sqlite3@12.10.0`, still has the same source shape, so bumping the minimum package version is not enough to unblock `make build-app`.

## Validation

- `make build-app`
- isolated `better-sqlite3@12.9.0` rebuild against Electron `42.0.1` headers after applying the installer patch
- `bash -n scripts/lib/native-modules.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
