### PR TITLE
[codex] use Cachix substitutions in Nix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,12 @@ jobs:
 
       - uses: cachix/install-nix-action@v27
 
+      - name: Configure Cachix for Nix build substitutions
+        uses: cachix/cachix-action@v17
+        with:
+          name: codex-desktop-linux
+          skipPush: true
+
       - name: Install validation dependencies
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- configure the normal Nix CI job to use the public `codex-desktop-linux` Cachix cache

- set `skipPush: true` so PR/main CI only substitutes from the cache and does not upload store paths

## Validation
- `nix shell nixpkgs#actionlint --command actionlint .github/workflows/ci.yml`

## Follow-up

This makes CI able to consume cached paths. The next build-speed win is to narrow/factor DMG-independent derivations so Computer Use binaries and Electron native modules keep stable store paths across unrelated repo and DMG changes.