### PR TITLE
Fix open-target startup crash from path alias shadowing

### DIFF
--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -130,6 +130,8 @@ function insertOpenTargetHelpers(currentSource, insertionIndex, { fsVar, pathVar
   }
 
   const helpers =
+    `function codexLinuxNodeFs(){return require(\`node:fs\`)}` +
+    `function codexLinuxNodePath(){return require(\`node:path\`)}` +
     `function codexLinuxFindExecutable(e){if(process.platform!==\`linux\`||!e)return null;let t=process.env.PATH||\`\`;for(let n of t.split(\`:\`)){if(!n||!${pathVar}.isAbsolute(n))continue;let r=(0,${pathVar}.join)(n,e);try{if((0,${fsVar}.existsSync)(r)){let e=(0,${fsVar}.statSync)(r);if(e.isFile())try{(0,${fsVar}.accessSync)(r,${fsVar}.constants.X_OK);return r}catch{}}}catch{}}return null}` +
     `function codexLinuxResolveExistingTarget(e){if(typeof e!==\`string\`||e.length===0)return null;let t=e;for(;;){try{if((0,${fsVar}.existsSync)(t))return t}catch{}let n=(0,${pathVar}.dirname)(t);if(n===t)return null;t=n}}` +
     `function codexLinuxShouldDropXdgConfigHome(e){let t=e.XDG_CONFIG_HOME,n=e.CODEX_ELECTRON_USER_DATA_DIR;if(typeof t!==\`string\`)return!1;if(typeof n===\`string\`&&t===(0,${pathVar}.join)((0,${pathVar}.dirname)(n),\`xdg-config\`))return!0;let r=e.CODEX_LINUX_APP_ID;return!!(r&&t.endsWith(\`/\${r}/xdg-config\`))}` +
@@ -458,7 +460,11 @@ function applyMainBundlePatch(currentSource) {
     return currentSource;
   }
 
-  const deps = { electronVar, fsVar, pathVar };
+  const deps = {
+    electronVar,
+    fsVar: "codexLinuxNodeFs()",
+    pathVar: "codexLinuxNodePath()",
+  };
   let patchedSource = currentSource;
   if (electronVar != null) {
     patchedSource = applyFileManagerDiscoveryPatch(patchedSource, deps);

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -28,6 +28,11 @@ const terminalOpenTargetBundle =
 const ideOpenTargetsBundle =
   "function ih({id:e,label:t,icon:n,darwinDetect:r,win32Detect:i,darwinEnv:a,darwinArgs:o,hidden:s}){return{id:e,platforms:{darwin:r?{label:t,icon:n,kind:`editor`,hidden:s,detect:r,env:a,args:o??ah,supportsSsh:!0}:void 0,win32:i?{label:t,icon:n,kind:`editor`,hidden:s,detect:i,args:ah,supportsSsh:!0}:void 0}}}var ah=(e,t)=>t?[`${e}:${t.line}:${t.column}`]:[e];var Og=ih({id:`vscode`,label:`VS Code`,icon:`apps/vscode.png`,darwinDetect:()=>`open`,win32Detect:()=>`Code.exe`});var jh=ih({id:`cursor`,label:`Cursor`,icon:`apps/cursor.png`,darwinDetect:()=>`open`,win32Detect:()=>`Cursor.exe`});function sg({id:e,label:t,icon:n,toolboxTarget:r,macExecutable:i,windowsPathCommands:a,windowsInstallDirPrefixes:o,windowsInstallExecutables:s}){return{id:e,platforms:{darwin:{label:t,icon:n,kind:`editor`,detect:()=>`open`,args:mg},win32:a&&o&&s?{label:t,icon:n,kind:`editor`,detect:()=>`idea.exe`,args:mg}:void 0}}}function mg(e,t){return t?[`--line`,t.line.toString(),`--column`,t.column.toString(),e]:[e]}var $h=sg({id:`intellij`,label:`IntelliJ IDEA`,icon:`apps/intellij.png`,toolboxTarget:`intellij`,macExecutable:`idea`,windowsPathCommands:[`idea`],windowsInstallDirPrefixes:[`idea`],windowsInstallExecutables:[`idea`]});var Wg={id:`zed`,platforms:{darwin:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Gg,args:hg},win32:{label:`Zed`,icon:`apps/zed.png`,kind:`editor`,detect:Kg,args:hg}}};function Gg(){}function Kg(){}function hg(e,t){return t?[`${e}:${t.line}:${t.column}`]:[e]}var Xg=[Og,jh,Wg,$h];";
 const openTargetsBundle = `${mainBundlePrefix}${fileManagerBundle}${terminalOpenTargetBundle}${ideOpenTargetsBundle}`;
+const collidingPathAliasBundle =
+  "let n=require(`electron`),o=require(`node:path`),c=require(`node:fs`),u=require(`node:child_process`);" +
+  fileManagerBundle +
+  terminalOpenTargetBundle +
+  ideOpenTargetsBundle;
 const iconResolverBundle =
   "async function c_(e,t,a){return e===`win32`?Promise.all(t.map(async e=>{let t=a?.get(e.id)??null,r=e.iconPath?e.iconPath(t):t;return{id:e.id,label:e.label,icon:await d_(r,e.icon),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}})):l_(t)}function l_(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}async function d_(e,t){if(!e)return t;try{let r=e.toLowerCase().endsWith(`.lnk`)?await f_(e):await n.app.getFileIcon(e,{size:`normal`});return!r||r.isEmpty()?t:r.toDataURL()}catch(e){return t}}async function f_(e){return n.nativeImage.createFromPath(e)}";
 
@@ -381,6 +386,19 @@ test("open-target discovery evaluates TryExec parser", () => {
       "[codexLinuxDesktopTryExecAvailable(" + quoted + "),codexLinuxTerminalTryExecAvailable(" + quoted + ")]",
     );
     assert.deepEqual(result, [expected, expected], command);
+  });
+});
+
+test("open-target discovery tolerates path and fs aliases used by helper locals", () => {
+  withTempDir((tmp) => {
+    const command = "env /missing/Cursor.AppImage";
+    const result = evaluatePatched(
+      collidingPathAliasBundle,
+      tryExecEnv(tmp, { binNames: ["env"] }),
+      "[codexLinuxDesktopTryExecAvailable(" + JSON.stringify(command) + "),codexLinuxTerminalTryExecAvailable(" + JSON.stringify(command) + ")]",
+    );
+
+    assert.deepEqual(result, [false, false]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Added stable `codexLinuxNodeFs()` / `codexLinuxNodePath()` accessors for injected open-target helpers instead of reusing upstream minified module aliases.
- Added a regression test that reproduces a `node:path` alias collision with helper-local variables.

## Why
The current upstream bundle can minify `node:path` to `o`. `codexLinuxDesktopTryExecAvailable()` also declared local `var o`, which hoisted over the path module alias and made startup throw `Cannot read properties of undefined (reading 'basename')` while scanning Linux desktop entries.

## Source of truth
- `linux-features/open-target-discovery/patch.js`
- `linux-features/open-target-discovery/test.js`

## Validation
- `node --test linux-features/open-target-discovery/test.js`
- `./install.sh --reuse-dmg`
- `CODEX_MULTI_LAUNCH=1 ./codex-app/start.sh` reached normal renderer/app-server startup instead of the bootstrap `basename` crash.
- `make pacman` built `dist/codex-desktop-2026.05.30.080638-1-x86_64.pkg.tar.zst`.

## Risks / follow-up
- No generated artifacts are included in this PR.
- Scope is limited to the opt-in `open-target-discovery` Linux feature.