### PR TITLE
Align Computer Use readiness with input backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ sudo pacman -S ydotool
 sudo zypper install ydotool
 ```
 
-`ydotool` needs `/dev/uinput` access. The usual setup is to run `ydotoold`, add your user to the `input` group, then re-login:
+The preferred coordinate input path opens `/dev/uinput` directly. The XDG RemoteDesktop portal can also provide input on desktops that expose it. `ydotool` remains the fallback path; when you need it, run `ydotoold`, add your user to the `input` group, then re-login:
 
 ```bash
 sudo systemctl enable --now ydotoold
@@ -533,7 +533,7 @@ make clean-state
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | `make build-app-fresh` removes the existing install dir and cached DMG, then re-downloads |
 | Computer Use plugin invisible in UI | Ensure you enabled the Computer Use UI. If it is enabled and still hidden, the OpenAI per-account rollout may not be available |
-| Computer Use `doctor` reports `ydotool not running` | Start the distro-provided daemon unit (`ydotoold` or `ydotool`), or use a user-session `ydotoold` service, then add your user to the `input` group |
+| Computer Use `doctor` reports no input backend | Grant read/write `/dev/uinput`, enable the XDG RemoteDesktop portal, or start the distro-provided `ydotoold` / `ydotool` daemon with a socket accessible to your user |
 | Computer Use `doctor` reports `ydotool_socket: Permission denied` | The daemon socket is root-only. Adjust the `ydotoold` service so `/tmp/.ydotool_socket` becomes `root:input` with `0660` permissions |
 | `ConnectTimeoutError` for `www.electronjs.org` during `@electron/rebuild` | Re-run `make build-app`; the installer now uses `https://artifacts.electronjs.org/headers/dist` for Electron headers by default |
 | Computer Use AT-SPI tree empty | Run `codex-computer-use-linux setup` to flip GNOME accessibility on, then restart the target app |

--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -175,7 +175,7 @@ pub fn doctor_report() -> DoctorReport {
     let accessibility = accessibility_report();
     let windowing = windowing_report(&platform);
     let input = input_report();
-    let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+    let readiness = readiness_report(&platform, &portals, &accessibility, &windowing, &input);
 
     let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
 
@@ -619,6 +619,7 @@ fn input_report() -> InputReport {
 
 fn readiness_report(
     platform: &PlatformReport,
+    portals: &PortalReport,
     accessibility: &AccessibilityReport,
     windowing: &WindowingReport,
     input: &InputReport,
@@ -628,8 +629,7 @@ fn readiness_report(
     let can_query_windows = windowing.can_list_windows;
     let can_focus_apps = windowing.can_focus_apps;
     let can_focus_windows = windowing.can_focus_windows;
-    let can_send_development_input =
-        input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok;
+    let can_send_development_input = can_send_development_input(portals, input);
 
     if !can_build_accessibility_tree {
         blockers.push(
@@ -656,7 +656,7 @@ fn readiness_report(
 
     if !can_send_development_input {
         blockers.push(
-            "Development input fallback is unavailable; ydotool needs a running ydotoold daemon with a connectable ydotoold socket."
+            "Development input is unavailable; enable read/write /dev/uinput, XDG RemoteDesktop portal input, or ydotool with a connectable ydotoold socket."
                 .to_string(),
         );
     }
@@ -676,10 +676,10 @@ fn readiness_report(
     } else if !can_focus_windows {
         "Enable an exact-focus window backend before using window_id, title, or terminal-targeted input.".to_string()
     } else if !can_send_development_input {
-        "Fix ydotool input access: start ydotoold with a socket accessible to this desktop user."
+        "Enable a supported input backend: grant read/write /dev/uinput, enable the XDG RemoteDesktop portal, or start ydotoold with a socket accessible to this desktop user."
             .to_string()
     } else {
-        "Computer Use is ready: AT-SPI tree support, window targeting, and ydotool input fallback are available."
+        "Computer Use is ready: AT-SPI tree support, window targeting, and a Linux input backend are available."
             .to_string()
     };
 
@@ -693,6 +693,12 @@ fn readiness_report(
         recommended_next_step,
         blockers,
     }
+}
+
+fn can_send_development_input(portals: &PortalReport, input: &InputReport) -> bool {
+    input.uinput.ok
+        || portals.remote_desktop.ok
+        || input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok
 }
 
 fn is_cosmic_wayland_platform(platform: &PlatformReport) -> bool {
@@ -966,6 +972,18 @@ mod tests {
         }
     }
 
+    fn portal_report(remote_desktop: Check) -> PortalReport {
+        PortalReport {
+            desktop_portal: Check::ok("ok"),
+            remote_desktop,
+            screencast: Check::fail("missing"),
+            screenshot: Check::fail("missing"),
+            input_capture: Check::fail("missing"),
+            mutter_remote_desktop: Check::fail("missing"),
+            mutter_screencast: Check::fail("missing"),
+        }
+    }
+
     fn accessibility_report(
         at_spi_bus: Check,
         toolkit_accessibility: Check,
@@ -1107,7 +1125,13 @@ mod tests {
         let windowing = windowing_report(true, false);
         let input = input_report(true);
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(readiness.can_query_windows);
         assert!(!readiness.can_focus_windows);
@@ -1131,7 +1155,13 @@ mod tests {
         windowing.can_focus_windows = true;
         let input = input_report(true);
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(readiness.can_query_windows);
         assert!(readiness.can_focus_apps);
@@ -1146,7 +1176,13 @@ mod tests {
         let windowing = windowing_report(true, true);
         let input = input_report(true);
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(readiness.blockers.is_empty());
         assert!(readiness
@@ -1170,14 +1206,20 @@ mod tests {
             Check::fail("/dev/uinput: Permission denied"),
         );
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(readiness.can_send_development_input);
         assert!(readiness.blockers.is_empty());
     }
 
     #[test]
-    fn readiness_rejects_direct_uinput_without_connectable_ydotool_socket() {
+    fn readiness_accepts_direct_uinput_without_connectable_ydotool_socket() {
         let platform = platform_report();
         let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
         let windowing = windowing_report(true, true);
@@ -1188,13 +1230,40 @@ mod tests {
             Check::ok("read/write: /dev/uinput"),
         );
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
-        assert!(!readiness.can_send_development_input);
-        assert!(readiness
-            .blockers
-            .iter()
-            .any(|blocker| blocker.contains("connectable ydotoold socket")));
+        assert!(readiness.can_send_development_input);
+        assert!(readiness.blockers.is_empty());
+    }
+
+    #[test]
+    fn readiness_accepts_remote_desktop_portal_without_local_input_backend() {
+        let platform = platform_report();
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::fail("missing ydotool"),
+            Check::fail("ydotoold not running"),
+            Check::fail("no connectable ydotool socket"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::ok("org.freedesktop.portal.RemoteDesktop")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
+
+        assert!(readiness.can_send_development_input);
+        assert!(readiness.blockers.is_empty());
     }
 
     #[test]
@@ -1209,16 +1278,22 @@ mod tests {
             Check::fail("/dev/uinput: Permission denied"),
         );
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(!readiness.can_send_development_input);
         assert!(readiness
             .recommended_next_step
-            .contains("Fix ydotool input access"));
+            .contains("Enable a supported input backend"));
         assert!(readiness
             .blockers
             .iter()
-            .any(|blocker| blocker.contains("connectable ydotoold socket")));
+            .any(|blocker| blocker.contains("Development input is unavailable")));
     }
 
     #[test]
@@ -1267,7 +1342,13 @@ mod tests {
         let windowing = windowing_report(false, false);
         let input = input_report(true);
 
-        let readiness = readiness_report(&platform, &accessibility, &windowing, &input);
+        let readiness = readiness_report(
+            &platform,
+            &portal_report(Check::fail("missing")),
+            &accessibility,
+            &windowing,
+            &input,
+        );
 
         assert!(readiness
             .blockers


### PR DESCRIPTION
## Summary
- treat direct `/dev/uinput` access and XDG RemoteDesktop portal input as valid Computer Use input backends
- keep `ydotool` as the fallback readiness path instead of the only path
- update README troubleshooting/setup text to match the doctor logic

## Validation
- `cargo fmt --check`
- `cargo test -p codex-computer-use-linux diagnostics`
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `git diff --cached --check`