### PR TITLE
fix(ci): open PRs for Nix hash refreshes

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -6,7 +6,9 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  actions: write
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-nix-upstream-hashes
@@ -45,7 +47,10 @@ jobs:
       - name: Refresh Nix upstream hash
         run: scripts/ci/update-nix-hashes.sh
 
-      - name: Commit refreshed hashes
+      - name: Open refreshed hashes pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REFRESH_BRANCH: codex/nix-upstream-refresh
         run: |
           set -euo pipefail
 
@@ -59,10 +64,44 @@ jobs:
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
+          git checkout -B "$REFRESH_BRANCH"
           git add flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json
           git commit \
             -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
             -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the upstream Sparkle appcast latest." \
             -m "Verified all Codex Desktop Nix package outputs against the refreshed DMG." \
             -m "[skip ci]"
-          git push origin main
+          git push --force origin "$REFRESH_BRANCH"
+
+          pr_body="$RUNNER_TEMP/nix-refresh-pr-body.md"
+          cat >"$pr_body" <<EOF
+          ## Summary
+          - refresh Codex.dmg hash and upstream version pins to the Sparkle appcast latest
+          - update Electron fixed-output hashes when electronVersion changes
+          - regenerate nix/native-modules/package-lock.json when native module pins change
+
+          ## Validation
+          - this workflow verified all Codex Desktop Nix package outputs before opening the PR
+          - refreshed Codex.dmg SRI hash: \`$CODEX_DMG_HASH\`
+          EOF
+
+          pr_url="$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --head "$REFRESH_BRANCH" --state open --json url --jq '.[0].url // ""')"
+          if [ -z "$pr_url" ]; then
+            pr_url="$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$REFRESH_BRANCH" \
+              --title "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
+              --body-file "$pr_body")"
+          else
+            gh pr edit "$pr_url" \
+              --title "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
+              --body-file "$pr_body"
+          fi
+
+          echo "Opened or updated refresh PR: $pr_url"
+
+          # Branch pushes made with GITHUB_TOKEN do not trigger normal push/PR
+          # workflows. Dispatch CI explicitly so required checks attach to the
+          # bot branch head SHA and the PR can satisfy the repository ruleset.
+          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$REFRESH_BRANCH"


### PR DESCRIPTION
## Summary
- change the Nix hash refresh workflow to push refreshed pins to a bot branch
- create or update a pull request instead of pushing directly to main
- explicitly dispatch CI on the bot branch so required checks attach to the PR head

## Validation
- git diff --check
- enabled the repository setting that allows GitHub Actions to create pull requests while keeping default workflow token permissions read-only