### PR TITLE
fix(browser): trust patched Linux browser clients

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
@@ -88,6 +89,10 @@ const currentOpaqueBackgroundBundle =
   "var QK=`#00000000`,$K=`#000000`,eq=`#f9f9f9`;function vq(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`}function xq({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!vq(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?$K:eq,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!vq(t)?{backgroundColor:QK,backgroundMaterial:`mica`}:{backgroundColor:QK,backgroundMaterial:null}}";
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function cryptoHash(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
 }
 
 function applyPatchTwice(patchFn, source, ...args) {
@@ -2410,6 +2415,59 @@ test("auto-approves the current Browser Use node_repl runtime config builder", (
     patched,
     /e\.Dn\(\{codexCliPath:o\.codexCliPath,nodePath:o\.nodePath,nodeReplPath:o\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:o\.platform\}\)/,
   );
+});
+
+test("trusts Linux patched bundled Browser Use clients by hashing staged files", () => {
+  const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-browser-client-hash-"));
+  try {
+    const browserClient = path.join(
+      resourcesRoot,
+      "plugins",
+      "openai-bundled",
+      "plugins",
+      "browser",
+      "scripts",
+      "browser-client.mjs",
+    );
+    const chromeClient = path.join(
+      resourcesRoot,
+      "plugins",
+      "openai-bundled",
+      "plugins",
+      "chrome",
+      "scripts",
+      "browser-client.mjs",
+    );
+    fs.mkdirSync(path.dirname(browserClient), { recursive: true });
+    fs.mkdirSync(path.dirname(chromeClient), { recursive: true });
+    fs.writeFileSync(browserClient, "patched browser client\n", "utf8");
+    fs.writeFileSync(chromeClient, "patched chrome client\n", "utf8");
+    const browserHash = cryptoHash("patched browser client\n");
+    const chromeHash = cryptoHash("patched chrome client\n");
+    const source =
+      "\"use strict\";let o=require(`node:fs`),i=require(`node:path`),s=require(`node:crypto`),nt=[`upstream-hash`];function nn({trustedBrowserClientSha256s:e}){return e}function build(){let p=!0,v=!1,f=nt;return nn({trustedBrowserClientSha256s:p||v?f:[]})}";
+
+    const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
+
+    assert.match(patched, /^"use strict";function codexLinuxTrustedBrowserClientSha256s/);
+    assert.equal(
+      (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
+      1,
+    );
+    assert.match(patched, /codexLinuxTrustedBrowserClientSha256s\(f\)/);
+    const linuxHashes = vm.runInNewContext(`${patched};build();`, {
+      require,
+      process: { platform: "linux", resourcesPath: resourcesRoot },
+    });
+    assert.deepEqual(Array.from(linuxHashes), ["upstream-hash", browserHash, chromeHash]);
+    const darwinHashes = vm.runInNewContext(`${patched};build();`, {
+      require,
+      process: { platform: "darwin", resourcesPath: resourcesRoot },
+    });
+    assert.deepEqual(Array.from(darwinHashes), ["upstream-hash"]);
+  } finally {
+    fs.rmSync(resourcesRoot, { recursive: true, force: true });
+  }
 });
 
 test("keeps removed IAB visible patch export as a no-op", () => {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -730,6 +730,7 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
   const needle = "startup_timeout_sec:120,env:{";
   let patchedSource = currentSource;
+  let patchedTrustedHashes = false;
   if (patchedSource.includes(needle)) {
     patchedSource = patchedSource.split(needle).join(approvalPatch);
   }
@@ -745,10 +746,65 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     },
   );
 
+  const trustedHashesRegex =
+    /trustedBrowserClientSha256s:([^,{}]+)\|\|([^,{}]+)\?([A-Za-z_$][\w$]*):\[\]/g;
+  patchedSource = patchedSource.replace(
+    trustedHashesRegex,
+    (match, browserUseEnabledVar, nativePipeEnabledVar, trustedHashesVar) => {
+      if (match.includes("codexLinuxTrustedBrowserClientSha256s(")) {
+        return match;
+      }
+      patchedTrustedHashes = true;
+      return `trustedBrowserClientSha256s:${browserUseEnabledVar}||${nativePipeEnabledVar}?codexLinuxTrustedBrowserClientSha256s(${trustedHashesVar}):[]`;
+    },
+  );
+
+  if (
+    patchedTrustedHashes &&
+    !patchedSource.includes("function codexLinuxTrustedBrowserClientSha256s(")
+  ) {
+    const fsVar = requireName(patchedSource, "node:fs");
+    const pathVar = requireName(patchedSource, "node:path");
+    const cryptoVar = requireName(patchedSource, "node:crypto");
+    if (fsVar == null || pathVar == null || cryptoVar == null) {
+      console.warn(
+        "WARN: Could not find fs/path/crypto aliases — skipping Linux Browser Use trusted hash patch",
+      );
+      patchedSource = patchedSource.replace(
+        /trustedBrowserClientSha256s:([^,{}]+)\|\|([^,{}]+)\?codexLinuxTrustedBrowserClientSha256s\(([A-Za-z_$][\w$]*)\):\[\]/g,
+        "trustedBrowserClientSha256s:$1||$2?$3:[]",
+      );
+      patchedTrustedHashes = false;
+    } else {
+      const helper =
+        `function codexLinuxTrustedBrowserClientSha256s(e,t=process.resourcesPath){if(process.platform!==\`linux\`)return e;let n=Array.isArray(e)?[...e]:[],r=t??"";if(r.length===0)return Array.from(new Set(n));for(let a of[\`browser\`,\`chrome\`])try{let e=(0,${pathVar}.join)(r,\`plugins\`,\`openai-bundled\`,\`plugins\`,a,\`scripts\`,\`browser-client.mjs\`);(0,${fsVar}.existsSync)(e)&&n.push((0,${cryptoVar}.createHash)(\`sha256\`).update((0,${fsVar}.readFileSync)(e)).digest(\`hex\`))}catch{}return Array.from(new Set(n))}`;
+      const strictDirective = '"use strict";';
+      const helperInsertionIndex = patchedSource.startsWith(strictDirective)
+        ? strictDirective.length
+        : 0;
+      patchedSource =
+        patchedSource.slice(0, helperInsertionIndex) +
+        helper +
+        patchedSource.slice(helperInsertionIndex);
+    }
+  }
+
+  if (
+    !patchedTrustedHashes &&
+    !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(") &&
+    patchedSource.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S")
+  ) {
+    console.warn(
+      "WARN: Could not find Browser Use trusted hash insertion point — skipping Linux Browser Use trusted hash patch",
+    );
+  }
+
   if (
     patchedSource === currentSource &&
     !patchedSource.includes(approvalPatch) &&
-    !patchedAnyCurrentRuntimeConfig
+    !patchedAnyCurrentRuntimeConfig &&
+    !patchedTrustedHashes &&
+    !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(")
   ) {
     console.warn(
       "WARN: Could not find Browser Use node_repl config insertion point — skipping node_repl approval patch",


### PR DESCRIPTION
Fixes #296

## Summary
- compute Linux Browser/Chrome browser-client.mjs hashes from staged resources at runtime
- append those hashes to the upstream node_repl trusted hash defaults
- add a regression test for patched Linux Browser Use client trust

## Tests
- node --test scripts/patch-linux-window-ui.test.js
- bash tests/scripts_smoke.sh