### PR TITLE
fix multi-instance app lock bypass

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -36,6 +36,9 @@ MULTI_LAUNCH_ACTIVE=0
 CODEX_LINUX_INSTANCE_ID=""
 LAUNCHER_ARGS=()
 
+# Internal marker consumed by patched Electron bundles; never trust inheritance.
+unset CODEX_LINUX_MULTI_LAUNCH
+
 early_truthy_env_value() {
     case "${1:-}" in
         1|true|TRUE|yes|YES|on|ON) return 0 ;;
@@ -156,6 +159,7 @@ configure_multi_launch_instance() {
     CODEX_LINUX_WEBVIEW_PORT="$selected_port"
     CODEX_LINUX_INSTANCE_ID="port-$CODEX_LINUX_WEBVIEW_PORT"
     MULTI_LAUNCH_ACTIVE=1
+    CODEX_LINUX_MULTI_LAUNCH=1
 
     APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"
     APP_PID_FILE="$APP_STATE_DIR/app.pid"
@@ -173,7 +177,7 @@ configure_multi_launch_instance() {
     else
         CODEX_ELECTRON_USER_DATA_DIR="$APP_STATE_DIR/electron-user-data"
     fi
-    export CODEX_ELECTRON_USER_DATA_DIR
+    export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_WEBVIEW_PORT
 }
 
 configure_multi_launch_instance "$@"

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -23,6 +23,10 @@ const {
   patchLinuxAppUpdaterBridge,
 } = require("./lib/linux-update-bridge-patch.js");
 const {
+  applyLinuxMultiInstanceBootstrapPatch,
+  patchLinuxMultiInstanceBootstrap,
+} = require("./patches/bootstrap.js");
+const {
   applyLinuxChromePluginAutoInstallPatch,
 } = require("./patches/chrome-plugin.js");
 const {
@@ -158,6 +162,7 @@ module.exports = {
   applyLinuxKeybindOverridesRuntimePatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
+  applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxQuitGuardPatch,
@@ -187,6 +192,7 @@ module.exports = {
   patchCommentPreloadBundle,
   patchExtractedApp,
   patchKeybindsSettingsAssets,
+  patchLinuxMultiInstanceBootstrap,
   patchLinuxAppUpdaterBridge,
   patchMainBundleSource,
   patchPackageJson,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -31,6 +31,7 @@ const {
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxMenuPatch,
+  applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
@@ -244,6 +245,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-explicit-ipc-quit",
     "linux-window-options",
     "linux-menu",
+    "linux-multi-instance-bootstrap-lock",
     "linux-set-icon",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
@@ -891,7 +893,10 @@ test("scopes close-to-tray already-patched detection to the handler", () => {
 test("adds Linux single-instance lock and second-instance handoff", () => {
   const patched = applyPatchTwice(applyLinuxSingleInstancePatch, singleInstanceBundleFixture());
 
-  assert.match(patched, /process\.platform===`linux`&&!n\.app\.requestSingleInstanceLock\(\)/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n\.app\.requestSingleInstanceLock\(\)/,
+  );
   assert.match(patched, /n\.app\.quit\(\);return/);
   assert.match(patched, /codexLinuxBeforeQuitHandler=\(\)=>\{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\)\}/);
   assert.match(patched, /n\.app\.on\(`before-quit`,codexLinuxBeforeQuitHandler\)/);
@@ -899,6 +904,18 @@ test("adds Linux single-instance lock and second-instance handoff", () => {
   assert.match(patched, /codexLinuxSecondInstanceHandler/);
   assert.match(patched, /n\.app\.on\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
   assert.match(patched, /n\.app\.off\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
+});
+
+test("lets explicit Linux multi-instance launches bypass the bootstrap single-instance lock", () => {
+  const source =
+    "var S=t.x({isMacOS:b,isPackaged:n.app.isPackaged});if(!(!S||n.app.requestSingleInstanceLock()))t.Jr().info(`Exiting second desktop instance`,{safe:{packaged:n.app.isPackaged,platform:process.platform}}),n.app.exit(0);else{let e=t.C(x);}";
+  const patched = applyPatchTwice(applyLinuxMultiInstanceBootstrapPatch, source);
+
+  assert.match(
+    patched,
+    /if\(!\(!S\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|n\.app\.requestSingleInstanceLock\(\)\)\)/,
+  );
+  assert.match(patched, /Exiting second desktop instance/);
 });
 
 test("recognizes bootstrap-owned single-instance handoff in current bundles", () => {
@@ -1891,7 +1908,10 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
     patched,
     /process\.platform!==`win32`&&process\.platform!==`darwin`&&process\.platform!==`linux`\?null:/,
   );
-  assert.match(patched, /process\.platform===`linux`&&!n\.app\.requestSingleInstanceLock\(\)/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n\.app\.requestSingleInstanceLock\(\)/,
+  );
   assert.match(patched, /\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/);
   assert.doesNotMatch(patched, /setIcon\(process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\//);
   assert.doesNotMatch(

--- a/scripts/patches/bootstrap.js
+++ b/scripts/patches/bootstrap.js
@@ -1,0 +1,49 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function applyLinuxMultiInstanceBootstrapPatch(currentSource) {
+  const unguardedLock =
+    "if(!(!S||n.app.requestSingleInstanceLock()))";
+  const guardedLock =
+    "if(!(!S||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||n.app.requestSingleInstanceLock()))";
+
+  if (currentSource.includes(guardedLock)) {
+    return currentSource;
+  }
+  if (currentSource.includes(unguardedLock)) {
+    return currentSource.replace(unguardedLock, guardedLock);
+  }
+
+  if (
+    currentSource.includes("requestSingleInstanceLock") &&
+    currentSource.includes("Exiting second desktop instance")
+  ) {
+    console.warn(
+      "WARN: Could not find bootstrap single-instance lock — skipping Linux multi-instance bootstrap patch",
+    );
+  }
+  return currentSource;
+}
+
+function patchLinuxMultiInstanceBootstrap(extractedDir) {
+  const target = path.join(extractedDir, ".vite", "build", "bootstrap.js");
+  if (!fs.existsSync(target)) {
+    return { changed: false, reason: "bootstrap.js not found" };
+  }
+
+  const source = fs.readFileSync(target, "utf8");
+  const patched = applyLinuxMultiInstanceBootstrapPatch(source);
+  if (patched === source) {
+    return { changed: false };
+  }
+
+  fs.writeFileSync(target, patched, "utf8");
+  return { changed: true };
+}
+
+module.exports = {
+  applyLinuxMultiInstanceBootstrapPatch,
+  patchLinuxMultiInstanceBootstrap,
+};

--- a/scripts/patches/core/all-linux/extracted-app/bootstrap/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/bootstrap/patch.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const {
+  patchLinuxMultiInstanceBootstrap,
+} = require("../../../../bootstrap.js");
+
+module.exports = {
+  id: "linux-multi-instance-bootstrap-lock",
+  phase: "extracted-app",
+  order: 125,
+  ciPolicy: "optional",
+  apply: patchLinuxMultiInstanceBootstrap,
+};

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -597,9 +597,15 @@ function applyLinuxSingleInstancePatch(currentSource) {
   const singleInstanceLockNeedle =
     "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady()";
   const singleInstanceLockPatch =
-    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});if(process.platform===`linux`&&!n.app.requestSingleInstanceLock()){n.app.quit();return}let A=Date.now();await n.app.whenReady()";
-  if (patchedSource.includes("process.platform===`linux`&&!n.app.requestSingleInstanceLock()")) {
+    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});if(process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()){n.app.quit();return}let A=Date.now();await n.app.whenReady()";
+  const unguardedSingleInstanceLock =
+    "process.platform===`linux`&&!n.app.requestSingleInstanceLock()";
+  const guardedSingleInstanceLock =
+    "process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()";
+  if (patchedSource.includes(guardedSingleInstanceLock)) {
     // Already patched.
+  } else if (patchedSource.includes(unguardedSingleInstanceLock)) {
+    patchedSource = patchedSource.replaceAll(unguardedSingleInstanceLock, guardedSingleInstanceLock);
   } else if (patchedSource.includes(singleInstanceLockNeedle)) {
     patchedSource = patchedSource.replace(singleInstanceLockNeedle, singleInstanceLockPatch);
   } else if (patchedSource.includes("setSecondInstanceArgsHandler")) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1230,10 +1230,16 @@ if 'LAUNCHER_ARGS=()' not in source:
     raise SystemExit("launcher must keep a sanitized argv for launcher-only flags")
 if 'configure_multi_launch_instance "$@"' not in source:
     raise SystemExit("launcher must configure multi-launch before deriving WEBVIEW_ORIGIN")
+if 'unset CODEX_LINUX_MULTI_LAUNCH' not in source.split('parse_launcher_args() {', 1)[0]:
+    raise SystemExit("launcher must clear inherited internal multi-launch markers before parsing args")
 if '$((CODEX_LINUX_WEBVIEW_PORT + 4))' not in source:
     raise SystemExit("multi-launch default range must cap the default at five ports")
 if 'CODEX_LINUX_INSTANCE_ID="port-$CODEX_LINUX_WEBVIEW_PORT"' not in multi_body:
     raise SystemExit("multi-launch must derive a stable instance id from the allocated port")
+if 'CODEX_LINUX_MULTI_LAUNCH=1' not in multi_body:
+    raise SystemExit("multi-launch must export an app-visible multi-launch marker")
+if 'export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_WEBVIEW_PORT' not in multi_body:
+    raise SystemExit("multi-launch must export instance identity for Electron")
 if 'APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
     raise SystemExit("multi-launch must isolate app pid/webview state per allocated port")
 if 'LAUNCH_ACTION_RUNTIME_DIR="$XDG_RUNTIME_DIR/$CODEX_LINUX_APP_ID/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
@@ -2462,7 +2468,7 @@ JS
     make_fake_extracted_asar "$extracted" "$bundle_body"
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!n.app.requestSingleInstanceLock()'
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxHandleLaunchActionArgs'
     assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--new-chat`)'
     assert_contains "$extracted/.vite/build/main-test.js" 'e.includes(`--quick-chat`)'

--- a/tests/webview_probe_equivalence.sh
+++ b/tests/webview_probe_equivalence.sh
@@ -29,6 +29,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATE="$REPO_DIR/launcher/start.sh.template"
+MAIN_BASHPID="${BASHPID:-$$}"
 
 info() { echo "[probe-eq] $*" >&2; }
 fail() { echo "[probe-eq][FAIL] $*" >&2; exit 1; }
@@ -200,9 +201,28 @@ EOF
     PORT_OPEN=$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));p=s.getsockname()[1];s.close();print(p)')
     PORT_CLOSED=$(find_closed_tcp_port) || fail "could not find an unused closed localhost port"
 
-    # exec into python so $! is the python PID directly (not the subshell's),
-    # making teardown reliable and avoiding orphan http.server processes.
-    (cd "$FIXTURES" && exec python3 -m http.server "$PORT_OPEN" --bind 127.0.0.1 >/dev/null 2>&1) &
+    start_fixture_server || return 1
+}
+
+start_fixture_server() {
+    # Use a threaded server because the TCP-open probes intentionally connect
+    # without sending an HTTP request. A single-threaded http.server can spend
+    # enough time draining those empty probe connections that the next marker
+    # fetch flakes on slower CI runners.
+    (cd "$FIXTURES" && exec python3 - "$PORT_OPEN" <<'PY' >/dev/null 2>&1) &
+import http.server
+import sys
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), QuietHandler)
+server.daemon_threads = True
+server.serve_forever()
+PY
     SERVER_PID=$!
 
     # Readiness is HTTP-level, not just TCP — http.server binds before it can
@@ -216,9 +236,15 @@ EOF
     return 1
 }
 
-teardown() {
+stop_fixture_server() {
     [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null
     [ -n "${SERVER_PID:-}" ] && wait "$SERVER_PID" 2>/dev/null
+    SERVER_PID=""
+}
+
+teardown() {
+    [ "${BASHPID:-$$}" = "$MAIN_BASHPID" ] || return 0
+    stop_fixture_server
     [ -n "${FIXTURES:-}"   ] && rm -rf "$FIXTURES"
     [ -n "${CURLRC_HOME:-}" ] && rm -rf "$CURLRC_HOME"
 }
@@ -248,17 +274,26 @@ main() {
     load_new_impls
     setup_server || fail "fixture server did not bind"
 
-    local URL_OK="http://127.0.0.1:$PORT_OPEN/index.html"
-    local URL_404="http://127.0.0.1:$PORT_OPEN/missing.html"
-    local URL_BADTITLE="http://127.0.0.1:$PORT_OPEN/wrong-title.html"
-    local URL_NOLOADER="http://127.0.0.1:$PORT_OPEN/missing-loader.html"
-    local URL_DEAD="http://127.0.0.1:$PORT_CLOSED/index.html"
-
     info "TCP probe — open / closed"
     assert_rc "orig  open  ($PORT_OPEN)"     0 webview_port_is_open__orig    "$PORT_OPEN"
     assert_rc "new   open  ($PORT_OPEN)"     0 webview_port_is_open_at__new  "$PORT_OPEN"
     assert_rc "orig  closed ($PORT_CLOSED)"  1 webview_port_is_open__orig    "$PORT_CLOSED"
     assert_rc "new   closed ($PORT_CLOSED)"  1 webview_port_is_open_at__new  "$PORT_CLOSED"
+
+    # Keep TCP probe side effects isolated from HTTP marker checks. The open
+    # probes intentionally create empty loopback connections, and the launcher
+    # only requires those verdicts to match; HTTP verification gets a fresh
+    # fixture server below.
+    stop_fixture_server
+    [ -n "${FIXTURES:-}" ] && rm -rf "$FIXTURES"
+    FIXTURES=""
+    setup_server || fail "fixture server did not bind after TCP probes"
+
+    local URL_OK="http://127.0.0.1:$PORT_OPEN/index.html"
+    local URL_404="http://127.0.0.1:$PORT_OPEN/missing.html"
+    local URL_BADTITLE="http://127.0.0.1:$PORT_OPEN/wrong-title.html"
+    local URL_NOLOADER="http://127.0.0.1:$PORT_OPEN/missing-loader.html"
+    local URL_DEAD="http://127.0.0.1:$PORT_CLOSED/index.html"
 
     info "HTTP origin verify — markers + failure modes"
     assert_rc "orig  ok markers"             0 verify_webview_origin__orig "$URL_OK"


### PR DESCRIPTION
Follow-up to #227.

## What changed
- Mark explicit Linux multi-instance launches with `CODEX_LINUX_MULTI_LAUNCH=1` and export the instance identity into Electron.
- Let only explicit multi-instance launches bypass the Linux app-level `requestSingleInstanceLock()` guard in the main-process patch.
- Add an extracted-app bootstrap patch for the earlier bootstrap-owned single-instance lock, which was still able to exit the second app before the main-process patch mattered.
- Cover both lock paths in patch tests and smoke checks.

## Why
The launcher-side port/state isolation from #227 was necessary but not sufficient: current upstream bundles also have app-level single-instance locks. A second `--new-instance` launch could allocate a separate port and user data dir, then Electron would exit from the bootstrap/main lock path.

## Validation
- `git diff --check`
- `node --check scripts/patches/bootstrap.js`
- `node --check scripts/patch-linux-window-ui.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash -n launcher/start.sh.template && bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- Local rebuilt install smoke: original app stayed on `127.0.0.1:5175`; `--new-instance` stayed up on `127.0.0.1:5176` with isolated Electron user data under `~/.local/state/codex-desktop/instances/port-5176/electron-user-data`.
