### PR TITLE
[codex] Show update errors in updater status

### DIFF
--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -293,6 +293,7 @@ fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> R
                 .as_deref()
                 .unwrap_or("none")
         );
+        println!("{}", update_error_status_line(state));
         println!("cli_status: {:?}", state.cli_status);
         println!(
             "cli_installed_version: {}",
@@ -309,6 +310,13 @@ fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> R
     }
 
     Ok(())
+}
+
+fn update_error_status_line(state: &PersistedState) -> String {
+    format!(
+        "update_error: {}",
+        state.error_message.as_deref().unwrap_or("none")
+    )
 }
 
 fn run_prompt_install_cli(
@@ -1200,6 +1208,21 @@ mod tests {
 
         state.last_successful_check_at = Some(Utc::now() - ChronoDuration::hours(7));
         assert!(!upstream_check_is_fresh(&config, &state));
+    }
+
+    #[test]
+    fn plain_status_reports_update_error() {
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::Failed;
+        state.error_message = Some("install.sh failed during local rebuild".to_string());
+
+        assert_eq!(
+            update_error_status_line(&state),
+            "update_error: install.sh failed during local rebuild"
+        );
+
+        state.error_message = None;
+        assert_eq!(update_error_status_line(&state), "update_error: none");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Print the persisted app update error in plain `codex-update-manager status`, next to the existing CLI error line.
- Add a focused unit test for failed-update and no-error status formatting.

## Why

When a local rebuild fails, the updater already stores `error_message` in state, but the human-readable `status` command only showed `status: Failed` and `cli_error`. That makes update failures look opaque unless the user knows to inspect `state.json` or the workspace logs directly.

This keeps JSON status unchanged and only makes the existing persisted app-update error visible in the plain CLI output.

## Validation

- `cargo fmt -p codex-update-manager -- --check`
- `cargo test -p codex-update-manager plain_status_reports_update_error`
- `cargo test -p codex-update-manager status`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-update-manager`
- `git diff --check`
