### PR TITLE
Sync Linux Computer Use from agent-sh 0.2.2

### DIFF
--- a/.github/workflows/computer-use-sync-reminder.yml
+++ b/.github/workflows/computer-use-sync-reminder.yml
@@ -1,0 +1,73 @@
+name: computer-use sync reminder
+
+# When a merge to main touches the vendored Linux Computer Use crate, open (or
+# update) an issue so the change can be propagated to the standalone
+# agent-sh/computer-use-linux repo. Version-number parity between the two crates
+# is the coordination signal; this makes the reminder explicit so the numbers do
+# not silently drift apart.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'computer-use-linux/**'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remind:
+    name: open sync reminder
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'computer-use-sync';
+            const otherRepo = 'agent-sh/computer-use-linux';
+            const compare = context.payload.compare || '';
+            const sha = context.sha.slice(0, 8);
+            const body = [
+              'A merge to `main` touched `computer-use-linux/**` (the vendored Linux Computer Use crate).',
+              '',
+              `Propagate the change to **${otherRepo}** if it is not codex-specific glue.`,
+              'Keep the upstream generic naming there — do **not** push `codex-*` /',
+              '`CODEX_COMPUTER_USE_*` names, `identity.rs`, or the chrome-extension host upstream.',
+              '',
+              `- Compare: ${compare || sha}`,
+              `- Triggering commit: ${context.sha}`,
+              '',
+              'Once synced, bump both crates to the same enumeration. A version mismatch',
+              'between this crate and the standalone one means a sync is still pending.',
+            ].join('\n');
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch (e) {
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: label,
+                color: 'fbca04',
+                description: 'Pending Linux Computer Use sync to the other repo',
+              });
+            }
+            const existing = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'open',
+              labels: label,
+              per_page: 1,
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                ...context.repo,
+                title: 'Sync Linux Computer Use → agent-sh/computer-use-linux',
+                labels: [label],
+                body,
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ This path is for users who do not want a system-wide native package; the daily-d
 ## Crate Versioning
 
 - Current updater crate version: `0.7.1` (`updater/Cargo.toml`).
-- Current `codex-computer-use-linux` crate version: `0.1.2-linux-alpha1` (`computer-use-linux/Cargo.toml`).
+- Current `codex-computer-use-linux` crate version: `0.2.3-linux-alpha1` (`computer-use-linux/Cargo.toml`). The enumeration tracks the standalone `agent-sh/computer-use-linux` crate (currently `0.2.3`); a mismatch means a sync between the two is pending.
 - Bump `patch` for fixes, docs, and maintenance-only updates.
 - Bump `minor` for compatible feature additions.
 - Bump `major` for incompatible CLI, persisted-state, or install-flow changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +470,7 @@ dependencies = [
  "atspi",
  "base64",
  "cosmic-protocols",
+ "evdev",
  "futures-util",
  "libc",
  "rmcp",
@@ -768,6 +781,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "libc",
+ "nix",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +861,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1456,6 +1487,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "notify-rust"
 version = "4.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1827,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2321,6 +2370,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tauri-winrt-notification"
@@ -3432,6 +3487,15 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xkeysym"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +490,7 @@ dependencies = [
  "cosmic-protocols",
  "evdev",
  "futures-util",
+ "image",
  "libc",
  "rmcp",
  "schemars",
@@ -588,6 +607,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -820,10 +848,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1316,6 +1363,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,6 +1554,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1667,6 +1747,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,6 +1824,12 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
@@ -2293,6 +2392,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "codex-computer-use-linux"
-version = "0.1.2-linux-alpha1"
+version = "0.2.3-linux-alpha1"
 dependencies = [
  "anyhow",
  "atspi",

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control d
 - app listing and accessibility trees via AT-SPI
 - screenshots through GNOME Shell DBus or XDG Desktop Portal
 - window listing and focusing on GNOME, KWin/Plasma, Hyprland, and i3
-- keyboard, text, click, scroll, and drag input through `ydotool`
+- keyboard, text, click, scroll, and drag input through a uinput absolute pointer, the XDG Desktop Portal RemoteDesktop session, or `ydotool`
 
 ### Runtime dependencies
 

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.102"
 atspi = { version = "0.29.0", features = ["tokio"] }
 base64 = "0.22.1"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = ["client"] }
+evdev = "0.13.2"
 futures-util = "0.3.32"
 libc = "0.2"
 rmcp = { version = "1.5.0", features = ["transport-io"] }

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -18,6 +18,7 @@ base64 = "0.22.1"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = ["client"] }
 evdev = "0.13.2"
 futures-util = "0.3.32"
+image = { version = "0.25", default-features = false, features = ["png"] }
 libc = "0.2"
 rmcp = { version = "1.5.0", features = ["transport-io"] }
 schemars = "1.0"

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-computer-use-linux"
-version = "0.1.2-linux-alpha1"
+version = "0.2.3-linux-alpha1"
 edition = "2021"
 
 [[bin]]

--- a/computer-use-linux/src/abs_pointer.rs
+++ b/computer-use-linux/src/abs_pointer.rs
@@ -1,0 +1,143 @@
+//! Direct uinput **absolute** pointer.
+//!
+//! ydotool's virtual device is relative-only (`EV=7`: SYN|KEY|REL), so its
+//! `--absolute` is faked as "pin-to-corner + relative move", which the
+//! compositor then distorts with pointer acceleration and fractional display
+//! scaling — clicks land in the wrong place on multi-monitor / HiDPI setups.
+//!
+//! Here we create our own uinput device that exposes a true `ABS_X`/`ABS_Y`
+//! axis whose range equals the **logical desktop size** (the same coordinate
+//! space the portal screenshot reports). The compositor maps an absolute
+//! device's axis range across the whole logical layout, so `ABS(x, y)` lands at
+//! screenshot pixel `(x, y)` regardless of scaling — and with no approval
+//! dialog (we already hold `/dev/uinput` access).
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use evdev::{
+    uinput::VirtualDevice, AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent, KeyCode,
+    PropType, UinputAbsSetup,
+};
+
+pub struct AbsPointer {
+    device: VirtualDevice,
+    width: i32,
+    height: i32,
+}
+
+impl AbsPointer {
+    /// Create the absolute pointer sized to the logical desktop `width`×`height`
+    /// (the portal screenshot dimensions). Blocks ~`settle` ms so libinput picks
+    /// the device up before the first event.
+    pub fn create(width: i32, height: i32) -> Result<Self> {
+        let width = width.max(1);
+        let height = height.max(1);
+        // value, min, max, fuzz, flat, resolution. resolution=1 unit/px.
+        let abs_x =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, AbsInfo::new(0, 0, width, 0, 0, 1));
+        let abs_y =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, AbsInfo::new(0, 0, height, 0, 0, 1));
+        let keys =
+            AttributeSet::from_iter([KeyCode::BTN_LEFT, KeyCode::BTN_RIGHT, KeyCode::BTN_MIDDLE]);
+        // INPUT_PROP_DIRECT marks the device as a direct (absolute) pointer so
+        // libinput maps its axes to screen coordinates rather than treating it
+        // as a relative touchpad.
+        let props = AttributeSet::from_iter([PropType::DIRECT]);
+
+        let device = VirtualDevice::builder()
+            .context("uinput builder (is /dev/uinput writable?)")?
+            .name("codex-computer-use-linux absolute pointer")
+            .with_properties(&props)?
+            .with_absolute_axis(&abs_x)?
+            .with_absolute_axis(&abs_y)?
+            .with_keys(&keys)?
+            .build()
+            .context("failed to create uinput absolute pointer device")?;
+
+        // Give udev/libinput time to enumerate the new device.
+        sleep(Duration::from_millis(500));
+
+        Ok(Self {
+            device,
+            width,
+            height,
+        })
+    }
+
+    /// Move the pointer to absolute logical coordinates `(x, y)`.
+    pub fn move_to(&mut self, x: i32, y: i32) -> Result<()> {
+        let x = x.clamp(0, self.width);
+        let y = y.clamp(0, self.height);
+        self.device
+            .emit(&[
+                InputEvent::new_now(EventType::ABSOLUTE.0, AbsoluteAxisCode::ABS_X.0, x),
+                InputEvent::new_now(EventType::ABSOLUTE.0, AbsoluteAxisCode::ABS_Y.0, y),
+            ])
+            .context("failed to emit absolute motion")?;
+        Ok(())
+    }
+
+    /// Move to `(x, y)` then press+release `button` `count` times.
+    pub fn click(&mut self, x: i32, y: i32, button: PointerButton, count: u32) -> Result<()> {
+        self.move_to(x, y)?;
+        sleep(Duration::from_millis(30));
+        let code = button.key_code();
+        for _ in 0..count.max(1) {
+            self.device
+                .emit(&[InputEvent::new_now(EventType::KEY.0, code, 1)])?;
+            sleep(Duration::from_millis(30));
+            self.device
+                .emit(&[InputEvent::new_now(EventType::KEY.0, code, 0)])?;
+            sleep(Duration::from_millis(40));
+        }
+        Ok(())
+    }
+
+    /// Press at `(start)`, move to `(end)`, release — a drag with `button`.
+    pub fn drag(
+        &mut self,
+        start: (i32, i32),
+        end: (i32, i32),
+        button: PointerButton,
+    ) -> Result<()> {
+        let code = button.key_code();
+        self.move_to(start.0, start.1)?;
+        sleep(Duration::from_millis(30));
+        self.device
+            .emit(&[InputEvent::new_now(EventType::KEY.0, code, 1)])?;
+        sleep(Duration::from_millis(40));
+        self.move_to(end.0, end.1)?;
+        sleep(Duration::from_millis(40));
+        self.device
+            .emit(&[InputEvent::new_now(EventType::KEY.0, code, 0)])?;
+        Ok(())
+    }
+}
+
+/// Pointer buttons we can synthesize.
+#[derive(Clone, Copy, Debug)]
+pub enum PointerButton {
+    Left,
+    Right,
+    Middle,
+}
+
+impl PointerButton {
+    pub fn from_name(name: Option<&str>) -> Self {
+        match name.unwrap_or("left").to_ascii_lowercase().as_str() {
+            "right" => Self::Right,
+            "middle" => Self::Middle,
+            _ => Self::Left,
+        }
+    }
+
+    fn key_code(self) -> u16 {
+        match self {
+            Self::Left => KeyCode::BTN_LEFT.0,
+            Self::Right => KeyCode::BTN_RIGHT.0,
+            Self::Middle => KeyCode::BTN_MIDDLE.0,
+        }
+    }
+}

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -34,6 +34,33 @@ pub struct DoctorReport {
     pub windowing: WindowingReport,
     pub input: InputReport,
     pub readiness: ReadinessReport,
+    /// Which interchangeable backends this environment supports, per layer, plus
+    /// the one the tool prefers. Lets an agent (or selector) understand what's
+    /// available and choose accordingly instead of assuming one fixed path.
+    pub capabilities: CapabilityMap,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct CapabilityMap {
+    /// Pointer/keyboard injection backends, best-first.
+    pub input: Vec<String>,
+    /// Screen capture backends, best-first.
+    pub screenshot: Vec<String>,
+    /// Window listing/focus backends available.
+    pub window_control: Vec<String>,
+    /// Accessibility (element-targeted, non-pointer) backends.
+    pub accessibility: Vec<String>,
+    /// Display/session isolation contexts the host can provide.
+    pub isolation: Vec<String>,
+    /// The backend the tool will use by default for each selectable layer.
+    pub preferred: PreferredBackends,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct PreferredBackends {
+    pub input: Option<String>,
+    pub screenshot: Option<String>,
+    pub window_control: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -145,6 +172,8 @@ pub fn doctor_report() -> DoctorReport {
     let input = input_report();
     let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
 
+    let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+
     DoctorReport {
         platform,
         portals,
@@ -152,6 +181,82 @@ pub fn doctor_report() -> DoctorReport {
         windowing,
         input,
         readiness,
+        capabilities,
+    }
+}
+
+/// Derive the per-layer backend capability map from the individual checks. Lists
+/// are ordered best-first and mirror the order the tool actually tries them.
+fn capability_map(
+    platform: &PlatformReport,
+    portals: &PortalReport,
+    accessibility: &AccessibilityReport,
+    windowing: &WindowingReport,
+    input: &InputReport,
+) -> CapabilityMap {
+    let mut input_backends = Vec::new();
+    // Absolute uinput pointer: accurate, non-blocking of coordinates; preferred.
+    if input.uinput.ok {
+        input_backends.push("abs_pointer".to_string());
+    }
+    if portals.remote_desktop.ok {
+        input_backends.push("portal".to_string());
+    }
+    if input.ydotool_socket.ok {
+        input_backends.push("ydotool".to_string());
+    }
+
+    let mut screenshot_backends = Vec::new();
+    if platform.gnome_shell_version.ok {
+        screenshot_backends.push("gnome_shell".to_string());
+    }
+    if portals.screenshot.ok {
+        screenshot_backends.push("portal".to_string());
+    }
+
+    let mut window_backends = Vec::new();
+    if windowing.codex_gnome_shell_extension.ok {
+        window_backends.push("gnome_shell_extension".to_string());
+    }
+    if windowing.gnome_shell_introspect.ok {
+        window_backends.push("gnome_introspect".to_string());
+    }
+    if windowing.kwin.ok {
+        window_backends.push("kwin".to_string());
+    }
+    if windowing.hyprland.ok {
+        window_backends.push("hyprland".to_string());
+    }
+    if windowing.cosmic_helper.ok {
+        window_backends.push("cosmic".to_string());
+    }
+
+    let mut accessibility_backends = Vec::new();
+    if accessibility.at_spi_enabled.ok || accessibility.toolkit_accessibility.ok {
+        accessibility_backends.push("at_spi".to_string());
+    }
+
+    // Isolation contexts: the live shared session is always available; a headless
+    // GNOME session is possible when gnome-shell is installed (it supports
+    // --headless --virtual-monitor), giving the agent its own seat.
+    let mut isolation = vec!["shared".to_string()];
+    if platform.gnome_shell_version.ok {
+        isolation.push("headless_gnome".to_string());
+    }
+
+    let preferred = PreferredBackends {
+        input: input_backends.first().cloned(),
+        screenshot: screenshot_backends.first().cloned(),
+        window_control: window_backends.first().cloned(),
+    };
+
+    CapabilityMap {
+        input: input_backends,
+        screenshot: screenshot_backends,
+        window_control: window_backends,
+        accessibility: accessibility_backends,
+        isolation,
+        preferred,
     }
 }
 

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -58,6 +58,28 @@ async fn main() -> Result<()> {
             );
             Ok(())
         }
+        // Hidden dev command: empirically test the absolute pointer.
+        // `abs-test X Y` moves to logical (X,Y) and left-clicks, sizing the
+        // device to the live screenshot dimensions.
+        Some("abs-test") => {
+            let x: i32 = std::env::args()
+                .nth(2)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            let y: i32 = std::env::args()
+                .nth(3)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0);
+            let cap = screenshot::capture_screenshot().await?;
+            eprintln!("desktop logical size: {}x{}", cap.width, cap.height);
+            let mut p = abs_pointer::AbsPointer::create(cap.width as i32, cap.height as i32)?;
+            p.click(x, y, abs_pointer::PointerButton::Left, 1)?;
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "x": x, "y": y, "w": cap.width, "h": cap.height})
+            );
+            Ok(())
+        }
         Some("screenshot") => {
             let capture = screenshot::capture_screenshot().await?;
             println!(

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -1,3 +1,4 @@
+mod abs_pointer;
 mod atspi_tree;
 mod cosmic_helper;
 mod diagnostics;

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -992,7 +992,7 @@ impl ComputerUseLinux {
 
 #[tool_handler(
     name = "codex-computer-use-linux",
-    version = "0.1.0",
+    version = "0.2.3-linux-alpha1",
     instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through registered Linux window backends when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available, and send layout-safe literal type_text through KDE clipboard integration on Plasma Wayland or through portal keysyms on other Wayland sessions before falling back to ydotool. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -41,6 +41,8 @@ pub struct ComputerUseLinux {
     last_nodes: Arc<Mutex<Vec<AccessibilityNode>>>,
     portal_pointer_session: Arc<Mutex<Option<PortalPointerSession>>>,
     portal_keyboard_session: Arc<Mutex<Option<PortalKeyboardSession>>>,
+    /// Lazily-created uinput absolute pointer (preferred coordinate backend).
+    abs_pointer: Arc<Mutex<Option<crate::abs_pointer::AbsPointer>>>,
 }
 
 #[tool_router]
@@ -259,6 +261,58 @@ impl ComputerUseLinux {
         })
     }
 
+    /// Lazily create the uinput absolute pointer, sizing its ABS range to the
+    /// logical desktop (the portal screenshot dimensions). Returns `false` if it
+    /// can't be created or is disabled via `CODEX_COMPUTER_USE_DISABLE_ABS_POINTER`.
+    async fn ensure_abs_pointer(&self) -> bool {
+        if env::var("CODEX_COMPUTER_USE_DISABLE_ABS_POINTER")
+            .ok()
+            .as_deref()
+            == Some("1")
+        {
+            return false;
+        }
+        if self
+            .abs_pointer
+            .lock()
+            .map(|g| g.is_some())
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        let Ok(cap) = crate::screenshot::capture_screenshot().await else {
+            return false;
+        };
+        match crate::abs_pointer::AbsPointer::create(cap.width as i32, cap.height as i32) {
+            Ok(pointer) => {
+                if let Ok(mut guard) = self.abs_pointer.lock() {
+                    *guard = Some(pointer);
+                    return true;
+                }
+                false
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Try a coordinate click through the absolute uinput pointer. `Some(ok)` if
+    /// the backend was used; `None` to fall through to portal / ydotool.
+    async fn try_abs_click(
+        &self,
+        x: i32,
+        y: i32,
+        button: Option<&str>,
+        count: u32,
+    ) -> Option<bool> {
+        if !self.ensure_abs_pointer().await {
+            return None;
+        }
+        let btn = crate::abs_pointer::PointerButton::from_name(button);
+        let mut guard = self.abs_pointer.lock().ok()?;
+        let pointer = guard.as_mut()?;
+        Some(pointer.click(x, y, btn, count).is_ok())
+    }
+
     #[tool(
         name = "click",
         description = "Click an element by index, semantic selector, or pixel coordinates from screenshot."
@@ -322,6 +376,29 @@ impl ComputerUseLinux {
         };
         let button = mouse_button_code(params.button.as_deref());
         let click_count = params.click_count.unwrap_or(1).clamp(1, 10).to_string();
+        // Preferred backend: the uinput absolute pointer. Unlike ydotool's
+        // relative-only device (faked `--absolute` via pin-to-corner + relative
+        // move, which acceleration + fractional scaling distort) and unlike the
+        // portal (per-monitor coordinate scaling + an approval dialog), the
+        // absolute pointer lands exactly at the screenshot pixel.
+        if self
+            .try_abs_click(
+                x,
+                y,
+                params.button.as_deref(),
+                params.click_count.unwrap_or(1).clamp(1, 10),
+            )
+            .await
+            == Some(true)
+        {
+            return Json(ActionOutput {
+                ok: true,
+                implemented: true,
+                action: "click".to_string(),
+                message: "Action sent through the uinput absolute pointer.".to_string(),
+                received,
+            });
+        }
         if let Some(session) = self.cached_portal_pointer_session() {
             match portal_click(
                 &session,
@@ -546,6 +623,32 @@ impl ComputerUseLinux {
     )]
     async fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
+        // Preferred backend: the uinput absolute pointer (accurate landing).
+        if self.ensure_abs_pointer().await {
+            let dragged = {
+                if let Ok(mut guard) = self.abs_pointer.lock() {
+                    guard.as_mut().map(|p| {
+                        p.drag(
+                            (params.start_x, params.start_y),
+                            (params.end_x, params.end_y),
+                            crate::abs_pointer::PointerButton::Left,
+                        )
+                        .is_ok()
+                    })
+                } else {
+                    None
+                }
+            };
+            if dragged == Some(true) {
+                return Json(ActionOutput {
+                    ok: true,
+                    implemented: true,
+                    action: "drag".to_string(),
+                    message: "Action sent through the uinput absolute pointer.".to_string(),
+                    received,
+                });
+            }
+        }
         if let Some(session) = self.cached_portal_pointer_session() {
             match portal_drag(
                 &session,

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -820,6 +820,12 @@ struct ActivateWindowOutput {
     focus: Option<WindowFocusResult>,
     error: Option<String>,
     permissions_hint: Option<String>,
+    // Debug-only echo of the request. `serde_json::Value` serializes to a
+    // non-object schema (schemars emits the boolean schema `true`), which strict
+    // MCP clients reject in `outputSchema` — one invalid tool fails the whole
+    // `tools/list`. Keep it in the runtime response (serde) but omit it from the
+    // generated schema.
+    #[schemars(skip)]
     received: Option<serde_json::Value>,
 }
 
@@ -1087,6 +1093,12 @@ struct ActionOutput {
     implemented: bool,
     action: String,
     message: String,
+    // Debug-only echo of the request. `serde_json::Value` serializes to a
+    // non-object schema (schemars emits the boolean schema `true`), which strict
+    // MCP clients reject in `outputSchema` — one invalid tool fails the whole
+    // `tools/list`. Keep it in the runtime response (serde) but omit it from the
+    // generated schema.
+    #[schemars(skip)]
     received: Option<serde_json::Value>,
 }
 

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -314,10 +314,10 @@ impl ComputerUseLinux {
         name = "screenshot",
         description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds).",
         annotations(
-            read_only_hint = true,
+            read_only_hint = false,
             destructive_hint = false,
-            idempotent_hint = true,
-            open_world_hint = false
+            idempotent_hint = false,
+            open_world_hint = true
         )
     )]
     async fn screenshot(

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -21,8 +21,9 @@ use crate::windows::{
 use anyhow::Result;
 use rmcp::{
     handler::server::wrapper::{Json, Parameters},
+    model::{CallToolResult, Content},
     schemars::JsonSchema,
-    tool, tool_handler, tool_router, ServerHandler, ServiceExt,
+    tool, tool_handler, tool_router, ErrorData, ServerHandler, ServiceExt,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -259,6 +260,64 @@ impl ComputerUseLinux {
             diagnostics,
             message,
         })
+    }
+
+    #[tool(
+        name = "screenshot",
+        description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds)."
+    )]
+    async fn screenshot(
+        &self,
+        Parameters(params): Parameters<ScreenshotParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let target = params.window_target();
+
+        // When targeting a window, raise it first (so it isn't occluded) and
+        // resolve its bounds so we can crop to just that window.
+        let mut crop: Option<crate::windowing::WindowBounds> = None;
+        let mut window_label: Option<String> = None;
+        if let Some(target) = &target {
+            if params.raise_window.unwrap_or(true) {
+                let _ = focus_window_target(target).await;
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+            if !params.full_screen.unwrap_or(false) {
+                if let Ok(windows) = list_windows().await {
+                    if let Ok(window) = resolve_window_target(&windows, target) {
+                        crop = window.bounds.clone();
+                        window_label = window.title.clone();
+                    }
+                }
+            }
+        }
+
+        let capture = capture_screenshot()
+            .await
+            .map_err(|e| ErrorData::internal_error(format!("screenshot failed: {e}"), None))?;
+        let raw =
+            decode_data_url(&capture.data_url).map_err(|e| ErrorData::internal_error(e, None))?;
+
+        let (png, width, height, cropped) = match crop.as_ref().and_then(window_crop_rect) {
+            Some((x, y, w, h)) => match crop_png(&raw, x, y, w, h) {
+                Ok((bytes, cw, ch)) => (bytes, cw, ch, true),
+                // If cropping fails, fall back to the full frame rather than erroring.
+                Err(_) => (raw, capture.width, capture.height, false),
+            },
+            None => (raw, capture.width, capture.height, false),
+        };
+
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &png);
+        let caption = serde_json::json!({
+            "width": width,
+            "height": height,
+            "source": capture.source,
+            "cropped_to_window": cropped,
+            "window_title": window_label,
+        });
+        Ok(CallToolResult::success(vec![
+            Content::image(b64, "image/png".to_string()),
+            Content::text(caption.to_string()),
+        ]))
     }
 
     /// Lazily create the uinput absolute pointer, sizing its ABS range to the
@@ -1967,6 +2026,98 @@ fn env_contains(key: &str, needle: &str) -> bool {
     env::var(key)
         .ok()
         .is_some_and(|value| value.to_ascii_lowercase().contains(needle))
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+struct ScreenshotParams {
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    /// Raise the targeted window before capture (default true). Ignored without
+    /// a window target.
+    #[serde(default)]
+    raise_window: Option<bool>,
+    /// Capture the whole desktop even when a window is targeted (default false).
+    #[serde(default)]
+    full_screen: Option<bool>,
+}
+
+impl ScreenshotParams {
+    fn window_target(&self) -> Option<WindowTarget> {
+        if self.window_id.is_none()
+            && self.pid.is_none()
+            && self.app_id.is_none()
+            && self.wm_class.is_none()
+            && self.title.is_none()
+        {
+            return None;
+        }
+        Some(WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: None,
+            terminal_pid: None,
+            terminal_command: None,
+            terminal_cwd: None,
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.title.clone(),
+        })
+    }
+}
+
+/// Decode the base64 payload of a `data:` URL (or a bare base64 string) to bytes.
+fn decode_data_url(data_url: &str) -> std::result::Result<Vec<u8>, String> {
+    use base64::Engine;
+    let b64 = data_url.split_once(',').map(|(_, b)| b).unwrap_or(data_url);
+    base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| format!("invalid screenshot base64: {e}"))
+}
+
+/// Convert a window's bounds into a crop rectangle, if it has a usable origin
+/// and non-zero size.
+fn window_crop_rect(bounds: &crate::windowing::WindowBounds) -> Option<(i32, i32, u32, u32)> {
+    let x = bounds.x?;
+    let y = bounds.y?;
+    if bounds.width == 0 || bounds.height == 0 {
+        return None;
+    }
+    Some((x, y, bounds.width, bounds.height))
+}
+
+/// Crop a PNG image to `(x, y, w, h)` (clamped to the image), returning the
+/// re-encoded PNG and the actual cropped dimensions.
+fn crop_png(
+    raw: &[u8],
+    x: i32,
+    y: i32,
+    w: u32,
+    h: u32,
+) -> std::result::Result<(Vec<u8>, u32, u32), String> {
+    use std::io::Cursor;
+    let img = image::load_from_memory_with_format(raw, image::ImageFormat::Png)
+        .map_err(|e| format!("decode png: {e}"))?;
+    let (iw, ih) = (img.width(), img.height());
+    let x = x.max(0) as u32;
+    let y = y.max(0) as u32;
+    if x >= iw || y >= ih {
+        return Err("crop origin outside image".into());
+    }
+    let w = w.min(iw - x);
+    let h = h.min(ih - y);
+    let sub = img.crop_imm(x, y, w, h);
+    let mut out = Vec::new();
+    sub.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+        .map_err(|e| format!("encode png: {e}"))?;
+    Ok((out, w, h))
 }
 
 fn action_result(

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -50,7 +50,13 @@ pub struct ComputerUseLinux {
 impl ComputerUseLinux {
     #[tool(
         name = "doctor",
-        description = "Report Linux Computer Use desktop integration readiness."
+        description = "Report Linux Computer Use desktop integration readiness.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     fn doctor(&self) -> Json<DoctorReport> {
         Json(doctor_report())
@@ -58,7 +64,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "setup_accessibility",
-        description = "Enable GNOME accessibility through gsettings so Linux Computer Use can read AT-SPI trees."
+        description = "Enable GNOME accessibility through gsettings so Linux Computer Use can read AT-SPI trees.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     fn setup_accessibility(&self) -> Json<SetupReport> {
         Json(setup_accessibility_report())
@@ -66,7 +78,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "setup_window_targeting",
-        description = "Install and enable the optional GNOME Shell extension used for exact window list/focus targeting when GNOME blocks native introspection."
+        description = "Install and enable the optional GNOME Shell extension used for exact window list/focus targeting when GNOME blocks native introspection.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn setup_window_targeting(&self) -> Json<WindowTargetingSetupReport> {
         Json(setup_window_targeting_report().await)
@@ -74,7 +92,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "list_apps",
-        description = "List running Linux desktop app candidates visible to the Computer Use backend."
+        description = "List running Linux desktop app candidates visible to the Computer Use backend.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn list_apps(&self) -> Json<ListAppsOutput> {
         let (accessible_apps, accessibility_error) = match list_accessible_apps(50).await {
@@ -92,7 +116,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "list_windows",
-        description = "List compositor windows with title, app id, class, focus state, client type, and known bounds."
+        description = "List compositor windows with title, app id, class, focus state, client type, and known bounds.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn list_windows(&self) -> Json<ListWindowsOutput> {
         Json(window_list_output().await)
@@ -100,7 +130,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "focused_window",
-        description = "Return the compositor window that currently has keyboard focus."
+        description = "Return the compositor window that currently has keyboard focus.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn focused_window(&self) -> Json<FocusedWindowOutput> {
         match focused_window().await {
@@ -131,7 +167,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "activate_window",
-        description = "Focus a Linux desktop window by window_id, pid, app_id, wm_class, title, or terminal selectors when the compositor permits it."
+        description = "Focus a Linux desktop window by window_id, pid, app_id, wm_class, title, or terminal selectors when the compositor permits it.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn activate_window(
         &self,
@@ -169,7 +211,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "get_app_state",
-        description = "Start an app use session if needed, then get screenshot and accessibility state for a Linux app."
+        description = "Start an app use session if needed, then get screenshot and accessibility state for a Linux app.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true
+        )
     )]
     async fn get_app_state(
         &self,
@@ -264,7 +312,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "screenshot",
-        description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds)."
+        description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds).",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
     )]
     async fn screenshot(
         &self,
@@ -374,7 +428,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "click",
-        description = "Click an element by index, semantic selector, or pixel coordinates from screenshot."
+        description = "Click an element by index, semantic selector, or pixel coordinates from screenshot.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn click(&self, Parameters(params): Parameters<ClickParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
@@ -519,7 +579,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "perform_action",
-        description = "Invoke an accessibility action exposed by an element selected by index, identifier, or semantic selector. Defaults to the primary action unless action is provided."
+        description = "Invoke an accessibility action exposed by an element selected by index, identifier, or semantic selector. Defaults to the primary action unless action is provided.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn perform_action(
         &self,
@@ -531,7 +597,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "set_value",
-        description = "Set the value of a settable accessibility element selected by index, identifier, or semantic selector."
+        description = "Set the value of a settable accessibility element selected by index, identifier, or semantic selector.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn set_value(
         &self,
@@ -583,7 +655,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "scroll",
-        description = "Scroll an element in a direction by a number of pages."
+        description = "Scroll an element in a direction by a number of pages.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn scroll(&self, Parameters(params): Parameters<ScrollParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
@@ -678,7 +756,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "drag",
-        description = "Drag from one point to another using pixel coordinates."
+        description = "Drag from one point to another using pixel coordinates.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn drag(&self, Parameters(params): Parameters<DragParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
@@ -766,7 +850,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "press_key",
-        description = "Press a key or key-combination on the keyboard, optionally after focusing a target window or terminal selector."
+        description = "Press a key or key-combination on the keyboard, optionally after focusing a target window or terminal selector.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn press_key(
         &self,
@@ -807,7 +897,13 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "type_text",
-        description = "Type literal text using keyboard input, optionally after focusing a target window or terminal selector."
+        description = "Type literal text using keyboard input, optionally after focusing a target window or terminal selector.",
+        annotations(
+            read_only_hint = false,
+            destructive_hint = true,
+            idempotent_hint = false,
+            open_world_hint = true
+        )
     )]
     async fn type_text(
         &self,


### PR DESCRIPTION
Syncs the vendored `computer-use-linux/` crate up from the standalone
[agent-sh/computer-use-linux](https://github.com/agent-sh/computer-use-linux) 0.2.2.
Codex naming/branding is preserved throughout (merge, not wholesale copy).

## Ported
- **MCP `outputSchema` fix** — `#[schemars(skip)]` on the debug `received` field of `ActionOutput`/`ActivateWindowOutput`. `Option<serde_json::Value>` serialized to a non-object schema (`true`) that strict MCP clients (Claude Code, mcphub, MCP SDK) reject, failing the whole `tools/list`. Affected click/drag/perform_action/press_key/scroll/set_value/type_text/activate_window.
- **uinput absolute pointer** (`abs_pointer.rs`) — accurate clicks on multi-monitor/HiDPI/fractional-scaling. Wired as the preferred coordinate backend in `click()`/`drag()` ahead of portal and ydotool. Opt out with `CODEX_COMPUTER_USE_DISABLE_ABS_POINTER`. Adds `evdev`.
- **`screenshot` MCP tool** — returns a viewable PNG, optionally raised + cropped to a targeted window. Adds `image` (png).
- **doctor `CapabilityMap`** — lists interchangeable backends per layer (input/screenshot/window_control/accessibility/isolation) + preferred, aggregating existing checks.
- **Tool mutability annotations** on all 16 MCP tools.
- **Hidden `abs-test` dev command** to verify pointer landing.

## Naming preserved (codex side)
`CODEX_COMPUTER_USE_*` env vars, `codex_gnome_shell_extension`, `com.openai.Codex.*` KWin DBus, `codex-*` temp paths, the absolute-pointer device name. `identity.rs` and the chrome-extension host are untouched (chrome host is a separate tool, not part of this sync).

## Already at parity (no port)
hyprland (diff was only a test-module relocation), the portal-keyboard text-input path (`remote_desktop.rs` byte-identical), kwin/registry/cosmic_helper/screenshot.rs (pure codex branding).

## Versioning + coordination
Bumped crate to `0.2.3-linux-alpha1` (AGENTS.md updated). The enumeration tracks the standalone crate (`0.2.3`); a mismatch signals a pending sync. Adds a `computer-use sync reminder` workflow that opens an issue when `main` touches `computer-use-linux/**`.

## Validation
`cargo test -p codex-computer-use-linux` → 98 passed, 0 failed. README Computer Use input-backend list updated for the new abs_pointer/portal chain.