### PR TITLE
Add MAX_BUILD_THREADS setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,15 @@ NEXT_APP_DIR := $(CURDIR)/codex-app-next
 REBUILD_REPORT_DIR := $(CURDIR)/dist-next/rebuild
 PACKAGE_NAME := codex-desktop
 PACKAGE_WITH_UPDATER ?= 1
+MAX_BUILD_THREADS ?= 0
+MAX_BUILD_THREADS_VALUE := $(strip $(MAX_BUILD_THREADS))
+MAX_BUILD_THREADS_ENABLED := $(filter-out 0,$(MAX_BUILD_THREADS_VALUE))
+ifneq ($(MAX_BUILD_THREADS_ENABLED),)
+RPM_BINARY_PAYLOAD ?= w19T$(MAX_BUILD_THREADS_VALUE).zstdio
+else
+RPM_BINARY_PAYLOAD ?=
+endif
+CARGO_JOBS_ARG = $(if $(MAX_BUILD_THREADS_ENABLED),--jobs $(MAX_BUILD_THREADS_VALUE),)
 DEV_APP_ID ?= codex-cua-lab
 DEV_APP_NAME ?= Codex CUA Lab
 DEV_APP_DIR ?= $(CURDIR)/$(DEV_APP_ID)-app
@@ -91,6 +100,8 @@ help:
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
 	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage"
 	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
+	@printf '  %-18s %s\n' "MAX_BUILD_THREADS=8" "Set supported build jobs/compression threads (default: 0, tool/user defaults)"
+	@printf '  %-18s %s\n' "RPM_BINARY_PAYLOAD=..." "Advanced RPM payload flags override (default follows MAX_BUILD_THREADS)"
 	@printf '  %-18s %s\n' "APPIMAGETOOL=..." "Override the appimagetool executable for make appimage"
 	@printf '  %-18s %s\n' "DEB=/path/file.deb" "Override the .deb used by make install"
 	@printf '  %-18s %s\n' "RPM=/path/file.rpm" "Override the .rpm used by make install"
@@ -112,6 +123,8 @@ help:
 	@printf '  %s\n' "./bin/codex-cua-lab"
 	@printf '  %s\n' "make deb PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make rpm PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
+	@printf '  %s\n' "MAX_BUILD_THREADS=8 make install-native"
+	@printf '  %s\n' "MAX_BUILD_THREADS=8 make rpm"
 	@printf '  %s\n' "make pacman PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make appimage PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make install"
@@ -119,15 +132,15 @@ help:
 
 check:
 	@echo "[make] Running cargo check"
-	cargo check -p codex-update-manager
+	cargo check $(CARGO_JOBS_ARG) -p codex-update-manager
 
 test:
 	@echo "[make] Running cargo test"
-	cargo test -p codex-update-manager
+	cargo test $(CARGO_JOBS_ARG) -p codex-update-manager
 
 build-updater:
 	@echo "[make] Building codex-update-manager (release)"
-	cargo build --release -p codex-update-manager
+	cargo build $(CARGO_JOBS_ARG) --release -p codex-update-manager
 
 maybe-build-updater:
 	@case "$(PACKAGE_WITH_UPDATER)" in \
@@ -141,12 +154,14 @@ update: rebuild-install
 
 rebuild:
 	@echo "[make] Running safe rebuild flow"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
 		./scripts/rebuild-candidate.sh "$(DMG)"
 
 rebuild-install:
 	@echo "[make] Running rebuild and local install flow"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
 	CODEX_FINAL_APP_DIR="$(APP_DIR)" \
@@ -154,15 +169,15 @@ rebuild-install:
 
 inspect-upstream:
 	@echo "[make] Inspecting upstream DMG"
-	./install.sh --inspect --report-dir "$(REBUILD_REPORT_DIR)" "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --inspect --report-dir "$(REBUILD_REPORT_DIR)" "$(DMG)"
 
 build-app:
 	@echo "[make] Regenerating codex-app from DMG"
-	./install.sh "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh "$(DMG)"
 
 build-app-fresh:
 	@echo "[make] Regenerating codex-app from fresh DMG"
-	./install.sh --fresh "$(DMG)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --fresh "$(DMG)"
 
 setup-native:
 	@echo "[make] Running guided native setup"
@@ -186,6 +201,7 @@ update-native:
 
 rebuild-next:
 	@echo "[make] Building side-by-side rebuild candidate"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	CODEX_INSTALL_DIR="$(NEXT_APP_DIR)" \
 	CODEX_PATCH_REPORT_JSON="$(REBUILD_REPORT_DIR)/patch-report.json" \
 	CODEX_REBUILD_REPORT_JSON="$(REBUILD_REPORT_DIR)/rebuild-report.json" \
@@ -200,6 +216,7 @@ run-app:
 
 build-dev-app:
 	@echo "[make] Building side-by-side Electron app as $(DEV_APP_ID)"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	CODEX_APP_ID="$(DEV_APP_ID)" \
 	CODEX_APP_DISPLAY_NAME="$(DEV_APP_NAME)" \
 	CODEX_INSTALL_DIR="$(DEV_APP_DIR)" \
@@ -214,29 +231,29 @@ run-dev-app:
 
 deb: maybe-build-updater
 	@echo "[make] Building Debian package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh
 
 rpm: maybe-build-updater
 	@echo "[make] Building RPM package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" RPM_BINARY_PAYLOAD="$(RPM_BINARY_PAYLOAD)" ./scripts/build-rpm.sh
 
 pacman: maybe-build-updater
 	@echo "[make] Building pacman package"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
 
 appimage:
 	@echo "[make] Building AppImage"
-	PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
 
 package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"
 	@format="$$( $(NATIVE_PKG_FORMAT_CMD) )"; \
 	if [ "$$format" = "pacman" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh; \
 	elif [ "$$format" = "rpm" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-rpm.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" RPM_BINARY_PAYLOAD="$(RPM_BINARY_PAYLOAD)" ./scripts/build-rpm.sh; \
 	elif [ "$$format" = "deb" ]; then \
-		PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh; \
+		MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-deb.sh; \
 	else \
 		echo "[make] No supported packaging tool found. Install dpkg-dev (Debian), rpm-build (Fedora), or pacman (Arch)." >&2; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -474,6 +474,16 @@ After `make build-app` or `make build-app-fresh`, build a native package from `c
 
 Override the package version with `PACKAGE_VERSION=YYYY.MM.DD.HHMMSS+commitish ./scripts/build-*.sh`. AppImage builds require `appimagetool` on `PATH`, or `APPIMAGETOOL=/path/to/appimagetool`.
 
+Tune local build parallelism with one Make variable:
+
+```bash
+MAX_BUILD_THREADS=8 make build-app-fresh
+MAX_BUILD_THREADS=8 make package
+MAX_BUILD_THREADS=8 make install-native
+```
+
+`MAX_BUILD_THREADS=0` is the default, which preserves each tool's automatic/default behavior and existing user config such as `MAKEFLAGS`, makepkg config, and RPM macros. Set a nonzero value to opt in to one repo-level requested worker count for supported build steps. When nonzero, `MAX_BUILD_THREADS` is authoritative for the phases it controls and overrides inherited `MAKEFLAGS` for make-backed subprocesses. Supported phases use the value for Cargo `--jobs`, native module rebuild jobs, Debian package compression, pacman package compression, and RPM zstd payload compression (`w19T<threads>.zstdio`). RPM builders can still set `RPM_BINARY_PAYLOAD=w19.zstdio make rpm` for exact payload flags when needed.
+
 The packaging scripts only repackage what's already in `codex-app/`. They do not download or extract the DMG themselves.
 
 Native packages bundle the managed Node.js runtime and do not hard-depend on distro `nodejs` / `npm`. Packages built with the default updater pull in `polkit` (or `policykit-1` on older Debian/Ubuntu) plus `pkexec` for privileged update installs; `PACKAGE_WITH_UPDATER=0` packages do not install those updater-specific artifacts.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -19,9 +19,18 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-0}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
+
+validate_max_build_threads() {
+    case "$MAX_BUILD_THREADS" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+}
 
 map_arch() {
     case "$(dpkg --print-architecture)" in
@@ -35,6 +44,8 @@ map_arch() {
 }
 
 main() {
+    validate_max_build_threads
+
     ensure_app_layout
     ensure_file_exists "$CONTROL_TEMPLATE" "control template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
@@ -101,7 +112,12 @@ CONTROL
 
     mkdir -p "$DIST_DIR"
     info "Building $output_file"
-    dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    if [ "$MAX_BUILD_THREADS" != "0" ]; then
+        info "Debian package compression threads: $MAX_BUILD_THREADS"
+        DPKG_DEB_THREADS_MAX="$MAX_BUILD_THREADS" dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    else
+        dpkg-deb --root-owner-group --build "$PKG_ROOT" "$output_file" >&2
+    fi
     info "Built package: $output_file"
 }
 

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -16,9 +16,18 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-0}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
+
+validate_max_build_threads() {
+	case "$MAX_BUILD_THREADS" in
+	""|*[!0-9]*)
+		error "MAX_BUILD_THREADS must be 0 or a positive integer"
+		;;
+	esac
+}
 
 map_arch() {
 	case "$(uname -m)" in
@@ -36,7 +45,41 @@ pacman_version_parts() {
 	PACMAN_PKGREL="1"
 }
 
+write_threaded_makepkg_config() {
+	local target="$1"
+	local home_dir="${HOME:-}"
+	local xdg_config_home="${XDG_CONFIG_HOME:-}"
+	local user_makepkg_conf=""
+
+	if [ -z "$xdg_config_home" ] && [ -n "$home_dir" ]; then
+		xdg_config_home="$home_dir/.config"
+	fi
+	if [ -n "$xdg_config_home" ] && [ -r "$xdg_config_home/pacman/makepkg.conf" ]; then
+		user_makepkg_conf="$xdg_config_home/pacman/makepkg.conf"
+	elif [ -n "$home_dir" ] && [ -r "$home_dir/.makepkg.conf" ]; then
+		user_makepkg_conf="$home_dir/.makepkg.conf"
+	fi
+
+	{
+		if [ -n "${MAKEPKG_CONF:-}" ]; then
+			[ -r "$MAKEPKG_CONF" ] || error "MAKEPKG_CONF is not readable: $MAKEPKG_CONF"
+			printf '. %q\n' "$MAKEPKG_CONF"
+		else
+			[ -r /etc/makepkg.conf ] && printf '. %q\n' /etc/makepkg.conf
+			local system_makepkg_conf
+			for system_makepkg_conf in /etc/makepkg.conf.d/*.conf; do
+				[ -r "$system_makepkg_conf" ] && printf '. %q\n' "$system_makepkg_conf"
+			done
+			[ -n "$user_makepkg_conf" ] && printf '. %q\n' "$user_makepkg_conf"
+		fi
+		printf 'MAKEFLAGS="${MAKEFLAGS:+$MAKEFLAGS }-j%s"\n' "$MAX_BUILD_THREADS"
+		printf 'COMPRESSZST=(zstd -c -z -T%s -)\n' "$MAX_BUILD_THREADS"
+	} >"$target"
+}
+
 main() {
+	validate_max_build_threads
+
 	ensure_app_layout
 	ensure_file_exists "$PKGBUILD_TEMPLATE" "PKGBUILD template"
 	ensure_file_exists "$DESKTOP_TEMPLATE" "desktop template"
@@ -67,6 +110,14 @@ main() {
 	trap "rm -rf '$build_root'" EXIT
 
 	local staging_root="$build_root/staging"
+	local -a makepkg_env=("PKGDEST=$DIST_DIR")
+
+	if [ "$MAX_BUILD_THREADS" != "0" ]; then
+		local makepkg_config="$build_root/makepkg.conf"
+		write_threaded_makepkg_config "$makepkg_config"
+		makepkg_env+=("MAKEPKG_CONF=$makepkg_config")
+		info "Pacman package build/compression threads: $MAX_BUILD_THREADS"
+	fi
 
 	stage_common_package_files "$staging_root"
 	stage_optional_update_builder_bundle "$staging_root"
@@ -108,7 +159,7 @@ main() {
 	# Build the package; --nodeps skips dependency checks at build time (they
 	# are enforced by pacman at install time), and --skipinteg is needed
 	# because we have no remote sources to verify.
-	(cd "$build_root" && PKGDEST="$DIST_DIR" makepkg -f --nodeps --skipinteg 2>&1) >&2
+	(cd "$build_root" && env "${makepkg_env[@]}" makepkg -f --nodeps --skipinteg 2>&1) >&2
 
 	local pkg_file=""
 	pkg_file="$(find "$DIST_DIR" \( -name "${PACKAGE_NAME}-${PACMAN_PKGVER}-*.pkg.tar.zst" \

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -14,6 +14,8 @@ PACKAGED_RUNTIME_TEMPLATE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
 
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_VERSION="${PACKAGE_VERSION:-$(date -u +%Y.%m.%d.%H%M%S)}"
+MAX_BUILD_THREADS="${MAX_BUILD_THREADS:-0}"
+RPM_BINARY_PAYLOAD="${RPM_BINARY_PAYLOAD:-}"
 UPDATER_BINARY_SOURCE="${UPDATER_BINARY_SOURCE:-$REPO_DIR/target/release/codex-update-manager}"
 UPDATER_SERVICE_SOURCE="${UPDATER_SERVICE_SOURCE:-$SERVICE_TEMPLATE}"
 PACKAGED_RUNTIME_SOURCE="${PACKAGED_RUNTIME_SOURCE:-$PACKAGED_RUNTIME_TEMPLATE}"
@@ -25,6 +27,14 @@ UPDATE_BUILDER_ROOT_PLACEHOLDER="__UPDATE_BUILDER_ROOT__"
 
 info()  { echo "[INFO] $*" >&2; }
 error() { echo "[ERROR] $*" >&2; exit 1; }
+
+validate_max_build_threads() {
+    case "$MAX_BUILD_THREADS" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+}
 
 map_arch() {
     case "$(uname -m)" in
@@ -49,6 +59,11 @@ rpm_version_parts() {
 }
 
 main() {
+    validate_max_build_threads
+    if [ -z "$RPM_BINARY_PAYLOAD" ] && [ "$MAX_BUILD_THREADS" != "0" ]; then
+        RPM_BINARY_PAYLOAD="w19T${MAX_BUILD_THREADS}.zstdio"
+    fi
+
     [ -d "$APP_DIR" ] || error "Missing app directory: $APP_DIR. Run ./install.sh first."
     [ -x "$APP_DIR/start.sh" ] || error "Missing launcher: $APP_DIR/start.sh"
     [ -f "$SPEC_TEMPLATE" ] || error "Missing spec template: $SPEC_TEMPLATE"
@@ -108,14 +123,23 @@ SCRIPT
 
     mkdir -p "$DIST_DIR"
     info "Building $PACKAGE_NAME-${rpm_ver}-${rpm_rel}.${arch}.rpm"
-    rpmbuild -bb \
+    local -a rpmbuild_args=(
+        -bb
         --define "_rpmdir $rpmbuild_dir/RPMS" \
         --define "_srcrpmdir $rpmbuild_dir/SRPMS" \
         --define "_builddir $rpmbuild_dir/BUILD" \
         --define "_sourcedir $rpmbuild_dir/SOURCES" \
         --define "_specdir $build_root" \
         --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
-        "$spec_file" >&2
+    )
+    if [ -n "$RPM_BINARY_PAYLOAD" ]; then
+        info "RPM binary payload compression: $RPM_BINARY_PAYLOAD"
+        rpmbuild_args+=(--define "_binary_payload $RPM_BINARY_PAYLOAD")
+    else
+        info "RPM binary payload compression: tool default"
+    fi
+    rpmbuild_args+=("$spec_file")
+    rpmbuild "${rpmbuild_args[@]}" >&2
 
     local rpm_file
     rpm_file="$(find "$rpmbuild_dir/RPMS" -name "*.rpm" | head -n 1)"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -172,6 +172,28 @@ CPP
 
 build_native_modules() {
     local app_extracted="$1"
+    local max_build_threads="${MAX_BUILD_THREADS:-0}"
+    local -a electron_rebuild_mode_args=()
+    local -a native_build_env=()
+
+    case "$max_build_threads" in
+        ""|*[!0-9]*)
+            error "MAX_BUILD_THREADS must be 0 or a positive integer"
+            ;;
+    esac
+
+    if [ "$max_build_threads" != "0" ]; then
+        electron_rebuild_mode_args+=(--sequential)
+    fi
+
+    if [ "$max_build_threads" != "0" ]; then
+        native_build_env+=(
+            "npm_config_jobs=$max_build_threads"
+            "NPM_CONFIG_JOBS=$max_build_threads"
+            "MAKEFLAGS=-j$max_build_threads"
+        )
+        info "Max build threads: $max_build_threads"
+    fi
 
     # Read versions from extracted app
     local bs3_ver bs3_build_ver npty_ver
@@ -213,9 +235,11 @@ build_native_modules() {
     info "Using Electron headers: $ELECTRON_HEADERS_URL"
     [ -f "$build_dir/node_modules/@electron/rebuild/lib/cli.js" ] || error "electron-rebuild CLI not found in native build toolchain"
     apply_v8_nullptr_t_workaround_if_needed "$build_dir"
-    npm_config_disturl="$ELECTRON_HEADERS_URL" \
-    NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
-    node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" 2>&1 >&2
+    env \
+        npm_config_disturl="$ELECTRON_HEADERS_URL" \
+        NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
+        "${native_build_env[@]}" \
+        node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" "${electron_rebuild_mode_args[@]}" 2>&1 >&2
 
     info "Native modules built successfully"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -179,8 +179,9 @@ test_deb_builder_smoke() {
     local dist_dir="$workspace/dist"
     local pkg_root="$workspace/deb-root"
     local updater_bin="$workspace/codex-update-manager"
+    local capture_dir="$workspace/capture"
 
-    mkdir -p "$workspace" "$dist_dir"
+    mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
@@ -197,6 +198,8 @@ SCRIPT
     cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
 #!/usr/bin/env bash
 output="${@: -1}"
+printf '%s\n' "$*" > "$CAPTURE_DIR/dpkg-deb-args"
+printf '%s\n' "${DPKG_DEB_THREADS_MAX:-}" > "$CAPTURE_DIR/dpkg-deb-threads"
 mkdir -p "$(dirname "$output")"
 touch "$output"
 SCRIPT
@@ -211,11 +214,15 @@ SCRIPT
     APP_DIR_OVERRIDE="$app_dir" \
     PKG_ROOT_OVERRIDE="$pkg_root" \
     DIST_DIR_OVERRIDE="$dist_dir" \
+    CAPTURE_DIR="$capture_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
+    MAX_BUILD_THREADS=6 \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
     bash "$REPO_DIR/scripts/build-deb.sh"
 
     assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+deadbeef_amd64.deb"
+    [ "$(cat "$capture_dir/dpkg-deb-threads")" = "6" ] \
+        || fail "Expected MAX_BUILD_THREADS to reach dpkg-deb"
     assert_file_exists "$pkg_root/DEBIAN/prerm"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=New Window"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=Check for Updates"
@@ -517,11 +524,13 @@ test_rpm_builder_smoke() {
     cat > "$bin_dir/rpmbuild" <<'SCRIPT'
 #!/usr/bin/env bash
 rpmdir=""
+binary_payload=""
 spec_file="${@: -1}"
 while [ $# -gt 0 ]; do
     if [ "$1" = "--define" ]; then
         case "$2" in
             _rpmdir\ *) rpmdir="${2#_rpmdir }" ;;
+            _binary_payload\ *) binary_payload="${2#_binary_payload }" ;;
         esac
         shift 2
         continue
@@ -531,6 +540,7 @@ done
 [ -n "$rpmdir" ] || exit 1
 if [ -n "${CAPTURE_DIR:-}" ]; then
     cp "$spec_file" "$CAPTURE_DIR/codex-desktop.spec"
+    printf '%s\n' "$binary_payload" > "$CAPTURE_DIR/rpm-binary-payload"
     staging_dir="$(sed -n 's|cp -a "\(.*\)/\." "%{buildroot}/"|\1|p' "$spec_file" | head -n 1)"
     if [ -n "$staging_dir" ] && [ -d "$staging_dir" ]; then
         cp -a "$staging_dir" "$CAPTURE_DIR/staging"
@@ -547,6 +557,7 @@ SCRIPT
     chmod +x "$bin_dir/rpmbuild" "$bin_dir/cargo"
 
     PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
     APP_DIR_OVERRIDE="$app_dir" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
@@ -554,6 +565,8 @@ SCRIPT
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
+    [ "$(cat "$capture_dir/rpm-binary-payload")" = "" ] \
+        || fail "Expected default RPM binary payload to use tool default"
 
     rm -rf "$dist_dir" "$capture_dir"
     mkdir -p "$dist_dir" "$capture_dir"
@@ -564,10 +577,13 @@ SCRIPT
     DIST_DIR_OVERRIDE="$dist_dir" \
     PACKAGE_WITH_UPDATER=0 \
     PACKAGE_VERSION="2026.03.24.120000+manual" \
+    MAX_BUILD_THREADS=8 \
     bash "$REPO_DIR/scripts/build-rpm.sh"
 
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-manual.x86_64.rpm"
     assert_file_exists "$capture_dir/codex-desktop.spec"
+    [ "$(cat "$capture_dir/rpm-binary-payload")" = "w19T8.zstdio" ] \
+        || fail "Expected MAX_BUILD_THREADS to reach rpmbuild payload compression"
     assert_file_exists "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh"
     assert_file_not_exists "$capture_dir/staging/usr/bin/codex-update-manager"
     assert_file_not_exists "$capture_dir/staging/usr/lib/systemd/user/codex-update-manager.service"
@@ -585,6 +601,21 @@ SCRIPT
     assert_not_contains "$capture_dir/codex-desktop.spec" "mesa-libgbm"
     assert_contains "$capture_dir/codex-desktop.spec" "codex_no_updater_cleanup_update_manager_service"
     assert_contains "$capture_dir/staging/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh" "codex_no_updater_cleanup_user_enablement_links"
+
+    rm -rf "$dist_dir" "$capture_dir"
+    mkdir -p "$dist_dir" "$capture_dir"
+
+    PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    UPDATER_BINARY_SOURCE="$updater_bin" \
+    PACKAGE_VERSION="2026.03.24.120000+payload" \
+    RPM_BINARY_PAYLOAD="w19.zstdio" \
+    bash "$REPO_DIR/scripts/build-rpm.sh"
+
+    [ "$(cat "$capture_dir/rpm-binary-payload")" = "w19.zstdio" ] \
+        || fail "Expected RPM_BINARY_PAYLOAD to override tool default"
 }
 
 test_pacman_builder_without_updater_transition_hook() {
@@ -600,16 +631,23 @@ test_pacman_builder_without_updater_transition_hook() {
     local dist_dir="$workspace/dist"
     local capture_dir="$workspace/capture"
     local ampersand_tmpdir="$workspace/ampersand&tmp"
+    local base_makepkg_conf="$workspace/base-makepkg.conf"
 
     mkdir -p "$workspace" "$dist_dir" "$capture_dir" "$ampersand_tmpdir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
+    printf 'MAKEFLAGS="-j12"\n' > "$base_makepkg_conf"
 
     cat > "$bin_dir/makepkg" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
 cp PKGBUILD "$CAPTURE_DIR/PKGBUILD"
 cp codex-desktop.install "$CAPTURE_DIR/codex-desktop.install"
+printf '%s\n' "${MAKEPKG_CONF:-}" > "$CAPTURE_DIR/makepkg-conf-path"
+if [ -n "${MAKEPKG_CONF:-}" ]; then
+    cp "$MAKEPKG_CONF" "$CAPTURE_DIR/makepkg.conf"
+    bash -c 'set -euo pipefail; . "$1"; printf "%s\n" "$MAKEFLAGS"' _ "$MAKEPKG_CONF" > "$CAPTURE_DIR/makepkg-evaluated-makeflags"
+fi
 pkgname="$(sed -n 's/^pkgname=//p' PKGBUILD)"
 pkgver="$(sed -n 's/^pkgver=//p' PKGBUILD)"
 pkgrel="$(sed -n 's/^pkgrel=//p' PKGBUILD)"
@@ -631,7 +669,9 @@ SCRIPT
         CAPTURE_DIR="$capture_dir" \
         APP_DIR_OVERRIDE="$app_dir" \
         DIST_DIR_OVERRIDE="$dist_dir" \
+        MAKEPKG_CONF="$base_makepkg_conf" \
         PACKAGE_WITH_UPDATER=0 \
+        MAX_BUILD_THREADS=5 \
         PACKAGE_VERSION="2026.03.24.120000+manual" \
         bash "$REPO_DIR/scripts/build-pacman.sh"
     )"
@@ -642,6 +682,11 @@ SCRIPT
     [ "$(readlink "$dist_dir/codex-desktop-latest.pkg.tar.zst")" = "codex-desktop-2026.03.24.120000+manual-1-x86_64.pkg.tar.zst" ] || fail "Expected latest pacman symlink to point at built package"
     assert_file_exists "$capture_dir/PKGBUILD"
     assert_file_exists "$capture_dir/codex-desktop.install"
+    assert_file_exists "$capture_dir/makepkg.conf"
+    assert_contains "$capture_dir/makepkg.conf" "MAKEFLAGS=\"\${MAKEFLAGS:+\$MAKEFLAGS }-j5\""
+    [ "$(cat "$capture_dir/makepkg-evaluated-makeflags")" = "-j12 -j5" ] \
+        || fail "Expected generated makepkg config to make MAX_BUILD_THREADS win over existing MAKEFLAGS"
+    assert_contains "$capture_dir/makepkg.conf" "COMPRESSZST=(zstd -c -z -T5 -)"
     assert_contains "$capture_dir/PKGBUILD" "pkgver=2026.03.24.120000+manual"
     assert_contains "$capture_dir/PKGBUILD" "pkgrel=1"
     assert_contains "$capture_dir/PKGBUILD" "ampersand&tmp"
@@ -1928,6 +1973,7 @@ case "$args" in
 #!/usr/bin/env node
 const fs = require("fs");
 fs.appendFileSync(process.env.NATIVE_TOOLCHAIN_LOG, `electron-rebuild ${process.argv.slice(2).join(" ")}\n`);
+fs.appendFileSync(process.env.NATIVE_TOOLCHAIN_LOG, `electron-rebuild-env jobs=${process.env.npm_config_jobs || ""} makeflags=${process.env.MAKEFLAGS || ""}\n`);
 fs.mkdirSync("node_modules/better-sqlite3/build/Release", { recursive: true });
 fs.mkdirSync("node_modules/node-pty/build/Release", { recursive: true });
 fs.closeSync(fs.openSync("node_modules/better-sqlite3/build/Release/better_sqlite3.node", "w"));
@@ -1985,6 +2031,10 @@ SCRIPT
         export PATH
         NATIVE_TOOLCHAIN_LOG="$toolchain_log"
         export NATIVE_TOOLCHAIN_LOG
+        MAX_BUILD_THREADS=4
+        MAKEFLAGS="-j12 -l8"
+        export MAX_BUILD_THREADS
+        export MAKEFLAGS
         WORK_DIR="$workspace/work"
         ELECTRON_VERSION="42.0.1"
         ELECTRON_HEADERS_URL="https://example.invalid/electron"
@@ -1999,7 +2049,8 @@ SCRIPT
 
     assert_contains "$toolchain_log" "@electron/rebuild@4.0.4"
     assert_contains "$toolchain_log" "node-abi@^4.31.0"
-    assert_contains "$toolchain_log" "electron-rebuild -v 42.0.1 --force --dist-url https://example.invalid/electron"
+    assert_contains "$toolchain_log" "electron-rebuild -v 42.0.1 --force --dist-url https://example.invalid/electron --sequential"
+    assert_contains "$toolchain_log" "electron-rebuild-env jobs=4 makeflags=-j4"
     assert_contains "$output_log" "Native modules built successfully"
     assert_file_exists "$app_dir/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
     assert_file_exists "$app_dir/node_modules/node-pty/build/Release/pty.node"


### PR DESCRIPTION
## Summary
- add one opt-in MAX_BUILD_THREADS setting across Make targets, Cargo updater builds/tests, native module rebuilds, and Debian/RPM/pacman packaging
- keep the default at MAX_BUILD_THREADS=0 so existing tool defaults, MAKEFLAGS, makepkg config, and RPM macros continue to apply unless a user opts in
- avoid multiplying native-module concurrency by running electron-rebuild sequentially when MAX_BUILD_THREADS is nonzero while passing the requested job count to each native build
- make MAX_BUILD_THREADS authoritative for native-module MAKEFLAGS so inherited GNU make metadata cannot turn -jN into a bogus make target
- document the setting and add smoke coverage for thread propagation, default behavior, and override precedence

## TL;DR
I want one repo-level knob for local build parallelism so a native rebuild/package does not spend several extra minutes in single-threaded defaults, and so users do not have to remember separate Cargo, node-gyp, dpkg, rpm, and makepkg controls for each Make target.

## User-visible behavior
- Existing builds keep their current behavior by default because MAX_BUILD_THREADS defaults to 0.
- Users can opt in with commands such as MAX_BUILD_THREADS=8 make build-app-fresh, MAX_BUILD_THREADS=8 make package, or MAX_BUILD_THREADS=8 make install-native.
- For supported phases, a nonzero MAX_BUILD_THREADS value is the requested per-phase worker count. It also overrides inherited MAKEFLAGS for controlled make-backed subprocesses.
- RPM builders can still set RPM_BINARY_PAYLOAD directly when they need exact payload flags instead of the MAX_BUILD_THREADS-derived zstd thread setting.

## Existing configurability check
- origin/main had no first-class Make/script setting for native build parallelism across app rebuilds and package builders
- tool-specific escape hatches exist, including Cargo jobs, RPM payload flags, dpkg-deb threads, makepkg config, and MAKEFLAGS, but they were not wired into one repo-level knob for this flow
- MAX_BUILD_THREADS=0 preserves those existing escape hatches; nonzero MAX_BUILD_THREADS opts into the new repo-level behavior

## Source of truth
- Makefile
- scripts/lib/native-modules.sh
- scripts/build-deb.sh
- scripts/build-rpm.sh
- scripts/build-pacman.sh
- README.md
- tests/scripts_smoke.sh

## Local benchmark
Host: 32 logical CPUs, 31 GiB RAM. Inputs used cached local Codex.dmg and warm local dependency caches. Builds targeted temporary install/package directories under /tmp and did not overwrite the working app install.

| Phase | MAX_BUILD_THREADS=0 | MAX_BUILD_THREADS=32 | Result |
| --- | ---: | ---: | ---: |
| make build-app from cached DMG | 59.96s | 58.41s | ~1.03x faster |
| RPM package build, PACKAGE_WITH_UPDATER=0 | 332.89s | 40.45s | ~8.2x faster |
| Approx. local RPM rebuild + package | 392.85s | 98.86s | ~4.0x faster, ~4m54s saved |

The app-rebuild phase was not meaningfully faster on this warm-cache machine; the measured win came from threaded RPM zstd payload compression. Debian and pacman thread wiring is covered by smoke tests, but this host lacks dpkg-deb/makepkg for comparable real package timings.

## Validation
- bash -n scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/lib/native-modules.sh tests/scripts_smoke.sh
- bash tests/scripts_smoke.sh
- git diff --check origin/main...HEAD
- make -n PACKAGE_WITH_UPDATER=0 rpm
- make -n MAX_BUILD_THREADS=32 PACKAGE_WITH_UPDATER=0 rpm
- make -n MAX_BUILD_THREADS=0 PACKAGE_WITH_UPDATER=0 rpm
- make -n MAX_BUILD_THREADS= PACKAGE_WITH_UPDATER=0 rpm
- make -n MAX_BUILD_THREADS=32 PACKAGE_WITH_UPDATER=0 check
- CODEX_INSTALL_DIR=/tmp/... make build-app DMG=./Codex.dmg
- CODEX_INSTALL_DIR=/tmp/... make build-app MAX_BUILD_THREADS=32 DMG=./Codex.dmg
- APP_DIR_OVERRIDE=/tmp/... PACKAGE_WITH_UPDATER=0 bash scripts/build-rpm.sh
- APP_DIR_OVERRIDE=/tmp/... PACKAGE_WITH_UPDATER=0 MAX_BUILD_THREADS=32 bash scripts/build-rpm.sh

## CI
Head e3925d4 is green:

- Build App Against Upstream DMG: pass
- Build Debian Package: pass
- Build RPM Package: pass
- Build Pacman Package: pass
- Nix Package Builds: pass
- Rust and Smoke Tests: pass
