### PR TITLE
fix(appshots): handle upstream hotkey drift

### DIFF
--- a/linux-features/appshots/README.md
+++ b/linux-features/appshots/README.md
@@ -34,12 +34,13 @@ Privacy and correctness constraints:
 - Capture fails closed when no screenshot tool is available or the crop does not
   intersect the captured image.
 - Global hotkeys are disabled by default on Linux until the user chooses one in
-  AppShots settings. The dropdown includes upstream-style `Shift + Shift` plus
-  ordinary Electron accelerators such as `Ctrl+Super+A`, `Alt+Super+A`, and
-  `Ctrl+Alt+A`.
-- `Shift + Shift` is backed by a feature-local `bare-modifier-monitor` helper
-  staged into `resources/native/`. It uses `xinput` and `xmodmap`, so it is
-  expected to work on X11 sessions and fail closed elsewhere.
+  AppShots settings. The dropdown mirrors upstream's bare-modifier choices where
+  they are practical on Linux (`Alt + Alt` and `Shift + Shift`) and keeps
+  `Ctrl+Super+A` as a non-bare fallback.
+- `Alt + Alt` and `Shift + Shift` are backed by a feature-local
+  `bare-modifier-monitor` helper staged into `resources/native/`. It uses
+  `xinput` and `xmodmap`, so it is expected to work on X11 sessions and fail
+  closed elsewhere.
 
 Run the feature self-test:
 

--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -2,10 +2,9 @@
 
 const APPSHOT_HELPER_MARKER = "codexLinuxAppshotStartCapture";
 const LINUX_APPSHOT_HOTKEYS = [
+  { hotkey: "DoubleOption", label: "Alt + Alt" },
   { hotkey: "DoubleShift", label: "Shift + Shift" },
   { hotkey: "Ctrl+Super+A", label: "Ctrl + Super + A" },
-  { hotkey: "Alt+Super+A", label: "Alt + Super + A" },
-  { hotkey: "Ctrl+Alt+A", label: "Ctrl + Alt + A" },
 ];
 
 function warn(message, patchName) {
@@ -77,19 +76,41 @@ function applyLinuxAppshotMainProcessPatch(currentSource) {
 
 function applyLinuxAppshotHotkeyPatch(currentSource) {
   currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?`DoubleShift`:([A-Za-z_$][\w$]*)\);/g,
-    (match, configuredVar, globalStateVar, defaultHotkeyVar) =>
-      `let ${configuredVar}=${globalStateVar}.get(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?`DoubleShift`:([A-Za-z_$][\w$]*)\);/g,
+    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar) =>
+      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
   );
   currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\);/g,
-    (match, configuredVar, globalStateVar, defaultHotkeyVar) =>
-      `let ${configuredVar}=${globalStateVar}.get(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\);/g,
+    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar) =>
+      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
   );
   currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*);let ([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:\1,isActive:\4!=null\}\)/g,
-    (match, configuredVar, globalStateVar, defaultHotkeyVar, registrationVar, stateFnVar, enabledVar) =>
-      `let ${configuredVar}=${globalStateVar}.get(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null})`,
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*);let ([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:\1,isActive:\5!=null\}\)/g,
+    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar, registrationVar, stateFnVar, enabledVar) =>
+      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null})`,
+  );
+  currentSource = currentSource.replace(
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\),([A-Za-z_$][\w$]*)=\1===void 0\?([A-Za-z_$][\w$]*):\1,([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\4,isActive:\6!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\6\?\.unregister\(\),\6=null,!\8\|\|process\.platform!==`darwin`\|\|\4==null\)\{/g,
+    (
+      match,
+      storedVar,
+      globalStateVar,
+      getterName,
+      configuredVar,
+      defaultHotkeyVar,
+      registrationVar,
+      stateFnVar,
+      enabledVar,
+      reconcileFnVar,
+    ) => {
+      return `let ${storedVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`),${configuredVar}=${storedVar}===void 0?(process.platform===\`linux\`?null:${defaultHotkeyVar}):${storedVar},${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
+    },
+  );
+  currentSource = currentSource.replace(
+    /return ([A-Za-z_$][\w$]*)\.length===1\?([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\2\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/g,
+    (match, partsVar, platformVar, supportedBareModifierFn, hotkeyVar) =>
+      `return ${partsVar}.length===1?(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)?${supportedBareModifierFn}(${hotkeyVar},${platformVar})?null:\`This shortcut key is not supported.\`:\`Choose a shortcut with Ctrl or Alt plus another key.\`:\`Use Ctrl, Alt, or Command when combining with another key.\``,
   );
 
   if (
@@ -119,11 +140,12 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
   );
 
   patchedSource = patchedSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\1,isActive:\4!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\4\?\.unregister\(\),\4=null,!\6\|\|process\.platform!==`darwin`\|\|\1==null\)\{/,
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\1,isActive:\5!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\5\?\.unregister\(\),\5=null,!\7\|\|process\.platform!==`darwin`\|\|\1==null\)\{/,
     (
       match,
       configuredVar,
       globalStateVar,
+      getterName,
       defaultHotkeyVar,
       registrationVar,
       stateFnVar,
@@ -131,7 +153,7 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
       reconcileFnVar,
     ) => {
       changed = true;
-      return `let ${configuredVar}=${globalStateVar}.get(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
+      return `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
     },
   );
 

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -52,6 +52,16 @@ function appshotHotkeyMainBundleFixture() {
   ].join("");
 }
 
+function appshotHotkeyStoredMainBundleFixture() {
+  return [
+    "var bX=`DoubleCommand`,xX=6e4;",
+    "function CE(e,t=process.platform){return t===`darwin`&&TE(e)!=null}",
+    "function vE(e,t,n=`press`){if(process.platform!==`darwin`)return null;let r=TE(e);return r==null?null:DE(r,t,n)}",
+    "function HE(e,t=process.platform){let n=GE(e);if(CE(e,t))return null;if(n.some(wE))return n.length===1?t===`darwin`?CE(e,t)?null:`This shortcut key is not supported.`:`Choose a shortcut with Ctrl or Alt plus another key.`:`Use Ctrl, Alt, or Command when combining with another key.`;return null}",
+    "function SX({globalState:e,windowManager:n,enabled:r}){let i=e.getStored(`appshotHotkey`),a=i===void 0?bX:i,o=null,s=()=>({supported:r&&process.platform===`darwin`,configuredHotkey:a,isActive:o!=null}),c=()=>{if(o?.unregister(),o=null,!r||process.platform!==`darwin`||a==null){t.Nr().info(`Appshot hotkey inactive`,{safe:{enabled:r,platform:process.platform,configured:a!=null},sensitive:{}});return}if(t.Nr().info(`Registering appshot hotkey`,{safe:{hotkey:a},sensitive:{}}),UE(a,{bareModifierTrigger:`immediatePress`}),o=BE(a,{onPressed:()=>{t.Nr().info(`Appshot hotkey pressed`,{safe:{hotkey:a},sensitive:{}});let e=n.getPrimaryWindow();if(e==null||e.isDestroyed()){return}let r=n.wasPrimaryWindowFocusedWithin(e,xX);r||n.sendMessageToWindow(e,{type:`navigate-to-route`,path:`/`,state:{focusComposerNonce:Date.now()}}),n.sendMessageToWindow(e,{type:`appshot-shortcut`})}},{bareModifierTrigger:`immediatePress`}),o==null)throw Error(`Unable to register shortcut: ${a}`);t.Nr().info(`Registered appshot hotkey`,{safe:{hotkey:a},sensitive:{}})},l=n=>{if(!r||process.platform!==`darwin`&&process.platform!==`linux`)return{success:!1,error:`Not supported.`,state:s()};if(n!=null){let e=HE(n);if(e!=null)return{success:!1,error:e,state:s()}}let i=a;a=n;try{c()}catch(e){a=i;return{success:!1,error:e instanceof Error?e.message:String(e),state:s()}}return e.set(`appshotHotkey`,a),{success:!0,state:s()}};try{c()}catch(e){}return{rpc:{getState:s,setHotkey:l},dispose:()=>{o?.unregister(),o=null}}}",
+  ].join("");
+}
+
 function appshotSettingsBundleFixture() {
   return [
     "var O=d(),A=e(t(),1),j=n(),M=[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}];",
@@ -226,6 +236,38 @@ test("enables AppShots hotkeys and bare modifiers on Linux", () => {
   assert.doesNotMatch(patched, /codexLinuxAppshotRegisterBareModifierHotkey/);
 });
 
+test("enables Linux AppShots hotkeys for stored upstream controller shape", () => {
+  const patched = applyPatchTwice(
+    applyLinuxAppshotHotkeyPatch,
+    appshotHotkeyStoredMainBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /function CE\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`\)&&TE\(e\)!=null\}/,
+  );
+  assert.match(
+    patched,
+    /function vE\(e,t,n=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
+  );
+  assert.match(
+    patched,
+    /return n\.length===1\?\(t===`darwin`\|\|t===`linux`\)\?CE\(e,t\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/,
+  );
+  assert.match(
+    patched,
+    /let i=e\.getStored\(`appshotHotkey`\),a=i===void 0\?\(process\.platform===`linux`\?null:bX\):i,o=null/,
+  );
+  assert.match(
+    patched,
+    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\)/,
+  );
+  assert.match(
+    patched,
+    /!r\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|a==null/,
+  );
+});
+
 test("shows Linux AppShots accelerator choices in settings", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotSettingsHotkeyPatch,
@@ -233,10 +275,11 @@ test("shows Linux AppShots accelerator choices in settings", () => {
   );
 
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /hotkey:`DoubleOption`,label:`Alt \+ Alt`/);
   assert.match(patched, /hotkey:`DoubleShift`,label:`Shift \+ Shift`/);
   assert.match(patched, /hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`/);
-  assert.match(patched, /hotkey:`Alt\+Super\+A`,label:`Alt \+ Super \+ A`/);
-  assert.match(patched, /hotkey:`Ctrl\+Alt\+A`,label:`Ctrl \+ Alt \+ A`/);
+  assert.doesNotMatch(patched, /hotkey:`Alt\+Super\+A`/);
+  assert.doesNotMatch(patched, /hotkey:`Ctrl\+Alt\+A`/);
   assert.match(patched, /hotkey:`DoubleCommand`,label:`\\u2318 \+ \\u2318`/);
   assert.match(patched, /hotkey:`DoubleShift`,label:`\\u21e7 \+ \\u21e7`/);
 });
@@ -247,9 +290,11 @@ test("upgrades stale Linux AppShots settings accelerators", () => {
     previouslyPatchedAppshotSettingsBundleFixture(),
   );
 
+  assert.match(patched, /hotkey:`DoubleOption`,label:`Alt \+ Alt`/);
   assert.match(patched, /hotkey:`DoubleShift`,label:`Shift \+ Shift`/);
   assert.match(patched, /hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`/);
-  assert.match(patched, /hotkey:`Alt\+Super\+A`,label:`Alt \+ Super \+ A`/);
+  assert.doesNotMatch(patched, /Alt\+Super\+A/);
+  assert.doesNotMatch(patched, /Ctrl\+Alt\+A/);
   assert.doesNotMatch(patched, /Alt\+Shift\+A/);
   assert.doesNotMatch(patched, /Ctrl\+Shift\+A/);
 });


### PR DESCRIPTION
## Summary
- update the Linux AppShots hotkey patch for upstream's current `getStored` / stored-default controller shape
- keep Linux AppShots defaulting to no hotkey until the user chooses one
- expose Linux hotkeys with better macOS parity: `Alt + Alt`, `Shift + Shift`, plus `Ctrl + Super + A` as the fallback chord

## Source of truth
- `linux-features/appshots/patch.js`
- `linux-features/appshots/test.js`
- `linux-features/appshots/README.md`

## Validation
- `node --test linux-features/appshots/test.js`
- `git diff --check origin/main..HEAD`
- `env npm_config_cache=/tmp/codex-npm-cache make build-dev-app`
- inspected generated `appshots-settings` webview asset for `Alt + Alt`, `Shift + Shift`, `Ctrl + Super + A`, and absence of removed Linux options

## Notes
- AppShots remains an opt-in `linux-features/appshots` feature.
- Bare modifier hotkeys use the feature-local `xinput`/`xmodmap` helper, so they are expected to work on X11 and fail closed elsewhere.