### PR TITLE
[codex] Fix bundled backend plugin discovery

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -826,6 +826,8 @@ sync_computer_use_bundled_plugin_cache() {
     local tmp_plugin
     local marketplace_root
     local marketplace_plugins_dir
+    local marketplace_plugin_link
+    local needs_copy=1
 
     [ -f "$plugin_json" ] || return 0
     [ -f "$source_backend" ] || return 0
@@ -833,8 +835,9 @@ sync_computer_use_bundled_plugin_cache() {
 
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
+    marketplace_plugin_link="$marketplace_root/plugins/computer-use"
     if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir"
+        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
         rm -f "$marketplace_plugins_dir/marketplace.json"
         cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
             chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
@@ -852,24 +855,38 @@ sync_computer_use_bundled_plugin_cache() {
     if [ -f "$cache_backend" ] && [ -f "$cache_cosmic_helper" ] && \
         cmp -s "$source_backend" "$cache_backend" && \
         cmp -s "$source_cosmic_helper" "$cache_cosmic_helper"; then
-        return 0
+        needs_copy=0
     fi
 
-    cache_parent="$(dirname "$cache_plugin")"
-    tmp_plugin="$cache_parent/.computer-use-$version.tmp.$$"
-    remove_tree_if_exists "$tmp_plugin"
-    mkdir -p "$cache_parent"
-
-    if cp -R "$source_plugin" "$tmp_plugin"; then
-        make_tree_owner_writable "$tmp_plugin"
-        find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-        remove_tree_if_exists "$cache_plugin"
-        mv "$tmp_plugin" "$cache_plugin"
-        echo "Computer Use plugin cache synced from bundled resources: $cache_plugin"
-    else
+    if [ "$needs_copy" -eq 1 ]; then
+        cache_parent="$(dirname "$cache_plugin")"
+        tmp_plugin="$cache_parent/.computer-use-$version.tmp.$$"
         remove_tree_if_exists "$tmp_plugin"
-        echo "Computer Use plugin cache sync failed; continuing with existing cache."
+        mkdir -p "$cache_parent"
+
+        if cp -R "$source_plugin" "$tmp_plugin"; then
+            make_tree_owner_writable "$tmp_plugin"
+            find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
+            remove_tree_if_exists "$cache_plugin"
+            mv "$tmp_plugin" "$cache_plugin"
+            echo "Computer Use plugin cache synced from bundled resources: $cache_plugin"
+        else
+            remove_tree_if_exists "$tmp_plugin"
+            echo "Computer Use plugin cache sync failed; continuing with existing cache."
+            return 0
+        fi
     fi
+
+    if [ -e "$cache_root/latest" ] && [ ! -L "$cache_root/latest" ]; then
+        remove_tree_if_exists "$cache_root/latest"
+    fi
+    ln -sfn "$version" "$cache_root/latest"
+
+    mkdir -p "$marketplace_root/plugins"
+    if [ -e "$marketplace_plugin_link" ] && [ ! -L "$marketplace_plugin_link" ]; then
+        remove_tree_if_exists "$marketplace_plugin_link"
+    fi
+    ln -sfn "$cache_root/latest" "$marketplace_plugin_link"
 }
 
 sync_read_aloud_bundled_plugin_cache() {
@@ -890,6 +907,8 @@ sync_read_aloud_bundled_plugin_cache() {
     local tmp_plugin
     local marketplace_root
     local marketplace_plugins_dir
+    local marketplace_plugin_link
+    local needs_copy=1
 
     [ -f "$plugin_json" ] || return 0
     [ -x "$source_backend" ] || return 0
@@ -898,8 +917,9 @@ sync_read_aloud_bundled_plugin_cache() {
 
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
+    marketplace_plugin_link="$marketplace_root/plugins/read-aloud"
     if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir"
+        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
         rm -f "$marketplace_plugins_dir/marketplace.json"
         cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
             chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
@@ -919,24 +939,38 @@ sync_read_aloud_bundled_plugin_cache() {
         cmp -s "$source_backend" "$cache_backend" && \
         cmp -s "$source_runner" "$cache_runner" && \
         cmp -s "$source_python_runner" "$cache_python_runner"; then
-        return 0
+        needs_copy=0
     fi
 
-    cache_parent="$(dirname "$cache_plugin")"
-    tmp_plugin="$cache_parent/.read-aloud-$version.tmp.$$"
-    remove_tree_if_exists "$tmp_plugin"
-    mkdir -p "$cache_parent"
-
-    if cp -R "$source_plugin" "$tmp_plugin"; then
-        make_tree_owner_writable "$tmp_plugin"
-        find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-        remove_tree_if_exists "$cache_plugin"
-        mv "$tmp_plugin" "$cache_plugin"
-        echo "Read Aloud plugin cache synced from bundled resources: $cache_plugin"
-    else
+    if [ "$needs_copy" -eq 1 ]; then
+        cache_parent="$(dirname "$cache_plugin")"
+        tmp_plugin="$cache_parent/.read-aloud-$version.tmp.$$"
         remove_tree_if_exists "$tmp_plugin"
-        echo "Read Aloud plugin cache sync failed; continuing with existing cache."
+        mkdir -p "$cache_parent"
+
+        if cp -R "$source_plugin" "$tmp_plugin"; then
+            make_tree_owner_writable "$tmp_plugin"
+            find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
+            remove_tree_if_exists "$cache_plugin"
+            mv "$tmp_plugin" "$cache_plugin"
+            echo "Read Aloud plugin cache synced from bundled resources: $cache_plugin"
+        else
+            remove_tree_if_exists "$tmp_plugin"
+            echo "Read Aloud plugin cache sync failed; continuing with existing cache."
+            return 0
+        fi
     fi
+
+    if [ -e "$cache_root/latest" ] && [ ! -L "$cache_root/latest" ]; then
+        remove_tree_if_exists "$cache_root/latest"
+    fi
+    ln -sfn "$version" "$cache_root/latest"
+
+    mkdir -p "$marketplace_root/plugins"
+    if [ -e "$marketplace_plugin_link" ] && [ ! -L "$marketplace_plugin_link" ]; then
+        remove_tree_if_exists "$marketplace_plugin_link"
+    fi
+    ln -sfn "$cache_root/latest" "$marketplace_plugin_link"
 }
 
 resolve_browser_use_runtime_env() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2137,6 +2137,44 @@ PY
     assert_contains "$REPO_DIR/contrib/user-local-install/install-user-local.sh" "--force-x11"
     assert_contains "$REPO_DIR/contrib/user-local-install/install-user-local.sh" "user-local.env"
     assert_contains "$REPO_DIR/contrib/user-local-install/README.md" "--force-x11"
+
+    node - "$REPO_DIR/launcher/start.sh.template" <<'NODE' || fail "Bundled backend plugin cache syncs must expose marketplace plugin links"
+const fs = require("node:fs");
+const launcher = fs.readFileSync(process.argv[2], "utf8");
+
+function functionBody(name, nextName) {
+  const pattern = new RegExp(`${name}\\(\\) \\{([\\s\\S]*?)\\n\\}\\n\\n${nextName}\\(\\) \\{`, "u");
+  const match = launcher.match(pattern);
+  if (match == null) {
+    throw new Error(`missing ${name}`);
+  }
+  return match[1];
+}
+
+function assertCacheLinks({ body, plugin }) {
+  for (const required of [
+    `marketplace_plugin_link="$marketplace_root/plugins/${plugin}"`,
+    'ln -sfn "$version" "$cache_root/latest"',
+    'ln -sfn "$cache_root/latest" "$marketplace_plugin_link"',
+  ]) {
+    if (!body.includes(required)) {
+      throw new Error(`${plugin} sync missing ${required}`);
+    }
+  }
+  if (!body.includes("needs_copy=0")) {
+    throw new Error(`${plugin} sync must refresh links on cache hits`);
+  }
+}
+
+assertCacheLinks({
+  body: functionBody("sync_computer_use_bundled_plugin_cache", "sync_read_aloud_bundled_plugin_cache"),
+  plugin: "computer-use",
+});
+assertCacheLinks({
+  body: functionBody("sync_read_aloud_bundled_plugin_cache", "resolve_browser_use_runtime_env"),
+  plugin: "read-aloud",
+});
+NODE
 }
 
 test_side_by_side_launcher_identity() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1086,7 +1086,9 @@ test_setup_native_wizard_prints_deep_readiness_guidance() {
     XDG_DATA_HOME="$fake_home/.local/share" \
     XDG_CURRENT_DESKTOP=KDE \
     DESKTOP_SESSION=plasma \
+    XDG_SESSION_DESKTOP=plasma \
     XDG_SESSION_TYPE=wayland \
+    CODEX_LINUX_SETTINGS_FILE="$fake_home/.config/codex-desktop/settings.json" \
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
     CODEX_LINUX_FEATURES_ROOT="$features_root" \
     CODEX_LINUX_FEATURES_CONFIG="$config" \
@@ -1154,6 +1156,7 @@ test_setup_native_wizard_read_aloud_paths_match_runtime_defaults() {
     XDG_DATA_HOME="$fake_home/.local/share" \
     CODEX_LINUX_APP_ID="codex-cua-lab" \
     CODEX_APP_ID="codex-desktop" \
+    CODEX_LINUX_SETTINGS_FILE="$fake_home/.config/codex-cua-lab/settings.json" \
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
     CODEX_LINUX_FEATURES_ROOT="$features_root" \
     CODEX_LINUX_FEATURES_CONFIG="$config" \
@@ -1178,6 +1181,7 @@ test_setup_native_wizard_sway_hint_is_conservative() {
 
     XDG_CURRENT_DESKTOP=sway \
     DESKTOP_SESSION=sway \
+    XDG_SESSION_DESKTOP=sway \
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
     CODEX_LINUX_FEATURES_ROOT="$features_root" \
     CODEX_LINUX_FEATURES_CONFIG="$config" \
@@ -1448,7 +1452,7 @@ SCRIPT
     chmod +x "$start_script"
 
     set +e
-    CODEX_WEBVIEW_PORT="$huge_port" "$start_script" --help >"$launcher_stdout" 2>"$launcher_stderr"
+    CODEX_WEBVIEW_PORT="$huge_port" bash "$start_script" --help >"$launcher_stdout" 2>"$launcher_stderr"
     rc=$?
     set -e
     [ "$rc" -ne 0 ] || fail "Expected launcher validation to reject oversized CODEX_WEBVIEW_PORT"
@@ -1469,7 +1473,7 @@ SCRIPT
 printf '%s\n' "$CODEX_LINUX_WEBVIEW_PORT"
 SCRIPT
     chmod +x "$launcher_probe_script"
-    CODEX_WEBVIEW_PORT=00080 "$launcher_probe_script" >"$launcher_stdout" 2>"$launcher_stderr"
+    CODEX_WEBVIEW_PORT=00080 bash "$launcher_probe_script" >"$launcher_stdout" 2>"$launcher_stderr"
     [ "$(tail -n 1 "$launcher_stdout")" = "80" ] || fail "Expected launcher validation to canonicalize leading-zero CODEX_WEBVIEW_PORT"
     [ ! -s "$launcher_stderr" ] || fail "Expected launcher leading-zero canonicalization to be quiet, got: $(cat "$launcher_stderr")"
 }


### PR DESCRIPTION
## Summary

- refresh runtime marketplace plugin links for bundled Computer Use and Read Aloud backends
- keep refreshing `latest` and marketplace symlinks even when plugin cache contents are already current
- add a launcher smoke invariant so backend plugin cache syncs must expose marketplace plugin links

## Root Cause

The launcher copied bundled backend plugins into `~/.codex/plugins/cache/openai-bundled/<plugin>/<version>`, but Computer Use and Read Aloud did not create the `latest` symlink or `~/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/<plugin>` link used by runtime plugin discovery. Remote mobile control could therefore show UI/enrollment surfaces while app-server could not resolve the actual Computer Use backend plugin.

## Validation

- `bash -n launcher/start.sh.template tests/scripts_smoke.sh`
- `git diff --check`
- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `nix build .#codex-desktop-remote-mobile-control` and inspected generated launcher/backend binary
- `nix build .#codex-desktop-computer-use-ui-remote-mobile-control` and inspected generated launcher/backend binary

Note: full `bash tests/scripts_smoke.sh` did not complete locally; plain PATH lacked `awk`, and rerunning with `nix shell nixpkgs#gawk` hit an unrelated existing packaging-log assertion before the launcher sanity block.