### PR TITLE
fix: avoid unsupported app-server feature sync during connector login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - The bundled Chrome plugin is now auto-installed during app startup, matching Browser Use, so the plugin page no longer falls back to an install button after restart when the Linux native host is already staged.
 - Nix builds, installer apps, and dev shells now use modern `7zz`, and the installer dependency check accepts `7zz` without requiring a separate legacy `7z` binary.
 - Codex Desktop no longer removes user-enabled `remote_control = true` from the local Linux config before starting the app server.
+- Linux webview bundles no longer ask current Codex CLI app servers to enable unsupported feature flags, avoiding connector authentication sync errors.
 
 ## [0.8.0] - 2026-05-16
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -63,6 +63,7 @@ const {
 } = require("./ci/validate-patch-report.js");
 const {
   applyPersistentRateLimitFooterPatch,
+  applyLinuxAppServerFeatureEnablementPatch,
 } = require("./patches/webview-assets.js");
 const { patchAssetFiles } = require("./patches/shared.js");
 
@@ -292,6 +293,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-hotkey-window-prewarm",
     "linux-git-origins-source-fallback",
     "linux-app-sunset-gate",
+    "linux-app-server-feature-enablement",
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "opaque-window-default-resolved-theme",
@@ -1259,6 +1261,62 @@ test("warns when the app sunset key is present but the gate shape drifts", () =>
   assert.equal(patched, appSunsetBundleWithDriftingGateFixture());
   assert.deepEqual(warnings, [
     "WARN: Could not find app sunset gate needle — skipping Linux app sunset patch",
+  ]);
+});
+
+test("removes unsupported features from default app-server feature sync", () => {
+  const source = [
+    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];",
+    "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
+    "return e[0]!==r?(a=()=>{let r=qF(n);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r}).catch(n=>{q.error(`Failed to sync experimental feature enablement`,{sensitive:{error:n}})})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
+    "function qF(e){let t={};for(let n of GF){let r=e[n];r!=null&&(t[n]=r)}return t}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
+
+  assert.match(
+    patched,
+    /var GF=\[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`\];/,
+  );
+  assert.doesNotMatch(patched, /`auth_elicitation`/);
+  assert.doesNotMatch(patched, /`enable_mcp_apps`/);
+  assert.doesNotMatch(patched, /,te\]/);
+});
+
+test("patches the matched app-server feature sync array when an identical array appears earlier", () => {
+  const unsupportedFeatureArray =
+    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];";
+  const supportedFeatureArray =
+    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`];";
+  const source = [
+    unsupportedFeatureArray,
+    "function OF(){return GF}",
+    unsupportedFeatureArray,
+    "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
+    "return e[0]!==r?(a=()=>{let r=qF(n);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
+
+  assert.equal(patched.indexOf(unsupportedFeatureArray), 0);
+  assert.match(patched, new RegExp(`${escapeRegExp(unsupportedFeatureArray)}function OF`));
+  assert.match(patched, new RegExp(`function OF\\(\\)\\{return GF\\}${escapeRegExp(supportedFeatureArray)}function KF`));
+});
+
+test("warns when app-server feature sync still has unsupported features but the list shape drifts", () => {
+  const source = [
+    "var GF=new Set([`apps`,unsupportedAuthFeature]);",
+    "function KF(){let e=ts(`statsig_default_enable_features`);",
+    "return qn(`set-experimental-feature-enablement-for-host`,{enablement:{name:`auth_elicitation`}})}",
+  ].join("");
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxAppServerFeatureEnablementPatch(source),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find app-server feature enablement list — skipping unsupported feature compatibility patch",
   ]);
 });
 

--- a/scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const {
+  applyLinuxAppServerFeatureEnablementPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "linux-app-server-feature-enablement",
+    phase: "webview-asset",
+    order: 1040,
+    ciPolicy: "optional",
+    pattern: /^(app-main|index)-.*\.js$/,
+    missingDescription: "webview app main bundle",
+    skipDescription: "app-server feature enablement compatibility patch",
+    apply: applyLinuxAppServerFeatureEnablementPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -151,6 +151,69 @@ function applyLinuxAppSunsetPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
+  const supportedFeatures = new Set([
+    "apps",
+    "memories",
+    "plugins",
+    "remote_control",
+    "tool_call_mcp_elicitation",
+    "tool_search",
+    "tool_suggest",
+  ]);
+  const defaultFeaturesMarker = "statsig_default_enable_features";
+  const syncMethodMarker = "set-experimental-feature-enablement-for-host";
+  if (
+    !currentSource.includes(defaultFeaturesMarker) ||
+    !currentSource.includes(syncMethodMarker)
+  ) {
+    return currentSource;
+  }
+
+  const featureArrayRegex =
+    /var ([A-Za-z_$][\w$]*)=\[([^\]]*?)\];function ([A-Za-z_$][\w$]*)\(\)\{let [\s\S]{0,2400}?statsig_default_enable_features[\s\S]{0,2400}?set-experimental-feature-enablement-for-host/u;
+  const featureArrayMatch = currentSource.match(featureArrayRegex);
+
+  if (featureArrayMatch == null) {
+    console.warn(
+      "WARN: Could not find app-server feature enablement list — skipping unsupported feature compatibility patch",
+    );
+    return currentSource;
+  }
+
+  const [, arrayVar, featureArrayItems] = featureArrayMatch;
+  const supportedFeatureArrayItems = featureArrayItems
+    .split(",")
+    .filter((entry) => {
+      const featureMatch = entry.trim().match(/^`([^`]+)`$/u);
+      return featureMatch != null && supportedFeatures.has(featureMatch[1]);
+    })
+    .join(",");
+  if (supportedFeatureArrayItems === featureArrayItems) {
+    return currentSource;
+  }
+
+  const featureArrayNeedle = `var ${arrayVar}=[${featureArrayItems}];`;
+  const featureArrayPatch = `var ${arrayVar}=[${supportedFeatureArrayItems}];`;
+  const featureArrayIndex = featureArrayMatch.index;
+  if (
+    featureArrayIndex == null ||
+    currentSource.slice(featureArrayIndex, featureArrayIndex + featureArrayNeedle.length) !==
+      featureArrayNeedle
+  ) {
+    console.warn(
+      "WARN: Could not locate matched app-server feature enablement list — skipping unsupported feature compatibility patch",
+    );
+    return currentSource;
+  }
+
+  return [
+    currentSource.slice(0, featureArrayIndex),
+    featureArrayPatch,
+    currentSource.slice(featureArrayIndex + featureArrayNeedle.length),
+  ].join("");
+}
+
 function applyBrowserAnnotationScreenshotPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -464,6 +527,7 @@ function patchCommentPreloadBundle(extractedDir) {
 
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
+  applyLinuxAppServerFeatureEnablementPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,


### PR DESCRIPTION
## Problem

On Linux, Codex Desktop's webview syncs its Statsig default feature enablement to the local Codex CLI app-server. Current CLI app servers reject some feature keys present in the bundled webview assets, including `auth_elicitation`, `enable_mcp_apps`, and the default-list entry that resolves to `workspace_dependencies`.

This shows up during connector authentication flows such as Google/Gmail/Drive/Calendar login. After the browser OAuth flow returns, the app can log `unsupported feature enablement ...` and `Failed to sync experimental feature enablement`, leaving the connector auth state looking like it did not make it back into Codex Desktop.

## Root Cause

The Linux package reuses upstream webview assets whose default feature list assumes those keys can be sent to `set-experimental-feature-enablement-for-host`. The current local Codex CLI app-server only accepts a smaller allowlist for that method.

## Changes

- Adds a core Linux webview-asset patch for app-server feature enablement compatibility.
- Filters the default app-server feature sync array down to currently supported feature keys before the webview calls `set-experimental-feature-enablement-for-host`.
- Keeps the broader Statsig mapping data intact; only the default sync payload is filtered.
- Adds patch tests for the current minified bundle shape and drift warning behavior.
- Updates the changelog.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` passes: 112/112.
- `nix build .#codex-desktop --print-out-paths -L` succeeds.
- Inspected the packaged webview asset and confirmed the default sync array is reduced to `apps`, `memories`, `plugins`, `tool_call_mcp_elicitation`, `tool_search`, and `tool_suggest`.
- Launched the patched build side-by-side with the current local Codex CLI app-server and confirmed `experimentalFeature/enablement/set` returns `errorCode=null`.
- Manually tested Google connector login locally with the patched build; the login flow returned successfully and the logs no longer show `unsupported feature enablement` or `Failed to sync experimental feature enablement` for the connector flow.
