### PR TITLE
fix: handle Linux side-by-side edge cases

### DIFF
--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -284,6 +284,42 @@ mod tests {
     }
 
     #[test]
+    fn rounded_window_id_can_be_disambiguated_by_title() {
+        let first_window_id = 7_511_476_032_840_641_491;
+        let second_window_id = 7_511_476_032_840_641_999;
+        let rounded_window_id = 7_511_476_032_840_642_000;
+        assert_eq!(first_window_id as f64, rounded_window_id as f64);
+        assert_eq!(second_window_id as f64, rounded_window_id as f64);
+
+        let windows = vec![
+            window(
+                first_window_id,
+                "First — Kate",
+                "org.kde.kate",
+                "org.kde.kate",
+            ),
+            window(
+                second_window_id,
+                "Second — Kate",
+                "org.kde.kate",
+                "org.kde.kate",
+            ),
+        ];
+
+        let matched = resolve_window_target(
+            &windows,
+            &WindowTarget {
+                window_id: Some(rounded_window_id),
+                title: Some("Second".to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(matched.window_id, second_window_id);
+    }
+
+    #[test]
     fn pid_target_reports_ambiguous_matches() {
         let mut first = window(1, "Ghostty One", "com.mitchellh.ghostty.desktop", "Ghostty");
         let mut second = window(2, "Ghostty Two", "com.mitchellh.ghostty.desktop", "Ghostty");

--- a/computer-use-linux/src/windowing/target.rs
+++ b/computer-use-linux/src/windowing/target.rs
@@ -95,7 +95,7 @@ pub fn resolve_window_target<'a>(
     target: &WindowTarget,
 ) -> Result<&'a WindowInfo> {
     if let Some(window_id) = target.window_id {
-        return resolve_window_id_target(windows, window_id);
+        return resolve_window_id_target(windows, target, window_id);
     }
 
     if target.has_terminal_target() {
@@ -158,7 +158,11 @@ pub fn resolve_window_target<'a>(
     bail!("Pass window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd to target a window.");
 }
 
-fn resolve_window_id_target(windows: &[WindowInfo], window_id: u64) -> Result<&WindowInfo> {
+fn resolve_window_id_target<'a>(
+    windows: &'a [WindowInfo],
+    target: &WindowTarget,
+    window_id: u64,
+) -> Result<&'a WindowInfo> {
     if let Some(window) = windows.iter().find(|window| window.window_id == window_id) {
         return Ok(window);
     }
@@ -170,17 +174,53 @@ fn resolve_window_id_target(windows: &[WindowInfo], window_id: u64) -> Result<&W
     match matches.as_slice() {
         [window] => Ok(*window),
         [] => Err(anyhow::anyhow!("No window matched window_id {window_id}.")),
-        windows => {
-            let ids = windows
-                .iter()
-                .map(|window| window.window_id.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
-            bail!(
-                "window_id {window_id} matched multiple windows after JSON number rounding ({ids}); add title, pid, app_id, or wm_class to disambiguate."
-            );
+        windows => resolve_rounded_window_id_matches(windows, target, window_id),
+    }
+}
+
+fn resolve_rounded_window_id_matches<'a>(
+    windows: &[&'a WindowInfo],
+    target: &WindowTarget,
+    window_id: u64,
+) -> Result<&'a WindowInfo> {
+    let ids = windows
+        .iter()
+        .map(|window| window.window_id.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    if has_window_id_disambiguator(target) {
+        let matches = windows
+            .iter()
+            .copied()
+            .filter(|window| window_id_disambiguators_match(window, target))
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [window] => return Ok(*window),
+            [] => bail!(
+                "window_id {window_id} matched multiple windows after JSON number rounding ({ids}), but none matched the provided title, pid, app_id, or wm_class disambiguators."
+            ),
+            _ => {}
         }
     }
+
+    bail!(
+        "window_id {window_id} matched multiple windows after JSON number rounding ({ids}); add title, pid, app_id, or wm_class to disambiguate."
+    );
+}
+
+fn has_window_id_disambiguator(target: &WindowTarget) -> bool {
+    target.pid.is_some()
+        || normalized_target(target.app_id.as_deref()).is_some()
+        || normalized_target(target.wm_class.as_deref()).is_some()
+        || normalized_target(target.title.as_deref()).is_some()
+}
+
+fn window_id_disambiguators_match(window: &WindowInfo, target: &WindowTarget) -> bool {
+    target.pid.is_none_or(|pid| window.pid == Some(pid))
+        && optional_exact_match(&window.app_id, target.app_id.as_deref())
+        && optional_exact_match(&window.wm_class, target.wm_class.as_deref())
+        && optional_title_match(&window.title, target.title.as_deref())
 }
 
 fn window_id_matches_json_number(actual: u64, requested: u64) -> bool {

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -28,9 +28,11 @@ map_arch() {
 	esac
 }
 
-# Arch pkgver must not contain '+' or '-'; split on '+' and use the base as pkgver.
+# Arch pkgver may contain '+', so keep the caller-provided commitish suffix in
+# pkgver. pkgrel is reserved for distro/package rebuilds of the same upstream
+# app version.
 pacman_version_parts() {
-	PACMAN_PKGVER="${PACKAGE_VERSION%%+*}"
+	PACMAN_PKGVER="$PACKAGE_VERSION"
 	PACMAN_PKGREL="1"
 }
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1639,9 +1639,11 @@ function withIsolatedHome(body) {
   const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-cu-ui-test-"));
   const previousHome = process.env.HOME;
   const previousXdg = process.env.XDG_CONFIG_HOME;
+  const previousAppId = process.env.CODEX_APP_ID;
   const previousFlag = process.env[COMPUTER_USE_UI_ENV_VAR];
   process.env.HOME = tempHome;
   delete process.env.XDG_CONFIG_HOME;
+  delete process.env.CODEX_APP_ID;
   delete process.env[COMPUTER_USE_UI_ENV_VAR];
   try {
     return body(tempHome);
@@ -1656,6 +1658,11 @@ function withIsolatedHome(body) {
     } else {
       process.env.XDG_CONFIG_HOME = previousXdg;
     }
+    if (previousAppId == null) {
+      delete process.env.CODEX_APP_ID;
+    } else {
+      process.env.CODEX_APP_ID = previousAppId;
+    }
     if (previousFlag == null) {
       delete process.env[COMPUTER_USE_UI_ENV_VAR];
     } else {
@@ -1665,8 +1672,8 @@ function withIsolatedHome(body) {
   }
 }
 
-function writeSettingsFile(home, content) {
-  const dir = path.join(home, ".config", "codex-desktop");
+function writeSettingsFile(home, content, appId = "codex-desktop") {
+  const dir = path.join(home, ".config", appId);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, "settings.json"), content, "utf8");
 }
@@ -1689,6 +1696,14 @@ test("isComputerUseUiEnabled honours the env var", () => {
 test("isComputerUseUiEnabled honours the persisted settings flag", () => {
   withIsolatedHome((home) => {
     writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }));
+    assert.equal(isComputerUseUiEnabled(), true);
+  });
+});
+
+test("isComputerUseUiEnabled honours side-by-side CODEX_APP_ID settings", () => {
+  withIsolatedHome((home) => {
+    process.env.CODEX_APP_ID = "codex-cua-lab";
+    writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "codex-cua-lab");
     assert.equal(isComputerUseUiEnabled(), true);
   });
 });

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1640,10 +1640,12 @@ function withIsolatedHome(body) {
   const previousHome = process.env.HOME;
   const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousAppId = process.env.CODEX_APP_ID;
+  const previousLinuxAppId = process.env.CODEX_LINUX_APP_ID;
   const previousFlag = process.env[COMPUTER_USE_UI_ENV_VAR];
   process.env.HOME = tempHome;
   delete process.env.XDG_CONFIG_HOME;
   delete process.env.CODEX_APP_ID;
+  delete process.env.CODEX_LINUX_APP_ID;
   delete process.env[COMPUTER_USE_UI_ENV_VAR];
   try {
     return body(tempHome);
@@ -1662,6 +1664,11 @@ function withIsolatedHome(body) {
       delete process.env.CODEX_APP_ID;
     } else {
       process.env.CODEX_APP_ID = previousAppId;
+    }
+    if (previousLinuxAppId == null) {
+      delete process.env.CODEX_LINUX_APP_ID;
+    } else {
+      process.env.CODEX_LINUX_APP_ID = previousLinuxAppId;
     }
     if (previousFlag == null) {
       delete process.env[COMPUTER_USE_UI_ENV_VAR];

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -44,7 +44,16 @@ function computerUseUiSettingsPath(env) {
     : home
       ? path.join(home, ".config")
       : null;
-  return configHome == null ? null : path.join(configHome, "codex-desktop", "settings.json");
+  if (configHome == null) {
+    return null;
+  }
+  const appId = computerUseUiSettingsAppId(env);
+  return path.join(configHome, appId, "settings.json");
+}
+
+function computerUseUiSettingsAppId(env) {
+  const appId = env.CODEX_APP_ID || env.CODEX_LINUX_APP_ID || "codex-desktop";
+  return /^[A-Za-z0-9._-]+$/.test(appId) ? appId : "codex-desktop";
 }
 
 // Lookback/lookahead windows used when searching for the nearest minified

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -443,8 +443,12 @@ test_pacman_builder_without_updater_transition_hook() {
 set -euo pipefail
 cp PKGBUILD "$CAPTURE_DIR/PKGBUILD"
 cp codex-desktop.install "$CAPTURE_DIR/codex-desktop.install"
+pkgname="$(sed -n 's/^pkgname=//p' PKGBUILD)"
+pkgver="$(sed -n 's/^pkgver=//p' PKGBUILD)"
+pkgrel="$(sed -n 's/^pkgrel=//p' PKGBUILD)"
+arch="$(sed -n "s/^arch=('\([^']*\)').*/\1/p" PKGBUILD)"
 mkdir -p "$PKGDEST"
-touch "$PKGDEST/codex-desktop-2026.03.24.120000-1-x86_64.pkg.tar.zst"
+touch "$PKGDEST/${pkgname}-${pkgver}-${pkgrel}-${arch}.pkg.tar.zst"
 SCRIPT
     cat > "$bin_dir/cargo" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -462,9 +466,11 @@ SCRIPT
     PACKAGE_VERSION="2026.03.24.120000+manual" \
     bash "$REPO_DIR/scripts/build-pacman.sh"
 
-    assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-1-x86_64.pkg.tar.zst"
+    assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst"
     assert_file_exists "$capture_dir/PKGBUILD"
     assert_file_exists "$capture_dir/codex-desktop.install"
+    assert_contains "$capture_dir/PKGBUILD" "pkgver=2026.03.24.120000+manual"
+    assert_contains "$capture_dir/PKGBUILD" "pkgrel=1"
     assert_contains "$capture_dir/PKGBUILD" "ampersand&tmp"
     assert_not_contains "$capture_dir/PKGBUILD" "__STAGING_DIR__"
     assert_contains "$capture_dir/PKGBUILD" "install=codex-desktop.install"


### PR DESCRIPTION
## Summary
- Read the Linux Computer Use UI opt-in from the active app id settings directory, so side-by-side builds such as `codex-cua-lab` do not silently ignore their own settings.
- Let rounded large `window_id` matches be narrowed by `title`, `pid`, `app_id`, or `wm_class`, matching the resolver error message and avoiding dead-end ambiguity.
- Preserve `+commitish` suffixes in Arch/pacman `pkgver` while keeping `pkgrel=1` for package rebuilds.

## Test plan
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `bash tests/webview_probe_equivalence.sh`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/install-deps.sh`
- `cargo fmt --check`
- `cargo test --workspace`
- `cargo check --workspace`
- `git diff --check`
