### PR TITLE
fix: report missing packages from make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,37 +216,44 @@ package: maybe-build-updater
 
 install:
 	@echo "[make] Installing latest native package"
-	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
+	@latest_matching_file() { \
+		local pattern="$$1"; \
+		local matches; \
+		matches="$$(compgen -G "$$pattern" || true)"; \
+		[ -n "$$matches" ] || return 0; \
+		printf '%s\n' "$$matches" | sort -V | tail -n 1; \
+	}; \
+	format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
 	if [ "$$format" = "pacman" ]; then \
-		pkg="$${PKG:-$$(ls -1 $(PACMAN_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		pkg="$${PKG:-$$(latest_matching_file "$(PACMAN_GLOB)")}"; \
 		if [ -z "$$pkg" ]; then \
 			echo "[make] No pacman package found. Run 'make pacman' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$pkg"; \
 		sudo pacman -U --noconfirm "$$pkg"; \
 	elif [ "$$format" = "rpm" ] && command -v dnf >/dev/null 2>&1; then \
-		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		rpm="$${RPM:-$$(latest_matching_file "$(RPM_GLOB)")}"; \
 		if [ -z "$$rpm" ]; then \
 			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$rpm"; \
 		sudo dnf install -y "$$rpm"; \
 	elif [ "$$format" = "rpm" ] && command -v zypper >/dev/null 2>&1; then \
-		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		rpm="$${RPM:-$$(latest_matching_file "$(RPM_GLOB)")}"; \
 		if [ -z "$$rpm" ]; then \
 			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$rpm"; \
 		sudo zypper --non-interactive --no-gpg-checks install -y "$$rpm"; \
 	elif [ "$$format" = "rpm" ]; then \
-		rpm="$${RPM:-$$(ls -1 $(RPM_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		rpm="$${RPM:-$$(latest_matching_file "$(RPM_GLOB)")}"; \
 		if [ -z "$$rpm" ]; then \
 			echo "[make] No RPM package found. Run 'make rpm' first." >&2; exit 1; \
 		fi; \
 		echo "[make] Installing $$rpm"; \
 		sudo rpm -Uvh "$$rpm"; \
 	elif [ "$$format" = "deb" ]; then \
-		deb="$${DEB:-$$(ls -1 $(DEB_GLOB) 2>/dev/null | sort -V | tail -n 1)}"; \
+		deb="$${DEB:-$$(latest_matching_file "$(DEB_GLOB)")}"; \
 		if [ -z "$$deb" ]; then \
 			echo "[make] No Debian package found. Run 'make deb' first." >&2; exit 1; \
 		fi; \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -584,6 +584,33 @@ SCRIPT
     assert_contains "$rpm_log" "Missing packaged launcher runtime helper"
 }
 
+test_make_install_reports_missing_native_packages() {
+    info "Checking make install missing-package diagnostics"
+    local workspace="$TMP_DIR/make-install-missing"
+    local output_log
+    local format
+    local expected
+
+    mkdir -p "$workspace/dist"
+
+    for format in pacman rpm deb; do
+        output_log="$workspace/$format.log"
+        case "$format" in
+            pacman) expected="No pacman package found. Run 'make pacman' first." ;;
+            rpm) expected="No RPM package found. Run 'make rpm' first." ;;
+            deb) expected="No Debian package found. Run 'make deb' first." ;;
+        esac
+
+        if make -f "$REPO_DIR/Makefile" -C "$workspace" install \
+            NATIVE_PKG_FORMAT_CMD="printf $format" >"$output_log" 2>&1
+        then
+            fail "make install should fail when no $format package exists"
+        fi
+
+        assert_contains "$output_log" "$expected"
+    done
+}
+
 test_make_build_app_uses_installer_download_flow_by_default() {
     info "Checking make build-app default DMG behavior"
     local workspace="$TMP_DIR/make-build-app"
@@ -2747,6 +2774,7 @@ main() {
     test_pacman_builder_without_updater_transition_hook
     test_appimage_builder_smoke
     test_missing_input_failure
+    test_make_install_reports_missing_native_packages
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
     test_upstream_build_app_workflow_tracks_dmg_metadata


### PR DESCRIPTION
## Summary

`make install` currently exits early when there are no built packages in `dist/`. Because the recipe runs with `set -e` and `pipefail`, the `ls | sort | tail` lookup can abort before the intended "Run make pacman/rpm/deb first" message is printed.

This changes the package lookup to use a small pipefail-safe matcher, then keeps the existing friendly diagnostics for pacman, rpm, and deb installs.

## Test Plan

- `bash tests/scripts_smoke.sh`
- `make test`
- `make check`

