### PR TITLE
fix: preserve linux-features config in update-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ By default, the native package installs a companion `systemd --user` service nam
 
 - It checks upstream `Codex.dmg` on daemon startup, every 6 hours, and in the background on app launch when stale.
 - When a new DMG is available, it rebuilds a local native package with `/opt/codex-desktop/update-builder`.
+- Rebuilds reuse the package's staged optional Linux feature config, so enabled `linux-features/` choices survive auto-updates.
 - If Codex Desktop is open, the final install waits until Electron exits.
 - The updater runs unprivileged and uses `pkexec` only for the final package install.
 - Codex CLI checks are best-effort and launcher-scoped. Set `CODEX_SYNC_CLI_PREFLIGHT=1` when debugging launch-time CLI preflight.

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -19,6 +19,9 @@ building packages, then list the feature ids you want:
 `features.json` is ignored by git so local choices do not leak into commits.
 Feature choices are read during the install/build pipeline; if you change this
 file after an app has already been generated, rerun the install/build step.
+Native packages preserve the enabled feature id list in the packaged
+update-builder bundle, so `codex-update-manager` rebuilds keep the same opt-in
+features across auto-updates.
 
 Each feature directory should include:
 

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -38,6 +38,45 @@ package_with_updater_enabled() {
     esac
 }
 
+package_node_binary() {
+    local managed_node="${APP_DIR:-}/resources/node-runtime/bin/node"
+    if [ -x "$managed_node" ] && [ "$("$managed_node" -e 'process.stdout.write("ok")' 2>/dev/null || true)" = "ok" ]; then
+        printf '%s\n' "$managed_node"
+        return 0
+    fi
+
+    command -v node >/dev/null 2>&1 || error "node is required"
+    command -v node
+}
+
+stage_update_builder_linux_features_config() {
+    local update_builder_root="$1"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local target="$update_builder_root/linux-features/features.json"
+    local node_bin
+
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+
+    node_bin="$(package_node_binary)"
+    "$node_bin" - "$helper" "$target" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const helperPath = path.resolve(process.argv[2]);
+const targetPath = path.resolve(process.argv[3]);
+const { enabledLinuxFeatureIds } = require(helperPath);
+
+const enabled = enabledLinuxFeatureIds();
+if (enabled.length === 0) {
+  fs.rmSync(targetPath, { force: true });
+  process.exit(0);
+}
+
+fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+fs.writeFileSync(targetPath, `${JSON.stringify({ enabled }, null, 2)}\n`);
+NODE
+}
+
 render_desktop_entry() {
     local target="$1"
     local package_name
@@ -417,7 +456,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/packaging/linux/codex-update-manager.postinst" "$update_builder_root/packaging/linux/codex-update-manager.postinst"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.prerm" "$update_builder_root/packaging/linux/codex-update-manager.prerm"
     cp -r "$REPO_DIR/linux-features/." "$update_builder_root/linux-features/"
-    rm -f "$update_builder_root/linux-features/features.json"
+    stage_update_builder_linux_features_config "$update_builder_root"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.postrm" "$update_builder_root/packaging/linux/codex-update-manager.postrm"
     cp "$REPO_DIR/assets/codex.png" "$update_builder_root/assets/codex.png"
     if [ -d "$node_runtime_source" ]; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -168,6 +168,50 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/resources/node-runtime/bin/node"
 }
 
+test_update_builder_preserves_enabled_linux_features_config() {
+    info "Checking update-builder preserves sanitized enabled Linux feature config"
+    local workspace="$TMP_DIR/update-builder-linux-features"
+    local root="$workspace/root"
+    local app_dir="$workspace/app"
+    local feature_config="$workspace/features.json"
+    local staged_config="$root/opt/codex-desktop/update-builder/linux-features/features.json"
+
+    mkdir -p "$workspace"
+    make_fake_app "$app_dir"
+    cat > "$feature_config" <<'JSON'
+{
+  "enabled": [
+    "example-feature"
+  ],
+  "localComment": "should not be packaged"
+}
+JSON
+
+    (
+        export APP_DIR="$app_dir"
+        export PACKAGE_NAME="codex-desktop"
+        export UPDATER_SERVICE_SOURCE="$REPO_DIR/packaging/linux/codex-update-manager.service"
+        export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
+
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/package-common.sh"
+        stage_update_builder_bundle "$root"
+    )
+
+    assert_file_exists "$staged_config"
+    assert_contains "$staged_config" "example-feature"
+    assert_not_contains "$staged_config" "localComment"
+
+    node - "$staged_config" <<'NODE' || fail "Expected staged Linux features config to be sanitized"
+const fs = require("node:fs");
+const configPath = process.argv[2];
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+if (JSON.stringify(config) !== JSON.stringify({ enabled: ["example-feature"] })) {
+  process.exit(1);
+}
+NODE
+}
+
 test_deb_builder_respects_package_identity() {
     info "Running side-by-side Debian packaging smoke test"
     local workspace="$TMP_DIR/deb-identity"
@@ -3325,6 +3369,7 @@ EOF
 main() {
     test_common_helper_sourcing
     test_deb_builder_smoke
+    test_update_builder_preserves_enabled_linux_features_config
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater
     test_no_updater_cleanup_helper_removes_inactive_user_enablement


### PR DESCRIPTION
## Summary
- preserve enabled linux-features in the packaged update-builder bundle
- write only a sanitized { enabled: [...] } config when optional features are enabled
- document auto-update behavior for staged Linux feature choices

Fixes #212

## Tests
- bash -n scripts/lib/package-common.sh tests/scripts_smoke.sh
- bash tests/scripts_smoke.sh
- cargo test -p codex-update-manager
- git diff --check