### PR TITLE
[codex] Fix Linux remote mobile control auth

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -339,13 +339,16 @@ function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
 }
 
 function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
-  if (source.includes("Remote-control client has been revoked")) {
+  if (
+    source.includes("e.message===`Remote-control client key material missing`") &&
+    source.includes("e.message===`Remote-control client has been revoked`")
+  ) {
     return source;
   }
 
   const recoverableErrorNeedle =
-    "e.message===`Remote control request failed (403): Remote-control client key material missing`:!1";
-  if (!source.includes(recoverableErrorNeedle)) {
+    /e\.message===`Remote control request failed \(403\): Remote-control client key material missing`(?:\|\|e\.message===`Remote-control client key material missing`)?(?:\|\|e\.message===`Remote-control client has been revoked`)?:!1/u;
+  if (!recoverableErrorNeedle.test(source)) {
     if (!source.includes("Remote-control client key material missing")) {
       return source;
     }
@@ -355,7 +358,7 @@ function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
 
   return source.replace(
     recoverableErrorNeedle,
-    "e.message===`Remote control request failed (403): Remote-control client key material missing`||e.message===`Remote-control client has been revoked`:!1",
+    "e.message===`Remote control request failed (403): Remote-control client key material missing`||e.message===`Remote-control client key material missing`||e.message===`Remote-control client has been revoked`:!1",
   );
 }
 

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -21,6 +21,9 @@ const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
+const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
+const REMOTE_CONTROL_LOAD_GATE_NEEDLE =
+  /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\(`1042620455`\)\}/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],
   ["Keep this Mac awake", "Keep this Linux desktop awake"],
@@ -40,6 +43,33 @@ const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["Connect a device to this Mac", "Connect a device to this Linux desktop"],
   ["Connect your phone to this Mac", "Connect your phone to this Linux desktop"],
 ];
+const CLIENT_ACCOUNT_COMPAT_MARKER = "codexLinuxRemoteControlAccountMatches";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function replaceOnce(source, needle, replacement) {
+  if (!source.includes(needle)) {
+    return null;
+  }
+  return source.replace(needle, replacement);
+}
+
+function linuxRemoteControlClientAccountCompatibilityHelpers(loadEnrollmentFn) {
+  return [
+    "function codexLinuxRemoteControlEnrollmentAccountUserIds(e){",
+    "return[...new Set([e.tokenAccountUserId,e.tokenAuthUserId].filter(e=>e!=null))]",
+    "}",
+    "function codexLinuxRemoteControlAccountMatches({candidateAccountId:e,candidateAccountUserId:t,candidateUserId:n,expectedAccountId:r,expectedAccountUserId:i}){",
+    "return t===i||r!=null&&e===r&&n===i",
+    "}",
+    "async function codexLinuxRemoteControlLoadEnrollment({authIdentity:e,deviceKeyClient:t,enrollmentKey:n,globalState:r}){",
+    `let i=(await Promise.all(codexLinuxRemoteControlEnrollmentAccountUserIds(e).map(async e=>{let i=pd(n,e);return{enrollment:await ${loadEnrollmentFn}({deviceKeyClient:t,enrollmentKey:i,globalState:r}),enrollmentRecordKey:i}}))).find(e=>e.enrollment!=null);`,
+    "return i?.enrollment==null?null:i",
+    "}",
+  ].join("");
+}
 
 function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
   return [
@@ -132,6 +162,229 @@ function applyLinuxRemoteControlPreserveConfigPatch(source) {
   return source;
 }
 
+function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
+  if (
+    source.includes(CLIENT_ACCOUNT_COMPAT_MARKER) ||
+    source.includes("candidateAccountUserId") &&
+      source.includes("expectedAccountUserId") &&
+      source.includes("tokenAuthUserId")
+  ) {
+    return source;
+  }
+
+  if (!source.includes("Remote control enrollment start does not match current account.")) {
+    return source;
+  }
+
+  const enrollmentStartRegex =
+    /let ([A-Za-z_$][\w$]*)=Sd\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=\1\.tokenAccountUserId;if\(\3==null\)throw Error\(`Remote control enrollment requires the current ChatGPT account user id\.`\);let ([A-Za-z_$][\w$]*)=pd\(([A-Za-z_$][\w$]*),\3\),([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\{deviceKeyClient:([A-Za-z_$][\w$]*),enrollmentKey:\4,globalState:([A-Za-z_$][\w$]*)\}\),([A-Za-z_$][\w$]*)=\6,([A-Za-z_$][\w$]*);/u;
+  const startMatch = source.match(enrollmentStartRegex);
+  if (startMatch == null) {
+    console.warn("WARN: Could not find remote-control enrollment start shape - skipping account compatibility patch");
+    return source;
+  }
+
+  const [
+    startNeedle,
+    authIdentityVar,
+    headersVar,
+    tokenAccountUserIdVar,
+    enrollmentRecordKeyVar,
+    enrollmentKeyVar,
+    loadedEnrollmentVar,
+    loadEnrollmentFn,
+    deviceKeyClientVar,
+    globalStateVar,
+    enrollmentVar,
+    tokenResponseVar,
+  ] = startMatch;
+
+  const stepUpValidatorRegex =
+    /function ([A-Za-z_$][\w$]*)\(\{accountUserId:([A-Za-z_$][\w$]*),stepUpToken:([A-Za-z_$][\w$]*)\}\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\3\);([A-Za-z_$][\w$]*)\(\{payload:\4\}\);let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.parse\(\4\),([A-Za-z_$][\w$]*)=\7\[`https:\/\/api\.openai\.com\/auth`\],([A-Za-z_$][\w$]*)=\9\.chatgpt_account_user_id\?\?\9\.account_user_id,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\7\);if\(\10!==\2\)throw Error\(`Remote control enrollment step-up token does not match current account\.`\);if\(Math\.floor\(Date\.now\(\)\/1e3\)-\7\.iat>([A-Za-z_$][\w$]*)\)throw Error\(`Remote control enrollment step-up token is not fresh\.`\);if\(Date\.now\(\)-\7\.pwd_auth_time>\13\*1e3\)throw Error\(`Remote control enrollment step-up token does not have fresh password auth\.`\);if\(\11\.length!==1\|\|\11\[0\]!==([A-Za-z_$][\w$]*)\)throw Error\(`Remote control enrollment step-up token is missing required authorization\.`\);return\{accountUserId:\10\?\?null,issuedAt:\7\.iat,passwordAuthTime:\7\.pwd_auth_time,scopes:\11\}\}/u;
+  const validatorMatch = source.match(stepUpValidatorRegex);
+  if (validatorMatch == null) {
+    console.warn("WARN: Could not find remote-control step-up token validator - skipping account compatibility patch");
+    return source;
+  }
+
+  const [
+    validatorNeedle,
+    stepUpValidatorFn,
+    ,
+    ,
+    ,
+    decodeTokenFn,
+    logPayloadFn,
+    ,
+    tokenParserVar,
+    ,
+    ,
+    ,
+    readScopesFn,
+    freshnessWindowVar,
+    requiredScopeVar,
+  ] = validatorMatch;
+
+  let patched = source;
+  const helpersNeedle = /function pd\(e,t\)\{return`\$\{e\}\\n\$\{t\}`\}/u;
+  const helpersMatch = patched.match(helpersNeedle);
+  if (helpersMatch == null) {
+    console.warn("WARN: Could not find remote-control enrollment key helper - skipping account compatibility patch");
+    return source;
+  }
+  patched = patched.replace(
+    helpersNeedle,
+    `${helpersMatch[0]}${linuxRemoteControlClientAccountCompatibilityHelpers(loadEnrollmentFn)}`,
+  );
+
+  patched = patched.replace(
+    startNeedle,
+    [
+      `let ${authIdentityVar}=Sd(${headersVar}),${tokenAccountUserIdVar}=${authIdentityVar}.tokenAccountUserId;`,
+      `if(${tokenAccountUserIdVar}==null)throw Error(\`Remote control enrollment requires the current ChatGPT account user id.\`);`,
+      `let codexLinuxRemoteControlCurrentAccountId=${authIdentityVar}.tokenAccountId??${authIdentityVar}.headerChatGptAccountId,`,
+      `codexLinuxRemoteControlEnrollmentKey=${enrollmentKeyVar},`,
+      `codexLinuxRemoteControlExistingEnrollment=await codexLinuxRemoteControlLoadEnrollment({authIdentity:${authIdentityVar},deviceKeyClient:${deviceKeyClientVar},enrollmentKey:${enrollmentKeyVar},globalState:${globalStateVar}}),`,
+      `${enrollmentRecordKeyVar}=codexLinuxRemoteControlExistingEnrollment?.enrollmentRecordKey??pd(${enrollmentKeyVar},${tokenAccountUserIdVar}),`,
+      `${loadedEnrollmentVar}=codexLinuxRemoteControlExistingEnrollment?.enrollment??null,`,
+      `${enrollmentVar}=${loadedEnrollmentVar},${tokenResponseVar};`,
+    ].join(""),
+  );
+
+  const authCheckRegex =
+    /remote_control_client_enrollment_start_response[\s\S]{0,500}?\),([A-Za-z_$][\w$]*)\.account_user_id!==([A-Za-z_$][\w$]*)\)throw/u;
+  const authCheckMatch = patched.match(authCheckRegex);
+  if (authCheckMatch == null) {
+    console.warn("WARN: Could not find remote-control enrollment account check - skipping account compatibility patch");
+    return source;
+  }
+  const responseVar = authCheckMatch[1];
+  const checkedAccountUserVar = authCheckMatch[2];
+  if (checkedAccountUserVar !== tokenAccountUserIdVar) {
+    console.warn("WARN: Remote-control enrollment account check used unexpected token variable - skipping account compatibility patch");
+    return source;
+  }
+  patched = replaceOnce(
+    patched,
+    `${responseVar}.account_user_id!==${tokenAccountUserIdVar}`,
+    `!codexLinuxRemoteControlAccountMatches({candidateAccountId:codexLinuxRemoteControlCurrentAccountId,candidateAccountUserId:${authIdentityVar}.tokenAccountUserId,candidateUserId:${authIdentityVar}.tokenAuthUserId,expectedAccountId:codexLinuxRemoteControlCurrentAccountId,expectedAccountUserId:${responseVar}.account_user_id})`,
+  );
+  if (patched == null) {
+    console.warn("WARN: Could not replace remote-control enrollment account check - skipping account compatibility patch");
+    return source;
+  }
+
+  const createEnrollmentRegex = new RegExp(
+    `${escapeRegExp(enrollmentVar)}=await ([A-Za-z_$][\\w$]*)\\(\\{accountUserId:${escapeRegExp(tokenAccountUserIdVar)},clientId:${escapeRegExp(responseVar)}\\.client_id,deviceKeyClient:${escapeRegExp(deviceKeyClientVar)}\\}\\);try\\{`,
+    "u",
+  );
+  const createEnrollmentMatch = patched.match(createEnrollmentRegex);
+  if (createEnrollmentMatch == null) {
+    console.warn("WARN: Could not find remote-control enrollment creation - skipping account compatibility patch");
+    return source;
+  }
+  const createEnrollmentFn = createEnrollmentMatch[1];
+  patched = patched.replace(
+    createEnrollmentRegex,
+    `${enrollmentVar}=await ${createEnrollmentFn}({accountUserId:${responseVar}.account_user_id,clientId:${responseVar}.client_id,deviceKeyClient:${deviceKeyClientVar}});${enrollmentRecordKeyVar}=pd(codexLinuxRemoteControlEnrollmentKey,${enrollmentVar}.accountUserId);try{`,
+  );
+
+  const stepUpCallRegex = new RegExp(
+    `let ([A-Za-z_$][\\w$]*)=await ([A-Za-z_$][\\w$]*)\\(\\),([A-Za-z_$][\\w$]*)=${escapeRegExp(stepUpValidatorFn)}\\(\\{accountUserId:${escapeRegExp(tokenAccountUserIdVar)},stepUpToken:\\1\\}\\),`,
+    "u",
+  );
+  const stepUpCallMatch = patched.match(stepUpCallRegex);
+  if (stepUpCallMatch == null) {
+    console.warn("WARN: Could not find remote-control step-up validation call - skipping account compatibility patch");
+    return source;
+  }
+  const [, stepUpTokenVar, requestStepUpVar, parsedStepUpVar] = stepUpCallMatch;
+  patched = patched.replace(
+    stepUpCallRegex,
+    `let ${stepUpTokenVar}=await ${requestStepUpVar}({accountId:codexLinuxRemoteControlCurrentAccountId}),${parsedStepUpVar}=${stepUpValidatorFn}({accountId:codexLinuxRemoteControlCurrentAccountId,accountUserId:${enrollmentVar}.accountUserId,stepUpToken:${stepUpTokenVar}}),`,
+  );
+
+  patched = patched.replace(
+    validatorNeedle,
+    [
+      `function ${stepUpValidatorFn}({accountId:e,accountUserId:t,stepUpToken:n}){`,
+      `let r=${decodeTokenFn}(n);${logPayloadFn}({payload:r});`,
+      `let i=${tokenParserVar}.parse(r),a=i[\`https://api.openai.com/auth\`],`,
+      `o=a.chatgpt_account_user_id??a.account_user_id??null,`,
+      `s=a.chatgpt_account_id??a.account_id??null,c=${readScopesFn}(i);`,
+      "if(!codexLinuxRemoteControlAccountMatches({candidateAccountId:s,candidateAccountUserId:o,candidateUserId:a.user_id??null,expectedAccountId:e,expectedAccountUserId:t}))",
+      "throw Error(`Remote control enrollment step-up token does not match current account.`);",
+      `if(Math.floor(Date.now()/1e3)-i.iat>${freshnessWindowVar})throw Error(\`Remote control enrollment step-up token is not fresh.\`);`,
+      `if(Date.now()-i.pwd_auth_time>${freshnessWindowVar}*1e3)throw Error(\`Remote control enrollment step-up token does not have fresh password auth.\`);`,
+      `if(c.length!==1||c[0]!==${requiredScopeVar})throw Error(\`Remote control enrollment step-up token is missing required authorization.\`);`,
+      "return{accountUserId:o??null,issuedAt:i.iat,passwordAuthTime:i.pwd_auth_time,scopes:c}}",
+    ].join(""),
+  );
+
+  const authorizationCheckRegex =
+    /async function ([A-Za-z_$][\w$]*)\(\{appServerClient:([A-Za-z_$][\w$]*),desktopApiOptions:([A-Za-z_$][\w$]*),deviceKeyClient:([A-Za-z_$][\w$]*),globalState:([A-Za-z_$][\w$]*)\}\)\{let ([A-Za-z_$][\w$]*)=Sd\(await ([A-Za-z_$][\w$]*)\(\{action:`check remote control authorization`,appServerClient:\2,desktopApiOptions:\3\}\)\)\.tokenAccountUserId;if\(\6==null\)return\{clientAuthorized:!1,clientId:null\};let ([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\{deviceKeyClient:\4,enrollmentKey:pd\(([A-Za-z_$][\w$]*)\(\3\),\6\),globalState:\5\}\);return\{clientAuthorized:\8!=null,clientId:\8\?\.clientId\?\?null\}\}/u;
+  const authorizationCheckMatch = patched.match(authorizationCheckRegex);
+  if (authorizationCheckMatch == null) {
+    console.warn("WARN: Could not find remote-control authorization status check - skipping account compatibility patch");
+    return source;
+  }
+  const [, authCheckFn, appServerClientVar, desktopApiOptionsVar, authDeviceKeyClientVar, authGlobalStateVar, authStatusIdentityVar, authHeadersFn, enrollmentVarForStatus, , enrollmentKeyFn] =
+    authorizationCheckMatch;
+  patched = patched.replace(
+    authorizationCheckRegex,
+    `async function ${authCheckFn}({appServerClient:${appServerClientVar},desktopApiOptions:${desktopApiOptionsVar},deviceKeyClient:${authDeviceKeyClientVar},globalState:${authGlobalStateVar}}){let ${authStatusIdentityVar}=Sd(await ${authHeadersFn}({action:\`check remote control authorization\`,appServerClient:${appServerClientVar},desktopApiOptions:${desktopApiOptionsVar}}));if(${authStatusIdentityVar}.tokenAccountUserId==null)return{clientAuthorized:!1,clientId:null};let ${enrollmentVarForStatus}=await codexLinuxRemoteControlLoadEnrollment({authIdentity:${authStatusIdentityVar},deviceKeyClient:${authDeviceKeyClientVar},enrollmentKey:${enrollmentKeyFn}(${desktopApiOptionsVar}),globalState:${authGlobalStateVar}});return{clientAuthorized:${enrollmentVarForStatus}!=null,clientId:${enrollmentVarForStatus}?.enrollment.clientId??null}}`,
+  );
+
+  return patched;
+}
+
+function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
+  if (source.includes("Remote-control client has been revoked")) {
+    return source;
+  }
+
+  const recoverableErrorNeedle =
+    "e.message===`Remote control request failed (403): Remote-control client key material missing`:!1";
+  if (!source.includes(recoverableErrorNeedle)) {
+    if (!source.includes("Remote-control client key material missing")) {
+      return source;
+    }
+    console.warn("WARN: Could not find remote-control recoverable error predicate - skipping revoked-client recovery patch");
+    return source;
+  }
+
+  return source.replace(
+    recoverableErrorNeedle,
+    "e.message===`Remote control request failed (403): Remote-control client key material missing`||e.message===`Remote-control client has been revoked`:!1",
+  );
+}
+
+function applyLinuxRemoteControlLoadGatePatch(source) {
+  if (source.includes(REMOTE_CONTROL_LOAD_GATE_MARKER)) {
+    return source;
+  }
+  if (!source.includes("`1042620455`")) {
+    return source;
+  }
+
+  const match = source.match(REMOTE_CONTROL_LOAD_GATE_NEEDLE);
+  if (match == null) {
+    console.warn("WARN: Could not find remote-control loader rollout gate - skipping Linux remote-control load gate patch");
+    return source;
+  }
+
+  const [, functionName, statsigFn] = match;
+  return source.replace(
+    REMOTE_CONTROL_LOAD_GATE_NEEDLE,
+    [
+      `function ${functionName}(){return codexLinuxRemoteControlLoadGateEnabled()||${statsigFn}(\`1042620455\`)}`,
+      "function codexLinuxRemoteControlLoadGateEnabled(){",
+      "return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)",
+      "}",
+    ].join(""),
+  );
+}
+
 function applyLinuxRemoteControlVisibilityPatch(source) {
   if (
     source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT) ||
@@ -203,6 +456,30 @@ module.exports = [
     apply: applyLinuxRemoteControlPreserveConfigPatch,
   },
   {
+    id: "linux-remote-control-client-account-compatibility",
+    phase: "main-bundle",
+    order: 20_115,
+    ciPolicy: "optional",
+    apply: applyLinuxRemoteControlClientAccountCompatibilityPatch,
+  },
+  {
+    id: "linux-remote-control-client-revocation-recovery",
+    phase: "main-bundle",
+    order: 20_116,
+    ciPolicy: "optional",
+    apply: applyLinuxRemoteControlClientRevocationRecoveryPatch,
+  },
+  {
+    id: "linux-remote-control-load-gate",
+    phase: "webview-asset",
+    pattern: /^remote-connection-visibility-.*\.js$/,
+    order: 20_118,
+    ciPolicy: "optional",
+    missingDescription: "remote-control loader gate bundle",
+    skipDescription: "Linux remote-control load gate patch",
+    apply: applyLinuxRemoteControlLoadGatePatch,
+  },
+  {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
     pattern: /^(?:remote-control-connections-visibility|remote-connections-settings)-.*\.js$/,
@@ -226,5 +503,10 @@ module.exports = [
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
 module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
+module.exports.applyLinuxRemoteControlClientAccountCompatibilityPatch =
+  applyLinuxRemoteControlClientAccountCompatibilityPatch;
+module.exports.applyLinuxRemoteControlClientRevocationRecoveryPatch =
+  applyLinuxRemoteControlClientRevocationRecoveryPatch;
+module.exports.applyLinuxRemoteControlLoadGatePatch = applyLinuxRemoteControlLoadGatePatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -204,9 +204,16 @@ test("Linux remote-control client revocation triggers local cleanup and re-enrol
   const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
 
   assert.notEqual(patched, source);
+  assert.match(patched, /Remote-control client key material missing`\|\|e\.message===`Remote-control client has been revoked/);
   assert.match(patched, /Remote-control client has been revoked/);
-  assert.match(patched, /Remote-control client key material missing`\|\|e\.message===`Remote-control client has been revoked`:!1/);
   assert.equal(applyLinuxRemoteControlClientRevocationRecoveryPatch(patched), patched);
+});
+
+test("Linux remote-control client recovery handles bare missing key material errors", () => {
+  const source = syntheticRecoverableErrorPredicateBundle();
+  const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
+
+  assert.match(patched, /e\.message===`Remote-control client key material missing`/);
 });
 
 test("Linux remote-control load gate enables remote-control environment loading", () => {

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -18,8 +18,11 @@ const {
 } = require("../../scripts/patch-linux-window-ui.js");
 const {
   applyLinuxRemoteControlDeviceKeyPatch,
+  applyLinuxRemoteControlClientAccountCompatibilityPatch,
+  applyLinuxRemoteControlClientRevocationRecoveryPatch,
   applyLinuxRemoteControlCopyPatch,
   applyLinuxRemoteControlPreserveConfigPatch,
+  applyLinuxRemoteControlLoadGatePatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
 
@@ -45,6 +48,25 @@ function syntheticCurrentMainBundle() {
     "function pz({resourcesPath:e}){let t=null,n=()=>{if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=lz((0,i.join)(e,`native`,uz)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=mz(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
     "async function vV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{await yV(i.default.join(e??t.Rr({hostConfig:n,preferWsl:t.Kr(n)}),_V))&&r.info(`Removed remote_control from config before app-server start`)}catch(e){r.warning(`Failed to remove remote_control before app-server start`,{safe:{},sensitive:{error:e}})}}",
   ].join("");
+}
+
+function syntheticOldClientEnrollmentBundle() {
+  return [
+    "async function dd({appServerClient:e,desktopApiOptions:t,deviceKeyClient:n,globalState:r}){let i=Sd(await md({action:`check remote control authorization`,appServerClient:e,desktopApiOptions:t})).tokenAccountUserId;if(i==null)return{clientAuthorized:!1,clientId:null};let a=await Ld({deviceKeyClient:n,enrollmentKey:pd(fd(t),i),globalState:r});return{clientAuthorized:a!=null,clientId:a?.clientId??null}}",
+    "function fd(e){return[e.desktopOriginator,e.devApiBaseUrl,e.prodApiBaseUrl].join(`\\n`)}",
+    "function pd(e,t){return`${e}\\n${t}`}",
+    "async function md({action:e=`connect remote control environments`,appServerClient:t,desktopApiOptions:n,headers:r}){return Ou({action:e,appServerClient:t,desktopOriginator:n.desktopOriginator,headers:r})}",
+    "async function hd({appServerClient:e,deviceKeyClient:t,desktopApiOptions:n,enrollmentKey:r,globalState:i,headers:a,requestRemoteControlEnrollmentStepUpToken:o}){let s=Sd(a),c=s.tokenAccountUserId;if(c==null)throw Error(`Remote control enrollment requires the current ChatGPT account user id.`);let l=pd(r,c),u=await Ld({deviceKeyClient:t,enrollmentKey:l,globalState:i}),d=u,f;if(d==null){if(o==null)throw Error(`Remote control enrollment requires explicit authorization in settings.`);Qu().info(`remote_control_client_enrollment_start_request`,{...Cd({authIdentity:s,hasExistingEnrollment:!1})});let r=await jd({appServerClient:e,body:{},desktopApiOptions:n,headers:a});if(Qu().info(`remote_control_client_enrollment_start_response`,{...Cd({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:r.account_user_id,responseClientId:r.client_id,responseChallengeId:r.device_key_challenge.challenge_id})}),r.account_user_id!==c)throw Qu().warning(`remote_control_client_enrollment_start_account_mismatch`,{...Cd({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:r.account_user_id,responseClientId:r.client_id,responseChallengeId:r.device_key_challenge.challenge_id})}),Error(`Remote control enrollment start does not match current account.`);d=await Vd({accountUserId:c,clientId:r.client_id,deviceKeyClient:t});try{if(Qu().info(`remote_control_client_enrollment_key_created`,{safe:{algorithm:d.algorithm,protectionClass:d.protectionClass},sensitive:{accountUserId:d.accountUserId,clientId:d.clientId,keyId:d.keyId}}),o==null)throw Error(`Remote control enrollment requires a step-up authorization flow.`);Qu().info(`remote_control_client_enrollment_step_up_requested`,{...Cd({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:r.account_user_id,responseChallengeId:r.device_key_challenge.challenge_id,responseClientId:r.client_id})});let u=await o(),p=Td({accountUserId:c,stepUpToken:u}),m=Cd({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:r.account_user_id,responseChallengeId:r.device_key_challenge.challenge_id,responseClientId:r.client_id});Qu().info(`remote_control_client_enrollment_step_up_validated`,{safe:{...m.safe,stepUpTokenScopes:p.scopes},sensitive:{...m.sensitive,stepUpIssuedAt:p.issuedAt,stepUpPasswordAuthTime:p.passwordAuthTime,stepUpTokenAccountUserId:p.accountUserId}}),f=await Md({appServerClient:e,body:{client_id:d.clientId,step_up_token:u,device_identity:Ud(d),device_key_proof:await Gd({challenge:r.device_key_challenge,deviceKeyClient:t,desktopApiOptions:n,enrollment:d,expectedPath:`/codex/remote/control/client/enroll/finish`,requireDeviceIdentityHash:!1})},desktopApiOptions:n,headers:a}),Qu().info(`remote_control_client_enrollment_finish_response`,{...wd(f)}),_d(f,d),Rd(i,l,d)}catch(e){throw await Hd({deviceKeyClient:t,enrollment:d}),e}}else{Qu().info(`remote_control_client_refresh_start_request`,{...Cd({authIdentity:s,existingEnrollment:u,hasExistingEnrollment:!0})});let c;try{c=await Nd({appServerClient:e,body:{client_id:d.clientId},desktopApiOptions:n,headers:a})}catch(s){if(!Bd(s))throw s;return await Hd({deviceKeyClient:t,enrollment:d}),zd(i,l),hd({appServerClient:e,deviceKeyClient:t,desktopApiOptions:n,enrollmentKey:r,globalState:i,headers:a,requestRemoteControlEnrollmentStepUpToken:o})}if(Qu().info(`remote_control_client_refresh_start_response`,{...Cd({authIdentity:s,existingEnrollment:u,hasExistingEnrollment:!0,responseAccountUserId:c.account_user_id,responseClientId:c.client_id,responseChallengeId:c.device_key_challenge.challenge_id})}),c.client_id!==d.clientId||c.account_user_id!==d.accountUserId)throw Error(`Remote control refresh challenge does not match local enrollment.`);f=await Pd({appServerClient:e,body:{client_id:d.clientId,device_key_proof:await Gd({challenge:c.device_key_challenge,deviceKeyClient:t,desktopApiOptions:n,enrollment:d,expectedPath:`/codex/remote/control/client/refresh/finish`,requireDeviceIdentityHash:!0})},desktopApiOptions:n,headers:a})}let p=_d(f,d);return{clientId:f.client_id,headers:{\"x-codex-client-session-token\":`Bearer ${f.remote_control_token}`},tokenExpiresAt:p.tokenExpiresAt,scopes:p.scopes,requiresDeviceKeyProof:!0}}",
+    "function Td({accountUserId:e,stepUpToken:t}){let n=Od(t);Dd({payload:n});let r=od.parse(n),i=r[`https://api.openai.com/auth`],a=i.chatgpt_account_user_id??i.account_user_id,o=Ed(r);if(a!==e)throw Error(`Remote control enrollment step-up token does not match current account.`);if(Math.floor(Date.now()/1e3)-r.iat>id)throw Error(`Remote control enrollment step-up token is not fresh.`);if(Date.now()-r.pwd_auth_time>id*1e3)throw Error(`Remote control enrollment step-up token does not have fresh password auth.`);if(o.length!==1||o[0]!==rd)throw Error(`Remote control enrollment step-up token is missing required authorization.`);return{accountUserId:a??null,issuedAt:r.iat,passwordAuthTime:r.pwd_auth_time,scopes:o}}",
+  ].join("");
+}
+
+function syntheticRecoverableErrorPredicateBundle() {
+  return "function Bd(e){return e instanceof Error?e.message.startsWith(`Remote control request failed (404):`)||e.message===`Remote control request failed (401): Remote-control client enrollment is incomplete`||e.message===`Remote control request failed (403): Remote-control client key material missing`:!1}";
+}
+
+function syntheticRemoteConnectionVisibilityBundle() {
+  return "function d(){return true}function f(){return c(`1042620455`)}function p(){return []}export{d as n,f as r,p as t};";
 }
 
 function syntheticCurrentVisibilityBundle() {
@@ -114,12 +136,18 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.deepEqual(descriptors.map((descriptor) => descriptor.id), [
       "feature:remote-mobile-control:linux-remote-control-device-key",
       "feature:remote-mobile-control:linux-remote-control-preserve-config",
+      "feature:remote-mobile-control:linux-remote-control-client-account-compatibility",
+      "feature:remote-mobile-control:linux-remote-control-client-revocation-recovery",
+      "feature:remote-mobile-control:linux-remote-control-load-gate",
       "feature:remote-mobile-control:linux-remote-control-visibility",
       "feature:remote-mobile-control:linux-remote-control-copy",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
       "main-bundle",
+      "main-bundle",
+      "main-bundle",
+      "webview-asset",
       "webview-asset",
       "webview-asset",
     ]);
@@ -151,6 +179,45 @@ test("Linux remote-control device-key patch handles current minified aliases", (
   assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
   assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
   assert.equal(applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)), patched);
+});
+
+test("Linux remote-control client enrollment accepts account-scoped and base user ids", () => {
+  const source = syntheticOldClientEnrollmentBundle();
+  const patched = applyLinuxRemoteControlClientAccountCompatibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlAccountMatches/);
+  assert.match(patched, /codexLinuxRemoteControlLoadEnrollment/);
+  assert.doesNotMatch(patched, /account_user_id!==c/);
+  assert.match(patched, /accountUserId:r\.account_user_id/);
+  assert.match(patched, /l=pd\(codexLinuxRemoteControlEnrollmentKey,d\.accountUserId\)/);
+  assert.match(
+    patched,
+    /Td\(\{accountId:codexLinuxRemoteControlCurrentAccountId,accountUserId:d\.accountUserId,stepUpToken:u\}\)/,
+  );
+  assert.match(patched, /clientId:a\?\.enrollment\.clientId\?\?null/);
+  assert.equal(applyLinuxRemoteControlClientAccountCompatibilityPatch(patched), patched);
+});
+
+test("Linux remote-control client revocation triggers local cleanup and re-enrollment", () => {
+  const source = syntheticRecoverableErrorPredicateBundle();
+  const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /Remote-control client has been revoked/);
+  assert.match(patched, /Remote-control client key material missing`\|\|e\.message===`Remote-control client has been revoked`:!1/);
+  assert.equal(applyLinuxRemoteControlClientRevocationRecoveryPatch(patched), patched);
+});
+
+test("Linux remote-control load gate enables remote-control environment loading", () => {
+  const source = syntheticRemoteConnectionVisibilityBundle();
+  const patched = applyLinuxRemoteControlLoadGatePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlLoadGateEnabled/);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /return codexLinuxRemoteControlLoadGateEnabled\(\)\|\|c\(`1042620455`\)/);
+  assert.equal(applyLinuxRemoteControlLoadGatePatch(patched), patched);
 });
 
 test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
@@ -276,6 +343,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.mkdirSync(assetsDir, { recursive: true });
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
         fs.writeFileSync(
+          path.join(assetsDir, "remote-connection-visibility-test.js"),
+          syntheticRemoteConnectionVisibilityBundle(),
+        );
+        fs.writeFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           syntheticVisibilityBundle(),
         );
@@ -300,6 +371,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           "utf8",
         );
+        const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
+          path.join(assetsDir, "remote-connection-visibility-test.js"),
+          "utf8",
+        );
         const patchedRemoteConnectionsSettingsFile = fs.readFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
           "utf8",
@@ -314,6 +389,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
+        assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
         assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
         assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
@@ -335,6 +411,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-preserve-config" &&
             patch.status === "already-applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-load-gate" &&
+            patch.status === "applied",
           ),
         );
         assert.ok(


### PR DESCRIPTION
## Summary

Fix Linux remote mobile control so a Linux desktop can both enroll as a controller and load remote-control environments after authorization.

This carries three narrow compatibility fixes in the `remote-mobile-control` Linux feature:

- Accept the server-returned account user id when the auth token uses the account-scoped user id shape, and store the enrollment under the server-returned id.
- Treat a revoked remote-control client as recoverable, deleting the stale local enrollment/key and re-enrolling instead of leaving the UI stuck.
- Enable the remote-control environment loader gate on Linux. The settings UI was visible on Linux, but the app-main bridge still only loaded environments when the upstream rollout flag was true.

## Why

On Linux the UI could reach the authorization flow, but the client enrollment could fail on account id shape mismatches. After reconnect/revoke flows, a stale revoked local client was reused. Once authorization succeeded, the Linux renderer still did not ask the backend for environments because the loader gate remained tied to the upstream rollout flag.

## Validation

- `node --test linux-features/remote-mobile-control/test.js`
