### PR TITLE
Fix Linux remote mobile Desktop-owned host cleanup

### DIFF
--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -8,6 +8,30 @@ truthy_env_value() {
     esac
 }
 
+cleanup_remote_mobile_control_interactive_symlink() {
+    local codex_home="$1"
+    local home_dir="${HOME:-}"
+    local user_codex=""
+    local resolved_user_codex=""
+    local standalone_root=""
+
+    [ -n "$home_dir" ] || return 0
+    user_codex="$home_dir/.local/bin/codex"
+    [ -L "$user_codex" ] || return 0
+    resolved_user_codex="$(readlink -f "$user_codex" 2>/dev/null || true)"
+    [ -n "$resolved_user_codex" ] || return 0
+    standalone_root="$(readlink -f "$codex_home/packages/standalone" 2>/dev/null || true)"
+    [ -n "$standalone_root" ] || standalone_root="$codex_home/packages/standalone"
+
+    case "$resolved_user_codex" in
+        "$standalone_root"/*)
+            if rm -f "$user_codex"; then
+                echo "Removed remote mobile control standalone symlink from interactive PATH: $user_codex -> $resolved_user_codex"
+            fi
+            ;;
+    esac
+}
+
 install_remote_mobile_control_runtime() {
     local codex_home="$1"
     local private_bin="$codex_home/packages/standalone/.bin"
@@ -57,7 +81,51 @@ install_remote_mobile_control_runtime() {
     fi
 }
 
+remote_mobile_control_daemon_pid() {
+    local pid_file="$1"
+
+    [ -f "$pid_file" ] || return 1
+    sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$pid_file" | head -n 1
+}
+
+cleanup_stale_remote_mobile_daemon_state() {
+    local codex_home="$1"
+    local pid_file=""
+    local pid=""
+
+    for pid_file in \
+        "$codex_home/app-server-daemon/app-server.pid" \
+        "$codex_home/app-server-daemon/app-server-updater.pid"
+    do
+        [ -e "$pid_file" ] || continue
+        pid="$(remote_mobile_control_daemon_pid "$pid_file" || true)"
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            continue
+        fi
+        if rm -f "$pid_file"; then
+            echo "Removed stale remote mobile control daemon pid file: $pid_file"
+        fi
+    done
+}
+
+desktop_app_server_remote_control_enabled() {
+    local app_dir="${CODEX_LINUX_APP_DIR:-}"
+    local marker=""
+
+    if truthy_env_value "${CODEX_REMOTE_CONTROL_FORCE_COLD_START_DAEMON:-}"; then
+        return 1
+    fi
+
+    [ -n "$app_dir" ] || return 1
+    marker="$app_dir/.codex-linux/desktop-app-server-remote-control-enabled"
+    [ -f "$marker" ]
+}
+
 remote_mobile_control_main() {
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+
+    cleanup_remote_mobile_control_interactive_symlink "$codex_home"
+
     if truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
         echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
         return 0
@@ -67,8 +135,12 @@ remote_mobile_control_main() {
         echo "Remote mobile control daemon autostart skipped; codex-remote-control.service is already active"
         return 0
     fi
+    if desktop_app_server_remote_control_enabled; then
+        cleanup_stale_remote_mobile_daemon_state "$codex_home"
+        echo "Remote mobile control daemon autostart skipped; Desktop app-server launches with remote-control enabled"
+        return 0
+    fi
 
-    local codex_home="${CODEX_HOME:-$HOME/.codex}"
     local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
 
     if [ ! -x "$standalone_codex" ]; then

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -41,6 +41,7 @@ const REMOTE_MOBILE_ACTIVE_STATUS_MARKER = "codexLinuxRemoteMobileActiveStatus";
 const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMobileSetupAfterRevoke";
 const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAppServerArgs";
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE = "args:[`app-server`,`--analytics-default-enabled`]";
+const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProjectlessRemoteTaskId";
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -914,6 +915,49 @@ function applyLinuxRemoteMobileActiveStatusPatch(source) {
   );
 }
 
+function applyLinuxRemoteMobileProjectlessRemoteTaskPatch(source) {
+  if (source.includes(REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER)) {
+    return source;
+  }
+  if (!source.includes("No owner repo found for remote task")) {
+    return source;
+  }
+
+  const fallbackPattern =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\5\);if\(!\7\)\{([A-Za-z_$][\w$]*)\.warning\(`No owner repo found for remote task`,\{safe:\{taskId:\2\.task\.id\},sensitive:\{\}\}\);return\}/u;
+  const match = source.match(fallbackPattern);
+  if (match == null) {
+    console.warn("WARN: Could not find remote task owner-repo grouping needle - skipping projectless remote task patch");
+    return source;
+  }
+
+  const [
+    needle,
+    functionName,
+    remoteTaskVar,
+    remoteProjectsByLabelVar,
+    projectGroupsVar,
+    remoteProjectVar,
+    remoteProjectForTaskFn,
+    ownerRepoVar,
+    ownerRepoForProjectFn,
+  ] = match;
+
+  return source.replace(
+    needle,
+    [
+      `function ${functionName}(${remoteTaskVar},${remoteProjectsByLabelVar},${projectGroupsVar}){`,
+      `let ${remoteProjectVar}=${remoteProjectForTaskFn}(${remoteTaskVar},${remoteProjectsByLabelVar}),`,
+      `${ownerRepoVar}=${ownerRepoForProjectFn}(${remoteProjectVar});`,
+      `if(!${ownerRepoVar}){`,
+      `let ${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}=${remoteTaskVar}.task?.id??${remoteTaskVar}.conversationId??${remoteTaskVar}.key??\`unknown\`,`,
+      `codexLinuxRemoteMobileProjectlessRemoteTaskLabel=${remoteTaskVar}.task?.task_status_display?.environment_label??${remoteTaskVar}.task?.title??\`Remote task\`,`,
+      `codexLinuxRemoteMobileProjectlessRemoteTaskGroup={projectId:\`remote-task:\${${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}}\`,projectKind:\`remote\`,label:codexLinuxRemoteMobileProjectlessRemoteTaskLabel,path:\`\${${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}}\`,repositoryData:null,isCodexWorktree:!1,threadKeys:[]};`,
+      `${projectGroupsVar}.push(codexLinuxRemoteMobileProjectlessRemoteTaskGroup),codexLinuxRemoteMobileProjectlessRemoteTaskGroup.threadKeys.push(${remoteTaskVar}.key);return}`,
+    ].join(""),
+  );
+}
+
 module.exports = [
   {
     id: "linux-remote-control-device-key",
@@ -1050,6 +1094,16 @@ module.exports = [
     skipDescription: "Linux remote-mobile active status patch",
     apply: applyLinuxRemoteMobileActiveStatusPatch,
   },
+  {
+    id: "linux-remote-mobile-projectless-remote-task",
+    phase: "webview-asset",
+    pattern: /^sidebar-project-groups-.*\.js$/,
+    order: 20_170,
+    ciPolicy: "optional",
+    missingDescription: "sidebar project groups bundle",
+    skipDescription: "Linux remote-mobile projectless remote task patch",
+    apply: applyLinuxRemoteMobileProjectlessRemoteTaskPatch,
+  },
 ];
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
@@ -1072,3 +1126,5 @@ module.exports.applyLinuxRemoteControlFeatureSyncPatch = applyLinuxRemoteControl
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;
 module.exports.applyLinuxRemoteControlSettingsUxPatch = applyLinuxRemoteControlSettingsUxPatch;
+module.exports.applyLinuxRemoteMobileProjectlessRemoteTaskPatch =
+  applyLinuxRemoteMobileProjectlessRemoteTaskPatch;

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -5,12 +5,21 @@ client="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/chrome/scripts/bro
 patch_module="$SCRIPT_DIR/linux-features/remote-mobile-control/patch.js"
 feature_marker_dir="$INSTALL_DIR/.codex-linux"
 feature_marker="$feature_marker_dir/remote-mobile-control-enabled"
+desktop_remote_control_marker="$feature_marker_dir/desktop-app-server-remote-control-enabled"
 cold_start_hook_dir="$feature_marker_dir/cold-start.d"
 cold_start_hook="$cold_start_hook_dir/remote-mobile-control"
 
 mkdir -p "$feature_marker_dir" "$cold_start_hook_dir"
 printf '%s\n' "remote-mobile-control" > "$feature_marker"
 install -m 0755 "$SCRIPT_DIR/linux-features/remote-mobile-control/cold-start-hook.sh" "$cold_start_hook"
+
+if [ -d "$WORK_DIR/app-extracted/.vite/build" ] &&
+    grep -R -q "codexLinuxRemoteMobileAppServerArgs" "$WORK_DIR/app-extracted/.vite/build" 2>/dev/null; then
+    printf '%s\n' "desktop-app-server-remote-control" > "$desktop_remote_control_marker"
+else
+    rm -f "$desktop_remote_control_marker"
+    echo "WARN: Desktop app-server remote-control marker not found; standalone remote mobile daemon remains enabled" >&2
+fi
 
 if [ ! -f "$client" ]; then
     echo "WARN: Chrome browser-client.mjs not found; skipping remote-mobile Chrome bridge patch" >&2

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -30,10 +31,13 @@ const {
   applyLinuxRemoteMobileAppServerRemoteControlPatch,
   applyLinuxRemoteMobileChromeBridgePatch,
   applyLinuxRemoteMobileConversationHydrationPatch,
+  applyLinuxRemoteMobileProjectlessRemoteTaskPatch,
   applyLinuxRemoteConnectionsRefreshPatch,
   applyLinuxRemoteControlSettingsUxPatch,
   applyLinuxRemoteControlVisibilityPatch,
 } = require("./patch.js");
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
 
 function syntheticMainBundle() {
   return [
@@ -179,6 +183,12 @@ function syntheticAppMainActiveStatusBundle() {
   ].join("");
 }
 
+function syntheticSidebarProjectGroupsBundle() {
+  return [
+    "function X(e,t,n){let r=Q(e,t),i=$(r);if(!i){s.warning(`No owner repo found for remote task`,{safe:{taskId:e.task.id},sensitive:{}});return}let a=i.repoName.toLowerCase();(n.find(e=>I(e.repositoryData?.ownerRepo,i)&&e.repositoryData?.repoPath===``&&e.repositoryData?.rootFolder?.toLowerCase()===a)??null??n.find(e=>I(e.repositoryData?.ownerRepo,i))??Z(i,r,n)).threadKeys.push(e.key)}",
+  ].join("");
+}
+
 function syntheticAppMainEnablementBridgeBundle() {
   return [
     "var DF=`[remote-connections/slingshot-gate-bridge]`;",
@@ -230,10 +240,241 @@ function captureWarnings(fn) {
   }
 }
 
+function runColdStartHook(env) {
+  return spawnSync("bash", [path.join(__dirname, "cold-start-hook.sh"), "--run-main"], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+function runStageHook(env) {
+  return spawnSync("bash", [path.join(__dirname, "stage.sh")], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+function writeDesktopAppServerRemoteControlMarker(appDir) {
+  const marker = path.join(appDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
+  fs.mkdirSync(path.dirname(marker), { recursive: true });
+  fs.writeFileSync(marker, "desktop-app-server-remote-control\n");
+}
+
 test("remote mobile control feature stays disabled until listed in features.json", () => {
   withTempFeatureRoot([], (root) => {
     assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot: root }), []);
   });
+});
+
+test("remote mobile stage hook writes installed Desktop app-server ownership marker from patched app layout", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
+  try {
+    const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
+    const workDir = path.join(tempRoot, "work");
+    const buildDir = path.join(workDir, "app-extracted", ".vite", "build");
+    const marker = path.join(installDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
+    const coldStartHook = path.join(installDir, ".codex-linux", "cold-start.d", "remote-mobile-control");
+
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileAppServerArgs=true;");
+
+    const result = runStageHook({
+      ARCH: "x64",
+      CODEX_UPSTREAM_APP_DIR: path.join(tempRoot, "upstream-app"),
+      INSTALL_DIR: installDir,
+      SCRIPT_DIR: REPO_ROOT,
+      WORK_DIR: workDir,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(marker, "utf8"), "desktop-app-server-remote-control\n");
+    assert.equal(fs.existsSync(coldStartHook), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile stage hook leaves Desktop ownership marker absent when patch marker is missing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
+  try {
+    const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
+    const workDir = path.join(tempRoot, "work");
+    const buildDir = path.join(workDir, "app-extracted", ".vite", "build");
+    const marker = path.join(installDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
+
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.someOtherPatch=true;");
+
+    const result = runStageHook({
+      ARCH: "x64",
+      CODEX_UPSTREAM_APP_DIR: path.join(tempRoot, "upstream-app"),
+      INSTALL_DIR: installDir,
+      SCRIPT_DIR: REPO_ROOT,
+      WORK_DIR: workDir,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(marker), false);
+    assert.match(result.stderr, /Desktop app-server remote-control marker not found/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes leaked standalone codex symlink from interactive PATH", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "codex");
+    const userCodex = path.join(home, ".local", "bin", "codex");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(path.dirname(userCodex), { recursive: true });
+    fs.writeFileSync(standaloneCodex, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(standaloneCodex, 0o755);
+    fs.symlinkSync(standaloneCodex, userCodex);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(userCodex), false);
+    assert.match(result.stdout, /Removed remote mobile control standalone symlink from interactive PATH/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook preserves user codex symlinks outside the standalone runtime", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const userManagedCodex = path.join(tempRoot, "brew", "bin", "codex");
+    const userCodex = path.join(home, ".local", "bin", "codex");
+
+    fs.mkdirSync(path.dirname(userManagedCodex), { recursive: true });
+    fs.mkdirSync(path.dirname(userCodex), { recursive: true });
+    fs.writeFileSync(userManagedCodex, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(userManagedCodex, 0o755);
+    fs.symlinkSync(userManagedCodex, userCodex);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readlinkSync(userCodex), userManagedCodex);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook skips daemon when Desktop app-server owns remote-control", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const appDir = path.join(tempRoot, "package", "share", "codex-desktop", "app");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "codex");
+    const callsLog = path.join(tempRoot, "calls.log");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(
+      standaloneCodex,
+      `#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsLog)}\nexit 0\n`,
+    );
+    fs.chmodSync(standaloneCodex, 0o755);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_LINUX_APP_DIR: appDir,
+      CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(callsLog), false);
+    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes dead standalone daemon pid files when Desktop app-server owns remote-control", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "package", "share", "codex-desktop", "app");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(
+      path.join(daemonDir, "app-server.pid"),
+      JSON.stringify({ pid: 999999, processStartTime: "fixture" }),
+    );
+    fs.writeFileSync(
+      path.join(daemonDir, "app-server-updater.pid"),
+      JSON.stringify({ pid: 999998, processStartTime: "fixture" }),
+    );
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_LINUX_APP_DIR: appDir,
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(path.join(daemonDir, "app-server.pid")), false);
+    assert.equal(fs.existsSync(path.join(daemonDir, "app-server-updater.pid")), false);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
+    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook preserves live standalone daemon pid files when Desktop app-server owns remote-control", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "package", "share", "codex-desktop", "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(appDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, JSON.stringify({ pid: process.pid, processStartTime: "fixture" }));
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_LINUX_APP_DIR: appDir,
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), true);
+    assert.doesNotMatch(result.stdout, /Removed stale remote mobile control daemon pid file/);
+    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("remote mobile control feature exposes opt-in main-bundle and webview patches", () => {
@@ -255,6 +496,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
       "feature:remote-mobile-control:linux-remote-control-enablement-bridge",
       "feature:remote-mobile-control:linux-remote-mobile-active-status",
+      "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
@@ -262,6 +504,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "main-bundle",
       "main-bundle",
       "extracted-app",
+      "webview-asset",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -652,6 +895,19 @@ test("Linux remote mobile conversation hydration patch upgrades local-path guard
   assert.equal(applyLinuxRemoteMobileConversationHydrationPatch(upgraded), upgraded);
 });
 
+test("Linux remote mobile projectless remote task patch groups tasks without owner repo metadata", () => {
+  const source = syntheticSidebarProjectGroupsBundle();
+  const patched = applyLinuxRemoteMobileProjectlessRemoteTaskPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileProjectlessRemoteTaskId/);
+  assert.match(patched, /projectId:`remote-task:\$\{codexLinuxRemoteMobileProjectlessRemoteTaskId\}`/);
+  assert.match(patched, /repositoryData:null/);
+  assert.match(patched, /threadKeys:\[\]/);
+  assert.doesNotMatch(patched, /No owner repo found for remote task/);
+  assert.equal(applyLinuxRemoteMobileProjectlessRemoteTaskPatch(patched), patched);
+});
+
 test("Linux remote mobile active-status patch treats active thread status as active without stream role", () => {
   const source = syntheticAppMainActiveStatusBundle();
   const patched = applyLinuxRemoteMobileActiveStatusPatch(source);
@@ -881,6 +1137,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             syntheticAppMainEnablementBridgeBundle() +
             syntheticAppMainActiveStatusBundle(),
         );
+        fs.writeFileSync(
+          path.join(assetsDir, "sidebar-project-groups-test.js"),
+          syntheticSidebarProjectGroupsBundle(),
+        );
 
         const report = createPatchReport();
         patchExtractedApp(tempApp, { report });
@@ -918,6 +1178,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "app-server-manager-signals-test.js"),
           "utf8",
         );
+        const patchedSidebarProjectGroupsFile = fs.readFileSync(
+          path.join(assetsDir, "sidebar-project-groups-test.js"),
+          "utf8",
+        );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
@@ -935,6 +1199,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedMobileConnectedSettingsFile, /apps on this Linux desktop/);
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileHydrateUnknownTurn/);
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileThreadRuntimeStatus/);
+        assert.match(patchedSidebarProjectGroupsFile, /codexLinuxRemoteMobileProjectlessRemoteTaskId/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteControlEnablementBridge/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteMobileActiveStatus/);
         assert.ok(
@@ -1018,6 +1283,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-mobile-active-status" &&
+            patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task" &&
             patch.status === "applied",
           ),
         );


### PR DESCRIPTION
Fixes #266.

## Summary

Follow-up to #260. Once the Linux Desktop app-server is patched to launch with `--remote-control`, the remote-mobile cold-start hook should not also launch a standalone remote-control daemon. This keeps Android from seeing duplicate/stale hosts and avoids stale local daemon ownership after rebuilds or reinstalls.

## Changes

- Stage an installed `.codex-linux/desktop-app-server-remote-control-enabled` marker when the patched app layout contains the Desktop app-server remote-control marker.
- Skip the cold-start standalone daemon from that installed marker instead of depending on a build-only `patch-report.json` path.
- Remove dead `app-server.pid` and `app-server-updater.pid` files before handing remote-control ownership to Desktop app-server.
- Remove leaked `~/.local/bin/codex` symlinks that point into the remote-mobile standalone runtime, while preserving user-managed Codex symlinks elsewhere.
- Keep remote/mobile tasks without owner/repo metadata visible as synthetic projectless remote task groups instead of dropping them after `No owner repo found for remote task`.

## Validation

- `node --test linux-features/remote-mobile-control/test.js`
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh linux-features/remote-mobile-control/cold-start-hook.sh linux-features/remote-mobile-control/stage.sh`
- `git diff --check`
- `env -u CODEX_LINUX_SETTINGS_FILE bash tests/scripts_smoke.sh`

The last command unsets a local Codex Desktop runtime override from this development session; CI should not inherit that Desktop-specific `CODEX_LINUX_SETTINGS_FILE` value.