### PR TITLE
fix(launcher): close successful webview tcp probes

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1382,7 +1382,9 @@ webview_port_is_open() {
     # the 200 ms cap it would enforce.
     local probe_pid kill_pid rc=1 self_pid=$$
     ( trap - EXIT
-      exec 3<>/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT" ) 2>/dev/null &
+      exec 3<>/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT" || exit 1
+      exec 3>&- 3<&-
+      exit 0 ) 2>/dev/null &
     probe_pid=$!
     # Watchdog: before SIGKILL, verify /proc/<probe>/stat still reports us as
     # the parent. Guards against PID reuse: if the probe has already exited

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2013,7 +2013,7 @@ if 'unset CODEX_LINUX_MULTI_LAUNCH' not in source.split('parse_launcher_args() {
     raise SystemExit("launcher must clear inherited internal multi-launch markers before parsing args")
 if '$((CODEX_LINUX_WEBVIEW_PORT + 4))' not in source:
     raise SystemExit("multi-launch default range must cap the default at five ports")
-if '( trap - EXIT\n      exec 3<>/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT" )' not in webview_probe_body:
+if '( trap - EXIT\n      exec 3<>/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT" || exit 1\n      exec 3>&- 3<&-\n      exit 0 )' not in webview_probe_body:
     raise SystemExit("webview port probe must not inherit the launcher EXIT cleanup trap")
 if '( trap - EXIT\n      sleep 0.2' not in webview_probe_body:
     raise SystemExit("webview port probe watchdog must not inherit the launcher EXIT cleanup trap")


### PR DESCRIPTION
## Summary
- make the launcher webview TCP probe close its successful `/dev/tcp` file descriptor and exit cleanly before the watchdog fires
- preserve the closed-port failure path by exiting early when the TCP connect itself fails
- update the launcher smoke assertion so the probe-equivalence harness covers the fixed subshell shape

## Validation
- `bash -n launcher/start.sh.template`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- verified the fixed probe against the live packaged webview server on `/opt/codex-desktop`
