### PR TITLE
fix(remote-mobile-control): keep outbound tab reachable

### DIFF
--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -1,8 +1,8 @@
 # Experimental Remote Mobile Control
 
 This feature is disabled by default. It patches the upstream Codex Desktop main
-bundle so Linux can try the mobile remote-control host flow that upstream
-currently limits to macOS.
+bundle so Linux can try the remote-control host and outbound control flows that
+upstream currently limits to macOS.
 
 Enable it by adding the feature id to `linux-features/features.json` before
 building:
@@ -35,6 +35,8 @@ What it changes:
   Linux JavaScript ECDSA P-256 key provider.
 - Lets the remote-control Connections UI render on Linux when upstream marks
   the feature unavailable or withholds the remote-control visibility rollout.
+- Keeps the `Control other devices` settings tab reachable on Linux so this
+  desktop can authorize outbound control of another enrolled device.
 - Refreshes the remote Connections settings state every 5 seconds and
   immediately after focus, visibility, online, or resume signals.
 - Keeps Chrome Browser Use available to remote/mobile controlled sessions when
@@ -140,8 +142,9 @@ Known risks:
 
 - This is not equivalent to macOS Secure Enclave-backed storage. Private key
   material is file-backed and protected by ordinary user file permissions.
-- OpenAI may still reject Linux host enrollment server-side. This feature only
-  removes local macOS-only blockers in the repackaged app.
+- OpenAI may still reject Linux host enrollment or outbound authorization
+  server-side. This feature only removes local macOS-only blockers in the
+  repackaged app.
 - Treat this as experimental account-level remote-control plumbing.
 
 Run the feature tests with:

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -25,6 +25,10 @@ const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)(?:&&\2\?\.accessRequired!==!0)?\}/u;
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
+const REMOTE_CONTROL_SETTINGS_TABS_HELPER =
+  "function codexLinuxRemoteControlSettingsTabs(e){return e}";
+const REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER =
+  "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
@@ -45,7 +49,7 @@ const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProj
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
-  "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){let i=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);if(i){if(!n)return`ssh`;if(e===`access-other-devices`)return t?`control-this-mac`:`ssh`;if(e===`control-this-mac`&&!t)return`ssh`;if(e===`ssh`&&!r)return t?`control-this-mac`:`ssh`;return e}return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
+  "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){let i=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);if(i){if(!n)return`ssh`;if(e===`control-this-mac`&&!t)return`access-other-devices`;if(e===`ssh`&&!r)return`access-other-devices`;return e}return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REGEX =
   /function ([A-Za-z_$][\w$]*)\(\{selectedConnectionsTab:([A-Za-z_$][\w$]*),showControlThisMacTab:([A-Za-z_$][\w$]*),showRemoteControlConnectionsSection:([A-Za-z_$][\w$]*),showTabbedSshPage:([A-Za-z_$][\w$]*)\}\)\{return \4\?\2===`control-this-mac`&&!\3\|\|\2===`ssh`&&!\5\?`access-other-devices`:\2:`ssh`\}/u;
 const REMOTE_CONTROL_SELECTED_TAB_MARKER = "codexLinuxRemoteControlSelectedTab";
@@ -686,6 +690,10 @@ function applyLinuxRemoteControlCopyPatch(source) {
 function applyLinuxRemoteControlSettingsUxPatch(source) {
   let patched = replaceLinuxRemoteControlCopy(source).patched;
 
+  if (patched.includes(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER)) {
+    patched = patched.replace(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER, REMOTE_CONTROL_SETTINGS_TABS_HELPER);
+  }
+
   if (!patched.includes(REMOTE_CONTROL_SETTINGS_UX_MARKER)) {
     const helperNeedle = /function ([A-Za-z_$][\w$]*)\(e,t\)\{return e\.displayName\.localeCompare\(t\.displayName\)\}/u;
     const helperMatch = patched.match(helperNeedle);
@@ -693,9 +701,7 @@ function applyLinuxRemoteControlSettingsUxPatch(source) {
       console.warn("WARN: Could not find remote-control settings helper needle - skipping Linux remote-control settings UX patch");
       return patched;
     }
-    const helper =
-      "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
-    patched = patched.replace(helperNeedle, `${helper}${helperMatch[0]}`);
+    patched = patched.replace(helperNeedle, `${REMOTE_CONTROL_SETTINGS_TABS_HELPER}${helperMatch[0]}`);
   }
 
   patched = wrapRemoteControlTabs(patched, "control-this-mac");
@@ -713,8 +719,8 @@ function applyLinuxRemoteControlSelectedTabPatch(source) {
   }
 
   // 26.527.x moved the selected-tab resolver into the plugin-install-flow bundle
-  // and added showControlOtherDevices / showRemoteSshConnections params. Inject a
-  // Linux branch that avoids the Mac-only access-other-devices/control-this-mac tabs.
+  // and added showControlOtherDevices / showRemoteSshConnections params. Keep
+  // outbound control reachable on Linux while still avoiding hidden tabs.
   const newRegex =
     /function ([A-Za-z_$][\w$]*)\(\{selectedConnectionsTab:([A-Za-z_$][\w$]*),showControlOtherDevices:([A-Za-z_$][\w$]*),showControlThisMacTab:([A-Za-z_$][\w$]*),showRemoteControlConnectionsSection:([A-Za-z_$][\w$]*),showRemoteSshConnections:([A-Za-z_$][\w$]*),showTabbedSshPage:([A-Za-z_$][\w$]*)\}\)\{return ([^{}]*)\}/u;
   const newMatch = source.match(newRegex);
@@ -723,8 +729,10 @@ function applyLinuxRemoteControlSelectedTabPatch(source) {
     const replacement =
       `function ${fn}({selectedConnectionsTab:${sel},showControlOtherDevices:${otherDevices},showControlThisMacTab:${controlThisMac},showRemoteControlConnectionsSection:${section},showRemoteSshConnections:${sshConns},showTabbedSshPage:${tabbedSsh}}){` +
       `/*${REMOTE_CONTROL_SELECTED_TAB_MARKER}*/if(typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){` +
-      `if(!${section})return\`ssh\`;if(${sel}===\`access-other-devices\`)return ${controlThisMac}?\`control-this-mac\`:\`ssh\`;` +
-      `if(${sel}===\`control-this-mac\`&&!${controlThisMac})return\`ssh\`;if(${sel}===\`ssh\`&&!${tabbedSsh})return ${controlThisMac}?\`control-this-mac\`:\`ssh\`;return ${sel}}` +
+      `if(!${section})return ${sshConns}?\`ssh\`:\`access-other-devices\`;` +
+      `if(${sel}===\`control-this-mac\`&&!${controlThisMac})return ${otherDevices}?\`access-other-devices\`:\`ssh\`;` +
+      `if(${sel}===\`access-other-devices\`&&!${otherDevices})return ${controlThisMac}?\`control-this-mac\`:\`ssh\`;` +
+      `if(${sel}===\`ssh\`&&!${tabbedSsh})return ${otherDevices}?\`access-other-devices\`:${controlThisMac}?\`control-this-mac\`:\`ssh\`;return ${sel}}` +
       `return ${body}}`;
     return source.replace(newRegex, replacement);
   }
@@ -736,8 +744,8 @@ function applyLinuxRemoteControlSelectedTabPatch(source) {
     const replacement =
       `function ${functionName}({selectedConnectionsTab:${selectedVar},showControlThisMacTab:${controlThisMacVar},showRemoteControlConnectionsSection:${sectionVar},showTabbedSshPage:${sshVar}}){` +
       `/*${REMOTE_CONTROL_SELECTED_TAB_MARKER}*/let i=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);` +
-      `if(i){if(!${sectionVar})return\`ssh\`;if(${selectedVar}===\`access-other-devices\`)return ${controlThisMacVar}?\`control-this-mac\`:\`ssh\`;` +
-      `if(${selectedVar}===\`control-this-mac\`&&!${controlThisMacVar})return\`ssh\`;if(${selectedVar}===\`ssh\`&&!${sshVar})return ${controlThisMacVar}?\`control-this-mac\`:\`ssh\`;return ${selectedVar}}` +
+      `if(i){if(!${sectionVar})return\`ssh\`;if(${selectedVar}===\`control-this-mac\`&&!${controlThisMacVar})return\`access-other-devices\`;` +
+      `if(${selectedVar}===\`ssh\`&&!${sshVar})return\`access-other-devices\`;return ${selectedVar}}` +
       `return ${sectionVar}?${selectedVar}===\`control-this-mac\`&&!${controlThisMacVar}||${selectedVar}===\`ssh\`&&!${sshVar}?\`access-other-devices\`:${selectedVar}:\`ssh\`}`;
     return source.replace(REMOTE_CONTROL_SELECTED_TAB_REGEX, replacement);
   }

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -878,13 +878,15 @@ test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
   assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
-test("Linux remote-control settings UX patch hides unsupported outbound tab and removes Mac copy", () => {
+test("Linux remote-control settings UX patch keeps outbound tab visible and removes Mac copy", () => {
   const source = syntheticSettingsBundle();
   const patched = applyLinuxRemoteControlSettingsUxPatch(source);
 
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxRemoteControlSettingsTabs/);
-  assert.match(patched, /e\.filter\(e=>e\.key!==`access-other-devices`\)/);
+  assert.match(patched, /function codexLinuxRemoteControlSettingsTabs\(e\)\{return e\}/);
+  assert.doesNotMatch(patched, /e\.filter\(e=>e\.key!==`access-other-devices`\)/);
+  assert.match(patched, /key:`access-other-devices`/);
   assert.match(patched, /Control this Linux desktop/);
   assert.match(patched, /Control this Linux desktop from your phone or other device/);
   assert.match(patched, /Add device to control this Linux desktop remotely/);
@@ -902,13 +904,15 @@ test("Linux remote-control settings UX patch handles current minified helper nam
 
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxRemoteControlSettingsTabs/);
+  assert.match(patched, /function codexLinuxRemoteControlSettingsTabs\(e\)\{return e\}/);
   assert.match(patched, /tabs:codexLinuxRemoteControlSettingsTabs/);
+  assert.match(patched, /key:`access-other-devices`/);
   assert.match(patched, /Control this Linux desktop/);
   assert.doesNotMatch(patched, /Control this Mac/);
   assert.equal(applyLinuxRemoteControlSettingsUxPatch(patched), patched);
 });
 
-test("Linux remote-control selected-tab fallback avoids outbound control on Linux", () => {
+test("Linux remote-control selected-tab fallback keeps outbound control reachable on Linux", () => {
   const patched = applyLinuxRemoteControlSelectedTabPatch(syntheticSelectedTabBundle());
   assert.match(patched, /codexLinuxRemoteControlSelectedTab/);
   const context = {
@@ -925,7 +929,7 @@ test("Linux remote-control selected-tab fallback avoids outbound control on Linu
       showRemoteControlConnectionsSection: true,
       showTabbedSshPage: true,
     }),
-    "control-this-mac",
+    "access-other-devices",
   );
   assert.equal(
     resolveTab({
@@ -934,7 +938,16 @@ test("Linux remote-control selected-tab fallback avoids outbound control on Linu
       showRemoteControlConnectionsSection: true,
       showTabbedSshPage: true,
     }),
-    "ssh",
+    "access-other-devices",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "control-this-mac",
+      showControlThisMacTab: false,
+      showRemoteControlConnectionsSection: true,
+      showTabbedSshPage: true,
+    }),
+    "access-other-devices",
   );
   assert.equal(applyLinuxRemoteControlSelectedTabPatch(patched), patched);
 });
@@ -959,7 +972,7 @@ test("Linux remote-control selected-tab patch handles the current six-param reso
       showRemoteSshConnections: true,
       showTabbedSshPage: true,
     }),
-    "control-this-mac",
+    "access-other-devices",
   );
   assert.equal(
     resolveTab({
@@ -969,6 +982,50 @@ test("Linux remote-control selected-tab patch handles the current six-param reso
       showRemoteControlConnectionsSection: true,
       showRemoteSshConnections: true,
       showTabbedSshPage: true,
+    }),
+    "access-other-devices",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "access-other-devices",
+      showControlOtherDevices: false,
+      showControlThisMacTab: false,
+      showRemoteControlConnectionsSection: true,
+      showRemoteSshConnections: true,
+      showTabbedSshPage: true,
+    }),
+    "ssh",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "control-this-mac",
+      showControlOtherDevices: true,
+      showControlThisMacTab: false,
+      showRemoteControlConnectionsSection: true,
+      showRemoteSshConnections: true,
+      showTabbedSshPage: true,
+    }),
+    "access-other-devices",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "ssh",
+      showControlOtherDevices: true,
+      showControlThisMacTab: true,
+      showRemoteControlConnectionsSection: true,
+      showRemoteSshConnections: true,
+      showTabbedSshPage: false,
+    }),
+    "access-other-devices",
+  );
+  assert.equal(
+    resolveTab({
+      selectedConnectionsTab: "ssh",
+      showControlOtherDevices: false,
+      showControlThisMacTab: false,
+      showRemoteControlConnectionsSection: true,
+      showRemoteSshConnections: true,
+      showTabbedSshPage: false,
     }),
     "ssh",
   );


### PR DESCRIPTION
## Summary
- keep the remote-mobile-control `Control other devices` tab reachable on Linux
- update the selected-tab fallback so `access-other-devices` is preserved when upstream exposes outbound control
- document outbound control as part of the experimental opt-in feature

Addresses #381.

## Validation
- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `git diff --check`