### PR TITLE
[codex] Fix Linux Computer Use UI patch for current upstream bundle

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -337,6 +337,10 @@ function computerUseFeatureBundleFixture() {
   return "function me(e,{env:t=process.env,platform:n=process.platform}={}){return n!==`win32`||t.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`?e:{...e,computerUse:!0,computerUseNodeRepl:!0}}";
 }
 
+function currentComputerUseFeatureBundleFixture() {
+  return "function ye(e,{buildFlavor:n=t.D.resolve(),env:r=d.default.env,platform:i=d.default.platform}={}){let a=i===`win32`&&r.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`?{...e,computerUse:!0,computerUseNodeRepl:!0}:e,o=n===t.D.Dev?be(r):null;return o==null?a:{...a,...o}}";
+}
+
 function computerUseRendererAvailabilityBundleFixture() {
   return [
     "function hae(e){return e===`macOS`||e===`windows`}",
@@ -1493,6 +1497,19 @@ test("enables Computer Use desktop features on Linux", () => {
   assert.match(
     patched,
     /return n===`linux`\?\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}:n!==`win32`\|\|t\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?e:\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}/,
+  );
+  assert.match(patched, /CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE/);
+});
+
+test("enables current Computer Use desktop features on Linux", () => {
+  const patched = applyPatchTwice(
+    applyLinuxComputerUseFeaturePatch,
+    currentComputerUseFeatureBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /let a=i===`linux`\?\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}:i===`win32`&&r\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.e,computerUse:!0,computerUseNodeRepl:!0\}:e,o=n===t\.D\.Dev\?be\(r\):null;return o==null\?a:\{\.\.\.a,\.\.\.o\}/,
   );
   assert.match(patched, /CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE/);
 });

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -144,10 +144,14 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
 function applyLinuxComputerUseFeaturePatch(currentSource) {
   const patchedFeaturePattern =
     /function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,\{env:[A-Za-z_$][\w$]*=process\.env,platform:[A-Za-z_$][\w$]*=process\.platform\}=\{\}\)\{return [A-Za-z_$][\w$]*===`linux`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:/;
+  const currentPatchedFeaturePattern =
+    /let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*===`linux`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:[A-Za-z_$][\w$]*===`win32`&&[A-Za-z_$][\w$]*\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:[A-Za-z_$][\w$]*,/;
   const windowsOnlyFeaturePattern =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{env:([A-Za-z_$][\w$]*)=process\.env,platform:([A-Za-z_$][\w$]*)=process\.platform\}=\{\}\)\{return \4!==`win32`\|\|\3\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?\2:\{\.\.\.\2,computerUse:!0,computerUseNodeRepl:!0\}\}/;
+  const currentWindowsOnlyFeaturePattern =
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`win32`&&([A-Za-z_$][\w$]*)\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.([A-Za-z_$][\w$]*),computerUse:!0,computerUseNodeRepl:!0\}:\4,/;
 
-  if (patchedFeaturePattern.test(currentSource)) {
+  if (patchedFeaturePattern.test(currentSource) || currentPatchedFeaturePattern.test(currentSource)) {
     return currentSource;
   }
 
@@ -156,6 +160,14 @@ function applyLinuxComputerUseFeaturePatch(currentSource) {
       windowsOnlyFeaturePattern,
       (_, fnName, featuresVar, envVar, platformVar) =>
         `function ${fnName}(${featuresVar},{env:${envVar}=process.env,platform:${platformVar}=process.platform}={}){return ${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}!==\`win32\`||${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==\`1\`?${featuresVar}:{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}}`,
+    );
+  }
+
+  if (currentWindowsOnlyFeaturePattern.test(currentSource)) {
+    return currentSource.replace(
+      currentWindowsOnlyFeaturePattern,
+      (_, gateVar, platformVar, envVar, featuresVar) =>
+        `let ${gateVar}=${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}===\`win32\`&&${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===\`1\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${featuresVar},`,
     );
   }
 


### PR DESCRIPTION
## Summary

Fix the Linux Computer Use UI patcher so it still matches the current upstream minified desktop bundle.

This is a focused bug fix in the ASAR patching path. It does not add a new feature and it does not change the opt-in behavior; it only restores the existing Linux compatibility patch when upstream bundle structure drifts.

## Why this changed

The Linux wrapper uses fail-soft regex patching against the upstream desktop bundle.

Upstream changed the Computer Use desktop feature gate from the older return-expression form to a newer `let gate = ... ? ... : features` form before the dev override merge. The old Linux regex no longer matched that shape, so builds could silently skip the Computer Use desktop feature patch even when the Linux UI opt-in flag was enabled.

In that failure mode the build emitted:

`WARN: Could not find Computer Use desktop feature gate — skipping Linux Computer Use feature patch`

## Source-of-truth files changed

- `scripts/patches/computer-use.js`
- `scripts/patch-linux-window-ui.test.js`

## What changed

- extend `applyLinuxComputerUseFeaturePatch()` to match the current upstream feature gate shape as well as the older one
- keep the patch idempotent by recognizing the already-patched current shape
- add a regression fixture and test for the current minified upstream bundle form

## User-visible impact

Linux builds that opt in to the Computer Use UI keep surfacing the existing in-app controls after upstream bundle drift, instead of silently dropping the desktop feature patch.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
  - locally passed: `91/91`
- rebuilt and inspected the installed Linux app bundle
  - confirmed the patched `app.asar` contains the Linux branch for the current Computer Use desktop feature gate

## Environment notes

- validated on a Linux source-build workflow
- this change is limited to the bundle patching path and should apply equally to source installs and package builds that use the same patcher