### PR TITLE
Enable Linux Desktop app-server as mobile Remote host

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
+
 function requireName(source, moduleName) {
   const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\(\`${escaped}\`\\)`));
@@ -44,6 +47,10 @@ const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["Connect your phone to this Mac", "Connect your phone to this Linux desktop"],
 ];
 const CLIENT_ACCOUNT_COMPAT_MARKER = "codexLinuxRemoteControlAccountMatches";
+const INLINE_SETUP_FLOW_MARKER = "codexLinuxRemoteControlInlineSetupFlow";
+const APP_SERVER_ARGS_NEEDLE = "args:[`app-server`,`--analytics-default-enabled`]";
+const APP_SERVER_ARGS_REPLACEMENT =
+  "args:[`app-server`,`--analytics-default-enabled`,`--remote-control`]";
 
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -160,6 +167,47 @@ function applyLinuxRemoteControlPreserveConfigPatch(source) {
 
   console.warn("WARN: Could not find remote-control config stripping needle - skipping Linux remote-control config patch");
   return source;
+}
+
+function applyLinuxRemoteControlAppServerHostModePatch(source) {
+  if (!source.includes(APP_SERVER_ARGS_NEEDLE)) {
+    return source;
+  }
+  return source.split(APP_SERVER_ARGS_NEEDLE).join(APP_SERVER_ARGS_REPLACEMENT);
+}
+
+function patchLinuxRemoteControlAppServerHostModeInExtractedApp(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  if (!fs.existsSync(buildDir)) {
+    console.warn(
+      `WARN: Could not find Vite build directory in ${buildDir} - skipping Linux remote-control app-server host mode patch`,
+    );
+    return { changed: false, matched: 0 };
+  }
+
+  let matched = 0;
+  let changed = 0;
+  for (const filename of fs.readdirSync(buildDir).filter((name) => name.endsWith(".js")).sort()) {
+    const filePath = path.join(buildDir, filename);
+    const source = fs.readFileSync(filePath, "utf8");
+    if (!source.includes(APP_SERVER_ARGS_NEEDLE) && !source.includes(APP_SERVER_ARGS_REPLACEMENT)) {
+      continue;
+    }
+    matched += 1;
+    const patched = applyLinuxRemoteControlAppServerHostModePatch(source);
+    if (patched !== source) {
+      fs.writeFileSync(filePath, patched, "utf8");
+      changed += 1;
+    }
+  }
+
+  if (matched === 0) {
+    console.warn(
+      `WARN: Could not find local app-server launch args in ${buildDir} - skipping Linux remote-control app-server host mode patch`,
+    );
+  }
+
+  return { changed: changed > 0, matched };
 }
 
 function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
@@ -443,6 +491,52 @@ function applyLinuxRemoteControlCopyPatch(source) {
   return patched;
 }
 
+function applyLinuxRemoteControlInlineSetupFlowPatch(source) {
+  if (source.includes(INLINE_SETUP_FLOW_MARKER)) {
+    return source;
+  }
+  if (
+    !source.includes("CODEX_MOBILE_SETUP_COMPLETED") ||
+    !source.includes("mode:`setup`") ||
+    !source.includes("variant:`dialog`")
+  ) {
+    return source;
+  }
+
+  const dialogSetupFlowRegex =
+    /function [A-Za-z_$][\w$]*\(e\)\{[\s\S]{0,800}?\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{onClose:[A-Za-z_$][\w$]*,variant:`dialog`\}\)[\s\S]{0,300}?\}/u;
+  const dialogSetupFlowMatch = source.match(dialogSetupFlowRegex);
+  if (dialogSetupFlowMatch == null) {
+    console.warn("WARN: Could not find Codex mobile setup flow dialog wrapper - skipping Linux inline setup flow patch");
+    return source;
+  }
+  const [, jsxRuntimeVar, setupFlowComponentVar] = dialogSetupFlowMatch;
+
+  const setupCardRegex = new RegExp(
+    `\\(0,${escapeRegExp(jsxRuntimeVar)}\\.jsx\\)\\(([A-Za-z_$][\\w$]*),\\{mode:\`setup\`\\}\\)`,
+    "u",
+  );
+  const setupCardMatch = source.match(setupCardRegex);
+  if (setupCardMatch == null) {
+    console.warn("WARN: Could not find remote-control setup card render - skipping Linux inline setup flow patch");
+    return source;
+  }
+
+  const setupCardIndex = source.search(setupCardRegex);
+  const setupFunctionStart = source.lastIndexOf("function ", setupCardIndex);
+  if (setupFunctionStart < 0) {
+    console.warn("WARN: Could not find remote-control setup state function - skipping Linux inline setup flow patch");
+    return source;
+  }
+
+  const helper = `function ${INLINE_SETUP_FLOW_MARKER}(e,t){return(0,e.jsx)(t,{onClose:()=>{},variant:\`page\`})}`;
+  const patched = source.replace(
+    setupCardRegex,
+    `${INLINE_SETUP_FLOW_MARKER}(${jsxRuntimeVar},${setupFlowComponentVar})`,
+  );
+  return `${patched.slice(0, setupFunctionStart)}${helper}${patched.slice(setupFunctionStart)}`;
+}
+
 module.exports = [
   {
     id: "linux-remote-control-device-key",
@@ -457,6 +551,13 @@ module.exports = [
     order: 20_110,
     ciPolicy: "optional",
     apply: applyLinuxRemoteControlPreserveConfigPatch,
+  },
+  {
+    id: "linux-remote-control-app-server-host-mode",
+    phase: "extracted-app",
+    order: 20_112,
+    ciPolicy: "optional",
+    apply: patchLinuxRemoteControlAppServerHostModeInExtractedApp,
   },
   {
     id: "linux-remote-control-client-account-compatibility",
@@ -493,6 +594,16 @@ module.exports = [
     apply: applyLinuxRemoteControlVisibilityPatch,
   },
   {
+    id: "linux-remote-control-inline-setup-flow",
+    phase: "webview-asset",
+    pattern: /^remote-connections-settings-.*\.js$/,
+    order: 20_125,
+    ciPolicy: "optional",
+    missingDescription: "remote-control settings setup bundle",
+    skipDescription: "Linux remote-control inline setup flow patch",
+    apply: applyLinuxRemoteControlInlineSetupFlowPatch,
+  },
+  {
     id: "linux-remote-control-copy",
     phase: "webview-asset",
     pattern: /^(?:codex-mobile-setup-flow|remote-connections-settings|use-codex-mobile-connected-settings)-.*\.js$/,
@@ -506,10 +617,15 @@ module.exports = [
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
 module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
+module.exports.applyLinuxRemoteControlAppServerHostModePatch =
+  applyLinuxRemoteControlAppServerHostModePatch;
+module.exports.patchLinuxRemoteControlAppServerHostModeInExtractedApp =
+  patchLinuxRemoteControlAppServerHostModeInExtractedApp;
 module.exports.applyLinuxRemoteControlClientAccountCompatibilityPatch =
   applyLinuxRemoteControlClientAccountCompatibilityPatch;
 module.exports.applyLinuxRemoteControlClientRevocationRecoveryPatch =
   applyLinuxRemoteControlClientRevocationRecoveryPatch;
 module.exports.applyLinuxRemoteControlLoadGatePatch = applyLinuxRemoteControlLoadGatePatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
+module.exports.applyLinuxRemoteControlInlineSetupFlowPatch = applyLinuxRemoteControlInlineSetupFlowPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -18,11 +18,13 @@ const {
 } = require("../../scripts/patch-linux-window-ui.js");
 const {
   applyLinuxRemoteControlDeviceKeyPatch,
+  applyLinuxRemoteControlAppServerHostModePatch,
   applyLinuxRemoteControlClientAccountCompatibilityPatch,
   applyLinuxRemoteControlClientRevocationRecoveryPatch,
   applyLinuxRemoteControlCopyPatch,
   applyLinuxRemoteControlPreserveConfigPatch,
   applyLinuxRemoteControlLoadGatePatch,
+  applyLinuxRemoteControlInlineSetupFlowPatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
 
@@ -47,6 +49,27 @@ function syntheticCurrentMainBundle() {
     "var lz=(0,b.createRequire)(__filename),uz=`remote-control-device-key.node`,dz=`codex-device-key-sign-payload/v1`;",
     "function pz({resourcesPath:e}){let t=null,n=()=>{if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=lz((0,i.join)(e,`native`,uz)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=mz(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
     "async function vV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{await yV(i.default.join(e??t.Rr({hostConfig:n,preferWsl:t.Kr(n)}),_V))&&r.info(`Removed remote_control from config before app-server start`)}catch(e){r.warning(`Failed to remove remote_control before app-server start`,{safe:{},sensitive:{error:e}})}}",
+  ].join("");
+}
+
+function syntheticAppServerLaunchBundle() {
+  return [
+    "function Pd(e){",
+    "let t=e.hostConfig.codex_cli_command;",
+    "if(t&&t.length>0){let[e,...n]=t;return!e||e.trim().length===0?null:{executablePath:e,args:n}}",
+    "let n=Kd();",
+    "if(n!=null)return{executablePath:n,args:[`app-server`,`--analytics-default-enabled`]};",
+    "let r=Nd(e.repoRoot,{resourcesPath:e.resourcesPath});",
+    "return r?{executablePath:r.executablePath,args:[`app-server`,`--analytics-default-enabled`],binDirectory:r.binDirectory}:null",
+    "}",
+    "function Fd(e){",
+    "let t=e.hostConfig.codex_cli_command;",
+    "if(t&&t.length>0){let[e,...n]=t;return!e||e.trim().length===0?null:{executablePath:e,args:n}}",
+    "let n=Kd();",
+    "if(n!=null)return{executablePath:n,args:[`app-server`,`--analytics-default-enabled`]};",
+    "let r=Ud(e.repoRoot,{resourcesPath:e.resourcesPath,windowsCodexHome:e.windowsCodexHome});",
+    "return r?{executablePath:r.executablePath,args:[`app-server`,`--analytics-default-enabled`],binDirectory:r.binDirectory}:null",
+    "}",
   ].join("");
 }
 
@@ -79,6 +102,27 @@ function syntheticMobileConnectedSettingsBundle() {
 
 function syntheticRemoteConnectionsSettingsCopyBundle() {
   return [
+    syntheticCurrentVisibilityBundle(),
+    "let platformLabel={id:`settings.remoteConnections.platform.mac`,defaultMessage:`Mac`,description:`Short label for a Mac device`};",
+    "let a={id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`};",
+    "let b={id:`settings.remoteControlConnections.devices.title`,defaultMessage:`Devices that can control this Mac`,description:`Header title for devices that can control this Mac`};",
+    "let c={id:`settings.remoteConnections.accessOtherDevices.header.title`,defaultMessage:`Devices you can control from this Mac`,description:`Header title for the devices this computer can access`};",
+    "let d={id:`settings.remoteConnections.ssh.header.title`,defaultMessage:`SSH connections from this Mac`,description:`Header title for SSH connections from this Mac`};",
+    "let e={id:`settings.remoteControlConnections.keepAwake.title`,defaultMessage:`Keep this Mac awake`,description:`Keep awake title`};",
+  ].join("");
+}
+
+function syntheticRemoteConnectionsSettingsSetupBundle() {
+  return [
+    "var Q={jsx:(e,t)=>({e,t}),jsxs:(e,t)=>({e,t})};",
+    "function pt(e){let t=(0,$.c)(2),{onClose:n}=e,r;return t[0]===n?r=t[1]:(r=(0,Q.jsx)(rt,{onClose:n,variant:`dialog`}),t[0]=n,t[1]=r),r}",
+    "function xt(){let e=(0,$.c)(2),{data:n,isLoading:r}=B(t.CODEX_MOBILE_SETUP_COMPLETED);if(r)return null;if(!n){let t;return e[0]===Symbol.for(`react.memo_cache_sentinel`)?(t=(0,Q.jsx)(Ct,{mode:`setup`}),e[0]=t):t=e[0],t}let i;return e[1]===Symbol.for(`react.memo_cache_sentinel`)?(i=(0,Q.jsxs)(Q.Fragment,{children:[(0,Q.jsx)(Ct,{mode:`manage`}),(0,Q.jsx)(St,{})]}),e[1]=i):i=e[1],i}",
+  ].join("");
+}
+
+function syntheticRemoteConnectionsSettingsSetupAndCopyBundle() {
+  return [
+    syntheticRemoteConnectionsSettingsSetupBundle(),
     syntheticCurrentVisibilityBundle(),
     "let platformLabel={id:`settings.remoteConnections.platform.mac`,defaultMessage:`Mac`,description:`Short label for a Mac device`};",
     "let a={id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`};",
@@ -136,17 +180,21 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.deepEqual(descriptors.map((descriptor) => descriptor.id), [
       "feature:remote-mobile-control:linux-remote-control-device-key",
       "feature:remote-mobile-control:linux-remote-control-preserve-config",
+      "feature:remote-mobile-control:linux-remote-control-app-server-host-mode",
       "feature:remote-mobile-control:linux-remote-control-client-account-compatibility",
       "feature:remote-mobile-control:linux-remote-control-client-revocation-recovery",
       "feature:remote-mobile-control:linux-remote-control-load-gate",
       "feature:remote-mobile-control:linux-remote-control-visibility",
+      "feature:remote-mobile-control:linux-remote-control-inline-setup-flow",
       "feature:remote-mobile-control:linux-remote-control-copy",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
       "main-bundle",
+      "extracted-app",
       "main-bundle",
       "main-bundle",
+      "webview-asset",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -179,6 +227,20 @@ test("Linux remote-control device-key patch handles current minified aliases", (
   assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
   assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
   assert.equal(applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)), patched);
+});
+
+test("Linux remote-control host mode patch starts the Desktop app-server as a Remote host", () => {
+  const source = syntheticAppServerLaunchBundle();
+  const patched = applyLinuxRemoteControlAppServerHostModePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(/`--remote-control`/g) ?? []).length, 4);
+  assert.doesNotMatch(patched, /args:\[`app-server`,`--analytics-default-enabled`\]/);
+  assert.match(
+    patched,
+    /args:\[`app-server`,`--analytics-default-enabled`,`--remote-control`\]/,
+  );
+  assert.equal(applyLinuxRemoteControlAppServerHostModePatch(patched), patched);
 });
 
 test("Linux remote-control client enrollment accepts account-scoped and base user ids", () => {
@@ -245,6 +307,18 @@ test("Linux remote-control visibility patch handles current settings bundle shap
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
   assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)/);
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("Linux remote-control settings setup renders the full mobile setup flow inline", () => {
+  const source = syntheticRemoteConnectionsSettingsSetupBundle();
+  const patched = applyLinuxRemoteControlInlineSetupFlowPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlInlineSetupFlow/);
+  assert.doesNotMatch(patched, /\(0,Q\.jsx\)\(Ct,\{mode:`setup`\}\)/);
+  assert.match(patched, /codexLinuxRemoteControlInlineSetupFlow\(Q,rt\)/);
+  assert.match(patched, /variant:`page`/);
+  assert.equal(applyLinuxRemoteControlInlineSetupFlowPatch(patched), patched);
 });
 
 test("Linux mobile setup copy does not refer to Mac-only Computer Use", () => {
@@ -350,6 +424,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.mkdirSync(assetsDir, { recursive: true });
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
         fs.writeFileSync(
+          path.join(buildDir, "workspace-root-drop-handler-test.js"),
+          syntheticAppServerLaunchBundle(),
+        );
+        fs.writeFileSync(
           path.join(assetsDir, "remote-connection-visibility-test.js"),
           syntheticRemoteConnectionVisibilityBundle(),
         );
@@ -359,7 +437,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
-          syntheticRemoteConnectionsSettingsCopyBundle(),
+          syntheticRemoteConnectionsSettingsSetupAndCopyBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
@@ -374,6 +452,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         patchExtractedApp(tempApp, { report });
 
         const patchedFile = fs.readFileSync(path.join(buildDir, "main.js"), "utf8");
+        const patchedLaunchFile = fs.readFileSync(
+          path.join(buildDir, "workspace-root-drop-handler-test.js"),
+          "utf8",
+        );
         const patchedVisibilityFile = fs.readFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           "utf8",
@@ -396,9 +478,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
+        assert.match(patchedLaunchFile, /`--remote-control`/);
         assert.match(patchedRemoteConnectionVisibilityFile, /codexLinuxRemoteControlLoadGateEnabled/);
         assert.match(patchedVisibilityFile, /navigator\.userAgent\.includes\(`Linux`\)/);
         assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
+        assert.match(patchedRemoteConnectionsSettingsFile, /codexLinuxRemoteControlInlineSetupFlow/);
         assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
         assert.match(patchedMobileSetupFlowFile, /Connect your phone to this Linux desktop/);
         assert.match(patchedMobileConnectedSettingsFile, /apps on this Linux desktop/);
@@ -422,6 +506,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.ok(
           report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-app-server-host-mode" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-load-gate" &&
             patch.status === "applied",
           ),
@@ -429,6 +519,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-visibility" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-inline-setup-flow" &&
             patch.status === "applied",
           ),
         );


### PR DESCRIPTION
## Summary
- start the Linux Desktop-managed local app-server with `--remote-control` by default
- keep custom `hostConfig.codex_cli_command` launches untouched
- render the full mobile setup flow inline for the Linux `Control this Linux desktop` setup state

## Why
On Linux, Codex Desktop starts its own child app-server for the local Electron host. The previous default launch args were only:

```text
app-server --analytics-default-enabled
```

That left the Desktop-managed host out of mobile Remote host mode, even when a separate official CLI Remote daemon was working. The phone could connect to the CLI identity, while the Desktop identity appeared grey/unusable.

After this patch, the packaged Linux Desktop child process starts as:

```text
app-server --analytics-default-enabled --remote-control
```

Local validation confirmed the Desktop child app-server established its own Remote 443 connection and the Android app could connect to the Desktop entry.

## Tests
- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `git diff --check -- linux-features/remote-mobile-control/patch.js linux-features/remote-mobile-control/test.js`
- rebuilt and installed local `.deb`; verified `/opt/codex-desktop/resources/app.asar` contains the patched default app-server args
