### PR TITLE
fix: bypass proxies for webview origin probe

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1101,9 +1101,12 @@ verify_webview_origin() {
     # SSL error, etc.) instead of a generic "HTTP fetch failed", matching
     # what the original python3 urllib version exposed via its raised
     # exception text.
+    # --noproxy keeps loopback validation pointed at the embedded webview
+    # server even when the user's shell exports http_proxy/ALL_PROXY without a
+    # localhost NO_PROXY exemption.
     local body err detail
     err=$(mktemp 2>/dev/null) || err="${TMPDIR:-/tmp}/codex-curl-err.$$"
-    if ! body="$(curl --disable --silent --show-error --fail --max-time 2 "$url" 2>"$err")"; then
+    if ! body="$(curl --disable --noproxy 127.0.0.1,localhost --silent --show-error --fail --max-time 2 "$url" 2>"$err")"; then
         detail=$(< "$err" 2>/dev/null)
         rm -f "$err"
         echo "Webview origin validation failed for $url; ${detail:-curl exited non-zero with no diagnostic}" >&2

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1117,7 +1117,7 @@ PY
     # bounded-execution defenses preserved (0.2 s watchdog + 2 s curl cap).
     assert_contains "$REPO_DIR/launcher/start.sh.template" '/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "kill -9 \"\$probe_pid\""
-    assert_contains "$REPO_DIR/launcher/start.sh.template" 'curl --disable --silent --show-error --fail --max-time 2'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'curl --disable --noproxy 127.0.0.1,localhost --silent --show-error --fail --max-time 2'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "for attempt in \$(seq 1 250)"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sleep 0.02"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Webview origin verified."

--- a/tests/webview_probe_equivalence.sh
+++ b/tests/webview_probe_equivalence.sh
@@ -136,6 +136,16 @@ with_home() {
     return "$rc"
 }
 
+with_bad_loopback_proxy_env() {
+    http_proxy="http://127.0.0.1:9" \
+    HTTP_PROXY="http://127.0.0.1:9" \
+    all_proxy="http://127.0.0.1:9" \
+    ALL_PROXY="http://127.0.0.1:9" \
+    no_proxy="" \
+    NO_PROXY="" \
+    "$@"
+}
+
 find_closed_tcp_port() {
     local candidate attempt
     for attempt in $(seq 1 50); do
@@ -256,6 +266,7 @@ main() {
     CURLRC_HOME=$(mktemp -d) || fail "mktemp -d failed for curlrc fixture"
     printf '%s\n' 'output = "curlrc-out"' > "$CURLRC_HOME/.curlrc"
     assert_rc "new   ok markers ignores .curlrc" 0 with_home "$CURLRC_HOME" verify_webview_origin__new "$URL_OK"
+    assert_rc "new   ok markers ignores proxy env" 0 with_bad_loopback_proxy_env verify_webview_origin__new "$URL_OK"
     assert_rc "orig  404 path"               1 verify_webview_origin__orig "$URL_404"
     assert_rc "new   404 path"               1 verify_webview_origin__new  "$URL_404"
     assert_rc "orig  wrong title"            1 verify_webview_origin__orig "$URL_BADTITLE"


### PR DESCRIPTION
## Summary

The launcher validates `http://127.0.0.1:$CODEX_WEBVIEW_PORT/index.html` before handing the URL to Electron. That validation uses `curl --disable`, which ignores `.curlrc` but still honors proxy environment variables.

If a user's shell has `http_proxy` or `ALL_PROXY` set and no localhost `NO_PROXY` exemption, the local webview-origin fetch can go through the proxy instead of the embedded loopback server. That makes startup fail even though the webview server is healthy.

This adds `--noproxy 127.0.0.1,localhost` to the probe and adds a regression that forces a broken loopback proxy while serving valid Codex markers locally.

## Test Plan

- Regression observed before the fix: `bash tests/webview_probe_equivalence.sh` failed `new ok markers ignores proxy env`
- `bash tests/webview_probe_equivalence.sh`
- `bash -n launcher/start.sh.template tests/webview_probe_equivalence.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `make test`
- `make check`

