### PR TITLE
Persist user-local X11 fallback preference

### DIFF
--- a/contrib/user-local-install/README.md
+++ b/contrib/user-local-install/README.md
@@ -53,6 +53,18 @@ To also enable the weekly auto-update timer, pass `--enable-timer`:
 ./contrib/user-local-install/install-user-local.sh --enable-timer
 ```
 
+To persistently force the user-local launcher through X11/XWayland, pass `--force-x11`:
+
+```bash
+./contrib/user-local-install/install-user-local.sh --force-x11
+```
+
+To return to the default generated launcher behavior, pass `--no-force-x11`:
+
+```bash
+./contrib/user-local-install/install-user-local.sh --no-force-x11
+```
+
 The installer:
 
 1. copies standalone helper scripts into `~/.local/opt/codex-desktop-linux`
@@ -80,4 +92,5 @@ codex-desktop-version
 - The icon is not committed as a binary asset here. It is generated locally from `Codex.dmg`.
 - The helper scripts track both upstream wrapper changes and upstream `Codex.dmg` headers.
 - The helper scripts are copied into `~/.local/opt` and do not run from the git checkout directly.
+- The X11/XWayland preference is stored in `~/.config/codex-desktop-linux/user-local.env` and is preserved across updater refreshes.
 - The weekly timer runs `codex-desktop-update --quiet`. It is opt-in: pass `--enable-timer` to `install-user-local.sh` to activate it, or run `systemctl --user enable --now codex-desktop-update.timer` manually after install.

--- a/contrib/user-local-install/files/.local/bin/codex-desktop
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop
@@ -3,4 +3,29 @@ set -euo pipefail
 
 OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
 APP_DIR="${OPT_ROOT}/codex-app"
-exec "${APP_DIR}/start.sh" "$@"
+CONFIG_FILE="${XDG_CONFIG_HOME:-${HOME}/.config}/codex-desktop-linux/user-local.env"
+
+USER_LOCAL_OZONE_PLATFORM_OVERRIDE="${CODEX_USER_LOCAL_OZONE_PLATFORM:-}"
+if [ -f "$CONFIG_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$CONFIG_FILE"
+fi
+if [ -n "$USER_LOCAL_OZONE_PLATFORM_OVERRIDE" ]; then
+    CODEX_USER_LOCAL_OZONE_PLATFORM="$USER_LOCAL_OZONE_PLATFORM_OVERRIDE"
+fi
+
+case "${CODEX_USER_LOCAL_OZONE_PLATFORM:-auto}" in
+    auto|"")
+        exec "${APP_DIR}/start.sh" "$@"
+        ;;
+    x11)
+        exec "${APP_DIR}/start.sh" --x11 "$@"
+        ;;
+    wayland)
+        exec "${APP_DIR}/start.sh" --wayland "$@"
+        ;;
+    *)
+        echo "Invalid CODEX_USER_LOCAL_OZONE_PLATFORM='${CODEX_USER_LOCAL_OZONE_PLATFORM}'; expected auto, x11, or wayland" >&2
+        exec "${APP_DIR}/start.sh" "$@"
+        ;;
+esac

--- a/contrib/user-local-install/install-user-local.sh
+++ b/contrib/user-local-install/install-user-local.sh
@@ -9,11 +9,15 @@ OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
 OPT_BIN_DIR="${OPT_ROOT}/bin"
 OPT_LIB_DIR="${OPT_ROOT}/lib/codex-desktop-linux"
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-${HOME}/.config}"
 DATA_DIR="${XDG_DATA_HOME}/codex-desktop-linux"
+CONFIG_DIR="${XDG_CONFIG_HOME}/codex-desktop-linux"
+USER_LOCAL_ENV_FILE="${CONFIG_DIR}/user-local.env"
 MANAGED_REPO_DIR="${DATA_DIR}/managed-repo"
 STATE_DIR="${XDG_STATE_HOME:-${HOME}/.local/state}/codex-desktop-linux"
 FROM_UPDATE=0
 ENABLE_TIMER=0
+USER_LOCAL_OZONE_PLATFORM_SETTING=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -22,6 +26,12 @@ while [ $# -gt 0 ]; do
             ;;
         --enable-timer)
             ENABLE_TIMER=1
+            ;;
+        --force-x11|--x11-fallback)
+            USER_LOCAL_OZONE_PLATFORM_SETTING="x11"
+            ;;
+        --no-force-x11|--no-x11-fallback)
+            USER_LOCAL_OZONE_PLATFORM_SETTING="auto"
             ;;
         *)
             echo "Unknown option: $1" >&2
@@ -36,6 +46,15 @@ copy_file() {
     local dst="$2"
     mkdir -p "$(dirname "$dst")"
     cp "$src" "$dst"
+}
+
+write_user_local_preferences() {
+    [ -n "$USER_LOCAL_OZONE_PLATFORM_SETTING" ] || return 0
+
+    mkdir -p "$CONFIG_DIR"
+    cat > "$USER_LOCAL_ENV_FILE" <<EOF
+CODEX_USER_LOCAL_OZONE_PLATFORM=$(printf '%q' "$USER_LOCAL_OZONE_PLATFORM_SETTING")
+EOF
 }
 
 repo_origin_url() {
@@ -117,6 +136,7 @@ EOF
 }
 
 install_manager_files
+write_user_local_preferences
 
 if command -v systemctl >/dev/null 2>&1; then
     systemctl --user daemon-reload >/dev/null 2>&1 || true

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1458,6 +1458,12 @@ PY
     assert_contains "$REPO_DIR/packaging/linux/codex-desktop.desktop" "codex-update-manager install-ready"
     assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop" "@HOME@/.local/bin/codex-desktop %U"
     assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/share/applications/codex-desktop.desktop" "MimeType=x-scheme-handler/codex;x-scheme-handler/codex-browser-sidebar;"
+    assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/bin/codex-desktop" "CODEX_USER_LOCAL_OZONE_PLATFORM"
+    assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/bin/codex-desktop" 'exec "${APP_DIR}/start.sh" --x11 "$@"'
+    assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/bin/codex-desktop" 'exec "${APP_DIR}/start.sh" --wayland "$@"'
+    assert_contains "$REPO_DIR/contrib/user-local-install/install-user-local.sh" "--force-x11"
+    assert_contains "$REPO_DIR/contrib/user-local-install/install-user-local.sh" "user-local.env"
+    assert_contains "$REPO_DIR/contrib/user-local-install/README.md" "--force-x11"
 }
 
 test_side_by_side_launcher_identity() {
@@ -3264,6 +3270,49 @@ SCRIPT
     assert_file_exists "$marker"
 }
 
+test_user_local_install_preserves_persisted_x11_preference_on_refresh() {
+    info "Checking user-local X11 fallback preference persists across helper refreshes"
+    local workspace="$TMP_DIR/user-local-x11-preference"
+    local stub_bin="$workspace/bin"
+    local home="$workspace/home"
+    local config_home="$workspace/config"
+    local preference_file="$config_home/codex-desktop-linux/user-local.env"
+
+    mkdir -p "$stub_bin"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stub_bin/7z"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stub_bin/systemctl"
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$stub_bin/update-desktop-database"
+    chmod +x "$stub_bin/7z" "$stub_bin/systemctl" "$stub_bin/update-desktop-database"
+
+    PATH="$stub_bin:$PATH" \
+        HOME="$home" \
+        XDG_CONFIG_HOME="$config_home" \
+        XDG_DATA_HOME="$workspace/data" \
+        XDG_STATE_HOME="$workspace/state" \
+        CODEX_USER_LOCAL_SOURCE_REPO_DIR="$REPO_DIR" \
+        bash "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --force-x11 >/dev/null
+    assert_file_exists "$preference_file"
+    assert_contains "$preference_file" "CODEX_USER_LOCAL_OZONE_PLATFORM=x11"
+
+    PATH="$stub_bin:$PATH" \
+        HOME="$home" \
+        XDG_CONFIG_HOME="$config_home" \
+        XDG_DATA_HOME="$workspace/data" \
+        XDG_STATE_HOME="$workspace/state" \
+        CODEX_USER_LOCAL_SOURCE_REPO_DIR="$REPO_DIR" \
+        bash "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --from-update >/dev/null
+    assert_contains "$preference_file" "CODEX_USER_LOCAL_OZONE_PLATFORM=x11"
+
+    PATH="$stub_bin:$PATH" \
+        HOME="$home" \
+        XDG_CONFIG_HOME="$config_home" \
+        XDG_DATA_HOME="$workspace/data" \
+        XDG_STATE_HOME="$workspace/state" \
+        CODEX_USER_LOCAL_SOURCE_REPO_DIR="$REPO_DIR" \
+        bash "$REPO_DIR/contrib/user-local-install/install-user-local.sh" --no-force-x11 >/dev/null
+    assert_contains "$preference_file" "CODEX_USER_LOCAL_OZONE_PLATFORM=auto"
+}
+
 test_user_local_prepare_build_repo_updates_existing_single_branch_fetch_refspec() {
     info "Checking user-local managed checkout can switch branches after a single-branch clone"
     local workspace="$TMP_DIR/user-local-single-branch-refspec"
@@ -3564,6 +3613,7 @@ main() {
     test_user_local_prepare_build_repo_ignores_stale_recorded_default_branch
     test_user_local_prepare_build_repo_ignores_stale_source_origin_head
     test_user_local_install_from_update_defers_record_only_metadata
+    test_user_local_install_preserves_persisted_x11_preference_on_refresh
     test_user_local_prepare_build_repo_updates_existing_single_branch_fetch_refspec
     test_user_local_prepare_build_repo_handles_deleted_overlay_paths
     test_user_local_prepare_build_repo_removes_rename_source_paths


### PR DESCRIPTION
## Summary
- add user-local installer flags to persistently enable or disable the X11/XWayland fallback
- store the preference in ~/.config/codex-desktop-linux/user-local.env so updater refreshes preserve it
- have the user-local wrapper apply --x11 only when that persisted preference, or an explicit environment override, requests it

Fixes #215.

## Validation
- bash -n contrib/user-local-install/install-user-local.sh contrib/user-local-install/files/.local/bin/codex-desktop tests/scripts_smoke.sh
- bash tests/scripts_smoke.sh