### PR TITLE
Add local AppImage packaging target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           bash -n scripts/build-deb.sh
           bash -n scripts/build-rpm.sh
           bash -n scripts/build-pacman.sh
+          bash -n scripts/build-appimage.sh
           bash -n scripts/ci/update-nix-hashes.sh
 
       - name: Check Node patcher syntax

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ DEV_APP_BIN ?= $(CURDIR)/bin/$(DEV_APP_ID)
 DEB_GLOB := $(CURDIR)/dist/$(PACKAGE_NAME)_*.deb
 RPM_GLOB := $(CURDIR)/dist/$(PACKAGE_NAME)-*.rpm
 PACMAN_GLOB := $(CURDIR)/dist/$(PACKAGE_NAME)-[0-9]*.pkg.tar.*
-
 .DEFAULT_GOAL := help
 
 NATIVE_PKG_FORMAT_CMD = format=""; \
@@ -52,7 +51,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -71,6 +70,7 @@ help:
 	@printf '  %-18s %s\n' "make deb" "Build the Debian package into dist/"
 	@printf '  %-18s %s\n' "make rpm" "Build the RPM package into dist/ (Fedora/openSUSE)"
 	@printf '  %-18s %s\n' "make pacman" "Build the pacman package into dist/ (Arch)"
+	@printf '  %-18s %s\n' "make appimage" "Build the AppImage into dist/ (local self-build)"
 	@printf '  %-18s %s\n' "make package" "Build native package (auto-detects deb, rpm, or pacman)"
 	@printf '  %-18s %s\n' "make install" "Install the latest generated native package"
 	@printf '  %-18s %s\n' "make service-enable" "Enable and start codex-update-manager.service for the current user"
@@ -84,8 +84,9 @@ help:
 	@printf '  %-18s %s\n' "REBUILD_REPORT_DIR=..." "Override inspect/rebuild report output directory"
 	@printf '  %-18s %s\n' "DEV_APP_ID=..." "Override side-by-side test app id/bin (default: codex-cua-lab)"
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
-	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman"
+	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage"
 	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
+	@printf '  %-18s %s\n' "APPIMAGETOOL=..." "Override the appimagetool executable for make appimage"
 	@printf '  %-18s %s\n' "DEB=/path/file.deb" "Override the .deb used by make install"
 	@printf '  %-18s %s\n' "RPM=/path/file.rpm" "Override the .rpm used by make install"
 	@printf '  %-18s %s\n' "PKG=/path/file.pkg.tar.zst" "Override the pacman package used by make install"
@@ -102,6 +103,7 @@ help:
 	@printf '  %s\n' "make deb PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make rpm PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make pacman PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
+	@printf '  %s\n' "make appimage PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make install"
 	@printf '  %s\n\n' "make service-enable"
 
@@ -187,6 +189,10 @@ rpm: maybe-build-updater
 pacman: maybe-build-updater
 	@echo "[make] Building pacman package"
 	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
+
+appimage:
+	@echo "[make] Building AppImage"
+	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
 
 package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codex Desktop for Linux
 
-Unofficial Linux build of [OpenAI Codex Desktop](https://openai.com/codex/). The official Codex Desktop app is macOS-only — this project converts the upstream macOS `Codex.dmg` into a runnable Linux Electron app, ships native `.deb` / `.rpm` / `.pkg.tar.zst` packages plus a Nix flake, and includes a local auto-updater that rebuilds future Linux packages from newer upstream DMGs.
+Unofficial Linux build of [OpenAI Codex Desktop](https://openai.com/codex/). The official Codex Desktop app is macOS-only — this project converts the upstream macOS `Codex.dmg` into a runnable Linux Electron app, ships native `.deb` / `.rpm` / `.pkg.tar.zst` packages plus local AppImage self-builds and a Nix flake, and includes a local auto-updater that rebuilds future native Linux packages from newer upstream DMGs.
 
 Before opening a pull request, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -17,6 +17,7 @@ Optional Linux-only additions live in `linux-features/`. Use them for integratio
 | Fedora < 41 | `dnf` | `.rpm` | |
 | openSUSE Tumbleweed / Leap | `zypper` | `.rpm` | Uses `zypper --no-gpg-checks install` for the local rebuild |
 | Arch, Manjaro, EndeavourOS | `pacman` | `.pkg.tar.zst` | |
+| Atomic desktops / other Linux distros | none | `.AppImage` | Local self-build only; no bundled auto-updater |
 | NixOS / Nix | flake | runnable directly | `nix run github:ilysenko/codex-desktop-linux` |
 
 Anything systemd-based should work for the optional auto-updater service (`systemd --user`). The launcher targets Wayland with `XWayland` first (better Electron popup positioning); pure Wayland sessions fall through to `--ozone-platform-hint=auto`. X11 is fully supported.
@@ -26,8 +27,9 @@ Anything systemd-based should work for the optional auto-updater service (`syste
 | Feature | Status | Notes |
 |---|---|---|
 | Standard Codex Desktop UI | ✅ always | Chats, browser, files, MCP plugins |
-| Auto-updater (`codex-update-manager`) | ✅ always | Detects newer upstream DMGs, rebuilds + installs locally |
+| Auto-updater (`codex-update-manager`) | ✅ native packages | Detects newer upstream DMGs, rebuilds + installs native packages locally |
 | Native packaging (`.deb` / `.rpm` / `.pkg.tar.zst`) | ✅ always | One-shot `make package` picks your distro |
+| AppImage self-build | ✅ manual | `make appimage` writes a local `dist/*.AppImage`; rebuild manually after upstream updates |
 | Linux tray + warm-start handoff | ✅ always | Single-instance lock, second-instance window focus |
 | GUI install prompts (`kdialog` / `zenity`) | ✅ if installed | Falls back to interactive terminal prompt |
 | Linux browser annotations | ✅ always | Stored-anchor screenshots, isolated marker rendering |
@@ -69,6 +71,24 @@ make install        # installs the newest package from dist/
 ```
 
 `make package` picks the format that matches your distro. `make install` then runs the right `dpkg -i` / `dnf install` / `zypper install` / `pacman -U` against the freshly built artifact.
+
+### AppImage local self-build
+
+For atomic desktops or systems where installing a native package is awkward, build an AppImage locally from the generated app:
+
+```bash
+make build-app
+make appimage
+./dist/codex-desktop-*.AppImage
+```
+
+The AppImage flow does not include `codex-update-manager`, the systemd user service, polkit policy, or the native-package update builder. When upstream Codex Desktop changes, update your checkout and rebuild locally:
+
+```bash
+git pull --ff-only
+make build-app
+make appimage
+```
 
 ### NixOS / Nix one-liner
 
@@ -299,7 +319,7 @@ make build-app
 
 `ELECTRON_HEADERS_URL` is passed to `@electron/rebuild --dist-url` and must provide both `node-v<version>-headers.tar.gz` and the matching `SHASUMS256.txt`.
 
-## Native package formats
+## Package formats
 
 After `make build-app`, build a native package from `codex-app/` with the format you need:
 
@@ -308,9 +328,10 @@ After `make build-app`, build a native package from `codex-app/` with the format
 | Debian | `make deb` or `./scripts/build-deb.sh` | `dist/codex-desktop_*.deb` | `sudo dpkg -i dist/codex-desktop_*.deb` |
 | RPM (Fedora / openSUSE) | `make rpm` or `./scripts/build-rpm.sh` | `dist/codex-desktop-*.x86_64.rpm` | `sudo dnf install dist/codex-desktop-*.rpm` (Fedora) or `sudo zypper install dist/codex-desktop-*.rpm` (openSUSE) |
 | Arch (pacman) | `make pacman` or `./scripts/build-pacman.sh` | `dist/codex-desktop-*.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-*.pkg.tar.zst` |
+| AppImage | `make appimage` or `./scripts/build-appimage.sh` | `dist/codex-desktop-*.AppImage` | Run directly; no system install |
 | Auto-detect | `make package && make install` | matches your distro | handled by `make install` |
 
-Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish ./scripts/build-*.sh`.
+Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish ./scripts/build-*.sh`. AppImage builds require `appimagetool` on `PATH`, or `APPIMAGETOOL=/path/to/appimagetool`.
 
 The packaging scripts only repackage what's already in `codex-app/`. They do not download or extract the DMG themselves.
 
@@ -342,6 +363,7 @@ make run-dev-app
 make deb
 make rpm
 make pacman
+make appimage
 make package           # auto-detect distro
 make install           # install latest dist/ artifact
 make service-enable
@@ -379,9 +401,9 @@ make clean-state
 4. It rebuilds native Node modules (`better-sqlite3`, `node-pty`) for Linux via `@electron/rebuild`
 5. It downloads the matching Linux Electron runtime (cached under `~/.cache/codex-desktop/electron/`)
 6. It writes the Linux launcher into `codex-app/start.sh` (body sourced from `launcher/start.sh.template`)
-7. `scripts/build-{deb,rpm,pacman}.sh` packages `codex-app/` into a native artifact
+7. `scripts/build-{deb,rpm,pacman}.sh` packages `codex-app/` into a native artifact; `scripts/build-appimage.sh` creates a local AppImage
 8. Default native packages provide `codex-update-manager` plus a `systemd --user` service unit
-9. The updater watches for newer upstream DMGs and rebuilds future Linux packages locally, unless the package was built with `PACKAGE_WITH_UPDATER=0`
+9. The updater watches for newer upstream DMGs and rebuilds future native Linux packages locally, unless the package was built with `PACKAGE_WITH_UPDATER=0`
 
 The installer replaces the macOS Electron binary with a Linux build, recompiles native modules, and removes macOS-only pieces such as `sparkle`.
 
@@ -396,7 +418,7 @@ The current evaluation for a future Rust replacement of the local webview server
 After changing installer, packaging, or updater logic:
 
 ```bash
-bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/install-deps.sh
+bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/install-deps.sh
 node --check scripts/patch-linux-window-ui.js
 for file in scripts/patches/*.js; do node --check "$file"; done
 node --check scripts/ci/validate-patch-report.js

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+resolve_appdir() {
+    local source="${BASH_SOURCE[0]}"
+    local dir
+
+    while [ -L "$source" ]; do
+        dir="$(cd -P "$(dirname "$source")" && pwd)"
+        source="$(readlink "$source")"
+        case "$source" in
+            /*) ;;
+            *) source="$dir/$source" ;;
+        esac
+    done
+
+    cd -P "$(dirname "$source")" && pwd
+}
+
+APPDIR="${APPDIR:-$(resolve_appdir)}"
+export APPDIR
+
+exec "$APPDIR/opt/__PACKAGE_NAME__/start.sh" "$@"

--- a/packaging/appimage/codex-appimage-runtime.sh
+++ b/packaging/appimage/codex-appimage-runtime.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+codex_packaged_runtime_export_env() {
+    export CHROME_DESKTOP="__PACKAGE_NAME__.desktop"
+
+    if [ -n "${APPDIR:-}" ] && [ -f "$APPDIR/__PACKAGE_NAME__.desktop" ]; then
+        export BAMF_DESKTOP_FILE_HINT="$APPDIR/__PACKAGE_NAME__.desktop"
+    else
+        export BAMF_DESKTOP_FILE_HINT="__PACKAGE_NAME__.desktop"
+    fi
+}

--- a/packaging/appimage/codex-desktop.desktop
+++ b/packaging/appimage/codex-desktop.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=__PACKAGE_DISPLAY_NAME__
+Comment=__PACKAGE_COMMENT__
+Exec=AppRun %u
+Icon=__PACKAGE_NAME__
+Terminal=false
+Type=Application
+Categories=Development;
+MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;
+StartupNotify=true
+StartupWMClass=Codex
+X-GNOME-WMClass=Codex
+X-AppImage-Version=__VERSION__

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$REPO_DIR/scripts/lib/package-common.sh"
+
+APP_DIR="${APP_DIR_OVERRIDE:-$REPO_DIR/codex-app}"
+DIST_DIR="${DIST_DIR_OVERRIDE:-$REPO_DIR/dist}"
+APPDIR="${APPIMAGE_APPDIR_OVERRIDE:-$REPO_DIR/dist/appimage.AppDir}"
+APPRUN_TEMPLATE="$REPO_DIR/packaging/appimage/AppRun"
+DESKTOP_TEMPLATE="$REPO_DIR/packaging/appimage/codex-desktop.desktop"
+APPIMAGE_RUNTIME_TEMPLATE="$REPO_DIR/packaging/appimage/codex-appimage-runtime.sh"
+ICON_SOURCE="$REPO_DIR/assets/codex.png"
+
+PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
+PACKAGE_DISPLAY_NAME="${PACKAGE_DISPLAY_NAME:-Codex Desktop}"
+PACKAGE_COMMENT="${PACKAGE_COMMENT:-Run Codex Desktop on Linux}"
+PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+
+map_arch() {
+    case "$(uname -m)" in
+        x86_64)  echo "x86_64" ;;
+        aarch64|arm64) echo "aarch64" ;;
+        armv7l|armhf) echo "armhf" ;;
+        *)       error "Unsupported AppImage architecture: $(uname -m)" ;;
+    esac
+}
+
+resolve_appimagetool() {
+    if [ -n "${APPIMAGETOOL:-}" ]; then
+        [ -x "$APPIMAGETOOL" ] || error "APPIMAGETOOL is not executable: $APPIMAGETOOL"
+        printf '%s\n' "$APPIMAGETOOL"
+        return 0
+    fi
+
+    command -v appimagetool >/dev/null 2>&1 || error "appimagetool is required.
+Install appimagetool or set APPIMAGETOOL=/path/to/appimagetool."
+    command -v appimagetool
+}
+
+render_template() {
+    local source="$1"
+    local target="$2"
+    local package_name
+    local display_name
+    local comment
+    local version
+
+    package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+    display_name="$(sed_escape_replacement "$PACKAGE_DISPLAY_NAME")"
+    comment="$(sed_escape_replacement "$PACKAGE_COMMENT")"
+    version="$(sed_escape_replacement "$PACKAGE_VERSION")"
+
+    sed \
+        -e "s/__PACKAGE_NAME__/$package_name/g" \
+        -e "s/__PACKAGE_DISPLAY_NAME__/$display_name/g" \
+        -e "s/__PACKAGE_COMMENT__/$comment/g" \
+        -e "s/__VERSION__/$version/g" \
+        "$source" > "$target"
+}
+
+prepare_appdir() {
+    info "Preparing AppDir at $APPDIR"
+    rm -rf "$APPDIR"
+    mkdir -p \
+        "$APPDIR/opt" \
+        "$APPDIR/usr/share/applications" \
+        "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+    cp -aT "$APP_DIR" "$APPDIR/opt/$PACKAGE_NAME"
+    mkdir -p "$APPDIR/opt/$PACKAGE_NAME/.codex-linux"
+
+    render_template "$APPRUN_TEMPLATE" "$APPDIR/AppRun"
+    chmod 0755 "$APPDIR/AppRun"
+
+    render_template "$DESKTOP_TEMPLATE" "$APPDIR/$PACKAGE_NAME.desktop"
+    chmod 0644 "$APPDIR/$PACKAGE_NAME.desktop"
+    cp "$APPDIR/$PACKAGE_NAME.desktop" "$APPDIR/usr/share/applications/$PACKAGE_NAME.desktop"
+
+    cp "$ICON_SOURCE" "$APPDIR/$PACKAGE_NAME.png"
+    cp "$ICON_SOURCE" "$APPDIR/.DirIcon"
+    cp "$ICON_SOURCE" "$APPDIR/usr/share/icons/hicolor/256x256/apps/$PACKAGE_NAME.png"
+    cp "$ICON_SOURCE" "$APPDIR/opt/$PACKAGE_NAME/.codex-linux/$PACKAGE_NAME.png"
+
+    render_template \
+        "$APPIMAGE_RUNTIME_TEMPLATE" \
+        "$APPDIR/opt/$PACKAGE_NAME/.codex-linux/codex-packaged-runtime.sh"
+    chmod 0644 "$APPDIR/opt/$PACKAGE_NAME/.codex-linux/codex-packaged-runtime.sh"
+}
+
+main() {
+    ensure_app_layout
+    ensure_file_exists "$APPRUN_TEMPLATE" "AppImage AppRun template"
+    ensure_file_exists "$DESKTOP_TEMPLATE" "AppImage desktop template"
+    ensure_file_exists "$APPIMAGE_RUNTIME_TEMPLATE" "AppImage runtime helper template"
+    ensure_file_exists "$ICON_SOURCE" "icon"
+
+    local arch
+    local appimagetool
+    local output_file
+    arch="$(map_arch)"
+    appimagetool="$(resolve_appimagetool)"
+    output_file="$DIST_DIR/${PACKAGE_NAME}-${PACKAGE_VERSION}-${arch}.AppImage"
+
+    prepare_appdir
+
+    mkdir -p "$DIST_DIR"
+    rm -f "$output_file"
+    info "Building AppImage: $output_file"
+    ARCH="$arch" VERSION="$PACKAGE_VERSION" \
+        "$appimagetool" --no-appstream "$APPDIR" "$output_file" >&2
+    chmod 0755 "$output_file"
+    info "Built AppImage: $output_file"
+}
+
+main "$@"

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -235,6 +235,7 @@ run_core_job() {
     bash -n scripts/build-deb.sh
     bash -n scripts/build-rpm.sh
     bash -n scripts/build-pacman.sh
+    bash -n scripts/build-appimage.sh
     bash -n scripts/ci-local.sh
     bash -n scripts/ci/*.sh
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -472,6 +472,88 @@ SCRIPT
     assert_not_contains "$capture_dir/codex-desktop.install" "update-builder"
 }
 
+test_appimage_builder_smoke() {
+    info "Running AppImage packaging smoke test"
+    local workspace="$TMP_DIR/appimage"
+    local bin_dir="$workspace/bin"
+    local app_dir="$workspace/app"
+    local dist_dir="$workspace/dist"
+    local appdir="$workspace/codex-desktop.AppDir"
+    local capture_dir="$workspace/capture"
+    local arch
+
+    case "$(uname -m)" in
+        x86_64) arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        armv7l|armhf) arch="armhf" ;;
+        *) fail "Unsupported AppImage smoke-test architecture: $(uname -m)" ;;
+    esac
+
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
+    make_stub_bin_dir "$bin_dir"
+    make_fake_app "$app_dir"
+
+    cat > "$bin_dir/appimagetool" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+saw_no_appstream=0
+previous=""
+last=""
+for arg in "$@"; do
+    [ "$arg" = "--no-appstream" ] && saw_no_appstream=1
+    previous="$last"
+    last="$arg"
+done
+
+[ "$saw_no_appstream" -eq 1 ] || exit 2
+[ -n "$previous" ] || exit 3
+[ -d "$previous" ] || exit 4
+[ -n "${ARCH:-}" ] || exit 5
+[ -n "${VERSION:-}" ] || exit 6
+
+mkdir -p "$(dirname "$last")" "$CAPTURE_DIR"
+cp -a "$previous" "$CAPTURE_DIR/AppDir"
+printf '%s\n' "$ARCH" > "$CAPTURE_DIR/arch"
+printf '%s\n' "$VERSION" > "$CAPTURE_DIR/version"
+touch "$last"
+SCRIPT
+    chmod +x "$bin_dir/appimagetool"
+
+    PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+    PACKAGE_VERSION="2026.03.24.120000+appimage" \
+    bash "$REPO_DIR/scripts/build-appimage.sh"
+
+    assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000+appimage-$arch.AppImage"
+    assert_file_exists "$capture_dir/AppDir/AppRun"
+    [ -x "$capture_dir/AppDir/AppRun" ] || fail "Expected AppRun to be executable"
+    assert_file_exists "$capture_dir/AppDir/codex-desktop.desktop"
+    assert_file_exists "$capture_dir/AppDir/codex-desktop.png"
+    assert_file_exists "$capture_dir/AppDir/.DirIcon"
+    assert_file_exists "$capture_dir/AppDir/usr/share/applications/codex-desktop.desktop"
+    assert_file_exists "$capture_dir/AppDir/usr/share/icons/hicolor/256x256/apps/codex-desktop.png"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/start.sh"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-desktop.png"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/resources/node-runtime/bin/node"
+    assert_file_not_exists "$capture_dir/AppDir/usr/bin/codex-update-manager"
+    assert_file_not_exists "$capture_dir/AppDir/usr/lib/systemd/user/codex-update-manager.service"
+    assert_file_not_exists "$capture_dir/AppDir/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
+    assert_file_not_exists "$capture_dir/AppDir/opt/codex-desktop/update-builder"
+    assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Exec=AppRun %u"
+    assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "Icon=codex-desktop"
+    assert_contains "$capture_dir/AppDir/codex-desktop.desktop" "X-AppImage-Version=2026.03.24.120000+appimage"
+    assert_not_contains "$capture_dir/AppDir/codex-desktop.desktop" "codex-update-manager"
+    assert_contains "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" 'CHROME_DESKTOP="codex-desktop.desktop"'
+    assert_not_contains "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "/usr/share/applications"
+    [ "$(cat "$capture_dir/arch")" = "$arch" ] || fail "Expected appimagetool ARCH=$arch"
+    [ "$(cat "$capture_dir/version")" = "2026.03.24.120000+appimage" ] || fail "Expected appimagetool VERSION override"
+}
+
 test_missing_input_failure() {
     info "Checking missing-input failure path"
     local workspace="$TMP_DIR/missing"
@@ -2630,6 +2712,7 @@ main() {
     test_no_updater_cleanup_helper_removes_inactive_user_enablement
     test_rpm_builder_smoke
     test_pacman_builder_without_updater_transition_hook
+    test_appimage_builder_smoke
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default
     test_upstream_build_app_workflow_tracks_dmg_metadata


### PR DESCRIPTION
## Summary

This adds a minimal local AppImage packaging flow for Codex Desktop Linux.

It follows the shape suggested in #169:

- add a dedicated `scripts/build-appimage.sh`
- add AppImage-specific files under `packaging/appimage/`
- add a `make appimage` target
- build from the already generated `codex-app/`
- write `dist/codex-desktop-<version>-<arch>.AppImage`

I kept this separate from `codex-update-manager` on purpose. The AppImage does not include the updater binary, systemd user service, polkit policy, or update-builder bundle. The documented flow is local/self-build: users run `make build-app`, then `make appimage`, and rebuild locally when upstream Codex Desktop changes.

There has not been much movement on #169, so I decided to offer a small implementation. Feel free to accept it as-is, or use it as a draft/reference for follow-up PRs if you would prefer a different final shape.

Closes #169.

## Validation

- `bash -n scripts/build-appimage.sh packaging/appimage/AppRun tests/scripts_smoke.sh`
- `git diff --check`
- `make appimage` with a local fake `appimagetool` smoke test
- Built and launched locally by the contributor with real `appimagetool`

Note: the full `bash tests/scripts_smoke.sh` run passed the new AppImage smoke test, then stopped later in an existing Chrome marketplace fallback test unrelated to this change.
