### PR TITLE
fix: surface required patch report failures

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1473,7 +1473,7 @@ test("handles literal Chrome plugin gate names", () => {
   assert.doesNotMatch(patched, /installWhenMissing:!0,name:'chrome-internal'/);
 });
 
-test("reports missing required Chrome plugin auto-install gate as upstream validation failure", () => {
+test("reports missing required Chrome plugin auto-install gate as required upstream validation failure", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-chrome-"));
   try {
     const buildDir = path.join(tempRoot, ".vite", "build");
@@ -1484,11 +1484,11 @@ test("reports missing required Chrome plugin auto-install gate as upstream valid
     captureWarns(() => patchExtractedApp(tempRoot, { report }));
 
     const pluginGatePatch = report.patches.find((patch) => patch.name === "linux-chrome-plugin-auto-install");
-    assert.equal(pluginGatePatch.status, "skipped-optional");
+    assert.equal(pluginGatePatch.status, "failed-required");
     assert.match(pluginGatePatch.reason, /Could not find Chrome plugin gate literal/);
     assert.ok(
       validateReport(report, "upstream-build").some((failure) =>
-        failure.startsWith("linux-chrome-plugin-auto-install: skipped-optional"),
+        failure.startsWith("linux-chrome-plugin-auto-install: failed-required"),
       ),
     );
   } finally {
@@ -1516,7 +1516,7 @@ test("fails hard when the Computer Use gate is recognizable but unpatchable", ()
   );
 });
 
-test("reports missing required Computer Use plugin gate as upstream validation failure", () => {
+test("reports missing required Computer Use plugin gate as required upstream validation failure", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-computer-use-"));
   try {
     const buildDir = path.join(tempRoot, ".vite", "build");
@@ -1527,11 +1527,11 @@ test("reports missing required Computer Use plugin gate as upstream validation f
     captureWarns(() => patchExtractedApp(tempRoot, { report }));
 
     const pluginGatePatch = report.patches.find((patch) => patch.name === "linux-computer-use-plugin-gate");
-    assert.equal(pluginGatePatch.status, "skipped-optional");
+    assert.equal(pluginGatePatch.status, "failed-required");
     assert.match(pluginGatePatch.reason, /Could not find Computer Use plugin gate literal/);
     assert.ok(
       validateReport(report, "upstream-build").some((failure) =>
-        failure.startsWith("linux-computer-use-plugin-gate: skipped-optional"),
+        failure.startsWith("linux-computer-use-plugin-gate: failed-required"),
       ),
     );
   } finally {
@@ -2040,7 +2040,54 @@ test("patchExtractedApp records a structured patch report", () => {
   }
 });
 
-test("patch report marks warned asset patches as skipped", () => {
+test("patch report marks missing required webview assets as required failures", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-webview-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), mainBundlePrefix);
+    fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const sunsetPatch = report.patches.find((patch) => patch.name === "linux-app-sunset-gate");
+    assert.equal(sunsetPatch.status, "failed-required");
+    assert.match(sunsetPatch.reason, /Could not find webview assets directory/);
+    assert.ok(
+      validateReport(report, "upstream-build").some((failure) =>
+        failure.startsWith("linux-app-sunset-gate: failed-required"),
+      ),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patch report marks missing required package metadata as required failure", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-package-json-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), mainBundlePrefix);
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const packagePatch = report.patches.find((patch) => patch.name === "package-desktop-name");
+    assert.equal(packagePatch.status, "failed-required");
+    assert.match(packagePatch.reason, /package\.json missing or unreadable/);
+    assert.ok(
+      validateReport(report, "upstream-build").some((failure) =>
+        failure.startsWith("package-desktop-name: failed-required"),
+      ),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patch report marks warned asset patches as required failures", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-warned-asset-"));
   try {
     const assetsDir = path.join(tempRoot, "webview", "assets");
@@ -2051,11 +2098,11 @@ test("patch report marks warned asset patches as skipped", () => {
     captureWarns(() => patchExtractedApp(tempRoot, { report }));
 
     const sunsetPatch = report.patches.find((patch) => patch.name === "linux-app-sunset-gate");
-    assert.equal(sunsetPatch.status, "skipped-optional");
+    assert.equal(sunsetPatch.status, "failed-required");
     assert.match(sunsetPatch.reason, /Could not find app sunset gate needle/);
     assert.ok(
       validateReport(report, "upstream-build").some((failure) =>
-        failure.startsWith("linux-app-sunset-gate: skipped-optional"),
+        failure.startsWith("linux-app-sunset-gate: failed-required"),
       ),
     );
   } finally {

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -14,6 +14,9 @@ const {
   patchAssetFiles,
 } = require("./shared.js");
 
+const FAILED_REQUIRED = "failed-required";
+const REQUIRED_UPSTREAM = "required-upstream";
+const SKIPPED_OPTIONAL = "skipped-optional";
 const SKIPPED_TARGET = "skipped-target";
 
 function descriptorId(descriptor) {
@@ -123,8 +126,29 @@ function patchTargetSummary(descriptor, context) {
     : `conditional-linux:${linuxTargetSummary(context.linux)}`;
 }
 
+function descriptorFailureStatus(descriptor) {
+  return descriptor.ciPolicy === REQUIRED_UPSTREAM ? FAILED_REQUIRED : SKIPPED_OPTIONAL;
+}
+
+function patchStatusFromDescriptorChange(descriptor, changed, warnings) {
+  if (changed) {
+    return "applied";
+  }
+  if (warnings.length > 0) {
+    return descriptorFailureStatus(descriptor);
+  }
+  return "already-applied";
+}
+
+function normalizeDescriptorStatus(descriptor, status) {
+  if (descriptor.ciPolicy === REQUIRED_UPSTREAM && status === SKIPPED_OPTIONAL) {
+    return FAILED_REQUIRED;
+  }
+  return status;
+}
+
 function recordDescriptorPatch(report, descriptor, status, reason, context) {
-  recordPatch(report, descriptor.id, status, reason, {
+  recordPatch(report, descriptor.id, normalizeDescriptorStatus(descriptor, status), reason, {
     phase: descriptor.phase,
     targetSummary: patchTargetSummary(descriptor, context),
   });
@@ -163,7 +187,7 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
     recordDescriptorPatch(
       report,
       descriptor,
-      patchStatusFromChange(patched !== before, result.warnings),
+      patchStatusFromDescriptorChange(descriptor, patched !== before, result.warnings),
       result.warnings[0] ?? null,
       context,
     );
@@ -179,13 +203,13 @@ function defaultWebviewMissingWarning(extractedDir, descriptor) {
 
 function recordAssetDescriptorPatch(report, descriptor, patchResult, warnings, context) {
   if (patchResult.matched === 0) {
-    recordDescriptorPatch(report, descriptor, "skipped-optional", warnings[0] ?? "no matching bundle found", context);
+    recordDescriptorPatch(report, descriptor, descriptorFailureStatus(descriptor), warnings[0] ?? "no matching bundle found", context);
     return;
   }
   recordDescriptorPatch(
     report,
     descriptor,
-    patchStatusFromChange(patchResult.changed > 0, warnings),
+    patchStatusFromDescriptorChange(descriptor, patchResult.changed > 0, warnings),
     warnings[0] ?? null,
     context,
   );


### PR DESCRIPTION
## Summary
- Mark missing or warned `required-upstream` patch descriptors as `failed-required` instead of `skipped-optional`
- Preserve optional descriptor behavior for optional patches
- Add regression coverage for missing Chrome/Computer Use gates, missing webview assets, missing package metadata, and drifted app-sunset asset patches

## Why
Required upstream patch drift was being recorded as optional skips in patch reports. That could hide required patch failures until later/manual inspection even though the report validator treats required failures as build-blocking.

## Validation
- `bash -n install.sh scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/ci/update-nix-hashes.sh scripts/ci/validate-nix-pins.sh`
- `node --check scripts/patch-linux-window-ui.js scripts/patch-linux-window-ui.test.js scripts/ci/validate-patch-report.js`
- `find scripts/patches -name '*.js' -print0 | xargs -0 -n1 node --check`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
