### PR TITLE
[codex] set up Cachix population for Nix builds

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,71 @@
+name: Populate Cachix
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '37 7 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: populate-cachix-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CACHIX_CACHE_NAME: codex-desktop-linux
+  CARGO_TERM_COLOR: always
+  NIX_CONFIG: experimental-features = nix-command flakes
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+jobs:
+  populate:
+    name: Build Nix flake outputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - name: Configure Cachix for push
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v17
+        with:
+          name: ${{ env.CACHIX_CACHE_NAME }}
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+
+      - name: Warn when Cachix push token is missing
+        if: env.CACHIX_AUTH_TOKEN == ''
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Cachix
+
+          `CACHIX_AUTH_TOKEN` is not configured, so this run will build without pushing to Cachix.
+          Add a write token for the `codex-desktop-linux` Cachix cache as a repository secret to populate it automatically.
+          EOF
+
+      - name: Build cacheable Nix outputs
+        run: |
+          set -euo pipefail
+          nix build \
+            .#codex-desktop \
+            .#codex-desktop-computer-use-ui \
+            .#codex-desktop-remote-mobile-control \
+            .#codex-desktop-computer-use-ui-remote-mobile-control \
+            .#installer \
+            --no-link \
+            --print-build-logs
+          {
+            echo "## Cachix population"
+            echo ""
+            echo "- Cache: \`${CACHIX_CACHE_NAME}\`"
+            echo "- Built: \`.#codex-desktop\`"
+            echo "- Built: \`.#codex-desktop-computer-use-ui\`"
+            echo "- Built: \`.#codex-desktop-remote-mobile-control\`"
+            echo "- Built: \`.#codex-desktop-computer-use-ui-remote-mobile-control\`"
+            echo "- Built: \`.#installer\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 90
     env:
       NIX_CONFIG: experimental-features = nix-command flakes
+      CACHIX_CACHE_NAME: codex-desktop-linux
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +27,14 @@ jobs:
         with:
           node-version: 24
 
-      - uses: cachix/install-nix-action@v27
+      - uses: cachix/install-nix-action@v31
+
+      - name: Configure Cachix for hash refresh builds
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v17
+        with:
+          name: ${{ env.CACHIX_CACHE_NAME }}
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
 
       - name: Install validation dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-contro
 
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
+### Cachix binary cache
+
+CI can populate a Cachix cache named `codex-desktop-linux` for the flake package outputs. To enable pushes, create that cache in Cachix and add a repository secret named `CACHIX_AUTH_TOKEN` with write access to the cache.
+
+After the cache exists, users can opt in locally with:
+
+```bash
+cachix use codex-desktop-linux
+```
+
+The scheduled `Populate Cachix` workflow builds the default Codex Desktop package, the feature-specific Nix package variants, and `.#installer`. The upstream-hash refresh workflow also uploads its verification build when the token is present.
+
 ## Linux Computer Use
 
 Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control desktop apps on Linux through a native Rust MCP backend (`codex-computer-use-linux`). It is designed and maintained by [@avifenesh](https://github.com/avifenesh) and supports:


### PR DESCRIPTION
## Summary

- Adds a `Populate Cachix` GitHub Actions workflow that builds the current Nix package outputs on `main`, on a daily schedule, and via manual dispatch.
- Hooks Cachix into the upstream Nix hash refresh workflow so its verification build can upload fresh store paths after hash updates.
- Documents the Cachix setup and user opt-in command in the README.

This redoes #196 after the Nix output structure changed in #221.

## Maintainer setup needed

This PR expects a maintainer to create a Cachix cache named `codex-desktop-linux`, then add a repository secret named `CACHIX_AUTH_TOKEN` with write access to that cache.

Without the secret, the new workflow still builds the Nix outputs but intentionally skips pushing to Cachix and writes a warning to the workflow summary.

## Validation

- `git diff --check`
- `bash -n scripts/ci/update-nix-hashes.sh`
- `nix run nixpkgs#actionlint -- .github/workflows/cachix.yml .github/workflows/update-codex-hash.yml`
