### PR TITLE
[codex] Fix build info tray patch for current bundle

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1326,6 +1326,7 @@ test("adds Linux build information to the app Help menu", () => {
   const patched = applyPatchTwice(applyLinuxBuildInfoTrayPatch, source);
 
   assert.match(patched, /function codexLinuxShowBuildInfo\(\)/);
+  assert.doesNotThrow(() => new Function(patched));
   assert.match(
     patched,
     /\{role:`help`,id:e\.bn\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],\{label:`Codex Documentation`/,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -546,6 +546,12 @@ function trayBundleFixture() {
   ].join("");
 }
 
+function currentTrayMenuBundleFixture() {
+  return [
+    "var sW=class{trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(){this.tray={on(){},setContextMenu(){},popUpContextMenu(){}}}getNativeTrayMenuItems(){let{pinnedThreads:e,recentThreads:t,runningThreads:r,unreadThreads:i,usageLimits:a}=this.trayMenuThreads,o=this.nativeIntl.formatMessage({messageId:vc,defaultMessage:yc}),s=this.nativeIntl.formatMessage({messageId:gc,defaultMessage:_c}),c=uW({label:this.nativeIntl.formatMessage({messageId:oc,defaultMessage:sc}),moreLabel:s,threads:r,projectlessLabel:o,onOpenThread:this.onTrayMenuOpenRecentThread}),h=[c].filter(e=>e.length>0).flatMap((e,t)=>t===0?e:[{type:`separator`},...e]);return[...h,...h.length>0?[{type:`separator`}]:[],{label:this.nativeIntl.formatMessage({messageId:nc,defaultMessage:rc}),click:()=>{this.onTrayMenuOpenNewThread()}},{type:`separator`},{label:fW(this.appName),click:()=>{n.app.quit()}}]}};",
+  ].join("");
+}
+
 function singleInstanceBundleFixture() {
   return [
     "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();",
@@ -1302,6 +1308,16 @@ test("adds Linux build information to the tray menu", () => {
   assert.match(patched, /Enabled features:/);
   assert.match(patched, /Upstream DMG SHA256:/);
   assert.match(patched, /Linux source revision:/);
+});
+
+test("adds Linux build information to current tray menu shape", () => {
+  const patched = applyPatchTwice(applyLinuxBuildInfoTrayPatch, `${mainBundlePrefix}${currentTrayMenuBundleFixture()}`);
+
+  assert.match(patched, /function codexLinuxShowBuildInfo\(\)/);
+  assert.match(
+    patched,
+    /getNativeTrayMenuItems\(\)\{let\{pinnedThreads:e,[^]*?;return\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],\.\.\.h/,
+  );
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1320,6 +1320,18 @@ test("adds Linux build information to current tray menu shape", () => {
   );
 });
 
+test("adds Linux build information to the app Help menu", () => {
+  const source =
+    "let n=require(`electron`),o=require(`node:fs`),i=require(`node:path`),e={bn:{help:`help`}};let $e=[{role:`help`,id:e.bn.help,submenu:[{label:`Codex Documentation`,click:()=>{n.shell.openExternal(`https://developers.openai.com/codex/app`)}}]}],et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(et);";
+  const patched = applyPatchTwice(applyLinuxBuildInfoTrayPatch, source);
+
+  assert.match(patched, /function codexLinuxShowBuildInfo\(\)/);
+  assert.match(
+    patched,
+    /\{role:`help`,id:e\.bn\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],\{label:`Codex Documentation`/,
+  );
+});
+
 test("adds Linux tray support for current minified window and startup identifiers", () => {
   const source = [
     "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -645,6 +645,19 @@ function buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar) {
   return `function codexLinuxBuildInfoPaths(){let e=[];try{e.push((0,${pathVar}.join)(process.resourcesPath,\`codex-linux-build-info.json\`)),e.push((0,${pathVar}.join)(process.resourcesPath,\`..\`,\`.codex-linux\`,\`build-info.json\`))}catch{}return e}function codexLinuxReadBuildInfo(){for(let e of codexLinuxBuildInfoPaths())try{if(${fsVar}.existsSync(e)){let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));return t&&typeof t===\`object\`&&!Array.isArray(t)?t:null}}catch{}return null}function codexLinuxBuildInfoValue(e,t=\`unknown\`){return typeof e===\`string\`&&e.trim().length>0?e:Array.isArray(e)&&e.length>0?e.join(\`, \`):e==null?t:String(e)}function codexLinuxBuildInfoDetail(e){if(!e)return\`No Linux build metadata file was found in this app install.\`;let t=e.linuxTarget??{},n=t.distro??{},r=e.upstreamDmg??{},i=e.source??{},a=e.linuxFeatures?.enabled??[],o=e.packageProfile??{},s=i.shortCommit||i.commit,c=s?i.dirty?\`\${s} (dirty)\`:s:\`unknown\`,l=n.prettyName||[n.id,n.versionId].filter(Boolean).join(\` \`)||\`unknown\`;return[\`Linux package profile: \${codexLinuxBuildInfoValue(o.label)}\`,\`Distro: \${l}\`,\`Package manager: \${codexLinuxBuildInfoValue(t.packageManager??o.packageManager)}\`,\`Package format: \${codexLinuxBuildInfoValue(t.packageFormat??o.format)}\`,\`Enabled features: \${a.length>0?a.join(\`, \`):\`none\`}\`,\`Upstream app version: \${codexLinuxBuildInfoValue(r.appVersion)}\`,\`Upstream DMG SHA256: \${codexLinuxBuildInfoValue(r.sha256)}\`,\`Electron: \${codexLinuxBuildInfoValue(e.electronVersion)}\`,\`Linux source revision: \${c}\`,\`Source branch: \${codexLinuxBuildInfoValue(i.branch)}\`,\`Generated: \${codexLinuxBuildInfoValue(e.generatedAt)}\`].join(\`\\n\`)}async function codexLinuxShowBuildInfo(){try{let e=codexLinuxReadBuildInfo();await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:[\`OK\`],defaultId:0,noLink:!0,message:\`Codex Desktop Linux build information\`,detail:codexLinuxBuildInfoDetail(e)})}catch{}}`;
 }
 
+function findLinuxBuildInfoHelperInsertionIndex(source, classMatch, helpMenuMatch) {
+  if (classMatch?.index != null) {
+    return classMatch.index;
+  }
+  if (helpMenuMatch?.index == null) {
+    return null;
+  }
+
+  const statementStart = source.lastIndexOf(";", helpMenuMatch.index) + 1;
+  const insertionIndex = statementStart === 0 ? 0 : statementStart;
+  return insertionIndex <= helpMenuMatch.index ? insertionIndex : null;
+}
+
 function applyLinuxBuildInfoTrayPatch(currentSource) {
   const electronVar = requireName(currentSource, "electron");
   const fsVar = requireName(currentSource, "node:fs");
@@ -658,6 +671,14 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
   let patchedSource = currentSource;
   let changed = false;
   const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
+  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
+  const helpMenuPattern = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/;
+  const helperInsertionIndex = findLinuxBuildInfoHelperInsertionIndex(
+    currentSource,
+    currentSource.match(classRegex),
+    currentSource.match(helpMenuPattern),
+  );
+  const canInstallHelper = hasHelper || helperInsertionIndex != null;
   const trayMenuMatch = patchedSource.match(trayMenuRegex);
   if (trayMenuMatch == null && !patchedSource.includes("role:`help`")) {
     console.warn("WARN: Could not find tray menu items method — skipping Linux build info tray patch");
@@ -671,18 +692,21 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
     changed = true;
   }
 
-  const helpMenuPattern = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/;
   const helpMenuRegex = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/g;
   if (
     !/\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],/.test(patchedSource)
   ) {
-    let patchedHelpMenu = false;
-    patchedSource = patchedSource.replace(helpMenuRegex, (match) => {
-      patchedHelpMenu = true;
-      return `${match}...process.platform===\`linux\`?[{label:\`Build Information\`,click:()=>{codexLinuxShowBuildInfo()}},{type:\`separator\`}]:[],`;
-    });
-    changed = changed || patchedHelpMenu;
-    if (!patchedHelpMenu && patchedSource.includes("role:`help`")) {
+    if (canInstallHelper) {
+      let patchedHelpMenu = false;
+      patchedSource = patchedSource.replace(helpMenuRegex, (match) => {
+        patchedHelpMenu = true;
+        return `${match}...process.platform===\`linux\`?[{label:\`Build Information\`,click:()=>{codexLinuxShowBuildInfo()}},{type:\`separator\`}]:[],`;
+      });
+      changed = changed || patchedHelpMenu;
+      if (!patchedHelpMenu && patchedSource.includes("role:`help`")) {
+        console.warn("WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch");
+      }
+    } else if (patchedSource.includes("role:`help`")) {
       console.warn("WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch");
     }
   }
@@ -691,10 +715,9 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
     return patchedSource;
   }
 
-  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
   const classMatch = patchedSource.match(classRegex);
   const helpMenuMatch = patchedSource.match(helpMenuPattern);
-  const helperIndex = classMatch?.index ?? helpMenuMatch?.index;
+  const helperIndex = findLinuxBuildInfoHelperInsertionIndex(patchedSource, classMatch, helpMenuMatch);
   if (helperIndex == null) {
     console.warn("WARN: Could not find build info helper insertion point — skipping Linux build info patch");
     return currentSource;

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -658,13 +658,14 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
     return currentSource;
   }
 
-  const trayMenuRegex = /getNativeTrayMenuItems\(\)\{return\[/g;
-  if (!trayMenuRegex.test(currentSource)) {
+  const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
+  const trayMenuMatch = currentSource.match(trayMenuRegex);
+  if (trayMenuMatch == null) {
     console.warn("WARN: Could not find tray menu items method — skipping Linux build info tray patch");
     return currentSource;
   }
 
-  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{return\[/;
+  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
   const classMatch = currentSource.match(classRegex);
   if (classMatch == null || classMatch.index == null) {
     console.warn("WARN: Could not find tray class insertion point — skipping Linux build info tray patch");
@@ -674,7 +675,7 @@ function applyLinuxBuildInfoTrayPatch(currentSource) {
   const helpers = buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar);
   const menuPrefix =
     "...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
-  const withMenuItem = currentSource.replace(trayMenuRegex, `getNativeTrayMenuItems(){return[${menuPrefix}`);
+  const withMenuItem = currentSource.replace(trayMenuRegex, (match) => `${match}${menuPrefix}`);
   return `${withMenuItem.slice(0, classMatch.index)}${helpers};${withMenuItem.slice(classMatch.index)}`;
 }
 

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -646,37 +646,62 @@ function buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar) {
 }
 
 function applyLinuxBuildInfoTrayPatch(currentSource) {
-  if (currentSource.includes("function codexLinuxShowBuildInfo()")) {
-    return currentSource;
-  }
-
   const electronVar = requireName(currentSource, "electron");
   const fsVar = requireName(currentSource, "node:fs");
   const pathVar = requireName(currentSource, "node:path");
-  if (electronVar == null || fsVar == null || pathVar == null) {
+  const hasHelper = currentSource.includes("function codexLinuxShowBuildInfo()");
+  if (!hasHelper && (electronVar == null || fsVar == null || pathVar == null)) {
     console.warn("WARN: Could not find build info module bindings — skipping Linux build info tray patch");
     return currentSource;
   }
 
+  let patchedSource = currentSource;
+  let changed = false;
   const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
-  const trayMenuMatch = currentSource.match(trayMenuRegex);
-  if (trayMenuMatch == null) {
+  const trayMenuMatch = patchedSource.match(trayMenuRegex);
+  if (trayMenuMatch == null && !patchedSource.includes("role:`help`")) {
     console.warn("WARN: Could not find tray menu items method — skipping Linux build info tray patch");
-    return currentSource;
+  } else if (
+    trayMenuMatch != null &&
+    !/getNativeTrayMenuItems\(\)\{[^]*?label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}/.test(patchedSource)
+  ) {
+    const menuPrefix =
+      "...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
+    patchedSource = patchedSource.replace(trayMenuRegex, (match) => `${match}${menuPrefix}`);
+    changed = true;
+  }
+
+  const helpMenuPattern = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/;
+  const helpMenuRegex = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/g;
+  if (
+    !/\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],/.test(patchedSource)
+  ) {
+    let patchedHelpMenu = false;
+    patchedSource = patchedSource.replace(helpMenuRegex, (match) => {
+      patchedHelpMenu = true;
+      return `${match}...process.platform===\`linux\`?[{label:\`Build Information\`,click:()=>{codexLinuxShowBuildInfo()}},{type:\`separator\`}]:[],`;
+    });
+    changed = changed || patchedHelpMenu;
+    if (!patchedHelpMenu && patchedSource.includes("role:`help`")) {
+      console.warn("WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch");
+    }
+  }
+
+  if (!changed || hasHelper) {
+    return patchedSource;
   }
 
   const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
-  const classMatch = currentSource.match(classRegex);
-  if (classMatch == null || classMatch.index == null) {
-    console.warn("WARN: Could not find tray class insertion point — skipping Linux build info tray patch");
+  const classMatch = patchedSource.match(classRegex);
+  const helpMenuMatch = patchedSource.match(helpMenuPattern);
+  const helperIndex = classMatch?.index ?? helpMenuMatch?.index;
+  if (helperIndex == null) {
+    console.warn("WARN: Could not find build info helper insertion point — skipping Linux build info patch");
     return currentSource;
   }
 
   const helpers = buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar);
-  const menuPrefix =
-    "...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
-  const withMenuItem = currentSource.replace(trayMenuRegex, (match) => `${match}${menuPrefix}`);
-  return `${withMenuItem.slice(0, classMatch.index)}${helpers};${withMenuItem.slice(classMatch.index)}`;
+  return `${patchedSource.slice(0, helperIndex)}${helpers};${patchedSource.slice(helperIndex)}`;
 }
 
 function applyLinuxSingleInstancePatch(currentSource) {


### PR DESCRIPTION
## Summary
- restore the Linux Build Information tray item for current Codex Desktop bundles
- add the same Build Information dialog to the app Help menu on Linux
- relax the tray menu matcher so it handles method-local setup before `return[`
- add regression tests for both the current tray menu shape and the Help menu insertion

## Root Cause
The build-info tray patch was narrowed to match only `getNativeTrayMenuItems(){return[`. Current upstream bundles initialize local variables before the returned menu array, so the patch skipped with `WARN: Could not find tray menu items method` even though build metadata was present.

## Impact
Linux users can reach package/build provenance from the tray menu and from the app Help menu. Both surfaces use the same `codex-linux-build-info.json` metadata and dialog renderer.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
