### PR TITLE
Promote Linux Zed opener to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   bundled plugin registry so the app keeps `read-aloud` installed, and the
   launcher syncs the plugin cache so new Codex windows expose the MCP tools
   through the same auto-install path as Computer Use.
+- Linux Zed editor opener support is now enabled by default when the `zed`,
+  `zeditor`, `zedit`, or `zed-cli` command is available.
 
 ### Fixed
 

--- a/linux-features/open-target-discovery/README.md
+++ b/linux-features/open-target-discovery/README.md
@@ -18,7 +18,7 @@ The feature is disabled by default. Enable it locally by copying `linux-features
 }
 ```
 
-This feature is broader than `zed-opener`. If both are enabled, `zed-opener` can provide the focused Zed target while this feature avoids adding a second built-in Zed target and still discovers other editors.
+This feature is broader than the core Zed opener. It avoids adding a second built-in Zed target and still discovers other editors.
 
 Run the feature tests with:
 

--- a/linux-features/zed-opener/README.md
+++ b/linux-features/zed-opener/README.md
@@ -1,12 +1,13 @@
 # Zed Opener
 
-Adds Zed as an opt-in Linux editor opener in Codex Desktop. The patch extends
-the upstream Zed opener block with a Linux platform entry and reuses the
-upstream `path:line:column` argument builder.
+Historically added Zed as an opt-in Linux editor opener in Codex Desktop. Core
+Linux patching now enables the same Zed opener by default, and this feature is
+kept as a compatibility wrapper for local configs that still list
+`zed-opener`.
 
-This feature is opt-in. The loader reads enabled feature ids from the root
-config at `linux-features/features.json`, then loads this feature's manifest
-from `linux-features/zed-opener/feature.json`.
+The loader reads enabled feature ids from the root config at
+`linux-features/features.json`, then loads this feature's manifest from
+`linux-features/zed-opener/feature.json`.
 
 To enable it locally, create the root config if needed:
 
@@ -45,5 +46,5 @@ node scripts/patch-linux-window-ui.js /path/to/extracted/app.asar
 ```
 
 Known risk: the patch depends on the upstream minified Zed opener block. If
-that block changes shape, the feature fails soft and leaves the bundle
-unchanged.
+that block changes shape, the core patch and compatibility feature fail soft
+and leave the bundle unchanged.

--- a/linux-features/zed-opener/test.js
+++ b/linux-features/zed-opener/test.js
@@ -95,14 +95,14 @@ test("Zed opener feature fails soft when the opener block is missing", () => {
   assert.match(warnings.join("\n"), /Could not find Zed opener block/);
 });
 
-test("Zed opener feature stays disabled until listed in features.json", () => {
+test("Zed opener feature stays disabled while core Zed support remains enabled", () => {
   withTempFeatureConfig([], (root) => {
     assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), []);
     assert.deepEqual(loadLinuxFeatureMainBundlePatches({ featuresRoot: root }), []);
 
     withLinuxFeatureRootEnv(root, () => {
       const { value: patched } = captureWarns(() => patchMainBundleSource(zedOpenerBundle, null));
-      assert.doesNotMatch(patched, /linux:\{label:`Zed`/);
+      assert.match(patched, /linux:\{label:`Zed`/);
     });
   });
 });
@@ -140,7 +140,10 @@ test("Zed opener feature participates in main bundle patching and patch reports"
 
         assert.match(fs.readFileSync(path.join(buildDir, "main.js"), "utf8"), /linux:\{label:`Zed`/);
         assert.ok(
-          report.patches.some((patch) => patch.name === "feature:zed-opener" && patch.status === "applied"),
+          report.patches.some((patch) => patch.name === "linux-zed-opener" && patch.status === "applied"),
+        );
+        assert.ok(
+          report.patches.some((patch) => patch.name === "feature:zed-opener" && patch.status === "already-applied"),
         );
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -75,6 +75,7 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxZedOpenerPatch,
 } = require("./patches/main-process.js");
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
@@ -190,6 +191,7 @@ module.exports = {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxZedOpenerPatch,
   applySubagentNicknameMetadataPatch,
   createPatchReport,
   corePatchDescriptors,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -49,6 +49,7 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxZedOpenerPatch,
   applySubagentNicknameMetadataPatch,
   isComputerUseUiEnabled,
   patchMainBundleSource,
@@ -84,6 +85,8 @@ const mainBundlePrefix =
   "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
 const fileManagerBundle =
   "var lu=jl({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>il(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:uu,args:e=>il(e),open:async({path:e})=>du(e)}});function uu(){}";
+const zedOpenerBundle =
+  "function Tw(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}function Rp(e){return e}var eT={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:tT,args:Tw,open:async({command:e,path:t,location:n})=>{await aT(e,t,n)}},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:nT,args:Tw}}};function tT(){return Rp(`zed`)??nC(`Zed`,`zed`)}function nT(){let e=Rp(`zed.exe`)??Rp(`zed`);return e}";
 const alreadyOpaqueBackgroundBundle =
   "process.platform===`linux`?{backgroundColor:e?t:n,backgroundMaterial:null}:{backgroundColor:r,backgroundMaterial:null}";
 const opaqueBackgroundBundleWithDriftingGw =
@@ -493,6 +496,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
     "linux-file-manager",
+    "linux-zed-opener",
     "linux-tray",
     "linux-build-info-tray",
     "linux-single-instance",
@@ -783,6 +787,29 @@ test("adds Linux file manager support without relying on exact minified variable
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
   assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+});
+
+test("adds Linux Zed opener support to the upstream opener block", () => {
+  const patched = applyPatchTwice(applyLinuxZedOpenerPatch, zedOpenerBundle);
+
+  assert.match(patched, /linux:\{label:`Zed`,icon:`apps\/zed\.png`,kind:`editor`/);
+  assert.match(
+    patched,
+    /detect:\(\)=>Rp\(`zed`\)\?\?Rp\(`zeditor`\)\?\?Rp\(`zedit`\)\?\?Rp\(`zed-cli`\)/,
+  );
+  assert.match(patched, /args:Tw/);
+});
+
+test("keeps an existing Linux Zed opener unchanged", () => {
+  const zedAlreadyLinux = zedOpenerBundle.replace(
+    "win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:nT,args:Tw}}",
+    "win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:nT,args:Tw},linux:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:tT,args:Tw}}",
+  );
+
+  const patched = applyPatchTwice(applyLinuxZedOpenerPatch, zedAlreadyLinux);
+
+  assert.equal((patched.match(/linux:\{label:`Zed`/g) ?? []).length, 1);
+  assert.match(patched, /detect:tT,args:Tw/);
 });
 
 test("preserves user-enabled remote_control config on Linux", () => {

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -7,6 +7,7 @@ const {
   applyLinuxReadyToShowWindowStatePatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxFileManagerPatch,
+  applyLinuxZedOpenerPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxTrayPatch,
   applyLinuxSingleInstancePatch,
@@ -63,6 +64,13 @@ module.exports = [
     order: 100,
     ciPolicy: "required-upstream",
     apply: applyLinuxFileManagerPatch,
+  },
+  {
+    id: "linux-zed-opener",
+    phase: "main-bundle",
+    order: 105,
+    ciPolicy: "optional",
+    apply: applyLinuxZedOpenerPatch,
   },
   {
     id: "linux-tray",

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -59,6 +59,94 @@ function applyLinuxFileManagerPatch(currentSource) {
   return patchedSource;
 }
 
+function findZedOpenerBlock(source) {
+  const markerStart = source.indexOf("id:`zed`");
+  if (markerStart === -1) {
+    return null;
+  }
+
+  const blockStart = Math.max(
+    source.lastIndexOf("var ", markerStart),
+    source.lastIndexOf("let ", markerStart),
+    source.lastIndexOf("const ", markerStart),
+  );
+  const objectStart = blockStart === -1 ? -1 : source.indexOf("{", blockStart);
+  const objectEnd = objectStart === -1 ? -1 : findMatchingBrace(source, objectStart);
+  if (blockStart === -1 || objectStart === -1 || objectEnd === -1) {
+    return null;
+  }
+
+  const blockEnd = source[objectEnd + 1] === ";" ? objectEnd + 2 : objectEnd + 1;
+  return {
+    start: blockStart,
+    end: blockEnd,
+    text: source.slice(blockStart, blockEnd),
+  };
+}
+
+function findZedPathLookupFunction(source, detectFn) {
+  const detectFunctionRegex = new RegExp(
+    `function ${escapeRegExp(detectFn)}\\(\\)\\{return ([A-Za-z_$][\\w$]*)\\(\\\`zed\\\`\\)`,
+  );
+  return source.match(detectFunctionRegex)?.[1] ?? null;
+}
+
+function applyLinuxZedOpenerPatch(currentSource) {
+  if (!currentSource.includes("id:`zed`")) {
+    return currentSource;
+  }
+
+  const block = findZedOpenerBlock(currentSource);
+  if (block == null) {
+    console.warn("WARN: Could not parse Zed opener block - skipping Linux Zed opener patch");
+    return currentSource;
+  }
+  if (block.text.includes("linux:{")) {
+    return currentSource;
+  }
+
+  const argsFn = block.text.match(/\bargs:([A-Za-z_$][\w$]*)/)?.[1];
+  const detectFn = block.text.match(/\bdarwin:\{[^}]*\bdetect:([A-Za-z_$][\w$]*)/)?.[1];
+  if (argsFn == null || detectFn == null) {
+    console.warn("WARN: Could not identify Zed opener helpers - skipping Linux Zed opener patch");
+    return currentSource;
+  }
+
+  const pathLookupFn = findZedPathLookupFunction(currentSource, detectFn);
+  if (pathLookupFn == null) {
+    console.warn("WARN: Could not identify Zed path lookup helper - skipping Linux Zed opener patch");
+    return currentSource;
+  }
+
+  let insertionPoint = block.text.lastIndexOf("}}};");
+  if (insertionPoint === -1) {
+    insertionPoint = block.text.lastIndexOf("}}}");
+  }
+  if (insertionPoint === -1) {
+    console.warn("WARN: Could not find Zed opener insertion point - skipping Linux Zed opener patch");
+    return currentSource;
+  }
+
+  const linuxZed =
+    `,linux:{label:\`Zed\`,icon:\`apps/zed.png\`,kind:\`editor\`,detect:()=>${pathLookupFn}(\`zed\`)??${pathLookupFn}(\`zeditor\`)??${pathLookupFn}(\`zedit\`)??${pathLookupFn}(\`zed-cli\`),args:${argsFn}}`;
+  const patchedBlock =
+    block.text.slice(0, insertionPoint + 1) + linuxZed + block.text.slice(insertionPoint + 1);
+  const patchedSource =
+    currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
+  const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
+  if (
+    !patchedBlockCheck.includes("id:`zed`") ||
+    !patchedBlockCheck.includes("linux:{label:`Zed`") ||
+    !patchedBlockCheck.includes(`${pathLookupFn}(\`zeditor\`)`) ||
+    !patchedBlockCheck.includes(`args:${argsFn}`)
+  ) {
+    console.warn("WARN: Failed to apply Linux Zed opener patch");
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
   if (iconAsset == null) {
     return currentSource;
@@ -1030,4 +1118,5 @@ module.exports = {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxZedOpenerPatch,
 };


### PR DESCRIPTION
## Summary
- add a core Linux Zed opener patch for `zed`, `zeditor`, `zedit`, and `zed-cli`
- keep the opt-in `zed-opener` feature as a compatibility no-op once core has patched the bundle
- update Zed/open-target docs and patch report tests for the new core baseline

## Validation
- `node --check scripts/patches/main-process.js`
- `node --test linux-features/zed-opener/test.js`
- `node --test linux-features/open-target-discovery/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `git diff --check HEAD~1..HEAD`