### PR TITLE
fix(remote-mobile-control): harden SSH host handling

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -29,10 +29,12 @@ const REMOTE_CONTROL_SETTINGS_TABS_HELPER =
   "function codexLinuxRemoteControlSettingsTabs(e){return e}";
 const REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER =
   "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
+const REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER = "codexLinuxRemoteControlSshInstallActions";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
 const REMOTE_CONTROL_FEATURE_SYNC_MARKER = "codexLinuxRemoteControlFeatureSyncEnabled";
+const REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER = "codexLinuxRemoteControlFeatureSyncHostScoped";
 const REMOTE_CONTROL_LOAD_GATE_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\)\{return ([A-Za-z_$][\w$]*)\(`1042620455`\)\}/u;
 const REMOTE_MOBILE_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntimeStatus";
@@ -573,10 +575,6 @@ function applyLinuxRemoteControlLoadGatePatch(source) {
 }
 
 function applyLinuxRemoteControlFeatureSyncPatch(source) {
-  if (source.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
-    return source;
-  }
-
   if (!source.includes("set-experimental-feature-enablement-for-host")) {
     return source;
   }
@@ -587,32 +585,95 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
   // remote_control on and drop the unsupported remote_plugin entry before sync.
   // The core Linux patch may already have removed the remote_plugin tail; compose
   // with that sanitized shape instead of treating it as drift.
+  let patched = source;
+  let changed = false;
   const enablementRegex =
     /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\[([A-Za-z_$][\w$]*)\]=([A-Za-z_$][\w$]*),\4\}/u;
-  const match = source.match(enablementRegex);
-  if (match != null) {
-    const [, loopBlock, , , enablementVar, remotePluginVar, remotePluginValue] = match;
-    const replacement =
-      `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
-      `?(${enablementVar}.remote_control=!0,/*${REMOTE_CONTROL_FEATURE_SYNC_MARKER}*/${enablementVar})` +
-      `:(${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})}`;
-    return source.replace(enablementRegex, replacement);
+  if (!patched.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
+    const match = patched.match(enablementRegex);
+    if (match != null) {
+      const [, loopBlock, , , enablementVar, remotePluginVar, remotePluginValue] = match;
+      const replacement =
+        `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
+        `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar})` +
+        `:(${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})}` +
+        `function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
+      patched = patched.replace(enablementRegex, replacement);
+      changed = true;
+    } else {
+      const sanitizedEnablementRegex =
+        /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\}/u;
+      const sanitizedMatch = patched.match(sanitizedEnablementRegex);
+      if (sanitizedMatch != null) {
+        const [, loopBlock, , , enablementVar] = sanitizedMatch;
+        const replacement =
+          `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
+          `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar})` +
+          `:${enablementVar}}function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
+        patched = patched.replace(sanitizedEnablementRegex, replacement);
+        changed = true;
+      }
+    }
   }
 
-  const sanitizedEnablementRegex =
-    /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\}/u;
-  const sanitizedMatch = source.match(sanitizedEnablementRegex);
-  if (sanitizedMatch != null) {
-    const [, loopBlock, , , enablementVar] = sanitizedMatch;
-    const replacement =
-      `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
-      `?(${enablementVar}.remote_control=!0,/*${REMOTE_CONTROL_FEATURE_SYNC_MARKER}*/${enablementVar})` +
-      `:${enablementVar}}`;
-    return source.replace(sanitizedEnablementRegex, replacement);
+  const scoped = applyLinuxRemoteControlFeatureSyncHostScopePatch(patched);
+  if (scoped !== patched) {
+    patched = scoped;
+    changed = true;
+  }
+
+  if (changed || patched.includes(REMOTE_CONTROL_FEATURE_SYNC_MARKER)) {
+    return patched;
   }
 
   console.warn("WARN: Could not find app-server feature sync list - skipping Linux remote-control feature sync patch");
   return source;
+}
+
+function applyLinuxRemoteControlFeatureSyncHostScopePatch(source) {
+  if (source.includes(REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER)) {
+    return source;
+  }
+
+  const builderCallRegex =
+    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*|![01])\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.get\(([A-Za-z_$][\w$]*)\),/u;
+  const builderCallMatch = source.match(builderCallRegex);
+  if (builderCallMatch == null) {
+    return source;
+  }
+
+  const [
+    ,
+    enablementVar,
+    builderFn,
+    featureConfigVar,
+    remotePluginValueVar,
+    localHostVar,
+  ] = builderCallMatch;
+  const id = "[A-Za-z_$][\\w$]*";
+  const flatMapRegex = new RegExp(
+    `\\(0,(${id})\\.(${id})\\)\\((${id})\\.get\\((${id})\\),${enablementVar}\\)\\?\\[\\]:` +
+      `\\(\\3\\.set\\(\\4,${enablementVar}\\),\\[(${id})\\(\\x60set-experimental-feature-enablement-for-host\\x60,` +
+      `\\{hostId:\\4,enablement:${enablementVar}\\}\\)`,
+    "u",
+  );
+  const match = source.match(flatMapRegex);
+  if (match == null) {
+    return source;
+  }
+
+  const [needle, compareNamespaceVar, compareFnVar, cacheMapVar, hostVar, requestFnVar] = match;
+  const helperName = "codexLinuxRemoteControlFeatureSyncForHost";
+  const scopedEnablement =
+    `${helperName}(${builderFn},${featureConfigVar},${remotePluginValueVar},${hostVar},${localHostVar})`;
+  const replacement =
+    `(0,${compareNamespaceVar}.${compareFnVar})(${cacheMapVar}.get(${hostVar}),${scopedEnablement})?[]:` +
+    `(${cacheMapVar}.set(${hostVar},${scopedEnablement}),[${requestFnVar}(\`set-experimental-feature-enablement-for-host\`,` +
+    `{hostId:${hostVar},enablement:${scopedEnablement}})/*${REMOTE_CONTROL_FEATURE_SYNC_HOST_SCOPE_MARKER}*/`;
+  const helper =
+    `function ${helperName}(e,t,n,r,i){return e(t,n,r,i)}`;
+
+  return `${source.replace(needle, replacement)}\n${helper}`;
 }
 
 function applyLinuxRemoteControlVisibilityPatch(source) {
@@ -688,8 +749,31 @@ function applyLinuxRemoteControlCopyPatch(source) {
   return patched;
 }
 
+function applyLinuxRemoteControlSshInstallActionPatch(source) {
+  if (source.includes(REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER)) {
+    return source;
+  }
+  if (!source.includes("remote-codex-not-found") && !source.includes("update-required")) {
+    return source;
+  }
+
+  const actionGateRegex =
+    /let ([A-Za-z_$][\w$]*)=!([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,/u;
+  const match = source.match(actionGateRegex);
+  if (match == null) {
+    console.warn("WARN: Could not find remote-control SSH install action gate - skipping Linux install action patch");
+    return source;
+  }
+
+  const [, gateVar, , , renderedActionVar, connectionActionVar, renderActionFn] = match;
+  return source.replace(
+    actionGateRegex,
+    `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1;${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
+  );
+}
+
 function applyLinuxRemoteControlSettingsUxPatch(source) {
-  let patched = replaceLinuxRemoteControlCopy(source).patched;
+  let patched = applyLinuxRemoteControlSshInstallActionPatch(replaceLinuxRemoteControlCopy(source).patched);
 
   if (patched.includes(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER)) {
     patched = patched.replace(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER, REMOTE_CONTROL_SETTINGS_TABS_HELPER);
@@ -1249,6 +1333,7 @@ module.exports.applyLinuxRemoteConnectionsRefreshPatch = applyLinuxRemoteConnect
 module.exports.applyLinuxRemoteControlFeatureSyncPatch = applyLinuxRemoteControlFeatureSyncPatch;
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;
+module.exports.applyLinuxRemoteControlSshInstallActionPatch = applyLinuxRemoteControlSshInstallActionPatch;
 module.exports.applyLinuxRemoteControlSettingsUxPatch = applyLinuxRemoteControlSettingsUxPatch;
 module.exports.applyLinuxRemoteControlSelectedTabPatch = applyLinuxRemoteControlSelectedTabPatch;
 module.exports.applyLinuxRemoteMobileProjectlessRemoteTaskPatch =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -123,6 +123,14 @@ function syntheticAppMainFeatureSyncBundle() {
   ].join("");
 }
 
+function syntheticCurrentAppMainFeatureSyncBundle() {
+  return [
+    "var gI=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],vI=`remote_plugin`,Ir=`local-host`,Vt=`hosts`,Ro=`features-query`,G={error(){}};",
+    "function yI(){let e=new Map,o=()=>{if(ln(`set-default-feature-overrides`,{overrides:features??null}),features==null)return;let i=bI(features,!0),o=store.get(Ir),s=new Set(store.get(Vt).filter(e=>e===o||xn(store,e).state===`connected`));for(let t of e.keys())s.has(t)||e.delete(t);let c=store.get(Vt).filter(e=>s.has(e)).flatMap(t=>(0,dv.default)(e.get(t),i)?[]:(e.set(t,i),[ln(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:i}).catch(n=>{e.delete(t),G.error(`Failed to sync experimental feature enablement`,{safe:{hostId:t},sensitive:{error:n}})})]));c.length!==0&&Promise.all(c).then(()=>{query.invalidateQueries({queryKey:Ro})})};return o()}",
+    "function bI(e,t){let n={};for(let t of gI){let r=e[t];r!=null&&(n[t]=r)}return n[vI]=t,n}",
+  ].join("");
+}
+
 function syntheticCurrentVisibilityBundle() {
   return "function Et({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)}export{Et as t};";
 }
@@ -162,6 +170,7 @@ function syntheticSettingsBundle() {
     "tabs:[{key:`control-this-mac`,name:o===`windows`?(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac.windows`,defaultMessage:`Control this PC`,description:`Tab label for settings that let other devices control this Windows device`}):(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.controlThisMac`,defaultMessage:`Control this Mac`,description:`Tab label for settings that let other devices control this computer`})},{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
     "tabs:[{key:`access-other-devices`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.accessOtherDevices`,defaultMessage:`Control other devices`,description:`Tab label for settings that let this computer control other devices`})},{key:`ssh`,name:(0,Q.jsx)(z,{id:`settings.remoteConnections.tabs.ssh`,defaultMessage:`SSH`,description:`Tab label for SSH remote connections`})}],selectedKey:je,variant:`underline`,onSelect:se}",
     "const a=`Control this Mac from your phone or other device`,b=`Add device to control this Mac remotely`,c=`Devices that can control this Mac`,d=`Keep Mac awake`,e=`Allow this Mac to be discovered and controlled`,f=`Control other devices from this Mac`,g=`Authorize this Mac to control other devices signed in to your ChatGPT account`,h=`Devices you can control from this Mac`;",
+    "let xe=!Pe&&(Te?.code===`remote-codex-not-found`||Te?.code===`update-required`);Ce=Ae==null||xe?null:Re({action:Ae.action,connection:Ee});",
     "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
     "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}",
   ].join("");
@@ -823,6 +832,46 @@ test("Linux remote-control feature sync composes with core-sanitized dynamic bui
   assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
 });
 
+test("Linux remote-control feature sync does not advertise SSH hosts to mobile", async () => {
+  const source = syntheticCurrentAppMainFeatureSyncBundle();
+  const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled/);
+
+  const calls = [];
+  const context = {
+    Promise,
+    features: { apps: true, memories: false },
+    navigator: { userAgent: "X11; Linux x86_64" },
+    query: { invalidateQueries() {} },
+    store: {
+      get(key) {
+        if (key === "local-host") return "local";
+        if (key === "hosts") return ["local", "remote-ssh-discovered:devpod"];
+        return undefined;
+      },
+    },
+    dv: { default: () => false },
+    ln(method, params) {
+      calls.push({ method, params });
+      return Promise.resolve();
+    },
+    xn(_store, hostId) {
+      return { state: hostId === "remote-ssh-discovered:devpod" ? "connected" : "disconnected" };
+    },
+  };
+  vm.runInNewContext(`${patched};yI();`, context);
+  await Promise.resolve();
+
+  const hostCalls = calls.filter((call) => call.method === "set-experimental-feature-enablement-for-host");
+  assert.equal(hostCalls.length, 2);
+  assert.equal(hostCalls[0].params.hostId, "local");
+  assert.equal(hostCalls[0].params.enablement.remote_control, true);
+  assert.equal(hostCalls[1].params.hostId, "remote-ssh-discovered:devpod");
+  assert.equal(hostCalls[1].params.enablement.remote_control, undefined);
+});
+
 test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
   const source = syntheticVisibilityBundle();
   const patched = applyLinuxRemoteControlVisibilityPatch(source);
@@ -897,9 +946,11 @@ test("Linux remote-control settings UX patch keeps outbound tab visible and remo
 
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxRemoteControlSettingsTabs/);
+  assert.match(patched, /codexLinuxRemoteControlSshInstallActions/);
   assert.match(patched, /function codexLinuxRemoteControlSettingsTabs\(e\)\{return e\}/);
   assert.doesNotMatch(patched, /e\.filter\(e=>e\.key!==`access-other-devices`\)/);
   assert.match(patched, /key:`access-other-devices`/);
+  assert.match(patched, /Ce=Ae==null\?null:Re\(\{action:Ae\.action/);
   assert.match(patched, /Control this Linux desktop/);
   assert.match(patched, /Control this Linux desktop from your phone or other device/);
   assert.match(patched, /Add device to control this Linux desktop remotely/);


### PR DESCRIPTION
## Summary
- keep SSH install/update actions visible when Linux remote-control rows report `remote-codex-not-found` or `update-required`
- keep Linux `remote_control` feature sync scoped to the local Desktop host so connected SSH/devcontainer app-servers do not register as mobile-controllable hosts
- cover both paths in remote-mobile settings/feature-sync fixtures

## Tests
- `node --test linux-features/remote-mobile-control/test.js`
- `node --test --test-name-pattern "remote-control|feature sync|SSH install" scripts/patch-linux-window-ui.test.js`
- `git diff --check upstream/main..HEAD`