### PR TITLE
fix: avoid stale config write versions on Linux

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -97,6 +97,7 @@ const {
 const {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppSunsetPatch,
+  applyLinuxConfigWriteVersionConflictPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxFastModeModelGuardPatch,
   applySubagentNicknameMetadataPatch,
@@ -163,6 +164,7 @@ module.exports = {
   applyLinuxBuildInfoTrayPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxChromePluginAutoInstallPatch,
+  applyLinuxConfigWriteVersionConflictPatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -77,6 +77,7 @@ const {
   applyBrowserAnnotationScreenshotPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppServerFeatureEnablementPatch,
+  applyLinuxConfigWriteVersionConflictPatch,
 } = require("./patches/webview-assets.js");
 const { patchAssetFiles } = require("./patches/shared.js");
 
@@ -511,6 +512,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "automation-schedule-multi-time-rrule",
     "linux-app-sunset-gate",
     "linux-app-server-feature-enablement",
+    "linux-config-write-version-conflict",
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "opaque-window-default-resolved-theme",
@@ -1870,6 +1872,28 @@ test("warns when app-server feature sync still has unsupported features but the 
   assert.deepEqual(warnings, [
     "WARN: Could not find app-server feature enablement list — skipping unsupported feature compatibility patch",
   ]);
+});
+
+test("drops stale expectedVersion from Linux webview config writes", () => {
+  const source = [
+    "async function X(e,t,n){await o(`write-config-value`,{hostId:r,keyPath:t,value:n,mergeStrategy:`upsert`,filePath:B.filePath,expectedVersion:B.expectedVersion})}",
+    "async function Y(e){await qn(`batch-write-config-value`,{hostId:h,edits:e,filePath:v?.configWriteTarget?.filePath??null,expectedVersion:v?.configWriteTarget?.expectedVersion??null,reloadUserConfig:!0})}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxConfigWriteVersionConflictPatch, source);
+
+  assert.match(patched, /write-config-value/);
+  assert.equal((patched.match(/expectedVersion:null/g) || []).length, 2);
+  assert.equal(patched.includes("expectedVersion:B.expectedVersion"), false);
+  assert.equal(patched.includes("expectedVersion:v?.configWriteTarget?.expectedVersion??null"), false);
+});
+
+test("leaves already-null config write versions unchanged", () => {
+  const source = "async function X(){await o(`write-config-value`,{expectedVersion:null})}";
+
+  const patched = applyPatchTwice(applyLinuxConfigWriteVersionConflictPatch, source);
+
+  assert.equal(patched, source);
 });
 
 test("adds Linux package updater behind the existing app updater manager", () => {

--- a/scripts/patches/core/all-linux/webview/config-write-version-conflict/patch.js
+++ b/scripts/patches/core/all-linux/webview/config-write-version-conflict/patch.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const {
+  applyLinuxConfigWriteVersionConflictPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "linux-config-write-version-conflict",
+    phase: "webview-asset",
+    order: 1045,
+    ciPolicy: "optional",
+    pattern: /^(agent-settings|apps-availability|plugins-availability|use-plugin-install-flow|use-personality|experimental-features-queries|hooks-settings-queries|mcp-settings|personalization-settings|permissions-mode-helpers)-.*\.js$/,
+    missingDescription: "config-writing webview bundle",
+    skipDescription: "Linux config write version-conflict patch",
+    apply: applyLinuxConfigWriteVersionConflictPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -225,6 +225,32 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
   ].join("");
 }
 
+function applyLinuxConfigWriteVersionConflictPatch(currentSource) {
+  if (!currentSource.includes("expectedVersion:")) {
+    return currentSource;
+  }
+
+  const patchedSource = currentSource.replace(
+    /expectedVersion:(?:[A-Za-z_$][\w$]*\?\.[^,{}]+|[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)(?:\?\?null)?/g,
+    "expectedVersion:null",
+  );
+
+  if (patchedSource !== currentSource) {
+    return patchedSource;
+  }
+
+  if (
+    currentSource.includes("expectedVersion:") &&
+    !currentSource.includes("expectedVersion:null")
+  ) {
+    console.warn(
+      "WARN: Could not find config write expectedVersion needle — skipping config version-conflict patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function applySubagentNicknameMetadataPatch(currentSource) {
   let patchedSource = currentSource;
   const sourceShapePatchedMarker = "`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null";
@@ -679,6 +705,7 @@ function patchCommentPreloadBundle(extractedDir) {
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppServerFeatureEnablementPatch,
+  applyLinuxConfigWriteVersionConflictPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,


### PR DESCRIPTION
## Summary
- Add a Linux webview asset patch that drops stale `expectedVersion` fields from config write requests.
- Register the patch for settings/config-writing bundles, including agent settings, apps/plugins availability, MCP settings, personalization, and personality assets.
- Add tests for expectedVersion rewriting and descriptor discovery.

## Why
Some settings writes can be rejected after startup changes the local config version first. On Linux we can avoid that stale version guard by letting the app-server write against the current config state.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js` (153/153 pass)
- Manually verified by user: settings persisted after quit/reopen

No linked issue.