### PR TITLE
Fix AppShots bare modifier repeat detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The opt-in Linux AppShots bare-modifier shortcuts now require left and right
+  modifier keycodes, preventing a fast double-tap on one physical Alt or Shift
+  key from opening AppShots.
 - The wrapper updater no longer offers a "downgrade as update" when the
   installed build is ahead of the tracked remote. Detection records dev mode
   when the candidate does not descend from the installed commit, clears stale

--- a/linux-features/appshots/README.md
+++ b/linux-features/appshots/README.md
@@ -38,9 +38,10 @@ Privacy and correctness constraints:
   they are practical on Linux (`Alt + Alt` and `Shift + Shift`) and keeps
   `Ctrl+Super+A` as a non-bare fallback.
 - `Alt + Alt` and `Shift + Shift` are backed by a feature-local
-  `bare-modifier-monitor` helper staged into `resources/native/`. It uses
-  `xinput` and `xmodmap`, so it is expected to work on X11 sessions and fail
-  closed elsewhere.
+  `bare-modifier-monitor` helper staged into `resources/native/`. It requires
+  the left and right modifier keycodes, so tapping only one physical modifier
+  twice does not trigger AppShots. It uses `xinput` and `xmodmap`, so it is
+  expected to work on X11 sessions and fail closed elsewhere.
 
 Run the feature self-test:
 

--- a/linux-features/appshots/bin/bare-modifier-monitor
+++ b/linux-features/appshots/bin/bare-modifier-monitor
@@ -137,6 +137,7 @@ now_ms() {
 }
 
 last_tap_ms=0
+last_tap_code=""
 active=0
 
 keyboard_ids="$(
@@ -209,19 +210,27 @@ while read -r pending code <&3; do
     code="${code//[[:space:]]/}"
     [ -n "$code" ] || continue
 
-    is_target_keycode "$code" || continue
+    if ! is_target_keycode "$code"; then
+        if [ "$pending" = "press" ]; then
+            last_tap_ms=0
+            last_tap_code=""
+        fi
+        continue
+    fi
 
     if [ "$pending" = "press" ]; then
         current_ms="$(now_ms)"
         elapsed_ms=$((current_ms - last_tap_ms))
-        if [ "$last_tap_ms" -gt 0 ] && [ "$elapsed_ms" -le "$double_tap_ms" ]; then
+        if [ "$last_tap_ms" -gt 0 ] && [ "$elapsed_ms" -le "$double_tap_ms" ] && [ "$code" != "$last_tap_code" ]; then
             active=1
             last_tap_ms=0
+            last_tap_code=""
             if [ "$trigger_mode" = "press" ]; then
                 echo "down"
             fi
         else
             last_tap_ms="$current_ms"
+            last_tap_code="$code"
         fi
         continue
     fi

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -136,6 +136,11 @@ test("stages the Linux bare modifier monitor helper", () => {
   assert.match(helperSource, /pkill -TERM -P "\$pid"/);
   assert.match(helperSource, /while read -r pending code <&3; do/);
   assert.match(helperSource, /\) >"\$event_fifo" 2>\/dev\/null &/);
+  assert.match(helperSource, /doublealt\|doubleoption\|alt\+alt/);
+  assert.match(helperSource, /doubleshift\|shift\+shift\|leftshift\+rightshift/);
+  assert.match(helperSource, /Shift_L Shift_R/);
+  assert.match(helperSource, /last_tap_code=""/);
+  assert.match(helperSource, /\[ "\$code" != "\$last_tap_code" \]/);
   assert.doesNotMatch(helperSource, /while IFS= read -r pending code/);
   assert.doesNotMatch(helperSource, /test-xi2 --root/);
   execFileSync("bash", ["-n", path.join(__dirname, "bin", "bare-modifier-monitor")]);
@@ -217,6 +222,7 @@ test("enables AppShots hotkeys and bare modifiers on Linux", () => {
     /function QC\(e,t,r=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
   );
   assert.match(patched, /appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:uG\)/);
+  assert.doesNotMatch(patched, /process\.platform===`linux`\?`DoubleShift`/);
   assert.doesNotMatch(patched, /process\.platform===`linux`&&i!=null&&iw\(i\)&&\(i=null\)/);
   assert.match(
     patched,


### PR DESCRIPTION
## Summary
- require AppShots bare-modifier hotkeys to use two distinct physical keycodes
- keep Shift + Shift and Alt + Alt available while preventing same-side double taps from firing
- document the X11 helper behavior and cover it in the AppShots feature test

## User-visible behavior
- pressing Left Shift twice or the same Alt key twice quickly no longer opens AppShots
- pressing opposite-side modifiers within the timeout still triggers the configured bare-modifier shortcut

## Source of truth
- linux-features/appshots/bin/bare-modifier-monitor
- linux-features/appshots/test.js
- linux-features/appshots/README.md
- CHANGELOG.md

## Validation
- node --test linux-features/appshots/test.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check
- env npm_config_cache=/home/mohit/.cache/npm make build-dev-app
- launched /home/mohit/Github/codex-desktop-linux/bin/codex-cua-lab for manual testing

## Notes
- The helper remains X11-oriented because it still depends on xinput/xmodmap and fails closed elsewhere.