### PR TITLE
Fix packaging after deleted updater binary

### DIFF
--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -447,8 +447,18 @@ find_cargo_command() {
     return 1
 }
 
+updater_build_output_binary() {
+    local target_dir="${CARGO_TARGET_DIR:-$REPO_DIR/target}"
+    case "$target_dir" in
+        /*) ;;
+        *) target_dir="$REPO_DIR/$target_dir" ;;
+    esac
+    printf '%s\n' "$target_dir/release/codex-update-manager"
+}
+
 ensure_updater_binary() {
     local cargo_cmd=""
+    local built_binary=""
 
     if ! package_with_updater_enabled; then
         return
@@ -466,6 +476,10 @@ Install the Rust toolchain:
 
     info "Building codex-update-manager release binary"
     "$cargo_cmd" build --release -p codex-update-manager >&2
+    built_binary="$(updater_build_output_binary)"
+    if [ -x "$built_binary" ]; then
+        UPDATER_BINARY_SOURCE="$built_binary"
+    fi
     [ -x "$UPDATER_BINARY_SOURCE" ] || error "Failed to build updater binary: $UPDATER_BINARY_SOURCE"
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -288,6 +288,60 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/resources/node-runtime/bin/node"
 }
 
+test_deb_builder_rebuilds_deleted_updater_source() {
+    info "Checking package builder recovers from deleted updater binary source"
+    local workspace="$TMP_DIR/deb-deleted-updater-source"
+    local bin_dir="$workspace/bin"
+    local app_dir="$workspace/app"
+    local dist_dir="$workspace/dist"
+    local pkg_root="$workspace/deb-root"
+    local cargo_target_dir="$workspace/cargo-target"
+
+    mkdir -p "$workspace" "$dist_dir"
+    make_stub_bin_dir "$bin_dir"
+    make_fake_app "$app_dir"
+
+    cat > "$bin_dir/dpkg" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "$1" = "--print-architecture" ]; then
+    echo amd64
+    exit 0
+fi
+exit 0
+SCRIPT
+    cat > "$bin_dir/dpkg-deb" <<'SCRIPT'
+#!/usr/bin/env bash
+output="${@: -1}"
+mkdir -p "$(dirname "$output")"
+touch "$output"
+SCRIPT
+    cat > "$bin_dir/cargo" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+target_dir="${CARGO_TARGET_DIR:-target}"
+mkdir -p "$target_dir/release"
+cat > "$target_dir/release/codex-update-manager" <<'BIN'
+#!/usr/bin/env bash
+echo rebuilt updater
+BIN
+chmod +x "$target_dir/release/codex-update-manager"
+SCRIPT
+    chmod +x "$bin_dir/dpkg" "$bin_dir/dpkg-deb" "$bin_dir/cargo"
+
+    PATH="$bin_dir:$PATH" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    PKG_ROOT_OVERRIDE="$pkg_root" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    CARGO_TARGET_DIR="$cargo_target_dir" \
+    UPDATER_BINARY_SOURCE="$workspace/codex-update-manager (deleted)" \
+    PACKAGE_VERSION="2026.03.24.120000+rebuilt" \
+    bash "$REPO_DIR/scripts/build-deb.sh"
+
+    assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+rebuilt_amd64.deb"
+    assert_file_exists "$pkg_root/usr/bin/codex-update-manager"
+    assert_contains "$pkg_root/usr/bin/codex-update-manager" "rebuilt updater"
+}
+
 test_update_builder_preserves_enabled_linux_features_config() {
     info "Checking update-builder preserves sanitized enabled Linux feature config"
     local workspace="$TMP_DIR/update-builder-linux-features"
@@ -5250,6 +5304,7 @@ main() {
     test_common_helper_sourcing
     test_package_payload_permission_normalization
     test_deb_builder_smoke
+    test_deb_builder_rebuilds_deleted_updater_source
     test_update_builder_preserves_enabled_linux_features_config
     test_update_builder_source_info_survives_without_git_checkout
     test_linux_feature_package_hook_discovery_failure_blocks_build


### PR DESCRIPTION
## Summary
- use the Cargo release output after rebuilding codex-update-manager during native packaging
- cover a deleted updater binary source path in package-builder smoke tests

## Source of truth
- scripts/lib/package-common.sh
- tests/scripts_smoke.sh

## Validation
- bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/install-deps.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh
- git diff --check
- cargo check -p codex-update-manager
- cargo test -p codex-update-manager
- bash tests/scripts_smoke.sh

## Not run
- full native package builds outside the smoke suite