### PR TITLE
Validate app-server schemas during update rebuilds

### DIFF
--- a/scripts/app-server-schema-guard.js
+++ b/scripts/app-server-schema-guard.js
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const REQUIRED_CLIENT_REQUEST_METHODS = [
+  "initialize",
+  "thread/list",
+  "thread/loaded/list",
+  "plugin/list",
+  "plugin/installed",
+  "plugin/read",
+  "plugin/install",
+  "plugin/uninstall",
+  "app/list",
+  "mcpServerStatus/list",
+  "mcpServer/resource/read",
+  "mcpServer/tool/call",
+  "skills/list",
+  "skills/config/write",
+  "model/list",
+  "modelProvider/capabilities/read",
+  "experimentalFeature/list",
+  "experimentalFeature/enablement/set",
+  "permissionProfile/list",
+  "collaborationMode/list",
+  "fs/createDirectory",
+  "fs/copy",
+  "fs/getMetadata",
+  "fs/readDirectory",
+  "fs/readFile",
+  "fs/remove",
+  "fs/unwatch",
+  "fs/watch",
+  "fs/writeFile",
+  "config/read",
+  "configRequirements/read",
+  "externalAgentConfig/detect",
+  "externalAgentConfig/import",
+  "command/exec",
+  "thread/start",
+  "thread/read",
+  "thread/goal/get",
+  "thread/goal/set",
+  "thread/goal/clear",
+];
+
+const REQUIRED_SERVER_NOTIFICATION_METHODS = [
+  "remoteControl/status/changed",
+  "app/list/updated",
+  "command/exec/outputDelta",
+  "fs/changed",
+];
+
+const OPTIONAL_PARITY_CLIENT_REQUEST_METHODS = [
+  "remoteControl/status/read",
+  "remoteControl/enable",
+  "remoteControl/disable",
+  "marketplace/add",
+  "marketplace/upgrade",
+  "thread/read",
+  "thread/resume",
+  "thread/fork",
+  "thread/goal/get",
+  "thread/goal/set",
+  "thread/rollback",
+  "review/start",
+  "fs/readFile",
+  "fs/writeFile",
+  "fs/readDirectory",
+  "process/spawn",
+  "process/kill",
+];
+
+const REQUIRED_SCHEMA_FILES = [
+  "ClientRequest.json",
+  "ServerNotification.json",
+  "v1/InitializeParams.json",
+  "v1/InitializeResponse.json",
+  "v2/ThreadListParams.json",
+  "v2/ThreadListResponse.json",
+  "v2/ThreadLoadedListParams.json",
+  "v2/ThreadLoadedListResponse.json",
+  "v2/PluginListParams.json",
+  "v2/PluginListResponse.json",
+  "v2/PluginInstalledParams.json",
+  "v2/PluginInstalledResponse.json",
+  "v2/PluginReadParams.json",
+  "v2/PluginReadResponse.json",
+  "v2/PluginInstallParams.json",
+  "v2/PluginInstallResponse.json",
+  "v2/PluginUninstallParams.json",
+  "v2/PluginUninstallResponse.json",
+  "v2/AppsListParams.json",
+  "v2/AppsListResponse.json",
+  "v2/ListMcpServerStatusParams.json",
+  "v2/ListMcpServerStatusResponse.json",
+  "v2/McpResourceReadParams.json",
+  "v2/McpResourceReadResponse.json",
+  "v2/McpServerToolCallParams.json",
+  "v2/McpServerToolCallResponse.json",
+  "v2/SkillsListParams.json",
+  "v2/SkillsListResponse.json",
+  "v2/SkillsConfigWriteParams.json",
+  "v2/SkillsConfigWriteResponse.json",
+  "v2/ModelListParams.json",
+  "v2/ModelListResponse.json",
+  "v2/ModelProviderCapabilitiesReadParams.json",
+  "v2/ModelProviderCapabilitiesReadResponse.json",
+  "v2/ExperimentalFeatureListParams.json",
+  "v2/ExperimentalFeatureListResponse.json",
+  "v2/ExperimentalFeatureEnablementSetParams.json",
+  "v2/ExperimentalFeatureEnablementSetResponse.json",
+  "v2/PermissionProfileListParams.json",
+  "v2/PermissionProfileListResponse.json",
+  "v2/CollaborationModeListParams.json",
+  "v2/CollaborationModeListResponse.json",
+  "v2/FsCreateDirectoryParams.json",
+  "v2/FsCreateDirectoryResponse.json",
+  "v2/FsCopyParams.json",
+  "v2/FsCopyResponse.json",
+  "v2/FsGetMetadataParams.json",
+  "v2/FsGetMetadataResponse.json",
+  "v2/FsReadDirectoryParams.json",
+  "v2/FsReadDirectoryResponse.json",
+  "v2/FsReadFileParams.json",
+  "v2/FsReadFileResponse.json",
+  "v2/FsRemoveParams.json",
+  "v2/FsRemoveResponse.json",
+  "v2/FsUnwatchParams.json",
+  "v2/FsUnwatchResponse.json",
+  "v2/FsWatchParams.json",
+  "v2/FsWatchResponse.json",
+  "v2/FsWriteFileParams.json",
+  "v2/FsWriteFileResponse.json",
+  "v2/FsChangedNotification.json",
+  "v2/ConfigReadParams.json",
+  "v2/ConfigReadResponse.json",
+  "v2/ConfigRequirementsReadResponse.json",
+  "v2/ExternalAgentConfigDetectParams.json",
+  "v2/ExternalAgentConfigDetectResponse.json",
+  "v2/ExternalAgentConfigImportParams.json",
+  "v2/ExternalAgentConfigImportResponse.json",
+  "v2/CommandExecParams.json",
+  "v2/CommandExecResponse.json",
+  "v2/CommandExecOutputDeltaNotification.json",
+  "v2/ThreadStartParams.json",
+  "v2/ThreadStartResponse.json",
+  "v2/ThreadReadParams.json",
+  "v2/ThreadReadResponse.json",
+  "v2/ThreadGoalGetParams.json",
+  "v2/ThreadGoalGetResponse.json",
+  "v2/ThreadGoalSetParams.json",
+  "v2/ThreadGoalSetResponse.json",
+  "v2/ThreadGoalClearParams.json",
+  "v2/ThreadGoalClearResponse.json",
+  "v2/AppListUpdatedNotification.json",
+  "v2/RemoteControlStatusChangedNotification.json",
+];
+
+function usage() {
+  return [
+    "Usage: app-server-schema-guard.js [options]",
+    "",
+    "Generates or reads Codex app-server JSON schemas and checks that the",
+    "Linux desktop parity probes still have the protocol surface they need.",
+    "",
+    "Options:",
+    "  --json                 Print JSON summary",
+    "  --codex-bin PATH       Codex CLI binary to use (default: codex)",
+    "  --schema-dir DIR       Read existing schema bundle instead of generating one",
+    "  --keep-output DIR      Generate schema bundle into DIR and keep it",
+    "  --timeout-ms MS        Timeout for schema generation (default: 30000)",
+    "  --no-experimental      Omit --experimental when generating schemas",
+    "  -h, --help             Show this help",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const timeoutMs = Number.parseInt(process.env.CODEX_SCHEMA_GUARD_TIMEOUT_MS || "30000", 10);
+  const options = {
+    codexBin: process.env.CODEX_PARITY_CODEX_BIN || "codex",
+    experimental: true,
+    json: false,
+    keepOutput: null,
+    schemaDir: null,
+    timeoutMs,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--codex-bin") {
+      options.codexBin = argv[index + 1];
+      if (!options.codexBin) {
+        throw new Error(usage());
+      }
+      index += 1;
+    } else if (arg === "--schema-dir") {
+      options.schemaDir = argv[index + 1];
+      if (!options.schemaDir) {
+        throw new Error(usage());
+      }
+      index += 1;
+    } else if (arg === "--keep-output") {
+      options.keepOutput = argv[index + 1];
+      if (!options.keepOutput) {
+        throw new Error(usage());
+      }
+      index += 1;
+    } else if (arg === "--timeout-ms") {
+      options.timeoutMs = Number.parseInt(argv[index + 1], 10);
+      if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+        throw new Error(usage());
+      }
+      index += 1;
+    } else if (arg === "--no-experimental") {
+      options.experimental = false;
+    } else if (arg === "-h" || arg === "--help") {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+    }
+  }
+
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error(usage());
+  }
+
+  return options;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function collectMethods(schemaPath) {
+  const schema = readJson(schemaPath);
+  const methods = [];
+  for (const variant of schema.oneOf || []) {
+    const method = variant?.properties?.method?.enum?.[0];
+    if (typeof method === "string") {
+      methods.push(method);
+    }
+  }
+  return methods.sort();
+}
+
+function missingFrom(expected, actualSet) {
+  return expected.filter((name) => !actualSet.has(name));
+}
+
+function generateSchemas(options) {
+  if (options.schemaDir) {
+    return { cleanup: null, schemaDir: path.resolve(options.schemaDir) };
+  }
+
+  const schemaDir = options.keepOutput
+    ? path.resolve(options.keepOutput)
+    : fs.mkdtempSync(path.join(os.tmpdir(), "codex-app-server-schema-"));
+  fs.mkdirSync(schemaDir, { recursive: true });
+
+  const args = ["app-server", "generate-json-schema", "--out", schemaDir];
+  if (options.experimental) {
+    args.push("--experimental");
+  }
+  const result = spawnSync(options.codexBin, args, {
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+    timeout: options.timeoutMs,
+  });
+  if (result.error) {
+    throw new Error(`failed to generate app-server JSON schemas: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = String(result.stderr || result.stdout || "").trim();
+    throw new Error(`failed to generate app-server JSON schemas: ${stderr || `exit ${result.status}`}`);
+  }
+
+  return {
+    cleanup: options.keepOutput
+      ? null
+      : () => fs.rmSync(schemaDir, { force: true, recursive: true }),
+    schemaDir,
+  };
+}
+
+function run(options) {
+  const generated = generateSchemas(options);
+  try {
+    const requiredFileMissing = REQUIRED_SCHEMA_FILES.filter((relativePath) => {
+      return !fs.existsSync(path.join(generated.schemaDir, relativePath));
+    });
+    const clientMethods = collectMethods(path.join(generated.schemaDir, "ClientRequest.json"));
+    const serverNotifications = collectMethods(path.join(generated.schemaDir, "ServerNotification.json"));
+    const clientMethodSet = new Set(clientMethods);
+    const serverNotificationSet = new Set(serverNotifications);
+
+    const missingRequiredClientMethods = missingFrom(REQUIRED_CLIENT_REQUEST_METHODS, clientMethodSet);
+    const missingRequiredServerNotifications = missingFrom(
+      REQUIRED_SERVER_NOTIFICATION_METHODS,
+      serverNotificationSet,
+    );
+    const missingOptionalClientMethods = missingFrom(OPTIONAL_PARITY_CLIENT_REQUEST_METHODS, clientMethodSet);
+
+    const ok =
+      requiredFileMissing.length === 0 &&
+      missingRequiredClientMethods.length === 0 &&
+      missingRequiredServerNotifications.length === 0;
+
+    return {
+      ok,
+      schemaDir: options.keepOutput || options.schemaDir ? generated.schemaDir : null,
+      counts: {
+        clientRequestMethods: clientMethods.length,
+        serverNotifications: serverNotifications.length,
+        requiredClientMethods: REQUIRED_CLIENT_REQUEST_METHODS.length,
+        requiredServerNotifications: REQUIRED_SERVER_NOTIFICATION_METHODS.length,
+        optionalClientMethods: OPTIONAL_PARITY_CLIENT_REQUEST_METHODS.length,
+        optionalClientMethodsPresent:
+          OPTIONAL_PARITY_CLIENT_REQUEST_METHODS.length - missingOptionalClientMethods.length,
+      },
+      missing: {
+        requiredFiles: requiredFileMissing,
+        requiredClientMethods: missingRequiredClientMethods,
+        requiredServerNotifications: missingRequiredServerNotifications,
+        optionalClientMethods: missingOptionalClientMethods,
+      },
+    };
+  } finally {
+    if (generated.cleanup) {
+      generated.cleanup();
+    }
+  }
+}
+
+function printText(summary) {
+  console.log(
+    `[schema] result=${summary.ok ? "pass" : "fail"} ` +
+      `clientMethods=${summary.counts.clientRequestMethods} ` +
+      `serverNotifications=${summary.counts.serverNotifications} ` +
+      `optionalPresent=${summary.counts.optionalClientMethodsPresent}/${summary.counts.optionalClientMethods}`,
+  );
+  for (const [key, value] of Object.entries(summary.missing)) {
+    if (value.length > 0) {
+      console.log(`[schema] missing ${key}: ${value.join(", ")}`);
+    }
+  }
+  if (summary.schemaDir) {
+    console.log(`[schema] output=${summary.schemaDir}`);
+  }
+}
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+    const summary = run(options);
+    if (options.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      printText(summary);
+    }
+    if (!summary.ok) {
+      process.exit(1);
+    }
+  } catch (error) {
+    const summary = { ok: false, error: error.message };
+    if (options?.json) {
+      console.log(JSON.stringify(summary, null, 2));
+    } else {
+      console.error(`[schema] FAIL ${error.message}`);
+    }
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  OPTIONAL_PARITY_CLIENT_REQUEST_METHODS,
+  REQUIRED_CLIENT_REQUEST_METHODS,
+  REQUIRED_SCHEMA_FILES,
+  REQUIRED_SERVER_NOTIFICATION_METHODS,
+  run,
+};

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -249,6 +249,7 @@ run_core_job() {
     for file in scripts/patches/*.js; do
         node --check "$file"
     done
+    node --check scripts/app-server-schema-guard.js
     node --check scripts/ci/validate-patch-report.js
     node --test scripts/patch-linux-window-ui.test.js
 
@@ -280,6 +281,8 @@ run_deb_job() {
     assert_contains_file /tmp/deb-contents.txt './usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/launcher/webview-server.py'
+    assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/scripts/ci/validate-patch-report.js'
+    assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/scripts/app-server-schema-guard.js'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist
@@ -335,6 +338,8 @@ run_rpm_job() {
     assert_contains_file /tmp/rpm-contents.txt '/usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/launcher/webview-server.py'
+    assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/scripts/ci/validate-patch-report.js'
+    assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/scripts/app-server-schema-guard.js'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist
@@ -384,6 +389,8 @@ run_pacman_job() {
     assert_contains_file /tmp/pacman-contents.txt 'usr/lib/systemd/user/codex-update-manager.service'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/launcher/webview-server.py'
+    assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/scripts/ci/validate-patch-report.js'
+    assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/scripts/app-server-schema-guard.js'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -540,6 +540,7 @@ stage_update_builder_bundle() {
     mkdir -p \
         "$update_builder_root/scripts" \
         "$update_builder_root/scripts/lib" \
+        "$update_builder_root/scripts/ci" \
         "$update_builder_root/scripts/patches" \
         "$update_builder_root/launcher" \
         "$update_builder_root/linux-features" \
@@ -563,6 +564,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/build-rpm.sh" "$update_builder_root/scripts/build-rpm.sh"
     cp "$REPO_DIR/scripts/build-pacman.sh" "$update_builder_root/scripts/build-pacman.sh"
     cp "$REPO_DIR/scripts/rebuild-candidate.sh" "$update_builder_root/scripts/rebuild-candidate.sh"
+    cp "$REPO_DIR/scripts/app-server-schema-guard.js" "$update_builder_root/scripts/app-server-schema-guard.js"
     cp "$REPO_DIR/scripts/patch-linux-window-ui.js" "$update_builder_root/scripts/patch-linux-window-ui.js"
     cp -r "$REPO_DIR/scripts/patches/." "$update_builder_root/scripts/patches/"
     cp "$REPO_DIR/scripts/lib/package-common.sh" "$update_builder_root/scripts/lib/package-common.sh"
@@ -583,6 +585,8 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/lib/rebuild-report.sh" "$update_builder_root/scripts/lib/rebuild-report.sh"
     cp "$REPO_DIR/scripts/lib/build-info.js" "$update_builder_root/scripts/lib/build-info.js"
     cp "$REPO_DIR/scripts/lib/build-info.sh" "$update_builder_root/scripts/lib/build-info.sh"
+    cp "$REPO_DIR/scripts/ci/validate-patch-report.js" \
+        "$update_builder_root/scripts/ci/validate-patch-report.js"
     cp "$REPO_DIR/packaging/linux/control" "$update_builder_root/packaging/linux/control"
     cp "$REPO_DIR/packaging/linux/codex-desktop.spec" "$update_builder_root/packaging/linux/codex-desktop.spec"
     cp "$REPO_DIR/packaging/linux/codex-desktop.desktop" "$update_builder_root/packaging/linux/codex-desktop.desktop"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -232,6 +232,8 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-features.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-features.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-target-context.js"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/app-server-schema-guard.js"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/ci/validate-patch-report.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/engine.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/registry.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/shared.js"
@@ -1537,6 +1539,60 @@ test_upstream_build_app_workflow_tracks_dmg_metadata() {
     assert_contains "$workflow" 'make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg'
     assert_contains "$workflow" 'DMG Last-Modified'
     assert_contains "$workflow" 'DMG SHA-256'
+}
+
+test_app_server_schema_guard_static_contract() {
+    info "Checking app-server schema guard static contract"
+    local guard="$REPO_DIR/scripts/app-server-schema-guard.js"
+
+    assert_file_exists "$guard"
+    node --check "$guard"
+    assert_contains "$guard" "app-server"
+    assert_contains "$guard" "generate-json-schema"
+    assert_contains "$guard" "v2/PluginInstallParams.json"
+    assert_contains "$guard" "v2/McpServerToolCallParams.json"
+    assert_contains "$guard" "v2/ConfigReadResponse.json"
+    assert_contains "$guard" "v2/AppsListResponse.json"
+    assert_contains "$guard" "v2/CommandExecResponse.json"
+    assert_contains "$guard" "v2/RemoteControlStatusChangedNotification.json"
+    assert_contains "$guard" "v2/AppListUpdatedNotification.json"
+    assert_contains "$guard" "v2/CommandExecOutputDeltaNotification.json"
+    assert_contains "$guard" "thread/goal/set"
+    assert_contains "$guard" "fs/writeFile"
+
+    node - "$guard" "$TMP_DIR/schema-guard-fixture" <<'NODE' \
+        || fail "Expected app-server schema guard to validate schema-dir fixtures"
+const fs = require("node:fs");
+const path = require("node:path");
+const guard = require(process.argv[2]);
+const schemaDir = process.argv[3];
+fs.rmSync(schemaDir, { force: true, recursive: true });
+for (const relativePath of guard.REQUIRED_SCHEMA_FILES) {
+  const filePath = path.join(schemaDir, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "{}\n");
+}
+const variant = (method) => ({ properties: { method: { enum: [method] } } });
+fs.writeFileSync(
+  path.join(schemaDir, "ClientRequest.json"),
+  JSON.stringify({ oneOf: guard.REQUIRED_CLIENT_REQUEST_METHODS.map(variant) }),
+);
+fs.writeFileSync(
+  path.join(schemaDir, "ServerNotification.json"),
+  JSON.stringify({ oneOf: guard.REQUIRED_SERVER_NOTIFICATION_METHODS.map(variant) }),
+);
+let summary = guard.run({ schemaDir, keepOutput: null });
+if (!summary.ok) {
+  console.error(summary);
+  process.exit(1);
+}
+fs.rmSync(path.join(schemaDir, "v2/CommandExecResponse.json"));
+summary = guard.run({ schemaDir, keepOutput: null });
+if (summary.ok || !summary.missing.requiredFiles.includes("v2/CommandExecResponse.json")) {
+  console.error(summary);
+  process.exit(1);
+}
+NODE
 }
 
 test_installer_detects_electron_version_from_plist() {
@@ -5014,6 +5070,7 @@ main() {
     test_setup_native_wizard_dry_run_cleanup_does_not_delete_confirmed_paths
     test_setup_native_wizard_cleanup_deletes_only_confirmed_paths
     test_upstream_build_app_workflow_tracks_dmg_metadata
+    test_app_server_schema_guard_static_contract
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata
     test_port_validation_rejects_oversized_numeric_values

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -1,6 +1,7 @@
 //! Rebuilds native Linux packages from a downloaded upstream DMG.
 
 use crate::{
+    codex_cli,
     config::{RuntimeConfig, RuntimePaths},
     install::PackageKind,
     state::{ArtifactPaths, PersistedState, UpdateStatus},
@@ -14,7 +15,7 @@ use std::{
 use tokio::process::Command;
 use tracing::info;
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 17] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 19] = [
     ("Cargo.toml", "Cargo.toml"),
     ("Cargo.lock", "Cargo.lock"),
     ("computer-use-linux", "computer-use-linux"),
@@ -36,8 +37,13 @@ const REQUIRED_BUNDLE_FILES: [(&str, &str); 17] = [
         "scripts/patch-linux-window-ui.js",
         "scripts/patch-linux-window-ui.js",
     ),
+    (
+        "scripts/app-server-schema-guard.js",
+        "scripts/app-server-schema-guard.js",
+    ),
     ("scripts/patches", "scripts/patches"),
     ("scripts/lib", "scripts/lib"),
+    ("scripts/ci", "scripts/ci"),
     ("packaging/linux", "packaging/linux"),
     ("assets/codex.png", "assets/codex.png"),
     ("linux-features", "linux-features"),
@@ -109,6 +115,11 @@ pub async fn build_update(
     .await
     .context("install.sh failed during local rebuild")?;
 
+    let schema_guard_node = schema_guard_node_program(&config.builder_bundle_root);
+    run_app_server_schema_guard(state, paths, &workspace, &build_path, &schema_guard_node)
+        .await
+        .context("app-server schema guard failed during local rebuild")?;
+
     state.status = UpdateStatus::BuildingPackage;
     state.save(&paths.state_file)?;
 
@@ -157,6 +168,7 @@ struct BuilderWorkspace {
     app_dir: PathBuf,
     reports_dir: PathBuf,
     install_log: PathBuf,
+    schema_guard_log: PathBuf,
     build_log: PathBuf,
 }
 
@@ -169,6 +181,7 @@ impl BuilderWorkspace {
         let logs_dir = workspace_dir.join("logs");
         let reports_dir = workspace_dir.join("reports");
         let install_log = logs_dir.join("install.log");
+        let schema_guard_log = logs_dir.join("app-server-schema-guard.log");
         let build_log = logs_dir.join("build-package.log");
 
         if workspace_dir.exists() {
@@ -188,9 +201,52 @@ impl BuilderWorkspace {
             app_dir,
             reports_dir,
             install_log,
+            schema_guard_log,
             build_log,
         })
     }
+}
+
+fn schema_guard_cli_path(state: &PersistedState) -> Result<PathBuf> {
+    codex_cli::resolve_cli_path(state.cli_path.as_deref())
+        .context("Codex CLI is required to validate app-server schema during local rebuild")
+}
+
+fn schema_guard_node_program(builder_bundle_root: &Path) -> PathBuf {
+    let managed_node = builder_bundle_root.join("node-runtime/bin/node");
+    if managed_node.is_file() {
+        managed_node
+    } else {
+        PathBuf::from("node")
+    }
+}
+
+async fn run_app_server_schema_guard(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    workspace: &BuilderWorkspace,
+    build_path: &OsString,
+    node_program: &Path,
+) -> Result<()> {
+    let cli_path = schema_guard_cli_path(state)?;
+    state.cli_path = Some(cli_path.clone());
+    state.save(&paths.state_file)?;
+
+    run_and_log(
+        Command::new(node_program)
+            .arg(
+                workspace
+                    .bundle_dir
+                    .join("scripts/app-server-schema-guard.js"),
+            )
+            .arg("--codex-bin")
+            .arg(&cli_path)
+            .arg("--json")
+            .env("PATH", build_path)
+            .current_dir(&workspace.bundle_dir),
+        &workspace.schema_guard_log,
+    )
+    .await
 }
 
 /// Returns the path to the native-package build script appropriate for the running system.
@@ -416,7 +472,7 @@ async fn run_and_log(command: &mut Command, log_path: &Path) -> Result<()> {
     let mut combined = Vec::new();
     combined.extend_from_slice(&output.stdout);
     combined.extend_from_slice(&output.stderr);
-    fs::write(log_path, &combined)
+    fs::write(log_path, redact_command_log(&combined))
         .with_context(|| format!("Failed to write {}", log_path.display()))?;
 
     if !output.status.success() {
@@ -428,6 +484,276 @@ async fn run_and_log(command: &mut Command, log_path: &Path) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn redact_command_log(bytes: &[u8]) -> Vec<u8> {
+    let text = String::from_utf8_lossy(bytes);
+    let without_pem = redact_pem_blocks(&text);
+    let without_bearer = redact_after_prefix(
+        &redact_after_prefix(&without_pem, "Bearer ", "Bearer <redacted>"),
+        "bearer ",
+        "bearer <redacted>",
+    );
+    let without_api_keys = redact_prefixed_token(&without_bearer, "sk-", "sk-<redacted>");
+    redact_sensitive_fields(&without_api_keys).into_bytes()
+}
+
+fn redact_sensitive_fields(input: &str) -> String {
+    const FIELDS: &[&str] = &[
+        "pairingCode",
+        "pairing_code",
+        "accountId",
+        "account_id",
+        "accountUserId",
+        "account_user_id",
+        "accessToken",
+        "access_token",
+        "apiKey",
+        "api_key",
+        "authToken",
+        "auth_token",
+        "authorization",
+        "browserProfile",
+        "browser_profile",
+        "browserProfilePath",
+        "browser_profile_path",
+        "conversationId",
+        "conversation_id",
+        "cookie",
+        "cookies",
+        "deviceKey",
+        "device_key",
+        "email",
+        "idToken",
+        "id_token",
+        "clientId",
+        "client_id",
+        "clientSecret",
+        "client_secret",
+        "installationId",
+        "installation_id",
+        "environmentId",
+        "environment_id",
+        "keyId",
+        "key_id",
+        "password",
+        "privateKey",
+        "private_key",
+        "privateKeyPkcs8Pem",
+        "private_key_pkcs8_pem",
+        "profilePath",
+        "profile_path",
+        "refreshToken",
+        "refresh_token",
+        "remoteControlToken",
+        "remote_control_token",
+        "secret",
+        "sensitive",
+        "stepUpToken",
+        "step_up_token",
+        "tabTitle",
+        "tabUrl",
+        "threadId",
+        "thread_id",
+        "conversationText",
+        "threadPreview",
+        "token",
+        "screenshot",
+    ];
+    let mut output = redact_url_tokens(input);
+    for field in FIELDS {
+        output = redact_named_field(&output, field);
+    }
+    output
+}
+
+fn redact_url_tokens(input: &str) -> String {
+    let with_https = redact_after_prefix(input, "https://", "<url-redacted>");
+    redact_after_prefix(&with_https, "http://", "<url-redacted>")
+}
+
+fn redact_named_field(input: &str, field: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut search_start = 0;
+
+    while let Some(relative_index) = input[search_start..].find(field) {
+        let field_start = search_start + relative_index;
+        if let Some((value_start, value_end)) = field_value_span(input, field, field_start) {
+            output.push_str(&input[search_start..value_start]);
+            output.push_str("<redacted>");
+            search_start = value_end;
+        } else {
+            let field_end = field_start + field.len();
+            output.push_str(&input[search_start..field_end]);
+            search_start = field_end;
+        }
+    }
+
+    output.push_str(&input[search_start..]);
+    output
+}
+
+fn field_value_span(input: &str, field: &str, field_start: usize) -> Option<(usize, usize)> {
+    let field_end = field_start + field.len();
+    let previous = input[..field_start].chars().next_back();
+    let next = input[field_end..].chars().next();
+
+    let delimiter_start = if matches!(previous, Some('"') | Some('\'')) && next == previous {
+        field_end + next?.len_utf8()
+    } else {
+        if previous.is_some_and(is_identifier_char) || next.is_some_and(is_identifier_char) {
+            return None;
+        }
+        field_end
+    };
+
+    let delimiter_index = skip_whitespace(input, delimiter_start);
+    let delimiter = input[delimiter_index..].chars().next()?;
+    if !matches!(delimiter, ':' | '=') {
+        return None;
+    }
+
+    let value_start = skip_whitespace(input, delimiter_index + delimiter.len_utf8());
+    let value_char = input[value_start..].chars().next()?;
+    if matches!(value_char, '"' | '\'') {
+        let content_start = value_start + value_char.len_utf8();
+        return find_closing_quote(input, content_start, value_char)
+            .map(|content_end| (content_start, content_end));
+    }
+    if value_char == '{' {
+        return find_balanced_value(input, value_start, '{', '}')
+            .map(|value_end| (value_start, value_end));
+    }
+    if value_char == '[' {
+        return find_balanced_value(input, value_start, '[', ']')
+            .map(|value_end| (value_start, value_end));
+    }
+
+    let value_end = input[value_start..]
+        .find(|ch: char| {
+            ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | ';' | ')' | '}' | ']')
+        })
+        .map(|end| value_start + end)
+        .unwrap_or(input.len());
+    (value_end > value_start).then_some((value_start, value_end))
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-')
+}
+
+fn skip_whitespace(input: &str, start: usize) -> usize {
+    let mut index = start;
+    for ch in input[start..].chars() {
+        if !ch.is_whitespace() {
+            break;
+        }
+        index += ch.len_utf8();
+    }
+    index
+}
+
+fn find_closing_quote(input: &str, start: usize, quote: char) -> Option<usize> {
+    let mut escaped = false;
+    for (offset, ch) in input[start..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == quote {
+            return Some(start + offset);
+        }
+    }
+    None
+}
+
+fn find_balanced_value(input: &str, start: usize, open: char, close: char) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut quoted = None;
+    let mut escaped = false;
+    for (offset, ch) in input[start..].char_indices() {
+        if let Some(quote) = quoted {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                quoted = None;
+            }
+            continue;
+        }
+
+        if matches!(ch, '"' | '\'') {
+            quoted = Some(ch);
+        } else if ch == open {
+            depth += 1;
+        } else if ch == close {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return Some(start + offset + ch.len_utf8());
+            }
+        }
+    }
+    None
+}
+
+fn redact_pem_blocks(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("-----BEGIN ") {
+        output.push_str(&rest[..start]);
+        output.push_str("<pem-redacted>");
+        let after_begin = &rest[start + "-----BEGIN ".len()..];
+        let Some(end_relative) = after_begin.find("-----END ") else {
+            rest = "";
+            break;
+        };
+        let after_end = &after_begin[end_relative + "-----END ".len()..];
+        let Some(end_marker_relative) = after_end.find("-----") else {
+            rest = "";
+            break;
+        };
+        rest = &after_end[end_marker_relative + "-----".len()..];
+    }
+    output.push_str(rest);
+    output
+}
+
+fn redact_after_prefix(input: &str, prefix: &str, replacement: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(index) = rest.find(prefix) {
+        output.push_str(&rest[..index]);
+        output.push_str(replacement);
+        let token_start = index + prefix.len();
+        let token_end = rest[token_start..]
+            .find(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | ';' | ')'))
+            .map(|end| token_start + end)
+            .unwrap_or(rest.len());
+        rest = &rest[token_end..];
+    }
+    output.push_str(rest);
+    output
+}
+
+fn redact_prefixed_token(input: &str, prefix: &str, replacement: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(index) = rest.find(prefix) {
+        output.push_str(&rest[..index]);
+        output.push_str(replacement);
+        let token_end = rest[index..]
+            .find(|ch: char| ch.is_whitespace() || matches!(ch, '"' | '\'' | ',' | ';' | ')'))
+            .map(|end| index + end)
+            .unwrap_or(rest.len());
+        rest = &rest[token_end..];
+    }
+    output.push_str(rest);
+    output
 }
 
 #[cfg(test)]
@@ -546,6 +872,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         let state_root = temp.path().join("state");
         let cache_root = temp.path().join("cache");
         fs::create_dir_all(bundle_root.join("scripts/lib"))?;
+        fs::create_dir_all(bundle_root.join("scripts/ci"))?;
         fs::create_dir_all(bundle_root.join("scripts/patches"))?;
         fs::create_dir_all(bundle_root.join("launcher"))?;
         fs::create_dir_all(bundle_root.join("packaging/linux"))?;
@@ -652,6 +979,10 @@ fi
             b"console.log('patched');\n",
         )?;
         fs::write(
+            bundle_root.join("scripts/app-server-schema-guard.js"),
+            b"#!/usr/bin/env node\n",
+        )?;
+        fs::write(
             bundle_root.join("scripts/patches/registry.js"),
             b"module.exports = {};\n",
         )?;
@@ -662,6 +993,10 @@ fi
         fs::write(
             bundle_root.join("scripts/lib/node-runtime.sh"),
             b"#!/bin/bash\n",
+        )?;
+        fs::write(
+            bundle_root.join("scripts/ci/validate-patch-report.js"),
+            b"#!/usr/bin/env node\n",
         )?;
 
         let paths = RuntimePaths {
@@ -686,8 +1021,16 @@ fi
         };
         let dmg_path = temp.path().join("Codex.dmg");
         fs::write(&dmg_path, b"dmg")?;
+        let fake_codex = temp.path().join("codex");
+        fs::write(&fake_codex, b"#!/bin/sh\necho codex 0.0.0\n")?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&fake_codex, fs::Permissions::from_mode(0o755))?;
+        }
 
         let mut state = PersistedState::new(true);
+        state.cli_path = Some(fake_codex.clone());
         let artifacts = build_update(
             &config,
             &mut state,
@@ -717,6 +1060,14 @@ fi
             .exists());
         assert!(artifacts
             .workspace_dir
+            .join("builder/scripts/app-server-schema-guard.js")
+            .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("builder/scripts/ci/validate-patch-report.js")
+            .exists());
+        assert!(artifacts
+            .workspace_dir
             .join("builder/linux-features/features.example.json")
             .exists());
         assert!(artifacts
@@ -727,6 +1078,11 @@ fi
             .workspace_dir
             .join("reports/rebuild-report.json")
             .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("logs/app-server-schema-guard.log")
+            .exists());
+        assert_eq!(state.cli_path.as_deref(), Some(fake_codex.as_path()));
         assert!(
             is_native_package_file(&artifacts.package_path),
             "expected a native package (.deb, .rpm, or .pkg.tar.zst), got {}",
@@ -742,6 +1098,7 @@ fi
         let destination_root = temp.path().join("destination");
 
         fs::create_dir_all(source_root.join("scripts/lib"))?;
+        fs::create_dir_all(source_root.join("scripts/ci"))?;
         fs::create_dir_all(source_root.join("scripts/patches"))?;
         fs::create_dir_all(source_root.join("launcher"))?;
         fs::create_dir_all(source_root.join("packaging/linux"))?;
@@ -763,6 +1120,10 @@ fi
             b"console.log('patched');\n",
         )?;
         fs::write(
+            source_root.join("scripts/app-server-schema-guard.js"),
+            b"#!/usr/bin/env node\n",
+        )?;
+        fs::write(
             source_root.join("scripts/patches/registry.js"),
             b"module.exports = {};\n",
         )?;
@@ -773,6 +1134,10 @@ fi
         fs::write(
             source_root.join("scripts/lib/node-runtime.sh"),
             b"#!/bin/bash\n",
+        )?;
+        fs::write(
+            source_root.join("scripts/ci/validate-patch-report.js"),
+            b"#!/usr/bin/env node\n",
         )?;
         fs::write(
             source_root.join("packaging/linux/control"),
@@ -790,6 +1155,9 @@ fi
         assert!(destination_root
             .join("scripts/patch-linux-window-ui.js")
             .exists());
+        assert!(destination_root
+            .join("scripts/app-server-schema-guard.js")
+            .exists());
         assert!(destination_root.join("launcher/webview-server.py").exists());
         assert!(destination_root
             .join("scripts/patches/registry.js")
@@ -805,6 +1173,9 @@ fi
             .exists());
         assert!(destination_root
             .join("scripts/lib/node-runtime.sh")
+            .exists());
+        assert!(destination_root
+            .join("scripts/ci/validate-patch-report.js")
             .exists());
         assert!(destination_root
             .join("linux-features/features.example.json")
@@ -881,6 +1252,65 @@ fi
         let path = build_command_path(temp.path());
         let directories = std::env::split_paths(&path).collect::<Vec<_>>();
         assert_eq!(directories.first(), Some(&runtime_bin));
+        Ok(())
+    }
+
+    #[test]
+    fn schema_guard_node_program_prefers_packaged_managed_node() -> Result<()> {
+        let temp = tempdir()?;
+        let managed_node = temp.path().join("node-runtime/bin/node");
+        fs::create_dir_all(managed_node.parent().unwrap())?;
+        fs::write(&managed_node, b"bin")?;
+
+        assert_eq!(schema_guard_node_program(temp.path()), managed_node);
+        assert_eq!(
+            schema_guard_node_program(&temp.path().join("missing")),
+            PathBuf::from("node")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn command_log_redaction_covers_private_app_state() -> Result<()> {
+        let input = br#"schema guard failed Bearer secret-token bearer lower-secret sk-test-secret https://signed.example/path?token=url-fixture {"installationId":"install-fixture","tabUrl":"https://private.example/tab","tabTitle":"private tab fixture", "accountUserId" : "account-user-fixture", "privateKeyPkcs8Pem": "pkcs8-fixture"} deviceKey = "device-key-fixture" threadPreview=private-preview remote_control_token: remote-token-fixture sensitive:{error:"sensitive-fixture"} conversationId='conversation-fixture' stepUpToken = step-up-fixture -----BEGIN PRIVATE KEY----- pem-fixture -----END PRIVATE KEY-----"#;
+        let output = String::from_utf8(redact_command_log(input))?;
+
+        assert!(output.contains("Bearer <redacted>"));
+        assert!(output.contains("bearer <redacted>"));
+        assert!(output.contains("sk-<redacted>"));
+        assert!(output.contains("<url-redacted>"));
+        assert!(output.contains(r#""installationId":"<redacted>""#));
+        assert!(output.contains(r#""tabUrl":"<redacted>""#));
+        assert!(output.contains(r#""tabTitle":"<redacted>""#));
+        assert!(output.contains(r#""accountUserId" : "<redacted>""#));
+        assert!(output.contains(r#""privateKeyPkcs8Pem": "<redacted>""#));
+        assert!(output.contains(r#"deviceKey = "<redacted>""#));
+        assert!(output.contains("threadPreview=<redacted>"));
+        assert!(output.contains("remote_control_token: <redacted>"));
+        assert!(output.contains("sensitive:<redacted>"));
+        assert!(output.contains("conversationId='<redacted>'"));
+        assert!(output.contains("stepUpToken = <redacted>"));
+        assert!(output.contains("<pem-redacted>"));
+        for forbidden in [
+            "secret-token",
+            "lower-secret",
+            "sk-test-secret",
+            "signed.example",
+            "install-fixture",
+            "private.example",
+            "private tab fixture",
+            "account-user-fixture",
+            "pkcs8-fixture",
+            "device-key-fixture",
+            "private-preview",
+            "remote-token-fixture",
+            "sensitive-fixture",
+            "conversation-fixture",
+            "step-up-fixture",
+            "pem-fixture",
+        ] {
+            assert!(!output.contains(forbidden), "leaked {forbidden}");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Second focused split from the closed oversized #313 branch.

Scope:
- Adds `scripts/app-server-schema-guard.js` to generate/read Codex app-server JSON schemas and verify the request/notification surface needed by Linux desktop parity probes.
- Stages the schema guard and `scripts/ci/validate-patch-report.js` into packaged update-builder bundles.
- Runs the schema guard during local update rebuilds after `install.sh` and before native package creation.
- Redacts sensitive tokens/private app fields from update-builder command logs, including common remote-control/app-server token and key field variants.
- Adds CI/package smoke assertions, schema-dir fixture coverage, and updater unit coverage.

Local validation:
- `node --check scripts/app-server-schema-guard.js`
- `bash -n tests/scripts_smoke.sh`
- `bash -n scripts/ci/container-entrypoint.sh`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p codex-update-manager builder`
- `cargo test -p codex-update-manager`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `bash tests/scripts_smoke.sh`
- `node scripts/app-server-schema-guard.js --json --timeout-ms 30000` passed locally with `ok=true` (summary only; no raw schema output included here).

GitHub validation:
- `CI` run `26516478578` passed on `ad577fb`:
  - Rust and Smoke Tests
  - Build Debian Package
  - Build RPM Package
  - Build Pacman Package
  - Nix Package Builds