### PR TITLE
Fix Browser Use bundled plugin staging on Linux

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -534,7 +534,7 @@ PY
 }
 
 sync_browser_use_bundled_plugin_cache() {
-    local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"
+    local source_plugin=""
     local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local plugin_json=""
     local source_client=""
@@ -551,6 +551,69 @@ sync_browser_use_bundled_plugin_cache() {
     local marketplace_plugins_dir
     local marketplace_plugin_link
     local needs_copy=1
+
+    if [ -f "$source_marketplace" ]; then
+        source_plugin="$(python3 - "$SCRIPT_DIR/resources/plugins/openai-bundled" "$source_marketplace" <<'PY' 2>/dev/null || true
+import json
+import os
+import sys
+
+root = os.path.abspath(sys.argv[1])
+marketplace_path = sys.argv[2]
+browser_names = ("browser-use", "browser")
+
+try:
+    with open(marketplace_path, "r", encoding="utf-8") as handle:
+        marketplace = json.load(handle)
+except (OSError, json.JSONDecodeError):
+    raise SystemExit(1)
+
+plugins = marketplace.get("plugins")
+if not isinstance(plugins, list):
+    raise SystemExit(1)
+
+for name in browser_names:
+    for plugin in plugins:
+        if not isinstance(plugin, dict) or plugin.get("name") != name:
+            continue
+        source = plugin.get("source")
+        if not isinstance(source, dict):
+            continue
+        if source.get("source") != "local":
+            continue
+        path = source.get("path")
+        if not isinstance(path, str) or path == "":
+            continue
+        candidate = os.path.abspath(os.path.join(root, path))
+        try:
+            if os.path.commonpath([root, candidate]) != root:
+                continue
+        except ValueError:
+            continue
+        if (
+            os.path.isfile(os.path.join(candidate, ".codex-plugin", "plugin.json"))
+            and os.path.isfile(os.path.join(candidate, "scripts", "browser-client.mjs"))
+        ):
+            print(candidate)
+            raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+)"
+    fi
+
+    if [ -z "$source_plugin" ]; then
+        for candidate in \
+            "$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser-use" \
+            "$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"
+        do
+            if [ -f "$candidate/.codex-plugin/plugin.json" ] && [ -f "$candidate/scripts/browser-client.mjs" ]; then
+                source_plugin="$candidate"
+                break
+            fi
+        done
+    fi
+    [ -n "$source_plugin" ] || return 0
 
     plugin_json="$source_plugin/.codex-plugin/plugin.json"
     source_client="$source_plugin/scripts/browser-client.mjs"

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -679,24 +679,36 @@ const path = require("path");
 const bundledRoot = process.argv[2];
 const marketplacePath = process.argv[3];
 const candidates = [];
+const browserPluginNames = new Set(["browser-use", "browser"]);
+
+function isInsideRoot(candidate) {
+  const relative = path.relative(bundledRoot, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
 
 try {
   const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
   const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
-  const plugin = plugins.find((entry) => entry && entry.name === "browser");
-  const source = plugin && plugin.source;
-  if (
-    source &&
-    source.source === "local" &&
-    typeof source.path === "string" &&
-    source.path.length > 0
-  ) {
-    candidates.push(path.resolve(bundledRoot, source.path));
+  for (const name of browserPluginNames) {
+    const plugin = plugins.find((entry) => entry && entry.name === name);
+    const source = plugin && plugin.source;
+    if (
+      source &&
+      source.source === "local" &&
+      typeof source.path === "string" &&
+      source.path.length > 0
+    ) {
+      const candidate = path.resolve(bundledRoot, source.path);
+      if (isInsideRoot(candidate)) {
+        candidates.push(candidate);
+      }
+    }
   }
 } catch (_err) {
-  // Fall back to the known upstream directory name below.
+  // Fall back to the known upstream directory names below.
 }
 
+candidates.push(path.join(bundledRoot, "plugins", "browser-use"));
 candidates.push(path.join(bundledRoot, "plugins", "browser"));
 
 const seen = new Set();
@@ -726,6 +738,7 @@ stage_browser_plugin_from_upstream() {
     local target_name
     target_name="$(basename "$source_plugin")"
     local target_plugin="$target_plugins/$target_name"
+    local obsolete_plugin=""
     local source_client="$source_plugin/scripts/browser-client.mjs"
     local target_client="$target_plugin/scripts/browser-client.mjs"
 
@@ -744,6 +757,14 @@ stage_browser_plugin_from_upstream() {
         return 1
     fi
 
+    case "$target_name" in
+        browser-use) obsolete_plugin="$target_plugins/browser" ;;
+        browser) obsolete_plugin="$target_plugins/browser-use" ;;
+    esac
+
+    if [ -n "$obsolete_plugin" ]; then
+        rm -rf "$obsolete_plugin"
+    fi
     rm -rf "$target_plugin"
     cp -R "$source_plugin" "$target_plugin"
     remove_macos_sidecar_files "$target_plugin"
@@ -776,61 +797,80 @@ const plugins = [];
 
 if (includeBrowser) {
   const marketplaceRoot = path.resolve(path.dirname(destinationPath), "..", "..");
-  const browser = sourcePlugins.find((plugin) => {
-    if (plugin == null || typeof plugin !== "object") {
-      return false;
+  function isInsideMarketplaceRoot(candidate) {
+    const relative = path.relative(marketplaceRoot, candidate);
+    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+  }
+  let browser = null;
+  for (const browserPluginName of ["browser-use", "browser"]) {
+    browser = sourcePlugins.find((plugin) => {
+      if (plugin == null || typeof plugin !== "object") {
+        return false;
+      }
+      if (plugin.name !== browserPluginName) {
+        return false;
+      }
+      const source = plugin.source || {};
+      if (source.source !== "local" || typeof source.path !== "string") {
+        return false;
+      }
+      const stagedPlugin = path.resolve(marketplaceRoot, source.path);
+      if (!isInsideMarketplaceRoot(stagedPlugin)) {
+        return false;
+      }
+      const stagedManifest = path.join(
+        stagedPlugin,
+        ".codex-plugin",
+        "plugin.json",
+      );
+      return fs.existsSync(stagedManifest);
+    });
+    if (browser != null) {
+      break;
     }
-    if (plugin.name !== "browser") {
-      return false;
-    }
-    const source = plugin.source || {};
-    if (source.source !== "local" || typeof source.path !== "string") {
-      return true;
-    }
-    const stagedManifest = path.join(
-      path.resolve(marketplaceRoot, source.path),
-      ".codex-plugin",
-      "plugin.json",
-    );
-    return fs.existsSync(stagedManifest);
-  });
+  }
   if (browser == null) {
     let fallback = null;
-    const stagedManifestPath = path.join(
-      marketplaceRoot,
-      "plugins",
-      "browser",
-      ".codex-plugin",
-      "plugin.json",
-    );
-    try {
-      const manifest = JSON.parse(fs.readFileSync(stagedManifestPath, "utf8"));
-      const name =
-        typeof manifest.name === "string" && manifest.name.length > 0 ? manifest.name : "browser";
-      const category =
-        manifest &&
-        manifest.interface &&
-        typeof manifest.interface.category === "string" &&
-        manifest.interface.category.length > 0
-          ? manifest.interface.category
-          : "Engineering";
-      fallback = {
-        name,
-        source: {
-          source: "local",
-          path: "./plugins/browser",
-        },
-        policy: {
-          installation: "AVAILABLE",
-          authentication: "ON_INSTALL",
-        },
-        category,
-      };
-    } catch (_err) {
-      // Fall through to the explicit error below.
+    for (const pluginDirName of ["browser-use", "browser"]) {
+      const stagedManifestPath = path.join(
+        marketplaceRoot,
+        "plugins",
+        pluginDirName,
+        ".codex-plugin",
+        "plugin.json",
+      );
+      try {
+        const manifest = JSON.parse(fs.readFileSync(stagedManifestPath, "utf8"));
+        const name =
+          typeof manifest.name === "string" && manifest.name.length > 0
+            ? manifest.name
+            : pluginDirName;
+        const category =
+          manifest &&
+          manifest.interface &&
+          typeof manifest.interface.category === "string" &&
+          manifest.interface.category.length > 0
+            ? manifest.interface.category
+            : "Engineering";
+        fallback = {
+          name,
+          source: {
+            source: "local",
+            path: `./plugins/${pluginDirName}`,
+          },
+          policy: {
+            installation: "AVAILABLE",
+            authentication: "ON_INSTALL",
+          },
+          category,
+        };
+        break;
+      } catch (_err) {
+        // Try the next known browser plugin directory.
+      }
     }
     if (fallback == null) {
-      throw new Error("Bundled marketplace does not contain browser plugin");
+      throw new Error("Bundled marketplace does not contain Browser Use plugin");
     }
     plugins.push(fallback);
   } else {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -97,18 +97,20 @@ JSON
 
 make_fake_browser_upstream_app() {
     local app_dir="$1"
+    local plugin_name="${2:-browser}"
+    local plugin_dir_name="${3:-$plugin_name}"
     local resources_dir="$app_dir/Contents/Resources"
     mkdir -p \
         "$resources_dir/plugins/openai-bundled/.agents/plugins" \
-        "$resources_dir/plugins/openai-bundled/plugins/browser/.codex-plugin" \
-        "$resources_dir/plugins/openai-bundled/plugins/browser/scripts"
-    cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
-{"plugins":[{"name":"browser","source":{"source":"local","path":"./plugins/browser"},"policy":{"installation":"AVAILABLE","authentication":"ON_INSTALL"},"category":"Engineering"}]}
+        "$resources_dir/plugins/openai-bundled/plugins/$plugin_dir_name/.codex-plugin" \
+        "$resources_dir/plugins/openai-bundled/plugins/$plugin_dir_name/scripts"
+    cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<JSON
+{"plugins":[{"name":"$plugin_name","source":{"source":"local","path":"./plugins/$plugin_dir_name"},"policy":{"installation":"AVAILABLE","authentication":"ON_INSTALL"},"category":"Engineering"}]}
 JSON
-    cat > "$resources_dir/plugins/openai-bundled/plugins/browser/.codex-plugin/plugin.json" <<'JSON'
-{"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
+    cat > "$resources_dir/plugins/openai-bundled/plugins/$plugin_dir_name/.codex-plugin/plugin.json" <<JSON
+{"name":"$plugin_name","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
-    cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
+    cat > "$resources_dir/plugins/openai-bundled/plugins/$plugin_dir_name/scripts/browser-client.mjs" <<'JS'
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}class Uf{async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}export function setupAtlasRuntime() {}
 JS
 }
@@ -2072,7 +2074,8 @@ PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "resolve_update_manager_path"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_browser_use_bundled_plugin_cache"
-    assert_contains "$REPO_DIR/launcher/start.sh.template" 'source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'resources/plugins/openai-bundled/plugins/browser-use'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'resources/plugins/openai-bundled/plugins/browser'
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_chrome_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_read_aloud_bundled_plugin_cache"
@@ -2241,7 +2244,7 @@ test_browser_use_node_repl_fallback_runtime() {
     local true_bin
 
     mkdir -p "$workspace" "$install_dir/resources" "$archive_root/codex-primary-runtime/dependencies/bin"
-    make_fake_browser_upstream_app "$app_dir"
+    make_fake_browser_upstream_app "$app_dir" browser-use browser-use
 
     # Simulate the current upstream DMG shape: node_repl exists, but it is not a Linux ELF.
     printf '\xfe\xed\xfa\xcf' > "$app_dir/Contents/Resources/node_repl"
@@ -2282,11 +2285,11 @@ test_browser_use_node_repl_fallback_runtime() {
     ) >"$output_log" 2>&1
 
     assert_file_exists "$install_dir/resources/node_repl"
-    assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs"
+    assert_file_exists "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs"
     cmp -s "$true_bin" "$install_dir/resources/node_repl" || fail "Expected fallback node_repl to come from the runtime archive"
-    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env?.\[e\]'
-    assert_not_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
-    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env?.\[e\]'
+    assert_not_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
+    assert_contains "$install_dir/resources/plugins/openai-bundled/plugins/browser-use/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$output_log" "Browser Use node_repl runtime is not a Linux executable for x86_64; skipping"
     assert_not_contains "$output_log" "WARN.*Browser Use node_repl runtime is not a Linux executable"
     assert_contains "$output_log" "Downloading Browser Use node_repl fallback runtime"
@@ -2298,11 +2301,11 @@ test_browser_plugin_renamed_upstream_staging() {
     local app_dir="$workspace/Codex.app"
     local install_dir="$workspace/install"
     local output_log="$workspace/output.log"
-    local browser_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser"
+    local browser_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser-use"
     local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
 
     mkdir -p "$workspace" "$install_dir/resources"
-    make_fake_browser_upstream_app "$app_dir"
+    make_fake_browser_upstream_app "$app_dir" browser-use browser-use
 
     (
         SCRIPT_DIR="$REPO_DIR"
@@ -2322,6 +2325,51 @@ test_browser_plugin_renamed_upstream_staging() {
     ) >"$output_log" 2>&1
 
     assert_file_exists "$browser_dir/scripts/browser-client.mjs"
+    assert_contains "$browser_dir/.codex-plugin/plugin.json" '"name":"browser-use"'
+    assert_contains "$browser_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env?.\[e\]'
+    assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_contains "$marketplace" '"name": "browser-use"'
+    assert_contains "$marketplace" '"path": "./plugins/browser-use"'
+    assert_contains "$output_log" "Browser plugin staged from upstream DMG"
+    assert_not_contains "$output_log" "Browser bundled plugin resources not present"
+}
+
+test_browser_plugin_legacy_upstream_staging() {
+    info "Checking Browser plugin staging from legacy upstream resources"
+    local workspace="$TMP_DIR/browser-plugin-legacy"
+    local app_dir="$workspace/Codex.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local browser_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser"
+    local stale_browser_use_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser-use"
+    local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_browser_upstream_app "$app_dir"
+    mkdir -p "$stale_browser_use_dir/.codex-plugin" "$stale_browser_use_dir/scripts"
+    printf '%s\n' '{"name":"browser-use","version":"stale"}' > "$stale_browser_use_dir/.codex-plugin/plugin.json"
+    printf '%s\n' 'stale browser-use client' > "$stale_browser_use_dir/scripts/browser-client.mjs"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$browser_dir/scripts/browser-client.mjs"
+    assert_file_not_exists "$stale_browser_use_dir/scripts/browser-client.mjs"
     assert_contains "$browser_dir/.codex-plugin/plugin.json" '"name":"browser"'
     assert_contains "$browser_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env?.\[e\]'
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
@@ -2330,6 +2378,80 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_contains "$marketplace" '"path": "./plugins/browser"'
     assert_contains "$output_log" "Browser plugin staged from upstream DMG"
     assert_not_contains "$output_log" "Browser bundled plugin resources not present"
+}
+
+test_browser_marketplace_ignores_unusable_preferred_entry() {
+    info "Checking Browser marketplace ignores unusable preferred entries"
+    local workspace="$TMP_DIR/browser-plugin-mixed-marketplace"
+    local app_dir="$workspace/Codex.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local browser_dir="$install_dir/resources/plugins/openai-bundled/plugins/browser"
+    local external_browser_use_dir="$workspace/external-browser-use"
+    local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_browser_upstream_app "$app_dir"
+    mkdir -p "$external_browser_use_dir/.codex-plugin" "$external_browser_use_dir/scripts"
+    printf '%s\n' '{"name":"browser-use","version":"outside"}' > "$external_browser_use_dir/.codex-plugin/plugin.json"
+    printf '%s\n' 'outside browser-use client' > "$external_browser_use_dir/scripts/browser-client.mjs"
+    cat > "$app_dir/Contents/Resources/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
+{
+  "plugins": [
+    {
+      "name": "browser-use",
+      "source": {
+        "source": "local",
+        "path": "__EXTERNAL_BROWSER_USE_DIR__"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "BrokenPreferred"
+    },
+    {
+      "name": "browser",
+      "source": {
+        "source": "local",
+        "path": "./plugins/browser"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    }
+  ]
+}
+JSON
+    sed -i "s#__EXTERNAL_BROWSER_USE_DIR__#$external_browser_use_dir#g" \
+        "$app_dir/Contents/Resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$browser_dir/scripts/browser-client.mjs"
+    assert_not_contains "$browser_dir/scripts/browser-client.mjs" "outside browser-use client"
+    assert_contains "$marketplace" '"name": "browser"'
+    assert_contains "$marketplace" '"path": "./plugins/browser"'
+    assert_not_contains "$marketplace" '"name": "browser-use"'
+    assert_not_contains "$marketplace" "BrokenPreferred"
+    assert_contains "$output_log" "Browser plugin staged from upstream DMG"
 }
 
 test_browser_use_node_repl_glibc_pidfd_patch_static() {
@@ -4511,6 +4633,8 @@ main() {
     test_bundled_plugin_builders_accept_prebuilt_binaries
     test_browser_use_node_repl_fallback_runtime
     test_browser_plugin_renamed_upstream_staging
+    test_browser_plugin_legacy_upstream_staging
+    test_browser_marketplace_ignores_unusable_preferred_entry
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility
     test_chrome_plugin_staging


### PR DESCRIPTION
## Summary

- Support both current upstream `browser-use` and legacy `browser` bundled plugin layouts.
- Make launcher-side Browser Use cache sync follow the generated bundled marketplace metadata.
- Remove stale Browser Use sibling directories during non-fresh rebuilds so marketplace entries and staged files cannot drift.
- Guard bundled marketplace local paths so Browser Use discovery cannot escape the `openai-bundled/` root.

## User-Visible Behavior

Browser Use is now discovered and installed from the bundled Linux resources again.

Before this fix, builds using the current upstream plugin layout could stage `plugins/browser-use/` but still generate/sync Linux metadata that expected `plugins/browser/`, causing Browser Use to be missing or reported as unavailable.

After this fix, the bundled marketplace exposes `browser-use`, the launcher syncs the matching plugin cache, and Browser Use is available in the Linux app.

Left is before, right is after. 

<img width="1258" height="406" alt="image" src="https://github.com/user-attachments/assets/b04a8ff8-943c-41af-92cf-ccc7d362aa4f" />

## Source Files

- `scripts/lib/bundled-plugins.sh`
  - discovers `browser-use` first and falls back to legacy `browser`
  - removes obsolete sibling directories on non-fresh rebuilds
  - writes marketplace entries only for usable local plugin paths
  - rejects marketplace paths outside `openai-bundled/`
- `launcher/start.sh.template`
  - resolves Browser Use from bundled marketplace metadata before filesystem fallback
  - keeps runtime plugin cache and temporary bundled marketplace links aligned
- `tests/scripts_smoke.sh`
  - covers current `browser-use`, legacy `browser`, stale sibling cleanup, and unsafe/malformed marketplace paths

## Validation

```bash
bash -n install.sh
bash -n scripts/lib/install-helpers.sh scripts/lib/node-runtime.sh scripts/lib/process-detection.sh scripts/lib/dmg.sh scripts/lib/native-modules.sh scripts/lib/asar-patch.sh scripts/lib/webview-install.sh scripts/lib/bundled-plugins.sh scripts/lib/linux-features.sh scripts/lib/package-common.sh
bash -n launcher/start.sh.template
bash -n scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh
```

## Notes

- This does not change the Browser Use runtime itself.
- A separate authenticated fetch error, `Codex auth token is unavailable`, can still occur for external URL safety checks, but local Browser Use flows such as `localhost:3000` work after the plugin staging fix.
