### PR TITLE
fix(launcher): keep GPU compositing on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Nix builds, installer apps, and dev shells now use modern `7zz`, and the installer dependency check accepts `7zz` without requiring a separate legacy `7z` binary.
 - Codex Desktop no longer removes user-enabled `remote_control = true` from the local Linux config before starting the app server.
 - Linux webview bundles no longer ask current Codex CLI app servers to enable unsupported feature flags, avoiding connector authentication sync errors.
+- Native Linux launches now keep GPU compositing enabled by default, avoiding sustained Electron GPU-process CPU usage on some X11/NVIDIA desktops. Users who still need the old flicker workaround can opt in with `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1`.
 
 ## [0.8.0] - 2026-05-16
 

--- a/README.md
+++ b/README.md
@@ -503,8 +503,8 @@ make clean-state
 | `CODEX_CLI_PATH` error | Reopen the app to retry the automatic CLI install flow, or install manually with `npm i -g @openai/codex` / `npm i -g --prefix ~/.local @openai/codex` |
 | `gh auth status` works in a terminal but fails inside Codex Desktop | The app shell may be using isolated XDG paths or missing keyring DBus access. See [GitHub CLI auth in app-launched shells](docs/github-cli-auth.md) |
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log`. Best-effort CLI preflight will warn if the automatic refresh fails |
-| GPU / Vulkan / Wayland errors | Under Wayland with `DISPLAY` available, the launcher uses `--ozone-platform=x11` for window-positioning compatibility. Otherwise it uses `--ozone-platform-hint=auto`. GPU sandbox / compositing are disabled by default |
-| Window flickering | GPU compositing is disabled by default. If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |
+| GPU / Vulkan / Wayland errors | Under Wayland with `DISPLAY` available, the launcher uses `--ozone-platform=x11` for window-positioning compatibility. Otherwise it uses `--ozone-platform-hint=auto`. The GPU sandbox is disabled by default, while GPU compositing stays enabled |
+| Window flickering | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh` to use the legacy compositing workaround. If flickering persists, try `./codex-app/start.sh --disable-gpu` to fully disable GPU acceleration |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | `make build-app-fresh` removes the existing install dir and cached DMG, then re-downloads |
 | Computer Use plugin invisible in UI | Ensure you enabled the Computer Use UI. If it is enabled and still hidden, the OpenAI per-account rollout may not be available |

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -220,7 +220,7 @@ Environment:
   CODEX_LINUX_RENDERING_MODE=auto|default|wslg
                               Auto-detect WSLg, keep generic Linux defaults, or force the WSLg profile
   CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0|1
-                              Override the launcher's default --disable-gpu-compositing decision
+                              Set to 1 to add --disable-gpu-compositing for flicker workarounds
   CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1
                               Override --force-renderer-accessibility; auto skips it under WSLg
   CODEX_MULTI_LAUNCH=1        Treat normal launches like --new-instance
@@ -1774,7 +1774,7 @@ should_disable_gpu_compositing() {
         echo "Invalid CODEX_ELECTRON_DISABLE_GPU_COMPOSITING='${CODEX_ELECTRON_DISABLE_GPU_COMPOSITING:-}'; using rendering profile default" >&2
     fi
 
-    [ "$ELECTRON_RENDERING_MODE" != "wslg" ]
+    return 1
 }
 
 should_force_renderer_accessibility() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1946,6 +1946,7 @@ PY
     [[ "$output" == *"electron=<--use-gl=angle>"* ]] || fail "launcher must pass Electron args after -- without the separator: $output"
     [[ "$output" != *"electron=<--><--use-gl=angle>"* ]] || fail "launcher must not pass the -- separator to Electron: $output"
     [[ "$output" == *"<--ozone-platform=x11>"* ]] || fail "launcher --x11 must still set the Electron ozone platform: $output"
+    [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "default Linux profile must keep GPU compositing enabled: $output"
     [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "default Linux profile must still force renderer accessibility: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --ozone-platform=x11)"
@@ -1953,7 +1954,7 @@ PY
     [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "launcher must not add ozone hint when pass-through supplies an ozone platform: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe)"
-    [[ "$output" == *"mode=wslg"* && "$output" == *"comp=0"* && "$output" == *"gl_added=1"* ]] || fail "forced WSLg profile must disable GPU compositing default and add ANGLE: $output"
+    [[ "$output" == *"mode=wslg"* && "$output" == *"comp=0"* && "$output" == *"gl_added=1"* ]] || fail "forced WSLg profile must keep GPU compositing enabled and add ANGLE: $output"
     [[ "$output" == *"<--ozone-platform=x11>"* && "$output" == *"electron=<--use-gl=angle>"* ]] || fail "forced WSLg profile must use X11 and ANGLE by default: $output"
     [[ "$output" != *"<--disable-gpu-compositing>"* ]] || fail "forced WSLg profile must not add disable-gpu-compositing by default: $output"
     [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "forced WSLg profile must skip renderer accessibility by default: $output"
@@ -1974,6 +1975,9 @@ PY
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 "$launcher_probe" probe)"
     [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 must force the compositor flag: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 "$launcher_probe" probe)"
+    [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 must force the compositor flag under default Linux: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 "$launcher_probe" probe)"
     [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 must suppress the compositor flag: $output"


### PR DESCRIPTION
## Summary

- Keep native Linux launches from adding `--disable-gpu-compositing` by default
- Preserve `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1` as the opt-in flicker workaround
- Update launcher smoke coverage, troubleshooting docs, and changelog notes for the proposed default

## Context

The current launcher history looks like this:

- `8f8f150` added `--disable-gpu-compositing` as a default Linux launcher flag to work around Ubuntu window flickering
- `8c52fa4` added the WSLg rendering profile and carved WSLg out of that default, so WSLg keeps GPU compositing enabled while native/default Linux still disables it
- This PR proposes making native/default Linux match WSLg: keep GPU compositing enabled unless the user explicitly opts into the old workaround

The reason for proposing the flip is that on my native Linux desktop, the live Electron GPU process was pinned around 100% CPU with `--disable-gpu-compositing`. A side-by-side launch with `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0` idled normally around 0-1% GPU-process CPU. That suggests the old flicker workaround can be much more expensive than the default compositor path on at least some native Linux setups.

## Maintainer question

@ilysenko does this default flip match how you want to handle the tradeoff? My read is that GPU compositing is the more performant/default Electron path, and `--disable-gpu-compositing` should be a fallback for users who still see the original flickering issue. If you think this should stay default-on for a narrower class of Linux sessions, I can rework this into detection or a more targeted launcher profile instead.

## User-visible behavior

- Native Linux/X11 users keep Electron GPU compositing enabled unless they explicitly opt into the legacy workaround
- This avoids sustained Electron GPU-process CPU usage seen when `--disable-gpu-compositing` is forced on some X11/NVIDIA desktops
- Users who still hit flickering can start with `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1`

## Validation

- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- Isolated `test_launcher_template_sanity` smoke function passed
- `git diff --check`
- `bash tests/scripts_smoke.sh` currently fails before the launcher coverage on fresh `main` at `setup-native-read-aloud-defaults`: expected `Settings file: .../settings.json (file)` in the generated output log
