### PR TITLE
[codex] add opt-in Linux read aloud voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.dmg
 node_modules/
+__pycache__/
+*.py[cod]
 codex-app/
 codex-app.backup-*/
 codex-*-app/

--- a/linux-features/read-aloud/README.md
+++ b/linux-features/read-aloud/README.md
@@ -1,0 +1,129 @@
+# Read aloud
+
+Opt-in Linux read-aloud support for assistant responses.
+
+This feature stays thin. It does not bundle a voice model and it does not speak
+automatically. It adds an explicit icon button under assistant messages. A click
+is the only app-rendering path that starts speech.
+
+## Enable the feature
+
+Add the feature to `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["read-aloud"]
+}
+```
+
+Then rebuild/package the app. The installed app remains silent unless the user
+also enables the runtime opt-in:
+
+```bash
+mkdir -p ~/.config/codex-desktop
+node -e 'const fs=require("fs"),p=process.env.HOME+"/.config/codex-desktop/settings.json";let s={};try{s=JSON.parse(fs.readFileSync(p,"utf8"))}catch{}s["codex-linux-read-aloud-enabled"]=true;fs.writeFileSync(p,JSON.stringify(s,null,2)+"\n")'
+```
+
+or:
+
+```bash
+CODEX_LINUX_READ_ALOUD_ENABLED=1 codex-desktop
+```
+
+The generated General settings page also gets a disabled-by-default
+`Read aloud responses` toggle near the top of the page when the feature is
+enabled at build time. After the toggle is enabled, the row offers two explicit
+setup actions for machines where the default Kokoro paths are not ready:
+
+- `Choose folder` stores a folder that already contains `kokoro-v1.0.onnx` and
+  `voices-v1.0.bin`.
+- `Download voice` creates the default Python runtime and downloads the Kokoro
+  model files into the default data directory.
+- `Speech pace` controls Kokoro playback speed from `0.70x` to `1.40x`
+  and stores the value in `codex-linux-read-aloud-kokoro-speed`.
+
+Nothing is downloaded during app install or on first launch.
+
+## Conversation mode direction
+
+The current feature intentionally stops at an explicit output button. A
+higher-level conversation mode should be layered on top of this instead of
+hidden inside message rendering:
+
+- enter an explicit voice/conversation mode from the UI or by user instruction;
+- stream microphone audio through a separate opt-in STT component;
+- after a short quiet period, submit the transcribed user turn to Codex;
+- stream the assistant response into the voice backend as chunks become stable;
+- when the user starts talking again, call `stop` and steer the active response.
+
+That keeps the safe primitive small while leaving room for a real back-and-forth
+voice experience.
+
+## Voice model
+
+Default speech uses an opt-in Kokoro ONNX runtime, similar in shape to `readd`
+but not dependent on a local `readd` checkout. The app stages only a tiny runner.
+Users provide or download the model files and Python runtime outside the Electron
+bundle.
+
+Default paths:
+
+- Python runtime: `~/.local/share/codex-desktop/read-aloud/kokoro-venv/bin/python`
+- Model: `~/.local/share/kokoro/kokoro-v1.0.onnx`
+- Voices: `~/.local/share/kokoro/voices-v1.0.bin`
+
+Install the Python runtime and model files from the command line:
+
+```bash
+bash linux-features/read-aloud/install-kokoro-runtime.sh
+```
+
+Set `CODEX_LINUX_READ_ALOUD_SKIP_MODEL_DOWNLOAD=1` to install only the Python
+runtime.
+
+Runtime overrides:
+
+- `CODEX_LINUX_READ_ALOUD_KOKORO_PYTHON`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_MODEL`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_VOICES`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_VOICE`, default `bm_george`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_SPEED`, default `1.05`, clamped to `0.70`-`1.40`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_LANG`, default `en-us`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_THREADS`, default `4`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_FIRST_CHARS`, default `90`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_CHUNK_CHARS`, default `180`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_MODEL_URL`
+- `CODEX_LINUX_READ_ALOUD_KOKORO_VOICES_URL`
+
+Kokoro speech is chunk-streamed: the runner synthesizes a short first chunk and
+starts writing PCM to `aplay`, then prepares the next chunks while audio is
+already playing. It does not synthesize the whole assistant response before
+playback starts.
+
+The default downloads use Hugging Face-hosted Kokoro files that match the
+`kokoro-onnx` runtime shape:
+
+- `https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/kokoro-v1.0.onnx`
+- `https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/voices-v1.0.bin`
+
+The settings page has a `?` help affordance beside the setup actions. It
+summarizes the two supported setup paths: choose a local folder containing both
+files, or let Codex create the managed Python runtime and download the Hugging
+Face files into the default data directory.
+
+For private/local setups, a custom command can still be used. Codex writes the
+cleaned response text to stdin:
+
+```bash
+CODEX_LINUX_READ_ALOUD_COMMAND="/path/to/tts-stdin-command" codex-desktop
+```
+
+System TTS fallbacks are disabled by default because `spd-say` and `espeak-ng`
+are widely available but usually unpleasant. Enable them explicitly only when
+that tradeoff is acceptable:
+
+```bash
+CODEX_LINUX_READ_ALOUD_NATIVE_FALLBACK=1 codex-desktop
+```
+
+The handler never invokes a shell for response text.

--- a/linux-features/read-aloud/bin/kokoro-stdin
+++ b/linux-features/read-aloud/bin/kokoro-stdin
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+python_bin="${CODEX_LINUX_READ_ALOUD_KOKORO_PYTHON:-$data_home/codex-desktop/read-aloud/kokoro-venv/bin/python}"
+model="${CODEX_LINUX_READ_ALOUD_KOKORO_MODEL:-$data_home/kokoro/kokoro-v1.0.onnx}"
+voices="${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES:-$data_home/kokoro/voices-v1.0.bin}"
+runner_dir="$(cd "$(dirname "$0")" && pwd)"
+
+[ -x "$python_bin" ] || {
+    echo "Kokoro Python runtime not found: $python_bin" >&2
+    exit 127
+}
+[ -f "$model" ] || {
+    echo "Kokoro model not found: $model" >&2
+    exit 66
+}
+[ -f "$voices" ] || {
+    echo "Kokoro voices file not found: $voices" >&2
+    exit 66
+}
+command -v aplay >/dev/null 2>&1 || {
+    echo "aplay not found" >&2
+    exit 127
+}
+
+export CODEX_LINUX_READ_ALOUD_KOKORO_MODEL="$model"
+export CODEX_LINUX_READ_ALOUD_KOKORO_VOICES="$voices"
+exec "$python_bin" "$runner_dir/kokoro_stdin.py"

--- a/linux-features/read-aloud/bin/kokoro_stdin.py
+++ b/linux-features/read-aloud/bin/kokoro_stdin.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Read stdin aloud with Kokoro ONNX and aplay."""
+
+from __future__ import annotations
+
+import os
+import queue
+import re
+import subprocess
+import sys
+import threading
+
+
+def env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+
+
+def split_fragment_at_limit(text: str, max_chars: int) -> tuple[str, str]:
+    if len(text) <= max_chars:
+        return text, ""
+
+    cut = text.rfind(" ", 0, max_chars + 1)
+    if cut < max_chars // 2:
+        cut = max_chars
+    return text[:cut].strip(), text[cut:].strip()
+
+
+def split_for_streaming(text: str) -> list[str]:
+    first_chars = max(40, env_int("CODEX_LINUX_READ_ALOUD_KOKORO_FIRST_CHARS", 90))
+    chunk_chars = max(80, env_int("CODEX_LINUX_READ_ALOUD_KOKORO_CHUNK_CHARS", 180))
+    cleaned = text.strip()
+    sentences = re.split(r"(?<=[.!?])\s+", cleaned)
+    chunks: list[str] = []
+    current = ""
+    for sentence in sentences:
+        fragment = sentence.strip()
+        while fragment:
+            limit = first_chars if not chunks else chunk_chars
+            if current:
+                candidate = f"{current} {fragment}".strip()
+                if len(candidate) <= limit:
+                    current = candidate
+                    break
+                chunks.append(current.strip())
+                current = ""
+                continue
+
+            current, fragment = split_fragment_at_limit(fragment, limit)
+            if fragment:
+                chunks.append(current.strip())
+                current = ""
+    if current:
+        chunks.append(current.strip())
+    return chunks or ([cleaned] if cleaned else [])
+
+
+def enqueue(output: queue.Queue[object], item: object, stop_event: threading.Event) -> None:
+    while not stop_event.is_set():
+        try:
+            output.put(item, timeout=0.1)
+            return
+        except queue.Full:
+            continue
+
+
+def synthesize_chunks(
+    output: queue.Queue[object],
+    stop_event: threading.Event,
+    chunks: list[str],
+    model: str,
+    voices: str,
+    voice: str,
+    speed: float,
+    lang: str,
+) -> None:
+    try:
+        from kokoro_onnx import Kokoro  # type: ignore
+        import numpy as np
+
+        kokoro = Kokoro(model, voices)
+        for chunk in chunks:
+            if stop_event.is_set():
+                break
+            samples, _ = kokoro.create(chunk, voice=voice, speed=speed, lang=lang)
+            pcm = np.clip(samples, -1.0, 1.0)
+            enqueue(output, (pcm * 32767.0).astype("<i2").tobytes(), stop_event)
+    except Exception as exc:
+        enqueue(output, exc, stop_event)
+    finally:
+        enqueue(output, None, stop_event)
+
+
+def main() -> int:
+    threads = str(env_int("CODEX_LINUX_READ_ALOUD_KOKORO_THREADS", 4))
+    os.environ.setdefault("OMP_NUM_THREADS", threads)
+    os.environ.setdefault("ORT_NUM_THREADS", threads)
+
+    text = sys.stdin.read().strip()
+    if not text:
+        return 0
+
+    model = os.environ["CODEX_LINUX_READ_ALOUD_KOKORO_MODEL"]
+    voices = os.environ["CODEX_LINUX_READ_ALOUD_KOKORO_VOICES"]
+    voice = os.environ.get("CODEX_LINUX_READ_ALOUD_KOKORO_VOICE", "bm_george")
+    speed = min(1.4, max(0.7, env_float("CODEX_LINUX_READ_ALOUD_KOKORO_SPEED", 1.05)))
+    lang = os.environ.get("CODEX_LINUX_READ_ALOUD_KOKORO_LANG", "en-us")
+
+    sample_rate = 24000
+    player = subprocess.Popen(
+        ["aplay", "-q", "-r", str(sample_rate), "-c", "1", "-f", "S16_LE", "-t", "raw"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    chunks = split_for_streaming(text)
+    audio_queue: queue.Queue[object] = queue.Queue(maxsize=2)
+    stop_event = threading.Event()
+    worker = threading.Thread(
+        target=synthesize_chunks,
+        args=(audio_queue, stop_event, chunks, model, voices, voice, speed, lang),
+        daemon=True,
+    )
+    worker.start()
+
+    try:
+        assert player.stdin is not None
+        while True:
+            if player.poll() is not None:
+                break
+            item = audio_queue.get()
+            if item is None:
+                break
+            if isinstance(item, Exception):
+                return 1
+            if not isinstance(item, (bytes, bytearray, memoryview)):
+                return 1
+            player.stdin.write(item)
+            player.stdin.flush()
+        player.stdin.close()
+        player.wait(timeout=5)
+    except BrokenPipeError:
+        return 0
+    except subprocess.TimeoutExpired:
+        return 0
+    finally:
+        stop_event.set()
+        if player.poll() is None:
+            player.terminate()
+        worker.join(timeout=0.2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/linux-features/read-aloud/feature.json
+++ b/linux-features/read-aloud/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "read-aloud",
+  "name": "Read aloud",
+  "description": "Opt-in Linux read-aloud button for assistant responses.",
+  "entrypoints": {
+    "patches": "./patch.js",
+    "stageHook": "./stage.sh"
+  }
+}

--- a/linux-features/read-aloud/install-kokoro-runtime.sh
+++ b/linux-features/read-aloud/install-kokoro-runtime.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+venv="${CODEX_LINUX_READ_ALOUD_KOKORO_VENV:-$data_home/codex-desktop/read-aloud/kokoro-venv}"
+model="${CODEX_LINUX_READ_ALOUD_KOKORO_MODEL:-$data_home/kokoro/kokoro-v1.0.onnx}"
+voices="${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES:-$data_home/kokoro/voices-v1.0.bin}"
+model_url="${CODEX_LINUX_READ_ALOUD_KOKORO_MODEL_URL:-https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/kokoro-v1.0.onnx}"
+voices_url="${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES_URL:-https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/voices-v1.0.bin}"
+
+choose_python() {
+    local candidate
+    for candidate in "${PYTHON:-}" python3.12 python3.13 python3.11 python3.10 python3; do
+        [ -n "$candidate" ] || continue
+        command -v "$candidate" >/dev/null 2>&1 || continue
+        "$candidate" -c 'import sys; raise SystemExit(0 if (3, 10) <= sys.version_info < (3, 14) else 1)' >/dev/null 2>&1 && {
+            printf '%s\n' "$candidate"
+            return 0
+        }
+    done
+    return 1
+}
+
+download_file() {
+    local url="$1"
+    local target="$2"
+    local min_bytes="$3"
+    local tmp="$target.tmp"
+    local actual_bytes
+
+    [ -f "$target" ] && return 0
+    mkdir -p "$(dirname "$target")"
+    rm -f "$tmp"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl --fail --location --show-error --output "$tmp" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget --output-document "$tmp" "$url"
+    else
+        "$python_bin" - "$url" "$tmp" <<'PY'
+import sys
+import urllib.request
+urllib.request.urlretrieve(sys.argv[1], sys.argv[2])
+PY
+    fi
+
+    actual_bytes="$(wc -c < "$tmp" | tr -d ' ')"
+    if [ "${actual_bytes:-0}" -lt "$min_bytes" ]; then
+        rm -f "$tmp"
+        echo "Downloaded file is unexpectedly small: $url" >&2
+        exit 1
+    fi
+
+    mv "$tmp" "$target"
+}
+
+python_bin="$(choose_python || true)"
+[ -n "$python_bin" ] || {
+    echo "Python 3.10-3.13 is required for kokoro-onnx" >&2
+    exit 127
+}
+
+mkdir -p "$(dirname "$venv")"
+
+if command -v uv >/dev/null 2>&1; then
+    if [ ! -x "$venv/bin/python" ]; then
+        uv venv --python "$python_bin" "$venv"
+    fi
+    uv pip install --python "$venv/bin/python" 'kokoro-onnx>=0.5.0' 'numpy>=2.0.2'
+else
+    if [ ! -x "$venv/bin/python" ]; then
+        "$python_bin" -m venv "$venv"
+    fi
+    "$venv/bin/python" -m ensurepip --upgrade
+    "$venv/bin/python" -m pip install --upgrade pip
+    "$venv/bin/python" -m pip install 'kokoro-onnx>=0.5.0' 'numpy>=2.0.2'
+fi
+
+echo "Kokoro runtime installed at $venv" >&2
+
+if [ "${CODEX_LINUX_READ_ALOUD_SKIP_MODEL_DOWNLOAD:-0}" != "1" ]; then
+    download_file "$model_url" "$model" 50000000
+    download_file "$voices_url" "$voices" 1000000
+    echo "Kokoro model installed at $model" >&2
+    echo "Kokoro voices installed at $voices" >&2
+else
+    echo "Place kokoro-v1.0.onnx and voices-v1.0.bin under $data_home/kokoro" >&2
+fi

--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -1,0 +1,503 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  requireName,
+} = require("../../scripts/patches/shared.js");
+
+const SETTINGS_KEY = "codex-linux-read-aloud-enabled";
+const KOKORO_MODEL_KEY = "codex-linux-read-aloud-kokoro-model";
+const KOKORO_PYTHON_KEY = "codex-linux-read-aloud-kokoro-python";
+const KOKORO_SPEED_KEY = "codex-linux-read-aloud-kokoro-speed";
+const KOKORO_VOICES_KEY = "codex-linux-read-aloud-kokoro-voices";
+const KOKORO_MODEL_URL =
+  "https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/kokoro-v1.0.onnx";
+const KOKORO_VOICES_URL =
+  "https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/voices-v1.0.bin";
+const HELPER_MARKER = "codexLinuxReadAloudClick";
+const SETUP_MARKER = "codexLinuxReadAloudSetup";
+const HANDLER_NAME = "linux-read-aloud";
+const RUNTIME_VERSION = "kokoro-explicit-v3";
+const READ_ALOUD_SETTINGS_SLUG = "read-aloud-settings";
+const GENERAL_SETTINGS_ROW_CALL = "(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})";
+const GENERAL_SETTINGS_CHILDREN = "children:[S,C,w,T,D,O,k,A,j,M,N,P,L]";
+const GENERAL_SETTINGS_CHILDREN_WITH_ROW =
+  `children:[S,C,w,T,${GENERAL_SETTINGS_ROW_CALL},D,O,k,A,j,M,N,P,L]`;
+const GENERAL_SETTINGS_CHILDREN_WITH_OLD_ROW =
+  `children:[S,C,w,T,D,O,k,${GENERAL_SETTINGS_ROW_CALL},A,j,M,N,P,L]`;
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function applyMainBundlePatch(source) {
+  if (source.includes(`"${HANDLER_NAME}":async`)) {
+    return source;
+  }
+
+  const childProcessVar = requireName(source, "node:child_process") ?? requireName(source, "child_process");
+  const fsVar = requireName(source, "node:fs");
+  const pathVar = requireName(source, "node:path");
+  const osVar = requireName(source, "node:os") ?? requireName(source, "os");
+  if (childProcessVar == null || fsVar == null || pathVar == null || osVar == null) {
+    warn("Could not find node:child_process/node:fs/node:path/node:os dependencies", "read aloud main-bundle patch");
+    return source;
+  }
+
+  const helper = [
+    `function codexLinuxReadAloudCleanText(e){return typeof e!==\`string\`?\`\`:e.replace(/\\r\\n/g,\`\\n\`).replace(new RegExp(\`\\\`\\\`\\\`[\\\\s\\\\S]*?\\\`\\\`\\\`\`,\`gu\`),\` code block. \`).replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/gu,\`$1\`).replace(/[*_#>~]/gu,\`\`).replace(/\\n{3,}/gu,\`\\n\\n\`).trim().slice(0,8e3)}`,
+    `function codexLinuxReadAloudHasHebrew(e){return /[\\u0590-\\u05ff]/u.test(e)}`,
+    `function codexLinuxReadAloudHome(){return process.env.HOME||process.env.USERPROFILE||${osVar}.homedir?.()||\`\`}`,
+    `function codexLinuxReadAloudDataHome(){let e=codexLinuxReadAloudHome(),t=process.env.XDG_DATA_HOME||e&&${pathVar}.join(e,\`.local\`,\`share\`);return t||\`\`}`,
+    `function codexLinuxReadAloudSettingsPath(){let e=codexLinuxReadAloudHome(),t=process.env.XDG_CONFIG_HOME||e&&${pathVar}.join(e,\`.config\`);return t?${pathVar}.join(t,\`codex-desktop\`,\`settings.json\`):null}`,
+    `function codexLinuxReadAloudSettings(){try{let e=codexLinuxReadAloudSettingsPath();if(!e||!${fsVar}.existsSync(e))return{};let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:{}}catch{return{}}}`,
+    `function codexLinuxReadAloudWriteSettings(e){let t=codexLinuxReadAloudSettingsPath();if(!t)throw Error(\`settings path unavailable\`);${fsVar}.mkdirSync(${pathVar}.dirname(t),{recursive:!0});${fsVar}.writeFileSync(t,JSON.stringify(e,null,2)+\`\\n\`)}`,
+    `function codexLinuxReadAloudEnabled(){if(process.env.CODEX_LINUX_READ_ALOUD_ENABLED===\`1\`)return!0;let e=codexLinuxReadAloudSettings();return e[${JSON.stringify(SETTINGS_KEY)}]===!0}`,
+    `function codexLinuxReadAloudFileExists(e){try{return!!e&&${fsVar}.existsSync(e)}catch{return!1}}`,
+    `function codexLinuxReadAloudCommandExists(e){if(!e)return!1;if(e.includes(\`/\`))try{return!!e&&${fsVar}.existsSync(e)&&(${fsVar}.accessSync(e,${fsVar}.constants.X_OK),!0)}catch{return!1};try{return ${childProcessVar}.spawnSync(\`which\`,[e],{stdio:\`ignore\`}).status===0}catch{return!1}}`,
+    `function codexLinuxReadAloudKokoroRunner(){let e=process.env.CODEX_LINUX_READ_ALOUD_KOKORO_RUNNER?.trim();if(e)return e;let t=process.resourcesPath;return t?${pathVar}.join(t,\`read-aloud\`,\`kokoro-stdin\`):\`\`}`,
+    `function codexLinuxReadAloudKokoroPython(){let e=process.env.CODEX_LINUX_READ_ALOUD_KOKORO_PYTHON?.trim(),t=codexLinuxReadAloudSettings()[${JSON.stringify(KOKORO_PYTHON_KEY)}];return e||typeof t===\`string\`&&t.trim()||${pathVar}.join(codexLinuxReadAloudDataHome(),\`codex-desktop\`,\`read-aloud\`,\`kokoro-venv\`,\`bin\`,\`python\`)}`,
+    `function codexLinuxReadAloudKokoroModel(){let e=process.env.CODEX_LINUX_READ_ALOUD_KOKORO_MODEL?.trim(),t=codexLinuxReadAloudSettings()[${JSON.stringify(KOKORO_MODEL_KEY)}];return e||typeof t===\`string\`&&t.trim()||${pathVar}.join(codexLinuxReadAloudDataHome(),\`kokoro\`,\`kokoro-v1.0.onnx\`)}`,
+    `function codexLinuxReadAloudKokoroVoices(){let e=process.env.CODEX_LINUX_READ_ALOUD_KOKORO_VOICES?.trim(),t=codexLinuxReadAloudSettings()[${JSON.stringify(KOKORO_VOICES_KEY)}];return e||typeof t===\`string\`&&t.trim()||${pathVar}.join(codexLinuxReadAloudDataHome(),\`kokoro\`,\`voices-v1.0.bin\`)}`,
+    `function codexLinuxReadAloudKokoroVoice(){return process.env.CODEX_LINUX_READ_ALOUD_KOKORO_VOICE?.trim()||\`bm_george\`}`,
+    `function codexLinuxReadAloudClampSpeed(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}`,
+    `function codexLinuxReadAloudKokoroSpeed(){let e=process.env.CODEX_LINUX_READ_ALOUD_KOKORO_SPEED?.trim(),t=codexLinuxReadAloudSettings()[${JSON.stringify(KOKORO_SPEED_KEY)}];return codexLinuxReadAloudClampSpeed(e!==void 0&&e!==\`\`?e:t??1.05)}`,
+    `function codexLinuxReadAloudKokoroMissing(){let e=[];codexLinuxReadAloudCommandExists(codexLinuxReadAloudKokoroRunner())||e.push(\`runner\`);codexLinuxReadAloudCommandExists(codexLinuxReadAloudKokoroPython())||e.push(\`python\`);codexLinuxReadAloudFileExists(codexLinuxReadAloudKokoroModel())||e.push(\`model\`);codexLinuxReadAloudFileExists(codexLinuxReadAloudKokoroVoices())||e.push(\`voices\`);codexLinuxReadAloudCommandExists(\`aplay\`)||e.push(\`aplay\`);return e}`,
+    `function codexLinuxReadAloudKokoroModelUrl(){return process.env.CODEX_LINUX_READ_ALOUD_KOKORO_MODEL_URL?.trim()||${JSON.stringify(KOKORO_MODEL_URL)}}`,
+    `function codexLinuxReadAloudKokoroVoicesUrl(){return process.env.CODEX_LINUX_READ_ALOUD_KOKORO_VOICES_URL?.trim()||${JSON.stringify(KOKORO_VOICES_URL)}}`,
+    `function codexLinuxReadAloudConfig(){let e=codexLinuxReadAloudKokoroMissing();return{enabled:codexLinuxReadAloudEnabled(),engine:(process.env.CODEX_LINUX_READ_ALOUD_ENGINE?.trim()||\`kokoro\`).toLowerCase(),nativeFallback:process.env.CODEX_LINUX_READ_ALOUD_NATIVE_FALLBACK===\`1\`,customCommand:!!process.env.CODEX_LINUX_READ_ALOUD_COMMAND?.trim(),kokoro:{available:e.length===0,missing:e,voice:codexLinuxReadAloudKokoroVoice(),speed:codexLinuxReadAloudKokoroSpeed(),python:codexLinuxReadAloudKokoroPython(),model:codexLinuxReadAloudKokoroModel(),voices:codexLinuxReadAloudKokoroVoices(),modelUrl:codexLinuxReadAloudKokoroModelUrl(),voicesUrl:codexLinuxReadAloudKokoroVoicesUrl()}}}`,
+    `function codexLinuxReadAloudRun(e,t,n=3e5){return new Promise((r,i)=>{let a,o;try{a=${childProcessVar}.spawn(e,t,{stdio:\`ignore\`,windowsHide:!0}),o=setTimeout(()=>{try{a.kill(\`SIGTERM\`)}catch{}i(Error(\`command timed out\`))},n),o.unref?.(),a.on(\`error\`,e=>{clearTimeout(o),i(e)}),a.on(\`close\`,e=>{clearTimeout(o),e===0?r():i(Error(\`command failed\`))})}catch(e){clearTimeout(o),i(e)}})}`,
+    `function codexLinuxReadAloudPythonOk(e){try{return ${childProcessVar}.spawnSync(e,[\`-c\`,\`import sys; raise SystemExit(0 if (3,10) <= sys.version_info < (3,14) else 1)\`],{stdio:\`ignore\`}).status===0}catch{return!1}}`,
+    `function codexLinuxReadAloudFindPython(){for(let e of [process.env.PYTHON?.trim(),\`python3.12\`,\`python3.13\`,\`python3.11\`,\`python3.10\`,\`python3\`])if(e&&codexLinuxReadAloudCommandExists(e)&&codexLinuxReadAloudPythonOk(e))return e;return null}`,
+    `async function codexLinuxReadAloudInstallRuntime(){let e=codexLinuxReadAloudKokoroPython();if(codexLinuxReadAloudCommandExists(e))return;let t=${pathVar}.dirname(${pathVar}.dirname(e)),n=codexLinuxReadAloudFindPython();if(!n)throw Error(\`Python 3.10-3.13 is required for Kokoro\`);${fsVar}.mkdirSync(${pathVar}.dirname(t),{recursive:!0});if(codexLinuxReadAloudCommandExists(\`uv\`)){await codexLinuxReadAloudRun(\`uv\`,[\`venv\`,\`--python\`,n,t]);await codexLinuxReadAloudRun(\`uv\`,[\`pip\`,\`install\`,\`--python\`,e,\`kokoro-onnx>=0.5.0\`,\`numpy>=2.0.2\`],6e5);return}await codexLinuxReadAloudRun(n,[\`-m\`,\`venv\`,t]);await codexLinuxReadAloudRun(e,[\`-m\`,\`ensurepip\`,\`--upgrade\`]);await codexLinuxReadAloudRun(e,[\`-m\`,\`pip\`,\`install\`,\`--upgrade\`,\`pip\`],6e5);await codexLinuxReadAloudRun(e,[\`-m\`,\`pip\`,\`install\`,\`kokoro-onnx>=0.5.0\`,\`numpy>=2.0.2\`],6e5)}`,
+    `function codexLinuxReadAloudDownloadFile(url,target,minBytes,redirects=0){return new Promise((resolve,reject)=>{if(redirects>5){reject(Error(\`too many redirects\`));return}let parsed;try{parsed=new URL(url)}catch{reject(Error(\`invalid download URL\`));return}let get=parsed.protocol===\`https:\`?require(\`node:https\`).get:parsed.protocol===\`http:\`?require(\`node:http\`).get:null;if(!get){reject(Error(\`unsupported download URL\`));return}${fsVar}.mkdirSync(${pathVar}.dirname(target),{recursive:!0});let partial=\`\${target}.part\`,bytes=0,done=!1;try{${fsVar}.rmSync(partial,{force:!0})}catch{}let cleanup=()=>{try{${fsVar}.rmSync(partial,{force:!0})}catch{}};let fail=e=>{if(done)return;done=!0;cleanup();reject(e instanceof Error?e:Error(String(e)))};let fileStream=${fsVar}.createWriteStream(partial),request=get(parsed,response=>{if(response.statusCode>=300&&response.statusCode<400&&response.headers.location){response.resume?.();fileStream.close(()=>{});cleanup();codexLinuxReadAloudDownloadFile(new URL(response.headers.location,parsed).toString(),target,minBytes,redirects+1).then(resolve,reject);return}if(response.statusCode!==200){response.resume?.();fileStream.close(()=>{});fail(Error(\`download failed with status \${response.statusCode}\`));return}response.on(\`data\`,chunk=>{bytes+=chunk.length}),response.pipe(fileStream),fileStream.on(\`finish\`,()=>fileStream.close(()=>{if(done)return;if(bytes<minBytes){fail(Error(\`download too small\`));return}try{${fsVar}.renameSync(partial,target),done=!0,resolve()}catch(error){fail(error)}}))});request.on(\`error\`,fail),fileStream.on(\`error\`,fail)})}`,
+    `async function codexLinuxReadAloudDownloadKokoro(){let e=codexLinuxReadAloudKokoroModel(),t=codexLinuxReadAloudKokoroVoices();codexLinuxReadAloudFileExists(e)||await codexLinuxReadAloudDownloadFile(codexLinuxReadAloudKokoroModelUrl(),e,5e7);codexLinuxReadAloudFileExists(t)||await codexLinuxReadAloudDownloadFile(codexLinuxReadAloudKokoroVoicesUrl(),t,1e6)}`,
+    `async function codexLinuxReadAloudChooseModelDir(){let electron;try{electron=require(\`electron\`)}catch{return{ok:!1,reason:\`dialog-unavailable\`}}let result=await electron.dialog.showOpenDialog({title:\`Choose Kokoro model folder\`,properties:[\`openDirectory\`]});if(result.canceled||!result.filePaths?.[0])return{ok:!1,reason:\`cancelled\`};let dir=result.filePaths[0],modelPath=${pathVar}.join(dir,\`kokoro-v1.0.onnx\`),voicesPath=${pathVar}.join(dir,\`voices-v1.0.bin\`);if(!codexLinuxReadAloudFileExists(modelPath)||!codexLinuxReadAloudFileExists(voicesPath))return{ok:!1,reason:\`missing-files\`,path:dir};let settings=codexLinuxReadAloudSettings();settings[${JSON.stringify(KOKORO_MODEL_KEY)}]=modelPath,settings[${JSON.stringify(KOKORO_VOICES_KEY)}]=voicesPath,codexLinuxReadAloudWriteSettings(settings);return{ok:!0,config:codexLinuxReadAloudConfig()}}`,
+    `async function codexLinuxReadAloudSetup(e={}){if(process.platform!==\`linux\`)return{ok:!1,reason:\`not-linux\`};try{if(e.mode===\`choose-folder\`)return await codexLinuxReadAloudChooseModelDir();if(e.mode===\`download\`){await codexLinuxReadAloudInstallRuntime();await codexLinuxReadAloudDownloadKokoro();return{ok:!0,config:codexLinuxReadAloudConfig()}}return{ok:!1,reason:\`unknown-mode\`}}catch(t){let n=t?.message??String(t);return{ok:!1,reason:n.includes(\`Python 3.10-3.13\`)?\`python-unavailable\`:\`setup-failed\`,message:n}}}`,
+    `function codexLinuxReadAloudReport(e){try{console.info(\`[linux-read-aloud] \${JSON.stringify(e)}\`)}catch{}return e}`,
+    `let codexLinuxReadAloudProc=null;function codexLinuxReadAloudStop(){let e=codexLinuxReadAloudProc;codexLinuxReadAloudProc=null;if(!e)return codexLinuxReadAloudReport({stopped:!1,reason:\`idle\`});try{e.pid&&process.kill(-e.pid,\`SIGTERM\`)}catch{try{e.kill?.(\`SIGTERM\`)}catch{}}return codexLinuxReadAloudReport({stopped:!0})}`,
+    `function codexLinuxReadAloudSpawn(e,t,n={}){if(!codexLinuxReadAloudCommandExists(e))return!1;try{codexLinuxReadAloudStop();let r=${childProcessVar}.spawn(e,t,{...n,stdio:n.stdio??\`ignore\`,windowsHide:!0,detached:!0});codexLinuxReadAloudProc=r,r.on?.(\`exit\`,()=>{codexLinuxReadAloudProc===r&&(codexLinuxReadAloudProc=null)}),r.unref?.();return!0}catch{return!1}}`,
+    `function codexLinuxReadAloudSpawnStdin(e,t,n,r={}){if(!codexLinuxReadAloudCommandExists(e))return!1;try{codexLinuxReadAloudStop();let i=${childProcessVar}.spawn(e,t,{stdio:[\`pipe\`,\`ignore\`,\`ignore\`],windowsHide:!0,detached:!0,env:{...process.env,...r}});codexLinuxReadAloudProc=i,i.on?.(\`exit\`,()=>{codexLinuxReadAloudProc===i&&(codexLinuxReadAloudProc=null)}),i.stdin?.end(n),i.unref?.();return!0}catch{return!1}}`,
+    `function codexLinuxReadAloudKokoro(e){let t=codexLinuxReadAloudKokoroMissing();if(t.length)return{spoken:!1,reason:\`kokoro-unavailable\`,missing:t};let n=codexLinuxReadAloudKokoroSpeed(),r={CODEX_LINUX_READ_ALOUD_KOKORO_MODEL:codexLinuxReadAloudKokoroModel(),CODEX_LINUX_READ_ALOUD_KOKORO_VOICES:codexLinuxReadAloudKokoroVoices(),CODEX_LINUX_READ_ALOUD_KOKORO_VOICE:codexLinuxReadAloudKokoroVoice(),CODEX_LINUX_READ_ALOUD_KOKORO_SPEED:String(n)};return codexLinuxReadAloudSpawnStdin(codexLinuxReadAloudKokoroRunner(),[],e,r)?{spoken:!0,engine:\`kokoro\`,voice:codexLinuxReadAloudKokoroVoice(),speed:n}:{spoken:!1,reason:\`kokoro-spawn-failed\`}}`,
+    `function codexLinuxReadAloudPiper(e,t){let n=process.env.CODEX_LINUX_READ_ALOUD_PIPER_BIN?.trim()||\`piper\`;if(!t||!${fsVar}.existsSync(t)||!codexLinuxReadAloudCommandExists(n)||!codexLinuxReadAloudCommandExists(\`aplay\`))return!1;try{codexLinuxReadAloudStop();let r=${childProcessVar}.spawn(n,[\`--model\`,t,\`--output-raw\`],{stdio:[\`pipe\`,\`pipe\`,\`ignore\`],windowsHide:!0,detached:!0}),i=${childProcessVar}.spawn(\`aplay\`,[\`-q\`,\`-r\`,\`22050\`,\`-c\`,\`1\`,\`-f\`,\`S16_LE\`,\`-t\`,\`raw\`],{stdio:[\`pipe\`,\`ignore\`,\`ignore\`],windowsHide:!0,detached:!0});codexLinuxReadAloudProc=r,r.on?.(\`exit\`,()=>{codexLinuxReadAloudProc===r&&(codexLinuxReadAloudProc=null)}),r.stdout?.pipe(i.stdin),r.stdin?.end(e),r.unref?.(),i.unref?.();return!0}catch{return!1}}`,
+    `function codexLinuxReadAloudSpeak(e){if(process.platform!==\`linux\`)return codexLinuxReadAloudReport({spoken:!1,reason:\`not-linux\`});if(!codexLinuxReadAloudEnabled())return codexLinuxReadAloudReport({spoken:!1,reason:\`disabled\`});let t=codexLinuxReadAloudCleanText(e);if(!t)return codexLinuxReadAloudReport({spoken:!1,reason:\`empty\`});let n=process.env.CODEX_LINUX_READ_ALOUD_COMMAND?.trim();if(n&&codexLinuxReadAloudSpawnStdin(n,[],t))return codexLinuxReadAloudReport({spoken:!0,engine:\`custom\`});let r=(process.env.CODEX_LINUX_READ_ALOUD_ENGINE?.trim()||\`kokoro\`).toLowerCase(),a=codexLinuxReadAloudHasHebrew(t),o=process.env.CODEX_LINUX_READ_ALOUD_PIPER_MODEL?.trim();if(r===\`piper\`)return codexLinuxReadAloudReport(codexLinuxReadAloudPiper(t,o)?{spoken:!0,engine:\`piper\`}:{spoken:!1,reason:\`piper-unavailable\`});let i=codexLinuxReadAloudKokoro(t);if(i.spoken)return codexLinuxReadAloudReport(i);if(process.env.CODEX_LINUX_READ_ALOUD_NATIVE_FALLBACK!==\`1\`)return codexLinuxReadAloudReport(i);if(codexLinuxReadAloudPiper(t,o))return codexLinuxReadAloudReport({spoken:!0,engine:\`piper\`});let s=process.env.CODEX_LINUX_READ_ALOUD_VOICE?.trim(),c=process.env.CODEX_LINUX_READ_ALOUD_RATE?.trim()||\`-10\`,l=process.env.CODEX_LINUX_READ_ALOUD_VOICE_TYPE?.trim()||\`female1\`;try{codexLinuxReadAloudCommandExists(\`spd-say\`)&&${childProcessVar}.spawn(\`spd-say\`,[\`-C\`],{stdio:\`ignore\`,windowsHide:!0}).unref?.()}catch{}let u=[\`-r\`,c,\`-t\`,l,...(s?[\`-y\`,s]:[]),\`-l\`,a?\`he\`:\`en\`,\`--\`,t];if(codexLinuxReadAloudSpawn(\`spd-say\`,u))return codexLinuxReadAloudReport({spoken:!0,engine:\`spd-say\`});let d=s||a?\`he\`:\`en-us\`;return codexLinuxReadAloudReport(codexLinuxReadAloudSpawn(\`espeak-ng\`,[\`-v\`,d,\`-s\`,process.env.CODEX_LINUX_READ_ALOUD_ESPEAK_RATE?.trim()||\`165\`,\`--\`,t])?{spoken:!0,engine:\`espeak-ng\`}:i)}`,
+    `function codexLinuxReadAloudHandle(e={}){return e.action===\`config\`?codexLinuxReadAloudConfig():e.action===\`setup\`?codexLinuxReadAloudSetup(e):e.action===\`stop\`?codexLinuxReadAloudStop():e.action===\`speak\`&&e.source===\`button\`?codexLinuxReadAloudSpeak(e.text):codexLinuxReadAloudReport({spoken:!1,reason:\`not-explicit\`})}`,
+  ].join("");
+
+  const handler = `"${HANDLER_NAME}":async(e)=>codexLinuxReadAloudHandle(e),`;
+  const needle = `"native-desktop-apps":`;
+  const handlerIndex = source.indexOf(needle);
+  if (handlerIndex === -1) {
+    warn("Could not find native-desktop-apps handler", "read aloud main-bundle patch");
+    return source;
+  }
+
+  const withHandler = source.slice(0, handlerIndex) + handler + source.slice(handlerIndex);
+  const helperInsertAt = withHandler.startsWith(`"use strict";`)
+    ? `"use strict";`.length
+    : withHandler.startsWith(`'use strict';`)
+      ? `'use strict';`.length
+      : 0;
+  return withHandler.slice(0, helperInsertAt) + helper + withHandler.slice(helperInsertAt);
+}
+
+function readAloudRuntimeSource() {
+  return [
+    `;(()=>{const VERSION=${JSON.stringify(RUNTIME_VERSION)};if(globalThis.codexLinuxReadAloudVersion===VERSION)return;globalThis.codexLinuxReadAloudVersion=VERSION;try{globalThis.speechSynthesis?.cancel?.()}catch{}`,
+    `const METHOD=${JSON.stringify(HANDLER_NAME)};let seq=0,pending=new Map,currentButton=null,currentSpeakTimer=null;`,
+    `function onMessage(e){let t=e?.data;if(!t||typeof t!="object"||t.type!=="fetch-response")return;let n=pending.get(t.requestId);if(!n)return;pending.delete(t.requestId);if(t.responseType==="success"){let e=null;try{e=t.bodyJsonString?JSON.parse(t.bodyJsonString):null}catch{}n.resolve({status:t.status,body:e})}else n.reject(Error(t.error||"fetch failed"))}`,
+    `window.addEventListener("message",onMessage);`,
+    `function dispatch(payload){let bridge=window.electronBridge,event=new CustomEvent("codex-message-from-view",{detail:payload});if(bridge?.sendMessageFromView){event.__codexForwardedViaBridge=!0;bridge.sendMessageFromView(payload).catch(()=>{})}window.dispatchEvent(event)}`,
+    `function log(message,tags={}){dispatch({type:"log-message",level:"info",message,tags:{safe:tags,sensitive:{}}})}`,
+    `function post(params,timeoutMs=4000){let requestId="codex-linux-read-aloud-"+ ++seq;let payload={type:"fetch",hostId:"local",requestId,method:"POST",url:"vscode://codex/"+METHOD,body:JSON.stringify(params??{})};return new Promise((resolve,reject)=>{pending.set(requestId,{resolve,reject});setTimeout(()=>{pending.delete(requestId);reject(Error("timeout"))},timeoutMs);dispatch(payload)})}`,
+    `function clean(text){return String(text||"").replace(/\\r\\n/g,"\\n").replace(/\`\`\`[\\s\\S]*?\`\`\`/g," code block. ").replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/g,"$1").replace(/[*_#>~]/g,"").replace(/\\n{3,}/g,"\\n\\n").trim().slice(0,8e3)}`,
+    `function buttonLabel(state,label){return label??(state==="speaking"?"Stop read aloud":state==="loading"?"Loading voice":state==="error"?"No voice available":"Read assistant response aloud")}`,
+    `function setButton(button,state,label){if(!button)return;let title=buttonLabel(state,label);button.dataset.codexLinuxReadAloudState=state;button.title=title;button.setAttribute("aria-label",title);button.disabled=state==="loading"}`,
+    `function flash(button,label){setButton(button,"error",label);setTimeout(()=>setButton(button,"ready"),1500)}`,
+    `function resetButton(button=currentButton){if(currentSpeakTimer!=null){clearTimeout(currentSpeakTimer);currentSpeakTimer=null}if(button)setButton(button,"ready");if(button===currentButton)currentButton=null}`,
+    `function stopSpeech(){resetButton();post({action:"stop"}).catch(()=>{})}`,
+    `function estimateMs(text){let words=text.split(/\\s+/).filter(Boolean).length;return Math.max(3000,Math.min(120000,words*360))}`,
+    `function failureLabel(result){let reason=result?.reason;if(reason==="disabled")return"Enable Read aloud in settings";if(reason==="kokoro-unavailable")return"Install Read aloud voice model";if(reason==="empty")return"Nothing to read";return"No voice available"}`,
+    `async function click(item,copyText,conversationId,button){try{button?.blur?.();if(button?.dataset.codexLinuxReadAloudState==="speaking"){stopSpeech();return}let text=clean(copyText||item?.content||"");if(text.length<2)return;setButton(button,"loading","Starting voice");let result=await post({action:"speak",source:"button",text}).then(e=>e.body).catch(()=>({spoken:!1,reason:"request-failed"}));log("[linux-read-aloud] click",{conversationId:conversationId||null,textLength:text.length,spoken:result?.spoken===!0,engine:result?.engine||null,reason:result?.reason||null,missing:Array.isArray(result?.missing)?result.missing.join(","):null});if(result?.spoken){currentButton=button;setButton(button,"speaking");currentSpeakTimer=setTimeout(()=>resetButton(button),estimateMs(text));return}flash(button,failureLabel(result))}catch{flash(button,"No voice available")}}`,
+    `function setupLabel(result){let reason=result?.reason;if(reason==="cancelled")return"Cancelled";if(reason==="missing-files")return"Folder is missing model files";if(reason==="python-unavailable")return"Python 3.10-3.13 required";return result?.ok?"Voice ready":"Setup failed"}`,
+    `async function setup(mode,button){let original=button?.dataset.codexLinuxReadAloudOriginalLabel||button?.textContent||"";if(button&&!button.dataset.codexLinuxReadAloudOriginalLabel)button.dataset.codexLinuxReadAloudOriginalLabel=original;try{button&&(button.disabled=!0,button.textContent=mode==="download"?"Downloading...":"Choosing...");let result=await post({action:"setup",mode},mode==="download"?9e5:6e4).then(e=>e.body).catch(()=>({ok:!1,reason:"request-failed"}));button&&(button.textContent=setupLabel(result));setTimeout(()=>{button&&(button.textContent=original,button.disabled=!1)},1800);return result}catch{button&&(button.textContent="Setup failed",setTimeout(()=>{button.textContent=original,button.disabled=!1},1800))}}`,
+    `function installStyle(){if(document.getElementById("codex-linux-read-aloud-style"))return;let e=document.createElement("style");e.id="codex-linux-read-aloud-style";e.textContent=".codex-linux-read-aloud-row{display:flex;align-items:center;margin-top:4px}.codex-linux-read-aloud-button{width:28px;height:24px;display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--token-border);background:transparent;color:var(--text-secondary,var(--token-description-foreground));border-radius:6px;padding:0;cursor:pointer}.codex-linux-read-aloud-icon{width:15px;height:15px}.codex-linux-read-aloud-button:hover{background:var(--token-list-hover-background,rgba(127,127,127,.12));color:var(--text-primary,var(--token-foreground))}.codex-linux-read-aloud-button:disabled{opacity:.65;cursor:default}.codex-linux-read-aloud-button[data-codex-linux-read-aloud-state=speaking]{background:var(--token-list-hover-background,rgba(127,127,127,.14));color:var(--text-primary,var(--token-foreground))}.codex-linux-read-aloud-button[data-codex-linux-read-aloud-state=error]{color:var(--token-error-foreground,#c00);border-color:currentColor}";document.head.appendChild(e)}`,
+    `installStyle();globalThis.${HELPER_MARKER}=click;globalThis.${SETUP_MARKER}=setup;})();`,
+  ].join("");
+}
+
+function readAloudIconButtonSource(itemVar, copyVar, conversationVar, eventVar) {
+  return `(0,$.jsx)("button",{type:"button",className:"codex-linux-read-aloud-button",title:"Read assistant response aloud","aria-label":"Read assistant response aloud",onClick:${eventVar}=>{${eventVar}.stopPropagation(),globalThis.${HELPER_MARKER}?.(${itemVar},${copyVar},${conversationVar},${eventVar}.currentTarget)},children:(0,$.jsxs)("svg",{"aria-hidden":"true",viewBox:"0 0 24 24",className:"codex-linux-read-aloud-icon",fill:"none",stroke:"currentColor",strokeWidth:2,strokeLinecap:"round",strokeLinejoin:"round",children:[(0,$.jsx)("path",{d:"M11 5 6 9H3v6h3l5 4V5z"}),(0,$.jsx)("path",{d:"M15 9a5 5 0 0 1 0 6"}),(0,$.jsx)("path",{d:"M18 6a9 9 0 0 1 0 12"})]})})`;
+}
+
+function readAloudButtonRowSource(itemVar, copyVar, conversationVar, eventVar) {
+  return `(0,$.jsx)("div",{className:"codex-linux-read-aloud-row",children:${readAloudIconButtonSource(itemVar, copyVar, conversationVar, eventVar)}})`;
+}
+
+function applyIndexRuntimePatch(source) {
+  if (source.includes(RUNTIME_VERSION)) {
+    return source;
+  }
+  return `${source}\n${readAloudRuntimeSource()}`;
+}
+
+function applyAssistantRenderPatch(source) {
+  if (source.includes(`globalThis.${HELPER_MARKER}?.(`)) {
+    return source;
+  }
+  const jsxCallPattern =
+    /\(0,\$\.jsx\)\(([A-Za-z_$][\w$]*),\{item:([A-Za-z_$][\w$]*),([^{}]*?)assistantCopyText:([A-Za-z_$][\w$]*),([^{}]*?)conversationId:([A-Za-z_$][\w$]*),([^{}]*?)renderCodeBlocksAsWritingBlocks:([A-Za-z_$][\w$]*)\}\)/g;
+  const patched = source.replace(
+    jsxCallPattern,
+    (match, _component, itemVar, _beforeCopy, copyVar, _beforeConversation, conversationVar) =>
+      `(0,$.jsxs)($.Fragment,{children:[${match},${readAloudButtonRowSource(itemVar, copyVar, conversationVar, "e")}]})`,
+  );
+  if (patched !== source) {
+    return patched;
+  }
+
+  const needle = "(0,$.jsx)(O6,{item:e,assistantCopyText:l,assistantRatingEventContext:f,after:u,conversationId:n,cwd:o,onFork:g})";
+  if (!source.includes(needle)) {
+    if (source.includes("assistantCopyText") || source.includes("renderPlaceholderWhileStreaming")) {
+      warn("Could not find assistant message render call", "read aloud assistant render patch");
+    }
+    return source;
+  }
+  return source.replace(
+    needle,
+    `(0,$.jsxs)($.Fragment,{children:[${needle},${readAloudButtonRowSource("e", "l", "n", "t")}]})`,
+  );
+}
+
+function applySettingsPatch(source) {
+  if (source.includes(SETTINGS_KEY)) {
+    return source;
+  }
+  const keyNeedle = "warmStart:\"codex-linux-warm-start-enabled\"";
+  const keyReplacement = `warmStart:"codex-linux-warm-start-enabled",readAloud:${JSON.stringify(SETTINGS_KEY)}`;
+  const rowNeedle = '$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})';
+  const rowReplacement = `${rowNeedle},$.jsx(LinuxToggle,{settingKey:KEYS.readAloud,label:"Read aloud responses",description:"Show a Read aloud button on assistant responses.",defaultValue:!1})`;
+  if (!source.includes(keyNeedle) || !source.includes(rowNeedle)) {
+    warn("Could not find Linux settings toggle insertion point", "read aloud settings patch");
+    return source;
+  }
+  return source.replace(keyNeedle, keyReplacement).replace(rowNeedle, rowReplacement);
+}
+
+function generalSettingsReadAloudRowSource() {
+  return `function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let e=w(C),t=N(),{data:n,isLoading:r}=L(${JSON.stringify(SETTINGS_KEY)}),{data:i,isLoading:a}=L(${JSON.stringify(KOKORO_SPEED_KEY)}),o=n===!0,s=codexLinuxReadAloudPaceValue(i),c=(0,$.jsx)(F,{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),l=(0,$.jsx)(F,{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`}),u=(0,$.jsx)(F,{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),d=(0,$.jsx)(F,{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),f=n=>{P(e,${JSON.stringify(SETTINGS_KEY)},n)},p=t.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),m=t.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),h=t.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),g=t.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),x=t.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),_=n=>{P(e,${JSON.stringify(KOKORO_SPEED_KEY)},codexLinuxReadAloudPaceValue(n.currentTarget.value))},v=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,y=\`h-2 w-36 accent-token-text-primary\`,b=(0,$.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,$.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:s,disabled:a,onChange:_,"aria-label":g,className:y}),(0,$.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${s.toFixed(2)}x\`})]});return(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(J,{label:c,description:l,control:(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(q,{checked:o,disabled:r,onChange:f,ariaLabel:p}),o?(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(\`button\`,{type:\`button\`,className:v,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:m}),(0,$.jsx)(\`button\`,{type:\`button\`,className:v,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:h}),(0,$.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:x,"aria-label":x,children:\`?\`})]}):null]})}),o?(0,$.jsx)(J,{label:u,description:d,control:b}):null]})}`;
+}
+
+function generalSettingsReadAloudPageSource() {
+  return `function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(pt,{title:(0,$.jsx)(F,{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),subtitle:(0,$.jsx)(F,{id:\`settings.readAloud.subtitle\`,defaultMessage:\`Listen to assistant responses with a local Kokoro voice.\`,description:\`Subtitle for Linux read aloud settings section\`}),children:(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)(Y,{children:[(0,$.jsx)(Y.Header,{title:(0,$.jsx)(F,{id:\`settings.readAloud.voice.title\`,defaultMessage:\`Voice\`,description:\`Title for Linux read aloud voice settings group\`})}),(0,$.jsx)(Y.Content,{children:(0,$.jsx)(ht,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})})]})})})}`;
+}
+
+function generalSettingsReadAloudBlockSource() {
+  return `${generalSettingsReadAloudRowSource()}${generalSettingsReadAloudPageSource()}`;
+}
+
+function replaceExistingGeneralSettingsReadAloudRow(source) {
+  const rowStart = source.indexOf("function codexLinuxReadAloudSettingsRow(){");
+  if (rowStart === -1) {
+    return source;
+  }
+  const paceStart = source.indexOf("function codexLinuxReadAloudPaceValue(");
+  const start = paceStart !== -1 && paceStart < rowStart ? paceStart : rowStart;
+  const end = source.indexOf("function Gn(){", rowStart);
+  if (end === -1) {
+    return source;
+  }
+  return `${source.slice(0, start)}${generalSettingsReadAloudBlockSource()}${source.slice(end)}`;
+}
+
+function applyGeneralSettingsRowPlacement(source) {
+  if (source.includes(GENERAL_SETTINGS_CHILDREN_WITH_ROW)) {
+    return source;
+  }
+  if (source.includes(GENERAL_SETTINGS_CHILDREN_WITH_OLD_ROW)) {
+    return source.replace(GENERAL_SETTINGS_CHILDREN_WITH_OLD_ROW, GENERAL_SETTINGS_CHILDREN_WITH_ROW);
+  }
+  if (source.includes(GENERAL_SETTINGS_CHILDREN)) {
+    return source.replace(GENERAL_SETTINGS_CHILDREN, GENERAL_SETTINGS_CHILDREN_WITH_ROW);
+  }
+  return source;
+}
+
+function applyGeneralSettingsPatch(source) {
+  const functionNeedle = "function Gn(){";
+  if (!source.includes(functionNeedle)) {
+    return source;
+  }
+  let patched = source;
+  if (patched.includes(SETTINGS_KEY)) {
+    if (
+      !patched.includes(KOKORO_SPEED_KEY) ||
+      !patched.includes("settings.general.readAloud.chooseFolder") ||
+      !patched.includes("settings.general.readAloud.help") ||
+      !patched.includes("function codexLinuxReadAloudSettingsPage")
+    ) {
+      patched = replaceExistingGeneralSettingsReadAloudRow(patched);
+    }
+  } else {
+    patched = patched.replace(functionNeedle, `${generalSettingsReadAloudBlockSource()}${functionNeedle}`);
+  }
+  return applyGeneralSettingsExportPatch(applyGeneralSettingsRowPlacement(patched));
+}
+
+function applyGeneralSettingsExportPatch(source) {
+  if (source.includes("codexLinuxReadAloudSettingsPage as ReadAloudSettings")) {
+    return source;
+  }
+  const currentExport = "export{Yn as i,Jn as n,Gn as r,fr as t};";
+  const patchedExport = "export{Yn as i,Jn as n,Gn as r,fr as t,codexLinuxReadAloudSettingsPage as ReadAloudSettings};";
+  if (source.includes(currentExport)) {
+    return source.replace(currentExport, patchedExport);
+  }
+  const exportPattern = /export\{([^}]*)\};/;
+  if (exportPattern.test(source)) {
+    return source.replace(exportPattern, (_match, exports) =>
+      exports.includes("codexLinuxReadAloudSettingsPage as ReadAloudSettings")
+        ? _match
+        : `export{${exports},codexLinuxReadAloudSettingsPage as ReadAloudSettings};`,
+    );
+  }
+  return source;
+}
+
+function applyGeneralSettingsWrapperPatch(source) {
+  if (!source.includes("GeneralSettings") || !source.includes("general-settings-") || source.includes("ReadAloudSettings")) {
+    return source;
+  }
+  return source.replace(
+    /import\{r as ([A-Za-z_$][\w$]*)\}from"(\.\/general-settings-[^"]+\.js)";export\{\1 as GeneralSettings\};/,
+    (_match, generalAlias, innerAsset) =>
+      `import{r as ${generalAlias},ReadAloudSettings as t}from"${innerAsset}";export{${generalAlias} as GeneralSettings,t as ReadAloudSettings};`,
+  );
+}
+
+function applySettingsSectionsNavPatch(source) {
+  if (source.includes(`slug:\`${READ_ALOUD_SETTINGS_SLUG}\``)) {
+    return source;
+  }
+  const slugNeedle = "{slug:`computer-use`},{slug:`mcp-settings`}";
+  if (source.includes(slugNeedle)) {
+    return source.replace(
+      slugNeedle,
+      `{slug:\`computer-use\`},{slug:\`${READ_ALOUD_SETTINGS_SLUG}\`},{slug:\`mcp-settings\`}`,
+    );
+  }
+  return source;
+}
+
+function applySettingsSharedNavPatch(source) {
+  let patched = source;
+  if (!patched.includes("settings.nav.read-aloud-settings")) {
+    const navNeedle =
+      '"computer-use":{id:`settings.nav.computer-use`,defaultMessage:`Computer use`,description:`Title for computer use settings section`},';
+    const navPatch =
+      `${navNeedle}"read-aloud-settings":{id:\`settings.nav.read-aloud-settings\`,defaultMessage:\`Read Aloud\`,description:\`Title for Read Aloud settings section\`},`;
+    patched = patched.replace(navNeedle, navPatch);
+  }
+  if (!patched.includes("settings.section.read-aloud-settings")) {
+    const sectionNeedle = "case`browser-use`:{";
+    const sectionPatch =
+      "case`read-aloud-settings`:{return (0,d.jsx)(r,{id:`settings.section.read-aloud-settings`,defaultMessage:`Read Aloud`,description:`Title for Read Aloud settings section`})}case`browser-use`:{";
+    patched = patched.replace(sectionNeedle, sectionPatch);
+  }
+  return patched;
+}
+
+function readAloudSettingsNavIconSource() {
+  return `codexLinuxReadAloudSettingsIcon=e=>(0,Z.jsxs)(\`svg\`,{width:16,height:16,viewBox:\`0 0 16 16\`,fill:\`none\`,xmlns:\`http://www.w3.org/2000/svg\`,...e,children:[(0,Z.jsx)(\`path\`,{d:\`M7.25 3.25 4.35 5.7H2.75A1.25 1.25 0 0 0 1.5 6.95v2.1c0 .69.56 1.25 1.25 1.25h1.6l2.9 2.45c.5.42 1.25.06 1.25-.59V3.84c0-.65-.75-1.01-1.25-.59Z\`,fill:\`currentColor\`}),(0,Z.jsx)(\`path\`,{d:\`M10.25 6.1a2.7 2.7 0 0 1 0 3.8\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`}),(0,Z.jsx)(\`path\`,{d:\`M12.25 4.45a5.05 5.05 0 0 1 0 7.1\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`})]})`;
+}
+
+function applySettingsPageNavPatch(source) {
+  let patched = source;
+  if (!patched.includes("codexLinuxReadAloudSettingsIcon=e=>")) {
+    const iconSource = readAloudSettingsNavIconSource();
+    if (patched.includes(",pe={")) {
+      patched = patched.replace(",pe={", `,${iconSource},pe={`);
+    }
+  }
+  if (!patched.includes(`"read-aloud-settings":codexLinuxReadAloudSettingsIcon`)) {
+    patched = patched.replace(
+      `"computer-use":oe,"local-environments"`,
+      `"computer-use":oe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments"`,
+    );
+    patched = patched.replace(
+      `"computer-use":oe,"read-aloud-settings":G,"local-environments"`,
+      `"computer-use":oe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments"`,
+    );
+  }
+  if (!patched.includes("`computer-use`,`read-aloud-settings`,`data-controls`")) {
+    patched = patched.replace(
+      "`browser-use`,`computer-use`,`data-controls`",
+      "`browser-use`,`computer-use`,`read-aloud-settings`,`data-controls`",
+    );
+  }
+  if (!patched.includes("`computer-use`,`read-aloud-settings`,`local-environments`")) {
+    patched = patched.replace(
+      "`browser-use`,`computer-use`,`local-environments`",
+      "`browser-use`,`computer-use`,`read-aloud-settings`,`local-environments`",
+    );
+  }
+  if (!patched.includes("case`read-aloud-settings`:return a;case`computer-use`")) {
+    patched = patched.replace(
+      "case`computer-use`:return A;",
+      "case`read-aloud-settings`:return a;case`computer-use`:return A;",
+    );
+  }
+  if (!patched.includes("case`read-aloud-settings`:z=!1;break bb0;case`computer-use`")) {
+    patched = patched.replace(
+      "case`computer-use`:z=k.isLoading||m.isLoading;break bb0;",
+      "case`read-aloud-settings`:z=!1;break bb0;case`computer-use`:z=k.isLoading||m.isLoading;break bb0;",
+    );
+  }
+  return patched;
+}
+
+function applyAppMainRoutePatch(source) {
+  if (source.includes(`"${READ_ALOUD_SETTINGS_SLUG}":`)) {
+    return source;
+  }
+  const generalRouteStart = source.indexOf('"general-settings":');
+  if (generalRouteStart === -1) {
+    return source;
+  }
+  const nextRouteStart = source.indexOf(',"keyboard-shortcuts":', generalRouteStart);
+  if (nextRouteStart === -1) {
+    return source;
+  }
+  const generalRoute = source.slice(generalRouteStart, nextRouteStart);
+  const readAloudRoute = generalRoute
+    .replace('"general-settings":', `"${READ_ALOUD_SETTINGS_SLUG}":`)
+    .replace(/e=>\(\{default:e\.GeneralSettings\}\)/, "e=>({default:e.ReadAloudSettings})");
+  if (readAloudRoute === generalRoute || !readAloudRoute.includes("ReadAloudSettings")) {
+    return source;
+  }
+  return `${source.slice(0, generalRouteStart)}${readAloudRoute},${source.slice(generalRouteStart)}`;
+}
+
+function patchMatchingAssets(assetsDir, pattern, apply) {
+  let matched = false;
+  let changed = 0;
+  for (const candidate of fs.readdirSync(assetsDir).filter((name) => pattern.test(name)).sort()) {
+    const assetPath = path.join(assetsDir, candidate);
+    const source = fs.readFileSync(assetPath, "utf8");
+    const patched = apply(source);
+    if (patched === source) {
+      continue;
+    }
+    fs.writeFileSync(assetPath, patched, "utf8");
+    matched = true;
+    changed += 1;
+  }
+  return { matched, changed };
+}
+
+function applySettingsAssetPatch(extractedDir) {
+  const keybindsAssetPath = path.join(extractedDir, "webview", "assets", "keybinds-settings-linux.js");
+  if (fs.existsSync(keybindsAssetPath)) {
+    const source = fs.readFileSync(keybindsAssetPath, "utf8");
+    const patched = applySettingsPatch(source);
+    if (patched === source) {
+      return { matched: true, changed: 0 };
+    }
+    fs.writeFileSync(keybindsAssetPath, patched, "utf8");
+    return { matched: true, changed: 1 };
+  }
+
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(assetsDir)) {
+    return { matched: false, changed: 0, reason: "webview assets directory not found" };
+  }
+
+  let matched = false;
+  let changed = 0;
+  const generalCandidates = fs
+    .readdirSync(assetsDir)
+    .filter((name) => /^general-settings-.*\.js$/.test(name))
+    .sort();
+  for (const candidate of generalCandidates) {
+    const assetPath = path.join(assetsDir, candidate);
+    const source = fs.readFileSync(assetPath, "utf8");
+    let patched = applyGeneralSettingsPatch(source);
+    patched = applyGeneralSettingsWrapperPatch(patched);
+    if (patched !== source) {
+      fs.writeFileSync(assetPath, patched, "utf8");
+      changed += 1;
+      matched = true;
+    } else if (source.includes(SETTINGS_KEY) || source.includes("ReadAloudSettings")) {
+      matched = true;
+    }
+  }
+
+  for (const assetPatch of [
+    [/^settings-sections-.*\.js$/, applySettingsSectionsNavPatch],
+    [/^settings-shared-.*\.js$/, applySettingsSharedNavPatch],
+    [/^settings-page-.*\.js$/, applySettingsPageNavPatch],
+    [/^app-main-.*\.js$/, applyAppMainRoutePatch],
+  ]) {
+    const result = patchMatchingAssets(assetsDir, assetPatch[0], assetPatch[1]);
+    matched = matched || result.matched;
+    changed += result.changed;
+  }
+
+  return matched
+    ? { matched: true, changed }
+    : { matched: false, changed: 0, reason: "settings asset insertion point not found" };
+}
+
+function applyWebviewPatch(source) {
+  return applyAssistantRenderPatch(applyIndexRuntimePatch(source));
+}
+
+module.exports = {
+  applyAppMainRoutePatch,
+  applyGeneralSettingsPatch,
+  applyGeneralSettingsWrapperPatch,
+  applyAssistantRenderPatch,
+  applyIndexRuntimePatch,
+  applyMainBundlePatch,
+  applySettingsAssetPatch,
+  applySettingsPageNavPatch,
+  applySettingsPatch,
+  applySettingsSectionsNavPatch,
+  applySettingsSharedNavPatch,
+  patches: [
+    {
+      id: "main-handler",
+      phase: "main-bundle",
+      order: 20600,
+      ciPolicy: "optional",
+      apply: applyMainBundlePatch,
+    },
+    {
+      id: "assistant-runtime",
+      phase: "webview-asset",
+      order: 20620,
+      ciPolicy: "optional",
+      pattern: /^(index|local-conversation-thread)-.*\.js$/,
+      missingDescription: "webview index or local conversation thread bundle",
+      skipDescription: "read aloud assistant runtime patch",
+      apply: applyWebviewPatch,
+    },
+    {
+      id: "settings-toggle",
+      phase: "extracted-app",
+      order: 20640,
+      ciPolicy: "optional",
+      apply: applySettingsAssetPatch,
+      status: (result, warnings) => ({
+        status: result?.changed
+          ? "applied"
+          : result?.matched
+            ? "already-applied"
+            : "skipped-optional",
+        reason: result?.reason ?? warnings[0] ?? null,
+      }),
+    },
+  ],
+};

--- a/linux-features/read-aloud/stage.sh
+++ b/linux-features/read-aloud/stage.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+feature_dir="$(cd "$(dirname "$0")" && pwd)"
+target_dir="$INSTALL_DIR/resources/read-aloud"
+
+mkdir -p "$target_dir"
+cp "$feature_dir/bin/kokoro-stdin" "$target_dir/kokoro-stdin"
+cp "$feature_dir/bin/kokoro_stdin.py" "$target_dir/kokoro_stdin.py"
+chmod 0755 "$target_dir/kokoro-stdin"
+chmod 0644 "$target_dir/kokoro_stdin.py"
+
+echo "Read aloud Kokoro runner staged" >&2

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  applyAppMainRoutePatch,
+  applyGeneralSettingsPatch,
+  applyGeneralSettingsWrapperPatch,
+  applyAssistantRenderPatch,
+  applyIndexRuntimePatch,
+  applyMainBundlePatch,
+  applySettingsAssetPatch,
+  applySettingsPageNavPatch,
+  applySettingsPatch,
+  applySettingsSectionsNavPatch,
+  applySettingsSharedNavPatch,
+} = require("./patch.js");
+
+function twice(fn, source) {
+  const patched = fn(source);
+  assert.equal(fn(patched), patched);
+  return patched;
+}
+
+test("main bundle patch adds a Linux read aloud handler", () => {
+  const source = [
+    "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+    "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+  ].join("");
+  const patched = twice(applyMainBundlePatch, source);
+  assert.match(patched, /"linux-read-aloud":async/);
+  assert.match(patched, /function codexLinuxReadAloudSpeak/);
+  assert.match(patched, /function codexLinuxReadAloudConfig/);
+  assert.match(patched, /function codexLinuxReadAloudSetup/);
+  assert.match(patched, /codex-linux-read-aloud-kokoro-model/);
+  assert.match(patched, /codex-linux-read-aloud-kokoro-speed/);
+  assert.match(patched, /codex-linux-read-aloud-kokoro-voices/);
+  assert.match(patched, /CODEX_LINUX_READ_ALOUD_KOKORO_SPEED/);
+  assert.match(patched, /kokoro-unavailable/);
+  assert.match(patched, /piper-unavailable/);
+  assert.match(patched, /not-explicit/);
+  assert.match(patched, /action===`setup`/);
+  assert.match(patched, /source===`button`/);
+  assert.match(patched, /constants\.X_OK/);
+  assert.match(patched, /kokoro-stdin/);
+  assert.match(patched, /kokoro-v1\.0\.onnx/);
+  assert.match(patched, /huggingface\.co\/zijuncheng\/kokoro_model_v1\.0\/resolve\/main\/kokoro-v1\.0\.onnx/);
+  assert.match(patched, /huggingface\.co\/zijuncheng\/kokoro_model_v1\.0\/resolve\/main\/voices-v1\.0\.bin/);
+  assert.match(patched, /download too small/);
+  assert.doesNotMatch(patched, /readd-stdin/);
+  assert.match(patched, /spd-say/);
+  assert.match(patched, /espeak-ng/);
+  assert.doesNotThrow(() => new Function("require", "process", patched));
+});
+
+test("webview runtime appends only once", () => {
+  const patched = twice(applyIndexRuntimePatch, "console.log(`index`);");
+  assert.match(patched, /codexLinuxReadAloudClick/);
+  assert.match(patched, /vscode:\/\/codex\/"\+METHOD/);
+  assert.match(patched, /codex-message-from-view/);
+  assert.match(patched, /__codexForwardedViaBridge/);
+  assert.match(patched, /Starting voice/);
+  assert.match(patched, /kokoro-explicit-v3/);
+  assert.match(patched, /speechSynthesis\?\.cancel/);
+  assert.match(patched, /action:"speak",source:"button",text/);
+  assert.match(patched, /codexLinuxReadAloudSetup/);
+  assert.match(patched, /action:"setup",mode/);
+  assert.match(patched, /9e5/);
+  assert.match(applyIndexRuntimePatch("globalThis.codexLinuxReadAloudClick=()=>{};"), /kokoro-explicit-v3/);
+  assert.doesNotMatch(patched, /SpeechSynthesisUtterance/);
+  assert.doesNotMatch(patched, /browser speech/);
+  assert.doesNotMatch(patched, /no-voices/);
+  assert.doesNotMatch(patched, /completed===false/);
+  assert.doesNotThrow(() => new Function("window", "localStorage", patched));
+});
+
+test("kokoro stdin runner compiles and makes a bounded first streaming chunk", (t) => {
+  const python = spawnSync("python3", ["--version"], { encoding: "utf8" });
+  if (python.error) {
+    t.skip("python3 not available");
+    return;
+  }
+
+  const runner = path.join(__dirname, "bin", "kokoro_stdin.py");
+  const compile = spawnSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import pathlib, py_compile, sys, tempfile",
+        "runner = pathlib.Path(sys.argv[1])",
+        "with tempfile.NamedTemporaryFile(suffix='.pyc') as out:",
+        "    py_compile.compile(str(runner), cfile=out.name, doraise=True)",
+      ].join("\n"),
+      runner,
+    ],
+    { encoding: "utf8" },
+  );
+  assert.equal(compile.status, 0, compile.stderr);
+
+  const chunkCheck = spawnSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import importlib.util, sys",
+        "sys.dont_write_bytecode = True",
+        "runner = sys.argv[1]",
+        "spec = importlib.util.spec_from_file_location('kokoro_stdin', runner)",
+        "mod = importlib.util.module_from_spec(spec)",
+        "spec.loader.exec_module(mod)",
+        "text = ('streamingword ' * 40).strip()",
+        "chunks = mod.split_for_streaming(text)",
+        "assert chunks, chunks",
+        "assert len(chunks[0]) <= 50, chunks[0]",
+        "assert all(len(chunk) <= 100 for chunk in chunks[1:]), chunks",
+      ].join("\n"),
+      runner,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODEX_LINUX_READ_ALOUD_KOKORO_FIRST_CHARS: "50",
+        CODEX_LINUX_READ_ALOUD_KOKORO_CHUNK_CHARS: "100",
+      },
+    },
+  );
+  assert.equal(chunkCheck.status, 0, chunkCheck.stderr);
+});
+
+test("main handler stores a chosen Kokoro model folder", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-main-"));
+  try {
+    const configHome = path.join(root, "config");
+    const modelDir = path.join(root, "kokoro");
+    fs.mkdirSync(modelDir, { recursive: true });
+    fs.writeFileSync(path.join(modelDir, "kokoro-v1.0.onnx"), "");
+    fs.writeFileSync(path.join(modelDir, "voices-v1.0.bin"), "");
+
+    const source = [
+      "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+      "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+    ].join("");
+    const patched = twice(applyMainBundlePatch, source);
+    assert.doesNotMatch(patched, /\bo=o\.createWriteStream\b/);
+    assert.doesNotMatch(patched, /let n=[^;]*,r=p\.join\(n,[^;]*,p=p\.join/);
+
+    const requireStub = (name) => {
+      if (name === "node:child_process") {
+        return { spawnSync: () => ({ status: 1 }) };
+      }
+      if (name === "node:fs") return fs;
+      if (name === "node:path") return path;
+      if (name === "node:os") return { homedir: () => root };
+      if (name === "electron") {
+        return {
+          dialog: {
+            showOpenDialog: async () => ({ canceled: false, filePaths: [modelDir] }),
+          },
+        };
+      }
+      return require(name);
+    };
+    const processStub = {
+      platform: "linux",
+      env: { HOME: root, XDG_CONFIG_HOME: configHome },
+      resourcesPath: path.join(root, "resources"),
+    };
+    const result = await new Function(
+      "require",
+      "process",
+      `${patched};return codexLinuxReadAloudHandle({action:"setup",mode:"choose-folder"});`,
+    )(requireStub, processStub);
+
+    assert.equal(result.ok, true);
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(configHome, "codex-desktop", "settings.json"), "utf8"),
+    );
+    assert.equal(settings["codex-linux-read-aloud-kokoro-model"], path.join(modelDir, "kokoro-v1.0.onnx"));
+    assert.equal(settings["codex-linux-read-aloud-kokoro-voices"], path.join(modelDir, "voices-v1.0.bin"));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("main handler reports missing Python during download setup", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-main-"));
+  try {
+    const source = [
+      "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+      "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+    ].join("");
+    const patched = twice(applyMainBundlePatch, source);
+    const requireStub = (name) => {
+      if (name === "node:child_process") {
+        return { spawnSync: () => ({ status: 1 }) };
+      }
+      if (name === "node:fs") return fs;
+      if (name === "node:path") return path;
+      if (name === "node:os") return { homedir: () => root };
+      return require(name);
+    };
+    const processStub = {
+      platform: "linux",
+      env: { HOME: root },
+      resourcesPath: path.join(root, "resources"),
+    };
+    const result = await new Function(
+      "require",
+      "process",
+      `${patched};return codexLinuxReadAloudHandle({action:"setup",mode:"download"});`,
+    )(requireStub, processStub);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "python-unavailable");
+    assert.match(result.message, /Python 3\.10-3\.13/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("main handler reads and clamps stored Kokoro pace", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-main-"));
+  try {
+    const configHome = path.join(root, "config");
+    const settingsDir = path.join(configHome, "codex-desktop");
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, "settings.json"),
+      JSON.stringify({ "codex-linux-read-aloud-kokoro-speed": 9 }, null, 2),
+    );
+
+    const source = [
+      "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+      "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+    ].join("");
+    const patched = twice(applyMainBundlePatch, source);
+    const requireStub = (name) => {
+      if (name === "node:child_process") {
+        return { spawnSync: () => ({ status: 1 }) };
+      }
+      if (name === "node:fs") return fs;
+      if (name === "node:path") return path;
+      if (name === "node:os") return { homedir: () => root };
+      return require(name);
+    };
+    const processStub = {
+      platform: "linux",
+      env: { HOME: root, XDG_CONFIG_HOME: configHome },
+      resourcesPath: path.join(root, "resources"),
+    };
+    const result = await new Function(
+      "require",
+      "process",
+      `${patched};return codexLinuxReadAloudHandle({action:"config"});`,
+    )(requireStub, processStub);
+
+    assert.equal(result.kokoro.speed, 1.4);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("main handler exposes Hugging Face Kokoro download defaults", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-main-"));
+  try {
+    const source = [
+      "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+      "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+    ].join("");
+    const patched = twice(applyMainBundlePatch, source);
+    const requireStub = (name) => {
+      if (name === "node:child_process") {
+        return { spawnSync: () => ({ status: 1 }) };
+      }
+      if (name === "node:fs") return fs;
+      if (name === "node:path") return path;
+      if (name === "node:os") return { homedir: () => root };
+      return require(name);
+    };
+    const processStub = {
+      platform: "linux",
+      env: { HOME: root },
+      resourcesPath: path.join(root, "resources"),
+    };
+    const result = await new Function(
+      "require",
+      "process",
+      `${patched};return codexLinuxReadAloudHandle({action:"config"});`,
+    )(requireStub, processStub);
+
+    assert.equal(
+      result.kokoro.modelUrl,
+      "https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/kokoro-v1.0.onnx",
+    );
+    assert.equal(
+      result.kokoro.voicesUrl,
+      "https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/voices-v1.0.bin",
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("main handler downloads setup files atomically", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-main-"));
+  try {
+    const source = [
+      "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
+      "var h={handlers:{\"set-vs-context\":async()=>{},\"native-desktop-apps\":async()=>({apps:[]})}};",
+    ].join("");
+    const patched = twice(applyMainBundlePatch, source);
+    const target = path.join(root, "kokoro", "sample.bin");
+    const requireStub = (name) => {
+      if (name === "node:child_process") {
+        return { spawnSync: () => ({ status: 1 }) };
+      }
+      if (name === "node:fs") return fs;
+      if (name === "node:path") return path;
+      if (name === "node:os") return { homedir: () => root };
+      if (name === "node:https") {
+        return {
+          get: (_url, callback) => {
+            const { EventEmitter } = require("node:events");
+            const { PassThrough } = require("node:stream");
+            const request = new EventEmitter();
+            process.nextTick(() => {
+              const response = new PassThrough();
+              response.statusCode = 200;
+              response.headers = {};
+              callback(response);
+              response.end(Buffer.from("downloaded voice bytes"));
+            });
+            return request;
+          },
+        };
+      }
+      return require(name);
+    };
+    const processStub = {
+      platform: "linux",
+      env: { HOME: root },
+      resourcesPath: path.join(root, "resources"),
+    };
+    await new Function(
+      "require",
+      "process",
+      `${patched};return codexLinuxReadAloudDownloadFile("https://huggingface.co/test.bin", ${JSON.stringify(target)}, 10);`,
+    )(requireStub, processStub);
+
+    assert.equal(fs.readFileSync(target, "utf8"), "downloaded voice bytes");
+    assert.equal(fs.existsSync(`${target}.part`), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("assistant render patch adds an explicit read aloud button under the message", () => {
+  const source = "return (0,$.jsx)(Ov,{item:n,alwaysShowActions:M,assistantCopyText:p,turnId:m,autoReviewStats:y,hookStats:b,completedThreadGoal:x,after:g,conversationId:o,cwd:u,forceCodeBlockWordWrap:V,hasArtifacts:F,onAddSelectedTextToChat:H,onFileLinkOpen:v,onFork:D,renderCodeBlocksAsWritingBlocks:V})";
+  const patched = twice(applyAssistantRenderPatch, source);
+  assert.match(patched, /codex-linux-read-aloud-button/);
+  assert.match(patched, /codex-linux-read-aloud-icon/);
+  assert.match(patched, /viewBox:"0 0 24 24"/);
+  assert.doesNotMatch(patched, /children:"Read aloud"/);
+  assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(n,p,o,e\.currentTarget\)/);
+  assert.match(patched, /\$\.Fragment/);
+});
+
+test("settings patch adds disabled-by-default toggle", () => {
+  const source = 'KEYS={promptWindow:"codex-linux-prompt-window-enabled",systemTray:"codex-linux-system-tray-enabled",warmStart:"codex-linux-warm-start-enabled"};$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})';
+  const patched = twice(applySettingsPatch, source);
+  assert.match(patched, /readAloud:"codex-linux-read-aloud-enabled"/);
+  assert.match(patched, /label:"Read aloud responses"/);
+  assert.match(patched, /Show a Read aloud button/);
+  assert.match(patched, /defaultValue:!1/);
+});
+
+test("general settings patch adds current upstream read aloud toggle", () => {
+  const source = "function Gn(){return (0,$.jsxs)(ht,{children:[S,C,w,T,D,O,k,A,j,M,N,P,L]})}";
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.match(patched, /function codexLinuxReadAloudSettingsRow/);
+  assert.match(patched, /codex-linux-read-aloud-enabled/);
+  assert.match(patched, /settings\.general\.readAloud\.label/);
+  assert.match(patched, /Read aloud responses/);
+  assert.match(patched, /codex-linux-read-aloud-kokoro-speed/);
+  assert.match(patched, /Choose folder/);
+  assert.match(patched, /Download voice/);
+  assert.match(patched, /settings\.general\.readAloud\.help/);
+  assert.match(patched, /Hugging Face/);
+  assert.match(patched, /children:`\?`/);
+  assert.match(patched, /Speech pace/);
+  assert.match(patched, /function codexLinuxReadAloudSettingsPage/);
+  assert.match(patched, /settings\.readAloud\.title/);
+  assert.match(patched, /Listen to assistant responses with a local Kokoro voice/);
+  assert.match(patched, /type:`range`/);
+  assert.match(patched, /min:\.7/);
+  assert.match(patched, /max:1\.4/);
+  assert.match(patched, /codexLinuxReadAloudSetup/);
+  assert.doesNotThrow(() => new Function("$", "w", "C", "N", "L", "F", "P", "J", "q", patched));
+  assert.match(
+    patched,
+    /children:\[S,C,w,T,\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow,\{\}\),D,O,k,A,j,M,N,P,L\]/,
+  );
+});
+
+test("general settings patch upgrades and repositions an older injected row", () => {
+  const source = [
+    "function codexLinuxReadAloudSettingsRow(){let e=(0,Q.c)(11),t=w(C),n=N(),{data:r,isLoading:i}=L(\"codex-linux-read-aloud-enabled\"),a=r===!0,o,s;e[0]===Symbol.for(`react.memo_cache_sentinel`)?(o=(0,$.jsx)(F,{id:`settings.general.readAloud.label`,defaultMessage:`Read aloud responses`,description:`Label for Linux read aloud setting`}),s=(0,$.jsx)(F,{id:`settings.general.readAloud.description`,defaultMessage:`Show a read aloud button under assistant responses`,description:`Description for Linux read aloud setting`}),e[0]=o,e[1]=s):(o=e[0],s=e[1]);let c;e[2]===t?c=e[3]:(c=e=>{P(t,\"codex-linux-read-aloud-enabled\",e)},e[2]=t,e[3]=c);let l;e[4]===n?l=e[5]:(l=n.formatMessage({id:`settings.general.readAloud.label`,defaultMessage:`Read aloud responses`,description:`Label for Linux read aloud setting`}),e[4]=n,e[5]=l);let u;return e[6]!==i||e[7]!==a||e[8]!==c||e[9]!==l?(u=(0,$.jsx)(J,{label:o,description:s,control:(0,$.jsx)(q,{checked:a,disabled:i,onChange:c,ariaLabel:l})}),e[6]=i,e[7]=a,e[8]=c,e[9]=l,e[10]=u):u=e[10],u}",
+    "function Gn(){return (0,$.jsxs)(ht,{children:[S,C,w,T,D,O,k,(0,$.jsx)(codexLinuxReadAloudSettingsRow,{}),A,j,M,N,P,L]})}",
+  ].join("");
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.match(patched, /codex-linux-read-aloud-kokoro-speed/);
+  assert.match(patched, /Choose folder/);
+  assert.match(patched, /Download voice/);
+  assert.match(patched, /settings\.general\.readAloud\.help/);
+  assert.match(patched, /Speech pace/);
+  assert.match(patched, /function codexLinuxReadAloudSettingsPage/);
+  assert.match(
+    patched,
+    /children:\[S,C,w,T,\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow,\{\}\),D,O,k,A,j,M,N,P,L\]/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /children:\[S,C,w,T,D,O,k,\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow,\{\}\),A,j,M,N,P,L\]/,
+  );
+  assert.equal((patched.match(/function codexLinuxReadAloudSettingsRow/g) ?? []).length, 1);
+});
+
+test("general settings patch exports a dedicated read aloud settings page", () => {
+  const source = [
+    "function Gn(){return (0,$.jsxs)(pt,{children:[]})}",
+    "export{Yn as i,Jn as n,Gn as r,fr as t};",
+  ].join("");
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.match(patched, /function codexLinuxReadAloudSettingsPage/);
+  assert.match(patched, /codexLinuxReadAloudSettingsPage as ReadAloudSettings/);
+  assert.match(patched, /settings\.readAloud\.voice\.title/);
+});
+
+test("general settings wrapper re-exports the read aloud settings page", () => {
+  const source = 'import{r as e}from"./general-settings-Bvwhh0-i.js";export{e as GeneralSettings};';
+  const patched = twice(applyGeneralSettingsWrapperPatch, source);
+  assert.match(patched, /ReadAloudSettings as t/);
+  assert.match(patched, /t as ReadAloudSettings/);
+});
+
+test("settings nav patches add a visible read aloud section after computer use", () => {
+  const sections = "var n=[{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`}];";
+  const patchedSections = twice(applySettingsSectionsNavPatch, sections);
+  assert.match(patchedSections, /slug:`computer-use`},{slug:`read-aloud-settings`},{slug:`mcp-settings`/);
+
+  const shared = [
+    '"computer-use":{id:`settings.nav.computer-use`,defaultMessage:`Computer use`,description:`Title for computer use settings section`},',
+    "function m(e){switch(e){case`computer-use`:{return null}case`browser-use`:{return null}}}",
+  ].join("");
+  const patchedShared = twice(applySettingsSharedNavPatch, shared);
+  assert.match(patchedShared, /settings\.nav\.read-aloud-settings/);
+  assert.match(patchedShared, /defaultMessage:`Read Aloud`/);
+  assert.match(patchedShared, /case`read-aloud-settings`/);
+
+  const page = [
+    'var Z={},de=null,oe=null,G=null,pe={"browser-use":de,"computer-use":oe,"local-environments":q};',
+    "me=[`browser-use`,`computer-use`,`data-controls`];",
+    "he=[{slugs:[`browser-use`,`computer-use`,`local-environments`]}];",
+    "case`computer-use`:return A;",
+    "case`computer-use`:z=k.isLoading||m.isLoading;break bb0;",
+  ].join("");
+  const patchedPage = twice(applySettingsPageNavPatch, page);
+  assert.match(patchedPage, /codexLinuxReadAloudSettingsIcon=e=>/);
+  assert.match(patchedPage, /"read-aloud-settings":codexLinuxReadAloudSettingsIcon/);
+  assert.match(patchedPage, /`computer-use`,`read-aloud-settings`,`data-controls`/);
+  assert.match(patchedPage, /`computer-use`,`read-aloud-settings`,`local-environments`/);
+  assert.match(patchedPage, /case`read-aloud-settings`:return a;case`computer-use`/);
+  assert.match(patchedPage, /case`read-aloud-settings`:z=!1;break bb0;case`computer-use`/);
+});
+
+test("app route patch wires read aloud settings to the generated page export", () => {
+  const source =
+    'var iD={"general-settings":(0,Q.lazy)(()=>Mr(()=>import(`./general-settings-B89XeV4U.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([1,2]),import.meta.url)),"keyboard-shortcuts":K};';
+  const patched = twice(applyAppMainRoutePatch, source);
+  assert.match(patched, /"read-aloud-settings":\(0,Q\.lazy\)/);
+  assert.match(patched, /default:e\.ReadAloudSettings/);
+  assert.match(patched, /"general-settings":\(0,Q\.lazy\)/);
+});
+
+test("settings asset patch updates generated keybinds settings file", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-settings-"));
+  try {
+    const assets = path.join(root, "webview", "assets");
+    fs.mkdirSync(assets, { recursive: true });
+    const asset = path.join(assets, "keybinds-settings-linux.js");
+    fs.writeFileSync(
+      asset,
+      'KEYS={promptWindow:"codex-linux-prompt-window-enabled",systemTray:"codex-linux-system-tray-enabled",warmStart:"codex-linux-warm-start-enabled"};$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})',
+    );
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 1 });
+    const patched = fs.readFileSync(asset, "utf8");
+    assert.match(patched, /readAloud:"codex-linux-read-aloud-enabled"/);
+    assert.match(patched, /label:"Read aloud responses"/);
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 0 });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("settings asset patch upgrades older general settings bundle", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-settings-"));
+  try {
+    const assets = path.join(root, "webview", "assets");
+    fs.mkdirSync(assets, { recursive: true });
+    const asset = path.join(assets, "general-settings-current.js");
+    fs.writeFileSync(
+      asset,
+      [
+        "function codexLinuxReadAloudSettingsRow(){let e=(0,Q.c)(11),t=w(C),n=N(),{data:r,isLoading:i}=L(\"codex-linux-read-aloud-enabled\"),a=r===!0;return (0,$.jsx)(J,{control:(0,$.jsx)(q,{checked:a,disabled:i,onChange:e=>P(t,\"codex-linux-read-aloud-enabled\",e),ariaLabel:n.formatMessage({id:`settings.general.readAloud.label`,defaultMessage:`Read aloud responses`})})})}",
+        "function Gn(){return (0,$.jsxs)(ht,{children:[S,C,w,T,D,O,k,(0,$.jsx)(codexLinuxReadAloudSettingsRow,{}),A,j,M,N,P,L]})}",
+      ].join(""),
+    );
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 1 });
+    const patched = fs.readFileSync(asset, "utf8");
+    assert.match(patched, /codex-linux-read-aloud-kokoro-speed/);
+    assert.match(patched, /Choose folder/);
+    assert.match(
+      patched,
+      /children:\[S,C,w,T,\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow,\{\}\),D,O,k,A,j,M,N,P,L\]/,
+    );
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 0 });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("settings asset patch updates current general settings bundle", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-settings-"));
+  try {
+    const assets = path.join(root, "webview", "assets");
+    fs.mkdirSync(assets, { recursive: true });
+    const asset = path.join(assets, "general-settings-current.js");
+    fs.writeFileSync(
+      asset,
+      "function Gn(){return (0,$.jsxs)(ht,{children:[S,C,w,T,D,O,k,A,j,M,N,P,L]})}",
+    );
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 1 });
+    const patched = fs.readFileSync(asset, "utf8");
+    assert.match(patched, /codex-linux-read-aloud-enabled/);
+    assert.match(patched, /codexLinuxReadAloudSettingsRow/);
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 0 });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("settings asset patch creates a first-class read aloud settings section", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-read-aloud-settings-"));
+  try {
+    const assets = path.join(root, "webview", "assets");
+    fs.mkdirSync(assets, { recursive: true });
+    fs.writeFileSync(
+      path.join(assets, "general-settings-inner.js"),
+      [
+        "function Gn(){return (0,$.jsxs)(ht,{children:[S,C,w,T,D,O,k,A,j,M,N,P,L]})}",
+        "export{Yn as i,Jn as n,Gn as r,fr as t};",
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(assets, "general-settings-wrapper.js"),
+      'import{r as e}from"./general-settings-inner.js";export{e as GeneralSettings};',
+    );
+    fs.writeFileSync(
+      path.join(assets, "settings-sections-current.js"),
+      "var n=[{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`}];",
+    );
+    fs.writeFileSync(
+      path.join(assets, "settings-shared-current.js"),
+      [
+        '"computer-use":{id:`settings.nav.computer-use`,defaultMessage:`Computer use`,description:`Title for computer use settings section`},',
+        "function m(e){switch(e){case`computer-use`:{return null}case`browser-use`:{return null}}}",
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(assets, "settings-page-current.js"),
+      [
+        'var Z={},de=null,oe=null,G=null,pe={"browser-use":de,"computer-use":oe,"local-environments":q};',
+        "me=[`browser-use`,`computer-use`,`data-controls`];",
+        "he=[{slugs:[`browser-use`,`computer-use`,`local-environments`]}];",
+        "case`computer-use`:return A;",
+        "case`computer-use`:z=k.isLoading||m.isLoading;break bb0;",
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(assets, "app-main-current.js"),
+      'var iD={"general-settings":(0,Q.lazy)(()=>Mr(()=>import(`./general-settings-wrapper.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([1,2]),import.meta.url)),"keyboard-shortcuts":K};',
+    );
+
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 6 });
+    assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 0 });
+    assert.match(
+      fs.readFileSync(path.join(assets, "settings-page-current.js"), "utf8"),
+      /"read-aloud-settings":codexLinuxReadAloudSettingsIcon/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(assets, "app-main-current.js"), "utf8"),
+      /default:e\.ReadAloudSettings/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Adds a first-version Linux Read Aloud feature as an optional linux-feature, without an MCP server or bundled model. The feature adds an explicit icon button under assistant responses, a first-class Read Aloud settings section, Kokoro path/download setup, and a speech pace control. Speech only starts from the explicit button after the user opts in.

Refs #234.

## Details

- stages a tiny Kokoro stdin runner into `resources/read-aloud`
- supports `Choose folder` for local `kokoro-v1.0.onnx` and `voices-v1.0.bin` files
- supports `Download voice`, which creates a managed Python runtime and downloads Kokoro files from Hugging Face
- includes a `?` help affordance explaining the setup paths
- streams Kokoro chunks to `aplay` instead of synthesizing the whole response first
- keeps native system TTS fallbacks disabled unless explicitly requested

## Validation

- `node linux-features/read-aloud/test.js`
- `bash -n linux-features/read-aloud/stage.sh linux-features/read-aloud/install-kokoro-runtime.sh linux-features/read-aloud/bin/kokoro-stdin`
- `node scripts/lib/linux-features.js --enabled`
- `git diff --cached --check`
- `bash tests/scripts_smoke.sh`
- verified Hugging Face HEAD responses for both default model files
