### PR TITLE
[codex] Document Fedora ydotool troubleshooting for Computer Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,14 @@ sudo systemctl enable --now ydotoold
 sudo usermod -a -G input "$USER"
 ```
 
-Some distros install `/usr/bin/ydotoold` without a service unit. If `systemctl enable --now ydotoold` fails, create or install a distro-appropriate unit. If `doctor` reports `ydotool_socket: Permission denied`, make sure the socket is usable by users in the `input` group.
+On Fedora 44, the packaged unit is commonly named `ydotool.service` rather than `ydotoold.service`. Some distros install `/usr/bin/ydotoold` without any service unit. If `systemctl enable --now ydotoold` fails, start the distro-provided unit instead or create a user-session service that binds `%t/.ydotool_socket`. If `doctor` reports `ydotool_socket: Permission denied`, make sure the socket is usable by users in the `input` group.
+
+If you are on Fedora + KDE Plasma and the system unit path is awkward, a user-session `ydotoold` service is also a valid setup. In that case, make sure:
+
+- the socket is reachable at `%t/.ydotool_socket`
+- the service runs inside your user session
+- old system-level overrides are removed if they force the wrong socket path
+- `codex-computer-use-linux doctor` reports `can_send_development_input: true`
 
 A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway / Hyprland, or your distro's preferred portal backend for i3. GNOME ships a working portal by default.
 
@@ -365,7 +372,7 @@ make clean-state
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | `./install.sh --fresh` removes the existing install dir and re-downloads |
 | Computer Use plugin invisible in UI | Ensure you enabled the Computer Use UI. If it is enabled and still hidden, the OpenAI per-account rollout may not be available |
-| Computer Use `doctor` reports `ydotool not running` | `sudo systemctl enable --now ydotoold` and add your user to the `input` group |
+| Computer Use `doctor` reports `ydotool not running` | Start the distro-provided daemon unit (`ydotoold` or `ydotool`), or use a user-session `ydotoold` service, then add your user to the `input` group |
 | Computer Use `doctor` reports `ydotool_socket: Permission denied` | The daemon socket is root-only. Adjust the `ydotoold` service so `/tmp/.ydotool_socket` becomes `root:input` with `0660` permissions |
 | `ConnectTimeoutError` for `www.electronjs.org` during `@electron/rebuild` | Re-run `make build-app`; the installer now uses `https://artifacts.electronjs.org/headers/dist` for Electron headers by default |
 | Computer Use AT-SPI tree empty | Run `codex-computer-use-linux setup` to flip GNOME accessibility on, then restart the target app |


### PR DESCRIPTION
## Summary

Add a small README troubleshooting update for Linux Computer Use on Fedora, especially the `ydotool` daemon naming and user-session service path.

This is a docs-only PR. It does not change runtime behavior, installer logic, or packaged services.

## Why this changed

The current README already documents the generic `ydotoold` setup, but Fedora users can still hit a confusing gap:

- the packaged daemon unit may be named `ydotool.service` instead of `ydotoold.service`
- some setups work better with a user-session `ydotoold` service bound to `%t/.ydotool_socket`
- stale system-level overrides can keep Computer Use input synthesis broken even when `ydotoold` itself is installed

That makes the current troubleshooting steps too narrow for Fedora + KDE Plasma style setups.

## Source-of-truth files changed

- `README.md`

## What changed

- clarify that Fedora 44 commonly exposes the daemon as `ydotool.service`
- mention the user-session `ydotoold` service pattern with `%t/.ydotool_socket`
- add a short Fedora + KDE Plasma troubleshooting checklist near the Computer Use dependency section
- widen the troubleshooting table entry so it refers to either `ydotoold`, `ydotool`, or a user-session service

## User-visible impact

Fedora users get a clearer path to making Linux Computer Use input synthesis work, especially when the distro service naming differs from the generic `ydotoold` instructions.

## Validation

- reviewed the README Computer Use dependency section for placement and scope
- confirmed the added guidance matches a working Fedora + KDE Plasma setup where `codex-computer-use-linux doctor` reports `can_send_development_input: true`

## Environment notes

- based on Fedora 44 + KDE Plasma behavior
- docs-only change; no runtime code or packaged units were modified