### PR TITLE
fix(webview): handle fast-mode guard bundle drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1118,6 +1118,17 @@ test("guards fast-mode model tier lookup when serviceTiers is missing", () => {
   assert.doesNotMatch(patched, /e\.serviceTiers\.length/);
 });
 
+test("guards current fast-mode model tier lookup with an array precheck", () => {
+  const source =
+    "function m(e){return Array.isArray(e.serviceTiers)&&e.serviceTiers.length>0||e.additionalSpeedTiers?.includes(u)===!0}";
+
+  const patched = applyPatchTwice(applyLinuxFastModeModelGuardPatch, source);
+
+  assert.match(patched, /\(e\?\.serviceTiers\?\.length\?\?0\)>0/);
+  assert.doesNotMatch(patched, /Array\.isArray\(e\.serviceTiers\)/);
+  assert.doesNotMatch(patched, /e\.additionalSpeedTiers\?\.includes/);
+});
+
 test("warns when a matched webview opaque bundle has no known insertion point", () => {
   const { warnings } = captureWarns(() =>
     applyLinuxOpaqueWindowsDefaultPatch("function runtime(){let C=theme;if(C.opaqueWindows&&!ba()){}}"),

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -649,6 +649,15 @@ function applyLinuxFastModeModelGuardPatch(currentSource) {
     return currentSource.replace(exactNeedle, exactPatch);
   }
 
+  const arrayGuardNeedle = /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return Array\.isArray\(\2\.serviceTiers\)&&\2\.serviceTiers\.length>0\|\|\2\.additionalSpeedTiers\?\.includes\(([A-Za-z_$][\w$]*)\)===!0\}/u;
+  if (arrayGuardNeedle.test(currentSource)) {
+    return currentSource.replace(
+      arrayGuardNeedle,
+      (match, fnName, modelVar, fastTierVar) =>
+        `function ${fnName}(${modelVar}){return(${modelVar}?.serviceTiers?.length??0)>0||${modelVar}?.additionalSpeedTiers?.includes(${fastTierVar})===!0}`,
+    );
+  }
+
   const driftedNeedle = /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2\.serviceTiers\.length>0\|\|\2\.additionalSpeedTiers\?\.includes\(([A-Za-z_$][\w$]*)\)===!0\}/u;
   if (driftedNeedle.test(currentSource)) {
     return currentSource.replace(


### PR DESCRIPTION
## Summary

- teach the required fast-mode model guard patch to recognize the current upstream Array.isArray serviceTiers shape
- keep the existing null-safe Linux guard replacement so missing serviceTiers cannot crash the fast-mode availability hook
- add targeted patcher coverage for the drifted upstream bundle shape

## Review order

This PR should be reviewed after #322. The code change itself is independent, but its Nix check is currently red only because main lacks #322's PR-only upstream DMG rollout handling. Once #322 lands, this PR should go green after rebase or rerun.

## User-visible behavior

Linux app builds from the current upstream DMG should no longer fail required upstream patch validation because of the fast-mode guard shape.

## Source of truth

- scripts/patches/webview-assets.js
- scripts/patch-linux-window-ui.test.js

## Validation

Local validation:

- node --check scripts/patches/webview-assets.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check origin/main...HEAD

GitHub validation on this draft PR:

- Build App Against Upstream DMG: pass
- Rust and Smoke Tests: pass
- Build Debian Package: pass
- Build RPM Package: pass
- Build Pacman Package: pass
- Nix Package Builds: fail only on the existing upstream Codex app version pin mismatch, which is addressed by #322

## Known scope

This only fixes the fast-mode required patch drift. It intentionally leaves unrelated remote-mobile and subagent drift handling to separate focused changes.