### PR TITLE
Feat/remote control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - The bundled Chrome plugin is now auto-installed during app startup, matching Browser Use, so the plugin page no longer falls back to an install button after restart when the Linux native host is already staged.
 - Nix builds, installer apps, and dev shells now use modern `7zz`, and the installer dependency check accepts `7zz` without requiring a separate legacy `7z` binary.
 
+## [0.8.0] - 2026-05-16
+
+### Added
+
+- New opt-in Linux feature `remote-control-ui` that patches upstream webview bundles to expose the `remote_control` / Codex mobile UI surfaces on Linux without faking backend state, MFA, or connected-client data.
+- `linux-features` can now contribute opt-in `webview-asset` patch descriptors in addition to main-bundle patches, so feature-scoped Linux UI experiments can hook hashed webview assets without being promoted into the core patch registry.
+
 ## [0.7.1] - 2026-05-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ pacman -Qlp dist/codex-desktop-*.pkg.tar.zst | sed -n '1,40p'
 
 ## Versioning
 
-`codex-update-manager` current crate version: `0.7.1`
+`codex-update-manager` current crate version: `0.8.0`
 
 SemVer policy:
 

--- a/linux-features/remote-control-ui/README.md
+++ b/linux-features/remote-control-ui/README.md
@@ -1,0 +1,23 @@
+# Remote Control UI
+
+Opt-in Linux UI patches for upstream `remote_control` and Codex mobile surfaces.
+
+This feature only opens the Linux UI gates. It does not fake backend state such
+as connected clients, MFA completion, or remote control environments.
+
+Enable it locally with:
+
+```json
+{
+  "enabled": [
+    "remote-control-ui"
+  ]
+}
+```
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/remote-control-ui/test.js
+```
+

--- a/linux-features/remote-control-ui/feature.json
+++ b/linux-features/remote-control-ui/feature.json
@@ -1,0 +1,10 @@
+{
+  "id": "remote-control-ui",
+  "title": "Remote Control UI",
+  "description": "Adds opt-in Linux visibility patches for remote control, Codex mobile onboarding, and related settings surfaces.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patches": "./patch.js"
+  }
+}
+

--- a/linux-features/remote-control-ui/patch.js
+++ b/linux-features/remote-control-ui/patch.js
@@ -1,0 +1,126 @@
+"use strict";
+
+const LINUX_GATE = "navigator.userAgent.includes(`Linux`)";
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} — skipping ${patchName}`);
+}
+
+function replaceOnce(source, needle, replacement, patchName) {
+  if (source.includes(replacement)) {
+    return source;
+  }
+  if (!source.includes(needle)) {
+    warn("Could not find expected needle", patchName);
+    return source;
+  }
+  return source.replace(needle, replacement);
+}
+
+function applyRemoteConnectionsVisibilityPatch(source) {
+  return replaceOnce(
+    source,
+    "return c;",
+    `return c||${LINUX_GATE};`,
+    "remote control UI remote connections visibility patch",
+  );
+}
+
+function applyRemoteControlConnectionsVisibilityPatch(source) {
+  const patched = source.replace(
+    /return!!([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)\?\.available===!0(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
+    `return!!$1&&$2?.available===!0||${LINUX_GATE}`,
+  );
+  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
+    return patched;
+  }
+  warn(
+    "Could not find remote control connections visibility gate",
+    "remote control UI remote control connections visibility patch",
+  );
+  return source;
+}
+
+function applyExperimentalFeaturesPatch(source) {
+  const needle = "&&e.name!==`remote_control`";
+  if (source.includes(needle)) {
+    return source.replace(needle, "");
+  }
+  if (source.includes("e.name!==`realtime_conversation`&&e.name!==`chronicle`")) {
+    return source;
+  }
+  if (source.includes("remote_control")) {
+    warn(
+      "Could not find remote_control experimental feature filter",
+      "remote control UI experimental features patch",
+    );
+  }
+  return source;
+}
+
+function applyMobileStatsigLinuxPatch(source, patchName) {
+  const patched = source.replace(
+    /o\(`2798711298`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
+    `o(\`2798711298\`)||${LINUX_GATE}`,
+  );
+  if (patched !== source || source.includes(`o(\`2798711298\`)||${LINUX_GATE}`)) {
+    return patched;
+  }
+  warn("Could not find mobile Statsig gate", patchName);
+  return source;
+}
+
+module.exports = {
+  patches: [
+    {
+      id: "remote-connections-visibility",
+      phase: "webview-asset",
+      order: 20500,
+      ciPolicy: "optional",
+      pattern: /^remote-connection-visibility-.*\.js$/,
+      missingDescription: "remote connection visibility bundle",
+      skipDescription: "remote control UI remote connections visibility patch",
+      apply: applyRemoteConnectionsVisibilityPatch,
+    },
+    {
+      id: "remote-control-connections-visibility",
+      phase: "webview-asset",
+      order: 20510,
+      ciPolicy: "optional",
+      pattern: /^remote-control-connections-visibility-.*\.js$/,
+      missingDescription: "remote control connections visibility bundle",
+      skipDescription: "remote control UI remote control connections visibility patch",
+      apply: applyRemoteControlConnectionsVisibilityPatch,
+    },
+    {
+      id: "experimental-features",
+      phase: "webview-asset",
+      order: 20520,
+      ciPolicy: "optional",
+      pattern: /^experimental-features-queries-.*\.js$/,
+      missingDescription: "experimental features query bundle",
+      skipDescription: "remote control UI experimental features patch",
+      apply: applyExperimentalFeaturesPatch,
+    },
+    {
+      id: "nux-gate",
+      phase: "webview-asset",
+      order: 20530,
+      ciPolicy: "optional",
+      pattern: /^nux-gate-.*\.js$/,
+      missingDescription: "Codex mobile NUX gate bundle",
+      skipDescription: "remote control UI mobile NUX gate patch",
+      apply: (source) => applyMobileStatsigLinuxPatch(source, "remote control UI mobile NUX gate patch"),
+    },
+    {
+      id: "app-main",
+      phase: "webview-asset",
+      order: 20540,
+      ciPolicy: "optional",
+      pattern: /^app-main-.*\.js$/,
+      missingDescription: "Codex mobile app main bundle",
+      skipDescription: "remote control UI mobile app main patch",
+      apply: (source) => applyMobileStatsigLinuxPatch(source, "remote control UI mobile app main patch"),
+    },
+  ],
+};

--- a/linux-features/remote-control-ui/patch.js
+++ b/linux-features/remote-control-ui/patch.js
@@ -18,18 +18,25 @@ function replaceOnce(source, needle, replacement, patchName) {
 }
 
 function applyRemoteConnectionsVisibilityPatch(source) {
-  return replaceOnce(
-    source,
-    "return c;",
-    `return c||${LINUX_GATE};`,
-    "remote control UI remote connections visibility patch",
+  const patched = source.replace(
+    /([A-Za-z_$][\w$]*)\(`4114442250`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
+    `($1(\`4114442250\`)||${LINUX_GATE})`,
   );
+  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
+    return patched;
+  }
+  warn("Could not find remote connections Statsig gate", "remote control UI remote connections visibility patch");
+  return source;
 }
 
 function applyRemoteControlConnectionsVisibilityPatch(source) {
-  const patched = source.replace(
+  let patched = source.replace(
     /return!!([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)\?\.available===!0(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
     `return!!$1&&$2?.available===!0||${LINUX_GATE}`,
+  );
+  patched = patched.replace(
+    /return\s+([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.available\?\?!0\)&&\2\?\.accessRequired!==!0(?!&&navigator\.userAgent\.includes\(`Linux`\))/g,
+    `return ($1||${LINUX_GATE})&&($2?.available??!0)&&$2?.accessRequired!==!0`,
   );
   if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
     return patched;
@@ -60,11 +67,14 @@ function applyExperimentalFeaturesPatch(source) {
 
 function applyMobileStatsigLinuxPatch(source, patchName) {
   const patched = source.replace(
-    /o\(`2798711298`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
-    `o(\`2798711298\`)||${LINUX_GATE}`,
+    /([A-Za-z_$][\w$]*)\(`2798711298`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
+    `($1(\`2798711298\`)||${LINUX_GATE})`,
   );
-  if (patched !== source || source.includes(`o(\`2798711298\`)||${LINUX_GATE}`)) {
+  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
     return patched;
+  }
+  if (source.includes("remote-connection-visibility-")) {
+    return source;
   }
   warn("Could not find mobile Statsig gate", patchName);
   return source;

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  enabledLinuxFeatureIds,
+  loadLinuxFeatureMainBundlePatches,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  createPatchReport,
+  patchExtractedApp,
+} = require("../../scripts/patch-linux-window-ui.js");
+const {
+  patches: featurePatches,
+} = require("./patch.js");
+
+function withTempFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const root = path.resolve(__dirname, "..");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-control-feature-test-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }, null, 2));
+    return fn(root);
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function withLinuxFeatureRootEnv(root, fn) {
+  const originalRoot = process.env.CODEX_LINUX_FEATURES_ROOT;
+  process.env.CODEX_LINUX_FEATURES_ROOT = root;
+  try {
+    return fn();
+  } finally {
+    if (originalRoot == null) {
+      delete process.env.CODEX_LINUX_FEATURES_ROOT;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_ROOT = originalRoot;
+    }
+  }
+}
+
+function captureWarns(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+test("remote-control UI feature stays disabled until listed in features.json", () => {
+  withTempFeatureConfig([], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
+    assert.deepEqual(loadLinuxFeatureMainBundlePatches({ featuresRoot: root }), []);
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
+  });
+});
+
+test("remote-control UI feature exposes optional webview asset descriptors when enabled", () => {
+  withTempFeatureConfig(["remote-control-ui"], (root) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["remote-control-ui"]);
+
+    const patches = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
+    assert.equal(patches.length, 5);
+    assert.deepEqual(
+      patches.map((patch) => [patch.name, patch.phase, patch.ciPolicy]),
+      [
+        ["feature:remote-control-ui:remote-connections-visibility", "webview-asset", "optional"],
+        ["feature:remote-control-ui:remote-control-connections-visibility", "webview-asset", "optional"],
+        ["feature:remote-control-ui:experimental-features", "webview-asset", "optional"],
+        ["feature:remote-control-ui:nux-gate", "webview-asset", "optional"],
+        ["feature:remote-control-ui:app-main", "webview-asset", "optional"],
+      ],
+    );
+  });
+});
+
+test("remote-control UI feature patches are idempotent and fail soft", () => {
+  const remoteConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-connections-visibility");
+  const experimentalFeaturesPatch = featurePatches.find((patch) => patch.id === "experimental-features");
+  const remoteConnectionsSource =
+    "function c(){let e=(0,s.c)(3),{data:n}=t(a,r(i)),c=o(`4114442250`);if(n?.config[`features.remote_connections`]===!0)return!0;let l=n?.config.features;if(typeof l!=`object`||!l||Array.isArray(l))return c;let u;return e[0]!==l||e[1]!==c?(u=Object.getOwnPropertyDescriptor(l,`remote_connections`)?.value===!0||c,e[0]=l,e[1]=c,e[2]=u):u=e[2],u}";
+  const experimentalFeaturesSource =
+    "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`realtime_conversation`&&e.name!==`remote_control`&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}";
+
+  const firstPatched = remoteConnectionsPatch.apply(remoteConnectionsSource, {});
+  assert.match(firstPatched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.equal(remoteConnectionsPatch.apply(firstPatched, {}), firstPatched);
+
+  const filtered = experimentalFeaturesPatch.apply(experimentalFeaturesSource, {});
+  assert.doesNotMatch(filtered, /e\.name!==`remote_control`/);
+  assert.equal(experimentalFeaturesPatch.apply(filtered, {}), filtered);
+
+  const { value, warnings } = captureWarns(() => remoteConnectionsPatch.apply("real codex bundle", {}));
+  assert.equal(value, "real codex bundle");
+  assert.match(warnings.join("\n"), /Could not find expected needle/);
+});
+
+test("remote-control UI feature patches matching webview assets and records patch report entries", () => {
+  withTempFeatureConfig(["remote-control-ui"], (root) => {
+    withLinuxFeatureRootEnv(root, () => {
+      const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-control-feature-app-"));
+      try {
+        const buildDir = path.join(tempApp, ".vite", "build");
+        const assetsDir = path.join(tempApp, "webview", "assets");
+        fs.mkdirSync(buildDir, { recursive: true });
+        fs.mkdirSync(assetsDir, { recursive: true });
+        fs.writeFileSync(path.join(buildDir, "main.js"), "console.log('main bundle');");
+        fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
+
+        fs.writeFileSync(
+          path.join(assetsDir, "remote-connection-visibility-test.js"),
+          "function c(){let e=(0,s.c)(3),{data:n}=t(a,r(i)),c=o(`4114442250`);if(n?.config[`features.remote_connections`]===!0)return!0;let l=n?.config.features;if(typeof l!=`object`||!l||Array.isArray(l))return c;let u;return e[0]!==l||e[1]!==c?(u=Object.getOwnPropertyDescriptor(l,`remote_connections`)?.value===!0||c,e[0]=l,e[1]=c,e[2]=u):u=e[2],u}",
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          "function p(){let e=t(`1042620455`),n=r(`remote_control_connections_state`);return!!e&&n?.available===!0}",
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "experimental-features-queries-test.js"),
+          "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`realtime_conversation`&&e.name!==`remote_control`&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}",
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "nux-gate-test.js"),
+          "function g(){let e=o(`2798711298`),t=n?.remote_control??!1;return e&&!t}",
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "app-main-test.js"),
+          "function h(){let e=o(`2798711298`),t=n?.remote_control??!1;return e&&!t&&r!==`CODEX_MOBILE_SETUP_COMPLETED`}",
+        );
+
+        const report = createPatchReport();
+        const { warnings } = captureWarns(() => patchExtractedApp(tempApp, { report }));
+        assert.ok(
+          warnings.every((warning) => !warning.includes("remote control UI")),
+          warnings.join("\n"),
+        );
+
+        assert.match(
+          fs.readFileSync(path.join(assetsDir, "remote-connection-visibility-test.js"), "utf8"),
+          /navigator\.userAgent\.includes\(`Linux`\)/,
+        );
+        assert.match(
+          fs.readFileSync(path.join(assetsDir, "remote-control-connections-visibility-test.js"), "utf8"),
+          /navigator\.userAgent\.includes\(`Linux`\)/,
+        );
+        assert.doesNotMatch(
+          fs.readFileSync(path.join(assetsDir, "experimental-features-queries-test.js"), "utf8"),
+          /e\.name!==`remote_control`/,
+        );
+        assert.match(
+          fs.readFileSync(path.join(assetsDir, "nux-gate-test.js"), "utf8"),
+          /o\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/,
+        );
+        assert.match(
+          fs.readFileSync(path.join(assetsDir, "app-main-test.js"), "utf8"),
+          /o\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/,
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "remote-connections-visibility" && patch.status === "applied"
+          ),
+        );
+      } finally {
+        fs.rmSync(tempApp, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -93,9 +93,20 @@ test("remote-control UI feature exposes optional webview asset descriptors when 
 
 test("remote-control UI feature patches are idempotent and fail soft", () => {
   const remoteConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-connections-visibility");
+  const remoteControlConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-control-connections-visibility");
   const experimentalFeaturesPatch = featurePatches.find((patch) => patch.id === "experimental-features");
+  const appMainPatch = featurePatches.find((patch) => patch.id === "app-main");
+  const nuxGatePatch = featurePatches.find((patch) => patch.id === "nux-gate");
   const remoteConnectionsSource =
     "function c(){let e=(0,s.c)(3),{data:n}=t(a,r(i)),c=o(`4114442250`);if(n?.config[`features.remote_connections`]===!0)return!0;let l=n?.config.features;if(typeof l!=`object`||!l||Array.isArray(l))return c;let u;return e[0]!==l||e[1]!==c?(u=Object.getOwnPropertyDescriptor(l,`remote_connections`)?.value===!0||c,e[0]=l,e[1]=c,e[2]=u):u=e[2],u}";
+  const currentRemoteConnectionsSource =
+    "function d(){let e=(0,u.c)(3),{data:i}=n(s,r(t)),a=c(`4114442250`);if(i?.config[`features.remote_connections`]===!0)return!0;let o=i?.config.features;if(typeof o!=`object`||!o||Array.isArray(o))return a;let l;return e[0]!==o||e[1]!==a?(l=Object.getOwnPropertyDescriptor(o,`remote_connections`)?.value===!0||a,e[0]=o,e[1]=a,e[2]=l):l=e[2],l}";
+  const currentRemoteControlConnectionsSource =
+    "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
+  const currentAppMainSource =
+    "function m_(){let e=(0,Z.c)(14),t=Pg(),{data:n,isLoading:r}=Ps(d.CODEX_MOBILE_SETUP_COMPLETED),i=Ql(),a=ec(`2798711298`),[o]=ts(`local_app_server_feature_enablement`),[s,c]=gt(Vg),l=o?.remote_control??!1,u=t&&i&&a&&!l&&!r&&!n&&!s;return u}";
+  const currentNuxGateSource =
+    "import{r as ee}from\"./remote-connection-visibility-6MV6akfy.js\";function wt(){let i=ee(),a=z(),[o]=E(`remote_connections`),s=o?.some(Tt)??!1;return i&&!a&&o!=null&&s}";
   const experimentalFeaturesSource =
     "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`realtime_conversation`&&e.name!==`remote_control`&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}";
 
@@ -103,13 +114,31 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
   assert.match(firstPatched, /navigator\.userAgent\.includes\(`Linux`\)/);
   assert.equal(remoteConnectionsPatch.apply(firstPatched, {}), firstPatched);
 
+  const currentRemoteConnectionsPatched = remoteConnectionsPatch.apply(currentRemoteConnectionsSource, {});
+  assert.match(currentRemoteConnectionsPatched, /c\(`4114442250`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.equal(remoteConnectionsPatch.apply(currentRemoteConnectionsPatched, {}), currentRemoteConnectionsPatched);
+
+  const currentRemoteControlConnectionsPatched = remoteControlConnectionsPatch.apply(currentRemoteControlConnectionsSource, {});
+  assert.match(currentRemoteControlConnectionsPatched, /\(t\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&\(e\?\.available\?\?!0\)/);
+  assert.equal(remoteControlConnectionsPatch.apply(currentRemoteControlConnectionsPatched, {}), currentRemoteControlConnectionsPatched);
+
+  const currentAppMainPatched = appMainPatch.apply(currentAppMainSource, {});
+  assert.match(currentAppMainPatched, /ec\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.equal(appMainPatch.apply(currentAppMainPatched, {}), currentAppMainPatched);
+
+  const { value: currentNuxGatePatched, warnings: currentNuxGateWarnings } = captureWarns(() =>
+    nuxGatePatch.apply(currentNuxGateSource, {}),
+  );
+  assert.equal(currentNuxGatePatched, currentNuxGateSource);
+  assert.deepEqual(currentNuxGateWarnings, []);
+
   const filtered = experimentalFeaturesPatch.apply(experimentalFeaturesSource, {});
   assert.doesNotMatch(filtered, /e\.name!==`remote_control`/);
   assert.equal(experimentalFeaturesPatch.apply(filtered, {}), filtered);
 
   const { value, warnings } = captureWarns(() => remoteConnectionsPatch.apply("real codex bundle", {}));
   assert.equal(value, "real codex bundle");
-  assert.match(warnings.join("\n"), /Could not find expected needle/);
+  assert.match(warnings.join("\n"), /Could not find remote connections Statsig gate/);
 });
 
 test("remote-control UI feature patches matching webview assets and records patch report entries", () => {
@@ -174,7 +203,7 @@ test("remote-control UI feature patches matching webview assets and records patc
         );
         assert.ok(
           report.patches.some((patch) =>
-            patch.name === "remote-connections-visibility" && patch.status === "applied"
+            patch.name === "feature:remote-control-ui:remote-connections-visibility" && patch.status === "applied"
           ),
         );
       } finally {

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -213,8 +213,28 @@ function featurePatchDescriptorListFromExports(feature, moduleExports, sourcePat
 function loadLinuxFeaturePatchDescriptors(options = {}) {
   const descriptors = [];
   for (const [featureIndex, feature] of loadEnabledLinuxFeatures(options).entries()) {
-    const loaded = loadFeatureEntrypointModule(feature, "patchDescriptors");
+    const loaded = loadFeatureEntrypointModule(feature, "patchDescriptors") ??
+      loadFeatureEntrypointModule(feature, "patches");
     if (loaded == null) {
+      const legacyLoaded = loadFeatureEntrypointModule(feature, "mainBundlePatch");
+      if (legacyLoaded == null) {
+        continue;
+      }
+
+      const moduleExports = legacyLoaded.moduleExports;
+      const apply = moduleExports.applyMainBundlePatch ?? moduleExports.apply ?? moduleExports;
+      if (typeof apply !== "function") {
+        console.warn(`WARN: Linux feature '${feature.id}' mainBundlePatch must export a function`);
+        continue;
+      }
+
+      descriptors.push({
+        id: `feature:${feature.id}`,
+        name: `feature:${feature.id}`,
+        phase: "main-bundle",
+        ciPolicy: "optional",
+        apply: (source, context) => apply(source, featureContext(context, feature)),
+      });
       continue;
     }
     descriptors.push(
@@ -230,27 +250,9 @@ function loadLinuxFeaturePatchDescriptors(options = {}) {
 }
 
 function loadLinuxFeatureMainBundlePatches(options = {}) {
-  const patches = [];
-  for (const feature of loadEnabledLinuxFeatures(options)) {
-    const loaded = loadFeatureEntrypointModule(feature, "mainBundlePatch");
-    if (loaded == null) {
-      continue;
-    }
-
-    const moduleExports = loaded.moduleExports;
-    const apply = moduleExports.applyMainBundlePatch ?? moduleExports.apply ?? moduleExports;
-    if (typeof apply !== "function") {
-      console.warn(`WARN: Linux feature '${feature.id}' mainBundlePatch must export a function`);
-      continue;
-    }
-
-    patches.push({
-      name: `feature:${feature.id}`,
-      ciPolicy: "optional",
-      apply: (source, context) => apply(source, { ...context, feature }),
-    });
-  }
-  return patches;
+  return loadLinuxFeaturePatchDescriptors(options)
+    .filter((patch) => (patch.phase ?? "main-bundle") === "main-bundle")
+    .map(({ apply, ciPolicy, id, name }) => ({ apply, ciPolicy, id, name }));
 }
 
 function enabledLinuxFeatureStageHooks(options = {}) {

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -166,9 +166,11 @@ function wrapFeaturePatchDescriptor(feature, descriptor, sourcePath, index, feat
     return null;
   }
 
+  const wrappedId = prefixedFeaturePatchId(feature, descriptorId);
   const wrapped = {
     ...descriptor,
-    id: prefixedFeaturePatchId(feature, descriptorId),
+    id: wrappedId,
+    name: descriptor.name ?? wrappedId,
     ciPolicy: descriptor.ciPolicy ?? "optional",
     order: descriptor.order ?? 20_000 + featureIndex * 100 + index * 10,
     sourcePath,

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -12,8 +12,8 @@ const {
   linuxTargetSummary,
 } = require("../lib/linux-target-context.js");
 const {
-  loadLinuxFeatureMainBundlePatches,
   loadLinuxFeaturePatchDescriptors,
+  loadLinuxFeatureMainBundlePatches,
 } = require("../lib/linux-features.js");
 const {
   findIconAsset,
@@ -66,6 +66,21 @@ function featurePatchDescriptors() {
       })),
       ...loadLinuxFeaturePatchDescriptors(),
     ],
+  );
+}
+
+function featureWebviewAssetDescriptors() {
+  return normalizePatchDescriptors(
+    loadLinuxFeaturePatchDescriptors()
+      .filter((patch) => patch.phase === "webview-asset")
+      .map((patch, index) => ({
+        ...patch,
+        id: patch.id ?? patch.name,
+        name: patch.name ?? patch.id,
+        phase: "webview-asset",
+        order: patch.order ?? 20_500 + index * 10,
+        ciPolicy: patch.ciPolicy ?? OPTIONAL,
+      })),
   );
 }
 
@@ -207,6 +222,12 @@ function allPatchPolicies(options = {}) {
       appliesTo,
     })),
     ...featurePatchDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
+      name: name ?? id,
+      ciPolicy,
+      phase,
+      appliesTo,
+    })),
+    ...featureWebviewAssetDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
       name: name ?? id,
       ciPolicy,
       phase,

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -13,7 +13,6 @@ const {
 } = require("../lib/linux-target-context.js");
 const {
   loadLinuxFeaturePatchDescriptors,
-  loadLinuxFeatureMainBundlePatches,
 } = require("../lib/linux-features.js");
 const {
   findIconAsset,
@@ -54,34 +53,7 @@ function legacyCorePatchDescriptors(options = {}) {
 }
 
 function featurePatchDescriptors() {
-  return normalizePatchDescriptors(
-    [
-      ...loadLinuxFeatureMainBundlePatches().map((patch, index) => ({
-        ...patch,
-        id: patch.id ?? patch.name,
-        name: patch.name ?? patch.id,
-        phase: "main-bundle",
-        order: 20_000 + index * 10,
-        ciPolicy: patch.ciPolicy ?? OPTIONAL,
-      })),
-      ...loadLinuxFeaturePatchDescriptors(),
-    ],
-  );
-}
-
-function featureWebviewAssetDescriptors() {
-  return normalizePatchDescriptors(
-    loadLinuxFeaturePatchDescriptors()
-      .filter((patch) => patch.phase === "webview-asset")
-      .map((patch, index) => ({
-        ...patch,
-        id: patch.id ?? patch.name,
-        name: patch.name ?? patch.id,
-        phase: "webview-asset",
-        order: patch.order ?? 20_500 + index * 10,
-        ciPolicy: patch.ciPolicy ?? OPTIONAL,
-      })),
-  );
+  return normalizePatchDescriptors(loadLinuxFeaturePatchDescriptors());
 }
 
 function createMainBundleContext(iconAsset, options = {}) {
@@ -222,12 +194,6 @@ function allPatchPolicies(options = {}) {
       appliesTo,
     })),
     ...featurePatchDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
-      name: name ?? id,
-      ciPolicy,
-      phase,
-      appliesTo,
-    })),
-    ...featureWebviewAssetDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
       name: name ?? id,
       ciPolicy,
       phase,

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Related: #217, but this PR does not close it.

This adds an opt-in Linux feature, `remote-control-ui`, that exposes upstream `remote_control` and Codex mobile UI surfaces on Linux without faking backend state, MFA completion, connected-client data, or remote-control environments.

The feature also extends the Linux feature patching system so opt-in features can contribute webview asset patch descriptors in addition to legacy main-bundle patches.

Included here:

- `linux-features/remote-control-ui/` feature manifest, README, patch descriptors, and tests.
- Webview asset patch descriptor loading through the Linux feature registry.
- Current upstream webview asset needles for remote connection visibility, remote control connection visibility, and Codex mobile app-main gates.
- Updater version and changelog bump to `0.8.0`.

Validation:

- `node --test linux-features/remote-control-ui/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- Fresh upstream DMG patch smoke with `remote-control-ui` enabled