### PR TITLE
Add appcast-driven Linux update flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "fs4",
  "futures-util",
  "notify-rust",
+ "quick-xml 0.38.4",
  "reqwest",
  "semver",
  "serde",
@@ -1694,6 +1695,15 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -280,8 +280,9 @@ CODEX_MULTI_LAUNCH=1 CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.s
 
 By default, the native package installs a companion `systemd --user` service named `codex-update-manager`.
 
-- It checks upstream `Codex.dmg` on daemon startup, every 6 hours, and in the background on app launch when stale.
-- When a new DMG is available, it rebuilds a local native package with `/opt/codex-desktop/update-builder`.
+- It checks the upstream Codex Sparkle appcast on daemon startup, every 6 hours, and in the background whenever the app launches.
+- When a newer upstream appcast item is available, it downloads that archive and rebuilds a local native package with `/opt/codex-desktop/update-builder`.
+- The app's existing update UI is enabled on Linux. Choosing the update action asks which optional Linux features to include before the ready package is installed.
 - If Codex Desktop is open, the final install waits until Electron exits.
 - The updater runs unprivileged and uses `pkexec` only for the final package install.
 - Codex CLI checks are best-effort and launcher-scoped. Set `CODEX_SYNC_CLI_PREFLIGHT=1` when debugging launch-time CLI preflight.
@@ -291,6 +292,7 @@ Inspect the live service and runtime files with:
 ```bash
 systemctl --user status codex-update-manager.service
 codex-update-manager status --json
+codex-update-manager features --json
 sed -n '1,160p' ~/.local/state/codex-update-manager/state.json
 sed -n '1,160p' ~/.local/state/codex-update-manager/service.log
 ```
@@ -307,12 +309,17 @@ Runtime files live in standard XDG locations:
 
 ```text
 ~/.config/codex-update-manager/config.toml
+~/.config/codex-update-manager/features.json
 ~/.local/state/codex-update-manager/state.json
 ~/.local/state/codex-update-manager/service.log
 ~/.cache/codex-update-manager/
 ~/.cache/codex-desktop/launcher.log
 ~/.local/state/codex-desktop/app.pid
 ```
+
+`features.json` stores the opt-in Linux feature selection used for future update
+rebuilds. If it is missing, the updater keeps the feature list that was bundled
+with the installed package.
 
 ### Manual-update packages
 

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -56,6 +56,8 @@ Descriptor patches use the same shape as `scripts/patches/core/**/patch.js`.
 They can target `main-bundle`, `webview-asset`, or `extracted-app` phases.
 Feature descriptor ids are namespaced as `feature:<feature-id>:<descriptor-id>`
 in patch reports and are optional by default.
+Set `"hidden": true` in `feature.json` for developer-only fixtures that should
+not appear in native setup or update feature-selection prompts.
 
 Feature self-tests live inside each feature directory. Run them with:
 

--- a/linux-features/example-feature/feature.json
+++ b/linux-features/example-feature/feature.json
@@ -3,6 +3,7 @@
   "title": "Example Linux Feature",
   "description": "Disabled example showing the linux-features ASAR patch and stage hook contract.",
   "defaultEnabled": false,
+  "hidden": true,
   "entrypoints": {
     "mainBundlePatch": "./patch.js",
     "stageHook": "./stage.sh"

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -351,6 +351,8 @@ def discover_features(root):
         if not isinstance(feature_id, str) or not id_re.match(feature_id):
             warn(f"Skipping feature with invalid id in {manifest_path}")
             continue
+        if data.get("hidden") is True:
+            continue
         if feature_id in features:
             warn(f"Skipping duplicate Linux feature id: {feature_id}")
             continue

--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -43,7 +43,7 @@ function buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
       : `async function codexLinuxShowUpdateMessage(codexLinuxMessage,codexLinuxDetail){try{await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:[\`OK\`],defaultId:0,noLink:!0,message:codexLinuxMessage,detail:codexLinuxDetail})}catch{}}`;
   const installAfterQuit = buildInstallAfterQuitSource(childProcessVar);
   const quitForUpdate = buildQuitForUpdateSource(electronVar, true);
-  return `function codexLinuxUpdateStatePath(){let e=process.env.XDG_STATE_HOME||process.env.HOME&&(0,${pathVar}.join)(process.env.HOME,\`.local\`,\`state\`);return e?(0,${pathVar}.join)(e,\`codex-update-manager\`,\`state.json\`):null}function codexLinuxReadUpdateState(){let e=codexLinuxUpdateStatePath();if(!e||!${fsVar}.existsSync(e))return null;try{let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}catch{return null}}function codexLinuxUpdateLifecycleState(e){switch(e){case\`ready_to_install\`:case\`waiting_for_app_exit\`:return\`ready\`;case\`installing\`:return\`installing\`;case\`checking_upstream\`:case\`update_detected\`:case\`downloading_dmg\`:case\`preparing_workspace\`:case\`patching_app\`:case\`building_package\`:return\`checking\`;default:return\`idle\`}}function codexLinuxUpdateManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}${showUpdateMessage}${installAfterQuit}${quitForUpdate}function codexLinuxRunUpdateManager(e){return new Promise((t,n)=>{${childProcessVar}.execFile(codexLinuxUpdateManagerPath(),e,{encoding:\`utf8\`,windowsHide:!0},(e,r,i)=>{if(e){e.stdout=r,e.stderr=i,n(e);return}t({stdout:r??\`\`,stderr:i??\`\`})})})}async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([\`--help\`])}async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}`;
+  return `function codexLinuxUpdateStatePath(){let e=process.env.XDG_STATE_HOME||process.env.HOME&&(0,${pathVar}.join)(process.env.HOME,\`.local\`,\`state\`);return e?(0,${pathVar}.join)(e,\`codex-update-manager\`,\`state.json\`):null}function codexLinuxReadUpdateState(){let e=codexLinuxUpdateStatePath();if(!e||!${fsVar}.existsSync(e))return null;try{let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}catch{return null}}function codexLinuxUpdateLifecycleState(e){switch(e){case\`ready_to_install\`:case\`waiting_for_app_exit\`:return\`ready\`;case\`installing\`:return\`installing\`;case\`checking_upstream\`:case\`update_detected\`:case\`downloading_dmg\`:case\`preparing_workspace\`:case\`patching_app\`:case\`building_package\`:return\`checking\`;default:return\`idle\`}}function codexLinuxUpdateManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}${showUpdateMessage}${installAfterQuit}${quitForUpdate}function codexLinuxRunUpdateManager(e){return new Promise((t,n)=>{${childProcessVar}.execFile(codexLinuxUpdateManagerPath(),e,{encoding:\`utf8\`,windowsHide:!0},(e,r,i)=>{if(e){e.stdout=r,e.stderr=i,n(e);return}t({stdout:r??\`\`,stderr:i??\`\`})})})}async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([\`--help\`])}async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}async function codexLinuxCheckForUpdatesOnOpen(){try{await codexLinuxRunUpdateManager([\`check-now\`])}catch{}}async function codexLinuxPromptUpdateFeatures(){try{let e=await codexLinuxRunUpdateManager([\`prompt-features\`,\`--json\`]),t=JSON.parse(e.stdout||\`{}\`);return t?.cancelled!==!0}catch{return!0}}`;
 }
 
 function migrateLinuxUpdaterBridgeSource(source) {
@@ -55,6 +55,36 @@ function migrateLinuxUpdaterBridgeSource(source) {
     "async function codexLinuxProbeUpdateManager(){await codexLinuxRunUpdateManager([`--help`])}";
   const refreshSource =
     "async function codexLinuxRefreshUpdateState(){return codexLinuxReadUpdateState()}";
+  const staleCheckSource =
+    "async function codexLinuxCheckForUpdatesOnOpen(){try{await codexLinuxRunUpdateManager([`check-now`])}catch{}}";
+  const featurePromptSource =
+    "async function codexLinuxPromptUpdateFeatures(){try{let e=await codexLinuxRunUpdateManager([`prompt-features`,`--json`]),t=JSON.parse(e.stdout||`{}`);return t?.cancelled!==!0}catch{return!0}}";
+  patchedSource = patchedSource
+    .replace(
+      "async function codexLinuxCheckForUpdatesOnOpen(){try{await codexLinuxRunUpdateManager([`check-now`,`--if-stale`])}catch{}}",
+      staleCheckSource,
+    )
+    .replace(
+      "async function codexLinuxCheckForUpdatesIfStale(){try{await codexLinuxRunUpdateManager([`check-now`,`--if-stale`])}catch{}}",
+      staleCheckSource,
+    )
+    .replaceAll("codexLinuxCheckForUpdatesIfStale", "codexLinuxCheckForUpdatesOnOpen");
+  const insertMissingHelper = (helperSource) => {
+    if (!patchedSource.includes("function codexLinuxRunUpdateManager(") || patchedSource.includes(helperSource)) {
+      return;
+    }
+    for (const needle of [
+      "function codexLinuxCreatePackageUpdateManager(",
+      "var tD=class{",
+      refreshSource,
+      probeSource,
+    ]) {
+      if (patchedSource.includes(needle)) {
+        patchedSource = patchedSource.replace(needle, `${helperSource}${needle}`);
+        return;
+      }
+    }
+  };
   if (
     patchedSource.includes("function codexLinuxRunUpdateManager(") &&
     patchedSource.includes(refreshSource) &&
@@ -65,17 +95,24 @@ function migrateLinuxUpdaterBridgeSource(source) {
       `${probeSource}${refreshSource}`,
     );
   }
+  insertMissingHelper(staleCheckSource);
+  insertMissingHelper(featurePromptSource);
 
   const bootstrapNeedle = "function codexLinuxCreatePackageUpdateManager(";
   const isBootstrapSource = patchedSource.includes(bootstrapNeedle);
   if (
     patchedSource.includes("function codexLinuxRunUpdateManager(") &&
     isBootstrapSource &&
-    (!patchedSource.includes(probeSource) || !patchedSource.includes(refreshSource))
+    (!patchedSource.includes(probeSource) ||
+      !patchedSource.includes(refreshSource) ||
+      !patchedSource.includes(staleCheckSource) ||
+      !patchedSource.includes(featurePromptSource))
   ) {
     const helperSource =
       `${patchedSource.includes(probeSource) ? "" : probeSource}` +
-      `${patchedSource.includes(refreshSource) ? "" : refreshSource}`;
+      `${patchedSource.includes(refreshSource) ? "" : refreshSource}` +
+      `${patchedSource.includes(staleCheckSource) ? "" : staleCheckSource}` +
+      `${patchedSource.includes(featurePromptSource) ? "" : featurePromptSource}`;
     patchedSource = patchedSource.replace(bootstrapNeedle, `${helperSource}${bootstrapNeedle}`);
   }
 
@@ -83,9 +120,23 @@ function migrateLinuxUpdaterBridgeSource(source) {
     "await codexLinuxRefreshUpdateState(),e()",
     "await codexLinuxProbeUpdateManager(),e()",
   );
+  patchedSource = patchedSource.replace(
+    "await codexLinuxProbeUpdateManager(),e()}catch(e){",
+    "await codexLinuxProbeUpdateManager(),e(),codexLinuxCheckForUpdatesOnOpen().then(()=>e()).catch(()=>{})}catch(e){",
+  );
+  patchedSource = patchedSource.replace(
+    "try{let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();",
+    "try{if(!await codexLinuxPromptUpdateFeatures()){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);return}let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();",
+  );
 
   const probeStateSource =
-    "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=";
+    "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a(),codexLinuxCheckForUpdatesOnOpen().then(()=>{i(),a()}).catch(()=>{});return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=";
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
+    "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
+    probeStateSource,
+  );
   const hasProbeState = () => patchedSource.includes("c=codexLinuxProbeUpdateManager().then(");
   if (isBootstrapSource && !hasProbeState() && patchedSource.includes(probeSource)) {
     patchedSource = replaceAfter(
@@ -128,6 +179,12 @@ function migrateLinuxUpdaterBridgeSource(source) {
   patchedSource = replaceAfter(
     patchedSource,
     bootstrapNeedle,
+    "try{let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+    "try{if(!await codexLinuxPromptUpdateFeatures()){r=null,n=t?`ready`:`idle`,a();return}let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+  );
+  patchedSource = replaceAfter(
+    patchedSource,
+    bootstrapNeedle,
     "refresh:async()=>{try{await codexLinuxRefreshUpdateState()}catch{}i(),a()}",
     "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
   );
@@ -140,7 +197,7 @@ function migrateLinuxUpdaterBridgeSource(source) {
 }
 
 function buildBootstrapBridgeSource({ childProcessVar, electronVar, fsVar, pathVar }) {
-  return `${buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};function codexLinuxCreatePackageUpdateManager(e){let t=!1,n=\`idle\`,r=null,i=()=>{try{let e=codexLinuxReadUpdateState(),r=e?.status;t=r===\`ready_to_install\`||r===\`waiting_for_app_exit\`,n=codexLinuxUpdateLifecycleState(r);return e}catch{return null}},a=()=>{try{e.send({type:\`app-update-ready-changed\`,isUpdateReady:t}),e.send({type:\`app-update-lifecycle-state-changed\`,lifecycleState:n}),e.send({type:\`app-update-install-progress-changed\`,installProgressPercent:r})}catch{}},s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=\`idle\`,a();return!1});let o=()=>{e.allowQuit?.();codexLinuxQuitForUpdate()};return{manager:{getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:\`idle\`,getInstallProgressPercent:()=>r,checkForUpdates:async()=>{if(!await c)return;n=\`checking\`,a();try{await codexLinuxRunUpdateManager([\`check-now\`]),i(),a()}catch(e){n=t?\`ready\`:\`idle\`,a();throw e}},installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}r=0,n=\`installing\`,a();try{let e=await codexLinuxRunUpdateManager([\`install-ready\`]),s=i();if(s?.status===\`waiting_for_app_exit\`){r=null,n=\`ready\`,a(),o();return}r=null,a(),e.stdout?.includes(\`already installed\`)?await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`The ready update is already installed.\`):e.stdout?.includes(\`No Codex Desktop update is ready\`)&&await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`There is no rebuilt update waiting to install.\`)}catch(e){r=null,n=t?\`ready\`:\`idle\`,a();throw e}}},quitForUpdate:o,refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=\`idle\`;a()}}}`;
+  return `${buildBridgeSource({ childProcessVar, electronVar, fsVar, pathVar })};function codexLinuxCreatePackageUpdateManager(e){let t=!1,n=\`idle\`,r=null,i=()=>{try{let e=codexLinuxReadUpdateState(),r=e?.status;t=r===\`ready_to_install\`||r===\`waiting_for_app_exit\`,n=codexLinuxUpdateLifecycleState(r);return e}catch{return null}},a=()=>{try{e.send({type:\`app-update-ready-changed\`,isUpdateReady:t}),e.send({type:\`app-update-lifecycle-state-changed\`,lifecycleState:n}),e.send({type:\`app-update-install-progress-changed\`,installProgressPercent:r})}catch{}},s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a(),codexLinuxCheckForUpdatesOnOpen().then(()=>{i(),a()}).catch(()=>{});return!0}).catch(()=>{s=!1,t=!1,n=\`idle\`,a();return!1});let o=()=>{e.allowQuit?.();codexLinuxQuitForUpdate()};return{manager:{getIsUpdateReady:()=>s&&t,getUpdateLifecycleState:()=>s?n:\`idle\`,getInstallProgressPercent:()=>r,checkForUpdates:async()=>{if(!await c)return;n=\`checking\`,a();try{await codexLinuxRunUpdateManager([\`check-now\`]),i(),a()}catch(e){n=t?\`ready\`:\`idle\`,a();throw e}},installUpdatesIfAvailable:async()=>{if(!await c){a();return}i();if(!t){a();return}r=0,n=\`installing\`,a();try{if(!await codexLinuxPromptUpdateFeatures()){r=null,n=t?\`ready\`:\`idle\`,a();return}let e=await codexLinuxRunUpdateManager([\`install-ready\`]),s=i();if(s?.status===\`waiting_for_app_exit\`){r=null,n=\`ready\`,a(),o();return}r=null,a(),e.stdout?.includes(\`already installed\`)?await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`The ready update is already installed.\`):e.stdout?.includes(\`No Codex Desktop update is ready\`)&&await codexLinuxShowUpdateMessage(\`Codex Desktop update\`,\`There is no rebuilt update waiting to install.\`)}catch(e){r=null,n=t?\`ready\`:\`idle\`,a();throw e}}},quitForUpdate:o,refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=\`idle\`;a()}}}`;
 }
 
 function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
@@ -303,7 +360,7 @@ function applyLinuxAppUpdaterBridgePatch(currentSource) {
   if (!patchedSource.includes("async initializeLinuxPackageUpdater(){")) {
     const methodNeedle = "async initializeWindowsUpdater(){";
     const methodPatch =
-      "async initializeLinuxPackageUpdater(){if(process.platform!==`linux`){this.lastUnavailableReason=`unsupported platform`;return}let e=()=>{let e=codexLinuxReadUpdateState(),t=e?.status;this.setUpdateReady(t===`ready_to_install`||t===`waiting_for_app_exit`),this.setUpdateLifecycleState(codexLinuxUpdateLifecycleState(t)),this.lastUnavailableReason=null;return e};try{await codexLinuxProbeUpdateManager(),e()}catch(e){this.lastUnavailableReason=e?.code===`ENOENT`?`codex-update-manager not found`:`codex-update-manager unavailable`,ZE().warning(`Linux updater unavailable`,{safe:{reason:this.lastUnavailableReason},sensitive:{error:e}});return}this.updater={checkForUpdates:async()=>{this.setUpdateLifecycleState(`checking`);try{await codexLinuxRunUpdateManager([`check-now`]),e()}catch(t){this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw t}},installUpdatesIfAvailable:async()=>{e();if(!this.isUpdateReady)return;this.setInstallProgressPercent(0),this.setUpdateLifecycleState(`installing`);try{let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();if(t?.status===`waiting_for_app_exit`){this.setInstallProgressPercent(null),codexLinuxQuitForUpdate();return}this.setInstallProgressPercent(null),n.stdout?.includes(`already installed`)?await codexLinuxShowUpdateMessage(`Codex Desktop update`,`The ready update is already installed.`):n.stdout?.includes(`No Codex Desktop update is ready`)&&await codexLinuxShowUpdateMessage(`Codex Desktop update`,`There is no rebuilt update waiting to install.`)}catch(e){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw e}}};let t=setInterval(()=>{codexLinuxRefreshUpdateState().then(()=>e()).catch(e=>{ZE().warning(`Linux updater state refresh failed`,{safe:{},sensitive:{error:e}})})},3e4);t.unref?.()}";
+      "async initializeLinuxPackageUpdater(){if(process.platform!==`linux`){this.lastUnavailableReason=`unsupported platform`;return}let e=()=>{let e=codexLinuxReadUpdateState(),t=e?.status;this.setUpdateReady(t===`ready_to_install`||t===`waiting_for_app_exit`),this.setUpdateLifecycleState(codexLinuxUpdateLifecycleState(t)),this.lastUnavailableReason=null;return e};try{await codexLinuxProbeUpdateManager(),e(),codexLinuxCheckForUpdatesOnOpen().then(()=>e()).catch(()=>{})}catch(e){this.lastUnavailableReason=e?.code===`ENOENT`?`codex-update-manager not found`:`codex-update-manager unavailable`,ZE().warning(`Linux updater unavailable`,{safe:{reason:this.lastUnavailableReason},sensitive:{error:e}});return}this.updater={checkForUpdates:async()=>{this.setUpdateLifecycleState(`checking`);try{await codexLinuxRunUpdateManager([`check-now`]),e()}catch(t){this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw t}},installUpdatesIfAvailable:async()=>{e();if(!this.isUpdateReady)return;this.setInstallProgressPercent(0),this.setUpdateLifecycleState(`installing`);try{if(!await codexLinuxPromptUpdateFeatures()){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);return}let n=await codexLinuxRunUpdateManager([`install-ready`]),t=e();if(t?.status===`waiting_for_app_exit`){this.setInstallProgressPercent(null),codexLinuxQuitForUpdate();return}this.setInstallProgressPercent(null),n.stdout?.includes(`already installed`)?await codexLinuxShowUpdateMessage(`Codex Desktop update`,`The ready update is already installed.`):n.stdout?.includes(`No Codex Desktop update is ready`)&&await codexLinuxShowUpdateMessage(`Codex Desktop update`,`There is no rebuilt update waiting to install.`)}catch(e){this.setInstallProgressPercent(null),this.setUpdateLifecycleState(this.isUpdateReady?`ready`:`idle`);throw e}}};let t=setInterval(()=>{codexLinuxRefreshUpdateState().then(()=>e()).catch(e=>{ZE().warning(`Linux updater state refresh failed`,{safe:{},sensitive:{error:e}})})},3e4);t.unref?.()}";
     if (!patchedSource.includes(methodNeedle)) {
       console.warn("WARN: Could not find updater method insertion point - skipping Linux updater bridge patch");
       return currentSource;

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1485,13 +1485,18 @@ test("adds Linux package updater behind the existing app updater manager", () =>
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`--help`\]\)/);
   assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)/);
   assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
+  assert.match(patched, /async function codexLinuxCheckForUpdatesOnOpen\(\)/);
+  assert.match(patched, /codexLinuxRunUpdateManager\(\[`check-now`\]\)/);
+  assert.match(patched, /async function codexLinuxPromptUpdateFeatures\(\)/);
+  assert.match(patched, /codexLinuxRunUpdateManager\(\[`prompt-features`,`--json`\]\)/);
   assert.doesNotMatch(patched, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
-  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\)/);
+  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\),codexLinuxCheckForUpdatesOnOpen\(\)/);
   assert.match(patched, /if\(!this\.options\.enableUpdater&&process\.platform!==`linux`\)/);
   assert.match(patched, /process\.platform===`linux`\?await this\.initializeLinuxPackageUpdater\(\)/);
   assert.match(patched, /async initializeLinuxPackageUpdater\(\)/);
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`check-now`\]\)/);
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`install-ready`\]\)/);
+  assert.match(patched, /if\(!await codexLinuxPromptUpdateFeatures\(\)\)/);
   assert.match(patched, /this\.setInstallProgressPercent\(0\),this\.setUpdateLifecycleState\(`installing`\)/);
   assert.match(patched, /this\.setInstallProgressPercent\(null\),codexLinuxQuitForUpdate\(\)/);
   assert.doesNotMatch(patched, /this\.options\.onInstallUpdatesRequested\?\.\(\)/);
@@ -1504,7 +1509,7 @@ test("does not run bootstrap probe-state migration on class-style updater bundle
   const patched = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, source);
 
   assert.match(patched, /function unrelated\(\)\{i\(\);let o=1;return o\}/);
-  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\)/);
+  assert.match(patched, /await codexLinuxProbeUpdateManager\(\),e\(\),codexLinuxCheckForUpdatesOnOpen\(\)/);
   assert.doesNotMatch(patched, /let s=!1,c=codexLinuxProbeUpdateManager/);
   assert.doesNotMatch(patched, /getIsUpdateReady:\(\)=>s&&t/);
 });
@@ -1521,10 +1526,11 @@ test("adds Linux package updater to current bootstrap updater wiring", () => {
   assert.match(patched, /async function codexLinuxProbeUpdateManager\(\)/);
   assert.match(patched, /codexLinuxRunUpdateManager\(\[`--help`\]\)/);
   assert.match(patched, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
-  assert.match(patched, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\);return!0\}\)/);
+  assert.match(patched, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\),codexLinuxCheckForUpdatesOnOpen\(\)/);
   assert.match(patched, /getIsUpdateReady:\(\)=>s&&t/);
   assert.match(patched, /checkForUpdates:async\(\)=>\{if\(!await c\)return;n=`checking`/);
   assert.match(patched, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+  assert.match(patched, /if\(!await codexLinuxPromptUpdateFeatures\(\)\)\{r=null,n=t\?`ready`:`idle`,a\(\);return\}/);
   assert.match(patched, /refresh:async\(\)=>\{if\(await c\)\{try\{await codexLinuxRefreshUpdateState\(\)\}/);
   assert.doesNotMatch(patched, /codexLinuxRunUpdateManager\(\[`status`,`--json`\]\)/);
 });
@@ -1533,7 +1539,7 @@ test("migrates already-patched bootstrap updater bridge to probe before enabling
   const patched = applyLinuxAppUpdaterBridgePatch(currentBootstrapUpdaterBundleFixture());
   const oldPatched = patched
     .replace(
-      "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
+      "let s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a(),codexLinuxCheckForUpdatesOnOpen().then(()=>{i(),a()}).catch(()=>{});return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
       "i(),codexLinuxRefreshUpdateState().then(()=>{i(),a()}).catch(()=>{});let o=",
     )
     .replace(
@@ -1549,15 +1555,20 @@ test("migrates already-patched bootstrap updater bridge to probe before enabling
       "installUpdatesIfAvailable:async()=>{i();if(!t)return;",
     )
     .replace(
+      "try{if(!await codexLinuxPromptUpdateFeatures()){r=null,n=t?`ready`:`idle`,a();return}let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+      "try{let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+    )
+    .replace(
       "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
       "refresh:async()=>{try{await codexLinuxRefreshUpdateState()}catch{}i(),a()}",
     );
 
   const migrated = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, oldPatched);
 
-  assert.match(migrated, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\);return!0\}\)/);
+  assert.match(migrated, /codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\),codexLinuxCheckForUpdatesOnOpen\(\)/);
   assert.match(migrated, /getIsUpdateReady:\(\)=>s&&t/);
   assert.match(migrated, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+  assert.match(migrated, /if\(!await codexLinuxPromptUpdateFeatures\(\)\)\{r=null,n=t\?`ready`:`idle`,a\(\);return\}/);
 });
 
 test("migrates previous bootstrap updater bridge without leaving undefined probe state", () => {
@@ -1572,7 +1583,15 @@ test("migrates previous bootstrap updater bridge without leaving undefined probe
       "",
     )
     .replace(
-      ",s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a();return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
+      "async function codexLinuxCheckForUpdatesOnOpen(){try{await codexLinuxRunUpdateManager([`check-now`])}catch{}}",
+      "",
+    )
+    .replace(
+      "async function codexLinuxPromptUpdateFeatures(){try{let e=await codexLinuxRunUpdateManager([`prompt-features`,`--json`]),t=JSON.parse(e.stdout||`{}`);return t?.cancelled!==!0}catch{return!0}}",
+      "",
+    )
+    .replace(
+      ",s=!1,c=codexLinuxProbeUpdateManager().then(()=>{s=!0,i(),a(),codexLinuxCheckForUpdatesOnOpen().then(()=>{i(),a()}).catch(()=>{});return!0}).catch(()=>{s=!1,t=!1,n=`idle`,a();return!1});let o=",
       ";i();let o=",
     )
     .replace(
@@ -1588,22 +1607,31 @@ test("migrates previous bootstrap updater bridge without leaving undefined probe
       "installUpdatesIfAvailable:async()=>{i();if(!t)return;",
     )
     .replace(
+      "try{if(!await codexLinuxPromptUpdateFeatures()){r=null,n=t?`ready`:`idle`,a();return}let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+      "try{let e=await codexLinuxRunUpdateManager([`install-ready`]),s=i();",
+    )
+    .replace(
       "refresh:async()=>{if(await c){try{await codexLinuxRefreshUpdateState()}catch{}i()}else t=!1,n=`idle`;a()}",
       "refresh:()=>{i(),a()}",
     );
 
   assert.doesNotMatch(oldPatched, /codexLinuxProbeUpdateManager/);
   assert.doesNotMatch(oldPatched, /codexLinuxRefreshUpdateState/);
+  assert.doesNotMatch(oldPatched, /codexLinuxCheckForUpdatesOnOpen/);
+  assert.doesNotMatch(oldPatched, /codexLinuxPromptUpdateFeatures/);
   assert.match(oldPatched, /i\(\);let o=/);
 
   const migrated = applyPatchTwice(applyLinuxAppUpdaterBridgePatch, oldPatched);
 
   assert.match(migrated, /async function codexLinuxProbeUpdateManager\(\)\{await codexLinuxRunUpdateManager\(\[`--help`\]\)\}/);
   assert.match(migrated, /async function codexLinuxRefreshUpdateState\(\)\{return codexLinuxReadUpdateState\(\)\}/);
-  assert.match(migrated, /let s=!1,c=codexLinuxProbeUpdateManager\(\)\.then/);
+  assert.match(migrated, /async function codexLinuxCheckForUpdatesOnOpen\(\)\{try\{await codexLinuxRunUpdateManager\(\[`check-now`\]\)\}catch\{\}\}/);
+  assert.match(migrated, /async function codexLinuxPromptUpdateFeatures\(\)/);
+  assert.match(migrated, /let s=!1,c=codexLinuxProbeUpdateManager\(\)\.then\(\(\)=>\{s=!0,i\(\),a\(\),codexLinuxCheckForUpdatesOnOpen\(\)/);
   assert.match(migrated, /getIsUpdateReady:\(\)=>s&&t/);
   assert.match(migrated, /checkForUpdates:async\(\)=>\{if\(!await c\)return;n=`checking`/);
   assert.match(migrated, /installUpdatesIfAvailable:async\(\)=>\{if\(!await c\)\{a\(\);return\}i\(\);if\(!t\)\{a\(\);return\}/);
+  assert.match(migrated, /if\(!await codexLinuxPromptUpdateFeatures\(\)\)\{r=null,n=t\?`ready`:`idle`,a\(\);return\}/);
   assert.match(migrated, /refresh:async\(\)=>\{if\(await c\)\{try\{await codexLinuxRefreshUpdateState\(\)\}/);
 });
 

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -11,6 +11,7 @@ directories = "6.0.0"
 futures-util = "0.3.32"
 fs4 = "0.13.1"
 notify-rust = "4.14.0"
+quick-xml = "0.38.4"
 reqwest = { version = "0.13.2", default-features = false, features = ["http2", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{Cli, Commands},
     codex_cli,
     config::{RuntimeConfig, RuntimePaths},
-    install, install_rollback, liveness, logging, notify, rollback,
+    features, install, install_rollback, liveness, logging, notify, rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
     upstream,
 };
@@ -64,6 +64,8 @@ pub async fn run(cli: Cli) -> Result<()> {
             print_path,
         } => run_prompt_install_cli(&mut state, &paths, cli_path, print_path),
         Commands::Status { json } => run_status(&mut state, &paths, json),
+        Commands::Features { json } => run_features(&config, &paths, json),
+        Commands::PromptFeatures { json } => run_prompt_features(&config, &paths, json),
         Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
         Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
         Commands::InstallDeb { path } => install::install_deb(&path),
@@ -312,6 +314,57 @@ fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> R
     Ok(())
 }
 
+fn run_features(config: &RuntimeConfig, paths: &RuntimePaths, json: bool) -> Result<()> {
+    let selection = features::selection(config, paths)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&selection)?);
+    } else {
+        println!("features_config: {}", selection.config_path.display());
+        println!(
+            "enabled_features: {}",
+            if selection.enabled.is_empty() {
+                "none".to_string()
+            } else {
+                selection.enabled.join(",")
+            }
+        );
+        for option in selection.available {
+            println!(
+                "{} [{}] - {}",
+                option.id,
+                if option.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                option.title
+            );
+        }
+    }
+    Ok(())
+}
+
+fn run_prompt_features(config: &RuntimeConfig, paths: &RuntimePaths, json: bool) -> Result<()> {
+    let outcome = features::prompt_for_update(config, paths)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&outcome)?);
+    } else if outcome.cancelled {
+        println!("Feature selection cancelled.");
+    } else if outcome.prompted {
+        println!(
+            "Enabled update features: {}",
+            if outcome.selection.enabled.is_empty() {
+                "none".to_string()
+            } else {
+                outcome.selection.enabled.join(",")
+            }
+        );
+    } else {
+        println!("No graphical feature selection prompt was available.");
+    }
+    Ok(())
+}
+
 fn update_error_status_line(state: &PersistedState) -> String {
     format!(
         "update_error: {}",
@@ -539,7 +592,12 @@ async fn run_check_cycle(
     persist_state(paths, state)?;
 
     let result: Result<()> = async {
-        let metadata = upstream::fetch_remote_metadata(&client, &config.dmg_url).await?;
+        let metadata = upstream::fetch_remote_metadata(
+            &client,
+            &config.dmg_url,
+            config.appcast_url.as_deref(),
+        )
+        .await?;
         let previous_headers_fingerprint = state.remote_headers_fingerprint.clone();
         state.remote_headers_fingerprint = Some(metadata.headers_fingerprint.clone());
         state.last_successful_check_at = Some(Utc::now());
@@ -547,6 +605,7 @@ async fn run_check_cycle(
         if previous_headers_fingerprint.as_deref() == Some(metadata.headers_fingerprint.as_str())
             && state.dmg_sha256.is_some()
             && !retrying_failed_update
+            && installed_version_satisfies_remote_candidate(state, &metadata)
         {
             set_status(state, paths, UpdateStatus::Idle)?;
             info!("upstream fingerprint unchanged; skipping download");
@@ -556,8 +615,15 @@ async fn run_check_cycle(
         set_status(state, paths, UpdateStatus::DownloadingDmg)?;
 
         let downloads_dir = config.workspace_root.join("downloads");
-        let downloaded =
-            upstream::download_dmg(&client, &config.dmg_url, &downloads_dir, Utc::now()).await?;
+        let downloaded = upstream::download_dmg(
+            &client,
+            &metadata.download_url,
+            &downloads_dir,
+            Utc::now(),
+            metadata.candidate_version.as_deref(),
+            metadata.upstream_version.as_deref(),
+        )
+        .await?;
 
         if state
             .rollback_blocked_candidate_version
@@ -581,6 +647,10 @@ async fn run_check_cycle(
 
         if state.dmg_sha256.as_deref() == Some(downloaded.sha256.as_str())
             && !retrying_failed_update
+            && installed_version_satisfies_candidate(
+                &state.installed_version,
+                &downloaded.candidate_version,
+            )
         {
             state.status = UpdateStatus::Idle;
             state.artifact_paths.dmg_path = Some(downloaded.path);
@@ -747,6 +817,8 @@ async fn run_install_ready(
         }
     }
 
+    rebuild_ready_update_if_features_changed(config, state, paths).await?;
+
     let Some(package_path) = state.artifact_paths.package_path.clone() else {
         mark_failed_and_persist(state, paths, "No ready update package is recorded")?;
         maybe_send_notification(
@@ -793,6 +865,36 @@ async fn run_install_ready(
 
     clear_install_auth_required_event(state, paths)?;
     trigger_install(state, paths, &package_path).await
+}
+
+async fn rebuild_ready_update_if_features_changed(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let enabled_feature_ids = features::effective_enabled_feature_ids(config, paths)?;
+    if enabled_feature_ids == state.enabled_feature_ids {
+        return Ok(());
+    }
+
+    let Some(candidate_version) = state.candidate_version.clone() else {
+        return Ok(());
+    };
+    let Some(dmg_path) = state.artifact_paths.dmg_path.clone() else {
+        return Ok(());
+    };
+    if !dmg_path.exists() {
+        return Ok(());
+    }
+
+    info!(
+        candidate_version,
+        previous_features = ?state.enabled_feature_ids,
+        selected_features = ?enabled_feature_ids,
+        "rebuilding ready update because Linux feature selection changed"
+    );
+    builder::build_update(config, state, paths, &candidate_version, &dmg_path).await?;
+    Ok(())
 }
 
 fn complete_pending_install_if_already_installed(
@@ -900,6 +1002,18 @@ fn installed_version_matches_candidate(installed: &str, candidate: &str) -> bool
         Some(std::cmp::Ordering::Equal) => true,
         Some(_) => false,
         None => installed == candidate,
+    }
+}
+
+fn installed_version_satisfies_remote_candidate(
+    state: &PersistedState,
+    metadata: &upstream::RemoteMetadata,
+) -> bool {
+    match metadata.candidate_version.as_deref() {
+        Some(candidate) => {
+            installed_version_satisfies_candidate(&state.installed_version, candidate)
+        }
+        None => true,
     }
 }
 
@@ -1191,6 +1305,7 @@ mod tests {
     fn upstream_check_freshness_respects_configured_interval() {
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -1248,6 +1363,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: false,
@@ -1285,6 +1401,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://invalid.example/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -1385,6 +1502,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -1432,6 +1550,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -1476,6 +1595,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: false,
@@ -1515,6 +1635,7 @@ mod tests {
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 1,
             check_interval_hours: 6,
             auto_install_on_app_exit: false,
@@ -1951,6 +2072,30 @@ mod tests {
     #[test]
     fn generated_version_comparison_rejects_non_generated_versions() {
         assert_eq!(compare_generated_versions("0.34.1", "0.35.0"), None);
+    }
+
+    #[test]
+    fn appcast_candidate_skip_requires_installed_package_to_satisfy_candidate() {
+        let mut state = PersistedState::new(true);
+        state.installed_version = "2026.05.15.010203+oldbuild".to_string();
+        let metadata = upstream::RemoteMetadata {
+            etag: Some("\"appcast\"".to_string()),
+            last_modified: None,
+            content_length: Some(42),
+            headers_fingerprint: "appcast=fingerprint".to_string(),
+            download_url: "https://example.com/Codex.zip".to_string(),
+            candidate_version: Some("2026.05.16.013614+26.513.31313".to_string()),
+            upstream_version: Some("26.513.31313".to_string()),
+        };
+
+        assert!(!installed_version_satisfies_remote_candidate(
+            &state, &metadata
+        ));
+
+        state.installed_version = "2026.05.16.013614+26.513.31313".to_string();
+        assert!(installed_version_satisfies_remote_candidate(
+            &state, &metadata
+        ));
     }
 
     #[tokio::test]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     config::{RuntimeConfig, RuntimePaths},
+    features,
     install::PackageKind,
     state::{ArtifactPaths, PersistedState, UpdateStatus},
 };
@@ -83,6 +84,8 @@ pub async fn build_update(
     state.save(&paths.state_file)?;
 
     copy_builder_bundle(&config.builder_bundle_root, &workspace.bundle_dir)?;
+    let enabled_feature_ids = features::effective_enabled_feature_ids(config, paths)?;
+    features::write_features_config(&workspace.features_config, &enabled_feature_ids)?;
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
@@ -90,6 +93,7 @@ pub async fn build_update(
         Command::new(workspace.bundle_dir.join("install.sh"))
             .arg(dmg_path)
             .env("CODEX_INSTALL_DIR", &workspace.app_dir)
+            .env("CODEX_LINUX_FEATURES_CONFIG", &workspace.features_config)
             .env(
                 "CODEX_MANAGED_NODE_SOURCE",
                 config.builder_bundle_root.join("node-runtime"),
@@ -126,6 +130,7 @@ pub async fn build_update(
 
     let package_path = find_package_in(&workspace.dist_dir)?;
     state.status = UpdateStatus::ReadyToInstall;
+    state.enabled_feature_ids = enabled_feature_ids;
     state.artifact_paths = ArtifactPaths {
         dmg_path: Some(dmg_path.to_path_buf()),
         workspace_dir: Some(workspace.workspace_dir.clone()),
@@ -149,6 +154,7 @@ struct BuilderWorkspace {
     app_dir: PathBuf,
     install_log: PathBuf,
     build_log: PathBuf,
+    features_config: PathBuf,
 }
 
 impl BuilderWorkspace {
@@ -160,6 +166,7 @@ impl BuilderWorkspace {
         let logs_dir = workspace_dir.join("logs");
         let install_log = logs_dir.join("install.log");
         let build_log = logs_dir.join("build-package.log");
+        let features_config = workspace_dir.join("features.json");
 
         if workspace_dir.exists() {
             fs::remove_dir_all(&workspace_dir)
@@ -176,6 +183,7 @@ impl BuilderWorkspace {
             app_dir,
             install_log,
             build_log,
+            features_config,
         })
     }
 }
@@ -596,8 +604,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
             bundle_root.join("install.sh"),
             r#"#!/bin/bash
 set -euo pipefail
+test -f "${CODEX_LINUX_FEATURES_CONFIG}"
 mkdir -p "${CODEX_INSTALL_DIR}"
 echo launcher > "${CODEX_INSTALL_DIR}/start.sh"
+cp "${CODEX_LINUX_FEATURES_CONFIG}" "${CODEX_INSTALL_DIR}/features.json"
 chmod +x "${CODEX_INSTALL_DIR}/start.sh"
 "#,
         )?;
@@ -655,6 +665,7 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
 
         let config = RuntimeConfig {
             dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
             initial_check_delay_seconds: 30,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -663,6 +674,10 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             builder_bundle_root: bundle_root,
             app_executable_path: PathBuf::from("/opt/codex-desktop/electron"),
         };
+        features::write_features_config(
+            &features::user_features_config_path(&paths),
+            &["example-feature".to_string()],
+        )?;
         let dmg_path = temp.path().join("Codex.dmg");
         fs::write(&dmg_path, b"dmg")?;
 
@@ -698,6 +713,15 @@ chmod +x "${CODEX_INSTALL_DIR}/start.sh"
             .workspace_dir
             .join("builder/linux-features/features.example.json")
             .exists());
+        assert_eq!(state.enabled_feature_ids, vec!["example-feature"]);
+        assert_eq!(
+            fs::read_to_string(artifacts.workspace_dir.join("features.json"))?,
+            "{\n  \"enabled\": [\n    \"example-feature\"\n  ]\n}\n"
+        );
+        assert_eq!(
+            fs::read_to_string(artifacts.workspace_dir.join("codex-app/features.json"))?,
+            "{\n  \"enabled\": [\n    \"example-feature\"\n  ]\n}\n"
+        );
         assert!(
             is_native_package_file(&artifacts.package_path),
             "expected a native package (.deb, .rpm, or .pkg.tar.zst), got {}",

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -37,6 +37,16 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Print available optional Linux features and the current update selection.
+    Features {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show a native feature-selection prompt for the next update rebuild.
+    PromptFeatures {
+        #[arg(long)]
+        json: bool,
+    },
     /// Install the already rebuilt update package, if one is ready.
     InstallReady,
     /// Roll back to the last retained known-good package.

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -837,6 +837,7 @@ mod tests {
 
     #[test]
     fn refresh_status_uses_persisted_cli_path_and_cached_latest() -> Result<()> {
+        let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
         paths.ensure_dirs()?;
@@ -864,6 +865,7 @@ mod tests {
 
     #[test]
     fn preflight_uses_cached_latest_for_fresh_explicit_cli_path() -> Result<()> {
+        let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
         paths.ensure_dirs()?;
@@ -895,6 +897,7 @@ mod tests {
 
     #[test]
     fn refresh_cached_status_uses_cached_installed_version_without_running_cli() -> Result<()> {
+        let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
         paths.ensure_dirs()?;

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -11,6 +11,8 @@ const SERVICE_NAME: &str = "codex-update-manager";
 /// Runtime configuration values that control how the updater behaves on Linux.
 pub struct RuntimeConfig {
     pub dmg_url: String,
+    #[serde(default = "default_appcast_url")]
+    pub appcast_url: Option<String>,
     pub initial_check_delay_seconds: u64,
     pub check_interval_hours: u64,
     pub auto_install_on_app_exit: bool,
@@ -84,6 +86,7 @@ impl RuntimeConfig {
 
         Self {
             dmg_url: "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg".to_string(),
+            appcast_url: default_appcast_url(),
             initial_check_delay_seconds: 30,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,
@@ -108,6 +111,13 @@ impl RuntimeConfig {
     }
 }
 
+fn default_appcast_url() -> Option<String> {
+    Some(match std::env::consts::ARCH {
+        "x86_64" => "https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml".to_string(),
+        _ => "https://persistent.oaistatic.com/codex-app-prod/appcast.xml".to_string(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -128,6 +138,9 @@ mod tests {
 
         let config = RuntimeConfig::load_or_default(&paths)?;
         assert_eq!(config.initial_check_delay_seconds, 30);
+        assert!(config.appcast_url.as_deref().is_some_and(
+            |url| url.starts_with("https://persistent.oaistatic.com/codex-app-prod/appcast")
+        ));
         assert!(config.auto_install_on_app_exit);
         assert_eq!(config.workspace_root, paths.cache_dir);
         assert!(config.builder_bundle_root.is_absolute());
@@ -150,6 +163,7 @@ mod tests {
             &paths.config_file,
             r#"
 dmg_url = "https://example.com/Codex.dmg"
+appcast_url = "https://example.com/appcast.xml"
 initial_check_delay_seconds = 5
 check_interval_hours = 12
 auto_install_on_app_exit = false
@@ -162,6 +176,10 @@ app_executable_path = "/opt/codex-desktop/electron"
 
         let config = RuntimeConfig::load_or_default(&paths)?;
         assert_eq!(config.dmg_url, "https://example.com/Codex.dmg");
+        assert_eq!(
+            config.appcast_url.as_deref(),
+            Some("https://example.com/appcast.xml")
+        );
         assert_eq!(config.initial_check_delay_seconds, 5);
         assert_eq!(config.check_interval_hours, 12);
         assert!(!config.auto_install_on_app_exit);

--- a/updater/src/features.rs
+++ b/updater/src/features.rs
@@ -1,0 +1,533 @@
+//! Runtime Linux feature selection for app-driven update rebuilds.
+
+use crate::config::{RuntimeConfig, RuntimePaths};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    ffi::OsString,
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PromptHelper {
+    Zenity,
+    Kdialog,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PromptHelperOutcome {
+    Selected(Vec<String>),
+    Cancelled,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureConfig {
+    pub enabled: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureOption {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub enabled: bool,
+    pub default_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureSelection {
+    pub config_path: PathBuf,
+    pub available: Vec<FeatureOption>,
+    pub enabled: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptFeaturesOutcome {
+    pub prompted: bool,
+    pub changed: bool,
+    pub cancelled: bool,
+    pub selection: FeatureSelection,
+}
+
+#[derive(Debug, Deserialize)]
+struct FeatureManifest {
+    id: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default, rename = "defaultEnabled")]
+    default_enabled: bool,
+    #[serde(default)]
+    hidden: bool,
+}
+
+pub fn user_features_config_path(paths: &RuntimePaths) -> PathBuf {
+    paths.config_dir.join("features.json")
+}
+
+pub fn effective_enabled_feature_ids(
+    config: &RuntimeConfig,
+    paths: &RuntimePaths,
+) -> Result<Vec<String>> {
+    let path = user_features_config_path(paths);
+    if path.exists() {
+        return read_enabled_feature_ids(&path);
+    }
+
+    let bundled = bundled_features_config_path(config);
+    if bundled.exists() {
+        return read_enabled_feature_ids(&bundled);
+    }
+
+    Ok(Vec::new())
+}
+
+pub fn write_features_config(path: &Path, enabled: &[String]) -> Result<()> {
+    let parent = path
+        .parent()
+        .with_context(|| format!("{} has no parent directory", path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("Failed to create {}", parent.display()))?;
+    let config = FeatureConfig {
+        enabled: normalize_feature_ids(enabled.iter().map(String::as_str)),
+    };
+    fs::write(
+        path,
+        format!("{}\n", serde_json::to_string_pretty(&config)?),
+    )
+    .with_context(|| format!("Failed to write {}", path.display()))
+}
+
+pub fn selection(config: &RuntimeConfig, paths: &RuntimePaths) -> Result<FeatureSelection> {
+    let enabled = effective_enabled_feature_ids(config, paths)?;
+    let enabled_set = enabled.iter().cloned().collect::<BTreeSet<_>>();
+    let available = discover_feature_options(config)?
+        .into_iter()
+        .map(|mut option| {
+            option.enabled = enabled_set.contains(&option.id);
+            option
+        })
+        .collect::<Vec<_>>();
+
+    Ok(FeatureSelection {
+        config_path: user_features_config_path(paths),
+        available,
+        enabled,
+    })
+}
+
+pub fn prompt_for_update(
+    config: &RuntimeConfig,
+    paths: &RuntimePaths,
+) -> Result<PromptFeaturesOutcome> {
+    let before = selection(config, paths)?;
+    if before.available.is_empty() || !has_graphical_session() {
+        return Ok(PromptFeaturesOutcome {
+            prompted: false,
+            changed: false,
+            cancelled: false,
+            selection: before,
+        });
+    }
+
+    let enabled = match prompt_with_available_helper(&before.available)? {
+        PromptHelperOutcome::Selected(enabled) => enabled,
+        PromptHelperOutcome::Cancelled => {
+            return Ok(PromptFeaturesOutcome {
+                prompted: true,
+                changed: false,
+                cancelled: true,
+                selection: before,
+            });
+        }
+        PromptHelperOutcome::Unavailable => {
+            return Ok(PromptFeaturesOutcome {
+                prompted: false,
+                changed: false,
+                cancelled: false,
+                selection: before,
+            });
+        }
+    };
+
+    let enabled = normalize_feature_ids(enabled.iter().map(String::as_str));
+    let changed = enabled != before.enabled;
+    if changed {
+        write_features_config(&before.config_path, &enabled)?;
+    }
+
+    Ok(PromptFeaturesOutcome {
+        prompted: true,
+        changed,
+        cancelled: false,
+        selection: selection(config, paths)?,
+    })
+}
+
+fn bundled_features_config_path(config: &RuntimeConfig) -> PathBuf {
+    config
+        .builder_bundle_root
+        .join("linux-features")
+        .join("features.json")
+}
+
+fn read_enabled_feature_ids(path: &Path) -> Result<Vec<String>> {
+    let contents =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let config = serde_json::from_str::<FeatureConfig>(&contents)
+        .with_context(|| format!("Failed to parse {}", path.display()))?;
+    Ok(normalize_feature_ids(
+        config.enabled.iter().map(String::as_str),
+    ))
+}
+
+fn discover_feature_options(config: &RuntimeConfig) -> Result<Vec<FeatureOption>> {
+    let root = config.builder_bundle_root.join("linux-features");
+    let mut options = Vec::new();
+    if !root.is_dir() {
+        return Ok(options);
+    }
+
+    for entry in
+        fs::read_dir(&root).with_context(|| format!("Failed to read {}", root.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let manifest_path = entry.path().join("feature.json");
+        if !manifest_path.is_file() {
+            continue;
+        }
+        let contents = fs::read_to_string(&manifest_path)
+            .with_context(|| format!("Failed to read {}", manifest_path.display()))?;
+        let manifest = serde_json::from_str::<FeatureManifest>(&contents)
+            .with_context(|| format!("Failed to parse {}", manifest_path.display()))?;
+        if manifest.hidden {
+            continue;
+        }
+        if !is_valid_feature_id(&manifest.id) {
+            continue;
+        }
+        let title = manifest
+            .title
+            .or(manifest.name)
+            .unwrap_or_else(|| manifest.id.clone());
+        options.push(FeatureOption {
+            id: manifest.id,
+            title,
+            description: manifest.description.unwrap_or_default(),
+            enabled: false,
+            default_enabled: manifest.default_enabled,
+        });
+    }
+
+    options.sort_by(|left, right| left.title.cmp(&right.title).then(left.id.cmp(&right.id)));
+    Ok(options)
+}
+
+fn prompt_with_available_helper(options: &[FeatureOption]) -> Result<PromptHelperOutcome> {
+    let helper = choose_prompt_helper(
+        prefers_kdialog(),
+        command_in_path("zenity").is_some(),
+        command_in_path("kdialog").is_some(),
+    );
+    match helper {
+        Some(PromptHelper::Zenity) => run_zenity_checklist(options),
+        Some(PromptHelper::Kdialog) => run_kdialog_checklist(options),
+        None => Ok(PromptHelperOutcome::Unavailable),
+    }
+}
+
+fn choose_prompt_helper(
+    prefers_kdialog: bool,
+    has_zenity: bool,
+    has_kdialog: bool,
+) -> Option<PromptHelper> {
+    if prefers_kdialog && has_kdialog {
+        return Some(PromptHelper::Kdialog);
+    }
+    if has_zenity {
+        return Some(PromptHelper::Zenity);
+    }
+    if has_kdialog {
+        return Some(PromptHelper::Kdialog);
+    }
+    None
+}
+
+fn run_zenity_checklist(options: &[FeatureOption]) -> Result<PromptHelperOutcome> {
+    let mut command = Command::new("zenity");
+    command.args([
+        "--list",
+        "--checklist",
+        "--title=Codex Desktop update",
+        "--text=Choose optional Linux features for this update rebuild.",
+        "--column=Use",
+        "--column=Id",
+        "--column=Feature",
+        "--column=Description",
+        "--hide-column=2",
+        "--print-column=2",
+        "--separator=,",
+    ]);
+    for option in options {
+        command
+            .arg(if option.enabled { "TRUE" } else { "FALSE" })
+            .arg(&option.id)
+            .arg(&option.title)
+            .arg(option.description.trim());
+    }
+
+    let output = command.output().context("Failed to launch zenity")?;
+    if !output.status.success() {
+        return Ok(PromptHelperOutcome::Cancelled);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(PromptHelperOutcome::Selected(
+        stdout
+            .trim()
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+            .collect(),
+    ))
+}
+
+fn run_kdialog_checklist(options: &[FeatureOption]) -> Result<PromptHelperOutcome> {
+    let mut command = Command::new("kdialog");
+    command.args([
+        "--title",
+        "Codex Desktop update",
+        "--checklist",
+        "Choose optional Linux features for this update rebuild.",
+    ]);
+    for option in options {
+        command
+            .arg(&option.id)
+            .arg(feature_prompt_label(option))
+            .arg(if option.enabled { "on" } else { "off" });
+    }
+
+    let output = command.output().context("Failed to launch kdialog")?;
+    if !output.status.success() {
+        return Ok(PromptHelperOutcome::Cancelled);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(PromptHelperOutcome::Selected(
+        stdout
+            .split_whitespace()
+            .map(|value| value.trim_matches('"').to_string())
+            .filter(|value| !value.is_empty())
+            .collect(),
+    ))
+}
+
+fn feature_prompt_label(option: &FeatureOption) -> String {
+    if option.description.trim().is_empty() {
+        return option.title.clone();
+    }
+    format!("{} - {}", option.title, option.description)
+}
+
+fn normalize_feature_ids<'a>(ids: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    ids.into_iter()
+        .map(str::trim)
+        .filter(|id| is_valid_feature_id(id))
+        .filter(|id| seen.insert((*id).to_string()))
+        .map(str::to_string)
+        .collect()
+}
+
+fn is_valid_feature_id(id: &str) -> bool {
+    let mut chars = id.chars();
+    matches!(chars.next(), Some(ch) if ch.is_ascii_lowercase() || ch.is_ascii_digit())
+        && chars.all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
+}
+
+fn has_graphical_session() -> bool {
+    let has_display =
+        std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let has_dbus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some()
+        || std::env::var_os("XDG_RUNTIME_DIR").is_some();
+    has_display && has_dbus
+}
+
+fn prefers_kdialog() -> bool {
+    desktop_tokens().iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "kde" | "plasma" | "plasmawayland" | "plasmax11"
+        )
+    })
+}
+
+fn desktop_tokens() -> Vec<String> {
+    [
+        std::env::var("XDG_CURRENT_DESKTOP").ok(),
+        std::env::var("DESKTOP_SESSION").ok(),
+    ]
+    .into_iter()
+    .flatten()
+    .flat_map(|value| {
+        value
+            .split(':')
+            .map(|segment| segment.trim().to_ascii_lowercase())
+            .collect::<Vec<_>>()
+    })
+    .filter(|token| !token.is_empty())
+    .collect()
+}
+
+fn command_in_path(name: &str) -> Option<PathBuf> {
+    let path_env = std::env::var_os("PATH").unwrap_or_else(|| OsString::from(""));
+    std::env::split_paths(&path_env).find_map(|entry| {
+        let candidate = entry.join(name);
+        if is_executable_file(&candidate) {
+            Some(candidate)
+        } else {
+            None
+        }
+    })
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn test_paths(root: &Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config/config.toml"),
+            state_file: root.join("state/state.json"),
+            log_file: root.join("state/service.log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    fn test_config(root: &Path) -> RuntimeConfig {
+        RuntimeConfig {
+            dmg_url: "https://example.com/Codex.dmg".to_string(),
+            appcast_url: None,
+            initial_check_delay_seconds: 1,
+            check_interval_hours: 6,
+            auto_install_on_app_exit: true,
+            notifications: false,
+            workspace_root: root.join("cache"),
+            builder_bundle_root: root.join("builder"),
+            app_executable_path: root.join("not-running-electron"),
+        }
+    }
+
+    #[test]
+    fn reads_user_feature_config_before_bundled_default() -> Result<()> {
+        let temp = tempdir()?;
+        let paths = test_paths(temp.path());
+        let config = test_config(temp.path());
+        let bundled = config
+            .builder_bundle_root
+            .join("linux-features")
+            .join("features.json");
+        write_features_config(&bundled, &["read-aloud".to_string()])?;
+        write_features_config(
+            &user_features_config_path(&paths),
+            &["remote-control-ui".to_string()],
+        )?;
+
+        assert_eq!(
+            effective_enabled_feature_ids(&config, &paths)?,
+            vec!["remote-control-ui"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn discovers_feature_manifest_options() -> Result<()> {
+        let temp = tempdir()?;
+        let paths = test_paths(temp.path());
+        let config = test_config(temp.path());
+        let feature_dir = config.builder_bundle_root.join("linux-features/read-aloud");
+        fs::create_dir_all(&feature_dir)?;
+        fs::write(
+            feature_dir.join("feature.json"),
+            r#"{
+  "id": "read-aloud",
+  "title": "Read Aloud",
+  "description": "Speak assistant responses",
+  "defaultEnabled": false
+}"#,
+        )?;
+        write_features_config(
+            &user_features_config_path(&paths),
+            &["read-aloud".to_string()],
+        )?;
+
+        let selection = selection(&config, &paths)?;
+
+        assert_eq!(selection.enabled, vec!["read-aloud"]);
+        assert_eq!(selection.available.len(), 1);
+        assert!(selection.available[0].enabled);
+        assert_eq!(selection.available[0].title, "Read Aloud");
+        Ok(())
+    }
+
+    #[test]
+    fn hidden_feature_manifests_are_not_prompted() -> Result<()> {
+        let temp = tempdir()?;
+        let config = test_config(temp.path());
+        let feature_dir = config
+            .builder_bundle_root
+            .join("linux-features/example-feature");
+        fs::create_dir_all(&feature_dir)?;
+        fs::write(
+            feature_dir.join("feature.json"),
+            r#"{
+  "id": "example-feature",
+  "title": "Example Linux Feature",
+  "description": "Developer-only fixture",
+  "hidden": true
+}"#,
+        )?;
+
+        assert!(discover_feature_options(&config)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn prompt_helper_selection_degrades_when_dialog_helpers_are_missing() {
+        assert_eq!(choose_prompt_helper(false, false, false), None);
+        assert_eq!(
+            choose_prompt_helper(false, true, false),
+            Some(PromptHelper::Zenity)
+        );
+        assert_eq!(
+            choose_prompt_helper(true, true, true),
+            Some(PromptHelper::Kdialog)
+        );
+        assert_eq!(
+            choose_prompt_helper(false, false, true),
+            Some(PromptHelper::Kdialog)
+        );
+    }
+}

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -5,6 +5,7 @@ mod builder;
 mod cli;
 mod codex_cli;
 mod config;
+mod features;
 mod install;
 mod install_rollback;
 mod liveness;

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -96,6 +96,8 @@ pub struct PersistedState {
     pub cli_error_message: Option<String>,
     #[serde(default)]
     pub cli_prompt_dismissed_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub enabled_feature_ids: Vec<String>,
 }
 
 impl PersistedState {
@@ -123,6 +125,7 @@ impl PersistedState {
             cli_last_verified_at: None,
             cli_error_message: None,
             cli_prompt_dismissed_at: None,
+            enabled_feature_ids: Vec::new(),
         }
     }
 

--- a/updater/src/upstream.rs
+++ b/updater/src/upstream.rs
@@ -1,32 +1,53 @@
-//! Upstream DMG metadata and download helpers.
+//! Upstream archive metadata and download helpers.
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
+use quick_xml::{events::Event, reader::Reader};
 use reqwest::{header, Client};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Selected HTTP metadata used to detect upstream DMG changes.
+/// Selected HTTP metadata used to detect upstream archive changes.
 pub struct RemoteMetadata {
     pub etag: Option<String>,
     pub last_modified: Option<String>,
     pub content_length: Option<u64>,
     pub headers_fingerprint: String,
+    pub download_url: String,
+    pub candidate_version: Option<String>,
+    pub upstream_version: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Result of downloading the current upstream DMG snapshot.
+/// Result of downloading the current upstream archive snapshot.
 pub struct DownloadedDmg {
     pub path: PathBuf,
     pub sha256: String,
     pub candidate_version: String,
+    pub upstream_version: Option<String>,
 }
 
-/// Fetches the upstream DMG headers used to detect candidate updates.
-pub async fn fetch_remote_metadata(client: &Client, dmg_url: &str) -> Result<RemoteMetadata> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AppcastRelease {
+    upstream_version: String,
+    candidate_version: String,
+    download_url: String,
+    content_length: Option<u64>,
+}
+
+/// Fetches the upstream release metadata used to detect candidate updates.
+pub async fn fetch_remote_metadata(
+    client: &Client,
+    dmg_url: &str,
+    appcast_url: Option<&str>,
+) -> Result<RemoteMetadata> {
+    if let Some(appcast_url) = appcast_url.filter(|url| !url.trim().is_empty()) {
+        return fetch_appcast_metadata(client, dmg_url, appcast_url).await;
+    }
+
     let response = client
         .head(dmg_url)
         .send()
@@ -66,38 +87,100 @@ pub async fn fetch_remote_metadata(client: &Client, dmg_url: &str) -> Result<Rem
         last_modified,
         content_length,
         headers_fingerprint,
+        download_url: dmg_url.to_string(),
+        candidate_version: None,
+        upstream_version: None,
     })
 }
 
-/// Downloads the upstream DMG and derives a package version from its hash.
+async fn fetch_appcast_metadata(
+    client: &Client,
+    fallback_dmg_url: &str,
+    appcast_url: &str,
+) -> Result<RemoteMetadata> {
+    let response = client
+        .get(appcast_url)
+        .send()
+        .await
+        .with_context(|| format!("Failed GET request for {appcast_url}"))?
+        .error_for_status()
+        .with_context(|| format!("GET request for {appcast_url} returned an error status"))?;
+
+    let etag = response
+        .headers()
+        .get(header::ETAG)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let last_modified = response
+        .headers()
+        .get(header::LAST_MODIFIED)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_string);
+    let body = response
+        .text()
+        .await
+        .with_context(|| format!("Failed reading appcast body from {appcast_url}"))?;
+    let release = parse_latest_appcast_release(&body)?;
+
+    let headers_fingerprint = format!(
+        "appcast={appcast_url}|etag={}|last_modified={}|upstream_version={}|download_url={}|content_length={}",
+        etag.as_deref().unwrap_or(""),
+        last_modified.as_deref().unwrap_or(""),
+        release.upstream_version,
+        release.download_url,
+        release
+            .content_length
+            .map(|value| value.to_string())
+            .as_deref()
+            .unwrap_or("")
+    );
+
+    Ok(RemoteMetadata {
+        etag,
+        last_modified,
+        content_length: release.content_length,
+        headers_fingerprint,
+        download_url: if release.download_url.is_empty() {
+            fallback_dmg_url.to_string()
+        } else {
+            release.download_url
+        },
+        candidate_version: Some(release.candidate_version),
+        upstream_version: Some(release.upstream_version),
+    })
+}
+
+/// Downloads the upstream archive and derives a package version from its hash.
 pub async fn download_dmg(
     client: &Client,
-    dmg_url: &str,
+    download_url: &str,
     destination_dir: &Path,
     version_timestamp: DateTime<Utc>,
+    preferred_candidate_version: Option<&str>,
+    upstream_version: Option<&str>,
 ) -> Result<DownloadedDmg> {
     tokio::fs::create_dir_all(destination_dir)
         .await
         .with_context(|| format!("Failed to create {}", destination_dir.display()))?;
 
-    let destination = destination_dir.join("Codex.dmg");
+    let destination = destination_dir.join(download_file_name(download_url));
     let mut file = File::create(&destination)
         .await
         .with_context(|| format!("Failed to create {}", destination.display()))?;
 
     let response = client
-        .get(dmg_url)
+        .get(download_url)
         .send()
         .await
-        .with_context(|| format!("Failed GET request for {dmg_url}"))?
+        .with_context(|| format!("Failed GET request for {download_url}"))?
         .error_for_status()
-        .with_context(|| format!("GET request for {dmg_url} returned an error status"))?;
+        .with_context(|| format!("GET request for {download_url} returned an error status"))?;
 
     let mut hasher = Sha256::new();
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.with_context(|| format!("Failed downloading {dmg_url}"))?;
+        let chunk = chunk.with_context(|| format!("Failed downloading {download_url}"))?;
         file.write_all(&chunk)
             .await
             .with_context(|| format!("Failed writing {}", destination.display()))?;
@@ -113,16 +196,19 @@ pub async fn download_dmg(
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
-    let candidate_version = derive_candidate_version(&sha256, version_timestamp)?;
+    let candidate_version = preferred_candidate_version
+        .map(str::to_string)
+        .unwrap_or(derive_candidate_version(&sha256, version_timestamp)?);
 
     Ok(DownloadedDmg {
         path: destination,
         sha256,
         candidate_version,
+        upstream_version: upstream_version.map(str::to_string),
     })
 }
 
-/// Derives a local package version from the DMG hash and download timestamp.
+/// Derives a local package version from the archive hash and download timestamp.
 pub fn derive_candidate_version(sha256: &str, timestamp: DateTime<Utc>) -> Result<String> {
     let short_hash = sha256
         .get(0..8)
@@ -132,6 +218,164 @@ pub fn derive_candidate_version(sha256: &str, timestamp: DateTime<Utc>) -> Resul
         timestamp.format("%Y.%m.%d.%H%M%S"),
         short_hash
     ))
+}
+
+fn parse_latest_appcast_release(xml: &str) -> Result<AppcastRelease> {
+    let mut reader = Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+
+    let mut buf = Vec::new();
+    let mut in_item = false;
+    let mut current_element: Option<Vec<u8>> = None;
+    let mut title: Option<String> = None;
+    let mut short_version: Option<String> = None;
+    let mut pub_date: Option<String> = None;
+    let mut enclosure_url: Option<String> = None;
+    let mut enclosure_length: Option<u64> = None;
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(event)) => {
+                let name = event.name().as_ref().to_vec();
+                if name.as_slice() == b"item" {
+                    in_item = true;
+                } else if in_item {
+                    if name.as_slice() == b"enclosure" && enclosure_url.is_none() {
+                        for attribute in event.attributes() {
+                            let attribute = attribute?;
+                            match attribute.key.as_ref() {
+                                b"url" => {
+                                    enclosure_url =
+                                        Some(String::from_utf8_lossy(&attribute.value).to_string())
+                                }
+                                b"length" => {
+                                    enclosure_length = String::from_utf8_lossy(&attribute.value)
+                                        .parse::<u64>()
+                                        .ok()
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    current_element = Some(name);
+                }
+            }
+            Ok(Event::Empty(event))
+                if in_item && event.name().as_ref() == b"enclosure" && enclosure_url.is_none() =>
+            {
+                for attribute in event.attributes() {
+                    let attribute = attribute?;
+                    match attribute.key.as_ref() {
+                        b"url" => {
+                            enclosure_url =
+                                Some(String::from_utf8_lossy(&attribute.value).to_string())
+                        }
+                        b"length" => {
+                            enclosure_length = String::from_utf8_lossy(&attribute.value)
+                                .parse::<u64>()
+                                .ok()
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::Text(event)) if in_item => {
+                let text = event.decode()?.into_owned();
+                match current_element.as_deref() {
+                    Some(b"title") if title.is_none() => title = Some(text),
+                    Some(b"sparkle:shortVersionString") if short_version.is_none() => {
+                        short_version = Some(text)
+                    }
+                    Some(b"pubDate") if pub_date.is_none() => pub_date = Some(text),
+                    _ => {}
+                }
+            }
+            Ok(Event::End(event)) => {
+                if event.name().as_ref() == b"item" && in_item {
+                    break;
+                }
+                current_element = None;
+            }
+            Ok(Event::Eof) => break,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to parse appcast at byte {}",
+                        reader.error_position()
+                    )
+                });
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let upstream_version = short_version
+        .or(title)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .context("Appcast did not contain a release version")?;
+    let download_url = enclosure_url
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .context("Appcast did not contain a release enclosure URL")?;
+    let timestamp = pub_date
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc2822(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+        .unwrap_or_else(Utc::now);
+    let candidate_version = derive_appcast_candidate_version(&upstream_version, timestamp);
+
+    Ok(AppcastRelease {
+        upstream_version,
+        candidate_version,
+        download_url,
+        content_length: enclosure_length,
+    })
+}
+
+fn derive_appcast_candidate_version(upstream_version: &str, timestamp: DateTime<Utc>) -> String {
+    let suffix = sanitize_package_version_suffix(upstream_version);
+    format!("{}+{}", timestamp.format("%Y.%m.%d.%H%M%S"), suffix)
+}
+
+fn sanitize_package_version_suffix(value: &str) -> String {
+    let mut suffix = String::new();
+    let mut previous_was_dot = false;
+    for ch in value.chars() {
+        let next = if ch.is_ascii_alphanumeric() || ch == '.' {
+            ch
+        } else {
+            '.'
+        };
+        if next == '.' {
+            if previous_was_dot {
+                continue;
+            }
+            previous_was_dot = true;
+        } else {
+            previous_was_dot = false;
+        }
+        suffix.push(next);
+    }
+
+    let suffix = suffix.trim_matches('.');
+    if suffix.is_empty() {
+        "upstream".to_string()
+    } else {
+        suffix.to_string()
+    }
+}
+
+fn download_file_name(download_url: &str) -> String {
+    download_url
+        .split('?')
+        .next()
+        .and_then(|without_query| without_query.rsplit('/').next())
+        .filter(|name| !name.is_empty())
+        .filter(|name| !name.contains('/') && !name.contains('\\'))
+        .unwrap_or("Codex.dmg")
+        .to_string()
 }
 
 #[cfg(test)]
@@ -161,7 +405,7 @@ mod tests {
 
         let client = Client::builder().build()?;
         let metadata =
-            fetch_remote_metadata(&client, &format!("{}/Codex.dmg", server.uri())).await?;
+            fetch_remote_metadata(&client, &format!("{}/Codex.dmg", server.uri()), None).await?;
         assert_eq!(metadata.etag.as_deref(), Some("\"abc\""));
         assert_eq!(
             metadata.last_modified.as_deref(),
@@ -169,6 +413,59 @@ mod tests {
         );
         assert_eq!(metadata.content_length, Some(42));
         assert!(metadata.headers_fingerprint.contains("etag=\"abc\""));
+        assert_eq!(metadata.download_url, format!("{}/Codex.dmg", server.uri()));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fetches_latest_release_from_appcast() -> Result<()> {
+        let server = MockServer::start().await;
+        let appcast = format!(
+            r#"<?xml version='1.0' encoding='utf-8'?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>26.513.31313</title>
+      <pubDate>Fri, 15 May 2026 18:36:14 -0700</pubDate>
+      <sparkle:shortVersionString>26.513.31313</sparkle:shortVersionString>
+      <enclosure url="{}/Codex-darwin-x64-26.513.31313.zip" length="338767820" type="application/octet-stream" />
+    </item>
+  </channel>
+</rss>"#,
+            server.uri()
+        );
+        Mock::given(method("GET"))
+            .and(path("/appcast-x64.xml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ETag", "\"appcast\"")
+                    .set_body_string(appcast),
+            )
+            .mount(&server)
+            .await;
+
+        let client = Client::builder().build()?;
+        let metadata = fetch_remote_metadata(
+            &client,
+            &format!("{}/Codex.dmg", server.uri()),
+            Some(&format!("{}/appcast-x64.xml", server.uri())),
+        )
+        .await?;
+
+        assert_eq!(metadata.etag.as_deref(), Some("\"appcast\""));
+        assert_eq!(metadata.content_length, Some(338767820));
+        assert_eq!(
+            metadata.download_url,
+            format!("{}/Codex-darwin-x64-26.513.31313.zip", server.uri())
+        );
+        assert_eq!(metadata.upstream_version.as_deref(), Some("26.513.31313"));
+        assert_eq!(
+            metadata.candidate_version.as_deref(),
+            Some("2026.05.16.013614+26.513.31313")
+        );
+        assert!(metadata
+            .headers_fingerprint
+            .contains("upstream_version=26.513.31313"));
         Ok(())
     }
 
@@ -189,6 +486,8 @@ mod tests {
             &format!("{}/Codex.dmg", server.uri()),
             temp.path(),
             Utc.with_ymd_and_hms(2026, 3, 24, 12, 0, 0).unwrap(),
+            None,
+            None,
         )
         .await?;
 
@@ -199,6 +498,49 @@ mod tests {
         );
         assert_eq!(downloaded.candidate_version, "2026.03.24.120000+678cd508");
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn downloads_versioned_archive_with_preferred_candidate_version() -> Result<()> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Codex-darwin-x64-26.513.31313.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"zip".to_vec()))
+            .mount(&server)
+            .await;
+
+        let client = Client::builder().build()?;
+        let temp = tempdir()?;
+        let downloaded = download_dmg(
+            &client,
+            &format!("{}/Codex-darwin-x64-26.513.31313.zip", server.uri()),
+            temp.path(),
+            Utc.with_ymd_and_hms(2026, 3, 24, 12, 0, 0).unwrap(),
+            Some("2026.05.16.013614+26.513.31313"),
+            Some("26.513.31313"),
+        )
+        .await?;
+
+        assert_eq!(
+            downloaded.path,
+            temp.path().join("Codex-darwin-x64-26.513.31313.zip")
+        );
+        assert_eq!(
+            downloaded.candidate_version,
+            "2026.05.16.013614+26.513.31313"
+        );
+        assert_eq!(downloaded.upstream_version.as_deref(), Some("26.513.31313"));
+        Ok(())
+    }
+
+    #[test]
+    fn appcast_candidate_version_suffix_is_package_portable() {
+        let version = derive_appcast_candidate_version(
+            "26.513 beta/rc-1",
+            Utc.with_ymd_and_hms(2026, 5, 16, 1, 36, 14).unwrap(),
+        );
+
+        assert_eq!(version, "2026.05.16.013614+26.513.beta.rc.1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Use the upstream Codex Sparkle appcast as the Linux updater source of truth, including the appcast enclosure URL and upstream version.
- Enable the existing app update UI on Linux and check for appcast updates on app launch.
- Add an opt-in Linux feature selection flow before installing a ready update, with the selection persisted under XDG config and replayed into rebuilds.
- Rebuild a ready package when the user changes optional features before install, and hide developer-only fixture features from native prompts.

## Validation

- `curl -fsSI https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p codex-update-manager`
- `cargo build -p codex-update-manager`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `git diff --check`
- `codex-update-manager features --json` with isolated XDG config
- `CODEX_BOOTSTRAP_NONINTERACTIVE=1 scripts/bootstrap-wizard.sh` with isolated feature config
- Computer Use visual smoke: opened the native `Codex Desktop update` feature checklist and verified cancel returns structured JSON with `cancelled: true`.
