### PR TITLE
launcher: prevent webview-server orphaning on parent death

### DIFF
--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -1,7 +1,35 @@
 #!/usr/bin/env python3
+import ctypes
+import ctypes.util
 import functools
 import http.server
+import os
+import signal
 import sys
+
+
+def _install_parent_death_signal():
+    # Ensure the kernel terminates this process if the launcher (parent) exits
+    # without invoking its cleanup trap (SIGKILL, OOM, crash). Without this,
+    # the HTTP server can outlive the launcher and block its webview port,
+    # which is fatal for multi-instance launches pinned to a single port.
+    if sys.platform != "linux":
+        return
+    libc_name = ctypes.util.find_library("c") or "libc.so.6"
+    try:
+        libc = ctypes.CDLL(libc_name, use_errno=True)
+    except OSError:
+        return
+    PR_SET_PDEATHSIG = 1
+    if libc.prctl(PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0) != 0:
+        return
+    # The parent may have died between fork() and prctl(); in that case the
+    # death signal never fires. Bail out now so the port is freed promptly.
+    if os.getppid() == 1:
+        os._exit(0)
+
+
+_install_parent_death_signal()
 
 
 port = int(sys.argv[1])


### PR DESCRIPTION
## Summary
- `launcher/webview-server.py` now installs `PR_SET_PDEATHSIG(SIGTERM)` so the kernel terminates the HTTP server the moment its launcher parent dies, regardless of how the launcher exited (clean exit, SIGKILL, OOM, crash).
- Guards the race where the parent has already died between `fork()` and `prctl()` by exiting if `getppid() == 1`.
- Linux-only path (`sys.platform != "linux"` short-circuits); this repo is Linux-only anyway.

## Why
`cleanup_launcher`'s EXIT trap in `start.sh.template` is the only thing currently killing the spawned webview-server. The trap is bypassed on SIGKILL/OOM/crash, leaving an orphan Python process listening on the configured port.

Under the opt-in multi-instance launcher (#227), each slot can be pinned to a single port via `CODEX_MULTI_LAUNCH_PORT_RANGE=<n>-<n>`. An orphan webview on that port causes `choose_multi_launch_port` to fail with `No free Codex Desktop webview port`, permanently breaking the slot until the user manually kills the orphan — `ensure_webview_server`'s `stop_stale_webview_server` cleanup is never reached because port selection fails first.

`PR_SET_PDEATHSIG` is a kernel-level guarantee, so it survives any failure mode of the launcher itself.

## Test plan
- [x] `python3 -c "import py_compile; py_compile.compile('launcher/webview-server.py')"` passes
- [x] Spawn `webview-server.py` from a bash parent, `kill -9` the parent → confirm Python child dies within ~2s and the port is released (verified live)
- [ ] Normal `start.sh` cold launch still works (the trap-based cleanup remains in place; pdeathsig is a redundant safety net)
- [ ] Verify under multi-launch: `start.sh --new-instance` then `kill -9` the launcher PID → webview-server.py on the allocated port no longer outlives the parent