### PR TITLE
Add explicit fresh app rebuild target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -62,7 +62,8 @@ help:
 	@printf '  %-18s %s\n' "make rebuild" "Inspect a DMG and build a side-by-side candidate"
 	@printf '  %-18s %s\n' "make rebuild-install" "Find a DMG, rebuild, and install into codex-app/"
 	@printf '  %-18s %s\n' "make inspect-upstream" "Inspect a DMG and write rebuild reports without changing codex-app/"
-	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/"
+	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/ (reuses cached Codex.dmg)"
+	@printf '  %-18s %s\n' "make build-app-fresh" "Remove cached Codex.dmg and regenerate codex-app/"
 	@printf '  %-18s %s\n' "make rebuild-next" "Build a side-by-side candidate in codex-app-next/"
 	@printf '  %-18s %s\n' "make run-app" "Launch the local generated Electron app from codex-app/"
 	@printf '  %-18s %s\n' "make build-dev-app" "Build a side-by-side test app with a distinct app id/bin"
@@ -95,6 +96,7 @@ help:
 	@printf '  %s\n' "make rebuild-install"
 	@printf '  %s\n' "make rebuild DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make build-app DMG=/tmp/Codex.dmg"
+	@printf '  %s\n' "make build-app-fresh"
 	@printf '  %s\n' "make inspect-upstream DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make rebuild-next DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make run-app"
@@ -149,6 +151,10 @@ inspect-upstream:
 build-app:
 	@echo "[make] Regenerating codex-app from DMG"
 	./install.sh "$(DMG)"
+
+build-app-fresh:
+	@echo "[make] Regenerating codex-app from fresh DMG"
+	./install.sh --fresh "$(DMG)"
 
 rebuild-next:
 	@echo "[make] Building side-by-side rebuild candidate"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The AppImage flow does not include `codex-update-manager`, the systemd user serv
 
 ```bash
 git pull --ff-only
-make build-app
+make build-app-fresh
 make appimage
 ```
 
@@ -246,7 +246,7 @@ Manual updates should come from a checkout you have chosen to trust:
 
 ```bash
 git pull --ff-only
-make build-app
+make build-app-fresh
 PACKAGE_WITH_UPDATER=0 make package
 make install
 ```
@@ -307,7 +307,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 This produces `codex-app/` from the upstream DMG and writes the Linux launcher to `codex-app/start.sh`:
 
 ```bash
-make build-app                              # downloads upstream DMG
+make build-app                              # download upstream DMG if no cached Codex.dmg exists
+make build-app-fresh                        # remove codex-app/ + cached Codex.dmg, then download current upstream DMG
 make build-app DMG=/path/to/Codex.dmg       # use a local copy
 make run-app                                # launches the generated app
 ```
@@ -323,7 +324,7 @@ Equivalent direct commands:
 
 ### Electron download mirrors
 
-`make build-app` downloads Electron headers while rebuilding native modules, then downloads a Linux Electron runtime. If the runtime download from GitHub is slow or blocked, use a mirror:
+The app build commands download Electron headers while rebuilding native modules, then download a Linux Electron runtime. If the runtime download from GitHub is slow or blocked, use a mirror:
 
 ```bash
 ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ \
@@ -334,7 +335,7 @@ make build-app
 
 ## Package formats
 
-After `make build-app`, build a native package from `codex-app/` with the format you need:
+After `make build-app` or `make build-app-fresh`, build a native package from `codex-app/` with the format you need:
 
 | Format | Build command | Output | Install |
 |---|---|---|---|
@@ -370,6 +371,7 @@ make check
 make test
 make build-updater
 make build-app
+make build-app-fresh
 make run-app
 make build-dev-app
 make run-dev-app
@@ -398,7 +400,7 @@ make clean-state
 | GPU / Vulkan / Wayland errors | Under Wayland with `DISPLAY` available, the launcher uses `--ozone-platform=x11` for window-positioning compatibility. Otherwise it uses `--ozone-platform-hint=auto`. GPU sandbox / compositing are disabled by default |
 | Window flickering | GPU compositing is disabled by default. If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
-| Stale install / cached DMG | `./install.sh --fresh` removes the existing install dir and re-downloads |
+| Stale install / cached DMG | `make build-app-fresh` removes the existing install dir and cached DMG, then re-downloads |
 | Computer Use plugin invisible in UI | Ensure you enabled the Computer Use UI. If it is enabled and still hidden, the OpenAI per-account rollout may not be available |
 | Computer Use `doctor` reports `ydotool not running` | Start the distro-provided daemon unit (`ydotoold` or `ydotool`), or use a user-session `ydotoold` service, then add your user to the `input` group |
 | Computer Use `doctor` reports `ydotool_socket: Permission denied` | The daemon socket is root-only. Adjust the `ydotoold` service so `/tmp/.ydotool_socket` becomes `root:input` with `0660` permissions |

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -588,6 +588,8 @@ test_make_build_app_uses_installer_download_flow_by_default() {
     info "Checking make build-app default DMG behavior"
     local workspace="$TMP_DIR/make-build-app"
     local install_log="$workspace/install-args.log"
+    local first_line
+    local second_line
 
     mkdir -p "$workspace"
 
@@ -608,6 +610,37 @@ SCRIPT
     second_line="$(sed -n '2p' "$install_log")"
     [ "$first_line" = "1" ] || fail "Expected make build-app to call install.sh with a single default argument slot, got: $(cat "$install_log")"
     [ -z "$second_line" ] || fail "Expected make build-app default DMG argument to be empty so install.sh falls back to reuse/download, got: $(cat "$install_log")"
+}
+
+test_make_build_app_fresh_uses_installer_fresh_flow() {
+    info "Checking make build-app-fresh DMG behavior"
+    local workspace="$TMP_DIR/make-build-app-fresh"
+    local install_log="$workspace/install-args.log"
+    local first_line
+    local second_line
+    local third_line
+
+    mkdir -p "$workspace"
+
+    cat > "$workspace/install.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$#" > "$TEST_INSTALL_LOG"
+for arg in "$@"; do
+    printf '%s\n' "$arg" >> "$TEST_INSTALL_LOG"
+done
+SCRIPT
+    chmod +x "$workspace/install.sh"
+
+    TEST_INSTALL_LOG="$install_log" make -f "$REPO_DIR/Makefile" -C "$workspace" build-app-fresh >/dev/null
+
+    assert_file_exists "$install_log"
+    first_line="$(sed -n '1p' "$install_log")"
+    second_line="$(sed -n '2p' "$install_log")"
+    third_line="$(sed -n '3p' "$install_log")"
+    [ "$first_line" = "2" ] || fail "Expected make build-app-fresh to pass --fresh plus the default argument slot, got: $(cat "$install_log")"
+    [ "$second_line" = "--fresh" ] || fail "Expected make build-app-fresh to pass --fresh first, got: $(cat "$install_log")"
+    [ -z "$third_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
 }
 
 test_upstream_build_app_workflow_tracks_dmg_metadata() {
@@ -2715,6 +2748,7 @@ main() {
     test_appimage_builder_smoke
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default
+    test_make_build_app_fresh_uses_installer_fresh_flow
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata


### PR DESCRIPTION
## Summary

- add `make build-app-fresh` as a small wrapper around `./install.sh --fresh`
- document when manual update flows should use a fresh upstream DMG instead of the cached `Codex.dmg`
- cover the new Makefile target in the script smoke tests

Closes #203.

Context: this follows the local AppImage flow from #202 and the no-updater/manual-update flow from #180, where `make build-app` can currently rebuild from an older cached DMG.

## Validation

- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`