### PR TITLE
[codex] Add Nix remote mobile control package

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -36,9 +36,10 @@ jobs:
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
-          PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopPayload = mkCodexDesktopPayload {' 'outputHash = ')"
-          COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {' 'outputHash = ')"
-          REMOTE_MOBILE_CONTROL_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {' 'outputHash = ')"
+          PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktop = mkCodexDesktop {' 'payloadHash = ')"
+          COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUi = mkCodexDesktop {' 'payloadHash = ')"
+          REMOTE_MOBILE_CONTROL_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopRemoteMobileControl = mkCodexDesktop {' 'payloadHash = ')"
+          COMBINED_FEATURES_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {' 'payloadHash = ')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -46,8 +47,9 @@ jobs:
           git commit \
             -m "fix(nix): update upstream Nix hashes" \
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
-            -m "Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH." \
-            -m "Refreshed codexDesktopComputerUseUiPayload recursive outputHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
-            -m "Refreshed codexDesktopRemoteMobileControlPayload recursive outputHash to $REMOTE_MOBILE_CONTROL_PAYLOAD_HASH." \
+            -m "Refreshed codexDesktop recursive payloadHash to $PAYLOAD_HASH." \
+            -m "Refreshed codexDesktopComputerUseUi recursive payloadHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
+            -m "Refreshed codexDesktopRemoteMobileControl recursive payloadHash to $REMOTE_MOBILE_CONTROL_PAYLOAD_HASH." \
+            -m "Refreshed codexDesktopComputerUseUiRemoteMobileControl recursive payloadHash to $COMBINED_FEATURES_PAYLOAD_HASH." \
             -m "[skip ci]"
           git push origin main

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -38,6 +38,7 @@ jobs:
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
           PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopPayload = mkCodexDesktopPayload {' 'outputHash = ')"
           COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {' 'outputHash = ')"
+          REMOTE_MOBILE_CONTROL_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {' 'outputHash = ')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -47,5 +48,6 @@ jobs:
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
             -m "Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH." \
             -m "Refreshed codexDesktopComputerUseUiPayload recursive outputHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
+            -m "Refreshed codexDesktopRemoteMobileControlPayload recursive outputHash to $REMOTE_MOBILE_CONTROL_PAYLOAD_HASH." \
             -m "[skip ci]"
           git push origin main

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Because flakes do not include the git-ignored `linux-features/features.json` opt
 nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
 ```
 
+Feature-specific Nix outputs are additive. To enable both the Computer Use UI and experimental mobile remote control:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+```
+
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
 ## Linux Computer Use
@@ -166,6 +172,12 @@ Nix users can also run the opt-in flake output directly:
 
 ```bash
 nix run github:ilysenko/codex-desktop-linux#codex-desktop-computer-use-ui
+```
+
+The Computer Use UI output can also be combined with Linux feature outputs, for example:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
 ```
 
 ### Side-by-side dev variant

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ nix run github:ilysenko/codex-desktop-linux
 
 The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot refreshes the upstream `Codex.dmg` and recursive Nix payload hashes in `main`; if you hit a hash mismatch right after an upstream release, wait for the next bot run and retry.
 
+Because flakes do not include the git-ignored `linux-features/features.json` opt-in file, Nix exposes feature-specific app variants for optional integrations. To build and run Codex Desktop with the experimental mobile remote-control feature enabled:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
+```
+
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
 ## Linux Computer Use

--- a/flake.nix
+++ b/flake.nix
@@ -184,12 +184,18 @@ PY
             enabled = linuxFeatureIds;
           });
 
-        packageSuffix = linuxFeatureIds:
-          if linuxFeatureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" linuxFeatureIds}";
+        enabledFeatureIds = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+          pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ] ++ linuxFeatureIds;
+
+        packageSuffix = args:
+          let
+            featureIds = enabledFeatureIds args;
+          in
+          if featureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" featureIds}";
 
         mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], outputHash }:
         pkgs.stdenv.mkDerivation {
-          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload${packageSuffix linuxFeatureIds}";
+          pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi linuxFeatureIds; }}-payload";
           version = "26.506.21252";
           src = sourceRoot;
           __structuredAttrs = true;
@@ -267,23 +273,16 @@ PY
           '';
         };
 
-        codexDesktopPayload = mkCodexDesktopPayload {
-          outputHash = "sha256-oikRvP+7uKLnue/Kt2QYi62+SGshTa+pa/bGgDF0/MU=";
-        };
-
-        codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {
-          enableComputerUseUi = true;
-          outputHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
-        };
-
-        codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {
-          linuxFeatureIds = [ "remote-mobile-control" ];
-          outputHash = "sha256-T7Vd20fWm7Yz5vNxC05H40rE8Oq3NFLErgxr/s/0mEk=";
-        };
-
-        mkCodexDesktop = { pname ? "codex-desktop", payload }:
+        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], payloadHash }:
+        let
+          featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
+          payload = mkCodexDesktopPayload {
+            inherit enableComputerUseUi linuxFeatureIds;
+            outputHash = payloadHash;
+          };
+        in
         pkgs.stdenv.mkDerivation {
-          inherit pname;
+          pname = "codex-desktop${packageSuffix featureArgs}";
           version = "26.506.21252";
           src = payload;
 
@@ -344,7 +343,14 @@ PY
           '';
 
           meta = {
-            description = if pname == "codex-desktop-computer-use-ui" then "Codex Desktop for Linux with Computer Use UI enabled" else "Codex Desktop for Linux";
+            description =
+              let
+                featureIds = enabledFeatureIds featureArgs;
+              in
+              if featureIds == [ ] then
+                "Codex Desktop for Linux"
+              else
+                "Codex Desktop for Linux with ${pkgs.lib.concatStringsSep ", " featureIds} enabled";
             homepage = "https://github.com/ilysenko/codex-desktop-linux";
             license = pkgs.lib.licenses.mit;
             platforms = pkgs.lib.platforms.linux;
@@ -353,17 +359,23 @@ PY
         };
 
         codexDesktop = mkCodexDesktop {
-          payload = codexDesktopPayload;
+          payloadHash = "sha256-oikRvP+7uKLnue/Kt2QYi62+SGshTa+pa/bGgDF0/MU=";
         };
 
         codexDesktopComputerUseUi = mkCodexDesktop {
-          pname = "codex-desktop-computer-use-ui";
-          payload = codexDesktopComputerUseUiPayload;
+          enableComputerUseUi = true;
+          payloadHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
         };
 
         codexDesktopRemoteMobileControl = mkCodexDesktop {
-          pname = "codex-desktop-remote-mobile-control";
-          payload = codexDesktopRemoteMobileControlPayload;
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          payloadHash = "sha256-qNJEgQ0aj4b8HxF4syav6gxfID3NGfTxh6kN4FvSDuU=";
+        };
+
+        codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {
+          enableComputerUseUi = true;
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          payloadHash = "sha256-qRQjww+XmHcNjmKuKqTCh5JjNaMPe4Ujz6a1Fl3njcI=";
         };
 
         installer = pkgs.writeShellApplication {
@@ -413,6 +425,7 @@ PY
           codex-desktop = codexDesktop;
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
           codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
+          codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
           installer = installer;
         };
 
@@ -424,6 +437,11 @@ PY
         apps.remote-mobile-control = {
           type = "app";
           program = "${codexDesktopRemoteMobileControl}/bin/codex-desktop";
+        };
+
+        apps.computer-use-ui-remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopComputerUseUiRemoteMobileControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/flake.nix
+++ b/flake.nix
@@ -179,9 +179,17 @@ PY
           fi
         '';
 
-        mkCodexDesktopPayload = { enableComputerUseUi ? false, outputHash }:
+        linuxFeaturesConfig = linuxFeatureIds:
+          pkgs.writeText "codex-linux-features.json" (builtins.toJSON {
+            enabled = linuxFeatureIds;
+          });
+
+        packageSuffix = linuxFeatureIds:
+          if linuxFeatureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" linuxFeatureIds}";
+
+        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], outputHash }:
         pkgs.stdenv.mkDerivation {
-          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload";
+          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload${packageSuffix linuxFeatureIds}";
           version = "26.506.21252";
           src = sourceRoot;
           __structuredAttrs = true;
@@ -227,6 +235,7 @@ PY
             export CXXFLAGS="''${CXXFLAGS:-} -ffile-prefix-map=$TMPDIR=/build -fdebug-prefix-map=$TMPDIR=/build -fmacro-prefix-map=$TMPDIR=/build"
             export RUSTFLAGS="''${RUSTFLAGS:-} --remap-path-prefix=$TMPDIR=/build -C link-arg=-Wl,--build-id=none"
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
+            export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfig linuxFeatureIds}"
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 
             source_dir="$TMPDIR/codex-source"
@@ -265,6 +274,11 @@ PY
         codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {
           enableComputerUseUi = true;
           outputHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
+        };
+
+        codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          outputHash = "sha256-T7Vd20fWm7Yz5vNxC05H40rE8Oq3NFLErgxr/s/0mEk=";
         };
 
         mkCodexDesktop = { pname ? "codex-desktop", payload }:
@@ -347,6 +361,11 @@ PY
           payload = codexDesktopComputerUseUiPayload;
         };
 
+        codexDesktopRemoteMobileControl = mkCodexDesktop {
+          pname = "codex-desktop-remote-mobile-control";
+          payload = codexDesktopRemoteMobileControlPayload;
+        };
+
         installer = pkgs.writeShellApplication {
           name = "codex-desktop-installer";
           runtimeInputs = [
@@ -393,12 +412,18 @@ PY
           default = codexDesktop;
           codex-desktop = codexDesktop;
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
+          codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
           installer = installer;
         };
 
         apps.default = {
           type = "app";
           program = "${codexDesktop}/bin/codex-desktop";
+        };
+
+        apps.remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopRemoteMobileControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -15,6 +15,13 @@ building:
 }
 ```
 
+For the Nix flake build, use the declarative app variant instead because the
+git-ignored `features.json` file is not part of the flake source:
+
+```bash
+nix run .#remote-mobile-control
+```
+
 What it changes:
 
 - Replaces the macOS-only `remote-control-device-key.node` requirement with a

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -22,6 +22,13 @@ git-ignored `features.json` file is not part of the flake source:
 nix run .#remote-mobile-control
 ```
 
+Feature-specific Nix outputs are additive. To combine this feature with the
+Computer Use UI opt-in:
+
+```bash
+nix run .#computer-use-ui-remote-mobile-control
+```
+
 What it changes:
 
 - Replaces the macOS-only `remote-control-device-key.node` requirement with a

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -8,6 +8,7 @@ UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
 COMPUTER_USE_UI_BUILD_LOG="${COMPUTER_USE_UI_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui.log}"
 REMOTE_MOBILE_CONTROL_BUILD_LOG="${REMOTE_MOBILE_CONTROL_BUILD_LOG:-/tmp/codex-nix-build-remote-mobile-control.log}"
+COMBINED_FEATURES_BUILD_LOG="${COMBINED_FEATURES_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui-remote-mobile-control.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
 FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
@@ -116,18 +117,22 @@ restore_flake_hashes() {
     local payload_hash="$2"
     local computer_use_ui_payload_hash="$3"
     local remote_mobile_control_payload_hash="$4"
+    local combined_features_payload_hash="$5"
 
     if [ -n "$dmg_hash" ]; then
         replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
     fi
     if [ -n "$payload_hash" ]; then
-        replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$payload_hash"
+        replace_flake_hash "codexDesktop = mkCodexDesktop {" "payloadHash = " "$payload_hash"
     fi
     if [ -n "$computer_use_ui_payload_hash" ]; then
-        replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$computer_use_ui_payload_hash"
+        replace_flake_hash "codexDesktopComputerUseUi = mkCodexDesktop {" "payloadHash = " "$computer_use_ui_payload_hash"
     fi
     if [ -n "$remote_mobile_control_payload_hash" ]; then
-        replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$remote_mobile_control_payload_hash"
+        replace_flake_hash "codexDesktopRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$remote_mobile_control_payload_hash"
+    fi
+    if [ -n "$combined_features_payload_hash" ]; then
+        replace_flake_hash "codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$combined_features_payload_hash"
     fi
 }
 
@@ -136,6 +141,7 @@ main() {
     local current_payload_hash=""
     local current_computer_use_ui_payload_hash=""
     local current_remote_mobile_control_payload_hash=""
+    local current_combined_features_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -146,6 +152,11 @@ main() {
     fi
 
     current_dmg_hash="$(read_flake_hash "codexDmg = pkgs.fetchurl {" "hash = ")"
+    current_payload_hash="$(read_flake_hash "codexDesktop = mkCodexDesktop {" "payloadHash = ")"
+    current_computer_use_ui_payload_hash="$(read_flake_hash "codexDesktopComputerUseUi = mkCodexDesktop {" "payloadHash = ")"
+    current_remote_mobile_control_payload_hash="$(read_flake_hash "codexDesktopRemoteMobileControl = mkCodexDesktop {" "payloadHash = ")"
+    current_combined_features_payload_hash="$(read_flake_hash "codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {" "payloadHash = ")"
+
     echo "Current Codex.dmg hash:  $current_dmg_hash"
     echo "Upstream Codex.dmg hash: $new_dmg_hash"
     replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$new_dmg_hash"
@@ -154,89 +165,112 @@ main() {
     # for hashing instead of fetching the same 300MB artifact again.
     nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
 
-    current_payload_hash="$(read_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current payload outputHash: $current_payload_hash"
-    echo "Forcing payload outputHash refresh..."
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
+    echo "Current codex-desktop payloadHash: $current_payload_hash"
+    echo "Forcing codex-desktop payloadHash refresh..."
+    replace_flake_hash "codexDesktop = mkCodexDesktop {" "payloadHash = " "$FAKE_SRI_HASH"
 
     if run_nix_build "$BUILD_LOG" .#codex-desktop; then
-        echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        echo "Nix build unexpectedly succeeded with the fake codex-desktop payloadHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
     if [ -z "$new_payload_hash" ]; then
         echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_payload_hash"; then
         echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
-    echo "Actual payload outputHash:  $new_payload_hash"
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$new_payload_hash"
+    echo "Actual codex-desktop payloadHash:  $new_payload_hash"
+    replace_flake_hash "codexDesktop = mkCodexDesktop {" "payloadHash = " "$new_payload_hash"
 
-    current_computer_use_ui_payload_hash="$(read_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current Computer Use UI payload outputHash: $current_computer_use_ui_payload_hash"
-    echo "Forcing Computer Use UI payload outputHash refresh..."
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
+    echo "Current Computer Use UI payloadHash: $current_computer_use_ui_payload_hash"
+    echo "Forcing Computer Use UI payloadHash refresh..."
+    replace_flake_hash "codexDesktopComputerUseUi = mkCodexDesktop {" "payloadHash = " "$FAKE_SRI_HASH"
 
     if run_nix_build "$COMPUTER_USE_UI_BUILD_LOG" .#codex-desktop-computer-use-ui; then
-        echo "Nix build unexpectedly succeeded with the fake Computer Use UI payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        echo "Nix build unexpectedly succeeded with the fake Computer Use UI payloadHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     new_computer_use_ui_payload_hash="$(extract_got_sri_hash "$COMPUTER_USE_UI_BUILD_LOG" || true)"
     if [ -z "$new_computer_use_ui_payload_hash" ]; then
         echo "Nix build failed without a Computer Use UI fixed-output hash mismatch; leaving log at $COMPUTER_USE_UI_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_computer_use_ui_payload_hash"; then
         echo "Refusing to proceed: extracted Computer Use UI payload hash '$new_computer_use_ui_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
-    echo "Actual Computer Use UI payload outputHash:  $new_computer_use_ui_payload_hash"
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$new_computer_use_ui_payload_hash"
+    echo "Actual Computer Use UI payloadHash:  $new_computer_use_ui_payload_hash"
+    replace_flake_hash "codexDesktopComputerUseUi = mkCodexDesktop {" "payloadHash = " "$new_computer_use_ui_payload_hash"
 
-    current_remote_mobile_control_payload_hash="$(read_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current Remote Mobile Control payload outputHash: $current_remote_mobile_control_payload_hash"
-    echo "Forcing Remote Mobile Control payload outputHash refresh..."
-    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
+    echo "Current Remote Mobile Control payloadHash: $current_remote_mobile_control_payload_hash"
+    echo "Forcing Remote Mobile Control payloadHash refresh..."
+    replace_flake_hash "codexDesktopRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$FAKE_SRI_HASH"
 
     if run_nix_build "$REMOTE_MOBILE_CONTROL_BUILD_LOG" .#codex-desktop-remote-mobile-control; then
-        echo "Nix build unexpectedly succeeded with the fake Remote Mobile Control payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        echo "Nix build unexpectedly succeeded with the fake Remote Mobile Control payloadHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     new_remote_mobile_control_payload_hash="$(extract_got_sri_hash "$REMOTE_MOBILE_CONTROL_BUILD_LOG" || true)"
     if [ -z "$new_remote_mobile_control_payload_hash" ]; then
         echo "Nix build failed without a Remote Mobile Control fixed-output hash mismatch; leaving log at $REMOTE_MOBILE_CONTROL_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_remote_mobile_control_payload_hash"; then
         echo "Refusing to proceed: extracted Remote Mobile Control payload hash '$new_remote_mobile_control_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
         exit 1
     fi
 
-    echo "Actual Remote Mobile Control payload outputHash:  $new_remote_mobile_control_payload_hash"
-    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$new_remote_mobile_control_payload_hash"
+    echo "Actual Remote Mobile Control payloadHash:  $new_remote_mobile_control_payload_hash"
+    replace_flake_hash "codexDesktopRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$new_remote_mobile_control_payload_hash"
 
-    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control
-    echo "Nix builds succeeded after refreshing the payload outputHashes."
+    echo "Current combined feature payloadHash: $current_combined_features_payload_hash"
+    echo "Forcing combined feature payloadHash refresh..."
+    replace_flake_hash "codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$FAKE_SRI_HASH"
+
+    if run_nix_build "$COMBINED_FEATURES_BUILD_LOG" .#codex-desktop-computer-use-ui-remote-mobile-control; then
+        echo "Nix build unexpectedly succeeded with the fake combined feature payloadHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
+        exit 1
+    fi
+
+    new_combined_features_payload_hash="$(extract_got_sri_hash "$COMBINED_FEATURES_BUILD_LOG" || true)"
+    if [ -z "$new_combined_features_payload_hash" ]; then
+        echo "Nix build failed without a combined feature fixed-output hash mismatch; leaving log at $COMBINED_FEATURES_BUILD_LOG" >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
+        exit 1
+    fi
+
+    if ! validate_sri_hash "$new_combined_features_payload_hash"; then
+        echo "Refusing to proceed: extracted combined feature payload hash '$new_combined_features_payload_hash' is not a valid SRI sha256." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash" "$current_combined_features_payload_hash"
+        exit 1
+    fi
+
+    echo "Actual combined feature payloadHash:  $new_combined_features_payload_hash"
+    replace_flake_hash "codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {" "payloadHash = " "$new_combined_features_payload_hash"
+
+    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control .#codex-desktop-computer-use-ui-remote-mobile-control
+    echo "Nix builds succeeded after refreshing the payloadHashes."
 }
 
 case "${1:-}" in

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -7,6 +7,7 @@ UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
 COMPUTER_USE_UI_BUILD_LOG="${COMPUTER_USE_UI_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui.log}"
+REMOTE_MOBILE_CONTROL_BUILD_LOG="${REMOTE_MOBILE_CONTROL_BUILD_LOG:-/tmp/codex-nix-build-remote-mobile-control.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
 FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
@@ -114,6 +115,7 @@ restore_flake_hashes() {
     local dmg_hash="$1"
     local payload_hash="$2"
     local computer_use_ui_payload_hash="$3"
+    local remote_mobile_control_payload_hash="$4"
 
     if [ -n "$dmg_hash" ]; then
         replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
@@ -124,12 +126,16 @@ restore_flake_hashes() {
     if [ -n "$computer_use_ui_payload_hash" ]; then
         replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$computer_use_ui_payload_hash"
     fi
+    if [ -n "$remote_mobile_control_payload_hash" ]; then
+        replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$remote_mobile_control_payload_hash"
+    fi
 }
 
 main() {
     local current_dmg_hash=""
     local current_payload_hash=""
     local current_computer_use_ui_payload_hash=""
+    local current_remote_mobile_control_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -155,20 +161,20 @@ main() {
 
     if run_nix_build "$BUILD_LOG" .#codex-desktop; then
         echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
     if [ -z "$new_payload_hash" ]; then
         echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_payload_hash"; then
         echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
@@ -182,27 +188,54 @@ main() {
 
     if run_nix_build "$COMPUTER_USE_UI_BUILD_LOG" .#codex-desktop-computer-use-ui; then
         echo "Nix build unexpectedly succeeded with the fake Computer Use UI payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     new_computer_use_ui_payload_hash="$(extract_got_sri_hash "$COMPUTER_USE_UI_BUILD_LOG" || true)"
     if [ -z "$new_computer_use_ui_payload_hash" ]; then
         echo "Nix build failed without a Computer Use UI fixed-output hash mismatch; leaving log at $COMPUTER_USE_UI_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_computer_use_ui_payload_hash"; then
         echo "Refusing to proceed: extracted Computer Use UI payload hash '$new_computer_use_ui_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     echo "Actual Computer Use UI payload outputHash:  $new_computer_use_ui_payload_hash"
     replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$new_computer_use_ui_payload_hash"
 
-    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui
+    current_remote_mobile_control_payload_hash="$(read_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = ")"
+    echo "Current Remote Mobile Control payload outputHash: $current_remote_mobile_control_payload_hash"
+    echo "Forcing Remote Mobile Control payload outputHash refresh..."
+    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
+
+    if run_nix_build "$REMOTE_MOBILE_CONTROL_BUILD_LOG" .#codex-desktop-remote-mobile-control; then
+        echo "Nix build unexpectedly succeeded with the fake Remote Mobile Control payload outputHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    new_remote_mobile_control_payload_hash="$(extract_got_sri_hash "$REMOTE_MOBILE_CONTROL_BUILD_LOG" || true)"
+    if [ -z "$new_remote_mobile_control_payload_hash" ]; then
+        echo "Nix build failed without a Remote Mobile Control fixed-output hash mismatch; leaving log at $REMOTE_MOBILE_CONTROL_BUILD_LOG" >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    if ! validate_sri_hash "$new_remote_mobile_control_payload_hash"; then
+        echo "Refusing to proceed: extracted Remote Mobile Control payload hash '$new_remote_mobile_control_payload_hash' is not a valid SRI sha256." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    echo "Actual Remote Mobile Control payload outputHash:  $new_remote_mobile_control_payload_hash"
+    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$new_remote_mobile_control_payload_hash"
+
+    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control
     echo "Nix builds succeeded after refreshing the payload outputHashes."
 }
 


### PR DESCRIPTION
## Summary

Builds on and acknowledges https://github.com/ilysenko/codex-desktop-linux/pull/193 by adding a Nix flake entrypoint for the experimental `remote-mobile-control` Linux feature.

## What changed

- Factors the Nix package construction so feature-enabled payload variants can be built declaratively.
- Adds `packages.*.codex-desktop-remote-mobile-control` and `apps.*.remote-mobile-control`.
- Passes an explicit `CODEX_LINUX_FEATURES_CONFIG` during the fixed-output payload build so the git-ignored local `linux-features/features.json` file is not required.
- Documents `nix run .#remote-mobile-control` / `nix run github:ilysenko/codex-desktop-linux#remote-mobile-control`.

## Why

PR #193 relies on the normal local opt-in path via `linux-features/features.json`. That file is intentionally gitignored, so a Nix flake consumer cannot enable the feature from a pure flake build without a committed/declarative variant.

## Validation

- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `nix flake show --no-write-lock-file`
- `nix build .#codex-desktop --no-link --print-build-logs`
- `nix build .#codex-desktop-remote-mobile-control --no-link --print-build-logs`

## Notes

The default `codex-desktop` package remains feature-disabled. The new package/app is explicitly opt-in and uses the fixed-output payload hash for the remote-control-enabled build.
