### PR TITLE
fix(nix): appcast-gate the upstream pin refresh bot so version bumps self-heal

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -2,7 +2,7 @@ name: Update Nix upstream hashes
 
 on:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -49,19 +49,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- flake.nix; then
-            echo "Nix hashes unchanged, nothing to do."
+          if git diff --quiet -- flake.nix nix/native-modules/package.json; then
+            echo "Nix pins unchanged, nothing to do."
             exit 0
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
+          CODEX_VERSION="$(grep -m1 'codexVersion = ' flake.nix | sed 's/.*"\(.*\)".*/\1/')"
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
-          git add flake.nix
+          git add flake.nix nix/native-modules/package.json
           git commit \
-            -m "fix(nix): update upstream Nix hashes" \
-            -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH." \
+            -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
+            -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the upstream Sparkle appcast latest." \
             -m "Verified all Codex Desktop Nix package outputs against the refreshed DMG." \
             -m "[skip ci]"
           git push origin main

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- flake.nix nix/native-modules/package.json; then
+          if git diff --quiet -- flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json; then
             echo "Nix pins unchanged, nothing to do."
             exit 0
           fi
@@ -59,7 +59,7 @@ jobs:
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
-          git add flake.nix nix/native-modules/package.json
+          git add flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json
           git commit \
             -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the upstream Sparkle appcast latest." \

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -23,6 +23,31 @@ validate_sri_hash() {
     [[ "$hash" =~ ^sha256-[A-Za-z0-9+/=]{44}$ ]]
 }
 
+read_flake_string() {
+    local name="$1"
+    grep -m1 "$name = " "$FLAKE_FILE" | sed 's/.*"\(.*\)".*/\1/'
+}
+
+prefetch_sri() {
+    local url="$1"
+    nix store prefetch-file --json --hash-type sha256 "$url" \
+        | python3 -c 'import sys, json; print(json.load(sys.stdin)["hash"])'
+}
+
+# When electronVersion changes, the electron zip + headers URLs move to the new
+# version while flake.nix keeps the old fixed-output hashes, so the verify build
+# would fail. Refresh both per-arch electron zip hashes and the headers hash.
+refresh_electron_hashes() {
+    local version="$1"
+    local base="https://github.com/electron/electron/releases/download/v${version}"
+    replace_flake_hash "x86_64-linux = {" "hash = " \
+        "$(prefetch_sri "${base}/electron-v${version}-linux-x64.zip")"
+    replace_flake_hash "aarch64-linux = {" "hash = " \
+        "$(prefetch_sri "${base}/electron-v${version}-linux-arm64.zip")"
+    replace_flake_hash "electronHeaders = pkgs.fetchurl {" "hash = " \
+        "$(prefetch_sri "https://artifacts.electronjs.org/headers/dist/v${version}/node-v${version}-headers.tar.gz")"
+}
+
 replace_flake_hash() {
     local anchor="$1"
     local key="$2"
@@ -116,6 +141,9 @@ main() {
     # moving Codex.dmg has caught up to the appcast's advertised latest version,
     # so we never pin a transient mid-rollout build. Exit 75 means "rollout in
     # progress" and is treated as a no-op skip.
+    local old_electron_version
+    old_electron_version="$(read_flake_string electronVersion)"
+
     local validate_status=0
     WRITE_PINS=1 APPCAST_URL="$APPCAST_URL" \
         "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH" || validate_status="$?"
@@ -125,6 +153,22 @@ main() {
     fi
     if [ "$validate_status" -ne 0 ]; then
         exit "$validate_status"
+    fi
+
+    # If the Electron pin moved, refresh its fixed-output hashes so the verify
+    # build does not fail on the new download URLs.
+    local new_electron_version
+    new_electron_version="$(read_flake_string electronVersion)"
+    if [ "$old_electron_version" != "$new_electron_version" ]; then
+        echo "Electron pin: $old_electron_version -> $new_electron_version; refreshing electron hashes."
+        refresh_electron_hashes "$new_electron_version"
+    fi
+
+    # Regenerate the native-module lockfile whenever its package.json changed, so
+    # the committed refresh stays reproducible for importNpmLock / npm ci.
+    if ! git -C "$REPO_DIR" diff --quiet -- nix/native-modules/package.json; then
+        echo "native-modules package.json changed; regenerating package-lock.json."
+        ( cd "$REPO_DIR/nix/native-modules" && npm install --package-lock-only --ignore-scripts >/dev/null )
     fi
 
     current_dmg_hash="$(read_flake_hash "codexDmg = pkgs.fetchurl {" "hash = ")"

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -6,6 +6,9 @@ FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
 UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
+# Upstream Codex Sparkle appcast (x64 runners). Used to gate the pin refresh on
+# the advertised latest release so we never pin a transient mid-rollout DMG.
+APPCAST_URL="${APPCAST_URL:-https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml}"
 
 PACKAGE_OUTPUTS=(
     ".#codex-desktop"
@@ -108,6 +111,22 @@ main() {
         exit 1
     fi
 
+    # Refresh the version pins (codexVersion/electronVersion + native-modules)
+    # from the DMG, gated on the upstream Sparkle appcast: only proceed when the
+    # moving Codex.dmg has caught up to the appcast's advertised latest version,
+    # so we never pin a transient mid-rollout build. Exit 75 means "rollout in
+    # progress" and is treated as a no-op skip.
+    local validate_status=0
+    WRITE_PINS=1 APPCAST_URL="$APPCAST_URL" \
+        "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH" || validate_status="$?"
+    if [ "$validate_status" -eq 75 ]; then
+        echo "Upstream rollout in progress; leaving pins unchanged until Codex.dmg matches the appcast."
+        exit 0
+    fi
+    if [ "$validate_status" -ne 0 ]; then
+        exit "$validate_status"
+    fi
+
     current_dmg_hash="$(read_flake_hash "codexDmg = pkgs.fetchurl {" "hash = ")"
     echo "Current Codex.dmg hash:  $current_dmg_hash"
     echo "Upstream Codex.dmg hash: $new_dmg_hash"
@@ -117,9 +136,8 @@ main() {
     # already downloaded for hashing instead of fetching the same artifact again.
     nix-store --add-fixed sha256 "$UPSTREAM_DMG_PATH" >/dev/null
 
-    "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH"
     run_nix_build "$VERIFY_LOG" "${PACKAGE_OUTPUTS[@]}"
-    echo "Nix builds succeeded after refreshing the Codex.dmg hash."
+    echo "Nix builds succeeded after refreshing the upstream pins and Codex.dmg hash."
 }
 
 case "${1:-}" in

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -5,6 +5,16 @@ REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
 UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 UPSTREAM_DMG_PATH="${1:-${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}}"
+NATIVE_MODULES_PKG="${NATIVE_MODULES_PKG:-$REPO_DIR/nix/native-modules/package.json}"
+
+# Opt-in pin-writing mode (used by the hash-refresh bot, not by PR CI). When set,
+# the version pins are rewritten from the DMG before the assertions run, so they
+# confirm the write instead of failing on drift. APPCAST_URL, when also set,
+# gates the write on the upstream Sparkle appcast: the moving Codex.dmg must
+# already match the appcast's advertised latest version, otherwise we are mid
+# rollout and exit 75 (skip) rather than pinning a transient build.
+WRITE_PINS="${WRITE_PINS:-0}"
+APPCAST_URL="${APPCAST_URL:-}"
 
 fail() {
     echo "ERROR: $*" >&2
@@ -36,6 +46,62 @@ if not match:
     raise SystemExit(f"Could not find Nix string {sys.argv[2]!r}")
 print(match.group(1))
 PY
+}
+
+write_nix_string() {
+    local name="$1"
+    local value="$2"
+    python3 - "$FLAKE_FILE" "$name" "$value" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+name = re.escape(sys.argv[2])
+value = sys.argv[3]
+text = path.read_text()
+new_text, count = re.subn(
+    rf'(\b{name}\s*=\s*")[^"]+(";)',
+    lambda match: match.group(1) + value + match.group(2),
+    text,
+    count=1,
+)
+if count != 1:
+    raise SystemExit(f"Could not write Nix string {sys.argv[2]!r}")
+path.write_text(new_text)
+PY
+}
+
+write_json_dep() {
+    local file="$1"
+    local dep="$2"
+    local value="$3"
+    node -e '
+const fs = require("fs");
+const [file, dep, value] = process.argv.slice(1);
+const pkg = JSON.parse(fs.readFileSync(file, "utf8"));
+if (!pkg.dependencies || !(dep in pkg.dependencies)) {
+  console.error(`missing dependency ${dep} in ${file}`);
+  process.exit(1);
+}
+pkg.dependencies[dep] = value;
+fs.writeFileSync(file, JSON.stringify(pkg, null, 2) + "\n");
+' "$file" "$dep" "$value"
+}
+
+fetch_appcast_latest_version() {
+    local url="$1"
+    curl -fsSL --retry 3 "$url" | python3 -c '
+import re
+import sys
+
+xml = sys.stdin.read()
+# Appcast items are newest-first; the first shortVersionString is the latest.
+match = re.search(r"<sparkle:shortVersionString>([^<]+)</sparkle:shortVersionString>", xml)
+if not match:
+    sys.exit("Could not find sparkle:shortVersionString in appcast")
+sys.stdout.write(match.group(1).strip())
+'
 }
 
 read_nix_fetchurl_field() {
@@ -117,6 +183,32 @@ nix_electron_version="$(read_nix_string electronVersion)"
 native_electron_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies.electron")"
 native_better_sqlite3_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies['better-sqlite3']")"
 native_node_pty_version="$(node -p "require('$REPO_DIR/nix/native-modules/package.json').dependencies['node-pty']")"
+
+if [ "$WRITE_PINS" = "1" ]; then
+    if [ -n "$APPCAST_URL" ]; then
+        appcast_latest_version="$(fetch_appcast_latest_version "$APPCAST_URL")"
+        echo "Appcast latest version: $appcast_latest_version"
+        echo "DMG codex version:      $dmg_codex_version"
+        if [ "$dmg_codex_version" != "$appcast_latest_version" ]; then
+            echo "DMG ($dmg_codex_version) is not yet aligned with the appcast latest ($appcast_latest_version);" >&2
+            echo "upstream rollout in progress, skipping pin update (exit 75)." >&2
+            exit 75
+        fi
+    fi
+
+    write_nix_string codexVersion "$dmg_codex_version"
+    write_nix_string electronVersion "$dmg_electron_version"
+    write_json_dep "$NATIVE_MODULES_PKG" electron "$dmg_electron_version"
+    write_json_dep "$NATIVE_MODULES_PKG" better-sqlite3 "$dmg_better_sqlite3_version"
+    write_json_dep "$NATIVE_MODULES_PKG" node-pty "$dmg_node_pty_version"
+
+    # Re-read so the assertions below confirm the writes landed.
+    nix_codex_version="$(read_nix_string codexVersion)"
+    nix_electron_version="$(read_nix_string electronVersion)"
+    native_electron_version="$(node -p "require('$NATIVE_MODULES_PKG').dependencies.electron")"
+    native_better_sqlite3_version="$(node -p "require('$NATIVE_MODULES_PKG').dependencies['better-sqlite3']")"
+    native_node_pty_version="$(node -p "require('$NATIVE_MODULES_PKG').dependencies['node-pty']")"
+fi
 
 assert_equal "Codex app version pin" "$dmg_codex_version" "$nix_codex_version"
 assert_equal "Electron version pin" "$dmg_electron_version" "$nix_electron_version"


### PR DESCRIPTION
Fixes #272.

## The error
The `Update Nix upstream hashes` bot wedges on every upstream Codex release, and the stale pin then breaks `nix run`/`nix build` for everyone:

```
ERROR: Codex app version pin mismatch: expected '26.519.31651', got '26.513.31313'
```
```
error: hash mismatch in fixed-output derivation '…-Codex.dmg.drv':
         specified: sha256-bUQMcTN3GTXIYKVUa81gP4ubZbN+m4K9sAGdT9DIW2o=
            got:    sha256-f4/zAyMCeW9hDeIy6Hrac5VdGJyq1a0UAlSGXLrXtyk=
```

## Root cause
`update-nix-hashes.sh` refreshes only the **Codex.dmg SRI hash** — it never updates the **version strings** (`codexVersion`/`electronVersion` in `flake.nix`, plus the native-module pins). When upstream bumps the version it refreshes the hash, then `validate-nix-pins.sh` fails on the now-stale version pins, so the bot exits before committing. It's been failing every run since the last upstream release, and meanwhile every PR's *Nix Package Builds* job fails identically on the stale pin.

## Fix — appcast-gated, version-self-healing refresh
- **`validate-nix-pins.sh`**: opt-in `WRITE_PINS` mode rewrites all five version pins from the DMG before the assertions (so they confirm the write). PR-CI path is unchanged (neither env var set → same strict behavior). With `APPCAST_URL` set, the write is gated on the upstream **Sparkle appcast** (`appcast-x64.xml`): the moving `Codex.dmg` must already match the appcast's advertised latest version, otherwise it's mid-rollout and the script exits `75` (skip) instead of pinning a transient build.
- **`update-nix-hashes.sh`**: runs validate in `WRITE+APPCAST` mode, treats exit `75` as a clean no-op skip, and only writes the DMG hash + runs the verify build once the pins are aligned.
- **`update-codex-hash.yml`**: stages and diff-guards `nix/native-modules/package.json` alongside `flake.nix`; commit message names the version. Cron tightened 2h → 1h (each run is cheap now).

## Why appcast-gated
The bot previously hashed the moving `Codex.dmg` blindly. That URL lags/rolls (we observed `26.519.22136` and `26.519.31651` minutes apart), so even a naive version-bump could pin a transient artifact. The appcast is the canonical release feed (exact `sparkle:shortVersionString`, newest-first); gating on it makes the refresh release-accurate and race-free. The feed is pull-only (no upstream webhook), so it stays a poll — just precise.

## Validation
`bash -n` both scripts; workflow YAML parses; live appcast parse → `26.519.31651`; `write_nix_string`/`write_json_dep` exercised on temp copies. Full e2e (`nix build`) runs in the workflow itself.