### PR TITLE
[codex] Fix updater Arch install and CLI path recovery

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1163,6 +1163,7 @@ find_codex_cli() {
     local candidate
     for candidate in \
         "$HOME/.bun/bin/codex" \
+        "$HOME/.npm-global/bin/codex" \
         "$HOME/.nvm/versions/node/current/bin/codex" \
         "$HOME/.nvm/versions/node"/*/bin/codex \
         "$HOME/.local/share/pnpm/codex" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2067,6 +2067,7 @@ PY
     assert_contains "$REPO_DIR/scripts/lib/process-detection.sh" "Codex Desktop is currently running from"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "prompt_install_missing_cli"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "prompt-install-cli"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" '.npm-global/bin/codex'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_UPDATE_MANAGER_PATH"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "resolve_update_manager_path"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -118,10 +118,17 @@ pub fn preflight(
     persist_state(paths, state)?;
     install_latest_cli(&latest_version)?;
 
-    let refreshed_path = resolve_cli_path(requested_path)
-        .or_else(|| resolve_cli_path(None))
-        .ok_or_else(|| anyhow!("Codex CLI disappeared after the automatic upgrade attempt"))?;
-    let refreshed_version = read_installed_version(&refreshed_path)?;
+    let (refreshed_path, refreshed_version) = if let Some(updated_cli) =
+        resolve_cli_path_with_version(requested_path, &latest_version)
+    {
+        updated_cli
+    } else {
+        let fallback_path = resolve_cli_path(requested_path)
+            .or_else(|| resolve_cli_path(None))
+            .ok_or_else(|| anyhow!("Codex CLI disappeared after the automatic upgrade attempt"))?;
+        let fallback_version = read_installed_version(&fallback_path)?;
+        (fallback_path, fallback_version)
+    };
     state.cli_path = Some(refreshed_path.clone());
     state.cli_installed_version = Some(refreshed_version.clone());
 
@@ -277,17 +284,45 @@ fn persist_if_changed(
 }
 
 pub(crate) fn resolve_cli_path(explicit_path: Option<&Path>) -> Option<PathBuf> {
+    cli_path_candidates(explicit_path)
+        .into_iter()
+        .find(|path| is_executable(path))
+}
+
+fn resolve_cli_path_with_version(
+    explicit_path: Option<&Path>,
+    expected_version: &str,
+) -> Option<(PathBuf, String)> {
+    post_install_cli_path_candidates(explicit_path)
+        .into_iter()
+        .filter(|path| is_executable(path))
+        .find_map(|path| match read_installed_version(&path) {
+            Ok(version) if installed_cli_version_satisfies_latest(&version, expected_version) => {
+                Some((path, version))
+            }
+            _ => None,
+        })
+}
+
+fn cli_path_candidates(explicit_path: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
     if let Some(path) = explicit_path {
-        if is_executable(path) {
-            return Some(path.to_path_buf());
-        }
+        candidates.push(path.to_path_buf());
     }
 
-    find_in_path("codex", &command_path_env()).or_else(|| {
-        known_cli_locations()
-            .into_iter()
-            .find(|path| is_executable(path))
-    })
+    candidates.extend(find_all_in_path("codex", &command_path_env()));
+    candidates.extend(known_cli_locations());
+    dedupe_paths(candidates)
+}
+
+fn post_install_cli_path_candidates(explicit_path: Option<&Path>) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    candidates.extend(find_all_in_path("codex", &command_path_env()));
+    candidates.extend(known_cli_locations());
+    if let Some(path) = explicit_path {
+        candidates.push(path.to_path_buf());
+    }
+    dedupe_paths(candidates)
 }
 
 fn known_cli_locations() -> Vec<PathBuf> {
@@ -303,6 +338,7 @@ fn known_cli_locations() -> Vec<PathBuf> {
             versioned_paths.reverse();
             candidates.extend(versioned_paths);
         }
+        candidates.push(home.join(".npm-global/bin/codex"));
         candidates.push(home.join(".local/share/pnpm/codex"));
         candidates.push(home.join(".local/bin/codex"));
     }
@@ -634,14 +670,24 @@ fn format_command_output(output: &Output) -> String {
 }
 
 fn find_in_path(name: &str, path_env: &OsString) -> Option<PathBuf> {
-    std::env::split_paths(path_env).find_map(|entry| {
-        let candidate = entry.join(name);
-        if is_executable(&candidate) {
-            Some(candidate)
-        } else {
-            None
+    find_all_in_path(name, path_env).into_iter().next()
+}
+
+fn find_all_in_path(name: &str, path_env: &OsString) -> Vec<PathBuf> {
+    std::env::split_paths(path_env)
+        .map(|entry| entry.join(name))
+        .filter(|candidate| is_executable(candidate))
+        .collect()
+}
+
+fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if !deduped.iter().any(|existing| existing == &path) {
+            deduped.push(path);
         }
-    })
+    }
+    deduped
 }
 
 fn command_path_env() -> OsString {
@@ -1102,6 +1148,74 @@ mod tests {
         assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&codex_path)?, "0.42.1");
+        Ok(())
+    }
+
+    #[test]
+    fn preflight_accepts_user_prefix_cli_after_system_cli_upgrade() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let home = temp.path().join("home");
+        let npm_bin = temp.path().join("npm-bin");
+        let system_bin = temp.path().join("system-bin");
+        fs::create_dir_all(&home)?;
+        fs::create_dir_all(&npm_bin)?;
+        fs::create_dir_all(&system_bin)?;
+
+        let system_codex = system_bin.join("codex");
+        write_executable_script(
+            &system_codex,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+        let user_codex = home.join(".npm-global/bin/codex");
+        fs::create_dir_all(user_codex.parent().expect("user codex should have parent"))?;
+        write_executable_script(
+            &user_codex,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.1'\n  exit 0\nfi\nexit 1\n",
+        )?;
+
+        let npm_path = npm_bin.join("npm");
+        write_executable_script(
+            &npm_path,
+            r#"#!/bin/sh
+if [ "$1" = "view" ] && [ "$2" = "@openai/codex" ] && [ "$3" = "version" ]; then
+  echo '0.42.1'
+  exit 0
+fi
+if [ "$1" = "install" ] && [ "$2" = "-g" ]; then
+  exit 0
+fi
+exit 1
+"#,
+        )?;
+
+        let _restore_env = EnvRestoreGuard::capture(&["HOME", "PATH", "NVM_DIR", "CODEX_CLI_PATH"]);
+        std::env::set_var("HOME", &home);
+        std::env::set_var("PATH", std::env::join_paths([npm_bin, system_bin])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(system_codex.clone());
+
+        assert_eq!(
+            resolve_cli_path_with_version(Some(&system_codex), "0.42.1"),
+            Some((user_codex.clone(), "0.42.1".to_string()))
+        );
+
+        let outcome = preflight(&mut state, &paths, Some(system_codex.clone()), false)?;
+
+        assert!(outcome.updated);
+        assert_eq!(outcome.cli_path, user_codex);
+        assert_eq!(outcome.installed_version, "0.42.1");
+        assert_eq!(state.cli_path.as_deref(), Some(user_codex.as_path()));
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert_eq!(read_installed_version(&system_codex)?, "0.42.0");
         Ok(())
     }
 

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -304,15 +304,22 @@ pub(crate) fn stable_validated_package(path: &Path) -> Result<StablePackage> {
         "Package path is not a file: {}",
         path.display()
     );
-    let kind = PackageKind::from_path(path);
-    ensure_codex_package(path)?;
+    let source_path = package_identity_path(path)?;
+    let requested_kind = PackageKind::from_path(path);
+    let kind = PackageKind::from_path(&source_path);
+    anyhow::ensure!(
+        requested_kind == kind,
+        "Package format changed while resolving {}",
+        path.display()
+    );
+    ensure_codex_package(&source_path)?;
 
     let dir = create_private_temp_dir()?;
-    let stable_path = dir.join(stable_file_name(kind, path)?);
-    fs::copy(path, &stable_path).with_context(|| {
+    let stable_path = dir.join(stable_file_name(kind, &source_path)?);
+    fs::copy(&source_path, &stable_path).with_context(|| {
         format!(
             "Failed to copy package {} into private staging area",
-            path.display()
+            source_path.display()
         )
     })?;
     set_private_file_permissions(&stable_path)?;
@@ -328,6 +335,11 @@ pub(crate) fn stable_validated_package(path: &Path) -> Result<StablePackage> {
         dir,
         path: stable_path,
     })
+}
+
+fn package_identity_path(path: &Path) -> Result<PathBuf> {
+    fs::canonicalize(path)
+        .with_context(|| format!("Failed to resolve package path {}", path.display()))
 }
 
 pub(crate) fn ensure_codex_package(path: &Path) -> Result<()> {
@@ -1198,6 +1210,33 @@ mod tests {
             pacman_package_version(Path::new(
                 "/tmp/codex-desktop-2026.04.02.120000-1-x86_64.pkg.tar.zst"
             ))?,
+            "2026.04.02.120000-1"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_pacman_latest_symlink_to_versioned_package_identity() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let package_name = "codex-desktop-2026.04.02.120000-1-x86_64.pkg.tar.zst";
+        let package_path = temp.path().join(package_name);
+        let latest_path = temp.path().join("codex-desktop-latest.pkg.tar.zst");
+        std::fs::write(&package_path, b"pkg")?;
+        std::os::unix::fs::symlink(package_name, &latest_path)?;
+
+        let identity_path = package_identity_path(&latest_path)?;
+
+        assert_eq!(
+            identity_path.file_name().and_then(|name| name.to_str()),
+            Some(package_name)
+        );
+        assert_eq!(
+            stable_file_name(PackageKind::Pacman, &identity_path)?,
+            package_name
+        );
+        assert_eq!(
+            pacman_package_version(&identity_path)?,
             "2026.04.02.120000-1"
         );
         Ok(())


### PR DESCRIPTION
## Summary

- resolve pacman latest symlinks before validating and staging package identity
- let CLI preflight accept the newly installed user-prefix Codex CLI instead of rechecking only the old explicit/system binary
- include ~/.npm-global/bin/codex in launcher/updater CLI discovery

## Root cause

Issue #282 happens because privileged pacman installation validates the stable codex-desktop-latest.pkg.tar.zst symlink name, which does not include the Arch architecture suffix needed by the filename parser.

Issue #283 is separate: after npm succeeds, the updater can keep validating the previously persisted /usr/bin/codex path even when the new CLI landed in a user npm prefix.

## Validation

- cargo fmt --check
- git diff --check
- bash -n launcher/start.sh.template tests/scripts_smoke.sh
- cargo test -p codex-update-manager
- cargo clippy -p codex-update-manager --all-targets -- -D warnings
- bash tests/scripts_smoke.sh

Addresses #282.
Addresses #283.