### PR TITLE
[codex] Fix CI rust and smoke tests

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -41,6 +41,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -200,16 +200,6 @@ function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
     return source;
   }
 
-  if (
-    source.includes("function ep({authIdentity:e,connectionKey:t,deviceKeyClient:n,globalState:r})") &&
-    source.includes("Promise.all(tp(e).map(async e=>{let i=jf(t,e);") &&
-    source.includes("function tp(e){if(e.tokenAccountUserId==null)return[];") &&
-    source.includes("tokenAuthUserId!==e.tokenAccountUserId&&t.push(e.tokenAuthUserId)") &&
-    source.includes("u.account_user_id!==c&&!(s.tokenAccountId!=null&&s.headerChatGptAccountId===s.tokenAccountId&&s.tokenAuthUserId===u.account_user_id)")
-  ) {
-    return source;
-  }
-
   if (!source.includes("Remote control enrollment start does not match current account.")) {
     return source;
   }
@@ -230,27 +220,36 @@ function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
       `([A-Za-z_$][\\w$]*)=\\7,([A-Za-z_$][\\w$]*);`,
     "u",
   );
+  const currentEnrollmentStartRegex = new RegExp(
+    `let ([A-Za-z_$][\\w$]*)=([A-Za-z_$][\\w$]*)\\(([A-Za-z_$][\\w$]*)\\),([A-Za-z_$][\\w$]*)=\\1\\.tokenAccountUserId;` +
+      `if\\(\\4==null\\)throw Error\\(\`Remote control enrollment requires the current ChatGPT account user id\\.\`\\);` +
+      `let ([A-Za-z_$][\\w$]*)=\\1\\.tokenAccountId\\?\\?\\1\\.headerChatGptAccountId,` +
+      `([A-Za-z_$][\\w$]*)=await ([A-Za-z_$][\\w$]*)\\(\\{authIdentity:\\1,connectionKey:([A-Za-z_$][\\w$]*),deviceKeyClient:([A-Za-z_$][\\w$]*),globalState:([A-Za-z_$][\\w$]*)\\}\\),` +
+      `([A-Za-z_$][\\w$]*)=\\6\\?\\.record\\?\\?null,` +
+      `([A-Za-z_$][\\w$]*)=\\6\\?\\.key\\?\\?${enrollmentKeyFn}\\(\\8,\\4\\),` +
+      `([A-Za-z_$][\\w$]*)=\\11,([A-Za-z_$][\\w$]*);`,
+    "u",
+  );
   const startMatch = source.match(enrollmentStartRegex);
-  if (startMatch == null) {
+  const currentStartMatch = startMatch == null ? source.match(currentEnrollmentStartRegex) : null;
+  if (startMatch == null && currentStartMatch == null) {
     console.warn("WARN: Could not find remote-control enrollment start shape - skipping account compatibility patch");
     return source;
   }
 
-  const [
-    startNeedle,
-    authIdentityVar,
-    authIdentityFn,
-    headersVar,
-    tokenAccountUserIdVar,
-    enrollmentRecordKeyVar,
-    enrollmentKeyVar,
-    loadedEnrollmentVar,
-    loadEnrollmentFn,
-    deviceKeyClientVar,
-    globalStateVar,
-    enrollmentVar,
-    tokenResponseVar,
-  ] = startMatch;
+  const startNeedle = (startMatch ?? currentStartMatch)[0];
+  const authIdentityVar = (startMatch ?? currentStartMatch)[1];
+  const authIdentityFn = (startMatch ?? currentStartMatch)[2];
+  const headersVar = (startMatch ?? currentStartMatch)[3];
+  const tokenAccountUserIdVar = (startMatch ?? currentStartMatch)[4];
+  const enrollmentRecordKeyVar = startMatch != null ? startMatch[5] : currentStartMatch[12];
+  const enrollmentKeyVar = startMatch != null ? startMatch[6] : currentStartMatch[8];
+  const loadedEnrollmentVar = startMatch != null ? startMatch[7] : currentStartMatch[11];
+  const loadEnrollmentFn = startMatch != null ? startMatch[8] : currentStartMatch[7];
+  const deviceKeyClientVar = startMatch != null ? startMatch[9] : currentStartMatch[9];
+  const globalStateVar = startMatch != null ? startMatch[10] : currentStartMatch[10];
+  const enrollmentVar = startMatch != null ? startMatch[11] : currentStartMatch[13];
+  const tokenResponseVar = startMatch != null ? startMatch[12] : currentStartMatch[14];
 
   const stepUpValidatorRegex =
     /function ([A-Za-z_$][\w$]*)\(\{accountUserId:([A-Za-z_$][\w$]*),stepUpToken:([A-Za-z_$][\w$]*)\}\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\3\);([A-Za-z_$][\w$]*)\(\{payload:\4\}\);let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\.parse\(\4\),([A-Za-z_$][\w$]*)=\7\[`https:\/\/api\.openai\.com\/auth`\],([A-Za-z_$][\w$]*)=\9\.chatgpt_account_user_id\?\?\9\.account_user_id,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\7\);if\(\10!==\2\)throw (?:Error\(`Remote control enrollment step-up token does not match current account\.`\)|new [A-Za-z_$][\w$]*);if\(Math\.floor\(Date\.now\(\)\/1e3\)-\7\.iat>([A-Za-z_$][\w$]*)\)throw Error\(`Remote control enrollment step-up token is not fresh\.`\);if\(Date\.now\(\)-\7\.pwd_auth_time>\13\*1e3\)throw Error\(`Remote control enrollment step-up token does not have fresh password auth\.`\);if\(\11\.length!==1\|\|\11\[0\]!==([A-Za-z_$][\w$]*)\)throw Error\(`Remote control enrollment step-up token is missing required authorization\.`\);return\{accountUserId:\10\?\?null,issuedAt:\7\.iat,passwordAuthTime:\7\.pwd_auth_time,scopes:\11\}\}/u;
@@ -341,7 +340,7 @@ function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
   );
 
   const stepUpCallRegex = new RegExp(
-    `let ([A-Za-z_$][\\w$]*)=await ([A-Za-z_$][\\w$]*)\\(\\),([A-Za-z_$][\\w$]*)=${escapeRegExp(stepUpValidatorFn)}\\(\\{accountUserId:${escapeRegExp(tokenAccountUserIdVar)},stepUpToken:\\1\\}\\),`,
+    `let ([A-Za-z_$][\\w$]*)=await ([A-Za-z_$][\\w$]*)\\((?:\\{accountId:[A-Za-z_$][\\w$]*\\})?\\),([A-Za-z_$][\\w$]*)=${escapeRegExp(stepUpValidatorFn)}\\(\\{accountUserId:${escapeRegExp(tokenAccountUserIdVar)},stepUpToken:\\1\\}\\),`,
     "u",
   );
   const stepUpCallMatch = patched.match(stepUpCallRegex);
@@ -381,15 +380,36 @@ function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
         `return\\{clientAuthorized:\\9!=null,clientId:\\9\\?\\.clientId\\?\\?null\\}\\}`,
       "u",
     );
+  const currentAuthorizationCheckRegex =
+    new RegExp(
+      `async function ([A-Za-z_$][\\w$]*)\\(\\{appServerClient:([A-Za-z_$][\\w$]*),desktopApiOptions:([A-Za-z_$][\\w$]*),deviceKeyClient:([A-Za-z_$][\\w$]*),globalState:([A-Za-z_$][\\w$]*)\\}\\)\\{` +
+        `let ([A-Za-z_$][\\w$]*)=([A-Za-z_$][\\w$]*)\\(await ([A-Za-z_$][\\w$]*)\\(\\{action:\`check remote control authorization\`,appServerClient:\\2,desktopApiOptions:\\3\\}\\)\\);` +
+        `if\\(\\6\\.tokenAccountUserId==null\\)return\\{clientAuthorized:!1,clientId:null\\};` +
+        `let ([A-Za-z_$][\\w$]*)=await ([A-Za-z_$][\\w$]*)\\(\\{authIdentity:\\6,connectionKey:([A-Za-z_$][\\w$]*)\\(\\3\\),deviceKeyClient:\\4,globalState:\\5\\}\\);` +
+        `return\\{clientAuthorized:\\9!=null,clientId:\\9\\?\\.record\\.clientId\\?\\?null\\}\\}`,
+      "u",
+    );
   const authorizationCheckMatch = patched.match(authorizationCheckRegex);
-  if (authorizationCheckMatch == null) {
+  const currentAuthorizationCheckMatch =
+    authorizationCheckMatch == null ? patched.match(currentAuthorizationCheckRegex) : null;
+  if (authorizationCheckMatch == null && currentAuthorizationCheckMatch == null) {
     console.warn("WARN: Could not find remote-control authorization status check - skipping account compatibility patch");
     return source;
   }
-  const [, authCheckFn, appServerClientVar, desktopApiOptionsVar, authDeviceKeyClientVar, authGlobalStateVar, authStatusIdentityVar, authStatusIdentityFn, authHeadersFn, enrollmentVarForStatus, , statusBaseEnrollmentKeyFn] =
-    authorizationCheckMatch;
+  const authCheckFn = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[1];
+  const appServerClientVar = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[2];
+  const desktopApiOptionsVar = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[3];
+  const authDeviceKeyClientVar = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[4];
+  const authGlobalStateVar = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[5];
+  const authStatusIdentityVar = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[6];
+  const authStatusIdentityFn = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[7];
+  const authHeadersFn = (authorizationCheckMatch ?? currentAuthorizationCheckMatch)[8];
+  const enrollmentVarForStatus =
+    authorizationCheckMatch != null ? authorizationCheckMatch[9] : currentAuthorizationCheckMatch[9];
+  const statusBaseEnrollmentKeyFn =
+    authorizationCheckMatch != null ? authorizationCheckMatch[11] : currentAuthorizationCheckMatch[11];
   patched = patched.replace(
-    authorizationCheckRegex,
+    authorizationCheckMatch != null ? authorizationCheckRegex : currentAuthorizationCheckRegex,
     `async function ${authCheckFn}({appServerClient:${appServerClientVar},desktopApiOptions:${desktopApiOptionsVar},deviceKeyClient:${authDeviceKeyClientVar},globalState:${authGlobalStateVar}}){let ${authStatusIdentityVar}=${authStatusIdentityFn}(await ${authHeadersFn}({action:\`check remote control authorization\`,appServerClient:${appServerClientVar},desktopApiOptions:${desktopApiOptionsVar}}));if(${authStatusIdentityVar}.tokenAccountUserId==null)return{clientAuthorized:!1,clientId:null};let ${enrollmentVarForStatus}=await codexLinuxRemoteControlLoadEnrollment({authIdentity:${authStatusIdentityVar},deviceKeyClient:${authDeviceKeyClientVar},enrollmentKey:${statusBaseEnrollmentKeyFn}(${desktopApiOptionsVar}),globalState:${authGlobalStateVar}});return{clientAuthorized:${enrollmentVarForStatus}!=null,clientId:${enrollmentVarForStatus}?.enrollment.clientId??null}}`,
   );
 
@@ -636,15 +656,6 @@ function replaceLinuxRemoteControlCopy(source) {
 function applyLinuxRemoteControlCopyPatch(source) {
   const { patched, changed } = replaceLinuxRemoteControlCopy(source);
   if (!changed) {
-    if (
-      !source.includes("this Mac") &&
-      !source.includes("Keep this Mac awake") &&
-      !source.includes("Control this Mac") &&
-      !source.includes("local Mac") &&
-      !source.includes("settings.remoteConnections")
-    ) {
-      return source;
-    }
     console.warn("WARN: Could not find remote-control Mac copy - skipping Linux remote-control copy patch");
     return source;
   }
@@ -751,6 +762,7 @@ function applyLinuxRemoteMobileChromeBridgePatch(source) {
     return source;
   }
 
+  let patched = source;
   const backendNeedle =
     "var tE=\"x-codex-browser-use-available-backends\",X6=[\"chrome\",\"iab\",\"cdp\"];function rE(t){return X6.some(e=>e===t)}";
   const backendReplacement =
@@ -759,22 +771,36 @@ function applyLinuxRemoteMobileChromeBridgePatch(source) {
     "function yC(){let t=globalThis.nodeRepl?.requestMeta?.[tE];return t==null?null:Array.isArray(t)?t.filter(rE):[]}";
   const currentBackendReplacement =
     "function yC(){let t=globalThis.nodeRepl?.requestMeta?.[tE];return codexLinuxRemoteMobileBrowserBackends(t)}";
+  const envBackendNeedle =
+    "var R2=[\"chrome\",\"iab\",\"cdp\"];function Jb(e){return R2.some(t=>t===e)}";
+  const envBackendReplacement =
+    "var R2=[\"chrome\",\"iab\",\"cdp\"];function Jb(e){return R2.some(t=>t===e)}function codexLinuxRemoteMobileBrowserBackends(e){if(e==null)return null;let t=typeof e==`string`?ly(e):Array.isArray(e)?e:[],r=t.filter(Jb);return typeof process!=`undefined`&&process.platform===`linux`&&!r.includes(`chrome`)?[`chrome`,...r]:r}";
+  const currentEnvBackendNeedle = "function oy(){let e=lu(Yb);return e==null?null:ly(e).filter(Jb)}";
+  const currentEnvBackendReplacement = "function oy(){let e=lu(Yb);return codexLinuxRemoteMobileBrowserBackends(e)}";
 
-  if (!source.includes(backendNeedle) || !source.includes(currentBackendNeedle)) {
+  if (patched.includes(backendNeedle) && patched.includes(currentBackendNeedle)) {
+    patched = patched.replace(backendNeedle, backendReplacement).replace(currentBackendNeedle, currentBackendReplacement);
+  } else if (patched.includes(envBackendNeedle) && patched.includes(currentEnvBackendNeedle)) {
+    patched = patched
+      .replace(envBackendNeedle, envBackendReplacement)
+      .replace(currentEnvBackendNeedle, currentEnvBackendReplacement);
+  } else {
     console.warn("WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch");
     return source;
   }
-
-  let patched = source
-    .replace(backendNeedle, backendReplacement)
-    .replace(currentBackendNeedle, currentBackendReplacement);
 
   const nativePipeNeedle =
     "function Cm(){let t=import.meta.__codexNativePipeUnavailableMessage;return typeof t==\"string\"&&t.length>0?t:\"privileged native pipe bridge is not available; browser-client is not trusted\"}";
   const nativePipeReplacement =
     "function codexLinuxRemoteMobileBrowserBridgeDiagnostic(e){return typeof process!=`undefined`&&process.platform===`linux`?`${e}; Chrome bridge was not exposed to this remote/mobile session. Check that the Chrome plugin, native host manifest, and x-codex-browser-use-available-backends request metadata include chrome.`:e}function Cm(){let t=import.meta.__codexNativePipeUnavailableMessage,e=typeof t==\"string\"&&t.length>0?t:\"privileged native pipe bridge is not available; browser-client is not trusted\";return codexLinuxRemoteMobileBrowserBridgeDiagnostic(e)}";
+  const envNativePipeNeedle =
+    "function eh(){let e=sy();return e?`privileged native pipe bridge is not available; browser-client is not trusted. Load browser-client from the ${e} marketplace directory.`:\"privileged native pipe bridge is not available; browser-client is not trusted\"}";
+  const envNativePipeReplacement =
+    "function codexLinuxRemoteMobileBrowserBridgeDiagnostic(e){return typeof process!=`undefined`&&process.platform===`linux`?`${e}; Chrome bridge was not exposed to this remote/mobile session. Check that the Chrome plugin, native host manifest, and BROWSER_USE_AVAILABLE_BACKENDS environment include chrome.`:e}function eh(){let e=sy(),t=e?`privileged native pipe bridge is not available; browser-client is not trusted. Load browser-client from the ${e} marketplace directory.`:\"privileged native pipe bridge is not available; browser-client is not trusted\";return codexLinuxRemoteMobileBrowserBridgeDiagnostic(t)}";
   if (patched.includes(nativePipeNeedle)) {
     patched = patched.replace(nativePipeNeedle, nativePipeReplacement);
+  } else if (patched.includes(envNativePipeNeedle)) {
+    patched = patched.replace(envNativePipeNeedle, envNativePipeReplacement);
   } else {
     console.warn("WARN: Could not find Chrome browser-client native pipe diagnostic needle - leaving default bridge diagnostic unchanged");
   }

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -85,6 +85,17 @@ function syntheticCurrentClientEnrollmentBundle() {
   ].join("");
 }
 
+function syntheticLatestClientEnrollmentBundle() {
+  return [
+    "async function kf({appServerClient:e,desktopApiOptions:t,deviceKeyClient:n,globalState:r}){let i=Bf(await Mf({action:`check remote control authorization`,appServerClient:e,desktopApiOptions:t}));if(i.tokenAccountUserId==null)return{clientAuthorized:!1,clientId:null};let a=await ep({authIdentity:i,connectionKey:Af(t),deviceKeyClient:n,globalState:r});return{clientAuthorized:a!=null,clientId:a?.record.clientId??null}}",
+    "function Af(e){return[e.desktopOriginator,e.devApiBaseUrl,e.prodApiBaseUrl].join(`\\n`)}",
+    "function jf(e,t){return`${e}\\n${t}`}",
+    "async function Mf({action:e=`connect remote control environments`,appServerClient:t,desktopApiOptions:n,headers:r}){return Yd({action:e,appServerClient:t,desktopOriginator:n.desktopOriginator,headers:r})}",
+    "async function Nf({appServerClient:e,deviceKeyClient:t,desktopApiOptions:n,enrollmentKey:r,globalState:i,headers:a,requestRemoteControlEnrollmentStepUpToken:o}){let s=Bf(a),c=s.tokenAccountUserId;if(c==null)throw Error(`Remote control enrollment requires the current ChatGPT account user id.`);let l=s.tokenAccountId??s.headerChatGptAccountId,u=await ep({authIdentity:s,connectionKey:r,deviceKeyClient:t,globalState:i}),d=u?.record??null,f=u?.key??jf(r,c),p=d,m;if(p==null){if(o==null)throw Error(`Remote control enrollment requires explicit authorization in settings.`);bf().info(`remote_control_client_enrollment_start_request`,{...Vf({authIdentity:s,hasExistingEnrollment:!1})});let u=await Yf({appServerClient:e,body:{},desktopApiOptions:n,headers:a});if(bf().info(`remote_control_client_enrollment_start_response`,{...Vf({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:u.account_user_id,responseClientId:u.client_id,responseChallengeId:u.device_key_challenge.challenge_id})}),u.account_user_id!==c&&!(s.tokenAccountId!=null&&s.headerChatGptAccountId===s.tokenAccountId&&s.tokenAuthUserId===u.account_user_id))throw bf().warning(`remote_control_client_enrollment_start_account_mismatch`,{...Vf({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:u.account_user_id,responseClientId:u.client_id,responseChallengeId:u.device_key_challenge.challenge_id})}),Error(`Remote control enrollment start does not match current account.`);p=await sp({accountUserId:u.account_user_id,clientId:u.client_id,deviceKeyClient:t});try{if(bf().info(`remote_control_client_enrollment_key_created`,{safe:{algorithm:p.algorithm,protectionClass:p.protectionClass},sensitive:{accountUserId:p.accountUserId,clientId:p.clientId,keyId:p.keyId}}),o==null)throw Error(`Remote control enrollment requires a step-up authorization flow.`);bf().info(`remote_control_client_enrollment_step_up_requested`,{...Vf({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:u.account_user_id,responseChallengeId:u.device_key_challenge.challenge_id,responseClientId:u.client_id})});let d=await o({accountId:l}),f=Uf({accountUserId:c,stepUpToken:d}),h=Vf({authIdentity:s,hasExistingEnrollment:!1,responseAccountUserId:u.account_user_id,responseChallengeId:u.device_key_challenge.challenge_id,responseClientId:u.client_id});bf().info(`remote_control_client_enrollment_step_up_validated`,{safe:{...h.safe,stepUpTokenScopes:f.scopes},sensitive:{...h.sensitive,stepUpIssuedAt:f.issuedAt,stepUpPasswordAuthTime:f.passwordAuthTime,stepUpTokenAccountUserId:f.accountUserId}})}}",
+    "function Uf({accountUserId:t,stepUpToken:n}){let r=Kf(n);Gf({payload:r});let i=e.J.parse(r),a=i[`https://api.openai.com/auth`],o=a.chatgpt_account_user_id??a.account_user_id,s=Wf(i);if(o!==t)throw new Sf;if(Math.floor(Date.now()/1e3)-i.iat>wf)throw Error(`Remote control enrollment step-up token is not fresh.`);if(Date.now()-i.pwd_auth_time>wf*1e3)throw Error(`Remote control enrollment step-up token does not have fresh password auth.`);if(s.length!==1||s[0]!==Cf)throw Error(`Remote control enrollment step-up token is missing required authorization.`);return{accountUserId:o??null,issuedAt:i.iat,passwordAuthTime:i.pwd_auth_time,scopes:s}}",
+  ].join("");
+}
+
 function syntheticRecoverableErrorPredicateBundle() {
   return "function Bd(e){return e instanceof Error?e.message.startsWith(`Remote control request failed (404):`)||e.message===`Remote control request failed (401): Remote-control client enrollment is incomplete`||e.message===`Remote control request failed (403): Remote-control client key material missing`:!1}";
 }
@@ -200,6 +211,18 @@ function syntheticChromeBrowserClientBundle() {
   ].join("");
 }
 
+function syntheticCurrentChromeBrowserClientBundle() {
+  return [
+    "var R2=[\"chrome\",\"iab\",\"cdp\"];function Jb(e){return R2.some(t=>t===e)}",
+    "var Yb=\"BROWSER_USE_AVAILABLE_BACKENDS\",ey=\"BROWSER_USE_MARKETPLACE_NAME\";",
+    "function oy(){let e=lu(Yb);return e==null?null:ly(e).filter(Jb)}",
+    "function sy(){let e=lu(ey)?.trim();return e||void 0}",
+    "function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t==\"string\"?t:void 0}",
+    "function ly(e){return(e??\"\").split(\",\").map(t=>t.trim()).filter(Boolean)}",
+    "function eh(){let e=sy();return e?`privileged native pipe bridge is not available; browser-client is not trusted. Load browser-client from the ${e} marketplace directory.`:\"privileged native pipe bridge is not available; browser-client is not trusted\"}",
+  ].join("");
+}
+
 function syntheticAppServerManagerSignalsBundle() {
   return [
     "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let p=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=p)});return}}",
@@ -297,20 +320,18 @@ function coldStartTestEnv(env) {
 }
 
 function runColdStartHook(env) {
-  const tempBin = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-bin-"));
+  const fakeBin = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-test-bin-"));
+  fs.writeFileSync(path.join(fakeBin, "systemctl"), "#!/usr/bin/env sh\nexit 3\n");
+  fs.chmodSync(path.join(fakeBin, "systemctl"), 0o755);
   try {
-    const systemctl = path.join(tempBin, "systemctl");
-    fs.writeFileSync(systemctl, "#!/usr/bin/env sh\nexit 3\n");
-    fs.chmodSync(systemctl, 0o755);
-
-    const childEnv = coldStartTestEnv(env);
-    childEnv.PATH = `${tempBin}${path.delimiter}${childEnv.PATH ?? ""}`;
+    const hookEnv = coldStartTestEnv(env);
+    hookEnv.PATH = `${fakeBin}${path.delimiter}${hookEnv.PATH ?? ""}`;
     return spawnSync("bash", [path.join(__dirname, "cold-start-hook.sh"), "--run-main"], {
-      env: childEnv,
+      env: hookEnv,
       encoding: "utf8",
     });
   } finally {
-    fs.rmSync(tempBin, { recursive: true, force: true });
+    fs.rmSync(fakeBin, { recursive: true, force: true });
   }
 }
 
@@ -648,6 +669,24 @@ test("Linux remote-control client enrollment handles current upstream account co
   assert.equal(applyLinuxRemoteControlClientAccountCompatibilityPatch(patched), patched);
 });
 
+test("Linux remote-control client enrollment handles latest account compatibility shape", () => {
+  const source = syntheticLatestClientEnrollmentBundle();
+  const patched = applyLinuxRemoteControlClientAccountCompatibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlAccountMatches/);
+  assert.match(patched, /codexLinuxRemoteControlLoadEnrollment/);
+  assert.match(patched, /codexLinuxRemoteControlEnrollmentKey=r/);
+  assert.match(patched, /f=codexLinuxRemoteControlExistingEnrollment\?\.enrollmentRecordKey\?\?jf\(r,c\)/);
+  assert.match(patched, /d=codexLinuxRemoteControlExistingEnrollment\?\.enrollment\?\?null/);
+  assert.match(patched, /p=d,m/);
+  assert.match(patched, /p=await sp\(\{accountUserId:u\.account_user_id,clientId:u\.client_id,deviceKeyClient:t\}\)/);
+  assert.match(patched, /d=await o\(\{accountId:codexLinuxRemoteControlCurrentAccountId\}\)/);
+  assert.match(patched, /f=Uf\(\{accountId:codexLinuxRemoteControlCurrentAccountId,accountUserId:p\.accountUserId,stepUpToken:d\}\)/);
+  assert.match(patched, /clientId:a\?\.enrollment\.clientId\?\?null/);
+  assert.equal(applyLinuxRemoteControlClientAccountCompatibilityPatch(patched), patched);
+});
+
 test("Linux remote-control client revocation triggers local cleanup and re-enrollment", () => {
   const source = syntheticRecoverableErrorPredicateBundle();
   const patched = applyLinuxRemoteControlClientRevocationRecoveryPatch(source);
@@ -923,6 +962,31 @@ test("Linux remote mobile Chrome bridge patch preserves Chrome when request meta
   const nativePipeIndex = patched.indexOf("function codexLinuxRemoteMobileBrowserBridgeDiagnostic");
   const browserBackendsOnly = patched.slice(0, nativePipeIndex) + patched.slice(patched.indexOf("function yC"));
   vm.runInNewContext(`${browserBackendsOnly};module.exports=yC;`, context);
+  assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
+});
+
+test("Linux remote mobile Chrome bridge patch preserves Chrome when env narrows browser backends", () => {
+  const source = syntheticCurrentChromeBrowserClientBundle();
+  const patched = applyLinuxRemoteMobileChromeBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileBrowserBackends/);
+  assert.match(patched, /BROWSER_USE_AVAILABLE_BACKENDS environment include chrome/);
+  assert.equal(applyLinuxRemoteMobileChromeBridgePatch(patched), patched);
+
+  const context = {
+    globalThis: {
+      nodeRepl: {
+        env: {
+          BROWSER_USE_AVAILABLE_BACKENDS: "iab",
+        },
+      },
+    },
+    module: { exports: {} },
+    process: { platform: "linux" },
+  };
+  context.globalThis.globalThis = context.globalThis;
+  vm.runInNewContext(`${patched};module.exports=oy;`, context);
   assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
 });
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -478,6 +478,12 @@ function trayBundleFixture() {
   ].join("");
 }
 
+function currentTrayMenuBundleFixture() {
+  return [
+    "var sW=class{trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(){this.tray={on(){},setContextMenu(){},popUpContextMenu(){}}}getNativeTrayMenuItems(){let{pinnedThreads:e,recentThreads:t,runningThreads:r,unreadThreads:i,usageLimits:a}=this.trayMenuThreads,o=this.nativeIntl.formatMessage({messageId:vc,defaultMessage:yc}),s=this.nativeIntl.formatMessage({messageId:gc,defaultMessage:_c}),c=uW({label:this.nativeIntl.formatMessage({messageId:oc,defaultMessage:sc}),moreLabel:s,threads:r,projectlessLabel:o,onOpenThread:this.onTrayMenuOpenRecentThread}),h=[c].filter(e=>e.length>0).flatMap((e,t)=>t===0?e:[{type:`separator`},...e]);return[...h,...h.length>0?[{type:`separator`}]:[],{label:this.nativeIntl.formatMessage({messageId:nc,defaultMessage:rc}),click:()=>{this.onTrayMenuOpenNewThread()}},{type:`separator`},{label:fW(this.appName),click:()=>{n.app.quit()}}]}};",
+  ].join("");
+}
+
 function singleInstanceBundleFixture() {
   return [
     "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();",
@@ -1234,6 +1240,16 @@ test("adds Linux build information to the tray menu", () => {
   assert.match(patched, /Enabled features:/);
   assert.match(patched, /Upstream DMG SHA256:/);
   assert.match(patched, /Linux source revision:/);
+});
+
+test("adds Linux build information to current tray menu shape", () => {
+  const patched = applyPatchTwice(applyLinuxBuildInfoTrayPatch, `${mainBundlePrefix}${currentTrayMenuBundleFixture()}`);
+
+  assert.match(patched, /function codexLinuxShowBuildInfo\(\)/);
+  assert.match(
+    patched,
+    /getNativeTrayMenuItems\(\)\{let\{pinnedThreads:e,[^]*?;return\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],\.\.\.h/,
+  );
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2166,6 +2166,42 @@ test("handles literal Chrome plugin gate names", () => {
   assert.doesNotMatch(patched, /installWhenMissing:!0,name:'chrome-internal'/);
 });
 
+test("does not fail when external browser flags appear outside Chrome plugin gates", () => {
+  const source =
+    "var me={externalBrowserUse:!1,externalBrowserUseAllowed:!1},ut=`chrome`;";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("reports Chrome plugin auto-install as already applied when only feature defaults remain", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-chrome-feature-defaults-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      `${mainBundlePrefix}var me={externalBrowserUse:!1,externalBrowserUseAllowed:!1},ut=\`chrome\`;`,
+    );
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const pluginGatePatch = report.patches.find((patch) => patch.name === "linux-chrome-plugin-auto-install");
+    assert.equal(pluginGatePatch.status, "already-applied");
+    assert.doesNotMatch(
+      validateReport(report, "upstream-build").join("\n"),
+      /linux-chrome-plugin-auto-install/,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("reports missing required Chrome plugin auto-install gate as required upstream validation failure", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-missing-chrome-"));
   try {

--- a/scripts/patches/chrome-plugin.js
+++ b/scripts/patches/chrome-plugin.js
@@ -17,6 +17,43 @@ function hasChromeAutoInstall(source, chromeNameVar) {
   return new RegExp(String.raw`installWhenMissing:!0,name:(?:${namePatterns.join("|")})`).test(source);
 }
 
+function applyNearbyChromeGateFallback(currentSource, chromeNameVar, nameExpressionPattern) {
+  const nameAvailabilityRegex =
+    new RegExp(String.raw`name:(${nameExpressionPattern}),((?:isEnabled|isAvailable):)`, "g");
+
+  let patched = "";
+  let lastIndex = 0;
+  let didPatch = false;
+
+  for (const match of currentSource.matchAll(nameAvailabilityRegex)) {
+    const [matchText, nameExpr, availabilityPrefix] = match;
+    const matchIndex = match.index;
+    if (matchIndex == null || !isChromeNameExpr(nameExpr, chromeNameVar)) {
+      continue;
+    }
+
+    const before = currentSource.slice(Math.max(0, matchIndex - 300), matchIndex);
+    const after = currentSource.slice(matchIndex, Math.min(currentSource.length, matchIndex + 900));
+    if (
+      before.includes("installWhenMissing:!0") ||
+      !after.includes("externalBrowserUseAllowed")
+    ) {
+      continue;
+    }
+
+    patched += currentSource.slice(lastIndex, matchIndex);
+    patched += `installWhenMissing:!0,name:${nameExpr},${availabilityPrefix}`;
+    lastIndex = matchIndex + matchText.length;
+    didPatch = true;
+  }
+
+  if (!didPatch) {
+    return currentSource;
+  }
+
+  return patched + currentSource.slice(lastIndex);
+}
+
 function applyLinuxChromePluginAutoInstallPatch(currentSource) {
   if (!hasChromePluginLiteral(currentSource)) {
     console.warn(
@@ -71,13 +108,15 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
     return currentSource;
   }
 
-  if (currentSource.includes("externalBrowserUseAllowed")) {
-    throw new Error("Required Linux Chrome plugin auto-install patch failed: could not enable bundled Chrome auto-install");
+  const fallbackPatched = applyNearbyChromeGateFallback(
+    currentSource,
+    chromeNameVar,
+    nameExpressionPattern,
+  );
+  if (fallbackPatched !== currentSource) {
+    return fallbackPatched;
   }
 
-  console.warn(
-    "WARN: Could not find Chrome plugin auto-install gate — skipping Linux Chrome plugin auto-install patch",
-  );
   return currentSource;
 }
 

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -658,13 +658,14 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
     return currentSource;
   }
 
-  const trayMenuRegex = /getNativeTrayMenuItems\(\)\{return\[/g;
-  if (!trayMenuRegex.test(currentSource)) {
+  const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
+  const trayMenuMatch = currentSource.match(trayMenuRegex);
+  if (trayMenuMatch == null) {
     console.warn("WARN: Could not find tray menu items method — skipping Linux build info tray patch");
     return currentSource;
   }
 
-  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{return\[/;
+  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
   const classMatch = currentSource.match(classRegex);
   if (classMatch == null || classMatch.index == null) {
     console.warn("WARN: Could not find tray class insertion point — skipping Linux build info tray patch");
@@ -674,7 +675,7 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
   const helpers = buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar);
   const menuPrefix =
     "...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
-  const withMenuItem = currentSource.replace(trayMenuRegex, `getNativeTrayMenuItems(){return[${menuPrefix}`);
+  const withMenuItem = currentSource.replace(trayMenuRegex, (match) => `${match}${menuPrefix}`);
   return `${withMenuItem.slice(0, classMatch.index)}${helpers};${withMenuItem.slice(classMatch.index)}`;
 }
 

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -335,6 +335,8 @@ fn managed_node_bin_dirs(builder_bundle_root: &Path) -> Vec<PathBuf> {
 
 fn system_bin_dirs() -> Vec<PathBuf> {
     [
+        "/run/current-system/sw/bin",
+        "/nix/var/nix/profiles/default/bin",
         "/usr/local/sbin",
         "/usr/local/bin",
         "/usr/sbin",
@@ -446,21 +448,21 @@ mod tests {
     fn write_fake_build_script(path: &Path, output: FakePackageOutput) -> Result<()> {
         let script_body = match output {
             FakePackageOutput::Deb => {
-                r#"#!/bin/bash
+                r#"#!/usr/bin/env bash
 set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop_${PACKAGE_VERSION}_amd64.deb"
 "#
             }
             FakePackageOutput::Rpm => {
-                r#"#!/bin/bash
+                r#"#!/usr/bin/env bash
 set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop-${PACKAGE_VERSION}.x86_64.rpm"
 "#
             }
             FakePackageOutput::Pacman => {
-                r#"#!/bin/bash
+                r#"#!/usr/bin/env bash
 set -euo pipefail
 VER="${PACKAGE_VERSION%%+*}"
 mkdir -p "${DIST_DIR_OVERRIDE}"
@@ -607,7 +609,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         )?;
         fs::write(
             bundle_root.join("install.sh"),
-            r#"#!/bin/bash
+            r#"#!/usr/bin/env bash
 set -euo pipefail
 mkdir -p "${CODEX_INSTALL_DIR}"
 echo launcher > "${CODEX_INSTALL_DIR}/start.sh"


### PR DESCRIPTION
## Summary

- Update remote-mobile Linux patching to handle the latest upstream enrollment, authorization, settings, refresh, Chrome bridge, and hydration bundle shapes.
- Make Chrome plugin auto-install reporting tolerate upstream feature-default-only shapes without failing required patch validation.
- Make updater rebuild tests and command PATH fallback work on NixOS-style layouts where bash is not under /bin or /usr/bin.

## Validation

- bash -n install.sh scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh scripts/ci/update-nix-hashes.sh scripts/ci/validate-nix-pins.sh
- node --check scripts/patch-linux-window-ui.js scripts/patch-linux-window-ui.test.js scripts/patches/*.js scripts/ci/validate-patch-report.js
- node --test scripts/patch-linux-window-ui.test.js linux-features/remote-mobile-control/test.js
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check --workspace --all-targets
- cargo test --workspace --all-targets
- bash tests/scripts_smoke.sh
