### PR TITLE
fix: patch all matching Linux bundle helpers

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -623,6 +623,37 @@ test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
   assert.doesNotThrow(() => new Function(patched));
 });
 
+test("patches remaining before-quit and drain guards when another copy is already patched", () => {
+  const promptBypassExpression =
+    "(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||";
+  const patchedPrompt = `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}`;
+  const unpatchedPrompt =
+    "if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
+  const patchedPromptSource = applyPatchTwice(
+    applyLinuxExplicitQuitPromptBypassPatch,
+    `${patchedPrompt}function secondPrompt(){${unpatchedPrompt}}`,
+  );
+  assert.equal((patchedPromptSource.match(/codexLinuxShouldBypassQuitPrompt\(\)/g) ?? []).length, 2);
+  assert.match(
+    patchedPromptSource,
+    /function secondPrompt\(\)\{if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{g=!0,a\.markAppQuitting\(\);return\}\}/,
+  );
+
+  const unpatchedDrain =
+    "Promise.all([...u.values()].map(e=>e.flush())).finally(()=>{d(),f.dispose(),n.app.quit()})";
+  const patchedDrain =
+    "(()=>{let codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all([...u.values()].map(e=>e.flush()));if(process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()";
+  const patchedDrainSource = applyPatchTwice(
+    applyLinuxWillQuitDrainTimeoutPatch,
+    `${patchedDrain}function secondDrain(){${unpatchedDrain}}`,
+  );
+  assert.equal((patchedDrainSource.match(/codexLinuxDrainPromise=Promise\.all/g) ?? []).length, 2);
+  assert.match(
+    patchedDrainSource,
+    /function secondDrain\(\)\{\(\(\)=>\{let codexLinuxFinalizeQuit=\(\)=>\{d\(\),f\.dispose\(\),n\.app\.quit\(\)\},codexLinuxDrainPromise=Promise\.all\(\[\.\.\.u\.values\(\)\]\.map\(e=>e\.flush\(\)\)\);/,
+  );
+});
+
 test("marks Linux quit-in-progress for the tray quit path", () => {
   const source = `${mainBundlePrefix}${explicitQuitBundleFixture()}`;
   const patched = applyPatchTwice(
@@ -682,6 +713,35 @@ test("supports explicit IPC quit patching when minified aliases drift", () => {
   );
 });
 
+test("patches remaining explicit quit handlers when another copy is already patched", () => {
+  const quitMarkerExpression =
+    "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
+  const patchedTrayQuit = `{label:rB(this.appName),click:()=>{${quitMarkerExpression}n.app.quit()}}`;
+  const unpatchedTrayQuit = "{label:rB(this.appName),click:()=>{n.app.quit()}}";
+  const patchedIpcQuit = `if(o.type===\`quit-app\`){${quitMarkerExpression}n.app.quit();return}`;
+  const unpatchedIpcQuit = "if(o.type===`quit-app`){n.app.quit();return}";
+
+  const patchedTray = applyPatchTwice(
+    applyLinuxExplicitTrayQuitPatch,
+    `${patchedTrayQuit}function createSecondTray(){return ${unpatchedTrayQuit}}`,
+  );
+  const patchedIpc = applyPatchTwice(
+    applyLinuxExplicitIpcQuitPatch,
+    `${patchedIpcQuit}function createSecondIpc(){${unpatchedIpcQuit}}`,
+  );
+
+  assert.equal((patchedTray.match(/codexLinuxPrepareForExplicitQuit\(\)/g) ?? []).length, 2);
+  assert.match(
+    patchedTray,
+    /function createSecondTray\(\)\{return \{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\)\}\}\}/,
+  );
+  assert.equal((patchedIpc.match(/codexLinuxPrepareForExplicitQuit\(\)/g) ?? []).length, 2);
+  assert.match(
+    patchedIpc,
+    /function createSecondIpc\(\)\{if\(o\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\);return\}\}/,
+  );
+});
+
 test("adds Linux menu hiding next to Windows removeMenu calls", () => {
   const source = "process.platform===`win32`&&k.removeMenu(),k.on(`closed`,()=>{})";
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
@@ -689,6 +749,20 @@ test("adds Linux menu hiding next to Windows removeMenu calls", () => {
   assert.equal(
     patched,
     "process.platform===`linux`&&k.setMenuBarVisibility(!1),process.platform===`win32`&&k.removeMenu(),k.on(`closed`,()=>{})",
+  );
+});
+
+test("patches remaining Windows menu snippets when another copy is already Linux-patched", () => {
+  const windowsMenuSnippet = "process.platform===`win32`&&k.removeMenu(),";
+  const linuxMenuPatch = "process.platform===`linux`&&k.setMenuBarVisibility(!1),";
+  const source = `${linuxMenuPatch}${windowsMenuSnippet}function createSecondWindow(){${windowsMenuSnippet}}`;
+
+  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
+
+  assert.equal((patched.match(/setMenuBarVisibility\(!1\)/g) ?? []).length, 2);
+  assert.match(
+    patched,
+    /function createSecondWindow\(\)\{process\.platform===`linux`&&k\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
   );
 });
 
@@ -849,6 +923,40 @@ test("adds Linux window icon handling when an icon asset is available", () => {
   );
   assert.match(patchedMain, new RegExp(`icon:${escapeRegExp(iconPathExpression)}`));
   assert.match(patchedMain, new RegExp(`D\\.setIcon\\(${escapeRegExp(iconPathExpression)}\\)`));
+});
+
+test("patches remaining Linux window icon snippets when another window is already patched", () => {
+  const iconAsset = "app-test.png";
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const windowOptionsSource = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+  const patchedWindowOptionsNeedle =
+    `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{icon:${iconPathExpression}}:{}}:{},`;
+  const readyToShowSource = "D.once(`ready-to-show`,()=>{})";
+  const readyToShowSource2 = "E.once(`ready-to-show`,()=>{})";
+  const patchedSetIconNeedle =
+    `process.platform===\`linux\`&&D.setIcon(${iconPathExpression}),${readyToShowSource}`;
+
+  const patchedWindowOptions = applyPatchTwice(
+    applyLinuxWindowOptionsPatch,
+    `${patchedWindowOptionsNeedle}function createSecondWindow(){return {${windowOptionsSource}}}`,
+    iconAsset,
+  );
+  const patchedSetIcon = applyPatchTwice(
+    applyLinuxSetIconPatch,
+    `${patchedSetIconNeedle}function createSecondWindow(){${readyToShowSource2}}`,
+    iconAsset,
+  );
+
+  assert.equal((patchedWindowOptions.match(/icon:process\.resourcesPath/g) ?? []).length, 2);
+  assert.match(
+    patchedWindowOptions,
+    /function createSecondWindow\(\)\{return \{\.\.\.process\.platform===`win32`\|\|process\.platform===`linux`\?\{autoHideMenuBar:!0,\.\.\.process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/app-test\.png`\}:\{\}\}:\{\},\}\}/,
+  );
+  assert.equal((patchedSetIcon.match(/\.setIcon\(/g) ?? []).length, 2);
+  assert.match(
+    patchedSetIcon,
+    /function createSecondWindow\(\)\{process\.platform===`linux`&&E\.setIcon\(process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/app-test\.png`\),E\.once\(`ready-to-show`,\(\)=>\{\}\)\}/,
+  );
 });
 
 test("adds Linux tray support including the platform guard", () => {
@@ -1533,6 +1641,20 @@ test("keeps scanning Computer Use gates after an already patched match", () => {
   assert.doesNotMatch(patched, /r===`darwin`&&n\.computerUse/);
 });
 
+test("patches all unpatched Computer Use gates in one pass", () => {
+  const source = [
+    "var tn=`computer-use`;",
+    "var $n=[{name:tn,isEnabled:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:on},{name:tn,isEnabled:({features:n,platform:r})=>r===`darwin`&&n.computerUse,migrate:wn}];",
+  ].join("");
+
+  const patched = applyLinuxComputerUsePluginGatePatch(source);
+
+  assert.equal((patched.match(/installWhenMissing:!0,name:tn/g) || []).length, 2);
+  assert.match(patched, /\(t===`darwin`\|\|t===`linux`\)&&e\.computerUse/);
+  assert.match(patched, /\(r===`darwin`\|\|r===`linux`\)&&n\.computerUse/);
+  assert.doesNotMatch(patched, /===`darwin`&&/);
+});
+
 test("handles reordered Computer Use gate destructuring", () => {
   const darwinOnlySource = [
     "var tn=`computer-use`;",
@@ -1732,6 +1854,21 @@ test("enables current Computer Use desktop features on Linux", () => {
   assert.match(patched, /CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE/);
 });
 
+test("patches all Computer Use desktop feature gates in one pass", () => {
+  const patchedFeature =
+    "function A(e,{env:t=process.env,platform:n=process.platform}={}){return n===`linux`?{...e,computerUse:!0,computerUseNodeRepl:!0}:n!==`win32`||t.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`?e:{...e,computerUse:!0,computerUseNodeRepl:!0}}";
+  const unpatchedFeature =
+    "function B(e,{env:r=process.env,platform:i=process.platform}={}){return i!==`win32`||r.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`?e:{...e,computerUse:!0,computerUseNodeRepl:!0}}";
+
+  const patched = applyLinuxComputerUseFeaturePatch(`${patchedFeature}${unpatchedFeature}`);
+
+  assert.equal((patched.match(/===`linux`/g) || []).length, 2);
+  assert.doesNotMatch(
+    patched,
+    /function B\(e,\{env:r=process\.env,platform:i=process\.platform\}=\{\}\)\{return i!==`win32`/,
+  );
+});
+
 test("shows Computer Use plugin UI on Linux without the upstream rollout flag", () => {
   const patched = applyPatchTwice(
     applyLinuxComputerUseRendererAvailabilityPatch,
@@ -1759,6 +1896,18 @@ test("shows current Computer Use plugin UI on Linux without the upstream rollout
   );
 });
 
+test("patches all Computer Use renderer availability gates in one pass", () => {
+  const source = [
+    "let m=a&&(i||l===`linux`)&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;",
+    "let _=a&&i&&l&&(o||m),v=_&&!o&&p.enabled&&!p.isLoading,y=_&&p.isLoading,b=_&&(o||p.isLoading),x;",
+  ].join("");
+
+  const patched = applyLinuxComputerUseRendererAvailabilityPatch(source);
+
+  assert.match(patched, /c===`linux`\|\|l&&\(o\|\|m\)/);
+  assert.doesNotMatch(patched, /let _=a&&i&&l&&\(o\|\|m\)/);
+});
+
 test("allows Computer Use install flow on Linux", () => {
   const patched = applyPatchTwice(
     applyLinuxComputerUseInstallFlowPatch,
@@ -1783,6 +1932,18 @@ test("allows current Computer Use install flow on Linux", () => {
   );
 });
 
+test("patches all Computer Use install flow gates in one pass", () => {
+  const source = [
+    "ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled||navigator.userAgent.includes(`Linux`),",
+    "xe=g({featureName:`computer_use`,hostId:o}),ye=!xe.isLoading&&xe.enabled,",
+  ].join("");
+
+  const patched = applyLinuxComputerUseInstallFlowPatch(source);
+
+  assert.equal((patched.match(/navigator\.userAgent\.includes\(`Linux`\)/g) || []).length, 2);
+  assert.doesNotMatch(patched, /ye=!xe\.isLoading&&xe\.enabled,/);
+});
+
 test("auto-approves the app-provided Browser Use node_repl bridge", () => {
   const source =
     "return{[`mcp_servers.${pt}`]:{command:i.nodeReplPath,args:[],startup_timeout_sec:120,env:{[dt]:l,[ft]:i.nodePath}}}";
@@ -1791,6 +1952,18 @@ test("auto-approves the app-provided Browser Use node_repl bridge", () => {
 
   assert.match(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
   assert.match(patched, /env:\{\[dt\]:l,\[ft\]:i\.nodePath/);
+});
+
+test("patches all Browser Use node_repl approval configs in one pass", () => {
+  const source = [
+    "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{[dt]:l}",
+    "startup_timeout_sec:120,env:{[ft]:i.nodePath}",
+  ].join("");
+
+  const patched = applyBrowserUseNodeReplApprovalPatch(source);
+
+  assert.equal((patched.match(/approval_mode:`approve`/g) || []).length, 2);
+  assert.doesNotMatch(patched, /startup_timeout_sec:120,env:\{/);
 });
 
 test("shows the Linux IAB panel after Browser Use creates or reuses a tab", () => {
@@ -1809,6 +1982,18 @@ test("shows the Linux IAB panel after Browser Use creates or reuses a tab", () =
     patched,
     /return \(\(\)=>\{try\{n\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)\}/,
   );
+});
+
+test("patches all Browser Use IAB tab-creation paths in one pass", () => {
+  const source = [
+    "if(t!=null)return await this.navigateTabToInitialPage(t),this.serializeTab(t);let n=this.getRequiredBrowserHost(e);n.setBrowserUseActive(!0,e.turnId);let r=await n.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:e.turnId}),i=this.updateTabForPage(r,n.routeKey);return",
+    "if(a!=null)return await this.navigateTabToInitialPage(a),this.serializeTab(a);let b=this.getRequiredBrowserHost(s);b.setBrowserUseActive(!0,s.turnId);let c=await b.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:s.turnId}),d=this.updateTabForPage(c,b.routeKey);return",
+  ].join(";");
+
+  const patched = applyLinuxBrowserUseIabVisibleOnCreatePatch(source);
+
+  assert.equal((patched.match(/codexLinuxBrowserUseAutoVisible/g) || []).length, 4);
+  assert.doesNotMatch(patched, /return await this\.navigateTabToInitialPage\([ta]\),this\.serializeTab/);
 });
 
 test("detects Chrome extension installation from Linux browser profiles", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1896,6 +1896,22 @@ test("shows current Computer Use plugin UI on Linux without the upstream rollout
   );
 });
 
+test("warns without partially patching when Computer Use renderer availability gate drifts", () => {
+  const source =
+    "function g(e){return e===`macOS`||e===`windows`}" +
+    "const isComputerUseAvailable=true;" +
+    "function _(e){let t=(0,d.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,{isLoading:o,platform:c}=u(),l=s(`1506311413`),f;t[0]===r?f=t[1]:(f={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=f);let p=h(f),m;t[2]===c?m=t[3]:(m=g(c),t[2]=c,t[3]=m);let _=a&&i&&l&&(o||m||drifted),v=_&&!o&&p.enabled&&!p.isLoading,y=_&&p.isLoading,b=_&&(o||p.isLoading),x;return x}";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxComputerUseRendererAvailabilityPatch(source),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find Computer Use renderer availability gate — skipping Linux Computer Use UI availability patch",
+  ]);
+});
+
 test("patches all Computer Use renderer availability gates in one pass", () => {
   const source = [
     "let m=a&&(i||l===`linux`)&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;",

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -112,31 +112,39 @@ function applyLinuxComputerUsePluginGatePatch(currentSource) {
     new RegExp(String.raw`\{(installWhenMissing:!0,)?name:(${nameExpressionPattern}),(isEnabled|isAvailable):\(\{([^}]*)\}\)=>([^{}]*?\.computerUse),migrate:([A-Za-z_$][\w$]*)\}`, "g");
   let sawEnabledGate = false;
   let sawUnpatchableGate = false;
-  let match;
-  while ((match = gateRegex.exec(currentSource)) != null) {
-    const [gateSource, installWhenMissing, nameExpr, availabilityProp, paramsText, expression, migrateVar] = match;
-    if (!isComputerUseNameExpr(nameExpr, computerUseNameVar)) {
-      continue;
-    }
+  let patchedGateCount = 0;
+  const patchedSource = currentSource.replace(
+    gateRegex,
+    (gateSource, installWhenMissing, nameExpr, availabilityProp, paramsText, expression, migrateVar) => {
+      if (!isComputerUseNameExpr(nameExpr, computerUseNameVar)) {
+        return gateSource;
+      }
 
-    const aliases = parseDestructuredParamAliases(paramsText);
-    const featuresVar = aliases.features;
-    const platformVar = aliases.platform;
-    if (featuresVar == null || platformVar == null) {
-      continue;
-    }
+      const aliases = parseDestructuredParamAliases(paramsText);
+      const featuresVar = aliases.features;
+      const platformVar = aliases.platform;
+      if (featuresVar == null || platformVar == null) {
+        sawUnpatchableGate = true;
+        return gateSource;
+      }
 
-    const darwinOnlyExpression = `${platformVar}===\`darwin\`&&${featuresVar}.computerUse`;
-    const linuxExpression = `(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse`;
-    if (installWhenMissing != null && expression === linuxExpression) {
-      sawEnabledGate = true;
-      continue;
-    }
-    if (expression === darwinOnlyExpression || expression === linuxExpression) {
-      const replacement = buildComputerUseGate({ nameExpr, availabilityProp, featuresVar, platformVar, migrateVar });
-      return `${currentSource.slice(0, match.index)}${replacement}${currentSource.slice(match.index + gateSource.length)}`;
-    }
-    sawUnpatchableGate = true;
+      const darwinOnlyExpression = `${platformVar}===\`darwin\`&&${featuresVar}.computerUse`;
+      const linuxExpression = `(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${featuresVar}.computerUse`;
+      if (installWhenMissing != null && expression === linuxExpression) {
+        sawEnabledGate = true;
+        return gateSource;
+      }
+      if (expression === darwinOnlyExpression || expression === linuxExpression) {
+        patchedGateCount += 1;
+        return buildComputerUseGate({ nameExpr, availabilityProp, featuresVar, platformVar, migrateVar });
+      }
+      sawUnpatchableGate = true;
+      return gateSource;
+    },
+  );
+
+  if (patchedGateCount > 0) {
+    return patchedSource;
   }
 
   if (sawEnabledGate && !sawUnpatchableGate) {
@@ -156,28 +164,32 @@ function applyLinuxComputerUseFeaturePatch(currentSource) {
   const currentPatchedFeaturePattern =
     /let [A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*===`linux`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:[A-Za-z_$][\w$]*===`win32`&&[A-Za-z_$][\w$]*\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.[A-Za-z_$][\w$]*,computerUse:!0,computerUseNodeRepl:!0\}:[A-Za-z_$][\w$]*,/;
   const windowsOnlyFeaturePattern =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{env:([A-Za-z_$][\w$]*)=process\.env,platform:([A-Za-z_$][\w$]*)=process\.platform\}=\{\}\)\{return \4!==`win32`\|\|\3\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?\2:\{\.\.\.\2,computerUse:!0,computerUseNodeRepl:!0\}\}/;
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{env:([A-Za-z_$][\w$]*)=process\.env,platform:([A-Za-z_$][\w$]*)=process\.platform\}=\{\}\)\{return \4!==`win32`\|\|\3\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==`1`\?\2:\{\.\.\.\2,computerUse:!0,computerUseNodeRepl:!0\}\}/g;
   const currentWindowsOnlyFeaturePattern =
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`win32`&&([A-Za-z_$][\w$]*)\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.([A-Za-z_$][\w$]*),computerUse:!0,computerUseNodeRepl:!0\}:\4,/;
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`win32`&&([A-Za-z_$][\w$]*)\.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===`1`\?\{\.\.\.([A-Za-z_$][\w$]*),computerUse:!0,computerUseNodeRepl:!0\}:\4,/g;
+
+  let changed = false;
+  let patchedSource = currentSource.replace(
+    windowsOnlyFeaturePattern,
+    (_, fnName, featuresVar, envVar, platformVar) => {
+      changed = true;
+      return `function ${fnName}(${featuresVar},{env:${envVar}=process.env,platform:${platformVar}=process.platform}={}){return ${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}!==\`win32\`||${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==\`1\`?${featuresVar}:{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}}`;
+    },
+  );
+  patchedSource = patchedSource.replace(
+    currentWindowsOnlyFeaturePattern,
+    (_, gateVar, platformVar, envVar, featuresVar) => {
+      changed = true;
+      return `let ${gateVar}=${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}===\`win32\`&&${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===\`1\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${featuresVar},`;
+    },
+  );
+
+  if (changed) {
+    return patchedSource;
+  }
 
   if (patchedFeaturePattern.test(currentSource) || currentPatchedFeaturePattern.test(currentSource)) {
     return currentSource;
-  }
-
-  if (windowsOnlyFeaturePattern.test(currentSource)) {
-    return currentSource.replace(
-      windowsOnlyFeaturePattern,
-      (_, fnName, featuresVar, envVar, platformVar) =>
-        `function ${fnName}(${featuresVar},{env:${envVar}=process.env,platform:${platformVar}=process.platform}={}){return ${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}!==\`win32\`||${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE!==\`1\`?${featuresVar}:{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}}`,
-    );
-  }
-
-  if (currentWindowsOnlyFeaturePattern.test(currentSource)) {
-    return currentSource.replace(
-      currentWindowsOnlyFeaturePattern,
-      (_, gateVar, platformVar, envVar, featuresVar) =>
-        `let ${gateVar}=${platformVar}===\`linux\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${platformVar}===\`win32\`&&${envVar}.CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE===\`1\`?{...${featuresVar},computerUse:!0,computerUseNodeRepl:!0}:${featuresVar},`,
-    );
   }
 
   if (currentSource.includes("CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE")) {
@@ -191,21 +203,22 @@ function applyLinuxComputerUseFeaturePatch(currentSource) {
 
 function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
   let patchedSource = currentSource;
+  let changed = false;
 
   const platformPredicateNeedle = "function hae(e){return e===`macOS`||e===`windows`}";
   const platformPredicatePatch =
     "function hae(e){return e===`macOS`||e===`windows`||e===`linux`}";
   const currentPlatformPredicateNeedle =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2===`macOS`\|\|\2===`windows`\}/;
-  const currentPlatformPredicatePatch = (_, fnName, platformVar) =>
-    `function ${fnName}(${platformVar}){return ${platformVar}===\`macOS\`||${platformVar}===\`windows\`||${platformVar}===\`linux\`}`;
-  if (patchedSource.includes(platformPredicatePatch)) {
-    // Already patched.
-  } else if (patchedSource.includes(platformPredicateNeedle)) {
-    patchedSource = patchedSource.replace(platformPredicateNeedle, platformPredicatePatch);
-  } else if (currentPlatformPredicateNeedle.test(patchedSource)) {
-    patchedSource = patchedSource.replace(currentPlatformPredicateNeedle, currentPlatformPredicatePatch);
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2===`macOS`\|\|\2===`windows`\}/g;
+  const currentPlatformPredicatePatch = (_, fnName, platformVar) => {
+    changed = true;
+    return `function ${fnName}(${platformVar}){return ${platformVar}===\`macOS\`||${platformVar}===\`windows\`||${platformVar}===\`linux\`}`;
+  };
+  if (patchedSource.includes(platformPredicateNeedle)) {
+    patchedSource = patchedSource.split(platformPredicateNeedle).join(platformPredicatePatch);
+    changed = true;
   }
+  patchedSource = patchedSource.replace(currentPlatformPredicateNeedle, currentPlatformPredicatePatch);
 
   const availabilityNeedle =
     "let m=a&&i&&s===`electron`&&u&&(c||p),h=m&&!c&&f.enabled&&!f.isLoading,g=m&&f.isLoading,_=m&&(c||f.isLoading),v;";
@@ -213,28 +226,26 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
     "let m=a&&i&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;";
   const availabilityPatch =
     "let m=a&&(i||l===`linux`)&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;";
-  if (patchedSource.includes(availabilityPatch)) {
-    return patchedSource;
-  }
-
   if (patchedSource.includes(availabilityHostLocalLinuxPatch)) {
-    return patchedSource.replace(availabilityHostLocalLinuxPatch, availabilityPatch);
+    patchedSource = patchedSource.split(availabilityHostLocalLinuxPatch).join(availabilityPatch);
+    changed = true;
   }
-
   if (patchedSource.includes(availabilityNeedle)) {
-    return patchedSource.replace(availabilityNeedle, availabilityPatch);
+    patchedSource = patchedSource.split(availabilityNeedle).join(availabilityPatch);
+    changed = true;
   }
 
   const currentAvailabilityNeedle =
     "let _=a&&i&&l&&(o||m),v=_&&!o&&p.enabled&&!p.isLoading,y=_&&p.isLoading,b=_&&(o||p.isLoading),x;";
   const currentAvailabilityPatch =
     "let _=a&&i&&(c===`linux`||l&&(o||m)),v=_&&!o&&(c===`linux`||p.enabled)&&!p.isLoading,y=_&&c!==`linux`&&p.isLoading,b=_&&(o||c!==`linux`&&p.isLoading),x;";
-  if (patchedSource.includes(currentAvailabilityPatch)) {
-    return patchedSource;
+  if (patchedSource.includes(currentAvailabilityNeedle)) {
+    patchedSource = patchedSource.split(currentAvailabilityNeedle).join(currentAvailabilityPatch);
+    changed = true;
   }
 
-  if (patchedSource.includes(currentAvailabilityNeedle)) {
-    return patchedSource.replace(currentAvailabilityNeedle, currentAvailabilityPatch);
+  if (changed || patchedSource.includes(availabilityPatch) || patchedSource.includes(currentAvailabilityPatch)) {
+    return patchedSource;
   }
 
   if (currentSource.includes("featureName:`computer_use`") && currentSource.includes("isComputerUseAvailable")) {
@@ -252,26 +263,30 @@ function applyLinuxComputerUseInstallFlowPatch(currentSource) {
   const availabilityPatch =
     "ne=f({featureName:`computer_use`,hostId:t}),re=!ne.isLoading&&ne.enabled||navigator.userAgent.includes(`Linux`),";
   const currentAvailabilityPattern =
-    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\{featureName:`computer_use`,hostId:([^}]+)\}\),([^;]{0,300}?)([A-Za-z_$][\w$]*)=!\1\.isLoading&&\1\.enabled,/;
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\{featureName:`computer_use`,hostId:([^}]+)\}\),([^;]{0,300}?)([A-Za-z_$][\w$]*)=!\1\.isLoading&&\1\.enabled,/g;
 
-  if (currentSource.includes(availabilityPatch)) {
-    return currentSource;
+  let changed = false;
+  let patchedSource = currentSource;
+
+  if (patchedSource.includes(availabilityNeedle)) {
+    patchedSource = patchedSource.split(availabilityNeedle).join(availabilityPatch);
+    changed = true;
   }
 
-  if (currentSource.includes(availabilityNeedle)) {
-    return currentSource.replace(availabilityNeedle, availabilityPatch);
+  patchedSource = patchedSource.replace(
+    currentAvailabilityPattern,
+    (_, queryVar, queryFn, hostExpr, between, availableVar) => {
+      changed = true;
+      return `${queryVar}=${queryFn}({featureName:\`computer_use\`,hostId:${hostExpr}}),${between}${availableVar}=!${queryVar}.isLoading&&${queryVar}.enabled||navigator.userAgent.includes(\`Linux\`),`;
+    },
+  );
+
+  if (changed) {
+    return patchedSource;
   }
 
   if (/=[^=]+\.isLoading&&[^=]+\.enabled\|\|navigator\.userAgent\.includes\(`Linux`\),/.test(currentSource)) {
     return currentSource;
-  }
-
-  if (currentAvailabilityPattern.test(currentSource)) {
-    return currentSource.replace(
-      currentAvailabilityPattern,
-      (_, queryVar, queryFn, hostExpr, between, availableVar) =>
-        `${queryVar}=${queryFn}({featureName:\`computer_use\`,hostId:${hostExpr}}),${between}${availableVar}=!${queryVar}.isLoading&&${queryVar}.enabled||navigator.userAgent.includes(\`Linux\`),`,
-    );
   }
 
   if (currentSource.includes("featureName:`computer_use`")) {

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -203,7 +203,8 @@ function applyLinuxComputerUseFeaturePatch(currentSource) {
 
 function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
   let patchedSource = currentSource;
-  let changed = false;
+  let platformPredicateChanged = false;
+  let availabilityChanged = false;
 
   const platformPredicateNeedle = "function hae(e){return e===`macOS`||e===`windows`}";
   const platformPredicatePatch =
@@ -211,12 +212,12 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
   const currentPlatformPredicateNeedle =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2===`macOS`\|\|\2===`windows`\}/g;
   const currentPlatformPredicatePatch = (_, fnName, platformVar) => {
-    changed = true;
+    platformPredicateChanged = true;
     return `function ${fnName}(${platformVar}){return ${platformVar}===\`macOS\`||${platformVar}===\`windows\`||${platformVar}===\`linux\`}`;
   };
   if (patchedSource.includes(platformPredicateNeedle)) {
     patchedSource = patchedSource.split(platformPredicateNeedle).join(platformPredicatePatch);
-    changed = true;
+    platformPredicateChanged = true;
   }
   patchedSource = patchedSource.replace(currentPlatformPredicateNeedle, currentPlatformPredicatePatch);
 
@@ -228,11 +229,11 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
     "let m=a&&(i||l===`linux`)&&s===`electron`&&(l===`linux`||u&&(c||p)),h=m&&!c&&(l===`linux`||f.enabled)&&!f.isLoading,g=m&&l!==`linux`&&f.isLoading,_=m&&(c||l!==`linux`&&f.isLoading),v;";
   if (patchedSource.includes(availabilityHostLocalLinuxPatch)) {
     patchedSource = patchedSource.split(availabilityHostLocalLinuxPatch).join(availabilityPatch);
-    changed = true;
+    availabilityChanged = true;
   }
   if (patchedSource.includes(availabilityNeedle)) {
     patchedSource = patchedSource.split(availabilityNeedle).join(availabilityPatch);
-    changed = true;
+    availabilityChanged = true;
   }
 
   const currentAvailabilityNeedle =
@@ -241,10 +242,10 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
     "let _=a&&i&&(c===`linux`||l&&(o||m)),v=_&&!o&&(c===`linux`||p.enabled)&&!p.isLoading,y=_&&c!==`linux`&&p.isLoading,b=_&&(o||c!==`linux`&&p.isLoading),x;";
   if (patchedSource.includes(currentAvailabilityNeedle)) {
     patchedSource = patchedSource.split(currentAvailabilityNeedle).join(currentAvailabilityPatch);
-    changed = true;
+    availabilityChanged = true;
   }
 
-  if (changed || patchedSource.includes(availabilityPatch) || patchedSource.includes(currentAvailabilityPatch)) {
+  if (availabilityChanged || patchedSource.includes(availabilityPatch) || patchedSource.includes(currentAvailabilityPatch)) {
     return patchedSource;
   }
 
@@ -252,9 +253,10 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
     console.warn(
       "WARN: Could not find Computer Use renderer availability gate — skipping Linux Computer Use UI availability patch",
     );
+    return currentSource;
   }
 
-  return patchedSource;
+  return platformPredicateChanged ? patchedSource : currentSource;
 }
 
 function applyLinuxComputerUseInstallFlowPatch(currentSource) {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -70,12 +70,12 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
   const windowOptionsReplacement =
     `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
 
-  if (currentSource.includes(iconPathNeedle)) {
-    return currentSource;
+  if (currentSource.includes(windowOptionsNeedle)) {
+    return currentSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
   }
 
-  if (currentSource.includes(windowOptionsNeedle)) {
-    return currentSource.replace(windowOptionsNeedle, windowOptionsReplacement);
+  if (currentSource.includes(iconPathNeedle)) {
+    return currentSource;
   }
 
   console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
@@ -85,17 +85,20 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
 function applyLinuxMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
   let patchedAny = false;
-  const patchedSource = currentSource.replace(menuRegex, (match, windowVar) => {
+  const patchedSource = currentSource.replace(menuRegex, (match, windowVar, offset) => {
     const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
-    if (currentSource.includes(`${linuxPatch}${match}`)) {
+    if (currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
       return match;
     }
     patchedAny = true;
     return `${linuxPatch}${match}`;
   });
 
-  if (!patchedAny && menuRegex.test(currentSource) && !currentSource.includes("setMenuBarVisibility(!1),process.platform===`win32`")) {
-    console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
+  if (!patchedAny && !currentSource.includes("setMenuBarVisibility(!1)")) {
+    const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(currentSource);
+    if (hasWindowsRemoveMenu) {
+      console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
+    }
   }
 
   return patchedSource;
@@ -107,22 +110,27 @@ function applyLinuxSetIconPatch(currentSource, iconAsset) {
   }
 
   const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
+  const readyRegex = /([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/g;
+  let patchedAny = false;
+  const patchedSource = currentSource.replace(readyRegex, (match, windowVar, offset) => {
+    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setIcon(${iconPathExpression}),`;
+    if (currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
+      return match;
+    }
+    patchedAny = true;
+    return `${linuxPatch}${match}`;
+  });
+
+  if (patchedAny) {
+    return patchedSource;
+  }
+
   if (currentSource.includes(`setIcon(${iconPathExpression})`)) {
     return currentSource;
   }
 
-  const readyRegex = /([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/;
-  const match = currentSource.match(readyRegex);
-  if (match == null) {
-    console.warn("WARN: Could not find window setIcon insertion point — skipping setIcon patch");
-    return currentSource;
-  }
-
-  const windowVar = match[1];
-  return currentSource.replace(
-    readyRegex,
-    `process.platform===\`linux\`&&${windowVar}.setIcon(${iconPathExpression}),${match[0]}`,
-  );
+  console.warn("WARN: Could not find window setIcon insertion point — skipping setIcon patch");
+  return currentSource;
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
@@ -290,24 +298,26 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
     "(()=>{let codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all([...u.values()].map(e=>e.flush()));" +
     `if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}` +
     "codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()";
-
-  if (patchedSource.includes("codexLinuxDrainPromise=Promise.all([...u.values()].map(e=>e.flush()))")) {
-    return patchedSource;
-  }
+  let patchedAny = false;
 
   if (patchedSource.includes(originalDrainSnippet)) {
-    return patchedSource.replace(originalDrainSnippet, patchedDrainSnippet);
+    patchedAny = true;
+    patchedSource = patchedSource.split(originalDrainSnippet).join(patchedDrainSnippet);
   }
 
   const drainRegex =
-    /Promise\.all\(\[\.\.\.([A-Za-z_$][\w$]*)\.values\(\)\]\.map\(e=>e\.flush\(\)\)\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/;
-  if (drainRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      drainRegex,
-      (_match, globalStatesVar, flushDisposeVar, disposablesVar, electronVar) =>
-        `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([...${globalStatesVar}.values()].map(e=>e.flush()));if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`,
-    );
-  } else if (
+    /Promise\.all\(\[\.\.\.([A-Za-z_$][\w$]*)\.values\(\)\]\.map\(e=>e\.flush\(\)\)\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
+  patchedSource = patchedSource.replace(
+    drainRegex,
+    (_match, globalStatesVar, flushDisposeVar, disposablesVar, electronVar) => {
+      patchedAny = true;
+      return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([...${globalStatesVar}.values()].map(e=>e.flush()));if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
+    },
+  );
+
+  if (
+    !patchedAny &&
+    !patchedSource.includes("codexLinuxDrainPromise=Promise.all(") &&
     patchedSource.includes("n.app.on(`will-quit`,") &&
     patchedSource.includes(".map(e=>e.flush())")
   ) {
@@ -328,23 +338,25 @@ function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
   const beforeQuitPatch =
     `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}`;
   const beforeQuitRegex =
-    /if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/;
-
-  if (patchedSource.includes(promptBypassGuard)) {
-    return patchedSource;
-  }
+    /if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
+  let patchedAny = false;
 
   if (patchedSource.includes(beforeQuitNeedle)) {
-    return patchedSource.replace(beforeQuitNeedle, beforeQuitPatch);
+    patchedAny = true;
+    patchedSource = patchedSource.split(beforeQuitNeedle).join(beforeQuitPatch);
   }
 
-  if (beforeQuitRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      beforeQuitRegex,
-      (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) =>
-        `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`,
-    );
-  } else if (
+  patchedSource = patchedSource.replace(
+    beforeQuitRegex,
+    (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
+      patchedAny = true;
+      return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
+    },
+  );
+
+  if (
+    !patchedAny &&
+    !patchedSource.includes(promptBypassGuard) &&
     patchedSource.includes("showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`]") &&
     patchedSource.includes(".canQuitWithoutPrompt()")
   ) {
@@ -365,26 +377,31 @@ function applyLinuxExplicitTrayQuitPatch(currentSource) {
   const patchedTrayQuitRegex =
     /\{label:[^{}]+,click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\)\}\}/;
   const trayQuitRegex =
-    /\{label:rB\(([^)]+)\),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/;
+    /\{label:rB\(([^)]+)\),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
   const genericTrayQuitRegex =
-    /\{label:([A-Za-z_$][\w$]*\(this\.appName\)),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/;
-  if (patchedSource.includes(trayQuitPatch) || patchedTrayQuitRegex.test(patchedSource)) {
-    // Already patched.
-  } else if (patchedSource.includes(trayQuitNeedle)) {
-    patchedSource = patchedSource.replace(trayQuitNeedle, trayQuitPatch);
-  } else if (trayQuitRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      trayQuitRegex,
-      (_match, appNameExpr, electronVar) =>
-        `{label:rB(${appNameExpr}),click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`,
-    );
-  } else if (genericTrayQuitRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      genericTrayQuitRegex,
-      (_match, labelExpression, electronVar) =>
-        `{label:${labelExpression},click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`,
-    );
-  } else if (
+    /\{label:([A-Za-z_$][\w$]*\(this\.appName\)),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
+  let patchedAny = false;
+  if (patchedSource.includes(trayQuitNeedle)) {
+    patchedAny = true;
+    patchedSource = patchedSource.split(trayQuitNeedle).join(trayQuitPatch);
+  }
+  patchedSource = patchedSource.replace(
+    trayQuitRegex,
+    (_match, appNameExpr, electronVar) => {
+      patchedAny = true;
+      return `{label:rB(${appNameExpr}),click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
+    },
+  );
+  patchedSource = patchedSource.replace(
+    genericTrayQuitRegex,
+    (_match, labelExpression, electronVar) => {
+      patchedAny = true;
+      return `{label:${labelExpression},click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
+    },
+  );
+  if (
+    !patchedAny &&
+    !patchedTrayQuitRegex.test(patchedSource) &&
     patchedSource.includes("getNativeTrayMenuItems(){") &&
     (patchedSource.includes("label:rB(") || patchedSource.includes("role:`quit`"))
   ) {
@@ -402,18 +419,22 @@ function applyLinuxExplicitIpcQuitPatch(currentSource) {
   const quitAppNeedle = "if(o.type===`quit-app`){n.app.quit();return}";
   const quitAppPatch = `if(o.type===\`quit-app\`){${quitMarkerExpression}n.app.quit();return}`;
   const quitAppRegex =
-    /if\(([A-Za-z_$][\w$]*)\.type===`quit-app`\)\{([A-Za-z_$][\w$]*)\.app\.quit\(\);return\}/;
-  if (patchedSource.includes(quitAppPatch)) {
-    // Already patched.
-  } else if (patchedSource.includes(quitAppNeedle)) {
-    patchedSource = patchedSource.replace(quitAppNeedle, quitAppPatch);
-  } else if (quitAppRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      quitAppRegex,
-      (_match, messageVar, electronVar) =>
-        `if(${messageVar}.type===\`quit-app\`){${quitMarkerExpression}${electronVar}.app.quit();return}`,
-    );
-  } else if (patchedSource.includes("type===`quit-app`")) {
+    /if\(([A-Za-z_$][\w$]*)\.type===`quit-app`\)\{([A-Za-z_$][\w$]*)\.app\.quit\(\);return\}/g;
+  const patchedQuitAppRegex =
+    /if\([A-Za-z_$][\w$]*\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\);return\}/;
+  let patchedAny = false;
+  if (patchedSource.includes(quitAppNeedle)) {
+    patchedAny = true;
+    patchedSource = patchedSource.split(quitAppNeedle).join(quitAppPatch);
+  }
+  patchedSource = patchedSource.replace(
+    quitAppRegex,
+    (_match, messageVar, electronVar) => {
+      patchedAny = true;
+      return `if(${messageVar}.type===\`quit-app\`){${quitMarkerExpression}${electronVar}.app.quit();return}`;
+    },
+  );
+  if (!patchedAny && !patchedQuitAppRegex.test(patchedSource) && patchedSource.includes("type===`quit-app`")) {
     console.warn("WARN: Could not find quit-app IPC handler — skipping Linux explicit quit-app patch");
   }
 
@@ -641,57 +662,56 @@ function applyLinuxSingleInstancePatch(currentSource) {
 function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   const approvalPatch =
     "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
-  if (currentSource.includes(approvalPatch)) {
-    return currentSource;
-  }
-
   const needle = "startup_timeout_sec:120,env:{";
   if (!currentSource.includes(needle)) {
-    console.warn(
-      "WARN: Could not find Browser Use node_repl config insertion point — skipping node_repl approval patch",
-    );
-    return currentSource;
-  }
-
-  return currentSource.replace(needle, approvalPatch);
-}
-
-function applyLinuxBrowserUseIabVisibleOnCreatePatch(currentSource) {
-  const marker = "codexLinuxBrowserUseAutoVisible";
-  if (currentSource.includes(marker)) {
-    return currentSource;
-  }
-
-  const visibilityExpr = (hostExpr, sessionExpr) =>
-    `(()=>{try{${hostExpr}.setBrowserVisibleForBrowserUse(!0,${sessionExpr}.turnId)}catch(__codexLinuxErr){console.warn("${marker}",__codexLinuxErr?.message??__codexLinuxErr)}})()`;
-  const createTabRegex =
-    /if\(([A-Za-z_$][\w$]*)!=null\)return await this\.navigateTabToInitialPage\(\1\),this\.serializeTab\(\1\);let ([A-Za-z_$][\w$]*)=this\.getRequiredBrowserHost\(([A-Za-z_$][\w$]*)\);\2\.setBrowserUseActive\(!0,\3\.turnId\);let ([A-Za-z_$][\w$]*)=await \2\.openPageForBrowserUse\(\{startingUrl:this\.initialPageUrl,turnId:\3\.turnId\}\),([A-Za-z_$][\w$]*)=this\.updateTabForPage\(\4,\2\.routeKey\);return/;
-  const match = currentSource.match(createTabRegex);
-  if (match == null) {
-    if (
-      currentSource.includes("createTabForBrowserUse") &&
-      currentSource.includes("openPageForBrowserUse")
-    ) {
+    if (!currentSource.includes(approvalPatch)) {
       console.warn(
-        "WARN: Could not find Browser Use IAB tab creation point — skipping Linux IAB visibility patch",
+        "WARN: Could not find Browser Use node_repl config insertion point — skipping node_repl approval patch",
       );
     }
     return currentSource;
   }
 
-  const [needle, tabVar, hostVar, sessionVar, pageVar, tabInfoVar] = match;
-  const activeTabVisibility = visibilityExpr(
-    `this.getRequiredBrowserHost(${sessionVar})`,
-    sessionVar,
-  );
-  const newTabVisibility = visibilityExpr(hostVar, sessionVar);
-  const replacement =
-    `if(${tabVar}!=null)return await this.navigateTabToInitialPage(${tabVar}),${activeTabVisibility},this.serializeTab(${tabVar});` +
-    `let ${hostVar}=this.getRequiredBrowserHost(${sessionVar});${hostVar}.setBrowserUseActive(!0,${sessionVar}.turnId);` +
-    `let ${pageVar}=await ${hostVar}.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:${sessionVar}.turnId}),${tabInfoVar}=this.updateTabForPage(${pageVar},${hostVar}.routeKey);` +
-    `return ${newTabVisibility},`;
+  return currentSource.split(needle).join(approvalPatch);
+}
 
-  return currentSource.replace(needle, replacement);
+function applyLinuxBrowserUseIabVisibleOnCreatePatch(currentSource) {
+  const marker = "codexLinuxBrowserUseAutoVisible";
+  const visibilityExpr = (hostExpr, sessionExpr) =>
+    `(()=>{try{${hostExpr}.setBrowserVisibleForBrowserUse(!0,${sessionExpr}.turnId)}catch(__codexLinuxErr){console.warn("${marker}",__codexLinuxErr?.message??__codexLinuxErr)}})()`;
+  const createTabRegex =
+    /if\(([A-Za-z_$][\w$]*)!=null\)return await this\.navigateTabToInitialPage\(\1\),this\.serializeTab\(\1\);let ([A-Za-z_$][\w$]*)=this\.getRequiredBrowserHost\(([A-Za-z_$][\w$]*)\);\2\.setBrowserUseActive\(!0,\3\.turnId\);let ([A-Za-z_$][\w$]*)=await \2\.openPageForBrowserUse\(\{startingUrl:this\.initialPageUrl,turnId:\3\.turnId\}\),([A-Za-z_$][\w$]*)=this\.updateTabForPage\(\4,\2\.routeKey\);return/g;
+  let changed = false;
+  const patchedSource = currentSource.replace(
+    createTabRegex,
+    (needle, tabVar, hostVar, sessionVar, pageVar, tabInfoVar) => {
+      changed = true;
+      const activeTabVisibility = visibilityExpr(
+        `this.getRequiredBrowserHost(${sessionVar})`,
+        sessionVar,
+      );
+      const newTabVisibility = visibilityExpr(hostVar, sessionVar);
+      return (
+        `if(${tabVar}!=null)return await this.navigateTabToInitialPage(${tabVar}),${activeTabVisibility},this.serializeTab(${tabVar});` +
+        `let ${hostVar}=this.getRequiredBrowserHost(${sessionVar});${hostVar}.setBrowserUseActive(!0,${sessionVar}.turnId);` +
+        `let ${pageVar}=await ${hostVar}.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:${sessionVar}.turnId}),${tabInfoVar}=this.updateTabForPage(${pageVar},${hostVar}.routeKey);` +
+        `return ${newTabVisibility},`
+      );
+    },
+  );
+  if (changed || currentSource.includes(marker)) {
+    return patchedSource;
+  }
+
+  if (
+    currentSource.includes("createTabForBrowserUse") &&
+    currentSource.includes("openPageForBrowserUse")
+  ) {
+    console.warn(
+      "WARN: Could not find Browser Use IAB tab creation point — skipping Linux IAB visibility patch",
+    );
+  }
+  return currentSource;
 }
 
 function applyLinuxChromeExtensionStatusPatch(currentSource) {


### PR DESCRIPTION
## Summary

Fixes a broader class of Linux bundle patch-helper regressions where one already-patched or first matching occurrence could leave later matching snippets unpatched in the same source.

Covered helpers now patch all matching eligible occurrences in one pass:

- Linux BrowserWindow icon/menu/quit helper paths
- Linux Computer Use plugin/feature/renderer/install-flow gates
- Browser Use node_repl approval config
- Browser Use IAB visibility tab-creation path

## Tests

- `node --test scripts/patch-linux-window-ui.test.js` — 120 pass
- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- Added-line secret scan — no findings
- Independent diff review — passed, no blockers/security issues

Diff size: 3 files, 413 insertions / 193 deletions, 606 total changed LOC (< 1000).
