### PR TITLE
[codex] Fix openSUSE RPM install

### DIFF
--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -6,16 +6,23 @@ License:        Proprietary
 ExclusiveArch:  __ARCH__
 %global __requires_exclude_from ^/opt/__PACKAGE_NAME__/.*$
 %global __provides_exclude_from ^/opt/__PACKAGE_NAME__/.*$
+%global codex_elf_suffix %{nil}
+%ifarch x86_64 aarch64 ppc64le s390x riscv64
+%global codex_elf_suffix ()(64bit)
+%endif
 
 %if __PACKAGE_WITH_UPDATER__
 Requires:       python3, /usr/bin/7z, polkit, curl, unzip, gcc-c++, make
 %else
 Requires:       python3, /usr/bin/7z, curl, unzip, gcc-c++, make
 %endif
-Requires:       alsa-lib, at-spi2-atk, atk, glib2, gtk3, libdrm
-Requires:       nspr, nss, pango, libstdc++, libX11, libxcb
-Requires:       libXcomposite, libXdamage, libXext, libXfixes, libxkbcommon, libXrandr
-Requires:       mesa-libgbm
+Requires:       libasound.so.2%{codex_elf_suffix}, libatk-bridge-2.0.so.0%{codex_elf_suffix}
+Requires:       libatk-1.0.so.0%{codex_elf_suffix}, libglib-2.0.so.0%{codex_elf_suffix}, libgtk-3.so.0%{codex_elf_suffix}
+Requires:       libdrm.so.2%{codex_elf_suffix}, libnspr4.so%{codex_elf_suffix}, libnss3.so%{codex_elf_suffix}
+Requires:       libpango-1.0.so.0%{codex_elf_suffix}, libstdc++.so.6%{codex_elf_suffix}, libX11.so.6%{codex_elf_suffix}
+Requires:       libxcb.so.1%{codex_elf_suffix}, libXcomposite.so.1%{codex_elf_suffix}, libXdamage.so.1%{codex_elf_suffix}
+Requires:       libXext.so.6%{codex_elf_suffix}, libXfixes.so.3%{codex_elf_suffix}, libxkbcommon.so.0%{codex_elf_suffix}
+Requires:       libXrandr.so.2%{codex_elf_suffix}, libgbm.so.1%{codex_elf_suffix}
 Recommends:     zenity, kdialog
 
 %description

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -67,6 +67,7 @@ main() {
     stage_common_package_files "$PKG_ROOT"
     stage_optional_update_builder_bundle "$PKG_ROOT"
     write_launcher_stub "$PKG_ROOT"
+    normalize_package_payload_permissions "$PKG_ROOT"
 
     sed \
         -e "s/__PACKAGE_NAME__/$PACKAGE_NAME/g" \

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -71,6 +71,7 @@ main() {
 	stage_common_package_files "$staging_root"
 	stage_optional_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
+	normalize_package_payload_permissions "$staging_root"
 
 	local package_name
 	local pacman_pkgver

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -86,6 +86,7 @@ main() {
 exec /opt/$PACKAGE_NAME/start.sh "\$@"
 SCRIPT
     chmod 0755 "$staging_root/usr/bin/$PACKAGE_NAME"
+    normalize_package_payload_permissions "$staging_root"
 
     local spec_file="$build_root/codex-desktop.spec"
     sed \

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -535,6 +535,15 @@ stage_optional_update_builder_bundle() {
     fi
 }
 
+normalize_package_payload_permissions() {
+    local root="$1"
+
+    [ -d "$root" ] || error "Missing package root: $root"
+    find "$root" -type d -exec chmod 0755 {} +
+    find "$root" -type f \( -perm /u=x -o -perm /g=x -o -perm /o=x \) -exec chmod 0755 {} +
+    find "$root" -type f ! \( -perm /u=x -o -perm /g=x -o -perm /o=x \) -exec chmod 0644 {} +
+}
+
 write_launcher_stub() {
     local root="$1"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -31,6 +31,20 @@ assert_file_not_exists() {
     [ ! -e "$path" ] || fail "Expected file not to exist: $path"
 }
 
+assert_mode() {
+    local path="$1"
+    local expected="$2"
+    local actual
+    actual="$(python3 - "$path" <<'PY'
+import os
+import sys
+
+print(format(os.lstat(sys.argv[1]).st_mode & 0o777, "o"))
+PY
+)"
+    [ "$actual" = "$expected" ] || fail "Expected mode $expected for $path, got $actual"
+}
+
 assert_contains() {
     local path="$1"
     local pattern="$2"
@@ -131,6 +145,30 @@ test_common_helper_sourcing() {
     # shellcheck disable=SC1091
     source "$REPO_DIR/scripts/lib/package-common.sh"
     ensure_file_exists "$probe_file" "probe file"
+}
+
+test_package_payload_permission_normalization() {
+    info "Checking package payload permission normalization"
+    local root="$TMP_DIR/package-permissions"
+    local app_root="$root/opt/codex-desktop"
+
+    mkdir -p "$app_root/content/webview" "$root/usr/bin"
+    printf '%s\n' '#!/bin/bash' 'echo start' > "$app_root/start.sh"
+    printf '%s\n' '<!doctype html>' > "$app_root/content/webview/index.html"
+    printf '%s\n' '#!/bin/bash' 'exec /opt/codex-desktop/start.sh "$@"' > "$root/usr/bin/codex-desktop"
+    chmod 0700 "$root/opt" "$app_root" "$app_root/content" "$app_root/content/webview"
+    chmod 0700 "$app_root/start.sh" "$root/usr/bin/codex-desktop"
+    chmod 0600 "$app_root/content/webview/index.html"
+
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/scripts/lib/package-common.sh"
+    normalize_package_payload_permissions "$root"
+
+    assert_mode "$app_root" "755"
+    assert_mode "$app_root/content/webview" "755"
+    assert_mode "$app_root/start.sh" "755"
+    assert_mode "$root/usr/bin/codex-desktop" "755"
+    assert_mode "$app_root/content/webview/index.html" "644"
 }
 
 test_deb_builder_smoke() {
@@ -452,6 +490,9 @@ test_rpm_builder_smoke() {
     mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
+    chmod 0700 "$app_dir" "$app_dir/content" "$app_dir/content/webview"
+    chmod 0700 "$app_dir/start.sh"
+    chmod 0600 "$app_dir/content/webview/index.html"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
     chmod +x "$updater_bin"
 
@@ -514,7 +555,16 @@ SCRIPT
     assert_file_not_exists "$capture_dir/staging/usr/lib/systemd/user/codex-update-manager.service"
     assert_file_not_exists "$capture_dir/staging/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
     assert_file_not_exists "$capture_dir/staging/opt/codex-desktop/update-builder"
+    assert_mode "$capture_dir/staging/opt/codex-desktop" "755"
+    assert_mode "$capture_dir/staging/opt/codex-desktop/content/webview" "755"
+    assert_mode "$capture_dir/staging/opt/codex-desktop/start.sh" "755"
+    assert_mode "$capture_dir/staging/opt/codex-desktop/content/webview/index.html" "644"
     assert_contains "$capture_dir/codex-desktop.spec" "%if 0"
+    assert_contains "$capture_dir/codex-desktop.spec" "codex_elf_suffix ()(64bit)"
+    assert_contains "$capture_dir/codex-desktop.spec" "libatk-bridge-2.0.so.0"
+    assert_contains "$capture_dir/codex-desktop.spec" "libgbm.so.1"
+    assert_not_contains "$capture_dir/codex-desktop.spec" "at-spi2-atk"
+    assert_not_contains "$capture_dir/codex-desktop.spec" "mesa-libgbm"
     assert_contains "$capture_dir/codex-desktop.spec" "codex_no_updater_cleanup_update_manager_service"
     assert_contains "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "codex_no_updater_cleanup_user_enablement_links"
 }
@@ -4476,6 +4526,7 @@ EOF
 
 main() {
     test_common_helper_sourcing
+    test_package_payload_permission_normalization
     test_deb_builder_smoke
     test_update_builder_preserves_enabled_linux_features_config
     test_deb_builder_respects_package_identity


### PR DESCRIPTION
## Summary
- replace Fedora-specific RPM desktop library package names with shared-library capabilities so openSUSE can resolve them
- make the RPM library capability suffix architecture-aware instead of hardcoding 64-bit for every target
- normalize staged native package payload permissions so private local build dirs do not ship as unreadable /opt trees

## Validation
- git diff --check
- bash -n scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/lib/package-common.sh tests/scripts_smoke.sh
- rpmspec --target x86_64 -P rendered spec
- rpmspec --target armv7hl -P rendered spec
- rpmbuild -bb rendered no-updater spec with a minimal staging tree
- bash tests/scripts_smoke.sh

Fixes #292