### PR TITLE
fix(nix): refresh pins from current upstream DMG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
                 echo "## Nix Pin Validation"
                 echo ""
                 echo "- Skipped package-output builds because upstream \`Codex.dmg\` metadata is ahead of the committed flake pins during rollout."
-                echo "- This is PR-only; main-branch validation still fails so the scheduled hash-refresh workflow can update pins once the rollout stabilizes."
+                echo "- This is PR-only; main-branch validation still fails so the scheduled hash-refresh workflow can open a full pin-refresh PR from the current upstream DMG."
               } >> "$GITHUB_STEP_SUMMARY"
               echo "skip_package_outputs=true" >> "$GITHUB_OUTPUT"
               rm -f "$validation_log"
@@ -213,7 +213,7 @@ jobs:
                   echo ""
                   echo "- Skipped package-output builds after \`$output\` because upstream \`Codex.dmg\` is rolling between fixed-output hashes."
                   echo "- This does not mask non-DMG Nix failures; main-branch builds still fail on this condition."
-                  echo "- The scheduled hash-refresh workflow owns updating the committed DMG pin once the rollout stabilizes."
+                  echo "- The scheduled hash-refresh workflow owns updating the committed DMG pin from the current upstream DMG."
                 } >> "$GITHUB_STEP_SUMMARY"
                 exit 0
               fi

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -60,7 +60,15 @@ jobs:
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
-          CODEX_VERSION="$(grep -m1 'codexVersion = ' flake.nix | sed 's/.*"\(.*\)".*/\1/')"
+          CODEX_VERSION="$(scripts/ci/update-nix-hashes.sh read-flake-string codexVersion)"
+          APPCAST_VERSION="$(scripts/ci/update-nix-hashes.sh read-appcast-version 2>/dev/null || true)"
+          if [ -n "$APPCAST_VERSION" ] && [ "$APPCAST_VERSION" != "$CODEX_VERSION" ]; then
+            APPCAST_NOTE="- warning: Sparkle appcast currently advertises \`$APPCAST_VERSION\`, while current \`Codex.dmg\` contains \`$CODEX_VERSION\`; this PR follows the verified DMG payload."
+          elif [ -n "$APPCAST_VERSION" ]; then
+            APPCAST_NOTE="- Sparkle appcast also advertises \`$APPCAST_VERSION\`."
+          else
+            APPCAST_NOTE="- Sparkle appcast version could not be read during PR creation; pins follow the verified DMG payload."
+          fi
 
           git config user.name  "codex-dmg-hash-bot"
           git config user.email "actions@github.com"
@@ -68,7 +76,7 @@ jobs:
           git add flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json
           git commit \
             -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
-            -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the upstream Sparkle appcast latest." \
+            -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the current upstream DMG." \
             -m "Verified all Codex Desktop Nix package outputs against the refreshed DMG." \
             -m "[skip ci]"
           git push --force origin "$REFRESH_BRANCH"
@@ -76,9 +84,10 @@ jobs:
           pr_body="$RUNNER_TEMP/nix-refresh-pr-body.md"
           cat >"$pr_body" <<EOF
           ## Summary
-          - refresh Codex.dmg hash and upstream version pins to the Sparkle appcast latest
+          - refresh Codex.dmg hash and upstream version pins to the current upstream DMG
           - update Electron fixed-output hashes when electronVersion changes
           - regenerate nix/native-modules/package-lock.json when native module pins change
+          $APPCAST_NOTE
 
           ## Validation
           - this workflow verified all Codex Desktop Nix package outputs before opening the PR

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-MQHAXf1AMUEVQYxK2H7e4CQZ0Jf3FkxnfdvdRVmtikI=";
+          hash = "sha256-yanuEZhqD4gBWLgeRZtktoRkI5b0nq9/oOAY9KjDe0I=";
         };
 
-        codexVersion = "26.519.41501";
+        codexVersion = "26.519.81530";
         electronVersion = "42.1.0";
         electronPlatform =
           {

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -6,8 +6,8 @@ FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
 UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
-# Upstream Codex Sparkle appcast (x64 runners). Used to gate the pin refresh on
-# the advertised latest release so we never pin a transient mid-rollout DMG.
+# Upstream Codex Sparkle appcast (x64 runners). Used only for reporting when it
+# lags behind the moving Codex.dmg; the verified DMG payload is the pin source.
 APPCAST_URL="${APPCAST_URL:-https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml}"
 
 PACKAGE_OUTPUTS=(
@@ -26,6 +26,20 @@ validate_sri_hash() {
 read_flake_string() {
     local name="$1"
     grep -m1 "$name = " "$FLAKE_FILE" | sed 's/.*"\(.*\)".*/\1/'
+}
+
+fetch_appcast_latest_version() {
+    local url="${1:-$APPCAST_URL}"
+    curl -fsSL --retry 3 "$url" | python3 -c '
+import re
+import sys
+
+xml = sys.stdin.read()
+match = re.search(r"<sparkle:shortVersionString>([^<]+)</sparkle:shortVersionString>", xml)
+if not match:
+    sys.exit("Could not find sparkle:shortVersionString in appcast")
+sys.stdout.write(match.group(1).strip())
+'
 }
 
 prefetch_sri() {
@@ -137,28 +151,29 @@ main() {
     fi
 
     # Refresh the version pins (codexVersion/electronVersion + native-modules)
-    # from the DMG, gated on the upstream Sparkle appcast: only proceed when the
-    # moving Codex.dmg has caught up to the appcast's advertised latest version,
-    # so we never pin a transient mid-rollout build. Exit 75 means "rollout in
-    # progress" and is treated as a no-op skip.
+    # from the current upstream DMG. The appcast can lag the moving DMG for many
+    # hours, so it is reported as metadata instead of blocking the refresh PR.
     local old_electron_version
     old_electron_version="$(read_flake_string electronVersion)"
 
-    local validate_status=0
-    WRITE_PINS=1 APPCAST_URL="$APPCAST_URL" \
-        "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH" || validate_status="$?"
-    if [ "$validate_status" -eq 75 ]; then
-        echo "Upstream rollout in progress; leaving pins unchanged until Codex.dmg matches the appcast."
-        exit 0
+    local appcast_latest_version=""
+    if appcast_latest_version="$(fetch_appcast_latest_version "$APPCAST_URL" 2>/dev/null)"; then
+        echo "Appcast latest version: $appcast_latest_version"
+    else
+        echo "WARN: Could not read upstream appcast version from $APPCAST_URL; continuing with Codex.dmg pins." >&2
     fi
-    if [ "$validate_status" -ne 0 ]; then
-        exit "$validate_status"
-    fi
+
+    WRITE_PINS=1 APPCAST_URL= "$REPO_DIR/scripts/ci/validate-nix-pins.sh" "$UPSTREAM_DMG_PATH"
 
     # If the Electron pin moved, refresh its fixed-output hashes so the verify
     # build does not fail on the new download URLs.
     local new_electron_version
     new_electron_version="$(read_flake_string electronVersion)"
+    local new_codex_version
+    new_codex_version="$(read_flake_string codexVersion)"
+    if [ -n "$appcast_latest_version" ] && [ "$new_codex_version" != "$appcast_latest_version" ]; then
+        echo "WARN: Appcast latest version ($appcast_latest_version) differs from Codex.dmg version ($new_codex_version); proceeding with verified DMG pins." >&2
+    fi
     if [ "$old_electron_version" != "$new_electron_version" ]; then
         echo "Electron pin: $old_electron_version -> $new_electron_version; refreshing electron hashes."
         refresh_electron_hashes "$new_electron_version"
@@ -191,6 +206,20 @@ case "${1:-}" in
             exit 2
         fi
         read_flake_hash "$2" "$3"
+        ;;
+    read-flake-string)
+        if [ "$#" -ne 2 ]; then
+            echo "usage: $0 read-flake-string <name>" >&2
+            exit 2
+        fi
+        read_flake_string "$2"
+        ;;
+    read-appcast-version)
+        if [ "$#" -gt 2 ]; then
+            echo "usage: $0 read-appcast-version [url]" >&2
+            exit 2
+        fi
+        fetch_appcast_latest_version "${2:-$APPCAST_URL}"
         ;;
     "")
         main

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -7,12 +7,10 @@ UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app
 UPSTREAM_DMG_PATH="${1:-${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}}"
 NATIVE_MODULES_PKG="${NATIVE_MODULES_PKG:-$REPO_DIR/nix/native-modules/package.json}"
 
-# Opt-in pin-writing mode (used by the hash-refresh bot, not by PR CI). When set,
-# the version pins are rewritten from the DMG before the assertions run, so they
-# confirm the write instead of failing on drift. APPCAST_URL, when also set,
-# gates the write on the upstream Sparkle appcast: the moving Codex.dmg must
-# already match the appcast's advertised latest version, otherwise we are mid
-# rollout and exit 75 (skip) rather than pinning a transient build.
+# Opt-in pin-writing mode (used by refresh flows, not by PR CI). When set, the
+# version pins are rewritten from the DMG before the assertions run, so they
+# confirm the write instead of failing on drift. APPCAST_URL remains an optional
+# caller-controlled guard for flows that explicitly want Sparkle appcast parity.
 WRITE_PINS="${WRITE_PINS:-0}"
 APPCAST_URL="${APPCAST_URL:-}"
 


### PR DESCRIPTION
## Summary
- make the scheduled Nix refresh follow the verified current Codex.dmg payload even when Sparkle appcast lags
- keep appcast mismatch as a PR-body warning instead of a blocker
- refresh codexDmg.hash and codexVersion for the current 26.519.81530 DMG

## Validation
- bash -n scripts/ci/update-nix-hashes.sh
- bash -n scripts/ci/validate-nix-pins.sh
- YAML parse for .github/workflows/*.yml
- bash -n over extracted workflow run snippets
- scripts/ci/validate-nix-pins.sh /tmp/Codex.dmg
- git diff --check

## Notes
- Local full Nix build was not run because nix is not installed in this workspace; GitHub Actions will run the strict Nix Package Builds job.
- Supersedes #328, which updates only the DMG hash and leaves codexVersion stale.