### PR TITLE
fix(read-aloud): route settings to dedicated page

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -211,6 +211,24 @@ function generalSettingsReadAloudBlockSource() {
   return `${generalSettingsReadAloudRowSource()}${generalSettingsReadAloudPageSource()}`;
 }
 
+function currentGeneralSettingsReadAloudBlockSource() {
+  return `function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let[e,t]=(0,X.useState)(!1),[n,r]=(0,X.useState)(1.05),[i,a]=(0,X.useState)(!0),[o,s]=(0,X.useState)(null),c=x();(0,X.useEffect)(()=>{let e=!0;return a(!0),Promise.all([N(\`get-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)}}}),N(\`get-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)}}})]).then(([n,i])=>{e&&(t(n?.value===!0),r(codexLinuxReadAloudPaceValue(i?.value??1.05)),s(null))}).catch(t=>{e&&s(t instanceof Error?t.message:String(t))}).finally(()=>{e&&a(!1)}),()=>{e=!1}},[]);let l=(0,$.jsx)(w,{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),u=(0,$.jsx)(w,{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`});o&&(u=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[u,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:o})]}));let d=c.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),f=c.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),p=c.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),m=c.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),h=c.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),g=e=>{let n=e;t(n),s(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)},value:n}}).catch(e=>{t(!n),s(e instanceof Error?e.message:String(e))})},_=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,v=e=>{let t=codexLinuxReadAloudPaceValue(e.currentTarget.value);r(t),N(\`set-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)},value:t}}).catch(e=>{s(e instanceof Error?e.message:String(e))})};return(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(J,{label:l,description:u,control:(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(q,{checked:e===!0,disabled:i,onChange:g,ariaLabel:d}),e?(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(\`button\`,{type:\`button\`,className:_,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:f}),(0,$.jsx)(\`button\`,{type:\`button\`,className:_,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:p}),(0,$.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:h,"aria-label":h,children:\`?\`})]}):null]})}),e?(0,$.jsx)(J,{label:(0,$.jsx)(w,{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),description:(0,$.jsx)(w,{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),control:(0,$.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,$.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:n,disabled:i,onChange:v,"aria-label":m,className:\`h-2 w-36 accent-token-text-primary\`}),(0,$.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${n.toFixed(2)}x\`})]})}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(vt,{title:(0,$.jsx)(w,{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),children:(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)(Y,{children:[(0,$.jsx)(Y.Header,{title:(0,$.jsx)(w,{id:\`settings.readAloud.voice.title\`,defaultMessage:\`Voice\`,description:\`Title for Linux read aloud voice settings group\`})}),(0,$.jsx)(Y.Content,{children:(0,$.jsx)(bt,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})})]})})})}`;
+}
+
+function exportedGeneralSettingsFunctionName(source) {
+  const exportMatch = source.match(/export\{([^}]*)\};/);
+  if (exportMatch == null) {
+    return null;
+  }
+  for (const exportEntry of exportMatch[1].split(",")) {
+    const match = exportEntry.trim().match(/^([A-Za-z_$][\w$]*) as r$/);
+    if (match != null) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
 function replaceExistingGeneralSettingsReadAloudRow(source) {
   const rowStart = source.indexOf("function codexLinuxReadAloudSettingsRow(){");
   if (rowStart === -1) {
@@ -232,10 +250,17 @@ function removeGeneralSettingsRowPlacement(source) {
 }
 
 function applyGeneralSettingsPatch(source) {
-  const functionNeedle = "function Gn(){";
+  const functionName = source.includes("function Gn(){") ? "Gn" : exportedGeneralSettingsFunctionName(source);
+  if (functionName == null) {
+    return source;
+  }
+  const functionNeedle = `function ${functionName}(){`;
   if (!source.includes(functionNeedle)) {
     return source;
   }
+  const blockSource = functionName === "Gn"
+    ? generalSettingsReadAloudBlockSource()
+    : currentGeneralSettingsReadAloudBlockSource();
   let patched = source;
   if (patched.includes(SETTINGS_KEY)) {
     if (
@@ -247,7 +272,7 @@ function applyGeneralSettingsPatch(source) {
       patched = replaceExistingGeneralSettingsReadAloudRow(patched);
     }
   } else {
-    patched = patched.replace(functionNeedle, `${generalSettingsReadAloudBlockSource()}${functionNeedle}`);
+    patched = patched.replace(functionNeedle, `${blockSource}${functionNeedle}`);
   }
   return ensureReadAloudRuntime(applyGeneralSettingsExportPatch(removeGeneralSettingsRowPlacement(patched)));
 }
@@ -276,18 +301,17 @@ function applyGeneralSettingsWrapperPatch(source) {
   if (!source.includes("GeneralSettings") || !source.includes("general-settings-")) {
     return source;
   }
-  const wrapperSource = (generalAlias, innerAsset) =>
-    `import{r as ${generalAlias}}from"${innerAsset}";export{${generalAlias} as GeneralSettings,${generalAlias} as ReadAloudSettings};`;
-  const brokenWrapperPattern =
+  const wrapperSource = (generalAlias, readAloudAlias, innerAsset) =>
+    `import{r as ${generalAlias},ReadAloudSettings as ${readAloudAlias}}from"${innerAsset}";export{${generalAlias} as GeneralSettings,${readAloudAlias} as ReadAloudSettings};`;
+  const correctWrapperPattern =
     /import\{r as ([A-Za-z_$][\w$]*),ReadAloudSettings as ([A-Za-z_$][\w$]*)\}from"(\.\/general-settings-[^"]+\.js)";export\{\1 as GeneralSettings,\2 as ReadAloudSettings\};/;
-  if (brokenWrapperPattern.test(source)) {
-    return source.replace(brokenWrapperPattern, (_match, generalAlias, _readAloudAlias, innerAsset) =>
-      wrapperSource(generalAlias, innerAsset),
-    );
+  if (correctWrapperPattern.test(source)) {
+    return source;
   }
   return source.replace(
     /import\{r as ([A-Za-z_$][\w$]*)\}from"(\.\/general-settings-[^"]+\.js)";export\{\1 as GeneralSettings(?:,\1 as ReadAloudSettings)?\};/,
-    (_match, generalAlias, innerAsset) => wrapperSource(generalAlias, innerAsset),
+    (_match, generalAlias, innerAsset) =>
+      wrapperSource(generalAlias, "codexLinuxReadAloudSettings", innerAsset),
   );
 }
 

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -829,21 +829,35 @@ test("general settings patch exports a dedicated read aloud settings page", () =
   assert.match(patched, /settings\.readAloud\.voice\.title/);
 });
 
+test("general settings patch exports read aloud from the current inner chunk", () => {
+  const source = [
+    "function $n(){return (0,$.jsxs)(vt,{children:[]})}",
+    "export{ir as i,rr as n,$n as r,Cr as t};",
+  ].join("");
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.match(patched, /function codexLinuxReadAloudSettingsPage/);
+  assert.match(patched, /codexLinuxReadAloudSettingsPage as ReadAloudSettings/);
+  assert.match(patched, /export\{ir as i,rr as n,\$n as r,Cr as t,codexLinuxReadAloudSettingsPage as ReadAloudSettings\}/);
+});
+
 test("general settings wrapper re-exports the read aloud settings page", () => {
   const source = 'import{r as e}from"./general-settings-Bvwhh0-i.js";export{e as GeneralSettings};';
   const patched = twice(applyGeneralSettingsWrapperPatch, source);
-  assert.match(patched, /import\{r as e\}from"\.\/general-settings-Bvwhh0-i\.js"/);
-  assert.match(patched, /export\{e as GeneralSettings,e as ReadAloudSettings\}/);
-  assert.doesNotMatch(patched, /ReadAloudSettings as t/);
+  assert.match(
+    patched,
+    /import\{r as e,ReadAloudSettings as codexLinuxReadAloudSettings\}from"\.\/general-settings-Bvwhh0-i\.js"/,
+  );
+  assert.match(patched, /export\{e as GeneralSettings,codexLinuxReadAloudSettings as ReadAloudSettings\}/);
+  assert.doesNotMatch(patched, /e as GeneralSettings,e as ReadAloudSettings/);
 });
 
-test("general settings wrapper removes a stale read aloud import", () => {
+test("general settings wrapper preserves an existing read aloud import", () => {
   const source =
     'import{r as e,ReadAloudSettings as t}from"./general-settings-CV9Safs7.js";export{e as GeneralSettings,t as ReadAloudSettings};';
   const patched = twice(applyGeneralSettingsWrapperPatch, source);
-  assert.match(patched, /import\{r as e\}from"\.\/general-settings-CV9Safs7\.js"/);
-  assert.match(patched, /export\{e as GeneralSettings,e as ReadAloudSettings\}/);
-  assert.doesNotMatch(patched, /ReadAloudSettings as t/);
+  assert.equal(patched, source);
+  assert.match(patched, /ReadAloudSettings as t/);
+  assert.doesNotMatch(patched, /e as GeneralSettings,e as ReadAloudSettings/);
 });
 
 test("settings nav patches add a visible read aloud section after computer use", () => {
@@ -1057,7 +1071,7 @@ test("settings asset patch creates a first-class read aloud settings section", (
     );
     assert.match(
       fs.readFileSync(path.join(assets, "general-settings-wrapper.js"), "utf8"),
-      /export\{e as GeneralSettings,e as ReadAloudSettings\}/,
+      /export\{e as GeneralSettings,codexLinuxReadAloudSettings as ReadAloudSettings\}/,
     );
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Route the Read Aloud settings section to a dedicated generated settings page instead of aliasing General Settings.
- Patch the current inner `general-settings` chunk to export `ReadAloudSettings` before the wrapper imports it.
- Add regression coverage for the current exported inner-chunk shape so Settings does not crash on missing named exports.

## Why
The Read Aloud nav/route existed, but the generated wrapper previously exported `GeneralSettings` under the `ReadAloudSettings` name. A later correction made the wrapper import `ReadAloudSettings`, but the current inner chunk did not export it, causing the Settings route to show the app error screen.

## Validation
- `node --test linux-features/read-aloud/test.js` passed, 32 tests.
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js` passed, 399 tests on the final stack.
- `git diff --check` passed.
- Rebuilt and synced the local user app; verified the restarted app opens Settings without the error screen.
