### PR TITLE
[codex] Add persistent composer rate limit footer patch

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -57,6 +57,9 @@ const {
 const {
   validateReport,
 } = require("./ci/validate-patch-report.js");
+const {
+  applyPersistentRateLimitFooterPatch,
+} = require("./patches/webview-assets.js");
 
 const mainBundlePrefix =
   "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
@@ -266,6 +269,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-computer-use-install-flow",
     "linux-app-updater-bridge",
     "browser-annotation-screenshot",
+    "composer-persistent-rate-limit-footer",
     "keybinds-settings",
     "package-desktop-name",
   ];
@@ -1971,6 +1975,137 @@ test("patch report marks warned asset patches as skipped", () => {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("persistent rate limit footer uses existing account signal without dropdown copy", () => {
+  const source = [
+    'import{A as Do,E as Oo,I as ko,L as Ao,M as jo,N as Mo,P as No,S as Po,W as Fo,_ as Io,a as Lo,c as Ro,d as zo,f as Bo,g as Vo,h as Ho,j as Uo,l as Wo,m as Go,o as Ko,p as qo,r as Jo,s as Yo,t as Xo,u as Zo,v as Qo,x as $o,y as es}from"./rate-limit-rows-HF3Xhn3F.js";',
+    "function TF(e){let t=(0,Z.c)(148),",
+    "t[131]!==Ut||t[132]!==Wt||t[133]!==Gt?(Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[131]=Ut,t[132]=Wt,t[133]=Gt,t[134]=Kt):Kt=t[134]",
+    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter/);
+  assert.match(patched, /catch\(e\)\{return null\}/);
+  assert.match(patched, /\{data:a=null\}=li\(Fn\)/);
+  assert.match(patched, /c=Xo\(Jo\(o,\{activeLimitName:s,selectedModel:i\}\)\)\.slice\(0,2\)/);
+  assert.doesNotMatch(patched, /codexLinuxUseRateLimitStatus/);
+  assert.doesNotMatch(patched, /codex-linux-rate-limit-footer/);
+  assert.equal((patched.match(/Rate limits remaining/g) || []).length, 1);
+});
+
+test("persistent rate limit footer skips current footer group when conversation id is missing", () => {
+  const source = [
+    "var Z=Ai();var Q=Hr();",
+    "function H_(e){let t=(0,Z.c)(6),{minutes:n,variant:r}=e,i=$i(),a;t[0]!==i||t[1]!==n||t[2]!==r?(a=Uo({intl:i,minutes:n,variant:r}),t[0]=i,t[1]=n,t[2]=r,t[3]=a):a=t[3];let o;return t[4]===a?o=t[5]:(o=(0,Q.jsx)(Q.Fragment,{children:a}),t[4]=a,t[5]=o),o}",
+    "function U_(e){let t=(0,Z.c)(75),{rateLimits:n,activeLimitName:r,planType:i,suppressUpsell:a,selectedModel:o}=e;return null}",
+    "function IG({activeCollaborationMode:t}){let le=t?.settings.model??null,{data:ue}=Oc(),{data:de}=ci(jn),fe=Qo(de),pe=Bo(de,le),me=de?.rate_limit_reached_type?.type,he=me!=null&&me!==`rate_limit_reached`,ge=ue?.structure===`workspace`&&Io(de)&&!es(de)&&!he,_e=fe&&!ge,ve=pe&&!ge,ye=Ro(de),be=Zo(de),xe=Ko(ye,{activeLimitName:be,selectedModel:le}),Se=Lo(ye,{activeLimitName:be,selectedModel:le});",
+    "let Ut=xt,Wt=null,Gt=yt,Kt;t[131]!==Ut||t[132]!==Wt||t[133]!==Gt?(Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[131]=Ut,t[132]=Wt,t[133]=Gt,t[134]=Kt):Kt=t[134];return Kt}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter\(\{conversationId:e\}\)/);
+  assert.match(patched, /catch\(e\)\{return null\}/);
+  assert.match(patched, /\{activeMode:n\}=Bi\(e\),r=n\?\.settings\.model\?\?null,\{data:i\}=ci\(jn\)/);
+  assert.doesNotMatch(patched, /codexLinuxRateLimitFooter,\{conversationId:z\}/);
+  assert.match(patched, /children:\[Ut,Wt,Gt\]/);
+  assert.match(patched, /\(0,Q\.jsx\)\(H_,\{minutes:e\.bucket\.windowDurationMins,variant:`summary`\}\)/);
+  assert.doesNotMatch(patched, /w===`home`\?\(0,Q\.jsx\)\(codexLinuxRateLimitFooter/);
+  assert.doesNotMatch(patched, /rateLimitEntries:ye/);
+});
+
+test("persistent rate limit footer adapts to current composer conversation id symbols", () => {
+  const source = [
+    "var Z=Ai();var Q=Hr();",
+    "function H_(e){let t=(0,Z.c)(6),{minutes:n,variant:r}=e,i=$i(),a;t[0]!==i||t[1]!==n||t[2]!==r?(a=Uo({intl:i,minutes:n,variant:r}),t[0]=i,t[1]=n,t[2]=r,t[3]=a):a=t[3];let o;return t[4]===a?o=t[5]:(o=(0,Q.jsx)(Q.Fragment,{children:a}),t[4]=a,t[5]=o),o}",
+    "function U_(e){let t=(0,Z.c)(75),{rateLimits:n,activeLimitName:r,planType:i,suppressUpsell:a,selectedModel:o}=e;return null}",
+    "function EF(e){let t=(0,Z.c)(148),{conversationId:a,activeCollaborationMode:o}=e,r=o?.settings.model??null,{data:de}=ci(jn),ye=Ro(de),be=Zo(de),xe=Ko(ye,{activeLimitName:be,selectedModel:r}),Se=Lo(ye,{activeLimitName:be,selectedModel:r}),R=M?.type===`local`?M.localConversationId:null,z=R??a,B=oi(fn,z);",
+    "let Ut=xt,Wt=null,Gt=yt,Kt;t[131]!==Ut||t[132]!==Wt||t[133]!==Gt?(Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[131]=Ut,t[132]=Wt,t[133]=Gt,t[134]=Kt):Kt=t[134];return Kt}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter\(\{conversationId:e\}\)/);
+  assert.match(patched, /catch\(e\)\{return null\}/);
+  assert.match(patched, /codexLinuxRateLimitFooter,\{conversationId:z\}/);
+  assert.match(patched, /Kt=\(0,Q\.jsxs\)\(`div`,\{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:\[Ut,\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:z\}\),Wt,Gt\]\}\)/);
+  assert.doesNotMatch(patched, /t\[131\]!==Ut\|\|t\[132\]!==Wt\|\|t\[133\]!==Gt\?\(Kt=.*codexLinuxRateLimitFooter/);
+  assert.doesNotMatch(patched, /children:\[Ut,Wt,Gt\]/);
+});
+
+test("persistent rate limit footer migrates broken current composer calls", () => {
+  const source = [
+    "var Z=Ai();var Q=Hr();",
+    "function H_(e){let t=(0,Z.c)(6),{minutes:n,variant:r}=e,i=$i(),a;t[0]!==i||t[1]!==n||t[2]!==r?(a=Uo({intl:i,minutes:n,variant:r}),t[0]=i,t[1]=n,t[2]=r,t[3]=a):a=t[3];let o;return t[4]===a?o=t[5]:(o=(0,Q.jsx)(Q.Fragment,{children:a}),t[4]=a,t[5]=o),o}",
+    "function U_(e){let t=(0,Z.c)(75),{rateLimits:n,activeLimitName:r,planType:i,suppressUpsell:a,selectedModel:o}=e;return null}",
+    "function IG({activeCollaborationMode:t}){let z=ci(Zt),le=t?.settings.model??null,{data:ue}=Oc(),{data:de}=ci(jn),fe=Qo(de),pe=Bo(de,le),me=de?.rate_limit_reached_type?.type,he=me!=null&&me!==`rate_limit_reached`,ge=ue?.structure===`workspace`&&Io(de)&&!es(de)&&!he,_e=fe&&!ge,ve=pe&&!ge,ye=Ro(de),be=Zo(de),xe=Ko(ye,{activeLimitName:be,selectedModel:le}),Se=Lo(ye,{activeLimitName:be,selectedModel:le});",
+    "let Ut=xt,Wt=null,Gt=yt,Kt;Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,w===`home`?(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:z}):null,Wt,Gt]});return Kt}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter/);
+  assert.match(patched, /catch\(e\)\{return null\}/);
+  assert.match(patched, /codexLinuxRateLimitFooter,\{conversationId:z\}/);
+  assert.doesNotMatch(patched, /w===`home`\?\(0,Q\.jsx\)\(codexLinuxRateLimitFooter/);
+  assert.doesNotMatch(patched, /codexLinuxRateLimitFooter,\{rateLimitEntries:/);
+});
+
+test("persistent rate limit footer upgrades existing current helper to guarded helper", () => {
+  const oldHelper =
+    "function codexLinuxRateLimitFooter({conversationId:e}){let t=(0,Z.c)(22),{activeMode:n}=Bi(e),r=n?.settings.model??null,{data:i}=ci(jn);return null}";
+  const source = [
+    "var Z=Ai();var Q=Hr();",
+    "function H_(e){let t=(0,Z.c)(6),{minutes:n,variant:r}=e,i=$i(),a;t[0]!==i||t[1]!==n||t[2]!==r?(a=Uo({intl:i,minutes:n,variant:r}),t[0]=i,t[1]=n,t[2]=r,t[3]=a):a=t[3];let o;return t[4]===a?o=t[5]:(o=(0,Q.jsx)(Q.Fragment,{children:a}),t[4]=a,t[5]=o),o}",
+    oldHelper,
+    "function U_(e){let t=(0,Z.c)(75),{rateLimits:n,activeLimitName:r,planType:i,suppressUpsell:a,selectedModel:o}=e;return null}",
+    "function IG({activeCollaborationMode:t}){let z=ci(Zt),le=t?.settings.model??null,{data:ue}=Oc(),{data:de}=ci(jn),fe=Qo(de),pe=Bo(de,le),me=de?.rate_limit_reached_type?.type,he=me!=null&&me!==`rate_limit_reached`,ge=ue?.structure===`workspace`&&Io(de)&&!es(de)&&!he,_e=fe&&!ge,ve=pe&&!ge,ye=Ro(de),be=Zo(de),xe=Ko(ye,{activeLimitName:be,selectedModel:le}),Se=Lo(ye,{activeLimitName:be,selectedModel:le});",
+    "let Ut=xt,Wt=null,Gt=yt,Kt;Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:z}),Wt,Gt]});return Kt}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal((patched.match(/function codexLinuxRateLimitFooter/g) || []).length, 1);
+  assert.match(patched, /catch\(e\)\{return null\}/);
+  assert.match(patched, /\{activeMode:n\}=Bi\(e\),r=n\?\.settings\.model\?\?null,\{data:i\}=ci\(jn\)/);
+  assert.doesNotMatch(patched, /function codexLinuxRateLimitFooter\(\{conversationId:e\}\)\{let t=/);
+});
+
+test("persistent rate limit footer repairs incorrectly adapted current composer calls", () => {
+  const brokenHelper =
+    "function codexLinuxRateLimitFooter({rateLimitEntries:e,activeLimitName:t,selectedModel:n}){let r=(0,Z.c)(20),i=Jo(e,{activeLimitName:t,selectedModel:n}),a=Xo(i).slice(0,2);if(a.length===0)return null;return a}";
+  const source = [
+    "var Z=Ai();var Q=Hr();",
+    "function H_(e){let t=(0,Z.c)(6),{minutes:n,variant:r}=e,i=$i(),a;t[0]!==i||t[1]!==n||t[2]!==r?(a=Uo({intl:i,minutes:n,variant:r}),t[0]=i,t[1]=n,t[2]=r,t[3]=a):a=t[3];let o;return t[4]===a?o=t[5]:(o=(0,Q.jsx)(Q.Fragment,{children:a}),t[4]=a,t[5]=o),o}",
+    brokenHelper,
+    "function U_(e){let t=(0,Z.c)(75),{rateLimits:n,activeLimitName:r,planType:i,suppressUpsell:a,selectedModel:o}=e;return null}",
+    "function IG({activeCollaborationMode:t}){let z=ci(Zt),le=t?.settings.model??null,{data:ue}=Oc(),{data:de}=ci(jn),fe=Qo(de),pe=Bo(de,le),me=de?.rate_limit_reached_type?.type,he=me!=null&&me!==`rate_limit_reached`,ge=ue?.structure===`workspace`&&Io(de)&&!es(de)&&!he,_e=fe&&!ge,ve=pe&&!ge,ye=Ro(de),be=Zo(de),xe=Ko(ye,{activeLimitName:be,selectedModel:le}),Se=Lo(ye,{activeLimitName:be,selectedModel:le});",
+    "let Ut=xt,Wt=null,Gt=yt,Kt;Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,w===`home`?(0,Q.jsx)(codexLinuxRateLimitFooter,{rateLimitEntries:ye,activeLimitName:be,selectedModel:le}):null,Wt,Gt]});return Kt}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter\(\{conversationId:e\}\)/);
+  assert.match(patched, /codexLinuxRateLimitFooter,\{conversationId:z\}/);
+  assert.doesNotMatch(patched, /w===`home`\?\(0,Q\.jsx\)\(codexLinuxRateLimitFooter/);
+  assert.doesNotMatch(patched, /rateLimitEntries:e/);
+  assert.doesNotMatch(patched, /rateLimitEntries:ye/);
+});
+
+test("persistent rate limit footer skips composer patch when helper cannot be inserted", () => {
+  const source = [
+    "function Cz(e){let t=(0,Z.c)(148),",
+    "t[131]!==Ut||t[132]!==Wt||t[133]!==Gt?(Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[131]=Ut,t[132]=Wt,t[133]=Gt,t[134]=Kt):Kt=t[134]",
+    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal(patched, source);
+  assert.doesNotMatch(patched, /codexLinuxRateLimitFooter/);
 });
 
 test("patcher CLI writes --report-json output", () => {

--- a/scripts/patches/core/all-linux/webview/rate-limits/patch.js
+++ b/scripts/patches/core/all-linux/webview/rate-limits/patch.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const {
+  applyPersistentRateLimitFooterPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "composer-persistent-rate-limit-footer",
+    phase: "webview-asset",
+    order: 1050,
+    ciPolicy: "optional",
+    pattern: /^composer-.*\.js$/,
+    missingDescription: "composer bundle",
+    skipDescription: "persistent composer rate limit footer patch",
+    apply: applyPersistentRateLimitFooterPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -210,6 +210,232 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
   return patchedSource;
 }
 
+function detectCurrentRateLimitFooterSymbols(source) {
+  const accountSignalMatch = source.match(
+    /[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\?\.settings\.model\?\?null,[\s\S]{0,1200}?\{data:[A-Za-z_$][\w$]*\}=ci\(([A-Za-z_$][\w$]*)\),[\s\S]{0,1200}?[A-Za-z_$][\w$]*=Ro\([A-Za-z_$][\w$]*\),[A-Za-z_$][\w$]*=Zo\([A-Za-z_$][\w$]*\)/,
+  );
+  const durationMatch = source.match(
+    /function ([A-Za-z_$][\w$]*)\(e\)\{let [A-Za-z_$][\w$]*=\(0,Z\.c\)\(\d+\),\{minutes:[A-Za-z_$][\w$]*,variant:[A-Za-z_$][\w$]*\}=e,[\s\S]{0,700}?=Uo\(\{intl:[A-Za-z_$][\w$]*,minutes:[A-Za-z_$][\w$]*,variant:[A-Za-z_$][\w$]*\}\)/,
+  );
+  if (accountSignalMatch == null || durationMatch == null) {
+    return null;
+  }
+
+  const durationComponent = durationMatch[1];
+  const durationIndex = source.indexOf(`function ${durationComponent}(e)`);
+  const afterDuration = durationIndex === -1 ? source : source.slice(durationIndex);
+  const rateLimitMenuMatch = afterDuration.match(
+    /function ([A-Za-z_$][\w$]*)\(e\)\{let [A-Za-z_$][\w$]*=\(0,Z\.c\)\(\d+\),\{rateLimits:/,
+  );
+  if (rateLimitMenuMatch == null) {
+    return null;
+  }
+
+  return {
+    accountSignalVar: accountSignalMatch[1],
+    durationComponent,
+    insertionNeedle: `function ${rateLimitMenuMatch[1]}(e){`,
+  };
+}
+
+function detectComposerFooterConversationIdVar(source, footerNeedles) {
+  const needles = Array.isArray(footerNeedles) ? footerNeedles : [footerNeedles];
+  const footerGroupIndex = needles
+    .map((needle) => source.indexOf(needle))
+    .filter((index) => index !== -1)
+    .sort((left, right) => left - right)[0];
+  if (footerGroupIndex == null) {
+    return null;
+  }
+
+  const functionStart = source.lastIndexOf("function ", footerGroupIndex);
+  const scopePrefix = source.slice(
+    functionStart === -1 ? Math.max(0, footerGroupIndex - 5000) : functionStart,
+    footerGroupIndex,
+  );
+  const conversationPropMatch = scopePrefix.match(/conversationId:([A-Za-z_$][\w$]*)/);
+  if (conversationPropMatch != null) {
+    const conversationPropVar = conversationPropMatch[1];
+    const normalizedConversationMatches = Array.from(
+      scopePrefix.matchAll(/(?:let |,)([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\?\?([A-Za-z_$][\w$]*)(?=,|;)/g),
+    ).filter((match) => match[2] === conversationPropVar);
+    if (normalizedConversationMatches.length > 0) {
+      return normalizedConversationMatches[normalizedConversationMatches.length - 1][1];
+    }
+    return conversationPropVar;
+  }
+
+  const conversationSignalMatches = Array.from(
+    scopePrefix.matchAll(/(?:let |,)([A-Za-z_$][\w$]*)=ci\([A-Za-z_$][\w$]*\)(?=,|;)/g),
+  );
+  if (conversationSignalMatches.length > 0) {
+    return conversationSignalMatches[conversationSignalMatches.length - 1][1];
+  }
+
+  return null;
+}
+
+function applyPersistentRateLimitFooterPatch(currentSource) {
+  let patchedSource = currentSource;
+  const currentSymbols = detectCurrentRateLimitFooterSymbols(currentSource);
+  const homeFooterGroupNeedle =
+    "t[131]!==Ut||t[132]!==Wt||t[133]!==Gt?(Kt=(0,Q.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[131]=Ut,t[132]=Wt,t[133]=Gt,t[134]=Kt):Kt=t[134]";
+  const previousHomeOnlyCall =
+    "w===`home`?(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:z}):null";
+  const previousUnguardedHomeGroupCall =
+    "children:[Ut,(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:z}),Wt,Gt]";
+  const previousBrokenCurrentCallNeedle =
+    "(0,Q.jsx)(codexLinuxRateLimitFooter,{rateLimitEntries:";
+  const homeFooterConversationIdVar = detectComposerFooterConversationIdVar(
+    currentSource,
+    [
+      homeFooterGroupNeedle,
+      previousHomeOnlyCall,
+      previousUnguardedHomeGroupCall,
+      previousBrokenCurrentCallNeedle,
+    ],
+  );
+  const homeFooterCall = homeFooterConversationIdVar == null
+    ? null
+    : `(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:${homeFooterConversationIdVar}})`;
+
+  const legacyFooterFunction =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,Z.c)(22),n=ea(),{modelSettings:r}=Bi(e),i=r.model??null,{data:a=null}=li(Fn),o=Ro(a),s=Zo(a),c=Xo(Jo(o,{activeLimitName:s,selectedModel:i})).slice(0,2);c.length===0&&(c=Xo(Jo(o,{activeLimitName:s,selectedModel:null})).slice(0,2));if(c.length===0)return null;let l;t[0]!==n?(l=(0,Q.jsx)(X,{id:`composer.linuxRateLimitFooter.tooltip`,defaultMessage:`Rate limits remaining`,description:`Tooltip for compact footer rate limit status`}),t[0]=n,t[1]=l):l=t[1];let u;if(t[2]!==c){u=c.map((e,t)=>{let n=No(e.bucket.usedPercent??0);return(0,Q.jsxs)(`span`,{className:`flex items-center gap-1 whitespace-nowrap`,children:[t>0?(0,Q.jsx)(`span`,{className:`text-token-input-placeholder-foreground`,children:`/`}):null,(0,Q.jsx)(`span`,{children:(0,Q.jsx)(V_,{minutes:e.bucket.windowDurationMins,variant:`summary`})}),(0,Q.jsx)(`span`,{className:`font-medium text-token-text-primary`,children:Do(n)})]},e.key)}),t[2]=c,t[3]=u}else u=t[3];let d;t[4]!==u?(d=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:u}),t[4]=u,t[5]=d):d=t[5];let f;return t[6]!==l||t[7]!==d?(f=(0,Q.jsx)(nc,{tooltipContent:l,children:d}),t[6]=l,t[7]=d,t[8]=f):f=t[8],f}catch(e){return null}}";
+  const currentFooterFunction = currentSymbols == null
+    ? null
+    : `function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,Z.c)(22),{activeMode:n}=Bi(e),r=n?.settings.model??null,{data:i}=ci(${currentSymbols.accountSignalVar}),a=i===void 0?null:i,o=Ro(a),s=Zo(a),c=Xo(Jo(o,{activeLimitName:s,selectedModel:r})).slice(0,2);c.length===0&&(c=Xo(Jo(o,{activeLimitName:s,selectedModel:null})).slice(0,2));if(c.length===0)return null;let l;t[0]===Symbol.for(\`react.memo_cache_sentinel\`)?(l=(0,Q.jsx)(X,{id:\`composer.linuxRateLimitFooter.tooltip\`,defaultMessage:\`Rate limits remaining\`,description:\`Tooltip for compact footer rate limit status\`}),t[0]=l):l=t[0];let u;if(t[1]!==c){u=c.map((e,t)=>{let n=No(e.bucket.usedPercent??0);return(0,Q.jsxs)(\`span\`,{className:\`flex items-center gap-1 whitespace-nowrap\`,children:[t>0?(0,Q.jsx)(\`span\`,{className:\`text-token-input-placeholder-foreground\`,children:\`/\`}):null,(0,Q.jsx)(\`span\`,{children:(0,Q.jsx)(${currentSymbols.durationComponent},{minutes:e.bucket.windowDurationMins,variant:\`summary\`})}),(0,Q.jsx)(\`span\`,{className:\`font-medium text-token-text-primary\`,children:Do(n)})]},e.key)}),t[1]=c,t[2]=u}else u=t[2];let d;t[3]!==u?(d=(0,Q.jsx)(\`span\`,{className:\`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10\`,children:u}),t[3]=u,t[4]=d):d=t[4];let f;return t[5]!==l||t[6]!==d?(f=(0,Q.jsx)(nc,{tooltipContent:l,children:d}),t[5]=l,t[6]=d,t[7]=f):f=t[7],f}catch(e){return null}}`;
+
+  if (!patchedSource.includes("function codexLinuxRateLimitFooter(")) {
+    const legacyInsertionNeedle = "function TF(e){";
+    if (currentSymbols != null && currentFooterFunction != null) {
+      patchedSource = patchedSource.replace(
+        currentSymbols.insertionNeedle,
+        `${currentFooterFunction}${currentSymbols.insertionNeedle}`,
+      );
+    } else if (patchedSource.includes(legacyInsertionNeedle)) {
+      patchedSource = patchedSource.replace(
+        legacyInsertionNeedle,
+        `${legacyFooterFunction}${legacyInsertionNeedle}`,
+      );
+    }
+  } else if (currentSymbols != null && currentFooterFunction != null) {
+    const functionStart = patchedSource.indexOf("function codexLinuxRateLimitFooter(");
+    const functionEnd = patchedSource.indexOf(currentSymbols.insertionNeedle, functionStart);
+    if (functionEnd !== -1) {
+      const existingFooterFunction = patchedSource.slice(functionStart, functionEnd);
+      if (existingFooterFunction !== currentFooterFunction) {
+        patchedSource =
+          patchedSource.slice(0, functionStart) +
+          currentFooterFunction +
+          patchedSource.slice(functionEnd);
+      }
+    }
+  } else {
+    const legacyInsertionNeedle = "function TF(e){";
+    const functionStart = patchedSource.indexOf("function codexLinuxRateLimitFooter(");
+    const functionEnd = patchedSource.indexOf(legacyInsertionNeedle, functionStart);
+    if (functionStart !== -1 && functionEnd !== -1) {
+      const existingFooterFunction = patchedSource.slice(functionStart, functionEnd);
+      if (existingFooterFunction !== legacyFooterFunction) {
+        patchedSource =
+          patchedSource.slice(0, functionStart) +
+          legacyFooterFunction +
+          patchedSource.slice(functionEnd);
+      }
+    }
+  }
+
+  const hasFooterFunction = patchedSource.includes("function codexLinuxRateLimitFooter(");
+  if (!hasFooterFunction) {
+    if (
+      currentSource.includes("composer-footer flex flex-nowrap") ||
+      currentSource.includes("function Cz(e)") ||
+      currentSource.includes("children:[Ut,Wt,Gt]") ||
+      currentSource.includes("(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w})")
+    ) {
+      console.warn("WARN: Could not insert persistent rate limit footer helper — skipping composer footer limit patch");
+    }
+    return currentSource;
+  }
+
+  const cacheNeedle = "function TF(e){let t=(0,Z.c)(148),";
+  const cachePatch = "function TF(e){let t=(0,Z.c)(149),";
+  if (patchedSource.includes(cacheNeedle)) {
+    patchedSource = patchedSource.replace(cacheNeedle, cachePatch);
+  }
+
+  // The upstream Kt cache only tracks Ut/Wt/Gt. Recompute this group once the
+  // injected child depends on conversationId, otherwise the footer can retain
+  // a stale conversationId while the other footer children stay stable.
+  const homeFooterGroupPatch = homeFooterCall == null
+    ? null
+    : `Kt=(0,Q.jsxs)(\`div\`,{className:\`flex min-w-0 flex-1 flex-nowrap items-center gap-1\`,children:[Ut,${homeFooterCall},Wt,Gt]})`;
+  if (homeFooterGroupPatch != null && patchedSource.includes(homeFooterGroupNeedle)) {
+    patchedSource = patchedSource.replace(homeFooterGroupNeedle, homeFooterGroupPatch);
+  }
+
+  if (patchedSource.includes(previousHomeOnlyCall)) {
+    patchedSource = patchedSource.replace(
+      previousHomeOnlyCall,
+      homeFooterCall ?? "null",
+    );
+  }
+
+  if (patchedSource.includes(previousUnguardedHomeGroupCall)) {
+    patchedSource = patchedSource.replace(
+      previousUnguardedHomeGroupCall,
+      `children:[Ut,${homeFooterCall ?? "null"},Wt,Gt]`,
+    );
+  }
+
+  const previousBrokenCurrentCall =
+    /\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{rateLimitEntries:[A-Za-z_$][\w$]*,activeLimitName:[A-Za-z_$][\w$]*,selectedModel:[A-Za-z_$][\w$]*\}\)/g;
+  if (
+    currentFooterFunction != null &&
+    previousBrokenCurrentCall.test(patchedSource) &&
+    currentSymbols != null
+  ) {
+    patchedSource = patchedSource.replace(
+      previousBrokenCurrentCall,
+      homeFooterCall ?? "null",
+    );
+  }
+  if (patchedSource.includes(previousHomeOnlyCall)) {
+    patchedSource = patchedSource.replace(
+      previousHomeOnlyCall,
+      homeFooterCall ?? "null",
+    );
+  }
+
+  const permissionsControlsNeedle =
+    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})";
+  const permissionsControlsPatch =
+    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),f==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})";
+  if (patchedSource.includes(permissionsControlsNeedle)) {
+    patchedSource = patchedSource.replace(permissionsControlsNeedle, permissionsControlsPatch);
+  }
+  const currentPermissionsControlsNeedle =
+    /\(0,Q\.jsx\)\(([A-Za-z_$][\w$]*),\{conversationId:f,hostId:C,cwdOverride:w\}\),\(0,Q\.jsx\)\(([A-Za-z_$][\w$]*),\{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0\}\)/;
+  if (currentPermissionsControlsNeedle.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      currentPermissionsControlsNeedle,
+      "(0,Q.jsx)($1,{conversationId:f,hostId:C,cwdOverride:w}),f==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)($2,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})",
+    );
+  }
+
+  if (
+    patchedSource === currentSource &&
+    !currentSource.includes("function codexLinuxRateLimitFooter(") &&
+    (currentSource.includes("composer-footer flex flex-nowrap") ||
+      currentSource.includes("function TF(e)") ||
+      currentSource.includes("function Cz(e)"))
+  ) {
+    console.warn("WARN: Could not find persistent rate limit footer needles — skipping composer footer limit patch");
+  }
+
+  return patchedSource;
+}
+
 function patchCommentPreloadBundle(extractedDir) {
   const commentPreloadBundle = path.join(extractedDir, ".vite", "build", "comment-preload.js");
   if (!fs.existsSync(commentPreloadBundle)) {
@@ -230,6 +456,7 @@ function patchCommentPreloadBundle(extractedDir) {
 
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
+  applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   patchCommentPreloadBundle,


### PR DESCRIPTION
## Summary

Adds an optional Linux webview asset patch that keeps the compact composer rate-limit footer visible across project chats, normal chats, and new chats.

The patcher now detects the current minified rate-limit symbols, injects a `conversationId`-based footer helper, migrates previously broken helper/call shapes, and removes the old home-only gate.

## Safety

This is intentionally fail-closed. If the expected composer needles drift, the optional patch skips instead of blocking launch. If the injected footer hits unexpected account or rate-limit data at runtime, the helper catches the error and returns `null` instead of tripping the renderer error boundary.

The footer group insertion also now requires a conversation-id binding in the matched composer scope before injecting a `conversationId` reference. When inserted, it replaces the old `Kt` memo branch with a recomputed group so the footer cannot retain a stale conversation id while `Ut`/`Wt`/`Gt` stay stable.

## Root Cause

A previous local patch could leave calls to `codexLinuxRateLimitFooter` without a valid helper after an app update, or pass rate-limit variables from the wrong minified scope. That produced renderer errors instead of simply hiding the footer.

## Validation

- `node -c scripts/patches/webview-assets.js`
- `node --test scripts/patch-linux-window-ui.test.js` (`97` tests passing)
- Local smoke check of the served installed composer bundle: one helper, one runtime guard, two footer placements, and no home-only gate
