### PR TITLE
fix(nix): refresh upstream Nix pins for 26.519.31651

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,20 +22,20 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-bUQMcTN3GTXIYKVUa81gP4ubZbN+m4K9sAGdT9DIW2o=";
+          hash = "sha256-0wuxD/77hV3NniIRhSDLb7Zhnc/X7GgYR6oVm08qDz0=";
         };
 
-        codexVersion = "26.513.31313";
-        electronVersion = "42.0.1";
+        codexVersion = "26.519.31651";
+        electronVersion = "42.1.0";
         electronPlatform =
           {
             x86_64-linux = {
               arch = "x64";
-              hash = "sha256-4bi1uG0//2nis1AlhjY9OECF7gV4vQQfpZFf0LVXxPE=";
+              hash = "sha256-iCBHNDqeIDxs/F05sWbqngJd0laUPg03EfhnJa0OO9k=";
             };
             aarch64-linux = {
               arch = "arm64";
-              hash = "sha256-oIpOaROATrBc6nmNi9CvrOTRuI6dB9uGt3nqSkSL4HA=";
+              hash = "sha256-HnAPfz2u95TMRSNeUcEXJmSu1JpOdze4iW3cOYv/TX0=";
             };
           }.${system} or (throw "codex-desktop-linux Nix package is not supported on ${system}");
 
@@ -46,7 +46,7 @@
 
         electronHeaders = pkgs.fetchurl {
           url = "https://artifacts.electronjs.org/headers/dist/v${electronVersion}/node-v${electronVersion}-headers.tar.gz";
-          hash = "sha256-yQBrv98qtbQ8cdZpuqx2uyP1mkIAVhLlUFjI/vxh9gA=";
+          hash = "sha256-DPwdIPJS1sKb3RSx88qjDtxkd9uT5aZiBnRCSzjc3f0=";
         };
 
         browserUseNodeReplRuntime = pkgs.fetchurl {

--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@electron/rebuild": "4.0.4",
         "better-sqlite3": "12.9.0",
-        "electron": "42.0.1",
+        "electron": "42.1.0",
         "node-abi": "^4.31.0",
         "node-pty": "1.1.0"
       }
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.0.1.tgz",
-      "integrity": "sha512-d8HnycE970DGESe91Nj30eonFBUcAI9EZ1TwUGJVzSAnJZdh0BkFEinAXjdklvDYst+bVDc8HsksCuqVLrnqdg==",
+      "version": "42.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.1.0.tgz",
+      "integrity": "sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==",
       "license": "MIT",
       "dependencies": {
         "@electron/get": "^5.0.0",

--- a/nix/native-modules/package.json
+++ b/nix/native-modules/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@electron/rebuild": "4.0.4",
     "better-sqlite3": "12.9.0",
-    "electron": "42.0.1",
+    "electron": "42.1.0",
     "node-abi": "^4.31.0",
     "node-pty": "1.1.0"
   }


### PR DESCRIPTION
## Summary
- refresh Codex.dmg hash and codexVersion to upstream appcast latest 26.519.31651
- update Electron to 42.1.0 including x64/arm64 zip hashes and Electron headers hash
- regenerate nix/native-modules/package-lock.json for electron@42.1.0

## Context
The manual "Update Nix upstream hashes" workflow run succeeded through the refresh/build step, including the full Nix package build verification, but failed to push directly to main because the repository ruleset requires changes through a pull request.

Workflow run: https://github.com/ilysenko/codex-desktop-linux/actions/runs/26271423897

## Validation
- Update Nix upstream hashes: refresh/build step succeeded in run 26271423897
- npm ci --dry-run in nix/native-modules
- git diff --check