### PR TITLE
fix: escape pacman staging path in PKGBUILD

### DIFF
--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -70,12 +70,23 @@ main() {
 	stage_optional_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
 
+	local package_name
+	local pacman_pkgver
+	local pacman_pkgrel
+	local staging_dir
+	local arch_replacement
+	package_name="$(sed_escape_replacement "$PACKAGE_NAME")"
+	pacman_pkgver="$(sed_escape_replacement "$PACMAN_PKGVER")"
+	pacman_pkgrel="$(sed_escape_replacement "$PACMAN_PKGREL")"
+	staging_dir="$(sed_escape_replacement "$staging_root")"
+	arch_replacement="$(sed_escape_replacement "$arch")"
+
 	sed \
-		-e "s/__PACKAGE_NAME__/$PACKAGE_NAME/g" \
-		-e "s/__PKGVER__/$PACMAN_PKGVER/g" \
-		-e "s/__PKGREL__/$PACMAN_PKGREL/g" \
-		-e "s|__STAGING_DIR__|$staging_root|g" \
-		-e "s/__ARCH__/$arch/g" \
+		-e "s/__PACKAGE_NAME__/$package_name/g" \
+		-e "s/__PKGVER__/$pacman_pkgver/g" \
+		-e "s/__PKGREL__/$pacman_pkgrel/g" \
+		-e "s|__STAGING_DIR__|$staging_dir|g" \
+		-e "s/__ARCH__/$arch_replacement/g" \
 		"$PKGBUILD_TEMPLATE" >"$build_root/PKGBUILD"
 	if package_with_updater_enabled; then
 		sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -432,8 +432,9 @@ test_pacman_builder_without_updater_transition_hook() {
     local app_dir="$workspace/app"
     local dist_dir="$workspace/dist"
     local capture_dir="$workspace/capture"
+    local ampersand_tmpdir="$workspace/ampersand&tmp"
 
-    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir" "$ampersand_tmpdir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
 
@@ -452,6 +453,7 @@ exit 99
 SCRIPT
     chmod +x "$bin_dir/makepkg" "$bin_dir/cargo"
 
+    TMPDIR="$ampersand_tmpdir" \
     PATH="$bin_dir:$PATH" \
     CAPTURE_DIR="$capture_dir" \
     APP_DIR_OVERRIDE="$app_dir" \
@@ -463,6 +465,8 @@ SCRIPT
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-1-x86_64.pkg.tar.zst"
     assert_file_exists "$capture_dir/PKGBUILD"
     assert_file_exists "$capture_dir/codex-desktop.install"
+    assert_contains "$capture_dir/PKGBUILD" "ampersand&tmp"
+    assert_not_contains "$capture_dir/PKGBUILD" "__STAGING_DIR__"
     assert_contains "$capture_dir/PKGBUILD" "install=codex-desktop.install"
     assert_not_contains "$capture_dir/PKGBUILD" "'polkit'"
     assert_contains "$capture_dir/codex-desktop.install" "codex_no_updater_cleanup_update_manager_service"


### PR DESCRIPTION
## Summary

`build-pacman.sh` renders `PKGBUILD` with `sed`. The staging directory is a filesystem path from `mktemp`, so it can legally contain `&` when `TMPDIR` includes one. In a `sed` replacement, `&` expands to the full matched placeholder, which corrupts the generated staging path and makes `makepkg` fail.

This routes the rendered values through the existing `sed_escape_replacement` helper before building the `PKGBUILD` sed expression.

## Test Plan

- Regression observed before the fix: `bash tests/scripts_smoke.sh` failed at the pacman smoke test with `Expected 'ampersand&tmp' in .../PKGBUILD`
- `bash tests/scripts_smoke.sh`
- Manual pacman build with `TMPDIR` containing `&`
- `make test`
- `make check`

