### PR TITLE
Improve Linux file manager reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Linux webview bundles no longer ask current Codex CLI app servers to enable unsupported feature flags, avoiding connector authentication sync errors.
 - Native Linux launches now keep GPU compositing enabled by default, avoiding sustained Electron GPU-process CPU usage on some X11/NVIDIA desktops. Users who still need the old flicker workaround can opt in with `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1`.
 - Linux Keybinds settings now show current upstream shortcut defaults for Quick Chat, alternate New Chat, search, terminal, browser, and thread actions, and no longer lists non-dispatchable runtime rows.
+- Linux `Open in File Manager` now prefers desktop file managers directly, selecting files in Dolphin and Nautilus where supported before falling back to Electron's shell opener.
 
 ## [0.8.0] - 2026-05-16
 

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -795,16 +795,16 @@ test("open-target discovery upgrades the baseline file manager target", async ()
   });
 });
 
-test("open-target discovery stays disabled until listed in features.json", () => {
+test("open-target discovery leaves terminal and IDE disabled until listed in features.json", () => {
   withTempFeatureConfig([], (root) => {
     assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
     assert.deepEqual(loadLinuxFeatureMainBundlePatches({ featuresRoot: root }), []);
 
     withLinuxFeatureRootEnv(root, () => {
       const patched = captureWarns(() => patchMainBundleSource(openTargetsBundle, null)).value;
+      assert.match(patched, /codexLinuxOpenFileManager\(e\)/);
       assert.doesNotMatch(patched, /linux:\{label:`Terminal`/);
       assert.doesNotMatch(patched, /\.\.\.codexLinuxDiscoveredIdeTargets\(\)/);
-      assert.doesNotMatch(patched, /codexLinuxOpenFileManager\(e\)/);
     });
   });
 });

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -780,9 +780,31 @@ test("adds Linux file manager support without relying on exact minified variable
 
   const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
 
+  assert.match(patched, /function codexLinuxFindExecutable\(/);
+  assert.match(patched, /function codexLinuxLaunchDetached\(e,t,n=\{\}\)/);
+  assert.match(patched, /cwd:n\.cwd/);
   assert.match(patched, /linux:\{label:`File Manager`/);
-  assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
-  assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+  assert.match(patched, /detect:\(\)=>codexLinuxFindExecutable\(`dolphin`\)\?\?/);
+  assert.match(patched, /\[`dolphin`,\[`--select`,t\]\]/);
+  assert.match(patched, /n\.shell\.openPath\(t\)/);
+  assert.doesNotMatch(patched, /__codexOpenTarget/);
+});
+
+test("replaces legacy Linux file manager opener with reveal-aware opener", () => {
+  const legacyLinuxFileManager =
+    "linux:{label:`File Manager`,icon:`apps/file-explorer.png`,detect:()=>`linux-file-manager`,args:e=>[e],open:async({path:e})=>{let __codexOpenTarget=e;let __codexError=await n.shell.openPath(__codexOpenTarget);if(__codexError)throw Error(__codexError)}}";
+  const legacyBundle = fileManagerBundle.replace(
+    "}});function uu(){}",
+    `},${legacyLinuxFileManager}});function uu(){}`,
+  );
+  const source = `${mainBundlePrefix}${legacyBundle}`;
+
+  const patched = applyPatchTwice(applyLinuxFileManagerPatch, source);
+
+  assert.equal((patched.match(/linux:\{label:`File Manager`/g) ?? []).length, 1);
+  assert.match(patched, /codexLinuxOpenFileManager\(e\)/);
+  assert.match(patched, /n\.shell\.openPath\(t\)/);
+  assert.doesNotMatch(patched, /__codexOpenTarget|__codexError/);
 });
 
 test("preserves user-enabled remote_control config on Linux", () => {

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -12,13 +12,13 @@ const {
 // Main-process patches adapt Electron shell behavior: windows, tray, menu,
 // single-instance handling, file manager integration, and packaged runtime glue.
 function applyLinuxFileManagerPatch(currentSource) {
-  const block = findCallBlock(currentSource, "id:`fileManager`");
+  let block = findCallBlock(currentSource, "id:`fileManager`");
   if (block == null) {
     console.warn("Failed to apply Linux File Manager Patch");
     return currentSource;
   }
 
-  if (block.text.includes("linux:{")) {
+  if (block.text.includes("codexLinuxOpenFileManager(e)")) {
     return currentSource;
   }
 
@@ -30,6 +30,15 @@ function applyLinuxFileManagerPatch(currentSource) {
     return currentSource;
   }
 
+  let patchedSource = insertLinuxFileManagerHelpers(currentSource, block.start, { fsVar, pathVar });
+  if (patchedSource !== currentSource) {
+    block = findCallBlock(patchedSource, "id:`fileManager`");
+    if (block == null) {
+      console.warn("Failed to apply Linux File Manager Patch");
+      return currentSource;
+    }
+  }
+
   const insertionPoint = block.text.lastIndexOf("}});");
   if (insertionPoint === -1) {
     console.warn("Failed to apply Linux File Manager Patch");
@@ -37,26 +46,64 @@ function applyLinuxFileManagerPatch(currentSource) {
   }
 
   const linuxFileManager =
-    `,linux:{label:\`File Manager\`,icon:\`apps/file-explorer.png\`,detect:()=>\`linux-file-manager\`,args:e=>[e],open:async({path:e})=>{let __codexResolved=e;for(;;){if((0,${fsVar}.existsSync)(__codexResolved))break;let __codexParent=(0,${pathVar}.dirname)(__codexResolved);if(__codexParent===__codexResolved){__codexResolved=null;break}__codexResolved=__codexParent}let __codexOpenTarget=__codexResolved??e;if((0,${fsVar}.existsSync)(__codexOpenTarget)&&(0,${fsVar}.statSync)(__codexOpenTarget).isFile())__codexOpenTarget=(0,${pathVar}.dirname)(__codexOpenTarget);let __codexError=await ${electronVar}.shell.openPath(__codexOpenTarget);if(__codexError)throw Error(__codexError)}}`;
+    `,linux:{label:\`File Manager\`,icon:\`apps/file-explorer.png\`,detect:()=>codexLinuxFindExecutable(\`dolphin\`)??codexLinuxFindExecutable(\`nautilus\`)??codexLinuxFindExecutable(\`nemo\`)??codexLinuxFindExecutable(\`thunar\`)??codexLinuxFindExecutable(\`pcmanfm\`)??codexLinuxFindExecutable(\`caja\`)??codexLinuxFindExecutable(\`xdg-open\`)??\`linux-file-manager\`,args:e=>[e],open:async({path:e})=>{await codexLinuxOpenFileManager(e).catch(async()=>{let t=codexLinuxResolveExistingTarget(e)??e;try{(0,${fsVar}.existsSync)(t)&&(0,${fsVar}.statSync)(t).isFile()&&(t=(0,${pathVar}.dirname)(t))}catch{}let r=await ${electronVar}.shell.openPath(t);if(r)throw Error(r)})}}`;
 
-  const patchedBlock =
-    block.text.slice(0, insertionPoint + 1) +
-    linuxFileManager +
-    block.text.slice(insertionPoint + 1);
-  const patchedSource =
-    currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
+  const existingLinuxBlock = findPropertyBlock(block.text, "linux");
+  const patchedBlock = existingLinuxBlock == null
+    ? block.text.slice(0, insertionPoint + 1) + linuxFileManager + block.text.slice(insertionPoint + 1)
+    : block.text.slice(0, existingLinuxBlock.start) +
+      linuxFileManager +
+      block.text.slice(existingLinuxBlock.end);
+  patchedSource =
+    patchedSource.slice(0, block.start) + patchedBlock + patchedSource.slice(block.end);
 
   const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
   if (
     !patchedBlockCheck.includes("linux:{label:`File Manager`") ||
-    !patchedBlockCheck.includes("detect:()=>`linux-file-manager`") ||
-    !patchedBlockCheck.includes(`${electronVar}.shell.openPath(__codexOpenTarget)`)
+    !patchedBlockCheck.includes("codexLinuxOpenFileManager(e)") ||
+    !patchedBlockCheck.includes(`${electronVar}.shell.openPath(t)`)
   ) {
     console.warn("Failed to apply Linux File Manager Patch");
     return currentSource;
   }
 
   return patchedSource;
+}
+
+function findPropertyBlock(source, propertyName) {
+  const propertyIndex = source.indexOf(`,${propertyName}:{`);
+  if (propertyIndex === -1) {
+    return null;
+  }
+
+  const openIndex = source.indexOf("{", propertyIndex);
+  const closeIndex = findMatchingBrace(source, openIndex);
+  if (openIndex === -1 || closeIndex === -1) {
+    return null;
+  }
+
+  return {
+    start: propertyIndex,
+    end: closeIndex + 1,
+    text: source.slice(propertyIndex, closeIndex + 1),
+  };
+}
+
+function insertLinuxFileManagerHelpers(currentSource, insertionIndex, { fsVar, pathVar }) {
+  if (currentSource.includes("function codexLinuxFindExecutable(")) {
+    return currentSource;
+  }
+
+  const helpers =
+    `function codexLinuxFindExecutable(e){if(process.platform!==\`linux\`||!e)return null;let t=process.env.PATH||\`\`;for(let n of t.split(\`:\`)){if(!n||!${pathVar}.isAbsolute(n))continue;let r=(0,${pathVar}.join)(n,e);try{if((0,${fsVar}.existsSync)(r)){let e=(0,${fsVar}.statSync)(r);if(e.isFile())try{(0,${fsVar}.accessSync)(r,${fsVar}.constants.X_OK);return r}catch{}}}catch{}}return null}` +
+    `function codexLinuxResolveExistingTarget(e){if(typeof e!==\`string\`||e.length===0)return null;let t=e;for(;;){try{if((0,${fsVar}.existsSync)(t))return t}catch{}let n=(0,${pathVar}.dirname)(t);if(n===t)return null;t=n}}` +
+    `function codexLinuxShouldDropXdgConfigHome(e){let t=e.XDG_CONFIG_HOME,n=e.CODEX_ELECTRON_USER_DATA_DIR;if(typeof t!==\`string\`)return!1;if(typeof n===\`string\`&&t===(0,${pathVar}.join)((0,${pathVar}.dirname)(n),\`xdg-config\`))return!0;let r=e.CODEX_LINUX_APP_ID;return!!(r&&t.endsWith(\`/\${r}/xdg-config\`))}` +
+    `function codexLinuxOpenTargetEnv(){let e={...process.env};codexLinuxShouldDropXdgConfigHome(e)&&delete e.XDG_CONFIG_HOME;for(let t of [\`NODE_OPTIONS\`,\`NODE_PATH\`,\`NODE_REPL_EXTERNAL_MODULE\`,\`ELECTRON_RUN_AS_NODE\`,\`ELECTRON_NO_ASAR\`,\`ELECTRON_ENABLE_LOGGING\`,\`VSCODE_NODE_OPTIONS\`,\`VSCODE_NODE_REPL_EXTERNAL_MODULE\`,\`npm_config_node_options\`,\`NPM_CONFIG_NODE_OPTIONS\`,\`CHROME_DESKTOP\`,\`ELECTRON_RENDERER_URL\`,\`CODEX_ELECTRON_RESOURCES_PATH\`,\`CODEX_ELECTRON_USER_DATA_DIR\`,\`CODEX_LINUX_APP_ID\`,\`CODEX_LINUX_APP_DISPLAY_NAME\`,\`CODEX_LINUX_WEBVIEW_PORT\`])delete e[t];return e}` +
+    `function codexLinuxLaunchDetached(e,t,n={}){return new Promise((r,i)=>{let a=!1,o;try{let s=require(\`node:child_process\`).spawn(e,t,{detached:!0,stdio:\`ignore\`,windowsHide:!0,cwd:n.cwd,env:codexLinuxOpenTargetEnv()});o=setTimeout(()=>{a=!0,s.unref?.(),r()},400),o.unref?.(),s.on(\`error\`,e=>{a||(clearTimeout(o),i(e))}),s.on(\`close\`,e=>{a||(clearTimeout(o),e===0?r():i(Error(\`Linux open target launch failed\`)))})}catch(e){clearTimeout(o),i(e)}})}` +
+    `function codexLinuxTryReveal(e,t){return new Promise((n,r)=>{let i=!1,a;try{let o=require(\`node:child_process\`).spawn(e,t,{stdio:\`ignore\`,windowsHide:!0,env:codexLinuxOpenTargetEnv()});a=setTimeout(()=>{i=!0,o.unref?.(),n()},400),a.unref?.(),o.on(\`error\`,e=>{i||(clearTimeout(a),r(e))}),o.on(\`close\`,e=>{i||(clearTimeout(a),e===0?n():r(Error(\`Linux file manager reveal failed\`)))})}catch(e){clearTimeout(a),r(e)}})}` +
+    `async function codexLinuxOpenFileManager(e){let t=codexLinuxResolveExistingTarget(e)??e;if(typeof t!==\`string\`||t.length===0)throw Error(\`No Linux file manager target available\`);let n=!1;try{n=(0,${fsVar}.existsSync)(t)&&(0,${fsVar}.statSync)(t).isFile()}catch{}if(n)for(let e of [[\`dolphin\`,[\`--select\`,t]],[\`nautilus\`,[\`--select\`,t]]]){let t=codexLinuxFindExecutable(e[0]);if(t)try{await codexLinuxTryReveal(t,e[1]);return}catch{}}t=n?(0,${pathVar}.dirname)(t):t;for(let e of [\`nemo\`,\`thunar\`,\`pcmanfm\`,\`caja\`,\`xdg-open\`]){let n=codexLinuxFindExecutable(e);if(n)try{await codexLinuxLaunchDetached(n,[t]);return}catch{}}throw Error(\`No Linux file manager available\`)}`;
+
+  return currentSource.slice(0, insertionIndex) + helpers + currentSource.slice(insertionIndex);
 }
 
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3236,8 +3236,12 @@ test_linux_file_manager_patch_smoke() {
     make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let n=require(`electron`),t=require(`node:path`),a=require(`node:fs`);...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>`linux-file-manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxFindExecutable(`dolphin`)'
+    assert_contains "$extracted/.vite/build/main-test.js" '--select'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxOpenFileManager(e)'
+    assert_contains "$extracted/.vite/build/main-test.js" 'n.shell.openPath(t)'
+    assert_not_contains "$extracted/.vite/build/main-test.js" '__codexOpenTarget'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.setMenuBarVisibility(!1),'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
     assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" '`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null'
@@ -3428,7 +3432,7 @@ if (!result.event.prevented || result.state.hideCalls !== 1) {
 NODE
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`linux`' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`?null:' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&!this.isAppQuitting' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'setLinuxTrayContextMenu(){' '1'


### PR DESCRIPTION
## Summary
- promote the reveal-aware Linux file-manager opener into the core main-process patch
- prefer Dolphin/Nautilus select-file behavior before folder open fallbacks and Electron shell fallback
- update open-target feature and smoke coverage for the new core baseline

## Validation
- node --check scripts/patches/main-process.js
- node --test scripts/patch-linux-window-ui.test.js
- node --test linux-features/open-target-discovery/test.js
- bash tests/scripts_smoke.sh
- git diff --check