### PR TITLE
Add guided native setup helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -64,6 +64,7 @@ help:
 	@printf '  %-18s %s\n' "make inspect-upstream" "Inspect a DMG and write rebuild reports without changing codex-app/"
 	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/ (reuses cached Codex.dmg)"
 	@printf '  %-18s %s\n' "make build-app-fresh" "Remove cached Codex.dmg and regenerate codex-app/"
+	@printf '  %-18s %s\n' "make setup-native" "Guided setup summary and Linux feature config helper"
 	@printf '  %-18s %s\n' "make bootstrap-native" "Install deps, fresh-build, package, and install"
 	@printf '  %-18s %s\n' "make install-native" "Fresh-build, package, and install"
 	@printf '  %-18s %s\n' "make update-native" "Pull trusted checkout, fresh-build, package, and install"
@@ -100,6 +101,7 @@ help:
 	@printf '  %s\n' "make rebuild DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make build-app DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make build-app-fresh"
+	@printf '  %s\n' "make setup-native"
 	@printf '  %s\n' "make bootstrap-native"
 	@printf '  %s\n' "make install-native"
 	@printf '  %s\n' "PACKAGE_WITH_UPDATER=0 make update-native"
@@ -161,6 +163,10 @@ build-app:
 build-app-fresh:
 	@echo "[make] Regenerating codex-app from fresh DMG"
 	./install.sh --fresh "$(DMG)"
+
+setup-native:
+	@echo "[make] Running guided native setup"
+	bash scripts/bootstrap-wizard.sh
 
 bootstrap-native:
 	@echo "[make] Installing native build dependencies"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,41 @@ make bootstrap-native
 
 If dependencies are already installed, use `make install-native` to run only the fresh app build, package, and install steps.
 
+## Guided native setup
+
+If you want a friendlier first-run checklist before building, use the optional guided setup helper:
+
+```bash
+git clone https://github.com/ilysenko/codex-desktop-linux.git
+cd codex-desktop-linux
+make setup-native
+```
+
+`make setup-native` is intentionally separate from `make bootstrap-native`, `make install-native`, `make package`, and `make install`, which remain non-interactive for scripts and CI. The guided helper detects your distro, package manager, native package format, desktop session, GUI prompt helpers, `pkexec`, portal status, and Computer Use readiness signals such as `ydotool`, `ydotoold` / `ydotool.service`, and the ydotool socket.
+
+It also discovers optional Linux features from `linux-features/*/feature.json` and can write the git-ignored `linux-features/features.json` file for the next build. Re-running it shows the currently enabled features and installed package/updater hints, then skips changes unless you ask for them.
+
+For repeatable setup docs or automation, pass feature choices through the environment:
+
+```bash
+CODEX_LINUX_FEATURES=remote-mobile-control,read-aloud \
+CODEX_LINUX_DISABLE_FEATURES=conversation-mode \
+PACKAGE_WITH_UPDATER=0 \
+CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+make setup-native
+```
+
+Build-time feature changes only apply after rebuilding and reinstalling:
+
+```bash
+make install-native
+
+# or, for manual-update native packages:
+PACKAGE_WITH_UPDATER=0 make install-native
+```
+
+The wizard is conservative with opt-outs. Removing a feature id from `features.json` does not delete local device keys, Read Aloud model files, Python runtimes, plugin caches, or system services. It prints the relevant paths and tells you when a rebuild/reinstall, `sudo` / `pkexec`, logout/login, input-group membership, ydotoold service work, or portal package install needs explicit user action.
+
 ### AppImage local self-build
 
 For atomic desktops or systems where installing a native package is awkward, build an AppImage locally from the generated app:

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -23,6 +23,23 @@ Native packages preserve the enabled feature id list in the packaged
 update-builder bundle, so `codex-update-manager` rebuilds keep the same opt-in
 features across auto-updates.
 
+You can also let the guided native setup helper discover feature manifests and
+write `features.json`:
+
+```bash
+make setup-native
+
+# non-interactive feature edits:
+CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+CODEX_LINUX_FEATURES=remote-mobile-control,read-aloud \
+CODEX_LINUX_DISABLE_FEATURES=conversation-mode \
+make setup-native
+```
+
+Disabling a feature in `features.json` only affects the next rebuild. The helper
+does not delete local device keys, Read Aloud model files, plugin caches, Python
+runtimes, or ydotool services.
+
 Each feature directory should include:
 
 - `feature.json` — metadata and entrypoints

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -5,6 +5,7 @@ set -Eeuo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FEATURES_ROOT="${CODEX_LINUX_FEATURES_ROOT:-$REPO_DIR/linux-features}"
+PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 
 info() {
     echo "[setup] $*"
@@ -181,14 +182,20 @@ command_status() {
 
 service_state() {
     local unit="$1"
+    local scope="${2:-system}"
     if ! command -v systemctl >/dev/null 2>&1; then
         printf 'systemctl missing'
         return
     fi
 
     local active enabled
-    active="$(systemctl is-active "$unit" 2>/dev/null || true)"
-    enabled="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
+    if [ "$scope" = "user" ]; then
+        active="$(systemctl --user is-active "$unit" 2>/dev/null || true)"
+        enabled="$(systemctl --user is-enabled "$unit" 2>/dev/null || true)"
+    else
+        active="$(systemctl is-active "$unit" 2>/dev/null || true)"
+        enabled="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
+    fi
     if [ -z "$active$enabled" ]; then
         printf 'unknown'
     else
@@ -226,25 +233,25 @@ portal_summary() {
 
 installed_package_version() {
     if command -v dpkg-query >/dev/null 2>&1 &&
-        dpkg-query -W -f='${Version}' codex-desktop >/dev/null 2>&1; then
-        dpkg-query -W -f='deb ${Version}' codex-desktop 2>/dev/null || true
+        dpkg-query -W -f='${Version}' "$PACKAGE_NAME" >/dev/null 2>&1; then
+        dpkg-query -W -f='deb ${Version}' "$PACKAGE_NAME" 2>/dev/null || true
         return
     fi
     if command -v rpm >/dev/null 2>&1 &&
-        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' codex-desktop >/dev/null 2>&1; then
-        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' codex-desktop 2>/dev/null || true
+        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' "$PACKAGE_NAME" >/dev/null 2>&1; then
+        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' "$PACKAGE_NAME" 2>/dev/null || true
         return
     fi
     if command -v pacman >/dev/null 2>&1 &&
-        pacman -Q codex-desktop >/dev/null 2>&1; then
-        pacman -Q codex-desktop 2>/dev/null | sed 's/^/pacman /'
+        pacman -Q "$PACKAGE_NAME" >/dev/null 2>&1; then
+        pacman -Q "$PACKAGE_NAME" 2>/dev/null | sed 's/^/pacman /'
         return
     fi
     printf 'not installed'
 }
 
 updater_install_summary() {
-    if [ -x /usr/bin/codex-update-manager ] || [ -d /opt/codex-desktop/update-builder ]; then
+    if [ -x /usr/bin/codex-update-manager ] || [ -d "/opt/$PACKAGE_NAME/update-builder" ]; then
         printf 'updater artifacts detected'
     else
         printf 'not detected'
@@ -263,7 +270,7 @@ print_system_summary() {
     info "Native package format: $(detect_package_format)"
     info "Session: XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unknown} DESKTOP_SESSION=${DESKTOP_SESSION:-unknown} XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-unknown} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-none} DISPLAY=${DISPLAY:-none}"
     info "Helpers: pkexec=$(command_status pkexec) kdialog=$(command_status kdialog) zenity=$(command_status zenity)"
-    info "Computer Use readiness: ydotool=$(command_status ydotool) ydotoold=$(command_status ydotoold) ydotoold.service=[$(service_state ydotoold.service)] ydotool.service=[$(service_state ydotool.service)] socket=$(ydotool_socket_summary) portal=$(portal_summary)"
+    info "Computer Use readiness: ydotool=$(command_status ydotool) ydotoold=$(command_status ydotoold) ydotoold.service(system)=[$(service_state ydotoold.service system)] ydotoold.service(user)=[$(service_state ydotoold.service user)] ydotool.service(system)=[$(service_state ydotool.service system)] ydotool.service(user)=[$(service_state ydotool.service user)] socket=$(ydotool_socket_summary) portal=$(portal_summary)"
     info "Installed package: $(installed_package_version)"
     info "Installed updater mode: $(updater_install_summary)"
 }
@@ -378,6 +385,9 @@ features = discover_features(features_root)
 current = read_enabled_ids(config_path)
 enable = split_ids(enable_raw)
 disable = split_ids(disable_raw)
+conflicting = sorted(set(enable) & set(disable))
+if conflicting:
+    die(f"Linux feature ids cannot be both enabled and disabled: {csv(conflicting)}")
 
 for feature_id in enable:
     if feature_id not in features:

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -221,11 +221,18 @@ ydotool_socket_summary() {
 }
 
 portal_summary() {
-    if pgrep -x xdg-desktop-portal >/dev/null 2>&1; then
-        printf 'running'
-    elif command -v busctl >/dev/null 2>&1 &&
-        busctl --user --list 2>/dev/null | grep -q 'org.freedesktop.portal.Desktop'; then
+    local bus_names
+    if command -v busctl >/dev/null 2>&1; then
+        bus_names="$(busctl --user --list 2>/dev/null || true)"
+    else
+        bus_names=""
+    fi
+
+    if grep 'org.freedesktop.portal.Desktop' >/dev/null 2>&1 <<<"$bus_names"; then
         printf 'available on session bus'
+    elif command -v pgrep >/dev/null 2>&1 &&
+        pgrep -f '(^|[/[:space:]])xdg-desktop-portal([[:space:]]|$)' >/dev/null 2>&1; then
+        printf 'running'
     else
         printf 'not detected'
     fi
@@ -415,6 +422,9 @@ print(f"[setup] Enabled Linux features: {csv(final)}")
 unknown_enabled = [feature_id for feature_id in final if feature_id not in features]
 if unknown_enabled:
     warn(f"Enabled feature ids not found in this checkout: {csv(unknown_enabled)}")
+
+if "conversation-mode" in final and "read-aloud" not in final:
+    warn("conversation-mode is enabled without read-aloud; speech output requires the Read Aloud feature.")
 
 if features:
     print("[setup] Available Linux features:")

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+# Guided, conservative setup helper for native Codex Desktop Linux builds.
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FEATURES_ROOT="${CODEX_LINUX_FEATURES_ROOT:-$REPO_DIR/linux-features}"
+
+info() {
+    echo "[setup] $*"
+}
+
+warn() {
+    echo "[setup][WARN] $*" >&2
+}
+
+error() {
+    echo "[setup][ERROR] $*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/bootstrap-wizard.sh [--help]
+
+Environment:
+  CODEX_BOOTSTRAP_NONINTERACTIVE=1     never prompt
+  CODEX_LINUX_FEATURES=a,b             enable build-time Linux features
+  CODEX_LINUX_DISABLE_FEATURES=a,b     disable build-time Linux features
+  CODEX_LINUX_FEATURES_ROOT=/path      override linux-features root
+  CODEX_LINUX_FEATURES_CONFIG=/path    override features.json path
+  PACKAGE_WITH_UPDATER=0               choose manual-update package mode
+
+The wizard is conservative: it does not install packages, start services, stop
+ydotoold, or delete feature-owned user data. It prepares feature config and
+prints the exact rebuild/reinstall command to run next.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    "")
+        ;;
+    *)
+        error "Unknown argument: $1"
+        ;;
+esac
+
+truthy() {
+    case "${1:-}" in
+        1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+package_with_updater_enabled() {
+    case "${PACKAGE_WITH_UPDATER:-1}" in
+        1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+            return 0
+            ;;
+        0|false|False|FALSE|no|No|NO|off|Off|OFF)
+            return 1
+            ;;
+        *)
+            error "PACKAGE_WITH_UPDATER must be 1 or 0"
+            ;;
+    esac
+}
+
+feature_config_path() {
+    if [ -n "${CODEX_LINUX_FEATURES_CONFIG:-}" ]; then
+        printf '%s\n' "$CODEX_LINUX_FEATURES_CONFIG"
+    else
+        printf '%s\n' "$FEATURES_ROOT/features.json"
+    fi
+}
+
+os_release_field() {
+    local field="$1"
+    local file line value
+
+    for file in ${OS_RELEASE_FILE:-} /etc/os-release /usr/lib/os-release; do
+        [ -n "$file" ] || continue
+        [ -r "$file" ] || continue
+        while IFS= read -r line; do
+            case "$line" in
+                "$field="*)
+                    value="${line#*=}"
+                    value="${value#\"}"
+                    value="${value%\"}"
+                    value="${value#\'}"
+                    value="${value%\'}"
+                    printf '%s\n' "${value,,}"
+                    return 0
+                    ;;
+            esac
+        done < "$file"
+    done
+
+    return 1
+}
+
+os_release_matches() {
+    local expected token
+    for expected in "$@"; do
+        [ "${OS_RELEASE_ID:-}" = "$expected" ] && return 0
+        for token in ${OS_RELEASE_ID_LIKE:-}; do
+            [ "$token" = "$expected" ] && return 0
+        done
+    done
+    return 1
+}
+
+detect_package_manager() {
+    if os_release_matches debian ubuntu linuxmint pop elementary zorin && command -v apt-get >/dev/null 2>&1; then
+        echo "apt"
+    elif os_release_matches arch archlinux manjaro endeavouros artix && command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    elif os_release_matches opensuse suse sles && command -v zypper >/dev/null 2>&1; then
+        echo "zypper"
+    elif os_release_matches fedora rhel centos rocky almalinux ol; then
+        if command -v dnf5 >/dev/null 2>&1; then
+            echo "dnf5"
+        elif command -v dnf >/dev/null 2>&1; then
+            echo "dnf"
+        else
+            echo "unknown"
+        fi
+    elif command -v apt-get >/dev/null 2>&1; then
+        echo "apt"
+    elif command -v dnf5 >/dev/null 2>&1; then
+        echo "dnf5"
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "dnf"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "zypper"
+    else
+        echo "unknown"
+    fi
+}
+
+detect_package_format() {
+    if os_release_matches arch archlinux manjaro endeavouros artix; then
+        echo "pacman"
+    elif os_release_matches fedora rhel centos rocky almalinux ol sles suse opensuse; then
+        echo "rpm"
+    elif os_release_matches debian ubuntu linuxmint pop elementary zorin; then
+        echo "deb"
+    elif command -v pacman >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
+        echo "pacman"
+    elif command -v rpmbuild >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
+        echo "rpm"
+    elif command -v dpkg-deb >/dev/null 2>&1; then
+        echo "deb"
+    elif command -v rpmbuild >/dev/null 2>&1; then
+        echo "rpm"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    else
+        echo "unknown"
+    fi
+}
+
+command_status() {
+    local name="$1"
+    if command -v "$name" >/dev/null 2>&1; then
+        printf '%s' "$(command -v "$name")"
+    else
+        printf 'missing'
+    fi
+}
+
+service_state() {
+    local unit="$1"
+    if ! command -v systemctl >/dev/null 2>&1; then
+        printf 'systemctl missing'
+        return
+    fi
+
+    local active enabled
+    active="$(systemctl is-active "$unit" 2>/dev/null || true)"
+    enabled="$(systemctl is-enabled "$unit" 2>/dev/null || true)"
+    if [ -z "$active$enabled" ]; then
+        printf 'unknown'
+    else
+        printf 'active=%s enabled=%s' "${active:-unknown}" "${enabled:-unknown}"
+    fi
+}
+
+ydotool_socket_summary() {
+    local uid runtime_dir candidate
+    uid="$(id -u 2>/dev/null || true)"
+    runtime_dir="${XDG_RUNTIME_DIR:-${uid:+/run/user/$uid}}"
+    for candidate in \
+        "${YDOTOOL_SOCKET:-}" \
+        "${runtime_dir:+$runtime_dir/.ydotool_socket}" \
+        "/tmp/.ydotool_socket"; do
+        [ -n "$candidate" ] || continue
+        if [ -S "$candidate" ]; then
+            printf '%s' "$candidate"
+            return
+        fi
+    done
+    printf 'not found'
+}
+
+portal_summary() {
+    if pgrep -x xdg-desktop-portal >/dev/null 2>&1; then
+        printf 'running'
+    elif command -v busctl >/dev/null 2>&1 &&
+        busctl --user --list 2>/dev/null | grep -q 'org.freedesktop.portal.Desktop'; then
+        printf 'available on session bus'
+    else
+        printf 'not detected'
+    fi
+}
+
+installed_package_version() {
+    if command -v dpkg-query >/dev/null 2>&1 &&
+        dpkg-query -W -f='${Version}' codex-desktop >/dev/null 2>&1; then
+        dpkg-query -W -f='deb ${Version}' codex-desktop 2>/dev/null || true
+        return
+    fi
+    if command -v rpm >/dev/null 2>&1 &&
+        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' codex-desktop >/dev/null 2>&1; then
+        rpm -q --qf 'rpm %{VERSION}-%{RELEASE}' codex-desktop 2>/dev/null || true
+        return
+    fi
+    if command -v pacman >/dev/null 2>&1 &&
+        pacman -Q codex-desktop >/dev/null 2>&1; then
+        pacman -Q codex-desktop 2>/dev/null | sed 's/^/pacman /'
+        return
+    fi
+    printf 'not installed'
+}
+
+updater_install_summary() {
+    if [ -x /usr/bin/codex-update-manager ] || [ -d /opt/codex-desktop/update-builder ]; then
+        printf 'updater artifacts detected'
+    else
+        printf 'not detected'
+    fi
+}
+
+print_system_summary() {
+    OS_RELEASE_ID="$(os_release_field ID 2>/dev/null || true)"
+    OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
+    OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID 2>/dev/null || true)"
+
+    info "Codex Desktop Linux guided setup"
+    info "Repository: $REPO_DIR"
+    info "Distro: ID=${OS_RELEASE_ID:-unknown} ID_LIKE=${OS_RELEASE_ID_LIKE:-unknown} VERSION_ID=${OS_RELEASE_VERSION_ID:-unknown}"
+    info "Package manager: $(detect_package_manager)"
+    info "Native package format: $(detect_package_format)"
+    info "Session: XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unknown} DESKTOP_SESSION=${DESKTOP_SESSION:-unknown} XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-unknown} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-none} DISPLAY=${DISPLAY:-none}"
+    info "Helpers: pkexec=$(command_status pkexec) kdialog=$(command_status kdialog) zenity=$(command_status zenity)"
+    info "Computer Use readiness: ydotool=$(command_status ydotool) ydotoold=$(command_status ydotoold) ydotoold.service=[$(service_state ydotoold.service)] ydotool.service=[$(service_state ydotool.service)] socket=$(ydotool_socket_summary) portal=$(portal_summary)"
+    info "Installed package: $(installed_package_version)"
+    info "Installed updater mode: $(updater_install_summary)"
+}
+
+run_feature_config_python() {
+    local enable_raw="$1"
+    local disable_raw="$2"
+    local apply_changes="$3"
+    local config_path
+    config_path="$(feature_config_path)"
+
+    if ! command -v python3 >/dev/null 2>&1; then
+        if [ -n "$enable_raw$disable_raw" ]; then
+            error "python3 is required to edit Linux feature config. Run bash scripts/install-deps.sh first."
+        fi
+        warn "python3 is missing; skipping Linux feature discovery and config editing"
+        return
+    fi
+
+    python3 - "$FEATURES_ROOT" "$config_path" "$enable_raw" "$disable_raw" "$apply_changes" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+features_root = pathlib.Path(sys.argv[1])
+config_path = pathlib.Path(sys.argv[2])
+enable_raw = sys.argv[3]
+disable_raw = sys.argv[4]
+apply_changes = sys.argv[5] == "1"
+
+id_re = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+def die(message):
+    print(f"[setup][ERROR] {message}", file=sys.stderr)
+    sys.exit(1)
+
+def warn(message):
+    print(f"[setup][WARN] {message}", file=sys.stderr)
+
+def split_ids(raw):
+    if not raw.strip():
+        return []
+    ids = [item for item in re.split(r"[,\s]+", raw.strip()) if item]
+    seen = set()
+    result = []
+    for item in ids:
+        if not id_re.match(item):
+            die(f"Invalid Linux feature id: {item}")
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+def read_json(path, label):
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except Exception as exc:
+        die(f"Could not read {label} at {path}: {exc}")
+
+def discover_features(root):
+    features = {}
+    if not root.exists():
+        warn(f"Linux features root not found: {root}")
+        return features
+    for manifest_path in sorted(root.glob("*/feature.json")):
+        data = read_json(manifest_path, f"Linux feature manifest {manifest_path}") or {}
+        feature_id = data.get("id")
+        if not isinstance(feature_id, str) or not id_re.match(feature_id):
+            warn(f"Skipping feature with invalid id in {manifest_path}")
+            continue
+        if feature_id in features:
+            warn(f"Skipping duplicate Linux feature id: {feature_id}")
+            continue
+        title = data.get("title") or data.get("name") or feature_id
+        description = data.get("description") or ""
+        features[feature_id] = {
+            "id": feature_id,
+            "title": str(title),
+            "description": str(description),
+        }
+    return dict(sorted(features.items()))
+
+def read_enabled_ids(path):
+    if not path.exists():
+        fallback = features_root / "features.example.json"
+        if fallback.exists():
+            data = read_json(fallback, "Linux features example config") or {}
+        else:
+            return []
+    else:
+        data = read_json(path, "Linux features config") or {}
+    enabled = data.get("enabled", [])
+    if not isinstance(enabled, list):
+        die(f"Linux features config {path} must contain an enabled array")
+    result = []
+    seen = set()
+    for item in enabled:
+        if not isinstance(item, str) or not id_re.match(item):
+            die(f"Invalid Linux feature id in {path}: {item}")
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+def csv(ids):
+    return ", ".join(ids) if ids else "none"
+
+features = discover_features(features_root)
+current = read_enabled_ids(config_path)
+enable = split_ids(enable_raw)
+disable = split_ids(disable_raw)
+
+for feature_id in enable:
+    if feature_id not in features:
+        die(f"Unknown Linux feature id: {feature_id}")
+for feature_id in disable:
+    if feature_id not in features and feature_id not in current:
+        die(f"Unknown Linux feature id: {feature_id}")
+
+final = [feature_id for feature_id in current if feature_id not in set(disable)]
+for feature_id in enable:
+    if feature_id not in final:
+        final.append(feature_id)
+
+if apply_changes and (enable or disable):
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"enabled": final}, indent=2) + "\n")
+    print(f"[setup] Updated Linux feature config: {config_path}")
+elif not config_path.exists():
+    print(f"[setup] Linux feature config: {config_path} (not created yet)")
+else:
+    print(f"[setup] Linux feature config: {config_path}")
+
+print(f"[setup] Enabled Linux features: {csv(final)}")
+
+unknown_enabled = [feature_id for feature_id in final if feature_id not in features]
+if unknown_enabled:
+    warn(f"Enabled feature ids not found in this checkout: {csv(unknown_enabled)}")
+
+if features:
+    print("[setup] Available Linux features:")
+    for feature_id, feature in features.items():
+        state = "enabled" if feature_id in final else "available"
+        sample = " (developer sample)" if feature_id == "example-feature" else ""
+        print(f"[setup]   [{state}] {feature_id}{sample} - {feature['title']}")
+else:
+    print("[setup] Available Linux features: none found")
+
+if apply_changes and (enable or disable):
+    print("[setup] Feature changes apply after rebuilding and reinstalling Codex Desktop Linux.")
+PY
+}
+
+list_includes_id() {
+    local raw="$1"
+    local needle="$2"
+    local item
+    raw="${raw//,/ }"
+    for item in $raw; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+print_safe_disable_guidance() {
+    local disable_raw="$1"
+    [ -n "$disable_raw" ] || return 0
+
+    info "Disabling a build-time feature only edits linux-features/features.json for the next rebuild."
+
+    if list_includes_id "$disable_raw" "remote-mobile-control"; then
+        local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+        local key_file="$config_home/codex-desktop/remote-control-device-keys-v1.json"
+        info "Remote mobile control opt-out: Not deleting $key_file."
+        info "Revoke paired devices from Codex Settings/Connections or ChatGPT before deleting local keys manually."
+    fi
+
+    if list_includes_id "$disable_raw" "read-aloud" ||
+        list_includes_id "$disable_raw" "read-aloud-mcp" ||
+        list_includes_id "$disable_raw" "conversation-mode"; then
+        local data_home="${XDG_DATA_HOME:-$HOME/.local/share}"
+        local read_aloud_data="$data_home/codex-desktop/read-aloud"
+        local read_aloud_cache="$HOME/.codex/plugins/cache/openai-bundled/read-aloud"
+        info "Read Aloud opt-out: Not removing Read Aloud model files, Python runtimes, or plugin caches."
+        info "Cleanup is separate and should list exact paths first, such as:"
+        info "  $read_aloud_data"
+        info "  $read_aloud_cache"
+    fi
+}
+
+print_package_mode_guidance() {
+    if package_with_updater_enabled; then
+        info "Default native package mode includes codex-update-manager."
+        info "Next rebuild/reinstall command: make install-native"
+    else
+        info "Manual-update native package mode selected (PACKAGE_WITH_UPDATER=0)."
+        info "No-updater mode takes effect only after rebuilding and reinstalling the native package."
+        info "Next rebuild/reinstall command: PACKAGE_WITH_UPDATER=0 make install-native"
+    fi
+    info "AppImage builds never include codex-update-manager. Nix feature choices stay declarative in flake outputs, not linux-features/features.json."
+}
+
+prompt_for_feature_changes() {
+    local enable_raw="${CODEX_LINUX_FEATURES:-}"
+    local disable_raw="${CODEX_LINUX_DISABLE_FEATURES:-}"
+
+    if truthy "${CODEX_BOOTSTRAP_NONINTERACTIVE:-0}" || ! [ -t 0 ]; then
+        run_feature_config_python "$enable_raw" "$disable_raw" "1"
+        print_safe_disable_guidance "$disable_raw"
+        return
+    fi
+
+    run_feature_config_python "" "" "0"
+    echo
+    read -r -p "[setup] Enable feature ids for the next build (comma-separated, blank keeps current): " enable_raw
+    read -r -p "[setup] Disable feature ids for the next build (comma-separated, blank disables none): " disable_raw
+    if [ -n "$enable_raw$disable_raw" ]; then
+        run_feature_config_python "$enable_raw" "$disable_raw" "1"
+        print_safe_disable_guidance "$disable_raw"
+    else
+        info "Feature config unchanged."
+    fi
+
+    local answer
+    if package_with_updater_enabled; then
+        read -r -p "[setup] Keep codex-update-manager in the next native package? [Y/n]: " answer
+        case "$answer" in
+            n|N|no|No|NO)
+                PACKAGE_WITH_UPDATER=0
+                ;;
+        esac
+    else
+        read -r -p "[setup] Keep manual-update package mode for the next native build? [Y/n]: " answer
+        case "$answer" in
+            n|N|no|No|NO)
+                PACKAGE_WITH_UPDATER=1
+                ;;
+        esac
+    fi
+}
+
+main() {
+    print_system_summary
+    prompt_for_feature_changes
+    print_package_mode_guidance
+    info "No system services, groups, key files, model files, plugin caches, or package installs were changed."
+    info "If Computer Use needs ydotoold, input group membership, a portal backend, or logout/login, run those steps explicitly after reviewing the commands."
+}
+
+main "$@"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -851,6 +851,29 @@ test_setup_native_wizard_rejects_invalid_feature_ids() {
     assert_json_enabled_equals "$config" '[]'
 }
 
+test_setup_native_wizard_rejects_conflicting_feature_ids() {
+    info "Checking setup-native wizard conflicting feature validation"
+    local workspace="$TMP_DIR/setup-native-conflicting-feature"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+
+    if CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+        CODEX_LINUX_FEATURES_ROOT="$features_root" \
+        CODEX_LINUX_FEATURES_CONFIG="$config" \
+        CODEX_LINUX_FEATURES="read-aloud" \
+        CODEX_LINUX_DISABLE_FEATURES="read-aloud" \
+            bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log" 2>&1; then
+        fail "setup wizard should reject conflicting feature ids"
+    fi
+
+    assert_contains "$output_log" "Linux feature ids cannot be both enabled and disabled: read-aloud"
+    assert_json_enabled_equals "$config" '[]'
+}
+
 test_setup_native_wizard_disable_is_non_destructive() {
     info "Checking setup-native wizard opt-out guidance is non-destructive"
     local workspace="$TMP_DIR/setup-native-disable-safe"
@@ -872,6 +895,7 @@ JSON
     printf '%s\n' 'cache marker' > "$plugin_cache/marker"
 
     HOME="$fake_home" \
+    XDG_CONFIG_HOME="$fake_home/.config" \
     XDG_DATA_HOME="$fake_home/.local/share" \
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
     CODEX_LINUX_FEATURES_ROOT="$features_root" \
@@ -910,6 +934,51 @@ JSON
     assert_contains "$output_log" "Enabled Linux features: remote-mobile-control"
     assert_contains "$output_log" "Default native package mode includes codex-update-manager"
     assert_contains "$output_log" "make install-native"
+}
+
+test_setup_native_wizard_uses_package_name_for_installed_state() {
+    info "Checking setup-native wizard package-name-aware installed state"
+    local workspace="$TMP_DIR/setup-native-package-name"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+    local bin_dir="$workspace/bin"
+    local dpkg_args="$workspace/dpkg-query.args"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/dpkg-query" <<SCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$dpkg_args"
+if [[ "\$*" != *codex-cua-lab* ]]; then
+    exit 1
+fi
+case "\$*" in
+    *"deb "*)
+        printf 'deb 1.2.3'
+        exit 0
+        ;;
+    *)
+        printf '1.2.3'
+        exit 0
+        ;;
+esac
+SCRIPT
+    chmod +x "$bin_dir/dpkg-query"
+
+    PATH="$bin_dir:$PATH" \
+    PACKAGE_NAME="codex-cua-lab" \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_contains "$output_log" "Installed package: deb 1.2.3"
+    assert_contains "$output_log" "ydotoold.service(system)="
+    assert_contains "$output_log" "ydotoold.service(user)="
+    assert_contains "$dpkg_args" "codex-cua-lab"
+    assert_not_contains "$dpkg_args" "codex-desktop"
 }
 
 test_upstream_build_app_workflow_tracks_dmg_metadata() {
@@ -3895,8 +3964,10 @@ main() {
     test_native_shortcut_targets_compose_existing_flows
     test_setup_native_wizard_noninteractive_feature_writer
     test_setup_native_wizard_rejects_invalid_feature_ids
+    test_setup_native_wizard_rejects_conflicting_feature_ids
     test_setup_native_wizard_disable_is_non_destructive
     test_setup_native_wizard_summary_keeps_existing_config
+    test_setup_native_wizard_uses_package_name_for_installed_state
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -981,6 +981,58 @@ SCRIPT
     assert_not_contains "$dpkg_args" "codex-desktop"
 }
 
+test_setup_native_wizard_portal_summary_survives_busctl_sigpipe() {
+    info "Checking setup-native wizard portal summary avoids pipefail SIGPIPE false negatives"
+    local workspace="$TMP_DIR/setup-native-portal-sigpipe"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+    local bin_dir="$workspace/bin"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/pgrep" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 1
+SCRIPT
+    cat > "$bin_dir/busctl" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = "--user" ] && [ "${2:-}" = "--list" ]; then
+    printf '%s\n' 'org.freedesktop.portal.Desktop 1234 xdg-desktop-portal'
+    exit 141
+fi
+exit 1
+SCRIPT
+    chmod +x "$bin_dir/pgrep" "$bin_dir/busctl"
+
+    PATH="$bin_dir:$PATH" \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log" 2>&1
+
+    assert_contains "$output_log" "portal=available on session bus"
+}
+
+test_setup_native_wizard_warns_when_conversation_mode_lacks_read_aloud() {
+    info "Checking setup-native wizard warns about conversation-mode without Read Aloud"
+    local workspace="$TMP_DIR/setup-native-conversation-warning"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":["conversation-mode"]}' > "$config"
+
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log" 2>&1
+
+    assert_contains "$output_log" "conversation-mode is enabled without read-aloud"
+}
+
 test_upstream_build_app_workflow_tracks_dmg_metadata() {
     info "Checking upstream build-app workflow metadata and cache behavior"
     local workflow="$REPO_DIR/.github/workflows/upstream-build-app.yml"
@@ -3968,6 +4020,8 @@ main() {
     test_setup_native_wizard_disable_is_non_destructive
     test_setup_native_wizard_summary_keeps_existing_config
     test_setup_native_wizard_uses_package_name_for_installed_state
+    test_setup_native_wizard_portal_summary_survives_busctl_sigpipe
+    test_setup_native_wizard_warns_when_conversation_mode_lacks_read_aloud
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -54,6 +54,47 @@ assert_occurrence_count() {
     [ "$actual" = "$expected" ] || fail "Expected '$pattern' to appear $expected times in $path, found $actual"
 }
 
+assert_json_enabled_equals() {
+    local path="$1"
+    local expected_json="$2"
+    node - "$path" "$expected_json" <<'NODE' || fail "Expected $path enabled list to equal $expected_json"
+const fs = require("node:fs");
+const path = process.argv[2];
+const expected = JSON.parse(process.argv[3]);
+const actual = JSON.parse(fs.readFileSync(path, "utf8")).enabled;
+if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+  console.error(`expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  process.exit(1);
+}
+NODE
+}
+
+make_wizard_feature_root() {
+    local features_root="$1"
+    mkdir -p \
+        "$features_root/conversation-mode" \
+        "$features_root/example-feature" \
+        "$features_root/read-aloud" \
+        "$features_root/read-aloud-mcp" \
+        "$features_root/remote-mobile-control"
+    printf '%s\n' '{"enabled":[]}' > "$features_root/features.example.json"
+    cat > "$features_root/conversation-mode/feature.json" <<'JSON'
+{"id":"conversation-mode","name":"Conversation mode","description":"Voice conversation loop."}
+JSON
+    cat > "$features_root/example-feature/feature.json" <<'JSON'
+{"id":"example-feature","title":"Example Linux Feature","description":"Developer sample."}
+JSON
+    cat > "$features_root/read-aloud/feature.json" <<'JSON'
+{"id":"read-aloud","name":"Read aloud","description":"Read assistant responses aloud."}
+JSON
+    cat > "$features_root/read-aloud-mcp/feature.json" <<'JSON'
+{"id":"read-aloud-mcp","title":"Read Aloud MCP","description":"Read Aloud MCP plugin staging."}
+JSON
+    cat > "$features_root/remote-mobile-control/feature.json" <<'JSON'
+{"id":"remote-mobile-control","title":"Experimental Remote Mobile Control","description":"Mobile host enrollment patches."}
+JSON
+}
+
 make_fake_browser_upstream_app() {
     local app_dir="$1"
     local resources_dir="$app_dir/Contents/Resources"
@@ -739,6 +780,7 @@ test_native_shortcut_targets_compose_existing_flows() {
     local install_log="$TMP_DIR/make-install-native.log"
     local bootstrap_log="$TMP_DIR/make-bootstrap-native.log"
     local update_log="$TMP_DIR/make-update-native.log"
+    local setup_log="$TMP_DIR/make-setup-native.log"
 
     make -n -C "$REPO_DIR" install-native >"$install_log"
     assert_contains "$install_log" './install.sh --fresh'
@@ -749,10 +791,125 @@ test_native_shortcut_targets_compose_existing_flows() {
     assert_contains "$bootstrap_log" 'bash scripts/install-deps.sh'
     assert_contains "$bootstrap_log" 'PATH="$HOME/.cargo/bin:$PATH"'
     assert_contains "$bootstrap_log" 'install-native'
+    assert_not_contains "$bootstrap_log" 'bootstrap-wizard.sh'
 
     make -n -C "$REPO_DIR" update-native >"$update_log"
     assert_contains "$update_log" 'git pull --ff-only'
     assert_contains "$update_log" 'install-native'
+
+    make -n -C "$REPO_DIR" setup-native >"$setup_log"
+    assert_contains "$setup_log" 'bash scripts/bootstrap-wizard.sh'
+}
+
+test_setup_native_wizard_noninteractive_feature_writer() {
+    info "Checking setup-native wizard non-interactive feature writer"
+    local workspace="$TMP_DIR/setup-native-writer"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    cat > "$config" <<'JSON'
+{"enabled":["conversation-mode"]}
+JSON
+
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+    CODEX_LINUX_FEATURES="remote-mobile-control,read-aloud" \
+    CODEX_LINUX_DISABLE_FEATURES="conversation-mode" \
+    PACKAGE_WITH_UPDATER=0 \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_json_enabled_equals "$config" '["remote-mobile-control","read-aloud"]'
+    assert_contains "$output_log" "remote-mobile-control"
+    assert_contains "$output_log" "read-aloud"
+    assert_contains "$output_log" "Manual-update native package mode selected"
+    assert_contains "$output_log" "PACKAGE_WITH_UPDATER=0 make install-native"
+    assert_contains "$output_log" "Feature changes apply after rebuilding and reinstalling"
+}
+
+test_setup_native_wizard_rejects_invalid_feature_ids() {
+    info "Checking setup-native wizard invalid feature validation"
+    local workspace="$TMP_DIR/setup-native-invalid-feature"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+
+    if CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+        CODEX_LINUX_FEATURES_ROOT="$features_root" \
+        CODEX_LINUX_FEATURES_CONFIG="$config" \
+        CODEX_LINUX_FEATURES="missing-feature" \
+            bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log" 2>&1; then
+        fail "setup wizard should reject unknown feature ids"
+    fi
+
+    assert_contains "$output_log" "Unknown Linux feature id: missing-feature"
+    assert_json_enabled_equals "$config" '[]'
+}
+
+test_setup_native_wizard_disable_is_non_destructive() {
+    info "Checking setup-native wizard opt-out guidance is non-destructive"
+    local workspace="$TMP_DIR/setup-native-disable-safe"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+    local fake_home="$workspace/home"
+    local key_file="$fake_home/.config/codex-desktop/remote-control-device-keys-v1.json"
+    local model_file="$fake_home/.local/share/codex-desktop/read-aloud/kokoro-venv/bin/python"
+    local plugin_cache="$fake_home/.codex/plugins/cache/openai-bundled/read-aloud"
+
+    make_wizard_feature_root "$features_root"
+    cat > "$config" <<'JSON'
+{"enabled":["remote-mobile-control","read-aloud","read-aloud-mcp"]}
+JSON
+    mkdir -p "$(dirname "$key_file")" "$(dirname "$model_file")" "$plugin_cache"
+    printf '%s\n' '{"deviceKeys":[]}' > "$key_file"
+    printf '%s\n' '#!/usr/bin/env python3' > "$model_file"
+    printf '%s\n' 'cache marker' > "$plugin_cache/marker"
+
+    HOME="$fake_home" \
+    XDG_DATA_HOME="$fake_home/.local/share" \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+    CODEX_LINUX_DISABLE_FEATURES="remote-mobile-control,read-aloud,read-aloud-mcp" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_json_enabled_equals "$config" '[]'
+    assert_file_exists "$key_file"
+    assert_file_exists "$model_file"
+    assert_file_exists "$plugin_cache/marker"
+    assert_contains "$output_log" "Not deleting $key_file"
+    assert_contains "$output_log" "Not removing Read Aloud model files, Python runtimes, or plugin caches"
+    assert_contains "$output_log" "$fake_home/.local/share/codex-desktop/read-aloud"
+    assert_contains "$output_log" "$plugin_cache"
+}
+
+test_setup_native_wizard_summary_keeps_existing_config() {
+    info "Checking setup-native wizard read-only summary keeps existing feature config"
+    local workspace="$TMP_DIR/setup-native-summary"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    cat > "$config" <<'JSON'
+{"enabled":["remote-mobile-control"]}
+JSON
+
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_json_enabled_equals "$config" '["remote-mobile-control"]'
+    assert_contains "$output_log" "Enabled Linux features: remote-mobile-control"
+    assert_contains "$output_log" "Default native package mode includes codex-update-manager"
+    assert_contains "$output_log" "make install-native"
 }
 
 test_upstream_build_app_workflow_tracks_dmg_metadata() {
@@ -3736,6 +3893,10 @@ main() {
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
     test_native_shortcut_targets_compose_existing_flows
+    test_setup_native_wizard_noninteractive_feature_writer
+    test_setup_native_wizard_rejects_invalid_feature_ids
+    test_setup_native_wizard_disable_is_non_destructive
+    test_setup_native_wizard_summary_keeps_existing_config
     test_upstream_build_app_workflow_tracks_dmg_metadata
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata


### PR DESCRIPTION
## Summary

- Add make setup-native as an optional guided native setup entrypoint that calls scripts/bootstrap-wizard.sh.
- Add a conservative wizard that reports distro/package/session readiness, discovers linux-features/*/feature.json, and can update the git-ignored feature config in non-interactive mode.
- Document guided setup, non-interactive feature edits, manual-update package mode, and safe opt-out behavior.
- Cover feature enable/disable, invalid feature ids, non-destructive opt-out guidance, and target composition in script smoke tests.

## Notes

This keeps make bootstrap-native, make install-native, make package, and make install non-interactive. The wizard does not install packages, change groups, start or stop services, or delete device keys, Read Aloud runtimes/models, plugin caches, or other user data.

## Test Plan

- bash -n scripts/bootstrap-wizard.sh
- git diff --check
- node --test linux-features/*/test.js
- bash tests/scripts_smoke.sh
