### PR TITLE
[codex] Ignore local Codex metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist-next/
 linux-features/features.json
 .idea/
 .claude/
+.codex/


### PR DESCRIPTION
## Summary
- add `.codex/` to `.gitignore` so local Codex skills, state, and review memory stay out of repository diffs

## Validation
- `git diff --check -- .gitignore`