### PR TITLE
Fix Linux remote mobile daemon runtime startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,31 @@ Feature-specific Nix outputs are additive. To enable both the Computer Use UI an
 nix run github:ilysenko/codex-desktop-linux#computer-use-ui-remote-mobile-control
 ```
 
+For a declarative NixOS/Home Manager install with the mobile remote-control
+app-server managed by systemd instead of the Desktop launcher, import the flake
+module:
+
+```nix
+{
+  imports = [
+    inputs.codex-desktop-linux.homeManagerModules.default
+  ];
+
+  programs.codexDesktopLinux = {
+    enable = true;
+    computerUseUi.enable = true;
+    remoteMobileControl.enable = true;
+    remoteControl.enable = true;
+  };
+}
+```
+
+This installs the selected Codex Desktop package variant and starts a user
+`codex-remote-control.service` with
+`codex app-server --remote-control --listen unix://`. A
+`nixosModules.default` export is also available for system-level configurations
+that prefer a global user unit.
+
 `nix develop github:ilysenko/codex-desktop-linux` enters a dev shell with the required tooling.
 
 ### Cachix binary cache

--- a/flake.nix
+++ b/flake.nix
@@ -609,5 +609,15 @@ PY
           ];
         };
       }
-    );
+    ) // {
+      homeManagerModules = rec {
+        default = import ./nix/home-manager-module.nix { inherit self; };
+        codex-desktop-linux = default;
+      };
+
+      nixosModules = rec {
+        default = import ./nix/nixos-module.nix { inherit self; };
+        codex-desktop-linux = default;
+      };
+    };
 }

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -28,7 +28,7 @@ WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
 LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/$CODEX_LINUX_APP_ID"
 LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
-REMOTE_MOBILE_CONTROL_MARKER="$SCRIPT_DIR/.codex-linux/remote-mobile-control-enabled"
+COLD_START_HOOK_DIR="$SCRIPT_DIR/.codex-linux/cold-start.d"
 MANAGED_NODE_BIN_DIR="$SCRIPT_DIR/resources/node-runtime/bin"
 APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
@@ -976,90 +976,20 @@ resolve_browser_use_runtime_env() {
     fi
 }
 
-ensure_remote_mobile_control_daemon() {
-    [ -f "$REMOTE_MOBILE_CONTROL_MARKER" ] || return 0
-    if early_truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
-        echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
-        return 0
-    fi
-
-    local codex_home="${CODEX_HOME:-$HOME/.codex}"
-    local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
-
-    if [ ! -x "$standalone_codex" ]; then
-        if [ -n "${CODEX_REMOTE_CONTROL_CODEX_PATH:-}" ]; then
-            echo "Remote mobile control daemon runtime override is not executable: $CODEX_REMOTE_CONTROL_CODEX_PATH"
-            return 0
-        fi
-        if early_truthy_env_value "${CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED:-}"; then
-            echo "Remote mobile control standalone runtime auto-install disabled by CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED"
-            return 0
-        fi
-        if ! install_remote_mobile_control_runtime "$codex_home"; then
-            echo "Remote mobile control is enabled, but the standalone Codex daemon runtime could not be installed at $standalone_codex"
-            echo "Brew or another CLI can remain the interactive Codex CLI; remote mobile control uses CODEX_REMOTE_CONTROL_CODEX_PATH separately."
-            return 0
-        fi
-        if [ ! -x "$standalone_codex" ]; then
-            echo "Remote mobile control standalone runtime installer completed but $standalone_codex is still missing"
-            return 0
-        fi
-    fi
-
-    if "$standalone_codex" app-server daemon start --enable remote_control; then
-        echo "Remote mobile control daemon is ready via $standalone_codex"
-    else
-        echo "Remote mobile control daemon start failed via $standalone_codex; Android remote hosts may remain disconnected."
-    fi
-}
-
-install_remote_mobile_control_runtime() {
-    local codex_home="$1"
-    local private_bin="$codex_home/packages/standalone/.bin"
-    local system_path="/usr/bin:/bin:/usr/sbin:/sbin"
-    local installer_path="$private_bin:$system_path"
-    local setsid_path=""
-    local fetch_cmd=""
-    local installer_args=()
-
-    mkdir -p "$private_bin"
-    if [ -n "${CODEX_REMOTE_CONTROL_CODEX_RELEASE:-}" ]; then
-        installer_args+=(--release "$CODEX_REMOTE_CONTROL_CODEX_RELEASE")
-    fi
-
-    if ! setsid_path="$(PATH="$system_path" command -v setsid 2>/dev/null)"; then
-        echo "Remote mobile control runtime install requires setsid"
-        return 1
-    fi
-    if fetch_cmd="$(PATH="$installer_path" command -v curl 2>/dev/null)"; then
-        :
-    elif fetch_cmd="$(PATH="$installer_path" command -v wget 2>/dev/null)"; then
-        :
-    else
-        echo "Remote mobile control runtime install requires curl or wget on the system PATH"
-        return 1
-    fi
-    if ! PATH="$installer_path" command -v tar >/dev/null 2>&1; then
-        echo "Remote mobile control runtime install requires tar on the system PATH"
-        return 1
-    fi
-
-    echo "Installing remote mobile control standalone runtime into $codex_home/packages/standalone"
-    # CODEX_INSTALL_DIR points the official installer at a private bin dir under
-    # CODEX_HOME. Running it through setsid and a system-only PATH prevents TTY
-    # prompts, user-managed CLI conflict prompts, ~/.local/bin/codex writes, and
-    # shell profile PATH blocks.
-    if [ "${fetch_cmd##*/}" = "curl" ]; then
-        ( set -o pipefail
-          "$fetch_cmd" -fsSL https://chatgpt.com/codex/install.sh | \
-              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
-        )
-    else
-        ( set -o pipefail
-          "$fetch_cmd" -q -O - https://chatgpt.com/codex/install.sh | \
-              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
-        )
-    fi
+run_cold_start_hooks() {
+    [ -d "$COLD_START_HOOK_DIR" ] || return 0
+    local hook
+    for hook in "$COLD_START_HOOK_DIR"/*; do
+        [ -f "$hook" ] || continue
+        [ -x "$hook" ] || continue
+        echo "Starting cold-start hook: $hook"
+        (
+            CODEX_LINUX_APP_DIR="$SCRIPT_DIR" \
+            CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
+            CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
+            "$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"
+        ) >>"$LOG_FILE" 2>&1 &
+    done
 }
 
 run_cli_preflight() {
@@ -2151,7 +2081,7 @@ if needs_cold_start; then
     sync_chrome_bundled_plugin_cache
     sync_computer_use_bundled_plugin_cache
     sync_read_aloud_bundled_plugin_cache
-    ensure_remote_mobile_control_daemon
+    run_cold_start_hooks
 fi
 resolve_browser_use_runtime_env
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -28,6 +28,7 @@ WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
 LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/$CODEX_LINUX_APP_ID"
 LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
+REMOTE_MOBILE_CONTROL_MARKER="$SCRIPT_DIR/.codex-linux/remote-mobile-control-enabled"
 MANAGED_NODE_BIN_DIR="$SCRIPT_DIR/resources/node-runtime/bin"
 APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
@@ -972,6 +973,92 @@ resolve_browser_use_runtime_env() {
 
     if [ -z "${CODEX_NODE_REPL_PATH:-}" ]; then
         echo "Browser Use node_repl runtime not found; in-app browser automation may be unavailable."
+    fi
+}
+
+ensure_remote_mobile_control_daemon() {
+    [ -f "$REMOTE_MOBILE_CONTROL_MARKER" ] || return 0
+    if early_truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
+        echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
+        return 0
+    fi
+
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
+
+    if [ ! -x "$standalone_codex" ]; then
+        if [ -n "${CODEX_REMOTE_CONTROL_CODEX_PATH:-}" ]; then
+            echo "Remote mobile control daemon runtime override is not executable: $CODEX_REMOTE_CONTROL_CODEX_PATH"
+            return 0
+        fi
+        if early_truthy_env_value "${CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED:-}"; then
+            echo "Remote mobile control standalone runtime auto-install disabled by CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED"
+            return 0
+        fi
+        if ! install_remote_mobile_control_runtime "$codex_home"; then
+            echo "Remote mobile control is enabled, but the standalone Codex daemon runtime could not be installed at $standalone_codex"
+            echo "Brew or another CLI can remain the interactive Codex CLI; remote mobile control uses CODEX_REMOTE_CONTROL_CODEX_PATH separately."
+            return 0
+        fi
+        if [ ! -x "$standalone_codex" ]; then
+            echo "Remote mobile control standalone runtime installer completed but $standalone_codex is still missing"
+            return 0
+        fi
+    fi
+
+    if "$standalone_codex" app-server daemon start --enable remote_control; then
+        echo "Remote mobile control daemon is ready via $standalone_codex"
+    else
+        echo "Remote mobile control daemon start failed via $standalone_codex; Android remote hosts may remain disconnected."
+    fi
+}
+
+install_remote_mobile_control_runtime() {
+    local codex_home="$1"
+    local private_bin="$codex_home/packages/standalone/.bin"
+    local system_path="/usr/bin:/bin:/usr/sbin:/sbin"
+    local installer_path="$private_bin:$system_path"
+    local setsid_path=""
+    local fetch_cmd=""
+    local installer_args=()
+
+    mkdir -p "$private_bin"
+    if [ -n "${CODEX_REMOTE_CONTROL_CODEX_RELEASE:-}" ]; then
+        installer_args+=(--release "$CODEX_REMOTE_CONTROL_CODEX_RELEASE")
+    fi
+
+    if ! setsid_path="$(PATH="$system_path" command -v setsid 2>/dev/null)"; then
+        echo "Remote mobile control runtime install requires setsid"
+        return 1
+    fi
+    if fetch_cmd="$(PATH="$installer_path" command -v curl 2>/dev/null)"; then
+        :
+    elif fetch_cmd="$(PATH="$installer_path" command -v wget 2>/dev/null)"; then
+        :
+    else
+        echo "Remote mobile control runtime install requires curl or wget on the system PATH"
+        return 1
+    fi
+    if ! PATH="$installer_path" command -v tar >/dev/null 2>&1; then
+        echo "Remote mobile control runtime install requires tar on the system PATH"
+        return 1
+    fi
+
+    echo "Installing remote mobile control standalone runtime into $codex_home/packages/standalone"
+    # CODEX_INSTALL_DIR points the official installer at a private bin dir under
+    # CODEX_HOME. Running it through setsid and a system-only PATH prevents TTY
+    # prompts, user-managed CLI conflict prompts, ~/.local/bin/codex writes, and
+    # shell profile PATH blocks.
+    if [ "${fetch_cmd##*/}" = "curl" ]; then
+        ( set -o pipefail
+          "$fetch_cmd" -fsSL https://chatgpt.com/codex/install.sh | \
+              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
+        )
+    else
+        ( set -o pipefail
+          "$fetch_cmd" -q -O - https://chatgpt.com/codex/install.sh | \
+              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
+        )
     fi
 }
 
@@ -2064,6 +2151,7 @@ if needs_cold_start; then
     sync_chrome_bundled_plugin_cache
     sync_computer_use_bundled_plugin_cache
     sync_read_aloud_bundled_plugin_cache
+    ensure_remote_mobile_control_daemon
 fi
 resolve_browser_use_runtime_env
 

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -43,10 +43,10 @@ What it changes:
   startup.
 - Updates remote-control settings and Codex mobile setup copy so the Linux flow
   is not described as Mac-only.
-- Stages `.codex-linux/remote-mobile-control-enabled`, which tells the Linux
-  launcher to provision the upstream managed standalone daemon runtime when it
-  is missing, then start the managed app-server daemon with
-  `app-server daemon start --enable remote_control` on cold start.
+- Stages `.codex-linux/cold-start.d/remote-mobile-control`, a feature-owned
+  cold-start hook that provisions the upstream managed standalone daemon runtime
+  when it is missing, then starts the managed app-server daemon with
+  `app-server daemon start --enable remote_control`.
 
 Remote mobile daemon requirement:
 
@@ -59,11 +59,18 @@ managed standalone daemon runtime at:
 ~/.codex/packages/standalone/current/codex
 ```
 
-If that binary is missing, the launcher runs the upstream standalone installer
-with `CODEX_INSTALL_DIR` pointed at a private bin directory under
-`~/.codex/packages/standalone/.bin`. That satisfies the managed daemon layout
-without changing `CODEX_CLI_PATH`, creating `~/.local/bin/codex`, or adding
-PATH blocks to your shell profile.
+If that binary is missing, the feature's cold-start hook runs the upstream
+standalone installer with `CODEX_INSTALL_DIR` pointed at a private bin directory
+under `~/.codex/packages/standalone/.bin`. That satisfies the managed daemon
+layout without changing `CODEX_CLI_PATH`, creating `~/.local/bin/codex`, or
+adding PATH blocks to your shell profile.
+
+The hook is launched best-effort in the background by the generic launcher hook
+runner. When the system `timeout` command is available, the installer/start path
+is capped by
+`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_TIMEOUT_SECONDS` (default `30`), so
+Desktop cold start is not blocked by network, GitHub, or installer stalls.
+Hook output is written to the launcher cache as `remote-mobile-control.log`.
 
 This is compatible with immutable Linux systems such as Bluefin / Universal
 Blue because the managed daemon runtime is user-scoped state under

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -35,6 +35,11 @@ What it changes:
   Linux JavaScript ECDSA P-256 key provider.
 - Lets the remote-control Connections UI render on Linux when upstream marks
   the feature unavailable or withholds the remote-control visibility rollout.
+- Refreshes the remote Connections settings state every 5 seconds and
+  immediately after focus, visibility, online, or resume signals.
+- Keeps Chrome Browser Use available to remote/mobile controlled sessions when
+  the local Chrome plugin and native host are healthy, and adds a diagnostic
+  when the native browser bridge is not exposed to the session.
 - Persists the private key material at
   `~/.config/codex-desktop/remote-control-device-keys-v1.json` with `0600`
   file permissions.

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -46,7 +46,7 @@ What it changes:
 - Stages `.codex-linux/cold-start.d/remote-mobile-control`, a feature-owned
   cold-start hook that provisions the upstream managed standalone daemon runtime
   when it is missing, then starts the managed app-server daemon with
-  `app-server daemon start --enable remote_control`.
+  `remote-control start`.
 
 Remote mobile daemon requirement:
 
@@ -71,6 +71,29 @@ is capped by
 `CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_TIMEOUT_SECONDS` (default `30`), so
 Desktop cold start is not blocked by network, GitHub, or installer stalls.
 Hook output is written to the launcher cache as `remote-mobile-control.log`.
+
+On NixOS, prefer the flake's Home Manager module instead of the launcher hook:
+
+```nix
+{
+  imports = [
+    inputs.codex-desktop-linux.homeManagerModules.default
+  ];
+
+  programs.codexDesktopLinux = {
+    enable = true;
+    computerUseUi.enable = true;
+    remoteMobileControl.enable = true;
+    remoteControl.enable = true;
+  };
+}
+```
+
+The module installs the remote-mobile package variant and manages
+`codex-remote-control.service` as a user systemd unit running
+`codex app-server --remote-control --listen unix://`. It also sets
+`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` so the launcher does not
+start a second mutable standalone daemon.
 
 This is compatible with immutable Linux systems such as Bluefin / Universal
 Blue because the managed daemon runtime is user-scoped state under

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -70,7 +70,8 @@ runner. When the system `timeout` command is available, the installer/start path
 is capped by
 `CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_TIMEOUT_SECONDS` (default `30`), so
 Desktop cold start is not blocked by network, GitHub, or installer stalls.
-Hook output is written to the launcher cache as `remote-mobile-control.log`.
+When `timeout` is unavailable, the hook continues the installer/start path in a
+background subprocess. Hook output is written to the launcher log.
 
 On NixOS, prefer the flake's Home Manager module instead of the launcher hook:
 

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -43,6 +43,47 @@ What it changes:
   startup.
 - Updates remote-control settings and Codex mobile setup copy so the Linux flow
   is not described as Mac-only.
+- Stages `.codex-linux/remote-mobile-control-enabled`, which tells the Linux
+  launcher to provision the upstream managed standalone daemon runtime when it
+  is missing, then start the managed app-server daemon with
+  `app-server daemon start --enable remote_control` on cold start.
+
+Remote mobile daemon requirement:
+
+The interactive Codex CLI and the remote-control daemon are separate concerns.
+You can keep using a Homebrew-installed `codex` for normal terminal and Desktop
+app-server usage, but Android remote control currently expects the upstream
+managed standalone daemon runtime at:
+
+```bash
+~/.codex/packages/standalone/current/codex
+```
+
+If that binary is missing, the launcher runs the upstream standalone installer
+with `CODEX_INSTALL_DIR` pointed at a private bin directory under
+`~/.codex/packages/standalone/.bin`. That satisfies the managed daemon layout
+without changing `CODEX_CLI_PATH`, creating `~/.local/bin/codex`, or adding
+PATH blocks to your shell profile.
+
+This is compatible with immutable Linux systems such as Bluefin / Universal
+Blue because the managed daemon runtime is user-scoped state under
+`~/.codex/packages/standalone`. It does not require `dnf`, `rpm-ostree`, host
+package layering, or base-OS mutation. The private `.bin` directory is only a
+launcher-owned target for the installer symlink; it is not prepended to the
+user's persistent shell `PATH`.
+
+Set `CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED=1` to disable that
+runtime provisioning and only use an already-installed standalone runtime.
+
+To force a specific daemon binary without affecting the interactive CLI, set:
+
+```bash
+CODEX_REMOTE_CONTROL_CODEX_PATH=/path/to/standalone/codex
+```
+
+To keep Desktop using Homebrew while the daemon uses standalone, set
+`CODEX_CLI_PATH` to the Brew binary and leave
+`CODEX_REMOTE_CONTROL_CODEX_PATH` unset or pointed at the standalone binary.
 
 KDE Plasma smoke check:
 

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+truthy_env_value() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+install_remote_mobile_control_runtime() {
+    local codex_home="$1"
+    local private_bin="$codex_home/packages/standalone/.bin"
+    local system_path="/usr/bin:/bin:/usr/sbin:/sbin"
+    local installer_path="$private_bin:$system_path"
+    local setsid_path=""
+    local fetch_cmd=""
+    local installer_args=()
+
+    mkdir -p "$private_bin"
+    if [ -n "${CODEX_REMOTE_CONTROL_CODEX_RELEASE:-}" ]; then
+        installer_args+=(--release "$CODEX_REMOTE_CONTROL_CODEX_RELEASE")
+    fi
+
+    if ! setsid_path="$(PATH="$system_path" command -v setsid 2>/dev/null)"; then
+        echo "Remote mobile control runtime install requires setsid"
+        return 1
+    fi
+    if fetch_cmd="$(PATH="$installer_path" command -v curl 2>/dev/null)"; then
+        :
+    elif fetch_cmd="$(PATH="$installer_path" command -v wget 2>/dev/null)"; then
+        :
+    else
+        echo "Remote mobile control runtime install requires curl or wget on the system PATH"
+        return 1
+    fi
+    if ! PATH="$installer_path" command -v tar >/dev/null 2>&1; then
+        echo "Remote mobile control runtime install requires tar on the system PATH"
+        return 1
+    fi
+
+    echo "Installing remote mobile control standalone runtime into $codex_home/packages/standalone"
+    # CODEX_INSTALL_DIR points the official installer at a private bin dir under
+    # CODEX_HOME. Running it through setsid and a system-only PATH prevents TTY
+    # prompts, user-managed CLI conflict prompts, ~/.local/bin/codex writes, and
+    # shell profile PATH blocks.
+    if [ "${fetch_cmd##*/}" = "curl" ]; then
+        ( set -o pipefail
+          "$fetch_cmd" -fsSL https://chatgpt.com/codex/install.sh | \
+              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
+        )
+    else
+        ( set -o pipefail
+          "$fetch_cmd" -q -O - https://chatgpt.com/codex/install.sh | \
+              CODEX_HOME="$codex_home" CODEX_INSTALL_DIR="$private_bin" PATH="$installer_path" "$setsid_path" sh -s -- "${installer_args[@]}"
+        )
+    fi
+}
+
+remote_mobile_control_main() {
+    if truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
+        echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
+        return 0
+    fi
+
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
+
+    if [ ! -x "$standalone_codex" ]; then
+        if [ -n "${CODEX_REMOTE_CONTROL_CODEX_PATH:-}" ]; then
+            echo "Remote mobile control daemon runtime override is not executable: $CODEX_REMOTE_CONTROL_CODEX_PATH"
+            return 0
+        fi
+        if truthy_env_value "${CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED:-}"; then
+            echo "Remote mobile control standalone runtime auto-install disabled by CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED"
+            return 0
+        fi
+        if ! install_remote_mobile_control_runtime "$codex_home"; then
+            echo "Remote mobile control is enabled, but the standalone Codex daemon runtime could not be installed at $standalone_codex"
+            echo "Brew or another CLI can remain the interactive Codex CLI; remote mobile control uses CODEX_REMOTE_CONTROL_CODEX_PATH separately."
+            return 0
+        fi
+        if [ ! -x "$standalone_codex" ]; then
+            echo "Remote mobile control standalone runtime installer completed but $standalone_codex is still missing"
+            return 0
+        fi
+    fi
+
+    if "$standalone_codex" app-server daemon start --enable remote_control; then
+        echo "Remote mobile control daemon is ready via $standalone_codex"
+    else
+        echo "Remote mobile control daemon start failed via $standalone_codex; Android remote hosts may remain disconnected."
+    fi
+}
+
+run_with_timeout() {
+    local timeout_seconds="${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_TIMEOUT_SECONDS:-30}"
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeout_seconds" "$0" --run-main || \
+            echo "Remote mobile control hook timed out or failed after ${timeout_seconds}s"
+    else
+        remote_mobile_control_main
+    fi
+}
+
+if [ "${1:-}" = "--run-main" ]; then
+    remote_mobile_control_main
+    exit $?
+fi
+
+echo "Remote mobile control cold-start hook started at $(date -Is 2>/dev/null || date)"
+run_with_timeout

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -11,7 +11,7 @@ truthy_env_value() {
 install_remote_mobile_control_runtime() {
     local codex_home="$1"
     local private_bin="$codex_home/packages/standalone/.bin"
-    local system_path="/usr/bin:/bin:/usr/sbin:/sbin"
+    local system_path="/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin"
     local installer_path="$private_bin:$system_path"
     local setsid_path=""
     local fetch_cmd=""
@@ -62,6 +62,11 @@ remote_mobile_control_main() {
         echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
         return 0
     fi
+    if command -v systemctl >/dev/null 2>&1 &&
+        systemctl --user is-active --quiet codex-remote-control.service 2>/dev/null; then
+        echo "Remote mobile control daemon autostart skipped; codex-remote-control.service is already active"
+        return 0
+    fi
 
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
     local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
@@ -86,7 +91,7 @@ remote_mobile_control_main() {
         fi
     fi
 
-    if "$standalone_codex" app-server daemon start --enable remote_control; then
+    if "$standalone_codex" remote-control start; then
         echo "Remote mobile control daemon is ready via $standalone_codex"
     else
         echo "Remote mobile control daemon start failed via $standalone_codex; Android remote hosts may remain disconnected."

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -104,7 +104,8 @@ run_with_timeout() {
         timeout "$timeout_seconds" "$0" --run-main || \
             echo "Remote mobile control hook timed out or failed after ${timeout_seconds}s"
     else
-        remote_mobile_control_main
+        echo "Remote mobile control hook running without timeout; continuing best-effort in the background"
+        remote_mobile_control_main &
     fi
 }
 

--- a/linux-features/remote-mobile-control/feature.json
+++ b/linux-features/remote-mobile-control/feature.json
@@ -4,6 +4,7 @@
   "description": "Opt-in Linux patches for Codex mobile remote-control host enrollment.",
   "defaultEnabled": false,
   "entrypoints": {
-    "patchDescriptors": "./patch.js"
+    "patchDescriptors": "./patch.js",
+    "stageHook": "./stage.sh"
   }
 }

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
+
 function requireName(source, moduleName) {
   const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\(\`${escaped}\`\\)`));
@@ -36,6 +39,8 @@ const REMOTE_CONTROL_AUTO_CONNECT_CLEANUP_MARKER = "codexLinuxRemoteControlAutoC
 const REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER = "codexLinuxRemoteControlSelfAutoConnect";
 const REMOTE_MOBILE_ACTIVE_STATUS_MARKER = "codexLinuxRemoteMobileActiveStatus";
 const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMobileSetupAfterRevoke";
+const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAppServerArgs";
+const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE = "args:[`app-server`,`--analytics-default-enabled`]";
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -380,6 +385,59 @@ function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
     recoverableErrorNeedle,
     "e.message===`Remote control request failed (403): Remote-control client key material missing`||e.message===`Remote-control client key material missing`||e.message===`Remote-control client has been revoked`:!1",
   );
+}
+
+function applyLinuxRemoteMobileAppServerRemoteControlPatch(source) {
+  if (source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)) {
+    return source;
+  }
+  if (!source.includes(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE)) {
+    return source;
+  }
+
+  const helper =
+    "function codexLinuxRemoteMobileAppServerArgs(){return process.platform===`linux`?[`app-server`,`--remote-control`,`--analytics-default-enabled`]:[`app-server`,`--analytics-default-enabled`]}";
+  return `${helper}${source.split(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE).join("args:codexLinuxRemoteMobileAppServerArgs()")}`;
+}
+
+function applyLinuxRemoteMobileAppServerRemoteControlExtractedAppPatch(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  if (!fs.existsSync(buildDir)) {
+    const reason = `missing build directory ${buildDir}`;
+    console.warn(`WARN: Could not find app-server launch bundle - skipping remote mobile app-server remote-control patch`);
+    return { matched: 0, changed: 0, reason };
+  }
+
+  const candidates = fs
+    .readdirSync(buildDir)
+    .filter((name) => /\.m?js$/u.test(name))
+    .sort();
+
+  let matched = 0;
+  let changed = 0;
+  for (const candidate of candidates) {
+    const filePath = path.join(buildDir, candidate);
+    const source = fs.readFileSync(filePath, "utf8");
+    if (
+      !source.includes(REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE) &&
+      !source.includes(REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER)
+    ) {
+      continue;
+    }
+    matched += 1;
+    const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
+    if (patched !== source) {
+      fs.writeFileSync(filePath, patched, "utf8");
+      changed += 1;
+    }
+  }
+
+  if (matched === 0) {
+    const reason = "no default app-server launch args found";
+    console.warn("WARN: Could not find default app-server launch args - skipping remote mobile app-server remote-control patch");
+    return { matched, changed, reason };
+  }
+  return { matched, changed };
 }
 
 function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
@@ -885,6 +943,13 @@ module.exports = [
     apply: applyLinuxRemoteControlClientRevocationRecoveryPatch,
   },
   {
+    id: "linux-remote-mobile-app-server-remote-control",
+    phase: "extracted-app",
+    order: 20_117,
+    ciPolicy: "optional",
+    apply: applyLinuxRemoteMobileAppServerRemoteControlExtractedAppPatch,
+  },
+  {
     id: "linux-remote-control-load-gate",
     phase: "webview-asset",
     pattern: /^remote-connection-visibility-.*\.js$/,
@@ -987,6 +1052,8 @@ module.exports = [
 ];
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
+module.exports.applyLinuxRemoteMobileAppServerRemoteControlPatch =
+  applyLinuxRemoteMobileAppServerRemoteControlPatch;
 module.exports.applyLinuxRemoteMobileChromeBridgePatch = applyLinuxRemoteMobileChromeBridgePatch;
 module.exports.applyLinuxRemoteMobileConversationHydrationPatch = applyLinuxRemoteMobileConversationHydrationPatch;
 module.exports.applyLinuxRemoteControlEnablementBridgePatch = applyLinuxRemoteControlEnablementBridgePatch;

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -782,7 +782,7 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       "this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(`Failed to hydrate conversation for turn/started`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}",
       "this.markConversationStreaming(r),",
     ].join("");
-    const unknownTurnReplacement = unknownTurnRetryNeedle;
+    const unknownTurnReplacement = unknownTurnLocalPathRetryNeedle;
     if (patched.includes(unknownTurnNeedle)) {
       patched = patched.replace(unknownTurnNeedle, unknownTurnReplacement);
     } else if (patched.includes(hydrationV1Needle)) {

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -670,13 +670,14 @@ function applyLinuxRemoteConnectionsRefreshPatch(source) {
   ] = match;
   const replacement =
     `(0,${reactVar}.useEffect)(()=>{let ${abortVar}=null,${pendingVar}=!1,${refreshVar}=async()=>{if(!${pendingVar}){${pendingVar}=!0,${abortVar}=new AbortController;try{await ${refreshEventVar}(${abortVar}.signal)}finally{${abortVar}=null,${pendingVar}=!1}}},` +
-    `${REMOTE_CONNECTIONS_REFRESH_MARKER}=()=>{document.visibilityState!==\`hidden\`&&${refreshVar}()},` +
+    `codexLinuxRemoteConnectionsRefreshTimer=null,codexLinuxRemoteConnectionsRefreshLast=0,${REMOTE_CONNECTIONS_REFRESH_MARKER}=()=>{if(document.visibilityState===\`hidden\`)return;let e=Date.now(),t=()=>{codexLinuxRemoteConnectionsRefreshLast=Date.now(),codexLinuxRemoteConnectionsRefreshTimer=null,${refreshVar}()};if(e-codexLinuxRemoteConnectionsRefreshLast<1e3){codexLinuxRemoteConnectionsRefreshTimer!=null&&window.clearTimeout(codexLinuxRemoteConnectionsRefreshTimer),codexLinuxRemoteConnectionsRefreshTimer=window.setTimeout(t,1e3-(e-codexLinuxRemoteConnectionsRefreshLast));return}t()},` +
     `${intervalVar}=window.setInterval(()=>{${refreshVar}()},${intervalConstantVar});` +
     `document.addEventListener(\`visibilitychange\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
     `window.addEventListener(\`focus\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
     `window.addEventListener(\`online\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
     `window.addEventListener(\`resume\`,${REMOTE_CONNECTIONS_REFRESH_MARKER});` +
     `return()=>{${abortVar}?.abort(),window.clearInterval(${intervalVar}),` +
+    `codexLinuxRemoteConnectionsRefreshTimer!=null&&window.clearTimeout(codexLinuxRemoteConnectionsRefreshTimer),` +
     `document.removeEventListener(\`visibilitychange\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
     `window.removeEventListener(\`focus\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
     `window.removeEventListener(\`online\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -678,8 +678,9 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
   }
 
   const hasNotificationQueue = patched.includes(REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER);
-  const hasPersistedHydrationGuard = patched.includes("Skipping hydration for non-persisted conversation");
-  if (!hasNotificationQueue || !hasPersistedHydrationGuard) {
+  const hasMissingHydrationGuard = patched.includes("Skipping hydration for missing conversation");
+  const hasLocalPathHydrationGuard = patched.includes("typeof t?.path==`string`&&t.path.endsWith(`.jsonl`)");
+  if (!hasNotificationQueue || !hasMissingHydrationGuard || hasLocalPathHydrationGuard) {
     const unknownTurnNeedle =
       "if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){R.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),";
     const hydrationV1Needle =
@@ -688,7 +689,7 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),R.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}}),this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch(e=>{this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}})});break}this.markConversationStreaming(r),`;
     const hydrationRetryUnsafeNeedle =
       `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),R.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});let s=(a=0)=>this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch(e=>{if(a<12){R.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:r,attempt:a+1},sensitive:{error:e}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}this.markConversationStreaming(r),`;
-    const unknownTurnRetryNeedle = [
+    const unknownTurnLocalPathRetryNeedle = [
       `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/`,
       "let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),",
       "R.warning(`Hydrating conversation for turn/started`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});",
@@ -705,6 +706,23 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       "this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(`Failed to hydrate conversation for turn/started`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}",
       "this.markConversationStreaming(r),",
     ].join("");
+    const unknownTurnRetryNeedle = [
+      `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/`,
+      "let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),",
+      "R.warning(`Hydrating conversation for turn/started`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});",
+      "let s=(a=0)=>this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];",
+      "if(!t){if(a<12){",
+      "R.warning(`Retrying hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),",
+      "setTimeout(()=>s(a+1),250);return}",
+      "this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;",
+      "this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),",
+      "this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}",
+      "R.warning(`Skipping hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});return}",
+      "this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch(e=>{",
+      "if(a<12){R.warning(`Retrying hydration for turn/started`,{safe:{conversationId:r,attempt:a+1},sensitive:{error:e}}),setTimeout(()=>s(a+1),250);return}",
+      "this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(`Failed to hydrate conversation for turn/started`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}",
+      "this.markConversationStreaming(r),",
+    ].join("");
     const unknownTurnReplacement = unknownTurnRetryNeedle;
     if (patched.includes(unknownTurnNeedle)) {
       patched = patched.replace(unknownTurnNeedle, unknownTurnReplacement);
@@ -714,6 +732,8 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       patched = patched.replace(hydrationQueuedUnsafeNeedle, unknownTurnReplacement);
     } else if (patched.includes(hydrationRetryUnsafeNeedle)) {
       patched = patched.replace(hydrationRetryUnsafeNeedle, unknownTurnReplacement);
+    } else if (patched.includes(unknownTurnLocalPathRetryNeedle)) {
+      patched = patched.replace(unknownTurnLocalPathRetryNeedle, unknownTurnReplacement);
     } else if (patched.includes(unknownTurnRetryNeedle)) {
       // Already upgraded to retry hydration.
     } else if (patched.includes("Received turn/started for unknown conversation")) {

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -22,6 +22,7 @@ const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
+const REMOTE_CONTROL_FEATURE_SYNC_MARKER = "codexLinuxRemoteControlFeatureSyncEnabled";
 const REMOTE_CONTROL_LOAD_GATE_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\(`1042620455`\)\}/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
@@ -388,6 +389,40 @@ function applyLinuxRemoteControlLoadGatePatch(source) {
   );
 }
 
+function applyLinuxRemoteControlFeatureSyncPatch(source) {
+  if (source.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
+    return source;
+  }
+
+  const defaultFeaturesMarker = "statsig_default_enable_features";
+  const syncMethodMarker = "set-experimental-feature-enablement-for-host";
+  if (!source.includes(defaultFeaturesMarker) || !source.includes(syncMethodMarker)) {
+    return source;
+  }
+
+  const featureArrayRegex =
+    /var ([A-Za-z_$][\w$]*)=\[([^\]]*?)\];function ([A-Za-z_$][\w$]*)\(\)\{let [\s\S]{0,2400}?statsig_default_enable_features[\s\S]{0,2400}?set-experimental-feature-enablement-for-host/u;
+  const featureArrayMatch = source.match(featureArrayRegex);
+  if (featureArrayMatch == null) {
+    console.warn("WARN: Could not find app-server feature sync list - skipping Linux remote-control feature sync patch");
+    return source;
+  }
+
+  const [, arrayVar, featureArrayItems] = featureArrayMatch;
+  const entries = featureArrayItems.split(",").filter((entry) => entry.trim().length > 0);
+  if (entries.some((entry) => entry.trim() === "`remote_control`")) {
+    return source.replace(
+      `var ${arrayVar}=[${featureArrayItems}];`,
+      `var ${arrayVar}=[${featureArrayItems}];function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(){return!0}`,
+    );
+  }
+
+  const patchedFeatureArrayItems = [...entries, "`remote_control`"].join(",");
+  const featureArrayNeedle = `var ${arrayVar}=[${featureArrayItems}];`;
+  const featureArrayPatch = `var ${arrayVar}=[${patchedFeatureArrayItems}];function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(){return!0}`;
+  return replaceOnce(source, featureArrayNeedle, featureArrayPatch) ?? source;
+}
+
 function applyLinuxRemoteControlVisibilityPatch(source) {
   if (
     source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT) ||
@@ -483,6 +518,16 @@ module.exports = [
     apply: applyLinuxRemoteControlLoadGatePatch,
   },
   {
+    id: "linux-remote-control-feature-sync",
+    phase: "webview-asset",
+    pattern: /^(?:app-main|index)-.*\.js$/,
+    order: 20_119,
+    ciPolicy: "optional",
+    missingDescription: "webview app main bundle",
+    skipDescription: "Linux remote-control feature sync patch",
+    apply: applyLinuxRemoteControlFeatureSyncPatch,
+  },
+  {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
     pattern: /^(?:remote-control-connections-visibility|remote-connections-settings)-.*\.js$/,
@@ -511,5 +556,6 @@ module.exports.applyLinuxRemoteControlClientAccountCompatibilityPatch =
 module.exports.applyLinuxRemoteControlClientRevocationRecoveryPatch =
   applyLinuxRemoteControlClientRevocationRecoveryPatch;
 module.exports.applyLinuxRemoteControlLoadGatePatch = applyLinuxRemoteControlLoadGatePatch;
+module.exports.applyLinuxRemoteControlFeatureSyncPatch = applyLinuxRemoteControlFeatureSyncPatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -21,10 +21,25 @@ const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
+const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
+const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
+const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
 const REMOTE_CONTROL_FEATURE_SYNC_MARKER = "codexLinuxRemoteControlFeatureSyncEnabled";
 const REMOTE_CONTROL_LOAD_GATE_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\(`1042620455`\)\}/u;
+const REMOTE_MOBILE_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntimeStatus";
+const REMOTE_MOBILE_UNKNOWN_TURN_MARKER = "codexLinuxRemoteMobileHydrateUnknownTurn";
+const REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER = "codexLinuxRemoteMobileNotificationQueue";
+const REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER = "codexLinuxRemoteControlEnablementBridge";
+const REMOTE_CONTROL_AUTO_CONNECT_CLEANUP_MARKER = "codexLinuxRemoteControlAutoConnectCleanup";
+const REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER = "codexLinuxRemoteControlSelfAutoConnect";
+const REMOTE_MOBILE_ACTIVE_STATUS_MARKER = "codexLinuxRemoteMobileActiveStatus";
+const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMobileSetupAfterRevoke";
+const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
+  "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
+const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
+  "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){let i=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);if(i){if(!n)return`ssh`;if(e===`access-other-devices`)return t?`control-this-mac`:`ssh`;if(e===`control-this-mac`&&!t)return`ssh`;if(e===`ssh`&&!r)return t?`control-this-mac`:`ssh`;return e}return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["defaultMessage:`Mac`", "defaultMessage:`Linux`"],
   ["Keep this Mac awake", "Keep this Linux desktop awake"],
@@ -43,6 +58,10 @@ const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["Let Codex control the apps on your Mac", "Let Codex control apps on this Linux desktop"],
   ["Connect a device to this Mac", "Connect a device to this Linux desktop"],
   ["Connect your phone to this Mac", "Connect your phone to this Linux desktop"],
+  ["Add device to control this Mac remotely", "Add a device to control this Linux desktop remotely"],
+  ["Keep Mac awake", "Keep Linux desktop awake"],
+  ["this Mac", "this Linux desktop"],
+  ["local Mac", "local Linux desktop"],
 ];
 const CLIENT_ACCOUNT_COMPAT_MARKER = "codexLinuxRemoteControlAccountMatches";
 
@@ -363,6 +382,51 @@ function applyLinuxRemoteControlClientRevocationRecoveryPatch(source) {
   );
 }
 
+function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
+  if (source.includes(REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER)) {
+    return source;
+  }
+  if (!source.includes("remote-control-client-revoke-success")) {
+    return source;
+  }
+
+  const setGlobalStateMatch = source.match(
+    /mutationFn:[A-Za-z_$][\w$]*=>([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.ADDED_REMOTE_CONTROL_ENV_IDS,/u,
+  );
+  if (setGlobalStateMatch == null) {
+    console.warn("WARN: Could not find global-state setter alias - skipping remote-control revoke setup reset patch");
+    return source;
+  }
+
+  const setGlobalStateFn = setGlobalStateMatch[1];
+  const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
+  if (helperNeedle == null) {
+    console.warn("WARN: Could not find remote-control revoke toast marker - skipping setup reset helper insertion");
+    return source;
+  }
+
+  const helper = [
+    `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n){`,
+    "let r=e?.filter(e=>e.client_id!==t);",
+    `return r?.length===0&&${setGlobalStateFn}(n,\`codex-mobile-has-connected-device\`,!1),r`,
+    "}",
+  ].join("");
+
+  const patched = source.replace(helperNeedle, `${helper}${helperNeedle}`);
+  const successPattern =
+    /([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{eventName:`codex_remote_control_client_revoke_result`,metadata:\{result:`succeeded`\}\}\),([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\4\?\.filter\(\4=>\4\.client_id!==([A-Za-z_$][\w$]*)\)\)/u;
+  if (!successPattern.test(patched)) {
+    console.warn("WARN: Could not find remote-control revoke success cache update - skipping setup reset patch");
+    return source;
+  }
+
+  return patched.replace(
+    successPattern,
+    (_needle, trackFn, queryClientVar, querySnapshotVar, dataVar, clientIdVar) =>
+      `${trackFn}(${queryClientVar},{eventName:\`codex_remote_control_client_revoke_result\`,metadata:{result:\`succeeded\`}}),${querySnapshotVar}.setData(${dataVar}=>${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(${dataVar},${clientIdVar},${queryClientVar}))`,
+  );
+}
+
 function applyLinuxRemoteControlLoadGatePatch(source) {
   if (source.includes(REMOTE_CONTROL_LOAD_GATE_MARKER)) {
     return source;
@@ -454,14 +518,19 @@ function applyLinuxRemoteControlVisibilityPatch(source) {
   return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
 }
 
-function applyLinuxRemoteControlCopyPatch(source) {
-  const hasMacCopy = REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS.some(([macCopy]) =>
-    source.includes(macCopy),
+function wrapRemoteControlTabs(source, firstKey) {
+  const key = firstKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `tabs:(\\[\\{key:\`${key}\`[\\s\\S]*?\\}\\]),selectedKey:([A-Za-z_$][\\w$]*),variant:\`underline\`,onSelect:([A-Za-z_$][\\w$]*)\\}`,
+    "g",
   );
-  if (!hasMacCopy && (source.includes("this Linux desktop") || source.includes("Linux apps"))) {
-    return source;
-  }
+  return source.replace(
+    pattern,
+    "tabs:codexLinuxRemoteControlSettingsTabs($1),selectedKey:$2,variant:`underline`,onSelect:$3}",
+  );
+}
 
+function replaceLinuxRemoteControlCopy(source) {
   let patched = source;
   let changed = false;
   for (const [macCopy, linuxCopy] of REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS) {
@@ -470,12 +539,300 @@ function applyLinuxRemoteControlCopyPatch(source) {
       changed = true;
     }
   }
+  return { patched, changed };
+}
 
+function applyLinuxRemoteControlCopyPatch(source) {
+  const { patched, changed } = replaceLinuxRemoteControlCopy(source);
   if (!changed) {
     console.warn("WARN: Could not find remote-control Mac copy - skipping Linux remote-control copy patch");
     return source;
   }
   return patched;
+}
+
+function applyLinuxRemoteControlSettingsUxPatch(source) {
+  let patched = replaceLinuxRemoteControlCopy(source).patched;
+
+  if (!patched.includes(REMOTE_CONTROL_SETTINGS_UX_MARKER)) {
+    const helperNeedle = "function nr(e,t){return e.displayName.localeCompare(t.displayName)}";
+    if (!patched.includes(helperNeedle)) {
+      console.warn("WARN: Could not find remote-control settings helper needle - skipping Linux remote-control settings UX patch");
+      return patched;
+    }
+    const helper =
+      "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
+    patched = patched.replace(helperNeedle, `${helper}${helperNeedle}`);
+  }
+
+  patched = wrapRemoteControlTabs(patched, "control-this-mac");
+  patched = wrapRemoteControlTabs(patched, "access-other-devices");
+
+  if (patched.includes(REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT)) {
+    return patched;
+  }
+  if (!patched.includes(REMOTE_CONTROL_SELECTED_TAB_NEEDLE)) {
+    console.warn("WARN: Could not find remote-control selected-tab needle - skipping Linux remote-control selected-tab patch");
+    return patched;
+  }
+  return patched.replace(REMOTE_CONTROL_SELECTED_TAB_NEEDLE, REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT);
+}
+
+function applyLinuxRemoteConnectionsRefreshPatch(source) {
+  if (source.includes(REMOTE_CONNECTIONS_REFRESH_MARKER)) {
+    return source;
+  }
+
+  let patched = source;
+  if (patched.includes("Qn=15e3")) {
+    patched = patched.replace("Qn=15e3", "Qn=5e3");
+  } else if (patched.includes("15e3") && patched.includes("refresh-remote-connections")) {
+    console.warn("WARN: Could not find remote-connections refresh interval constant - skipping interval patch");
+  }
+
+  const effectPattern =
+    /\(0,([A-Za-z_$][\w$]*)\.useEffect\)\(\(\)=>\{let ([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=!1,([A-Za-z_$][\w$]*)=async\(\)=>\{if\(![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*=!0,[A-Za-z_$][\w$]*=new AbortController;try\{await ([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\.signal\)\}finally\{[A-Za-z_$][\w$]*=null,[A-Za-z_$][\w$]*=!1\}\}\},([A-Za-z_$][\w$]*)=window\.setInterval\(\(\)=>\{[A-Za-z_$][\w$]*\(\)\},([A-Za-z_$][\w$]*)\);return\(\)=>\{[A-Za-z_$][\w$]*\?\.abort\(\),window\.clearInterval\([A-Za-z_$][\w$]*\)\}\},\[\]\);/;
+  const match = patched.match(effectPattern);
+  if (match == null) {
+    if (patched.includes("refresh-remote-connections") && patched.includes("setInterval")) {
+      console.warn("WARN: Could not find remote-connections auto-refresh effect - skipping resume refresh patch");
+    }
+    return patched;
+  }
+
+  const [
+    needle,
+    reactVar,
+    abortVar,
+    pendingVar,
+    refreshVar,
+    refreshEventVar,
+    intervalVar,
+    intervalConstantVar,
+  ] = match;
+  const replacement =
+    `(0,${reactVar}.useEffect)(()=>{let ${abortVar}=null,${pendingVar}=!1,${refreshVar}=async()=>{if(!${pendingVar}){${pendingVar}=!0,${abortVar}=new AbortController;try{await ${refreshEventVar}(${abortVar}.signal)}finally{${abortVar}=null,${pendingVar}=!1}}},` +
+    `${REMOTE_CONNECTIONS_REFRESH_MARKER}=()=>{document.visibilityState!==\`hidden\`&&${refreshVar}()},` +
+    `${intervalVar}=window.setInterval(()=>{${refreshVar}()},${intervalConstantVar});` +
+    `document.addEventListener(\`visibilitychange\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.addEventListener(\`focus\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.addEventListener(\`online\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.addEventListener(\`resume\`,${REMOTE_CONNECTIONS_REFRESH_MARKER});` +
+    `return()=>{${abortVar}?.abort(),window.clearInterval(${intervalVar}),` +
+    `document.removeEventListener(\`visibilitychange\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.removeEventListener(\`focus\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.removeEventListener(\`online\`,${REMOTE_CONNECTIONS_REFRESH_MARKER}),` +
+    `window.removeEventListener(\`resume\`,${REMOTE_CONNECTIONS_REFRESH_MARKER})}},[]);`;
+
+  return patched.replace(needle, replacement);
+}
+
+function applyLinuxRemoteMobileChromeBridgePatch(source) {
+  if (source.includes(REMOTE_MOBILE_CHROME_BRIDGE_MARKER)) {
+    return source;
+  }
+
+  const backendNeedle =
+    "var tE=\"x-codex-browser-use-available-backends\",X6=[\"chrome\",\"iab\",\"cdp\"];function rE(t){return X6.some(e=>e===t)}";
+  const backendReplacement =
+    "var tE=\"x-codex-browser-use-available-backends\",X6=[\"chrome\",\"iab\",\"cdp\"];function rE(t){return X6.some(e=>e===t)}function codexLinuxRemoteMobileBrowserBackends(e){if(e==null)return null;if(!Array.isArray(e))return[];let t=e.filter(rE);return typeof process!=`undefined`&&process.platform===`linux`&&!t.includes(`chrome`)?[`chrome`,...t]:t}";
+  const currentBackendNeedle =
+    "function yC(){let t=globalThis.nodeRepl?.requestMeta?.[tE];return t==null?null:Array.isArray(t)?t.filter(rE):[]}";
+  const currentBackendReplacement =
+    "function yC(){let t=globalThis.nodeRepl?.requestMeta?.[tE];return codexLinuxRemoteMobileBrowserBackends(t)}";
+
+  if (!source.includes(backendNeedle) || !source.includes(currentBackendNeedle)) {
+    console.warn("WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch");
+    return source;
+  }
+
+  let patched = source
+    .replace(backendNeedle, backendReplacement)
+    .replace(currentBackendNeedle, currentBackendReplacement);
+
+  const nativePipeNeedle =
+    "function Cm(){let t=import.meta.__codexNativePipeUnavailableMessage;return typeof t==\"string\"&&t.length>0?t:\"privileged native pipe bridge is not available; browser-client is not trusted\"}";
+  const nativePipeReplacement =
+    "function codexLinuxRemoteMobileBrowserBridgeDiagnostic(e){return typeof process!=`undefined`&&process.platform===`linux`?`${e}; Chrome bridge was not exposed to this remote/mobile session. Check that the Chrome plugin, native host manifest, and x-codex-browser-use-available-backends request metadata include chrome.`:e}function Cm(){let t=import.meta.__codexNativePipeUnavailableMessage,e=typeof t==\"string\"&&t.length>0?t:\"privileged native pipe bridge is not available; browser-client is not trusted\";return codexLinuxRemoteMobileBrowserBridgeDiagnostic(e)}";
+  if (patched.includes(nativePipeNeedle)) {
+    patched = patched.replace(nativePipeNeedle, nativePipeReplacement);
+  } else {
+    console.warn("WARN: Could not find Chrome browser-client native pipe diagnostic needle - leaving default bridge diagnostic unchanged");
+  }
+
+  return patched;
+}
+
+function applyLinuxRemoteMobileConversationHydrationPatch(source) {
+  let patched = source;
+
+  if (!patched.includes(REMOTE_MOBILE_THREAD_RUNTIME_MARKER)) {
+    const runtimeNeedle = "e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=p)";
+    const runtimeReplacement =
+      `/*${REMOTE_MOBILE_THREAD_RUNTIME_MARKER}*/(e.resumeState===\`needs_resume\`||p?.type===\`active\`||p?.type===\`idle\`)&&(e.threadRuntimeStatus=p)`;
+    if (patched.includes(runtimeNeedle)) {
+      patched = patched.replace(runtimeNeedle, runtimeReplacement);
+    } else if (patched.includes("threadRuntimeStatus") && patched.includes("resumeState")) {
+      console.warn("WARN: Could not find thread/list runtime-status needle - skipping remote mobile runtime-status patch");
+    }
+  }
+
+  const hasNotificationQueue = patched.includes(REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER);
+  const hasPersistedHydrationGuard = patched.includes("Skipping hydration for non-persisted conversation");
+  if (!hasNotificationQueue || !hasPersistedHydrationGuard) {
+    const unknownTurnNeedle =
+      "if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){R.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),";
+    const hydrationV1Needle =
+      `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*/R.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r},sensitive:{}}),this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;t&&(this.upsertConversationFromThread(t),this.onNotification(\`turn/started\`,n.params))}).catch(e=>R.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}}));break}this.markConversationStreaming(r),`;
+    const hydrationQueuedUnsafeNeedle =
+      `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),R.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}}),this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch(e=>{this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}})});break}this.markConversationStreaming(r),`;
+    const hydrationRetryUnsafeNeedle =
+      `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),R.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});let s=(a=0)=>this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch(e=>{if(a<12){R.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:r,attempt:a+1},sensitive:{error:e}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}this.markConversationStreaming(r),`;
+    const unknownTurnRetryNeedle = [
+      `if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/`,
+      "let a=this.codexLinuxRemoteMobilePendingNotifications??=new Map,o=a.get(r);o||(o=[],a.set(r,o)),o.push(n),",
+      "R.warning(`Hydrating conversation for turn/started`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});",
+      "let s=(a=0)=>this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];",
+      "if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){",
+      "R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),",
+      "setTimeout(()=>s(a+1),250);return}",
+      "this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;",
+      "this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),",
+      "this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}",
+      "R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}",
+      "this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch(e=>{",
+      "if(a<12){R.warning(`Retrying hydration for turn/started`,{safe:{conversationId:r,attempt:a+1},sensitive:{error:e}}),setTimeout(()=>s(a+1),250);return}",
+      "this.codexLinuxRemoteMobilePendingNotifications?.delete(r),R.error(`Failed to hydrate conversation for turn/started`,{safe:{conversationId:r},sensitive:{error:e}})});s();break}",
+      "this.markConversationStreaming(r),",
+    ].join("");
+    const unknownTurnReplacement = unknownTurnRetryNeedle;
+    if (patched.includes(unknownTurnNeedle)) {
+      patched = patched.replace(unknownTurnNeedle, unknownTurnReplacement);
+    } else if (patched.includes(hydrationV1Needle)) {
+      patched = patched.replace(hydrationV1Needle, unknownTurnReplacement);
+    } else if (patched.includes(hydrationQueuedUnsafeNeedle)) {
+      patched = patched.replace(hydrationQueuedUnsafeNeedle, unknownTurnReplacement);
+    } else if (patched.includes(hydrationRetryUnsafeNeedle)) {
+      patched = patched.replace(hydrationRetryUnsafeNeedle, unknownTurnReplacement);
+    } else if (patched.includes(unknownTurnRetryNeedle)) {
+      // Already upgraded to retry hydration.
+    } else if (patched.includes("Received turn/started for unknown conversation")) {
+      console.warn("WARN: Could not find unknown turn/started needle - skipping remote mobile hydration patch");
+    }
+  }
+
+  if (!hasNotificationQueue) {
+    const itemStartedNeedle =
+      "if(!this.conversations.get(i)){R.error(`Received item/started for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.markConversationStreaming(i),";
+    const itemStartedReplacement =
+      "if(!this.conversations.get(i)){let a=this.codexLinuxRemoteMobilePendingNotifications?.get(i);if(a){a.push(n),R.warning(`Queueing item/started for hydrating conversation`,{safe:{conversationId:i,queuedNotificationCount:a.length},sensitive:{}});break}R.error(`Received item/started for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.markConversationStreaming(i),";
+    if (patched.includes(itemStartedNeedle)) {
+      patched = patched.replace(itemStartedNeedle, itemStartedReplacement);
+    } else if (patched.includes("Received item/started for unknown conversation")) {
+      console.warn("WARN: Could not find unknown item/started needle - skipping remote mobile item queue patch");
+    }
+
+    const itemCompletedNeedle =
+      "if(!this.conversations.get(i)){R.error(`Received item/completed for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.updateConversationState(i,t=>{";
+    const itemCompletedReplacement =
+      "if(!this.conversations.get(i)){let a=this.codexLinuxRemoteMobilePendingNotifications?.get(i);if(a){a.push(n),R.warning(`Queueing item/completed for hydrating conversation`,{safe:{conversationId:i,queuedNotificationCount:a.length},sensitive:{}});break}R.error(`Received item/completed for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.updateConversationState(i,t=>{";
+    if (patched.includes(itemCompletedNeedle)) {
+      patched = patched.replace(itemCompletedNeedle, itemCompletedReplacement);
+    } else if (patched.includes("Received item/completed for unknown conversation")) {
+      console.warn("WARN: Could not find unknown item/completed needle - skipping remote mobile item queue patch");
+    }
+
+    const turnCompletedNeedle =
+      "if(!this.conversations.get(r)){this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id),R.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}";
+    const turnCompletedReplacement =
+      "if(!this.conversations.get(r)){let i=this.codexLinuxRemoteMobilePendingNotifications?.get(r);if(i){i.push(n),R.warning(`Queueing turn/completed for hydrating conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});break}this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id),R.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}";
+    if (patched.includes(turnCompletedNeedle)) {
+      patched = patched.replace(turnCompletedNeedle, turnCompletedReplacement);
+    } else if (patched.includes("Received turn/completed for unknown conversation")) {
+      console.warn("WARN: Could not find unknown turn/completed needle - skipping remote mobile turn queue patch");
+    }
+  }
+
+  return patched;
+}
+
+function applyLinuxRemoteControlEnablementBridgePatch(source) {
+  const markerIndex = source.indexOf("[remote-connections/slingshot-gate-bridge]");
+  if (markerIndex < 0 || source.indexOf("set-remote-control-connections-enabled", markerIndex) < 0) {
+    return source;
+  }
+
+  let patched = source;
+  let region = patched.slice(markerIndex, markerIndex + 4_500);
+
+  if (!patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER)) {
+    const bridgePattern =
+      /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return \2\[0\]===\4\?/u;
+    const patchedRegion = region.replace(
+      bridgePattern,
+      (_needle, functionName, cacheVar, compilerVar, enabledVar, gateVar, callbackVar, depsVar) =>
+        `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(3),${enabledVar}=${gateVar}()||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return ${cacheVar}[0]===${enabledVar}?`,
+    );
+
+    if (patchedRegion === region) {
+      console.warn("WARN: Could not find remote-control enablement bridge needle - skipping Linux remote-control bridge patch");
+      return source;
+    }
+
+    patched = patched.slice(0, markerIndex) + patchedRegion + patched.slice(markerIndex + region.length);
+    region = patched.slice(markerIndex, markerIndex + 4_500);
+  }
+
+  if (patched.includes(REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER)) {
+    return patched;
+  }
+
+  const selfAutoConnectReplacement = (desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
+    `${desktopHostRequestFn}(\`set-remote-control-connections-enabled\`,{params:{enabled:${enabledVar}}}).then(async e=>{if(${enabledVar}&&typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){let t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null;if(t.length===0)try{let e=await ${desktopHostRequestFn}(\`refresh-remote-control-connections\`,{params:{}});t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=n??e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_refresh_failed\`,{safe:{},sensitive:{error:e}})}if(n==null)try{let e=await ${desktopHostRequestFn}(\`get-global-state\`,{params:{key:\`electron-local-remote-control-installation-id\`}});n=e?.value??e?.state?.value??e?.globalState?.[\`electron-local-remote-control-installation-id\`]??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_identity_failed\`,{safe:{},sensitive:{error:e}})}let r=t.filter(e=>typeof e?.hostId==\`string\`&&e.hostId.startsWith(\`remote-control:\`)),i=new Set(r.filter(e=>n!=null&&(e.installationId??e.installation_id)===n).map(e=>e.hostId));await Promise.all(r.map(e=>${desktopHostRequestFn}(\`set-remote-connection-auto-connect\`,{params:{hostId:e.hostId,autoConnect:i.has(e.hostId)}}).catch(t=>{${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_failed\`,{safe:{hostId:e.hostId,autoConnect:i.has(e.hostId)},sensitive:{error:t}})})))}}/*${REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER}*/).catch(${errorVar}=>{${loggerVar}.warning(\`\${${logPrefixVar}} sync_failed\`,{safe:{enabled:${enabledVar}},sensitive:{error:${errorVar}}})})`;
+
+  const previousAutoConnectCleanupPattern =
+    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.then\(async ([A-Za-z_$][\w$]*)=>\{[\s\S]*?\/\*codexLinuxRemoteControlAutoConnectCleanup\*\/\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{enabled:\2\},sensitive:\{error:\4\}\}\)\}\)/u;
+  const selfAutoConnectPattern =
+    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{enabled:\2\},sensitive:\{error:\3\}\}\)\}\)/u;
+  let selfAutoConnectRegion = region.replace(
+    previousAutoConnectCleanupPattern,
+    (_needle, desktopHostRequestFn, enabledVar, _resultVar, errorVar, loggerVar, logPrefixVar) =>
+      selfAutoConnectReplacement(desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar),
+  );
+  if (selfAutoConnectRegion === region) {
+    selfAutoConnectRegion = region.replace(
+      selfAutoConnectPattern,
+      (_needle, desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
+        selfAutoConnectReplacement(desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar),
+    );
+  }
+
+  if (selfAutoConnectRegion === region) {
+    console.warn("WARN: Could not find remote-control self auto-connect needle - skipping Linux remote-control auto-connect patch");
+    return patched;
+  }
+
+  return patched.slice(0, markerIndex) + selfAutoConnectRegion + patched.slice(markerIndex + region.length);
+}
+
+function applyLinuxRemoteMobileActiveStatusPatch(source) {
+  if (source.includes(REMOTE_MOBILE_ACTIVE_STATUS_MARKER)) {
+    return source;
+  }
+
+  const statusPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{latestTurnStatus:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),streamRole:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{return \4==null\?\3===`needs_resume`\?`needs-resume`:`read-only`:\4\.role===`follower`\?`follower`:\5\?\.type===`active`\|\|\2===`inProgress`\?`active`:`inactive`\}/u;
+  if (!statusPattern.test(source)) {
+    if (source.includes("threadRuntimeStatus") && source.includes("needs-resume")) {
+      console.warn("WARN: Could not find active-status renderer needle - skipping remote mobile active-status patch");
+    }
+    return source;
+  }
+
+  return source.replace(
+    statusPattern,
+    `function $1({latestTurnStatus:$2,resumeState:$3,streamRole:$4,threadRuntimeStatus:$5}){/*${REMOTE_MOBILE_ACTIVE_STATUS_MARKER}*/return $4?.role===\`follower\`?\`follower\`:$5?.type===\`active\`||$2===\`inProgress\`?\`active\`:$4==null?$3===\`needs_resume\`?\`needs-resume\`:\`read-only\`:\`inactive\`}`,
+  );
 }
 
 module.exports = [
@@ -547,15 +904,83 @@ module.exports = [
     skipDescription: "Linux remote-control copy patch",
     apply: applyLinuxRemoteControlCopyPatch,
   },
+  {
+    id: "linux-remote-control-settings-ux",
+    phase: "webview-asset",
+    pattern: /^remote-connections-settings-.*\.js$/,
+    order: 20_135,
+    ciPolicy: "optional",
+    missingDescription: "remote connections settings bundle",
+    skipDescription: "Linux remote-control settings UX patch",
+    apply: applyLinuxRemoteControlSettingsUxPatch,
+  },
+  {
+    id: "linux-remote-control-client-revoke-setup-reset",
+    phase: "webview-asset",
+    pattern: /^remote-connections-settings-.*\.js$/,
+    order: 20_138,
+    ciPolicy: "optional",
+    missingDescription: "remote connections settings bundle",
+    skipDescription: "Linux remote-control client revoke setup reset patch",
+    apply: applyLinuxRemoteControlClientRevokeSetupResetPatch,
+  },
+  {
+    id: "linux-remote-connections-refresh",
+    phase: "webview-asset",
+    pattern: /^remote-connections-settings-.*\.js$/,
+    order: 20_140,
+    ciPolicy: "optional",
+    missingDescription: "remote connections settings bundle",
+    skipDescription: "Linux remote-connections refresh patch",
+    apply: applyLinuxRemoteConnectionsRefreshPatch,
+  },
+  {
+    id: "linux-remote-mobile-conversation-hydration",
+    phase: "webview-asset",
+    pattern: /^app-server-manager-signals-.*\.js$/,
+    order: 20_150,
+    ciPolicy: "optional",
+    missingDescription: "app-server manager signals bundle",
+    skipDescription: "Linux remote-mobile conversation hydration patch",
+    apply: applyLinuxRemoteMobileConversationHydrationPatch,
+  },
+  {
+    id: "linux-remote-control-enablement-bridge",
+    phase: "webview-asset",
+    pattern: /^app-main-.*\.js$/,
+    order: 20_155,
+    ciPolicy: "optional",
+    missingDescription: "app main bundle",
+    skipDescription: "Linux remote-control enablement bridge patch",
+    apply: applyLinuxRemoteControlEnablementBridgePatch,
+  },
+  {
+    id: "linux-remote-mobile-active-status",
+    phase: "webview-asset",
+    pattern: /^app-main-.*\.js$/,
+    order: 20_160,
+    ciPolicy: "optional",
+    missingDescription: "app main bundle",
+    skipDescription: "Linux remote-mobile active status patch",
+    apply: applyLinuxRemoteMobileActiveStatusPatch,
+  },
 ];
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
+module.exports.applyLinuxRemoteMobileChromeBridgePatch = applyLinuxRemoteMobileChromeBridgePatch;
+module.exports.applyLinuxRemoteMobileConversationHydrationPatch = applyLinuxRemoteMobileConversationHydrationPatch;
+module.exports.applyLinuxRemoteControlEnablementBridgePatch = applyLinuxRemoteControlEnablementBridgePatch;
+module.exports.applyLinuxRemoteMobileActiveStatusPatch = applyLinuxRemoteMobileActiveStatusPatch;
 module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
 module.exports.applyLinuxRemoteControlClientAccountCompatibilityPatch =
   applyLinuxRemoteControlClientAccountCompatibilityPatch;
 module.exports.applyLinuxRemoteControlClientRevocationRecoveryPatch =
   applyLinuxRemoteControlClientRevocationRecoveryPatch;
+module.exports.applyLinuxRemoteControlClientRevokeSetupResetPatch =
+  applyLinuxRemoteControlClientRevokeSetupResetPatch;
 module.exports.applyLinuxRemoteControlLoadGatePatch = applyLinuxRemoteControlLoadGatePatch;
+module.exports.applyLinuxRemoteConnectionsRefreshPatch = applyLinuxRemoteConnectionsRefreshPatch;
 module.exports.applyLinuxRemoteControlFeatureSyncPatch = applyLinuxRemoteControlFeatureSyncPatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;
+module.exports.applyLinuxRemoteControlSettingsUxPatch = applyLinuxRemoteControlSettingsUxPatch;

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -23,6 +23,11 @@ const fs = require("node:fs");
 const [clientPath, patchModulePath] = process.argv.slice(2);
 const { applyLinuxRemoteMobileChromeBridgePatch } = require(patchModulePath);
 
+if (typeof applyLinuxRemoteMobileChromeBridgePatch !== "function") {
+  console.error("WARN: Remote mobile Chrome bridge patch export not found; skipping");
+  process.exit(0);
+}
+
 const source = fs.readFileSync(clientPath, "utf8");
 const patched = applyLinuxRemoteMobileChromeBridgePatch(source);
 if (patched !== source) {

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -1,8 +1,34 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
+client="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/chrome/scripts/browser-client.mjs"
+patch_module="$SCRIPT_DIR/linux-features/remote-mobile-control/patch.js"
 feature_marker_dir="$INSTALL_DIR/.codex-linux"
 feature_marker="$feature_marker_dir/remote-mobile-control-enabled"
+cold_start_hook_dir="$feature_marker_dir/cold-start.d"
+cold_start_hook="$cold_start_hook_dir/remote-mobile-control"
 
-mkdir -p "$feature_marker_dir"
+mkdir -p "$feature_marker_dir" "$cold_start_hook_dir"
 printf '%s\n' "remote-mobile-control" > "$feature_marker"
+install -m 0755 "$SCRIPT_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "$cold_start_hook"
+
+if [ ! -f "$client" ]; then
+    echo "WARN: Chrome browser-client.mjs not found; skipping remote-mobile Chrome bridge patch" >&2
+    exit 0
+fi
+
+node - "$client" "$patch_module" <<'NODE'
+const fs = require("node:fs");
+
+const [clientPath, patchModulePath] = process.argv.slice(2);
+const { applyLinuxRemoteMobileChromeBridgePatch } = require(patchModulePath);
+
+const source = fs.readFileSync(clientPath, "utf8");
+const patched = applyLinuxRemoteMobileChromeBridgePatch(source);
+if (patched !== source) {
+  fs.writeFileSync(clientPath, patched, "utf8");
+  console.error("Remote mobile Chrome bridge patch applied");
+} else if (patched.includes("codexLinuxRemoteMobileBrowserBackends")) {
+  console.error("Remote mobile Chrome bridge patch already applied");
+}
+NODE

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -euo pipefail
+
+feature_marker_dir="$INSTALL_DIR/.codex-linux"
+feature_marker="$feature_marker_dir/remote-mobile-control-enabled"
+
+mkdir -p "$feature_marker_dir"
+printf '%s\n' "remote-mobile-control" > "$feature_marker"

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -27,6 +27,7 @@ const {
   applyLinuxRemoteControlLoadGatePatch,
   applyLinuxRemoteControlEnablementBridgePatch,
   applyLinuxRemoteMobileActiveStatusPatch,
+  applyLinuxRemoteMobileAppServerRemoteControlPatch,
   applyLinuxRemoteMobileChromeBridgePatch,
   applyLinuxRemoteMobileConversationHydrationPatch,
   applyLinuxRemoteConnectionsRefreshPatch,
@@ -135,6 +136,13 @@ function syntheticSettingsRefreshBundle() {
   ].join("");
 }
 
+function syntheticAppServerLaunchBundle() {
+  return [
+    "function Pd(e){let t=e.hostConfig.codex_cli_command;if(t&&t.length>0){let[e,...n]=t;return!e||e.trim().length===0?null:{executablePath:e,args:n}}let n=Kd();if(n!=null)return{executablePath:n,args:[`app-server`,`--analytics-default-enabled`]};let r=Nd(e.repoRoot,{resourcesPath:e.resourcesPath});return r?{executablePath:r.executablePath,args:[`app-server`,`--analytics-default-enabled`],binDirectory:r.binDirectory}:null}",
+    "function Fd(e){let t=e.hostConfig.codex_cli_command;if(t&&t.length>0){let[e,...n]=t;if(!e||e.trim().length===0)return null;return{executablePath:e,args:n}}let n=Kd();if(n!=null)return{executablePath:n,args:[`app-server`,`--analytics-default-enabled`]};let r=Ud(e.repoRoot,{resourcesPath:e.resourcesPath,windowsCodexHome:e.windowsCodexHome});return r?{executablePath:r.executablePath,args:[`app-server`,`--analytics-default-enabled`],binDirectory:r.binDirectory}:null}",
+  ].join("");
+}
+
 function syntheticRevokeSetupResetBundle() {
   return [
     "function b(e,t){e.events.push(t)}",
@@ -236,6 +244,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-control-preserve-config",
       "feature:remote-mobile-control:linux-remote-control-client-account-compatibility",
       "feature:remote-mobile-control:linux-remote-control-client-revocation-recovery",
+      "feature:remote-mobile-control:linux-remote-mobile-app-server-remote-control",
       "feature:remote-mobile-control:linux-remote-control-load-gate",
       "feature:remote-mobile-control:linux-remote-control-feature-sync",
       "feature:remote-mobile-control:linux-remote-control-visibility",
@@ -252,6 +261,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "main-bundle",
       "main-bundle",
       "main-bundle",
+      "extracted-app",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -326,6 +336,21 @@ test("Linux remote-control client recovery handles bare missing key material err
   const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
 
   assert.match(patched, /e\.message===`Remote-control client key material missing`/);
+});
+
+test("Linux remote mobile app-server launch enables remote control on the Desktop app-server", () => {
+  const source = syntheticAppServerLaunchBundle();
+  const patched = applyLinuxRemoteMobileAppServerRemoteControlPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileAppServerArgs/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`\?\[`app-server`,`--remote-control`,`--analytics-default-enabled`\]:\[`app-server`,`--analytics-default-enabled`\]/,
+  );
+  assert.doesNotMatch(patched, /args:\[`app-server`,`--analytics-default-enabled`\]/);
+  assert.match(patched, /args:codexLinuxRemoteMobileAppServerArgs\(\)/);
+  assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
 });
 
 test("Linux remote-control client revoke clears setup completion after last client is removed", () => {
@@ -821,6 +846,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.mkdirSync(buildDir, { recursive: true });
         fs.mkdirSync(assetsDir, { recursive: true });
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
+        fs.writeFileSync(path.join(buildDir, "workspace-root-drop-handler-test.js"), syntheticAppServerLaunchBundle());
         fs.writeFileSync(
           path.join(assetsDir, "remote-connection-visibility-test.js"),
           syntheticRemoteConnectionVisibilityBundle(),
@@ -859,6 +885,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         patchExtractedApp(tempApp, { report });
 
         const patchedFile = fs.readFileSync(path.join(buildDir, "main.js"), "utf8");
+        const patchedAppServerLaunchFile = fs.readFileSync(
+          path.join(buildDir, "workspace-root-drop-handler-test.js"),
+          "utf8",
+        );
         const patchedVisibilityFile = fs.readFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           "utf8",
@@ -889,6 +919,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
+        assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
+        assert.match(patchedAppServerLaunchFile, /`--remote-control`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
         assert.match(patchedAppMainFile, /`remote_control`/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
@@ -920,6 +952,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-preserve-config" &&
             patch.status === "already-applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-app-server-remote-control" &&
+            patch.status === "applied",
           ),
         );
         assert.ok(

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -22,6 +22,7 @@ const {
   applyLinuxRemoteControlClientRevocationRecoveryPatch,
   applyLinuxRemoteControlCopyPatch,
   applyLinuxRemoteControlPreserveConfigPatch,
+  applyLinuxRemoteControlFeatureSyncPatch,
   applyLinuxRemoteControlLoadGatePatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
@@ -67,6 +68,15 @@ function syntheticRecoverableErrorPredicateBundle() {
 
 function syntheticRemoteConnectionVisibilityBundle() {
   return "function d(){return true}function f(){return c(`1042620455`)}function p(){return []}export{d as n,f as r,p as t};";
+}
+
+function syntheticAppMainFeatureSyncBundle() {
+  return [
+    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`];",
+    "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
+    "return e[0]!==r?(a=()=>{let r=qF(n);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r}).catch(n=>{q.error(`Failed to sync experimental feature enablement`,{sensitive:{error:n}})})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
+    "function qF(e){let t={};for(let n of GF){let r=e[n];r!=null&&(t[n]=r)}return t}",
+  ].join("");
 }
 
 function syntheticCurrentVisibilityBundle() {
@@ -139,6 +149,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-control-client-account-compatibility",
       "feature:remote-mobile-control:linux-remote-control-client-revocation-recovery",
       "feature:remote-mobile-control:linux-remote-control-load-gate",
+      "feature:remote-mobile-control:linux-remote-control-feature-sync",
       "feature:remote-mobile-control:linux-remote-control-visibility",
       "feature:remote-mobile-control:linux-remote-control-copy",
     ]);
@@ -147,6 +158,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "main-bundle",
       "main-bundle",
       "main-bundle",
+      "webview-asset",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -225,6 +237,16 @@ test("Linux remote-control load gate enables remote-control environment loading"
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
   assert.match(patched, /return codexLinuxRemoteControlLoadGateEnabled\(\)\|\|c\(`1042620455`\)/);
   assert.equal(applyLinuxRemoteControlLoadGatePatch(patched), patched);
+});
+
+test("Linux remote-control feature sync includes remote_control", () => {
+  const source = syntheticAppMainFeatureSyncBundle();
+  const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /`tool_suggest`,`remote_control`\]/);
+  assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled/);
+  assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
 });
 
 test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
@@ -354,6 +376,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticRemoteConnectionVisibilityBundle(),
         );
         fs.writeFileSync(
+          path.join(assetsDir, "app-main-test.js"),
+          syntheticAppMainFeatureSyncBundle(),
+        );
+        fs.writeFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           syntheticVisibilityBundle(),
         );
@@ -382,6 +408,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "remote-connection-visibility-test.js"),
           "utf8",
         );
+        const patchedAppMainFile = fs.readFileSync(
+          path.join(assetsDir, "app-main-test.js"),
+          "utf8",
+        );
         const patchedRemoteConnectionsSettingsFile = fs.readFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
           "utf8",
@@ -397,6 +427,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
+        assert.match(patchedAppMainFile, /`remote_control`/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
         assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
         assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
@@ -423,6 +454,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-load-gate" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-feature-sync" &&
             patch.status === "applied",
           ),
         );

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -522,10 +522,14 @@ test("Linux remote-connections refresh patch shortens polling and refreshes on r
   assert.match(patched, /Qn=5e3/);
   assert.doesNotMatch(patched, /Qn=15e3/);
   assert.match(patched, /codexLinuxRemoteConnectionsRefreshNow/);
+  assert.match(patched, /codexLinuxRemoteConnectionsRefreshTimer=null/);
+  assert.match(patched, /codexLinuxRemoteConnectionsRefreshLast=0/);
+  assert.match(patched, /e-codexLinuxRemoteConnectionsRefreshLast<1e3/);
   assert.match(patched, /document\.addEventListener\(`visibilitychange`,codexLinuxRemoteConnectionsRefreshNow\)/);
   assert.match(patched, /window\.addEventListener\(`focus`,codexLinuxRemoteConnectionsRefreshNow\)/);
   assert.match(patched, /window\.addEventListener\(`online`,codexLinuxRemoteConnectionsRefreshNow\)/);
   assert.match(patched, /window\.addEventListener\(`resume`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /window\.clearTimeout\(codexLinuxRemoteConnectionsRefreshTimer\)/);
   assert.match(patched, /document\.removeEventListener\(`visibilitychange`,codexLinuxRemoteConnectionsRefreshNow\)/);
   assert.match(patched, /window\.removeEventListener\(`resume`,codexLinuxRemoteConnectionsRefreshNow\)/);
   assert.equal(applyLinuxRemoteConnectionsRefreshPatch(patched), patched);

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -591,12 +591,12 @@ test("Linux remote mobile conversation hydration patch handles stale refresh and
   assert.match(patched, /codexLinuxRemoteMobileNotificationQueue/);
   assert.match(patched, /codexLinuxRemoteMobilePendingNotifications\?\?=new Map/);
   assert.match(patched, /this\.readThread\(r,\{includeTurns:!1\}\)/);
-  assert.doesNotMatch(patched, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
-  assert.match(patched, /if\(!t\)\{if\(a<12\)/);
-  assert.match(patched, /Retrying hydration for missing conversation/);
+  assert.match(patched, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(patched, /if\(!\(typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)\)\)\{if\(a<12\)/);
+  assert.match(patched, /Retrying hydration for non-persisted conversation/);
   assert.match(patched, /queuedNotificationCount:i\.length,attempt:a\+1/);
   assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
-  assert.match(patched, /Skipping hydration for missing conversation/);
+  assert.match(patched, /Skipping hydration for non-persisted conversation/);
   assert.match(patched, /releaseBrowserUseTurnRoute\(r,t\.id\)/);
   assert.match(patched, /for\(let e of i\)this\.onNotification\(e\.method,e\.params\)/);
   assert.match(patched, /Queueing item\/started for hydrating conversation/);
@@ -610,7 +610,7 @@ test("Linux remote mobile conversation hydration patch retries transient thread 
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
 
   assert.match(patched, /Retrying hydration for turn\/started/);
-  assert.match(patched, /Retrying hydration for missing conversation/);
+  assert.match(patched, /Retrying hydration for non-persisted conversation/);
   assert.match(patched, /if\(a<12\)/);
   assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
   assert.match(patched, /Failed to hydrate conversation for turn\/started/);
@@ -620,7 +620,7 @@ test("Linux remote mobile conversation hydration patch upgrades unsafe queued hy
   const source = syntheticAppServerManagerSignalsBundle();
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
   const safeRead =
-    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!t){if(a<12){R.warning(`Retrying hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
   const unsafeRead =
     "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch";
   const unsafeQueued = patched.replace(safeRead, unsafeRead);
@@ -630,28 +630,25 @@ test("Linux remote mobile conversation hydration patch upgrades unsafe queued hy
   const upgraded = applyLinuxRemoteMobileConversationHydrationPatch(unsafeQueued);
 
   assert.match(upgraded, /codexLinuxRemoteMobileNotificationQueue/);
-  assert.match(upgraded, /Retrying hydration for missing conversation/);
-  assert.match(upgraded, /Skipping hydration for missing conversation/);
-  assert.doesNotMatch(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(upgraded, /Retrying hydration for non-persisted conversation/);
+  assert.match(upgraded, /Skipping hydration for non-persisted conversation/);
+  assert.match(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
   assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
 });
 
 test("Linux remote mobile conversation hydration patch upgrades local-path guarded hydration", () => {
   const source = syntheticAppServerManagerSignalsBundle();
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
-  const cloudBackedRead =
-    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!t){if(a<12){R.warning(`Retrying hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
   const localPathGuardedRead =
     "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
-  const oldGuarded = patched.replace(cloudBackedRead, localPathGuardedRead);
+  const oldGuarded = patched.replace(localPathGuardedRead, localPathGuardedRead);
 
-  assert.notEqual(oldGuarded, patched);
+  assert.equal(oldGuarded, patched);
   assert.match(oldGuarded, /Skipping hydration for non-persisted conversation/);
   const upgraded = applyLinuxRemoteMobileConversationHydrationPatch(oldGuarded);
 
-  assert.doesNotMatch(upgraded, /Skipping hydration for non-persisted conversation/);
-  assert.doesNotMatch(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
-  assert.match(upgraded, /Skipping hydration for missing conversation/);
+  assert.match(upgraded, /Skipping hydration for non-persisted conversation/);
+  assert.match(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
   assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
 });
 

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -562,11 +562,12 @@ test("Linux remote mobile conversation hydration patch handles stale refresh and
   assert.match(patched, /codexLinuxRemoteMobileNotificationQueue/);
   assert.match(patched, /codexLinuxRemoteMobilePendingNotifications\?\?=new Map/);
   assert.match(patched, /this\.readThread\(r,\{includeTurns:!1\}\)/);
-  assert.match(patched, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
-  assert.match(patched, /Retrying hydration for non-persisted conversation/);
+  assert.doesNotMatch(patched, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(patched, /if\(!t\)\{if\(a<12\)/);
+  assert.match(patched, /Retrying hydration for missing conversation/);
   assert.match(patched, /queuedNotificationCount:i\.length,attempt:a\+1/);
   assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
-  assert.match(patched, /Skipping hydration for non-persisted conversation/);
+  assert.match(patched, /Skipping hydration for missing conversation/);
   assert.match(patched, /releaseBrowserUseTurnRoute\(r,t\.id\)/);
   assert.match(patched, /for\(let e of i\)this\.onNotification\(e\.method,e\.params\)/);
   assert.match(patched, /Queueing item\/started for hydrating conversation/);
@@ -580,7 +581,7 @@ test("Linux remote mobile conversation hydration patch retries transient thread 
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
 
   assert.match(patched, /Retrying hydration for turn\/started/);
-  assert.match(patched, /Retrying hydration for non-persisted conversation/);
+  assert.match(patched, /Retrying hydration for missing conversation/);
   assert.match(patched, /if\(a<12\)/);
   assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
   assert.match(patched, /Failed to hydrate conversation for turn\/started/);
@@ -590,19 +591,38 @@ test("Linux remote mobile conversation hydration patch upgrades unsafe queued hy
   const source = syntheticAppServerManagerSignalsBundle();
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
   const safeRead =
-    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!t){if(a<12){R.warning(`Retrying hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
   const unsafeRead =
     "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch";
   const unsafeQueued = patched.replace(safeRead, unsafeRead);
 
   assert.notEqual(unsafeQueued, patched);
-  assert.doesNotMatch(unsafeQueued, /Skipping hydration for non-persisted conversation/);
+  assert.doesNotMatch(unsafeQueued, /Skipping hydration for missing conversation/);
   const upgraded = applyLinuxRemoteMobileConversationHydrationPatch(unsafeQueued);
 
   assert.match(upgraded, /codexLinuxRemoteMobileNotificationQueue/);
-  assert.match(upgraded, /Retrying hydration for non-persisted conversation/);
-  assert.match(upgraded, /Skipping hydration for non-persisted conversation/);
-  assert.match(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(upgraded, /Retrying hydration for missing conversation/);
+  assert.match(upgraded, /Skipping hydration for missing conversation/);
+  assert.doesNotMatch(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
+});
+
+test("Linux remote mobile conversation hydration patch upgrades local-path guarded hydration", () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+  const cloudBackedRead =
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!t){if(a<12){R.warning(`Retrying hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for missing conversation`,{safe:{conversationId:r,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
+  const localPathGuardedRead =
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
+  const oldGuarded = patched.replace(cloudBackedRead, localPathGuardedRead);
+
+  assert.notEqual(oldGuarded, patched);
+  assert.match(oldGuarded, /Skipping hydration for non-persisted conversation/);
+  const upgraded = applyLinuxRemoteMobileConversationHydrationPatch(oldGuarded);
+
+  assert.doesNotMatch(upgraded, /Skipping hydration for non-persisted conversation/);
+  assert.doesNotMatch(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(upgraded, /Skipping hydration for missing conversation/);
   assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
 });
 

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -19,11 +19,18 @@ const {
 const {
   applyLinuxRemoteControlDeviceKeyPatch,
   applyLinuxRemoteControlClientAccountCompatibilityPatch,
+  applyLinuxRemoteControlClientRevokeSetupResetPatch,
   applyLinuxRemoteControlClientRevocationRecoveryPatch,
   applyLinuxRemoteControlCopyPatch,
   applyLinuxRemoteControlPreserveConfigPatch,
   applyLinuxRemoteControlFeatureSyncPatch,
   applyLinuxRemoteControlLoadGatePatch,
+  applyLinuxRemoteControlEnablementBridgePatch,
+  applyLinuxRemoteMobileActiveStatusPatch,
+  applyLinuxRemoteMobileChromeBridgePatch,
+  applyLinuxRemoteMobileConversationHydrationPatch,
+  applyLinuxRemoteConnectionsRefreshPatch,
+  applyLinuxRemoteControlSettingsUxPatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
 
@@ -108,6 +115,76 @@ function syntheticMobileSetupFlowCopyBundle() {
   ].join("");
 }
 
+function syntheticSettingsBundle() {
+  return [
+    "const o=`linux`,Q={jsx(){},jsxs(){}};",
+    "tabs:[{key:`control-this-mac`,name:o===`windows`?(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac.windows`,defaultMessage:`Control this PC`,description:`Tab label for settings that let other devices control this Windows device`}):(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`})},{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
+    "tabs:[{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
+    "const a=`Control this Mac from your phone or other device`,b=`Add device to control this Mac remotely`,c=`Devices that can control this Mac`,d=`Keep Mac awake`,e=`Allow this Mac to be discovered and controlled`,f=`Control other devices from this Mac`,g=`Authorize this Mac to control other devices signed in to your ChatGPT account`,h=`Devices you can control from this Mac`;",
+    "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
+    "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}",
+  ].join("");
+}
+
+function syntheticSettingsRefreshBundle() {
+  return [
+    "var Qn=15e3,Z=React;",
+    "function tr(){let $=useEffectEvent(async e=>{await P(`refresh-remote-connections`,{signal:e})});",
+    "(0,Z.useEffect)(()=>{let e=null,t=!1,n=async()=>{if(!t){t=!0,e=new AbortController;try{await $(e.signal)}finally{e=null,t=!1}}},r=window.setInterval(()=>{n()},Qn);return()=>{e?.abort(),window.clearInterval(r)}},[]);",
+    "return null}",
+  ].join("");
+}
+
+function syntheticRevokeSetupResetBundle() {
+  return [
+    "function b(e,t){e.events.push(t)}",
+    "let J={},t={ADDED_REMOTE_CONTROL_ENV_IDS:`added-remote-control-env-ids`},e={},ye=[];",
+    "function ie(e,t,n){e.globalState[t]=n}",
+    "function ee(e){return e}",
+    "var vt=`remote-control-client-revoke-success`,yt=`remote-control-client-revoke-error`;",
+    "function Ct(){let i={events:[],globalState:{\"codex-mobile-has-connected-device\":!0},get(){return{success(){}}},query:{snapshot(){return{data:[],setData(e){this.data=e(this.data)},invalidate(){this.invalidated=!0}}}}},v=i.query.snapshot(tt),y;",
+    "y=(e,t)=>{let{clientId:n}=t;b(i,{eventName:`codex_remote_control_client_revoke_result`,metadata:{result:`succeeded`}}),v.setData(e=>e?.filter(e=>e.client_id!==n)),v.invalidate(),i.get(J).success(`Revoked device access`,{id:vt})};",
+    "return{handler:y,query:v,store:i}}",
+    "var Ue=ee({mutationFn:n=>ie(e,t.ADDED_REMOTE_CONTROL_ENV_IDS,[...ye,...n])}),tt={};",
+  ].join("");
+}
+
+function syntheticChromeBrowserClientBundle() {
+  return [
+    "var tE=\"x-codex-browser-use-available-backends\",X6=[\"chrome\",\"iab\",\"cdp\"];",
+    "function rE(t){return X6.some(e=>e===t)}",
+    "function Cm(){let t=import.meta.__codexNativePipeUnavailableMessage;return typeof t==\"string\"&&t.length>0?t:\"privileged native pipe bridge is not available; browser-client is not trusted\"}",
+    "function yC(){let t=globalThis.nodeRepl?.requestMeta?.[tE];return t==null?null:Array.isArray(t)?t.filter(rE):[]}",
+  ].join("");
+}
+
+function syntheticAppServerManagerSignalsBundle() {
+  return [
+    "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let p=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=p)});return}}",
+    "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`turn/started`:{let{threadId:e,turn:t}=n.params,r=j(e),i=this.conversations.get(r);if(this.captureBrowserUseTurnRoute(r,t.id),this.captureComputerUseTurnRoute(r,t.id),!i){R.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),this.updateConversationState(r,e=>{});break}case`turn/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`turn/completed`,n.params)}))break;let{threadId:e,turn:t}=n.params,r=j(e);if(!this.conversations.get(r)){this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id),R.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}break}case`item/started`:{let{item:e,threadId:t,turnId:r}=n.params,i=j(t);if(!this.conversations.get(i)){R.error(`Received item/started for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.markConversationStreaming(i),this.updateConversationState(i,t=>{});break}case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;let{item:e,threadId:t,turnId:r}=n.params,i=j(t);if(!this.conversations.get(i)){R.error(`Received item/completed for unknown conversation`,{safe:{conversationId:i},sensitive:{}});break}this.updateConversationState(i,t=>{});break}}}}",
+  ].join("");
+}
+
+function syntheticAppMainActiveStatusBundle() {
+  return [
+    "function pS({latestTurnStatus:e,resumeState:t,streamRole:n,threadRuntimeStatus:r}){return n==null?t===`needs_resume`?`needs-resume`:`read-only`:n.role===`follower`?`follower`:r?.type===`active`||e===`inProgress`?`active`:`inactive`}",
+  ].join("");
+}
+
+function syntheticAppMainEnablementBridgeBundle() {
+  return [
+    "var DF=`[remote-connections/slingshot-gate-bridge]`;",
+    "function OF(){let e=(0,Z.c)(3),t=sc(),n,r;return e[0]===t?(n=e[1],r=e[2]):(n=()=>{$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})},r=[t],e[0]=t,e[1]=n,e[2]=r),(0,Q.useEffect)(n,r),null}",
+  ].join("");
+}
+
+function syntheticSelectedTabBundle() {
+  return [
+    "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
+    "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}",
+  ].join("");
+}
+
 function withTempFeatureRoot(enabled, fn) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-feature-test-"));
   try {
@@ -134,6 +211,17 @@ function withFeatureRootEnv(root, fn) {
   }
 }
 
+function captureWarnings(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    return { result: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 test("remote mobile control feature stays disabled until listed in features.json", () => {
   withTempFeatureRoot([], (root) => {
     assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
@@ -152,12 +240,24 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-control-feature-sync",
       "feature:remote-mobile-control:linux-remote-control-visibility",
       "feature:remote-mobile-control:linux-remote-control-copy",
+      "feature:remote-mobile-control:linux-remote-control-settings-ux",
+      "feature:remote-mobile-control:linux-remote-control-client-revoke-setup-reset",
+      "feature:remote-mobile-control:linux-remote-connections-refresh",
+      "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
+      "feature:remote-mobile-control:linux-remote-control-enablement-bridge",
+      "feature:remote-mobile-control:linux-remote-mobile-active-status",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
       "main-bundle",
       "main-bundle",
       "main-bundle",
+      "webview-asset",
+      "webview-asset",
+      "webview-asset",
+      "webview-asset",
+      "webview-asset",
+      "webview-asset",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -226,6 +326,40 @@ test("Linux remote-control client recovery handles bare missing key material err
   const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
 
   assert.match(patched, /e\.message===`Remote-control client key material missing`/);
+});
+
+test("Linux remote-control client revoke clears setup completion after last client is removed", () => {
+  const source = syntheticRevokeSetupResetBundle();
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlResetMobileSetupAfterRevoke/);
+  assert.match(patched, /codex-mobile-has-connected-device/);
+  assert.equal(applyLinuxRemoteControlClientRevokeSetupResetPatch(patched), patched);
+
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=Ct();`, context);
+  const { handler, query, store } = context.module.exports;
+  query.data = [{ client_id: "phone_1" }];
+
+  handler(null, { clientId: "phone_1" });
+
+  assert.deepEqual(query.data, []);
+  assert.equal(store.globalState["codex-mobile-has-connected-device"], false);
+  assert.equal(query.invalidated, true);
+});
+
+test("Linux remote-control client revoke keeps setup completion while other clients remain", () => {
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticRevokeSetupResetBundle());
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=Ct();`, context);
+  const { handler, query, store } = context.module.exports;
+  query.data = [{ client_id: "phone_1" }, { client_id: "tablet_1" }];
+
+  handler(null, { clientId: "phone_1" });
+
+  assert.deepEqual(query.data, [{ client_id: "tablet_1" }]);
+  assert.equal(store.globalState["codex-mobile-has-connected-device"], true);
 });
 
 test("Linux remote-control load gate enables remote-control environment loading", () => {
@@ -307,6 +441,302 @@ test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
   assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
+test("Linux remote-control settings UX patch hides unsupported outbound tab and removes Mac copy", () => {
+  const source = syntheticSettingsBundle();
+  const patched = applyLinuxRemoteControlSettingsUxPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlSettingsTabs/);
+  assert.match(patched, /e\.filter\(e=>e\.key!==`access-other-devices`\)/);
+  assert.match(patched, /if\(e===`access-other-devices`\)return t\?`control-this-mac`:`ssh`/);
+  assert.match(patched, /Control this Linux desktop/);
+  assert.match(patched, /Control this Linux desktop from your phone or other device/);
+  assert.match(patched, /Add device to control this Linux desktop remotely/);
+  assert.match(patched, /Devices that can control this Linux desktop/);
+  assert.match(patched, /Keep Linux desktop awake/);
+  assert.match(patched, /Allow this Linux desktop to be discovered and controlled/);
+  assert.doesNotMatch(patched, /Control this Mac/);
+  assert.doesNotMatch(patched, /this Mac/);
+  assert.equal(applyLinuxRemoteControlSettingsUxPatch(patched), patched);
+});
+
+test("Linux remote-control selected-tab fallback avoids outbound control on Linux", () => {
+  const patched = applyLinuxRemoteControlSettingsUxPatch(syntheticSelectedTabBundle());
+  const context = {
+    navigator: { userAgent: "Linux x86_64" },
+    module: { exports: {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=rr;`, context);
+  const resolveTab = context.module.exports;
+
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "access-other-devices",
+      showControlThisMacTab: true,
+      showRemoteControlConnectionsSection: true,
+      showTabbedSshPage: true,
+    }),
+    "control-this-mac",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "access-other-devices",
+      showControlThisMacTab: false,
+      showRemoteControlConnectionsSection: true,
+      showTabbedSshPage: true,
+    }),
+    "ssh",
+  );
+});
+
+test("Linux remote-connections refresh patch shortens polling and refreshes on resume signals", () => {
+  const source = syntheticSettingsRefreshBundle();
+  const patched = applyLinuxRemoteConnectionsRefreshPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /Qn=5e3/);
+  assert.doesNotMatch(patched, /Qn=15e3/);
+  assert.match(patched, /codexLinuxRemoteConnectionsRefreshNow/);
+  assert.match(patched, /document\.addEventListener\(`visibilitychange`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /window\.addEventListener\(`focus`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /window\.addEventListener\(`online`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /window\.addEventListener\(`resume`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /document\.removeEventListener\(`visibilitychange`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.match(patched, /window\.removeEventListener\(`resume`,codexLinuxRemoteConnectionsRefreshNow\)/);
+  assert.equal(applyLinuxRemoteConnectionsRefreshPatch(patched), patched);
+});
+
+test("Linux remote-connections refresh patch warns when upstream refresh needles drift", () => {
+  const source = "const marker=`refresh-remote-connections`;window.setInterval(()=>marker,15e3);";
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteConnectionsRefreshPatch(source));
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("refresh interval constant")));
+  assert.ok(warnings.some((warning) => warning.includes("auto-refresh effect")));
+});
+
+test("Linux remote mobile Chrome bridge patch preserves Chrome when request metadata narrows browser backends", () => {
+  const source = syntheticChromeBrowserClientBundle();
+  const patched = applyLinuxRemoteMobileChromeBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileBrowserBackends/);
+  assert.match(patched, /codexLinuxRemoteMobileBrowserBridgeDiagnostic/);
+  assert.match(patched, /Chrome bridge was not exposed to this remote\/mobile session/);
+  assert.equal(applyLinuxRemoteMobileChromeBridgePatch(patched), patched);
+
+  const context = {
+    globalThis: {
+      nodeRepl: {
+        requestMeta: {
+          "x-codex-browser-use-available-backends": ["iab"],
+        },
+      },
+    },
+    module: { exports: {} },
+    process: { platform: "linux" },
+  };
+  context.globalThis.globalThis = context.globalThis;
+  const nativePipeIndex = patched.indexOf("function codexLinuxRemoteMobileBrowserBridgeDiagnostic");
+  const browserBackendsOnly = patched.slice(0, nativePipeIndex) + patched.slice(patched.indexOf("function yC"));
+  vm.runInNewContext(`${browserBackendsOnly};module.exports=yC;`, context);
+  assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
+});
+
+test("Linux remote mobile Chrome bridge patch warns when browser-client needles drift", () => {
+  const source = "var tE=\"x-codex-browser-use-available-backends\";function yC(){return null}";
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteMobileChromeBridgePatch(source));
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("backend allowlist needles")));
+});
+
+test("Linux remote mobile conversation hydration patch handles stale refresh and unknown turn starts", () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileThreadRuntimeStatus/);
+  assert.match(patched, /p\?\.type===`active`\|\|p\?\.type===`idle`/);
+  assert.match(patched, /codexLinuxRemoteMobileHydrateUnknownTurn/);
+  assert.match(patched, /codexLinuxRemoteMobileNotificationQueue/);
+  assert.match(patched, /codexLinuxRemoteMobilePendingNotifications\?\?=new Map/);
+  assert.match(patched, /this\.readThread\(r,\{includeTurns:!1\}\)/);
+  assert.match(patched, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.match(patched, /Retrying hydration for non-persisted conversation/);
+  assert.match(patched, /queuedNotificationCount:i\.length,attempt:a\+1/);
+  assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
+  assert.match(patched, /Skipping hydration for non-persisted conversation/);
+  assert.match(patched, /releaseBrowserUseTurnRoute\(r,t\.id\)/);
+  assert.match(patched, /for\(let e of i\)this\.onNotification\(e\.method,e\.params\)/);
+  assert.match(patched, /Queueing item\/started for hydrating conversation/);
+  assert.match(patched, /Queueing item\/completed for hydrating conversation/);
+  assert.match(patched, /Queueing turn\/completed for hydrating conversation/);
+  assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(patched), patched);
+});
+
+test("Linux remote mobile conversation hydration patch retries transient thread reads", () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+
+  assert.match(patched, /Retrying hydration for turn\/started/);
+  assert.match(patched, /Retrying hydration for non-persisted conversation/);
+  assert.match(patched, /if\(a<12\)/);
+  assert.match(patched, /setTimeout\(\(\)=>s\(a\+1\),250\)/);
+  assert.match(patched, /Failed to hydrate conversation for turn\/started/);
+});
+
+test("Linux remote mobile conversation hydration patch upgrades unsafe queued hydration", () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+  const safeRead =
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,i=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!(typeof t?.path==`string`&&t.path.endsWith(`.jsonl`))){if(a<12){R.warning(`Retrying hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length,attempt:a+1},sensitive:{}}),setTimeout(()=>s(a+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)if(e.method===`turn/completed`){let{turn:t}=e.params;this.browserUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseBrowserUseTurnRoute(r,t.id),this.computerUseTurnRouteIdsByConversationId.get(r)?.has(t.id)===!0&&this.releaseComputerUseTurnRoute(r,t.id)}R.warning(`Skipping hydration for non-persisted conversation`,{safe:{conversationId:r,path:t?.path??null,queuedNotificationCount:i.length},sensitive:{}});return}this.upsertConversationFromThread(t);this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of i)this.onNotification(e.method,e.params)}).catch";
+  const unsafeRead =
+    "this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e;if(t){this.upsertConversationFromThread(t);let e=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let t of e)this.onNotification(t.method,t.params)}}).catch";
+  const unsafeQueued = patched.replace(safeRead, unsafeRead);
+
+  assert.notEqual(unsafeQueued, patched);
+  assert.doesNotMatch(unsafeQueued, /Skipping hydration for non-persisted conversation/);
+  const upgraded = applyLinuxRemoteMobileConversationHydrationPatch(unsafeQueued);
+
+  assert.match(upgraded, /codexLinuxRemoteMobileNotificationQueue/);
+  assert.match(upgraded, /Retrying hydration for non-persisted conversation/);
+  assert.match(upgraded, /Skipping hydration for non-persisted conversation/);
+  assert.match(upgraded, /typeof t\?\.path==`string`&&t\.path\.endsWith\(`\.jsonl`\)/);
+  assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
+});
+
+test("Linux remote mobile active-status patch treats active thread status as active without stream role", () => {
+  const source = syntheticAppMainActiveStatusBundle();
+  const patched = applyLinuxRemoteMobileActiveStatusPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileActiveStatus/);
+  assert.equal(applyLinuxRemoteMobileActiveStatusPatch(patched), patched);
+
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=pS;`, context);
+  const status = context.module.exports;
+
+  assert.equal(
+    status({
+      latestTurnStatus: "completed",
+      resumeState: "needs_resume",
+      streamRole: null,
+      threadRuntimeStatus: { type: "active" },
+    }),
+    "active",
+  );
+  assert.equal(
+    status({
+      latestTurnStatus: "completed",
+      resumeState: "needs_resume",
+      streamRole: null,
+      threadRuntimeStatus: { type: "notLoaded" },
+    }),
+    "needs-resume",
+  );
+  assert.equal(
+    status({
+      latestTurnStatus: "completed",
+      resumeState: "resumed",
+      streamRole: { role: "follower" },
+      threadRuntimeStatus: { type: "active" },
+    }),
+    "follower",
+  );
+});
+
+test("Linux remote-control enablement bridge loads remote-control clients on Linux", async () => {
+  const source = syntheticAppMainEnablementBridgeBundle();
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlEnablementBridge/);
+  assert.equal(applyLinuxRemoteControlEnablementBridgePatch(patched), patched);
+
+  const calls = [];
+  const context = {
+    DF: "[remote-connections/slingshot-gate-bridge]",
+    navigator: { userAgent: "X11; Linux x86_64" },
+    q: { warning() {} },
+    Q: { useEffect(callback) { callback(); } },
+    sc: () => false,
+    Z: { c: () => [] },
+    $o: (method, { params }) => {
+      calls.push({ method, params });
+      return Promise.resolve();
+    },
+  };
+  vm.runInNewContext(`${patched};OF();`, context);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "set-remote-control-connections-enabled");
+  assert.equal(calls[0].params.enabled, true);
+});
+
+test("Linux remote-control enablement bridge migrates old auto-connect cleanup patch", () => {
+  const source = syntheticAppMainEnablementBridgeBundle().replace(
+    "$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})",
+    "$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).then(async e=>{if(t&&typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)){await Promise.resolve(e)}}/*codexLinuxRemoteControlAutoConnectCleanup*/).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})",
+  );
+
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
+
+  assert.match(patched, /codexLinuxRemoteControlSelfAutoConnect/);
+  assert.match(patched, /electron-local-remote-control-installation-id/);
+  assert.doesNotMatch(patched, /codexLinuxRemoteControlAutoConnectCleanup/);
+});
+
+test("Linux remote-control enablement bridge auto-connects only this Desktop host", async () => {
+  const source = syntheticAppMainEnablementBridgeBundle();
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
+
+  const calls = [];
+  const context = {
+    DF: "[remote-connections/slingshot-gate-bridge]",
+    navigator: { userAgent: "X11; Linux x86_64" },
+    Promise,
+    q: { warning() {} },
+    Q: {
+      useEffect(callback) {
+        callback();
+      },
+    },
+    sc: () => false,
+    Z: { c: () => [] },
+    $o: (method, { params }) => {
+      calls.push({ method, params });
+      if (method === "set-remote-control-connections-enabled") {
+        return Promise.resolve({
+          remoteControlConnections: [
+            { hostId: "remote-control:env_local", installationId: "install_local" },
+            { hostId: "remote-control:env_stale", installationId: "install_stale" },
+          ],
+        });
+      }
+      if (method === "get-global-state") {
+        return Promise.resolve({ value: "install_local" });
+      }
+      return Promise.resolve({});
+    },
+  };
+  vm.runInNewContext(`${patched};OF();`, context);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(calls.length, 4);
+  assert.equal(calls[0].method, "set-remote-control-connections-enabled");
+  assert.equal(calls[0].params.enabled, true);
+  assert.equal(calls[1].method, "get-global-state");
+  assert.equal(calls[1].params.key, "electron-local-remote-control-installation-id");
+  assert.equal(calls[2].method, "set-remote-connection-auto-connect");
+  assert.equal(calls[2].params.hostId, "remote-control:env_local");
+  assert.equal(calls[2].params.autoConnect, true);
+  assert.equal(calls[3].method, "set-remote-connection-auto-connect");
+  assert.equal(calls[3].params.hostId, "remote-control:env_stale");
+  assert.equal(calls[3].params.autoConnect, false);
+});
+
 test("patched Linux device-key provider can create, sign with, and delete a key", async () => {
   const configHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-key-store-"));
   try {
@@ -376,16 +806,15 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticRemoteConnectionVisibilityBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, "app-main-test.js"),
-          syntheticAppMainFeatureSyncBundle(),
-        );
-        fs.writeFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           syntheticVisibilityBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
-          syntheticRemoteConnectionsSettingsCopyBundle(),
+          syntheticSettingsBundle() +
+            syntheticRemoteConnectionsSettingsCopyBundle() +
+            syntheticSettingsRefreshBundle() +
+            syntheticRevokeSetupResetBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
@@ -394,6 +823,16 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.writeFileSync(
           path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
           syntheticMobileConnectedSettingsBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "app-server-manager-signals-test.js"),
+          syntheticAppServerManagerSignalsBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, "app-main-test.js"),
+          syntheticAppMainFeatureSyncBundle() +
+            syntheticAppMainEnablementBridgeBundle() +
+            syntheticAppMainActiveStatusBundle(),
         );
 
         const report = createPatchReport();
@@ -424,15 +863,27 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
           "utf8",
         );
+        const patchedSignalsFile = fs.readFileSync(
+          path.join(assetsDir, "app-server-manager-signals-test.js"),
+          "utf8",
+        );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
         assert.match(patchedAppMainFile, /`remote_control`/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteControlSettingsTabs/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteControlResetMobileSetupAfterRevoke/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteConnectionsRefreshNow/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /Qn=5e3/);
         assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
         assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
         assert.match(patchedMobileSetupFlowFile, /Connect your phone to this Linux desktop/);
         assert.match(patchedMobileConnectedSettingsFile, /apps on this Linux desktop/);
+        assert.match(patchedSignalsFile, /codexLinuxRemoteMobileHydrateUnknownTurn/);
+        assert.match(patchedSignalsFile, /codexLinuxRemoteMobileThreadRuntimeStatus/);
+        assert.match(patchedAppMainFile, /codexLinuxRemoteControlEnablementBridge/);
+        assert.match(patchedAppMainFile, /codexLinuxRemoteMobileActiveStatus/);
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-device-key" &&
@@ -472,6 +923,42 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-copy" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-settings-ux" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-client-revoke-setup-reset" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-connections-refresh" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-enablement-bridge" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-active-status" &&
             patch.status === "applied",
           ),
         );

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -168,6 +168,10 @@ in
       CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
     };
 
+    systemd.user.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+    };
+
     systemd.user.services.codex-remote-control = lib.mkIf remoteCfg.enable {
       Unit = {
         Description = "Codex remote-control app-server";

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,201 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.codexDesktopLinux;
+  remoteCfg = cfg.remoteControl;
+  system = pkgs.stdenv.hostPlatform.system;
+  flakePackages = self.packages.${system};
+  packageName =
+    if cfg.remoteMobileControl.enable && cfg.computerUseUi.enable then
+      "codex-desktop-computer-use-ui-remote-mobile-control"
+    else if cfg.remoteMobileControl.enable then
+      "codex-desktop-remote-mobile-control"
+    else if cfg.computerUseUi.enable then
+      "codex-desktop-computer-use-ui"
+    else
+      "codex-desktop";
+  desktopPackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  codexHome =
+    if remoteCfg.codexHome != null then remoteCfg.codexHome else "${config.home.homeDirectory}/.codex";
+  remoteControlPath = lib.makeSearchPath "bin" (
+    [
+      config.home.profileDirectory
+    ]
+    ++ remoteCfg.extraPackages
+  );
+  remoteControlEnvironment = {
+    CODEX_HOME = codexHome;
+    PATH = remoteControlPath;
+  }
+  // remoteCfg.environment;
+  remoteControlEnvironmentList = lib.mapAttrsToList (
+    name: value: "${name}=${if lib.isBool value then lib.boolToString value else toString value}"
+  ) (lib.filterAttrs (_name: value: value != null) remoteControlEnvironment);
+in
+{
+  options.programs.codexDesktopLinux = {
+    enable = lib.mkEnableOption "Codex Desktop for Linux";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      defaultText = lib.literalExpression ''
+        inputs.codex-desktop-linux.packages.''${pkgs.stdenv.hostPlatform.system}.codex-desktop
+      '';
+      description = ''
+        Codex Desktop package to install. When unset, the module selects one of
+        this flake's package variants from
+        {option}`programs.codexDesktopLinux.computerUseUi.enable` and
+        {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+      '';
+    };
+
+    computerUseUi.enable = lib.mkEnableOption "the Linux Computer Use UI package variant";
+
+    remoteMobileControl.enable = lib.mkEnableOption "the experimental Linux mobile remote-control package variant";
+
+    remoteControl = {
+      enable = lib.mkEnableOption "a user systemd app-server with remote control enabled";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.codex;
+        defaultText = lib.literalExpression "pkgs.codex";
+        description = "Codex CLI package used by the remote-control app-server service.";
+      };
+
+      codexHome = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "\${config.home.homeDirectory}/.codex";
+        description = ''
+          Value for {env}`CODEX_HOME` in the remote-control service. If unset,
+          this defaults to {file}`~/.codex`.
+        '';
+      };
+
+      listen = lib.mkOption {
+        type = lib.types.str;
+        default = "unix://";
+        description = ''
+          Local app-server transport endpoint passed to
+          {command}`codex app-server --listen`.
+        '';
+      };
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "default.target";
+        description = "Systemd user target that starts the remote-control service.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.int
+              lib.types.str
+            ]
+          )
+        );
+        default = { };
+        description = "Environment variables to set for the remote-control service.";
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/codex-remote-control.env";
+        description = ''
+          Additional environment file as defined in {manpage}`systemd.exec(5)`.
+        '';
+      };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = with pkgs; [
+          bash
+          coreutils
+          findutils
+          git
+          gnugrep
+          gnused
+          openssh
+        ];
+        description = "Extra packages to add to {env}`PATH` for commands launched by Codex.";
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--analytics-default-enabled"
+        ];
+        description = "Additional arguments passed to {command}`codex app-server`.";
+      };
+
+      disableLauncherAutostart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Set {env}`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` in the
+          user session when this declarative service is enabled, so the Desktop
+          launcher does not also start the mutable standalone daemon hook.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !remoteCfg.enable || pkgs.stdenv.hostPlatform.isLinux;
+        message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
+      }
+    ];
+
+    home.packages = [
+      desktopPackage
+    ];
+
+    home.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+    };
+
+    systemd.user.services.codex-remote-control = lib.mkIf remoteCfg.enable {
+      Unit = {
+        Description = "Codex remote-control app-server";
+        After = [ "network.target" ];
+      };
+
+      Service = {
+        Environment = remoteControlEnvironmentList;
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe remoteCfg.package)
+            "app-server"
+            "--remote-control"
+            "--listen"
+            remoteCfg.listen
+          ]
+          ++ remoteCfg.extraArgs
+        );
+        Restart = "on-failure";
+        RestartSec = 5;
+      }
+      // lib.optionalAttrs (remoteCfg.environmentFile != null) {
+        EnvironmentFile = remoteCfg.environmentFile;
+      };
+
+      Install.WantedBy = [
+        remoteCfg.target
+      ];
+    };
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,196 @@
+{ self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.codexDesktopLinux;
+  remoteCfg = cfg.remoteControl;
+  system = pkgs.stdenv.hostPlatform.system;
+  flakePackages = self.packages.${system};
+  packageName =
+    if cfg.remoteMobileControl.enable && cfg.computerUseUi.enable then
+      "codex-desktop-computer-use-ui-remote-mobile-control"
+    else if cfg.remoteMobileControl.enable then
+      "codex-desktop-remote-mobile-control"
+    else if cfg.computerUseUi.enable then
+      "codex-desktop-computer-use-ui"
+    else
+      "codex-desktop";
+  desktopPackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  remoteControlPath = lib.makeSearchPath "bin" (
+    [
+      "/run/current-system/sw"
+    ]
+    ++ remoteCfg.extraPackages
+  );
+  remoteControlEnvironment = {
+    CODEX_HOME = if remoteCfg.codexHome != null then remoteCfg.codexHome else "%h/.codex";
+    PATH = remoteControlPath;
+  }
+  // remoteCfg.environment;
+  remoteControlEnvironmentList = lib.mapAttrsToList (
+    name: value: "${name}=${if lib.isBool value then lib.boolToString value else toString value}"
+  ) (lib.filterAttrs (_name: value: value != null) remoteControlEnvironment);
+in
+{
+  options.programs.codexDesktopLinux = {
+    enable = lib.mkEnableOption "Codex Desktop for Linux";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      defaultText = lib.literalExpression ''
+        inputs.codex-desktop-linux.packages.''${pkgs.stdenv.hostPlatform.system}.codex-desktop
+      '';
+      description = ''
+        Codex Desktop package to install. When unset, the module selects one of
+        this flake's package variants from
+        {option}`programs.codexDesktopLinux.computerUseUi.enable` and
+        {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+      '';
+    };
+
+    computerUseUi.enable = lib.mkEnableOption "the Linux Computer Use UI package variant";
+
+    remoteMobileControl.enable = lib.mkEnableOption "the experimental Linux mobile remote-control package variant";
+
+    remoteControl = {
+      enable = lib.mkEnableOption "a system-wide user app-server unit with remote control enabled";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.codex;
+        defaultText = lib.literalExpression "pkgs.codex";
+        description = "Codex CLI package used by the remote-control app-server service.";
+      };
+
+      codexHome = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "%h/.codex";
+        description = ''
+          Value for {env}`CODEX_HOME` in the remote-control service. If unset,
+          the global user unit uses {file}`%h/.codex`.
+        '';
+      };
+
+      listen = lib.mkOption {
+        type = lib.types.str;
+        default = "unix://";
+        description = ''
+          Local app-server transport endpoint passed to
+          {command}`codex app-server --listen`.
+        '';
+      };
+
+      target = lib.mkOption {
+        type = lib.types.str;
+        default = "default.target";
+        description = "Systemd user target that starts the remote-control service.";
+      };
+
+      environment = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.nullOr (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.int
+              lib.types.str
+            ]
+          )
+        );
+        default = { };
+        description = "Environment variables to set for the remote-control service.";
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/secrets/codex-remote-control.env";
+        description = ''
+          Additional environment file as defined in {manpage}`systemd.exec(5)`.
+        '';
+      };
+
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = with pkgs; [
+          bash
+          coreutils
+          findutils
+          git
+          gnugrep
+          gnused
+          openssh
+        ];
+        description = "Extra packages to add to {env}`PATH` for commands launched by Codex.";
+      };
+
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [
+          "--analytics-default-enabled"
+        ];
+        description = "Additional arguments passed to {command}`codex app-server`.";
+      };
+
+      disableLauncherAutostart = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Set {env}`CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` for
+          graphical sessions when this declarative service is enabled, so the
+          Desktop launcher does not also start the mutable standalone daemon
+          hook.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !remoteCfg.enable || pkgs.stdenv.hostPlatform.isLinux;
+        message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
+      }
+    ];
+
+    environment.systemPackages = [
+      desktopPackage
+    ];
+
+    environment.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED = "1";
+    };
+
+    systemd.user.services.codex-remote-control = lib.mkIf remoteCfg.enable {
+      description = "Codex remote-control app-server";
+      after = [ "network.target" ];
+      wantedBy = [
+        remoteCfg.target
+      ];
+      serviceConfig = {
+        Environment = remoteControlEnvironmentList;
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe remoteCfg.package)
+            "app-server"
+            "--remote-control"
+            "--listen"
+            remoteCfg.listen
+          ]
+          ++ remoteCfg.extraArgs
+        );
+        Restart = "on-failure";
+        RestartSec = 5;
+      }
+      // lib.optionalAttrs (remoteCfg.environmentFile != null) {
+        EnvironmentFile = remoteCfg.environmentFile;
+      };
+    };
+  };
+}

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1431,7 +1431,7 @@ test("warns when the app sunset key is present but the gate shape drifts", () =>
 
 test("removes unsupported features from default app-server feature sync", () => {
   const source = [
-    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];",
+    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];",
     "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
     "return e[0]!==r?(a=()=>{let r=qF(n);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r}).catch(n=>{q.error(`Failed to sync experimental feature enablement`,{sensitive:{error:n}})})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
     "function qF(e){let t={};for(let n of GF){let r=e[n];r!=null&&(t[n]=r)}return t}",
@@ -1441,10 +1441,11 @@ test("removes unsupported features from default app-server feature sync", () => 
 
   assert.match(
     patched,
-    /var GF=\[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`\];/,
+    /var GF=\[`apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`tool_call_mcp_elicitation`,`tool_suggest`\];/,
   );
   assert.doesNotMatch(patched, /`auth_elicitation`/);
   assert.doesNotMatch(patched, /`enable_mcp_apps`/);
+  assert.doesNotMatch(patched, /`tool_search`/);
   assert.doesNotMatch(patched, /,te\]/);
 });
 
@@ -1452,7 +1453,7 @@ test("patches the matched app-server feature sync array when an identical array 
   const unsupportedFeatureArray =
     "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];";
   const supportedFeatureArray =
-    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`];";
+    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`];";
   const source = [
     unsupportedFeatureArray,
     "function OF(){return GF}",

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -155,10 +155,10 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
   const supportedFeatures = new Set([
     "apps",
     "memories",
+    "mentions_v2",
     "plugins",
     "remote_control",
     "tool_call_mcp_elicitation",
-    "tool_search",
     "tool_suggest",
   ]);
   const defaultFeaturesMarker = "statsig_default_enable_features";

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1791,9 +1791,12 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'launcher-$CODEX_LINUX_INSTANCE_ID.log'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "ADOPTED_WEBVIEW_PID"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Reusing webview server pid="
-    assert_contains "$REPO_DIR/launcher/start.sh.template" "ensure_remote_mobile_control_daemon"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "run_cold_start_hooks"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/feature.json" '"stageHook": "./stage.sh"'
-    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "remote-mobile-control-enabled"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "cold-start.d"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "remote-mobile-control"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "cold-start-hook.sh"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "app-server daemon start --enable remote_control"
     python3 - "$REPO_DIR/launcher/start.sh.template" <<'PY'
 import re
 import sys
@@ -1802,7 +1805,7 @@ source = open(sys.argv[1], encoding="utf-8").read()
 detect_body = source.split("detect_warm_start() {", 1)[1].split("send_warm_start_launch_action() {", 1)[0]
 launch_body = source.split("launch_electron() {", 1)[1].split("load_packaged_runtime_helper", 1)[0]
 runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_electron", 1)[0]
-remote_daemon_body = source.split("ensure_remote_mobile_control_daemon() {", 1)[1].split("run_cli_preflight() {", 1)[0]
+cold_start_hooks_body = source.split("run_cold_start_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 stale_body = source.split("pid_is_stale_webview_server() {", 1)[1].split("stop_owned_webview_server() {", 1)[0]
 multi_body = source.split("configure_multi_launch_instance() {", 1)[1].split('WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"', 1)[0]
@@ -1851,8 +1854,8 @@ if "second_instance_handoff_ready" not in runtime_body:
     raise SystemExit("second-instance handoff must skip cold-start setup")
 if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permissions\nreconcile_runtime_state" in runtime_body:
     raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
-if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache\s+sync_chrome_bundled_plugin_cache\s+sync_computer_use_bundled_plugin_cache\s+sync_read_aloud_bundled_plugin_cache\s+ensure_remote_mobile_control_daemon\s+fi', runtime_body, re.S):
-    raise SystemExit("bundled marketplace cleanup, plugin sync, and remote mobile daemon startup must run only on cold start")
+if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache\s+sync_chrome_bundled_plugin_cache\s+sync_computer_use_bundled_plugin_cache\s+sync_read_aloud_bundled_plugin_cache\s+run_cold_start_hooks\s+fi', runtime_body, re.S):
+    raise SystemExit("bundled marketplace cleanup, plugin sync, and cold-start hooks must run only on cold start")
 if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI lookup")
 if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
@@ -1861,24 +1864,14 @@ if '"$HOME/.bun/bin/codex"' not in source:
     raise SystemExit("CLI lookup must include bun global install path")
 if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
-if 'ensure_remote_mobile_control_daemon' not in runtime_body:
-    raise SystemExit("cold start must ensure the remote mobile daemon before Electron launches")
-if 'CODEX_REMOTE_CONTROL_CODEX_PATH' not in remote_daemon_body:
-    raise SystemExit("remote mobile daemon must use a separate standalone CLI path")
-if 'CODEX_CLI_PATH=' in remote_daemon_body or 'export CODEX_CLI_PATH' in remote_daemon_body:
-    raise SystemExit("remote mobile daemon startup must not overwrite the user's interactive CODEX_CLI_PATH")
-if 'CODEX_INSTALL_DIR' not in remote_daemon_body or '.bin' not in remote_daemon_body:
-    raise SystemExit("remote mobile daemon provisioning must install into a private standalone bin dir")
-if 'PATH="$installer_path"' not in remote_daemon_body or 'system_path="/usr/bin:/bin:/usr/sbin:/sbin"' not in remote_daemon_body:
-    raise SystemExit("remote mobile daemon provisioning must run with a sanitized system PATH")
-if 'setsid' not in remote_daemon_body:
-    raise SystemExit("remote mobile daemon provisioning must suppress installer TTY prompts")
-if ':$PATH' in remote_daemon_body:
-    raise SystemExit("remote mobile daemon provisioning must not expose the user's PATH to the installer")
-if '$HOME/.local/bin/codex' in remote_daemon_body:
-    raise SystemExit("remote mobile daemon provisioning must not install the visible ~/.local/bin/codex command")
-if 'app-server daemon start --enable remote_control' not in remote_daemon_body:
-    raise SystemExit("remote mobile daemon startup must enable remote_control on the managed daemon")
+if 'run_cold_start_hooks' not in runtime_body:
+    raise SystemExit("cold start must run feature-staged hooks before Electron launches")
+if 'COLD_START_HOOK_DIR' not in cold_start_hooks_body or '"$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"' not in cold_start_hooks_body:
+    raise SystemExit("launcher cold-start hook runner must be generic and pass standard paths")
+if '>>"$LOG_FILE" 2>&1 &' not in cold_start_hooks_body:
+    raise SystemExit("launcher cold-start hooks must be non-blocking")
+if 'remote_mobile_control_main' in source:
+    raise SystemExit("remote mobile daemon startup must live in the remote-mobile-control feature hook, not the main launcher")
 if "running_app_is_active" not in stop_body or "Preserving webview server" not in stop_body:
     raise SystemExit("stop_owned_webview_server must not stop the live app webview server")
 if "stale_webview_server_pid" not in source or "stop_stale_webview_server" not in source:

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1796,7 +1796,17 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "cold-start.d"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "remote-mobile-control"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "cold-start-hook.sh"
-    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "app-server daemon start --enable remote_control"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "remote-control start"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "/run/current-system/sw/bin"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "codex-remote-control.service"
+    assert_contains "$REPO_DIR/flake.nix" "homeManagerModules"
+    assert_contains "$REPO_DIR/flake.nix" "nixosModules"
+    assert_contains "$REPO_DIR/nix/home-manager-module.nix" "codex-remote-control"
+    assert_contains "$REPO_DIR/nix/home-manager-module.nix" "--remote-control"
+    assert_contains "$REPO_DIR/nix/home-manager-module.nix" "CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
+    assert_contains "$REPO_DIR/nix/nixos-module.nix" "codex-remote-control"
+    assert_contains "$REPO_DIR/nix/nixos-module.nix" "--remote-control"
+    assert_contains "$REPO_DIR/nix/nixos-module.nix" "CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
     python3 - "$REPO_DIR/launcher/start.sh.template" <<'PY'
 import re
 import sys

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1799,6 +1799,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "remote-control start"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "/run/current-system/sw/bin"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "codex-remote-control.service"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "continuing best-effort in the background"
     assert_contains "$REPO_DIR/flake.nix" "homeManagerModules"
     assert_contains "$REPO_DIR/flake.nix" "nixosModules"
     assert_contains "$REPO_DIR/nix/home-manager-module.nix" "codex-remote-control"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1791,6 +1791,9 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'launcher-$CODEX_LINUX_INSTANCE_ID.log'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "ADOPTED_WEBVIEW_PID"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Reusing webview server pid="
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "ensure_remote_mobile_control_daemon"
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/feature.json" '"stageHook": "./stage.sh"'
+    assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "remote-mobile-control-enabled"
     python3 - "$REPO_DIR/launcher/start.sh.template" <<'PY'
 import re
 import sys
@@ -1799,6 +1802,7 @@ source = open(sys.argv[1], encoding="utf-8").read()
 detect_body = source.split("detect_warm_start() {", 1)[1].split("send_warm_start_launch_action() {", 1)[0]
 launch_body = source.split("launch_electron() {", 1)[1].split("load_packaged_runtime_helper", 1)[0]
 runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_electron", 1)[0]
+remote_daemon_body = source.split("ensure_remote_mobile_control_daemon() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 stale_body = source.split("pid_is_stale_webview_server() {", 1)[1].split("stop_owned_webview_server() {", 1)[0]
 multi_body = source.split("configure_multi_launch_instance() {", 1)[1].split('WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"', 1)[0]
@@ -1847,8 +1851,8 @@ if "second_instance_handoff_ready" not in runtime_body:
     raise SystemExit("second-instance handoff must skip cold-start setup")
 if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permissions\nreconcile_runtime_state" in runtime_body:
     raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
-if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache\s+sync_chrome_bundled_plugin_cache\s+sync_computer_use_bundled_plugin_cache\s+sync_read_aloud_bundled_plugin_cache\s+fi', runtime_body, re.S):
-    raise SystemExit("bundled marketplace cleanup and plugin sync must run only on cold start")
+if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache\s+sync_chrome_bundled_plugin_cache\s+sync_computer_use_bundled_plugin_cache\s+sync_read_aloud_bundled_plugin_cache\s+ensure_remote_mobile_control_daemon\s+fi', runtime_body, re.S):
+    raise SystemExit("bundled marketplace cleanup, plugin sync, and remote mobile daemon startup must run only on cold start")
 if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI lookup")
 if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
@@ -1857,6 +1861,24 @@ if '"$HOME/.bun/bin/codex"' not in source:
     raise SystemExit("CLI lookup must include bun global install path")
 if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
+if 'ensure_remote_mobile_control_daemon' not in runtime_body:
+    raise SystemExit("cold start must ensure the remote mobile daemon before Electron launches")
+if 'CODEX_REMOTE_CONTROL_CODEX_PATH' not in remote_daemon_body:
+    raise SystemExit("remote mobile daemon must use a separate standalone CLI path")
+if 'CODEX_CLI_PATH=' in remote_daemon_body or 'export CODEX_CLI_PATH' in remote_daemon_body:
+    raise SystemExit("remote mobile daemon startup must not overwrite the user's interactive CODEX_CLI_PATH")
+if 'CODEX_INSTALL_DIR' not in remote_daemon_body or '.bin' not in remote_daemon_body:
+    raise SystemExit("remote mobile daemon provisioning must install into a private standalone bin dir")
+if 'PATH="$installer_path"' not in remote_daemon_body or 'system_path="/usr/bin:/bin:/usr/sbin:/sbin"' not in remote_daemon_body:
+    raise SystemExit("remote mobile daemon provisioning must run with a sanitized system PATH")
+if 'setsid' not in remote_daemon_body:
+    raise SystemExit("remote mobile daemon provisioning must suppress installer TTY prompts")
+if ':$PATH' in remote_daemon_body:
+    raise SystemExit("remote mobile daemon provisioning must not expose the user's PATH to the installer")
+if '$HOME/.local/bin/codex' in remote_daemon_body:
+    raise SystemExit("remote mobile daemon provisioning must not install the visible ~/.local/bin/codex command")
+if 'app-server daemon start --enable remote_control' not in remote_daemon_body:
+    raise SystemExit("remote mobile daemon startup must enable remote_control on the managed daemon")
 if "running_app_is_active" not in stop_body or "Preserving webview server" not in stop_body:
     raise SystemExit("stop_owned_webview_server must not stop the live app webview server")
 if "stale_webview_server_pid" not in source or "stop_stale_webview_server" not in source:
@@ -2475,6 +2497,12 @@ JSON
         # shellcheck disable=SC1091
         source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
         stage_linux_computer_use_plugin() { return 1; }
+        build_chrome_extension_host() {
+            local fake_host="$workspace/codex-chrome-extension-host"
+            printf '#!/bin/sh\n' > "$fake_host"
+            chmod +x "$fake_host"
+            printf '%s\n' "$fake_host"
+        }
         install_bundled_plugin_resources "$app_dir"
     ) >"$output_log" 2>&1
 


### PR DESCRIPTION
## Summary

Fixes #254.

Remote mobile control can pass the Linux enrollment/UI patches but still fail to reconnect from Android if the upstream managed standalone Codex runtime is missing at `~/.codex/packages/standalone/current/codex`.

This PR makes the opt-in `remote-mobile-control` feature stage a runtime marker, then has the Linux launcher cold-start the remote-control app-server daemon from that managed standalone runtime.

## Details

- Adds a `remote-mobile-control` stage hook that writes `.codex-linux/remote-mobile-control-enabled` into the generated app.
- On cold start, when that marker exists, the launcher provisions the standalone runtime under `~/.codex/packages/standalone` if it is missing.
- The installer is run with `CODEX_INSTALL_DIR` pointed at `~/.codex/packages/standalone/.bin`, a sanitized system PATH, and `setsid` so it does not prompt, does not see user-managed `codex`, does not write `~/.local/bin/codex`, does not edit shell profiles, and does not mutate `CODEX_CLI_PATH`.
- Starts `app-server daemon start --enable remote_control` from the managed standalone binary.
- Documents the split between the user's interactive CLI, such as Homebrew `codex`, and the daemon-only standalone runtime.
- Keeps the Chrome marketplace fallback smoke fixture isolated by stubbing the Chrome host builder in that test.

## Validation

From the upstream-main PR branch:

- `bash -n launcher/start.sh.template tests/scripts_smoke.sh linux-features/remote-mobile-control/stage.sh`
- `node --test linux-features/remote-mobile-control/test.js`
- `git diff --check`
- `bash tests/scripts_smoke.sh`

All passed locally.