### PR TITLE
fix: show subagent nicknames in webview

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -93,6 +93,7 @@ const {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applySubagentNicknameMetadataPatch,
   patchCommentPreloadBundle,
 } = require("./patches/webview-assets.js");
 
@@ -174,6 +175,7 @@ module.exports = {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applySubagentNicknameMetadataPatch,
   createPatchReport,
   corePatchDescriptors,
   createMainBundleContext,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -44,6 +44,7 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applySubagentNicknameMetadataPatch,
   isComputerUseUiEnabled,
   patchMainBundleSource,
   patchExtractedApp,
@@ -121,6 +122,36 @@ test("asset patch helpers match every file when passed a global regex", () => {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("subagent nickname metadata patch accepts session metadata shape", () => {
+  const source = [
+    "function j(e){return e}",
+    "function B(e){if(e==null||typeof e==`string`)return null;let t=Mi(e);return t==null?null:Ni(t)}",
+    "function Mi(e){return`subAgent`in e?e.subAgent:null}",
+    "function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}",
+    "function Pi(){return{parentThreadId:null,depth:null,agentNickname:null,agentRole:null}}",
+    "function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(B(e.source)?.agentNickname)}",
+    "function Zl(e){if(e==null)return null;let t=e.trim();return t.length===0?null:t}",
+  ].join("");
+  const patched = applyPatchTwice(applySubagentNicknameMetadataPatch, source);
+
+  assert.match(patched, /`subAgent`in e\?e\.subAgent:`subagent`in e\?e\.subagent:null/);
+  assert.match(patched, /Zl\(e\.agentNickname\)\?\?Zl\(e\.agent_nickname\)\?\?Zl\(B\(e\.source\)\?\.agentNickname\)/);
+
+  const sandbox = {
+    result: null,
+  };
+  vm.runInNewContext(
+    `${patched};result={top:Xl({agent_nickname:\`Ned\`}),source:Xl({source:{subagent:{thread_spawn:{parent_thread_id:\`parent\`,depth:1,agent_nickname:\`Pepper Potts\`,agent_role:\`worker\`}}}}),role:B({subagent:{thread_spawn:{parent_thread_id:\`parent\`,depth:1,agent_nickname:\`Pepper Potts\`,agent_role:\`worker\`}}}).agentRole};`,
+    sandbox,
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(sandbox.result)), {
+    top: "Ned",
+    source: "Pepper Potts",
+    role: "worker",
+  });
 });
 
 test("Linux target context parses distro, package, and desktop details", () => {
@@ -297,6 +328,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "opaque-window-default-resolved-theme",
+    "subagent-nickname-metadata-shape",
     "linux-computer-use-ui-availability",
     "linux-computer-use-install-flow",
     "linux-app-updater-bridge",

--- a/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
+++ b/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const {
+  applySubagentNicknameMetadataPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "subagent-nickname-metadata-shape",
+    phase: "webview-asset",
+    order: 1050,
+    ciPolicy: "required-upstream",
+    pattern: /^app-server-manager-signals-.*\.js$/,
+    missingDescription: "app-server manager webview bundle",
+    skipDescription: "subagent nickname metadata shape patch",
+    apply: applySubagentNicknameMetadataPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -214,6 +214,63 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
   ].join("");
 }
 
+function applySubagentNicknameMetadataPatch(currentSource) {
+  let patchedSource = currentSource;
+  const sourceShapePatchedMarker = "`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null";
+  const nicknamePatchedMarker =
+    "Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)";
+
+  const sourceShapeNeedle =
+    "function Mi(e){return`subAgent`in e?e.subAgent:null}function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}";
+  const sourceShapePatch =
+    "function Mi(e){return`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null}function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}";
+  if (patchedSource.includes(sourceShapePatchedMarker)) {
+    // Already patched.
+  } else if (patchedSource.includes(sourceShapeNeedle)) {
+    patchedSource = patchedSource.replace(sourceShapeNeedle, sourceShapePatch);
+  } else {
+    const sourceShapeRegex =
+      /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return`subAgent`in \2\?\2\.subAgent:null\}function ([A-Za-z_$][\w$]*)\(/u;
+    if (sourceShapeRegex.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        sourceShapeRegex,
+        "function $1($2){return`subAgent`in $2?$2.subAgent:`subagent`in $2?$2.subagent:null}function $3(",
+      );
+    }
+  }
+
+  const nicknameNeedle =
+    "function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(B(e.source)?.agentNickname)}";
+  const nicknamePatch =
+    "function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)}";
+  if (patchedSource.includes(nicknamePatchedMarker)) {
+    // Already patched.
+  } else if (patchedSource.includes(nicknameNeedle)) {
+    patchedSource = patchedSource.replace(nicknameNeedle, nicknamePatch);
+  } else {
+    const nicknameRegex =
+      /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2==null\?null:([A-Za-z_$][\w$]*)\(\2\.agentNickname\)\?\?\3\(([A-Za-z_$][\w$]*)\(\2\.source\)\?\.agentNickname\)\}/u;
+    if (nicknameRegex.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        nicknameRegex,
+        "function $1($2){return $2==null?null:$3($2.agentNickname)??$3($2.agent_nickname)??$3($4($2.source)?.agentNickname)}",
+      );
+    }
+  }
+
+  if (
+    patchedSource === currentSource &&
+    !(currentSource.includes(sourceShapePatchedMarker) && currentSource.includes(nicknamePatchedMarker)) &&
+    (currentSource.includes("agentNickname") ||
+      currentSource.includes("agent_nickname") ||
+      currentSource.includes("thread_spawn"))
+  ) {
+    console.warn("WARN: Could not find subagent nickname metadata needles — skipping metadata shape patch");
+  }
+
+  return patchedSource;
+}
+
 function applyBrowserAnnotationScreenshotPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -531,5 +588,6 @@ module.exports = {
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applySubagentNicknameMetadataPatch,
   patchCommentPreloadBundle,
 };

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1922,6 +1922,9 @@ make_fake_extracted_asar() {
     printf 'import{t as e}from"./chunk-test.js";Symbol.for(`react.transitional.element`);export{e as t};\n' > "$root/webview/assets/react-test.js"
     printf 'import{t as e}from"./chunk-test.js";Symbol.for(`react.transitional.element`);export{e as t};\n' > "$root/webview/assets/jsx-runtime-test.js"
     printf 'let marker=`vscode://codex`;async function n(){return{}}export{n};\n' > "$root/webview/assets/vscode-api-test.js"
+    cat > "$root/webview/assets/app-server-manager-signals-test.js" <<'JS'
+function j(e){return e}function B(e){if(e==null||typeof e==`string`)return null;let t=Mi(e);return t==null?null:Ni(t)}function Mi(e){return`subAgent`in e?e.subAgent:null}function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}function Pi(){return{parentThreadId:null,depth:null,agentNickname:null,agentRole:null}}function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(B(e.source)?.agentNickname)}function Zl(e){if(e==null)return null;let t=e.trim();return t.length===0?null:t}
+JS
     printf 'let marker=`hotkey-window-hotkey-state`;function i(){}export{i};\n' > "$root/webview/assets/general-settings-hotkey-test.js"
     printf 'function t(){}export{t};\n' > "$root/webview/assets/toggle-test.js"
     printf 'function n(){}export{n};\n' > "$root/webview/assets/settings-row-test.js"
@@ -1952,9 +1955,13 @@ test_linux_file_manager_patch_smoke() {
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.setMenuBarVisibility(!1),'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
+    assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" '`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null'
+    assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" 'Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)'
     assert_not_contains "$output_log" 'Failed to apply Linux File Manager Patch'
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
+    assert_occurrence_count "$extracted/webview/assets/app-server-manager-signals-test.js" '`subagent`in e?e.subagent' '1'
+    assert_occurrence_count "$extracted/webview/assets/app-server-manager-signals-test.js" 'Zl(e.agent_nickname)' '1'
     assert_not_contains "$output_log" 'Failed to apply Linux File Manager Patch'
 }
 


### PR DESCRIPTION
## Summary
- accept `source.subagent` in app-server manager metadata
- accept top-level `agent_nickname` fallback
- add required webview patch descriptor and coverage

## Why
Background task UI can have nickname/role data, but desktop webview drops the lower-case/snake-case metadata shape and falls back to raw agent/thread ids.

Closes #238
Refs https://github.com/openai/codex/pull/15513

## Test
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --check scripts/patches/webview-assets.js`
- `node --check scripts/patches/core/all-linux/webview/subagent-metadata/patch.js`
- `node --check scripts/patch-linux-window-ui.js`