### PR TITLE
Fix mobile control gate and add build thread knob

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ NEXT_APP_DIR := $(CURDIR)/codex-app-next
 REBUILD_REPORT_DIR := $(CURDIR)/dist-next/rebuild
 PACKAGE_NAME := codex-desktop
 PACKAGE_WITH_UPDATER ?= 1
+MAX_BUILD_THREADS ?= 4
+RPM_BINARY_PAYLOAD ?= w19T$(MAX_BUILD_THREADS).zstdio
+CARGO_JOBS_ARG = $(if $(filter-out 0,$(MAX_BUILD_THREADS)),--jobs $(MAX_BUILD_THREADS),)
 DEV_APP_ID ?= codex-cua-lab
 DEV_APP_NAME ?= Codex CUA Lab
 DEV_APP_DIR ?= $(CURDIR)/$(DEV_APP_ID)-app
@@ -91,6 +94,8 @@ help:
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
 	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage"
 	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
+	@printf '  %-18s %s\n' "MAX_BUILD_THREADS=8" "Cap supported build jobs/compression threads (default: 4, 0=auto/default)"
+	@printf '  %-18s %s\n' "RPM_BINARY_PAYLOAD=..." "Advanced RPM payload flags override (default: $(RPM_BINARY_PAYLOAD))"
 	@printf '  %-18s %s\n' "APPIMAGETOOL=..." "Override the appimagetool executable for make appimage"
 	@printf '  %-18s %s\n' "DEB=/path/file.deb" "Override the .deb used by make install"
 	@printf '  %-18s %s\n' "RPM=/path/file.rpm" "Override the .rpm used by make install"
@@ -112,6 +117,8 @@ help:
 	@printf '  %s\n' "./bin/codex-cua-lab"
 	@printf '  %s\n' "make deb PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make rpm PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
+	@printf '  %s\n' "MAX_BUILD_THREADS=8 make install-native"
+	@printf '  %s\n' "MAX_BUILD_THREADS=8 make rpm"
 	@printf '  %s\n' "make pacman PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make appimage PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make install"
@@ -119,15 +126,15 @@ help:
 
 check:
 	@echo "[make] Running cargo check"
-	cargo check -p codex-update-manager
+	cargo check $(CARGO_JOBS_ARG) -p codex-update-manager
 
 test:
 	@echo "[make] Running cargo test"
-	cargo test -p codex-update-manager
+	cargo test $(CARGO_JOBS_ARG) -p codex-update-manager
 
 build-updater:
 	@echo "[make] Building codex-update-manager (release)"
-	cargo build --release -p codex-update-manager
+	cargo build $(CARGO_JOBS_ARG) --release -p codex-update-manager
 
 maybe-build-updater:
 	@case "$(PACKAGE_WITH_UPDATER)" in \
@@ -141,12 +148,14 @@ update: rebuild-install
 
 rebuild:
 	@echo "[make] Running safe rebuild flow"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
 		./scripts/rebuild-candidate.sh "$(DMG)"
 
 rebuild-install:
 	@echo "[make] Running rebuild and local install flow"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
 	CODEX_FINAL_APP_DIR="$(APP_DIR)" \
@@ -154,15 +163,15 @@ rebuild-install:
 
 inspect-upstream:
 	@echo "[make] Inspecting upstream DMG"
-	./install.sh --inspect --report-dir "$(REBUILD_REPORT_DIR)" "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --inspect --report-dir "$(REBUILD_REPORT_DIR)" "$(DMG)"
 
 build-app:
 	@echo "[make] Regenerating codex-app from DMG"
-	./install.sh "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh "$(DMG)"
 
 build-app-fresh:
 	@echo "[make] Regenerating codex-app from fresh DMG"
-	./install.sh --fresh "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --fresh "$(DMG)"
 
 setup-native:
 	@echo "[make] Running guided native setup"
@@ -186,6 +195,7 @@ update-native:
 
 rebuild-next:
 	@echo "[make] Building side-by-side rebuild candidate"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	CODEX_INSTALL_DIR="$(NEXT_APP_DIR)" \
 	CODEX_PATCH_REPORT_JSON="$(REBUILD_REPORT_DIR)/patch-report.json" \
 	CODEX_REBUILD_REPORT_JSON="$(REBUILD_REPORT_DIR)/rebuild-report.json" \
@@ -200,6 +210,7 @@ run-app:
 
 build-dev-app:
 	@echo "[make] Building side-by-side Electron app as $(DEV_APP_ID)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	CODEX_APP_ID="$(DEV_APP_ID)" \
 	CODEX_APP_DISPLAY_NAME="$(DEV_APP_NAME)" \
 	CODEX_INSTALL_DIR="$(DEV_APP_DIR)" \
@@ -214,29 +225,29 @@ run-dev-app:
 
 deb: maybe-build-updater
 	@echo "[make] Building Debian package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh
 
 rpm: maybe-build-updater
 	@echo "[make] Building RPM package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" RPM_BINARY_PAYLOAD="$(RPM_BINARY_PAYLOAD)" ./scripts/build-rpm.sh
 
 pacman: maybe-build-updater
 	@echo "[make] Building pacman package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
 
 appimage:
 	@echo "[make] Building AppImage"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
 
 package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"
 	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
 	if [ "$$format" = "pacman" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh; \
 	elif [ "$$format" = "rpm" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" RPM_BINARY_PAYLOAD="$(RPM_BINARY_PAYLOAD)" ./scripts/build-rpm.sh; \
 	elif [ "$$format" = "deb" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh; \
 	else \
 		echo "[make] No supported packaging tool found. Install dpkg-dev (Debian), rpm-build (Fedora), or pacman (Arch)." >&2; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -474,6 +474,16 @@ After `make build-app` or `make build-app-fresh`, build a native package from `c
 
 Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish ./scripts/build-*.sh`. AppImage builds require `appimagetool` on `PATH`, or `APPIMAGETOOL=/path/to/appimagetool`.
 
+Tune local build parallelism with one Make variable:
+
+```bash
+MAX_BUILD_THREADS=8 make build-app-fresh
+MAX_BUILD_THREADS=8 make package
+MAX_BUILD_THREADS=8 make install-native
+```
+
+`MAX_BUILD_THREADS=4` is the default. Set `MAX_BUILD_THREADS=0` to let each tool use its own automatic/default behavior. Supported phases use the value for Cargo `--jobs`, native module rebuild jobs, Debian package compression, pacman package compression, and RPM zstd payload compression (`w19T<threads>.zstdio`). RPM builders can still set `RPM_BINARY_PAYLOAD=w19.zstdio make rpm` for exact payload flags when needed.
+
 The packaging scripts only repackage what's already in `codex-app/`. They do not download or extract the DMG themselves.
 
 Native packages bundle the managed Node.js runtime and do not hard-depend on distro `nodejs` / `npm`. Packages built with the default updater pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` for privileged update installs; `PACKAGE_WITH_UPDATER=0` packages do not install those updater-specific artifacts.

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -23,7 +23,7 @@ const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
 const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
-  /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
+  /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)(?:&&\2\?\.accessRequired!==!0)?\}/u;
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
@@ -603,7 +603,7 @@ function applyLinuxRemoteControlVisibilityPatch(source) {
     const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
     return source.replace(
       REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
-      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))}`,
+      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
     );
   }
   return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
@@ -1108,7 +1108,7 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings)-.*\.js$/,
+    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings|use-plugin-install-flow)-.*\.js$/,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -106,6 +106,10 @@ function syntheticCurrentVisibilityBundle() {
   return "function Et({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)}export{Et as t};";
 }
 
+function syntheticCurrentUsePluginVisibilityBundle() {
+  return "function ke({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{ke as l};";
+}
+
 function syntheticMobileConnectedSettingsBundle() {
   return "let y={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let Codex control the apps on your Mac.`,description:`Description for enabling Computer Use after mobile setup`};";
 }
@@ -583,6 +587,14 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "webview-asset",
       "webview-asset",
     ]);
+
+    const visibilityDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-visibility"
+    );
+    assert.ok(visibilityDescriptor);
+    assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), true);
+    assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), true);
+    assert.equal(visibilityDescriptor.pattern.test("app-main-fixture.js"), false);
   });
 });
 
@@ -751,7 +763,17 @@ test("Linux remote-control visibility patch handles current settings bundle shap
 
   assert.notEqual(patched, source);
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
-  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)/);
+  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
+  assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("Linux remote-control visibility patch handles current use-plugin gate shape", () => {
+  const source = syntheticCurrentUsePluginVisibilityBundle();
+  const patched = applyLinuxRemoteControlVisibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
 });
 

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -19,9 +19,18 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-4}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
+
+validate_max_build_threads() {
+    case "$MAX_BUILD_THREADS" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+}
 
 map_arch() {
     case "$(dpkg --print-architecture)" in
@@ -35,6 +44,8 @@ map_arch() {
 }
 
 main() {
+    validate_max_build_threads
+
     ensure_app_layout
     ensure_file_exists "$CONTROL_TEMPLATE" "control template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
@@ -101,7 +112,12 @@ CONTROL
 
     mkdir -p "$DIST_DIR"
     info "Building $output_file"
-    dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    if [ "$MAX_BUILD_THREADS" != "0" ]; then
+        info "Debian package compression threads: $MAX_BUILD_THREADS"
+        DPKG_DEB_THREADS_MAX="$MAX_BUILD_THREADS" dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    else
+        dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    fi
     info "Built package: $output_file"
 }
 

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -16,9 +16,18 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-4}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
+
+validate_max_build_threads() {
+	case "$MAX_BUILD_THREADS" in
+	""|*[!0-9]*)
+		error "MAX_BUILD_THREADS must be 0 or a positive integer"
+		;;
+	esac
+}
 
 map_arch() {
 	case "$(uname -m)" in
@@ -36,7 +45,41 @@ pacman_version_parts() {
 	PACMAN_PKGREL="1"
 }
 
+write_threaded_makepkg_config() {
+	local target="$1"
+	local home_dir="${HOME:-}"
+	local xdg_config_home="${XDG_CONFIG_HOME:-}"
+	local user_makepkg_conf=""
+
+	if [ -z "$xdg_config_home" ] && [ -n "$home_dir" ]; then
+		xdg_config_home="$home_dir/.config"
+	fi
+	if [ -n "$xdg_config_home" ] && [ -r "$xdg_config_home/pacman/makepkg.conf" ]; then
+		user_makepkg_conf="$xdg_config_home/pacman/makepkg.conf"
+	elif [ -n "$home_dir" ] && [ -r "$home_dir/.makepkg.conf" ]; then
+		user_makepkg_conf="$home_dir/.makepkg.conf"
+	fi
+
+	{
+		if [ -n "${MAKEPKG_CONF:-}" ]; then
+			[ -r "$MAKEPKG_CONF" ] || error "MAKEPKG_CONF is not readable: $MAKEPKG_CONF"
+			printf '. %q\n' "$MAKEPKG_CONF"
+		else
+			[ -r /etc/makepkg.conf ] && printf '. %q\n' /etc/makepkg.conf
+			local system_makepkg_conf
+			for system_makepkg_conf in /etc/makepkg.conf.d/*.conf; do
+				[ -r "$system_makepkg_conf" ] && printf '. %q\n' "$system_makepkg_conf"
+			done
+			[ -n "$user_makepkg_conf" ] && printf '. %q\n' "$user_makepkg_conf"
+		fi
+		printf 'MAKEFLAGS="-j%s${MAKEFLAGS:+ $MAKEFLAGS}"\n' "$MAX_BUILD_THREADS"
+		printf 'COMPRESSZST=(zstd -c -z -T%s -)\n' "$MAX_BUILD_THREADS"
+	} >"$target"
+}
+
 main() {
+	validate_max_build_threads
+
 	ensure_app_layout
 	ensure_file_exists "$PKGBUILD_TEMPLATE" "PKGBUILD template"
 	ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
@@ -67,6 +110,14 @@ main() {
 	trap "rm -rf '$build_root'" EXIT
 
 	local staging_root="$build_root/staging"
+	local -a makepkg_env=("PKGDEST=$DIST_DIR")
+
+	if [ "$MAX_BUILD_THREADS" != "0" ]; then
+		local makepkg_config="$build_root/makepkg.conf"
+		write_threaded_makepkg_config "$makepkg_config"
+		makepkg_env+=("MAKEPKG_CONF=$makepkg_config")
+		info "Pacman package build/compression threads: $MAX_BUILD_THREADS"
+	fi
 
 	stage_common_package_files "$staging_root"
 	stage_optional_update_builder_bundle "$staging_root"
@@ -108,7 +159,7 @@ main() {
 	# Build the package; --nodeps skips dependency checks at build time (they
 	# are enforced by pacman at install time), and --skipinteg is needed
 	# because we have no remote sources to verify.
-	(cd "$build_root" && PKGDEST="$DIST_DIR" makepkg -f --nodeps --skipinteg 2>&1) >&2
+	(cd "$build_root" && env "${makepkg_env[@]}" makepkg -f --nodeps --skipinteg 2>&1) >&2
 
 	local pkg_file=""
 	pkg_file="$(find "$DIST_DIR" \( -name "${PACKAGE_NAME}-${PACMAN_PKGVER}-*.pkg.tar.zst" \

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -14,6 +14,8 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-4}"
+RPM_BINARY_PAYLOAD="${RPM_BINARY_PAYLOAD:-w19T${MAX_BUILD_THREADS}.zstdio}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
@@ -25,6 +27,14 @@ UPDATE_BUILDER_ROOT_PLACEHOLDER="__UPDATE_BUILDER_ROOT__"
 
 info()  { echo "[INFO] $*" >&2; }
 error() { echo "[ERROR] $*" >&2; exit 1; }
+
+validate_max_build_threads() {
+    case "$MAX_BUILD_THREADS" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+}
 
 map_arch() {
     case "$(uname -m)" in
@@ -49,6 +59,8 @@ rpm_version_parts() {
 }
 
 main() {
+    validate_max_build_threads
+
     [ -d "$APP_DIR" ] || error "Missing app directory: $APP_DIR. Run ./install.sh first."
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
     [ -f "$SPEC_TEMPLATE" ] || error "Missing spec template: $SPEC_TEMPLATE"
@@ -108,12 +120,14 @@ SCRIPT
 
     mkdir -p "$DIST_DIR"
     info "Building $PACKAGE_NAME-${rpm_ver}-${rpm_rel}.${arch}.rpm"
+    info "RPM binary payload compression: $RPM_BINARY_PAYLOAD"
     rpmbuild -bb \
         --define "_rpmdir $rpmbuild_dir/RPMS" \
         --define "_srcrpmdir $rpmbuild_dir/SRPMS" \
         --define "_builddir $rpmbuild_dir/BUILD" \
         --define "_sourcedir $rpmbuild_dir/SOURCES" \
         --define "_specdir $build_root" \
+        --define "_binary_payload $RPM_BINARY_PAYLOAD" \
         --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
         "$spec_file" >&2
 

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -172,6 +172,30 @@ CPP
 
 build_native_modules() {
     local app_extracted="$1"
+    local max_build_threads="${MAX_BUILD_THREADS:-4}"
+    local -a electron_rebuild_mode_args=()
+    local -a native_build_env=()
+
+    case "$max_build_threads" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+
+    if [ "$max_build_threads" = "1" ]; then
+        electron_rebuild_mode_args+=(--sequential)
+    elif [ "$max_build_threads" != "0" ]; then
+        electron_rebuild_mode_args+=(--parallel)
+    fi
+
+    if [ "$max_build_threads" != "0" ]; then
+        native_build_env+=(
+            "npm_config_jobs=$max_build_threads"
+            "NPM_CONFIG_JOBS=$max_build_threads"
+            "MAKEFLAGS=-j$max_build_threads${MAKEFLAGS:+ $MAKEFLAGS}"
+        )
+        info "Max build threads: $max_build_threads"
+    fi
 
     # Read versions from extracted app
     local bs3_ver bs3_build_ver npty_ver
@@ -213,9 +237,11 @@ build_native_modules() {
     info "Using Electron headers: $ELECTRON_HEADERS_URL"
     [ -f "$build_dir/node_modules/@electron/rebuild/lib/cli.js" ] || error "electron-rebuild CLI not found in native build toolchain"
     apply_v8_nullptr_t_workaround_if_needed "$build_dir"
-    npm_config_disturl="$ELECTRON_HEADERS_URL" \
-    NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
-    node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
+    env \
+        npm_config_disturl="$ELECTRON_HEADERS_URL" \
+        NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
+        "${native_build_env[@]}" \
+        node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" "${electron_rebuild_mode_args[@]}" 2>&1 >&2
 
     info "Native modules built successfully"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -179,8 +179,9 @@ test_deb_builder_smoke() {
     local dist_dir="$workspace/dist"
     local pkg_root="$workspace/deb-root"
     local updater_bin="$workspace/codex-update-manager"
+    local capture_dir="$workspace/capture"
 
-    mkdir -p "$workspace" "$dist_dir"
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
@@ -197,6 +198,8 @@ SCRIPT
     cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
 #!/usr/bin/env bash
 output="${@: -1}"
+printf '%s\n' "$*" > "$CAPTURE_DIR/dpkg-deb-args"
+printf '%s\n' "${DPKG_DEB_THREADS_MAX:-}" > "$CAPTURE_DIR/dpkg-deb-threads"
 mkdir -p "$(dirname "$output")"
 touch "$output"
 SCRIPT
@@ -211,11 +214,15 @@ SCRIPT
     APP_DIR_OVERRIDE="$app_dir" \
     PKG_ROOT_OVERRIDE="$pkg_root" \
     DIST_DIR_OVERRIDE="$dist_dir" \
+    CAPTURE_DIR="$capture_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
+    MAX_BUILD_THREADS=6 \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
     bash "$REPO_DIR/scripts/build-deb.sh"
 
     assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+deadbeef_amd64.deb"
+    [ "$(cat "$capture_dir/dpkg-deb-threads")" = "6" ] \
+        || fail "Expected MAX_BUILD_THREADS to reach dpkg-deb"
     assert_file_exists "$pkg_root/DEBIAN/prerm"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=New Window"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=Check for Updates"
@@ -517,11 +524,13 @@ test_rpm_builder_smoke() {
     cat > "$bin_dir/rpmbuild" <<'SCRIPT'
 #!/usr/bin/env bash
 rpmdir=""
+binary_payload=""
 spec_file="${@: -1}"
 while [ $# -gt 0 ]; do
     if [ "$1" = "--define" ]; then
         case "$2" in
             _rpmdir\ *) rpmdir="${2#_rpmdir }" ;;
+            _binary_payload\ *) binary_payload="${2#_binary_payload }" ;;
         esac
         shift 2
         continue
@@ -531,6 +540,7 @@ done
 [ -n "$rpmdir" ] || exit 1
 if [ -n "${CAPTURE_DIR:-}" ]; then
     cp "$spec_file" "$CAPTURE_DIR/codex-desktop.spec"
+    printf '%s\n' "$binary_payload" > "$CAPTURE_DIR/rpm-binary-payload"
     staging_dir="$(sed -n 's|cp -a "\(.*\)/\." "%{buildroot}/"|\1|p' "$spec_file" | head -n 1)"
     if [ -n "$staging_dir" ] && [ -d "$staging_dir" ]; then
         cp -a "$staging_dir" "$CAPTURE_DIR/staging"
@@ -547,6 +557,7 @@ SCRIPT
     chmod +x "$bin_dir/rpmbuild" "$bin_dir/cargo"
 
     PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
     APP_DIR_OVERRIDE="$app_dir" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
@@ -554,6 +565,8 @@ SCRIPT
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
+    [ "$(cat "$capture_dir/rpm-binary-payload")" = "w19T4.zstdio" ] \
+        || fail "Expected default RPM binary payload to use conservative threaded zstd"
 
     rm -rf "$dist_dir" "$capture_dir"
     mkdir -p "$dist_dir" "$capture_dir"
@@ -564,10 +577,13 @@ SCRIPT
     DIST_DIR_OVERRIDE="$dist_dir" \
     PACKAGE_WITH_UPDATER=0 \
     PACKAGE_VERSION="2026.03.24.120000+manual" \
+    MAX_BUILD_THREADS=8 \
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-manual.x86_64.rpm"
     assert_file_exists "$capture_dir/codex-desktop.spec"
+    [ "$(cat "$capture_dir/rpm-binary-payload")" = "w19T8.zstdio" ] \
+        || fail "Expected MAX_BUILD_THREADS to reach rpmbuild payload compression"
     assert_file_exists "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh"
     assert_file_not_exists "$capture_dir/staging/usr/bin/codex-update-manager"
     assert_file_not_exists "$capture_dir/staging/usr/lib/systemd/user/codex-update-manager.service"
@@ -610,6 +626,10 @@ test_pacman_builder_without_updater_transition_hook() {
 set -euo pipefail
 cp PKGBUILD "$CAPTURE_DIR/PKGBUILD"
 cp codex-desktop.install "$CAPTURE_DIR/codex-desktop.install"
+printf '%s\n' "${MAKEPKG_CONF:-}" > "$CAPTURE_DIR/makepkg-conf-path"
+if [ -n "${MAKEPKG_CONF:-}" ]; then
+    cp "$MAKEPKG_CONF" "$CAPTURE_DIR/makepkg.conf"
+fi
 pkgname="$(sed -n 's/^pkgname=//p' PKGBUILD)"
 pkgver="$(sed -n 's/^pkgver=//p' PKGBUILD)"
 pkgrel="$(sed -n 's/^pkgrel=//p' PKGBUILD)"
@@ -632,6 +652,7 @@ SCRIPT
         APP_DIR_OVERRIDE="$app_dir" \
         DIST_DIR_OVERRIDE="$dist_dir" \
         PACKAGE_WITH_UPDATER=0 \
+        MAX_BUILD_THREADS=5 \
         PACKAGE_VERSION="2026.03.24.120000+manual" \
         bash "$REPO_DIR/scripts/build-pacman.sh"
     )"
@@ -642,6 +663,9 @@ SCRIPT
     [ "$(readlink "$dist_dir/codex-desktop-latest.pkg.tar.zst")" = "codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst" ] || fail "Expected latest pacman symlink to point at built package"
     assert_file_exists "$capture_dir/PKGBUILD"
     assert_file_exists "$capture_dir/codex-desktop.install"
+    assert_file_exists "$capture_dir/makepkg.conf"
+    assert_contains "$capture_dir/makepkg.conf" "MAKEFLAGS=\"-j5"
+    assert_contains "$capture_dir/makepkg.conf" "COMPRESSZST=(zstd -c -z -T5 -)"
     assert_contains "$capture_dir/PKGBUILD" "pkgver=2026.03.24.120000+manual"
     assert_contains "$capture_dir/PKGBUILD" "pkgrel=1"
     assert_contains "$capture_dir/PKGBUILD" "ampersand&tmp"
@@ -1768,6 +1792,7 @@ case "$args" in
 #!/usr/bin/env node
 const fs = require("fs");
 fs.appendFileSync(process.env.NATIVE_TOOLCHAIN_LOG, `electron-rebuild ${process.argv.slice(2).join(" ")}\n`);
+fs.appendFileSync(process.env.NATIVE_TOOLCHAIN_LOG, `electron-rebuild-env jobs=${process.env.npm_config_jobs || ""} makeflags=${process.env.MAKEFLAGS || ""}\n`);
 fs.mkdirSync("node_modules/better-sqlite3/build/Release", { recursive: true });
 fs.mkdirSync("node_modules/node-pty/build/Release", { recursive: true });
 fs.closeSync(fs.openSync("node_modules/better-sqlite3/build/Release/better_sqlite3.node", "w"));
@@ -1825,6 +1850,8 @@ SCRIPT
         export PATH
         NATIVE_TOOLCHAIN_LOG="$toolchain_log"
         export NATIVE_TOOLCHAIN_LOG
+        MAX_BUILD_THREADS=4
+        export MAX_BUILD_THREADS
         WORK_DIR="$workspace/work"
         ELECTRON_VERSION="42.0.1"
         ELECTRON_HEADERS_URL="https://example.invalid/electron"
@@ -1839,7 +1866,8 @@ SCRIPT
 
     assert_contains "$toolchain_log" "@electron/rebuild@4.0.4"
     assert_contains "$toolchain_log" "node-abi@^4.31.0"
-    assert_contains "$toolchain_log" "electron-rebuild -v 42.0.1 --force --dist-url https://example.invalid/electron"
+    assert_contains "$toolchain_log" "electron-rebuild -v 42.0.1 --force --dist-url https://example.invalid/electron --parallel"
+    assert_contains "$toolchain_log" "electron-rebuild-env jobs=4 makeflags=-j4"
     assert_contains "$output_log" "Native modules built successfully"
     assert_file_exists "$app_dir/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
     assert_file_exists "$app_dir/node_modules/node-pty/build/Release/pty.node"


### PR DESCRIPTION
## Summary
- patch the remote-mobile-control visibility gate for the current use-plugin-install-flow bundle shape while preserving accessRequired checks
- add one MAX_BUILD_THREADS setting across Cargo, native module rebuilds, Debian/RPM/pacman packaging, and Make targets
- propose a conservative default of MAX_BUILD_THREADS=4 so builds use more than one worker by default without saturating small systems; MAX_BUILD_THREADS=0 still preserves each tool's automatic/default behavior
- document the setting and add smoke coverage for the thread propagation paths

## Existing configurability check
- origin/main had no first-class Make/script setting for native build parallelism across app rebuilds and package builders
- there are tool-specific escape hatches (for example Cargo jobs, RPM payload flags, dpkg-deb threads, and makepkg config), but they were not wired into a single repo-level knob for this flow

## Test plan
- bash tests/scripts_smoke.sh
- node --test linux-features/remote-mobile-control/test.js
- git diff --check origin/main..HEAD
- make -n PACKAGE_WITH_UPDATER=0 rpm