### PR TITLE
Improve Linux remote mobile control patches

### DIFF
--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -27,6 +27,23 @@ What it changes:
 - Preserves `remote_control = true` / `features.remote_control = true` in the
   local Codex config instead of letting upstream strip it before app-server
   startup.
+- Updates remote-control settings and Codex mobile setup copy so the Linux flow
+  is not described as Mac-only.
+
+KDE Plasma smoke check:
+
+Mobile control depends on the Linux Computer Use backend once the host is
+enrolled. On Plasma/Wayland, verify that the KWin backend is ready after
+building or installing the package:
+
+```bash
+./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux doctor
+./codex-app/resources/plugins/openai-bundled/plugins/computer-use/bin/codex-computer-use-linux windows
+```
+
+The doctor report should show the KWin window backend, XDG Desktop Portal, and
+input checks as ready. The windows report should return `"backend": "kwin"` with
+a non-empty `windows` list.
 
 Known risks:
 

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -11,12 +11,35 @@ const DEVICE_KEY_GUARD =
   "if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
 const DEVICE_KEY_GUARD_REPLACEMENT =
   "if(process.platform===`linux`)return codexLinuxRemoteControlDeviceKeyClient();if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
+const DEVICE_KEY_REQUIRE_NEEDLE =
+  /(?:var|let|const)\s+[A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.createRequire\)\(__filename\),[A-Za-z_$][\w$]*=`remote-control-device-key\.node`/u;
 const REMOTE_CONTROL_VISIBILITY_NEEDLE =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return(n||t)&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
+const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
+  /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
+const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
+  ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],
+  ["Keep this Mac awake", "Keep this Linux desktop awake"],
+  ["Devices that can control this Mac", "Devices that can control this Linux desktop"],
+  ["Control this Mac from your phone or other device", "Control this Linux desktop from your phone or other device"],
+  ["Add device to control this Mac remotely", "Add device to control this Linux desktop remotely"],
+  ["Control other devices from this Mac", "Control other devices from this Linux desktop"],
+  ["Authorize this Mac to control other devices signed in to your ChatGPT account", "Authorize this Linux desktop to control other devices signed in to your ChatGPT account"],
+  ["Allow this Mac to be discovered and controlled", "Allow this Linux desktop to be discovered and controlled"],
+  ["Control this Mac", "Control this Linux desktop"],
+  ["Devices you can control from this Mac", "Devices you can control from this Linux desktop"],
+  ["SSH connections from this Mac", "SSH connections from this Linux desktop"],
+  ["Use your Mac apps while locked", "Use your Linux apps while locked"],
+  ["Control Mac apps from your phone", "Control Linux apps from your phone"],
+  ["Let Codex control the apps on your Mac.", "Let Codex control apps on this Linux desktop."],
+  ["Let Codex control the apps on your Mac", "Let Codex control apps on this Linux desktop"],
+  ["Connect a device to this Mac", "Connect a device to this Linux desktop"],
+  ["Connect your phone to this Mac", "Connect your phone to this Linux desktop"],
+];
 
 function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
   return [
@@ -70,8 +93,8 @@ function applyLinuxRemoteControlDeviceKeyPatch(source) {
     return source;
   }
 
-  const insertionNeedle = "var bV=(0,b.createRequire)(__filename),xV=`remote-control-device-key.node`";
-  if (!source.includes(insertionNeedle) || !source.includes(DEVICE_KEY_GUARD)) {
+  const insertionNeedle = source.match(DEVICE_KEY_REQUIRE_NEEDLE)?.[0] ?? null;
+  if (insertionNeedle == null || !source.includes(DEVICE_KEY_GUARD)) {
     console.warn("WARN: Could not find remote-control device-key bundle needles - skipping Linux remote-control device-key patch");
     return source;
   }
@@ -91,6 +114,12 @@ function applyLinuxRemoteControlPreserveConfigPatch(source) {
 
   const needle = "async function mV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{";
   if (!source.includes(needle)) {
+    if (
+      !source.includes("Removed remote_control from config before app-server start") &&
+      !source.includes("Failed to remove remote_control before app-server start")
+    ) {
+      return source;
+    }
     console.warn("WARN: Could not find remote-control config stripping needle - skipping Linux remote-control config patch");
     return source;
   }
@@ -99,17 +128,58 @@ function applyLinuxRemoteControlPreserveConfigPatch(source) {
 }
 
 function applyLinuxRemoteControlVisibilityPatch(source) {
-  if (source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT)) {
+  if (
+    source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT) ||
+    source.includes("remoteControlConnectionsState") &&
+      source.includes("navigator.userAgent.includes(`Linux`)")
+  ) {
     return source;
   }
   if (source.includes(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT)) {
     return source.replace(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
   }
   if (!source.includes(REMOTE_CONTROL_VISIBILITY_NEEDLE)) {
-    console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
-    return source;
+    if (!source.includes("remoteControlConnectionsState")) {
+      return source;
+    }
+
+    const settingsVisibilityMatch = source.match(REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE);
+    if (settingsVisibilityMatch == null) {
+      console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
+      return source;
+    }
+
+    const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
+    return source.replace(
+      REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
+      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))}`,
+    );
   }
   return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
+}
+
+function applyLinuxRemoteControlCopyPatch(source) {
+  const hasMacCopy = REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS.some(([macCopy]) =>
+    source.includes(macCopy),
+  );
+  if (!hasMacCopy && (source.includes("this Linux desktop") || source.includes("Linux apps"))) {
+    return source;
+  }
+
+  let patched = source;
+  let changed = false;
+  for (const [macCopy, linuxCopy] of REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS) {
+    if (patched.includes(macCopy)) {
+      patched = patched.split(macCopy).join(linuxCopy);
+      changed = true;
+    }
+  }
+
+  if (!changed) {
+    console.warn("WARN: Could not find remote-control Mac copy - skipping Linux remote-control copy patch");
+    return source;
+  }
+  return patched;
 }
 
 module.exports = [
@@ -130,15 +200,26 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: /^remote-control-connections-visibility-.*\.js$/,
+    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings)-.*\.js$/,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",
     skipDescription: "Linux remote-control visibility patch",
     apply: applyLinuxRemoteControlVisibilityPatch,
   },
+  {
+    id: "linux-remote-control-copy",
+    phase: "webview-asset",
+    pattern: /^(?:codex-mobile-setup-flow|remote-connections-settings|use-codex-mobile-connected-settings)-.*\.js$/,
+    order: 20_130,
+    ciPolicy: "optional",
+    missingDescription: "remote-control settings or mobile setup bundle",
+    skipDescription: "Linux remote-control copy patch",
+    apply: applyLinuxRemoteControlCopyPatch,
+  },
 ];
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
 module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
+module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -18,6 +18,7 @@ const {
 } = require("../../scripts/patch-linux-window-ui.js");
 const {
   applyLinuxRemoteControlDeviceKeyPatch,
+  applyLinuxRemoteControlCopyPatch,
   applyLinuxRemoteControlPreserveConfigPatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
@@ -34,6 +35,44 @@ function syntheticMainBundle() {
 
 function syntheticVisibilityBundle() {
   return "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{a as t};";
+}
+
+function syntheticCurrentMainBundle() {
+  return [
+    "let i=require(`node:path`),o=require(`node:fs`),s=require(`node:crypto`),b={createRequire:()=>()=>({})};",
+    "function mz(e){return Buffer.from(JSON.stringify({domain:`codex-device-key-sign-payload/v1`,payload:e}),`utf8`)}",
+    "var lz=(0,b.createRequire)(__filename),uz=`remote-control-device-key.node`,dz=`codex-device-key-sign-payload/v1`;",
+    "function pz({resourcesPath:e}){let t=null,n=()=>{if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=lz((0,i.join)(e,`native`,uz)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=mz(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
+  ].join("");
+}
+
+function syntheticCurrentVisibilityBundle() {
+  return "function Et({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)}export{Et as t};";
+}
+
+function syntheticMobileConnectedSettingsBundle() {
+  return "let y={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let Codex control the apps on your Mac.`,description:`Description for enabling Computer Use after mobile setup`};";
+}
+
+function syntheticRemoteConnectionsSettingsCopyBundle() {
+  return [
+    syntheticCurrentVisibilityBundle(),
+    "let platformLabel={id:`settings.remoteConnections.platform.mac`,defaultMessage:`Mac`,description:`Short label for a Mac device`};",
+    "let a={id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`};",
+    "let b={id:`settings.remoteControlConnections.devices.title`,defaultMessage:`Devices that can control this Mac`,description:`Header title for devices that can control this Mac`};",
+    "let c={id:`settings.remoteConnections.accessOtherDevices.header.title`,defaultMessage:`Devices you can control from this Mac`,description:`Header title for the devices this computer can access`};",
+    "let d={id:`settings.remoteConnections.ssh.header.title`,defaultMessage:`SSH connections from this Mac`,description:`Header title for SSH connections from this Mac`};",
+    "let e={id:`settings.remoteControlConnections.keepAwake.title`,defaultMessage:`Keep this Mac awake`,description:`Keep awake title`};",
+  ].join("");
+}
+
+function syntheticMobileSetupFlowCopyBundle() {
+  return [
+    "let a={id:`codexMobile.setupDialog.connected.lockedComputerUse.title`,defaultMessage:`Use your Mac apps while locked`,description:`Title for enabling Locked Computer Use after mobile setup`};",
+    "let b={id:`codexMobile.setupDialog.connected.lockedComputerUse.description`,defaultMessage:`Control Mac apps from your phone`,description:`Description for enabling Locked Computer Use after mobile setup`};",
+    "let c={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let Codex control the apps on your Mac`,description:`Description for enabling Computer Use after mobile setup`};",
+    "let d={id:`codexMobile.setupPage.initial.heading`,defaultMessage:`Connect your phone to this Mac`,description:`Heading for Codex mobile setup`};",
+  ].join("");
 }
 
 function withTempFeatureRoot(enabled, fn) {
@@ -75,10 +114,12 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-control-device-key",
       "feature:remote-mobile-control:linux-remote-control-preserve-config",
       "feature:remote-mobile-control:linux-remote-control-visibility",
+      "feature:remote-mobile-control:linux-remote-control-copy",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
       "main-bundle",
+      "webview-asset",
       "webview-asset",
     ]);
   });
@@ -100,6 +141,16 @@ test("Linux remote-control patches update the device-key provider and preserve c
   );
 });
 
+test("Linux remote-control device-key patch handles current minified aliases", () => {
+  const source = syntheticCurrentMainBundle();
+  const patched = applyLinuxRemoteControlDeviceKeyPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlDeviceKeyClient/);
+  assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
+  assert.equal(applyLinuxRemoteControlDeviceKeyPatch(patched), patched);
+});
+
 test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
   const source = syntheticVisibilityBundle();
   const patched = applyLinuxRemoteControlVisibilityPatch(source);
@@ -108,6 +159,54 @@ test("Linux remote-control visibility patch allows Linux when upstream marks ava
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
   assert.match(patched, /\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("Linux remote-control visibility patch handles current settings bundle shape", () => {
+  const source = syntheticCurrentVisibilityBundle();
+  const patched = applyLinuxRemoteControlVisibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)/);
+  assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("Linux mobile setup copy does not refer to Mac-only Computer Use", () => {
+  const source = syntheticMobileConnectedSettingsBundle();
+  const patched = applyLinuxRemoteControlCopyPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.doesNotMatch(patched, /apps on your Mac/);
+  assert.match(patched, /apps on this Linux desktop/);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
+});
+
+test("Linux remote-control settings copy does not refer to this Mac", () => {
+  const source = syntheticRemoteConnectionsSettingsCopyBundle();
+  const patched = applyLinuxRemoteControlCopyPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.doesNotMatch(patched, /defaultMessage:`[^`]*Mac/);
+  assert.match(patched, /Control this Linux desktop/);
+  assert.match(patched, /Devices that can control this Linux desktop/);
+  assert.match(patched, /Devices you can control from this Linux desktop/);
+  assert.match(patched, /SSH connections from this Linux desktop/);
+  assert.match(patched, /Keep this Linux desktop awake/);
+  assert.match(patched, /defaultMessage:`Linux`/);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
+});
+
+test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
+  const source = syntheticMobileSetupFlowCopyBundle();
+  const patched = applyLinuxRemoteControlCopyPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.doesNotMatch(patched, /defaultMessage:`[^`]*Mac/);
+  assert.match(patched, /Use your Linux apps while locked/);
+  assert.match(patched, /Control Linux apps from your phone/);
+  assert.match(patched, /apps on this Linux desktop/);
+  assert.match(patched, /Connect your phone to this Linux desktop/);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
 test("patched Linux device-key provider can create, sign with, and delete a key", async () => {
@@ -178,6 +277,18 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           syntheticVisibilityBundle(),
         );
+        fs.writeFileSync(
+          path.join(assetsDir, "remote-connections-settings-test.js"),
+          syntheticRemoteConnectionsSettingsCopyBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
+          syntheticMobileSetupFlowCopyBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
+          syntheticMobileConnectedSettingsBundle(),
+        );
 
         const report = createPatchReport();
         patchExtractedApp(tempApp, { report });
@@ -187,9 +298,25 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           "utf8",
         );
+        const patchedRemoteConnectionsSettingsFile = fs.readFileSync(
+          path.join(assetsDir, "remote-connections-settings-test.js"),
+          "utf8",
+        );
+        const patchedMobileSetupFlowFile = fs.readFileSync(
+          path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
+          "utf8",
+        );
+        const patchedMobileConnectedSettingsFile = fs.readFileSync(
+          path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
+          "utf8",
+        );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
+        assert.match(patchedMobileSetupFlowFile, /Connect your phone to this Linux desktop/);
+        assert.match(patchedMobileConnectedSettingsFile, /apps on this Linux desktop/);
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-device-key" &&
@@ -205,6 +332,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-visibility" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-copy" &&
             patch.status === "applied",
           ),
         );


### PR DESCRIPTION
## Summary

This hardens the opt-in `remote-mobile-control` Linux feature against the current upstream bundle shape and polishes the visible Linux copy in the remote/mobile control flow.

- match the current minified device-key `createRequire` aliases instead of one fixed variable pair
- support the current `remote-connections-settings-*` visibility gate while keeping the older visibility chunk path working
- treat the removed upstream config-stripping block as already handled instead of warning when it is absent
- replace Mac-only copy in Connections and Codex mobile setup bundles with Linux desktop wording
- document a Plasma/KWin smoke check for Computer Use after enrollment

## Validation

- `node --test linux-features/remote-mobile-control/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `git diff --check`
- Plasma/Wayland manual smoke: remote mobile enrollment succeeded, mobile control connected, and a phone-initiated test message completed in another Codex thread
- Real `app.asar` smoke with `remote-mobile-control` enabled: feature patches reported applied/already-applied and no `defaultMessage` strings containing `Mac` remained in the remote/mobile target bundles
