### PR TITLE
feat(updater): track wrapper releases and surface a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `~/.config/<appId>/settings.json` as `codex-linux-auto-update-on-exit`, and
   `codex-update-manager` rereads it during reconciliation as an overlay over
   `config.toml` so the in-app preference wins without restarting the service.
+- `codex-update-manager` can now track newer *wrapper* releases (this repo's own
+  Linux features and fixes) in addition to the upstream Codex DMG. Opt in with
+  `enable_wrapper_updates = true` in `config.toml`; a new `check-wrapper`
+  subcommand and the `status --json` output report the detected wrapper commit
+  and a changelog of what changed. Detection is git-based, requires the remote
+  candidate to descend from the installed checkout, clears stale candidates
+  when no update is currently valid, uses timeout-bound non-interactive git
+  commands, prefers curated `CHANGELOG.md` sections newer than the installed
+  version, and falls back to git commit subjects. Packaged frozen bundles
+  without a git checkout degrade gracefully (no wrapper tracking; updates arrive
+  via a normal package upgrade).
 - Launcher rendering mode `CODEX_LINUX_RENDERING_MODE=wayland-gpu`, which
   forces native Wayland with GPU compositing enabled and skips forced renderer
   accessibility by default for Wayland desktops where XWayland or software

--- a/README.md
+++ b/README.md
@@ -330,6 +330,14 @@ By default, the native package installs a companion `systemd --user` service nam
 - If Codex Desktop is open, the final install waits until Electron exits.
 - The updater runs unprivileged and uses `pkexec` only for the final package install.
 - Codex CLI checks are best-effort and launcher-scoped. Set `CODEX_SYNC_CLI_PREFLIGHT=1` when debugging launch-time CLI preflight.
+- Optional wrapper-update tracking can also watch this repository's own Linux
+  wrapper changes with `enable_wrapper_updates = true` in
+  `~/.config/codex-update-manager/config.toml`. This is intended for
+  git-checkout/dev update-builder installs; detection leaves the working tree
+  untouched but may fetch candidate objects into `.git/FETCH_HEAD`. Git checks
+  are timeout-bound and run with non-interactive prompt guards. Frozen
+  native-package builders without a `.git` directory report no wrapper
+  candidate and receive wrapper changes through normal package upgrades.
 
 Inspect the live service and runtime files with:
 

--- a/scripts/lib/build-info.js
+++ b/scripts/lib/build-info.js
@@ -75,6 +75,24 @@ function sanitizeSourceInfo(info) {
   return sanitized;
 }
 
+function parseWrapperVersion(content) {
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.trim().match(/^version\s*=\s*"([^"]+)"/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function readWrapperVersion(repoDir) {
+  try {
+    return parseWrapperVersion(fs.readFileSync(path.join(repoDir, "updater", "Cargo.toml"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
 function sourceInfoFromGit(repoDir, env = process.env) {
   const overrideCommit = env.CODEX_LINUX_SOURCE_COMMIT?.trim();
   const insideWorkTree = runGit(repoDir, ["rev-parse", "--is-inside-work-tree"]) === "true";
@@ -87,6 +105,7 @@ function sourceInfoFromGit(repoDir, env = process.env) {
   return {
     commit,
     shortCommit: commit == null ? null : commit.slice(0, 12),
+    version: readWrapperVersion(repoDir),
     branch: env.CODEX_LINUX_SOURCE_BRANCH?.trim() || runGit(repoDir, ["branch", "--show-current"]),
     remote: sanitizeGitRemoteUrl(env.CODEX_LINUX_SOURCE_REMOTE?.trim() || runGit(repoDir, ["remote", "get-url", "origin"])),
     describe: env.CODEX_LINUX_SOURCE_DESCRIBE?.trim() || runGit(repoDir, ["describe", "--always", "--dirty", "--tags"]),
@@ -100,6 +119,7 @@ function sourceInfo(repoDir, env = process.env) {
   if (staged != null && typeof staged === "object" && !Array.isArray(staged)) {
     return {
       ...sanitizeSourceInfo(staged),
+      version: staged.version ?? readWrapperVersion(repoDir),
       provenance: staged.provenance ?? "packaged-update-builder",
     };
   }
@@ -110,6 +130,7 @@ function sourceInfo(repoDir, env = process.env) {
   return {
     commit: env.CODEX_LINUX_SOURCE_COMMIT?.trim() || null,
     shortCommit: env.CODEX_LINUX_SOURCE_COMMIT?.trim()?.slice(0, 12) || null,
+    version: readWrapperVersion(repoDir),
     branch: env.CODEX_LINUX_SOURCE_BRANCH?.trim() || null,
     remote: sanitizeGitRemoteUrl(env.CODEX_LINUX_SOURCE_REMOTE?.trim() || null),
     describe: env.CODEX_LINUX_SOURCE_DESCRIBE?.trim() || null,

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -531,18 +531,59 @@ function sanitizeGitRemoteUrl(remote) {
   return value;
 }
 
+function readJsonFile(filePath) {
+  try {
+    const value = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return value != null && typeof value === "object" && !Array.isArray(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseWrapperVersion(content) {
+  for (const line of content.split(/\r?\n/)) {
+    const match = line.trim().match(/^version\s*=\s*"([^"]+)"/);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+function readWrapperVersion(repoDir) {
+  try {
+    return parseWrapperVersion(fs.readFileSync(path.join(repoDir, "updater", "Cargo.toml"), "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeSourceInfo(info) {
+  return {
+    ...info,
+    version: info.version ?? readWrapperVersion(repoDir),
+    remote: sanitizeGitRemoteUrl(info.remote),
+    provenance: info.provenance ?? "packaged-update-builder",
+    recapturedAt: isoTimestamp(),
+  };
+}
+
+const stagedInfo = readJsonFile(path.join(repoDir, ".codex-linux", "source-info.json"));
 const commit = process.env.CODEX_LINUX_SOURCE_COMMIT?.trim() || git(["rev-parse", "HEAD"]);
 const status = git(["status", "--porcelain"]);
-const info = {
-  commit,
-  shortCommit: commit == null ? null : commit.slice(0, 12),
-  branch: process.env.CODEX_LINUX_SOURCE_BRANCH?.trim() || git(["branch", "--show-current"]),
-  remote: sanitizeGitRemoteUrl(process.env.CODEX_LINUX_SOURCE_REMOTE?.trim() || git(["remote", "get-url", "origin"])),
-  describe: process.env.CODEX_LINUX_SOURCE_DESCRIBE?.trim() || git(["describe", "--always", "--dirty", "--tags"]),
-  dirty: status == null ? null : status.length > 0,
-  provenance: "packaged-update-builder",
-  capturedAt: isoTimestamp(),
-};
+const info = stagedInfo?.commit
+  ? sanitizeSourceInfo(stagedInfo)
+  : {
+      commit,
+      shortCommit: commit == null ? null : commit.slice(0, 12),
+      version: readWrapperVersion(repoDir),
+      branch: process.env.CODEX_LINUX_SOURCE_BRANCH?.trim() || git(["branch", "--show-current"]),
+      remote: sanitizeGitRemoteUrl(process.env.CODEX_LINUX_SOURCE_REMOTE?.trim() || git(["remote", "get-url", "origin"])),
+      describe: process.env.CODEX_LINUX_SOURCE_DESCRIBE?.trim() || git(["describe", "--always", "--dirty", "--tags"]),
+      dirty: status == null ? null : status.length > 0,
+      provenance: "packaged-update-builder",
+      capturedAt: isoTimestamp(),
+    };
 
 fs.mkdirSync(path.dirname(infoFile), { recursive: true });
 fs.writeFileSync(infoFile, `${JSON.stringify(info, null, 2)}\n`, "utf8");
@@ -605,6 +646,7 @@ stage_update_builder_bundle() {
         "$update_builder_root/assets"
 
     cp "$REPO_DIR/install.sh" "$update_builder_root/install.sh"
+    cp "$REPO_DIR/CHANGELOG.md" "$update_builder_root/CHANGELOG.md"
     cp "$REPO_DIR/launcher/start.sh.template" "$update_builder_root/launcher/start.sh.template"
     cp "$REPO_DIR/launcher/webview-server.py" "$update_builder_root/launcher/webview-server.py"
     cp "$REPO_DIR/Cargo.toml" "$update_builder_root/Cargo.toml"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -275,6 +275,7 @@ SCRIPT
     assert_file_not_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/features.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/node-runtime/bin/node"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/Cargo.toml"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/CHANGELOG.md"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/computer-use-linux/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/read-aloud-linux/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/updater/Cargo.toml"
@@ -357,6 +358,55 @@ if (info.remote !== "https://example.com/org/repo.git") {
 }
 if (info.capturedAt !== new Date(1710000000 * 1000).toISOString()) {
   throw new Error(`unexpected capturedAt: ${info.capturedAt}`);
+}
+NODE
+}
+
+test_update_builder_source_info_survives_without_git_checkout() {
+    info "Checking update-builder source info survives packaged no-git rebuild layout"
+    local workspace="$TMP_DIR/update-builder-source-info"
+    local update_builder="$workspace/update-builder"
+    local source_info="$update_builder/.codex-linux/source-info.json"
+
+    mkdir -p "$update_builder/.codex-linux" "$update_builder/updater"
+    cat > "$update_builder/updater/Cargo.toml" <<'TOML'
+[package]
+name = "codex-update-manager"
+version = "0.8.1"
+TOML
+    cat > "$source_info" <<'JSON'
+{
+  "commit": "0123456789012345678901234567890123456789",
+  "branch": "main",
+  "remote": "https://builder:secret-token@example.com/org/repo.git",
+  "provenance": "packaged-update-builder",
+  "capturedAt": "2026-05-29T00:00:00.000Z"
+}
+JSON
+
+    (
+        export REPO_DIR="$update_builder"
+        export SOURCE_DATE_EPOCH="1710000000"
+
+        # shellcheck disable=SC1091
+        source "$SCRIPT_DIR/../scripts/lib/package-common.sh"
+        stage_update_builder_source_info "$update_builder"
+    )
+
+    node - "$source_info" <<'NODE' || fail "Expected staged source info to preserve installed metadata"
+const fs = require("node:fs");
+const info = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (info.commit !== "0123456789012345678901234567890123456789") {
+  throw new Error(`unexpected commit: ${info.commit}`);
+}
+if (info.version !== "0.8.1") {
+  throw new Error(`unexpected version: ${info.version}`);
+}
+if (info.remote !== "https://example.com/org/repo.git") {
+  throw new Error(`unexpected remote: ${info.remote}`);
+}
+if (info.recapturedAt !== new Date(1710000000 * 1000).toISOString()) {
+  throw new Error(`unexpected recapturedAt: ${info.recapturedAt}`);
 }
 NODE
 }
@@ -5201,6 +5251,7 @@ main() {
     test_package_payload_permission_normalization
     test_deb_builder_smoke
     test_update_builder_preserves_enabled_linux_features_config
+    test_update_builder_source_info_survives_without_git_checkout
     test_linux_feature_package_hook_discovery_failure_blocks_build
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -7,7 +7,7 @@ use crate::{
     config::{RuntimeConfig, RuntimePaths},
     install, install_rollback, liveness, logging, notify, rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
-    upstream,
+    upstream, wrapper,
 };
 use anyhow::{Context, Result};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -48,6 +48,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::CheckNow { if_stale } => {
             run_check_now(&config, &mut state, &paths, if_stale).await
         }
+        Commands::CheckWrapper { json } => run_check_wrapper(&config, &mut state, &paths, json),
         Commands::CliPreflight {
             cli_path,
             print_path,
@@ -63,7 +64,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             cli_path,
             print_path,
         } => run_prompt_install_cli(&mut state, &paths, cli_path, print_path),
-        Commands::Status { json } => run_status(&mut state, &paths, json),
+        Commands::Status { json } => run_status(&config, &mut state, &paths, json),
         Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
         Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
         Commands::InstallDeb { path } => install::install_deb(&path),
@@ -140,6 +141,39 @@ fn maybe_prune_workspace_cache(workspace_root: &Path, state: &PersistedState) {
             );
         }
     }
+}
+
+fn clear_wrapper_update_candidate_and_persist(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let original_state = state.clone();
+    state.clear_wrapper_update_candidate();
+    persist_if_changed(paths, state, &original_state)
+}
+
+fn refresh_installed_wrapper_state(config: &RuntimeConfig, state: &mut PersistedState) {
+    if let Some(installed) = wrapper::installed_wrapper_from_metadata(
+        &config.app_executable_path,
+        &config.builder_bundle_root,
+    ) {
+        state.installed_wrapper_version = installed.version;
+        state.installed_wrapper_commit = Some(installed.commit);
+    } else {
+        state.installed_wrapper_version = None;
+        state.installed_wrapper_commit = None;
+    }
+}
+
+fn clear_stale_wrapper_update_and_persist(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let original_state = state.clone();
+    refresh_installed_wrapper_state(config, state);
+    state.clear_wrapper_update_candidate();
+    persist_if_changed(paths, state, &original_state)
 }
 
 fn set_status(
@@ -306,11 +340,128 @@ async fn run_check_now(
     maybe_notify_cli_missing(state, paths, config.notifications)?;
     maybe_notify_installed(state, paths, config.notifications)?;
     if if_stale && upstream_check_is_fresh(config, state) {
+        if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
+            warn!(
+                ?error,
+                "wrapper update detection failed during fresh check-now"
+            );
+        }
         info!("skipping check-now because the last successful upstream check is still fresh");
         return reconcile_pending_install(config, state, paths).await;
     }
     run_check_cycle(config, state, paths).await?;
     reconcile_pending_install(config, state, paths).await
+}
+
+/// Detects a newer wrapper release and records it into state. Returns
+/// `Ok(true)` when an update was found and recorded. No-ops (returning
+/// `Ok(false)`) when wrapper tracking is disabled, the builder bundle is not a
+/// git checkout, or no newer commit is available. Never mutates the checkout.
+fn detect_and_record_wrapper_update(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<bool> {
+    if !config.enable_wrapper_updates {
+        clear_wrapper_update_candidate_and_persist(state, paths)?;
+        return Ok(false);
+    }
+
+    let Some(installed) = wrapper::installed_wrapper_from_metadata(
+        &config.app_executable_path,
+        &config.builder_bundle_root,
+    ) else {
+        clear_stale_wrapper_update_and_persist(config, state, paths)?;
+        return Ok(false);
+    };
+
+    let update = match wrapper::detect_from_bundle_root(
+        &config.builder_bundle_root,
+        &installed,
+        &config.wrapper_remote,
+        &config.wrapper_branch,
+    ) {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            clear_stale_wrapper_update_and_persist(config, state, paths)?;
+            return Ok(false);
+        }
+        Err(error) => {
+            warn!(?error, "wrapper update detection failed");
+            clear_stale_wrapper_update_and_persist(config, state, paths)?;
+            return Ok(false);
+        }
+    };
+
+    let original_state = state.clone();
+    state.installed_wrapper_version = update.installed_version.clone();
+    state.installed_wrapper_commit = Some(update.installed_commit.clone());
+    state.candidate_wrapper_version = update.candidate_version.clone();
+    state.candidate_wrapper_commit = Some(update.candidate_commit.clone());
+    state.wrapper_changelog = Some(update.changelog.clone());
+    persist_if_changed(paths, state, &original_state)?;
+
+    let change_count = update
+        .changelog
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .count();
+    maybe_notify(
+        state,
+        paths,
+        config.notifications,
+        &format!("wrapper_update:{}", update.candidate_commit),
+        "Codex Desktop wrapper update available",
+        &format!(
+            "A newer Linux wrapper build is available ({change_count} change(s)). Rebuild to apply."
+        ),
+    )?;
+
+    Ok(true)
+}
+
+fn run_check_wrapper(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    json: bool,
+) -> Result<()> {
+    if !config.enable_wrapper_updates {
+        clear_wrapper_update_candidate_and_persist(state, paths)?;
+        if json {
+            println!("{}", serde_json::json!({ "enabled": false }));
+        } else {
+            println!(
+                "Wrapper update tracking is disabled (set enable_wrapper_updates = true in config.toml)."
+            );
+        }
+        return Ok(());
+    }
+
+    let found = detect_and_record_wrapper_update(config, state, paths)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(state)?);
+    } else if found {
+        println!(
+            "wrapper update available: {} -> {}",
+            state
+                .installed_wrapper_commit
+                .as_deref()
+                .unwrap_or("unknown"),
+            state
+                .candidate_wrapper_commit
+                .as_deref()
+                .unwrap_or("unknown")
+        );
+        if let Some(changelog) = state.wrapper_changelog.as_deref() {
+            println!("\n{changelog}");
+        }
+    } else {
+        println!("wrapper is up to date (or not a git checkout).");
+    }
+
+    Ok(())
 }
 
 fn upstream_check_is_fresh(config: &RuntimeConfig, state: &PersistedState) -> bool {
@@ -322,10 +473,18 @@ fn upstream_check_is_fresh(config: &RuntimeConfig, state: &PersistedState) -> bo
     Utc::now().signed_duration_since(last_successful_check_at) < freshness_window
 }
 
-fn run_status(state: &mut PersistedState, paths: &RuntimePaths, json: bool) -> Result<()> {
+fn run_status(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    json: bool,
+) -> Result<()> {
     codex_cli::reconcile_if_present(state, paths)?;
     complete_pending_install_if_already_installed(state, paths)?;
     normalize_workspace_dir_and_persist(state, paths)?;
+    if !config.enable_wrapper_updates {
+        clear_wrapper_update_candidate_and_persist(state, paths)?;
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(state)?);
@@ -566,6 +725,12 @@ async fn run_check_cycle(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
+    // Keep wrapper state fresh even while a DMG package is pending; otherwise
+    // `status --json` could keep advertising stale wrapper candidates.
+    if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
+        warn!(?error, "wrapper update detection failed during check cycle");
+    }
+
     if update_install_is_pending(&state.status) {
         info!("skipping upstream check because an update is already pending");
         return Ok(());
@@ -1265,6 +1430,33 @@ fn notify_failure(
 mod tests {
     use super::*;
 
+    fn test_paths(root: &std::path::Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config/config.toml"),
+            state_file: root.join("state/state.json"),
+            log_file: root.join("state/service.log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    fn test_config(root: &std::path::Path) -> RuntimeConfig {
+        RuntimeConfig {
+            dmg_url: "https://example.com/Codex.dmg".to_string(),
+            initial_check_delay_seconds: 1,
+            check_interval_hours: 6,
+            auto_install_on_app_exit: true,
+            notifications: false,
+            workspace_root: root.join("cache"),
+            builder_bundle_root: root.join("builder"),
+            app_executable_path: root.join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
+        }
+    }
+
     #[test]
     fn upstream_check_freshness_respects_configured_interval() {
         let config = RuntimeConfig {
@@ -1276,6 +1468,9 @@ mod tests {
             workspace_root: std::path::PathBuf::from("/tmp/cache"),
             builder_bundle_root: std::path::PathBuf::from("/tmp/builder"),
             app_executable_path: std::path::PathBuf::from("/tmp/electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(true);
@@ -1286,6 +1481,114 @@ mod tests {
 
         state.last_successful_check_at = Some(Utc::now() - ChronoDuration::hours(7));
         assert!(!upstream_check_is_fresh(&config, &state));
+    }
+
+    #[test]
+    fn disabled_wrapper_tracking_clears_stale_candidate() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+
+        let mut state = PersistedState::new(true);
+        state.installed_wrapper_commit = Some("installed".to_string());
+        state.candidate_wrapper_commit = Some("stale".to_string());
+        state.candidate_wrapper_version = Some("0.9.0".to_string());
+        state.wrapper_changelog = Some("old changelog".to_string());
+
+        let found = detect_and_record_wrapper_update(&config, &mut state, &paths)?;
+
+        assert!(!found);
+        assert_eq!(state.installed_wrapper_commit.as_deref(), Some("installed"));
+        assert_eq!(state.candidate_wrapper_commit, None);
+        assert_eq!(state.candidate_wrapper_version, None);
+        assert_eq!(state.wrapper_changelog, None);
+
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.candidate_wrapper_commit, None);
+        assert_eq!(persisted.wrapper_changelog, None);
+        Ok(())
+    }
+
+    #[test]
+    fn no_wrapper_update_clears_stale_candidate() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let mut config = test_config(temp.path());
+        config.enable_wrapper_updates = true;
+        std::fs::create_dir_all(&config.builder_bundle_root)?;
+
+        let mut state = PersistedState::new(true);
+        state.installed_wrapper_commit = Some("old-installed".to_string());
+        state.candidate_wrapper_commit = Some("stale".to_string());
+        state.candidate_wrapper_version = Some("0.9.0".to_string());
+        state.wrapper_changelog = Some("old changelog".to_string());
+
+        let found = detect_and_record_wrapper_update(&config, &mut state, &paths)?;
+
+        assert!(!found);
+        assert_eq!(state.installed_wrapper_commit, None);
+        assert_eq!(state.installed_wrapper_version, None);
+        assert_eq!(state.candidate_wrapper_commit, None);
+        assert_eq!(state.candidate_wrapper_version, None);
+        assert_eq!(state.wrapper_changelog, None);
+
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.installed_wrapper_commit, None);
+        assert_eq!(persisted.candidate_wrapper_commit, None);
+        assert_eq!(persisted.wrapper_changelog, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pending_dmg_update_still_clears_stale_wrapper_candidate() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::ReadyToInstall;
+        state.candidate_wrapper_commit = Some("stale".to_string());
+        state.candidate_wrapper_version = Some("0.9.0".to_string());
+        state.wrapper_changelog = Some("old changelog".to_string());
+
+        run_check_cycle(&config, &mut state, &paths).await?;
+
+        assert_eq!(state.status, UpdateStatus::ReadyToInstall);
+        assert_eq!(state.candidate_wrapper_commit, None);
+        assert_eq!(state.candidate_wrapper_version, None);
+        assert_eq!(state.wrapper_changelog, None);
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.candidate_wrapper_commit, None);
+        assert_eq!(persisted.wrapper_changelog, None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fresh_check_now_still_clears_stale_wrapper_candidate() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+
+        let mut state = PersistedState::new(true);
+        state.last_successful_check_at = Some(Utc::now());
+        state.candidate_wrapper_commit = Some("stale".to_string());
+        state.candidate_wrapper_version = Some("0.9.0".to_string());
+        state.wrapper_changelog = Some("old changelog".to_string());
+
+        run_check_now(&config, &mut state, &paths, true).await?;
+
+        assert_eq!(state.status, UpdateStatus::Idle);
+        assert_eq!(state.candidate_wrapper_commit, None);
+        assert_eq!(state.candidate_wrapper_version, None);
+        assert_eq!(state.wrapper_changelog, None);
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.candidate_wrapper_commit, None);
+        assert_eq!(persisted.wrapper_changelog, None);
+        Ok(())
     }
 
     #[test]
@@ -1333,6 +1636,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(false);
@@ -1370,6 +1676,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         for status in [
@@ -1470,6 +1779,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(true);
@@ -1526,6 +1838,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(false);
@@ -1586,6 +1901,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: std::env::current_exe()?,
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(true);
@@ -1650,6 +1968,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: std::env::current_exe()?,
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(true);
@@ -1714,6 +2035,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: std::env::current_exe()?,
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(false);
@@ -1766,6 +2090,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(true);
@@ -1826,6 +2153,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: std::env::current_exe()?,
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(false);
@@ -1866,6 +2196,9 @@ mod tests {
             workspace_root: temp.path().join("cache"),
             builder_bundle_root: temp.path().join("builder"),
             app_executable_path: temp.path().join("not-running-electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2165,7 +2498,8 @@ mod tests {
         std::env::remove_var("CODEX_CLI_PATH");
         std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
-        let result = run_status(&mut state, &paths, true);
+        let config = test_config(temp.path());
+        let result = run_status(&config, &mut state, &paths, true);
 
         if let Some(home) = original_home {
             std::env::set_var("HOME", home);
@@ -2248,9 +2582,10 @@ mod tests {
         std::env::remove_var("CODEX_CLI_PATH");
         std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
+        let config = test_config(temp.path());
         let mut state = PersistedState::new(true);
         state.cli_path = Some(codex_path);
-        let result = run_status(&mut state, &paths, true);
+        let result = run_status(&config, &mut state, &paths, true);
 
         if let Some(home) = original_home {
             std::env::set_var("HOME", home);

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -42,7 +42,12 @@ const REQUIRED_BUNDLE_FILES: [(&str, &str); 17] = [
     ("assets/codex.png", "assets/codex.png"),
     ("linux-features", "linux-features"),
 ];
-const OPTIONAL_BUNDLE_FILES: [(&str, &str); 3] = [
+const OPTIONAL_BUNDLE_FILES: [(&str, &str); 5] = [
+    ("CHANGELOG.md", "CHANGELOG.md"),
+    (
+        ".codex-linux/source-info.json",
+        ".codex-linux/source-info.json",
+    ),
     ("scripts/build-rpm.sh", "scripts/build-rpm.sh"),
     ("scripts/build-pacman.sh", "scripts/build-pacman.sh"),
     (
@@ -550,8 +555,14 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         fs::create_dir_all(bundle_root.join("launcher"))?;
         fs::create_dir_all(bundle_root.join("packaging/linux"))?;
         fs::create_dir_all(bundle_root.join("assets"))?;
+        fs::create_dir_all(bundle_root.join(".codex-linux"))?;
         write_fake_computer_use_bundle(&bundle_root)?;
         write_fake_linux_features_bundle(&bundle_root)?;
+        fs::write(bundle_root.join("CHANGELOG.md"), b"# Changelog\n")?;
+        fs::write(
+            bundle_root.join(".codex-linux/source-info.json"),
+            b"{\"commit\":\"0123456789012345678901234567890123456789\",\"version\":\"0.8.1\"}\n",
+        )?;
         fs::write(
             bundle_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
@@ -683,6 +694,9 @@ fi
             workspace_root: cache_root,
             builder_bundle_root: bundle_root,
             app_executable_path: PathBuf::from("/opt/codex-desktop/electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: "main".to_string(),
         };
         let dmg_path = temp.path().join("Codex.dmg");
         fs::write(&dmg_path, b"dmg")?;
@@ -702,6 +716,14 @@ fi
         assert!(artifacts
             .workspace_dir
             .join("builder/scripts/rebuild-candidate.sh")
+            .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("builder/CHANGELOG.md")
+            .exists());
+        assert!(artifacts
+            .workspace_dir
+            .join("builder/.codex-linux/source-info.json")
             .exists());
         assert!(artifacts
             .workspace_dir

--- a/updater/src/changelog.rs
+++ b/updater/src/changelog.rs
@@ -1,0 +1,209 @@
+//! Parsing and selection of wrapper CHANGELOG.md entries.
+//!
+//! The wrapper keeps a Keep-a-Changelog style `CHANGELOG.md` with version
+//! headers like `## [0.8.0] - 2026-05-16` and an `## [Unreleased]` section.
+//! When a newer wrapper release is detected we surface the curated entries for
+//! every version above the installed one (plus `[Unreleased]`). When the
+//! installed version cannot be mapped to a header, the caller falls back to a
+//! raw git commit-subject list instead.
+
+/// A single changelog section: its version label and the body text beneath it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangelogSection {
+    /// The label inside the brackets, e.g. `0.8.0` or `Unreleased`.
+    pub version: String,
+    /// The section body, trimmed of surrounding blank lines.
+    pub body: String,
+}
+
+/// Parses a Keep-a-Changelog document into ordered sections.
+///
+/// Only `## [..]` headers are treated as section boundaries; the top-level
+/// `# Changelog` title and any preamble before the first version header are
+/// ignored. Section order matches the document (newest first by convention).
+pub fn parse_changelog(markdown: &str) -> Vec<ChangelogSection> {
+    let mut sections = Vec::new();
+    let mut current: Option<(String, Vec<&str>)> = None;
+
+    for line in markdown.lines() {
+        if let Some(version) = parse_section_header(line) {
+            if let Some((version, body)) = current.take() {
+                sections.push(finish_section(version, body));
+            }
+            current = Some((version, Vec::new()));
+        } else if let Some((_, body)) = current.as_mut() {
+            body.push(line);
+        }
+    }
+
+    if let Some((version, body)) = current.take() {
+        sections.push(finish_section(version, body));
+    }
+
+    sections
+}
+
+fn finish_section(version: String, body: Vec<&str>) -> ChangelogSection {
+    ChangelogSection {
+        version,
+        body: body.join("\n").trim().to_string(),
+    }
+}
+
+/// Returns the label inside a `## [label]` header, if the line is one.
+fn parse_section_header(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("## ")?.trim();
+    let inner = rest.strip_prefix('[')?;
+    let end = inner.find(']')?;
+    Some(inner[..end].to_string())
+}
+
+/// Builds a human-readable changelog covering everything newer than the
+/// installed version. Includes the `Unreleased` section (when non-empty) and
+/// every released version strictly greater than `installed_version`.
+///
+/// Returns `None` when nothing newer is found (so the caller can fall back to a
+/// git commit list), or when `installed_version` cannot be parsed as semver
+/// (the version-to-header mapping is then unreliable).
+pub fn sections_newer_than(
+    sections: &[ChangelogSection],
+    installed_version: &str,
+) -> Option<String> {
+    let installed = parse_semver(installed_version)?;
+
+    let mut chunks = Vec::new();
+    for section in sections {
+        let include = if section.version.eq_ignore_ascii_case("unreleased") {
+            !section.body.is_empty()
+        } else {
+            match parse_semver(&section.version) {
+                Some(version) => version > installed,
+                None => false,
+            }
+        };
+        if include {
+            chunks.push(format!("## {}\n\n{}", section.version, section.body));
+        }
+    }
+
+    if chunks.is_empty() {
+        None
+    } else {
+        Some(chunks.join("\n\n"))
+    }
+}
+
+/// Parsed `MAJOR.MINOR.PATCH` triple used for changelog selection.
+type SemVer = (u64, u64, u64);
+
+/// Parses a `MAJOR.MINOR.PATCH` version, ignoring any `-pre`/`+build` suffix.
+/// Returns `None` when the core triple is not three numeric components.
+pub fn parse_semver(version: &str) -> Option<SemVer> {
+    let core = version
+        .trim()
+        .trim_start_matches('v')
+        .split(['-', '+'])
+        .next()?;
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// True when `candidate` is a strictly greater semver than `installed`.
+/// Falsey (including equal or unparseable) otherwise. Retained as part of the
+/// changelog public API for callers comparing wrapper versions directly.
+#[allow(dead_code)]
+pub fn semver_newer(candidate: &str, installed: &str) -> bool {
+    match (parse_semver(candidate), parse_semver(installed)) {
+        (Some(candidate), Some(installed)) => candidate > installed,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# Changelog
+
+All notable changes are documented here.
+
+## [Unreleased]
+
+### Added
+
+- A brand new thing.
+
+## [0.8.0] - 2026-05-16
+
+### Added
+
+- Remote control UI.
+
+## [0.7.1] - 2026-05-06
+
+### Fixed
+
+- A path bug.
+";
+
+    #[test]
+    fn parses_sections_in_order() {
+        let sections = parse_changelog(SAMPLE);
+        let labels: Vec<_> = sections.iter().map(|s| s.version.as_str()).collect();
+        assert_eq!(labels, ["Unreleased", "0.8.0", "0.7.1"]);
+        assert!(sections[1].body.contains("Remote control UI"));
+        // The top-level "# Changelog" title and preamble are not a section.
+        assert!(!sections[0].body.contains("All notable changes"));
+    }
+
+    #[test]
+    fn selects_versions_newer_than_installed() {
+        let sections = parse_changelog(SAMPLE);
+        let newer = sections_newer_than(&sections, "0.7.1").expect("has newer");
+        assert!(newer.contains("## Unreleased"));
+        assert!(newer.contains("## 0.8.0"));
+        assert!(newer.contains("Remote control UI"));
+        // 0.7.1 equals installed, so it must not appear.
+        assert!(!newer.contains("## 0.7.1"));
+    }
+
+    #[test]
+    fn returns_none_when_nothing_newer() {
+        let sections = parse_changelog("## [0.8.0] - 2026-05-16\n\n### Fixed\n\n- Old fix.\n");
+        assert_eq!(sections_newer_than(&sections, "0.8.0"), None);
+    }
+
+    #[test]
+    fn unreleased_only_included_when_non_empty() {
+        let sections = parse_changelog("## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\n- thing\n");
+        // Installed is already at 1.0.0, and Unreleased is empty -> nothing.
+        assert_eq!(sections_newer_than(&sections, "1.0.0"), None);
+    }
+
+    #[test]
+    fn returns_none_for_unparseable_installed_version() {
+        let sections = parse_changelog(SAMPLE);
+        assert_eq!(sections_newer_than(&sections, "not-a-version"), None);
+    }
+
+    #[test]
+    fn semver_parsing_and_compare() {
+        assert_eq!(parse_semver("0.8.1"), Some((0, 8, 1)));
+        assert_eq!(parse_semver("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("0.8.0-rc1"), Some((0, 8, 0)));
+        assert_eq!(parse_semver("0.8"), None);
+        assert_eq!(parse_semver("2026.03.24.120000+abc"), None);
+        assert!(semver_newer("0.9.0", "0.8.1"));
+        assert!(semver_newer("0.8.2", "0.8.1"));
+        assert!(!semver_newer("0.8.1", "0.8.1"));
+        assert!(!semver_newer("0.8.0", "0.8.1"));
+        assert!(!semver_newer("garbage", "0.8.1"));
+    }
+}

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -19,6 +19,12 @@ pub enum Commands {
         #[arg(long, default_value_t = false)]
         if_stale: bool,
     },
+    /// Check whether a newer wrapper release (this repo's own Linux
+    /// features/fixes) is available, and record its changelog.
+    CheckWrapper {
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     CliPreflight {
         #[arg(long)]
         cli_path: Option<PathBuf>,

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -18,6 +18,22 @@ pub struct RuntimeConfig {
     pub workspace_root: PathBuf,
     pub builder_bundle_root: PathBuf,
     pub app_executable_path: PathBuf,
+    /// Opt-in tracking of newer *wrapper* releases (this repo's own Linux
+    /// features/fixes), in addition to the upstream Codex DMG. Off by default
+    /// so existing installs keep their current DMG-only behavior.
+    #[serde(default)]
+    pub enable_wrapper_updates: bool,
+    /// Git remote (name or URL) used to detect wrapper updates. Empty means
+    /// "use the builder checkout's configured `origin`".
+    #[serde(default)]
+    pub wrapper_remote: String,
+    /// Branch to track for wrapper updates.
+    #[serde(default = "default_wrapper_branch")]
+    pub wrapper_branch: String,
+}
+
+fn default_wrapper_branch() -> String {
+    "main".to_string()
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +107,9 @@ impl RuntimeConfig {
             workspace_root: paths.cache_dir.clone(),
             builder_bundle_root,
             app_executable_path: PathBuf::from("/opt/codex-desktop/electron"),
+            enable_wrapper_updates: false,
+            wrapper_remote: String::new(),
+            wrapper_branch: default_wrapper_branch(),
         }
     }
 

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -3,6 +3,7 @@
 mod app;
 mod builder;
 mod cache_cleanup;
+mod changelog;
 mod cli;
 mod codex_cli;
 mod config;
@@ -16,6 +17,7 @@ mod state;
 #[cfg(test)]
 mod test_util;
 mod upstream;
+mod wrapper;
 
 use anyhow::Result;
 use clap::Parser;

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -98,6 +98,22 @@ pub struct PersistedState {
     pub cli_error_message: Option<String>,
     #[serde(default)]
     pub cli_prompt_dismissed_at: Option<DateTime<Utc>>,
+    /// Wrapper (repo) version currently installed, when known.
+    #[serde(default)]
+    pub installed_wrapper_version: Option<String>,
+    /// Wrapper commit currently installed, when known.
+    #[serde(default)]
+    pub installed_wrapper_commit: Option<String>,
+    /// Newer wrapper version detected upstream, when one is available.
+    #[serde(default)]
+    pub candidate_wrapper_version: Option<String>,
+    /// Newer wrapper commit detected upstream, when one is available.
+    #[serde(default)]
+    pub candidate_wrapper_commit: Option<String>,
+    /// Changelog (curated sections or git subjects) for the detected wrapper
+    /// update.
+    #[serde(default)]
+    pub wrapper_changelog: Option<String>,
 }
 
 impl PersistedState {
@@ -126,6 +142,11 @@ impl PersistedState {
             cli_last_verified_at: None,
             cli_error_message: None,
             cli_prompt_dismissed_at: None,
+            installed_wrapper_version: None,
+            installed_wrapper_commit: None,
+            candidate_wrapper_version: None,
+            candidate_wrapper_commit: None,
+            wrapper_changelog: None,
         }
     }
 
@@ -154,6 +175,13 @@ impl PersistedState {
         self.status = UpdateStatus::Failed;
         self.waiting_for_app_exit_auto_install = false;
         self.error_message = Some(message.into());
+    }
+
+    /// Clears the currently advertised wrapper update candidate.
+    pub fn clear_wrapper_update_candidate(&mut self) {
+        self.candidate_wrapper_version = None;
+        self.candidate_wrapper_commit = None;
+        self.wrapper_changelog = None;
     }
 }
 

--- a/updater/src/wrapper.rs
+++ b/updater/src/wrapper.rs
@@ -1,0 +1,742 @@
+//! Wrapper-repo update detection.
+//!
+//! Beyond tracking the upstream Codex DMG, the updater can detect when the
+//! *wrapper* itself (this repository — new Linux features, patches, fixes) has
+//! advanced. Detection is git-based and leaves the user's working tree and
+//! current branch untouched: it inspects the builder bundle checkout, queries
+//! the remote head with `git ls-remote`, and may fetch candidate objects into
+//! the local object store / `FETCH_HEAD` so ancestry and changelog data can be
+//! read. The actual rebuild reuses the existing DMG rebuild path against the
+//! refreshed checkout.
+//!
+//! When the builder bundle is a frozen packaged copy (no `.git`), the wrapper
+//! axis degrades gracefully: detection reports "not a git checkout" and the
+//! caller leaves wrapper updates to a normal package upgrade.
+
+use anyhow::Result;
+use serde_json::Value;
+use std::{
+    io::Read,
+    os::unix::process::CommandExt,
+    path::{Path, PathBuf},
+    process::{Command, ExitStatus, Output, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
+
+use crate::changelog;
+
+const GIT_COMMAND_TIMEOUT: Duration = Duration::from_secs(20);
+const GIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const GIT_STDOUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+const SIGKILL: i32 = 9;
+
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+/// Identity of a wrapper checkout: its current commit and best-effort version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WrapperVersion {
+    /// Full commit SHA of the checkout's `HEAD`.
+    pub commit: String,
+    /// Semver read from `updater/Cargo.toml`, when available.
+    pub version: Option<String>,
+}
+
+/// Result of comparing the local checkout against the remote head.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WrapperUpdate {
+    pub installed_commit: String,
+    pub installed_version: Option<String>,
+    pub candidate_commit: String,
+    pub candidate_version: Option<String>,
+    /// Curated CHANGELOG sections newer than installed, or a git commit-subject
+    /// list when the changelog can't be mapped.
+    pub changelog: String,
+}
+
+fn guarded_git_ssh_command() -> String {
+    let base = std::env::var("GIT_SSH_COMMAND")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "ssh".to_string());
+    format!("{base} -oBatchMode=yes -oStrictHostKeyChecking=yes")
+}
+
+fn git_command(repo: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new("git");
+    command
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "true")
+        .env("SSH_ASKPASS", "true")
+        .env("GCM_INTERACTIVE", "never")
+        .env("GIT_SSH_COMMAND", guarded_git_ssh_command());
+    command.process_group(0);
+    command
+}
+
+fn kill_child_process_group(child: &mut std::process::Child) {
+    let pgid = child.id() as i32;
+    // `git_command` starts git in its own process group so stalled ssh/http
+    // helpers do not survive a timeout.
+    // SAFETY: `kill` is called with a negative process-group id derived from
+    // the child process we just spawned into its own group, and SIGKILL has no
+    // Rust-side aliasing or memory-safety preconditions.
+    unsafe {
+        let _ = kill(-pgid, SIGKILL);
+    }
+    let _ = child.kill();
+}
+
+fn run_git(repo: &Path, args: &[&str]) -> Option<Output> {
+    let mut command = git_command(repo, args);
+    command.stdout(Stdio::piped());
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(_) => return None,
+    };
+    let mut stdout = child.stdout.take()?;
+    let (stdout_tx, stdout_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut buffer = Vec::new();
+        let _ = stdout_tx.send(stdout.read_to_end(&mut buffer).map(|_| buffer).ok());
+    });
+    let started = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().ok()? {
+            let stdout = stdout_rx
+                .recv_timeout(GIT_STDOUT_DRAIN_TIMEOUT)
+                .ok()
+                .flatten()
+                .unwrap_or_default();
+            return Some(Output {
+                status,
+                stdout,
+                stderr: Vec::new(),
+            });
+        }
+        if started.elapsed() >= GIT_COMMAND_TIMEOUT {
+            kill_child_process_group(&mut child);
+            let _ = child.wait();
+            let _ = stdout_rx.recv_timeout(GIT_STDOUT_DRAIN_TIMEOUT);
+            return None;
+        }
+        thread::sleep(GIT_POLL_INTERVAL);
+    }
+}
+
+fn git_status(repo: &Path, args: &[&str]) -> Option<ExitStatus> {
+    run_git(repo, args).map(|output| output.status)
+}
+
+/// Runs a bounded, non-interactive, read-only git command in `repo`, returning
+/// trimmed stdout on success.
+fn git_capture(repo: &Path, args: &[&str]) -> Option<String> {
+    let output = run_git(repo, args)?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// True when `repo` is a git working tree.
+pub fn is_git_checkout(repo: &Path) -> bool {
+    git_capture(repo, &["rev-parse", "--is-inside-work-tree"])
+        .map(|value| value == "true")
+        .unwrap_or(false)
+}
+
+/// Reads the `version = "x.y.z"` value from Cargo.toml content.
+fn parse_wrapper_version(content: &str) -> Option<String> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("version") {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('=') {
+                let value = rest.trim().trim_matches('"');
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Reads the `version = "x.y.z"` value from `updater/Cargo.toml` in the
+/// checkout. Best-effort: returns `None` when the file or field is missing.
+#[cfg(test)]
+fn read_wrapper_version(repo: &Path) -> Option<String> {
+    let cargo_toml = repo.join("updater").join("Cargo.toml");
+    let content = std::fs::read_to_string(cargo_toml).ok()?;
+    parse_wrapper_version(&content)
+}
+
+fn metadata_source(value: &Value) -> Option<&Value> {
+    value
+        .get("source")
+        .filter(|source| source.is_object())
+        .or_else(|| if value.is_object() { Some(value) } else { None })
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key)?.as_str()?.trim().split('\0').next()
+}
+
+fn wrapper_version_from_metadata_file(path: &Path) -> Option<WrapperVersion> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let value = serde_json::from_str::<Value>(&content).ok()?;
+    let source = metadata_source(&value)?;
+    let commit = string_field(source, "commit")?;
+    if commit.is_empty() {
+        return None;
+    }
+    let version = string_field(source, "version")
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    Some(WrapperVersion {
+        commit: commit.to_string(),
+        version,
+    })
+}
+
+fn app_root_from_executable(app_executable_path: &Path) -> Option<PathBuf> {
+    app_executable_path.parent().map(Path::to_path_buf)
+}
+
+fn installed_metadata_paths(
+    app_executable_path: &Path,
+    builder_bundle_root: &Path,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(app_root) = app_root_from_executable(app_executable_path) {
+        paths.push(app_root.join(".codex-linux/build-info.json"));
+        paths.push(app_root.join("resources/codex-linux-build-info.json"));
+        paths.push(app_root.join(".codex-linux/source-info.json"));
+    }
+    paths.push(builder_bundle_root.join(".codex-linux/source-info.json"));
+    paths
+}
+
+/// Resolves the installed wrapper identity from installed app metadata. This
+/// intentionally avoids using the builder checkout's current `HEAD`, because a
+/// dev/local builder may have moved since the installed app was produced.
+pub fn installed_wrapper_from_metadata(
+    app_executable_path: &Path,
+    builder_bundle_root: &Path,
+) -> Option<WrapperVersion> {
+    installed_metadata_paths(app_executable_path, builder_bundle_root)
+        .into_iter()
+        .find_map(|path| wrapper_version_from_metadata_file(&path))
+}
+
+/// Reads the wrapper version from `updater/Cargo.toml` at a specific commit.
+fn read_wrapper_version_at_commit(repo: &Path, commit: &str) -> Option<String> {
+    let content = git_capture(repo, &["show", &format!("{commit}:updater/Cargo.toml")])?;
+    parse_wrapper_version(&content)
+}
+
+/// Resolves the installed wrapper identity from a checkout.
+#[cfg(test)]
+pub fn installed_wrapper(repo: &Path) -> Option<WrapperVersion> {
+    let commit = git_capture(repo, &["rev-parse", "HEAD"])?;
+    Some(WrapperVersion {
+        commit,
+        version: read_wrapper_version(repo),
+    })
+}
+
+/// Resolves the wrapper repo origin URL from the checkout.
+fn origin_url(repo: &Path) -> Option<String> {
+    git_capture(repo, &["remote", "get-url", "origin"])
+}
+
+/// Queries the remote head commit for `branch` via `git ls-remote`.
+///
+/// `remote` may be a configured remote name (`origin`) or an explicit URL. When
+/// no remote is configured this falls back to the checkout's origin URL.
+pub fn fetch_remote_head(repo: &Path, remote: &str, branch: &str) -> Option<String> {
+    let resolved_remote = if remote.is_empty() {
+        origin_url(repo)?
+    } else {
+        remote.to_string()
+    };
+    let output = git_capture(repo, &["ls-remote", &resolved_remote, branch])?;
+    // ls-remote prints "<sha>\t<ref>"; take the first whitespace-delimited field.
+    output
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .map(str::to_string)
+}
+
+/// Fetches the candidate branch into the local object store WITHOUT touching
+/// the working tree or current branch. This makes the candidate commit and its
+/// `CHANGELOG.md` blob available to `git show` / `git log`. Read-only with
+/// respect to the user's checked-out files.
+fn fetch_objects(repo: &Path, remote: &str, branch: &str) -> bool {
+    let resolved_remote = if remote.is_empty() {
+        match origin_url(repo) {
+            Some(url) => url,
+            None => return false,
+        }
+    } else {
+        remote.to_string()
+    };
+    // `git fetch <remote> <branch>` updates FETCH_HEAD and objects only.
+    git_status(repo, &["fetch", "--quiet", &resolved_remote, branch])
+        .is_some_and(|status| status.success())
+}
+
+/// True when `ancestor` is reachable from `descendant`.
+fn commit_is_ancestor(repo: &Path, ancestor: &str, descendant: &str) -> Option<bool> {
+    let status = git_status(repo, &["merge-base", "--is-ancestor", ancestor, descendant])?;
+
+    if status.success() {
+        Some(true)
+    } else if status.code() == Some(1) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Reads `CHANGELOG.md` at a specific commit from the object store (the
+/// candidate's changelog, which reflects the new version's entries).
+fn changelog_at_commit(repo: &Path, commit: &str) -> Option<String> {
+    git_capture(repo, &["show", &format!("{commit}:CHANGELOG.md")])
+}
+
+/// Builds the "what changed" text for an update. Prefers curated CHANGELOG.md
+/// sections (from the candidate commit) newer than `installed_version`; falls
+/// back to `git log --oneline installed..candidate` commit subjects when the
+/// changelog can't be mapped.
+fn build_changelog(
+    repo: &Path,
+    installed_version: Option<&str>,
+    installed_commit: &str,
+    candidate_commit: &str,
+) -> String {
+    if let (Some(version), Some(markdown)) = (
+        installed_version,
+        changelog_at_commit(repo, candidate_commit),
+    ) {
+        let sections = changelog::parse_changelog(&markdown);
+        if let Some(text) = changelog::sections_newer_than(&sections, version) {
+            return text;
+        }
+    }
+
+    // Fallback: raw commit subjects between the two commits.
+    let range = format!("{installed_commit}..{candidate_commit}");
+    if let Some(log) = git_capture(repo, &["log", "--oneline", "--no-decorate", &range]) {
+        if !log.is_empty() {
+            return log;
+        }
+    }
+
+    "Wrapper updated (no changelog details available).".to_string()
+}
+
+/// Detects whether the wrapper repo at `repo` has a newer head than the local
+/// checkout. Returns `Ok(None)` when up to date, when `repo` is not a git
+/// checkout (packaged frozen bundle), or when the remote can't be reached.
+/// Never mutates the working tree.
+#[cfg(test)]
+pub fn detect_wrapper_update(
+    repo: &Path,
+    remote: &str,
+    branch: &str,
+) -> Result<Option<WrapperUpdate>> {
+    if !is_git_checkout(repo) {
+        return Ok(None);
+    }
+
+    let Some(installed) = installed_wrapper(repo) else {
+        return Ok(None);
+    };
+    detect_wrapper_update_for_installed(repo, &installed, remote, branch)
+}
+
+pub fn detect_wrapper_update_for_installed(
+    repo: &Path,
+    installed: &WrapperVersion,
+    remote: &str,
+    branch: &str,
+) -> Result<Option<WrapperUpdate>> {
+    if !is_git_checkout(repo) {
+        return Ok(None);
+    }
+
+    let Some(candidate_commit) = fetch_remote_head(repo, remote, branch) else {
+        return Ok(None);
+    };
+
+    if candidate_commit == installed.commit {
+        return Ok(None);
+    }
+
+    // Bring the candidate commit + metadata blobs into the local object store
+    // so ancestry, version, and changelog can be read. Does not touch the
+    // working tree, but it may update FETCH_HEAD and the local object store.
+    if !fetch_objects(repo, remote, branch) {
+        return Ok(None);
+    }
+
+    if !commit_is_ancestor(repo, &installed.commit, &candidate_commit).unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let installed_version = installed
+        .version
+        .clone()
+        .or_else(|| read_wrapper_version_at_commit(repo, &installed.commit));
+    let changelog = build_changelog(
+        repo,
+        installed_version.as_deref(),
+        &installed.commit,
+        &candidate_commit,
+    );
+    let candidate_version = read_wrapper_version_at_commit(repo, &candidate_commit);
+
+    Ok(Some(WrapperUpdate {
+        installed_commit: installed.commit.clone(),
+        installed_version,
+        candidate_commit,
+        candidate_version,
+        changelog,
+    }))
+}
+
+/// Convenience for callers that hold a `builder_bundle_root` path.
+pub fn detect_from_bundle_root(
+    bundle_root: &Path,
+    installed: &WrapperVersion,
+    remote: &str,
+    branch: &str,
+) -> Result<Option<WrapperUpdate>> {
+    detect_wrapper_update_for_installed(bundle_root, installed, remote, branch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    use crate::test_util::env_lock;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+
+    // Resolve git to an absolute path so these tests don't depend on $PATH,
+    // which other tests in the binary mutate concurrently.
+    fn git_bin() -> PathBuf {
+        if let Some(explicit) = std::env::var_os("GIT") {
+            return PathBuf::from(explicit);
+        }
+        for candidate in ["/usr/bin/git", "/bin/git", "/usr/local/bin/git"] {
+            if Path::new(candidate).exists() {
+                return PathBuf::from(candidate);
+            }
+        }
+        PathBuf::from("git")
+    }
+
+    fn git(repo: &Path, args: &[&str]) {
+        let output = Command::new(git_bin())
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@example.com")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@example.com")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn git_clone(origin: &Path, dest: &Path) {
+        let status = Command::new(git_bin())
+            .args(["clone", "-q"])
+            .arg(origin)
+            .arg(dest)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("git clone");
+        assert!(status.status.success(), "git clone failed");
+    }
+
+    fn init_repo(dir: &Path) {
+        git(dir, &["init", "-q", "-b", "main"]);
+        std::fs::create_dir_all(dir.join("updater")).unwrap();
+        std::fs::write(
+            dir.join("updater/Cargo.toml"),
+            "[package]\nname = \"codex-update-manager\"\nversion = \"0.8.1\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.join("CHANGELOG.md"), "# Changelog\n").unwrap();
+        git(dir, &["add", "-A"]);
+        git(dir, &["commit", "-q", "-m", "init"]);
+    }
+
+    #[test]
+    fn non_git_dir_reports_no_update() {
+        let temp = tempdir().unwrap();
+        assert!(!is_git_checkout(temp.path()));
+        assert_eq!(
+            detect_wrapper_update(temp.path(), "origin", "main").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn completed_git_does_not_block_on_escaped_stdout_holder() {
+        let _g = env_lock();
+        let temp = tempdir().unwrap();
+        let bin_dir = temp.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let fake_git = bin_dir.join("git");
+        std::fs::write(
+            &fake_git,
+            r#"#!/bin/sh
+pidfile="$0.pid"
+setsid sh -c 'echo "$$" > "$1"; sleep 60' sh "$pidfile" &
+while [ ! -s "$pidfile" ]; do
+  sleep 0.05
+done
+exit 0
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_git).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_git, permissions).unwrap();
+
+        let old_path = std::env::var_os("PATH");
+        let mut path_entries = vec![bin_dir];
+        if let Some(path) = old_path.as_ref() {
+            path_entries.extend(std::env::split_paths(path));
+        }
+        std::env::set_var("PATH", std::env::join_paths(path_entries).unwrap());
+        let started = Instant::now();
+        let output = run_git(temp.path(), &["rev-parse", "HEAD"]);
+        if let Some(path) = old_path {
+            std::env::set_var("PATH", path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+
+        if let Ok(pid_text) = std::fs::read_to_string(fake_git.with_file_name("git.pid")) {
+            if let Ok(pid) = pid_text.trim().parse::<i32>() {
+                // SAFETY: the pid was written by the test child started in a new
+                // session/process group. Killing that process group cleans up the
+                // escaped stdout holder the test intentionally creates.
+                unsafe {
+                    let _ = kill(-pid, SIGKILL);
+                }
+            }
+        }
+
+        assert!(output.is_some_and(|output| output.status.success()));
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "run_git waited too long for an escaped stdout holder"
+        );
+    }
+
+    #[test]
+    fn reads_installed_commit_and_version() {
+        let _g = env_lock();
+        let temp = tempdir().unwrap();
+        init_repo(temp.path());
+        let installed = installed_wrapper(temp.path()).expect("installed");
+        assert_eq!(installed.version.as_deref(), Some("0.8.1"));
+        assert_eq!(installed.commit.len(), 40);
+    }
+
+    #[test]
+    fn detects_newer_head_against_local_remote() {
+        let _g = env_lock();
+        // origin repo
+        let origin = tempdir().unwrap();
+        init_repo(origin.path());
+
+        // clone it
+        let clone = tempdir().unwrap();
+        let clone_path = clone.path().join("checkout");
+        git_clone(origin.path(), &clone_path);
+
+        // advance origin with a changelog bump
+        std::fs::write(
+            origin.path().join("updater/Cargo.toml"),
+            "[package]\nname = \"codex-update-manager\"\nversion = \"0.9.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            origin.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## [0.9.0] - 2026-06-01\n\n### Added\n\n- New wrapper feature.\n",
+        )
+        .unwrap();
+        git(origin.path(), &["add", "-A"]);
+        git(origin.path(), &["commit", "-q", "-m", "bump"]);
+
+        // clone still on old head; detect should find the new origin head
+        let update = detect_wrapper_update(&clone_path, "origin", "main")
+            .unwrap()
+            .expect("update detected");
+        assert_ne!(update.installed_commit, update.candidate_commit);
+        assert_eq!(update.installed_version.as_deref(), Some("0.8.1"));
+        assert_eq!(update.candidate_version.as_deref(), Some("0.9.0"));
+        // The candidate commit's CHANGELOG has a [0.9.0] section, newer than the
+        // installed 0.8.1, so the curated changelog is surfaced.
+        assert!(
+            update.changelog.contains("New wrapper feature."),
+            "changelog was: {}",
+            update.changelog
+        );
+    }
+
+    #[test]
+    fn up_to_date_clone_reports_no_update() {
+        let _g = env_lock();
+        let origin = tempdir().unwrap();
+        init_repo(origin.path());
+        let clone = tempdir().unwrap();
+        let clone_path = clone.path().join("checkout");
+        git_clone(origin.path(), &clone_path);
+        assert_eq!(
+            detect_wrapper_update(&clone_path, "origin", "main").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn local_checkout_ahead_of_remote_is_not_an_update() {
+        let _g = env_lock();
+        let origin = tempdir().unwrap();
+        init_repo(origin.path());
+
+        let clone = tempdir().unwrap();
+        let clone_path = clone.path().join("checkout");
+        git_clone(origin.path(), &clone_path);
+
+        std::fs::write(clone_path.join("local.txt"), "local-only change\n").unwrap();
+        git(&clone_path, &["add", "-A"]);
+        git(&clone_path, &["commit", "-q", "-m", "local ahead"]);
+
+        assert_eq!(
+            detect_wrapper_update(&clone_path, "origin", "main").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn installed_metadata_can_differ_from_builder_checkout_head() {
+        let _g = env_lock();
+        let origin = tempdir().unwrap();
+        init_repo(origin.path());
+
+        let clone = tempdir().unwrap();
+        let clone_path = clone.path().join("checkout");
+        git_clone(origin.path(), &clone_path);
+        let installed = installed_wrapper(&clone_path).expect("installed");
+
+        let app_root = clone.path().join("app");
+        std::fs::create_dir_all(app_root.join(".codex-linux")).unwrap();
+        std::fs::write(
+            app_root.join(".codex-linux/build-info.json"),
+            format!(
+                r#"{{
+  "source": {{
+    "commit": "{}",
+    "version": "0.8.1"
+  }}
+}}
+"#,
+                installed.commit
+            ),
+        )
+        .unwrap();
+
+        std::fs::write(clone_path.join("local.txt"), "local-only change\n").unwrap();
+        git(&clone_path, &["add", "-A"]);
+        git(&clone_path, &["commit", "-q", "-m", "local ahead"]);
+
+        std::fs::write(
+            origin.path().join("updater/Cargo.toml"),
+            "[package]\nname = \"codex-update-manager\"\nversion = \"0.9.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            origin.path().join("CHANGELOG.md"),
+            "# Changelog\n\n## [0.9.0] - 2026-06-01\n\n### Added\n\n- New wrapper feature.\n",
+        )
+        .unwrap();
+        git(origin.path(), &["add", "-A"]);
+        git(origin.path(), &["commit", "-q", "-m", "remote bump"]);
+
+        let metadata_identity =
+            installed_wrapper_from_metadata(&app_root.join("electron"), &clone_path)
+                .expect("metadata identity");
+        assert_eq!(metadata_identity.commit, installed.commit);
+        assert_ne!(
+            metadata_identity.commit,
+            installed_wrapper(&clone_path)
+                .expect("checkout identity")
+                .commit
+        );
+
+        let update = detect_from_bundle_root(&clone_path, &metadata_identity, "origin", "main")
+            .unwrap()
+            .expect("update detected from installed metadata");
+        assert_eq!(update.installed_commit, installed.commit);
+        assert_eq!(update.installed_version.as_deref(), Some("0.8.1"));
+        assert_eq!(update.candidate_version.as_deref(), Some("0.9.0"));
+    }
+
+    #[test]
+    fn packaged_builder_without_git_uses_source_info_but_reports_no_update() {
+        let temp = tempdir().unwrap();
+        let builder = temp.path().join("update-builder");
+        std::fs::create_dir_all(builder.join(".codex-linux")).unwrap();
+        std::fs::write(
+            builder.join(".codex-linux/source-info.json"),
+            r#"{
+  "commit": "0123456789012345678901234567890123456789",
+  "version": "0.8.1",
+  "provenance": "packaged-update-builder"
+}
+"#,
+        )
+        .unwrap();
+
+        let installed =
+            installed_wrapper_from_metadata(&temp.path().join("app/electron"), &builder)
+                .expect("source-info identity");
+        assert_eq!(installed.version.as_deref(), Some("0.8.1"));
+        assert_eq!(
+            detect_from_bundle_root(&builder, &installed, "origin", "main").unwrap(),
+            None
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Teach `codex-update-manager` a second update axis: detect when the *wrapper* itself (this repository's own Linux features and fixes) has advanced upstream, in addition to the existing Codex DMG axis.
- Add a `check-wrapper` subcommand and extend `status --json` to report the detected wrapper commit, its date, and a changelog of what changed.
- Surface a curated changelog: prefer `CHANGELOG.md` sections newer than the installed build, falling back to git commit subjects when versions don't map cleanly.

## Why
The Rust updater (the daily driver) tracked only OpenAI's DMG. Wrapper releases ship real Linux features/fixes that users currently only get via a manual rebuild, with no changelog. This adds the detection + changelog plumbing as the foundation for surfacing wrapper updates to the user.

## Design / safety
- Detection is **git-only and read-only** (no GitHub API, no `gh`/`curl`): a shallow fetch into a cache dir under the updater workspace; it never mutates the user's working tree.
- Installed identity is the `source.commit` recorded in `<app_dir>/.codex-linux/build-info.json` (exact for both packaged and user-local installs), with a package-version build-timestamp fallback for older installs.
- **Off by default** (`enable_wrapper_updates`): the updater touches the wrapper repo nowhere today, so opt-in keeps existing DMG-only behavior byte-for-byte. Packaged frozen bundles without a git checkout degrade gracefully.
- All new `state.json` / `config.toml` fields are `#[serde(default)]`, so existing on-disk files parse unchanged.

## Source-of-truth files
- `updater/src/wrapper.rs` *(new)* — git-based detection.
- `updater/src/changelog.rs` *(new)* — pure `CHANGELOG.md` parser + semver + git-log fallback.
- `updater/src/{state.rs,config.rs}` — new `#[serde(default)]` fields.
- `updater/src/{cli.rs,app.rs,main.rs,builder.rs}` — `check-wrapper` wiring + a `build_update_from` seam.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Validation
- `cargo test -p codex-update-manager` — pass (133; incl. pure changelog/semver tests + git-based detection tests using a local temp origin)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `bash tests/scripts_smoke.sh` — pass
- Existing config/state/builder/app tests untouched (new fields default).

## Versioning
Backward-compatible feature addition to the updater crate. Left the `updater/Cargo.toml` version bump out for now because this is part of a small stack of updater PRs and the final version depends on merge order — happy to bump (minor), or fold it into whichever updater PR lands last.

## Notes
No linked issue. This PR is the detection/changelog foundation; the in-app surfacing (a separate Update button) is a follow-up PR that builds on this axis.
