### PR TITLE
[codex] fix Fedora rpm-build bootstrap dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,10 +412,10 @@ Ubuntu-family `p7zip-full` can be too old for newer APFS DMGs, so `install-deps.
 
 ```bash
 # Fedora 41+
-sudo dnf install python3 7zip curl unzip @development-tools
+sudo dnf install python3 7zip curl unzip rpm-build @development-tools
 
 # Fedora < 41
-sudo dnf install python3 p7zip p7zip-plugins curl unzip
+sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build
 sudo dnf groupinstall 'Development Tools'
 
 # openSUSE

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -298,7 +298,7 @@ install_dnf5() {
     info "Detected RPM-based distro (dnf5)"
     # dnf5: 7zip provides /usr/bin/7z; @development-tools is the group syntax
     sudo dnf install -y \
-        python3 7zip curl unzip \
+        python3 7zip curl unzip rpm-build \
         @development-tools
 }
 
@@ -307,7 +307,7 @@ install_dnf() {
     # Older dnf: 7z comes from p7zip + p7zip-plugins
     sudo dnf install -y \
         nodejs npm python3 \
-        p7zip p7zip-plugins curl unzip
+        p7zip p7zip-plugins curl unzip rpm-build
     sudo dnf groupinstall -y 'Development Tools'
 }
 
@@ -483,8 +483,8 @@ case "$DISTRO" in
         error "Unsupported package manager. Install manually:
   # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install python3 7zip curl unzip @development-tools                       # Fedora 41+ (dnf5)
-  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
+  sudo dnf install python3 7zip curl unzip rpm-build @development-tools             # Fedora 41+ (dnf5)
+  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S nodejs npm python p7zip curl unzip zstd base-devel                 # Arch
   sudo zypper install nodejs-default npm-default python3 p7zip-full curl unzip      # openSUSE

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -20,8 +20,8 @@ Run the helper to install them automatically:
 
 Or install manually:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install python3 7zip curl unzip @development-tools                       # Fedora 41+ (dnf5)
-  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip                # Fedora <41 (dnf)
+  sudo dnf install python3 7zip curl unzip rpm-build @development-tools             # Fedora 41+ (dnf5)
+  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S python p7zip curl unzip zstd base-devel                            # Arch
   sudo zypper install python3 p7zip-full curl unzip                                 # openSUSE

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -881,6 +881,25 @@ test_native_shortcut_targets_compose_existing_flows() {
     assert_contains "$setup_log" 'bash scripts/bootstrap-wizard.sh'
 }
 
+test_fedora_dependency_bootstrap_installs_rpmbuild() {
+    info "Checking Fedora dependency bootstrap includes rpmbuild"
+    local install_deps="$REPO_DIR/scripts/install-deps.sh"
+    local helper="$REPO_DIR/scripts/lib/install-helpers.sh"
+    local readme="$REPO_DIR/README.md"
+
+    awk '/^install_dnf5\(\) \{/,/^}/' "$install_deps" | grep -q -- "rpm-build" \
+        || fail "install_dnf5 must install rpm-build for rpmbuild"
+    awk '/^install_dnf\(\) \{/,/^}/' "$install_deps" | grep -q -- "rpm-build" \
+        || fail "install_dnf must install rpm-build for rpmbuild"
+
+    assert_contains "$install_deps" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
+    assert_contains "$install_deps" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build"
+    assert_contains "$helper" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
+    assert_contains "$helper" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build"
+    assert_contains "$readme" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
+    assert_contains "$readme" "sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build"
+}
+
 test_setup_native_wizard_noninteractive_feature_writer() {
     info "Checking setup-native wizard non-interactive feature writer"
     local workspace="$TMP_DIR/setup-native-writer"
@@ -4558,6 +4577,7 @@ main() {
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
     test_native_shortcut_targets_compose_existing_flows
+    test_fedora_dependency_bootstrap_installs_rpmbuild
     test_setup_native_wizard_noninteractive_feature_writer
     test_setup_native_wizard_rejects_invalid_feature_ids
     test_setup_native_wizard_rejects_conflicting_feature_ids


### PR DESCRIPTION
## Summary
- install rpm-build in both Fedora dnf5 and dnf dependency bootstrap paths
- update Fedora manual dependency hints in install-deps, install.sh helper text, and README
- add a smoke-test contract so Fedora bootstrap keeps installing rpmbuild

Fixes #298

## Validation
- bash -n scripts/install-deps.sh scripts/lib/install-helpers.sh tests/scripts_smoke.sh
- git diff --check
- bash tests/scripts_smoke.sh