### PR TITLE
Fix Chrome plugin auto-install patch drift

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,20 +22,20 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-bUQMcTN3GTXIYKVUa81gP4ubZbN+m4K9sAGdT9DIW2o=";
+          hash = "sha256-f4/zAyMCeW9hDeIy6Hrac5VdGJyq1a0UAlSGXLrXtyk=";
         };
 
-        codexVersion = "26.513.31313";
-        electronVersion = "42.0.1";
+        codexVersion = "26.519.22136";
+        electronVersion = "42.1.0";
         electronPlatform =
           {
             x86_64-linux = {
               arch = "x64";
-              hash = "sha256-4bi1uG0//2nis1AlhjY9OECF7gV4vQQfpZFf0LVXxPE=";
+              hash = "sha256-iCBHNDqeIDxs/F05sWbqngJd0laUPg03EfhnJa0OO9k=";
             };
             aarch64-linux = {
               arch = "arm64";
-              hash = "sha256-oIpOaROATrBc6nmNi9CvrOTRuI6dB9uGt3nqSkSL4HA=";
+              hash = "sha256-HnAPfz2u95TMRSNeUcEXJmSu1JpOdze4iW3cOYv/TX0=";
             };
           }.${system} or (throw "codex-desktop-linux Nix package is not supported on ${system}");
 
@@ -46,7 +46,7 @@
 
         electronHeaders = pkgs.fetchurl {
           url = "https://artifacts.electronjs.org/headers/dist/v${electronVersion}/node-v${electronVersion}-headers.tar.gz";
-          hash = "sha256-yQBrv98qtbQ8cdZpuqx2uyP1mkIAVhLlUFjI/vxh9gA=";
+          hash = "sha256-DPwdIPJS1sKb3RSx88qjDtxkd9uT5aZiBnRCSzjc3f0=";
         };
 
         browserUseNodeReplRuntime = pkgs.fetchurl {

--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@electron/rebuild": "4.0.4",
         "better-sqlite3": "12.9.0",
-        "electron": "42.0.1",
+        "electron": "42.1.0",
         "node-abi": "^4.31.0",
         "node-pty": "1.1.0"
       }
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.1.tgz",
-      "integrity": "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==",
+      "version": "42.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.1.0.tgz",
+      "integrity": "sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^5.0.0",

--- a/nix/native-modules/package.json
+++ b/nix/native-modules/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@electron/rebuild": "4.0.4",
     "better-sqlite3": "12.9.0",
-    "electron": "42.0.1",
+    "electron": "42.1.0",
     "node-abi": "^4.31.0",
     "node-pty": "1.1.0"
   }

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1877,6 +1877,42 @@ test("handles literal Chrome plugin gate names", () => {
   assert.doesNotMatch(patched, /installWhenMissing:!0,name:'chrome-internal'/);
 });
 
+test("does not fail when external browser flags appear outside Chrome plugin gates", () => {
+  const source =
+    "var me={externalBrowserUse:!1,externalBrowserUseAllowed:!1},ut=`chrome`;";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("reports Chrome plugin auto-install as already applied when only feature defaults remain", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-chrome-feature-defaults-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      `${mainBundlePrefix}var me={externalBrowserUse:!1,externalBrowserUseAllowed:!1},ut=\`chrome\`;`,
+    );
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const pluginGatePatch = report.patches.find((patch) => patch.name === "linux-chrome-plugin-auto-install");
+    assert.equal(pluginGatePatch.status, "already-applied");
+    assert.doesNotMatch(
+      validateReport(report, "upstream-build").join("\n"),
+      /linux-chrome-plugin-auto-install/,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("reports missing required Chrome plugin auto-install gate as required upstream validation failure", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-chrome-"));
   try {

--- a/scripts/patches/chrome-plugin.js
+++ b/scripts/patches/chrome-plugin.js
@@ -17,6 +17,43 @@ function hasChromeAutoInstall(source, chromeNameVar) {
   return new RegExp(String.raw`installWhenMissing:!0,name:(?:${namePatterns.join("|")})`).test(source);
 }
 
+function applyNearbyChromeGateFallback(currentSource, chromeNameVar, nameExpressionPattern) {
+  const nameAvailabilityRegex =
+    new RegExp(String.raw`name:(${nameExpressionPattern}),((?:isEnabled|isAvailable):)`, "g");
+
+  let patched = "";
+  let lastIndex = 0;
+  let didPatch = false;
+
+  for (const match of currentSource.matchAll(nameAvailabilityRegex)) {
+    const [matchText, nameExpr, availabilityPrefix] = match;
+    const matchIndex = match.index;
+    if (matchIndex == null || !isChromeNameExpr(nameExpr, chromeNameVar)) {
+      continue;
+    }
+
+    const before = currentSource.slice(Math.max(0, matchIndex - 300), matchIndex);
+    const after = currentSource.slice(matchIndex, Math.min(currentSource.length, matchIndex + 900));
+    if (
+      before.includes("installWhenMissing:!0") ||
+      !after.includes("externalBrowserUseAllowed")
+    ) {
+      continue;
+    }
+
+    patched += currentSource.slice(lastIndex, matchIndex);
+    patched += `installWhenMissing:!0,name:${nameExpr},${availabilityPrefix}`;
+    lastIndex = matchIndex + matchText.length;
+    didPatch = true;
+  }
+
+  if (!didPatch) {
+    return currentSource;
+  }
+
+  return patched + currentSource.slice(lastIndex);
+}
+
 function applyLinuxChromePluginAutoInstallPatch(currentSource) {
   if (!hasChromePluginLiteral(currentSource)) {
     console.warn(
@@ -58,13 +95,15 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
     return currentSource;
   }
 
-  if (currentSource.includes("externalBrowserUseAllowed")) {
-    throw new Error("Required Linux Chrome plugin auto-install patch failed: could not enable bundled Chrome auto-install");
+  const fallbackPatched = applyNearbyChromeGateFallback(
+    currentSource,
+    chromeNameVar,
+    nameExpressionPattern,
+  );
+  if (fallbackPatched !== currentSource) {
+    return fallbackPatched;
   }
 
-  console.warn(
-    "WARN: Could not find Chrome plugin auto-install gate — skipping Linux Chrome plugin auto-install patch",
-  );
   return currentSource;
 }
 


### PR DESCRIPTION
## Summary
- tolerate upstream bundles where `externalBrowserUseAllowed` appears outside the Chrome plugin gate
- add a bounded fallback matcher for nearby Chrome plugin `name`/availability pairs
- add a regression test for feature-default occurrences that should not fail the patcher

## Root cause
The Chrome plugin patch treated any remaining `externalBrowserUseAllowed` string as proof that the Chrome auto-install gate was recognizable but unpatched. The current upstream Codex Desktop bundle also contains that string in feature defaults, so the Linux rebuild failed even when the plugin gate shape had simply drifted.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- local updater rebuild produced and installed `codex-desktop 2026.05.21.204000-1` after this patch