### PR TITLE
[codex] Expose remote control Nix variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,28 @@ nix run github:ilysenko/codex-desktop-linux
 
 The flake handles dependencies and patches Electron for NixOS. A GitHub Actions bot refreshes the upstream `Codex.dmg` hash and verifies the Nix package outputs in `main`; if you hit a hash mismatch right after an upstream release, wait for the next bot run and retry.
 
-Because flakes do not include the git-ignored `linux-features/features.json` opt-in file, Nix exposes feature-specific app variants for optional integrations. To build and run Codex Desktop with the experimental mobile remote-control feature enabled:
+Because flakes do not include the git-ignored `linux-features/features.json` opt-in file, Nix exposes feature-specific app variants for optional integrations. To build and run Codex Desktop with the experimental mobile remote-control host patches enabled:
 
 ```bash
 nix run github:ilysenko/codex-desktop-linux#remote-mobile-control
 ```
 
-Feature-specific Nix outputs are additive. To enable both the Computer Use UI and experimental mobile remote control:
+To enable the newer remote-control UI visibility patches without the host-enrollment patches:
 
 ```bash
-nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+nix run github:ilysenko/codex-desktop-linux#remote-control-ui
+```
+
+To enable both remote-control feature sets together:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#remote-control
+```
+
+Feature-specific Nix outputs are additive. To enable the Computer Use UI along with the full experimental remote-control set:
+
+```bash
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-control
 ```
 
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
@@ -196,7 +208,7 @@ nix run github:ilysenko/codex-desktop-linux#codex-desktop-computer-use-ui
 The Computer Use UI output can also be combined with Linux feature outputs, for example:
 
 ```bash
-nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
+nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-control
 ```
 
 ### Side-by-side dev variant

--- a/flake.nix
+++ b/flake.nix
@@ -422,15 +422,16 @@ PY
           '';
         };
 
-        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+        mkCodexDesktop = { pname ? null, enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
         let
           featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
+          packageName = if pname == null then "codex-desktop${packageSuffix featureArgs}" else pname;
           payload = mkCodexDesktopPayload {
             inherit enableComputerUseUi linuxFeatureIds;
           };
         in
         pkgs.stdenv.mkDerivation {
-          pname = "codex-desktop${packageSuffix featureArgs}";
+          pname = packageName;
           version = codexVersion;
           src = payload;
 
@@ -521,6 +522,26 @@ PY
           linuxFeatureIds = [ "remote-mobile-control" ];
         };
 
+        codexDesktopRemoteControlUi = mkCodexDesktop {
+          linuxFeatureIds = [ "remote-control-ui" ];
+        };
+
+        codexDesktopComputerUseUiRemoteControlUi = mkCodexDesktop {
+          enableComputerUseUi = true;
+          linuxFeatureIds = [ "remote-control-ui" ];
+        };
+
+        codexDesktopRemoteControl = mkCodexDesktop {
+          pname = "codex-desktop-remote-control";
+          linuxFeatureIds = [ "remote-mobile-control" "remote-control-ui" ];
+        };
+
+        codexDesktopComputerUseUiRemoteControl = mkCodexDesktop {
+          pname = "codex-desktop-computer-use-ui-remote-control";
+          enableComputerUseUi = true;
+          linuxFeatureIds = [ "remote-mobile-control" "remote-control-ui" ];
+        };
+
         installer = pkgs.writeShellApplication {
           name = "codex-desktop-installer";
           runtimeInputs = [
@@ -569,6 +590,10 @@ PY
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
           codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
           codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
+          codex-desktop-remote-control-ui = codexDesktopRemoteControlUi;
+          codex-desktop-computer-use-ui-remote-control-ui = codexDesktopComputerUseUiRemoteControlUi;
+          codex-desktop-remote-control = codexDesktopRemoteControl;
+          codex-desktop-computer-use-ui-remote-control = codexDesktopComputerUseUiRemoteControl;
           installer = installer;
         };
 
@@ -585,6 +610,26 @@ PY
         apps.computer-use-ui-remote-mobile-control = {
           type = "app";
           program = "${codexDesktopComputerUseUiRemoteMobileControl}/bin/codex-desktop";
+        };
+
+        apps.remote-control-ui = {
+          type = "app";
+          program = "${codexDesktopRemoteControlUi}/bin/codex-desktop";
+        };
+
+        apps.computer-use-ui-remote-control-ui = {
+          type = "app";
+          program = "${codexDesktopComputerUseUiRemoteControlUi}/bin/codex-desktop";
+        };
+
+        apps.remote-control = {
+          type = "app";
+          program = "${codexDesktopRemoteControl}/bin/codex-desktop";
+        };
+
+        apps.computer-use-ui-remote-control = {
+          type = "app";
+          program = "${codexDesktopComputerUseUiRemoteControl}/bin/codex-desktop";
         };
 
         apps.installer = {

--- a/linux-features/remote-control-ui/README.md
+++ b/linux-features/remote-control-ui/README.md
@@ -15,9 +15,21 @@ Enable it locally with:
 }
 ```
 
+For the Nix flake build, use the declarative app variant instead because the
+git-ignored `features.json` file is not part of the flake source:
+
+```bash
+nix run .#remote-control-ui
+```
+
+To combine these UI gates with the experimental Linux host-enrollment patches:
+
+```bash
+nix run .#remote-control
+```
+
 Run the feature tests with:
 
 ```bash
 node --test linux-features/remote-control-ui/test.js
 ```
-

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -22,11 +22,23 @@ git-ignored `features.json` file is not part of the flake source:
 nix run .#remote-mobile-control
 ```
 
+To combine the host-enrollment patches with the newer remote-control UI gates:
+
+```bash
+nix run .#remote-control
+```
+
 Feature-specific Nix outputs are additive. To combine this feature with the
 Computer Use UI opt-in:
 
 ```bash
 nix run .#computer-use-ui-remote-mobile-control
+```
+
+To combine the Computer Use UI with the full experimental remote-control set:
+
+```bash
+nix run .#computer-use-ui-remote-control
 ```
 
 What it changes:

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -12,6 +12,10 @@ PACKAGE_OUTPUTS=(
     ".#codex-desktop-computer-use-ui"
     ".#codex-desktop-remote-mobile-control"
     ".#codex-desktop-computer-use-ui-remote-mobile-control"
+    ".#codex-desktop-remote-control-ui"
+    ".#codex-desktop-computer-use-ui-remote-control-ui"
+    ".#codex-desktop-remote-control"
+    ".#codex-desktop-computer-use-ui-remote-control"
     ".#installer"
 )
 


### PR DESCRIPTION
## Summary

- expose a single public Nix `remote-control` variant that enables both Linux remote-control patch sets
- expose the combined `computer-use-ui-remote-control` variant
- keep the feature internals separate, but avoid separate user-facing Nix gates for partial remote-control states
- update docs and Nix hash-refresh verification outputs for the smaller variant set

## Why

`origin/main` contains two internal Linux remote-control feature modules: host-enrollment plumbing and UI visibility gates. Nix builds cannot use gitignored `linux-features/features.json`, so the flake needs declarative variants. Exposing the internals independently makes the public surface confusing, so this PR adds one remote-control gate that enables both together.

## Validation

- `node --test linux-features/remote-control-ui/test.js linux-features/remote-mobile-control/test.js`
- `nix eval --json .#packages.x86_64-linux --apply builtins.attrNames`
- `nix eval --json .#apps.x86_64-linux --apply builtins.attrNames`
- `git diff --check`