### PR TITLE
Stop forcing the in-app browser visible

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -54,7 +54,6 @@ const {
 } = require("./patches/launch-actions.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,
@@ -134,6 +133,11 @@ function main() {
 
 if (require.main === module) {
   main();
+}
+
+function applyLinuxBrowserUseIabVisibleOnCreatePatch(currentSource) {
+  // Compatibility shim for old callers after the runtime patch was removed.
+  return currentSource;
 }
 
 module.exports = {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -316,7 +316,6 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-computer-use-plugin-gate",
     "linux-chrome-plugin-auto-install",
     "browser-use-node-repl-approval",
-    "linux-browser-use-iab-visible-on-create",
     "linux-chrome-extension-status",
     "linux-remote-control-config-preservation",
     "linux-app-updater-menu",
@@ -2098,34 +2097,21 @@ test("patches all Browser Use node_repl approval configs in one pass", () => {
   assert.doesNotMatch(patched, /startup_timeout_sec:120,env:\{/);
 });
 
-test("shows the Linux IAB panel after Browser Use creates or reuses a tab", () => {
+test("keeps removed IAB visible patch export as a no-op", () => {
+  const source = "class BrowserSessionRegistry{}";
+
+  assert.equal(applyLinuxBrowserUseIabVisibleOnCreatePatch(source), source);
+});
+
+test("patchMainBundleSource does not force the in-app browser panel visible", () => {
   const source =
     "var CF=class{async createTabForBrowserUse(e){let t=this.getActiveBrowserUseTab(e,{assertCurrentPageAllowed:!1});if(t!=null)return await this.navigateTabToInitialPage(t),this.serializeTab(t);let n=this.getRequiredBrowserHost(e);n.setBrowserUseActive(!0,e.turnId);let r=await n.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:e.turnId}),i=this.updateTabForPage(r,n.routeKey);return SF().info(`IAB_LIFECYCLE iab createTab mapped page to tab`,{}),this.markBrowserUseCommandForTab(e,i),this.selectedTabIdsByRouteKey.set(n.routeKey,i.cdpTabId),this.serializeTab(i)}};";
 
-  const patched = applyPatchTwice(applyLinuxBrowserUseIabVisibleOnCreatePatch, source);
+  const patched = patchMainBundleSource(source, null);
 
-  assert.match(
-    patched,
-    /this\.getRequiredBrowserHost\(e\)\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)/,
-  );
-  assert.match(patched, /n\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)/);
-  assert.match(patched, /codexLinuxBrowserUseAutoVisible/);
-  assert.match(
-    patched,
-    /return \(\(\)=>\{try\{n\.setBrowserVisibleForBrowserUse\(!0,e\.turnId\)\}/,
-  );
-});
-
-test("patches all Browser Use IAB tab-creation paths in one pass", () => {
-  const source = [
-    "if(t!=null)return await this.navigateTabToInitialPage(t),this.serializeTab(t);let n=this.getRequiredBrowserHost(e);n.setBrowserUseActive(!0,e.turnId);let r=await n.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:e.turnId}),i=this.updateTabForPage(r,n.routeKey);return",
-    "if(a!=null)return await this.navigateTabToInitialPage(a),this.serializeTab(a);let b=this.getRequiredBrowserHost(s);b.setBrowserUseActive(!0,s.turnId);let c=await b.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:s.turnId}),d=this.updateTabForPage(c,b.routeKey);return",
-  ].join(";");
-
-  const patched = applyLinuxBrowserUseIabVisibleOnCreatePatch(source);
-
-  assert.equal((patched.match(/codexLinuxBrowserUseAutoVisible/g) || []).length, 4);
-  assert.doesNotMatch(patched, /return await this\.navigateTabToInitialPage\([ta]\),this\.serializeTab/);
+  assert.equal(patched, source);
+  assert.doesNotMatch(patched, /setBrowserVisibleForBrowserUse/);
+  assert.doesNotMatch(patched, /codexLinuxBrowserUseAutoVisible/);
 });
 
 test("detects Chrome extension installation from Linux browser profiles", () => {

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -2,7 +2,6 @@
 
 const {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../main-process.js");
 const { applyLinuxChromePluginAutoInstallPatch } = require("../../../../chrome-plugin.js");
@@ -21,13 +20,6 @@ module.exports = [
     order: 160,
     ciPolicy: "optional",
     apply: applyBrowserUseNodeReplApprovalPatch,
-  },
-  {
-    id: "linux-browser-use-iab-visible-on-create",
-    phase: "main-bundle",
-    order: 170,
-    ciPolicy: "optional",
-    apply: applyLinuxBrowserUseIabVisibleOnCreatePatch,
   },
   {
     id: "linux-chrome-extension-status",

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -704,45 +704,6 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   return currentSource.split(needle).join(approvalPatch);
 }
 
-function applyLinuxBrowserUseIabVisibleOnCreatePatch(currentSource) {
-  const marker = "codexLinuxBrowserUseAutoVisible";
-  const visibilityExpr = (hostExpr, sessionExpr) =>
-    `(()=>{try{${hostExpr}.setBrowserVisibleForBrowserUse(!0,${sessionExpr}.turnId)}catch(__codexLinuxErr){console.warn("${marker}",__codexLinuxErr?.message??__codexLinuxErr)}})()`;
-  const createTabRegex =
-    /if\(([A-Za-z_$][\w$]*)!=null\)return await this\.navigateTabToInitialPage\(\1\),this\.serializeTab\(\1\);let ([A-Za-z_$][\w$]*)=this\.getRequiredBrowserHost\(([A-Za-z_$][\w$]*)\);\2\.setBrowserUseActive\(!0,\3\.turnId\);let ([A-Za-z_$][\w$]*)=await \2\.openPageForBrowserUse\(\{startingUrl:this\.initialPageUrl,turnId:\3\.turnId\}\),([A-Za-z_$][\w$]*)=this\.updateTabForPage\(\4,\2\.routeKey\);return/g;
-  let changed = false;
-  const patchedSource = currentSource.replace(
-    createTabRegex,
-    (needle, tabVar, hostVar, sessionVar, pageVar, tabInfoVar) => {
-      changed = true;
-      const activeTabVisibility = visibilityExpr(
-        `this.getRequiredBrowserHost(${sessionVar})`,
-        sessionVar,
-      );
-      const newTabVisibility = visibilityExpr(hostVar, sessionVar);
-      return (
-        `if(${tabVar}!=null)return await this.navigateTabToInitialPage(${tabVar}),${activeTabVisibility},this.serializeTab(${tabVar});` +
-        `let ${hostVar}=this.getRequiredBrowserHost(${sessionVar});${hostVar}.setBrowserUseActive(!0,${sessionVar}.turnId);` +
-        `let ${pageVar}=await ${hostVar}.openPageForBrowserUse({startingUrl:this.initialPageUrl,turnId:${sessionVar}.turnId}),${tabInfoVar}=this.updateTabForPage(${pageVar},${hostVar}.routeKey);` +
-        `return ${newTabVisibility},`
-      );
-    },
-  );
-  if (changed || currentSource.includes(marker)) {
-    return patchedSource;
-  }
-
-  if (
-    currentSource.includes("createTabForBrowserUse") &&
-    currentSource.includes("openPageForBrowserUse")
-  ) {
-    console.warn(
-      "WARN: Could not find Browser Use IAB tab creation point — skipping Linux IAB visibility patch",
-    );
-  }
-  return currentSource;
-}
-
 function applyLinuxChromeExtensionStatusPatch(currentSource) {
   if (currentSource.includes("codexLinuxChromeProfileRoots")) {
     return currentSource;
@@ -893,7 +854,6 @@ function applyLinuxRemoteControlConfigPreservationPatch(currentSource) {
 
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
-  applyLinuxBrowserUseIabVisibleOnCreatePatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,


### PR DESCRIPTION
## Summary
- Remove the Linux in-app browser auto-visible core patch
- Keep browser automation itself, node_repl approval, and Chrome integration patches unchanged
- Add regression coverage that main bundle patching leaves in-app browser tab creation untouched

## Context
This removes a Linux-only convenience patch that forced the in-app browser panel visible during browser automation tab creation/reuse by injecting setBrowserVisibleForBrowserUse(true, turnId) into upstream createTabForBrowserUse.

I observed an Electron SIGSEGV on Linux immediately after the in-app browser webview detach/dispose path, so this PR avoids changing that upstream webContents lifecycle from the Linux patch layer.

## Validation
- node --test scripts/patch-linux-window-ui.test.js