### PR TITLE
Fix Browser plugin staging

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -512,12 +512,34 @@ print(version.strip())
 PY
 }
 
+bundled_plugin_name() {
+    local plugin_json="$1"
+
+    python3 - "$plugin_json" <<'PY'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        name = json.load(handle).get("name")
+except (OSError, json.JSONDecodeError):
+    name = None
+
+if not isinstance(name, str) or re.fullmatch(r"[A-Za-z0-9._-]+", name.strip()) is None:
+    raise SystemExit(1)
+print(name.strip())
+PY
+}
+
 sync_browser_use_bundled_plugin_cache() {
-    local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser-use"
+    local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"
     local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
-    local plugin_json="$source_plugin/.codex-plugin/plugin.json"
-    local source_client="$source_plugin/scripts/browser-client.mjs"
+    local plugin_json=""
+    local source_client=""
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local plugin_name
+    local plugin_dir_name
     local version
     local cache_root
     local cache_plugin
@@ -526,14 +548,25 @@ sync_browser_use_bundled_plugin_cache() {
     local tmp_plugin
     local marketplace_root
     local marketplace_plugins_dir
+    local marketplace_plugin_link
+    local needs_copy=1
+
+    plugin_json="$source_plugin/.codex-plugin/plugin.json"
+    source_client="$source_plugin/scripts/browser-client.mjs"
 
     [ -f "$plugin_json" ] || return 0
     [ -f "$source_client" ] || return 0
 
+    plugin_name="$(bundled_plugin_name "$plugin_json" 2>/dev/null || basename "$source_plugin")"
+    plugin_dir_name="$(basename "$source_plugin")"
+    [ -n "$plugin_name" ] || return 0
+    [ -n "$plugin_dir_name" ] || return 0
+
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
+    marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"
     if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir"
+        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
         rm -f "$marketplace_plugins_dir/marketplace.json"
         cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
             chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
@@ -543,29 +576,43 @@ sync_browser_use_bundled_plugin_cache() {
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
 
-    cache_root="$codex_home/plugins/cache/openai-bundled/browser-use"
+    cache_root="$codex_home/plugins/cache/openai-bundled/$plugin_name"
     cache_plugin="$cache_root/$version"
     cache_client="$cache_plugin/scripts/browser-client.mjs"
 
     if [ -f "$cache_client" ] && cmp -s "$source_client" "$cache_client"; then
-        return 0
+        needs_copy=0
     fi
 
-    cache_parent="$(dirname "$cache_plugin")"
-    tmp_plugin="$cache_parent/.browser-use-$version.tmp.$$"
-    remove_tree_if_exists "$tmp_plugin"
-    mkdir -p "$cache_parent"
-
-    if cp -R "$source_plugin" "$tmp_plugin"; then
-        make_tree_owner_writable "$tmp_plugin"
-        find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-        remove_tree_if_exists "$cache_plugin"
-        mv "$tmp_plugin" "$cache_plugin"
-        echo "Browser Use plugin cache synced from bundled resources: $cache_plugin"
-    else
+    if [ "$needs_copy" -eq 1 ]; then
+        cache_parent="$(dirname "$cache_plugin")"
+        tmp_plugin="$cache_parent/.browser-$version.tmp.$$"
         remove_tree_if_exists "$tmp_plugin"
-        echo "Browser Use plugin cache sync failed; continuing with existing cache."
+        mkdir -p "$cache_parent"
+
+        if cp -R "$source_plugin" "$tmp_plugin"; then
+            make_tree_owner_writable "$tmp_plugin"
+            find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
+            remove_tree_if_exists "$cache_plugin"
+            mv "$tmp_plugin" "$cache_plugin"
+            echo "Browser Use plugin cache synced from bundled resources: $cache_plugin"
+        else
+            remove_tree_if_exists "$tmp_plugin"
+            echo "Browser Use plugin cache sync failed; continuing with existing cache."
+            return 0
+        fi
     fi
+
+    if [ -e "$cache_root/latest" ] && [ ! -L "$cache_root/latest" ]; then
+        remove_tree_if_exists "$cache_root/latest"
+    fi
+    ln -sfn "$version" "$cache_root/latest"
+
+    mkdir -p "$marketplace_root/plugins"
+    if [ -e "$marketplace_plugin_link" ] && [ ! -L "$marketplace_plugin_link" ]; then
+        remove_tree_if_exists "$marketplace_plugin_link"
+    fi
+    ln -sfn "$cache_root/latest" "$marketplace_plugin_link"
 }
 
 chrome_extension_host_arch() {

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -641,25 +641,79 @@ path.write_text(source[:match.start()] + replacement + source[match.end():], enc
 PY
 }
 
-stage_browser_use_plugin_from_upstream() {
+find_browser_plugin_source() {
+    local bundled_root="$1"
+    local source_marketplace="$2"
+
+    node - "$bundled_root" "$source_marketplace" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const bundledRoot = process.argv[2];
+const marketplacePath = process.argv[3];
+const candidates = [];
+
+try {
+  const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+  const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
+  const plugin = plugins.find((entry) => entry && entry.name === "browser");
+  const source = plugin && plugin.source;
+  if (
+    source &&
+    source.source === "local" &&
+    typeof source.path === "string" &&
+    source.path.length > 0
+  ) {
+    candidates.push(path.resolve(bundledRoot, source.path));
+  }
+} catch (_err) {
+  // Fall back to the known upstream directory name below.
+}
+
+candidates.push(path.join(bundledRoot, "plugins", "browser"));
+
+const seen = new Set();
+for (const candidate of candidates) {
+  const normalized = path.normalize(candidate);
+  if (seen.has(normalized)) {
+    continue;
+  }
+  seen.add(normalized);
+
+  if (
+    fs.existsSync(path.join(normalized, ".codex-plugin", "plugin.json")) &&
+    fs.existsSync(path.join(normalized, "scripts", "browser-client.mjs"))
+  ) {
+    console.log(normalized);
+    process.exit(0);
+  }
+}
+
+process.exit(1);
+NODE
+}
+
+stage_browser_plugin_from_upstream() {
     local source_plugin="$1"
     local target_plugins="$2"
-    local target_plugin="$target_plugins/browser-use"
+    local target_name
+    target_name="$(basename "$source_plugin")"
+    local target_plugin="$target_plugins/$target_name"
     local source_client="$source_plugin/scripts/browser-client.mjs"
     local target_client="$target_plugin/scripts/browser-client.mjs"
 
     if [ ! -d "$source_plugin" ]; then
-        info "Browser Use bundled plugin resources not present in upstream app; skipping Browser Use"
+        info "Browser bundled plugin resources not present in upstream app; skipping Browser"
         return 1
     fi
 
     if [ ! -f "$source_plugin/.codex-plugin/plugin.json" ]; then
-        warn "Browser Use plugin manifest not found in upstream app; skipping Browser Use"
+        warn "Browser plugin manifest not found in upstream app; skipping Browser"
         return 1
     fi
 
     if [ ! -f "$source_client" ]; then
-        warn "Browser Use browser-client.mjs not found in upstream app; skipping Browser Use"
+        warn "Browser browser-client.mjs not found in upstream app; skipping Browser"
         return 1
     fi
 
@@ -668,7 +722,7 @@ stage_browser_use_plugin_from_upstream() {
     remove_macos_sidecar_files "$target_plugin"
     patch_browser_use_site_status_allowlist_fallback "$target_client"
 
-    info "Browser Use plugin staged from upstream DMG"
+    info "Browser plugin staged from upstream DMG"
     return 0
 }
 
@@ -693,11 +747,67 @@ const sourcePlugins = marketplace.plugins || [];
 const plugins = [];
 
 if (includeBrowser) {
-  const browserUse = sourcePlugins.find((plugin) => plugin.name === "browser-use");
-  if (browserUse == null) {
-    throw new Error("Bundled marketplace does not contain browser-use plugin");
+  const marketplaceRoot = path.resolve(path.dirname(destinationPath), "..", "..");
+  const browser = sourcePlugins.find((plugin) => {
+    if (plugin == null || typeof plugin !== "object") {
+      return false;
+    }
+    if (plugin.name !== "browser") {
+      return false;
+    }
+    const source = plugin.source || {};
+    if (source.source !== "local" || typeof source.path !== "string") {
+      return true;
+    }
+    const stagedManifest = path.join(
+      path.resolve(marketplaceRoot, source.path),
+      ".codex-plugin",
+      "plugin.json",
+    );
+    return fs.existsSync(stagedManifest);
+  });
+  if (browser == null) {
+    let fallback = null;
+    const stagedManifestPath = path.join(
+      marketplaceRoot,
+      "plugins",
+      "browser",
+      ".codex-plugin",
+      "plugin.json",
+    );
+    try {
+      const manifest = JSON.parse(fs.readFileSync(stagedManifestPath, "utf8"));
+      const name =
+        typeof manifest.name === "string" && manifest.name.length > 0 ? manifest.name : "browser";
+      const category =
+        manifest &&
+        manifest.interface &&
+        typeof manifest.interface.category === "string" &&
+        manifest.interface.category.length > 0
+          ? manifest.interface.category
+          : "Engineering";
+      fallback = {
+        name,
+        source: {
+          source: "local",
+          path: "./plugins/browser",
+        },
+        policy: {
+          installation: "AVAILABLE",
+          authentication: "ON_INSTALL",
+        },
+        category,
+      };
+    } catch (_err) {
+      // Fall through to the explicit error below.
+    }
+    if (fallback == null) {
+      throw new Error("Bundled marketplace does not contain browser plugin");
+    }
+    plugins.push(fallback);
+  } else {
+    plugins.push(browser);
   }
-  plugins.push(browserUse);
 }
 
 if (includeChrome) {
@@ -770,8 +880,9 @@ NODE
 install_bundled_plugin_resources() {
     local app_dir="$1"
     local upstream_resources="$app_dir/Contents/Resources"
-    local source_marketplace="$upstream_resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
-    local source_browser_plugin="$upstream_resources/plugins/openai-bundled/plugins/browser-use"
+    local bundled_source_root="$upstream_resources/plugins/openai-bundled"
+    local source_marketplace="$bundled_source_root/.agents/plugins/marketplace.json"
+    local source_browser_plugin=""
     local source_chrome_plugin="$upstream_resources/plugins/openai-bundled/plugins/chrome"
     local resources_dir="$INSTALL_DIR/resources"
     local bundled_plugins_dir="$resources_dir/plugins/openai-bundled"
@@ -786,8 +897,11 @@ install_bundled_plugin_resources() {
 
     mkdir -p "$bundled_plugins_dir/plugins" "$bundled_plugins_dir/.agents/plugins"
 
-    if stage_browser_use_plugin_from_upstream "$source_browser_plugin" "$bundled_plugins_dir/plugins"; then
+    if source_browser_plugin="$(find_browser_plugin_source "$bundled_source_root" "$source_marketplace")" &&
+        stage_browser_plugin_from_upstream "$source_browser_plugin" "$bundled_plugins_dir/plugins"; then
         include_browser=1
+    else
+        info "Browser bundled plugin resources not present in upstream app; skipping Browser"
     fi
 
     if stage_chrome_plugin_from_upstream "$source_chrome_plugin" "$bundled_plugins_dir/plugins"; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -54,20 +54,20 @@ assert_occurrence_count() {
     [ "$actual" = "$expected" ] || fail "Expected '$pattern' to appear $expected times in $path, found $actual"
 }
 
-make_fake_browser_use_upstream_app() {
+make_fake_browser_upstream_app() {
     local app_dir="$1"
     local resources_dir="$app_dir/Contents/Resources"
     mkdir -p \
         "$resources_dir/plugins/openai-bundled/.agents/plugins" \
-        "$resources_dir/plugins/openai-bundled/plugins/browser-use/.codex-plugin" \
-        "$resources_dir/plugins/openai-bundled/plugins/browser-use/scripts"
+        "$resources_dir/plugins/openai-bundled/plugins/browser/.codex-plugin" \
+        "$resources_dir/plugins/openai-bundled/plugins/browser/scripts"
     cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
-{"plugins":[{"name":"browser-use","source":{"source":"local","path":"./plugins/browser-use"},"policy":{"installation":"AVAILABLE"}}]}
+{"plugins":[{"name":"browser","source":{"source":"local","path":"./plugins/browser"},"policy":{"installation":"AVAILABLE","authentication":"ON_INSTALL"},"category":"Engineering"}]}
 JSON
-    cat > "$resources_dir/plugins/openai-bundled/plugins/browser-use/.codex-plugin/plugin.json" <<'JSON'
-{"name":"browser-use","version":"0.1.0-alpha1"}
+    cat > "$resources_dir/plugins/openai-bundled/plugins/browser/.codex-plugin/plugin.json" <<'JSON'
+{"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
-    cat > "$resources_dir/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" <<'JS'
+    cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
 class Uf{async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}export function setupAtlasRuntime() {}
 JS
 }
@@ -1442,6 +1442,8 @@ PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "resolve_update_manager_path"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_browser_use_bundled_plugin_cache"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_chrome_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_read_aloud_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "make_tree_owner_writable"
@@ -1566,7 +1568,7 @@ test_browser_use_node_repl_fallback_runtime() {
     local true_bin
 
     mkdir -p "$workspace" "$install_dir/resources" "$archive_root/codex-primary-runtime/dependencies/bin"
-    make_fake_browser_use_upstream_app "$app_dir"
+    make_fake_browser_upstream_app "$app_dir"
 
     # Simulate the current upstream DMG shape: node_repl exists, but it is not a Linux ELF.
     printf '\xfe\xed\xfa\xcf' > "$app_dir/Contents/Resources/node_repl"
@@ -1607,12 +1609,50 @@ test_browser_use_node_repl_fallback_runtime() {
     ) >"$output_log" 2>&1
 
     assert_file_exists "$install_dir/resources/node_repl"
-    assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs"
+    assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs"
     cmp -s "$true_bin" "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
-    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
     assert_not_contains "$output_log" "WARN.*Browser Use node_repl runtime is not a Linux executable"
     assert_contains "$output_log" "Downloading Browser Use node_repl fallback runtime"
+}
+
+test_browser_plugin_renamed_upstream_staging() {
+    info "Checking Browser plugin staging from renamed upstream resources"
+    local workspace="$TMP_DIR/browser-plugin-renamed"
+    local app_dir="$workspace/Codex.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local browser_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser"
+    local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_browser_upstream_app "$app_dir"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$browser_dir/scripts/browser-client.mjs"
+    assert_contains "$browser_dir/.codex-plugin/plugin.json" '"name":"browser"'
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_contains "$marketplace" '"name": "browser"'
+    assert_contains "$marketplace" '"path": "./plugins/browser"'
+    assert_contains "$output_log" "Browser plugin staged from upstream DMG"
+    assert_not_contains "$output_log" "Browser bundled plugin resources not present"
 }
 
 test_browser_use_node_repl_glibc_pidfd_patch_static() {
@@ -1831,7 +1871,7 @@ test_chrome_marketplace_fallback_synthesis() {
     # Upstream marketplace.json lists no chrome entry — exercises the
     # synthesized-fallback path in write_bundled_plugins_marketplace.
     cat > "$app_dir/Contents/Resources/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
-{"plugins":[{"name":"browser-use","source":{"source":"local","path":"./plugins/browser-use"},"policy":{"installation":"AVAILABLE"}}]}
+{"plugins":[{"name":"browser","source":{"source":"local","path":"./plugins/browser"},"policy":{"installation":"AVAILABLE"}}]}
 JSON
 
     # Distinctive name + category prove the synthesized entry actually
@@ -3706,6 +3746,7 @@ main() {
     test_native_module_rebuild_accepts_prebuilt_source
     test_bundled_plugin_builders_accept_prebuilt_binaries
     test_browser_use_node_repl_fallback_runtime
+    test_browser_plugin_renamed_upstream_staging
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility
     test_chrome_plugin_staging


### PR DESCRIPTION
## Summary
- Stage the upstream bundled Browser plugin from `plugins/browser`
- Sync the generated launcher cache and runtime marketplace path for the Browser plugin
- Update smoke coverage for Browser plugin staging and node_repl fallback

## User-visible behavior
- Linux builds include the bundled Browser plugin again when the upstream DMG uses the current `browser` plugin name
- The generated launcher publishes the Browser plugin through the same cache and marketplace path used at runtime

## Validation
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `./install.sh --reuse-dmg`
