### PR TITLE
[codex] Fix conversation mode composer hook drift

### DIFF
--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -89,31 +89,88 @@ function applyComposerRuntimePatch(source) {
   return `${source}\n${conversationRuntimeSource()}`;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function voiceControlVar(source, name, fallback) {
+  const match = source.match(/\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\}=z/);
+  if (!match) {
+    return fallback;
+  }
+  return match[1].match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`))?.[1] ?? fallback;
+}
+
+function composerVoiceVars(source) {
+  return {
+    isDictating: voiceControlVar(source, "isDictating", "J"),
+    isDictationSupported: voiceControlVar(source, "isDictationSupported", "q"),
+    isTranscribing: voiceControlVar(source, "isTranscribing", "re"),
+    isNewRealtimeConversationAvailable: voiceControlVar(source, "isNewRealtimeConversationAvailable", "J"),
+    startDictation: voiceControlVar(source, "startDictation", "se"),
+    startNewRealtimeConversation: voiceControlVar(source, "startNewRealtimeConversation", "ce"),
+    stopDictation: voiceControlVar(source, "stopDictation", "le"),
+    threadRealtime: voiceControlVar(source, "threadRealtime", "ue"),
+  };
+}
+
+function composerSyncPayload(vars) {
+  return [
+    "isResponseInProgress:A",
+    `isDictating:${vars.isDictating}`,
+    `isTranscribing:${vars.isTranscribing}`,
+    `startDictation:${vars.startDictation}`,
+    `stopDictation:${vars.stopDictation}`,
+    "onStop:P",
+  ].join(",");
+}
+
+function composerTogglePayload(vars) {
+  return [
+    "conversationId:v",
+    `startDictation:${vars.startDictation}`,
+    `stopDictation:${vars.stopDictation}`,
+    "onStop:P",
+    `isDictating:${vars.isDictating}`,
+    `isTranscribing:${vars.isTranscribing}`,
+    "isResponseInProgress:A",
+    `isDictationSupported:${vars.isDictationSupported}`,
+  ].join(",");
+}
+
 function applyComposerControlPatch(source) {
   let patched = source;
-  const visibleNeedle =
-    "let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`)";
-  if (patched.includes(visibleNeedle)) {
+  const vars = composerVoiceVars(patched);
+  const visiblePattern =
+    /let Be=ze,Ve=F===`empty-message`&&!A&&\((?:globalThis\.codexLinuxConversationAvailable\?\.\(\)\|\|)?([A-Za-z_$][\w$]*)\.isAvailable&&\1\.phase!==`active`\|\|([A-Za-z_$][\w$]*)\),He=([A-Za-z_$][\w$]*)\(fc,`composer\.startVoiceMode`\)/;
+  const visibleMatch = patched.match(visiblePattern);
+  if (visibleMatch && !patched.includes("codexLinuxConversationSync?.(v")) {
+    const threadRealtime = visibleMatch[1];
+    const realtimeAvailable = visibleMatch[2] || vars.isNewRealtimeConversationAvailable;
+    const shortcutFn = visibleMatch[3];
     patched = patched.replace(
-      visibleNeedle,
-      "let Be=ze;globalThis.codexLinuxConversationSync?.(v,{isResponseInProgress:A,isDictating:te,isTranscribing:re,startDictation:se,stopDictation:le,onStop:P});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(v)===!0,Ve=codexLinuxConversationActive||F===`empty-message`&&!A&&((v&&globalThis.codexLinuxConversationAvailable?.())||ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`)",
+      visiblePattern,
+      `let Be=ze;globalThis.codexLinuxConversationSync?.(v,{${composerSyncPayload(vars)}});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(v)===!0,Ve=codexLinuxConversationActive||F===\`empty-message\`&&!A&&((v&&globalThis.codexLinuxConversationAvailable?.())||${threadRealtime}.isAvailable&&${threadRealtime}.phase!==\`active\`||${realtimeAvailable}),He=${shortcutFn}(fc,\`composer.startVoiceMode\`)`,
     );
-  } else if (patched.includes("codexLinuxConversationAvailable") && !patched.includes("codexLinuxConversationSync?.(v")) {
-    patched = patched.replace(
-      "let Be=ze,Ve=F===`empty-message`&&!A&&(globalThis.codexLinuxConversationAvailable?.()||ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`)",
-      "let Be=ze;globalThis.codexLinuxConversationSync?.(v,{isResponseInProgress:A,isDictating:te,isTranscribing:re,startDictation:se,stopDictation:le,onStop:P});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(v)===!0,Ve=codexLinuxConversationActive||F===`empty-message`&&!A&&((v&&globalThis.codexLinuxConversationAvailable?.())||ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`)",
-    );
-  } else if (!patched.includes("codexLinuxConversationAvailable")) {
+  } else if (!patched.includes("codexLinuxConversationSync?.(v")) {
     warn("Could not find composer voice button visibility gate", "conversation mode composer control patch");
   }
 
-  const clickNeedle =
-    "Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()}";
-  if (patched.includes(clickNeedle)) {
+  const threadRealtime = escapeRegExp(vars.threadRealtime);
+  const startNewRealtimeConversation = escapeRegExp(vars.startNewRealtimeConversation);
+  const clickPattern = new RegExp(
+    `([A-Za-z_$][\\w$]*)=\\(\\)=>\\{if\\(${threadRealtime}\\.phase===\`starting\`\\|\\|${threadRealtime}\\.phase===\`active\`\\)\\{${threadRealtime}\\.stopRealtime\\(\\);return\\}if\\(${threadRealtime}\\.isAvailable\\)\\{${threadRealtime}\\.phase===\`inactive\`&&${threadRealtime}\\.startRealtime\\(\`composer_button_existing_thread\`\\);return\\}${startNewRealtimeConversation}\\(\\)\\}`,
+  );
+  const togglePattern =
+    /codexLinuxConversationToggle\?\.\(\{conversationId:v,startDictation:[A-Za-z_$][\w$]*,stopDictation:[A-Za-z_$][\w$]*,onStop:P,isDictating:[A-Za-z_$][\w$]*,isTranscribing:[A-Za-z_$][\w$]*,isResponseInProgress:A,isDictationSupported:[A-Za-z_$][\w$]*\}\)/;
+  const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars)}})`;
+  if (clickPattern.test(patched)) {
     patched = patched.replace(
-      clickNeedle,
-      "Ue=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:te,isTranscribing:re,isResponseInProgress:A,isDictationSupported:q}))return;if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()}",
+      clickPattern,
+      `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.threadRealtime}.startRealtime(\`composer_button_existing_thread\`);return}${vars.startNewRealtimeConversation}()}`,
     );
+  } else if (togglePattern.test(patched)) {
+    patched = patched.replace(togglePattern, toggleCall);
   } else if (!patched.includes("codexLinuxConversationToggle")) {
     warn("Could not find composer voice button click handler", "conversation mode composer control patch");
   }

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -85,6 +85,12 @@ const dictationSource =
 const composerControlSource =
   "function mz(e){let {voiceControls:z}=e;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};let e=G.formatMessage({id:`composer.realtime.start.aria`,defaultMessage:`Start realtime voice`,description:`Aria label for the button that starts realtime voice mode in the composer`});let n=G.formatMessage({id:`composer.realtime.start.tooltip`,defaultMessage:`Start realtime voice`,description:`Tooltip for the button that starts realtime voice mode in the composer`});}";
 
+const currentComposerControlSource =
+  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
+
+const halfPatchedCurrentComposerControlSource =
+  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:te,isTranscribing:re,isResponseInProgress:A,isDictationSupported:q}))return;if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
+
 const assistantRenderSource =
   "return (0,$.jsx)(Ov,{item:n,alwaysShowActions:M,assistantCopyText:p,turnId:m,after:g,conversationId:o,cwd:u,renderCodeBlocksAsWritingBlocks:V})";
 
@@ -1323,6 +1329,7 @@ test("composer control patch repurposes the voice button for conversation mode f
   const patched = twice(applyComposerControlPatch, composerControlSource);
   assert.match(patched, /codexLinuxConversationAvailable/);
   assert.match(patched, /codexLinuxConversationSync\?\.\(v,\{isResponseInProgress:A/);
+  assert.match(patched, /isDictating:J/);
   assert.match(patched, /codexLinuxConversationActive=globalThis\.codexLinuxConversationIsActive/);
   assert.match(patched, /Ve=codexLinuxConversationActive\|\|F===`empty-message`/);
   assert.match(patched, /codexLinuxConversationToggle/);
@@ -1332,6 +1339,30 @@ test("composer control patch repurposes the voice button for conversation mode f
   assert.match(patched, /onStop:P/);
   assert.match(patched, /Start conversation mode/);
   assert.match(patched, /ue\.startRealtime/);
+});
+
+test("composer control patch follows the current composer voiceControls shape", () => {
+  const patched = twice(applyComposerControlPatch, currentComposerControlSource);
+  assert.match(
+    patched,
+    /codexLinuxConversationSync\?\.\(v,\{isResponseInProgress:A,isDictating:J,isTranscribing:re,startDictation:se,stopDictation:le,onStop:P\}\)/,
+  );
+  assert.match(
+    patched,
+    /codexLinuxConversationToggle\?\.\(\{conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:J,isTranscribing:re,isResponseInProgress:A,isDictationSupported:ee\}\)/,
+  );
+  assert.match(patched, /He=oi\(fc,`composer\.startVoiceMode`\)/);
+  assert.match(patched, /\|\|ue\.isAvailable&&ue\.phase!==`active`\|\|te/);
+  assert.doesNotMatch(patched, /isDictating:te/);
+  assert.doesNotMatch(patched, /isDictationSupported:q/);
+});
+
+test("composer control patch repairs bundles where only the click handler was patched", () => {
+  const patched = twice(applyComposerControlPatch, halfPatchedCurrentComposerControlSource);
+  assert.match(patched, /codexLinuxConversationSync\?\.\(v,\{isResponseInProgress:A,isDictating:J/);
+  assert.match(patched, /isDictationSupported:ee/);
+  assert.doesNotMatch(patched, /isDictating:te/);
+  assert.doesNotMatch(patched, /isDictationSupported:q/);
 });
 
 test("composer patch ignores adjacent composer chunks", () => {


### PR DESCRIPTION
## Summary

- make the conversation-mode composer patch derive the current minified `voiceControls` variables instead of assuming the older bundle shape
- restore the active conversation sync/visibility gate when upstream renames the realtime availability variable or shortcut helper
- repair bundles that were only partially patched, where the click handler used stale dictation-state variables

## Root Cause

The current composer bundle still exposes `composer.startVoiceMode`, but its surrounding minified shape drifted from the hard-coded needle. The old patch could catch the click handler while missing the sync/active gate, leaving conversation mode without the visible active state and with stale dictation variables in the toggle payload.

## Validation

- `node --test linux-features/*/test.js`
- `git diff --check`
