### PR TITLE
Add niri Computer Use window backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Linux Computer Use is an **opt-in** plugin that lets Codex inspect and control d
 
 - app listing and accessibility trees via AT-SPI
 - screenshots through GNOME Shell DBus or XDG Desktop Portal
-- window listing and focusing on GNOME, KWin/Plasma, Hyprland, and i3
+- window listing and focusing on GNOME, KWin/Plasma, Hyprland, niri, and i3
 - keyboard, text, click, scroll, and drag input through a uinput absolute pointer, the XDG Desktop Portal RemoteDesktop session, or `ydotool`
 
 ### Runtime dependencies
@@ -248,7 +248,7 @@ If you are on Fedora + KDE Plasma and the system unit path is awkward, a user-se
 - old system-level overrides are removed if they force the wrong socket path
 - `codex-computer-use-linux doctor` reports `can_send_development_input: true`
 
-A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway, `xdg-desktop-portal-hyprland` for Hyprland, or your distro's preferred portal backend for i3. GNOME ships a working portal by default.
+A working XDG Desktop Portal implementation is needed if you are not on GNOME — `xdg-desktop-portal-kde` for KDE Plasma, `xdg-desktop-portal-wlr` for sway or niri, `xdg-desktop-portal-hyprland` for Hyprland, or your distro's preferred portal backend for i3. GNOME ships a working portal by default.
 
 ### Verifying readiness
 

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::windowing::registry::{
     self, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, KWIN_BACKEND,
+    HYPRLAND_BACKEND, KWIN_BACKEND, NIRI_BACKEND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -108,6 +108,7 @@ pub struct WindowingReport {
     pub cosmic_helper: Check,
     pub kwin: Check,
     pub hyprland: Check,
+    pub niri: Check,
     pub backends: BTreeMap<String, Check>,
     pub can_list_windows: bool,
     pub can_focus_apps: bool,
@@ -231,6 +232,9 @@ fn capability_map(
     }
     if windowing.hyprland.ok {
         window_backends.push("hyprland".to_string());
+    }
+    if windowing.niri.ok {
+        window_backends.push("niri".to_string());
     }
     if windowing.cosmic_helper.ok {
         window_backends.push("cosmic".to_string());
@@ -564,6 +568,7 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
     let cosmic_helper = backend_check(COSMIC_WAYLAND_BACKEND);
     let kwin = backend_check(KWIN_BACKEND);
     let hyprland = backend_check(HYPRLAND_BACKEND);
+    let niri = backend_check(NIRI_BACKEND);
     let backends = probes
         .iter()
         .map(|probe| (probe.id.to_string(), check_from_backend_probe(probe)))
@@ -578,11 +583,13 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
             "A KWin/Plasma window backend is available for list_windows, focused_window, and targeted input verification."
         } else if hyprland.ok {
             "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
+        } else if niri.ok {
+            "A niri window backend is available for list_windows, focused_window, and targeted input verification."
         } else {
             "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
         }
     } else {
-        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On COSMIC, ensure the bundled COSMIC helper is present and can connect to the session. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session."
+        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On COSMIC, ensure the bundled COSMIC helper is present and can connect to the session. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session. On niri, ensure niri msg is available in the session."
     }
     .to_string();
 
@@ -592,6 +599,7 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
         cosmic_helper,
         kwin,
         hyprland,
+        niri,
         backends,
         can_list_windows,
         can_focus_apps,
@@ -993,6 +1001,7 @@ mod tests {
             cosmic_helper: Check::fail("missing"),
             kwin: Check::fail("not a KWin session"),
             hyprland: Check::fail("not a Hyprland session"),
+            niri: Check::fail("not a niri session"),
             backends: BTreeMap::new(),
             can_list_windows,
             can_focus_apps: true,

--- a/computer-use-linux/src/windowing/backends/mod.rs
+++ b/computer-use-linux/src/windowing/backends/mod.rs
@@ -3,3 +3,4 @@ pub mod gnome;
 pub mod hyprland;
 pub mod i3;
 pub mod kwin;
+pub mod niri;

--- a/computer-use-linux/src/windowing/backends/niri.rs
+++ b/computer-use-linux/src/windowing/backends/niri.rs
@@ -1,0 +1,259 @@
+use crate::terminal::enrich_terminal_windows;
+use crate::windowing::registry::BackendProbe;
+use crate::windowing::types::{WindowBounds, WindowInfo};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+pub const NIRI_BACKEND: &str = "niri";
+
+pub fn probe() -> BackendProbe {
+    match niri_output(&["msg", "-j", "windows"]) {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let ok = matches!(
+                serde_json::from_str::<serde_json::Value>(&stdout),
+                Ok(serde_json::Value::Array(_))
+            );
+            BackendProbe {
+                id: NIRI_BACKEND,
+                ok,
+                can_list_windows: ok,
+                can_focus_apps: ok,
+                can_focus_windows: ok,
+                detail: if ok {
+                    "niri msg -j windows returned a JSON array".to_string()
+                } else {
+                    "niri msg -j windows did not return a JSON array".to_string()
+                },
+            }
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            BackendProbe {
+                id: NIRI_BACKEND,
+                ok: false,
+                can_list_windows: false,
+                can_focus_apps: false,
+                can_focus_windows: false,
+                detail: if stderr.is_empty() { stdout } else { stderr },
+            }
+        }
+        Err(error) => BackendProbe {
+            id: NIRI_BACKEND,
+            ok: false,
+            can_list_windows: false,
+            can_focus_apps: false,
+            can_focus_windows: false,
+            detail: error.to_string(),
+        },
+    }
+}
+
+pub fn list_windows() -> Result<Vec<WindowInfo>> {
+    let output =
+        niri_output(&["msg", "-j", "windows"]).context("failed to run niri msg -j windows")?;
+    if !output.status.success() {
+        bail!(
+            "niri msg -j windows failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    parse_niri_windows(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub fn focused_window() -> Result<Option<WindowInfo>> {
+    let output = niri_output(&["msg", "-j", "focused-window"])
+        .context("failed to run niri msg -j focused-window")?;
+    if !output.status.success() {
+        bail!(
+            "niri msg -j focused-window failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let mut window: Option<WindowInfo> =
+        serde_json::from_slice::<Option<NiriWindow>>(&output.stdout)
+            .context("failed to parse niri focused-window JSON")?
+            .map(WindowInfo::from);
+    if let Some(window) = window.as_mut() {
+        window.backend = NIRI_BACKEND.to_string();
+    }
+    Ok(window)
+}
+
+pub(crate) fn parse_niri_windows(json: &str) -> Result<Vec<WindowInfo>> {
+    let niri_windows: Vec<NiriWindow> =
+        serde_json::from_str(json).context("failed to parse niri msg -j windows output")?;
+
+    let mut windows = niri_windows
+        .into_iter()
+        .map(WindowInfo::from)
+        .collect::<Vec<_>>();
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub fn activate_window(window_id: u64) -> Result<()> {
+    let id = window_id.to_string();
+    let output = niri_output(&["msg", "action", "focus-window", "--id", &id])
+        .with_context(|| format!("failed to run niri msg action focus-window --id {id}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!(
+            "niri msg action focus-window --id {id} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+}
+
+fn niri_output(args: &[&str]) -> std::io::Result<std::process::Output> {
+    Command::new("niri").args(args).output()
+}
+
+fn clean_string(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriWindow {
+    id: u64,
+    title: Option<String>,
+    app_id: Option<String>,
+    pid: Option<i64>,
+    workspace_id: Option<i32>,
+    #[serde(default)]
+    is_focused: bool,
+    layout: Option<NiriWindowLayout>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriWindowLayout {
+    tile_size: Option<[f64; 2]>,
+    window_size: Option<[u32; 2]>,
+    tile_pos_in_workspace_view: Option<[f64; 2]>,
+}
+
+impl From<NiriWindow> for WindowInfo {
+    fn from(window: NiriWindow) -> Self {
+        let bounds = window.layout.as_ref().and_then(niri_window_bounds);
+        let app_id = clean_string(window.app_id);
+
+        WindowInfo {
+            window_id: window.id,
+            title: clean_string(window.title),
+            app_id: app_id.clone(),
+            wm_class: app_id,
+            pid: window.pid.and_then(|pid| u32::try_from(pid).ok()),
+            bounds,
+            workspace: window.workspace_id,
+            focused: window.is_focused,
+            hidden: false,
+            client_type: None,
+            backend: NIRI_BACKEND.to_string(),
+            terminal: None,
+        }
+    }
+}
+
+fn niri_window_bounds(layout: &NiriWindowLayout) -> Option<WindowBounds> {
+    let [width, height] = layout.window_size.or_else(|| {
+        layout
+            .tile_size
+            .map(|[width, height]| [width as u32, height as u32])
+    })?;
+    let [x, y] = layout
+        .tile_pos_in_workspace_view
+        .map(|[x, y]| [Some(x.round() as i32), Some(y.round() as i32)])
+        .unwrap_or([None, None]);
+
+    Some(WindowBounds {
+        x,
+        y,
+        width,
+        height,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_niri_window_json() {
+        let windows = parse_niri_windows(
+            r#"[
+                {
+                    "id": 14,
+                    "title": "Codex",
+                    "app_id": "codex-desktop",
+                    "pid": 16589,
+                    "workspace_id": 3,
+                    "is_focused": false,
+                    "is_floating": false,
+                    "layout": {
+                        "pos_in_scrolling_layout": [3, 1],
+                        "tile_size": [1888.0, 994.0],
+                        "window_size": [1888, 994],
+                        "tile_pos_in_workspace_view": null
+                    }
+                },
+                {
+                    "id": 2,
+                    "title": "tns /m/m/M/g/codex-desktop-linux",
+                    "app_id": "Alacritty",
+                    "pid": 1877,
+                    "workspace_id": 3,
+                    "is_focused": true,
+                    "is_floating": false,
+                    "layout": {
+                        "pos_in_scrolling_layout": [2, 1],
+                        "tile_size": [1888.0, 994.0],
+                        "window_size": [1888, 994],
+                        "tile_pos_in_workspace_view": null
+                    }
+                }
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].window_id, 2);
+        assert_eq!(windows[0].app_id.as_deref(), Some("Alacritty"));
+        assert_eq!(windows[0].pid, Some(1877));
+        assert_eq!(windows[0].workspace, Some(3));
+        assert!(windows[0].focused);
+        assert_eq!(windows[0].bounds.as_ref().unwrap().width, 1888);
+        assert_eq!(windows[0].bounds.as_ref().unwrap().x, None);
+        assert_eq!(windows[0].client_type, None);
+        assert_eq!(windows[0].backend, NIRI_BACKEND);
+    }
+
+    #[test]
+    fn parses_niri_workspace_view_position() {
+        let windows = parse_niri_windows(
+            r#"[
+                {
+                    "id": 3,
+                    "title": "Dialog",
+                    "app_id": "example",
+                    "layout": {
+                        "tile_size": [500.0, 400.0],
+                        "tile_pos_in_workspace_view": [12.5, 20.2]
+                    }
+                }
+            ]"#,
+        )
+        .unwrap();
+
+        assert_eq!(windows[0].bounds.as_ref().unwrap().x, Some(13));
+        assert_eq!(windows[0].bounds.as_ref().unwrap().y, Some(20));
+        assert_eq!(windows[0].client_type, None);
+    }
+}

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 #[allow(unused_imports)]
 pub use registry::{
     COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, WINDOW_PERMISSION_HINT,
+    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, NIRI_BACKEND, WINDOW_PERMISSION_HINT,
 };
 #[allow(unused_imports)]
 pub use target::{
@@ -24,6 +24,7 @@ mod tests {
     use super::backends::kwin::{
         kwin_activate_script_source, kwin_window_id_from_uuid, parse_kwin_windows, KWIN_BACKEND,
     };
+    use super::backends::niri::NIRI_BACKEND;
     use super::registry::{
         descriptors, list_note, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND,
         GNOME_SHELL_INTROSPECT_BACKEND,
@@ -54,6 +55,7 @@ mod tests {
                 COSMIC_WAYLAND_BACKEND,
                 KWIN_BACKEND,
                 HYPRLAND_BACKEND,
+                NIRI_BACKEND,
                 I3_BACKEND,
             ]
         );
@@ -226,6 +228,21 @@ mod tests {
     fn i3_backend_can_exact_focus_targets() {
         let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
         window.backend = I3_BACKEND.to_string();
+
+        ensure_backend_can_focus_target(
+            &WindowTarget {
+                title: Some("Codex".to_string()),
+                ..Default::default()
+            },
+            &window,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn niri_backend_can_exact_focus_targets() {
+        let mut window = window(2, "Codex", "codex-desktop", "codex-desktop");
+        window.backend = NIRI_BACKEND.to_string();
 
         ensure_backend_can_focus_target(
             &WindowTarget {

--- a/computer-use-linux/src/windowing/registry.rs
+++ b/computer-use-linux/src/windowing/registry.rs
@@ -1,4 +1,4 @@
-use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin};
+use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin, niri};
 use crate::windowing::types::WindowInfo;
 use anyhow::{anyhow, Result};
 
@@ -7,8 +7,9 @@ pub use gnome::{GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND};
 pub use hyprland::HYPRLAND_BACKEND;
 pub use i3::I3_BACKEND;
 pub use kwin::KWIN_BACKEND;
+pub use niri::NIRI_BACKEND;
 
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, niri msg, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
 
 #[derive(Debug, Clone, Copy)]
 pub struct BackendDescriptor {
@@ -36,6 +37,7 @@ enum BackendKind {
     Cosmic,
     Kwin,
     Hyprland,
+    Niri,
     I3,
 }
 
@@ -45,6 +47,7 @@ const BACKEND_ORDER: &[BackendKind] = &[
     BackendKind::Cosmic,
     BackendKind::Kwin,
     BackendKind::Hyprland,
+    BackendKind::Niri,
     BackendKind::I3,
 ];
 
@@ -82,6 +85,13 @@ const DESCRIPTORS: &[BackendDescriptor] = &[
         failure_label: "Hyprland",
         list_note: "Window list came from Hyprland hyprctl. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
         missing_hint: "On Hyprland, ensure hyprctl is available in the session.",
+        can_exact_focus: true,
+    },
+    BackendDescriptor {
+        id: NIRI_BACKEND,
+        failure_label: "niri",
+        list_note: "Window list came from niri msg. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
+        missing_hint: "On niri, ensure niri msg can reach the active compositor instance.",
         can_exact_focus: true,
     },
     BackendDescriptor {
@@ -152,6 +162,7 @@ async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
         BackendKind::Cosmic => cosmic::list_windows(),
         BackendKind::Kwin => kwin::list_windows().await,
         BackendKind::Hyprland => hyprland::list_windows(),
+        BackendKind::Niri => niri::list_windows(),
         BackendKind::I3 => i3::list_windows(),
     }
 }
@@ -175,6 +186,7 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
         COSMIC_WAYLAND_BACKEND => cosmic::activate_window(window.window_id),
         KWIN_BACKEND => kwin::activate_window(window.window_id).await,
         HYPRLAND_BACKEND => hyprland::activate_window(window.window_id),
+        NIRI_BACKEND => niri::activate_window(window.window_id),
         I3_BACKEND => i3::activate_window(window.window_id),
         backend => Err(anyhow!(
             "Unsupported window backend for activation: {backend}"
@@ -183,7 +195,10 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
 }
 
 pub fn focused_window_override() -> Option<WindowInfo> {
-    cosmic::focused_window().ok().flatten()
+    niri::focused_window()
+        .ok()
+        .flatten()
+        .or_else(|| cosmic::focused_window().ok().flatten())
 }
 
 pub fn probe_backends() -> Vec<BackendProbe> {
@@ -193,6 +208,7 @@ pub fn probe_backends() -> Vec<BackendProbe> {
         cosmic::probe(),
         kwin::probe(),
         hyprland::probe(),
+        niri::probe(),
         i3::probe(),
     ]
 }
@@ -205,6 +221,7 @@ impl BackendKind {
             BackendKind::Cosmic => COSMIC_WAYLAND_BACKEND,
             BackendKind::Kwin => KWIN_BACKEND,
             BackendKind::Hyprland => HYPRLAND_BACKEND,
+            BackendKind::Niri => NIRI_BACKEND,
             BackendKind::I3 => I3_BACKEND,
         }
     }

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -372,6 +372,8 @@ window_backend_hint() {
     desktop="${desktop,,}"
     if [[ "$desktop" == *hyprland* ]]; then
         printf 'Hyprland -> hyprctl backend'
+    elif [[ "$desktop" == *niri* ]]; then
+        printf 'niri -> niri msg backend'
     elif [[ "$desktop" == *sway* ]]; then
         printf 'Sway -> not explicitly supported by the current i3 backend; verify with Computer Use doctor after install'
     elif [[ "$desktop" == *i3* ]]; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1278,6 +1278,27 @@ test_setup_native_wizard_sway_hint_is_conservative() {
     assert_not_contains "$output_log" "Sway -> i3 IPC backend through swaymsg"
 }
 
+test_setup_native_wizard_niri_hint_reports_backend() {
+    info "Checking setup-native wizard niri backend hint"
+    local workspace="$TMP_DIR/setup-native-niri-hint"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+
+    XDG_CURRENT_DESKTOP=niri \
+    DESKTOP_SESSION=niri \
+    XDG_SESSION_DESKTOP=niri \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_contains "$output_log" "niri -> niri msg backend"
+}
+
 test_setup_native_wizard_cleanup_requires_interactive_confirmation() {
     info "Checking setup-native wizard cleanup refuses non-interactive deletion"
     local workspace="$TMP_DIR/setup-native-cleanup-noninteractive"


### PR DESCRIPTION
## Summary
- add a niri window backend using `niri msg -j windows` and `niri msg action focus-window --id`
- wire niri into Computer Use backend discovery, diagnostics, focused-window lookup, and permission hints
- update setup wizard and README backend documentation

## Testing
- `cargo fmt --check`
- `cargo test -p codex-computer-use-linux windowing::`
- targeted bootstrap wizard niri hint check

Note: full `tests/scripts_smoke.sh` was attempted but the sandbox denied Python localhost socket creation in the webview probe harness, unrelated to this change.