### PR TITLE
Support Flatpak Chrome extension bridge

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -633,6 +633,7 @@ write_chrome_native_host_manifests() {
 import json
 import pathlib
 import re
+import shlex
 import sys
 
 host_path = sys.argv[1]
@@ -667,18 +668,32 @@ if not isinstance(host_name, str) or re.fullmatch(r"[A-Za-z0-9_.]+", host_name) 
     raise SystemExit("Invalid Chrome native host name in bundled plugin metadata")
 
 manifest_name = f"{host_name}.json"
-manifest = {
-    "name": host_name,
-    "description": "Codex chrome native messaging host",
-    "type": "stdio",
-    "path": host_path,
-    "allowed_origins": [f"chrome-extension://{extension_id}/"],
-}
-text = json.dumps(manifest, separators=(",", ":"))
+def manifest_text(native_host_path):
+    manifest = {
+        "name": host_name,
+        "description": "Codex chrome native messaging host",
+        "type": "stdio",
+        "path": str(native_host_path),
+        "allowed_origins": [f"chrome-extension://{extension_id}/"],
+    }
+    return json.dumps(manifest, separators=(",", ":"))
+
+def ensure_flatpak_native_host_wrapper():
+    wrapper_path = home / ".var/app/com.google.Chrome/config/codex/extension-host-flatpak-wrapper.sh"
+    wrapper_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper_text = "#!/bin/sh\nexec /usr/bin/flatpak-spawn --host " + shlex.quote(host_path) + ' "$@"\n'
+    try:
+        if wrapper_path.read_text(encoding="utf-8") != wrapper_text:
+            wrapper_path.write_text(wrapper_text, encoding="utf-8")
+    except OSError:
+        wrapper_path.write_text(wrapper_text, encoding="utf-8")
+    wrapper_path.chmod(0o755)
+    return wrapper_path
 
 manifest_locations = [
     ".config/google-chrome/NativeMessagingHosts",
     ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+    ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts",
     ".config/chromium/NativeMessagingHosts",
 ]
 
@@ -702,6 +717,10 @@ for relative in manifest_locations:
     directory = home / relative
     directory.mkdir(parents=True, exist_ok=True)
     path = directory / manifest_name
+    native_host_path = host_path
+    if relative == ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts":
+        native_host_path = ensure_flatpak_native_host_wrapper()
+    text = manifest_text(native_host_path)
     try:
         if path.read_text(encoding="utf-8") == text:
             continue
@@ -826,6 +845,9 @@ sync_chrome_bundled_plugin_cache() {
 
     host_path="$cache_root/latest/extension-host/linux/$extension_arch/extension-host"
     [ -x "$host_path" ] || return 0
+    if command -v flatpak >/dev/null 2>&1 && flatpak info com.google.Chrome >/dev/null 2>&1; then
+        flatpak override --user --talk-name=org.freedesktop.Flatpak com.google.Chrome >/dev/null 2>&1 || true
+    fi
     write_chrome_native_host_manifests "$host_path" "$cache_root/latest" || \
         echo "Chrome native host manifest sync failed; continuing with existing browser manifests."
 }

--- a/scripts/lib/patch-chrome-plugin.js
+++ b/scripts/lib/patch-chrome-plugin.js
@@ -8,6 +8,12 @@ function warn(message) {
   process.stderr.write(`WARN: ${message}\n`);
 }
 
+function sourceIncludesAny(source, texts) {
+  return (Array.isArray(texts) ? texts : [texts]).some(
+    (text) => typeof text === "string" && text.length > 0 && source.includes(text),
+  );
+}
+
 function patchFile(filePath, patches) {
   let source;
   try {
@@ -19,7 +25,7 @@ function patchFile(filePath, patches) {
 
   let changed = false;
   for (const { label, oldText, newText, alreadyText = newText } of patches) {
-    if (source.includes(newText) || source.includes(alreadyText)) {
+    if (source.includes(newText) || sourceIncludesAny(source, alreadyText)) {
       console.log(`${path.basename(filePath)} already patched: ${label}`);
       continue;
     }
@@ -51,9 +57,9 @@ function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText =
   const candidates = oldTexts.map((candidate) =>
     typeof candidate === "string" ? { oldText: candidate, newText } : candidate,
   );
-  const alreadyPatched = [newText, alreadyText, ...candidates.map((candidate) => candidate.newText)]
-    .filter((text) => typeof text === "string" && text.length > 0)
-    .some((text) => source.includes(text));
+  const alreadyPatched =
+    sourceIncludesAny(source, [newText, ...candidates.map((candidate) => candidate.newText)]) ||
+    sourceIncludesAny(source, alreadyText);
   if (alreadyPatched) {
     console.log(`${path.basename(filePath)} already patched: ${label}`);
     return;
@@ -77,18 +83,35 @@ if (!pluginDir) {
 const scriptsDir = path.resolve(pluginDir, "scripts");
 
 const linuxExtensionAwareUserDataFallback = `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
-  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
   const linuxBraveUserDataDirectory = path.join(
     os.homedir(),
     ".config",
     "BraveSoftware",
     "Brave-Browser",
   );
+  const linuxFlatpakChromeUserDataDirectory = path.join(
+    os.homedir(),
+    ".var",
+    "app",
+    "com.google.Chrome",
+    "config",
+    "google-chrome",
+  );
+  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
+  const linuxHasBrowserUserDataDirectory = (candidate) => {
+    try {
+      return fs.existsSync(path.join(candidate, "Local State")) ||
+        findLatestChromeProfile(candidate) != null;
+    } catch {
+      return false;
+    }
+  };
   const linuxUserDataCandidates = [
     linuxBraveUserDataDirectory,
     linuxChromeUserDataDirectory,
+    linuxFlatpakChromeUserDataDirectory,
     linuxChromiumUserDataDirectory,
-  ].filter((candidate) => fs.existsSync(candidate));
+  ].filter(linuxHasBrowserUserDataDirectory);
   const linuxCandidateWithInstalledExtension = linuxUserDataCandidates.find(
     (candidate) => {
       try {
@@ -115,31 +138,72 @@ const linuxExtensionAwareUserDataFallback = `  const linuxChromeUserDataDirector
 
   return linuxChromeUserDataDirectory;`;
 
+const linuxExtensionAwareUserDataFallbackWithoutFlatpak = linuxExtensionAwareUserDataFallback
+  .replace(`  const linuxFlatpakChromeUserDataDirectory = path.join(
+    os.homedir(),
+    ".var",
+    "app",
+    "com.google.Chrome",
+    "config",
+    "google-chrome",
+  );
+`, "")
+  .replace("    linuxFlatpakChromeUserDataDirectory,\n", "");
+
 const linuxDefaultBrowserUserDataFallback = `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
-  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
   const linuxBraveUserDataDirectory = path.join(
     os.homedir(),
     ".config",
     "BraveSoftware",
     "Brave-Browser",
   );
+  const linuxFlatpakChromeUserDataDirectory = path.join(
+    os.homedir(),
+    ".var",
+    "app",
+    "com.google.Chrome",
+    "config",
+    "google-chrome",
+  );
+  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
+  const linuxHasBrowserUserDataDirectory = (candidate) => {
+    try {
+      return fs.existsSync(path.join(candidate, "Local State")) ||
+        findLatestChromeProfile(candidate) != null;
+    } catch {
+      return false;
+    }
+  };
   const defaultBrowser = runCommand(["xdg-settings", "get", "default-web-browser"]);
   if (
     defaultBrowser === "brave-browser.desktop" &&
-    fs.existsSync(linuxBraveUserDataDirectory)
+    linuxHasBrowserUserDataDirectory(linuxBraveUserDataDirectory)
   ) {
     return linuxBraveUserDataDirectory;
   }
   if (
+    defaultBrowser === "google-chrome.desktop" &&
+    linuxHasBrowserUserDataDirectory(linuxChromeUserDataDirectory)
+  ) {
+    return linuxChromeUserDataDirectory;
+  }
+  if (
+    defaultBrowser === "com.google.Chrome.desktop" &&
+    linuxHasBrowserUserDataDirectory(linuxFlatpakChromeUserDataDirectory)
+  ) {
+    return linuxFlatpakChromeUserDataDirectory;
+  }
+  if (
     ["chromium.desktop", "chromium-browser.desktop"].includes(defaultBrowser) &&
-    fs.existsSync(linuxChromiumUserDataDirectory)
+    linuxHasBrowserUserDataDirectory(linuxChromiumUserDataDirectory)
   ) {
     return linuxChromiumUserDataDirectory;
   }
 
-  if (fs.existsSync(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
-  if (fs.existsSync(linuxChromeUserDataDirectory)) return linuxChromeUserDataDirectory;
-  if (fs.existsSync(linuxChromiumUserDataDirectory)) return linuxChromiumUserDataDirectory;
+  if (linuxHasBrowserUserDataDirectory(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
+  if (linuxHasBrowserUserDataDirectory(linuxFlatpakChromeUserDataDirectory)) return linuxFlatpakChromeUserDataDirectory;
+  if (linuxHasBrowserUserDataDirectory(linuxChromeUserDataDirectory)) return linuxChromeUserDataDirectory;
+  if (linuxHasBrowserUserDataDirectory(linuxChromiumUserDataDirectory)) return linuxChromiumUserDataDirectory;
 
   return linuxChromeUserDataDirectory;`;
 
@@ -224,7 +288,90 @@ function chromeArgumentValue(argv, name) {
 
 `;
 
+const linuxDefaultBrowserUserDataFallbackWithoutFlatpak = linuxDefaultBrowserUserDataFallback
+  .replace(`  const linuxFlatpakChromeUserDataDirectory = path.join(
+    os.homedir(),
+    ".var",
+    "app",
+    "com.google.Chrome",
+    "config",
+    "google-chrome",
+  );
+`, "")
+  .replace(`  if (
+    defaultBrowser === "com.google.Chrome.desktop" &&
+    linuxHasBrowserUserDataDirectory(linuxFlatpakChromeUserDataDirectory)
+  ) {
+    return linuxFlatpakChromeUserDataDirectory;
+  }
+`, "")
+  .replace("  if (linuxHasBrowserUserDataDirectory(linuxFlatpakChromeUserDataDirectory)) return linuxFlatpakChromeUserDataDirectory;\n", "");
+
 const linuxNativeHostManifestFallback = `  if (process.platform === "linux") {
+    const linuxRunCommand = (argv) => {
+      try {
+        if (typeof require !== "function") return null;
+        const { execFileSync } = require("node:child_process");
+        return execFileSync(argv[0], argv.slice(1), {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+      } catch {
+        return null;
+      }
+    };
+    const linuxFlatpakChromeManifestPath = path.join(
+      os.homedir(),
+      ".var",
+      "app",
+      "com.google.Chrome",
+      "config",
+      "google-chrome",
+      "NativeMessagingHosts",
+      \`\${expectedHostName}.json\`,
+    );
+    const linuxFlatpakChromePreferred =
+      linuxRunCommand(["xdg-settings", "get", "default-web-browser"]) ===
+        "com.google.Chrome.desktop" ||
+      linuxRunCommand(["flatpak", "info", "com.google.Chrome"]) != null;
+    const manifestPaths = [
+      ...(linuxFlatpakChromePreferred ? [linuxFlatpakChromeManifestPath] : []),
+      path.join(
+        os.homedir(),
+        ".config",
+        "google-chrome",
+        "NativeMessagingHosts",
+        \`\${expectedHostName}.json\`,
+      ),
+      path.join(
+        os.homedir(),
+        ".config",
+        "BraveSoftware",
+        "Brave-Browser",
+        "NativeMessagingHosts",
+        \`\${expectedHostName}.json\`,
+      ),
+      path.join(
+        os.homedir(),
+        ".config",
+        "chromium",
+        "NativeMessagingHosts",
+        \`\${expectedHostName}.json\`,
+      ),
+      ...(!linuxFlatpakChromePreferred ? [linuxFlatpakChromeManifestPath] : []),
+    ];
+
+    return {
+      manifestPath:
+        manifestPaths.find((candidate) => fs.existsSync(candidate)) ||
+        manifestPaths[0],
+      registryKey: null,
+      registryManifestPath: null,
+      registryKeyExists: null,
+    };
+  }`;
+
+const linuxNativeHostManifestFallbackWithoutFlatpak = `  if (process.platform === "linux") {
     const manifestPaths = [
       path.join(
         os.homedir(),
@@ -265,9 +412,23 @@ patchFileFirstMatch(path.join(scriptsDir, "installManifest.mjs"), {
   oldTexts: [
     'linux:[".config/google-chrome/NativeMessagingHosts"]',
     'linux:[".config/google-chrome/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"]',
+    'linux:[".config/google-chrome/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",".config/chromium/NativeMessagingHosts"]',
   ],
   newText:
-    'linux:[".config/google-chrome/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",".config/chromium/NativeMessagingHosts"]',
+    'linux:[".config/google-chrome/NativeMessagingHosts",".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts",".config/chromium/NativeMessagingHosts"]',
+});
+
+patchFileFirstMatch(path.join(scriptsDir, "installManifest.mjs"), {
+  label: "Linux Flatpak native host wrapper manifest",
+  oldTexts: [
+    `async function y({appServerHostConfig:t,description:e=_,extensionHostName:o,extensionHostPath:n,extensionId:s,manifestPaths:p}){let f={allowed_origins:[\`chrome-extension://\${r(s,"extensionId")}/\`],description:e,name:r(o,"extensionHostName"),path:r(n,"extensionHostPath"),type:"stdio"},m=\`\${JSON.stringify(f,null,2)}
+\`,l=await T({appServerHostConfig:{...t,extensionId:r(s,"extensionId")},extensionHostPath:n});return await Promise.all(p.map(async u=>{await w(d(u),{recursive:!0}),await v(u,m,"utf8")})),{configPath:l,manifestPaths:p}}`,
+  ],
+  newText: `async function y({appServerHostConfig:t,description:e=_,extensionHostName:o,extensionHostPath:n,extensionId:s,manifestPaths:p}){function codexLinuxShellQuote(e){return "'"+String(e).replace(/'/g,"'\\\\''")+"'"}let h=r(n,"extensionHostPath"),l=await T({appServerHostConfig:{...t,extensionId:r(s,"extensionId")},extensionHostPath:h});return await Promise.all(p.map(async u=>{await w(d(u),{recursive:!0});let g=h;if(u.includes(".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts")){g=d(d(d(u)))+"/codex/extension-host-flatpak-wrapper.sh";await w(d(g),{recursive:!0}),await v(g,\`#!/bin/sh
+exec /usr/bin/flatpak-spawn --host \${codexLinuxShellQuote(h)} "$@"
+\`,"utf8"),await (await import("node:fs/promises")).chmod(g,493).catch(()=>{})}let f={allowed_origins:[\`chrome-extension://\${r(s,"extensionId")}/\`],description:e,name:r(o,"extensionHostName"),path:r(g,"extensionHostPath"),type:"stdio"},m=\`\${JSON.stringify(f,null,2)}
+\`;await v(u,m,"utf8")})),{configPath:l,manifestPaths:p}}`,
+  alreadyText: "extension-host-flatpak-wrapper.sh",
 });
 
 patchFile(path.join(scriptsDir, "check-native-host-manifest.js"), [
@@ -305,7 +466,7 @@ ${linuxNativeHostManifestFallback}
   throw new Error(
     \`Unsupported platform for native host manifest check: \${process.platform}. This script supports macOS, Linux, and Windows.\`,
   );`,
-    alreadyText: '"chromium",\n        "NativeMessagingHosts"',
+    alreadyText: ['"com.google.Chrome",\n        "config",\n        "google-chrome",\n        "NativeMessagingHosts"', '"chromium",\n        "NativeMessagingHosts"'],
   },
   {
     label: "Linux browser native host manifest fallback",
@@ -324,7 +485,13 @@ ${linuxNativeHostManifestFallback}
     };
   }`,
     newText: linuxNativeHostManifestFallback,
-    alreadyText: '"chromium",\n        "NativeMessagingHosts"',
+    alreadyText: ['"com.google.Chrome",\n        "config",\n        "google-chrome",\n        "NativeMessagingHosts"', '"chromium",\n        "NativeMessagingHosts"'],
+  },
+  {
+    label: "Linux Flatpak native host manifest fallback",
+    oldText: linuxNativeHostManifestFallbackWithoutFlatpak,
+    newText: linuxNativeHostManifestFallback,
+    alreadyText: '"com.google.Chrome",\n        "config",\n        "google-chrome",\n        "NativeMessagingHosts"',
   },
 ]);
 
@@ -333,18 +500,30 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   oldTexts: [
     {
       oldText: String.raw`var Tc=GF(VF(),WF()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
-      newText: String.raw`var Tc=GF(VF(),WF()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>WF()==="linux"?[GF(VF(),".config","BraveSoftware","Brave-Browser"),GF(VF(),".config","google-chrome"),GF(VF(),".config","chromium")]:[Tc];`,
+      newText: String.raw`var Tc=GF(VF(),WF()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>WF()==="linux"?[GF(VF(),".config","BraveSoftware","Brave-Browser"),GF(VF(),".config","google-chrome"),GF(VF(),".var","app","com.google.Chrome","config","google-chrome"),GF(VF(),".config","chromium")]:[Tc];`,
     },
     {
       oldText: String.raw`var Ic=eO(tO(),rO()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
-      newText: String.raw`var Ic=eO(tO(),rO()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>rO()==="linux"?[eO(tO(),".config","BraveSoftware","Brave-Browser"),eO(tO(),".config","google-chrome"),eO(tO(),".config","chromium")]:[Ic];`,
+      newText: String.raw`var Ic=eO(tO(),rO()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>rO()==="linux"?[eO(tO(),".config","BraveSoftware","Brave-Browser"),eO(tO(),".config","google-chrome"),eO(tO(),".var","app","com.google.Chrome","config","google-chrome"),eO(tO(),".config","chromium")]:[Ic];`,
+    },
+    {
+      oldText: String.raw`codexLinuxChromeUserDataDirectories=()=>WF()==="linux"?[GF(VF(),".config","BraveSoftware","Brave-Browser"),GF(VF(),".config","google-chrome"),GF(VF(),".config","chromium")]:[Tc]`,
+      newText: String.raw`codexLinuxChromeUserDataDirectories=()=>WF()==="linux"?[GF(VF(),".config","BraveSoftware","Brave-Browser"),GF(VF(),".config","google-chrome"),GF(VF(),".var","app","com.google.Chrome","config","google-chrome"),GF(VF(),".config","chromium")]:[Tc]`,
+    },
+    {
+      oldText: String.raw`codexLinuxChromeUserDataDirectories=()=>rO()==="linux"?[eO(tO(),".config","BraveSoftware","Brave-Browser"),eO(tO(),".config","google-chrome"),eO(tO(),".config","chromium")]:[Ic]`,
+      newText: String.raw`codexLinuxChromeUserDataDirectories=()=>rO()==="linux"?[eO(tO(),".config","BraveSoftware","Brave-Browser"),eO(tO(),".config","google-chrome"),eO(tO(),".var","app","com.google.Chrome","config","google-chrome"),eO(tO(),".config","chromium")]:[Ic]`,
+    },
+    {
+      oldText: String.raw`codexLinuxChromeUserDataDirectories=()=>X5()==="linux"?[Y5(Z5(),".config","BraveSoftware","Brave-Browser"),Y5(Z5(),".config","google-chrome"),Y5(Z5(),".config","chromium")]:[hl]`,
+      newText: String.raw`codexLinuxChromeUserDataDirectories=()=>X5()==="linux"?[Y5(Z5(),".config","BraveSoftware","Brave-Browser"),Y5(Z5(),".config","google-chrome"),Y5(Z5(),".var","app","com.google.Chrome","config","google-chrome"),Y5(Z5(),".config","chromium")]:[hl]`,
     },
     {
       oldText: String.raw`var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
-      newText: String.raw`var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>X5()==="linux"?[Y5(Z5(),".config","BraveSoftware","Brave-Browser"),Y5(Z5(),".config","google-chrome"),Y5(Z5(),".config","chromium")]:[hl];`,
+      newText: String.raw`var hl=Y5(Z5(),X5()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>X5()==="linux"?[Y5(Z5(),".config","BraveSoftware","Brave-Browser"),Y5(Z5(),".config","google-chrome"),Y5(Z5(),".var","app","com.google.Chrome","config","google-chrome"),Y5(Z5(),".config","chromium")]:[hl];`,
     },
   ],
-  alreadyText: "codexLinuxChromeUserDataDirectories",
+  alreadyText: '".var","app","com.google.Chrome"',
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
@@ -359,7 +538,7 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       newText: String.raw`var mT=async(e,t,r=hl)=>{let n=rh(r,e,"Local Extension Settings",t);if(!n9(n))return null;let o=await r9(rh(o9(),"codex"));await t9(n,o,{recursive:!0}),await fT(rh(o,"LOCK"));let i=new Q5(o,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await i.open();let s=await i.get("extensionInstanceId");if(!s)return null;let a=JSON.parse(s);return typeof a!="string"?null:a}finally{await i.close(),await fT(o,{force:!0,recursive:!0})}}`,
     },
   ],
-  alreadyText: "async(t,e,r=Tc)",
+  alreadyText: ["async(t,e,r=Tc)", "async(e,t,r=hl)"],
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
@@ -404,6 +583,36 @@ patchFile(path.join(scriptsDir, "installed-browsers.js"), [
   {
     name: "Google Chrome",
     bundleIds: ["com.google.Chrome"],
+    flatpakAppIds: ["com.google.Chrome"],
+    appNames: ["Google Chrome.app"],
+    commands: ["google-chrome", "chrome"],
+    windowsExecutable: "chrome.exe",
+  },
+  {
+    name: "Brave Browser",
+    bundleIds: ["com.brave.Browser"],
+    flatpakAppIds: ["com.brave.Browser"],
+    appNames: ["Brave Browser.app"],
+    commands: ["brave-browser", "brave"],
+    windowsExecutable: "brave.exe",
+  },
+  {
+    name: "Chromium",
+    bundleIds: ["org.chromium.Chromium"],
+    flatpakAppIds: ["org.chromium.Chromium"],
+    appNames: ["Chromium.app"],
+    commands: ["chromium", "chromium-browser"],
+    windowsExecutable: "chrome.exe",
+  },
+];`,
+    alreadyText: '"Brave Browser"',
+  },
+  {
+    label: "Linux Flatpak browser inventory metadata",
+    oldText: `const KNOWN_BROWSERS = [
+  {
+    name: "Google Chrome",
+    bundleIds: ["com.google.Chrome"],
     appNames: ["Google Chrome.app"],
     commands: ["google-chrome", "chrome"],
     windowsExecutable: "chrome.exe",
@@ -423,6 +632,165 @@ patchFile(path.join(scriptsDir, "installed-browsers.js"), [
     windowsExecutable: "chrome.exe",
   },
 ];`,
+    newText: `const KNOWN_BROWSERS = [
+  {
+    name: "Google Chrome",
+    bundleIds: ["com.google.Chrome"],
+    flatpakAppIds: ["com.google.Chrome"],
+    appNames: ["Google Chrome.app"],
+    commands: ["google-chrome", "chrome"],
+    windowsExecutable: "chrome.exe",
+  },
+  {
+    name: "Brave Browser",
+    bundleIds: ["com.brave.Browser"],
+    flatpakAppIds: ["com.brave.Browser"],
+    appNames: ["Brave Browser.app"],
+    commands: ["brave-browser", "brave"],
+    windowsExecutable: "brave.exe",
+  },
+  {
+    name: "Chromium",
+    bundleIds: ["org.chromium.Chromium"],
+    flatpakAppIds: ["org.chromium.Chromium"],
+    appNames: ["Chromium.app"],
+    commands: ["chromium", "chromium-browser"],
+    windowsExecutable: "chrome.exe",
+  },
+];`,
+    alreadyText: "flatpakAppIds",
+  },
+  {
+    label: "Linux Flatpak browser inventory detection",
+    oldText: `function findCommandBrowsers() {
+  const found = new Map();
+
+  for (const browser of KNOWN_BROWSERS) {
+    for (const command of browser.commands) {
+      const executable = commandPath(command);
+      if (!executable) continue;
+
+      found.set(browser.name, {
+        name: browser.name,
+        command,
+        path: executable,
+        bundle_id: browser.bundleIds[0] || null,
+        version: null,
+      });
+      break;
+    }
+  }
+
+  return [...found.values()].sort((a, b) => a.name.localeCompare(b.name));
+}`,
+    newText: `function findFlatpakBrowser(browser) {
+  if (!Array.isArray(browser.flatpakAppIds)) return null;
+
+  const flatpak = commandPath("flatpak");
+  if (!flatpak) return null;
+
+  for (const appId of browser.flatpakAppIds) {
+    const info = runCommand(["flatpak", "info", appId]);
+    if (info == null) continue;
+    const version = info
+      .split(/\\r?\\n/)
+      .map((line) => line.match(/^\\s*Version:\\s*(.+?)\\s*$/)?.[1] ?? null)
+      .find((value) => value != null) ?? null;
+
+    return {
+      name: browser.name,
+      command: "flatpak",
+      path: flatpak,
+      bundle_id: appId,
+      version,
+      flatpak_app_id: appId,
+    };
+  }
+
+  return null;
+}
+
+function findCommandBrowsers() {
+  const found = new Map();
+
+  for (const browser of KNOWN_BROWSERS) {
+    let browserFound = false;
+    for (const command of browser.commands) {
+      const executable = commandPath(command);
+      if (!executable) continue;
+
+      found.set(browser.name, {
+        name: browser.name,
+        command,
+        path: executable,
+        bundle_id: browser.bundleIds[0] || null,
+        version: null,
+      });
+      browserFound = true;
+      break;
+    }
+
+    if (!browserFound) {
+      const flatpakBrowser = findFlatpakBrowser(browser);
+      if (flatpakBrowser) found.set(browser.name, flatpakBrowser);
+    }
+  }
+
+  return [...found.values()].sort((a, b) => a.name.localeCompare(b.name));
+}`,
+    alreadyText: "findFlatpakBrowser",
+  },
+  {
+    label: "Linux Flatpak browser inventory version parsing",
+    oldText: `function findFlatpakBrowser(browser) {
+  if (!Array.isArray(browser.flatpakAppIds)) return null;
+
+  const flatpak = commandPath("flatpak");
+  if (!flatpak) return null;
+
+  for (const appId of browser.flatpakAppIds) {
+    const version = runCommand(["flatpak", "info", "--show-version", appId]);
+    if (version == null) continue;
+
+    return {
+      name: browser.name,
+      command: "flatpak",
+      path: flatpak,
+      bundle_id: appId,
+      version,
+      flatpak_app_id: appId,
+    };
+  }
+
+  return null;
+}`,
+    newText: `function findFlatpakBrowser(browser) {
+  if (!Array.isArray(browser.flatpakAppIds)) return null;
+
+  const flatpak = commandPath("flatpak");
+  if (!flatpak) return null;
+
+  for (const appId of browser.flatpakAppIds) {
+    const info = runCommand(["flatpak", "info", appId]);
+    if (info == null) continue;
+    const version = info
+      .split(/\\r?\\n/)
+      .map((line) => line.match(/^\\s*Version:\\s*(.+?)\\s*$/)?.[1] ?? null)
+      .find((value) => value != null) ?? null;
+
+    return {
+      name: browser.name,
+      command: "flatpak",
+      path: flatpak,
+      bundle_id: appId,
+      version,
+      flatpak_app_id: appId,
+    };
+  }
+
+  return null;
+}`,
+    alreadyText: 'runCommand(["flatpak", "info", appId])',
   },
 ]);
 
@@ -457,9 +825,48 @@ patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
   if (fs.existsSync(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
 
   return linuxChromeUserDataDirectory;`,
+    `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
+  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
+  const linuxBraveUserDataDirectory = path.join(
+    os.homedir(),
+    ".config",
+    "BraveSoftware",
+    "Brave-Browser",
+  );
+  const linuxUserDataCandidates = [
+    linuxBraveUserDataDirectory,
+    linuxChromeUserDataDirectory,
+    linuxChromiumUserDataDirectory,
+  ].filter((candidate) => fs.existsSync(candidate));
+  const linuxCandidateWithInstalledExtension = linuxUserDataCandidates.find(
+    (candidate) => {
+      try {
+        const extensionId = loadRemoteChromeExtensionId();
+        return findLatestChromeProfile(candidate) != null &&
+          fs.existsSync(
+            path.join(
+              candidate,
+              resolveChromeProfileDirectory(candidate),
+              "Extensions",
+              extensionId,
+            ),
+          );
+      } catch {
+        return false;
+      }
+    },
+  );
+  if (linuxCandidateWithInstalledExtension) {
+    return linuxCandidateWithInstalledExtension;
+  }
+
+  if (linuxUserDataCandidates.length > 0) return linuxUserDataCandidates[0];
+
+  return linuxChromeUserDataDirectory;`,
+    linuxExtensionAwareUserDataFallbackWithoutFlatpak,
   ],
   newText: linuxExtensionAwareUserDataFallback,
-  alreadyText: "linuxChromiumUserDataDirectory",
+  alreadyText: "linuxFlatpakChromeUserDataDirectory",
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "check-extension-installed.js"), {
@@ -507,9 +914,37 @@ patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
   if (fs.existsSync(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
 
   return linuxChromeUserDataDirectory;`,
+    `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
+  const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
+  const linuxBraveUserDataDirectory = path.join(
+    os.homedir(),
+    ".config",
+    "BraveSoftware",
+    "Brave-Browser",
+  );
+  const defaultBrowser = runCommand(["xdg-settings", "get", "default-web-browser"]);
+  if (
+    defaultBrowser === "brave-browser.desktop" &&
+    fs.existsSync(linuxBraveUserDataDirectory)
+  ) {
+    return linuxBraveUserDataDirectory;
+  }
+  if (
+    ["chromium.desktop", "chromium-browser.desktop"].includes(defaultBrowser) &&
+    fs.existsSync(linuxChromiumUserDataDirectory)
+  ) {
+    return linuxChromiumUserDataDirectory;
+  }
+
+  if (fs.existsSync(linuxBraveUserDataDirectory)) return linuxBraveUserDataDirectory;
+  if (fs.existsSync(linuxChromeUserDataDirectory)) return linuxChromeUserDataDirectory;
+  if (fs.existsSync(linuxChromiumUserDataDirectory)) return linuxChromiumUserDataDirectory;
+
+  return linuxChromeUserDataDirectory;`,
+    linuxDefaultBrowserUserDataFallbackWithoutFlatpak,
   ],
   newText: linuxDefaultBrowserUserDataFallback,
-  alreadyText: "linuxChromiumUserDataDirectory",
+  alreadyText: "linuxFlatpakChromeUserDataDirectory",
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "open-chrome-window.js"), {
@@ -550,6 +985,34 @@ patchFile(path.join(scriptsDir, "open-chrome-window.js"), [
   };`,
     newText: `  const linuxUserDataDirectory = resolveChromeUserDataDirectory();
   let linuxCommand = commandPath("google-chrome") || commandPath("chrome") || "google-chrome";
+  let linuxArgs = chromeArgs;
+  if (
+    linuxUserDataDirectory.includes(
+      path.join(".config", "BraveSoftware", "Brave-Browser"),
+    )
+  ) {
+    linuxCommand = commandPath("brave-browser") || commandPath("brave") || "brave-browser";
+  } else if (
+    linuxUserDataDirectory.includes(
+      path.join(".var", "app", "com.google.Chrome", "config", "google-chrome"),
+    )
+  ) {
+    linuxCommand = commandPath("flatpak") || "flatpak";
+    linuxArgs = ["run", "com.google.Chrome", ...chromeArgs];
+  } else if (linuxUserDataDirectory.includes(path.join(".config", "chromium"))) {
+    linuxCommand = commandPath("chromium") || commandPath("chromium-browser") || "chromium";
+  }
+
+  return {
+    command: linuxCommand,
+    args: linuxArgs,
+  };`,
+    alreadyText: ["linuxArgs", "linuxCommand"],
+  },
+  {
+    label: "Linux Flatpak browser window command",
+    oldText: `  const linuxUserDataDirectory = resolveChromeUserDataDirectory();
+  let linuxCommand = commandPath("google-chrome") || commandPath("chrome") || "google-chrome";
   if (
     linuxUserDataDirectory.includes(
       path.join(".config", "BraveSoftware", "Brave-Browser"),
@@ -564,5 +1027,30 @@ patchFile(path.join(scriptsDir, "open-chrome-window.js"), [
     command: linuxCommand,
     args: chromeArgs,
   };`,
+    newText: `  const linuxUserDataDirectory = resolveChromeUserDataDirectory();
+  let linuxCommand = commandPath("google-chrome") || commandPath("chrome") || "google-chrome";
+  let linuxArgs = chromeArgs;
+  if (
+    linuxUserDataDirectory.includes(
+      path.join(".config", "BraveSoftware", "Brave-Browser"),
+    )
+  ) {
+    linuxCommand = commandPath("brave-browser") || commandPath("brave") || "brave-browser";
+  } else if (
+    linuxUserDataDirectory.includes(
+      path.join(".var", "app", "com.google.Chrome", "config", "google-chrome"),
+    )
+  ) {
+    linuxCommand = commandPath("flatpak") || "flatpak";
+    linuxArgs = ["run", "com.google.Chrome", ...chromeArgs];
+  } else if (linuxUserDataDirectory.includes(path.join(".config", "chromium"))) {
+    linuxCommand = commandPath("chromium") || commandPath("chromium-browser") || "chromium";
+  }
+
+  return {
+    command: linuxCommand,
+    args: linuxArgs,
+  };`,
+    alreadyText: "linuxArgs",
   },
 ]);

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2441,6 +2441,8 @@ PY
     assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-id.json"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/chromium/NativeMessagingHosts"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-host-flatpak-wrapper.sh"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "flatpak override --user --talk-name=org.freedesktop.Flatpak com.google.Chrome"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "scripts/check-extension-installed.js"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "scripts/chrome-is-running.js"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".tmp/bundled-marketplaces/openai-bundled"
@@ -2817,7 +2819,8 @@ JSON
 {"name":"chrome","version":"0.1.7"}
 JSON
     cat > "$chrome_dir/scripts/installManifest.mjs" <<'JS'
-var n={extensionId:"hehggadaopoacecdllhhajmbjkdcmajg",extensionHostName:"com.openai.codexextension"};var p=o=>{let t=`${o.extensionHostName}.json`,r={darwin:["Library/Application Support/Google/Chrome/NativeMessagingHosts"],linux:[".config/google-chrome/NativeMessagingHosts"],win32:["AppData/Local/OpenAI/extension"]}[m.platform()];return r.map(s=>l.resolve(m.homedir(),s,t))};
+var n={extensionId:"hehggadaopoacecdllhhajmbjkdcmajg",extensionHostName:"com.openai.codexextension"};var p=o=>{let t=`${o.extensionHostName}.json`,r={darwin:["Library/Application Support/Google/Chrome/NativeMessagingHosts"],linux:[".config/google-chrome/NativeMessagingHosts"],win32:["AppData/Local/OpenAI/extension"]}[m.platform()];return r.map(s=>l.resolve(m.homedir(),s,t))};async function y({appServerHostConfig:t,description:e=_,extensionHostName:o,extensionHostPath:n,extensionId:s,manifestPaths:p}){let f={allowed_origins:[`chrome-extension://${r(s,"extensionId")}/`],description:e,name:r(o,"extensionHostName"),path:r(n,"extensionHostPath"),type:"stdio"},m=`${JSON.stringify(f,null,2)}
+`,l=await T({appServerHostConfig:{...t,extensionId:r(s,"extensionId")},extensionHostPath:n});return await Promise.all(p.map(async u=>{await w(d(u),{recursive:!0}),await v(u,m,"utf8")})),{configPath:l,manifestPaths:p}}
 JS
     cat > "$chrome_dir/scripts/extension-id.json" <<'JSON'
 {"extensionId":"hehggadaopoacecdllhhajmbjkdcmajg","extensionHostName":"com.openai.codexextension"}
@@ -2858,6 +2861,32 @@ const KNOWN_BROWSERS = [
     windowsExecutable: "chrome.exe",
   },
 ];
+
+function commandPath(command) {
+  return runCommand(["which", command]);
+}
+
+function findCommandBrowsers() {
+  const found = new Map();
+
+  for (const browser of KNOWN_BROWSERS) {
+    for (const command of browser.commands) {
+      const executable = commandPath(command);
+      if (!executable) continue;
+
+      found.set(browser.name, {
+        name: browser.name,
+        command,
+        path: executable,
+        bundle_id: browser.bundleIds[0] || null,
+        version: null,
+      });
+      break;
+    }
+  }
+
+  return [...found.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
 JS
     cat > "$chrome_dir/scripts/chrome-is-running.js" <<'JS'
 const CHROME_PROCESS_NAMES_BY_PLATFORM = {
@@ -2973,26 +3002,44 @@ test_chrome_plugin_staging() {
     assert_file_exists "$host"
     [ -x "$host" ] || fail "Expected Chrome extension host to be executable: $host"
     assert_contains "$chrome_dir/scripts/installManifest.mjs" "BraveSoftware/Brave-Browser/NativeMessagingHosts"
+    assert_contains "$chrome_dir/scripts/installManifest.mjs" ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts"
+    assert_contains "$chrome_dir/scripts/installManifest.mjs" "extension-host-flatpak-wrapper.sh"
+    assert_contains "$chrome_dir/scripts/installManifest.mjs" "flatpak-spawn --host"
+    assert_contains "$chrome_dir/scripts/installManifest.mjs" "codexLinuxShellQuote"
+    assert_not_contains "$chrome_dir/scripts/installManifest.mjs" "a(d(d(d(u)))"
+    assert_not_contains "$chrome_dir/scripts/installManifest.mjs" 'U("chmod"'
     assert_contains "$chrome_dir/scripts/installManifest.mjs" ".config/chromium/NativeMessagingHosts"
+    assert_contains "$chrome_dir/scripts/installed-browsers.js" "flatpakAppIds"
+    assert_contains "$chrome_dir/scripts/installed-browsers.js" "findFlatpakBrowser"
     assert_contains "$chrome_dir/scripts/installed-browsers.js" "Brave Browser"
     assert_contains "$chrome_dir/scripts/installed-browsers.js" "Chromium"
     assert_contains "$chrome_dir/scripts/chrome-is-running.js" "brave-browser"
     assert_contains "$chrome_dir/scripts/chrome-is-running.js" "chromium-browser"
     assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" 'process.platform === "linux"'
     assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" "BraveSoftware"
+    assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" "com.google.Chrome"
+    assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" "linuxFlatpakChromePreferred"
+    assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" "linuxRunCommand"
+    assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" '"flatpak", "info", "com.google.Chrome"'
     assert_contains "$chrome_dir/scripts/check-native-host-manifest.js" "chromium"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxBraveUserDataDirectory"
+    assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxFlatpakChromeUserDataDirectory"
+    assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxHasBrowserUserDataDirectory"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxChromiumUserDataDirectory"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "linuxCandidateWithInstalledExtension"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "resolveChromeProfileDirectoryFromRunningProcess"
     assert_contains "$chrome_dir/scripts/check-extension-installed.js" "defaultLinuxUserDataDirectoryForCommand"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "brave-browser"
+    assert_contains "$chrome_dir/scripts/open-chrome-window.js" "com.google.Chrome"
+    assert_contains "$chrome_dir/scripts/open-chrome-window.js" "linuxArgs"
+    assert_contains "$chrome_dir/scripts/open-chrome-window.js" "linuxHasBrowserUserDataDirectory"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "chromium"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "defaultBrowser ==="
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "resolveChromeProfileDirectoryFromRunningProcess"
     assert_contains "$chrome_dir/scripts/open-chrome-window.js" "defaultLinuxUserDataDirectoryForCommand"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxChromeUserDataDirectories"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" '"BraveSoftware","Brave-Browser"'
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" '"com.google.Chrome","config","google-chrome"'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" '".config","chromium"'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "instanceId:await IS(o.id,t,r)"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxRankBrowserBackends"
@@ -3021,6 +3068,7 @@ JS
     node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >/dev/null 2>&1
     assert_contains "$browser_client" "codexLinuxChromeUserDataDirectories"
     assert_contains "$browser_client" '"BraveSoftware","Brave-Browser"'
+    assert_contains "$browser_client" '"com.google.Chrome","config","google-chrome"'
     assert_contains "$browser_client" '".config","chromium"'
 
     cat > "$browser_client" <<'JS'
@@ -3029,6 +3077,7 @@ JS
     node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >/dev/null 2>&1
     assert_contains "$browser_client" "codexLinuxChromeUserDataDirectories"
     assert_contains "$browser_client" '"BraveSoftware","Brave-Browser"'
+    assert_contains "$browser_client" '"com.google.Chrome","config","google-chrome"'
     assert_contains "$browser_client" '".config","chromium"'
 
     cat > "$browser_client" <<'JS'
@@ -3037,9 +3086,90 @@ JS
     node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >/dev/null 2>&1
     assert_contains "$browser_client" "codexLinuxChromeUserDataDirectories"
     assert_contains "$browser_client" '"BraveSoftware","Brave-Browser"'
+    assert_contains "$browser_client" '"com.google.Chrome","config","google-chrome"'
     assert_contains "$browser_client" '".config","chromium"'
     assert_contains "$browser_client" "async(e,t,r=hl)"
     assert_contains "$browser_client" "instanceId:await mT(o.id,e,r)"
+}
+
+test_chrome_flatpak_install_manifest_runtime() {
+    info "Checking Chrome Flatpak install manifest wrapper runtime"
+    local workspace="$TMP_DIR/chrome-flatpak-install-manifest"
+    local chrome_dir="$workspace/chrome"
+    local install_manifest="$chrome_dir/scripts/installManifest.mjs"
+
+    mkdir -p "$chrome_dir/scripts"
+    cat > "$install_manifest" <<'JS'
+import { dirname as d } from "node:path";
+import { mkdir as w, writeFile as v } from "node:fs/promises";
+const _ = "Codex chrome native messaging host";
+function r(value) { return value; }
+async function T() { return "/tmp/codex-config.json"; }
+async function y({appServerHostConfig:t,description:e=_,extensionHostName:o,extensionHostPath:n,extensionId:s,manifestPaths:p}){let f={allowed_origins:[`chrome-extension://${r(s,"extensionId")}/`],description:e,name:r(o,"extensionHostName"),path:r(n,"extensionHostPath"),type:"stdio"},m=`${JSON.stringify(f,null,2)}
+`,l=await T({appServerHostConfig:{...t,extensionId:r(s,"extensionId")},extensionHostPath:n});return await Promise.all(p.map(async u=>{await w(d(u),{recursive:!0}),await v(u,m,"utf8")})),{configPath:l,manifestPaths:p}}
+export { y };
+JS
+
+    node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >/dev/null 2>&1
+
+    node - "$install_manifest" "$workspace" <<'NODE' || fail "Expected Flatpak manifest writer to run without hidden minifier aliases"
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+(async () => {
+  const installManifest = process.argv[2];
+  const workspace = process.argv[3];
+  const mod = await import(`${pathToFileURL(installManifest).href}?t=${Date.now()}`);
+  const hostPath = path.join(workspace, "host with ' quote", "extension-host");
+  const home = path.join(workspace, "home");
+  const hostName = "com.example.codextest";
+  const extensionId = "abcdefghijklmnopabcdefghijklmnop";
+  const regularManifest = path.join(
+    home,
+    ".config",
+    "google-chrome",
+    "NativeMessagingHosts",
+    `${hostName}.json`,
+  );
+  const flatpakManifest = path.join(
+    home,
+    ".var",
+    "app",
+    "com.google.Chrome",
+    "config",
+    "google-chrome",
+    "NativeMessagingHosts",
+    `${hostName}.json`,
+  );
+
+  fs.mkdirSync(path.dirname(hostPath), { recursive: true });
+  fs.writeFileSync(hostPath, "#!/bin/sh\n", "utf8");
+
+  await mod.y({
+    appServerHostConfig: {},
+    extensionHostName: hostName,
+    extensionHostPath: hostPath,
+    extensionId,
+    manifestPaths: [regularManifest, flatpakManifest],
+  });
+
+  const regular = JSON.parse(fs.readFileSync(regularManifest, "utf8"));
+  assert.equal(regular.path, hostPath);
+
+  const flatpak = JSON.parse(fs.readFileSync(flatpakManifest, "utf8"));
+  assert.match(flatpak.path, /extension-host-flatpak-wrapper\.sh$/);
+  const wrapper = fs.readFileSync(flatpak.path, "utf8");
+  assert.match(wrapper, /^#!\/bin\/sh\nexec \/usr\/bin\/flatpak-spawn --host /);
+  assert.equal(wrapper.includes(hostPath), false, "wrapper should shell-quote the raw host path");
+  assert.equal(wrapper.includes("'\\''"), true, "wrapper should escape single quotes safely");
+  assert.equal(fs.statSync(flatpak.path).mode & 0o111, 0o111);
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
 }
 
 test_chrome_marketplace_fallback_synthesis() {
@@ -3134,14 +3264,25 @@ PY
     for relative in \
         ".config/google-chrome/NativeMessagingHosts" \
         ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts" \
+        ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts" \
         ".config/chromium/NativeMessagingHosts" \
         ".config/example-browser/NativeMessagingHosts"; do
         manifest_path="$home_dir/$relative/com.example.codextest.json"
         assert_file_exists "$manifest_path"
         assert_contains "$manifest_path" "com.example.codextest"
         assert_contains "$manifest_path" "chrome-extension://abcdefghijklmnopabcdefghijklmnop/"
-        assert_contains "$manifest_path" "$host_path"
+        if [ "$relative" = ".var/app/com.google.Chrome/config/google-chrome/NativeMessagingHosts" ]; then
+            assert_contains "$manifest_path" "extension-host-flatpak-wrapper.sh"
+        else
+            assert_contains "$manifest_path" "$host_path"
+        fi
     done
+
+    local wrapper_path="$home_dir/.var/app/com.google.Chrome/config/codex/extension-host-flatpak-wrapper.sh"
+    assert_file_exists "$wrapper_path"
+    [ -x "$wrapper_path" ] || fail "Expected Flatpak native host wrapper to be executable: $wrapper_path"
+    assert_contains "$wrapper_path" "flatpak-spawn --host"
+    assert_contains "$wrapper_path" "$host_path"
 }
 
 make_fake_extracted_asar() {
@@ -5032,6 +5173,7 @@ main() {
     test_browser_use_node_repl_ldd_output_compatibility
     test_chrome_plugin_staging
     test_chrome_browser_client_profile_root_variants
+    test_chrome_flatpak_install_manifest_runtime
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_template_sanity


### PR DESCRIPTION
## Summary
- add Flatpak Google Chrome native-host manifest coverage and a Flatpak-safe wrapper for the Chrome extension host
- teach the bundled Chrome plugin patcher to discover Flatpak Chrome, prefer Flatpak profile roots when appropriate, and launch Flatpak Chrome with `flatpak run com.google.Chrome`
- extend smoke coverage for Flatpak manifest paths, wrapper quoting/executable behavior, browser inventory, profile roots, and launcher manifest sync

## Context
This is the third focused split from the closed oversized PR #313, following maintainer-requested order. It is based directly on current `origin/main` and intentionally excludes the later doctor/service/parity-tooling work from the parking branch.

## Validation
- `node --check scripts/lib/patch-chrome-plugin.js`
- `bash -n tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js`
- read-only subagent review pass after fixes: no remaining blockers found
- GitHub `CI` run `26518224848`: passed all five jobs on `15c69dc`