### PR TITLE
Fix remote SSH install runtime release

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -30,6 +30,7 @@ const REMOTE_CONTROL_SETTINGS_TABS_HELPER =
 const REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER =
   "function codexLinuxRemoteControlSettingsTabs(e){return typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?e.filter(e=>e.key!==`access-other-devices`):e}";
 const REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER = "codexLinuxRemoteControlSshInstallActions";
+const REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER = "codexLinuxRemoteControlSshInstallRelease";
 const REMOTE_CONNECTIONS_REFRESH_MARKER = "codexLinuxRemoteConnectionsRefreshNow";
 const REMOTE_MOBILE_CHROME_BRIDGE_MARKER = "codexLinuxRemoteMobileBrowserBackends";
 const REMOTE_CONTROL_LOAD_GATE_MARKER = "codexLinuxRemoteControlLoadGateEnabled";
@@ -772,8 +773,141 @@ function applyLinuxRemoteControlSshInstallActionPatch(source) {
   );
 }
 
+function applyLinuxRemoteControlSshInstallReleasePatch(source) {
+  if (source.includes(REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER)) {
+    return source;
+  }
+  if (!source.includes("install-remote-codex") || !source.includes("install-codex")) {
+    return source;
+  }
+
+  const actionBuilderRegex =
+    /function ([A-Za-z_$][\w$]*)\(\{action:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)\{if\(\2==null\)return null;switch\(\2\.kind\)\{case`install-codex`:return\{disabled:\3,label:\2\.label,loading:\5,loadingLabel:\2\.loadingLabel,renderInElectronOnly:!0,tooltipText:\2\.tooltipText,onClick:\(\)=>\7\(\4\)\}/u;
+  const actionCallRegex =
+    /let ([A-Za-z_$][\w$]*)=!([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
+  const mutationRegex =
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.mutate\(\{hostId:\2\},\{onSuccess:\(\{state:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)\}\}\)\}/u;
+  const localVersionRegex =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\((\d+)\),\{connection:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onEdit:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*),onLogoutConnection:([A-Za-z_$][\w$]*),onRemove:([A-Za-z_$][\w$]*),onShowDetails:([A-Za-z_$][\w$]*),onToggleConnection:([A-Za-z_$][\w$]*)\}=\2,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\6\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
+
+  const actionBuilderMatch = source.match(actionBuilderRegex);
+  const actionCallMatch = source.match(actionCallRegex);
+  const mutationMatch = source.match(mutationRegex);
+  const localVersionMatch = source.match(localVersionRegex);
+  if (
+    actionBuilderMatch == null ||
+    actionCallMatch == null ||
+    mutationMatch == null ||
+    localVersionMatch == null
+  ) {
+    console.warn("WARN: Could not find remote-control SSH install release needles - skipping Linux install release patch");
+    return source;
+  }
+
+  const [
+    ,
+    rowComponentFn,
+    rowPropsVar,
+    rowCacheVar,
+    rowCompilerVar,
+    rowCacheSize,
+    rowConnectionVar,
+    rowDisabledVar,
+    rowInstallPendingVar,
+    rowAuthenticateVar,
+    rowEditVar,
+    rowInstallVar,
+    rowLogoutVar,
+    rowRemoveVar,
+    rowShowDetailsVar,
+    rowToggleVar,
+    rowFormatVar,
+    rowFormatFn,
+    rowAppServerVersionVar,
+    rowErrorVar,
+    rowInstalledVersionVar,
+    rowStateVar,
+    rowConnectionStateFn,
+    rowDisplayNameVar,
+  ] = localVersionMatch;
+  const localVersionReplacement =
+    `function ${rowComponentFn}(${rowPropsVar}){let ${rowCacheVar}=(0,${rowCompilerVar}.c)(${rowCacheSize}),` +
+    `{connection:${rowConnectionVar},disabled:${rowDisabledVar},installCodexPending:${rowInstallPendingVar},` +
+    `onAuthenticate:${rowAuthenticateVar},onEdit:${rowEditVar},onInstallCodex:${rowInstallVar},` +
+    `onLogoutConnection:${rowLogoutVar},onRemove:${rowRemoveVar},onShowDetails:${rowShowDetailsVar},` +
+    `onToggleConnection:${rowToggleVar}}=${rowPropsVar},${rowFormatVar}=${rowFormatFn}(),` +
+    `{appServerVersion:${rowAppServerVersionVar},error:${rowErrorVar},installedCodexVersion:${rowInstalledVersionVar},state:${rowStateVar}}=${rowConnectionStateFn}(${rowConnectionVar}.hostId),` +
+    `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${rowConnectionStateFn}(\`local\`);` +
+    `codexLinuxRemoteControlSshInstallDefaultRelease=codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??codexLinuxRemoteControlSshInstallDefaultRelease;` +
+    `let ${rowDisplayNameVar}=${rowConnectionVar}.displayName`;
+
+  const [
+    ,
+    builderFn,
+    builderActionVar,
+    builderDisabledVar,
+    builderHostVar,
+    builderPendingVar,
+    builderAuthVar,
+    builderInstallVar,
+  ] = actionBuilderMatch;
+  const actionBuilderReplacement =
+    `function ${builderFn}({action:${builderActionVar},disabled:${builderDisabledVar},hostId:${builderHostVar},installCodexPending:${builderPendingVar},` +
+    `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}}){` +
+    `if(${builderActionVar}==null)return null;switch(${builderActionVar}.kind){case\`install-codex\`:return{disabled:${builderDisabledVar},label:${builderActionVar}.label,loading:${builderPendingVar},` +
+    `loadingLabel:${builderActionVar}.loadingLabel,renderInElectronOnly:!0,tooltipText:${builderActionVar}.tooltipText,onClick:()=>${builderInstallVar}(${builderHostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
+
+  const [
+    ,
+    gateVar,
+    loadGateVar,
+    errorVar,
+    renderedActionVar,
+    connectionActionVar,
+    renderActionFn,
+    disabledVar,
+    connectionVar,
+    pendingVar,
+    authenticateVar,
+    installVar,
+  ] = actionCallMatch;
+  const actionCallReplacement =
+    `let ${gateVar}=!${loadGateVar}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`);` +
+    `${renderedActionVar}=${connectionActionVar}==null||${gateVar}?null:${renderActionFn}({action:${connectionActionVar}.action,disabled:${disabledVar},hostId:${connectionVar}.hostId,` +
+    `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
+
+  const [
+    ,
+    mutationHandlerVar,
+    mutationHostVar,
+    mutationVar,
+    mutationStateVar,
+    mutationErrorVar,
+    syncStateFn,
+  ] = mutationMatch;
+  const mutationReplacement =
+    `${mutationHandlerVar}=(${mutationHostVar},codexLinuxRemoteControlSshInstallTargetRelease)=>{` +
+    `let codexLinuxRemoteControlSshInstallRequest={hostId:${mutationHostVar}},` +
+    `codexLinuxRemoteControlSshInstallResolvedRelease=codexLinuxRemoteControlSshInstallTargetRelease??codexLinuxRemoteControlSshInstallDefaultRelease;` +
+    `codexLinuxRemoteControlSshInstallResolvedRelease!=null&&(codexLinuxRemoteControlSshInstallRequest.release=codexLinuxRemoteControlSshInstallResolvedRelease),` +
+    `${mutationVar}.mutate(codexLinuxRemoteControlSshInstallRequest,{onSuccess:({state:${mutationStateVar},error:${mutationErrorVar}})=>{${syncStateFn}(${mutationHostVar},${mutationStateVar},${mutationErrorVar})}})}`;
+
+  const helper = [
+    "let codexLinuxRemoteControlSshInstallDefaultRelease=null;",
+    "function codexLinuxRemoteControlValidRelease(e){return typeof e==`string`&&e.trim().length>0?e.trim():null}",
+    `function ${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(e){return e?.code===\`update-required\`?codexLinuxRemoteControlValidRelease(e.minRequiredVersion):null}`,
+  ].join("");
+
+  return helper + source
+    .replace(localVersionRegex, localVersionReplacement)
+    .replace(actionBuilderRegex, actionBuilderReplacement)
+    .replace(actionCallRegex, actionCallReplacement)
+    .replace(mutationRegex, mutationReplacement);
+}
+
 function applyLinuxRemoteControlSettingsUxPatch(source) {
-  let patched = applyLinuxRemoteControlSshInstallActionPatch(replaceLinuxRemoteControlCopy(source).patched);
+  let patched = applyLinuxRemoteControlSshInstallReleasePatch(replaceLinuxRemoteControlCopy(source).patched);
+  patched = applyLinuxRemoteControlSshInstallActionPatch(patched);
 
   if (patched.includes(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER)) {
     patched = patched.replace(REMOTE_CONTROL_SETTINGS_TABS_OLD_HELPER, REMOTE_CONTROL_SETTINGS_TABS_HELPER);
@@ -1334,6 +1468,7 @@ module.exports.applyLinuxRemoteControlFeatureSyncPatch = applyLinuxRemoteControl
 module.exports.applyLinuxRemoteControlVisibilityPatch = applyLinuxRemoteControlVisibilityPatch;
 module.exports.applyLinuxRemoteControlCopyPatch = applyLinuxRemoteControlCopyPatch;
 module.exports.applyLinuxRemoteControlSshInstallActionPatch = applyLinuxRemoteControlSshInstallActionPatch;
+module.exports.applyLinuxRemoteControlSshInstallReleasePatch = applyLinuxRemoteControlSshInstallReleasePatch;
 module.exports.applyLinuxRemoteControlSettingsUxPatch = applyLinuxRemoteControlSettingsUxPatch;
 module.exports.applyLinuxRemoteControlSelectedTabPatch = applyLinuxRemoteControlSelectedTabPatch;
 module.exports.applyLinuxRemoteMobileProjectlessRemoteTaskPatch =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -176,6 +176,15 @@ function syntheticSettingsBundle() {
   ].join("");
 }
 
+function syntheticSshInstallSettingsBundle() {
+  return [
+    "function pn({action:e,disabled:t,hostId:n,installCodexPending:r,onAuthenticate:i,onInstallCodex:a}){if(e==null)return null;switch(e.kind){case`install-codex`:return{disabled:t,label:e.label,loading:r,loadingLabel:e.loadingLabel,renderInElectronOnly:!0,tooltipText:e.tooltipText,onClick:()=>a(n)};case`login`:return{label:e.label,onClick:()=>i(n)};case`settings`:return null}}",
+    "let et=R(`install-remote-codex`),vt=(e,t,n)=>{globalThis.__states.push({hostId:e,state:t,error:n})},bt=e=>{et.mutate({hostId:e},{onSuccess:({state:t,error:n})=>{vt(e,t,n)}})};",
+    "function un(e){let t=(0,$.c)(86),{connection:n,disabled:r,installCodexPending:i,onAuthenticate:a,onEdit:o,onInstallCodex:s,onLogoutConnection:c,onRemove:l,onShowDetails:u,onToggleConnection:d}=e,f=ee(),{appServerVersion:p,error:m,installedCodexVersion:h,state:g}=De(n.hostId),_=n.displayName,v;let T=w,E=oe(`2153867414`),D,O,k,A,j,M;if(t[8]!==p||t[9]!==n.hostId||t[10]!==r||t[11]!==m||t[12]!==i||t[13]!==h||t[14]!==f||t[15]!==a||t[16]!==s||t[17]!==E||t[18]!==g){k=fn({appServerVersion:p,installedCodexVersion:h,state:g}),D=g===`connected`||m?.code===`login-required`||m?.code===`update-required`||m?.code===`restart-required`;let{statusError:e,isRestartAvailableNotice:o,statusState:c}=dn({error:m,restartAvailableNotice:k,state:g});A=e,O=o,j=c==null?null:Ne(f,{canLogin:!0,error:A,state:c,surface:`connections-row`});let l=!E&&(A?.code===`remote-codex-not-found`||A?.code===`update-required`);M=j==null||l?null:pn({action:j.action,disabled:r,hostId:n.hostId,installCodexPending:i,onAuthenticate:a,onInstallCodex:s}),t[8]=p,t[9]=n.hostId,t[10]=r,t[11]=m,t[12]=i,t[13]=h,t[14]=f,t[15]=a,t[16]=s,t[17]=E,t[18]=g,t[19]=D,t[20]=O,t[21]=k,t[22]=A,t[23]=j,t[24]=M}else D=t[19],O=t[20],k=t[21],A=t[22],j=t[23],M=t[24];return M}",
+    "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
+  ].join("");
+}
+
 function syntheticSettingsRefreshBundle() {
   return [
     "var Qn=15e3,Z=React;",
@@ -960,6 +969,107 @@ test("Linux remote-control settings UX patch keeps outbound tab visible and remo
   assert.doesNotMatch(patched, /Control this Mac/);
   assert.doesNotMatch(patched, /this Mac/);
   assert.equal(applyLinuxRemoteControlSettingsUxPatch(patched), patched);
+});
+
+test("Linux remote-control SSH install sends the local Desktop app-server version for fresh installs", () => {
+  const source = syntheticSshInstallSettingsBundle();
+  const patched = applyLinuxRemoteControlSettingsUxPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlSshInstallRelease/);
+  assert.match(patched, /codexLinuxRemoteControlSshInstallDefaultRelease/);
+  assert.match(patched, /De\(`local`\)/);
+  assert.match(patched, /release=codexLinuxRemoteControlSshInstallResolvedRelease/);
+  assert.match(patched, /onClick:\(\)=>a\(n,codexLinuxRemoteControlSshInstallReleaseTarget\)/);
+
+  const context = {
+    $: { c: () => [] },
+    __mutations: [],
+    __states: [],
+    globalThis: null,
+    w: "Restart",
+    ee: () => ({}),
+    fn: () => null,
+    dn: ({ error, state }) => ({
+      isRestartAvailableNotice: false,
+      statusError: error,
+      statusState: state,
+    }),
+    Ne: () => ({
+      action: {
+        kind: "install-codex",
+        label: "Install Codex",
+        loadingLabel: "Installing",
+      },
+    }),
+    oe: () => true,
+    De: (hostId) =>
+      hostId === "local"
+        ? { appServerVersion: "0.136.0", error: null, installedCodexVersion: null, state: "connected" }
+        : {
+            appServerVersion: null,
+            error: { code: "remote-codex-not-found" },
+            installedCodexVersion: null,
+            state: "error",
+          },
+    R: () => ({
+      mutate(request, options) {
+        context.__mutations.push(request);
+        options.onSuccess({ state: "connected", error: null });
+      },
+    }),
+  };
+  context.globalThis = context;
+  vm.runInNewContext(`${patched};let action=un({connection:{hostId:'remote-ssh:dev',displayName:'dev'},disabled:false,installCodexPending:false,onAuthenticate(){},onEdit(){},onInstallCodex:bt,onLogoutConnection(){},onRemove(){},onShowDetails(){},onToggleConnection(){}});action.onClick();`, context);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.__mutations)), [{ hostId: "remote-ssh:dev", release: "0.136.0" }]);
+  assert.deepEqual(JSON.parse(JSON.stringify(context.__states)), [{ hostId: "remote-ssh:dev", state: "connected", error: null }]);
+  assert.equal(applyLinuxRemoteControlSettingsUxPatch(patched), patched);
+});
+
+test("Linux remote-control SSH install prefers update-required minRequiredVersion", () => {
+  const patched = applyLinuxRemoteControlSettingsUxPatch(syntheticSshInstallSettingsBundle());
+  const context = {
+    $: { c: () => [] },
+    __mutations: [],
+    __states: [],
+    globalThis: null,
+    w: "Restart",
+    ee: () => ({}),
+    fn: () => null,
+    dn: ({ error, state }) => ({
+      isRestartAvailableNotice: false,
+      statusError: error,
+      statusState: state,
+    }),
+    Ne: () => ({
+      action: {
+        kind: "install-codex",
+        label: "Update Codex",
+        loadingLabel: "Updating",
+      },
+    }),
+    oe: () => true,
+    De: (hostId) =>
+      hostId === "local"
+        ? { appServerVersion: "0.136.0", error: null, installedCodexVersion: null, state: "connected" }
+        : {
+            appServerVersion: "0.130.0",
+            error: { code: "update-required", currentVersion: "0.130.0", minRequiredVersion: "0.137.0" },
+            installedCodexVersion: "0.130.0",
+            state: "error",
+          },
+    R: () => ({
+      mutate(request, options) {
+        context.__mutations.push(request);
+        options.onSuccess({ state: "connected", error: null });
+      },
+    }),
+  };
+  context.globalThis = context;
+  vm.runInNewContext(`${patched};let action=un({connection:{hostId:'remote-ssh:dev',displayName:'dev'},disabled:false,installCodexPending:false,onAuthenticate(){},onEdit(){},onInstallCodex:bt,onLogoutConnection(){},onRemove(){},onShowDetails(){},onToggleConnection(){}});action.onClick();`, context);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.__mutations)), [{ hostId: "remote-ssh:dev", release: "0.137.0" }]);
 });
 
 test("Linux remote-control settings UX patch handles current minified helper names", () => {


### PR DESCRIPTION
## Summary
- Pass a target release through the remote SSH install action instead of letting the upstream default choose a stale runtime.
- Use update-required minRequiredVersion when the remote Codex app-server is too old.
- Fall back to the local Desktop app-server version for first-time remote installs where the remote Codex CLI is missing.

## Tests
- node --test linux-features/remote-mobile-control/test.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check
- node --check /tmp/codex-remote-settings-patched-check.js

Related to #386.