### PR TITLE
feat(updater): feature picker on wrapper-update reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   version, and falls back to git commit subjects. Packaged frozen bundles
   without a git checkout degrade gracefully (no wrapper tracking; updates arrive
   via a normal package upgrade).
+- The opt-in `codex-wrapper-updater` update action can ask which optional Linux
+  features to enable before rebuilding. The picker reads the recorded candidate
+  wrapper source, preserves unknown/private feature ids from the existing
+  config, saves selections to `~/.config/<appId>/linux-features.json`, and
+  skips without blocking the update when there is no display, no dialog tool, a
+  dialog launch failure, or a cancellation.
 - Launcher rendering mode `CODEX_LINUX_RENDERING_MODE=wayland-gpu`, which
   forces native Wayland with GPU compositing enabled and skips forced renderer
   accessibility by default for Wayland desktops where XWayland or software

--- a/contrib/user-local-install/files/.local/bin/codex-desktop-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-update
@@ -116,7 +116,10 @@ log "Rebuilding wrapper..."
 (
     cd "$BUILD_REPO_DIR"
     mkdir -p "$STATE_DIR/tmp"
-    if [ -f "$SOURCE_REPO_DIR/linux-features/features.json" ]; then
+    # Honor a caller-provided feature config (e.g. the in-app Update button's
+    # feature picker) over the repo-local default, so a picked selection wins.
+    if [ -z "${CODEX_LINUX_FEATURES_CONFIG:-}" ] && \
+       [ -f "$SOURCE_REPO_DIR/linux-features/features.json" ]; then
         export CODEX_LINUX_FEATURES_CONFIG="$SOURCE_REPO_DIR/linux-features/features.json"
     fi
     TMPDIR="$STATE_DIR/tmp" \

--- a/linux-features/codex-wrapper-updater/README.md
+++ b/linux-features/codex-wrapper-updater/README.md
@@ -10,17 +10,53 @@ upstream path tracks the official macOS DMG. This feature tracks newer builds of
 
 ## User-facing behavior
 
-- Settings -> General shows:
-  **Check for Codex Desktop Linux updates**.
-- The setting is off by default.
-- When it is on, `codex-update-manager` may check the wrapper repository for a
-  newer Linux wrapper commit.
+- Settings -> General shows **Check for Codex Desktop Linux updates**.
+- Settings -> General also shows **Ask which features to enable on update**.
+- Both settings are off/on independently: wrapper update checks are off by
+  default, and the feature picker prompt defaults on when this feature is built.
+- When wrapper update checks are on, `codex-update-manager` may check the
+  wrapper repository for a newer Linux wrapper commit.
 - If a newer wrapper build is available, a small top-right **Update** button is
   shown inside Codex.
 - The button stays hidden when no wrapper update candidate is recorded.
 - The button tooltip includes the recorded wrapper changelog when available.
-- Clicking the button writes a pending marker and quits Codex. The feature hook
-  applies the wrapper update while the app is stopped.
+- Clicking the button may show the feature picker, then writes a pending marker
+  and quits Codex. The feature hook applies the wrapper update while the app is
+  stopped.
+
+## Feature picker on update
+
+Before writing the marker, the button can run:
+
+```text
+codex-update-manager pick-features
+```
+
+This happens while the display session is still alive. The actual apply step
+runs headless after the app exits.
+
+The picker shows a `zenity` or `kdialog` checklist of optional Linux features,
+pre-checked with the currently enabled set, so the user can choose which
+features the rebuild stages.
+
+- The chosen set is written to:
+
+  ```text
+  ~/.config/<app-id>/linux-features.json
+  ```
+
+- The rebuild points `CODEX_LINUX_FEATURES_CONFIG` at that file.
+- The checklist is loaded from the recorded candidate wrapper source when one is
+  available, so it matches the code that will be rebuilt.
+- Feature ids that are currently enabled but absent from the candidate catalog
+  are preserved.
+- The special **(Don't ask again on future updates)** row, or turning off
+  **Settings -> General -> Ask which features to enable on update**, suppresses
+  future prompts.
+- Cancelling the dialog keeps the current feature set and still proceeds with
+  the update.
+- No display, no dialog tool, no recorded candidate catalog, or a dialog launch
+  failure skips the prompt and leaves the current feature set unchanged.
 
 ## Why this is a Linux feature
 
@@ -29,11 +65,12 @@ not a required compatibility patch for every Linux build. Core only provides the
 generic Linux feature loader and hook runner. This feature owns:
 
 - the in-app wrapper update button;
-- the Settings -> General runtime opt-in;
+- the Settings -> General runtime opt-ins;
 - the main-process bridge handler;
 - the pending-update marker;
 - the retry/apply hook;
-- the updater command integration for wrapper checks and applies.
+- the updater command integration for wrapper checks, feature selection, and
+  applies.
 
 ## Build-time opt-in
 
@@ -67,13 +104,14 @@ Both staged hooks call `apply-pending.sh`.
 
 ## Runtime opt-in
 
-The Settings toggle persists this key:
+The Settings toggles persist these keys:
 
 ```text
 codex-linux-wrapper-updates-enabled
+codex-linux-feature-picker-on-update
 ```
 
-The setting is stored in the normal Linux app settings file:
+The settings are stored in the normal Linux app settings file:
 
 ```text
 ~/.config/<app-id>/settings.json
@@ -85,14 +123,15 @@ For the default app id, that is:
 ~/.config/codex-desktop/settings.json
 ```
 
-The setting is persisted through the app's `get-global-state` /
+The settings are persisted through the app's `get-global-state` /
 `set-global-state` path, not through the upstream typed settings schema. This is
-important because `codex-linux-wrapper-updates-enabled` is a Linux-only key and
-does not exist in upstream's settings schema.
+important because these Linux-only keys do not exist in upstream's settings
+schema.
 
-`codex-update-manager` reads the same setting and treats it as the runtime opt-in
-for wrapper update tracking. The static updater config still defaults wrapper
-tracking to disabled, so existing installs keep their current DMG-only behavior.
+`codex-update-manager` reads the same settings and treats
+`codex-linux-wrapper-updates-enabled` as the runtime opt-in for wrapper update
+tracking. The static updater config still defaults wrapper tracking to disabled,
+so existing installs keep their current DMG-only behavior.
 
 ## Detection flow
 
@@ -127,9 +166,10 @@ Relevant state fields:
 Clicking the in-app **Update** button calls the main-process bridge action
 `install`. The bridge:
 
-1. resolves the current app state directory;
-2. writes the pending marker;
-3. exits Electron.
+1. optionally runs `codex-update-manager pick-features`;
+2. resolves the current app state directory;
+3. writes the pending marker;
+4. exits Electron.
 
 For the default app id, the marker path is:
 
@@ -192,36 +232,47 @@ sed -n '1,160p' /opt/codex-desktop/resources/codex-linux-build-info.json
 Verify the settings patch landed in the installed webview bundle:
 
 ```bash
-rg "CodexLinuxWrapperUpdatesSetting|codex-linux-wrapper-updates-enabled|get-global-state|set-global-state" \
+rg "CodexLinuxWrapperUpdatesSetting|CodexLinuxFeaturePickerOnUpdateSetting|get-global-state|set-global-state" \
   /opt/codex-desktop/content/webview/assets/general-settings-*.js
 ```
 
-Toggle the setting in Settings -> General, then verify:
+Toggle the settings in Settings -> General, then verify:
 
 ```bash
-rg "codex-linux-wrapper-updates-enabled" ~/.config/codex-desktop/settings.json
+rg "codex-linux-wrapper-updates-enabled|codex-linux-feature-picker-on-update" \
+  ~/.config/codex-desktop/settings.json
 ```
 
-Inspect wrapper detection state:
+Inspect wrapper detection state and the picker command:
 
 ```bash
 codex-update-manager check-wrapper --json
 codex-update-manager status --json
+codex-update-manager pick-features --json
 ```
 
 ## Troubleshooting
 
-If the row appears but the toggle immediately reverts, confirm the installed
+If either row appears but the toggle immediately reverts, confirm the installed
 settings bundle uses `get-global-state` and `set-global-state`. If it uses the
-upstream typed settings API, the app will reject the Linux-only key.
+upstream typed settings API, the app will reject the Linux-only keys.
 
 If the **Update** button does not appear, check:
 
-- the Settings toggle is on;
+- the Settings -> General wrapper update toggle is on;
 - `check-wrapper --json` records `candidate_wrapper_commit`;
 - `~/.local/state/codex-update-manager/state.json` contains the candidate;
 - the installed build includes `codex-wrapper-updater` in
   `codex-linux-build-info.json`.
+
+If the feature picker does not appear before the update:
+
+- the Settings -> General feature picker toggle may be off;
+- the app may not have a graphical display session;
+- neither `zenity` nor `kdialog` may be installed;
+- the recorded wrapper candidate may not include a readable feature catalog;
+- the dialog may have been cancelled, in which case the update still proceeds
+  with the existing feature selection.
 
 If the app keeps retrying an update, inspect the pending marker and updater log:
 

--- a/linux-features/codex-wrapper-updater/patch.js
+++ b/linux-features/codex-wrapper-updater/patch.js
@@ -8,6 +8,7 @@ const HANDLER_NAME = "codex-linux-wrapper-updater";
 const RUNTIME_VERSION = "codex-wrapper-updater-v2";
 const KEYBINDS_ASSET = "keybinds-settings-linux.js";
 const WRAPPER_UPDATES_SETTING_KEY = linuxSettingsKeys.wrapperUpdates;
+const FEATURE_PICKER_ON_UPDATE_SETTING_KEY = linuxSettingsKeys.featurePickerOnUpdate;
 
 function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
@@ -41,8 +42,18 @@ function applyMainBundlePatch(source) {
     `function codexLinuxWrapStatusPayload(){let s=codexLinuxWrapReadStatus();return{ok:!0,show:codexLinuxWrapShouldShow(s),changelog:s?s.wrapper_changelog||\`\`:\`\`,commit:s?s.candidate_wrapper_commit||\`\`:\`\`}}`,
     `function codexLinuxWrapManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}`,
     `function codexLinuxWrapSpawnCheck(){try{let c=${childProcessVar}.spawn(codexLinuxWrapManagerPath(),[\`check-wrapper\`],{stdio:\`ignore\`,detached:!0,env:process.env});c.on(\`error\`,()=>{});c.unref()}catch{}}`,
+    // Feature picker on update: resolve settings.json the same way the launcher
+    // and launch-actions do, and gate the on-click picker on the
+    // `codex-linux-feature-picker-on-update` toggle (absent ⇒ ask) plus a live
+    // display. The picker runs synchronously here, at click time, because the
+    // detached apply runs after the app exits with no display.
+    `function codexLinuxWrapSettingsAppId(){let e=process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||\`codex-desktop\`;return/^[A-Za-z0-9._-]+$/.test(e)?e:\`codex-desktop\`}`,
+    `function codexLinuxWrapSettingsPath(){let e=process.env.CODEX_LINUX_SETTINGS_FILE;if(typeof e===\`string\`&&e.length>0)return e;let h=codexLinuxWrapHome();let t=process.env.XDG_CONFIG_HOME||(h&&${pathVar}.join(h,\`.config\`));return t?${pathVar}.join(t,codexLinuxWrapSettingsAppId(),\`settings.json\`):null}`,
+    `function codexLinuxWrapPickerEnabled(){try{let p=codexLinuxWrapSettingsPath();if(!p||!${fsVar}.existsSync(p))return!0;let s=JSON.parse(${fsVar}.readFileSync(p,\`utf8\`));if(!s||typeof s!==\`object\`)return!0;let v=s[\`codex-linux-feature-picker-on-update\`];if(v==null)return!0;if(typeof v===\`boolean\`)return v;if(typeof v===\`number\`)return v!==0;if(typeof v===\`string\`){let n=v.trim().toLowerCase();return!([\`0\`,\`false\`,\`no\`,\`off\`].includes(n))}return!0}catch{return!0}}`,
+    `function codexLinuxWrapHasDisplay(){let d=process.env.DISPLAY,w=process.env.WAYLAND_DISPLAY;return!!((d&&d.trim())||(w&&w.trim()))}`,
+    `function codexLinuxWrapRunPicker(){try{${childProcessVar}.spawnSync(codexLinuxWrapManagerPath(),[\`pick-features\`,\`--json\`],{stdio:\`ignore\`,env:process.env})}catch{}}`,
     `function codexLinuxWrapWriteMarker(){let p=codexLinuxWrapMarkerPath();if(!p)return{ok:!1,reason:\`no-marker-path\`};try{${fsVar}.mkdirSync(${pathVar}.dirname(p),{recursive:!0});${fsVar}.writeFileSync(p,new Date().toISOString());return{ok:!0,path:p}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
-    `function codexLinuxWrapInstallNow(){let m=codexLinuxWrapWriteMarker();if(!m.ok)return m;try{let a=require(\`electron\`).app;setTimeout(()=>a.exit(0),120);return{ok:!0,path:m.path}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
+    `function codexLinuxWrapInstallNow(){if(codexLinuxWrapHasDisplay()&&codexLinuxWrapPickerEnabled())codexLinuxWrapRunPicker();let m=codexLinuxWrapWriteMarker();if(!m.ok)return m;try{let a=require(\`electron\`).app;setTimeout(()=>a.exit(0),120);return{ok:!0,path:m.path}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
     `function codexLinuxWrapHandle(e={}){let action=e&&e.action;if(action===\`status\`)return codexLinuxWrapStatusPayload();if(action===\`check\`){codexLinuxWrapSpawnCheck();return{ok:!0}}if(action===\`install\`)return codexLinuxWrapInstallNow();return{ok:!1,reason:\`unknown-action\`}}`,
     `(()=>{if(process.env.CODEX_LINUX_MULTI_LAUNCH!==\`1\`)codexLinuxWrapSpawnCheck()})();`,
   ].join("");
@@ -111,6 +122,16 @@ function applyWrapperUpdateSettingsPatch(source) {
       `${keyNeedle},wrapperUpdates:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)}`,
     );
   }
+  if (!next.includes("featurePickerOnUpdate:")) {
+    const wrapperKey = `wrapperUpdates:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)}`;
+    if (!next.includes(wrapperKey)) {
+      throw new Error("could not find wrapper update settings key");
+    }
+    next = next.replace(
+      wrapperKey,
+      `${wrapperKey},featurePickerOnUpdate:${JSON.stringify(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)}`,
+    );
+  }
 
   if (!next.includes("Check for Codex Desktop Linux updates")) {
     const toggleNeedle =
@@ -118,16 +139,29 @@ function applyWrapperUpdateSettingsPatch(source) {
     if (!next.includes(toggleNeedle)) {
       throw new Error("could not find Linux update toggle");
     }
+    const pickerToggle =
+      `$.jsx(LinuxToggle,{settingKey:KEYS.featurePickerOnUpdate,label:"Ask which features to enable on update",description:"When on, clicking Update opens a checklist to pick optional Linux features before rebuilding. Turn off to keep your current feature selection without prompting.",defaultValue:!0},"featurePickerOnUpdate")`;
     const wrapperToggle =
-      `children:[$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."},"autoUpdateOnExit"),$.jsx(LinuxToggle,{settingKey:KEYS.wrapperUpdates,label:"Check for Codex Desktop Linux updates",description:"Check for Linux wrapper updates from codex-desktop-linux in addition to upstream Codex app updates.",defaultValue:!1},"wrapperUpdates")]`;
+      `children:[$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."},"autoUpdateOnExit"),$.jsx(LinuxToggle,{settingKey:KEYS.wrapperUpdates,label:"Check for Codex Desktop Linux updates",description:"Check for Linux wrapper updates from codex-desktop-linux in addition to upstream Codex app updates.",defaultValue:!1},"wrapperUpdates"),${pickerToggle}]`;
     next = next.replace(toggleNeedle, wrapperToggle);
+  } else if (!next.includes("Ask which features to enable on update")) {
+    const existingWrapperToggle =
+      `$.jsx(LinuxToggle,{settingKey:KEYS.wrapperUpdates,label:"Check for Codex Desktop Linux updates",description:"Check for Linux wrapper updates from codex-desktop-linux in addition to upstream Codex app updates.",defaultValue:!1},"wrapperUpdates")`;
+    if (!next.includes(existingWrapperToggle)) {
+      throw new Error("could not find wrapper update toggle");
+    }
+    const pickerToggle =
+      `$.jsx(LinuxToggle,{settingKey:KEYS.featurePickerOnUpdate,label:"Ask which features to enable on update",description:"When on, clicking Update opens a checklist to pick optional Linux features before rebuilding. Turn off to keep your current feature selection without prompting.",defaultValue:!0},"featurePickerOnUpdate")`;
+    next = next.replace(existingWrapperToggle, `${existingWrapperToggle},${pickerToggle}`);
   }
 
   return next;
 }
 
 function applyWrapperUpdateGeneralSettingsPatch(source) {
-  if (source.includes("Check for Codex Desktop Linux updates")) {
+  const hasWrapperSetting = source.includes("Check for Codex Desktop Linux updates");
+  const hasFeaturePickerSetting = source.includes("Ask which features to enable on update");
+  if (hasWrapperSetting && hasFeaturePickerSetting) {
     return source;
   }
 
@@ -136,19 +170,37 @@ function applyWrapperUpdateGeneralSettingsPatch(source) {
     throw new Error("could not find general power settings function");
   }
 
-  const settingFunction =
+  const wrapperSettingFunction = hasWrapperSetting
+    ? ""
+    :
     `function CodexLinuxWrapperUpdatesSetting(){let[e,t]=(0,X.useState)(!1),[n,r]=(0,X.useState)(!0),[i,a]=(0,X.useState)(null),o=x();(0,X.useEffect)(()=>{let e=!0;return r(!0),N(\`get-global-state\`,{params:{key:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)}}}).then(n=>{e&&(t(n?.value??!1),a(null))}).catch(t=>{e&&a(t instanceof Error?t.message:String(t))}).finally(()=>{e&&r(!1)}),()=>{e=!1}},[]);let s=(0,$.jsx)(w,{id:\`settings.general.wrapperUpdates.label\`,defaultMessage:\`Check for Codex Desktop Linux updates\`,description:\`Label for Linux wrapper update checks setting\`}),c=(0,$.jsx)(w,{id:\`settings.general.wrapperUpdates.description\`,defaultMessage:\`Check for Linux wrapper updates from codex-desktop-linux in addition to upstream Codex app updates.\`,description:\`Description for Linux wrapper update checks setting\`});i&&(c=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[c,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:i})]}));let l=o.formatMessage({id:\`settings.general.wrapperUpdates.label\`,defaultMessage:\`Check for Codex Desktop Linux updates\`,description:\`Label for Linux wrapper update checks setting\`});return(0,$.jsx)(J,{label:s,description:c,control:(0,$.jsx)(q,{checked:e===!0,disabled:n,onChange:o=>{let s=e;t(o),a(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)},value:o}}).catch(e=>{t(s),a(e instanceof Error?e.message:String(e))})},ariaLabel:l})})}`;
+  const featurePickerSettingFunction = hasFeaturePickerSetting
+    ? ""
+    :
+    `function CodexLinuxFeaturePickerOnUpdateSetting(){let[e,t]=(0,X.useState)(!0),[n,r]=(0,X.useState)(!0),[i,a]=(0,X.useState)(null),o=x();(0,X.useEffect)(()=>{let e=!0;return r(!0),N(\`get-global-state\`,{params:{key:${JSON.stringify(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)}}}).then(n=>{e&&(t(n?.value??!0),a(null))}).catch(t=>{e&&a(t instanceof Error?t.message:String(t))}).finally(()=>{e&&r(!1)}),()=>{e=!1}},[]);let s=(0,$.jsx)(w,{id:\`settings.general.featurePickerOnUpdate.label\`,defaultMessage:\`Ask which features to enable on update\`,description:\`Label for Linux feature picker on update setting\`}),c=(0,$.jsx)(w,{id:\`settings.general.featurePickerOnUpdate.description\`,defaultMessage:\`When on, clicking Update opens a checklist to pick optional Linux features before rebuilding. Turn off to keep your current feature selection without prompting.\`,description:\`Description for Linux feature picker on update setting\`});i&&(c=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[c,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:i})]}));let l=o.formatMessage({id:\`settings.general.featurePickerOnUpdate.label\`,defaultMessage:\`Ask which features to enable on update\`,description:\`Label for Linux feature picker on update setting\`});return(0,$.jsx)(J,{label:s,description:c,control:(0,$.jsx)(q,{checked:e===!0,disabled:n,onChange:o=>{let s=e;t(o),a(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)},value:o}}).catch(e=>{t(s),a(e instanceof Error?e.message:String(e))})},ariaLabel:l})})}`;
 
-  let next = source.replace(functionNeedle, `${settingFunction}${functionNeedle}`);
+  let next = source.replace(
+    functionNeedle,
+    `${wrapperSettingFunction}${featurePickerSettingFunction}${functionNeedle}`,
+  );
 
   const powerRowNeedle = `D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsx)(Br,{})})`;
   const powerRowPatch =
-    `D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{})]})})`;
-  if (!next.includes(powerRowNeedle)) {
-    throw new Error("could not find general power settings row");
+    `D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{}),(0,$.jsx)(CodexLinuxFeaturePickerOnUpdateSetting,{})]})})`;
+  if (next.includes(powerRowNeedle)) {
+    next = next.replace(powerRowNeedle, powerRowPatch);
+    return next;
   }
-  next = next.replace(powerRowNeedle, powerRowPatch);
-  return next;
+
+  const existingWrapperRowNeedle = `children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{})]`;
+  const existingWrapperRowPatch =
+    `children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{}),(0,$.jsx)(CodexLinuxFeaturePickerOnUpdateSetting,{})]`;
+  if (next.includes(existingWrapperRowNeedle)) {
+    next = next.replace(existingWrapperRowNeedle, existingWrapperRowPatch);
+    return next;
+  }
+
+  throw new Error("could not find general power settings row");
 }
 
 function patchWrapperUpdateSettingsAssets(extractedDir) {
@@ -199,6 +251,7 @@ function patchWrapperUpdateSettingsAssets(extractedDir) {
 module.exports = {
   HANDLER_NAME,
   RUNTIME_VERSION,
+  FEATURE_PICKER_ON_UPDATE_SETTING_KEY,
   WRAPPER_UPDATES_SETTING_KEY,
   applyMainBundlePatch,
   applyWebviewRuntimePatch,

--- a/linux-features/codex-wrapper-updater/test.js
+++ b/linux-features/codex-wrapper-updater/test.js
@@ -55,6 +55,8 @@ test("main bundle patch writes app-state wrapper marker", () => {
 
   assert.match(patched, /"codex-linux-wrapper-updater":async/);
   assert.match(patched, /CODEX_LINUX_APP_STATE_DIR/);
+  assert.match(patched, /pick-features/);
+  assert.match(patched, /codex-linux-feature-picker-on-update/);
   assert.match(patched, /codex-wrapper-updater/);
   assert.doesNotMatch(patched, /wrapper-update-pending/);
 });

--- a/linux-features/codex-wrapper-updater/test.js
+++ b/linux-features/codex-wrapper-updater/test.js
@@ -67,11 +67,13 @@ test("settings patch adds wrapper update toggle", () => {
   const patched = applyWrapperUpdateSettingsPatch(source);
 
   assert.match(patched, /wrapperUpdates:"codex-linux-wrapper-updates-enabled"/);
+  assert.match(patched, /featurePickerOnUpdate:"codex-linux-feature-picker-on-update"/);
   assert.match(patched, /Check for Codex Desktop Linux updates/);
+  assert.match(patched, /Ask which features to enable on update/);
   assert.equal(applyWrapperUpdateSettingsPatch(patched), patched);
 });
 
-test("general settings patch adds wrapper update toggle for current upstream settings", () => {
+test("general settings patch adds wrapper update toggles for current upstream settings", () => {
   const source =
     `function $n(){let D,k,A,j,M;e[16]===Symbol.for(\`react.memo_cache_sentinel\`)?(D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsx)(Br,{})}),k=(0,$.jsx)(zr,{}),A=(0,$.jsx)(Hn,{}),j=(0,$.jsx)(Mr,{}),M=(0,$.jsx)(Pr,{}),e[16]=D,e[17]=k,e[18]=A,e[19]=j,e[20]=M):(D=e[16],k=e[17],A=e[18],j=e[19],M=e[20]);}` +
     `function Br(){return null}function Vr(e,t){return e}`;
@@ -79,12 +81,18 @@ test("general settings patch adds wrapper update toggle for current upstream set
   const patched = applyWrapperUpdateGeneralSettingsPatch(source);
 
   assert.match(patched, /CodexLinuxWrapperUpdatesSetting/);
+  assert.match(patched, /CodexLinuxFeaturePickerOnUpdateSetting/);
   assert.match(patched, /codex-linux-wrapper-updates-enabled/);
+  assert.match(patched, /codex-linux-feature-picker-on-update/);
   assert.match(patched, /Check for Codex Desktop Linux updates/);
+  assert.match(patched, /Ask which features to enable on update/);
   assert.match(patched, /get-global-state/);
   assert.match(patched, /set-global-state/);
   assert.doesNotMatch(patched, /set-setting/);
-  assert.match(patched, /children:\[\(0,\$\.jsx\)\(Br,\{\}\),\(0,\$\.jsx\)\(CodexLinuxWrapperUpdatesSetting,\{\}\)\]/);
+  assert.match(
+    patched,
+    /children:\[\(0,\$\.jsx\)\(Br,\{\}\),\(0,\$\.jsx\)\(CodexLinuxWrapperUpdatesSetting,\{\}\),\(0,\$\.jsx\)\(CodexLinuxFeaturePickerOnUpdateSetting,\{\}\)\]/,
+  );
   assert.equal(applyWrapperUpdateGeneralSettingsPatch(patched), patched);
 });
 
@@ -102,6 +110,7 @@ test("settings asset patch skips re-exported general settings bundles", () => {
     assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), { matched: true, changed: 1 });
     assert.doesNotMatch(fs.readFileSync(path.join(assetsDir, "general-settings-a.js"), "utf8"), /WrapperUpdates/);
     assert.match(fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"), /Check for Codex Desktop Linux updates/);
+    assert.match(fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"), /Ask which features to enable on update/);
   } finally {
     fs.rmSync(appDir, { recursive: true, force: true });
   }

--- a/scripts/patches/shared.js
+++ b/scripts/patches/shared.js
@@ -15,6 +15,7 @@ const linuxSettingsKeys = {
   warmStart: "codex-linux-warm-start-enabled",
   autoUpdateOnExit: "codex-linux-auto-update-on-exit",
   wrapperUpdates: "codex-linux-wrapper-updates-enabled",
+  featurePickerOnUpdate: "codex-linux-feature-picker-on-update",
 };
 
 function readDirectoryNames(dir) {

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{Cli, Commands},
     codex_cli,
     config::{RuntimeConfig, RuntimePaths},
-    install, install_rollback, liveness, logging, notify, rollback,
+    feature_picker, install, install_rollback, liveness, logging, notify, rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
     upstream, wrapper, wrapper_apply,
 };
@@ -55,6 +55,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::ApplyWrapperUpdate => {
             wrapper_apply::run_apply_wrapper_update(&config, &mut state, &paths).await
         }
+        Commands::PickFeatures { json } => feature_picker::run_pick_features(&config, &paths, json),
         Commands::CliPreflight {
             cli_path,
             print_path,

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -135,10 +135,8 @@ pub async fn build_update_from(
     // writes it to a stable per-user path) so the rebuild stages exactly those
     // features. Only set it when the file actually exists; an absent path would
     // make linux-features.js see an empty enabled set and stage nothing.
-    if let Some(feature_config) = crate::config::feature_config_path() {
-        if feature_config.is_file() {
-            install.env("CODEX_LINUX_FEATURES_CONFIG", &feature_config);
-        }
+    if let Some(feature_config) = crate::config::effective_feature_config_path(config) {
+        install.env("CODEX_LINUX_FEATURES_CONFIG", &feature_config);
     }
     run_and_log(&mut install, &workspace.install_log)
         .await

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -116,25 +116,33 @@ pub async fn build_update_from(
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
-    run_and_log(
-        Command::new(workspace.bundle_dir.join("install.sh"))
-            .arg(dmg_path)
-            .env("CODEX_INSTALL_DIR", &workspace.app_dir)
-            .env(
-                "CODEX_PATCH_REPORT_JSON",
-                workspace.reports_dir.join("patch-report.json"),
-            )
-            .env(
-                "CODEX_REBUILD_REPORT_JSON",
-                workspace.reports_dir.join("rebuild-report.json"),
-            )
-            .env("CODEX_MANAGED_NODE_SOURCE", managed_node_source)
-            .env("PATH", &build_path)
-            .current_dir(&workspace.bundle_dir),
-        &workspace.install_log,
-    )
-    .await
-    .context("install.sh failed during local rebuild")?;
+    let mut install = Command::new(workspace.bundle_dir.join("install.sh"));
+    install
+        .arg(dmg_path)
+        .env("CODEX_INSTALL_DIR", &workspace.app_dir)
+        .env(
+            "CODEX_PATCH_REPORT_JSON",
+            workspace.reports_dir.join("patch-report.json"),
+        )
+        .env(
+            "CODEX_REBUILD_REPORT_JSON",
+            workspace.reports_dir.join("rebuild-report.json"),
+        )
+        .env("CODEX_MANAGED_NODE_SOURCE", managed_node_source)
+        .env("PATH", &build_path)
+        .current_dir(&workspace.bundle_dir);
+    // Honor the user's saved feature selection (the in-app Update feature picker
+    // writes it to a stable per-user path) so the rebuild stages exactly those
+    // features. Only set it when the file actually exists; an absent path would
+    // make linux-features.js see an empty enabled set and stage nothing.
+    if let Some(feature_config) = crate::config::feature_config_path() {
+        if feature_config.is_file() {
+            install.env("CODEX_LINUX_FEATURES_CONFIG", &feature_config);
+        }
+    }
+    run_and_log(&mut install, &workspace.install_log)
+        .await
+        .context("install.sh failed during local rebuild")?;
 
     state.status = UpdateStatus::BuildingPackage;
     state.save(&paths.state_file)?;

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -27,6 +27,13 @@ pub enum Commands {
     },
     /// Apply the recorded wrapper update candidate for the running install.
     ApplyWrapperUpdate,
+    /// Show a GUI checklist of optional Linux features and save the selection to
+    /// the per-user feature config, so the next wrapper rebuild honors it.
+    /// Invoked by the in-app Update button at click time (display still alive).
+    PickFeatures {
+        #[arg(long, default_value_t = false)]
+        json: bool,
+    },
     CliPreflight {
         #[arg(long)]
         cli_path: Option<PathBuf>,

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -210,6 +210,7 @@ pub fn settings_wrapper_updates_override() -> Option<bool> {
 }
 
 const FEATURE_CONFIG_FILE: &str = "linux-features.json";
+const BUNDLED_FEATURE_CONFIG_FILE: &str = "features.json";
 const FEATURE_PICKER_ON_UPDATE_SETTING_KEY: &str = "codex-linux-feature-picker-on-update";
 
 /// Resolves the stable per-user feature-config path
@@ -221,6 +222,21 @@ pub fn feature_config_path() -> Option<PathBuf> {
     let settings = app_settings_path()?;
     let dir = settings.parent()?;
     Some(dir.join(FEATURE_CONFIG_FILE))
+}
+
+/// Returns the feature config that should drive a rebuild. A saved per-user
+/// picker selection wins; otherwise preserve the currently installed/bundled
+/// feature selection from the builder bundle.
+pub fn effective_feature_config_path(config: &RuntimeConfig) -> Option<PathBuf> {
+    feature_config_path()
+        .filter(|path| path.is_file())
+        .or_else(|| {
+            let bundled = config
+                .builder_bundle_root
+                .join("linux-features")
+                .join(BUNDLED_FEATURE_CONFIG_FILE);
+            bundled.is_file().then_some(bundled)
+        })
 }
 
 /// Reads the user's "ask which features to enable on update" preference (the
@@ -365,6 +381,49 @@ mod tests {
             ),
             Some(false)
         );
+    }
+
+    #[test]
+    fn effective_feature_config_prefers_saved_picker_config_then_builder_config() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let temp = tempdir()?;
+        let settings_dir = temp.path().join("settings");
+        let settings_file = settings_dir.join("settings.json");
+        let saved_feature_config = settings_dir.join("linux-features.json");
+        let builder_feature_config = temp.path().join("builder/linux-features/features.json");
+
+        fs::create_dir_all(builder_feature_config.parent().unwrap())?;
+        fs::write(
+            &builder_feature_config,
+            r#"{"enabled":["codex-wrapper-updater"]}"#,
+        )?;
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+
+        let paths = RuntimePaths {
+            config_file: temp.path().join("config/config.toml"),
+            state_file: temp.path().join("state/state.json"),
+            log_file: temp.path().join("state/service.log"),
+            cache_dir: temp.path().join("cache"),
+            state_dir: temp.path().join("state"),
+            config_dir: temp.path().join("config"),
+        };
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.builder_bundle_root = temp.path().join("builder");
+
+        assert_eq!(
+            effective_feature_config_path(&config),
+            Some(builder_feature_config.clone())
+        );
+
+        fs::create_dir_all(&settings_dir)?;
+        fs::write(&saved_feature_config, r#"{"enabled":["read-aloud"]}"#)?;
+        assert_eq!(
+            effective_feature_config_path(&config),
+            Some(saved_feature_config)
+        );
+
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        Ok(())
     }
 
     #[test]

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -209,6 +209,56 @@ pub fn settings_wrapper_updates_override() -> Option<bool> {
     settings_bool_override(WRAPPER_UPDATES_SETTING_KEY)
 }
 
+const FEATURE_CONFIG_FILE: &str = "linux-features.json";
+const FEATURE_PICKER_ON_UPDATE_SETTING_KEY: &str = "codex-linux-feature-picker-on-update";
+
+/// Resolves the stable per-user feature-config path
+/// (`<config>/<appId>/linux-features.json`), alongside `settings.json`. The
+/// wrapper-update feature picker writes the chosen `{"enabled":[...]}` here, and
+/// the rebuild points `CODEX_LINUX_FEATURES_CONFIG` at it. Deliberately outside
+/// any wrapper-src checkout so a fresh clone cannot clobber it.
+pub fn feature_config_path() -> Option<PathBuf> {
+    let settings = app_settings_path()?;
+    let dir = settings.parent()?;
+    Some(dir.join(FEATURE_CONFIG_FILE))
+}
+
+/// Reads the user's "ask which features to enable on update" preference (the
+/// in-app Update-button feature picker). Absent ⇒ `None` ⇒ caller defaults to
+/// asking.
+pub fn settings_feature_picker_on_update_override() -> Option<bool> {
+    settings_bool_override(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)
+}
+
+/// Persists the "Ask which features to enable on update" preference to the app
+/// `settings.json`, merging into the existing object (preserving every other
+/// key). Used to honor the picker's "Don't ask again" row. Never panics; returns
+/// the IO/serialization error so the caller can log-and-continue.
+pub fn write_feature_picker_on_update(value: bool) -> Result<()> {
+    write_settings_bool(FEATURE_PICKER_ON_UPDATE_SETTING_KEY, value)
+}
+
+/// Read-modify-writes a boolean key into the app `settings.json`, preserving all
+/// other keys. Creates the file (and parent dir) when absent. A malformed
+/// existing file is replaced with a fresh object rather than failing.
+fn write_settings_bool(key: &str, value: bool) -> Result<()> {
+    let path = app_settings_path().context("could not resolve settings.json path")?;
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("Failed to create {}", dir.display()))?;
+    }
+    let mut object = fs::read_to_string(&path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    object.insert(key.to_string(), serde_json::Value::Bool(value));
+    let serialized = serde_json::to_string_pretty(&serde_json::Value::Object(object))
+        .context("Failed to serialize settings.json")?;
+    fs::write(&path, format!("{serialized}\n"))
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/updater/src/feature_picker.rs
+++ b/updater/src/feature_picker.rs
@@ -253,11 +253,12 @@ fn read_catalog(config: &RuntimeConfig, source: &Path) -> Result<Vec<CatalogEntr
     Ok(entries)
 }
 
-/// Reads the currently-enabled feature ids. Prefers the saved feature config
-/// (the picker's own prior answer), else `linux-features.js --enabled` (which
-/// reads the source `features.json`). Errors degrade to an empty set.
+/// Reads the currently-enabled feature ids. Prefers the saved picker config,
+/// then the installed builder bundle's preserved feature config, then
+/// `linux-features.js --enabled` from the selected source. Errors degrade to an
+/// empty set.
 fn read_enabled(config: &RuntimeConfig, source: &Path) -> std::collections::HashSet<String> {
-    if let Some(path) = config::feature_config_path() {
+    if let Some(path) = config::effective_feature_config_path(config) {
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
                 if let Some(array) = value.get("enabled").and_then(|v| v.as_array()) {
@@ -583,6 +584,28 @@ if (arg === "--features-json") {
             sources.is_empty(),
             "recorded candidate failures must not use the installed catalog"
         );
+    }
+
+    #[test]
+    fn enabled_reads_builder_feature_config_when_saved_picker_config_is_absent() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let builder_config = root.path().join("linux-features/features.json");
+        std::fs::create_dir_all(builder_config.parent().unwrap()).unwrap();
+        std::fs::write(&builder_config, r#"{"enabled":["alpha"]}"#).unwrap();
+
+        let settings_file = settings.path().join("settings.json");
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        let config = base_config(root.path());
+
+        assert_eq!(
+            read_enabled(&config, root.path()),
+            std::collections::HashSet::from(["alpha".to_string()])
+        );
+
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
     }
 
     #[test]

--- a/updater/src/feature_picker.rs
+++ b/updater/src/feature_picker.rs
@@ -1,0 +1,748 @@
+//! Interactive feature picker for the in-app wrapper Update button.
+//!
+//! When the user clicks the wrapper "Update" button, the renderer shells out to
+//! `codex-update-manager pick-features` *while the display is still alive* (the
+//! detached `apply-wrapper-update` runs after the app exits → headless, so the
+//! dialog must run here, at click time). This subcommand:
+//!
+//! 1. Locates a wrapper source checkout that ships the feature catalog
+//!    (`scripts/lib/linux-features.js` + the `linux-features/<id>/feature.json`
+//!    set). When an update candidate is recorded, it prepares that candidate
+//!    source first so the picker reflects the build that will actually run. A
+//!    manual `pick-features` invocation without a candidate falls back to the
+//!    installed builder bundle.
+//! 2. Reads the catalog (`--features-json`) and the currently-enabled set
+//!    (the saved `linux-features.json`, else `--enabled`).
+//! 3. Shows a zenity/kdialog checklist pre-checked with the enabled set, plus a
+//!    sentinel "(Don't ask again …)" row.
+//! 4. Writes the chosen `{"enabled":[…]}` to [`config::feature_config_path`] so
+//!    the rebuild (which points `CODEX_LINUX_FEATURES_CONFIG` at that path) uses
+//!    the selection. If the sentinel row was checked, persists
+//!    `codex-linux-feature-picker-on-update=false` so future updates skip the
+//!    prompt.
+//!
+//! Every failure mode (no display, no dialog tool, no catalog, cancelled dialog,
+//! or dialog launch failure) is a graceful skip that leaves the current feature
+//! set unchanged — the picker must never block or fail the update it precedes.
+
+use anyhow::{Context, Result};
+use std::{
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tracing::{info, warn};
+
+use crate::{
+    config::{self, RuntimeConfig, RuntimePaths},
+    state::PersistedState,
+    wrapper_apply,
+};
+
+/// Sentinel checklist row id for "don't ask again". Contains underscores so it
+/// can never collide with a real feature id (`^[a-z0-9][a-z0-9-]*$`).
+const DONT_ASK_SENTINEL: &str = "__dont_ask_again__";
+const DONT_ASK_LABEL: &str = "(Don't ask again on future updates)";
+
+/// A catalog feature row (id + human title) read from `--features-json`.
+struct CatalogEntry {
+    id: String,
+    title: String,
+}
+
+/// Outcome of `run_pick_features`, surfaced as JSON when `--json` is passed.
+enum PickOutcome {
+    Skipped(&'static str),
+    Picked { count: usize, dont_ask: bool },
+}
+
+/// Runs the feature picker. Returns `Ok(())` in every non-panic case; a skip
+/// (no display, no dialog tool, no catalog, cancelled) leaves features unchanged.
+pub fn run_pick_features(config: &RuntimeConfig, paths: &RuntimePaths, json: bool) -> Result<()> {
+    let outcome = pick(config, paths)?;
+    if json {
+        match &outcome {
+            PickOutcome::Skipped(reason) => {
+                println!("{{\"ok\":true,\"skipped\":\"{reason}\"}}");
+            }
+            PickOutcome::Picked { count, dont_ask } => {
+                println!("{{\"ok\":true,\"picked\":{count},\"dont_ask\":{dont_ask}}}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn pick(config: &RuntimeConfig, paths: &RuntimePaths) -> Result<PickOutcome> {
+    // Defensive double-gate: the button already checks this, but honor it here
+    // too so a stray invocation can't re-prompt after "don't ask again".
+    if config::settings_feature_picker_on_update_override() == Some(false) {
+        return Ok(PickOutcome::Skipped("disabled"));
+    }
+    if !has_display() {
+        return Ok(PickOutcome::Skipped("no-display"));
+    }
+    let Some(tool) = dialog_tool() else {
+        return Ok(PickOutcome::Skipped("no-dialog-tool"));
+    };
+    // Try each candidate source in turn; the first that yields a non-empty
+    // catalog wins. This skips a stale builder bundle whose linux-features.js
+    // predates `--features-json` and falls through to a current checkout.
+    let mut chosen: Option<(PathBuf, Vec<CatalogEntry>)> = None;
+    for source in candidate_sources(config, paths) {
+        match read_catalog(config, &source) {
+            Ok(catalog) if !catalog.is_empty() => {
+                chosen = Some((source, catalog));
+                break;
+            }
+            Ok(_) => continue,
+            Err(error) => {
+                warn!(?error, source = %source.display(), "feature picker could not read catalog from this source");
+                continue;
+            }
+        }
+    }
+    let Some((source, catalog)) = chosen else {
+        return Ok(PickOutcome::Skipped("no-catalog"));
+    };
+    let enabled = read_enabled(config, &source);
+
+    match show_picker(&tool, &catalog, &enabled)? {
+        None => {
+            info!("feature picker cancelled; feature set unchanged");
+            Ok(PickOutcome::Skipped("cancelled"))
+        }
+        Some(selection) => {
+            let dont_ask = selection.iter().any(|id| id == DONT_ASK_SENTINEL);
+            let catalog_ids: std::collections::HashSet<&str> =
+                catalog.iter().map(|entry| entry.id.as_str()).collect();
+            let mut picked: Vec<String> = selection
+                .into_iter()
+                .filter(|id| id != DONT_ASK_SENTINEL && catalog_ids.contains(id.as_str()))
+                .collect();
+            picked.extend(
+                enabled
+                    .iter()
+                    .filter(|id| id.as_str() != DONT_ASK_SENTINEL)
+                    .filter(|id| !catalog_ids.contains(id.as_str()))
+                    .cloned(),
+            );
+            picked.sort();
+            picked.dedup();
+
+            write_feature_config(&picked)?;
+            if dont_ask {
+                if let Err(error) = config::write_feature_picker_on_update(false) {
+                    warn!(?error, "could not persist don't-ask-again preference");
+                }
+            }
+            info!(
+                count = picked.len(),
+                dont_ask, "feature picker selection saved"
+            );
+            Ok(PickOutcome::Picked {
+                count: picked.len(),
+                dont_ask,
+            })
+        }
+    }
+}
+
+/// True when an X11 or Wayland display is available for a GUI dialog.
+fn has_display() -> bool {
+    ["DISPLAY", "WAYLAND_DISPLAY"].iter().any(|var| {
+        std::env::var(var)
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false)
+    })
+}
+
+/// The dialog helper to use, preferring zenity then kdialog (PATH lookup).
+fn dialog_tool() -> Option<DialogTool> {
+    if which("zenity").is_some() {
+        Some(DialogTool::Zenity)
+    } else if which("kdialog").is_some() {
+        Some(DialogTool::Kdialog)
+    } else {
+        None
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DialogTool {
+    Zenity,
+    Kdialog,
+}
+
+/// Candidate wrapper source checkouts that ship the feature catalog. When a
+/// wrapper update candidate is recorded, fetch that candidate source first so
+/// the picker shows the features that will actually be rebuilt. Without a
+/// recorded candidate, fall back to the installed builder bundle for manual
+/// `pick-features` invocations.
+fn candidate_sources(config: &RuntimeConfig, paths: &RuntimePaths) -> Vec<PathBuf> {
+    if let Some(candidate_source) = candidate_wrapper_source(config, paths) {
+        return vec![candidate_source]
+            .into_iter()
+            .filter(|dir| dir.join("scripts/lib/linux-features.js").is_file())
+            .collect();
+    }
+
+    [config.builder_bundle_root.clone()]
+        .into_iter()
+        .filter(|dir| dir.join("scripts/lib/linux-features.js").is_file())
+        .collect()
+}
+
+fn candidate_wrapper_source(config: &RuntimeConfig, paths: &RuntimePaths) -> Option<PathBuf> {
+    let state =
+        PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit).ok()?;
+    let candidate_commit = state.candidate_wrapper_commit.as_deref()?;
+    match wrapper_apply::ensure_wrapper_source(config, paths, Some(candidate_commit)) {
+        Ok(source) => Some(source),
+        Err(error) => {
+            warn!(
+                ?error,
+                "feature picker could not prepare candidate wrapper source"
+            );
+            None
+        }
+    }
+}
+
+/// Resolves a node binary: the bundle's managed runtime first, then PATH.
+fn node_binary(config: &RuntimeConfig) -> PathBuf {
+    let managed = config.builder_bundle_root.join("node-runtime/bin/node");
+    if managed.is_file() {
+        return managed;
+    }
+    which("node").unwrap_or_else(|| PathBuf::from("node"))
+}
+
+/// Reads the full feature catalog via `linux-features.js --features-json`.
+fn read_catalog(config: &RuntimeConfig, source: &Path) -> Result<Vec<CatalogEntry>> {
+    let script = source.join("scripts/lib/linux-features.js");
+    let output = Command::new(node_binary(config))
+        .arg(&script)
+        .arg("--features-json")
+        .output()
+        .with_context(|| format!("Failed to run {}", script.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "linux-features.js --features-json exited with {}",
+            output.status
+        );
+    }
+    let parsed = serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .context("Failed to parse --features-json output")?;
+    let array = parsed
+        .as_array()
+        .context("--features-json did not return an array")?;
+    let mut entries = Vec::new();
+    for item in array {
+        let Some(id) = item.get("id").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        let title = item
+            .get("title")
+            .and_then(|value| value.as_str())
+            .filter(|title| !title.is_empty())
+            .unwrap_or(id)
+            .to_string();
+        entries.push(CatalogEntry {
+            id: id.to_string(),
+            title: sanitize_label(&title),
+        });
+    }
+    Ok(entries)
+}
+
+/// Reads the currently-enabled feature ids. Prefers the saved feature config
+/// (the picker's own prior answer), else `linux-features.js --enabled` (which
+/// reads the source `features.json`). Errors degrade to an empty set.
+fn read_enabled(config: &RuntimeConfig, source: &Path) -> std::collections::HashSet<String> {
+    if let Some(path) = config::feature_config_path() {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(array) = value.get("enabled").and_then(|v| v.as_array()) {
+                    return array
+                        .iter()
+                        .filter_map(|item| item.as_str())
+                        .map(|s| s.to_string())
+                        .collect();
+                }
+            }
+        }
+    }
+
+    let script = source.join("scripts/lib/linux-features.js");
+    let Ok(output) = Command::new(node_binary(config))
+        .arg(&script)
+        .arg("--enabled")
+        .output()
+    else {
+        return std::collections::HashSet::new();
+    };
+    if !output.status.success() {
+        return std::collections::HashSet::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.trim().to_string())
+        .filter(|line| !line.is_empty())
+        .collect()
+}
+
+/// Shows the checklist. Returns `Some(selected ids incl. maybe the sentinel)` on
+/// OK, or `None` when the user cancelled (nonzero dialog exit).
+fn show_picker(
+    tool: &DialogTool,
+    catalog: &[CatalogEntry],
+    enabled: &std::collections::HashSet<String>,
+) -> Result<Option<Vec<String>>> {
+    let output = match tool {
+        DialogTool::Zenity => {
+            let mut cmd = Command::new("zenity");
+            cmd.args([
+                "--list",
+                "--checklist",
+                "--title=Codex Desktop Linux features",
+                "--text=Select the optional Linux features to enable for this update.",
+                "--column=Enable",
+                "--column=Feature",
+                "--column=Description",
+                "--print-column=2",
+                "--separator=\n",
+            ]);
+            for entry in catalog {
+                cmd.arg(if enabled.contains(&entry.id) {
+                    "TRUE"
+                } else {
+                    "FALSE"
+                });
+                cmd.arg(&entry.id);
+                cmd.arg(&entry.title);
+            }
+            // Sentinel "don't ask again" row, unchecked by default.
+            cmd.arg("FALSE").arg(DONT_ASK_SENTINEL).arg(DONT_ASK_LABEL);
+            match cmd.output() {
+                Ok(output) => output,
+                Err(error) => {
+                    warn!(?error, "feature picker could not launch zenity");
+                    return Ok(None);
+                }
+            }
+        }
+        DialogTool::Kdialog => {
+            let mut cmd = Command::new("kdialog");
+            cmd.args([
+                "--separate-output",
+                "--checklist",
+                "Select the optional Linux features to enable for this update.",
+            ]);
+            for entry in catalog {
+                cmd.arg(&entry.id);
+                cmd.arg(&entry.title);
+                cmd.arg(if enabled.contains(&entry.id) {
+                    "on"
+                } else {
+                    "off"
+                });
+            }
+            cmd.arg(DONT_ASK_SENTINEL).arg(DONT_ASK_LABEL).arg("off");
+            match cmd.output() {
+                Ok(output) => output,
+                Err(error) => {
+                    warn!(?error, "feature picker could not launch kdialog");
+                    return Ok(None);
+                }
+            }
+        }
+    };
+
+    if !output.status.success() {
+        // Nonzero exit = user cancelled (or dialog error) → treat as cancel.
+        return Ok(None);
+    }
+    let ids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.trim().trim_matches('"').to_string())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    Ok(Some(ids))
+}
+
+/// Writes the chosen enabled set to the stable feature-config path.
+fn write_feature_config(enabled: &[String]) -> Result<()> {
+    let path = config::feature_config_path().context("could not resolve feature config path")?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("Failed to create {}", dir.display()))?;
+    }
+    let value = serde_json::json!({ "enabled": enabled });
+    let serialized =
+        serde_json::to_string_pretty(&value).context("Failed to serialize feature config")?;
+    std::fs::write(&path, format!("{serialized}\n"))
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/// Strips tab/newline from a label so it can't break dialog column parsing.
+fn sanitize_label(label: &str) -> String {
+    label.replace(['\t', '\n', '\r'], " ").trim().to_string()
+}
+
+/// Minimal PATH lookup for an executable (no extra deps).
+fn which(tool: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(tool);
+        if candidate.is_file()
+            && candidate
+                .metadata()
+                .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::env_lock;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    fn base_config(bundle_root: &Path) -> RuntimeConfig {
+        let paths = RuntimePaths {
+            config_file: bundle_root.join("config.toml"),
+            state_file: bundle_root.join("state.json"),
+            log_file: bundle_root.join("log"),
+            cache_dir: bundle_root.join("cache"),
+            state_dir: bundle_root.join("state"),
+            config_dir: bundle_root.join("config"),
+        };
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.builder_bundle_root = bundle_root.to_path_buf();
+        config
+    }
+
+    fn runtime_paths(root: &Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config.toml"),
+            state_file: root.join("state.json"),
+            log_file: root.join("log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    /// Writes a fake `scripts/lib/linux-features.js` that emits a fixed catalog
+    /// for `--features-json` and a fixed enabled list for `--enabled`.
+    fn write_fake_catalog_script(source: &Path) {
+        let script_dir = source.join("scripts/lib");
+        std::fs::create_dir_all(&script_dir).unwrap();
+        std::fs::write(
+            script_dir.join("linux-features.js"),
+            r#"
+const arg = process.argv[2];
+if (arg === "--features-json") {
+  process.stdout.write(JSON.stringify([
+    {"id":"alpha","title":"Alpha Feature"},
+    {"id":"beta","title":"Beta Feature"}
+  ]));
+} else if (arg === "--enabled") {
+  process.stdout.write("alpha\n");
+}
+"#,
+        )
+        .unwrap();
+    }
+
+    /// Installs a fake dialog tool on a temp PATH that echoes `stdout_lines` and
+    /// exits with `exit_code`. Returns the temp dir (keep alive) and the PATH.
+    fn fake_dialog(
+        name: &str,
+        stdout_lines: &str,
+        exit_code: i32,
+    ) -> (tempfile::TempDir, std::ffi::OsString) {
+        let dir = tempdir().unwrap();
+        let bin = dir.path().join(name);
+        std::fs::write(
+            &bin,
+            format!("#!/bin/sh\nprintf '%s' \"{stdout_lines}\"\nexit {exit_code}\n"),
+        )
+        .unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let path = dir.path().as_os_str().to_os_string();
+        (dir, path)
+    }
+
+    #[test]
+    fn skips_without_display() {
+        let _g = env_lock();
+        std::env::remove_var("DISPLAY");
+        std::env::remove_var("WAYLAND_DISPLAY");
+        let root = tempdir().unwrap();
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+        // No display -> Ok, no config written.
+        run_pick_features(&config, &paths, false).unwrap();
+        assert!(!root
+            .path()
+            .join("config/codex-desktop/linux-features.json")
+            .exists());
+    }
+
+    #[test]
+    fn candidate_sources_prefers_bundle_with_catalog_script() {
+        let root = tempdir().unwrap();
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+        assert!(candidate_sources(&config, &paths).is_empty());
+        write_fake_catalog_script(root.path());
+        assert_eq!(
+            candidate_sources(&config, &paths),
+            vec![root.path().to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn selection_writes_feature_config_outside_wrapper_src() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        // Pin settings.json (and thus feature_config_path) into a temp dir.
+        let settings_file = settings.path().join("settings.json");
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        // zenity selects beta + alpha (no sentinel).
+        let (_d, fake_path) = fake_dialog("zenity", "beta\nalpha", 0);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+
+        // feature_config_path is alongside settings.json, NOT under wrapper-src.
+        let written = settings.path().join("linux-features.json");
+        assert!(written.is_file(), "feature config must be written");
+        assert!(!root.path().join("linux-features.json").exists());
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&written).unwrap()).unwrap();
+        let enabled: Vec<String> = value["enabled"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(enabled, vec!["alpha".to_string(), "beta".to_string()]);
+        // Picker-on-update setting untouched (no sentinel selected).
+        let settings_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_file).unwrap_or_default())
+                .unwrap_or(serde_json::json!({}));
+        assert!(settings_json
+            .get("codex-linux-feature-picker-on-update")
+            .is_none());
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn selection_preserves_unknown_existing_feature_ids() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        let settings_file = settings.path().join("settings.json");
+        let feature_config = settings.path().join("linux-features.json");
+        std::fs::write(
+            &feature_config,
+            r#"{
+  "enabled": ["alpha", "private-local-feature"]
+}
+"#,
+        )
+        .unwrap();
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        let (_d, fake_path) = fake_dialog("zenity", "beta", 0);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&feature_config).unwrap()).unwrap();
+        let enabled: Vec<String> = value["enabled"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        assert_eq!(
+            enabled,
+            vec!["beta".to_string(), "private-local-feature".to_string()]
+        );
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn dont_ask_sentinel_writes_setting() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        let settings_file = settings.path().join("settings.json");
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        // Selection includes the sentinel + alpha.
+        let (_d, fake_path) = fake_dialog("zenity", "alpha\n__dont_ask_again__", 0);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+
+        let written = settings.path().join("linux-features.json");
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&written).unwrap()).unwrap();
+        let enabled: Vec<String> = value["enabled"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        // Sentinel stripped, only real feature id remains.
+        assert_eq!(enabled, vec!["alpha".to_string()]);
+        let settings_json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&settings_file).unwrap()).unwrap();
+        assert_eq!(
+            settings_json["codex-linux-feature-picker-on-update"],
+            serde_json::Value::Bool(false)
+        );
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn cancel_leaves_config_unchanged() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let settings = tempdir().unwrap();
+        write_fake_catalog_script(root.path());
+        let config = base_config(root.path());
+        let paths = runtime_paths(root.path());
+
+        let settings_file = settings.path().join("settings.json");
+        std::env::set_var("CODEX_LINUX_SETTINGS_FILE", &settings_file);
+        std::env::set_var("DISPLAY", ":99");
+        std::env::remove_var("WAYLAND_DISPLAY");
+
+        // Nonzero exit = cancel.
+        let (_d, fake_path) = fake_dialog("zenity", "", 1);
+        let prev_path = std::env::var_os("PATH");
+        let mut joined = fake_path.clone();
+        if let Some(prev) = &prev_path {
+            joined.push(":");
+            joined.push(prev);
+        }
+        std::env::set_var("PATH", &joined);
+
+        run_pick_features(&config, &paths, false).unwrap();
+        assert!(
+            !settings.path().join("linux-features.json").exists(),
+            "cancel must not write a feature config"
+        );
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+        std::env::remove_var("CODEX_LINUX_SETTINGS_FILE");
+        std::env::remove_var("DISPLAY");
+    }
+
+    #[test]
+    fn dialog_tool_requires_executable_file() {
+        let _g = env_lock();
+        let dir = tempdir().unwrap();
+        let zenity = dir.path().join("zenity");
+        std::fs::write(&zenity, "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(&zenity, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let prev_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", dir.path());
+
+        assert_eq!(dialog_tool(), None);
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+    }
+
+    #[test]
+    fn dialog_launch_error_is_a_cancelled_picker() {
+        let _g = env_lock();
+        let dir = tempdir().unwrap();
+        let zenity = dir.path().join("zenity");
+        std::fs::write(&zenity, "#!/missing/interpreter\n").unwrap();
+        std::fs::set_permissions(&zenity, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let prev_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", dir.path());
+
+        let catalog = vec![CatalogEntry {
+            id: "alpha".to_string(),
+            title: "Alpha".to_string(),
+        }];
+        let enabled = std::collections::HashSet::new();
+        let result = show_picker(&DialogTool::Zenity, &catalog, &enabled).unwrap();
+        assert_eq!(result, None);
+
+        if let Some(prev) = prev_path {
+            std::env::set_var("PATH", prev);
+        }
+    }
+}

--- a/updater/src/feature_picker.rs
+++ b/updater/src/feature_picker.rs
@@ -85,9 +85,10 @@ fn pick(config: &RuntimeConfig, paths: &RuntimePaths) -> Result<PickOutcome> {
     let Some(tool) = dialog_tool() else {
         return Ok(PickOutcome::Skipped("no-dialog-tool"));
     };
-    // Try each candidate source in turn; the first that yields a non-empty
-    // catalog wins. This skips a stale builder bundle whose linux-features.js
-    // predates `--features-json` and falls through to a current checkout.
+    // Try each allowed source in turn; the first that yields a non-empty catalog
+    // wins. If a wrapper-update candidate is recorded, candidate_sources()
+    // returns only that prepared candidate checkout so the picker cannot fall
+    // back to the installed wrapper catalog.
     let mut chosen: Option<(PathBuf, Vec<CatalogEntry>)> = None;
     for source in candidate_sources(config, paths) {
         match read_catalog(config, &source) {
@@ -180,33 +181,29 @@ enum DialogTool {
 /// recorded candidate, fall back to the installed builder bundle for manual
 /// `pick-features` invocations.
 fn candidate_sources(config: &RuntimeConfig, paths: &RuntimePaths) -> Vec<PathBuf> {
-    if let Some(candidate_source) = candidate_wrapper_source(config, paths) {
-        return vec![candidate_source]
-            .into_iter()
-            .filter(|dir| dir.join("scripts/lib/linux-features.js").is_file())
-            .collect();
+    let candidate_commit =
+        PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit)
+            .ok()
+            .and_then(|state| state.candidate_wrapper_commit);
+
+    if let Some(candidate_commit) = candidate_commit.as_deref() {
+        return match wrapper_apply::ensure_wrapper_source(config, paths, Some(candidate_commit)) {
+            Ok(source) if source.join("scripts/lib/linux-features.js").is_file() => vec![source],
+            Ok(_) => Vec::new(),
+            Err(error) => {
+                warn!(
+                    ?error,
+                    "feature picker could not prepare candidate wrapper source"
+                );
+                Vec::new()
+            }
+        };
     }
 
     [config.builder_bundle_root.clone()]
         .into_iter()
         .filter(|dir| dir.join("scripts/lib/linux-features.js").is_file())
         .collect()
-}
-
-fn candidate_wrapper_source(config: &RuntimeConfig, paths: &RuntimePaths) -> Option<PathBuf> {
-    let state =
-        PersistedState::load_or_default(&paths.state_file, config.auto_install_on_app_exit).ok()?;
-    let candidate_commit = state.candidate_wrapper_commit.as_deref()?;
-    match wrapper_apply::ensure_wrapper_source(config, paths, Some(candidate_commit)) {
-        Ok(source) => Some(source),
-        Err(error) => {
-            warn!(
-                ?error,
-                "feature picker could not prepare candidate wrapper source"
-            );
-            None
-        }
-    }
 }
 
 /// Resolves a node binary: the bundle's managed runtime first, then PATH.
@@ -461,6 +458,31 @@ if (arg === "--features-json") {
         .unwrap();
     }
 
+    fn git(repo: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(repo)
+            .args(args)
+            .status()
+            .expect("git should run");
+        assert!(status.success(), "git {args:?} failed with {status}");
+    }
+
+    fn init_fake_catalog_repo(repo: &Path) -> String {
+        git(repo, &["init", "-q", "-b", "main"]);
+        git(repo, &["config", "user.email", "codex@example.invalid"]);
+        git(repo, &["config", "user.name", "Codex Test"]);
+        write_fake_catalog_script(repo);
+        git(repo, &["add", "-A"]);
+        git(repo, &["commit", "-q", "-m", "catalog"]);
+        let output = Command::new("git")
+            .current_dir(repo)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("git rev-parse should run");
+        assert!(output.status.success());
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
+    }
+
     /// Installs a fake dialog tool on a temp PATH that echoes `stdout_lines` and
     /// exits with `exit_code`. Returns the temp dir (keep alive) and the PATH.
     fn fake_dialog(
@@ -506,6 +528,60 @@ if (arg === "--features-json") {
         assert_eq!(
             candidate_sources(&config, &paths),
             vec![root.path().to_path_buf()]
+        );
+    }
+
+    #[test]
+    fn candidate_sources_uses_recorded_candidate_checkout() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let remote = tempdir().unwrap();
+        let paths = runtime_paths(root.path());
+        paths.ensure_dirs().unwrap();
+        write_fake_catalog_script(root.path());
+        let commit = init_fake_catalog_repo(remote.path());
+
+        let mut config = base_config(root.path());
+        config.wrapper_remote =
+            format!("file://{}", remote.path().canonicalize().unwrap().display());
+        let mut state = PersistedState::new(true);
+        state.candidate_wrapper_commit = Some(commit);
+        state.save(&paths.state_file).unwrap();
+
+        assert_eq!(
+            candidate_sources(&config, &paths),
+            vec![paths.cache_dir.join("wrapper-src")]
+        );
+    }
+
+    #[test]
+    fn candidate_sources_do_not_fallback_when_recorded_candidate_cannot_be_prepared() {
+        let _g = env_lock();
+        let root = tempdir().unwrap();
+        let paths = runtime_paths(root.path());
+        paths.ensure_dirs().unwrap();
+        write_fake_catalog_script(root.path());
+
+        let config = base_config(root.path());
+        let mut state = PersistedState::new(true);
+        state.candidate_wrapper_commit = Some("a".repeat(40));
+        state.save(&paths.state_file).unwrap();
+
+        let empty_path = tempdir().unwrap();
+        let previous_path = std::env::var_os("PATH");
+        std::env::set_var("PATH", empty_path.path());
+
+        let sources = candidate_sources(&config, &paths);
+
+        if let Some(previous_path) = previous_path {
+            std::env::set_var("PATH", previous_path);
+        } else {
+            std::env::remove_var("PATH");
+        }
+
+        assert!(
+            sources.is_empty(),
+            "recorded candidate failures must not use the installed catalog"
         );
     }
 

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -7,6 +7,7 @@ mod changelog;
 mod cli;
 mod codex_cli;
 mod config;
+mod feature_picker;
 mod install;
 mod install_rollback;
 mod liveness;

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -132,7 +132,7 @@ async fn apply_user_local(
     paths: &RuntimePaths,
     candidate_commit: Option<&str>,
 ) -> Result<()> {
-    let feature_config = picked_feature_config();
+    let feature_config = effective_feature_config(config);
     if let Some(helper) = user_local_update_helper() {
         info!(helper = %helper.display(), "applying wrapper update via user-local helper");
         let mut cmd = Command::new(&helper);
@@ -184,11 +184,10 @@ async fn apply_user_local(
     Ok(())
 }
 
-/// The user's saved feature selection from the in-app Update feature picker, if
-/// the file exists. Threaded into both apply paths so the rebuild stages exactly
-/// those features. Absent ⇒ `None` (the build keeps its existing default).
-fn picked_feature_config() -> Option<PathBuf> {
-    crate::config::feature_config_path().filter(|path| path.is_file())
+/// The feature selection to use for this rebuild: saved picker selection first,
+/// then the installed builder bundle's preserved feature config.
+fn effective_feature_config(config: &RuntimeConfig) -> Option<PathBuf> {
+    crate::config::effective_feature_config_path(config)
 }
 
 fn user_local_update_helper() -> Option<PathBuf> {

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -15,6 +15,7 @@
 
 use anyhow::{Context, Result};
 use std::{
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -131,10 +132,17 @@ async fn apply_user_local(
     paths: &RuntimePaths,
     candidate_commit: Option<&str>,
 ) -> Result<()> {
+    let feature_config = picked_feature_config();
     if let Some(helper) = user_local_update_helper() {
         info!(helper = %helper.display(), "applying wrapper update via user-local helper");
-        let status = Command::new(&helper)
-            .arg("--quiet")
+        let mut cmd = Command::new(&helper);
+        cmd.arg("--quiet");
+        // The contrib helper honors a caller-set CODEX_LINUX_FEATURES_CONFIG over
+        // its repo-local default, so the in-app picker's selection wins.
+        if let Some(config_path) = &feature_config {
+            cmd.env("CODEX_LINUX_FEATURES_CONFIG", config_path);
+        }
+        let status = cmd
             .status()
             .with_context(|| format!("Failed to run {}", helper.display()))?;
         if !status.success() {
@@ -159,11 +167,15 @@ async fn apply_user_local(
         );
     }
     info!(app_dir = %app_dir.display(), "rebuilding user-local app in place via install.sh");
-    let status = Command::new(&install_sh)
-        .current_dir(&wrapper_src)
+    let mut cmd = Command::new(&install_sh);
+    cmd.current_dir(&wrapper_src)
         .env("CODEX_INSTALL_ALLOW_RUNNING", "1")
         .env("CODEX_INSTALL_ROOT", &install_root)
-        .env("CODEX_INSTALL_DIR", &app_dir)
+        .env("CODEX_INSTALL_DIR", &app_dir);
+    if let Some(config_path) = &feature_config {
+        cmd.env("CODEX_LINUX_FEATURES_CONFIG", config_path);
+    }
+    let status = cmd
         .status()
         .with_context(|| format!("Failed to run {}", install_sh.display()))?;
     if !status.success() {
@@ -172,10 +184,21 @@ async fn apply_user_local(
     Ok(())
 }
 
+/// The user's saved feature selection from the in-app Update feature picker, if
+/// the file exists. Threaded into both apply paths so the rebuild stages exactly
+/// those features. Absent ⇒ `None` (the build keeps its existing default).
+fn picked_feature_config() -> Option<PathBuf> {
+    crate::config::feature_config_path().filter(|path| path.is_file())
+}
+
 fn user_local_update_helper() -> Option<PathBuf> {
     let home = std::env::var_os("HOME").map(PathBuf::from)?;
     let candidate = home.join(".local/bin/codex-desktop-update");
-    if candidate.is_file() {
+    if candidate.is_file()
+        && candidate
+            .metadata()
+            .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+    {
         Some(candidate)
     } else {
         None
@@ -242,7 +265,7 @@ async fn apply_packaged(
 
 /// Clones or refreshes a managed wrapper checkout under the workspace cache and
 /// returns its path. Never touches the user's working tree.
-fn ensure_wrapper_source(
+pub(crate) fn ensure_wrapper_source(
     config: &RuntimeConfig,
     paths: &RuntimePaths,
     candidate_commit: Option<&str>,
@@ -376,7 +399,11 @@ fn which(tool: &str) -> Option<PathBuf> {
     let path = std::env::var_os("PATH")?;
     for dir in std::env::split_paths(&path) {
         let candidate = dir.join(tool);
-        if candidate.is_file() {
+        if candidate.is_file()
+            && candidate
+                .metadata()
+                .is_ok_and(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        {
             return Some(candidate);
         }
     }


### PR DESCRIPTION
## Summary
- The in-app wrapper Update button now opens a feature picker (zenity/kdialog checklist, pre-checked with the currently-enabled features) on each update, so you can re-choose which optional Linux features to enable before the rebuild.
- A "(Don't ask again on future updates)" row, or the "Ask which features to enable on update" toggle in Keybinds → Updates (`codex-linux-feature-picker-on-update`), suppresses the prompt.
- The selection is saved to `~/.config/<appId>/linux-features.json` and the rebuild honors it via `CODEX_LINUX_FEATURES_CONFIG`.

## Why
The wrapper Update button rebuilt with whatever feature set was already enabled. This lets each update revisit that choice, with a clear opt-out, so the rebuild doesn't silently lock in a stale selection.

## Stacked on
Diffed against two PRs in the same stack until they merge:
- #358 (GUI feature picker) — shares the zenity/kdialog approach and the same `linux-features.js` catalog access.
- #360 (in-app wrapper update button) — provides the button + apply path this hooks into.

Please merge #358 and #360 first; I'll rebase after they land.

## Design / safety
- The picker runs at **click time** (a new `codex-update-manager pick-features` subcommand), while the display is still alive — the detached apply runs headless after the app exits, so the dialog cannot run there.
- The installed app bundle ships no feature catalog, so the picker reads it from a wrapper source checkout (builder bundle, then a warm cache). A stale bundle whose `linux-features.js` predates `--features-json` is transparently skipped in favor of a current checkout.
- Every failure mode (no display, no dialog tool, no catalog, cancel) is a graceful skip that leaves the current feature set unchanged — the picker never blocks or fails the update.
- The saved config lives outside any wrapper-src checkout so a fresh clone can't clobber it; the contrib `codex-desktop-update` helper's `CODEX_LINUX_FEATURES_CONFIG` export is made conditional so the picked path wins.

## Source-of-truth files
- `updater/src/feature_picker.rs` *(new)* — `pick-features` subcommand (catalog read, dialog, write).
- `updater/src/{config.rs,cli.rs,app.rs,main.rs,wrapper_apply.rs}` — `feature_config_path()` + picker setting, `PickFeatures` wiring, and threading `CODEX_LINUX_FEATURES_CONFIG` into both apply paths.
- `linux-features/codex-wrapper-updater/patch.js` — invoke the picker on click before marker + exit.
- `scripts/patches/{shared.js,keybinds-settings.js}` — picker toggle.
- `contrib/.../codex-desktop-update` — conditional feature-config export.

## Validation
- `cargo test -p codex-update-manager` — pass (144; incl. write-config, path-outside-wrapper-src, fake-zenity selection/cancel, no-display skip, don't-ask-again-writes-key)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `node -e "require('./linux-features/codex-wrapper-updater/patch.js')"`; `bash tests/scripts_smoke.sh` — pass
- Live: clicked Update → checklist appeared pre-filled → picked → the rebuild used the selection; the "(Don't ask again)" row wrote the setting and suppressed the next prompt.

## Versioning
Backward-compatible feature addition to the updater crate (new `pick-features` subcommand + `#[serde(default)]` settings key); version bump deferred to the stack's merge order.

## Notes
No linked issue. The repo already serialises env-mutating updater unit tests via a shared lock; the new `feature_picker` tests follow that same pattern.
