### PR TITLE
fix(nix): use explicit package inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           bash -n scripts/build-pacman.sh
           bash -n scripts/build-appimage.sh
           bash -n scripts/ci/update-nix-hashes.sh
+          bash -n scripts/ci/validate-nix-pins.sh
 
       - name: Check Node patcher syntax
         run: |
@@ -101,6 +102,44 @@ jobs:
             echo "- Built: \`$(basename "$deb_file")\`"
             echo "- Verified updater binary, user service, update-builder bundle, and packaged runtime helper."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  nix:
+    name: Nix Package Builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      NIX_CONFIG: experimental-features = nix-command flakes
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - uses: cachix/install-nix-action@v27
+
+      - name: Install validation dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
+      - name: Validate Nix pins against upstream DMG
+        run: scripts/ci/validate-nix-pins.sh
+
+      - name: Check flake evaluation
+        run: nix flake check --no-build
+
+      - name: Build Nix package outputs
+        run: |
+          nix build \
+            .#codex-desktop \
+            .#codex-desktop-computer-use-ui \
+            .#codex-desktop-remote-mobile-control \
+            .#codex-desktop-computer-use-ui-remote-mobile-control \
+            .#installer \
+            --no-link \
+            --print-build-logs
 
   package-rpm:
     name: Build RPM Package

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -21,9 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - uses: cachix/install-nix-action@v27
 
-      - name: Refresh Nix fixed-output hashes
+      - name: Install validation dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y p7zip-full
+
+      - name: Refresh Nix upstream hash
         run: scripts/ci/update-nix-hashes.sh
 
       - name: Commit refreshed hashes
@@ -36,8 +46,6 @@ jobs:
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
-          PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopPayload = mkCodexDesktopPayload {' 'outputHash = ')"
-          COMPUTER_USE_UI_PAYLOAD_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {' 'outputHash = ')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -45,7 +53,6 @@ jobs:
           git commit \
             -m "fix(nix): update upstream Nix hashes" \
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
-            -m "Refreshed codexDesktopPayload recursive outputHash to $PAYLOAD_HASH." \
-            -m "Refreshed codexDesktopComputerUseUiPayload recursive outputHash to $COMPUTER_USE_UI_PAYLOAD_HASH." \
+            -m "Verified all Codex Desktop Nix package outputs against the refreshed DMG." \
             -m "[skip ci]"
           git push origin main

--- a/README.md
+++ b/README.md
@@ -95,7 +95,19 @@ make appimage
 nix run github:ilysenko/codex-desktop-linux
 ```
 
-The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot refreshes the upstream `Codex.dmg` and recursive Nix payload hashes in `main`; if you hit a hash mismatch right after an upstream release, wait for the next bot run and retry.
+The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot refreshes the upstream `Codex.dmg` hash and verifies the Nix package outputs in `main`; if you hit a hash mismatch right after an upstream release, wait for the next bot run and retry.
+
+Because flakes do not include the git-ignored `linux-features/features.json` opt-in file, Nix exposes feature-specific app variants for optional integrations. To build and run Codex Desktop with the experimental mobile remote-control feature enabled:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
+```
+
+Feature-specific Nix outputs are additive. To enable both the Computer Use UI and experimental mobile remote control:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+```
 
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
@@ -181,6 +193,12 @@ Nix users can also run the opt-in flake output directly:
 nix run github:ilysenko/codex-desktop-linux#codex-desktop-computer-use-ui
 ```
 
+The Computer Use UI output can also be combined with Linux feature outputs, for example:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+```
+
 ### Side-by-side dev variant
 
 If you'd like to test the backend without affecting your default install, the side-by-side dev variant builds a separate app under a different ID and webview port:
@@ -198,7 +216,6 @@ By default, the native package installs a companion `systemd --user` service nam
 
 - It checks upstream `Codex.dmg` on daemon startup, every 6 hours, and in the background on app launch when stale.
 - When a new DMG is available, it rebuilds a local native package with `/opt/codex-desktop/update-builder`.
-- Rebuilds reuse the package's staged optional Linux feature config, so enabled `linux-features/` choices survive auto-updates.
 - If Codex Desktop is open, the final install waits until Electron exits.
 - The updater runs unprivileged and uses `pkexec` only for the final package install.
 - Codex CLI checks are best-effort and launcher-scoped. Set `CODEX_SYNC_CLI_PREFLIGHT=1` when debugging launch-time CLI preflight.
@@ -340,7 +357,7 @@ After `make build-app` or `make build-app-fresh`, build a native package from `c
 |---|---|---|---|
 | Debian | `make deb` or `./scripts/build-deb.sh` | `dist/codex-desktop_*.deb` | `sudo dpkg -i dist/codex-desktop_*.deb` |
 | RPM (Fedora / openSUSE) | `make rpm` or `./scripts/build-rpm.sh` | `dist/codex-desktop-*.x86_64.rpm` | `sudo dnf install dist/codex-desktop-*.rpm` (Fedora) or `sudo zypper install dist/codex-desktop-*.rpm` (openSUSE) |
-| Arch (pacman) | `make pacman` or `./scripts/build-pacman.sh` | `dist/codex-desktop-*.pkg.tar.zst` plus `dist/codex-desktop-latest.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-latest.pkg.tar.zst` |
+| Arch (pacman) | `make pacman` or `./scripts/build-pacman.sh` | `dist/codex-desktop-*.pkg.tar.zst` | `sudo pacman -U dist/codex-desktop-*.pkg.tar.zst` |
 | AppImage | `make appimage` or `./scripts/build-appimage.sh` | `dist/codex-desktop-*.AppImage` | Run directly; no system install |
 | Auto-detect | `make package && make install` | matches your distro | handled by `make install` |
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
       let
         pkgs = import nixpkgs { inherit system; };
         sourceRoot = pkgs.lib.cleanSourceWith {
@@ -23,6 +23,155 @@
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
           hash = "sha256-bUQMcTN3GTXIYKVUa81gP4ubZbN+m4K9sAGdT9DIW2o=";
+        };
+
+        codexVersion = "26.513.31313";
+        electronVersion = "42.0.1";
+        electronPlatform =
+          {
+            x86_64-linux = {
+              arch = "x64";
+              hash = "sha256-4bi1uG0//2nis1AlhjY9OECF7gV4vQQfpZFf0LVXxPE=";
+            };
+            aarch64-linux = {
+              arch = "arm64";
+              hash = "sha256-oIpOaROATrBc6nmNi9CvrOTRuI6dB9uGt3nqSkSL4HA=";
+            };
+          }.${system} or (throw "codex-desktop-linux Nix package is not supported on ${system}");
+
+        electronZip = pkgs.fetchurl {
+          url = "https://github.com/electron/electron/releases/download/v${electronVersion}/electron-v${electronVersion}-linux-${electronPlatform.arch}.zip";
+          hash = electronPlatform.hash;
+        };
+
+        electronHeaders = pkgs.fetchurl {
+          url = "https://artifacts.electronjs.org/headers/dist/v${electronVersion}/node-v${electronVersion}-headers.tar.gz";
+          hash = "sha256-yQBrv98qtbQ8cdZpuqx2uyP1mkIAVhLlUFjI/vxh9gA=";
+        };
+
+        browserUseNodeReplRuntime = pkgs.fetchurl {
+          url = "https://persistent.oaistatic.com/codex-primary-runtime/26.426.12240/codex-primary-runtime-linux-x64-26.426.12240.tar.xz";
+          hash = "sha256-21Yk6276NrZuxvbdBIjO+5ZuSWNoYqq2IJpDNsHKkMQ=";
+        };
+
+        browserUseNodeRepl = if system == "x86_64-linux" then pkgs.stdenv.mkDerivation {
+          pname = "codex-browser-use-node-repl";
+          version = "26.426.12240";
+          src = browserUseNodeReplRuntime;
+
+          dontConfigure = true;
+          dontBuild = true;
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/bin"
+            tar -xJf "$src" -C "$TMPDIR" codex-primary-runtime/dependencies/bin/node_repl
+            install -m 0755 "$TMPDIR/codex-primary-runtime/dependencies/bin/node_repl" "$out/bin/node_repl"
+            runHook postInstall
+          '';
+        } else null;
+
+        codexComputerUseBinaries = pkgs.rustPlatform.buildRustPackage {
+          pname = "codex-computer-use-linux-binaries";
+          version = "0.1.2-linux-alpha1";
+          src = sourceRoot;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "cosmic-protocols-0.2.0" = "sha256-ymn+BUTTzyHquPn4hvuoA3y1owFj8LVrmsPu2cdkFQ8=";
+            };
+          };
+
+          buildAndTestSubdir = "computer-use-linux";
+          cargoBuildFlags = [
+            "-p"
+            "codex-computer-use-linux"
+            "--bins"
+          ];
+          doCheck = false;
+
+          installPhase = ''
+            runHook preInstall
+            release_dir="target/''${CARGO_BUILD_TARGET:-${pkgs.stdenv.hostPlatform.rust.rustcTarget}}/release"
+            if [ ! -d "$release_dir" ]; then
+              release_dir="target/release"
+            fi
+            install -Dm0755 "$release_dir/codex-computer-use-linux" "$out/bin/codex-computer-use-linux"
+            install -Dm0755 "$release_dir/codex-computer-use-cosmic" "$out/bin/codex-computer-use-cosmic"
+            install -Dm0755 "$release_dir/codex-chrome-extension-host" "$out/bin/codex-chrome-extension-host"
+            runHook postInstall
+          '';
+        };
+
+        nativeModulesNodeModules = pkgs.importNpmLock.buildNodeModules {
+          npmRoot = ./nix/native-modules;
+          inherit (pkgs) nodejs;
+          derivationArgs = {
+            npmRebuildFlags = [ "--ignore-scripts" ];
+          };
+        };
+
+        codexNativeModules = pkgs.stdenv.mkDerivation {
+          pname = "codex-desktop-electron-native-modules";
+          version = electronVersion;
+          dontUnpack = true;
+
+          nativeBuildInputs = [
+            pkgs.bash
+            pkgs.gcc
+            pkgs.gnumake
+            pkgs.nodejs
+            pkgs.python3
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            cp -R ${nativeModulesNodeModules}/node_modules .
+            cp ${nativeModulesNodeModules}/package.json .
+            cp ${nativeModulesNodeModules}/package-lock.json .
+            chmod -R u+w node_modules
+
+            mkdir -p "$TMPDIR/electron-headers"
+            tar -xzf ${electronHeaders} -C "$TMPDIR/electron-headers" --strip-components=1
+
+            export SCRIPT_DIR=${sourceRoot}
+            export WORK_DIR="$TMPDIR"
+            export ARCH="${pkgs.stdenv.hostPlatform.uname.processor}"
+            export ELECTRON_VERSION=${electronVersion}
+            export MIN_BETTER_SQLITE3_VERSION_FOR_ELECTRON_41="12.9.0"
+            export npm_config_nodedir="$TMPDIR/electron-headers"
+            export NPM_CONFIG_NODEDIR="$TMPDIR/electron-headers"
+
+            # Reuse the installer's Electron 42 source compatibility patch without
+            # sourcing install-helpers.sh, which owns the top-level installer traps.
+            info() { echo "[INFO] $*" >&2; }
+            warn() { echo "[WARN] $*" >&2; }
+            error() { echo "[ERROR] $*" >&2; exit 1; }
+            source ${sourceRoot}/scripts/lib/native-modules.sh
+            patch_better_sqlite3_for_v8_external_pointer_api "$PWD/node_modules/better-sqlite3"
+
+            node "$PWD/node_modules/@electron/rebuild/lib/cli.js" \
+              -v ${electronVersion} \
+              --force \
+              --module-dir "$PWD" \
+              --dist-url "file://$TMPDIR/electron-headers"
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            cp -R node_modules/better-sqlite3 "$out/better-sqlite3"
+            cp -R node_modules/node-pty "$out/node-pty"
+            find "$out/better-sqlite3/build" -type f ! -name "*.node" -delete 2>/dev/null || true
+            find "$out/node-pty/build" -type f ! -name "*.node" -delete 2>/dev/null || true
+            find "$out" -type d -empty -delete 2>/dev/null || true
+            find "$out" -type f -name "*.target.mk" -delete 2>/dev/null || true
+            runHook postInstall
+          '';
         };
 
         electronLibs = with pkgs; [
@@ -179,10 +328,24 @@ PY
           fi
         '';
 
-        mkCodexDesktopPayload = { enableComputerUseUi ? false, outputHash }:
+        linuxFeaturesConfig = linuxFeatureIds:
+          pkgs.writeText "codex-linux-features.json" (builtins.toJSON {
+            enabled = linuxFeatureIds;
+          });
+
+        enabledFeatureIds = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+          pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ] ++ linuxFeatureIds;
+
+        packageSuffix = args:
+          let
+            featureIds = enabledFeatureIds args;
+          in
+          if featureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" featureIds}";
+
+        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
         pkgs.stdenv.mkDerivation {
-          pname = if enableComputerUseUi then "codex-desktop-computer-use-ui-payload" else "codex-desktop-payload";
-          version = "26.506.21252";
+          pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi linuxFeatureIds; }}-payload";
+          version = codexVersion;
           src = sourceRoot;
           __structuredAttrs = true;
 
@@ -195,16 +358,12 @@ PY
             pkgs.gnused
             pkgs.makeWrapper
             pkgs.nodejs
+            pkgs.asar
             pkgs._7zz
             pkgs.patchelf
             pkgs.python3
             pkgs.unzip
           ];
-
-          outputHashAlgo = "sha256";
-          outputHashMode = "recursive";
-          inherit outputHash;
-          unsafeDiscardReferences.out = true;
 
           dontConfigure = true;
           dontBuild = true;
@@ -227,6 +386,15 @@ PY
             export CXXFLAGS="''${CXXFLAGS:-} -ffile-prefix-map=$TMPDIR=/build -fdebug-prefix-map=$TMPDIR=/build -fmacro-prefix-map=$TMPDIR=/build"
             export RUSTFLAGS="''${RUSTFLAGS:-} --remap-path-prefix=$TMPDIR=/build -C link-arg=-Wl,--build-id=none"
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
+            export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfig linuxFeatureIds}"
+            export CODEX_ELECTRON_ZIP_SOURCE="${electronZip}"
+            export CODEX_NATIVE_MODULES_SOURCE="${codexNativeModules}"
+            ${pkgs.lib.optionalString (browserUseNodeRepl != null) ''
+            export CODEX_LINUX_NODE_REPL_SOURCE="${browserUseNodeRepl}/bin/node_repl"
+            ''}
+            export CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-linux"
+            export CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-cosmic"
+            export CODEX_CHROME_EXTENSION_HOST_SOURCE="${codexComputerUseBinaries}/bin/codex-chrome-extension-host"
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 
             source_dir="$TMPDIR/codex-source"
@@ -235,10 +403,6 @@ PY
             chmod -R u+w "$source_dir"
             cp ${codexDmg} "$source_dir/Codex.dmg"
 
-            npm_tools="$TMPDIR/npm-tools"
-            npm install --prefix "$npm_tools" --ignore-scripts asar @electron/rebuild
-            patchShebangs "$npm_tools"
-            export PATH="$npm_tools/node_modules/.bin:$PATH"
             substituteInPlace "$source_dir/scripts/lib/asar-patch.sh" \
               --replace-fail "npx --yes asar" "asar" \
               --replace-fail "npx asar" "asar"
@@ -258,19 +422,16 @@ PY
           '';
         };
 
-        codexDesktopPayload = mkCodexDesktopPayload {
-          outputHash = "sha256-OnZLfHOaT3PQhUJhBuCXNYj3Bbinqa3oJNKVE0Xfrdw=";
-        };
-
-        codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {
-          enableComputerUseUi = true;
-          outputHash = "sha256-9l9nRn9HRVjSOjIw5zmLEkpuKBUuorApDEkMgAJnRYo=";
-        };
-
-        mkCodexDesktop = { pname ? "codex-desktop", payload }:
+        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+        let
+          featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
+          payload = mkCodexDesktopPayload {
+            inherit enableComputerUseUi linuxFeatureIds;
+          };
+        in
         pkgs.stdenv.mkDerivation {
-          inherit pname;
-          version = "26.506.21252";
+          pname = "codex-desktop${packageSuffix featureArgs}";
+          version = codexVersion;
           src = payload;
 
           nativeBuildInputs = [
@@ -330,7 +491,14 @@ PY
           '';
 
           meta = {
-            description = if pname == "codex-desktop-computer-use-ui" then "Codex Desktop for Linux with Computer Use UI enabled" else "Codex Desktop for Linux";
+            description =
+              let
+                featureIds = enabledFeatureIds featureArgs;
+              in
+              if featureIds == [ ] then
+                "Codex Desktop for Linux"
+              else
+                "Codex Desktop for Linux with ${pkgs.lib.concatStringsSep ", " featureIds} enabled";
             homepage = "https://github.com/ilysenko/codex-desktop-linux";
             license = pkgs.lib.licenses.mit;
             platforms = pkgs.lib.platforms.linux;
@@ -338,13 +506,19 @@ PY
           };
         };
 
-        codexDesktop = mkCodexDesktop {
-          payload = codexDesktopPayload;
-        };
+        codexDesktop = mkCodexDesktop { };
 
         codexDesktopComputerUseUi = mkCodexDesktop {
-          pname = "codex-desktop-computer-use-ui";
-          payload = codexDesktopComputerUseUiPayload;
+          enableComputerUseUi = true;
+        };
+
+        codexDesktopRemoteMobileControl = mkCodexDesktop {
+          linuxFeatureIds = [ "remote-mobile-control" ];
+        };
+
+        codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {
+          enableComputerUseUi = true;
+          linuxFeatureIds = [ "remote-mobile-control" ];
         };
 
         installer = pkgs.writeShellApplication {
@@ -393,12 +567,24 @@ PY
           default = codexDesktop;
           codex-desktop = codexDesktop;
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
+          codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
+          codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
           installer = installer;
         };
 
         apps.default = {
           type = "app";
           program = "${codexDesktop}/bin/codex-desktop";
+        };
+
+        apps.remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopRemoteMobileControl}/bin/codex-desktop";
+        };
+
+        apps.computer-use-ui-remote-mobile-control = {
+          type = "app";
+          program = "${codexDesktopComputerUseUiRemoteMobileControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -15,6 +15,20 @@ building:
 }
 ```
 
+For the Nix flake build, use the declarative app variant instead because the
+git-ignored `features.json` file is not part of the flake source:
+
+```bash
+nix run .#remote-mobile-control
+```
+
+Feature-specific Nix outputs are additive. To combine this feature with the
+Computer Use UI opt-in:
+
+```bash
+nix run .#computer-use-ui-remote-mobile-control
+```
+
 What it changes:
 
 - Replaces the macOS-only `remote-control-device-key.node` requirement with a

--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -1,0 +1,1048 @@
+{
+  "name": "codex-desktop-linux-native-modules",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-desktop-linux-native-modules",
+      "version": "0.0.0",
+      "dependencies": {
+        "@electron/rebuild": "4.0.4",
+        "better-sqlite3": "12.9.0",
+        "electron": "42.0.1",
+        "node-abi": "^4.31.0",
+        "node-pty": "1.1.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron": {
+      "version": "42.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.1.tgz",
+      "integrity": "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.3.0.tgz",
+      "integrity": "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/nix/native-modules/package.json
+++ b/nix/native-modules/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "codex-desktop-linux-native-modules",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@electron/rebuild": "4.0.4",
+    "better-sqlite3": "12.9.0",
+    "electron": "42.0.1",
+    "node-abi": "^4.31.0",
+    "node-pty": "1.1.0"
+  }
+}

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -5,10 +5,15 @@ REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
 UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
-BUILD_LOG="${BUILD_LOG:-/tmp/codex-nix-build.log}"
-COMPUTER_USE_UI_BUILD_LOG="${COMPUTER_USE_UI_BUILD_LOG:-/tmp/codex-nix-build-computer-use-ui.log}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
-FAKE_SRI_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+PACKAGE_OUTPUTS=(
+    ".#codex-desktop"
+    ".#codex-desktop-computer-use-ui"
+    ".#codex-desktop-remote-mobile-control"
+    ".#codex-desktop-computer-use-ui-remote-mobile-control"
+    ".#installer"
+)
 
 validate_sri_hash() {
     local hash="$1"
@@ -81,23 +86,6 @@ raise SystemExit(f"Could not find {key!r} after {anchor!r} in {path}")
 PY
 }
 
-extract_got_sri_hash() {
-    local log_path="$1"
-
-    python3 - "$log_path" <<'PY'
-from pathlib import Path
-import re
-import sys
-
-text = Path(sys.argv[1]).read_text(errors="replace")
-text = re.sub(r"\x1b\[[0-9;]*m", "", text)
-matches = re.findall(r"got:\s*(sha256-[A-Za-z0-9+/=]{44})", text)
-if not matches:
-    raise SystemExit(1)
-print(matches[-1])
-PY
-}
-
 run_nix_build() {
     local log_path="$1"
     shift
@@ -110,26 +98,7 @@ run_nix_build() {
     return "$status"
 }
 
-restore_flake_hashes() {
-    local dmg_hash="$1"
-    local payload_hash="$2"
-    local computer_use_ui_payload_hash="$3"
-
-    if [ -n "$dmg_hash" ]; then
-        replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$dmg_hash"
-    fi
-    if [ -n "$payload_hash" ]; then
-        replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$payload_hash"
-    fi
-    if [ -n "$computer_use_ui_payload_hash" ]; then
-        replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$computer_use_ui_payload_hash"
-    fi
-}
-
 main() {
-    local current_dmg_hash=""
-    local current_payload_hash=""
-    local current_computer_use_ui_payload_hash=""
     mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
     curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
 
@@ -144,66 +113,13 @@ main() {
     echo "Upstream Codex.dmg hash: $new_dmg_hash"
     replace_flake_hash "codexDmg = pkgs.fetchurl {" "hash = " "$new_dmg_hash"
 
-    # Seed the Nix store so the build can reuse the DMG that was already downloaded
-    # for hashing instead of fetching the same 300MB artifact again.
+    # Seed the Nix store so the verification build can reuse the DMG that was
+    # already downloaded for hashing instead of fetching the same artifact again.
     nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
 
-    current_payload_hash="$(read_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current payload outputHash: $current_payload_hash"
-    echo "Forcing payload outputHash refresh..."
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
-
-    if run_nix_build "$BUILD_LOG" .#codex-desktop; then
-        echo "Nix build unexpectedly succeeded with the fake payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    new_payload_hash="$(extract_got_sri_hash "$BUILD_LOG" || true)"
-    if [ -z "$new_payload_hash" ]; then
-        echo "Nix build failed without a fixed-output hash mismatch; leaving log at $BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    if ! validate_sri_hash "$new_payload_hash"; then
-        echo "Refusing to proceed: extracted payload hash '$new_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    echo "Actual payload outputHash:  $new_payload_hash"
-    replace_flake_hash "codexDesktopPayload = mkCodexDesktopPayload {" "outputHash = " "$new_payload_hash"
-
-    current_computer_use_ui_payload_hash="$(read_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = ")"
-    echo "Current Computer Use UI payload outputHash: $current_computer_use_ui_payload_hash"
-    echo "Forcing Computer Use UI payload outputHash refresh..."
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$FAKE_SRI_HASH"
-
-    if run_nix_build "$COMPUTER_USE_UI_BUILD_LOG" .#codex-desktop-computer-use-ui; then
-        echo "Nix build unexpectedly succeeded with the fake Computer Use UI payload outputHash." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    new_computer_use_ui_payload_hash="$(extract_got_sri_hash "$COMPUTER_USE_UI_BUILD_LOG" || true)"
-    if [ -z "$new_computer_use_ui_payload_hash" ]; then
-        echo "Nix build failed without a Computer Use UI fixed-output hash mismatch; leaving log at $COMPUTER_USE_UI_BUILD_LOG" >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    if ! validate_sri_hash "$new_computer_use_ui_payload_hash"; then
-        echo "Refusing to proceed: extracted Computer Use UI payload hash '$new_computer_use_ui_payload_hash' is not a valid SRI sha256." >&2
-        restore_flake_hashes "$current_dmg_hash" "$current_payload_hash" "$current_computer_use_ui_payload_hash"
-        exit 1
-    fi
-
-    echo "Actual Computer Use UI payload outputHash:  $new_computer_use_ui_payload_hash"
-    replace_flake_hash "codexDesktopComputerUseUiPayload = mkCodexDesktopPayload {" "outputHash = " "$new_computer_use_ui_payload_hash"
-
-    run_nix_build "$VERIFY_LOG" .#codex-desktop .#codex-desktop-computer-use-ui
-    echo "Nix builds succeeded after refreshing the payload outputHashes."
+    "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH"
+    run_nix_build "$VERIFY_LOG" "${PACKAGE_OUTPUTS[@]}"
+    echo "Nix builds succeeded after refreshing the Codex.dmg hash."
 }
 
 case "${1:-}" in

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
+UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+UPSTREAM_DMG_PATH="${1:-${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}}"
+
+fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+find_seven_zip() {
+    local candidate
+    for candidate in 7zz 7z 7za; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            command -v "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+read_nix_string() {
+    local name="$1"
+    python3 - "$FLAKE_FILE" "$name" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+name = re.escape(sys.argv[2])
+match = re.search(rf'\b{name}\s*=\s*"([^"]+)";', text)
+if not match:
+    raise SystemExit(f"Could not find Nix string {sys.argv[2]!r}")
+print(match.group(1))
+PY
+}
+
+read_nix_fetchurl_field() {
+    local binding="$1"
+    local field="$2"
+    python3 - "$FLAKE_FILE" "$binding" "$field" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+binding = re.escape(sys.argv[2])
+field = re.escape(sys.argv[3])
+block_match = re.search(rf'\b{binding}\s*=\s*pkgs\.fetchurl\s*\{{(?P<body>.*?)\n\s*\}};', text, re.S)
+if not block_match:
+    raise SystemExit(f"Could not find fetchurl block {sys.argv[2]!r}")
+field_match = re.search(rf'\b{field}\s*=\s*"([^"]+)";', block_match.group("body"))
+if not field_match:
+    raise SystemExit(f"Could not find field {sys.argv[3]!r} in {sys.argv[2]!r}")
+print(field_match.group(1))
+PY
+}
+
+json_file_field() {
+    local json_path="$1"
+    local expression="$2"
+
+    node -e "const value = require(process.argv[1]); process.stdout.write(String($expression ?? ''));" "$json_path"
+}
+
+assert_equal() {
+    local label="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "$expected" != "$actual" ]; then
+        fail "$label mismatch: expected '$expected', got '$actual'"
+    fi
+    echo "OK: $label = $actual"
+}
+
+if [ ! -s "$UPSTREAM_DMG_PATH" ]; then
+    mkdir -p "$(dirname "$UPSTREAM_DMG_PATH")"
+    curl -fL --retry 3 -o "$UPSTREAM_DMG_PATH" "$UPSTREAM_DMG_URL"
+fi
+
+SEVEN_ZIP_CMD="$(find_seven_zip)" || fail "7z/7zz/7za not found"
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+"$SEVEN_ZIP_CMD" x -y -snl "$UPSTREAM_DMG_PATH" -o"$WORK_DIR/dmg" >/dev/null 2>&1 || true
+APP_DIR="$(find "$WORK_DIR/dmg" -maxdepth 3 -name "*.app" -type d | head -1)"
+[ -n "$APP_DIR" ] || fail "Could not find .app bundle in $UPSTREAM_DMG_PATH"
+
+ASAR_PATH="$APP_DIR/Contents/Resources/app.asar"
+PLIST_PATH="$APP_DIR/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist"
+[ -f "$ASAR_PATH" ] || fail "Could not find app.asar in DMG"
+[ -f "$PLIST_PATH" ] || fail "Could not find Electron Info.plist in DMG"
+ASAR_EXTRACT_DIR="$WORK_DIR/app-extracted"
+npx --yes asar extract "$ASAR_PATH" "$ASAR_EXTRACT_DIR"
+
+dmg_electron_version="$(python3 - "$PLIST_PATH" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(plistlib.load(handle).get("CFBundleVersion", ""))
+PY
+)"
+dmg_codex_version="$(json_file_field "$ASAR_EXTRACT_DIR/package.json" "value.version")"
+dmg_better_sqlite3_version="$(json_file_field "$ASAR_EXTRACT_DIR/node_modules/better-sqlite3/package.json" "value.version")"
+dmg_node_pty_version="$(json_file_field "$ASAR_EXTRACT_DIR/node_modules/node-pty/package.json" "value.version")"
+
+nix_codex_version="$(read_nix_string codexVersion)"
+nix_electron_version="$(read_nix_string electronVersion)"
+native_electron_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies.electron")"
+native_better_sqlite3_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies['better-sqlite3']")"
+native_node_pty_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies['node-pty']")"
+
+assert_equal "Codex app version pin" "$dmg_codex_version" "$nix_codex_version"
+assert_equal "Electron version pin" "$dmg_electron_version" "$nix_electron_version"
+assert_equal "native-modules Electron pin" "$nix_electron_version" "$native_electron_version"
+assert_equal "native-modules better-sqlite3 pin" "$dmg_better_sqlite3_version" "$native_better_sqlite3_version"
+assert_equal "native-modules node-pty pin" "$dmg_node_pty_version" "$native_node_pty_version"
+
+flake_node_repl_url="$(read_nix_fetchurl_field browserUseNodeReplRuntime url)"
+flake_node_repl_sri="$(read_nix_fetchurl_field browserUseNodeReplRuntime hash)"
+installer_node_repl_url="$(python3 - "$REPO_DIR/scripts/lib/bundled-plugins.sh" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+match = re.search(r'CODEX_BROWSER_USE_NODE_REPL_RUNTIME_URL:-([^}"]+)', text)
+if not match:
+    raise SystemExit("Could not find Browser Use node_repl default URL")
+print(match.group(1))
+PY
+)"
+installer_node_repl_sha="$(python3 - "$REPO_DIR/scripts/lib/bundled-plugins.sh" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+match = re.search(r'CODEX_BROWSER_USE_NODE_REPL_RUNTIME_SHA256:-([0-9a-f]{64})', text)
+if not match:
+    raise SystemExit("Could not find Browser Use node_repl default SHA-256")
+print(match.group(1))
+PY
+)"
+flake_node_repl_sha="$(python3 - "$flake_node_repl_sri" <<'PY'
+import base64
+import sys
+
+sri = sys.argv[1]
+if not sri.startswith("sha256-"):
+    raise SystemExit("Browser Use node_repl flake hash is not an SRI sha256")
+print(base64.b64decode(sri.removeprefix("sha256-")).hex())
+PY
+)"
+
+assert_equal "Browser Use node_repl URL pin" "$installer_node_repl_url" "$flake_node_repl_url"
+assert_equal "Browser Use node_repl SHA-256 pin" "$installer_node_repl_sha" "$flake_node_repl_sha"
+
+echo "Nix pins match the upstream DMG and installer defaults."

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -25,6 +25,16 @@ build_linux_computer_use_backend() {
     local cosmic_helper_binary="$SCRIPT_DIR/target/release/codex-computer-use-cosmic"
     local cargo_cmd=""
 
+    if [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ]; then
+        [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE is not set"
+        [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE is not set"
+        [ -x "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || return 1
+        [ -x "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ] || return 1
+        info "Using prebuilt Linux Computer Use backend"
+        printf '%s\n%s\n' "$CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE" "$CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE"
+        return 0
+    fi
+
     if [ ! -d "$crate_dir" ]; then
         warn "Linux Computer Use backend source not found at $crate_dir"
         return 1
@@ -479,6 +489,16 @@ chrome_extension_host_arch() {
 build_chrome_extension_host() {
     local source_binary="$SCRIPT_DIR/target/release/codex-chrome-extension-host"
     local cargo_cmd=""
+
+    if [ -n "${CODEX_CHROME_EXTENSION_HOST_SOURCE:-}" ]; then
+        [ -x "$CODEX_CHROME_EXTENSION_HOST_SOURCE" ] || {
+            warn "CODEX_CHROME_EXTENSION_HOST_SOURCE is not executable: $CODEX_CHROME_EXTENSION_HOST_SOURCE"
+            return 1
+        }
+        info "Using prebuilt Chrome extension host"
+        printf '%s\n' "$CODEX_CHROME_EXTENSION_HOST_SOURCE"
+        return 0
+    fi
 
     if ! cargo_cmd="$(find_cargo_for_linux_computer_use)"; then
         warn "cargo not found; Chrome extension host will be unavailable"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -143,6 +143,11 @@ build_native_modules() {
         warn "Using better-sqlite3@$bs3_build_ver for Electron v$ELECTRON_VERSION compatibility (DMG has $bs3_ver)"
     fi
 
+    if [ -n "${CODEX_NATIVE_MODULES_SOURCE:-}" ]; then
+        install_native_modules_from_source "$app_extracted" "$CODEX_NATIVE_MODULES_SOURCE" "$bs3_build_ver" "$npty_ver"
+        return 0
+    fi
+
     # Build in a CLEAN directory (asar doesn't have full source)
     local build_dir="$WORK_DIR/native-build"
     mkdir -p "$build_dir"
@@ -178,6 +183,37 @@ build_native_modules() {
     prune_native_module_build_artifacts "$app_extracted/node_modules/node-pty"
 }
 
+install_native_modules_from_source() {
+    local app_extracted="$1"
+    local source_dir="$2"
+    local expected_better_sqlite3_version="$3"
+    local expected_node_pty_version="$4"
+    local source_better_sqlite3="$source_dir/better-sqlite3"
+    local source_node_pty="$source_dir/node-pty"
+    local actual_better_sqlite3_version
+    local actual_node_pty_version
+
+    [ -d "$source_better_sqlite3" ] || error "Prebuilt better-sqlite3 source not found at $source_better_sqlite3"
+    [ -d "$source_node_pty" ] || error "Prebuilt node-pty source not found at $source_node_pty"
+
+    actual_better_sqlite3_version=$(node -p "require('$source_better_sqlite3/package.json').version" 2>/dev/null || echo "")
+    actual_node_pty_version=$(node -p "require('$source_node_pty/package.json').version" 2>/dev/null || echo "")
+
+    [ "$actual_better_sqlite3_version" = "$expected_better_sqlite3_version" ] || \
+        error "Prebuilt better-sqlite3 version mismatch: expected $expected_better_sqlite3_version, got ${actual_better_sqlite3_version:-unknown}"
+    [ "$actual_node_pty_version" = "$expected_node_pty_version" ] || \
+        error "Prebuilt node-pty version mismatch: expected $expected_node_pty_version, got ${actual_node_pty_version:-unknown}"
+
+    info "Using prebuilt native modules from $source_dir"
+    rm -rf "$app_extracted/node_modules/better-sqlite3"
+    rm -rf "$app_extracted/node_modules/node-pty"
+    cp -r "$source_better_sqlite3" "$app_extracted/node_modules/"
+    cp -r "$source_node_pty" "$app_extracted/node_modules/"
+    chmod -R u+w "$app_extracted/node_modules/better-sqlite3" "$app_extracted/node_modules/node-pty"
+    prune_native_module_build_artifacts "$app_extracted/node_modules/better-sqlite3"
+    prune_native_module_build_artifacts "$app_extracted/node_modules/node-pty"
+}
+
 # ---- Download Linux Electron ----
 download_electron() {
     info "Downloading Electron v${ELECTRON_VERSION} for Linux..."
@@ -191,6 +227,17 @@ download_electron() {
     esac
 
     local electron_zip="electron-v${ELECTRON_VERSION}-linux-${electron_arch}.zip"
+    if [ -n "${CODEX_ELECTRON_ZIP_SOURCE:-}" ]; then
+        [ -f "$CODEX_ELECTRON_ZIP_SOURCE" ] || error "CODEX_ELECTRON_ZIP_SOURCE does not exist: $CODEX_ELECTRON_ZIP_SOURCE"
+        info "Using Electron runtime archive: $CODEX_ELECTRON_ZIP_SOURCE"
+        cp "$CODEX_ELECTRON_ZIP_SOURCE" "$WORK_DIR/electron.zip"
+        mkdir -p "$INSTALL_DIR"
+        cd "$INSTALL_DIR"
+        unzip -qo "$WORK_DIR/electron.zip"
+        info "Electron ready"
+        return 0
+    fi
+
     local url
     if [ -n "$ELECTRON_MIRROR" ]; then
         url="${ELECTRON_MIRROR%/}/v${ELECTRON_VERSION}/${electron_zip}"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1085,6 +1085,85 @@ SCRIPT
     assert_file_exists "$app_dir/node_modules/node-pty/build/Release/pty.node"
 }
 
+test_native_module_rebuild_accepts_prebuilt_source() {
+    info "Checking native module rebuild accepts prebuilt source"
+    local workspace="$TMP_DIR/native-module-prebuilt-source"
+    local app_dir="$workspace/app-extracted"
+    local source_dir="$workspace/prebuilt"
+    local output_log="$workspace/output.log"
+
+    mkdir -p \
+        "$app_dir/node_modules/better-sqlite3" \
+        "$app_dir/node_modules/node-pty" \
+        "$source_dir/better-sqlite3/build/Release" \
+        "$source_dir/node-pty/build/Release"
+    printf '%s\n' '{"version":"12.9.0"}' > "$app_dir/node_modules/better-sqlite3/package.json"
+    printf '%s\n' '{"version":"1.1.0"}' > "$app_dir/node_modules/node-pty/package.json"
+    printf '%s\n' stale > "$app_dir/node_modules/better-sqlite3/old.txt"
+
+    printf '%s\n' '{"version":"12.9.0"}' > "$source_dir/better-sqlite3/package.json"
+    printf '%s\n' '{"version":"1.1.0"}' > "$source_dir/node-pty/package.json"
+    : > "$source_dir/better-sqlite3/build/Release/better_sqlite3.node"
+    : > "$source_dir/better-sqlite3/build/Release/junk.o"
+    : > "$source_dir/node-pty/build/Release/pty.node"
+    : > "$source_dir/node-pty/build/Release/junk.o"
+
+    (
+        WORK_DIR="$workspace/work"
+        ELECTRON_VERSION="42.0.1"
+        CODEX_NATIVE_MODULES_SOURCE="$source_dir"
+        mkdir -p "$WORK_DIR"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/native-modules.sh"
+        build_native_modules "$app_dir"
+    ) > "$output_log" 2>&1
+
+    assert_contains "$output_log" "Using prebuilt native modules from $source_dir"
+    assert_file_exists "$app_dir/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+    assert_file_exists "$app_dir/node_modules/node-pty/build/Release/pty.node"
+    [ ! -f "$app_dir/node_modules/better-sqlite3/old.txt" ] || fail "Expected stale better-sqlite3 module to be replaced"
+    [ ! -f "$app_dir/node_modules/better-sqlite3/build/Release/junk.o" ] || fail "Expected better-sqlite3 build junk to be pruned"
+    [ ! -f "$app_dir/node_modules/node-pty/build/Release/junk.o" ] || fail "Expected node-pty build junk to be pruned"
+}
+
+test_bundled_plugin_builders_accept_prebuilt_binaries() {
+    info "Checking bundled plugin builders accept prebuilt binaries"
+    local workspace="$TMP_DIR/bundled-plugin-prebuilt-binaries"
+    local backend="$workspace/codex-computer-use-linux"
+    local cosmic="$workspace/codex-computer-use-cosmic"
+    local host="$workspace/codex-chrome-extension-host"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    printf '#!/usr/bin/env bash\n' > "$backend"
+    printf '#!/usr/bin/env bash\n' > "$cosmic"
+    printf '#!/usr/bin/env bash\n' > "$host"
+    chmod +x "$backend" "$cosmic" "$host"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE="$backend"
+        CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE="$cosmic"
+        CODEX_CHROME_EXTENSION_HOST_SOURCE="$host"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        build_linux_computer_use_backend
+        build_chrome_extension_host
+    ) > "$output_log" 2>&1
+
+    assert_contains "$output_log" "Using prebuilt Linux Computer Use backend"
+    assert_contains "$output_log" "Using prebuilt Chrome extension host"
+    assert_contains "$output_log" "$backend"
+    assert_contains "$output_log" "$cosmic"
+    assert_contains "$output_log" "$host"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -3457,6 +3536,8 @@ main() {
     test_managed_node_runtime_source_install
     test_better_sqlite3_electron_42_source_patch
     test_native_module_rebuild_uses_local_electron_rebuild_toolchain
+    test_native_module_rebuild_accepts_prebuilt_source
+    test_bundled_plugin_builders_accept_prebuilt_binaries
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility


### PR DESCRIPTION
## Summary
- replace recursive Nix payload output hashes with explicit Electron, native-module, Computer Use, and Browser Use inputs
- add Nix variants for the remote-mobile-control feature and combined Computer Use UI output
- validate Nix pins against the current upstream DMG and installer Browser Use defaults
- add a PR CI job that evaluates and builds the Nix package outputs

This is based on the direction from #206, but rebased onto current main and kept in a fresh branch to avoid the conflicts in that draft PR.

## Testing
- git diff --check
- bash -n scripts/ci/validate-nix-pins.sh
- bash -n scripts/ci/update-nix-hashes.sh
- bash -n tests/scripts_smoke.sh
- node --test scripts/patch-linux-window-ui.test.js
- scripts/ci/validate-nix-pins.sh Codex.dmg
- bash tests/scripts_smoke.sh
- ./install.sh --fresh

Note: local Nix is not installed on this machine, so the Nix build is covered by the new GitHub Actions job.