### PR TITLE
Fix remote mobile control visibility gate

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -23,7 +23,7 @@ const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
 const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
-  /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)\}/u;
+  /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)(?:&&\2\?\.accessRequired!==!0)?\}/u;
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
@@ -603,7 +603,7 @@ function applyLinuxRemoteControlVisibilityPatch(source) {
     const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
     return source.replace(
       REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
-      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))}`,
+      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
     );
   }
   return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
@@ -1108,7 +1108,7 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings)-.*\.js$/,
+    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings|use-plugin-install-flow)-.*\.js$/,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -106,6 +106,10 @@ function syntheticCurrentVisibilityBundle() {
   return "function Et({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)}export{Et as t};";
 }
 
+function syntheticCurrentUsePluginVisibilityBundle() {
+  return "function ke({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{ke as l};";
+}
+
 function syntheticMobileConnectedSettingsBundle() {
   return "let y={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let Codex control the apps on your Mac.`,description:`Description for enabling Computer Use after mobile setup`};";
 }
@@ -583,6 +587,14 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "webview-asset",
       "webview-asset",
     ]);
+
+    const visibilityDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-visibility"
+    );
+    assert.ok(visibilityDescriptor);
+    assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), true);
+    assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), true);
+    assert.equal(visibilityDescriptor.pattern.test("app-main-fixture.js"), false);
   });
 });
 
@@ -751,7 +763,17 @@ test("Linux remote-control visibility patch handles current settings bundle shap
 
   assert.notEqual(patched, source);
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
-  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)/);
+  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
+  assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
+});
+
+test("Linux remote-control visibility patch handles current use-plugin gate shape", () => {
+  const source = syntheticCurrentUsePluginVisibilityBundle();
+  const patched = applyLinuxRemoteControlVisibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /return\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
 });
 


### PR DESCRIPTION
## Summary
- patch the current use-plugin-install-flow visibility bundle for remote mobile control
- preserve the upstream accessRequired guard while allowing Linux hosts to expose the connection UI
- add coverage for the current bundle name/pattern and gate shape

## Review order
This PR should be reviewed after #322 lands or main otherwise gets the same PR-only Nix rollout handling. The code change is independent, but its current Nix check is red only because upstream Codex.dmg metadata is ahead of the committed flake pins.

## Why / user-visible behavior
- The current upstream bundle moved the remote-control visibility gate into use-plugin-install-flow, so the opt-in Linux mobile remote-control feature can miss the connection UI.
- With linux-features/remote-mobile-control enabled, Linux hosts can expose the mobile remote-control connection UI while still respecting upstream accessRequired state.

## Scope and limitations
- This stays inside the opt-in linux-features/remote-mobile-control feature and does not enable the feature by default.
- No committed features.example.json, distro packaging, installer, or updater behavior changes are included.
- Unrelated upstream/Nix pin drift is left out of scope for separate maintenance changes.

## Source of truth
- linux-features/remote-mobile-control/patch.js
- linux-features/remote-mobile-control/test.js

## Test plan
- node --test linux-features/remote-mobile-control/test.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check origin/main..HEAD

## CI note
- Current CI has Debian/RPM/pacman packaging and Rust/smoke tests passing.
- The remaining Nix Package Builds failure is from validate-nix-pins.sh reporting an upstream DMG app-version pin mismatch: expected 26.519.81530, got 26.519.41501. That happens before this feature patch is exercised and is addressed by #322.
