### PR TITLE
Handle fast-mode guard bundle drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1118,6 +1118,35 @@ test("guards fast-mode model tier lookup when serviceTiers is missing", () => {
   assert.doesNotMatch(patched, /e\.serviceTiers\.length/);
 });
 
+test("guards drifted fast-mode tier lookup shapes", () => {
+  const source = [
+    "function y(t){return t.serviceTiers.length > 0 || t.additionalSpeedTiers?.includes(`fast`)}",
+    "const z=e=>e.serviceTiers.length>0||e.additionalSpeedTiers.includes(\"fast\")===!0;",
+  ].join(";");
+
+  const patched = applyPatchTwice(applyLinuxFastModeModelGuardPatch, source);
+
+  assert.match(patched, /\(t\?\.serviceTiers\?\.length\?\?0\)>0\|\|t\?\.additionalSpeedTiers\?\.includes\(`fast`\)===!0/);
+  assert.match(patched, /\(e\?\.serviceTiers\?\.length\?\?0\)>0\|\|e\?\.additionalSpeedTiers\?\.includes\("fast"\)===!0/);
+  assert.doesNotMatch(patched, /[te]\.serviceTiers\.length/);
+});
+
+test("warns when the fast-mode tier lookup is recognizable but unpatchable", () => {
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxFastModeModelGuardPatch(
+      "function m(e){return currentModel().serviceTiers.length > 0 || e.additionalSpeedTiers?.includes(u)===!0}",
+    ),
+  );
+
+  assert.equal(
+    value,
+    "function m(e){return currentModel().serviceTiers.length > 0 || e.additionalSpeedTiers?.includes(u)===!0}",
+  );
+  assert.deepEqual(warnings, [
+    "WARN: Could not find fast-mode model guard insertion point — skipping fast-mode crash guard patch",
+  ]);
+});
+
 test("warns when a matched webview opaque bundle has no known insertion point", () => {
   const { warnings } = captureWarns(() =>
     applyLinuxOpaqueWindowsDefaultPatch("function runtime(){let C=theme;if(C.opaqueWindows&&!ba()){}}"),

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -638,27 +638,18 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
 }
 
 function applyLinuxFastModeModelGuardPatch(currentSource) {
-  const exactNeedle =
-    "function m(e){return e.serviceTiers.length>0||e.additionalSpeedTiers?.includes(u)===!0}";
-  const exactPatch =
-    "function m(e){return(e?.serviceTiers?.length??0)>0||e?.additionalSpeedTiers?.includes(u)===!0}";
-  if (currentSource.includes(exactPatch)) {
-    return currentSource;
-  }
-  if (currentSource.includes(exactNeedle)) {
-    return currentSource.replace(exactNeedle, exactPatch);
-  }
-
-  const driftedNeedle = /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{return \2\.serviceTiers\.length>0\|\|\2\.additionalSpeedTiers\?\.includes\(([A-Za-z_$][\w$]*)\)===!0\}/u;
-  if (driftedNeedle.test(currentSource)) {
-    return currentSource.replace(
-      driftedNeedle,
-      (match, fnName, modelVar, fastTierVar) =>
-        `function ${fnName}(${modelVar}){return(${modelVar}?.serviceTiers?.length??0)>0||${modelVar}?.additionalSpeedTiers?.includes(${fastTierVar})===!0}`,
-    );
+  const tierLookupNeedle =
+    /([A-Za-z_$][\w$]*)\.serviceTiers\.length\s*>\s*0\s*\|\|\s*\1\.additionalSpeedTiers(?:\?\.|\.)includes\(([^()]*)\)(?:\s*===\s*!0)?/gu;
+  const patchedSource = currentSource.replace(
+    tierLookupNeedle,
+    (match, modelVar, fastTierExpr) =>
+      `(${modelVar}?.serviceTiers?.length??0)>0||${modelVar}?.additionalSpeedTiers?.includes(${fastTierExpr})===!0`,
+  );
+  if (patchedSource !== currentSource) {
+    return patchedSource;
   }
 
-  if (currentSource.includes("serviceTiers.length>0") && currentSource.includes("additionalSpeedTiers")) {
+  if (/serviceTiers\.length\s*>\s*0/u.test(currentSource) && currentSource.includes("additionalSpeedTiers")) {
     console.warn(
       "WARN: Could not find fast-mode model guard insertion point — skipping fast-mode crash guard patch",
     );


### PR DESCRIPTION
## Summary
- generalize the fast-mode model guard patch to handle drifted minified tier lookup shapes
- keep required-upstream validation failing when a recognizable unsafe lookup cannot be patched
- add coverage for old, drifted, and unpatchable fast-mode guard shapes

## Validation
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check
- bash tests/scripts_smoke.sh