### PR TITLE
fix(nix): harden upstream hash refresh

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -8,9 +8,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-nix-upstream-hashes
+  cancel-in-progress: false
+
 jobs:
   update-hash:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       NIX_CONFIG: experimental-features = nix-command flakes
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-4FroU+UDXJSbB5FfjGhiGyXrQ/R+UYXuaYPoR7oXbyc=";
+          hash = "sha256-WTeptN8D9hF2ffvlJKppfLTOJr5Z0hjokHCnGX6drk0=";
         };
 
         electronLibs = with pkgs; [
@@ -202,7 +202,7 @@ PY
 
           outputHashAlgo = "sha256";
           outputHashMode = "recursive";
-          outputHash = "sha256-70GGJ1swnU3yywp+T7qO0ZzlmRcYHkV5uEngzuZ79TI=";
+          outputHash = "sha256-8IX6OpYitjbazWLUBi6h8iRDxOMir5Kdezry8OThM2Q=";
           unsafeDiscardReferences.out = true;
 
           dontConfigure = true;
@@ -240,8 +240,6 @@ PY
               --replace-fail "npx asar" "asar"
             substituteInPlace "$source_dir/scripts/lib/dmg.sh" \
               --replace-fail "npx --yes asar" "asar"
-            substituteInPlace "$source_dir/scripts/lib/native-modules.sh" \
-              --replace-fail "npx --yes @electron/rebuild" "electron-rebuild"
 
             export CODEX_INSTALL_DIR="$out/opt/codex-desktop"
             ${pkgs.bash}/bin/bash "$source_dir/install.sh" "$source_dir/Codex.dmg"

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -7,6 +7,7 @@ UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
+FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 validate_sri_hash() {
     local hash="$1"
@@ -100,13 +101,28 @@ run_nix_build() {
     local log_path="$1"
     rm -f "$log_path"
     set +e
-    nix build .#codex-desktop --no-link --print-build-logs 2>&1 | tee "$log_path"
-    local status="${PIPESTATUS[0]}"
+    nix build .#codex-desktop --no-link --print-build-logs >"$log_path" 2>&1
+    local status="$?"
     set -e
+    cat "$log_path"
     return "$status"
 }
 
+restore_flake_hashes() {
+    local dmg_hash="$1"
+    local payload_hash="$2"
+
+    if [ -n "$dmg_hash" ]; then
+        replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
+    fi
+    if [ -n "$payload_hash" ]; then
+        replace_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = " "$payload_hash"
+    fi
+}
+
 main() {
+    local current_dmg_hash=""
+    local current_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -125,24 +141,30 @@ main() {
     # for hashing instead of fetching the same 300MB artifact again.
     nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
 
+    current_payload_hash="$(read_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = ")"
+    echo "Current payload outputHash: $current_payload_hash"
+    echo "Forcing payload outputHash refresh..."
+    replace_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = " "$FAKE_SRI_HASH"
+
     if run_nix_build "$BUILD_LOG"; then
-        echo "Nix build succeeded with the current payload outputHash."
-        exit 0
+        echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash"
+        exit 1
     fi
 
     new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
     if [ -z "$new_payload_hash" ]; then
         echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_payload_hash"; then
         echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash"
         exit 1
     fi
 
-    current_payload_hash="$(read_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = ")"
-    echo "Current payload outputHash: $current_payload_hash"
     echo "Actual payload outputHash:  $new_payload_hash"
     replace_flake_hash "codexDesktopPayload = pkgs.stdenv.mkDerivation {" "outputHash = " "$new_payload_hash"
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -361,10 +361,15 @@ bootstrap_7zz() {
         return 0
     fi
 
-    # System 7z is already new enough — skip
-    if command -v 7z &>/dev/null && ! 7z 2>&1 | grep -m 1 "7-Zip" | grep -q "16.02"; then
-        info "System 7z is already new enough; skipping 7zz bootstrap"
-        return 0
+    # System 7z is already new enough — skip. p7zip 17.05 still cannot
+    # extract current APFS-based Codex DMGs, so only accept non-p7zip 7z.
+    if command -v 7z &>/dev/null; then
+        local seven_zip_banner
+        seven_zip_banner="$(7z 2>&1 | head -n 3 || true)"
+        if [[ "$seven_zip_banner" == *"7-Zip"* && "$seven_zip_banner" != *"16.02"* && "$seven_zip_banner" != *"p7zip Version"* ]]; then
+            info "System 7z is already new enough; skipping 7zz bootstrap"
+            return 0
+        fi
     fi
 
     local sevenzip_arch

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -172,9 +172,9 @@ $(dependency_help)"
     fi
 
     local seven_zip_banner
-    seven_zip_banner="$("$SEVEN_ZIP_CMD" 2>&1 | grep -m 1 "7-Zip" || true)"
-    if [[ "$seven_zip_banner" == *"16.02"* ]]; then
-        error "System 7-zip is too old for modern APFS DMGs.
+    seven_zip_banner="$("$SEVEN_ZIP_CMD" 2>&1 | head -n 3 || true)"
+    if [[ "$seven_zip_banner" == *"16.02"* || "$seven_zip_banner" == *"p7zip Version"* ]]; then
+        error "System 7-zip is too old for modern APFS DMGs or lacks APFS support.
 Install a newer 7zz first by running:
   bash scripts/install-deps.sh
 

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -162,10 +162,10 @@ build_native_modules() {
 
     info "Compiling for Electron v$ELECTRON_VERSION (this takes ~1 min)..."
     info "Using Electron headers: $ELECTRON_HEADERS_URL"
-    [ -x "$build_dir/node_modules/.bin/electron-rebuild" ] || error "electron-rebuild binary not found in native build toolchain"
+    [ -f "$build_dir/node_modules/@electron/rebuild/lib/cli.js" ] || error "electron-rebuild CLI not found in native build toolchain"
     npm_config_disturl="$ELECTRON_HEADERS_URL" \
     NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
-    "$build_dir/node_modules/.bin/electron-rebuild" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
+    node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
 
     info "Native modules built successfully"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -709,16 +709,16 @@ args=" $* "
 
 case "$args" in
     *" @electron/rebuild@4.0.4 "*)
-        mkdir -p node_modules/.bin
-        cat > node_modules/.bin/electron-rebuild <<'REBUILD'
-#!/usr/bin/env bash
-set -euo pipefail
-printf 'electron-rebuild %s\n' "$*" >> "$NATIVE_TOOLCHAIN_LOG"
-mkdir -p node_modules/better-sqlite3/build/Release node_modules/node-pty/build/Release
-: > node_modules/better-sqlite3/build/Release/better_sqlite3.node
-: > node_modules/node-pty/build/Release/pty.node
+        mkdir -p node_modules/@electron/rebuild/lib
+        cat > node_modules/@electron/rebuild/lib/cli.js <<'REBUILD'
+#!/usr/bin/env node
+const fs = require("fs");
+fs.appendFileSync(process.env.NATIVE_TOOLCHAIN_LOG, `electron-rebuild ${process.argv.slice(2).join(" ")}\n`);
+fs.mkdirSync("node_modules/better-sqlite3/build/Release", { recursive: true });
+fs.mkdirSync("node_modules/node-pty/build/Release", { recursive: true });
+fs.closeSync(fs.openSync("node_modules/better-sqlite3/build/Release/better_sqlite3.node", "w"));
+fs.closeSync(fs.openSync("node_modules/node-pty/build/Release/pty.node", "w"));
 REBUILD
-        chmod +x node_modules/.bin/electron-rebuild
         ;;
 esac
 
@@ -804,7 +804,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "patch_better_sqlite3_for_v8_external_pointer_api"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "@electron/rebuild@4.0.4"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "node-abi@^4.31.0"
-    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'node_modules/.bin/electron-rebuild'
+    assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'node_modules/@electron/rebuild/lib/cli.js'
     assert_not_contains "$REPO_DIR/scripts/lib/native-modules.sh" "npx --yes @electron/rebuild"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" "prune_native_module_build_artifacts"
     assert_contains "$REPO_DIR/scripts/lib/native-modules.sh" 'find "$build_dir" -type f ! -name'


### PR DESCRIPTION
## Summary

This hardens the Nix upstream hash refresh path for the current mutable Codex DMG.

- refreshes the pinned Codex.dmg and recursive payload hashes for the current upstream DMG
- forces the recursive fixed-output payload hash to be recomputed instead of letting Nix reuse a stale store path
- restores both hashes if the forced rebuild fails before a fixed-output mismatch is available
- rejects p7zip as APFS-capable in installer dependency checks and install-deps bootstrap logic
- removes a stale Nix substitution for `npx --yes @electron/rebuild`, which no longer exists in the current native-module rebuild path
- invokes the vendored Electron rebuild CLI through `node` so Nix builds do not depend on `/usr/bin/env`
- gives the scheduled hash updater workflow concurrency and a longer timeout

## Root cause

The old hash refresh script could update the DMG hash and then let Nix reuse an already-cached fixed-output `codexDesktopPayload` path with the old recursive output hash. That made the updater report success without actually rebuilding the payload from the new DMG. The latest upstream DMG also requires APFS-capable 7-Zip and exposed a couple of stale assumptions in the Nix native-module path.

## Validation

- `scripts/ci/update-nix-hashes.sh`
- `nix build .#codex-desktop --no-link --print-build-logs` via the hash refresh verification pass
- `tests/scripts_smoke.sh`
- `bash -n install.sh scripts/ci/update-nix-hashes.sh scripts/install-deps.sh scripts/lib/install-helpers.sh scripts/lib/native-modules.sh`
