### PR TITLE
Fix Linux Computer Use UI availability drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2038,6 +2038,20 @@ test("shows current Computer Use plugin UI on Linux without the upstream rollout
   );
 });
 
+test("shows current use-is-plugins-enabled Computer Use UI on Linux", () => {
+  const source =
+    "function p(e){return e===`macOS`||e===`windows`}" +
+    "function m(e){let t=(0,d.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,{isLoading:o,platform:s}=l(),u=c(`1506311413`),m;t[0]===r?m=t[1]:(m={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=m);let h=f(m),g;t[2]===s?g=t[3]:(g=p(s),t[2]=s,t[3]=g);let _=a&&i&&u&&(o||g),v=_&&!o&&h.enabled&&!h.isLoading,y=_&&h.isLoading,b=_&&(o||h.isLoading),x;return x}";
+
+  const patched = applyPatchTwice(applyLinuxComputerUseRendererAvailabilityPatch, source);
+
+  assert.match(patched, /function p\(e\)\{return e===`macOS`\|\|e===`windows`\|\|e===`linux`\}/);
+  assert.match(
+    patched,
+    /let _=a&&i&&\(s===`linux`\|\|u&&\(o\|\|g\)\),v=_&&!o&&\(s===`linux`\|\|h\.enabled\)&&!h\.isLoading,y=_&&s!==`linux`&&h\.isLoading,b=_&&\(o\|\|s!==`linux`&&h\.isLoading\),x;/,
+  );
+});
+
 test("warns without partially patching when Computer Use renderer availability gate drifts", () => {
   const source =
     "function g(e){return e===`macOS`||e===`windows`}" +
@@ -2492,6 +2506,11 @@ test("patchExtractedApp scans apps bundles for Computer Use availability when UI
         "function g(e){return e===`macOS`||e===`windows`}" +
           "function _(e){let t=(0,d.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,{isLoading:o,platform:c}=u(),l=s(`1506311413`),f;t[0]===r?f=t[1]:(f={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=f);let p=h(f),m;t[2]===c?m=t[3]:(m=g(c),t[2]=c,t[3]=m);let _=a&&i&&l&&(o||m),v=_&&!o&&p.enabled&&!p.isLoading,y=_&&p.isLoading,b=_&&(o||p.isLoading),x;return x}",
       );
+      fs.writeFileSync(
+        path.join(assetsDir, "use-is-plugins-enabled-current.js"),
+        "function p(e){return e===`macOS`||e===`windows`}" +
+          "function m(e){let t=(0,d.c)(8),{enabled:n,hostId:r,isHostLocal:i}=e,a=n===void 0?!0:n,{isLoading:o,platform:s}=l(),u=c(`1506311413`),m;t[0]===r?m=t[1]:(m={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=m);let h=f(m),g;t[2]===s?g=t[3]:(g=p(s),t[2]=s,t[3]=g);let _=a&&i&&u&&(o||g),v=_&&!o&&h.enabled&&!h.isLoading,y=_&&h.isLoading,b=_&&(o||h.isLoading),x;return x}",
+      );
       fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
 
       patchExtractedApp(tempRoot);
@@ -2499,6 +2518,10 @@ test("patchExtractedApp scans apps bundles for Computer Use availability when UI
       assert.match(
         fs.readFileSync(path.join(assetsDir, "apps-current.js"), "utf8"),
         /let _=a&&i&&\(c===`linux`\|\|l&&\(o\|\|m\)\),v=_&&!o&&\(c===`linux`\|\|p\.enabled\)&&!p\.isLoading/,
+      );
+      assert.match(
+        fs.readFileSync(path.join(assetsDir, "use-is-plugins-enabled-current.js"), "utf8"),
+        /let _=a&&i&&\(s===`linux`\|\|u&&\(o\|\|g\)\),v=_&&!o&&\(s===`linux`\|\|h\.enabled\)&&!h\.isLoading/,
       );
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true });

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -205,6 +205,23 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
   let patchedSource = currentSource;
   let platformPredicateChanged = false;
   let availabilityChanged = false;
+  let availabilityGateFound = false;
+
+  const computerUseFeatureNeedle = "featureName:`computer_use`";
+  const hasComputerUseAvailabilityGate = () =>
+    currentSource.includes(computerUseFeatureNeedle) &&
+    (currentSource.includes("isComputerUseAvailable") || currentSource.includes("1506311413"));
+  const availabilityAlreadyPatched = () =>
+    /featureName:`computer_use`[\s\S]{0,1200}?let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*&&\([A-Za-z_$][\w$]*===`linux`\|\|[A-Za-z_$][\w$]*&&\([A-Za-z_$][\w$]*\|\|[A-Za-z_$][\w$]*\)\),[A-Za-z_$][\w$]*=\1&&![A-Za-z_$][\w$]*&&\([A-Za-z_$][\w$]*===`linux`\|\|[A-Za-z_$][\w$]*\.enabled\)&&![A-Za-z_$][\w$]*\.isLoading/.test(patchedSource) ||
+    patchedSource.includes(availabilityPatch) ||
+    patchedSource.includes(currentAvailabilityPatch);
+
+  const findPlatformVarForAvailabilityGate = (offset, platformLoadingVar) => {
+    const lookback = patchedSource.slice(Math.max(0, offset - 900), offset);
+    const loadingFirst = new RegExp(String.raw`\{isLoading:${platformLoadingVar},platform:([A-Za-z_$][\w$]*)\}=`);
+    const platformFirst = new RegExp(String.raw`\{platform:([A-Za-z_$][\w$]*),isLoading:${platformLoadingVar}\}=`);
+    return lookback.match(loadingFirst)?.[1] ?? lookback.match(platformFirst)?.[1] ?? null;
+  };
 
   const platformPredicateNeedle = "function hae(e){return e===`macOS`||e===`windows`}";
   const platformPredicatePatch =
@@ -245,11 +262,45 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
     availabilityChanged = true;
   }
 
-  if (availabilityChanged || patchedSource.includes(availabilityPatch) || patchedSource.includes(currentAvailabilityPatch)) {
+  const currentHookAvailabilityPattern =
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=\1&&!\5&&([A-Za-z_$][\w$]*)\.enabled&&!\8\.isLoading,([A-Za-z_$][\w$]*)=\1&&\8\.isLoading,([A-Za-z_$][\w$]*)=\1&&\(\5\|\|\8\.isLoading\),([A-Za-z_$][\w$]*);/g;
+  patchedSource = patchedSource.replace(
+    currentHookAvailabilityPattern,
+    (
+      match,
+      availabilityVar,
+      enabledVar,
+      isHostLocalVar,
+      rolloutVar,
+      platformLoadingVar,
+      supportedPlatformVar,
+      availableVar,
+      featureQueryVar,
+      fetchingVar,
+      loadingVar,
+      resultVar,
+      offset,
+    ) => {
+      const contextStart = Math.max(0, offset - 900);
+      const context = patchedSource.slice(contextStart, offset + match.length);
+      if (!context.includes(computerUseFeatureNeedle)) {
+        return match;
+      }
+      availabilityGateFound = true;
+      const platformVar = findPlatformVarForAvailabilityGate(offset, platformLoadingVar);
+      if (platformVar == null) {
+        return match;
+      }
+      availabilityChanged = true;
+      return `let ${availabilityVar}=${enabledVar}&&${isHostLocalVar}&&(${platformVar}===\`linux\`||${rolloutVar}&&(${platformLoadingVar}||${supportedPlatformVar})),${availableVar}=${availabilityVar}&&!${platformLoadingVar}&&(${platformVar}===\`linux\`||${featureQueryVar}.enabled)&&!${featureQueryVar}.isLoading,${fetchingVar}=${availabilityVar}&&${platformVar}!==\`linux\`&&${featureQueryVar}.isLoading,${loadingVar}=${availabilityVar}&&(${platformLoadingVar}||${platformVar}!==\`linux\`&&${featureQueryVar}.isLoading),${resultVar};`;
+    },
+  );
+
+  if (availabilityChanged || availabilityAlreadyPatched()) {
     return patchedSource;
   }
 
-  if (currentSource.includes("featureName:`computer_use`") && currentSource.includes("isComputerUseAvailable")) {
+  if (hasComputerUseAvailabilityGate() || availabilityGateFound) {
     console.warn(
       "WARN: Could not find Computer Use renderer availability gate — skipping Linux Computer Use UI availability patch",
     );

--- a/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
+++ b/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
@@ -12,7 +12,7 @@ module.exports = [
     order: 1100,
     ciPolicy: "opt-in",
     enabled: (context) => context.enableComputerUseUi,
-    pattern: /^(use-model-settings|apps|use-in-app-browser-use-availability)-.*\.js$/,
+    pattern: /^(use-model-settings|apps|use-in-app-browser-use-availability|use-is-plugins-enabled)-.*\.js$/,
     missingDescription: "Computer Use availability bundle",
     skipDescription: "Linux Computer Use UI availability patch",
     apply: applyLinuxComputerUseRendererAvailabilityPatch,


### PR DESCRIPTION
Summary
- Include the drifted `use-is-plugins-enabled-*` webview chunk in the Linux Computer Use UI availability patch
- Make the availability rewrite tolerate the current minified hook variable names
- Add regression coverage for the new upstream chunk shape

User-visible behavior
- Restores the Linux Computer Use "Any App" control when the opt-in UI flag is enabled and upstream moves the availability gate into the shared plugins-enabled chunk

Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `git diff --check`
- `git diff --cached --check`

Notes
- Source-of-truth changes are limited to the patcher registry, Computer Use patch helper, and patcher tests
- Generated `codex-app/` output is not included in this PR