### PR TITLE
[codex] set up Cachix population for Nix builds

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,61 @@
+name: Populate Cachix
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '37 7 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: populate-cachix-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CACHIX_CACHE_NAME: codex-desktop-linux
+  CARGO_TERM_COLOR: always
+  NIX_CONFIG: experimental-features = nix-command flakes
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+jobs:
+  populate:
+    name: Build Nix flake outputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Configure Cachix for push
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v17
+        with:
+          name: ${{ env.CACHIX_CACHE_NAME }}
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+
+      - name: Warn when Cachix push token is missing
+        if: env.CACHIX_AUTH_TOKEN == ''
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Cachix
+
+          `CACHIX_AUTH_TOKEN` is not configured, so this run will build without pushing to Cachix.
+          Add a write token for the `codex-desktop-linux` Cachix cache as a repository secret to populate it automatically.
+          EOF
+
+      - name: Build cacheable Nix outputs
+        run: |
+          set -euo pipefail
+          nix build .#codex-desktop .#installer --no-link --print-build-logs
+          {
+            echo "## Cachix population"
+            echo ""
+            echo "- Cache: \`${CACHIX_CACHE_NAME}\`"
+            echo "- Built: \`.#codex-desktop\`"
+            echo "- Built: \`.#installer\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -13,10 +13,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NIX_CONFIG: experimental-features = nix-command flakes
+      CACHIX_CACHE_NAME: codex-desktop-linux
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
+
+      - name: Configure Cachix for hash refresh builds
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v17
+        with:
+          name: ${{ env.CACHIX_CACHE_NAME }}
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
 
       - name: Refresh Nix fixed-output hashes
         run: scripts/ci/update-nix-hashes.sh

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ The flake handles dependencies and patches Electron for NixOS. A GitHub Actions 
 
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
+### Cachix binary cache
+
+CI is wired to populate a Cachix cache named `codex-desktop-linux` for the flake outputs. To enable pushes, create that cache in Cachix and add a repository secret named `CACHIX_AUTH_TOKEN` with write access to the cache.
+
+After the cache exists, users can opt in locally with:
+
+```bash
+cachix use codex-desktop-linux
+```
+
+The scheduled `Populate Cachix` workflow builds `.#codex-desktop` and `.#installer`; the upstream-hash refresh workflow also uploads the verification build when the token is present.
+
 ## Linux Computer Use
 
 Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control desktop apps on Linux through a native Rust MCP backend (`codex-computer-use-linux`). It is designed and maintained by [@avifenesh](https://github.com/avifenesh) and supports:


### PR DESCRIPTION
## Summary

- Adds a `Populate Cachix` GitHub Actions workflow that builds `.#codex-desktop` and `.#installer` on `main`, on a daily schedule, and via manual dispatch.
- Hooks Cachix into the existing upstream Nix hash refresh workflow so its verification build can upload fresh store paths after hash updates.
- Documents the Cachix setup and user opt-in command in the README.

## Maintainer setup needed

This PR expects a maintainer to create a Cachix cache named `codex-desktop-linux`, then add a repository secret named `CACHIX_AUTH_TOKEN` with write access to that cache.

Without the secret, the new workflow still builds the Nix outputs but intentionally skips pushing to Cachix and writes a warning to the workflow summary.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/cachix.yml .github/workflows/update-codex-hash.yml`
- `git diff --check`
