### PR TITLE
docs: add GitHub CLI auth workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ make clean-state
 | `ERR_CONNECTION_REFUSED` on the webview port | The webview HTTP server failed to start. Ensure `python3` works and the configured port is free |
 | Stuck on Codex logo splash | Check `~/.cache/codex-desktop/launcher.log`. If webview origin validation failed, another process is probably serving the configured webview port or the extracted `content/webview/` bundle is incomplete |
 | `CODEX_CLI_PATH` error | Reopen the app to retry the automatic CLI install flow, or install manually with `npm i -g @openai/codex` / `npm i -g --prefix ~/.local @openai/codex` |
+| `gh auth status` works in a terminal but fails inside Codex Desktop | The app shell may be using isolated XDG paths or missing keyring DBus access. See [GitHub CLI auth in app-launched shells](docs/github-cli-auth.md) |
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log`. Best-effort CLI preflight will warn if the automatic refresh fails |
 | GPU / Vulkan / Wayland errors | Under Wayland with `DISPLAY` available, the launcher uses `--ozone-platform=x11` for window-positioning compatibility. Otherwise it uses `--ozone-platform-hint=auto`. GPU sandbox / compositing are disabled by default |
 | Window flickering | GPU compositing is disabled by default. If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |

--- a/docs/github-cli-auth.md
+++ b/docs/github-cli-auth.md
@@ -1,0 +1,74 @@
+# GitHub CLI auth in app-launched shells
+
+Codex Desktop can launch successfully while shell commands inside the app still
+see a different desktop session environment than a normal terminal. One common
+symptom is that `gh auth status` works in the user's terminal, but commands run
+from Codex Desktop report one of:
+
+- `You are not logged into any GitHub hosts`
+- `The token in .../hosts.yml is invalid`
+- device-login prompts even though `gh` is already authenticated elsewhere
+
+This usually means the app shell inherited an app-scoped `XDG_CONFIG_HOME`, or
+cannot reach the same Linux keyring over DBus that the normal terminal uses.
+`~/.config/gh/hosts.yml` may only contain account metadata while the actual
+token lives in the desktop keyring.
+
+## Verify the mismatch
+
+Run this in a normal terminal:
+
+```bash
+gh auth status
+```
+
+Then ask Codex Desktop to run the same command in a shell. If the terminal shows
+a valid login but the app shell does not, compare:
+
+```bash
+env | grep -E '^(XDG_CONFIG_HOME|XDG_DATA_HOME|XDG_STATE_HOME|XDG_CACHE_HOME|DBUS_SESSION_BUS_ADDRESS|GH_CONFIG_DIR)='
+```
+
+## Wrapper workaround
+
+Create a small wrapper on the host and ask Codex to use it for GitHub commands:
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/gh-normal <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prefer the user's normal GitHub CLI config/keyring instead of any
+# Electron/app-scoped XDG paths inherited by Codex Desktop.
+unset XDG_CONFIG_HOME XDG_DATA_HOME XDG_STATE_HOME XDG_CACHE_HOME
+export GH_CONFIG_DIR="${GH_CONFIG_DIR:-$HOME/.config/gh}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+
+exec gh "$@"
+EOF
+chmod +x ~/.local/bin/gh-normal
+```
+
+Validate it from the app shell:
+
+```bash
+~/.local/bin/gh-normal auth status
+```
+
+Then use the wrapper anywhere Codex Desktop needs authenticated GitHub CLI
+access:
+
+```bash
+~/.local/bin/gh-normal repo create my-project --private --source . --remote origin --push
+~/.local/bin/gh-normal pr create --fill
+```
+
+If the wrapper still cannot authenticate, refresh the GitHub CLI login from a
+normal desktop terminal:
+
+```bash
+gh auth login -h github.com
+```
+
+Then retry `~/.local/bin/gh-normal auth status` inside Codex Desktop.


### PR DESCRIPTION
## Summary
- document a GitHub CLI auth/keyring mismatch that can appear in app-launched Codex Desktop shells
- add a reusable gh-normal wrapper pattern for restoring normal XDG config and DBus keyring access
- link the workaround from the README troubleshooting table

## Validation
- git diff --check