### PR TITLE
Store remote mobile keys in Secret Service

### DIFF
--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -42,9 +42,10 @@ What it changes:
   when the native browser bridge is not exposed to the session.
 - Prefers the Linux Secret Service keyring via `secret-tool` for private key
   material, while keeping non-secret public key metadata at
-  `~/.config/codex-desktop/remote-control-device-keys-v1.json` with `0600`
-  file permissions. If `secret-tool` or the desktop keyring is unavailable, the
-  same JSON file remains the `0600` file-backed fallback.
+  `~/.config/<app-id>/remote-control-device-keys-v1.json` with `0600` file
+  permissions. The default app id is `codex-desktop`; side-by-side app ids use
+  their own metadata path. If `secret-tool` or the desktop keyring is
+  unavailable, the same JSON file remains the `0600` file-backed fallback.
 - Migrates existing file-backed private keys into Secret Service on the next
   successful key read when `secret-tool` is available.
 - Preserves `remote_control = true` / `features.remote_control = true` in the
@@ -129,10 +130,13 @@ Key storage:
 
 When `secret-tool` is available on `PATH`, newly enrolled Linux device keys are
 stored in the user's Secret Service keyring with attributes
-`application=codex-desktop-linux`, `kind=remote-control-device-key`, and
-`key-id=<device key id>`. The JSON file remains as public metadata plus lookup
-attributes. Set `CODEX_REMOTE_CONTROL_KEY_STORE=file` to force the older
-file-backed `0600` fallback for troubleshooting or minimal desktop sessions.
+`application=codex-desktop-linux`, `app-id=<app id>`,
+`kind=remote-control-device-key`, and `key-id=<device key id>`. The JSON file
+remains as public metadata plus lookup attributes. Set
+`CODEX_REMOTE_CONTROL_KEY_STORE=file` to force the older file-backed `0600`
+fallback for troubleshooting or minimal desktop sessions. Existing legacy
+Secret Service entries without `app-id` remain readable so already-enrolled
+devices are not stranded during upgrade.
 
 KDE Plasma smoke check:
 

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -40,9 +40,13 @@ What it changes:
 - Keeps Chrome Browser Use available to remote/mobile controlled sessions when
   the local Chrome plugin and native host are healthy, and adds a diagnostic
   when the native browser bridge is not exposed to the session.
-- Persists the private key material at
+- Prefers the Linux Secret Service keyring via `secret-tool` for private key
+  material, while keeping non-secret public key metadata at
   `~/.config/codex-desktop/remote-control-device-keys-v1.json` with `0600`
-  file permissions.
+  file permissions. If `secret-tool` or the desktop keyring is unavailable, the
+  same JSON file remains the `0600` file-backed fallback.
+- Migrates existing file-backed private keys into Secret Service on the next
+  successful key read when `secret-tool` is available.
 - Preserves `remote_control = true` / `features.remote_control = true` in the
   local Codex config instead of letting upstream strip it before app-server
   startup.
@@ -121,6 +125,15 @@ To keep Desktop using Homebrew while the daemon uses standalone, set
 `CODEX_CLI_PATH` to the Brew binary and leave
 `CODEX_REMOTE_CONTROL_CODEX_PATH` unset or pointed at the standalone binary.
 
+Key storage:
+
+When `secret-tool` is available on `PATH`, newly enrolled Linux device keys are
+stored in the user's Secret Service keyring with attributes
+`application=codex-desktop-linux`, `kind=remote-control-device-key`, and
+`key-id=<device key id>`. The JSON file remains as public metadata plus lookup
+attributes. Set `CODEX_REMOTE_CONTROL_KEY_STORE=file` to force the older
+file-backed `0600` fallback for troubleshooting or minimal desktop sessions.
+
 KDE Plasma smoke check:
 
 Mobile control depends on the Linux Computer Use backend once the host is
@@ -138,8 +151,10 @@ a non-empty `windows` list.
 
 Known risks:
 
-- This is not equivalent to macOS Secure Enclave-backed storage. Private key
-  material is file-backed and protected by ordinary user file permissions.
+- This is not equivalent to macOS Secure Enclave-backed storage. Secret Service
+  support improves the default Linux storage boundary when the desktop keyring
+  is available, but the feature intentionally falls back to ordinary `0600`
+  file-backed storage when it is not.
 - OpenAI may still reject Linux host enrollment server-side. This feature only
   removes local macOS-only blockers in the repackaged app.
 - Treat this as experimental account-level remote-control plumbing.

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -11,6 +11,7 @@ function requireName(source, moduleName) {
 
 const DEVICE_KEY_CLIENT_MARKER = "codexLinuxRemoteControlDeviceKeyClient";
 const DEVICE_KEY_SECRET_SERVICE_MARKER = "codexLinuxRemoteControlSecretTool";
+const DEVICE_KEY_APP_ID_MARKER = "codexLinuxRemoteControlAppId";
 const DEVICE_KEY_PROVIDER_START = "function codexLinuxRemoteControlDeviceKeyStorePath(){";
 const DEVICE_KEY_GUARD =
   "if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
@@ -103,11 +104,18 @@ function linuxRemoteControlClientAccountCompatibilityHelpers(loadEnrollmentFn, e
 
 function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
   return [
-    "function codexLinuxRemoteControlDeviceKeyStorePath(){",
+    "function codexLinuxRemoteControlAppId(){",
+    "let e=(process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||`codex-desktop`).trim();return/^[A-Za-z0-9._-]+$/.test(e)&&e!==`.`&&e!==`..`?e:`codex-desktop`",
+    "}",
+    "function codexLinuxRemoteControlConfigHome(){",
     `let e=process.env.XDG_CONFIG_HOME&&process.env.XDG_CONFIG_HOME.trim()?process.env.XDG_CONFIG_HOME.trim():process.env.HOME?${pathVar}.join(process.env.HOME,\`.config\`):null;`,
-    "if(e==null)throw Error(`Linux remote control device keys require HOME or XDG_CONFIG_HOME`);",
-    `${fsVar}.mkdirSync(${pathVar}.join(e,\`codex-desktop\`),{recursive:!0,mode:448});`,
-    `return ${pathVar}.join(e,\`codex-desktop\`,\`remote-control-device-keys-v1.json\`)`,
+    "if(e==null)throw Error(`Linux remote control device keys require HOME or XDG_CONFIG_HOME`);return e",
+    "}",
+    "function codexLinuxRemoteControlDeviceKeyStorePath(){",
+    `let e=codexLinuxRemoteControlConfigHome(),t=codexLinuxRemoteControlAppId();${fsVar}.mkdirSync(${pathVar}.join(e,t),{recursive:!0,mode:448});return ${pathVar}.join(e,t,\`remote-control-device-keys-v1.json\`)`,
+    "}",
+    "function codexLinuxRemoteControlLegacyDeviceKeyStorePath(){",
+    `let e=codexLinuxRemoteControlAppId();return e===\`codex-desktop\`?null:${pathVar}.join(codexLinuxRemoteControlConfigHome(),\`codex-desktop\`,\`remote-control-device-keys-v1.json\`)`,
     "}",
     "function codexLinuxRemoteControlPublicDeviceKey(e){",
     "return{algorithm:e.algorithm,keyId:e.keyId,protectionClass:e.protectionClass,publicKeySpkiDerBase64:e.publicKeySpkiDerBase64}",
@@ -115,24 +123,24 @@ function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
     "function codexLinuxRemoteControlKeyStorePrefersFile(){",
     "let e=(process.env.CODEX_REMOTE_CONTROL_KEY_STORE||process.env.CODEX_LINUX_REMOTE_CONTROL_KEY_STORE||`secret-service`).toLowerCase();return e===`file`||e===`json`",
     "}",
-    "function codexLinuxRemoteControlSecretAttributes(e){",
-    "return[`application`,`codex-desktop-linux`,`kind`,`remote-control-device-key`,`key-id`,String(e)]",
+    "function codexLinuxRemoteControlSecretAttributes(e,t=!1){",
+    "let n=[`application`,`codex-desktop-linux`];t||n.push(`app-id`,codexLinuxRemoteControlAppId());return n.push(`kind`,`remote-control-device-key`,`key-id`,String(e)),n",
     "}",
     "function codexLinuxRemoteControlSecretMetadata(e){",
-    "return{backend:`secret-service`,tool:`secret-tool`,attributes:{application:`codex-desktop-linux`,kind:`remote-control-device-key`,keyId:String(e)}}",
+    "return{backend:`secret-service`,tool:`secret-tool`,attributes:{application:`codex-desktop-linux`,appId:codexLinuxRemoteControlAppId(),kind:`remote-control-device-key`,keyId:String(e)}}",
     "}",
     "function codexLinuxRemoteControlSecretTool(e,t){",
     "if(codexLinuxRemoteControlKeyStorePrefersFile())return null;",
     "try{let n=require(`node:child_process`).spawnSync(`secret-tool`,e,{encoding:`utf8`,env:process.env,input:t??``,timeout:3000,windowsHide:!0});return n&&typeof n.status==`number`?n:null}catch{return null}",
     "}",
     "function codexLinuxStoreRemoteControlPrivateKeySecret(e,t){",
-    "let n=codexLinuxRemoteControlSecretTool([`store`,`--label=Codex Desktop Linux remote control device key`,...codexLinuxRemoteControlSecretAttributes(e)],t);return n?.status===0?codexLinuxRemoteControlSecretMetadata(e):null",
+    "let n=codexLinuxRemoteControlAppId(),r=codexLinuxRemoteControlSecretTool([`store`,`--label=Codex Desktop Linux (${n}) remote control device key`,...codexLinuxRemoteControlSecretAttributes(e)],t);return r?.status===0?codexLinuxRemoteControlSecretMetadata(e):null",
     "}",
     "function codexLinuxLookupRemoteControlPrivateKeySecret(e){",
-    "let t=codexLinuxRemoteControlSecretTool([`lookup`,...codexLinuxRemoteControlSecretAttributes(e)]);return t?.status===0&&typeof t.stdout==`string`&&t.stdout.length>0?t.stdout:null",
+    "let t=codexLinuxRemoteControlSecretTool([`lookup`,...codexLinuxRemoteControlSecretAttributes(e)]);if(t?.status===0&&typeof t.stdout==`string`&&t.stdout.length>0)return t.stdout;let n=codexLinuxRemoteControlSecretTool([`lookup`,...codexLinuxRemoteControlSecretAttributes(e,!0)]);return n?.status===0&&typeof n.stdout==`string`&&n.stdout.length>0?n.stdout:null",
     "}",
     "function codexLinuxClearRemoteControlPrivateKeySecret(e){",
-    "let t=codexLinuxRemoteControlSecretTool([`clear`,...codexLinuxRemoteControlSecretAttributes(e)]);return t?.status===0",
+    "let t=codexLinuxRemoteControlSecretTool([`clear`,...codexLinuxRemoteControlSecretAttributes(e)]),n=codexLinuxRemoteControlSecretTool([`clear`,...codexLinuxRemoteControlSecretAttributes(e,!0)]);return t?.status===0||n?.status===0",
     "}",
     "function codexLinuxMigrateRemoteControlDeviceKeySecrets(e){",
     "if(codexLinuxRemoteControlKeyStorePrefersFile())return e;",
@@ -141,19 +149,23 @@ function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
     "return n?{...e,keys:r}:e",
     "}",
     "function codexLinuxReadRemoteControlDeviceKeyStore(){",
-    "let e=codexLinuxRemoteControlDeviceKeyStorePath();",
+    "let e=codexLinuxRemoteControlDeviceKeyStorePath(),t=codexLinuxRemoteControlLegacyDeviceKeyStorePath(),n=e;",
+    `if(!${fsVar}.existsSync(e)&&t!=null&&${fsVar}.existsSync(t))e=t;`,
     `if(!${fsVar}.existsSync(e))return{keys:{}};`,
     "try{",
-    `let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));`,
-    "let n=t&&typeof t==`object`&&!Array.isArray(t)&&t.keys&&typeof t.keys==`object`&&!Array.isArray(t.keys)?t:{keys:{}};",
-    "let r=codexLinuxMigrateRemoteControlDeviceKeySecrets(n);",
-    "if(r!==n)try{codexLinuxWriteRemoteControlDeviceKeyStore(r)}catch{}",
-    "return r",
+    `let r=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));`,
+    "let i=r&&typeof r==`object`&&!Array.isArray(r)&&r.keys&&typeof r.keys==`object`&&!Array.isArray(r.keys)?r:{keys:{}};",
+    "let a=codexLinuxMigrateRemoteControlDeviceKeySecrets(i);",
+    "if(a!==i)try{codexLinuxWriteRemoteControlDeviceKeyStore(a);e!==n&&codexLinuxWriteRemoteControlDeviceKeyStoreAt(e,a)}catch{}",
+    "return a",
     "}catch{return{keys:{}}}",
     "}",
+    "function codexLinuxWriteRemoteControlDeviceKeyStoreAt(e,t){",
+    "let n=`${e}.tmp-${process.pid}-${Date.now()}`;",
+    `try{${fsVar}.writeFileSync(n,JSON.stringify(t,null,2)+\`\\n\`,{encoding:\`utf8\`,mode:384}),${fsVar}.chmodSync(n,384),${fsVar}.renameSync(n,e),${fsVar}.chmodSync(e,384)}catch(e){try{${fsVar}.rmSync(n,{force:!0})}catch{}throw e}`,
+    "}",
     "function codexLinuxWriteRemoteControlDeviceKeyStore(e){",
-    "let t=codexLinuxRemoteControlDeviceKeyStorePath(),n=`${t}.tmp-${process.pid}-${Date.now()}`;",
-    `try{${fsVar}.writeFileSync(n,JSON.stringify(e,null,2)+\`\\n\`,{encoding:\`utf8\`,mode:384}),${fsVar}.chmodSync(n,384),${fsVar}.renameSync(n,t),${fsVar}.chmodSync(t,384)}catch(e){try{${fsVar}.rmSync(n,{force:!0})}catch{}throw e}`,
+    "codexLinuxWriteRemoteControlDeviceKeyStoreAt(codexLinuxRemoteControlDeviceKeyStorePath(),e)",
     "}",
     "function codexLinuxRemoteControlDeviceKeyClient(){return{",
     "createDeviceKey:async e=>{",
@@ -174,7 +186,11 @@ function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
 }
 
 function applyLinuxRemoteControlDeviceKeyPatch(source) {
-  if (source.includes(DEVICE_KEY_CLIENT_MARKER) && source.includes(DEVICE_KEY_SECRET_SERVICE_MARKER)) {
+  if (
+    source.includes(DEVICE_KEY_CLIENT_MARKER) &&
+    source.includes(DEVICE_KEY_SECRET_SERVICE_MARKER) &&
+    source.includes(DEVICE_KEY_APP_ID_MARKER)
+  ) {
     return source;
   }
 

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -10,6 +10,8 @@ function requireName(source, moduleName) {
 }
 
 const DEVICE_KEY_CLIENT_MARKER = "codexLinuxRemoteControlDeviceKeyClient";
+const DEVICE_KEY_SECRET_SERVICE_MARKER = "codexLinuxRemoteControlSecretTool";
+const DEVICE_KEY_PROVIDER_START = "function codexLinuxRemoteControlDeviceKeyStorePath(){";
 const DEVICE_KEY_GUARD =
   "if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
 const DEVICE_KEY_GUARD_REPLACEMENT =
@@ -110,12 +112,43 @@ function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
     "function codexLinuxRemoteControlPublicDeviceKey(e){",
     "return{algorithm:e.algorithm,keyId:e.keyId,protectionClass:e.protectionClass,publicKeySpkiDerBase64:e.publicKeySpkiDerBase64}",
     "}",
+    "function codexLinuxRemoteControlKeyStorePrefersFile(){",
+    "let e=(process.env.CODEX_REMOTE_CONTROL_KEY_STORE||process.env.CODEX_LINUX_REMOTE_CONTROL_KEY_STORE||`secret-service`).toLowerCase();return e===`file`||e===`json`",
+    "}",
+    "function codexLinuxRemoteControlSecretAttributes(e){",
+    "return[`application`,`codex-desktop-linux`,`kind`,`remote-control-device-key`,`key-id`,String(e)]",
+    "}",
+    "function codexLinuxRemoteControlSecretMetadata(e){",
+    "return{backend:`secret-service`,tool:`secret-tool`,attributes:{application:`codex-desktop-linux`,kind:`remote-control-device-key`,keyId:String(e)}}",
+    "}",
+    "function codexLinuxRemoteControlSecretTool(e,t){",
+    "if(codexLinuxRemoteControlKeyStorePrefersFile())return null;",
+    "try{let n=require(`node:child_process`).spawnSync(`secret-tool`,e,{encoding:`utf8`,env:process.env,input:t??``,timeout:3000,windowsHide:!0});return n&&typeof n.status==`number`?n:null}catch{return null}",
+    "}",
+    "function codexLinuxStoreRemoteControlPrivateKeySecret(e,t){",
+    "let n=codexLinuxRemoteControlSecretTool([`store`,`--label=Codex Desktop Linux remote control device key`,...codexLinuxRemoteControlSecretAttributes(e)],t);return n?.status===0?codexLinuxRemoteControlSecretMetadata(e):null",
+    "}",
+    "function codexLinuxLookupRemoteControlPrivateKeySecret(e){",
+    "let t=codexLinuxRemoteControlSecretTool([`lookup`,...codexLinuxRemoteControlSecretAttributes(e)]);return t?.status===0&&typeof t.stdout==`string`&&t.stdout.length>0?t.stdout:null",
+    "}",
+    "function codexLinuxClearRemoteControlPrivateKeySecret(e){",
+    "let t=codexLinuxRemoteControlSecretTool([`clear`,...codexLinuxRemoteControlSecretAttributes(e)]);return t?.status===0",
+    "}",
+    "function codexLinuxMigrateRemoteControlDeviceKeySecrets(e){",
+    "if(codexLinuxRemoteControlKeyStorePrefersFile())return e;",
+    "let t=e.keys??{},n=!1,r={...t};",
+    "for(let[i,a]of Object.entries(t)){if(a&&typeof a.privateKeyPkcs8Pem==`string`&&a.secretService==null){let o=codexLinuxStoreRemoteControlPrivateKeySecret(i,a.privateKeyPkcs8Pem);if(o!=null){let{privateKeyPkcs8Pem:s,...c}=a;r[i]={...c,secretService:o},n=!0}}}",
+    "return n?{...e,keys:r}:e",
+    "}",
     "function codexLinuxReadRemoteControlDeviceKeyStore(){",
     "let e=codexLinuxRemoteControlDeviceKeyStorePath();",
     `if(!${fsVar}.existsSync(e))return{keys:{}};`,
     "try{",
     `let t=JSON.parse(${fsVar}.readFileSync(e,\`utf8\`));`,
-    "return t&&typeof t==`object`&&!Array.isArray(t)&&t.keys&&typeof t.keys==`object`&&!Array.isArray(t.keys)?t:{keys:{}}",
+    "let n=t&&typeof t==`object`&&!Array.isArray(t)&&t.keys&&typeof t.keys==`object`&&!Array.isArray(t.keys)?t:{keys:{}};",
+    "let r=codexLinuxMigrateRemoteControlDeviceKeySecrets(n);",
+    "if(r!==n)try{codexLinuxWriteRemoteControlDeviceKeyStore(r)}catch{}",
+    "return r",
     "}catch{return{keys:{}}}",
     "}",
     "function codexLinuxWriteRemoteControlDeviceKeyStore(e){",
@@ -127,19 +160,21 @@ function linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar }) {
     "let t=codexLinuxReadRemoteControlDeviceKeyStore();",
     `let{publicKey:n,privateKey:r}=(0,${cryptoVar}.generateKeyPairSync)(\`ec\`,{namedCurve:\`P-256\`});`,
     `let i=(0,${cryptoVar}.randomUUID)(),a=n.export({type:\`spki\`,format:\`der\`}).toString(\`base64\`),o=r.export({type:\`pkcs8\`,format:\`pem\`});`,
-    "let c={algorithm:`ecdsa_p256_sha256`,keyId:i,protectionClass:`os_protected_nonextractable`,publicKeySpkiDerBase64:a,privateKeyPkcs8Pem:o,createdAt:new Date().toISOString()};",
+    "let l=codexLinuxStoreRemoteControlPrivateKeySecret(i,o);",
+    "let c={algorithm:`ecdsa_p256_sha256`,keyId:i,protectionClass:`os_protected_nonextractable`,publicKeySpkiDerBase64:a,createdAt:new Date().toISOString()};",
+    "l==null?c.privateKeyPkcs8Pem=o:c.secretService=l;",
     "t.keys={...t.keys,[i]:c},codexLinuxWriteRemoteControlDeviceKeyStore(t);",
     "return codexLinuxRemoteControlPublicDeviceKey(c)",
     "},",
-    "deleteDeviceKey:async e=>{let t=codexLinuxReadRemoteControlDeviceKeyStore();t.keys&&delete t.keys[e],codexLinuxWriteRemoteControlDeviceKeyStore(t)},",
+    "deleteDeviceKey:async e=>{codexLinuxClearRemoteControlPrivateKeySecret(e);let t=codexLinuxReadRemoteControlDeviceKeyStore();t.keys&&delete t.keys[e],codexLinuxWriteRemoteControlDeviceKeyStore(t)},",
     "getDeviceKeyPublic:async e=>{let t=codexLinuxReadRemoteControlDeviceKeyStore().keys?.[e];if(t==null)throw Error(`Linux remote control device key not found`);return codexLinuxRemoteControlPublicDeviceKey(t)},",
-    `signDeviceKey:async(e,t)=>{let n=codexLinuxReadRemoteControlDeviceKeyStore().keys?.[e];if(n==null)throw Error(\`Linux remote control device key not found\`);let r=(0,${cryptoVar}.createPrivateKey)(n.privateKeyPkcs8Pem),i=(0,${cryptoVar}.sign)(\`sha256\`,t,r).toString(\`base64\`);return{algorithm:n.algorithm,signatureDerBase64:i}}`,
+    `signDeviceKey:async(e,t)=>{let n=codexLinuxReadRemoteControlDeviceKeyStore().keys?.[e];if(n==null)throw Error(\`Linux remote control device key not found\`);let r=n.secretService?codexLinuxLookupRemoteControlPrivateKeySecret(e):null,i=r??n.privateKeyPkcs8Pem;if(typeof i!=\`string\`||i.length===0)throw Error(\`Linux remote control device key not found\`);let a=(0,${cryptoVar}.createPrivateKey)(i),o=(0,${cryptoVar}.sign)(\`sha256\`,t,a).toString(\`base64\`);return{algorithm:n.algorithm,signatureDerBase64:o}}`,
     "}}",
   ].join("");
 }
 
 function applyLinuxRemoteControlDeviceKeyPatch(source) {
-  if (source.includes(DEVICE_KEY_CLIENT_MARKER)) {
+  if (source.includes(DEVICE_KEY_CLIENT_MARKER) && source.includes(DEVICE_KEY_SECRET_SERVICE_MARKER)) {
     return source;
   }
 
@@ -152,12 +187,27 @@ function applyLinuxRemoteControlDeviceKeyPatch(source) {
   }
 
   const insertionNeedle = source.match(DEVICE_KEY_REQUIRE_NEEDLE)?.[0] ?? null;
-  if (insertionNeedle == null || !source.includes(DEVICE_KEY_GUARD)) {
+  if (insertionNeedle == null) {
     console.warn("WARN: Could not find remote-control device-key bundle needles - skipping Linux remote-control device-key patch");
     return source;
   }
 
   const provider = linuxDeviceKeyProviderSource({ cryptoVar, fsVar, pathVar });
+  if (source.includes(DEVICE_KEY_CLIENT_MARKER)) {
+    const providerStart = source.indexOf(DEVICE_KEY_PROVIDER_START);
+    const providerEnd = source.indexOf(insertionNeedle);
+    if (providerStart >= 0 && providerEnd > providerStart) {
+      return `${source.slice(0, providerStart)}${provider}${source.slice(providerEnd)}`;
+    }
+    console.warn("WARN: Could not find existing Linux remote-control device-key provider - skipping provider upgrade");
+    return source;
+  }
+
+  if (!source.includes(DEVICE_KEY_GUARD)) {
+    console.warn("WARN: Could not find remote-control device-key platform guard - skipping Linux remote-control device-key patch");
+    return source;
+  }
+
   return source
     .replace(insertionNeedle, `${provider}${insertionNeedle}`)
     .replace(DEVICE_KEY_GUARD, DEVICE_KEY_GUARD_REPLACEMENT);

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -3,6 +3,7 @@
 
 const assert = require("node:assert/strict");
 const { spawnSync } = require("node:child_process");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -294,6 +295,10 @@ function installFakeSecretTool(binDir) {
   );
   fs.chmodSync(secretTool, 0o755);
   return secretTool;
+}
+
+function fakeSecretStoreEntries(secretStore) {
+  return fs.readdirSync(secretStore).map((name) => Buffer.from(name, "base64url").toString("utf8").split("\0"));
 }
 
 function captureWarnings(fn) {
@@ -668,6 +673,24 @@ test("Linux remote-control device-key patch upgrades older file-backed provider"
   assert.match(upgraded, /codexLinuxRemoteControlSecretTool/);
   assert.match(upgraded, /codexLinuxMigrateRemoteControlDeviceKeySecrets/);
   assert.doesNotMatch(upgraded, /old-file-backed/);
+  assert.equal(applyLinuxRemoteControlDeviceKeyPatch(upgraded), upgraded);
+});
+
+test("Linux remote-control device-key patch upgrades older Secret Service provider", () => {
+  const oldPatched = [
+    "let i=require(`node:path`),o=require(`node:fs`),s=require(`node:crypto`),b={createRequire:()=>()=>({})};",
+    "function TV(e){return Buffer.from(JSON.stringify(e),`utf8`)}",
+    "function codexLinuxRemoteControlDeviceKeyStorePath(){return`old-secret-service`}",
+    "function codexLinuxRemoteControlSecretTool(e,t){return null}",
+    "function codexLinuxRemoteControlDeviceKeyClient(){return{createDeviceKey:async e=>{},deleteDeviceKey:async e=>{},getDeviceKeyPublic:async e=>{},signDeviceKey:async(e,t)=>{}}}",
+    "var bV=(0,b.createRequire)(__filename),xV=`remote-control-device-key.node`,SV=`codex-device-key-sign-payload/v1`;",
+    "function wV({resourcesPath:e}){let t=null,n=()=>{if(process.platform===`linux`)return codexLinuxRemoteControlDeviceKeyClient();if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=bV(i.join(e,`native`,xV)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=TV(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
+  ].join("");
+
+  const upgraded = applyLinuxRemoteControlDeviceKeyPatch(oldPatched);
+  assert.match(upgraded, /codexLinuxRemoteControlAppId/);
+  assert.match(upgraded, /app-id/);
+  assert.doesNotMatch(upgraded, /old-secret-service/);
   assert.equal(applyLinuxRemoteControlDeviceKeyPatch(upgraded), upgraded);
 });
 
@@ -1287,6 +1310,45 @@ test("patched Linux device-key provider can create, sign with, and delete a key"
   }
 });
 
+test("patched Linux device-key provider scopes file-backed keys by app id", async () => {
+  const configHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-key-store-app-id-"));
+  try {
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const context = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_LINUX_APP_ID: "codex-cua-lab",
+          CODEX_REMOTE_CONTROL_KEY_STORE: "file",
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, context);
+    const client = context.module.exports;
+    const created = await client.createDeviceKey("allow_os_protected_nonextractable");
+    const scopedStorePath = path.join(configHome, "codex-cua-lab", "remote-control-device-keys-v1.json");
+    const defaultStorePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    const store = JSON.parse(fs.readFileSync(scopedStorePath, "utf8"));
+
+    assert.equal(fs.existsSync(defaultStorePath), false);
+    assert.match(store.keys[created.keyId].privateKeyPkcs8Pem, /BEGIN PRIVATE KEY/);
+  } finally {
+    fs.rmSync(configHome, { recursive: true, force: true });
+  }
+});
+
 test("patched Linux device-key provider prefers Secret Service when secret-tool is available", async () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-service-"));
   const configHome = path.join(workspace, "config");
@@ -1328,8 +1390,13 @@ test("patched Linux device-key provider prefers Secret Service when secret-tool 
     assert.equal(record.privateKeyPkcs8Pem, undefined);
     assert.equal(record.secretService.backend, "secret-service");
     assert.equal(record.secretService.tool, "secret-tool");
+    assert.equal(record.secretService.attributes.appId, "codex-desktop");
     assert.equal(record.secretService.attributes.keyId, created.keyId);
     assert.equal(fs.readdirSync(secretStore).length, 1);
+    assert.deepEqual(
+      fakeSecretStoreEntries(secretStore)[0].slice(0, 4),
+      ["application", "codex-desktop-linux", "app-id", "codex-desktop"],
+    );
 
     const signature = await client.signDeviceKey(created.keyId, { nonce: "secret-service" });
     assert.equal(signature.algorithm, "ecdsa_p256_sha256");
@@ -1338,6 +1405,55 @@ test("patched Linux device-key provider prefers Secret Service when secret-tool 
     await client.deleteDeviceKey(created.keyId);
     await assert.rejects(() => client.signDeviceKey(created.keyId, { nonce: "deleted" }), /not found/);
     assert.equal(fs.readdirSync(secretStore).length, 0);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("patched Linux device-key provider scopes Secret Service keys by app id", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-service-app-id-"));
+  const configHome = path.join(workspace, "config");
+  const binDir = path.join(workspace, "bin");
+  const secretStore = path.join(workspace, "secrets");
+  try {
+    installFakeSecretTool(binDir);
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const context = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_LINUX_APP_ID: "codex-cua-lab",
+          CODEX_REMOTE_CONTROL_KEY_STORE: "secret-service",
+          CODEX_TEST_SECRET_STORE: secretStore,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, context);
+    const client = context.module.exports;
+    const created = await client.createDeviceKey("allow_os_protected_nonextractable");
+    const storePath = path.join(configHome, "codex-cua-lab", "remote-control-device-keys-v1.json");
+    const defaultStorePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    const record = store.keys[created.keyId];
+    const secretAttrs = fakeSecretStoreEntries(secretStore)[0];
+
+    assert.equal(fs.existsSync(defaultStorePath), false);
+    assert.equal(record.privateKeyPkcs8Pem, undefined);
+    assert.equal(record.secretService.attributes.appId, "codex-cua-lab");
+    assert.deepEqual(secretAttrs.slice(0, 4), ["application", "codex-desktop-linux", "app-id", "codex-cua-lab"]);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
@@ -1407,6 +1523,159 @@ test("patched Linux device-key provider migrates existing file-backed keys to Se
 
     const signature = await secretClient.signDeviceKey(created.keyId, { nonce: "migrated" });
     assert.equal(signature.algorithm, "ecdsa_p256_sha256");
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("patched Linux device-key provider migrates legacy side-by-side file-backed keys safely", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-migrate-legacy-app-id-"));
+  const configHome = path.join(workspace, "config");
+  const binDir = path.join(workspace, "bin");
+  const secretStore = path.join(workspace, "secrets");
+  try {
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const fileContext = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: { CODEX_REMOTE_CONTROL_KEY_STORE: "file", XDG_CONFIG_HOME: configHome },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, fileContext);
+    const fileClient = fileContext.module.exports;
+    const created = await fileClient.createDeviceKey("allow_os_protected_nonextractable");
+
+    const legacyStorePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    const scopedStorePath = path.join(configHome, "codex-cua-lab", "remote-control-device-keys-v1.json");
+    let legacyStore = JSON.parse(fs.readFileSync(legacyStorePath, "utf8"));
+    assert.match(legacyStore.keys[created.keyId].privateKeyPkcs8Pem, /BEGIN PRIVATE KEY/);
+
+    installFakeSecretTool(binDir);
+    const secretContext = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_LINUX_APP_ID: "codex-cua-lab",
+          CODEX_REMOTE_CONTROL_KEY_STORE: "secret-service",
+          CODEX_TEST_SECRET_STORE: secretStore,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, secretContext);
+    const secretClient = secretContext.module.exports;
+
+    assert.equal(JSON.stringify(await secretClient.getDeviceKeyPublic(created.keyId)), JSON.stringify(created));
+    const scopedStore = JSON.parse(fs.readFileSync(scopedStorePath, "utf8"));
+    legacyStore = JSON.parse(fs.readFileSync(legacyStorePath, "utf8"));
+    assert.equal(scopedStore.keys[created.keyId].privateKeyPkcs8Pem, undefined);
+    assert.equal(legacyStore.keys[created.keyId].privateKeyPkcs8Pem, undefined);
+    assert.equal(scopedStore.keys[created.keyId].secretService.attributes.appId, "codex-cua-lab");
+    assert.equal(legacyStore.keys[created.keyId].secretService.attributes.appId, "codex-cua-lab");
+    assert.equal(fs.readdirSync(secretStore).length, 1);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("patched Linux device-key provider can read legacy side-by-side metadata and Secret Service entries", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-legacy-app-id-"));
+  const configHome = path.join(workspace, "config");
+  const binDir = path.join(workspace, "bin");
+  const secretStore = path.join(workspace, "secrets");
+  try {
+    installFakeSecretTool(binDir);
+    const keyId = "legacy-side-by-side-key";
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const privateKeyPkcs8Pem = privateKey.export({ type: "pkcs8", format: "pem" });
+    const publicKeySpkiDerBase64 = publicKey.export({ type: "spki", format: "der" }).toString("base64");
+    const legacyStorePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    const legacyAttrs = ["application", "codex-desktop-linux", "kind", "remote-control-device-key", "key-id", keyId];
+    fs.mkdirSync(path.dirname(legacyStorePath), { recursive: true });
+    fs.mkdirSync(secretStore, { recursive: true });
+    fs.writeFileSync(
+      legacyStorePath,
+      JSON.stringify(
+        {
+          keys: {
+            [keyId]: {
+              algorithm: "ecdsa_p256_sha256",
+              keyId,
+              protectionClass: "os_protected_nonextractable",
+              publicKeySpkiDerBase64,
+              createdAt: new Date().toISOString(),
+              secretService: {
+                backend: "secret-service",
+                tool: "secret-tool",
+                attributes: {
+                  application: "codex-desktop-linux",
+                  kind: "remote-control-device-key",
+                  keyId,
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(path.join(secretStore, Buffer.from(legacyAttrs.join("\0")).toString("base64url")), privateKeyPkcs8Pem);
+
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const context = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_LINUX_APP_ID: "codex-cua-lab",
+          CODEX_REMOTE_CONTROL_KEY_STORE: "secret-service",
+          CODEX_TEST_SECRET_STORE: secretStore,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, context);
+    const client = context.module.exports;
+    const readBack = await client.getDeviceKeyPublic(keyId);
+    const signature = await client.signDeviceKey(keyId, { nonce: "legacy" });
+
+    assert.equal(readBack.keyId, keyId);
+    assert.equal(readBack.publicKeySpkiDerBase64, publicKeySpkiDerBase64);
+    assert.equal(signature.algorithm, "ecdsa_p256_sha256");
+    assert.match(signature.signatureDerBase64, /^[A-Za-z0-9+/]+=*$/);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -270,6 +270,32 @@ function withFeatureRootEnv(root, fn) {
   }
 }
 
+function installFakeSecretTool(binDir) {
+  const secretTool = path.join(binDir, "secret-tool");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(
+    secretTool,
+    [
+      "#!/usr/bin/env node",
+      "const fs=require('node:fs');",
+      "const path=require('node:path');",
+      "const dir=process.env.CODEX_TEST_SECRET_STORE;",
+      "if(!dir)process.exit(2);",
+      "const [cmd,...rawArgs]=process.argv.slice(2);",
+      "function attrs(args){return args.filter((arg)=>!arg.startsWith('--label='));}",
+      "function fileFor(args){return path.join(dir,Buffer.from(attrs(args).join('\\0')).toString('base64url'));}",
+      "fs.mkdirSync(dir,{recursive:true});",
+      "if(cmd==='store'){fs.writeFileSync(fileFor(rawArgs),fs.readFileSync(0,'utf8'));process.exit(0);}",
+      "if(cmd==='lookup'){const file=fileFor(rawArgs);if(!fs.existsSync(file))process.exit(1);process.stdout.write(fs.readFileSync(file,'utf8'));process.exit(0);}",
+      "if(cmd==='clear'){fs.rmSync(fileFor(rawArgs),{force:true});process.exit(0);}",
+      "process.exit(2);",
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(secretTool, 0o755);
+  return secretTool;
+}
+
 function captureWarnings(fn) {
   const warnings = [];
   const originalWarn = console.warn;
@@ -623,6 +649,26 @@ test("Linux remote-control device-key patch handles current minified aliases", (
   assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
   assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
   assert.equal(applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)), patched);
+});
+
+test("Linux remote-control device-key patch upgrades older file-backed provider", () => {
+  const oldPatched = [
+    "let i=require(`node:path`),o=require(`node:fs`),s=require(`node:crypto`),b={createRequire:()=>()=>({})};",
+    "function TV(e){return Buffer.from(JSON.stringify(e),`utf8`)}",
+    "function codexLinuxRemoteControlDeviceKeyStorePath(){return`old-file-backed`}",
+    "function codexLinuxRemoteControlPublicDeviceKey(e){return e}",
+    "function codexLinuxReadRemoteControlDeviceKeyStore(){return{keys:{}}}",
+    "function codexLinuxWriteRemoteControlDeviceKeyStore(e){}",
+    "function codexLinuxRemoteControlDeviceKeyClient(){return{createDeviceKey:async e=>{},deleteDeviceKey:async e=>{},getDeviceKeyPublic:async e=>{},signDeviceKey:async(e,t)=>{}}}",
+    "var bV=(0,b.createRequire)(__filename),xV=`remote-control-device-key.node`,SV=`codex-device-key-sign-payload/v1`;",
+    "function wV({resourcesPath:e}){let t=null,n=()=>{if(process.platform===`linux`)return codexLinuxRemoteControlDeviceKeyClient();if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);if(e==null)throw Error(`Remote control device keys require resourcesPath`);return t??=bV(i.join(e,`native`,xV)),t};return{createDeviceKey:e=>n().createDeviceKey(e??`hardware_only`),deleteDeviceKey:e=>n().deleteDeviceKey(e),getDeviceKeyPublic:e=>n().getDeviceKeyPublic(e),signDeviceKey:async(e,t)=>{let r=TV(t);return{...await n().signDeviceKey(e,r),signedPayloadBase64:r.toString(`base64`)}}}}",
+  ].join("");
+
+  const upgraded = applyLinuxRemoteControlDeviceKeyPatch(oldPatched);
+  assert.match(upgraded, /codexLinuxRemoteControlSecretTool/);
+  assert.match(upgraded, /codexLinuxMigrateRemoteControlDeviceKeySecrets/);
+  assert.doesNotMatch(upgraded, /old-file-backed/);
+  assert.equal(applyLinuxRemoteControlDeviceKeyPatch(upgraded), upgraded);
 });
 
 test("Linux remote-control client enrollment accepts account-scoped and base user ids", () => {
@@ -1204,7 +1250,7 @@ test("patched Linux device-key provider can create, sign with, and delete a key"
       __filename: path.join(configHome, "main.js"),
       module: { exports: {} },
       process: {
-        env: { XDG_CONFIG_HOME: configHome },
+        env: { CODEX_REMOTE_CONTROL_KEY_STORE: "file", XDG_CONFIG_HOME: configHome },
         pid: process.pid,
         platform: "linux",
       },
@@ -1231,11 +1277,138 @@ test("patched Linux device-key provider can create, sign with, and delete a key"
 
     const storePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
     assert.equal(fs.statSync(storePath).mode & 0o777, 0o600);
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    assert.match(store.keys[created.keyId].privateKeyPkcs8Pem, /BEGIN PRIVATE KEY/);
 
     await client.deleteDeviceKey(created.keyId);
     await assert.rejects(() => client.getDeviceKeyPublic(created.keyId), /not found/);
   } finally {
     fs.rmSync(configHome, { recursive: true, force: true });
+  }
+});
+
+test("patched Linux device-key provider prefers Secret Service when secret-tool is available", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-service-"));
+  const configHome = path.join(workspace, "config");
+  const binDir = path.join(workspace, "bin");
+  const secretStore = path.join(workspace, "secrets");
+  try {
+    installFakeSecretTool(binDir);
+
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const context = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_REMOTE_CONTROL_KEY_STORE: "secret-service",
+          CODEX_TEST_SECRET_STORE: secretStore,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, context);
+    const client = context.module.exports;
+    const created = await client.createDeviceKey("allow_os_protected_nonextractable");
+    const storePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    const store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    const record = store.keys[created.keyId];
+
+    assert.equal(record.privateKeyPkcs8Pem, undefined);
+    assert.equal(record.secretService.backend, "secret-service");
+    assert.equal(record.secretService.tool, "secret-tool");
+    assert.equal(record.secretService.attributes.keyId, created.keyId);
+    assert.equal(fs.readdirSync(secretStore).length, 1);
+
+    const signature = await client.signDeviceKey(created.keyId, { nonce: "secret-service" });
+    assert.equal(signature.algorithm, "ecdsa_p256_sha256");
+    assert.match(signature.signatureDerBase64, /^[A-Za-z0-9+/]+=*$/);
+
+    await client.deleteDeviceKey(created.keyId);
+    await assert.rejects(() => client.signDeviceKey(created.keyId, { nonce: "deleted" }), /not found/);
+    assert.equal(fs.readdirSync(secretStore).length, 0);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("patched Linux device-key provider migrates existing file-backed keys to Secret Service", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-secret-migrate-"));
+  const configHome = path.join(workspace, "config");
+  const binDir = path.join(workspace, "bin");
+  const secretStore = path.join(workspace, "secrets");
+  try {
+    const patched = applyLinuxRemoteControlDeviceKeyPatch(syntheticMainBundle());
+    const fileContext = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: { CODEX_REMOTE_CONTROL_KEY_STORE: "file", XDG_CONFIG_HOME: configHome },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, fileContext);
+    const fileClient = fileContext.module.exports;
+    const created = await fileClient.createDeviceKey("allow_os_protected_nonextractable");
+
+    const storePath = path.join(configHome, "codex-desktop", "remote-control-device-keys-v1.json");
+    let store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    assert.match(store.keys[created.keyId].privateKeyPkcs8Pem, /BEGIN PRIVATE KEY/);
+
+    installFakeSecretTool(binDir);
+    const secretContext = {
+      Buffer,
+      Date,
+      Error,
+      JSON,
+      Promise,
+      console,
+      __filename: path.join(configHome, "main.js"),
+      module: { exports: {} },
+      process: {
+        env: {
+          CODEX_REMOTE_CONTROL_KEY_STORE: "secret-service",
+          CODEX_TEST_SECRET_STORE: secretStore,
+          PATH: `${binDir}:${process.env.PATH || ""}`,
+          XDG_CONFIG_HOME: configHome,
+        },
+        pid: process.pid,
+        platform: "linux",
+      },
+      require,
+    };
+    vm.runInNewContext(`${patched};module.exports=wV({resourcesPath:null});`, secretContext);
+    const secretClient = secretContext.module.exports;
+
+    assert.equal(JSON.stringify(await secretClient.getDeviceKeyPublic(created.keyId)), JSON.stringify(created));
+    store = JSON.parse(fs.readFileSync(storePath, "utf8"));
+    assert.equal(store.keys[created.keyId].privateKeyPkcs8Pem, undefined);
+    assert.equal(store.keys[created.keyId].secretService.backend, "secret-service");
+    assert.equal(fs.readdirSync(secretStore).length, 1);
+
+    const signature = await secretClient.signDeviceKey(created.keyId, { nonce: "migrated" });
+    assert.equal(signature.algorithm, "ecdsa_p256_sha256");
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
   }
 });
 

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -849,6 +849,7 @@ print_safe_disable_guidance() {
         local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
         local key_file="$config_home/codex-desktop/remote-control-device-keys-v1.json"
         info "Remote mobile control opt-out: Not deleting $key_file."
+        info "If Secret Service is available, that file may contain only key metadata while private keys live in the desktop keyring."
         info "Revoke paired devices from Codex Settings/Connections or ChatGPT before deleting local keys manually."
     fi
 
@@ -972,7 +973,8 @@ run_feature_cleanup() {
     if list_includes_id "$cleanup_raw" "remote-mobile-control"; then
         local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
         local key_file="$config_home/codex-desktop/remote-control-device-keys-v1.json"
-        info "Remote mobile control cleanup: revoke paired devices in Codex Settings/Connections or ChatGPT before deleting local keys."
+        info "Remote mobile control cleanup: revoke paired devices in Codex Settings/Connections or ChatGPT before deleting local key metadata or fallback keys."
+        info "Secret Service-backed keys are cleared by the app when the paired device is revoked; manual metadata deletion alone may leave orphaned keyring entries."
         confirm_and_delete_path "$key_file"
     fi
 

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -461,14 +461,30 @@ settings_file_path() {
         printf '%s\n' "$CODEX_LINUX_SETTINGS_FILE"
     else
         local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-        local app_id="${CODEX_LINUX_APP_ID:-${CODEX_APP_ID:-codex-desktop}}"
-        case "$app_id" in
-            */*|*[!A-Za-z0-9._-]*|"."|".."|"")
-                app_id="codex-desktop"
-                ;;
-        esac
+        local app_id
+        app_id="$(linux_app_id)"
         printf '%s\n' "$config_home/$app_id/settings.json"
     fi
+}
+
+linux_app_id() {
+    local app_id="${CODEX_LINUX_APP_ID:-${CODEX_APP_ID:-${PACKAGE_NAME:-codex-desktop}}}"
+    case "$app_id" in
+        */*|*[!A-Za-z0-9._-]*|"."|".."|"")
+            app_id="codex-desktop"
+            ;;
+    esac
+    printf '%s\n' "$app_id"
+}
+
+remote_mobile_key_file_path() {
+    local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    printf '%s/%s/remote-control-device-keys-v1.json\n' "$config_home" "$(linux_app_id)"
+}
+
+remote_mobile_legacy_key_file_path() {
+    local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    printf '%s/codex-desktop/remote-control-device-keys-v1.json\n' "$config_home"
 }
 
 json_setting_value() {
@@ -846,9 +862,12 @@ print_safe_disable_guidance() {
     info "Disabling a build-time feature only edits linux-features/features.json for the next rebuild."
 
     if list_includes_id "$disable_raw" "remote-mobile-control"; then
-        local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-        local key_file="$config_home/codex-desktop/remote-control-device-keys-v1.json"
+        local key_file
+        key_file="$(remote_mobile_key_file_path)"
         info "Remote mobile control opt-out: Not deleting $key_file."
+        if [ "$(linux_app_id)" != "codex-desktop" ]; then
+            info "Legacy default-app metadata may also exist at $(remote_mobile_legacy_key_file_path)."
+        fi
         info "If Secret Service is available, that file may contain only key metadata while private keys live in the desktop keyring."
         info "Revoke paired devices from Codex Settings/Connections or ChatGPT before deleting local keys manually."
     fi
@@ -971,11 +990,15 @@ run_feature_cleanup() {
     fi
 
     if list_includes_id "$cleanup_raw" "remote-mobile-control"; then
-        local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-        local key_file="$config_home/codex-desktop/remote-control-device-keys-v1.json"
+        local key_file legacy_key_file
+        key_file="$(remote_mobile_key_file_path)"
+        legacy_key_file="$(remote_mobile_legacy_key_file_path)"
         info "Remote mobile control cleanup: revoke paired devices in Codex Settings/Connections or ChatGPT before deleting local key metadata or fallback keys."
         info "Secret Service-backed keys are cleared by the app when the paired device is revoked; manual metadata deletion alone may leave orphaned keyring entries."
         confirm_and_delete_path "$key_file"
+        if [ "$legacy_key_file" != "$key_file" ] && [ -e "$legacy_key_file" ]; then
+            confirm_and_delete_path "$legacy_key_file"
+        fi
     fi
 
     if list_includes_id "$cleanup_raw" "read-aloud" ||

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1073,6 +1073,39 @@ test_setup_native_wizard_rejects_out_of_range_feature_numbers() {
     assert_json_enabled_equals "$config" '[]'
 }
 
+test_setup_native_wizard_remote_keys_follow_linux_app_id() {
+    info "Checking setup-native wizard remote key paths follow Linux app id"
+    local workspace="$TMP_DIR/setup-native-remote-keys-app-id"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+    local fake_home="$workspace/home"
+    local key_file="$fake_home/.config/codex-cua-lab/remote-control-device-keys-v1.json"
+    local legacy_key_file="$fake_home/.config/codex-desktop/remote-control-device-keys-v1.json"
+
+    make_wizard_feature_root "$features_root"
+    cat > "$config" <<'JSON'
+{"enabled":["remote-mobile-control"]}
+JSON
+    mkdir -p "$(dirname "$key_file")" "$(dirname "$legacy_key_file")"
+    printf '%s\n' '{"deviceKeys":[]}' > "$key_file"
+    printf '%s\n' '{"deviceKeys":[]}' > "$legacy_key_file"
+
+    HOME="$fake_home" \
+    XDG_CONFIG_HOME="$fake_home/.config" \
+    CODEX_LINUX_APP_ID="codex-cua-lab" \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+    CODEX_LINUX_DISABLE_FEATURES="remote-mobile-control" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_file_exists "$key_file"
+    assert_file_exists "$legacy_key_file"
+    assert_contains "$output_log" "Not deleting $key_file"
+    assert_contains "$output_log" "Legacy default-app metadata may also exist at $legacy_key_file"
+}
+
 test_setup_native_wizard_summary_keeps_existing_config() {
     info "Checking setup-native wizard read-only summary keeps existing feature config"
     local workspace="$TMP_DIR/setup-native-summary"
@@ -4999,6 +5032,7 @@ main() {
     test_setup_native_wizard_disable_is_non_destructive
     test_setup_native_wizard_accepts_numbered_feature_selection
     test_setup_native_wizard_rejects_out_of_range_feature_numbers
+    test_setup_native_wizard_remote_keys_follow_linux_app_id
     test_setup_native_wizard_summary_keeps_existing_config
     test_setup_native_wizard_uses_package_name_for_installed_state
     test_setup_native_wizard_portal_summary_survives_busctl_sigpipe


### PR DESCRIPTION
## Summary
- prefer Linux Secret Service via `secret-tool` for remote mobile private device keys, with file-backed `0600` storage remaining as the explicit fallback
- scope key metadata and Secret Service attributes by Linux app id so side-by-side installs do not share remote-control key material
- migrate existing file-backed and legacy side-by-side key records safely when Secret Service is available
- update setup cleanup messaging to describe keyring-backed keys and legacy metadata paths

## Validation
- `node --check linux-features/remote-mobile-control/patch.js`
- `node --test linux-features/remote-mobile-control/test.js`
- `bash -n tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `git diff --check origin/main..HEAD`

## Notes
- This is still not macOS Secure Enclave parity; it raises the default Linux storage boundary to the desktop keyring when available and keeps a controlled file fallback for minimal sessions.