### PR TITLE
Patch Linux monospace font fallback

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -81,6 +81,7 @@ const {
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppServerFeatureEnablementPatch,
   applyLinuxConfigWriteVersionConflictPatch,
+  applyLinuxSafeMonospaceFontStackPatch,
 } = require("./patches/webview-assets.js");
 const { patchAssetFiles } = require("./patches/shared.js");
 
@@ -202,6 +203,39 @@ test("asset patch helpers match every file when passed a global regex", () => {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("Linux safe monospace font stack patch prioritizes Linux mono families", () => {
+  const source = "var e=`ui-monospace, \"SFMono-Regular\", Menlo, Consolas, monospace`;export{e as t};";
+  const patched = applyPatchTwice(applyLinuxSafeMonospaceFontStackPatch, source);
+
+  assert.match(
+    patched,
+    /`"Noto Sans Mono", "DejaVu Sans Mono", "Liberation Mono", "Ubuntu Mono", ui-monospace,/,
+  );
+  assert.doesNotMatch(patched, /var e=`ui-monospace, "SFMono-Regular"/);
+});
+
+test("Linux safe monospace font stack patch accepts upstream-safe stacks", () => {
+  const source =
+    "var e=`DejaVu Sans Mono, ui-monospace, \"SFMono-Regular\", Menlo, Consolas, monospace`;export{e as t};";
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSafeMonospaceFontStackPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("Linux safe monospace font stack patch warns when the unsafe stack drifts", () => {
+  const source = "var e=buildFontStack(`ui-monospace`,`monospace`);export{e as t};";
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSafeMonospaceFontStackPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Could not find Linux monospace font stack insertion point/);
 });
 
 test("subagent nickname metadata patch accepts session metadata shape", () => {
@@ -536,6 +570,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "opaque-window-default-webview-index",
     "opaque-window-default-resolved-theme",
     "linux-fast-mode-model-guard",
+    "linux-safe-monospace-font-stack",
     "subagent-nickname-metadata-shape",
     "local-environment-action-modal-draft",
     "linux-computer-use-ui-availability",

--- a/scripts/patches/core/all-linux/webview/font-settings/patch.js
+++ b/scripts/patches/core/all-linux/webview/font-settings/patch.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const { applyLinuxSafeMonospaceFontStackPatch } = require("../../../../webview-assets.js");
+
+module.exports = [
+  {
+    id: "linux-safe-monospace-font-stack",
+    phase: "webview-asset",
+    order: 1045,
+    ciPolicy: "required-upstream",
+    pattern: /^font-settings-.*\.js$/,
+    missingDescription: "font settings bundle",
+    skipDescription: "Linux monospace font stack patch",
+    apply: applyLinuxSafeMonospaceFontStackPatch,
+  },
+];

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -5,6 +5,33 @@ const path = require("node:path");
 
 // Webview asset patches target hashed browser chunks copied out of app.asar.
 // They stay fail-soft because upstream chunk names and minified symbols drift.
+const LINUX_SAFE_MONOSPACE_FONT_STACK =
+  "\"Noto Sans Mono\", \"DejaVu Sans Mono\", \"Liberation Mono\", \"Ubuntu Mono\", ui-monospace, \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace";
+
+function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
+  const safeLinuxMonoFontPattern =
+    /`[^`]*(?:Noto Sans Mono|DejaVu Sans Mono|Liberation Mono|Ubuntu Mono)[^`]*monospace[^`]*`/u;
+  if (safeLinuxMonoFontPattern.test(currentSource)) {
+    return currentSource;
+  }
+
+  const unsafeDefaultStack = "`ui-monospace, \"SFMono-Regular\", Menlo, Consolas, monospace`";
+  if (currentSource.includes(unsafeDefaultStack)) {
+    return currentSource.replace(
+      unsafeDefaultStack,
+      `\`${LINUX_SAFE_MONOSPACE_FONT_STACK}\``,
+    );
+  }
+
+  if (currentSource.includes("ui-monospace") && currentSource.includes("monospace")) {
+    console.warn(
+      "WARN: Could not find Linux monospace font stack insertion point — skipping default font stack patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
   let patchedSource = currentSource;
   let warnedMissingNeedle = false;
@@ -942,6 +969,7 @@ module.exports = {
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxFastModeModelGuardPatch,
   applyLocalEnvironmentActionModalDraftPatch,
   applySubagentNicknameMetadataPatch,


### PR DESCRIPTION
## Summary

Refs #385.

This adds a core webview asset patch for the upstream font-settings bundle. On Linux, the upstream default stack starts with ui-monospace, which can resolve through fontconfig to a proportional font. The patch keeps user-configured code fonts untouched, but changes the default terminal/code fallback to prefer common Linux monospace families before ui-monospace.

The patch is intentionally narrow:
- it only targets font-settings-*.js
- it does not rewrite xterm or global CSS font variables
- it is idempotent and warns if the upstream bundle drifts
- upstream-build CI treats the patch as required so future DMG drift is visible

## Tests

- node --test scripts/patch-linux-window-ui.test.js
- git diff --check