### PR TITLE
Expand opt-in Linux features framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 dist/
 dist-next/
 linux-features/features.json
+linux-features/local/
 .idea/
 .claude/
 .codex/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Before opening a pull request, please read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Linux features
 
-Optional Linux-only additions live in `linux-features/`. Use them for integrations that are useful for some users but should not become mandatory core patches. Copy `linux-features/features.example.json` to the git-ignored `linux-features/features.json` before building; enabled features are applied during the install/build pipeline. See [`linux-features/README.md`](linux-features/README.md) for the feature contract.
+Optional Linux-only additions live in `linux-features/`. Use them for integrations that are useful for some users but should not become mandatory core patches. Copy `linux-features/features.example.json` to the git-ignored `linux-features/features.json` before building; enabled features are applied during the install/build pipeline. User-local features can live under the git-ignored `linux-features/local/<feature-id>/` directory. See [`linux-features/README.md`](linux-features/README.md) and [`docs/linux-features-architecture.md`](docs/linux-features-architecture.md) for the feature contract.
 
 ## Supported platforms
 
@@ -85,7 +85,7 @@ make setup-native
 
 `make setup-native` is intentionally separate from `make bootstrap-native`, `make install-native`, `make package`, and `make install`, which remain non-interactive for scripts and CI. The guided helper detects your distro, package manager, native package format, desktop session, GUI prompt helpers, `pkexec`, portal status, and Computer Use readiness signals such as `ydotool`, `ydotoold` / `ydotool.service`, the ydotool socket, `/dev/uinput`, input-group membership, desktop window backend hints, and portal package hints. It also reports Read Aloud Kokoro paths, plugin cache paths, settings paths, and doctor commands when available.
 
-It also discovers optional Linux features from `linux-features/*/feature.json` and can write the git-ignored `linux-features/features.json` file for the next build. Interactive prompts show a numbered feature list, so you can enter stable feature ids (`remote-mobile-control`), numbers (`3`), or ranges (`2-4`). The output uses section headings and ANSI color when the terminal supports it; set `CODEX_BOOTSTRAP_COLOR=0` to disable color or `CODEX_BOOTSTRAP_COLOR=1` to force it. Re-running it shows the currently enabled features and installed package/updater hints, then skips changes unless you ask for them. Non-interactive setup edits feature config and prints or runs explicitly requested next steps; it does not implicitly run build/package/install.
+It also discovers optional Linux features from `linux-features/*/feature.json` and private `linux-features/local/*/feature.json` manifests, then can write the git-ignored `linux-features/features.json` file for the next build. Interactive prompts show a numbered feature list, so you can enter stable feature ids (`remote-mobile-control`), numbers (`3`), or ranges (`2-4`). The output uses section headings and ANSI color when the terminal supports it; set `CODEX_BOOTSTRAP_COLOR=0` to disable color or `CODEX_BOOTSTRAP_COLOR=1` to force it. Re-running it shows the currently enabled features and installed package/updater hints, then skips changes unless you ask for them. Non-interactive setup edits feature config and prints or runs explicitly requested next steps; it does not implicitly run build/package/install.
 
 For repeatable setup docs or automation, pass feature choices through the environment:
 

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -1,0 +1,197 @@
+# Linux Features Architecture
+
+`linux-features/` is the extension boundary for optional Linux integrations.
+Core keeps a small generic loader; feature-specific behavior lives in feature
+directories and is disabled by default.
+
+## Layout
+
+Repository features live directly under `linux-features/<feature-id>/`.
+
+User-local features live under `linux-features/local/<feature-id>/`. The
+`linux-features/local/` directory is ignored by git, so a user can keep private
+or experimental integrations in the checkout without accidentally committing
+them.
+
+Every feature needs a `feature.json` manifest:
+
+```json
+{
+  "id": "my-feature",
+  "title": "My Feature",
+  "description": "Optional Linux integration.",
+  "defaultEnabled": false
+}
+```
+
+Feature ids must match `^[a-z0-9][a-z0-9-]*$`. Repository and local features
+share one id namespace; local features cannot shadow repository features.
+`defaultEnabled: true` is rejected. Enabling always happens through the
+git-ignored `linux-features/features.json` file:
+
+```json
+{
+  "enabled": ["my-feature"]
+}
+```
+
+## Lifecycle
+
+The build pipeline loads enabled features in these phases:
+
+1. ASAR patching: patch descriptors modify extracted upstream app files.
+2. App staging: declarative resources and runtime hooks are copied into
+   `codex-app/`.
+3. Legacy staging: optional `stage.sh` hooks run for features that still need
+   custom install-time logic.
+4. Native packaging: optional package hooks can mutate the `.deb`, `.rpm`, or
+   pacman staging root.
+5. Runtime: the launcher consumes staged environment files, prelaunch hooks,
+   Electron args, and cold-start hooks.
+
+Native packages copy the configured feature root into the packaged
+`update-builder` bundle, including `linux-features/local/`, and write a
+sanitized `features.json` containing only the enabled ids. Local auto-updates
+therefore rebuild with the same opt-in features.
+
+Declarative staged files are tracked in
+`.codex-linux/linux-features-staged.json`. On the next install, the framework
+removes the previously tracked declarative resources and runtime hooks before
+staging the currently enabled set, so disabling a feature removes its
+framework-owned runtime hooks. Legacy `stage.sh` hooks are not tracked by this
+manifest and must clean up any feature-owned files themselves.
+
+## Manifest Keys
+
+`entrypoints` keeps the existing patch and staging API:
+
+```json
+{
+  "entrypoints": {
+    "patchDescriptors": "./patch.js",
+    "patches": "./patch.js",
+    "mainBundlePatch": "./patch.js",
+    "stageHook": "./stage.sh"
+  }
+}
+```
+
+Prefer `patchDescriptors` for new patches. Feature descriptor ids are reported
+as `feature:<feature-id>:<descriptor-id>` and are optional in CI by default.
+`mainBundlePatch` is the compatibility path for older features that export
+`applyMainBundlePatch(source, context)`.
+
+Use `requires` and `conflicts` to declare feature relationships:
+
+```json
+{
+  "requires": ["read-aloud"],
+  "conflicts": ["other-voice-loop"]
+}
+```
+
+The setup wizard, installer, patcher, and package builders validate these
+relationships before applying enabled features.
+
+## Declarative App Staging
+
+Use `resources` to copy files into the generated app directory:
+
+```json
+{
+  "resources": [
+    {
+      "source": "assets/tool.json",
+      "target": ".codex-linux/features/my-feature/tool.json",
+      "mode": "0644"
+    }
+  ]
+}
+```
+
+`source` stays inside the feature directory. `target` is relative to the app
+directory and must point to a file or subdirectory, not the app root itself.
+File modes are optional, but when present they must be quoted octal strings
+such as `"0644"` or `"0755"`; numeric JSON modes are rejected. Declared modes
+are recorded in the staged manifest and restored after native package
+permission normalization, so restrictive resource modes survive `.deb`, `.rpm`,
+and pacman packaging.
+
+Use `runtimeHooks` for launcher-visible hooks:
+
+```json
+{
+  "runtimeHooks": {
+    "env": "env",
+    "prelaunch": "prelaunch.sh",
+    "electronArgs": "electron-args",
+    "coldStart": "cold-start.sh"
+  }
+}
+```
+
+The runtime hook types map to:
+
+- `env`: copied to `.codex-linux/env.d/`; each non-comment line is exported as
+  literal `KEY=VALUE` with no shell evaluation.
+- `prelaunch`: copied to `.codex-linux/prelaunch.d/`; executable hooks run
+  synchronously before the packaged runtime prelaunch and webview setup.
+- `electronArgs`: copied to `.codex-linux/electron-args.d/`; each non-comment
+  line is appended as one Electron argument.
+- `coldStart`: copied to `.codex-linux/cold-start.d/`; executable hooks run in
+  the background during cold start, after bundled plugin cache sync.
+
+## Package Hooks
+
+Use `packageHooks` only when a feature must mutate native package staging:
+
+```json
+{
+  "packageHooks": [
+    {
+      "path": "package.sh",
+      "formats": ["deb", "rpm", "pacman"]
+    }
+  ]
+}
+```
+
+Hooks run with:
+
+- `PACKAGE_FORMAT`
+- `PACKAGE_NAME`
+- `PACKAGE_VERSION`
+- `PACKAGE_ROOT` / `PACKAGE_STAGING_ROOT`
+- `APP_DIR` / `PACKAGE_APP_DIR`
+- `REPO_DIR`
+
+Package hooks should be idempotent and narrowly scoped.
+
+## Local Feature Example
+
+Create a private feature without touching tracked files:
+
+```bash
+mkdir -p linux-features/local/my-feature
+$EDITOR linux-features/local/my-feature/feature.json
+```
+
+Then enable it:
+
+```bash
+cp linux-features/features.example.json linux-features/features.json
+$EDITOR linux-features/features.json
+make install-native
+```
+
+`make setup-native` also discovers local features, marks them as `[local]`,
+and can enable them by id or list number.
+
+## Design Rule
+
+If a change is required for the basic Linux app to launch and behave correctly
+for most users, it belongs in core patches under `scripts/patches/`.
+
+If a change is optional, distro-specific, editor-specific, browser-specific,
+workflow-specific, or likely to add future support burden for a minority of
+users, put it in `linux-features/` and keep it disabled by default.

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -141,6 +141,15 @@ The runtime hook types map to:
 - `coldStart`: copied to `.codex-linux/cold-start.d/`; executable hooks run in
   the background during cold start, after bundled plugin cache sync.
 
+Runtime hooks receive `CODEX_HOME`, `CODEX_LINUX_APP_DIR`,
+`CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_FEATURES_DIR`, and
+`CODEX_LINUX_LAUNCHER_LOG`. Use this pattern for user-home artifacts such as
+Codex skills: stage the source file with `resources` under
+`.codex-linux/features/<feature-id>/...`, then copy it from
+`$CODEX_LINUX_FEATURES_DIR/<feature-id>/...` to `$CODEX_HOME/skills/...` in a
+`runtimeHooks.prelaunch` script. Do not write user-home files from `stage.sh`;
+install, package, and updater rebuilds may run outside the real user's session.
+
 ## Package Hooks
 
 Use `packageHooks` only when a feature must mutate native package staging:

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -13,7 +13,10 @@ User-local features live under `linux-features/local/<feature-id>/`. The
 or experimental integrations in the checkout without accidentally committing
 them.
 
-Every feature needs a `feature.json` manifest:
+Every feature needs a `feature.json` manifest and a neighboring `README.md`.
+The README is required for both repository features and git-ignored local
+features, and should describe what the feature does, how to test it, and known
+support risks.
 
 ```json
 {

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -29,6 +29,9 @@ LAUNCH_ACTION_RUNTIME_DIR="${XDG_RUNTIME_DIR:-$APP_STATE_DIR}/$CODEX_LINUX_APP_I
 LAUNCH_ACTION_SOCKET="$LAUNCH_ACTION_RUNTIME_DIR/launch-action.sock"
 PACKAGED_RUNTIME_HELPER="$SCRIPT_DIR/.codex-linux/codex-packaged-runtime.sh"
 COLD_START_HOOK_DIR="$SCRIPT_DIR/.codex-linux/cold-start.d"
+FEATURE_ENV_DIR="$SCRIPT_DIR/.codex-linux/env.d"
+FEATURE_PRELAUNCH_HOOK_DIR="$SCRIPT_DIR/.codex-linux/prelaunch.d"
+FEATURE_ELECTRON_ARGS_DIR="$SCRIPT_DIR/.codex-linux/electron-args.d"
 MANAGED_NODE_BIN_DIR="$SCRIPT_DIR/resources/node-runtime/bin"
 APP_NOTIFICATION_ICON_NAME="$CODEX_LINUX_APP_ID"
 APP_NOTIFICATION_ICON_BUNDLE="$SCRIPT_DIR/.codex-linux/$APP_NOTIFICATION_ICON_NAME.png"
@@ -493,6 +496,56 @@ prepend_managed_node_runtime_to_path() {
         *) export PATH="$MANAGED_NODE_BIN_DIR:$PATH" ;;
     esac
     export CODEX_MANAGED_NODE_RUNTIME_DIR="$SCRIPT_DIR/resources/node-runtime"
+}
+
+source_feature_env_files() {
+    [ -n "${FEATURE_ENV_DIR:-}" ] || return 0
+    [ -d "$FEATURE_ENV_DIR" ] || return 0
+
+    local env_file
+    local line
+    local name
+    local value
+    for env_file in "$FEATURE_ENV_DIR"/*; do
+        [ -f "$env_file" ] || continue
+        echo "Loading Linux feature environment: $env_file"
+        while IFS= read -r line || [ -n "$line" ]; do
+            line="${line%$'\r'}"
+            case "$line" in
+                ""|\#*) continue ;;
+                *=*) ;;
+                *)
+                    echo "Ignoring Linux feature env line without KEY=VALUE in $env_file"
+                    continue
+                    ;;
+            esac
+            name="${line%%=*}"
+            value="${line#*=}"
+            case "$name" in
+                ""|[!A-Za-z_]*|*[!A-Za-z0-9_]*)
+                    echo "Ignoring Linux feature env line with invalid key '$name' in $env_file"
+                    continue
+                    ;;
+            esac
+            export "$name=$value"
+        done < "$env_file"
+    done
+}
+
+run_feature_prelaunch_hooks() {
+    [ -n "${FEATURE_PRELAUNCH_HOOK_DIR:-}" ] || return 0
+    [ -d "$FEATURE_PRELAUNCH_HOOK_DIR" ] || return 0
+
+    local hook
+    for hook in "$FEATURE_PRELAUNCH_HOOK_DIR"/*; do
+        [ -f "$hook" ] || continue
+        [ -x "$hook" ] || continue
+        echo "Running Linux feature prelaunch hook: $hook"
+        CODEX_LINUX_APP_DIR="$SCRIPT_DIR" \
+            CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
+            CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
+            "$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"
+    done
 }
 
 bundled_plugin_version() {
@@ -2011,6 +2064,25 @@ set_electron_defaults() {
     apply_electron_rendering_profile
 }
 
+append_feature_electron_args() {
+    [ -n "${FEATURE_ELECTRON_ARGS_DIR:-}" ] || return 0
+    [ -d "$FEATURE_ELECTRON_ARGS_DIR" ] || return 0
+
+    local args_file
+    local line
+    for args_file in "$FEATURE_ELECTRON_ARGS_DIR"/*; do
+        [ -f "$args_file" ] || continue
+        echo "Loading Linux feature Electron args: $args_file"
+        while IFS= read -r line || [ -n "$line" ]; do
+            line="${line%$'\r'}"
+            case "$line" in
+                ""|\#*) continue ;;
+            esac
+            ELECTRON_LAUNCH_ARGS+=("$line")
+        done < "$args_file"
+    done
+}
+
 build_electron_launch_args() {
     ELECTRON_LAUNCH_ARGS=(
         --no-sandbox
@@ -2053,6 +2125,8 @@ build_electron_launch_args() {
     if [ "$ELECTRON_OZONE_PLATFORM" = "wayland" ]; then
         ELECTRON_LAUNCH_ARGS+=(--enable-features=WaylandWindowDecorations)
     fi
+
+    append_feature_electron_args
 }
 
 configure_side_by_side_app_env() {
@@ -2116,6 +2190,7 @@ hydrate_graphical_session_env
 configure_side_by_side_app_env
 load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
+source_feature_env_files
 register_url_scheme_handlers
 reconcile_runtime_state
 detect_warm_start
@@ -2133,6 +2208,8 @@ if using_second_instance_handoff; then
     echo "Detected running Codex Desktop pid=$RUNNING_APP_PID; using Electron second-instance handoff"
     log_phase "second_instance_handoff_ready"
 elif needs_cold_start; then
+    run_feature_prelaunch_hooks
+    log_phase "feature_prelaunch"
     run_packaged_runtime_prelaunch
     log_phase "packaged_prelaunch"
     ensure_webview_server

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -15,13 +15,21 @@ resolve_script_dir() {
 }
 
 SCRIPT_DIR="$(resolve_script_dir)"
+if [ -z "${CODEX_HOME:-}" ]; then
+    if [ -n "${HOME:-}" ]; then
+        CODEX_HOME="$HOME/.codex"
+    else
+        CODEX_HOME=""
+    fi
+fi
 WEBVIEW_DIR="$SCRIPT_DIR/content/webview"
 LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID"
 LOG_FILE="$LOG_DIR/launcher.log"
 APP_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/$CODEX_LINUX_APP_ID"
 APP_SETTINGS_FILE="$APP_CONFIG_DIR/settings.json"
 CODEX_LINUX_SETTINGS_FILE="$APP_SETTINGS_FILE"
-export CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE
+CODEX_LINUX_FEATURES_DIR="$SCRIPT_DIR/.codex-linux/features"
+export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR
 APP_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/$CODEX_LINUX_APP_ID"
 APP_PID_FILE="$APP_STATE_DIR/app.pid"
 WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
@@ -541,9 +549,11 @@ run_feature_prelaunch_hooks() {
         [ -f "$hook" ] || continue
         [ -x "$hook" ] || continue
         echo "Running Linux feature prelaunch hook: $hook"
+        CODEX_HOME="$CODEX_HOME" \
         CODEX_LINUX_APP_DIR="$SCRIPT_DIR" \
-            CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
-            CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
+        CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
+        CODEX_LINUX_FEATURES_DIR="$CODEX_LINUX_FEATURES_DIR" \
+        CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
             "$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"
     done
 }
@@ -1091,8 +1101,10 @@ run_cold_start_hooks() {
         [ -x "$hook" ] || continue
         echo "Starting cold-start hook: $hook"
         (
+            CODEX_HOME="$CODEX_HOME" \
             CODEX_LINUX_APP_DIR="$SCRIPT_DIR" \
             CODEX_LINUX_APP_STATE_DIR="$APP_STATE_DIR" \
+            CODEX_LINUX_FEATURES_DIR="$CODEX_LINUX_FEATURES_DIR" \
             CODEX_LINUX_LAUNCHER_LOG="$LOG_FILE" \
             "$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"
         ) >>"$LOG_FILE" 2>&1 &

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -2,7 +2,9 @@
 
 `linux-features/` contains opt-in Linux integration modules for this wrapper.
 These are not upstream Codex plugins; they are Linux-side extensions that can
-add ASAR patches, staged resources, or build/install hooks.
+add ASAR patches, staged resources, runtime hooks, package hooks, or legacy
+build/install hooks. The full architecture contract is documented in
+[`docs/linux-features-architecture.md`](../docs/linux-features-architecture.md).
 
 By default, no optional Linux features are enabled. Copy
 `features.example.json` to `features.json` before running `./install.sh` or
@@ -22,6 +24,13 @@ file after an app has already been generated, rerun the install/build step.
 Native packages preserve the enabled feature id list in the packaged
 update-builder bundle, so `codex-update-manager` rebuilds keep the same opt-in
 features across auto-updates.
+
+Feature directories can be tracked repository features at `linux-features/<id>/`
+or private user-local features at `linux-features/local/<id>/`. The
+`linux-features/local/` directory is ignored by git. Local features use the same
+`feature.json` contract and are enabled by adding their id to `features.json`.
+Repository and local features share one id namespace; local features cannot
+shadow tracked features.
 
 You can also let the guided native setup helper discover feature manifests and
 write `features.json`:
@@ -55,11 +64,31 @@ Each feature directory should include:
 - `README.md` — what it does, how to test it, and known risks
 - optional `patch.js` — exports `applyMainBundlePatch(source, context)`, or
   descriptor patches when `feature.json` uses `entrypoints.patchDescriptors`
-- optional `stage.sh` — install/build staging hook
+- optional declarative `resources`, `runtimeHooks`, and `packageHooks`
+- optional `stage.sh` — legacy install/build staging hook
 - optional `test.js` — self-contained tests for the feature
 
 `stage.sh` hooks run with `SCRIPT_DIR`, `INSTALL_DIR`, `WORK_DIR`, `ARCH`, and
 `CODEX_UPSTREAM_APP_DIR` in the environment.
+
+Declarative runtime hooks are staged under `codex-app/.codex-linux/`:
+
+- `runtimeHooks.env` writes literal `KEY=VALUE` files consumed by the launcher
+- `runtimeHooks.prelaunch` runs synchronously before webview setup
+- `runtimeHooks.electronArgs` appends one Electron argument per line
+- `runtimeHooks.coldStart` runs background hooks after bundled plugin cache sync
+
+Declarative resource targets must point to a file or subdirectory inside the app
+directory, not to the app root itself. Declarative `mode` fields must be quoted
+octal strings, for example `"0644"` or `"0755"`. Numeric JSON modes are
+rejected so `755` cannot be interpreted as the wrong permission bits. Declared
+modes are preserved in native packages.
+Declarative resources and runtime hooks are tracked in
+`.codex-linux/linux-features-staged.json` and removed on the next install when
+the owning feature is disabled. Legacy `stage.sh` hooks own their own cleanup.
+
+`packageHooks` run during native package staging and receive `PACKAGE_FORMAT`,
+`PACKAGE_ROOT`, `PACKAGE_NAME`, `PACKAGE_VERSION`, and `APP_DIR`.
 
 Descriptor patches use the same shape as `scripts/patches/core/**/patch.js`.
 They can target `main-bundle`, `webview-asset`, or `extracted-app` phases.

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -87,6 +87,14 @@ Declarative resources and runtime hooks are tracked in
 `.codex-linux/linux-features-staged.json` and removed on the next install when
 the owning feature is disabled. Legacy `stage.sh` hooks own their own cleanup.
 
+Runtime hooks receive `CODEX_HOME`, `CODEX_LINUX_APP_DIR`,
+`CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_FEATURES_DIR`, and
+`CODEX_LINUX_LAUNCHER_LOG`. If a feature needs to install a Codex skill or
+other user-home artifact, stage the source with `resources` and copy it from
+`$CODEX_LINUX_FEATURES_DIR/<feature-id>/...` in `runtimeHooks.prelaunch`.
+Avoid writing user-home files from `stage.sh`, because install/package/update
+rebuilds may run outside the real user's session.
+
 `packageHooks` run during native package staging and receive `PACKAGE_FORMAT`,
 `PACKAGE_ROOT`, `PACKAGE_NAME`, `PACKAGE_VERSION`, and `APP_DIR`.
 

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -58,7 +58,7 @@ The helper lists exact paths and deletes only paths confirmed with
 `DELETE <exact path>`. Add `CODEX_BOOTSTRAP_DRY_RUN=1` to preview cleanup
 targets without deleting them.
 
-Each feature directory should include:
+Each feature directory must include:
 
 - `feature.json` — metadata and entrypoints
 - `README.md` — what it does, how to test it, and known risks

--- a/linux-features/example-feature/test.js
+++ b/linux-features/example-feature/test.js
@@ -9,9 +9,15 @@ const path = require("node:path");
 const test = require("node:test");
 const { applyMainBundlePatch } = require("./patch.js");
 const {
+  discoverLinuxFeatureManifests,
   enabledLinuxFeatureIds,
+  enabledLinuxFeatureInstallPlan,
+  enabledLinuxFeaturePackageHooks,
   enabledLinuxFeatureStageHooks,
+  loadEnabledLinuxFeatures,
   loadLinuxFeatureMainBundlePatches,
+  stageEnabledLinuxFeatureInstall,
+  stagedLinuxFeatureFiles,
 } = require("../../scripts/lib/linux-features.js");
 const {
   createPatchReport,
@@ -21,14 +27,26 @@ const {
 
 function withTempFeatureRoot(enabled, fn) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-example-feature-test-"));
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
   try {
+    delete process.env.CODEX_LINUX_FEATURES_CONFIG;
     fs.writeFileSync(path.join(root, "features.example.json"), JSON.stringify({ enabled: [] }, null, 2));
     fs.writeFileSync(path.join(root, "features.json"), JSON.stringify({ enabled }, null, 2));
     fs.cpSync(__dirname, path.join(root, "example-feature"), { recursive: true });
     return fn(root);
   } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
     fs.rmSync(root, { recursive: true, force: true });
   }
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
 test("example feature patches only its synthetic marker", () => {
@@ -71,6 +89,307 @@ test("example feature exposes its patch and stage hook when enabled", () => {
     assert.equal(
       patches[0].apply("codexLinuxExampleFeatureDisabled()", {}),
       "codexLinuxExampleFeatureEnabled()",
+    );
+  });
+});
+
+test("local Linux features are discovered and enabled from linux-features/local", () => {
+  withTempFeatureRoot(["local-example"], (root) => {
+    const localDir = path.join(root, "local", "local-example");
+    writeJson(path.join(localDir, "feature.json"), {
+      id: "local-example",
+      title: "Local Example",
+      description: "Developer-local feature.",
+    });
+
+    const discovered = discoverLinuxFeatureManifests({ featuresRoot: root });
+    const localFeature = discovered.find((feature) => feature.id === "local-example");
+    assert.equal(localFeature.origin, "local");
+    assert.equal(localFeature.local, true);
+    assert.equal(localFeature.relativeDir, path.join("local", "local-example"));
+
+    const enabled = loadEnabledLinuxFeatures({ featuresRoot: root });
+    assert.deepEqual(enabled.map((feature) => feature.id), ["local-example"]);
+    assert.equal(enabled[0].origin, "local");
+  });
+});
+
+test("local Linux features cannot shadow repository features", () => {
+  withTempFeatureRoot([], (root) => {
+    writeJson(path.join(root, "local", "example-feature", "feature.json"), {
+      id: "example-feature",
+      title: "Duplicate Example",
+    });
+
+    assert.throws(
+      () => discoverLinuxFeatureManifests({ featuresRoot: root }),
+      /Duplicate Linux feature id 'example-feature'/,
+    );
+  });
+});
+
+test("Linux features must stay disabled by default", () => {
+  withTempFeatureRoot([], (root) => {
+    writeJson(path.join(root, "local", "bad-default", "feature.json"), {
+      id: "bad-default",
+      title: "Bad Default",
+      defaultEnabled: true,
+    });
+
+    assert.throws(
+      () => discoverLinuxFeatureManifests({ featuresRoot: root }),
+      /defaultEnabled true is not allowed/,
+    );
+  });
+});
+
+test("Linux feature dependencies and conflicts are validated", () => {
+  withTempFeatureRoot(["needs-other"], (root) => {
+    writeJson(path.join(root, "local", "needs-other", "feature.json"), {
+      id: "needs-other",
+      requires: ["other-feature"],
+    });
+
+    assert.throws(
+      () => loadEnabledLinuxFeatures({ featuresRoot: root }),
+      /requires 'other-feature' to be enabled/,
+    );
+  });
+
+  withTempFeatureRoot(["left-feature", "right-feature"], (root) => {
+    writeJson(path.join(root, "local", "left-feature", "feature.json"), {
+      id: "left-feature",
+      conflicts: ["right-feature"],
+    });
+    writeJson(path.join(root, "local", "right-feature", "feature.json"), {
+      id: "right-feature",
+    });
+
+    assert.throws(
+      () => loadEnabledLinuxFeatures({ featuresRoot: root }),
+      /conflicts with 'right-feature'/,
+    );
+  });
+});
+
+test("declarative Linux feature install plan stages resources and runtime hooks", () => {
+  withTempFeatureRoot(["local-tool"], (root) => {
+    const localDir = path.join(root, "local", "local-tool");
+    writeJson(path.join(localDir, "feature.json"), {
+      id: "local-tool",
+      title: "Local Tool",
+      resources: [
+        {
+          source: "payload.txt",
+          target: ".codex-linux/features/local-tool/payload.txt",
+          mode: "0640",
+        },
+      ],
+      runtimeHooks: {
+        env: "env",
+        prelaunch: "prelaunch.sh",
+        electronArgs: "electron-args",
+        coldStart: "cold-start.sh",
+      },
+      packageHooks: [
+        {
+          path: "package.sh",
+          formats: ["deb"],
+        },
+      ],
+    });
+    fs.writeFileSync(path.join(localDir, "payload.txt"), "payload\n");
+    fs.writeFileSync(path.join(localDir, "env"), "LOCAL_TOOL=1\n");
+    fs.writeFileSync(path.join(localDir, "prelaunch.sh"), "#!/bin/bash\nexit 0\n");
+    fs.writeFileSync(path.join(localDir, "electron-args"), "--local-tool\n");
+    fs.writeFileSync(path.join(localDir, "cold-start.sh"), "#!/bin/bash\nexit 0\n");
+    fs.writeFileSync(path.join(localDir, "package.sh"), "#!/bin/bash\nexit 0\n");
+
+    const plan = enabledLinuxFeatureInstallPlan({ featuresRoot: root });
+    assert.deepEqual(plan.resources.map((resource) => resource.target), [
+      ".codex-linux/features/local-tool/payload.txt",
+    ]);
+    assert.deepEqual(plan.runtimeHooks.map((hook) => `${hook.key}:${hook.name}`), [
+      "env:local-tool-env",
+      "prelaunch:local-tool-prelaunch.sh",
+      "electronArgs:local-tool-electron-args",
+      "coldStart:local-tool-cold-start.sh",
+    ]);
+
+    const appDir = path.join(root, "install");
+    stageEnabledLinuxFeatureInstall(appDir, { featuresRoot: root });
+
+    assert.equal(
+      fs.readFileSync(path.join(appDir, ".codex-linux", "features", "local-tool", "payload.txt"), "utf8"),
+      "payload\n",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(appDir, ".codex-linux", "env.d", "local-tool-env"), "utf8"),
+      "LOCAL_TOOL=1\n",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(appDir, ".codex-linux", "electron-args.d", "local-tool-electron-args"), "utf8"),
+      "--local-tool\n",
+    );
+    assert.equal(
+      fs.statSync(path.join(appDir, ".codex-linux", "features", "local-tool", "payload.txt")).mode & 0o777,
+      0o640,
+    );
+    assert.equal(
+      fs.statSync(path.join(appDir, ".codex-linux", "prelaunch.d", "local-tool-prelaunch.sh")).mode & 0o777,
+      0o755,
+    );
+    assert.deepEqual(
+      stagedLinuxFeatureFiles(appDir).map((entry) => [entry.target, entry.mode]),
+      [
+        [".codex-linux/features/local-tool/payload.txt", "0640"],
+        [".codex-linux/env.d/local-tool-env", "0644"],
+        [".codex-linux/prelaunch.d/local-tool-prelaunch.sh", "0755"],
+        [".codex-linux/electron-args.d/local-tool-electron-args", "0644"],
+        [".codex-linux/cold-start.d/local-tool-cold-start.sh", "0755"],
+      ],
+    );
+
+    const debHooks = enabledLinuxFeaturePackageHooks({ featuresRoot: root, packageFormat: "deb" });
+    assert.equal(debHooks.length, 1);
+    assert.equal(debHooks[0].id, "local-tool");
+    assert.equal(path.basename(debHooks[0].path), "package.sh");
+    assert.deepEqual(enabledLinuxFeaturePackageHooks({ featuresRoot: root, packageFormat: "rpm" }), []);
+  });
+});
+
+test("declarative Linux feature staging removes stale runtime hooks after opt-out", () => {
+  withTempFeatureRoot(["local-tool"], (root) => {
+    const localDir = path.join(root, "local", "local-tool");
+    writeJson(path.join(localDir, "feature.json"), {
+      id: "local-tool",
+      runtimeHooks: {
+        env: "env",
+        prelaunch: "prelaunch.sh",
+        electronArgs: "electron-args",
+        coldStart: "cold-start.sh",
+      },
+    });
+    fs.writeFileSync(path.join(localDir, "env"), "LOCAL_TOOL=1\n");
+    fs.writeFileSync(path.join(localDir, "prelaunch.sh"), "#!/bin/bash\nexit 0\n");
+    fs.writeFileSync(path.join(localDir, "electron-args"), "--local-tool\n");
+    fs.writeFileSync(path.join(localDir, "cold-start.sh"), "#!/bin/bash\nexit 0\n");
+
+    const appDir = path.join(root, "install");
+    stageEnabledLinuxFeatureInstall(appDir, { featuresRoot: root });
+
+    const hookPaths = [
+      path.join(appDir, ".codex-linux", "env.d", "local-tool-env"),
+      path.join(appDir, ".codex-linux", "prelaunch.d", "local-tool-prelaunch.sh"),
+      path.join(appDir, ".codex-linux", "electron-args.d", "local-tool-electron-args"),
+      path.join(appDir, ".codex-linux", "cold-start.d", "local-tool-cold-start.sh"),
+    ];
+    for (const hookPath of hookPaths) {
+      assert.equal(fs.existsSync(hookPath), true);
+    }
+
+    writeJson(path.join(root, "features.json"), { enabled: [] });
+    stageEnabledLinuxFeatureInstall(appDir, { featuresRoot: root });
+
+    for (const hookPath of hookPaths) {
+      assert.equal(fs.existsSync(hookPath), false);
+    }
+    assert.deepEqual(stagedLinuxFeatureFiles(appDir), []);
+  });
+});
+
+test("declarative Linux feature staging cleans pre-manifest generated runtime hooks", () => {
+  withTempFeatureRoot([], (root) => {
+    writeJson(path.join(root, "local", "local-tool", "feature.json"), {
+      id: "local-tool",
+      runtimeHooks: {
+        env: "env",
+      },
+    });
+
+    const appDir = path.join(root, "install");
+    const envDir = path.join(appDir, ".codex-linux", "env.d");
+    fs.mkdirSync(envDir, { recursive: true });
+    const staleHook = path.join(envDir, "local-tool-env");
+    const unrelatedHook = path.join(envDir, "custom-env");
+    fs.writeFileSync(staleHook, "LOCAL_TOOL=1\n");
+    fs.writeFileSync(unrelatedHook, "CUSTOM=1\n");
+
+    stageEnabledLinuxFeatureInstall(appDir, { featuresRoot: root });
+
+    assert.equal(fs.existsSync(staleHook), false);
+    assert.equal(fs.existsSync(unrelatedHook), true);
+  });
+});
+
+test("declarative Linux feature resources cannot target the install root", () => {
+  for (const target of [".", "./"]) {
+    withTempFeatureRoot(["root-target"], (root) => {
+      const localDir = path.join(root, "local", "root-target");
+      writeJson(path.join(localDir, "feature.json"), {
+        id: "root-target",
+        resources: [
+          {
+            source: "payload",
+            target,
+          },
+        ],
+      });
+      fs.writeFileSync(path.join(localDir, "payload"), "payload\n");
+
+      assert.throws(
+        () => enabledLinuxFeatureInstallPlan({ featuresRoot: root }),
+        /must not target the install directory root/,
+      );
+    });
+  }
+});
+
+test("declarative Linux feature staging refuses root targets from stale manifests", () => {
+  withTempFeatureRoot([], (root) => {
+    const appDir = path.join(root, "install");
+    fs.mkdirSync(appDir, { recursive: true });
+    const sentinelPath = path.join(appDir, "sentinel.txt");
+    fs.writeFileSync(sentinelPath, "keep me\n");
+    writeJson(path.join(appDir, ".codex-linux", "linux-features-staged.json"), {
+      version: 1,
+      resources: [
+        {
+          id: "old-local-feature",
+          type: "resource",
+          target: ".",
+          mode: "0644",
+        },
+      ],
+      runtimeHooks: [],
+    });
+
+    assert.throws(
+      () => stageEnabledLinuxFeatureInstall(appDir, { featuresRoot: root }),
+      /must not target the install directory root/,
+    );
+    assert.equal(fs.readFileSync(sentinelPath, "utf8"), "keep me\n");
+  });
+});
+
+test("numeric Linux feature file modes are rejected", () => {
+  withTempFeatureRoot(["bad-mode"], (root) => {
+    const localDir = path.join(root, "local", "bad-mode");
+    writeJson(path.join(localDir, "feature.json"), {
+      id: "bad-mode",
+      resources: [
+        {
+          source: "payload.txt",
+          target: ".codex-linux/features/bad-mode/payload.txt",
+          mode: 755,
+        },
+      ],
+    });
+    fs.writeFileSync(path.join(localDir, "payload.txt"), "payload\n");
+
+    assert.throws(
+      () => enabledLinuxFeatureInstallPlan({ featuresRoot: root }),
+      /file mode must be a quoted octal string/,
     );
   });
 });

--- a/linux-features/example-feature/test.js
+++ b/linux-features/example-feature/test.js
@@ -49,6 +49,11 @@ function writeJson(filePath, value) {
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
+function writeFeatureManifest(featureDir, value) {
+  writeJson(path.join(featureDir, "feature.json"), value);
+  fs.writeFileSync(path.join(featureDir, "README.md"), `# ${value.title ?? value.id}\n`);
+}
+
 test("example feature patches only its synthetic marker", () => {
   assert.equal(
     applyMainBundlePatch("before;codexLinuxExampleFeatureDisabled();after"),
@@ -96,7 +101,7 @@ test("example feature exposes its patch and stage hook when enabled", () => {
 test("local Linux features are discovered and enabled from linux-features/local", () => {
   withTempFeatureRoot(["local-example"], (root) => {
     const localDir = path.join(root, "local", "local-example");
-    writeJson(path.join(localDir, "feature.json"), {
+    writeFeatureManifest(localDir, {
       id: "local-example",
       title: "Local Example",
       description: "Developer-local feature.",
@@ -116,7 +121,7 @@ test("local Linux features are discovered and enabled from linux-features/local"
 
 test("local Linux features cannot shadow repository features", () => {
   withTempFeatureRoot([], (root) => {
-    writeJson(path.join(root, "local", "example-feature", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "example-feature"), {
       id: "example-feature",
       title: "Duplicate Example",
     });
@@ -128,9 +133,23 @@ test("local Linux features cannot shadow repository features", () => {
   });
 });
 
+test("Linux features must include README documentation", () => {
+  withTempFeatureRoot([], (root) => {
+    writeJson(path.join(root, "local", "missing-readme", "feature.json"), {
+      id: "missing-readme",
+      title: "Missing README",
+    });
+
+    assert.throws(
+      () => discoverLinuxFeatureManifests({ featuresRoot: root }),
+      /must include README\.md next to feature\.json/,
+    );
+  });
+});
+
 test("Linux features must stay disabled by default", () => {
   withTempFeatureRoot([], (root) => {
-    writeJson(path.join(root, "local", "bad-default", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "bad-default"), {
       id: "bad-default",
       title: "Bad Default",
       defaultEnabled: true,
@@ -145,7 +164,7 @@ test("Linux features must stay disabled by default", () => {
 
 test("Linux feature dependencies and conflicts are validated", () => {
   withTempFeatureRoot(["needs-other"], (root) => {
-    writeJson(path.join(root, "local", "needs-other", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "needs-other"), {
       id: "needs-other",
       requires: ["other-feature"],
     });
@@ -157,11 +176,11 @@ test("Linux feature dependencies and conflicts are validated", () => {
   });
 
   withTempFeatureRoot(["left-feature", "right-feature"], (root) => {
-    writeJson(path.join(root, "local", "left-feature", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "left-feature"), {
       id: "left-feature",
       conflicts: ["right-feature"],
     });
-    writeJson(path.join(root, "local", "right-feature", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "right-feature"), {
       id: "right-feature",
     });
 
@@ -175,7 +194,7 @@ test("Linux feature dependencies and conflicts are validated", () => {
 test("declarative Linux feature install plan stages resources and runtime hooks", () => {
   withTempFeatureRoot(["local-tool"], (root) => {
     const localDir = path.join(root, "local", "local-tool");
-    writeJson(path.join(localDir, "feature.json"), {
+    writeFeatureManifest(localDir, {
       id: "local-tool",
       title: "Local Tool",
       resources: [
@@ -261,7 +280,7 @@ test("declarative Linux feature install plan stages resources and runtime hooks"
 test("declarative Linux feature staging removes stale runtime hooks after opt-out", () => {
   withTempFeatureRoot(["local-tool"], (root) => {
     const localDir = path.join(root, "local", "local-tool");
-    writeJson(path.join(localDir, "feature.json"), {
+    writeFeatureManifest(localDir, {
       id: "local-tool",
       runtimeHooks: {
         env: "env",
@@ -300,7 +319,7 @@ test("declarative Linux feature staging removes stale runtime hooks after opt-ou
 
 test("declarative Linux feature staging cleans pre-manifest generated runtime hooks", () => {
   withTempFeatureRoot([], (root) => {
-    writeJson(path.join(root, "local", "local-tool", "feature.json"), {
+    writeFeatureManifest(path.join(root, "local", "local-tool"), {
       id: "local-tool",
       runtimeHooks: {
         env: "env",
@@ -326,7 +345,7 @@ test("declarative Linux feature resources cannot target the install root", () =>
   for (const target of [".", "./"]) {
     withTempFeatureRoot(["root-target"], (root) => {
       const localDir = path.join(root, "local", "root-target");
-      writeJson(path.join(localDir, "feature.json"), {
+      writeFeatureManifest(localDir, {
         id: "root-target",
         resources: [
           {
@@ -375,7 +394,7 @@ test("declarative Linux feature staging refuses root targets from stale manifest
 test("numeric Linux feature file modes are rejected", () => {
   withTempFeatureRoot(["bad-mode"], (root) => {
     const localDir = path.join(root, "local", "bad-mode");
-    writeJson(path.join(localDir, "feature.json"), {
+    writeFeatureManifest(localDir, {
       id: "bad-mode",
       resources: [
         {

--- a/linux-features/read-aloud-mcp/test.js
+++ b/linux-features/read-aloud-mcp/test.js
@@ -31,6 +31,10 @@ test("read-aloud-mcp stays disabled until listed in features.json", () => {
     path.join(featuresRoot, "read-aloud-mcp", "feature.json"),
   );
   fs.copyFileSync(
+    path.join(__dirname, "README.md"),
+    path.join(featuresRoot, "read-aloud-mcp", "README.md"),
+  );
+  fs.copyFileSync(
     path.join(__dirname, "stage.sh"),
     path.join(featuresRoot, "read-aloud-mcp", "stage.sh"),
   );

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -60,6 +60,7 @@ Environment:
   CODEX_LINUX_DISABLE_FEATURES=a,b     disable build-time Linux features
   CODEX_LINUX_FEATURES_ROOT=/path      override linux-features root
   CODEX_LINUX_FEATURES_CONFIG=/path    override features.json path
+  linux-features/local/<id>/           user-local feature dirs are discovered and marked [local]
   PACKAGE_NAME=codex-cua-lab           check side-by-side installed package state
   PACKAGE_WITH_UPDATER=0               choose manual-update package mode
 
@@ -723,26 +724,68 @@ def read_json(path, label):
     except Exception as exc:
         die(f"Could not read {label} at {path}: {exc}")
 
+def normalize_id_list(value, label, manifest_path):
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        die(f"Linux feature manifest {manifest_path} field {label} must be an array")
+    result = []
+    seen = set()
+    for item in value:
+        if not isinstance(item, str) or not id_re.match(item):
+            die(f"Linux feature manifest {manifest_path} field {label} contains invalid feature id: {item}")
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+def feature_manifest_paths(root):
+    if not root.exists():
+        return []
+    reserved = {"local", "README.md", "features.example.json", "features.json"}
+    paths = []
+    for child in sorted(root.iterdir(), key=lambda item: item.name):
+        if child.name.startswith(".") or child.name in reserved or not child.is_dir():
+            continue
+        manifest_path = child / "feature.json"
+        if manifest_path.exists():
+            paths.append(("repo", manifest_path))
+    local_root = root / "local"
+    if local_root.is_dir():
+        for child in sorted(local_root.iterdir(), key=lambda item: item.name):
+            if child.name.startswith(".") or not child.is_dir():
+                continue
+            manifest_path = child / "feature.json"
+            if manifest_path.exists():
+                paths.append(("local", manifest_path))
+    return paths
+
 def discover_features(root):
     features = {}
     if not root.exists():
         warn(f"Linux features root not found: {root}")
         return features
-    for manifest_path in sorted(root.glob("*/feature.json")):
+    for origin, manifest_path in feature_manifest_paths(root):
         data = read_json(manifest_path, f"Linux feature manifest {manifest_path}") or {}
         feature_id = data.get("id")
         if not isinstance(feature_id, str) or not id_re.match(feature_id):
             warn(f"Skipping feature with invalid id in {manifest_path}")
             continue
+        if data.get("defaultEnabled") is True:
+            die(f"Linux feature '{feature_id}' must be disabled by default; defaultEnabled true is not allowed")
         if feature_id in features:
-            warn(f"Skipping duplicate Linux feature id: {feature_id}")
-            continue
+            die(f"Duplicate Linux feature id '{feature_id}' in {manifest_path} and {features[feature_id]['manifest_path']}")
         title = data.get("title") or data.get("name") or feature_id
         description = data.get("description") or ""
         features[feature_id] = {
             "id": feature_id,
             "title": str(title),
             "description": str(description),
+            "origin": origin,
+            "local": origin == "local",
+            "requires": normalize_id_list(data.get("requires"), "requires", manifest_path),
+            "conflicts": normalize_id_list(data.get("conflicts"), "conflicts", manifest_path),
+            "manifest_path": str(manifest_path),
         }
     return dict(sorted(features.items()))
 
@@ -791,6 +834,18 @@ for feature_id in enable:
     if feature_id not in final:
         final.append(feature_id)
 
+final_set = set(final)
+for feature_id in final:
+    feature = features.get(feature_id)
+    if feature is None:
+        continue
+    missing_required = [required for required in feature["requires"] if required not in final_set]
+    if missing_required:
+        die(f"Linux feature '{feature_id}' requires enabled feature(s): {csv(missing_required)}")
+    conflicting_enabled = [conflict for conflict in feature["conflicts"] if conflict in final_set]
+    if conflicting_enabled:
+        die(f"Linux feature '{feature_id}' conflicts with enabled feature(s): {csv(conflicting_enabled)}")
+
 if apply_changes and (enable or disable):
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps({"enabled": final}, indent=2) + "\n")
@@ -814,7 +869,8 @@ if features:
     for index, (feature_id, feature) in enumerate(features.items(), start=1):
         state = "enabled" if feature_id in final else "available"
         sample = " (developer sample)" if feature_id == "example-feature" else ""
-        print(f"[setup]   {index}. [{state}] {feature_id}{sample} - {feature['title']}")
+        local = " [local]" if feature.get("local") else ""
+        print(f"[setup]   {index}. [{state}] {feature_id}{local}{sample} - {feature['title']}")
 else:
     print("[setup] Available Linux features: none found")
 

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -771,6 +771,8 @@ def discover_features(root):
         if not isinstance(feature_id, str) or not id_re.match(feature_id):
             warn(f"Skipping feature with invalid id in {manifest_path}")
             continue
+        if not (manifest_path.parent / "README.md").is_file():
+            die(f"Linux feature '{feature_id}' must include README.md next to feature.json")
         if data.get("defaultEnabled") is True:
             die(f"Linux feature '{feature_id}' must be disabled by default; defaultEnabled true is not allowed")
         if feature_id in features:

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -78,7 +78,9 @@ main() {
     stage_common_package_files "$PKG_ROOT"
     stage_optional_update_builder_bundle "$PKG_ROOT"
     write_launcher_stub "$PKG_ROOT"
+    run_linux_feature_package_hooks "$PKG_ROOT" "deb"
     normalize_package_payload_permissions "$PKG_ROOT"
+    restore_linux_feature_payload_permissions "$PKG_ROOT"
 
     sed \
         -e "s/__PACKAGE_NAME__/$PACKAGE_NAME/g" \

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -122,7 +122,9 @@ main() {
 	stage_common_package_files "$staging_root"
 	stage_optional_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
+	run_linux_feature_package_hooks "$staging_root" "pacman"
 	normalize_package_payload_permissions "$staging_root"
+	restore_linux_feature_payload_permissions "$staging_root"
 
 	local package_name
 	local pacman_pkgver

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -101,7 +101,9 @@ main() {
 exec /opt/$PACKAGE_NAME/start.sh "\$@"
 SCRIPT
     chmod 0755 "$staging_root/usr/bin/$PACKAGE_NAME"
+    run_linux_feature_package_hooks "$staging_root" "rpm"
     normalize_package_payload_permissions "$staging_root"
+    restore_linux_feature_payload_permissions "$staging_root"
 
     local spec_file="$build_root/codex-desktop.spec"
     sed \

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -4,6 +4,21 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const FEATURE_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const LOCAL_FEATURES_DIR = "local";
+const RESERVED_TOP_LEVEL_NAMES = new Set([
+  LOCAL_FEATURES_DIR,
+  "README.md",
+  "features.example.json",
+  "features.json",
+]);
+
+const RUNTIME_HOOK_DIRS = {
+  env: { dir: "env.d", executable: false },
+  prelaunch: { dir: "prelaunch.d", executable: true },
+  electronArgs: { dir: "electron-args.d", executable: false },
+  coldStart: { dir: "cold-start.d", executable: true },
+};
+const STAGED_FEATURE_MANIFEST_RELATIVE_PATH = ".codex-linux/linux-features-staged.json";
 
 function defaultLinuxFeaturesRoot() {
   return path.resolve(__dirname, "..", "..", "linux-features");
@@ -37,6 +52,32 @@ function readJsonFile(filePath, label) {
     console.warn(`WARN: Could not read ${label} at ${filePath}: ${error.message}`);
     return null;
   }
+}
+
+function assertFeatureId(value, label) {
+  if (typeof value !== "string" || !FEATURE_ID_PATTERN.test(value)) {
+    throw new Error(`${label} must match ${FEATURE_ID_PATTERN}`);
+  }
+  return value;
+}
+
+function normalizeFeatureIdList(value, label, featureId) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`Linux feature '${featureId}' ${label} must be an array`);
+  }
+  const seen = new Set();
+  const result = [];
+  for (const item of value) {
+    assertFeatureId(item, `Linux feature '${featureId}' ${label} entry`);
+    if (!seen.has(item)) {
+      seen.add(item);
+      result.push(item);
+    }
+  }
+  return result;
 }
 
 function normalizeEnabledFeatureIds(value, sourcePath) {
@@ -75,31 +116,185 @@ function enabledLinuxFeatureIds(options = {}) {
   return normalizeEnabledFeatureIds(config.enabled, configPath);
 }
 
-function loadLinuxFeatureManifest(featuresRoot, id) {
-  const featureDir = path.join(featuresRoot, id);
-  const manifestPath = path.join(featureDir, "feature.json");
-  if (!fs.existsSync(manifestPath)) {
+function isDirectory(filePath) {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function featureManifestCandidates(featuresRoot) {
+  if (!fs.existsSync(featuresRoot)) {
+    return [];
+  }
+
+  const candidates = [];
+  for (const name of fs.readdirSync(featuresRoot).sort()) {
+    if (RESERVED_TOP_LEVEL_NAMES.has(name) || name.startsWith(".")) {
+      continue;
+    }
+    const dir = path.join(featuresRoot, name);
+    if (isDirectory(dir) && fs.existsSync(path.join(dir, "feature.json"))) {
+      candidates.push({ dir, manifestPath: path.join(dir, "feature.json"), origin: "repo" });
+    }
+  }
+
+  const localRoot = path.join(featuresRoot, LOCAL_FEATURES_DIR);
+  if (isDirectory(localRoot)) {
+    for (const name of fs.readdirSync(localRoot).sort()) {
+      if (name.startsWith(".")) {
+        continue;
+      }
+      const dir = path.join(localRoot, name);
+      if (isDirectory(dir) && fs.existsSync(path.join(dir, "feature.json"))) {
+        candidates.push({ dir, manifestPath: path.join(dir, "feature.json"), origin: "local" });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function normalizeLinuxFeatureManifest(featuresRoot, candidate) {
+  const manifest = readJsonFile(candidate.manifestPath, "Linux feature manifest");
+  if (manifest == null || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error(`Linux feature manifest ${candidate.manifestPath} must be a JSON object`);
+  }
+
+  const id = assertFeatureId(manifest.id, `Linux feature id in ${candidate.manifestPath}`);
+  if (manifest.defaultEnabled === true) {
+    throw new Error(`Linux feature '${id}' must be disabled by default; defaultEnabled true is not allowed`);
+  }
+
+  const relativeDir = path.relative(featuresRoot, candidate.dir);
+  return {
+    id,
+    dir: candidate.dir,
+    manifestPath: candidate.manifestPath,
+    origin: candidate.origin,
+    local: candidate.origin === "local",
+    relativeDir,
+    manifest: {
+      ...manifest,
+      defaultEnabled: false,
+      requires: normalizeFeatureIdList(manifest.requires, "requires", id),
+      conflicts: normalizeFeatureIdList(manifest.conflicts, "conflicts", id),
+    },
+  };
+}
+
+function discoverLinuxFeatureManifests(options = {}) {
+  const featuresRoot = linuxFeaturesRoot(options);
+  const features = [];
+  const seen = new Map();
+  for (const candidate of featureManifestCandidates(featuresRoot)) {
+    const feature = normalizeLinuxFeatureManifest(featuresRoot, candidate);
+    const previous = seen.get(feature.id);
+    if (previous != null) {
+      throw new Error(
+        `Duplicate Linux feature id '${feature.id}' in ${feature.manifestPath} and ${previous.manifestPath}`,
+      );
+    }
+    seen.set(feature.id, feature);
+    features.push(feature);
+  }
+  return features.sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function linuxFeatureManifestMap(options = {}) {
+  return new Map(discoverLinuxFeatureManifests(options).map((feature) => [feature.id, feature]));
+}
+
+function loadLinuxFeatureManifest(featuresRoot, id, options = {}) {
+  const feature = linuxFeatureManifestMap({ ...options, featuresRoot }).get(id);
+  if (feature == null) {
     console.warn(`WARN: Enabled Linux feature '${id}' does not have feature.json`);
     return null;
   }
+  return feature;
+}
 
-  const manifest = readJsonFile(manifestPath, `Linux feature '${id}' manifest`);
-  if (manifest == null) {
-    return null;
+function validateEnabledFeatureDependencies(features) {
+  const enabled = new Set(features.map((feature) => feature.id));
+  for (const feature of features) {
+    for (const required of feature.manifest.requires) {
+      if (!enabled.has(required)) {
+        throw new Error(`Linux feature '${feature.id}' requires '${required}' to be enabled`);
+      }
+    }
+    for (const conflict of feature.manifest.conflicts) {
+      if (enabled.has(conflict)) {
+        throw new Error(`Linux feature '${feature.id}' conflicts with '${conflict}'`);
+      }
+    }
   }
-  if (manifest.id !== id) {
-    console.warn(`WARN: Linux feature '${id}' manifest id mismatch: ${String(manifest.id)}`);
-    return null;
-  }
-
-  return { id, dir: featureDir, manifestPath, manifest };
 }
 
 function loadEnabledLinuxFeatures(options = {}) {
   const featuresRoot = linuxFeaturesRoot(options);
-  return enabledLinuxFeatureIds({ ...options, featuresRoot })
-    .map((id) => loadLinuxFeatureManifest(featuresRoot, id))
-    .filter(Boolean);
+  const available = linuxFeatureManifestMap({ ...options, featuresRoot });
+  const features = [];
+  const missing = [];
+  for (const id of enabledLinuxFeatureIds({ ...options, featuresRoot })) {
+    const feature = available.get(id);
+    if (feature == null) {
+      missing.push(id);
+    } else {
+      features.push(feature);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`Enabled Linux feature ids not found in this checkout: ${missing.join(", ")}`);
+  }
+  validateEnabledFeatureDependencies(features);
+  return features;
+}
+
+function relativePathParts(relativePath) {
+  return String(relativePath).split(/[\\/]+/).filter((part) => part.length > 0 && part !== ".");
+}
+
+function normalizeInstallRelativePath(relativePath, label) {
+  if (typeof relativePath !== "string" || relativePath.trim().length === 0) {
+    throw new Error(`${label} must be a relative path`);
+  }
+  const parts = relativePathParts(relativePath);
+  if (path.isAbsolute(relativePath) || parts.includes("..")) {
+    throw new Error(`${label} must stay inside the install directory`);
+  }
+  if (parts.length === 0) {
+    throw new Error(`${label} must not target the install directory root`);
+  }
+  return parts.join("/");
+}
+
+function resolveInstallRelativePath(installDir, relativePath, label) {
+  const normalized = normalizeInstallRelativePath(relativePath, label);
+  const resolved = path.resolve(installDir, normalized);
+  const relative = path.relative(installDir, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside the install directory`);
+  }
+  return { normalized, resolved };
+}
+
+function resolveFeatureRelativePath(feature, relativePath, label, { mustExist = true } = {}) {
+  if (typeof relativePath !== "string" || relativePath.trim().length === 0) {
+    throw new Error(`Linux feature '${feature.id}' has invalid ${label}`);
+  }
+  if (path.isAbsolute(relativePath) || relativePathParts(relativePath).includes("..")) {
+    throw new Error(`Linux feature '${feature.id}' ${label} must stay inside the feature directory`);
+  }
+  const resolved = path.resolve(feature.dir, relativePath);
+  const relative = path.relative(feature.dir, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Linux feature '${feature.id}' ${label} must stay inside the feature directory`);
+  }
+  if (mustExist && !fs.existsSync(resolved)) {
+    throw new Error(`Linux feature '${feature.id}' ${label} not found: ${resolved}`);
+  }
+  return resolved;
 }
 
 function resolveFeatureEntrypoint(feature, key) {
@@ -107,20 +302,12 @@ function resolveFeatureEntrypoint(feature, key) {
   if (relativePath == null) {
     return null;
   }
-  if (typeof relativePath !== "string" || relativePath.trim().length === 0) {
-    console.warn(`WARN: Linux feature '${feature.id}' has invalid ${key} entrypoint`);
+  try {
+    return resolveFeatureRelativePath(feature, relativePath, `${key} entrypoint`);
+  } catch (error) {
+    console.warn(`WARN: ${error.message}`);
     return null;
   }
-  if (path.isAbsolute(relativePath) || relativePath.split(/[\\/]/).includes("..")) {
-    console.warn(`WARN: Linux feature '${feature.id}' ${key} entrypoint must stay inside the feature directory`);
-    return null;
-  }
-  const entrypoint = path.resolve(feature.dir, relativePath);
-  if (!fs.existsSync(entrypoint)) {
-    console.warn(`WARN: Linux feature '${feature.id}' ${key} entrypoint not found: ${entrypoint}`);
-    return null;
-  }
-  return entrypoint;
 }
 
 function loadFeatureEntrypointModule(feature, key) {
@@ -266,6 +453,278 @@ function enabledLinuxFeatureStageHooks(options = {}) {
     .filter((hook) => hook.path != null);
 }
 
+function normalizeEntryList(value, label, feature) {
+  if (value == null) {
+    return [];
+  }
+  const entries = Array.isArray(value) ? value : [value];
+  return entries.map((entry, index) => {
+    if (typeof entry === "string") {
+      return { source: resolveFeatureRelativePath(feature, entry, `${label} ${index + 1}`) };
+    }
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Linux feature '${feature.id}' ${label} ${index + 1} must be a string or object`);
+    }
+    const source = resolveFeatureRelativePath(feature, entry.source ?? entry.path, `${label} ${index + 1}`);
+    const name = entry.name == null ? path.basename(source) : String(entry.name);
+    if (name.length === 0 || path.isAbsolute(name) || relativePathParts(name).includes("..") || name.includes("/") || name.includes("\\")) {
+      throw new Error(`Linux feature '${feature.id}' ${label} ${index + 1} has invalid name`);
+    }
+    return { ...entry, source, name };
+  });
+}
+
+function normalizeInstallTarget(target, featureId) {
+  return normalizeInstallRelativePath(target, `Linux feature '${featureId}' resource target`);
+}
+
+function parseFileMode(value, fallback) {
+  if (value == null) {
+    return fallback;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`Invalid file mode: ${String(value)}; file mode must be a quoted octal string`);
+  }
+  const raw = value.trim();
+  if (!/^[0-7]{3,4}$/.test(raw)) {
+    throw new Error(`Invalid file mode: ${String(value)}; file mode must be a quoted octal string`);
+  }
+  return Number.parseInt(raw, 8);
+}
+
+function modeString(mode) {
+  return mode == null ? null : mode.toString(8).padStart(4, "0");
+}
+
+function enabledLinuxFeatureInstallPlan(options = {}) {
+  const resources = [];
+  const runtimeHooks = [];
+  for (const feature of loadEnabledLinuxFeatures(options)) {
+    for (const [index, resource] of normalizeEntryList(feature.manifest.resources, "resource", feature).entries()) {
+      const target = normalizeInstallTarget(resource.target, feature.id);
+      resources.push({
+        id: feature.id,
+        source: resource.source,
+        target,
+        mode: resource.mode == null ? null : parseFileMode(resource.mode, 0o644),
+        index,
+      });
+    }
+
+    const hooks = feature.manifest.runtimeHooks ?? {};
+    if (hooks != null && (typeof hooks !== "object" || Array.isArray(hooks))) {
+      throw new Error(`Linux feature '${feature.id}' runtimeHooks must be an object`);
+    }
+    for (const [hookKey, hookSpec] of Object.entries(hooks ?? {})) {
+      const runtimeHook = RUNTIME_HOOK_DIRS[hookKey];
+      if (runtimeHook == null) {
+        throw new Error(`Linux feature '${feature.id}' has unsupported runtime hook '${hookKey}'`);
+      }
+      for (const [index, entry] of normalizeEntryList(hookSpec, `runtimeHooks.${hookKey}`, feature).entries()) {
+        const name = `${feature.id}-${entry.name ?? path.basename(entry.source)}`;
+        runtimeHooks.push({
+          id: feature.id,
+          key: hookKey,
+          source: entry.source,
+          name,
+          mode: parseFileMode(entry.mode, runtimeHook.executable ? 0o755 : 0o644),
+          dir: runtimeHook.dir,
+          target: [".codex-linux", runtimeHook.dir, name].join("/"),
+          index,
+        });
+      }
+    }
+  }
+  return { resources, runtimeHooks };
+}
+
+function chmodRecursive(target, mode) {
+  const directory = isDirectory(target);
+  const targetMode = directory
+    ? mode |
+      ((mode & 0o400) ? 0o100 : 0) |
+      ((mode & 0o040) ? 0o010 : 0) |
+      ((mode & 0o004) ? 0o001 : 0)
+    : mode;
+  fs.chmodSync(target, targetMode);
+  if (!directory) {
+    return;
+  }
+  for (const name of fs.readdirSync(target)) {
+    chmodRecursive(path.join(target, name), mode);
+  }
+}
+
+function copyInstallFile(source, target, mode) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.cpSync(source, target, { recursive: true, force: true });
+  if (mode != null) {
+    chmodRecursive(target, mode);
+  }
+}
+
+function stagedManifestPath(installDir) {
+  return path.join(installDir, STAGED_FEATURE_MANIFEST_RELATIVE_PATH);
+}
+
+function stagedArtifactEntries(manifest) {
+  if (manifest == null || typeof manifest !== "object" || Array.isArray(manifest)) {
+    return [];
+  }
+  const resources = Array.isArray(manifest.resources) ? manifest.resources : [];
+  const runtimeHooks = Array.isArray(manifest.runtimeHooks) ? manifest.runtimeHooks : [];
+  return [...resources, ...runtimeHooks].filter((entry) => entry != null && typeof entry === "object");
+}
+
+function readStagedFeatureManifest(installDir) {
+  const manifestPath = stagedManifestPath(installDir);
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    console.warn(`WARN: Could not read Linux feature staged manifest at ${manifestPath}: ${error.message}`);
+    return null;
+  }
+}
+
+function writeStagedFeatureManifest(installDir, plan) {
+  const manifestPath = stagedManifestPath(installDir);
+  const manifest = {
+    version: 1,
+    resources: plan.resources.map((resource) => ({
+      id: resource.id,
+      type: "resource",
+      target: resource.target,
+      mode: modeString(resource.mode),
+    })),
+    runtimeHooks: plan.runtimeHooks.map((hook) => ({
+      id: hook.id,
+      type: "runtimeHook",
+      key: hook.key,
+      target: hook.target,
+      mode: modeString(hook.mode),
+    })),
+  };
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function removeInstallRelativePath(installDir, relativePath) {
+  const { normalized, resolved } = resolveInstallRelativePath(
+    installDir,
+    relativePath,
+    "Linux feature staged artifact target",
+  );
+  if (normalized === STAGED_FEATURE_MANIFEST_RELATIVE_PATH) {
+    return;
+  }
+  fs.rmSync(resolved, { recursive: true, force: true });
+}
+
+function removePreviouslyStagedArtifacts(installDir, manifest) {
+  for (const entry of stagedArtifactEntries(manifest)) {
+    if (typeof entry.target !== "string") {
+      continue;
+    }
+    removeInstallRelativePath(installDir, entry.target);
+  }
+}
+
+function removeLegacyDeclarativeRuntimeHooks(installDir, options = {}) {
+  const featureIds = discoverLinuxFeatureManifests(options).map((feature) => feature.id);
+  if (featureIds.length === 0) {
+    return;
+  }
+  for (const runtimeHook of Object.values(RUNTIME_HOOK_DIRS)) {
+    const hookDir = path.join(installDir, ".codex-linux", runtimeHook.dir);
+    if (!isDirectory(hookDir)) {
+      continue;
+    }
+    for (const name of fs.readdirSync(hookDir)) {
+      if (featureIds.some((id) => name.startsWith(`${id}-`))) {
+        fs.rmSync(path.join(hookDir, name), { recursive: true, force: true });
+      }
+    }
+  }
+}
+
+function stagedLinuxFeatureFiles(appDir) {
+  const installDir = path.resolve(appDir);
+  return stagedArtifactEntries(readStagedFeatureManifest(installDir))
+    .filter((entry) => typeof entry.target === "string" && typeof entry.mode === "string")
+    .map((entry) => ({
+      id: entry.id ?? null,
+      type: entry.type ?? null,
+      key: entry.key ?? null,
+      target: normalizeInstallRelativePath(entry.target, "Linux feature staged artifact target"),
+      mode: entry.mode,
+    }));
+}
+
+function stageEnabledLinuxFeatureInstall(appDir, options = {}) {
+  const installDir = path.resolve(appDir);
+  const plan = enabledLinuxFeatureInstallPlan(options);
+  const previousManifest = readStagedFeatureManifest(installDir);
+  if (previousManifest == null) {
+    removeLegacyDeclarativeRuntimeHooks(installDir, options);
+  } else {
+    removePreviouslyStagedArtifacts(installDir, previousManifest);
+  }
+  for (const resource of plan.resources) {
+    copyInstallFile(resource.source, path.join(installDir, resource.target), resource.mode);
+    console.error(`Staged Linux feature resource: ${resource.id} -> ${resource.target}`);
+  }
+  for (const hook of plan.runtimeHooks) {
+    const target = path.join(installDir, hook.target);
+    copyInstallFile(hook.source, target, hook.mode);
+    console.error(`Staged Linux feature ${hook.key} hook: ${hook.id} -> ${path.relative(installDir, target)}`);
+  }
+  writeStagedFeatureManifest(installDir, plan);
+  return plan;
+}
+
+function enabledLinuxFeaturePackageHooks(options = {}) {
+  const packageFormat = options.packageFormat ?? null;
+  const hooks = [];
+  for (const feature of loadEnabledLinuxFeatures(options)) {
+    for (const [index, entry] of normalizeEntryList(feature.manifest.packageHooks, "packageHook", feature).entries()) {
+      const formats = entry.formats == null
+        ? []
+        : normalizeFeatureIdList(entry.formats, "packageHook formats", feature.id);
+      if (packageFormat != null && formats.length > 0 && !formats.includes(packageFormat)) {
+        continue;
+      }
+      hooks.push({
+        id: feature.id,
+        path: entry.source,
+        formats,
+        index,
+      });
+    }
+  }
+  return hooks;
+}
+
+function featuresJsonSummary(options = {}) {
+  return discoverLinuxFeatureManifests(options).map((feature) => ({
+    id: feature.id,
+    title: feature.manifest.title ?? feature.manifest.name ?? feature.id,
+    name: feature.manifest.name ?? feature.manifest.title ?? feature.id,
+    description: feature.manifest.description ?? "",
+    origin: feature.origin,
+    local: feature.local,
+    relativeDir: feature.relativeDir,
+    requires: feature.manifest.requires,
+    conflicts: feature.manifest.conflicts,
+    defaultEnabled: false,
+    setup: feature.manifest.setup ?? null,
+    cleanup: feature.manifest.cleanup ?? null,
+  }));
+}
+
 function main() {
   const command = process.argv[2];
   if (command === "--stage-hooks") {
@@ -274,27 +733,72 @@ function main() {
     }
     return;
   }
+  if (command === "--package-hooks") {
+    const packageFormat = process.argv[3] ?? "";
+    for (const hook of enabledLinuxFeaturePackageHooks({ packageFormat })) {
+      process.stdout.write(`${hook.id}\t${hook.path}\n`);
+    }
+    return;
+  }
+  if (command === "--stage-install") {
+    const appDir = process.argv[3] ?? process.env.INSTALL_DIR;
+    if (!appDir) {
+      console.error("Usage: linux-features.js --stage-install <install-dir>");
+      process.exit(1);
+    }
+    stageEnabledLinuxFeatureInstall(appDir);
+    return;
+  }
+  if (command === "--staged-files-json") {
+    const appDir = process.argv[3] ?? process.env.INSTALL_DIR;
+    if (!appDir) {
+      console.error("Usage: linux-features.js --staged-files-json <install-dir>");
+      process.exit(1);
+    }
+    process.stdout.write(`${JSON.stringify(stagedLinuxFeatureFiles(appDir), null, 2)}\n`);
+    return;
+  }
   if (command === "--enabled") {
     for (const id of enabledLinuxFeatureIds()) {
       process.stdout.write(`${id}\n`);
     }
     return;
   }
-  console.error("Usage: linux-features.js --enabled | --stage-hooks");
+  if (command === "--features-json") {
+    process.stdout.write(`${JSON.stringify(featuresJsonSummary(), null, 2)}\n`);
+    return;
+  }
+  if (command === "--features-root") {
+    process.stdout.write(`${linuxFeaturesRoot()}\n`);
+    return;
+  }
+  console.error("Usage: linux-features.js --enabled | --features-json | --features-root | --stage-install <install-dir> | --staged-files-json <install-dir> | --stage-hooks | --package-hooks <format>");
   process.exit(1);
 }
 
 if (require.main === module) {
-  main();
+  try {
+    main();
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  }
 }
 
 module.exports = {
+  discoverLinuxFeatureManifests,
   enabledLinuxFeatureIds,
+  enabledLinuxFeatureInstallPlan,
+  enabledLinuxFeaturePackageHooks,
   enabledLinuxFeatureStageHooks,
+  featuresJsonSummary,
   loadEnabledLinuxFeatures,
   loadLinuxFeaturePatchDescriptors,
   loadLinuxFeatureMainBundlePatches,
+  linuxFeatureManifestMap,
   linuxFeaturesConfigPath,
   linuxFeaturesRoot,
   resolveFeatureEntrypoint,
+  stageEnabledLinuxFeatureInstall,
+  stagedLinuxFeatureFiles,
 };

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -163,6 +163,10 @@ function normalizeLinuxFeatureManifest(featuresRoot, candidate) {
   }
 
   const id = assertFeatureId(manifest.id, `Linux feature id in ${candidate.manifestPath}`);
+  const readmePath = path.join(candidate.dir, "README.md");
+  if (!fs.existsSync(readmePath) || isDirectory(readmePath)) {
+    throw new Error(`Linux feature '${id}' must include README.md next to feature.json`);
+  }
   if (manifest.defaultEnabled === true) {
     throw new Error(`Linux feature '${id}' must be disabled by default; defaultEnabled true is not allowed`);
   }
@@ -172,6 +176,7 @@ function normalizeLinuxFeatureManifest(featuresRoot, candidate) {
     id,
     dir: candidate.dir,
     manifestPath: candidate.manifestPath,
+    readmePath,
     origin: candidate.origin,
     local: candidate.origin === "local",
     relativeDir,

--- a/scripts/lib/linux-features.sh
+++ b/scripts/lib/linux-features.sh
@@ -15,6 +15,12 @@ run_linux_feature_stage_hooks() {
         return 0
     }
 
+    info "Staging declarative Linux feature resources and runtime hooks"
+    if ! SCRIPT_DIR="$SCRIPT_DIR" INSTALL_DIR="$INSTALL_DIR" WORK_DIR="$WORK_DIR" ARCH="$ARCH" CODEX_UPSTREAM_APP_DIR="$app_dir" node "$feature_helper" --stage-install "$INSTALL_DIR"; then
+        warn "Linux feature declarative staging failed"
+        return 1
+    fi
+
     while IFS=$'\t' read -r feature_id hook_path; do
         [ -n "$feature_id" ] || continue
         [ -n "$hook_path" ] || continue

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -77,6 +77,64 @@ fs.writeFileSync(targetPath, `${JSON.stringify({ enabled }, null, 2)}\n`);
 NODE
 }
 
+linux_features_root_path() {
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+
+    node_bin="$(package_node_binary)"
+    "$node_bin" "$helper" --features-root
+}
+
+stage_update_builder_linux_features_tree() {
+    local update_builder_root="$1"
+    local source_root
+    local target="$update_builder_root/linux-features"
+
+    source_root="$(linux_features_root_path)"
+    [ -d "$source_root" ] || error "Missing Linux features root: $source_root"
+
+    mkdir -p "$target"
+    cp -a "$source_root/." "$target/"
+}
+
+run_linux_feature_package_hooks() {
+    local staging_root="$1"
+    local package_format="$2"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+    local feature_id
+    local hook_path
+    local hooks_output
+    local app_dir="$staging_root/opt/$PACKAGE_NAME"
+
+    [ -d "$staging_root" ] || error "Missing package staging root: $staging_root"
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+
+    node_bin="$(package_node_binary)"
+    if ! hooks_output="$("$node_bin" "$helper" --package-hooks "$package_format")"; then
+        error "Failed to discover Linux feature package hooks for $package_format"
+    fi
+
+    while IFS=$'\t' read -r feature_id hook_path; do
+        [ -n "${feature_id:-}" ] || continue
+        [ -f "$hook_path" ] || error "Missing Linux feature package hook for $feature_id: $hook_path"
+
+        info "Running Linux feature package hook ($package_format): $feature_id"
+        REPO_DIR="$REPO_DIR" \
+            SCRIPT_DIR="$REPO_DIR" \
+            APP_DIR="$app_dir" \
+            PACKAGE_APP_DIR="$app_dir" \
+            PACKAGE_NAME="$PACKAGE_NAME" \
+            PACKAGE_VERSION="$PACKAGE_VERSION" \
+            PACKAGE_FORMAT="$package_format" \
+            PACKAGE_ROOT="$staging_root" \
+            PACKAGE_STAGING_ROOT="$staging_root" \
+            bash "$hook_path"
+    done <<< "$hooks_output"
+}
+
 render_desktop_entry() {
     local target="$1"
     local package_name
@@ -598,7 +656,7 @@ stage_update_builder_bundle() {
     cp "$UPDATER_SERVICE_SOURCE" "$update_builder_root/packaging/linux/codex-update-manager.service"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.postinst" "$update_builder_root/packaging/linux/codex-update-manager.postinst"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.prerm" "$update_builder_root/packaging/linux/codex-update-manager.prerm"
-    cp -r "$REPO_DIR/linux-features/." "$update_builder_root/linux-features/"
+    stage_update_builder_linux_features_tree "$update_builder_root"
     stage_update_builder_linux_features_config "$update_builder_root"
     cp "$REPO_DIR/packaging/linux/codex-update-manager.postrm" "$update_builder_root/packaging/linux/codex-update-manager.postrm"
     cp "$REPO_DIR/assets/codex.png" "$update_builder_root/assets/codex.png"
@@ -615,6 +673,68 @@ stage_optional_update_builder_bundle() {
         stage_update_builder_bundle "$@"
     else
         info "Skipping update-builder bundle (PACKAGE_WITH_UPDATER=0)"
+    fi
+}
+
+restore_linux_feature_payload_permissions() {
+    local root="$1"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local app_root="$root/opt/$PACKAGE_NAME"
+    local node_bin
+    local staged_files_json
+
+    [ -d "$root" ] || error "Missing package root: $root"
+    [ -d "$app_root" ] || error "Missing package app root: $app_root"
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+
+    node_bin="$(package_node_binary)"
+    if ! staged_files_json="$("$node_bin" "$helper" --staged-files-json "$app_root")"; then
+        error "Failed to read Linux feature staged file manifest"
+    fi
+
+    if ! "$node_bin" - "$app_root" "$staged_files_json" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [appRoot, rawJson] = process.argv.slice(2);
+const entries = JSON.parse(rawJson);
+
+if (!Array.isArray(entries)) {
+  throw new Error("Linux feature staged files payload must be an array");
+}
+
+function assertRelativeTarget(target) {
+  if (typeof target !== "string" || target.length === 0) {
+    throw new Error("Linux feature staged file target must be a relative path");
+  }
+  const parts = target.split(/[\\/]+/).filter(Boolean);
+  if (path.isAbsolute(target) || parts.includes("..")) {
+    throw new Error(`Unsafe Linux feature staged file target: ${target}`);
+  }
+  const resolved = path.resolve(appRoot, ...parts);
+  const relative = path.relative(appRoot, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Unsafe Linux feature staged file target: ${target}`);
+  }
+  return resolved;
+}
+
+for (const entry of entries) {
+  if (entry == null || typeof entry !== "object") {
+    throw new Error("Linux feature staged file entry must be an object");
+  }
+  if (typeof entry.mode !== "string" || !/^[0-7]{3,4}$/.test(entry.mode)) {
+    throw new Error(`Invalid Linux feature staged file mode for ${entry.target}: ${entry.mode}`);
+  }
+  const target = assertRelativeTarget(entry.target);
+  if (!fs.existsSync(target)) {
+    throw new Error(`Linux feature staged file is missing from package payload: ${entry.target}`);
+  }
+  fs.chmodSync(target, Number.parseInt(entry.mode, 8));
+}
+NODE
+    then
+        error "Failed to restore Linux feature staged file permissions"
     fi
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -151,24 +151,42 @@ test_package_payload_permission_normalization() {
     info "Checking package payload permission normalization"
     local root="$TMP_DIR/package-permissions"
     local app_root="$root/opt/codex-desktop"
+    local private_file="$app_root/.codex-linux/features/private/secret.txt"
 
-    mkdir -p "$app_root/content/webview" "$root/usr/bin"
+    mkdir -p "$app_root/content/webview" "$root/usr/bin" "$(dirname "$private_file")"
     printf '%s\n' '#!/bin/bash' 'echo start' > "$app_root/start.sh"
     printf '%s\n' '<!doctype html>' > "$app_root/content/webview/index.html"
     printf '%s\n' '#!/bin/bash' 'exec /opt/codex-desktop/start.sh "$@"' > "$root/usr/bin/codex-desktop"
+    printf '%s\n' 'secret' > "$private_file"
+    cat > "$app_root/.codex-linux/linux-features-staged.json" <<'JSON'
+{
+  "version": 1,
+  "resources": [
+    {
+      "id": "private",
+      "type": "resource",
+      "target": ".codex-linux/features/private/secret.txt",
+      "mode": "0600"
+    }
+  ],
+  "runtimeHooks": []
+}
+JSON
     chmod 0700 "$root/opt" "$app_root" "$app_root/content" "$app_root/content/webview"
     chmod 0700 "$app_root/start.sh" "$root/usr/bin/codex-desktop"
-    chmod 0600 "$app_root/content/webview/index.html"
+    chmod 0600 "$app_root/content/webview/index.html" "$private_file"
 
     # shellcheck disable=SC1091
     source "$REPO_DIR/scripts/lib/package-common.sh"
     normalize_package_payload_permissions "$root"
+    PACKAGE_NAME="codex-desktop" restore_linux_feature_payload_permissions "$root"
 
     assert_mode "$app_root" "755"
     assert_mode "$app_root/content/webview" "755"
     assert_mode "$app_root/start.sh" "755"
     assert_mode "$root/usr/bin/codex-desktop" "755"
     assert_mode "$app_root/content/webview/index.html" "644"
+    assert_mode "$private_file" "600"
 }
 
 test_deb_builder_smoke() {
@@ -269,16 +287,26 @@ test_update_builder_preserves_enabled_linux_features_config() {
     local workspace="$TMP_DIR/update-builder-linux-features"
     local root="$workspace/root"
     local app_dir="$workspace/app"
+    local features_root="$workspace/linux-features"
     local feature_config="$workspace/features.json"
     local staged_config="$root/opt/codex-desktop/update-builder/linux-features/features.json"
+    local staged_local_manifest="$root/opt/codex-desktop/update-builder/linux-features/local/local-tool/feature.json"
     local source_info="$root/opt/codex-desktop/update-builder/.codex-linux/source-info.json"
 
     mkdir -p "$workspace"
     make_fake_app "$app_dir"
+    mkdir -p "$features_root/example-feature" "$features_root/local/local-tool"
+    printf '%s\n' '# Linux Features' > "$features_root/README.md"
+    printf '%s\n' '{"enabled":[]}' > "$features_root/features.example.json"
+    printf '%s\n' '{"id":"example-feature","title":"Example Linux Feature"}' \
+        > "$features_root/example-feature/feature.json"
+    printf '%s\n' '{"id":"local-tool","title":"Local Tool"}' \
+        > "$features_root/local/local-tool/feature.json"
     cat > "$feature_config" <<'JSON'
 {
   "enabled": [
-    "example-feature"
+    "example-feature",
+    "local-tool"
   ],
   "localComment": "should not be packaged"
 }
@@ -288,6 +316,7 @@ JSON
         export APP_DIR="$app_dir"
         export PACKAGE_NAME="codex-desktop"
         export UPDATER_SERVICE_SOURCE="$REPO_DIR/packaging/linux/codex-update-manager.service"
+        export CODEX_LINUX_FEATURES_ROOT="$features_root"
         export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
         export CODEX_LINUX_SOURCE_REMOTE="https://builder:secret-token@example.com/org/repo.git"
         export SOURCE_DATE_EPOCH="1710000000"
@@ -298,14 +327,16 @@ JSON
     )
 
     assert_file_exists "$staged_config"
+    assert_file_exists "$staged_local_manifest"
     assert_contains "$staged_config" "example-feature"
+    assert_contains "$staged_config" "local-tool"
     assert_not_contains "$staged_config" "localComment"
 
     node - "$staged_config" <<'NODE' || fail "Expected staged Linux features config to be sanitized"
 const fs = require("node:fs");
 const configPath = process.argv[2];
 const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-if (JSON.stringify(config) !== JSON.stringify({ enabled: ["example-feature"] })) {
+if (JSON.stringify(config) !== JSON.stringify({ enabled: ["example-feature", "local-tool"] })) {
   process.exit(1);
 }
 NODE
@@ -321,6 +352,50 @@ if (info.capturedAt !== new Date(1710000000 * 1000).toISOString()) {
   throw new Error(`unexpected capturedAt: ${info.capturedAt}`);
 }
 NODE
+}
+
+test_linux_feature_package_hook_discovery_failure_blocks_build() {
+    info "Checking Linux feature package hook discovery failure blocks package staging"
+    local workspace="$TMP_DIR/package-hook-discovery-failure"
+    local root="$workspace/root"
+    local app_dir="$workspace/app"
+    local features_root="$workspace/linux-features"
+    local feature_config="$features_root/features.json"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$root" "$features_root/bad-package-hook"
+    make_fake_app "$app_dir"
+    printf '%s\n' '{"enabled":[]}' > "$features_root/features.example.json"
+    cat > "$features_root/bad-package-hook/feature.json" <<'JSON'
+{
+  "id": "bad-package-hook",
+  "title": "Bad Package Hook",
+  "packageHooks": [
+    {
+      "path": "missing.sh",
+      "formats": ["deb"]
+    }
+  ]
+}
+JSON
+    printf '%s\n' '{"enabled":["bad-package-hook"]}' > "$feature_config"
+
+    if (
+        export APP_DIR="$app_dir"
+        export PACKAGE_NAME="codex-desktop"
+        export PACKAGE_VERSION="2026.03.24.120000+hookfailure"
+        export CODEX_LINUX_FEATURES_ROOT="$features_root"
+        export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
+
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/package-common.sh"
+        run_linux_feature_package_hooks "$root" "deb"
+    ) >"$output_log" 2>&1; then
+        fail "Expected package hook discovery failure to stop package staging"
+    fi
+
+    assert_contains "$output_log" "Failed to discover Linux feature package hooks for deb"
+    assert_contains "$output_log" "packageHook 1 not found"
 }
 
 test_deb_builder_respects_package_identity() {
@@ -1139,6 +1214,30 @@ JSON
     assert_contains "$output_log" "Enabled Linux features: remote-mobile-control"
     assert_contains "$output_log" "Default native package mode includes codex-update-manager"
     assert_contains "$output_log" "make install-native"
+}
+
+test_setup_native_wizard_lists_local_features() {
+    info "Checking setup-native wizard discovers user-local Linux features"
+    local workspace="$TMP_DIR/setup-native-local-feature"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    mkdir -p "$features_root/local/local-tool"
+    printf '%s\n' '{"id":"local-tool","title":"Local Tool","description":"User-local integration."}' \
+        > "$features_root/local/local-tool/feature.json"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$config" \
+    CODEX_LINUX_FEATURES="local-tool" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
+
+    assert_json_enabled_equals "$config" '["local-tool"]'
+    assert_contains "$output_log" "local-tool \\[local\\] - Local Tool"
+    assert_contains "$output_log" "Enabled Linux features: local-tool"
 }
 
 test_setup_native_wizard_uses_package_name_for_installed_state() {
@@ -5046,6 +5145,7 @@ main() {
     test_package_payload_permission_normalization
     test_deb_builder_smoke
     test_update_builder_preserves_enabled_linux_features_config
+    test_linux_feature_package_hook_discovery_failure_blocks_build
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater
     test_no_updater_cleanup_helper_removes_inactive_user_enablement
@@ -5065,6 +5165,7 @@ main() {
     test_setup_native_wizard_accepts_numbered_feature_selection
     test_setup_native_wizard_rejects_out_of_range_feature_numbers
     test_setup_native_wizard_summary_keeps_existing_config
+    test_setup_native_wizard_lists_local_features
     test_setup_native_wizard_uses_package_name_for_installed_state
     test_setup_native_wizard_portal_summary_survives_busctl_sigpipe
     test_setup_native_wizard_warns_when_conversation_mode_lacks_read_aloud

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2308,6 +2308,7 @@ detect_body = source.split("detect_warm_start() {", 1)[1].split("send_warm_start
 launch_body = source.split("launch_electron() {", 1)[1].split("load_packaged_runtime_helper", 1)[0]
 runtime_body = source.split("trap cleanup_launcher EXIT", 1)[1].split("launch_electron", 1)[0]
 webview_probe_body = source.split("webview_port_is_open() {", 1)[1].split("wait_for_webview_server() {", 1)[0]
+prelaunch_hooks_body = source.split("run_feature_prelaunch_hooks() {", 1)[1].split("bundled_plugin_version() {", 1)[0]
 cold_start_hooks_body = source.split("run_cold_start_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 stale_body = source.split("pid_is_stale_webview_server() {", 1)[1].split("stop_owned_webview_server() {", 1)[0]
@@ -2317,6 +2318,10 @@ ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_we
 reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
 if 'LAUNCHER_ARGS=()' not in source:
     raise SystemExit("launcher must keep a sanitized argv for launcher-only flags")
+if 'CODEX_LINUX_FEATURES_DIR="$SCRIPT_DIR/.codex-linux/features"' not in source:
+    raise SystemExit("launcher must expose the app-local Linux feature resource directory")
+if 'export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR' not in source:
+    raise SystemExit("launcher must export CODEX_HOME and Linux feature resource directory")
 if 'configure_multi_launch_instance "$@"' not in source:
     raise SystemExit("launcher must configure multi-launch before deriving WEBVIEW_ORIGIN")
 if 'unset CODEX_LINUX_MULTI_LAUNCH' not in source.split('parse_launcher_args() {', 1)[0]:
@@ -2386,6 +2391,11 @@ if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
 if 'run_cold_start_hooks' not in runtime_body:
     raise SystemExit("cold start must run feature-staged hooks before Electron launches")
+for name, body in (("prelaunch", prelaunch_hooks_body), ("cold-start", cold_start_hooks_body)):
+    if 'CODEX_HOME="$CODEX_HOME"' not in body:
+        raise SystemExit(f"launcher {name} hooks must receive resolved CODEX_HOME")
+    if 'CODEX_LINUX_FEATURES_DIR="$CODEX_LINUX_FEATURES_DIR"' not in body:
+        raise SystemExit(f"launcher {name} hooks must receive the app-local Linux feature resource directory")
 if 'COLD_START_HOOK_DIR' not in cold_start_hooks_body or '"$hook" "$SCRIPT_DIR" "$APP_STATE_DIR" "$LOG_DIR"' not in cold_start_hooks_body:
     raise SystemExit("launcher cold-start hook runner must be generic and pass standard paths")
 if '>>"$LOG_FILE" 2>&1 &' not in cold_start_hooks_body:
@@ -2717,7 +2727,7 @@ test_side_by_side_launcher_identity() {
     assert_contains "$app_dir/start.sh" "CODEX_LINUX_APP_DISPLAY_NAME=Codex\\\\ CUA\\\\ Lab"
     assert_contains "$app_dir/start.sh" 'CODEX_LINUX_WEBVIEW_PORT=${CODEX_WEBVIEW_PORT:-5176}'
     assert_contains "$app_dir/start.sh" 'CODEX_LINUX_SETTINGS_FILE="$APP_SETTINGS_FILE"'
-    assert_contains "$app_dir/start.sh" 'export CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE'
+    assert_contains "$app_dir/start.sh" 'export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR'
     assert_contains "$app_dir/start.sh" 'WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"'
     assert_contains "$app_dir/start.sh" 'ELECTRON_RENDERER_URL="${ELECTRON_RENDERER_URL:-$WEBVIEW_ORIGIN/}"'
     assert_contains "$app_dir/start.sh" "resolve_script_dir"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -95,18 +95,23 @@ make_wizard_feature_root() {
     cat > "$features_root/conversation-mode/feature.json" <<'JSON'
 {"id":"conversation-mode","name":"Conversation mode","description":"Voice conversation loop."}
 JSON
+    printf '%s\n' '# Conversation Mode' > "$features_root/conversation-mode/README.md"
     cat > "$features_root/example-feature/feature.json" <<'JSON'
 {"id":"example-feature","title":"Example Linux Feature","description":"Developer sample."}
 JSON
+    printf '%s\n' '# Example Linux Feature' > "$features_root/example-feature/README.md"
     cat > "$features_root/read-aloud/feature.json" <<'JSON'
 {"id":"read-aloud","name":"Read aloud","description":"Read assistant responses aloud."}
 JSON
+    printf '%s\n' '# Read Aloud' > "$features_root/read-aloud/README.md"
     cat > "$features_root/read-aloud-mcp/feature.json" <<'JSON'
 {"id":"read-aloud-mcp","title":"Read Aloud MCP","description":"Read Aloud MCP plugin staging."}
 JSON
+    printf '%s\n' '# Read Aloud MCP' > "$features_root/read-aloud-mcp/README.md"
     cat > "$features_root/remote-mobile-control/feature.json" <<'JSON'
 {"id":"remote-mobile-control","title":"Experimental Remote Mobile Control","description":"Mobile host enrollment patches."}
 JSON
+    printf '%s\n' '# Remote Mobile Control' > "$features_root/remote-mobile-control/README.md"
 }
 
 make_fake_browser_upstream_app() {
@@ -300,8 +305,10 @@ test_update_builder_preserves_enabled_linux_features_config() {
     printf '%s\n' '{"enabled":[]}' > "$features_root/features.example.json"
     printf '%s\n' '{"id":"example-feature","title":"Example Linux Feature"}' \
         > "$features_root/example-feature/feature.json"
+    printf '%s\n' '# Example Linux Feature' > "$features_root/example-feature/README.md"
     printf '%s\n' '{"id":"local-tool","title":"Local Tool"}' \
         > "$features_root/local/local-tool/feature.json"
+    printf '%s\n' '# Local Tool' > "$features_root/local/local-tool/README.md"
     cat > "$feature_config" <<'JSON'
 {
   "enabled": [
@@ -378,6 +385,7 @@ test_linux_feature_package_hook_discovery_failure_blocks_build() {
   ]
 }
 JSON
+    printf '%s\n' '# Bad Package Hook' > "$features_root/bad-package-hook/README.md"
     printf '%s\n' '{"enabled":["bad-package-hook"]}' > "$feature_config"
 
     if (
@@ -1070,6 +1078,29 @@ test_setup_native_wizard_rejects_invalid_feature_ids() {
     assert_json_enabled_equals "$config" '[]'
 }
 
+test_setup_native_wizard_rejects_features_without_readme() {
+    info "Checking setup-native wizard rejects undocumented Linux features"
+    local workspace="$TMP_DIR/setup-native-missing-readme"
+    local features_root="$workspace/linux-features"
+    local config="$workspace/features.json"
+    local output_log="$workspace/output.log"
+
+    make_wizard_feature_root "$features_root"
+    rm -f "$features_root/read-aloud/README.md"
+    printf '%s\n' '{"enabled":[]}' > "$config"
+
+    if CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+        CODEX_LINUX_FEATURES_ROOT="$features_root" \
+        CODEX_LINUX_FEATURES_CONFIG="$config" \
+        CODEX_LINUX_FEATURES="read-aloud" \
+            bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log" 2>&1; then
+        fail "setup wizard should reject Linux features without README.md"
+    fi
+
+    assert_contains "$output_log" "must include README.md next to feature.json"
+    assert_json_enabled_equals "$config" '[]'
+}
+
 test_setup_native_wizard_rejects_conflicting_feature_ids() {
     info "Checking setup-native wizard conflicting feature validation"
     local workspace="$TMP_DIR/setup-native-conflicting-feature"
@@ -1227,6 +1258,7 @@ test_setup_native_wizard_lists_local_features() {
     mkdir -p "$features_root/local/local-tool"
     printf '%s\n' '{"id":"local-tool","title":"Local Tool","description":"User-local integration."}' \
         > "$features_root/local/local-tool/feature.json"
+    printf '%s\n' '# Local Tool' > "$features_root/local/local-tool/README.md"
     printf '%s\n' '{"enabled":[]}' > "$config"
 
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
@@ -5170,6 +5202,7 @@ main() {
     test_fedora_dependency_bootstrap_installs_rpmbuild
     test_setup_native_wizard_noninteractive_feature_writer
     test_setup_native_wizard_rejects_invalid_feature_ids
+    test_setup_native_wizard_rejects_features_without_readme
     test_setup_native_wizard_rejects_conflicting_feature_ids
     test_setup_native_wizard_disable_is_non_destructive
     test_setup_native_wizard_accepts_numbered_feature_selection


### PR DESCRIPTION
## Summary

This PR turns `linux-features/` into a more complete opt-in extension framework for Linux-specific integrations that should not live in the core patch flow.

The goal is to make optional Linux features easy to add, test, package, and carry through updater rebuilds while keeping the default app minimal. By default, no optional features are enabled. A feature becomes active only when its id is listed in the git-ignored `linux-features/features.json` file.

## How it works now

- Feature manifests are discovered from tracked `linux-features/<feature-id>/feature.json` directories.
- User-private features can live in git-ignored `linux-features/local/<feature-id>/feature.json` directories, using the same manifest contract.
- Every feature directory must include a neighboring `README.md` that documents what the feature does, how to test it, and known support risks.
- Enabled features can contribute ASAR patch descriptors, staged resources, runtime launcher hooks, package hooks, or legacy `stage.sh` hooks.
- Runtime hooks are consumed by the generated Linux launcher:
  - `runtimeHooks.env` exports environment variables before launch.
  - `runtimeHooks.prelaunch` runs before webview setup on cold start.
  - `runtimeHooks.electronArgs` appends Electron launch arguments.
  - `runtimeHooks.coldStart` runs after bundled plugin cache sync.
- Runtime hooks receive `CODEX_HOME`, `CODEX_LINUX_APP_DIR`, `CODEX_LINUX_APP_STATE_DIR`, `CODEX_LINUX_FEATURES_DIR`, and `CODEX_LINUX_LAUNCHER_LOG`, so feature-owned user artifacts can be installed from app-local staged resources at real user runtime.
- Package hooks run during `.deb`, `.rpm`, and pacman staging, so optional features can adjust native package payloads when needed.
- Native package update-builder bundles preserve the enabled feature ids, so local auto-update rebuilds keep the same opt-in Linux feature set.

## Safety and maintenance details

- Features are disabled by default; `defaultEnabled: true` is rejected.
- Repository and local features share one id namespace, so local features cannot shadow tracked ones.
- Feature dependencies and conflicts are validated before staging.
- Declarative resources and runtime hooks are tracked in `.codex-linux/linux-features-staged.json` and removed on the next install when the owning feature is disabled.
- Staged file modes must be quoted octal strings and are preserved after native package permission normalization.
- Resource targets must stay inside the app directory and cannot target the app root itself, preventing cleanup from deleting the install payload.
- The top-level README now links to `docs/linux-features-architecture.md`, which documents the extension contract and intended boundaries.

## Tests

- `node --check scripts/lib/linux-features.js`
- `bash -n scripts/lib/package-common.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/bootstrap-wizard.sh tests/scripts_smoke.sh launcher/start.sh.template`
- `node --test linux-features/example-feature/test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `git diff --check`
