### PR TITLE
[codex] Add opt-in multi-instance launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ This path is for users who do not want a system-wide native package; the daily-d
 - Desktop icon association:
   The launcher runs Electron with `--class=codex-desktop`, and the desktop file sets `StartupWMClass=codex-desktop` so the taskbar/dock can associate the correct icon.
 - Webview server:
-  The launcher starts a local `python3 -m http.server` on port `5175` (default identity) or `5176` (alternate identity) from `content/webview/`, waits for the port to become reachable, verifies that `http://127.0.0.1:<port>/index.html` serves the expected Codex startup markers, and only then launches Electron because the extracted app expects local webview assets there.
+  The launcher starts a local `python3 -m http.server` on port `5175` (default identity) or `5176` (alternate identity) from `content/webview/`, waits for the port to become reachable, verifies that `http://127.0.0.1:<port>/index.html` serves the expected Codex startup markers, and only then launches Electron because the extracted app expects local webview assets there. Opt-in multi-instance launches (`--new-instance` / `CODEX_MULTI_LAUNCH=1`) allocate the first free port from `CODEX_MULTI_LAUNCH_PORT_RANGE` and isolate pid files, launch sockets, logs, and Electron user-data dirs under the selected `port-<n>` instance id.
 - Wayland/GPU compatibility:
   The generated launcher enables `--ozone-platform-hint=auto`, `--disable-gpu-sandbox`, and `--enable-features=WaylandWindowDecorations` by default. Keep these in mind when debugging Pop!_OS, Wayland, or Nvidia-specific rendering issues.
 - Webview server roadmap:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Anything systemd-based should work for the optional auto-updater service (`syste
 | Native packaging (`.deb` / `.rpm` / `.pkg.tar.zst`) | ✅ always | One-shot `make package` picks your distro |
 | AppImage self-build | ✅ manual | `make appimage` writes a local `dist/*.AppImage`; rebuild manually after upstream updates |
 | Linux tray + warm-start handoff | ✅ always | Single-instance lock, second-instance window focus |
+| Multi-instance launcher | 🧪 opt-in | `--new-instance` or `CODEX_MULTI_LAUNCH=1` allocates a bounded webview port and isolated Electron profile |
 | GUI install prompts (`kdialog` / `zenity`) | ✅ if installed | Falls back to interactive terminal prompt |
 | Linux browser annotations | ✅ always | Stored-anchor screenshots, isolated marker rendering |
 | Chrome plugin native host | ✅ always | Auto-installs the upstream Chrome plugin plus Linux native-messaging support for Chrome, Brave, and Chromium |
@@ -221,6 +222,23 @@ make run-dev-app
 ```
 
 Override the dev identity with `DEV_APP_ID`, `DEV_APP_NAME`, and `CODEX_WEBVIEW_PORT` if needed.
+
+### Multiple app instances
+
+By default, second launches reuse the running app through the Linux warm-start handoff. To intentionally open another independent Codex Desktop process, use:
+
+```bash
+./codex-app/start.sh --new-instance
+```
+
+The launcher picks the first free webview port from a bounded range, then uses per-port pid files, launch socket, log, and Electron user-data dir. This keeps Electron's single-instance lock scoped to that new instance while leaving normal launches unchanged. The default range allows up to five instances.
+
+Configure the range or make every launch use this mode with:
+
+```bash
+CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh --new-instance
+CODEX_MULTI_LAUNCH=1 CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh
+```
 
 ## Auto-update Manager
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -31,24 +31,152 @@ APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
 APP_NOTIFICATION_ICON_SYSTEM="/usr/share/icons/hicolor/256x256/apps/$APP_NOTIFICATION_ICON_NAME.png"
 APP_NOTIFICATION_ICON_REPO="$SCRIPT_DIR/../assets/codex.png"
+MULTI_LAUNCH_REQUESTED=0
+MULTI_LAUNCH_ACTIVE=0
+CODEX_LINUX_INSTANCE_ID=""
+LAUNCHER_ARGS=()
 
-case "$CODEX_LINUX_WEBVIEW_PORT" in
-    ""|*[!0-9]*)
-        echo "CODEX_WEBVIEW_PORT must be a TCP port number" >&2
-        exit 1
-        ;;
-esac
-CODEX_LINUX_WEBVIEW_PORT_NUMBER="$CODEX_LINUX_WEBVIEW_PORT"
-while [ "${CODEX_LINUX_WEBVIEW_PORT_NUMBER#0}" != "$CODEX_LINUX_WEBVIEW_PORT_NUMBER" ]; do
-    CODEX_LINUX_WEBVIEW_PORT_NUMBER="${CODEX_LINUX_WEBVIEW_PORT_NUMBER#0}"
-done
-[ -n "$CODEX_LINUX_WEBVIEW_PORT_NUMBER" ] || CODEX_LINUX_WEBVIEW_PORT_NUMBER=0
-if [ "${#CODEX_LINUX_WEBVIEW_PORT_NUMBER}" -gt 5 ] || [ "$CODEX_LINUX_WEBVIEW_PORT_NUMBER" -lt 1 ] || [ "$CODEX_LINUX_WEBVIEW_PORT_NUMBER" -gt 65535 ]; then
-    echo "CODEX_WEBVIEW_PORT must be between 1 and 65535" >&2
+early_truthy_env_value() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+normalize_tcp_port() {
+    local name="$1"
+    local port="$2"
+    local value
+
+    case "$port" in
+        ""|*[!0-9]*)
+            echo "$name must be a TCP port number" >&2
+            return 1
+            ;;
+    esac
+    value="$port"
+    while [ "${value#0}" != "$value" ]; do
+        value="${value#0}"
+    done
+    [ -n "$value" ] || value=0
+
+    if [ "${#value}" -gt 5 ] || [ "$value" -lt 1 ] || [ "$value" -gt 65535 ]; then
+        echo "$name must be between 1 and 65535" >&2
+        return 1
+    fi
+
+    printf '%s\n' "$value"
+}
+
+validate_tcp_port() {
+    normalize_tcp_port "$1" "$2" >/dev/null
+}
+
+if ! CODEX_LINUX_WEBVIEW_PORT="$(normalize_tcp_port "CODEX_WEBVIEW_PORT" "$CODEX_LINUX_WEBVIEW_PORT")"; then
     exit 1
 fi
-CODEX_LINUX_WEBVIEW_PORT="$CODEX_LINUX_WEBVIEW_PORT_NUMBER"
 
+launcher_port_is_open() {
+    local port="$1"
+    ( exec 3<>/dev/tcp/127.0.0.1/"$port" ) 2>/dev/null
+}
+
+choose_multi_launch_port() {
+    local range="${CODEX_MULTI_LAUNCH_PORT_RANGE:-$CODEX_LINUX_WEBVIEW_PORT-$((CODEX_LINUX_WEBVIEW_PORT + 4))}"
+    local start end port
+
+    case "$range" in
+        *-*)
+            start="${range%-*}"
+            end="${range#*-}"
+            ;;
+        *)
+            start="$range"
+            end="$range"
+            ;;
+    esac
+
+    start="$(normalize_tcp_port "CODEX_MULTI_LAUNCH_PORT_RANGE start" "$start")" || return 1
+    end="$(normalize_tcp_port "CODEX_MULTI_LAUNCH_PORT_RANGE end" "$end")" || return 1
+    if [ "$start" -gt "$end" ]; then
+        echo "CODEX_MULTI_LAUNCH_PORT_RANGE start must be <= end" >&2
+        return 1
+    fi
+
+    for port in $(seq "$start" "$end"); do
+        if ! launcher_port_is_open "$port"; then
+            echo "$port"
+            return 0
+        fi
+    done
+
+    echo "No free Codex Desktop webview port found in CODEX_MULTI_LAUNCH_PORT_RANGE=$range" >&2
+    return 1
+}
+
+parse_launcher_args() {
+    local passthrough=0
+
+    LAUNCHER_ARGS=()
+    if early_truthy_env_value "${CODEX_MULTI_LAUNCH:-}"; then
+        MULTI_LAUNCH_REQUESTED=1
+    fi
+
+    while [ "$#" -gt 0 ]; do
+        if [ "$passthrough" -eq 1 ]; then
+            LAUNCHER_ARGS+=("$1")
+            shift
+            continue
+        fi
+
+        case "$1" in
+            --)
+                passthrough=1
+                LAUNCHER_ARGS+=("$1")
+                ;;
+            --new-instance|--multi-instance|--multi-launch)
+                MULTI_LAUNCH_REQUESTED=1
+                ;;
+            *)
+                LAUNCHER_ARGS+=("$1")
+                ;;
+        esac
+        shift
+    done
+}
+
+configure_multi_launch_instance() {
+    parse_launcher_args "$@"
+    [ "$MULTI_LAUNCH_REQUESTED" -eq 1 ] || return 0
+
+    local base_state_dir="$APP_STATE_DIR"
+    local selected_port
+
+    selected_port="$(choose_multi_launch_port)" || exit 1
+    CODEX_LINUX_WEBVIEW_PORT="$selected_port"
+    CODEX_LINUX_INSTANCE_ID="port-$CODEX_LINUX_WEBVIEW_PORT"
+    MULTI_LAUNCH_ACTIVE=1
+
+    APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"
+    APP_PID_FILE="$APP_STATE_DIR/app.pid"
+    WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
+    if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+        LAUNCH_ACTION_RUNTIME_DIR="$XDG_RUNTIME_DIR/$CODEX_LINUX_APP_ID/instances/$CODEX_LINUX_INSTANCE_ID"
+    else
+        LAUNCH_ACTION_RUNTIME_DIR="$APP_STATE_DIR"
+    fi
+    LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
+    LOG_FILE="$LOG_DIR/launcher-$CODEX_LINUX_INSTANCE_ID.log"
+
+    if [ -n "${CODEX_ELECTRON_USER_DATA_DIR:-}" ]; then
+        CODEX_ELECTRON_USER_DATA_DIR="$CODEX_ELECTRON_USER_DATA_DIR/instances/$CODEX_LINUX_INSTANCE_ID"
+    else
+        CODEX_ELECTRON_USER_DATA_DIR="$APP_STATE_DIR/electron-user-data"
+    fi
+    export CODEX_ELECTRON_USER_DATA_DIR
+}
+
+configure_multi_launch_instance "$@"
 WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"
 
 mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
@@ -60,7 +188,7 @@ ELECTRON_PID=""
 RUNNING_APP_PID=""
 WARM_START=0
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+if [[ "${LAUNCHER_ARGS[0]:-}" == "--help" || "${LAUNCHER_ARGS[0]:-}" == "-h" ]]; then
     cat <<HELP
 Usage: ./start.sh [OPTIONS] [-- ELECTRON_FLAGS...]
 
@@ -68,6 +196,7 @@ Launches the $CODEX_LINUX_APP_DISPLAY_NAME app.
 
 Options:
   -h, --help                  Show this help message and exit
+  --new-instance              Start a separate app instance on the first free port in the multi-launch range
   --new-chat                  Open the main window on a new chat
   --quick-chat                Open a projectless quick chat
   --prompt-chat               Show the compact prompt for a new chat
@@ -88,8 +217,11 @@ Environment:
                               Override the launcher's default --disable-gpu-compositing decision
   CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1
                               Override --force-renderer-accessibility; auto skips it under WSLg
+  CODEX_MULTI_LAUNCH=1        Treat normal launches like --new-instance
+  CODEX_MULTI_LAUNCH_PORT_RANGE=START-END
+                              Port allocation range for --new-instance (default: CODEX_WEBVIEW_PORT through +4)
 
-Logs: ${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID/launcher.log
+Logs: $LOG_FILE
 HELP
     exit 0
 fi
@@ -97,6 +229,9 @@ fi
 exec >>"$LOG_FILE" 2>&1
 
 echo "[$(date -Is)] Starting $CODEX_LINUX_APP_DISPLAY_NAME launcher"
+if [ "$MULTI_LAUNCH_ACTIVE" -eq 1 ]; then
+    echo "Multi-launch instance: id=$CODEX_LINUX_INSTANCE_ID webview_port=$CODEX_LINUX_WEBVIEW_PORT state_dir=$APP_STATE_DIR user_data_dir=$CODEX_ELECTRON_USER_DATA_DIR"
+fi
 
 now_ms() {
     local value seconds nanos
@@ -1152,12 +1287,18 @@ pid_is_webview_server() {
 pid_is_stale_webview_server() {
     local pid="$1"
     local cwd
+    local current_webview_dir
     local deleted_webview_dir
 
     pid_has_webview_server_cmdline "$pid" || return 1
     cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
-    deleted_webview_dir="$(canonical_path "$WEBVIEW_DIR") (deleted)"
-    [ "$cwd" = "$deleted_webview_dir" ]
+    [ -n "$cwd" ] || return 1
+
+    current_webview_dir="$(canonical_path "$WEBVIEW_DIR")"
+    deleted_webview_dir="$current_webview_dir (deleted)"
+    [ "$cwd" = "$deleted_webview_dir" ] && return 0
+
+    [ "$cwd" != "$current_webview_dir" ]
 }
 
 stop_owned_webview_server() {
@@ -1302,6 +1443,10 @@ ensure_webview_server() {
             notify_error "Codex Desktop webview server is already running for pid $RUNNING_APP_PID, but origin validation failed. Keeping the live app untouched."
             exit 1
         fi
+    fi
+
+    if webview_port_is_open; then
+        stop_stale_webview_server
     fi
 
     if webview_port_is_open && webview_origin_is_reachable; then
@@ -1732,7 +1877,7 @@ reconcile_runtime_state
 detect_warm_start
 trap cleanup_launcher EXIT
 
-if send_warm_start_launch_action "$@"; then
+if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
     echo "Sent launch args over warm-start IPC"
     log_phase "warm_start_ipc_sent"
     exit 0
@@ -1804,4 +1949,4 @@ resolve_browser_use_runtime_env
 echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
 echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"
 
-launch_electron "$@"
+launch_electron "${LAUNCHER_ARGS[@]}"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -882,9 +882,9 @@ set -euo pipefail
 CODEX_LINUX_WEBVIEW_PORT=${CODEX_WEBVIEW_PORT:-5175}
 SCRIPT
     awk '
-        /^case "\$CODEX_LINUX_WEBVIEW_PORT" in/ { emit = 1 }
+        /^normalize_tcp_port\(\) \{/ { emit = 1 }
+        /^launcher_port_is_open\(\) \{/ { exit }
         emit { print }
-        /^WEBVIEW_ORIGIN=/ { exit }
     ' "$REPO_DIR/launcher/start.sh.template" >> "$launcher_probe_script"
     cat >> "$launcher_probe_script" <<'SCRIPT'
 printf '%s\n' "$CODEX_LINUX_WEBVIEW_PORT"
@@ -1204,6 +1204,12 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" "x-scheme-handler/"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "codex-browser-sidebar"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "codex-linux-warm-start-enabled"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "--new-instance"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_MULTI_LAUNCH"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_MULTI_LAUNCH_PORT_RANGE"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "choose_multi_launch_port"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "configure_multi_launch_instance"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'launcher-$CODEX_LINUX_INSTANCE_ID.log'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "ADOPTED_WEBVIEW_PID"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Reusing webview server pid="
     python3 - "$REPO_DIR/launcher/start.sh.template" <<'PY'
@@ -1215,9 +1221,29 @@ detect_body = source.split("detect_warm_start() {", 1)[1].split("send_warm_start
 launch_body = source.split("launch_electron() {", 1)[1].split("load_packaged_runtime_helper", 1)[0]
 runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_electron", 1)[0]
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
+stale_body = source.split("pid_is_stale_webview_server() {", 1)[1].split("stop_owned_webview_server() {", 1)[0]
+multi_body = source.split("configure_multi_launch_instance() {", 1)[1].split('WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"', 1)[0]
 adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("ensure_webview_server() {", 1)[0]
 ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
 reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
+if 'LAUNCHER_ARGS=()' not in source:
+    raise SystemExit("launcher must keep a sanitized argv for launcher-only flags")
+if 'configure_multi_launch_instance "$@"' not in source:
+    raise SystemExit("launcher must configure multi-launch before deriving WEBVIEW_ORIGIN")
+if '$((CODEX_LINUX_WEBVIEW_PORT + 4))' not in source:
+    raise SystemExit("multi-launch default range must cap the default at five ports")
+if 'CODEX_LINUX_INSTANCE_ID="port-$CODEX_LINUX_WEBVIEW_PORT"' not in multi_body:
+    raise SystemExit("multi-launch must derive a stable instance id from the allocated port")
+if 'APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
+    raise SystemExit("multi-launch must isolate app pid/webview state per allocated port")
+if 'LAUNCH_ACTION_RUNTIME_DIR="$XDG_RUNTIME_DIR/$CODEX_LINUX_APP_ID/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
+    raise SystemExit("multi-launch must isolate warm-start sockets per allocated port")
+if 'CODEX_ELECTRON_USER_DATA_DIR="$APP_STATE_DIR/electron-user-data"' not in multi_body:
+    raise SystemExit("multi-launch must force a per-instance Electron user-data dir")
+if 'send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"' not in source:
+    raise SystemExit("warm-start handoff must not receive launcher-only multi-launch flags")
+if 'launch_electron "${LAUNCHER_ARGS[@]}"' not in source:
+    raise SystemExit("Electron launch must receive sanitized launcher args")
 if 'RUNNING_APP_PID="$(find_running_app_pid)"' not in detect_body:
     raise SystemExit("detect_warm_start must record a pid-file running app even when warm start is disabled")
 if '[ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"' not in detect_body:
@@ -1250,6 +1276,10 @@ if "running_app_is_active" not in stop_body or "Preserving webview server" not i
     raise SystemExit("stop_owned_webview_server must not stop the live app webview server")
 if "stale_webview_server_pid" not in source or "stop_stale_webview_server" not in source:
     raise SystemExit("launcher must detect stale deleted webview servers left behind by previous installs")
+if 'current_webview_dir="$(canonical_path "$WEBVIEW_DIR")"' not in stale_body:
+    raise SystemExit("stale webview detection must compare against the current bundle path")
+if '[ "$cwd" != "$current_webview_dir" ]' not in stale_body:
+    raise SystemExit("stale webview detection must catch servers moved into backup bundle directories")
 if 'ADOPTED_WEBVIEW_PID="$pid"' not in adopt_body:
     raise SystemExit("adopt_existing_webview_server must not mark a running app server as started by this launcher")
 if 'STARTED_WEBVIEW_PID="$pid"' not in adopt_body:
@@ -1260,6 +1290,8 @@ if "if adopt_existing_webview_server; then" not in ensure_body:
     raise SystemExit("ensure_webview_server must split adoption from origin verification")
 if "stop_stale_webview_server" not in ensure_body:
     raise SystemExit("ensure_webview_server must clear stale deleted webview servers before treating the port as foreign")
+if ensure_body.find("stop_stale_webview_server") > ensure_body.find("is already serving Codex content"):
+    raise SystemExit("ensure_webview_server must try stale-server cleanup before foreign reachable-port failure")
 if "Keeping the live app untouched" not in ensure_body:
     raise SystemExit("ensure_webview_server must not stop a live app server when validation fails")
 if 'if live_app_pid="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && live_app_pid="$(discover_running_app_pid)"; }; then' not in reconcile_body:


### PR DESCRIPTION
## Summary

Draft for #218.

This adds an opt-in multi-instance launcher mode for Linux:

- `--new-instance` starts a separate Codex Desktop process instead of reusing the existing warm-start instance.
- `CODEX_MULTI_LAUNCH=1` makes normal launches use the same mode.
- `CODEX_MULTI_LAUNCH_PORT_RANGE=START-END` bounds webview port allocation.
- The default range is five ports: `CODEX_WEBVIEW_PORT` through `CODEX_WEBVIEW_PORT + 4`.

Each selected port gets isolated launcher state: app pid, webview pid, launch-action socket, log file, and Electron user-data dir. That keeps Electron's single-instance lock scoped to the chosen instance while preserving the existing warm-start behavior by default.

The patch also tightens stale webview-server detection so a reachable server left behind from a backup bundle does not get mistaken for the current launcher-owned server.

## Validation

- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- generated-launcher probe for fixed range `6200-6200`
- generated-launcher probe where `6200` is occupied and range `6200-6201` selects `6201`

## Notes

Opening as a draft to get workflow feedback before marking ready. If the stale webview-server cleanup should be split out, I can move that into a separate PR.
