### PR TITLE
[codex] fix Nix pin validation for latest DMG

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,10 +66,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-yanuEZhqD4gBWLgeRZtktoRkI5b0nq9/oOAY9KjDe0I=";
+          hash = "sha256-L5fZniPJ9N1mwOAr2tpebGa/Z3cs2J+IaoG1udfrSHw=";
         };
 
-        codexVersion = "26.519.81530";
+        codexVersion = "26.527.30818";
         electronVersion = "42.1.0";
         electronPlatform =
           {

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -130,6 +130,57 @@ json_file_field() {
     node -e "const value = require(process.argv[1]); process.stdout.write(String($expression ?? ''));" "$json_path"
 }
 
+sanitize_electron_version() {
+    local value="$1"
+    value="${value#v}"
+    value="${value#^}"
+    value="${value#~}"
+
+    if [[ "$value" =~ ^[0-9]+(\.[0-9]+){2}([.-][0-9A-Za-z]+)*$ ]]; then
+        echo "$value"
+        return 0
+    fi
+
+    return 1
+}
+
+read_plist_key() {
+    local plist_path="$1"
+    local key="$2"
+
+    python3 - "$plist_path" "$key" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as handle:
+    print(plistlib.load(handle).get(sys.argv[2], ""))
+PY
+}
+
+detect_dmg_electron_version() {
+    local app_dir="$1"
+    local asar_extract_dir="$2"
+    local detected=""
+    local detected_version=""
+    local plist_path="$app_dir/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist"
+
+    if [ -f "$plist_path" ]; then
+        detected="$(read_plist_key "$plist_path" CFBundleVersion)"
+        if detected_version="$(sanitize_electron_version "$detected")"; then
+            echo "$detected_version"
+            return 0
+        fi
+    fi
+
+    detected="$(json_file_field "$asar_extract_dir/package.json" "(value.devDependencies?.electron || value.dependencies?.electron)")"
+    if detected_version="$(sanitize_electron_version "$detected")"; then
+        echo "$detected_version"
+        return 0
+    fi
+
+    fail "Could not find Electron version in DMG"
+}
+
 assert_equal() {
     local label="$1"
     local expected="$2"
@@ -158,20 +209,11 @@ APP_DIR="$(find "$WORK_DIR/dmg" -maxdepth 3 -name "*.app" -type d | head -1)"
 [ -n "$APP_DIR" ] || fail "Could not find .app bundle in $UPSTREAM_DMG_PATH"
 
 ASAR_PATH="$APP_DIR/Contents/Resources/app.asar"
-PLIST_PATH="$APP_DIR/Contents/Frameworks/Electron Framework.framework/Versions/A/Resources/Info.plist"
 [ -f "$ASAR_PATH" ] || fail "Could not find app.asar in DMG"
-[ -f "$PLIST_PATH" ] || fail "Could not find Electron Info.plist in DMG"
 ASAR_EXTRACT_DIR="$WORK_DIR/app-extracted"
 npx --yes asar extract "$ASAR_PATH" "$ASAR_EXTRACT_DIR"
 
-dmg_electron_version="$(python3 - "$PLIST_PATH" <<'PY'
-import plistlib
-import sys
-
-with open(sys.argv[1], "rb") as handle:
-    print(plistlib.load(handle).get("CFBundleVersion", ""))
-PY
-)"
+dmg_electron_version="$(detect_dmg_electron_version "$APP_DIR" "$ASAR_EXTRACT_DIR")"
 dmg_codex_version="$(json_file_field "$ASAR_EXTRACT_DIR/package.json" "value.version")"
 dmg_better_sqlite3_version="$(json_file_field "$ASAR_EXTRACT_DIR/node_modules/better-sqlite3/package.json" "value.version")"
 dmg_node_pty_version="$(json_file_field "$ASAR_EXTRACT_DIR/node_modules/node-pty/package.json" "value.version")"


### PR DESCRIPTION
## Summary

- refreshes `flake.nix` to the current upstream `Codex.dmg` (`26.527.30818`)

- teaches `validate-nix-pins.sh` to fall back to the Electron version in `app.asar` package metadata when upstream no longer ships `Electron Framework.framework/Versions/A/Resources/Info.plist`

## Validation
- `bash -n scripts/ci/validate-nix-pins.sh scripts/ci/update-nix-hashes.sh`

- `nix shell nixpkgs#{curl,p7zip,python3,nodejs_24} --command bash -lc 'bash scripts/ci/validate-nix-pins.sh /tmp/Codex.dmg'`

- `scripts/ci/update-nix-hashes.sh` via a Nix shell with curl/p7zip/python3/nodejs_24, including all configured Nix package outputs

- `nix flake check --no-build`
## Root cause

The latest upstream DMG layout renamed the embedded framework path, so CI failed before it could compare the actual app and native-module pins. The root package metadata still carries the Electron dependency and is already used as the installer fallback.