### PR TITLE
fix(webview): guard fast-mode model tiers

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -98,6 +98,7 @@ const {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxFastModeModelGuardPatch,
   applySubagentNicknameMetadataPatch,
   patchCommentPreloadBundle,
 } = require("./patches/webview-assets.js");
@@ -178,6 +179,7 @@ module.exports = {
   applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxFastModeModelGuardPatch,
   applyLinuxQuitGuardPatch,
   applyLinuxReadyToShowWindowStatePatch,
   applyLinuxRemoteControlConfigPreservationPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -39,6 +39,7 @@ const {
   applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueBackgroundPatch,
+  applyLinuxFastModeModelGuardPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxReadyToShowWindowStatePatch,
   applyLinuxSetIconPatch,
@@ -513,6 +514,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "opaque-window-default-resolved-theme",
+    "linux-fast-mode-model-guard",
     "subagent-nickname-metadata-shape",
     "linux-computer-use-ui-availability",
     "linux-computer-use-install-flow",
@@ -1098,6 +1100,16 @@ test("patches drifted comment preload screenshot anchor helper names", () => {
   );
   assert.doesNotMatch(patched, /\bWd\(/);
   assert.doesNotMatch(patched, /\bS\.width\b/);
+});
+
+test("guards fast-mode model tier lookup when serviceTiers is missing", () => {
+  const source =
+    "function m(e){return e.serviceTiers.length>0||e.additionalSpeedTiers?.includes(u)===!0}";
+
+  const patched = applyPatchTwice(applyLinuxFastModeModelGuardPatch, source);
+
+  assert.match(patched, /\(e\?\.serviceTiers\?\.length\?\?0\)>0/);
+  assert.doesNotMatch(patched, /e\.serviceTiers\.length/);
 });
 
 test("warns when a matched webview opaque bundle has no known insertion point", () => {

--- a/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
+++ b/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const { applyLinuxFastModeModelGuardPatch } = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "linux-fast-mode-model-guard",
+    phase: "webview-asset",
+    order: 1040,
+    ciPolicy: "required-upstream",
+    pattern: /^use-is-fast-mode-enabled-.*\.js$/,
+    missingDescription: "fast-mode availability hook bundle",
+    skipDescription: "fast-mode model guard patch",
+    apply: applyLinuxFastModeModelGuardPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -637,6 +637,36 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxFastModeModelGuardPatch(currentSource) {
+  const exactNeedle =
+    "function m(e){return e.serviceTiers.length>0||e.additionalSpeedTiers?.includes(u)===!0}";
+  const exactPatch =
+    "function m(e){return(e?.serviceTiers?.length??0)>0||e?.additionalSpeedTiers?.includes(u)===!0}";
+  if (currentSource.includes(exactPatch)) {
+    return currentSource;
+  }
+  if (currentSource.includes(exactNeedle)) {
+    return currentSource.replace(exactNeedle, exactPatch);
+  }
+
+  const driftedNeedle = /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2\.serviceTiers\.length>0\|\|\2\.additionalSpeedTiers\?\.includes\(([A-Za-z_$][\w$]*)\)===!0\}/u;
+  if (driftedNeedle.test(currentSource)) {
+    return currentSource.replace(
+      driftedNeedle,
+      (match, fnName, modelVar, fastTierVar) =>
+        `function ${fnName}(${modelVar}){return(${modelVar}?.serviceTiers?.length??0)>0||${modelVar}?.additionalSpeedTiers?.includes(${fastTierVar})===!0}`,
+    );
+  }
+
+  if (currentSource.includes("serviceTiers.length>0") && currentSource.includes("additionalSpeedTiers")) {
+    console.warn(
+      "WARN: Could not find fast-mode model guard insertion point — skipping fast-mode crash guard patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function patchCommentPreloadBundle(extractedDir) {
   const commentPreloadBundle = path.join(extractedDir, ".vite", "build", "comment-preload.js");
   if (!fs.existsSync(commentPreloadBundle)) {
@@ -661,6 +691,7 @@ module.exports = {
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxFastModeModelGuardPatch,
   applySubagentNicknameMetadataPatch,
   patchCommentPreloadBundle,
 };


### PR DESCRIPTION
## Summary
- add a required Linux webview patch for the fast-mode availability hook
- guard missing model serviceTiers with optional chaining while preserving additionalSpeedTiers detection
- cover the patch helper and core descriptor registration in tests

## Tests
- node --check scripts/patches/webview-assets.js
- node --check scripts/patch-linux-window-ui.js
- node --check scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js