### PR TITLE
[codex] Add experimental Linux mobile remote control feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Anything systemd-based should work for the optional auto-updater service (`syste
 | Linux browser annotations | ✅ always | Stored-anchor screenshots, isolated marker rendering |
 | Chrome plugin native host | ✅ always | Auto-installs the upstream Chrome plugin plus Linux native-messaging support for Chrome, Brave, and Chromium |
 | Linux Computer Use | ⚠️ opt-in | MCP backend registers by default; the in-app UI is opt-in. Supports screenshots, accessibility, window targeting, and input synthesis |
+| Mobile remote control host | 🧪 opt-in experiment | SSH remote projects work normally. Phone/Android host access is upstream macOS-only by default; `linux-features/remote-mobile-control` adds experimental Linux device-key, visibility, and host-enablement patches |
 | Server-gated features (e.g. `gpt-5.5`) | 🟡 server-side | OpenAI rolls per-account, not project-controlled. Building a fresh package does not unlock these. |
 
 ## Before you install

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -1,0 +1,43 @@
+# Experimental Remote Mobile Control
+
+This feature is disabled by default. It patches the upstream Codex Desktop main
+bundle so Linux can try the mobile remote-control host flow that upstream
+currently limits to macOS.
+
+Enable it by adding the feature id to `linux-features/features.json` before
+building:
+
+```json
+{
+  "enabled": [
+    "remote-mobile-control"
+  ]
+}
+```
+
+What it changes:
+
+- Replaces the macOS-only `remote-control-device-key.node` requirement with a
+  Linux JavaScript ECDSA P-256 key provider.
+- Lets the remote-control Connections UI render on Linux when upstream marks
+  the feature unavailable or withholds the remote-control visibility rollout.
+- Persists the private key material at
+  `~/.config/codex-desktop/remote-control-device-keys-v1.json` with `0600`
+  file permissions.
+- Preserves `remote_control = true` / `features.remote_control = true` in the
+  local Codex config instead of letting upstream strip it before app-server
+  startup.
+
+Known risks:
+
+- This is not equivalent to macOS Secure Enclave-backed storage. Private key
+  material is file-backed and protected by ordinary user file permissions.
+- OpenAI may still reject Linux host enrollment server-side. This feature only
+  removes local macOS-only blockers in the repackaged app.
+- Treat this as experimental account-level remote-control plumbing.
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/remote-mobile-control/test.js
+```

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -34,13 +34,6 @@ Known risks:
   material is file-backed and protected by ordinary user file permissions.
 - OpenAI may still reject Linux host enrollment server-side. This feature only
   removes local macOS-only blockers in the repackaged app.
-- Mobile projectless chats currently start from a generated local Desktop
-  directory such as `~/Documents/Codex/<date>-<prompt>`. SSH execution
-  environments from `~/.codex/environments.toml` can be selected, but they
-  inherit that local cwd. If the remote host does not have the same path, the
-  remote exec-server rejects shell startup and Codex falls back to the local
-  environment. This feature does not yet bridge Desktop SSH project state
-  (`remote-projects`) into the mobile remote-control thread cwd.
 - Treat this as experimental account-level remote-control plumbing.
 
 Run the feature tests with:

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -34,6 +34,13 @@ Known risks:
   material is file-backed and protected by ordinary user file permissions.
 - OpenAI may still reject Linux host enrollment server-side. This feature only
   removes local macOS-only blockers in the repackaged app.
+- Mobile projectless chats currently start from a generated local Desktop
+  directory such as `~/Documents/Codex/<date>-<prompt>`. SSH execution
+  environments from `~/.codex/environments.toml` can be selected, but they
+  inherit that local cwd. If the remote host does not have the same path, the
+  remote exec-server rejects shell startup and Codex falls back to the local
+  environment. This feature does not yet bridge Desktop SSH project state
+  (`remote-projects`) into the mobile remote-control thread cwd.
 - Treat this as experimental account-level remote-control plumbing.
 
 Run the feature tests with:

--- a/linux-features/remote-mobile-control/feature.json
+++ b/linux-features/remote-mobile-control/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "remote-mobile-control",
+  "title": "Experimental Remote Mobile Control",
+  "description": "Opt-in Linux patches for Codex mobile remote-control host enrollment.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -1,0 +1,144 @@
+"use strict";
+
+function requireName(source, moduleName) {
+  const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\(\`${escaped}\`\\)`));
+  return match?.[1] ?? null;
+}
+
+const DEVICE_KEY_CLIENT_MARKER = "codexLinuxRemoteControlDeviceKeyClient";
+const DEVICE_KEY_GUARD =
+  "if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
+const DEVICE_KEY_GUARD_REPLACEMENT =
+  "if(process.platform===`linux`)return codexLinuxRemoteControlDeviceKeyClient();if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
+const REMOTE_CONTROL_VISIBILITY_NEEDLE =
+  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
+const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
+  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return(n||t)&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
+const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
+  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
+
+function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
+  return [
+    "function codexLinuxRemoteControlDeviceKeyStorePath(){",
+    `let e=process.env.XDG_CONFIG_HOME&&process.env.XDG_CONFIG_HOME.trim()?process.env.XDG_CONFIG_HOME.trim():process.env.HOME?${pathVar}.join(process.env.HOME,\`.config\`):null;`,
+    "if(e==null)throw Error(`Linux remote control device keys require HOME or XDG_CONFIG_HOME`);",
+    `${fsVar}.mkdirSync(${pathVar}.join(e,\`codex-desktop\`),{recursive:!0,mode:448});`,
+    `return ${pathVar}.join(e,\`codex-desktop\`,\`remote-control-device-keys-v1.json\`)`,
+    "}",
+    "function codexLinuxRemoteControlPublicDeviceKey(e){",
+    "return{algorithm:e.algorithm,keyId:e.keyId,protectionClass:e.protectionClass,publicKeySpkiDerBase64:e.publicKeySpkiDerBase64}",
+    "}",
+    "function codexLinuxReadRemoteControlDeviceKeyStore(){",
+    "let e=codexLinuxRemoteControlDeviceKeyStorePath();",
+    `if(!${fsVar}.existsSync(e))return{keys:{}};`,
+    "try{",
+    `let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));`,
+    "return t&&typeof t==`object`&&!Array.isArray(t)&&t.keys&&typeof t.keys==`object`&&!Array.isArray(t.keys)?t:{keys:{}}",
+    "}catch{return{keys:{}}}",
+    "}",
+    "function codexLinuxWriteRemoteControlDeviceKeyStore(e){",
+    "let t=codexLinuxRemoteControlDeviceKeyStorePath(),n=`${t}.tmp-${process.pid}-${Date.now()}`;",
+    `try{${fsVar}.writeFileSync(n,JSON.stringify(e,null,2)+\`\\n\`,{encoding:\`utf8\`,mode:384}),${fsVar}.chmodSync(n,384),${fsVar}.renameSync(n,t),${fsVar}.chmodSync(t,384)}catch(e){try{${fsVar}.rmSync(n,{force:!0})}catch{}throw e}`,
+    "}",
+    "function codexLinuxRemoteControlDeviceKeyClient(){return{",
+    "createDeviceKey:async e=>{",
+    "let t=codexLinuxReadRemoteControlDeviceKeyStore();",
+    `let{publicKey:n,privateKey:r}=(0,${cryptoVar}.generateKeyPairSync)(\`ec\`,{namedCurve:\`P-256\`});`,
+    `let i=(0,${cryptoVar}.randomUUID)(),a=n.export({type:\`spki\`,format:\`der\`}).toString(\`base64\`),o=r.export({type:\`pkcs8\`,format:\`pem\`});`,
+    "let c={algorithm:`ecdsa_p256_sha256`,keyId:i,protectionClass:`os_protected_nonextractable`,publicKeySpkiDerBase64:a,privateKeyPkcs8Pem:o,createdAt:new Date().toISOString()};",
+    "t.keys={...t.keys,[i]:c},codexLinuxWriteRemoteControlDeviceKeyStore(t);",
+    "return codexLinuxRemoteControlPublicDeviceKey(c)",
+    "},",
+    "deleteDeviceKey:async e=>{let t=codexLinuxReadRemoteControlDeviceKeyStore();t.keys&&delete t.keys[e],codexLinuxWriteRemoteControlDeviceKeyStore(t)},",
+    "getDeviceKeyPublic:async e=>{let t=codexLinuxReadRemoteControlDeviceKeyStore().keys?.[e];if(t==null)throw Error(`Linux remote control device key not found`);return codexLinuxRemoteControlPublicDeviceKey(t)},",
+    `signDeviceKey:async(e,t)=>{let n=codexLinuxReadRemoteControlDeviceKeyStore().keys?.[e];if(n==null)throw Error(\`Linux remote control device key not found\`);let r=(0,${cryptoVar}.createPrivateKey)(n.privateKeyPkcs8Pem),i=(0,${cryptoVar}.sign)(\`sha256\`,t,r).toString(\`base64\`);return{algorithm:n.algorithm,signatureDerBase64:i}}`,
+    "}}",
+  ].join("");
+}
+
+function applyLinuxRemoteControlDeviceKeyPatch(source) {
+  if (source.includes(DEVICE_KEY_CLIENT_MARKER)) {
+    return source;
+  }
+
+  const cryptoVar = requireName(source, "node:crypto");
+  const fsVar = requireName(source, "node:fs");
+  const pathVar = requireName(source, "node:path");
+  if (cryptoVar == null || fsVar == null || pathVar == null) {
+    console.warn("WARN: Could not find Node module aliases - skipping Linux remote-control device-key patch");
+    return source;
+  }
+
+  const insertionNeedle = "var bV=(0,b.createRequire)(__filename),xV=`remote-control-device-key.node`";
+  if (!source.includes(insertionNeedle) || !source.includes(DEVICE_KEY_GUARD)) {
+    console.warn("WARN: Could not find remote-control device-key bundle needles - skipping Linux remote-control device-key patch");
+    return source;
+  }
+
+  const provider = linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar });
+  return source
+    .replace(insertionNeedle, `${provider}${insertionNeedle}`)
+    .replace(DEVICE_KEY_GUARD, DEVICE_KEY_GUARD_REPLACEMENT);
+}
+
+function applyLinuxRemoteControlPreserveConfigPatch(source) {
+  const patchedNeedle =
+    "async function mV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`&&process.platform!==`linux`)try{";
+  if (source.includes(patchedNeedle)) {
+    return source;
+  }
+
+  const needle = "async function mV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{";
+  if (!source.includes(needle)) {
+    console.warn("WARN: Could not find remote-control config stripping needle - skipping Linux remote-control config patch");
+    return source;
+  }
+
+  return source.replace(needle, patchedNeedle);
+}
+
+function applyLinuxRemoteControlVisibilityPatch(source) {
+  if (source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT)) {
+    return source;
+  }
+  if (source.includes(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT)) {
+    return source.replace(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
+  }
+  if (!source.includes(REMOTE_CONTROL_VISIBILITY_NEEDLE)) {
+    console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
+    return source;
+  }
+  return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
+}
+
+module.exports = [
+  {
+    id: "linux-remote-control-device-key",
+    phase: "main-bundle",
+    order: 20_100,
+    ciPolicy: "optional",
+    apply: applyLinuxRemoteControlDeviceKeyPatch,
+  },
+  {
+    id: "linux-remote-control-preserve-config",
+    phase: "main-bundle",
+    order: 20_110,
+    ciPolicy: "optional",
+    apply: applyLinuxRemoteControlPreserveConfigPatch,
+  },
+  {
+    id: "linux-remote-control-visibility",
+    phase: "webview-asset",
+    pattern: /^remote-control-connections-visibility-.*\.js$/,
+    order: 20_120,
+    ciPolicy: "optional",
+    missingDescription: "remote-control connections visibility bundle",
+    skipDescription: "Linux remote-control visibility patch",
+    apply: applyLinuxRemoteControlVisibilityPatch,
+  },
+];
+
+module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
+module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
+module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  createPatchReport,
+  patchExtractedApp,
+  patchMainBundleSource,
+} = require("../../scripts/patch-linux-window-ui.js");
+const {
+  applyLinuxRemoteControlDeviceKeyPatch,
+  applyLinuxRemoteControlPreserveConfigPatch,
+  applyLinuxRemoteControlVisibilityPatch,
+} = require("./patch.js");
+
+function syntheticMainBundle() {
+  return [
+    "let i=require(`node:path`),o=require(`node:fs`),s=require(`node:crypto`),b={createRequire:()=>()=>({})};",
+    "function TV(e){return Buffer.from(JSON.stringify(e),`utf8`)}",
+    "var bV=(0,b.createRequire)(__filename),xV=`remote-control-device-key.node`,SV=`codex-device-key-sign-payload/v1`;",
+    "function wV({resourcesPath:e}){let t=null,n=()=>{if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=bV(i.join(e,`native`,xV)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=TV(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
+    "async function mV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{await hV(i.default.join(e??t.Rr({hostConfig:n,preferWsl:t.Kr(n)}),pV))&&r.info(`Removed remote_control from config before app-server start`)}catch(e){r.warning(`Failed to remove remote_control before app-server start`,{safe:{},sensitive:{error:e}})}}",
+  ].join("");
+}
+
+function syntheticVisibilityBundle() {
+  return "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{a as t};";
+}
+
+function withTempFeatureRoot(enabled, fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-feature-test-"));
+  try {
+    fs.writeFileSync(path.join(root, "features.example.json"), JSON.stringify({ enabled: [] }, null, 2));
+    fs.writeFileSync(path.join(root, "features.json"), JSON.stringify({ enabled }, null, 2));
+    fs.cpSync(__dirname, path.join(root, "remote-mobile-control"), { recursive: true });
+    return fn(root);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function withFeatureRootEnv(root, fn) {
+  const previous = process.env.CODEX_LINUX_FEATURES_ROOT;
+  process.env.CODEX_LINUX_FEATURES_ROOT = root;
+  try {
+    return fn();
+  } finally {
+    if (previous == null) {
+      delete process.env.CODEX_LINUX_FEATURES_ROOT;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_ROOT = previous;
+    }
+  }
+}
+
+test("remote mobile control feature stays disabled until listed in features.json", () => {
+  withTempFeatureRoot([], (root) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
+  });
+});
+
+test("remote mobile control feature exposes opt-in main-bundle and webview patches", () => {
+  withTempFeatureRoot(["remote-mobile-control"], (root) => {
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
+    assert.deepEqual(descriptors.map((descriptor) => descriptor.id), [
+      "feature:remote-mobile-control:linux-remote-control-device-key",
+      "feature:remote-mobile-control:linux-remote-control-preserve-config",
+      "feature:remote-mobile-control:linux-remote-control-visibility",
+    ]);
+    assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
+      "main-bundle",
+      "main-bundle",
+      "webview-asset",
+    ]);
+  });
+});
+
+test("Linux remote-control patches update the device-key provider and preserve config", () => {
+  const source = syntheticMainBundle();
+  const patched = applyLinuxRemoteControlPreserveConfigPatch(
+    applyLinuxRemoteControlDeviceKeyPatch(source),
+  );
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlDeviceKeyClient/);
+  assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
+  assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
+  assert.equal(
+    applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)),
+    patched,
+  );
+});
+
+test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
+  const source = syntheticVisibilityBundle();
+  const patched = applyLinuxRemoteControlVisibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
+  assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("patched Linux device-key provider can create, sign with, and delete a key", async () => {
+  const configHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-key-store-"));
+  try {
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const context = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: { XDG_CONFIG_HOME: configHome },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, context);
+    const client = context.module.exports;
+    const created = await client.createDeviceKey("allow_os_protected_nonextractable");
+    assert.equal(created.algorithm, "ecdsa_p256_sha256");
+    assert.equal(created.protectionClass, "os_protected_nonextractable");
+    assert.match(created.publicKeySpkiDerBase64, /^[A-Za-z0-9+/]+=*$/);
+
+    const readBack = await client.getDeviceKeyPublic(created.keyId);
+    assert.deepEqual(readBack, created);
+
+    const signature = await client.signDeviceKey(created.keyId, {
+      type: "remoteControlClientEnrollment",
+      nonce: "test",
+    });
+    assert.equal(signature.algorithm, "ecdsa_p256_sha256");
+    assert.match(signature.signatureDerBase64, /^[A-Za-z0-9+/]+=*$/);
+    assert.match(signature.signedPayloadBase64, /^[A-Za-z0-9+/]+=*$/);
+
+    const storePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    assert.equal(fs.statSync(storePath).mode & 0o777, 0o600);
+
+    await client.deleteDeviceKey(created.keyId);
+    await assert.rejects(() => client.getDeviceKeyPublic(created.keyId), /not found/);
+  } finally {
+    fs.rmSync(configHome, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile control feature participates in ASAR patching and reports", () => {
+  withTempFeatureRoot(["remote-mobile-control"], (root) => {
+    withFeatureRootEnv(root, () => {
+      const source = syntheticMainBundle();
+      const patched = patchMainBundleSource(source, null);
+      assert.match(patched, /codexLinuxRemoteControlDeviceKeyClient/);
+      assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
+
+      const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-app-"));
+      try {
+        const buildDir = path.join(tempApp, ".vite", "build");
+        const assetsDir = path.join(tempApp, "webview", "assets");
+        fs.mkdirSync(buildDir, { recursive: true });
+        fs.mkdirSync(assetsDir, { recursive: true });
+        fs.writeFileSync(path.join(buildDir, "main.js"), source);
+        fs.writeFileSync(
+          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          syntheticVisibilityBundle(),
+        );
+
+        const report = createPatchReport();
+        patchExtractedApp(tempApp, { report });
+
+        const patchedFile = fs.readFileSync(path.join(buildDir, "main.js"), "utf8");
+        const patchedVisibilityFile = fs.readFileSync(
+          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          "utf8",
+        );
+        assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
+        assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
+        assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-device-key" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-preserve-config" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-visibility" &&
+            patch.status === "applied",
+          ),
+        );
+      } finally {
+        fs.rmSync(tempApp, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #188.

Adds an opt-in `linux-features/remote-mobile-control` feature that lets Linux builds try the upstream Codex mobile remote-control host flow.

## What changed

- Adds an experimental Linux device-key provider for the upstream `remote-control-device-key.node` interface.
- Preserves `remote_control` / `features.remote_control` for local Linux app-server startup instead of letting the upstream main bundle strip it.
- Patches the remote-control Connections visibility chunk so Linux opt-in builds are not hidden by the upstream availability / rollout gates.
- Documents the feature as experimental and disabled by default, including the file-backed key storage risk.

## Why

The upstream macOS app ships the mobile remote-control UI and app-server plumbing, but Linux builds hit local macOS-only blockers before pairing can be attempted:

- the main bundle throws on non-macOS before loading a device-key implementation;
- local host config removes `remote_control` before app-server startup;
- the renderer hides the mobile remote-control Connections UI when upstream marks the feature unavailable or withholds the visibility rollout.

## Validation

- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- Rebuilt and launched the local Linux app with `remote-mobile-control` enabled, then verified the mobile section appears and phone pairing starts.

## Notes

This is intentionally opt-in. The Linux provider uses file-backed ECDSA P-256 key material protected by ordinary user file permissions, not macOS Secure Enclave-backed storage. Server-side enrollment policy may still reject some Linux hosts/accounts.