### PR TITLE
[codex] Restrict GitHub Actions triggers

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   populate:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Build Nix flake outputs
     runs-on: ubuntu-latest
     timeout-minutes: 150

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   rust-and-smoke:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Rust and Smoke Tests
     runs-on: ubuntu-latest
     steps:
@@ -71,6 +72,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   package-deb:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Build Debian Package
     runs-on: ubuntu-latest
     steps:
@@ -104,6 +106,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   nix:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Nix Package Builds
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -142,6 +145,7 @@ jobs:
             --print-build-logs
 
   package-rpm:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Build RPM Package
     runs-on: ubuntu-latest
     steps:
@@ -182,6 +186,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   package-pacman:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Build Pacman Package
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -2,6 +2,10 @@ name: Install Dependencies
 
 on:
   pull_request:
+    branches:
+      - development
+      - test
+      - main
     paths:
       - install.sh
       - scripts/install-deps.sh

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   update-hash:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -39,6 +39,7 @@ env:
 
 jobs:
   build-app-upstream-dmg:
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["development","test","main"]'), github.ref_name)
     name: Build App Against Upstream DMG
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '30 6 * * *'
   pull_request:
+    branches:
+      - development
+      - test
+      - main
     paths:
       - install.sh
       - Makefile


### PR DESCRIPTION
## Summary
- Restricts branch-based GitHub Actions triggers to development, test, and main.
- Removes security scan execution from promotion branches where applicable.
- Keeps test/main promotion workflows available without rerunning development security checks.

## Validation
- Parsed all workflow YAML in the changed worktree with PyYAML.
- Ran the branch trigger policy scan and confirmed zero remaining branch/tag trigger violations in the targeted worktree.
- Ran agent-final-check where the base checkout was clean; dirty base checkouts were preserved and edited only through isolated worktrees.

