### PR TITLE
Add native install shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -64,6 +64,9 @@ help:
 	@printf '  %-18s %s\n' "make inspect-upstream" "Inspect a DMG and write rebuild reports without changing codex-app/"
 	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/ (reuses cached Codex.dmg)"
 	@printf '  %-18s %s\n' "make build-app-fresh" "Remove cached Codex.dmg and regenerate codex-app/"
+	@printf '  %-18s %s\n' "make bootstrap-native" "Install deps, fresh-build, package, and install"
+	@printf '  %-18s %s\n' "make install-native" "Fresh-build, package, and install"
+	@printf '  %-18s %s\n' "make update-native" "Pull trusted checkout, fresh-build, package, and install"
 	@printf '  %-18s %s\n' "make rebuild-next" "Build a side-by-side candidate in codex-app-next/"
 	@printf '  %-18s %s\n' "make run-app" "Launch the local generated Electron app from codex-app/"
 	@printf '  %-18s %s\n' "make build-dev-app" "Build a side-by-side test app with a distinct app id/bin"
@@ -97,6 +100,9 @@ help:
 	@printf '  %s\n' "make rebuild DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make build-app DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make build-app-fresh"
+	@printf '  %s\n' "make bootstrap-native"
+	@printf '  %s\n' "make install-native"
+	@printf '  %s\n' "PACKAGE_WITH_UPDATER=0 make update-native"
 	@printf '  %s\n' "make inspect-upstream DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make rebuild-next DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make run-app"
@@ -155,6 +161,22 @@ build-app:
 build-app-fresh:
 	@echo "[make] Regenerating codex-app from fresh DMG"
 	./install.sh --fresh "$(DMG)"
+
+bootstrap-native:
+	@echo "[make] Installing native build dependencies"
+	bash scripts/install-deps.sh
+	PATH="$$HOME/.cargo/bin:$$PATH" $(MAKE) install-native
+
+install-native:
+	$(MAKE) build-app-fresh
+	$(MAKE) package
+	$(MAKE) install
+	@echo "[make] Native package install complete"
+
+update-native:
+	@echo "[make] Updating trusted checkout"
+	git pull --ff-only
+	$(MAKE) install-native
 
 rebuild-next:
 	@echo "[make] Building side-by-side rebuild candidate"

--- a/README.md
+++ b/README.md
@@ -64,13 +64,12 @@ The fastest path: install deps, build the local app, build the native package, i
 ```bash
 git clone https://github.com/ilysenko/codex-desktop-linux.git
 cd codex-desktop-linux
-bash scripts/install-deps.sh
-make build-app
-make package        # auto-detects deb / rpm / pacman
-make install        # installs the newest package from dist/
+make bootstrap-native
 ```
 
-`make package` picks the format that matches your distro. `make install` then runs the right `dpkg -i` / `dnf install` / `zypper install` / `pacman -U` against the freshly built artifact.
+`make bootstrap-native` installs build dependencies, regenerates `codex-app/` from a fresh upstream `Codex.dmg`, builds the matching native package, and installs the newest artifact from `dist/`. It uses the same package auto-detection as `make package` / `make install`.
+
+If dependencies are already installed, use `make install-native` to run only the fresh app build, package, and install steps.
 
 ### AppImage local self-build
 
@@ -245,11 +244,10 @@ That package omits `codex-update-manager`, the user service unit, updater polkit
 Manual updates should come from a checkout you have chosen to trust:
 
 ```bash
-git pull --ff-only
-make build-app-fresh
-PACKAGE_WITH_UPDATER=0 make package
-make install
+PACKAGE_WITH_UPDATER=0 make update-native
 ```
+
+`make update-native` runs `git pull --ff-only`, regenerates `codex-app/` from a fresh upstream `Codex.dmg`, builds the native package, and installs it. Keep `PACKAGE_WITH_UPDATER=0` when you want the installed package to stay in manual-update mode.
 
 ## Build from source / custom DMG
 
@@ -372,6 +370,9 @@ make test
 make build-updater
 make build-app
 make build-app-fresh
+make bootstrap-native
+make install-native
+make update-native
 make run-app
 make build-dev-app
 make run-dev-app

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -643,6 +643,27 @@ SCRIPT
     [ -z "$third_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
 }
 
+test_native_shortcut_targets_compose_existing_flows() {
+    info "Checking native install/update shortcut targets"
+    local install_log="$TMP_DIR/make-install-native.log"
+    local bootstrap_log="$TMP_DIR/make-bootstrap-native.log"
+    local update_log="$TMP_DIR/make-update-native.log"
+
+    make -n -C "$REPO_DIR" install-native >"$install_log"
+    assert_contains "$install_log" './install.sh --fresh'
+    assert_contains "$install_log" 'Building native package'
+    assert_contains "$install_log" 'Installing latest native package'
+
+    make -n -C "$REPO_DIR" bootstrap-native >"$bootstrap_log"
+    assert_contains "$bootstrap_log" 'bash scripts/install-deps.sh'
+    assert_contains "$bootstrap_log" 'PATH="$HOME/.cargo/bin:$PATH"'
+    assert_contains "$bootstrap_log" 'install-native'
+
+    make -n -C "$REPO_DIR" update-native >"$update_log"
+    assert_contains "$update_log" 'git pull --ff-only'
+    assert_contains "$update_log" 'install-native'
+}
+
 test_upstream_build_app_workflow_tracks_dmg_metadata() {
     info "Checking upstream build-app workflow metadata and cache behavior"
     local workflow="$REPO_DIR/.github/workflows/upstream-build-app.yml"
@@ -2749,6 +2770,7 @@ main() {
     test_missing_input_failure
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
+    test_native_shortcut_targets_compose_existing_flows
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata


### PR DESCRIPTION
## Summary

- add `make bootstrap-native` for first-time native installs from a checkout
- add `make install-native` for the fresh-build, package, install sequence when dependencies are already present
- add `make update-native` for trusted-checkout manual updates
- document the simplified quick-install and no-updater manual-update flows
- cover the new shortcut targets in the script smoke tests

## Why

This follows the fresh-DMG distinction added in #204 and the no-updater/manual-update package flow from #180.

Those pieces are useful, but users still had to manually chain the same commands every time: install dependencies, fresh-build `codex-app/`, package for the host distro, then install the newest artifact from `dist/`. The new targets keep the existing build/package/install contracts intact and only compose them into clearer entrypoints.

## Relationship to the user-local updater

This is separate from the managed user-local update flow being discussed in #199. That PR hardens `contrib/user-local-install` so a user-local install can rebuild from a managed checkout instead of mutating the source checkout.

This PR only simplifies the native package workflow from a trusted checkout. `make update-native` intentionally keeps the existing `git pull --ff-only` behavior, so dirty or divergent checkouts fail visibly instead of being reconciled automatically.

## User-visible behavior

First-time native package install from a checkout becomes:

```bash
git clone https://github.com/ilysenko/codex-desktop-linux.git
cd codex-desktop-linux
make bootstrap-native
```

Manual no-updater updates can now use:

```bash
PACKAGE_WITH_UPDATER=0 make update-native
```

`make bootstrap-native` also runs the follow-up install step with `~/.cargo/bin` on `PATH`, so a fresh Rust install from `scripts/install-deps.sh` is available to the recursive package build.

## Validation

- `make -n install-native`
- `make -n bootstrap-native`
- `make -n update-native`
- `make help`
- `bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
