### PR TITLE
fix(chrome): prefer running Linux profiles

### DIFF
--- a/scripts/lib/patch-chrome-plugin.js
+++ b/scripts/lib/patch-chrome-plugin.js
@@ -48,14 +48,18 @@ function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText =
     return;
   }
 
-  if (source.includes(newText) || source.includes(alreadyText)) {
+  const candidates = oldTexts.map((candidate) =>
+    typeof candidate === "string" ? { oldText: candidate, newText } : candidate,
+  );
+  const alreadyPatched = [newText, alreadyText, ...candidates.map((candidate) => candidate.newText)]
+    .filter((text) => typeof text === "string" && text.length > 0)
+    .some((text) => source.includes(text));
+  if (alreadyPatched) {
     console.log(`${path.basename(filePath)} already patched: ${label}`);
     return;
   }
 
-  const match = oldTexts
-    .map((candidate) => typeof candidate === "string" ? { oldText: candidate, newText } : candidate)
-    .find((candidate) => source.includes(candidate.oldText));
+  const match = candidates.find((candidate) => source.includes(candidate.oldText));
   if (!match) {
     warn(`${path.basename(filePath)} missing patch target for ${label}`);
     return;
@@ -138,6 +142,87 @@ const linuxDefaultBrowserUserDataFallback = `  const linuxChromeUserDataDirector
   if (fs.existsSync(linuxChromiumUserDataDirectory)) return linuxChromiumUserDataDirectory;
 
   return linuxChromeUserDataDirectory;`;
+
+const linuxRunningProfileResolver = `function resolveChromeProfileDirectoryFromRunningProcess(userDataDirectory) {
+  if (process.platform !== "linux") return null;
+
+  const normalizedUserDataDirectory = path.resolve(userDataDirectory);
+  const runningProfiles = [];
+  for (const processDirectory of linuxProcessDirectories()) {
+    const argv = readLinuxProcessArgv(processDirectory);
+    if (argv.length === 0 || !isKnownLinuxBrowserCommand(argv[0])) continue;
+
+    const userDataDirectoryArg = chromeArgumentValue(argv, "user-data-dir");
+    const processUserDataDirectory = userDataDirectoryArg
+      ? path.resolve(userDataDirectoryArg)
+      : defaultLinuxUserDataDirectoryForCommand(argv[0]);
+    if (processUserDataDirectory !== normalizedUserDataDirectory) continue;
+
+    const profileDirectory = chromeArgumentValue(argv, "profile-directory");
+    if (
+      profileDirectory &&
+      isUsableChromeProfile(userDataDirectory, profileDirectory)
+    ) {
+      runningProfiles.push(profileDirectory);
+    }
+  }
+
+  return runningProfiles.at(-1) ?? null;
+}
+
+function linuxProcessDirectories() {
+  try {
+    return fs
+      .readdirSync("/proc")
+      .filter((entry) => /^\\d+$/.test(entry))
+      .map((entry) => path.join("/proc", entry));
+  } catch {
+    return [];
+  }
+}
+
+function readLinuxProcessArgv(processDirectory) {
+  try {
+    return fs
+      .readFileSync(path.join(processDirectory, "cmdline"), "utf8")
+      .split("\\0")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function isKnownLinuxBrowserCommand(command) {
+  return [
+    "brave",
+    "brave-browser",
+    "chrome",
+    "chrome_crashpad_handler",
+    "chromium",
+    "chromium-browser",
+    "google-chrome",
+    "google-chrome-stable",
+  ].includes(path.basename(command));
+}
+
+function defaultLinuxUserDataDirectoryForCommand(command) {
+  const commandName = path.basename(command);
+  if (["brave", "brave-browser"].includes(commandName)) {
+    return path.join(os.homedir(), ".config", "BraveSoftware", "Brave-Browser");
+  }
+  if (["chromium", "chromium-browser"].includes(commandName)) {
+    return path.join(os.homedir(), ".config", "chromium");
+  }
+  return path.join(os.homedir(), ".config", "google-chrome");
+}
+
+function chromeArgumentValue(argv, name) {
+  const prefix = \`--\${name}=\`;
+  const match = argv.find((argument) => argument.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+}
+
+`;
 
 const linuxNativeHostManifestFallback = `  if (process.platform === "linux") {
     const manifestPaths = [
@@ -254,6 +339,10 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       oldText: String.raw`var Ic=eO(tO(),rO()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
       newText: String.raw`var Ic=eO(tO(),rO()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>rO()==="linux"?[eO(tO(),".config","BraveSoftware","Brave-Browser"),eO(tO(),".config","google-chrome"),eO(tO(),".config","chromium")]:[Ic];`,
     },
+    {
+      oldText: String.raw`var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
+      newText: String.raw`var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>X5()==="linux"?[Y5(Z5(),".config","BraveSoftware","Brave-Browser"),Y5(Z5(),".config","google-chrome"),Y5(Z5(),".config","chromium")]:[hl];`,
+    },
   ],
   alreadyText: "codexLinuxChromeUserDataDirectories",
 });
@@ -264,6 +353,10 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
     {
       oldText: String.raw`var IS=async(t,e)=>{let r=Gf(Tc,t,"Local Extension Settings",e);if(!XF(r))return null;let n=await JF(Gf(QF(),"codex"));await ZF(r,n,{recursive:!0}),await kS(Gf(n,"LOCK"));let o=new KF(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await kS(n,{force:!0,recursive:!0})}}`,
       newText: String.raw`var IS=async(t,e,r=Tc)=>{let n=Gf(r,t,"Local Extension Settings",e);if(!XF(n))return null;let o=await JF(Gf(QF(),"codex"));await ZF(n,o,{recursive:!0}),await kS(Gf(o,"LOCK"));let i=new KF(o,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await i.open();let s=await i.get("extensionInstanceId");if(!s)return null;let a=JSON.parse(s);return typeof a!="string"?null:a}finally{await i.close(),await kS(o,{force:!0,recursive:!0})}}`,
+    },
+    {
+      oldText: String.raw`var mT=async(e,t)=>{let r=rh(hl,e,"Local Extension Settings",t);if(!n9(r))return null;let n=await r9(rh(o9(),"codex"));await t9(r,n,{recursive:!0}),await fT(rh(n,"LOCK"));let o=new Q5(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await fT(n,{force:!0,recursive:!0})}}`,
+      newText: String.raw`var mT=async(e,t,r=hl)=>{let n=rh(r,e,"Local Extension Settings",t);if(!n9(n))return null;let o=await r9(rh(o9(),"codex"));await t9(n,o,{recursive:!0}),await fT(rh(o,"LOCK"));let i=new Q5(o,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await i.open();let s=await i.get("extensionInstanceId");if(!s)return null;let a=JSON.parse(s);return typeof a!="string"?null:a}finally{await i.close(),await fT(o,{force:!0,recursive:!0})}}`,
     },
   ],
   alreadyText: "async(t,e,r=Tc)",
@@ -276,8 +369,23 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       oldText: String.raw`rO=async(t,e)=>(await nO(t)).find(o=>o.instanceId===e)||null,nO=async t=>{let e=await oO();return await Promise.all(e.map(async r=>({...r,instanceId:await IS(r.id,t).catch(n=>(ee(n),null))})))},oO=async()=>{let t=tO(Tc,"Local State"),e=JSON.parse(await eO(t,"utf8"));return e.profile.profiles_order.map((r,n)=>{let o=e.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:e.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}`,
       newText: String.raw`rO=async(t,e)=>{let r=(await nO(t)).filter(n=>n.instanceId===e);return r.length===1?r[0]:null},nO=async t=>{let e=[];for(let r of codexLinuxChromeUserDataDirectories())try{let n=await oO(r);e.push(...await Promise.all(n.map(async o=>({...o,userDataDir:r,instanceId:await IS(o.id,t,r).catch(i=>(ee(i),null))}))))}catch(n){ee(n)}return e},oO=async r=>{let n=tO(r,"Local State"),o=JSON.parse(await eO(n,"utf8"));return o.profile.profiles_order.map((i,s)=>{let a=o.profile.info_cache[i];return a?{id:i,name:a.name,isLastUsed:o.profile.last_used===i,orderingIndex:s,avatarUrl:a.avatar_icon}:null}).filter(i=>!!i)}`,
     },
+    {
+      oldText: String.raw`a9=async(e,t)=>(await u9(e)).find(o=>o.instanceId===t)||null,u9=async e=>{let t=await c9();return await Promise.all(t.map(async r=>({...r,instanceId:await mT(r.id,e).catch(n=>(ne(n),null))})))},c9=async()=>{let e=s9(hl,"Local State"),t=JSON.parse(await i9(e,"utf8"));return t.profile.profiles_order.map((r,n)=>{let o=t.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:t.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}`,
+      newText: String.raw`a9=async(e,t)=>{let r=(await u9(e)).filter(n=>n.instanceId===t);return r.length===1?r[0]:null},u9=async e=>{let t=[];for(let r of codexLinuxChromeUserDataDirectories())try{let n=await c9(r);t.push(...await Promise.all(n.map(async o=>({...o,userDataDir:r,instanceId:await mT(o.id,e,r).catch(i=>(ne(i),null))}))))}catch(n){ne(n)}return t},c9=async r=>{let n=s9(r,"Local State"),o=JSON.parse(await i9(n,"utf8"));return o.profile.profiles_order.map((i,s)=>{let a=o.profile.info_cache[i];return a?{id:i,name:a.name,isLastUsed:o.profile.last_used===i,orderingIndex:s,avatarUrl:a.avatar_icon}:null}).filter(i=>!!i)}`,
+    },
   ],
   alreadyText: "r.length===1?r[0]:null",
+});
+
+patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
+  label: "Linux Chrome active profile backend ordering",
+  oldTexts: [
+    {
+      oldText: String.raw`d9=async e=>{let t=ST(),r=e.filter(o=>o.info.type==="iab"),n=p9(r,t);return await Promise.all(r.filter(o=>!n.includes(o)).map(async({api:o})=>o.close())),[...e.filter(o=>o.info.type!=="iab"),...n]},p9=(e,t)=>t==null?[]:e.filter(r=>r.info.metadata?.codexSessionId===t);`,
+      newText: String.raw`d9=async e=>{let t=ST(),r=e.filter(o=>o.info.type==="iab"),n=p9(r,t);await Promise.all(r.filter(o=>!n.includes(o)).map(async({api:o})=>o.close()));let o=[...e.filter(i=>i.info.type!=="iab"),...n];return await codexLinuxRankBrowserBackends(o)},p9=(e,t)=>t==null?[]:e.filter(r=>r.info.metadata?.codexSessionId===t);async function codexLinuxRankBrowserBackends(e){if(yT()!=="linux")return e;let t=await Promise.all(e.map(async(r,n)=>({browser:r,index:n,userTabCount:await codexLinuxExtensionUserTabCount(r)})));return t.sort(codexLinuxBackendCompare).map(({browser:r})=>r)}function codexLinuxBackendCompare(e,t){let r=e.browser.info.type==="extension",n=t.browser.info.type==="extension";return!r||!n?e.index-t.index:codexLinuxExtensionBackendScore(t)-codexLinuxExtensionBackendScore(e)||e.index-t.index}async function codexLinuxExtensionUserTabCount(e){if(e.info.type!=="extension")return-1;try{let t=await Promise.race([e.api.getUserTabs(),new Promise((r,n)=>setTimeout(()=>n(new Error("Chrome profile tab probe timed out")),750))]);return Array.isArray(t)?t.length:0}catch(t){return ne(t),0}}function codexLinuxExtensionBackendScore(e){let t=e.userTabCount>0?1e4+e.userTabCount:0,r=e.browser.info.metadata??{};r.profileIsLastUsed==="true"&&(t+=100);let n=Number(r.profileOrdering);return Number.isFinite(n)?t-n:t}`,
+    },
+  ],
+  alreadyText: "codexLinuxRankBrowserBackends",
 });
 
 patchFile(path.join(scriptsDir, "installed-browsers.js"), [
@@ -354,6 +462,35 @@ patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
   alreadyText: "linuxChromiumUserDataDirectory",
 });
 
+patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
+  label: "Linux running browser extension profile preference",
+  oldTexts: [
+    `function resolveChromeProfileDirectory(userDataDirectory) {
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+`,
+  ],
+  newText: `function resolveChromeProfileDirectory(userDataDirectory) {
+  const runningProfile =
+    resolveChromeProfileDirectoryFromRunningProcess(userDataDirectory);
+  if (runningProfile) return runningProfile;
+
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+`,
+  alreadyText: `const runningProfile =
+    resolveChromeProfileDirectoryFromRunningProcess(userDataDirectory);`,
+});
+
+patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
+  label: "Linux running browser extension profile resolver",
+  oldTexts: [`function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {`],
+  newText: `${linuxRunningProfileResolver}function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {`,
+  alreadyText: "function linuxProcessDirectories()",
+});
+
 patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
   label: "Linux default-browser profile fallback",
   oldTexts: [
@@ -373,6 +510,35 @@ patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
   ],
   newText: linuxDefaultBrowserUserDataFallback,
   alreadyText: "linuxChromiumUserDataDirectory",
+});
+
+patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
+  label: "Linux running browser profile preference",
+  oldTexts: [
+    `function resolveChromeProfileDirectory(userDataDirectory) {
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+`,
+  ],
+  newText: `function resolveChromeProfileDirectory(userDataDirectory) {
+  const runningProfile =
+    resolveChromeProfileDirectoryFromRunningProcess(userDataDirectory);
+  if (runningProfile) return runningProfile;
+
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+`,
+  alreadyText: `const runningProfile =
+    resolveChromeProfileDirectoryFromRunningProcess(userDataDirectory);`,
+});
+
+patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
+  label: "Linux running browser profile resolver",
+  oldTexts: [`function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {`],
+  newText: `${linuxRunningProfileResolver}function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {`,
+  alreadyText: "function linuxProcessDirectories()",
 });
 
 patchFile(path.join(scriptsDir, "open-chrome-window.js"), [

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2661,6 +2661,7 @@ JS
 JSON
     cat > "$chrome_dir/scripts/browser-client.mjs" <<'JS'
 import{resolve as GF}from"path";import{homedir as VF,platform as WF}from"os";var Tc=GF(VF(),WF()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");import{ClassicLevel as KF}from"./node_modules/classic-level.mjs";import{resolve as Gf}from"path";import{tmpdir as YF}from"os";import{cp as ZF,mkdtemp as JF,rm as kS}from"fs/promises";import{existsSync as XF}from"fs";var IS=async(t,e)=>{let r=Gf(Tc,t,"Local Extension Settings",e);if(!XF(r))return null;let n=await JF(Gf(QF(),"codex"));await ZF(r,n,{recursive:!0}),await kS(Gf(n,"LOCK"));let o=new KF(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await kS(n,{force:!0,recursive:!0})}},QF=()=>"nodeRepl"in globalThis&&globalThis.nodeRepl?globalThis.nodeRepl.tmpDir:YF();var AS=async t=>{if(t.type!=="extension"||!t.metadata?.extensionInstanceId||!t.metadata.extensionId)return t;let e=await rO(t.metadata.extensionId,t.metadata.extensionInstanceId);return e?{...t,metadata:{...t.metadata,profileName:e.name,profileIsLastUsed:e.isLastUsed.toString(),profileOrdering:e.orderingIndex.toString()}}:t},rO=async(t,e)=>(await nO(t)).find(o=>o.instanceId===e)||null,nO=async t=>{let e=await oO();return await Promise.all(e.map(async r=>({...r,instanceId:await IS(r.id,t).catch(n=>(ee(n),null))})))},oO=async()=>{let t=tO(Tc,"Local State"),e=JSON.parse(await eO(t,"utf8"));return e.profile.profiles_order.map((r,n)=>{let o=e.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:e.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)};
+var oh=Vb(l9.platform()),d9=async e=>{let t=ST(),r=e.filter(o=>o.info.type==="iab"),n=p9(r,t);return await Promise.all(r.filter(o=>!n.includes(o)).map(async({api:o})=>o.close())),[...e.filter(o=>o.info.type!=="iab"),...n]},p9=(e,t)=>t==null?[]:e.filter(r=>r.info.metadata?.codexSessionId===t);
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}
 import{platform as yT}from"node:os";function eh(){return"privileged native pipe bridge is not available; browser-client is not trusted"}function th(){let e=globalThis.nodeRepl?.nativePipe;return e==null||typeof e.createConnection!="function"?null:e}var ml=class e{constructor(t){this.socket=t}static async create(t){let r=th();if(r!=null){let n=await r.createConnection(t);return new e(n)}throw new Error(eh())}};
 async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}
@@ -2705,10 +2706,56 @@ JS
 function resolveChromeUserDataDirectory() {
   return path.join(os.homedir(), ".config", "google-chrome");
 }
+
+function resolveChromeProfileDirectory(userDataDirectory) {
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+
+  const latestProfile = findLatestChromeProfile(userDataDirectory);
+  if (latestProfile) return latestProfile;
+
+  throw new Error(`No Chrome profile found in ${userDataDirectory}`);
+}
+
+function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {
+  return null;
+}
+
+function findLatestChromeProfile(userDataDirectory) {
+  return "Default";
+}
+
+function isUsableChromeProfile(userDataDirectory, profileDirectory) {
+  return profileDirectory.length > 0;
+}
 JS
     cat > "$chrome_dir/scripts/open-chrome-window.js" <<'JS'
 function resolveChromeUserDataDirectory() {
   return path.join(os.homedir(), ".config", "google-chrome");
+}
+
+function resolveChromeProfileDirectory(userDataDirectory) {
+  const localStateProfile =
+    resolveChromeProfileDirectoryFromLocalState(userDataDirectory);
+  if (localStateProfile) return localStateProfile;
+
+  const latestProfile = findLatestChromeProfile(userDataDirectory);
+  if (latestProfile) return latestProfile;
+
+  throw new Error(`No Chrome profile found in ${userDataDirectory}`);
+}
+
+function resolveChromeProfileDirectoryFromLocalState(userDataDirectory) {
+  return null;
+}
+
+function findLatestChromeProfile(userDataDirectory) {
+  return "Default";
+}
+
+function isUsableChromeProfile(userDataDirectory, profileDirectory) {
+  return profileDirectory.length > 0;
 }
 
 function getOpenChromeCommand(profileDirectory) {
@@ -2774,13 +2821,19 @@ test_chrome_plugin_staging() {
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxBraveUserDataDirectory"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxChromiumUserDataDirectory"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxCandidateWithInstalledExtension"
+    assert_contains "$chrome_dir/scripts/check-extension-installed.js" "resolveChromeProfileDirectoryFromRunningProcess"
+    assert_contains "$chrome_dir/scripts/check-extension-installed.js" "defaultLinuxUserDataDirectoryForCommand"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "brave-browser"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "chromium"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "defaultBrowser ==="
+    assert_contains "$chrome_dir/scripts/open-chrome-window.js" "resolveChromeProfileDirectoryFromRunningProcess"
+    assert_contains "$chrome_dir/scripts/open-chrome-window.js" "defaultLinuxUserDataDirectoryForCommand"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxChromeUserDataDirectories"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" '"BraveSoftware","Brave-Browser"'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" '".config","chromium"'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "instanceId:await IS(o.id,t,r)"
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxRankBrowserBackends"
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" "getUserTabs()"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env?.\[e\]'
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" 'globalThis.nodeRepl?.env\[e\]'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "nativePipe??import.meta.__codexNativePipe"
@@ -2814,6 +2867,16 @@ JS
     assert_contains "$browser_client" "codexLinuxChromeUserDataDirectories"
     assert_contains "$browser_client" '"BraveSoftware","Brave-Browser"'
     assert_contains "$browser_client" '".config","chromium"'
+
+    cat > "$browser_client" <<'JS'
+import{resolve as Y5}from"path";import{homedir as Z5,platform as X5}from"os";var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");import{ClassicLevel as Q5}from"./node_modules/classic-level.mjs";import{resolve as rh}from"path";import{tmpdir as o9}from"os";import{cp as t9,mkdtemp as r9,rm as fT}from"fs/promises";import{existsSync as n9}from"fs";var mT=async(e,t)=>{let r=rh(hl,e,"Local Extension Settings",t);if(!n9(r))return null;let n=await r9(rh(o9(),"codex"));await t9(r,n,{recursive:!0}),await fT(rh(n,"LOCK"));let o=new Q5(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await fT(n,{force:!0,recursive:!0})}};var a9=async(e,t)=>(await u9(e)).find(o=>o.instanceId===t)||null,u9=async e=>{let t=await c9();return await Promise.all(t.map(async r=>({...r,instanceId:await mT(r.id,e).catch(n=>(ne(n),null))})))},c9=async()=>{let e=s9(hl,"Local State"),t=JSON.parse(await i9(e,"utf8"));return t.profile.profiles_order.map((r,n)=>{let o=t.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:t.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}
+JS
+    node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >/dev/null 2>&1
+    assert_contains "$browser_client" "codexLinuxChromeUserDataDirectories"
+    assert_contains "$browser_client" '"BraveSoftware","Brave-Browser"'
+    assert_contains "$browser_client" '".config","chromium"'
+    assert_contains "$browser_client" "async(e,t,r=hl)"
+    assert_contains "$browser_client" "instanceId:await mT(o.id,e,r)"
 }
 
 test_chrome_marketplace_fallback_synthesis() {


### PR DESCRIPTION
## Summary
- Prefer currently running Chrome-family profile directories before Linux Local State fallbacks in extension setup/status and window opening
- Patch current upstream browser-client profile metadata minifier symbols so Linux profile metadata is restored
- Rank Linux extension backends with open user tabs ahead of idle profile sockets before agent selection
- Extend smoke coverage for running-profile routing, current browser-client variants, and backend ordering

## Validation
- node --check scripts/lib/patch-chrome-plugin.js
- bash tests/scripts_smoke.sh
- Patched a temporary copy of the current cached Chrome plugin, verified profile markers and backend ordering marker, and ran node --check on the patched browser-client.mjs