### PR TITLE
fix(pacman): expose latest package

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ After `make build-app` or `make build-app-fresh`, build a native package from `c
 |---|---|---|---|
 | Debian | `make deb` or `./scripts/build-deb.sh` | `dist/codex-desktop_*.deb` | `sudo dpkg -i dist/codex-desktop_*.deb` |
 | RPM (Fedora / openSUSE) | `make rpm` or `./scripts/build-rpm.sh` | `dist/codex-desktop-*.x86_64.rpm` | `sudo dnf install dist/codex-desktop-*.rpm` (Fedora) or `sudo zypper install dist/codex-desktop-*.rpm` (openSUSE) |
-| Arch (pacman) | `make pacman` or `./scripts/build-pacman.sh` | `dist/codex-desktop-*.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-*.pkg.tar.zst` |
+| Arch (pacman) | `make pacman` or `./scripts/build-pacman.sh` | `dist/codex-desktop-*.pkg.tar.zst` plus `dist/codex-desktop-latest.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-latest.pkg.tar.zst` |
 | AppImage | `make appimage` or `./scripts/build-appimage.sh` | `dist/codex-desktop-*.AppImage` | Run directly; no system install |
 | Auto-detect | `make package && make install` | matches your distro | handled by `make install` |
 

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -114,7 +114,10 @@ main() {
 		-print -quit 2>/dev/null || true)"
 	[ -f "$pkg_file" ] || error "makepkg did not produce a package"
 
+	ln -sfn "$(basename "$pkg_file")" "$DIST_DIR/${PACKAGE_NAME}-latest.pkg.tar.zst"
+
 	info "Built package: $pkg_file"
+	printf '%s\n' "$pkg_file"
 }
 
 main "$@"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5,6 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 
+export CODEX_LINUX_FEATURES_CONFIG="$REPO_DIR/linux-features/features.example.json"
+
 cleanup() {
     rm -rf "$TMP_DIR"
 }
@@ -457,16 +459,22 @@ exit 99
 SCRIPT
     chmod +x "$bin_dir/makepkg" "$bin_dir/cargo"
 
-    TMPDIR="$ampersand_tmpdir" \
-    PATH="$bin_dir:$PATH" \
-    CAPTURE_DIR="$capture_dir" \
-    APP_DIR_OVERRIDE="$app_dir" \
-    DIST_DIR_OVERRIDE="$dist_dir" \
-    PACKAGE_WITH_UPDATER=0 \
-    PACKAGE_VERSION="2026.03.24.120000+manual" \
-    bash "$REPO_DIR/scripts/build-pacman.sh"
+    local package_path
+    package_path="$(
+        TMPDIR="$ampersand_tmpdir" \
+        PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        PACKAGE_WITH_UPDATER=0 \
+        PACKAGE_VERSION="2026.03.24.120000+manual" \
+        bash "$REPO_DIR/scripts/build-pacman.sh"
+    )"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst"
+    [ "$package_path" = "$dist_dir/codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst" ] || fail "Expected build-pacman.sh to print built package path, got: $package_path"
+    assert_file_exists "$dist_dir/codex-desktop-latest.pkg.tar.zst"
+    [ "$(readlink "$dist_dir/codex-desktop-latest.pkg.tar.zst")" = "codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst" ] || fail "Expected latest pacman symlink to point at built package"
     assert_file_exists "$capture_dir/PKGBUILD"
     assert_file_exists "$capture_dir/codex-desktop.install"
     assert_contains "$capture_dir/PKGBUILD" "pkgver=2026.03.24.120000+manual"

--- a/tests/webview_probe_equivalence.sh
+++ b/tests/webview_probe_equivalence.sh
@@ -210,7 +210,7 @@ EOF
     # depends on the server returning a real response.
     local i
     for i in $(seq 1 40); do
-        curl --disable --silent --fail --max-time 0.2 "http://127.0.0.1:$PORT_OPEN/index.html" >/dev/null 2>&1 && return 0
+        curl --disable --silent --fail --max-time 1 "http://127.0.0.1:$PORT_OPEN/index.html" >/dev/null 2>&1 && return 0
         sleep 0.05
     done
     return 1


### PR DESCRIPTION
## Summary
- print the exact pacman package path produced by `scripts/build-pacman.sh`
- add a stable `dist/codex-desktop-latest.pkg.tar.zst` symlink and document it for Arch installs
- keep script smoke tests deterministic by ignoring local feature opt-ins and making the webview fixture readiness timeout less brittle

## User-visible behavior
- Arch users get a stable install target after building a pacman package, reducing the chance of installing an older artifact from `dist/`

## Validation
- `bash -n scripts/build-pacman.sh tests/scripts_smoke.sh tests/webview_probe_equivalence.sh`
- `bash tests/scripts_smoke.sh`