### PR TITLE
Fix user-local updates with relative origin URLs

### DIFF
--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -91,38 +91,63 @@ repo_origin_url_is_relative_local() {
 resolve_repo_origin_url() {
     local origin_url="$1"
     local base_dir="$2"
-    local base_abs target_dir target_name
+    local base_abs candidate target_dir target_name
 
-    if ! repo_origin_url_is_relative_local "$origin_url" || [ ! -d "$base_dir" ]; then
+    if ! repo_origin_url_is_relative_local "$origin_url" || [ -z "$base_dir" ]; then
         printf '%s\n' "$origin_url"
         return 0
     fi
 
-    base_abs="$(cd "$base_dir" && pwd -P)" || {
-        printf '%s\n' "$origin_url"
-        return 0
-    }
-    target_dir="$(dirname "$origin_url")"
-    target_name="$(basename "$origin_url")"
-    if [ -d "$base_abs/$target_dir" ]; then
-        printf '%s/%s\n' "$(cd "$base_abs/$target_dir" && pwd -P)" "$target_name"
+    if [ -d "$base_dir" ]; then
+        base_abs="$(cd "$base_dir" && pwd -P)" || base_abs="$base_dir"
     else
-        printf '%s/%s\n' "$base_abs" "$origin_url"
+        base_abs="$base_dir"
     fi
+
+    candidate="$base_abs/$origin_url"
+    target_dir="$(dirname "$candidate")"
+    target_name="$(basename "$candidate")"
+    if [ -d "$target_dir" ]; then
+        printf '%s/%s\n' "$(cd "$target_dir" && pwd -P)" "$target_name"
+    else
+        printf '%s\n' "$candidate"
+    fi
+}
+
+managed_repo_origin_url() {
+    [ -d "$MANAGED_REPO_DIR/.git" ] || return 1
+    git -C "$MANAGED_REPO_DIR" remote get-url origin 2>/dev/null
 }
 
 repo_origin_url() {
     local origin_url=""
+    local resolved_url=""
+    local managed_origin_url=""
 
     if [ -n "${REPO_ORIGIN_URL:-}" ]; then
         origin_url="$REPO_ORIGIN_URL"
+        if repo_origin_url_is_relative_local "$origin_url"; then
+            resolved_url="$(resolve_repo_origin_url "$origin_url" "$SOURCE_REPO_DIR")"
+            if [ -e "$resolved_url" ]; then
+                printf '%s\n' "$resolved_url"
+                return 0
+            fi
+            managed_origin_url="$(managed_repo_origin_url 2>/dev/null || true)"
+            if [ -n "$managed_origin_url" ]; then
+                printf '%s\n' "$managed_origin_url"
+                return 0
+            fi
+            printf '%s\n' "$resolved_url"
+            return 0
+        fi
+        printf '%s\n' "$origin_url"
+        return 0
     elif [ -d "$SOURCE_REPO_DIR/.git" ]; then
-        origin_url="$(git -C "$SOURCE_REPO_DIR" remote get-url origin)" || return 1
-    else
-        return 1
+        git -C "$SOURCE_REPO_DIR" remote get-url origin
+        return $?
     fi
 
-    resolve_repo_origin_url "$origin_url" "$(repo_remote_query_dir)"
+    managed_repo_origin_url
 }
 
 repo_remote_query_dir() {

--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -77,16 +77,52 @@ remote_repo_head() {
     git -C "$(repo_remote_query_dir)" ls-remote "$origin_url" HEAD | awk 'NR==1 { print $1 }'
 }
 
+repo_origin_url_is_relative_local() {
+    local origin_url="$1"
+
+    case "$origin_url" in
+        ""|/*|~*|*://*|*:*)
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+resolve_repo_origin_url() {
+    local origin_url="$1"
+    local base_dir="$2"
+    local base_abs target_dir target_name
+
+    if ! repo_origin_url_is_relative_local "$origin_url" || [ ! -d "$base_dir" ]; then
+        printf '%s\n' "$origin_url"
+        return 0
+    fi
+
+    base_abs="$(cd "$base_dir" && pwd -P)" || {
+        printf '%s\n' "$origin_url"
+        return 0
+    }
+    target_dir="$(dirname "$origin_url")"
+    target_name="$(basename "$origin_url")"
+    if [ -d "$base_abs/$target_dir" ]; then
+        printf '%s/%s\n' "$(cd "$base_abs/$target_dir" && pwd -P)" "$target_name"
+    else
+        printf '%s/%s\n' "$base_abs" "$origin_url"
+    fi
+}
+
 repo_origin_url() {
+    local origin_url=""
+
     if [ -n "${REPO_ORIGIN_URL:-}" ]; then
-        printf '%s\n' "$REPO_ORIGIN_URL"
-        return 0
+        origin_url="$REPO_ORIGIN_URL"
+    elif [ -d "$SOURCE_REPO_DIR/.git" ]; then
+        origin_url="$(git -C "$SOURCE_REPO_DIR" remote get-url origin)" || return 1
+    else
+        return 1
     fi
-    if [ -d "$SOURCE_REPO_DIR/.git" ]; then
-        git -C "$SOURCE_REPO_DIR" remote get-url origin
-        return 0
-    fi
-    return 1
+
+    resolve_repo_origin_url "$origin_url" "$(repo_remote_query_dir)"
 }
 
 repo_remote_query_dir() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3230,6 +3230,8 @@ test_user_local_prepare_build_repo_handles_relative_origin_url() {
     local workspace="$TMP_DIR/user-local-relative-origin"
     local origin_repo="$workspace/origin.git"
     local source_repo="$workspace/source"
+    local moved_source_repo="$workspace/source-moved"
+    local updater_repo="$workspace/updater"
     local managed_repo="$workspace/xdg-data/codex-desktop-linux/managed-repo"
     local install_env="$workspace/install.env"
 
@@ -3269,6 +3271,25 @@ EOF
 
         [ "$(cat "$MANAGED_REPO_DIR/relative.txt")" = "relative-origin" ] \
             || fail "Expected managed checkout contents from relative origin URL"
+        [ "$(git -C "$MANAGED_REPO_DIR" remote get-url origin)" = "$origin_repo" ] \
+            || fail "Expected first relative-origin checkout to store an absolute managed origin URL"
+
+        mv "$source_repo" "$moved_source_repo"
+        git clone "$origin_repo" "$updater_repo" >/dev/null 2>&1
+        git -C "$updater_repo" config user.name "Smoke Test"
+        git -C "$updater_repo" config user.email "smoke@example.com"
+        cat > "$updater_repo/relative.txt" <<'EOF'
+relative-origin-updated
+EOF
+        git -C "$updater_repo" commit -am "advance remote" >/dev/null
+        git -C "$updater_repo" push origin main >/dev/null
+
+        prepare_build_repo
+
+        [ "$(cat "$MANAGED_REPO_DIR/relative.txt")" = "relative-origin-updated" ] \
+            || fail "Expected managed checkout to update after source checkout moved away"
+        [ "$(git -C "$MANAGED_REPO_DIR" remote get-url origin)" = "$origin_repo" ] \
+            || fail "Expected moved-source update to keep using the absolute managed origin URL"
     )
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3225,6 +3225,53 @@ EOF
     )
 }
 
+test_user_local_prepare_build_repo_handles_relative_origin_url() {
+    info "Checking user-local managed checkout handles relative origin URLs"
+    local workspace="$TMP_DIR/user-local-relative-origin"
+    local origin_repo="$workspace/origin.git"
+    local source_repo="$workspace/source"
+    local managed_repo="$workspace/xdg-data/codex-desktop-linux/managed-repo"
+    local install_env="$workspace/install.env"
+
+    mkdir -p "$workspace"
+    git init --bare --initial-branch=main "$origin_repo" >/dev/null
+    git clone "$origin_repo" "$source_repo" >/dev/null 2>&1
+    git -C "$source_repo" config user.name "Smoke Test"
+    git -C "$source_repo" config user.email "smoke@example.com"
+    cat > "$source_repo/relative.txt" <<'EOF'
+relative-origin
+EOF
+    git -C "$source_repo" add relative.txt
+    git -C "$source_repo" commit -m "base" >/dev/null
+    git -C "$source_repo" push -u origin main >/dev/null
+    git -C "$source_repo" remote set-head origin -a >/dev/null 2>&1 || true
+    git -C "$source_repo" remote set-url origin ../origin.git
+
+    (
+        export HOME="$workspace/home"
+        export XDG_DATA_HOME="$workspace/xdg-data"
+        export XDG_STATE_HOME="$workspace/xdg-state"
+        mkdir -p "$HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
+
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh"
+
+        INSTALL_CONFIG_FILE="$install_env"
+        cat > "$INSTALL_CONFIG_FILE" <<EOF
+SOURCE_REPO_DIR=$(printf '%q' "$source_repo")
+MANAGED_REPO_DIR=$(printf '%q' "$managed_repo")
+REPO_ORIGIN_URL=$(printf '%q' "../origin.git")
+REPO_DEFAULT_BRANCH=$(printf '%q' "main")
+OPT_ROOT=$(printf '%q' "$workspace/opt")
+EOF
+
+        prepare_build_repo
+
+        [ "$(cat "$MANAGED_REPO_DIR/relative.txt")" = "relative-origin" ] \
+            || fail "Expected managed checkout contents from relative origin URL"
+    )
+}
+
 test_user_local_install_from_update_defers_record_only_metadata() {
     info "Checking user-local helper refresh does not record metadata before update success"
     local workspace="$TMP_DIR/user-local-from-update-record-only"
@@ -3563,6 +3610,7 @@ main() {
     test_user_local_prepare_build_repo_detects_default_branch_without_recorded_branch
     test_user_local_prepare_build_repo_ignores_stale_recorded_default_branch
     test_user_local_prepare_build_repo_ignores_stale_source_origin_head
+    test_user_local_prepare_build_repo_handles_relative_origin_url
     test_user_local_install_from_update_defers_record_only_metadata
     test_user_local_prepare_build_repo_updates_existing_single_branch_fetch_refspec
     test_user_local_prepare_build_repo_handles_deleted_overlay_paths


### PR DESCRIPTION
## Summary

Fixes the user-local managed checkout flow when the recorded/source Git origin is a relative local path such as `../origin.git`.

The helper previously passed that relative URL to `git ls-remote`/`git clone` from the updater script's current working directory, so Git resolved it against the wrong directory and failed before the managed checkout could refresh.

## Fix

- Resolve relative local origin URLs against the source/managed repository directory before using them outside that repository.
- Keep absolute paths, protocol URLs, and scp-style Git URLs unchanged.
- Run remote queries with `git -C` from the repository context.
- Add a smoke regression that creates a source checkout with `../origin.git`, then verifies `prepare_build_repo` can clone/read the managed checkout.

## Verification

Fail-first repro against `origin/main` with the new smoke case:

```text
RELATIVE_ORIGIN_FAIL_FIRST origin-main rc=128
fatal: repository '../origin.git' does not exist
```

Local gates on this branch:

```text
targeted_relative_origin PASS
shell_syntax PASS
helper_shell_syntax PASS
shell_smoke PASS
diff_check PASS
```
