### PR TITLE
[codex] Refactor Nix package inputs

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -36,9 +36,6 @@ jobs:
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
-          PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopPayload = mkCodexDesktopPayload {' 'outputHash = ')"
-          COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {' 'outputHash = ')"
-          REMOTE_MOBILE_CONTROL_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {' 'outputHash = ')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -46,8 +43,6 @@ jobs:
           git commit \
             -m "fix(nix): update upstream Nix hashes" \
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
-            -m "Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH." \
-            -m "Refreshed codexDesktopComputerUseUiPayload recursive outputHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
-            -m "Refreshed codexDesktopRemoteMobileControlPayload recursive outputHash to $REMOTE_MOBILE_CONTROL_PAYLOAD_HASH." \
+            -m "Verified all Codex Desktop Nix package outputs against the refreshed DMG." \
             -m "[skip ci]"
           git push origin main

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -38,6 +38,7 @@ jobs:
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
           PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopPayload = mkCodexDesktopPayload {' 'outputHash = ')"
           COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {' 'outputHash = ')"
+          REMOTE_MOBILE_CONTROL_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {' 'outputHash = ')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -47,5 +48,6 @@ jobs:
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
             -m "Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH." \
             -m "Refreshed codexDesktopComputerUseUiPayload recursive outputHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
+            -m "Refreshed codexDesktopRemoteMobileControlPayload recursive outputHash to $REMOTE_MOBILE_CONTROL_PAYLOAD_HASH." \
             -m "[skip ci]"
           git push origin main

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Because flakes do not include the git-ignored `linux-features/features.json` opt
 nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
 ```
 
+Feature-specific Nix outputs are additive. To enable both the Computer Use UI and experimental mobile remote control:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+```
+
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
 ## Linux Computer Use
@@ -166,6 +172,12 @@ Nix users can also run the opt-in flake output directly:
 
 ```bash
 nix run github:ilysenko/codex-desktop-linux#codex-desktop-computer-use-ui
+```
+
+The Computer Use UI output can also be combined with Linux feature outputs, for example:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
 ```
 
 ### Side-by-side dev variant

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ nix run github:ilysenko/codex-desktop-linux
 
 The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot refreshes the upstream `Codex.dmg` and recursive Nix payload hashes in `main`; if you hit a hash mismatch right after an upstream release, wait for the next bot run and retry.
 
+Because flakes do not include the git-ignored `linux-features/features.json` opt-in file, Nix exposes feature-specific app variants for optional integrations. To build and run Codex Desktop with the experimental mobile remote-control feature enabled:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
+```
+
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
 ## Linux Computer Use

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,155 @@
           hash = "sha256-WTeptN8D9hF2ffvlJKppfLTOJr5Z0hjokHCnGX6drk0=";
         };
 
+        codexVersion = "26.506.21252";
+        electronVersion = "42.0.1";
+        electronPlatform =
+          {
+            x86_64-linux = {
+              arch = "x64";
+              hash = "sha256-4bi1uG0//2nis1AlhjY9OECF7gV4vQQfpZFf0LVXxPE=";
+            };
+            aarch64-linux = {
+              arch = "arm64";
+              hash = "sha256-oIpOaROATrBc6nmNi9CvrOTRuI6dB9uGt3nqSkSL4HA=";
+            };
+          }.${system} or (throw "codex-desktop-linux Nix package is not supported on ${system}");
+
+        electronZip = pkgs.fetchurl {
+          url = "https://github.com/electron/electron/releases/download/v${electronVersion}/electron-v${electronVersion}-linux-${electronPlatform.arch}.zip";
+          hash = electronPlatform.hash;
+        };
+
+        electronHeaders = pkgs.fetchurl {
+          url = "https://artifacts.electronjs.org/headers/dist/v${electronVersion}/node-v${electronVersion}-headers.tar.gz";
+          hash = "sha256-yQBrv98qtbQ8cdZpuqx2uyP1mkIAVhLlUFjI/vxh9gA=";
+        };
+
+        browserUseNodeReplRuntime = pkgs.fetchurl {
+          url = "https://persistent.oaistatic.com/codex-primary-runtime/26.426.12240/codex-primary-runtime-linux-x64-26.426.12240.tar.xz";
+          hash = "sha256-21Yk6276NrZuxvbdBIjO+5ZuSWNoYqq2IJpDNsHKkMQ=";
+        };
+
+        browserUseNodeRepl = if system == "x86_64-linux" then pkgs.stdenv.mkDerivation {
+          pname = "codex-browser-use-node-repl";
+          version = "26.426.12240";
+          src = browserUseNodeReplRuntime;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/bin"
+            tar -xJf "$src" -C "$TMPDIR" codex-primary-runtime/dependencies/bin/node_repl
+            install -m 0755 "$TMPDIR/codex-primary-runtime/dependencies/bin/node_repl" "$out/bin/node_repl"
+            runHook postInstall
+          '';
+        } else null;
+
+        codexComputerUseBinaries = pkgs.rustPlatform.buildRustPackage {
+          pname = "codex-computer-use-linux-binaries";
+          version = "0.1.2-linux-alpha1";
+          src = sourceRoot;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "cosmic-protocols-0.2.0" = "sha256-ymn+BUTTzyHquPn4hvuoA3y1owFj8LVrmsPu2cdkFQ8=";
+            };
+          };
+
+          buildAndTestSubdir = "computer-use-linux";
+          cargoBuildFlags = [
+            "-p"
+            "codex-computer-use-linux"
+            "--bins"
+          ];
+          doCheck = false;
+
+          installPhase = ''
+            runHook preInstall
+            release_dir="target/''${CARGO_BUILD_TARGET:-${pkgs.stdenv.hostPlatform.rust.rustcTarget}}/release"
+            if [ ! -d "$release_dir" ]; then
+              release_dir="target/release"
+            fi
+            install -Dm0755 "$release_dir/codex-computer-use-linux" "$out/bin/codex-computer-use-linux"
+            install -Dm0755 "$release_dir/codex-computer-use-cosmic" "$out/bin/codex-computer-use-cosmic"
+            install -Dm0755 "$release_dir/codex-chrome-extension-host" "$out/bin/codex-chrome-extension-host"
+            runHook postInstall
+          '';
+        };
+
+        nativeModulesNodeModules = pkgs.importNpmLock.buildNodeModules {
+          npmRoot = ./nix/native-modules;
+          inherit (pkgs) nodejs;
+          derivationArgs = {
+            npmRebuildFlags = [ "--ignore-scripts" ];
+          };
+        };
+
+        codexNativeModules = pkgs.stdenv.mkDerivation {
+          pname = "codex-desktop-electron-native-modules";
+          version = electronVersion;
+          dontUnpack = true;
+
+          nativeBuildInputs = [
+            pkgs.bash
+            pkgs.gcc
+            pkgs.gnumake
+            pkgs.nodejs
+            pkgs.python3
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            cp -R ${nativeModulesNodeModules}/node_modules .
+            cp ${nativeModulesNodeModules}/package.json .
+            cp ${nativeModulesNodeModules}/package-lock.json .
+            chmod -R u+w node_modules
+
+            mkdir -p "$TMPDIR/electron-headers"
+            tar -xzf ${electronHeaders} -C "$TMPDIR/electron-headers" --strip-components=1
+
+            export SCRIPT_DIR=${sourceRoot}
+            export WORK_DIR="$TMPDIR"
+            export ARCH="${pkgs.stdenv.hostPlatform.uname.processor}"
+            export ELECTRON_VERSION=${electronVersion}
+            export MIN_BETTER_SQLITE3_VERSION_FOR_ELECTRON_41="12.9.0"
+            export npm_config_nodedir="$TMPDIR/electron-headers"
+            export NPM_CONFIG_NODEDIR="$TMPDIR/electron-headers"
+
+            # Reuse the installer's Electron 42 source compatibility patch without
+            # sourcing install-helpers.sh, which owns the top-level installer traps.
+            info() { echo "[INFO] $*" >&2; }
+            warn() { echo "[WARN] $*" >&2; }
+            error() { echo "[ERROR] $*" >&2; exit 1; }
+            source ${sourceRoot}/scripts/lib/native-modules.sh
+            patch_better_sqlite3_for_v8_external_pointer_api "$PWD/node_modules/better-sqlite3"
+
+            node "$PWD/node_modules/@electron/rebuild/lib/cli.js" \
+              -v ${electronVersion} \
+              --force \
+              --module-dir "$PWD" \
+              --dist-url "file://$TMPDIR/electron-headers"
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            cp -R node_modules/better-sqlite3 "$out/better-sqlite3"
+            cp -R node_modules/node-pty "$out/node-pty"
+            find "$out/better-sqlite3/build" -type f ! -name "*.node" -delete 2>/dev/null || true
+            find "$out/node-pty/build" -type f ! -name "*.node" -delete 2>/dev/null || true
+            find "$out" -type d -empty -delete 2>/dev/null || true
+            find "$out" -type f -name "*.target.mk" -delete 2>/dev/null || true
+            runHook postInstall
+          '';
+        };
+
         electronLibs = with pkgs; [
           glib
           gtk3
@@ -193,10 +342,10 @@ PY
           in
           if featureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" featureIds}";
 
-        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], outputHash }:
+        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
         pkgs.stdenv.mkDerivation {
           pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi linuxFeatureIds; }}-payload";
-          version = "26.506.21252";
+          version = codexVersion;
           src = sourceRoot;
           __structuredAttrs = true;
 
@@ -209,16 +358,12 @@ PY
             pkgs.gnused
             pkgs.makeWrapper
             pkgs.nodejs
+            pkgs.asar
             pkgs._7zz
             pkgs.patchelf
             pkgs.python3
             pkgs.unzip
           ];
-
-          outputHashAlgo = "sha256";
-          outputHashMode = "recursive";
-          inherit outputHash;
-          unsafeDiscardReferences.out = true;
 
           dontConfigure = true;
           dontBuild = true;
@@ -242,6 +387,14 @@ PY
             export RUSTFLAGS="''${RUSTFLAGS:-} --remap-path-prefix=$TMPDIR=/build -C link-arg=-Wl,--build-id=none"
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
             export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfig linuxFeatureIds}"
+            export CODEX_ELECTRON_ZIP_SOURCE="${electronZip}"
+            export CODEX_NATIVE_MODULES_SOURCE="${codexNativeModules}"
+            ${pkgs.lib.optionalString (browserUseNodeRepl != null) ''
+            export CODEX_LINUX_NODE_REPL_SOURCE="${browserUseNodeRepl}/bin/node_repl"
+            ''}
+            export CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-linux"
+            export CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-cosmic"
+            export CODEX_CHROME_EXTENSION_HOST_SOURCE="${codexComputerUseBinaries}/bin/codex-chrome-extension-host"
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 
             source_dir="$TMPDIR/codex-source"
@@ -250,10 +403,6 @@ PY
             chmod -R u+w "$source_dir"
             cp ${codexDmg} "$source_dir/Codex.dmg"
 
-            npm_tools="$TMPDIR/npm-tools"
-            npm install --prefix "$npm_tools" --ignore-scripts asar @electron/rebuild
-            patchShebangs "$npm_tools"
-            export PATH="$npm_tools/node_modules/.bin:$PATH"
             substituteInPlace "$source_dir/scripts/lib/asar-patch.sh" \
               --replace-fail "npx --yes asar" "asar" \
               --replace-fail "npx asar" "asar"
@@ -273,17 +422,16 @@ PY
           '';
         };
 
-        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], payloadHash }:
+        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
         let
           featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
           payload = mkCodexDesktopPayload {
             inherit enableComputerUseUi linuxFeatureIds;
-            outputHash = payloadHash;
           };
         in
         pkgs.stdenv.mkDerivation {
           pname = "codex-desktop${packageSuffix featureArgs}";
-          version = "26.506.21252";
+          version = codexVersion;
           src = payload;
 
           nativeBuildInputs = [
@@ -358,24 +506,19 @@ PY
           };
         };
 
-        codexDesktop = mkCodexDesktop {
-          payloadHash = "sha256-oikRvP+7uKLnue/Kt2QYi62+SGshTa+pa/bGgDF0/MU=";
-        };
+        codexDesktop = mkCodexDesktop { };
 
         codexDesktopComputerUseUi = mkCodexDesktop {
           enableComputerUseUi = true;
-          payloadHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
         };
 
         codexDesktopRemoteMobileControl = mkCodexDesktop {
           linuxFeatureIds = [ "remote-mobile-control" ];
-          payloadHash = "sha256-qNJEgQ0aj4b8HxF4syav6gxfID3NGfTxh6kN4FvSDuU=";
         };
 
         codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {
           enableComputerUseUi = true;
           linuxFeatureIds = [ "remote-mobile-control" ];
-          payloadHash = "sha256-qRQjww+XmHcNjmKuKqTCh5JjNaMPe4Ujz6a1Fl3njcI=";
         };
 
         installer = pkgs.writeShellApplication {

--- a/flake.nix
+++ b/flake.nix
@@ -184,12 +184,18 @@ PY
             enabled = linuxFeatureIds;
           });
 
-        packageSuffix = linuxFeatureIds:
-          if linuxFeatureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" linuxFeatureIds}";
+        enabledFeatureIds = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+          pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ] ++ linuxFeatureIds;
+
+        packageSuffix = args:
+          let
+            featureIds = enabledFeatureIds args;
+          in
+          if featureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" featureIds}";
 
         mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], outputHash }:
         pkgs.stdenv.mkDerivation {
-          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload${packageSuffix linuxFeatureIds}";
+          pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi linuxFeatureIds; }}-payload";
           version = "26.506.21252";
           src = sourceRoot;
           __structuredAttrs = true;
@@ -267,23 +273,16 @@ PY
           '';
         };
 
-        codexDesktopPayload = mkCodexDesktopPayload {
-          outputHash = "sha256-oikRvP+7uKLnue/Kt2QYi62+SGshTa+pa/bGgDF0/MU=";
-        };
-
-        codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {
-          enableComputerUseUi = true;
-          outputHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
-        };
-
-        codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {
-          linuxFeatureIds = [ "remote-mobile-control" ];
-          outputHash = "sha256-T7Vd20fWm7Yz5vNxC05H40rE8Oq3NFLErgxr/s/0mEk=";
-        };
-
-        mkCodexDesktop = { pname ? "codex-desktop", payload }:
+        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], payloadHash }:
+        let
+          featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
+          payload = mkCodexDesktopPayload {
+            inherit enableComputerUseUi linuxFeatureIds;
+            outputHash = payloadHash;
+          };
+        in
         pkgs.stdenv.mkDerivation {
-          inherit pname;
+          pname = "codex-desktop${packageSuffix featureArgs}";
           version = "26.506.21252";
           src = payload;
 
@@ -344,7 +343,14 @@ PY
           '';
 
           meta = {
-            description = if pname == "codex-desktop-computer-use-ui" then "Codex Desktop for Linux with Computer Use UI enabled" else "Codex Desktop for Linux";
+            description =
+              let
+                featureIds = enabledFeatureIds featureArgs;
+              in
+              if featureIds == [ ] then
+                "Codex Desktop for Linux"
+              else
+                "Codex Desktop for Linux with ${pkgs.lib.concatStringsSep ", " featureIds} enabled";
             homepage = "https://github.com/ilysenko/codex-desktop-linux";
             license = pkgs.lib.licenses.mit;
             platforms = pkgs.lib.platforms.linux;
@@ -353,17 +359,23 @@ PY
         };
 
         codexDesktop = mkCodexDesktop {
-          payload = codexDesktopPayload;
+          payloadHash = "sha256-oikRvP+7uKLnue/Kt2QYi62+SGshTa+pa/bGgDF0/MU=";
         };
 
         codexDesktopComputerUseUi = mkCodexDesktop {
-          pname = "codex-desktop-computer-use-ui";
-          payload = codexDesktopComputerUseUiPayload;
+          enableComputerUseUi = true;
+          payloadHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
         };
 
         codexDesktopRemoteMobileControl = mkCodexDesktop {
-          pname = "codex-desktop-remote-mobile-control";
-          payload = codexDesktopRemoteMobileControlPayload;
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          payloadHash = "sha256-qNJEgQ0aj4b8HxF4syav6gxfID3NGfTxh6kN4FvSDuU=";
+        };
+
+        codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {
+          enableComputerUseUi = true;
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          payloadHash = "sha256-qRQjww+XmHcNjmKuKqTCh5JjNaMPe4Ujz6a1Fl3njcI=";
         };
 
         installer = pkgs.writeShellApplication {
@@ -413,6 +425,7 @@ PY
           codex-desktop = codexDesktop;
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
           codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
+          codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
           installer = installer;
         };
 
@@ -424,6 +437,11 @@ PY
         apps.remote-mobile-control = {
           type = "app";
           program = "${codexDesktopRemoteMobileControl}/bin/codex-desktop";
+        };
+
+        apps.computer-use-ui-remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopComputerUseUiRemoteMobileControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/flake.nix
+++ b/flake.nix
@@ -179,9 +179,17 @@ PY
           fi
         '';
 
-        mkCodexDesktopPayload = { enableComputerUseUi ? false, outputHash }:
+        linuxFeaturesConfig = linuxFeatureIds:
+          pkgs.writeText "codex-linux-features.json" (builtins.toJSON {
+            enabled = linuxFeatureIds;
+          });
+
+        packageSuffix = linuxFeatureIds:
+          if linuxFeatureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" linuxFeatureIds}";
+
+        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], outputHash }:
         pkgs.stdenv.mkDerivation {
-          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload";
+          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload${packageSuffix linuxFeatureIds}";
           version = "26.506.21252";
           src = sourceRoot;
           __structuredAttrs = true;
@@ -227,6 +235,7 @@ PY
             export CXXFLAGS="''${CXXFLAGS:-} -ffile-prefix-map=$TMPDIR=/build -fdebug-prefix-map=$TMPDIR=/build -fmacro-prefix-map=$TMPDIR=/build"
             export RUSTFLAGS="''${RUSTFLAGS:-} --remap-path-prefix=$TMPDIR=/build -C link-arg=-Wl,--build-id=none"
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
+            export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfig linuxFeatureIds}"
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 
             source_dir="$TMPDIR/codex-source"
@@ -265,6 +274,11 @@ PY
         codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {
           enableComputerUseUi = true;
           outputHash = "sha256-bOjhutEpccYUYl3SfFhNoNOVZJKnsVaYeIVOANcA+a8=";
+        };
+
+        codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {
+          linuxFeatureIds = [ "remote-mobile-control" ];
+          outputHash = "sha256-T7Vd20fWm7Yz5vNxC05H40rE8Oq3NFLErgxr/s/0mEk=";
         };
 
         mkCodexDesktop = { pname ? "codex-desktop", payload }:
@@ -347,6 +361,11 @@ PY
           payload = codexDesktopComputerUseUiPayload;
         };
 
+        codexDesktopRemoteMobileControl = mkCodexDesktop {
+          pname = "codex-desktop-remote-mobile-control";
+          payload = codexDesktopRemoteMobileControlPayload;
+        };
+
         installer = pkgs.writeShellApplication {
           name = "codex-desktop-installer";
           runtimeInputs = [
@@ -393,12 +412,18 @@ PY
           default = codexDesktop;
           codex-desktop = codexDesktop;
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
+          codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
           installer = installer;
         };
 
         apps.default = {
           type = "app";
           program = "${codexDesktop}/bin/codex-desktop";
+        };
+
+        apps.remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopRemoteMobileControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -15,6 +15,13 @@ building:
 }
 ```
 
+For the Nix flake build, use the declarative app variant instead because the
+git-ignored `features.json` file is not part of the flake source:
+
+```bash
+nix run .#remote-mobile-control
+```
+
 What it changes:
 
 - Replaces the macOS-only `remote-control-device-key.node` requirement with a

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -22,6 +22,13 @@ git-ignored `features.json` file is not part of the flake source:
 nix run .#remote-mobile-control
 ```
 
+Feature-specific Nix outputs are additive. To combine this feature with the
+Computer Use UI opt-in:
+
+```bash
+nix run .#computer-use-ui-remote-mobile-control
+```
+
 What it changes:
 
 - Replaces the macOS-only `remote-control-device-key.node` requirement with a

--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -1,0 +1,1048 @@
+{
+  "name": "codex-desktop-linux-native-modules",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-desktop-linux-native-modules",
+      "version": "0.0.0",
+      "dependencies": {
+        "@electron/rebuild": "4.0.4",
+        "better-sqlite3": "12.9.0",
+        "electron": "42.0.1",
+        "node-abi": "^4.31.0",
+        "node-pty": "1.1.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron": {
+      "version": "42.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.1.tgz",
+      "integrity": "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/nix/native-modules/package.json
+++ b/nix/native-modules/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "codex-desktop-linux-native-modules",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@electron/rebuild": "4.0.4",
+    "better-sqlite3": "12.9.0",
+    "electron": "42.0.1",
+    "node-abi": "^4.31.0",
+    "node-pty": "1.1.0"
+  }
+}

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -5,11 +5,14 @@ REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
 UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
-BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
-COMPUTER_USE_UI_BUILD_LOG="${COMPUTER_USE_UI_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui.log}"
-REMOTE_MOBILE_CONTROL_BUILD_LOG="${REMOTE_MOBILE_CONTROL_BUILD_LOG:-/tmp/codex-nix-build-remote-mobile-control.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
-FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+PACKAGE_OUTPUTS=(
+    ".#codex-desktop"
+    ".#codex-desktop-computer-use-ui"
+    ".#codex-desktop-remote-mobile-control"
+    ".#codex-desktop-computer-use-ui-remote-mobile-control"
+)
 
 validate_sri_hash() {
     local hash="$1"
@@ -82,23 +85,6 @@ raise SystemExit(f"Could not find {key!r} after {anchor!r} in {path}")
 PY
 }
 
-extract_got_sri_hash() {
-    local log_path="$1"
-
-    python3 - "$log_path" <<'PY'
-from pathlib import Path
-import re
-import sys
-
-text = Path(sys.argv[1]).read_text(errors="replace")
-text = re.sub(r"\x1b\[[0-9;]*m", "", text)
-matches = re.findall(r"got:\s*(sha256-[A-Za-z0-9+/=]{44})", text)
-if not matches:
-    raise SystemExit(1)
-print(matches[-1])
-PY
-}
-
 run_nix_build() {
     local log_path="$1"
     shift
@@ -111,31 +97,7 @@ run_nix_build() {
     return "$status"
 }
 
-restore_flake_hashes() {
-    local dmg_hash="$1"
-    local payload_hash="$2"
-    local computer_use_ui_payload_hash="$3"
-    local remote_mobile_control_payload_hash="$4"
-
-    if [ -n "$dmg_hash" ]; then
-        replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
-    fi
-    if [ -n "$payload_hash" ]; then
-        replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$payload_hash"
-    fi
-    if [ -n "$computer_use_ui_payload_hash" ]; then
-        replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$computer_use_ui_payload_hash"
-    fi
-    if [ -n "$remote_mobile_control_payload_hash" ]; then
-        replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$remote_mobile_control_payload_hash"
-    fi
-}
-
 main() {
-    local current_dmg_hash=""
-    local current_payload_hash=""
-    local current_computer_use_ui_payload_hash=""
-    local current_remote_mobile_control_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -150,93 +112,12 @@ main() {
     echo "Upstream Codex.dmg hash: $new_dmg_hash"
     replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$new_dmg_hash"
 
-    # Seed the Nix store so the build can reuse the DMG that was already downloaded
-    # for hashing instead of fetching the same 300MB artifact again.
+    # Seed the Nix store so the verification build can reuse the DMG that was
+    # already downloaded for hashing instead of fetching the same artifact again.
     nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
 
-    current_payload_hash="$(read_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current payload outputHash: $current_payload_hash"
-    echo "Forcing payload outputHash refresh..."
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
-
-    if run_nix_build "$BUILD_LOG" .#codex-desktop; then
-        echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
-    if [ -z "$new_payload_hash" ]; then
-        echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    if ! validate_sri_hash "$new_payload_hash"; then
-        echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    echo "Actual payload outputHash:  $new_payload_hash"
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$new_payload_hash"
-
-    current_computer_use_ui_payload_hash="$(read_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current Computer Use UI payload outputHash: $current_computer_use_ui_payload_hash"
-    echo "Forcing Computer Use UI payload outputHash refresh..."
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
-
-    if run_nix_build "$COMPUTER_USE_UI_BUILD_LOG" .#codex-desktop-computer-use-ui; then
-        echo "Nix build unexpectedly succeeded with the fake Computer Use UI payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    new_computer_use_ui_payload_hash="$(extract_got_sri_hash "$COMPUTER_USE_UI_BUILD_LOG" || true)"
-    if [ -z "$new_computer_use_ui_payload_hash" ]; then
-        echo "Nix build failed without a Computer Use UI fixed-output hash mismatch; leaving log at $COMPUTER_USE_UI_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    if ! validate_sri_hash "$new_computer_use_ui_payload_hash"; then
-        echo "Refusing to proceed: extracted Computer Use UI payload hash '$new_computer_use_ui_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    echo "Actual Computer Use UI payload outputHash:  $new_computer_use_ui_payload_hash"
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$new_computer_use_ui_payload_hash"
-
-    current_remote_mobile_control_payload_hash="$(read_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current Remote Mobile Control payload outputHash: $current_remote_mobile_control_payload_hash"
-    echo "Forcing Remote Mobile Control payload outputHash refresh..."
-    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
-
-    if run_nix_build "$REMOTE_MOBILE_CONTROL_BUILD_LOG" .#codex-desktop-remote-mobile-control; then
-        echo "Nix build unexpectedly succeeded with the fake Remote Mobile Control payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    new_remote_mobile_control_payload_hash="$(extract_got_sri_hash "$REMOTE_MOBILE_CONTROL_BUILD_LOG" || true)"
-    if [ -z "$new_remote_mobile_control_payload_hash" ]; then
-        echo "Nix build failed without a Remote Mobile Control fixed-output hash mismatch; leaving log at $REMOTE_MOBILE_CONTROL_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    if ! validate_sri_hash "$new_remote_mobile_control_payload_hash"; then
-        echo "Refusing to proceed: extracted Remote Mobile Control payload hash '$new_remote_mobile_control_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
-        exit 1
-    fi
-
-    echo "Actual Remote Mobile Control payload outputHash:  $new_remote_mobile_control_payload_hash"
-    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$new_remote_mobile_control_payload_hash"
-
-    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control
-    echo "Nix builds succeeded after refreshing the payload outputHashes."
+    run_nix_build "$VERIFY_LOG" "${PACKAGE_OUTPUTS[@]}"
+    echo "Nix builds succeeded after refreshing the Codex.dmg hash."
 }
 
 case "${1:-}" in

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -7,6 +7,7 @@ UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
 COMPUTER_USE_UI_BUILD_LOG="${COMPUTER_USE_UI_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui.log}"
+REMOTE_MOBILE_CONTROL_BUILD_LOG="${REMOTE_MOBILE_CONTROL_BUILD_LOG:-/tmp/codex-nix-build-remote-mobile-control.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
 FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
@@ -114,6 +115,7 @@ restore_flake_hashes() {
     local dmg_hash="$1"
     local payload_hash="$2"
     local computer_use_ui_payload_hash="$3"
+    local remote_mobile_control_payload_hash="$4"
 
     if [ -n "$dmg_hash" ]; then
         replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
@@ -124,12 +126,16 @@ restore_flake_hashes() {
     if [ -n "$computer_use_ui_payload_hash" ]; then
         replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$computer_use_ui_payload_hash"
     fi
+    if [ -n "$remote_mobile_control_payload_hash" ]; then
+        replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$remote_mobile_control_payload_hash"
+    fi
 }
 
 main() {
     local current_dmg_hash=""
     local current_payload_hash=""
     local current_computer_use_ui_payload_hash=""
+    local current_remote_mobile_control_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -155,20 +161,20 @@ main() {
 
     if run_nix_build "$BUILD_LOG" .#codex-desktop; then
         echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
     if [ -z "$new_payload_hash" ]; then
         echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_payload_hash"; then
         echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
@@ -182,27 +188,54 @@ main() {
 
     if run_nix_build "$COMPUTER_USE_UI_BUILD_LOG" .#codex-desktop-computer-use-ui; then
         echo "Nix build unexpectedly succeeded with the fake Computer Use UI payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     new_computer_use_ui_payload_hash="$(extract_got_sri_hash "$COMPUTER_USE_UI_BUILD_LOG" || true)"
     if [ -z "$new_computer_use_ui_payload_hash" ]; then
         echo "Nix build failed without a Computer Use UI fixed-output hash mismatch; leaving log at $COMPUTER_USE_UI_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     if ! validate_sri_hash "$new_computer_use_ui_payload_hash"; then
         echo "Refusing to proceed: extracted Computer Use UI payload hash '$new_computer_use_ui_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
         exit 1
     fi
 
     echo "Actual Computer Use UI payload outputHash:  $new_computer_use_ui_payload_hash"
     replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$new_computer_use_ui_payload_hash"
 
-    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui
+    current_remote_mobile_control_payload_hash="$(read_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = ")"
+    echo "Current Remote Mobile Control payload outputHash: $current_remote_mobile_control_payload_hash"
+    echo "Forcing Remote Mobile Control payload outputHash refresh..."
+    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
+
+    if run_nix_build "$REMOTE_MOBILE_CONTROL_BUILD_LOG" .#codex-desktop-remote-mobile-control; then
+        echo "Nix build unexpectedly succeeded with the fake Remote Mobile Control payload outputHash." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    new_remote_mobile_control_payload_hash="$(extract_got_sri_hash "$REMOTE_MOBILE_CONTROL_BUILD_LOG" || true)"
+    if [ -z "$new_remote_mobile_control_payload_hash" ]; then
+        echo "Nix build failed without a Remote Mobile Control fixed-output hash mismatch; leaving log at $REMOTE_MOBILE_CONTROL_BUILD_LOG" >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    if ! validate_sri_hash "$new_remote_mobile_control_payload_hash"; then
+        echo "Refusing to proceed: extracted Remote Mobile Control payload hash '$new_remote_mobile_control_payload_hash' is not a valid SRI sha256." >&2
+        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash" "$current_remote_mobile_control_payload_hash"
+        exit 1
+    fi
+
+    echo "Actual Remote Mobile Control payload outputHash:  $new_remote_mobile_control_payload_hash"
+    replace_flake_hash "codexDesktopRemoteMobileControlPayload = mkCodexDesktopPayload {" "outputHash = " "$new_remote_mobile_control_payload_hash"
+
+    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control
     echo "Nix builds succeeded after refreshing the payload outputHashes."
 }
 

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -25,6 +25,16 @@ build_linux_computer_use_backend() {
     local cosmic_helper_binary="$SCRIPT_DIR/target/release/codex-computer-use-cosmic"
     local cargo_cmd=""
 
+    if [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ]; then
+        [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE is not set"
+        [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE is not set"
+        [ -x "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || return 1
+        [ -x "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ] || return 1
+        info "Using prebuilt Linux Computer Use backend"
+        printf '%s\n%s\n' "$CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE" "$CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE"
+        return 0
+    fi
+
     if [ ! -d "$crate_dir" ]; then
         warn "Linux Computer Use backend source not found at $crate_dir"
         return 1
@@ -479,6 +489,16 @@ chrome_extension_host_arch() {
 build_chrome_extension_host() {
     local source_binary="$SCRIPT_DIR/target/release/codex-chrome-extension-host"
     local cargo_cmd=""
+
+    if [ -n "${CODEX_CHROME_EXTENSION_HOST_SOURCE:-}" ]; then
+        [ -x "$CODEX_CHROME_EXTENSION_HOST_SOURCE" ] || {
+            warn "CODEX_CHROME_EXTENSION_HOST_SOURCE is not executable: $CODEX_CHROME_EXTENSION_HOST_SOURCE"
+            return 1
+        }
+        info "Using prebuilt Chrome extension host"
+        printf '%s\n' "$CODEX_CHROME_EXTENSION_HOST_SOURCE"
+        return 0
+    fi
 
     if ! cargo_cmd="$(find_cargo_for_linux_computer_use)"; then
         warn "cargo not found; Chrome extension host will be unavailable"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -143,6 +143,11 @@ build_native_modules() {
         warn "Using better-sqlite3@$bs3_build_ver for Electron v$ELECTRON_VERSION compatibility (DMG has $bs3_ver)"
     fi
 
+    if [ -n "${CODEX_NATIVE_MODULES_SOURCE:-}" ]; then
+        install_native_modules_from_source "$app_extracted" "$CODEX_NATIVE_MODULES_SOURCE" "$bs3_build_ver" "$npty_ver"
+        return 0
+    fi
+
     # Build in a CLEAN directory (asar doesn't have full source)
     local build_dir="$WORK_DIR/native-build"
     mkdir -p "$build_dir"
@@ -178,6 +183,37 @@ build_native_modules() {
     prune_native_module_build_artifacts "$app_extracted/node_modules/node-pty"
 }
 
+install_native_modules_from_source() {
+    local app_extracted="$1"
+    local source_dir="$2"
+    local expected_better_sqlite3_version="$3"
+    local expected_node_pty_version="$4"
+    local source_better_sqlite3="$source_dir/better-sqlite3"
+    local source_node_pty="$source_dir/node-pty"
+    local actual_better_sqlite3_version
+    local actual_node_pty_version
+
+    [ -d "$source_better_sqlite3" ] || error "Prebuilt better-sqlite3 source not found at $source_better_sqlite3"
+    [ -d "$source_node_pty" ] || error "Prebuilt node-pty source not found at $source_node_pty"
+
+    actual_better_sqlite3_version=$(node -p "require('$source_better_sqlite3/package.json').version" 2>/dev/null || echo "")
+    actual_node_pty_version=$(node -p "require('$source_node_pty/package.json').version" 2>/dev/null || echo "")
+
+    [ "$actual_better_sqlite3_version" = "$expected_better_sqlite3_version" ] || \
+        error "Prebuilt better-sqlite3 version mismatch: expected $expected_better_sqlite3_version, got ${actual_better_sqlite3_version:-unknown}"
+    [ "$actual_node_pty_version" = "$expected_node_pty_version" ] || \
+        error "Prebuilt node-pty version mismatch: expected $expected_node_pty_version, got ${actual_node_pty_version:-unknown}"
+
+    info "Using prebuilt native modules from $source_dir"
+    rm -rf "$app_extracted/node_modules/better-sqlite3"
+    rm -rf "$app_extracted/node_modules/node-pty"
+    cp -r "$source_better_sqlite3" "$app_extracted/node_modules/"
+    cp -r "$source_node_pty" "$app_extracted/node_modules/"
+    chmod -R u+w "$app_extracted/node_modules/better-sqlite3" "$app_extracted/node_modules/node-pty"
+    prune_native_module_build_artifacts "$app_extracted/node_modules/better-sqlite3"
+    prune_native_module_build_artifacts "$app_extracted/node_modules/node-pty"
+}
+
 # ---- Download Linux Electron ----
 download_electron() {
     info "Downloading Electron v${ELECTRON_VERSION} for Linux..."
@@ -191,6 +227,17 @@ download_electron() {
     esac
 
     local electron_zip="electron-v${ELECTRON_VERSION}-linux-${electron_arch}.zip"
+    if [ -n "${CODEX_ELECTRON_ZIP_SOURCE:-}" ]; then
+        [ -f "$CODEX_ELECTRON_ZIP_SOURCE" ] || error "CODEX_ELECTRON_ZIP_SOURCE does not exist: $CODEX_ELECTRON_ZIP_SOURCE"
+        info "Using Electron runtime archive: $CODEX_ELECTRON_ZIP_SOURCE"
+        cp "$CODEX_ELECTRON_ZIP_SOURCE" "$WORK_DIR/electron.zip"
+        mkdir -p "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+        unzip -qo "$WORK_DIR/electron.zip"
+        info "Electron ready"
+        return 0
+    fi
+
     local url
     if [ -n "$ELECTRON_MIRROR" ]; then
         url="${ELECTRON_MIRROR%/}/v${ELECTRON_VERSION}/${electron_zip}"


### PR DESCRIPTION
## Summary
- remove fixed-output payload hashes from the Nix package variants
- model external artifacts as explicit Nix inputs for Electron, native Node modules, Rust plugin binaries, and Browser Use node_repl
- add installer env hooks so the Nix build can inject explicit artifacts while the normal shell installer keeps its existing download/build flow
- simplify the Nix hash refresh script/workflow to update only the upstream DMG hash and verify all package outputs

## Why
The previous Nix build needed a separate fixed-output hash for each package variant because the payload derivation downloaded and built external artifacts during the payload build. This made every feature combination look like its own external artifact. Moving those external pieces into explicit Nix inputs makes the package variants ordinary derivations again and leaves the DMG hash as the main upstream refresh point.

## Validation
- nix flake check --no-build
- bash -n scripts/ci/update-nix-hashes.sh
- scripts/ci/update-nix-hashes.sh read-flake-hash ...
- nix build .#codex-desktop --no-link --print-build-logs
- nix build .#codex-desktop .#codex-desktop-computer-use-ui .#codex-desktop-remote-mobile-control .#codex-desktop-computer-use-ui-remote-mobile-control --no-link --print-build-logs

## Notes
This still pins Electron and native module versions explicitly in the Nix layer. A useful follow-up would be a CI guard that checks those pins against the downloaded DMG metadata during hash refresh.