### PR TITLE
Add optional X11/EWMH Computer Use feature

### DIFF
--- a/linux-features/x11-ewmh-computer-use/README.md
+++ b/linux-features/x11-ewmh-computer-use/README.md
@@ -1,0 +1,79 @@
+# X11/EWMH Computer Use Linux Feature
+
+This optional Linux Feature stages the standalone `codex-computer-use-x11` MCP plugin into Codex Desktop Linux. It stays disabled by default and is enabled only when listed in `linux-features/features.json`.
+
+## Enable
+
+Enable through the git-ignored upstream file `linux-features/features.json`:
+
+```json
+{ "enabled": ["x11-ewmh-computer-use"] }
+```
+
+## Baseline
+
+Supported baseline: Linux Mint Cinnamon on X11 / `x11-ewmh`.
+
+## Tools exposed
+
+The staged plugin exposes the standalone namespaced tool surface:
+
+- `x11_doctor`
+- `x11_list_windows`
+- `x11_focused_window`
+- `x11_focus_window`
+- `x11_accessibility_tree`
+- `x11_type_text`
+- `x11_press_key`
+- `x11_click`
+- `x11_scroll`
+- `x11_drag`
+- `x11_get_app_state`
+- `x11_target_window`
+- `x11_target_context`
+- `x11_release_window`
+
+## Staging modes
+
+Pinned local artifact mode:
+
+```bash
+CODEX_X11_COMPUTER_USE_RELEASE_TARBALL=/path/to/codex-computer-use-x11-v<VERSION>-x86_64-unknown-linux-gnu.tar.gz
+CODEX_X11_COMPUTER_USE_RELEASE_SHA256=<expected-sha256>
+```
+
+Default pinned release mode downloads and verifies v0.1.3 for x86_64 Linux:
+
+```bash
+CODEX_X11_COMPUTER_USE_DOWNLOAD_URL=https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz
+CODEX_X11_COMPUTER_USE_RELEASE_SHA256=067244a16f9e812eb369af42149658c8cf138b13057445bb9d10318f29b0c26b
+```
+
+Those values are built into `stage.sh`; set the variables only to override the pinned artifact.
+
+Local source mode:
+
+```bash
+CODEX_X11_COMPUTER_USE_SOURCE=/path/to/codex-computer-use-x11
+```
+
+Direct binary test mode:
+
+```bash
+CODEX_X11_COMPUTER_USE_BINARY=/path/to/codex-computer-use-x11
+```
+
+## Upstream alignment
+
+This feature wires the separate `codex-computer-use-x11` plugin as an opt-in Linux Feature. It does not move X11/EWMH behavior into the core Computer Use backend and does not replace the bundled `computer-use` plugin.
+
+`agent-sh/computer-use-linux` selectable backend/flavor integration is a separate future investigation. If that route proves a better fit, handle it in a separate change or pull request; no backend/flavor experiment may require enabling this feature by default or modifying core Computer Use behavior in this feature.
+
+## Non-goals
+
+- no core Computer Use replacement;
+- no Wayland/RemoteDesktop baseline;
+- no default enablement;
+- no submodule;
+- no global doctor changes;
+- no writes to user home from `stage.sh`.

--- a/linux-features/x11-ewmh-computer-use/README.md
+++ b/linux-features/x11-ewmh-computer-use/README.md
@@ -42,7 +42,7 @@ CODEX_X11_COMPUTER_USE_RELEASE_TARBALL=/path/to/codex-computer-use-x11-v<VERSION
 CODEX_X11_COMPUTER_USE_RELEASE_SHA256=<expected-sha256>
 ```
 
-Default pinned release mode downloads and verifies v0.1.3 for x86_64 Linux:
+Default pinned release mode downloads and verifies v0.1.3 for x86_64 Linux only. Unsupported architectures fail fast unless you provide an explicit source, binary, tarball, or download override:
 
 ```bash
 CODEX_X11_COMPUTER_USE_DOWNLOAD_URL=https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz

--- a/linux-features/x11-ewmh-computer-use/feature.json
+++ b/linux-features/x11-ewmh-computer-use/feature.json
@@ -1,0 +1,10 @@
+{
+  "id": "x11-ewmh-computer-use",
+  "title": "X11/EWMH Computer Use",
+  "description": "Disabled-by-default adapter for the standalone codex-computer-use-x11 MCP plugin.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patches.js",
+    "stageHook": "./stage.sh"
+  }
+}

--- a/linux-features/x11-ewmh-computer-use/patches.js
+++ b/linux-features/x11-ewmh-computer-use/patches.js
@@ -1,0 +1,105 @@
+"use strict";
+
+const X11_COMPUTER_USE_PLUGIN_NAME = "codex-computer-use-x11";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pluginNameExpressionRegex(pluginName) {
+  const escaped = escapeRegExp(pluginName);
+  return String.raw`(?:\`${escaped}\`|"${escaped}"|'${escaped}')`;
+}
+
+function hasX11ComputerUsePluginGate(source) {
+  const pluginGateArray = findBundledPluginGateArray(source);
+  const target = pluginGateArray?.text ?? source;
+  return new RegExp(
+    String.raw`\{(?:[^{}]*,)?name:${pluginNameExpressionRegex(X11_COMPUTER_USE_PLUGIN_NAME)},(?:isEnabled|isAvailable):`,
+  ).test(target);
+}
+
+function buildX11ComputerUseDescriptor(availabilityProp) {
+  return `{installWhenMissing:!0,name:\`${X11_COMPUTER_USE_PLUGIN_NAME}\`,${availabilityProp}:({platform:e})=>e===\`linux\`}`;
+}
+
+function findMatchingBracket(source, openIndex) {
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index];
+    if (quote != null) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") quote = char;
+    else if (char === "[") depth += 1;
+    else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return -1;
+}
+
+function findBundledPluginGateArray(source) {
+  let markerIndex = source.indexOf(".computerUse");
+  while (markerIndex !== -1) {
+    const openIndex = source.lastIndexOf("[", markerIndex);
+    if (openIndex === -1) return null;
+    const closeIndex = findMatchingBracket(source, openIndex);
+    if (closeIndex !== -1 && markerIndex < closeIndex) {
+      const text = source.slice(openIndex + 1, closeIndex);
+      if (text.includes("installWhenMissing") && text.includes("name:") && /(?:isEnabled|isAvailable):/.test(text)) {
+        return { start: openIndex + 1, end: closeIndex, text };
+      }
+    }
+    markerIndex = source.indexOf(".computerUse", markerIndex + ".computerUse".length);
+  }
+  return null;
+}
+
+function findAlwaysOnBundledDescriptor(pluginGateArray) {
+  const pluginNameExpression = "(?:[A-Za-z_$][\\w$]*(?:\\.[A-Za-z_$][\\w$]*)?|`[^`]+`|\"[^\"]+\"|'[^']+')";
+  const regex = new RegExp(String.raw`\{name:(${pluginNameExpression}),(isEnabled|isAvailable):\(\)=>!0\}`, "g");
+  let lastMatch = null;
+  for (const match of pluginGateArray.text.matchAll(regex)) lastMatch = match;
+  return lastMatch;
+}
+
+function applyX11ComputerUsePluginGatePatch(currentSource) {
+  if (hasX11ComputerUsePluginGate(currentSource)) return currentSource;
+  const pluginGateArray = findBundledPluginGateArray(currentSource);
+  if (pluginGateArray == null) {
+    if (currentSource.includes(".computerUse")) {
+      throw new Error("Required X11 Computer Use plugin gate patch failed: could not find bundled plugin descriptor array");
+    }
+    return currentSource;
+  }
+  const match = findAlwaysOnBundledDescriptor(pluginGateArray);
+  if (match == null) {
+    throw new Error("Required X11 Computer Use plugin gate patch failed: could not find bundled plugin descriptor insertion point");
+  }
+  const [_descriptor, _pluginName, availabilityProp] = match;
+  const insertionIndex = pluginGateArray.start + match.index;
+  return `${currentSource.slice(0, insertionIndex)}${buildX11ComputerUseDescriptor(availabilityProp)},${currentSource.slice(insertionIndex)}`;
+}
+
+const descriptors = [
+  {
+    id: "x11-ewmh-computer-use-plugin-gate",
+    phase: "main-bundle",
+    order: 156,
+    ciPolicy: "required-upstream",
+    apply: applyX11ComputerUsePluginGatePatch,
+  },
+];
+
+module.exports = {
+  X11_COMPUTER_USE_PLUGIN_NAME,
+  applyX11ComputerUsePluginGatePatch,
+  descriptors,
+};

--- a/linux-features/x11-ewmh-computer-use/patches.js
+++ b/linux-features/x11-ewmh-computer-use/patches.js
@@ -74,10 +74,7 @@ function applyX11ComputerUsePluginGatePatch(currentSource) {
   if (hasX11ComputerUsePluginGate(currentSource)) return currentSource;
   const pluginGateArray = findBundledPluginGateArray(currentSource);
   if (pluginGateArray == null) {
-    if (currentSource.includes(".computerUse")) {
-      throw new Error("Required X11 Computer Use plugin gate patch failed: could not find bundled plugin descriptor array");
-    }
-    return currentSource;
+    throw new Error("Optional X11 Computer Use plugin gate patch drift: could not find expected upstream .computerUse plugin descriptor array");
   }
   const match = findAlwaysOnBundledDescriptor(pluginGateArray);
   if (match == null) {
@@ -93,7 +90,7 @@ const descriptors = [
     id: "x11-ewmh-computer-use-plugin-gate",
     phase: "main-bundle",
     order: 156,
-    ciPolicy: "required-upstream",
+    ciPolicy: "optional",
     apply: applyX11ComputerUsePluginGatePatch,
   },
 ];

--- a/linux-features/x11-ewmh-computer-use/stage.sh
+++ b/linux-features/x11-ewmh-computer-use/stage.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+PLUGIN_NAME="codex-computer-use-x11"
+DEFAULT_RELEASE_URL="https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz"
+DEFAULT_RELEASE_SHA256="067244a16f9e812eb369af42149658c8cf138b13057445bb9d10318f29b0c26b"
+FEATURE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${INSTALL_DIR:?INSTALL_DIR is required}"
+WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
+TARGET_PLUGIN="$INSTALL_DIR/resources/plugins/openai-bundled/plugins/$PLUGIN_NAME"
+TARGET_MARKETPLACE="$INSTALL_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+
+find_cargo() {
+    if command -v cargo >/dev/null 2>&1; then command -v cargo; return 0; fi
+    if [ -x "$HOME/.cargo/bin/cargo" ]; then echo "$HOME/.cargo/bin/cargo"; return 0; fi
+    return 1
+}
+
+expected_sha_value() {
+    local value="${CODEX_X11_COMPUTER_USE_RELEASE_SHA256:-$DEFAULT_RELEASE_SHA256}"
+    [ -n "$value" ] || return 1
+    if [ -f "$value" ]; then
+        awk '{print $1; exit}' "$value"
+    else
+        printf '%s\n' "$value"
+    fi
+}
+
+verify_sha256() {
+    local file="$1"
+    local expected
+    expected="$(expected_sha_value)" || {
+        echo "CODEX_X11_COMPUTER_USE_RELEASE_SHA256 is required for tarball/download mode" >&2
+        return 1
+    }
+    local actual
+    actual="$(sha256sum "$file" | awk '{print $1}')"
+    if [ "$actual" != "$expected" ]; then
+        echo "sha256 mismatch for $file: expected $expected got $actual" >&2
+        return 1
+    fi
+}
+
+write_plugin_from_binary() {
+    local binary="$1"
+    local dest="$2"
+    [ -x "$binary" ] || { echo "codex-computer-use-x11 binary is not executable: $binary" >&2; return 1; }
+    rm -rf "$dest"
+    mkdir -p "$dest/.codex-plugin" "$dest/bin" "$dest/assets"
+    cp "$binary" "$dest/bin/codex-computer-use-x11"
+    chmod 0755 "$dest/bin/codex-computer-use-x11"
+    if [ -f "$FEATURE_DIR/assets/app-icon.png" ]; then
+        cp "$FEATURE_DIR/assets/app-icon.png" "$dest/assets/app-icon.png"
+    else
+        : > "$dest/assets/app-icon.png"
+    fi
+    cat > "$dest/.mcp.json" <<'JSON'
+{
+  "mcpServers": {
+    "codex-computer-use-x11": {
+      "command": "./bin/codex-computer-use-x11",
+      "args": ["mcp"],
+      "cwd": "."
+    }
+  }
+}
+JSON
+    cat > "$dest/.codex-plugin/plugin.json" <<'JSON'
+{
+  "name": "codex-computer-use-x11",
+  "version": "0.0.0-adapter",
+  "description": "Standalone X11/EWMH Computer Use MCP tools for Codex.",
+  "author": { "name": "AlekseiSeleznev", "url": "https://github.com/AlekseiSeleznev" },
+  "homepage": "https://github.com/AlekseiSeleznev/codex-computer-use-x11",
+  "license": "MIT",
+  "keywords": ["computer-use", "linux", "x11", "ewmh", "mcp"],
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "X11 Computer Use",
+    "shortDescription": "Standalone x11_* tools for Linux X11/EWMH",
+    "longDescription": "Provides standalone x11_* readiness diagnostics, window listing/focus, keyboard input, pointer actions, accessibility tree, app state, and target-window context tools without replacing the bundled Computer Use plugin.",
+    "developerName": "AlekseiSeleznev",
+    "category": "Productivity",
+    "websiteURL": "https://github.com/AlekseiSeleznev/codex-computer-use-x11",
+    "logo": "./assets/app-icon.png",
+    "defaultPrompt": ["Check whether standalone X11 Computer Use is ready with x11_doctor"],
+    "brandColor": "#1E293B",
+    "screenshots": []
+  }
+}
+JSON
+}
+
+stage_from_tarball() {
+    local tarball="$1"
+    verify_sha256 "$tarball"
+    local extract_dir="$WORK_DIR/x11-computer-use-extract"
+    rm -rf "$extract_dir"
+    mkdir -p "$extract_dir"
+    tar -xzf "$tarball" -C "$extract_dir"
+    [ -f "$extract_dir/$PLUGIN_NAME/.mcp.json" ] || { echo "tarball does not contain $PLUGIN_NAME/.mcp.json" >&2; return 1; }
+    rm -rf "$TARGET_PLUGIN"
+    mkdir -p "$(dirname "$TARGET_PLUGIN")"
+    cp -R "$extract_dir/$PLUGIN_NAME" "$TARGET_PLUGIN"
+    chmod 0755 "$TARGET_PLUGIN/bin/codex-computer-use-x11"
+}
+
+stage_from_source() {
+    local source="$1"
+    [ -f "$source/Cargo.toml" ] || { echo "CODEX_X11_COMPUTER_USE_SOURCE lacks Cargo.toml: $source" >&2; return 1; }
+    local cargo_cmd
+    cargo_cmd="$(find_cargo)" || { echo "cargo not found for CODEX_X11_COMPUTER_USE_SOURCE build" >&2; return 1; }
+    (cd "$source" && "$cargo_cmd" build --release >&2)
+    write_plugin_from_binary "$source/target/release/codex-computer-use-x11" "$TARGET_PLUGIN"
+}
+
+stage_from_download() {
+    local url="$1"
+    local tarball="$WORK_DIR/codex-computer-use-x11-download.tar.gz"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$url" -o "$tarball"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$tarball" "$url"
+    else
+        echo "curl or wget is required for CODEX_X11_COMPUTER_USE_DOWNLOAD_URL" >&2
+        return 1
+    fi
+    stage_from_tarball "$tarball"
+}
+
+write_marketplace_entry() {
+    local marketplace="$1"
+    node - "$marketplace" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const marketplacePath = process.argv[2];
+let marketplace = { plugins: [] };
+try { marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8")); } catch (_error) { marketplace = { plugins: [] }; }
+if (!Array.isArray(marketplace.plugins)) marketplace.plugins = [];
+marketplace.plugins = marketplace.plugins.filter((plugin) => plugin?.name !== "codex-computer-use-x11");
+marketplace.plugins.push({
+  name: "codex-computer-use-x11",
+  source: { source: "local", path: "./plugins/codex-computer-use-x11" },
+  policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+  category: "Productivity",
+});
+fs.mkdirSync(path.dirname(marketplacePath), { recursive: true });
+fs.writeFileSync(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`);
+NODE
+}
+
+mkdir -p "$WORK_DIR"
+if [ -n "${CODEX_X11_COMPUTER_USE_RELEASE_TARBALL:-}" ]; then
+    stage_from_tarball "$CODEX_X11_COMPUTER_USE_RELEASE_TARBALL"
+elif [ -n "${CODEX_X11_COMPUTER_USE_BINARY:-}" ]; then
+    write_plugin_from_binary "$CODEX_X11_COMPUTER_USE_BINARY" "$TARGET_PLUGIN"
+elif [ -n "${CODEX_X11_COMPUTER_USE_SOURCE:-}" ]; then
+    stage_from_source "$CODEX_X11_COMPUTER_USE_SOURCE"
+elif [ -n "${CODEX_X11_COMPUTER_USE_DOWNLOAD_URL:-}" ]; then
+    stage_from_download "$CODEX_X11_COMPUTER_USE_DOWNLOAD_URL"
+else
+    stage_from_download "$DEFAULT_RELEASE_URL"
+fi
+
+write_marketplace_entry "$TARGET_MARKETPLACE"
+echo "X11/EWMH Computer Use plugin staged" >&2

--- a/linux-features/x11-ewmh-computer-use/stage.sh
+++ b/linux-features/x11-ewmh-computer-use/stage.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 PLUGIN_NAME="codex-computer-use-x11"
-DEFAULT_RELEASE_URL="https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz"
-DEFAULT_RELEASE_SHA256="067244a16f9e812eb369af42149658c8cf138b13057445bb9d10318f29b0c26b"
+DEFAULT_X86_64_RELEASE_URL="https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz"
+DEFAULT_X86_64_RELEASE_SHA256="067244a16f9e812eb369af42149658c8cf138b13057445bb9d10318f29b0c26b"
 FEATURE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="${INSTALL_DIR:?INSTALL_DIR is required}"
 WORK_DIR="${WORK_DIR:-$(mktemp -d)}"
@@ -16,16 +16,43 @@ find_cargo() {
     return 1
 }
 
+canonical_arch() {
+    local arch="${ARCH:-$(uname -m)}"
+    case "$arch" in
+        x64|x86_64|amd64) printf '%s\n' "x86_64" ;;
+        arm64|aarch64) printf '%s\n' "aarch64" ;;
+        *) printf '%s\n' "$arch" ;;
+    esac
+}
+
+default_release_url() {
+    case "$(canonical_arch)" in
+        x86_64) printf '%s\n' "$DEFAULT_X86_64_RELEASE_URL" ;;
+        *)
+            echo "x11-ewmh-computer-use has no default release artifact for ARCH=${ARCH:-$(uname -m)}; set CODEX_X11_COMPUTER_USE_SOURCE, CODEX_X11_COMPUTER_USE_BINARY, CODEX_X11_COMPUTER_USE_RELEASE_TARBALL, or CODEX_X11_COMPUTER_USE_DOWNLOAD_URL explicitly" >&2
+            return 1
+            ;;
+    esac
+}
+
+default_release_sha256() {
+    case "$(canonical_arch)" in
+        x86_64) printf '%s\n' "$DEFAULT_X86_64_RELEASE_SHA256" ;;
+        *) return 1 ;;
+    esac
+}
+
 expected_sha_value() {
-    local value="${CODEX_X11_COMPUTER_USE_RELEASE_SHA256:-$DEFAULT_RELEASE_SHA256}"
-    [ -n "$value" ] || return 1
+    local value="${CODEX_X11_COMPUTER_USE_RELEASE_SHA256:-}"
+    if [ -z "$value" ]; then
+        value="$(default_release_sha256)" || return 1
+    fi
     if [ -f "$value" ]; then
         awk '{print $1; exit}' "$value"
     else
         printf '%s\n' "$value"
     fi
 }
-
 verify_sha256() {
     local file="$1"
     local expected
@@ -91,9 +118,68 @@ JSON
 JSON
 }
 
+validate_tarball_entries() {
+    local tarball="$1"
+    node - "$tarball" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const zlib = require("node:zlib");
+
+const tarball = process.argv[2];
+const data = zlib.gunzipSync(fs.readFileSync(tarball));
+
+function cString(buffer, start, length) {
+  const raw = buffer.subarray(start, start + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.length : end).toString("utf8");
+}
+
+function parseOctal(buffer, start, length) {
+  const raw = cString(buffer, start, length).trim();
+  if (raw.length === 0) return 0;
+  if (!/^[0-7]+$/.test(raw)) throw new Error(`tarball has invalid octal size field: ${raw}`);
+  return Number.parseInt(raw, 8);
+}
+
+function isZeroBlock(block) {
+  return block.every((byte) => byte === 0);
+}
+
+function validatePath(entryPath) {
+  if (!entryPath || entryPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(entryPath)) {
+    throw new Error(`tarball contains unsafe absolute path: ${entryPath}`);
+  }
+  const normalized = path.posix.normalize(entryPath);
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.includes("..") || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`tarball contains unsafe parent path: ${entryPath}`);
+  }
+}
+
+let offset = 0;
+while (offset + 512 <= data.length) {
+  const header = data.subarray(offset, offset + 512);
+  if (isZeroBlock(header)) break;
+  const name = cString(header, 0, 100);
+  const prefix = cString(header, 345, 155);
+  const entryPath = prefix ? `${prefix}/${name}` : name;
+  const typeflag = String.fromCharCode(header[156] || 0);
+  validatePath(entryPath);
+  if (typeflag === "1") throw new Error(`tarball contains unsupported hardlink entry: ${entryPath}`);
+  if (typeflag === "2") throw new Error(`tarball contains unsupported symlink entry: ${entryPath}`);
+  if (!(typeflag === "0" || typeflag.charCodeAt(0) === 0 || typeflag === "5")) {
+    throw new Error(`tarball contains unsupported entry type ${JSON.stringify(typeflag)}: ${entryPath}`);
+  }
+  const size = parseOctal(header, 124, 12);
+  offset += 512 + Math.ceil(size / 512) * 512;
+}
+NODE
+}
+
 stage_from_tarball() {
     local tarball="$1"
     verify_sha256 "$tarball"
+    validate_tarball_entries "$tarball"
     local extract_dir="$WORK_DIR/x11-computer-use-extract"
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
@@ -159,7 +245,7 @@ elif [ -n "${CODEX_X11_COMPUTER_USE_SOURCE:-}" ]; then
 elif [ -n "${CODEX_X11_COMPUTER_USE_DOWNLOAD_URL:-}" ]; then
     stage_from_download "$CODEX_X11_COMPUTER_USE_DOWNLOAD_URL"
 else
-    stage_from_download "$DEFAULT_RELEASE_URL"
+    stage_from_download "$(default_release_url)"
 fi
 
 write_marketplace_entry "$TARGET_MARKETPLACE"

--- a/linux-features/x11-ewmh-computer-use/test.js
+++ b/linux-features/x11-ewmh-computer-use/test.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { execFileSync } = require("node:child_process");
+
+const featureDir = __dirname;
+const featureId = "x11-ewmh-computer-use";
+
+function upstreamRepoRoot() {
+  const candidates = [
+    process.env.CODEX_DESKTOP_LINUX_REPO,
+    process.env.CODEX_DESKTOP_LINUX_FULL_PATH,
+    path.resolve(featureDir, "..", ".."),
+    "/home/as/Документы/AI_PROJECTS/codex-desktop-linux",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "scripts/lib/linux-features.js"))) {
+      return candidate;
+    }
+  }
+  throw new Error("Could not locate codex-desktop-linux scripts/lib/linux-features.js; set CODEX_DESKTOP_LINUX_REPO");
+}
+
+function linuxFeaturesLib() {
+  const repoRoot = upstreamRepoRoot();
+  return require(path.join(repoRoot, "scripts/lib/linux-features.js"));
+}
+
+function copyFeatureTo(featuresRoot) {
+  const target = path.join(featuresRoot, featureId);
+  fs.mkdirSync(target, { recursive: true });
+  for (const file of ["feature.json", "README.md", "stage.sh", "patches.js"]) {
+    fs.copyFileSync(path.join(featureDir, file), path.join(target, file));
+  }
+  fs.chmodSync(path.join(target, "stage.sh"), 0o755);
+}
+
+function tempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${prefix}-`));
+}
+
+function makeFakeExecutable(file) {
+  fs.writeFileSync(file, "#!/bin/sh\nif [ \"$1\" = doctor ]; then echo '{\"project\":\"codex-computer-use-x11\",\"version\":\"test\",\"backend\":\"x11-ewmh\",\"readiness\":{\"ok\":true}}'; fi\nexit 0\n");
+  fs.chmodSync(file, 0o755);
+}
+
+function applyPatchTwice(patchFn, source) {
+  const patched = patchFn(source);
+  assert.equal(patchFn(patched), patched);
+  return patched;
+}
+
+
+test("x11-ewmh-computer-use documents and pins v0.1.3 release artifact", () => {
+  const stage = fs.readFileSync(path.join(featureDir, "stage.sh"), "utf8");
+  const readme = fs.readFileSync(path.join(featureDir, "README.md"), "utf8");
+  const url = "https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/download/v0.1.3/codex-computer-use-x11-v0.1.3-x86_64-unknown-linux-gnu.tar.gz";
+  const sha = "067244a16f9e812eb369af42149658c8cf138b13057445bb9d10318f29b0c26b";
+  assert.equal(stage.includes(url), true);
+  assert.equal(stage.includes(sha), true);
+  assert.equal(readme.includes(url), true);
+  assert.equal(readme.includes(sha), true);
+});
+
+test("x11-ewmh-computer-use stays disabled until listed in features.json", () => {
+  const { enabledLinuxFeatureStageHooks, loadLinuxFeaturePatchDescriptors } = linuxFeaturesLib();
+  const workspace = tempDir("x11-ewmh-feature");
+  const featuresRoot = path.join(workspace, "features");
+  fs.mkdirSync(featuresRoot, { recursive: true });
+  copyFeatureTo(featuresRoot);
+  fs.writeFileSync(path.join(featuresRoot, "features.example.json"), '{"enabled":[]}\n');
+
+  assert.deepEqual(enabledLinuxFeatureStageHooks({ featuresRoot }), []);
+  assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+
+  fs.writeFileSync(path.join(featuresRoot, "features.json"), `{"enabled":["${featureId}"]}\n`);
+  assert.equal(enabledLinuxFeatureStageHooks({ featuresRoot }).length, 1);
+  assert.equal(loadLinuxFeaturePatchDescriptors({ featuresRoot }).length, 1);
+});
+
+test("x11-ewmh-computer-use plugin gate is idempotent and narrow", () => {
+  const { applyX11ComputerUsePluginGatePatch } = require("./patches.js");
+  const source = [
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+  const patched = applyPatchTwice(applyX11ComputerUsePluginGatePatch, source);
+  assert.match(patched, /name:`codex-computer-use-x11`,isAvailable:\(\{platform:e\}\)=>e===`linux`/);
+  assert.match(patched, /name:ft,isAvailable:\(\{features:e,platform:t\}\)=>t===`darwin`&&e\.computerUse/);
+});
+
+test("x11-ewmh-computer-use stage hook records marketplace entry and preserves computer-use", () => {
+  const workspace = tempDir("x11-ewmh-stage");
+  const installDir = path.join(workspace, "install");
+  const workDir = path.join(workspace, "work");
+  const fakeBinary = path.join(workspace, "codex-computer-use-x11");
+  const computerUseDir = path.join(installDir, "resources/plugins/openai-bundled/plugins/computer-use");
+  const computerUseMarker = path.join(computerUseDir, ".mcp.json");
+  const marketplace = path.join(installDir, "resources/plugins/openai-bundled/.agents/plugins/marketplace.json");
+  fs.mkdirSync(computerUseDir, { recursive: true });
+  fs.mkdirSync(path.dirname(marketplace), { recursive: true });
+  fs.writeFileSync(computerUseMarker, '{"mcpServers":{"computer-use":{"command":"./bin/codex-computer-use-linux"}}}\n');
+  fs.writeFileSync(marketplace, JSON.stringify({ plugins: [{ name: "computer-use", source: { path: "./plugins/computer-use" } }] }));
+  const beforeComputerUse = fs.readFileSync(computerUseMarker, "utf8");
+  makeFakeExecutable(fakeBinary);
+
+  execFileSync("bash", [path.join(featureDir, "stage.sh")], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      SCRIPT_DIR: upstreamRepoRoot(),
+      INSTALL_DIR: installDir,
+      WORK_DIR: workDir,
+      ARCH: process.arch === "arm64" ? "aarch64" : "x86_64",
+      CODEX_UPSTREAM_APP_DIR: path.join(workspace, "Codex.app"),
+      CODEX_X11_COMPUTER_USE_BINARY: fakeBinary,
+    },
+    stdio: "pipe",
+  });
+
+  const pluginDir = path.join(installDir, "resources/plugins/openai-bundled/plugins/codex-computer-use-x11");
+  assert.equal(fs.existsSync(path.join(pluginDir, ".mcp.json")), true);
+  assert.equal(fs.existsSync(path.join(pluginDir, "bin/codex-computer-use-x11")), true);
+  assert.equal(fs.statSync(path.join(pluginDir, "bin/codex-computer-use-x11")).mode & 0o111 ? true : false, true);
+  assert.equal(fs.readFileSync(computerUseMarker, "utf8"), beforeComputerUse);
+
+  const parsedMarketplace = JSON.parse(fs.readFileSync(marketplace, "utf8"));
+  assert.equal(parsedMarketplace.plugins.some((plugin) => plugin.name === "codex-computer-use-x11" && plugin.source?.path === "./plugins/codex-computer-use-x11" && plugin.policy?.authentication === "ON_INSTALL"), true);
+  assert.equal(parsedMarketplace.plugins.some((plugin) => plugin.name === "computer-use"), true);
+});

--- a/linux-features/x11-ewmh-computer-use/test.js
+++ b/linux-features/x11-ewmh-computer-use/test.js
@@ -1,10 +1,12 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const zlib = require("node:zlib");
 const { execFileSync } = require("node:child_process");
 
 const featureDir = __dirname;
@@ -48,6 +50,78 @@ function makeFakeExecutable(file) {
   fs.chmodSync(file, 0o755);
 }
 
+
+function sha256(file) {
+  return crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+}
+
+function writeTarOctal(header, offset, length, value) {
+  const text = value.toString(8).padStart(length - 1, "0").slice(-(length - 1));
+  header.write(`${text}\0`, offset, length, "ascii");
+}
+
+function writeTarString(header, offset, length, value) {
+  const encoded = Buffer.from(value, "utf8");
+  assert.equal(encoded.length <= length, true, `tar field too long: ${value}`);
+  encoded.copy(header, offset);
+}
+
+function tarHeader(entry) {
+  const content = Buffer.isBuffer(entry.content) ? entry.content : Buffer.from(entry.content ?? "");
+  const header = Buffer.alloc(512, 0);
+  writeTarString(header, 0, 100, entry.name);
+  writeTarOctal(header, 100, 8, entry.mode ?? (entry.type === "5" ? 0o755 : 0o644));
+  writeTarOctal(header, 108, 8, 0);
+  writeTarOctal(header, 116, 8, 0);
+  writeTarOctal(header, 124, 12, entry.type === "0" || entry.type == null ? content.length : 0);
+  writeTarOctal(header, 136, 12, 0);
+  header.fill(" ", 148, 156);
+  header.write(entry.type ?? "0", 156, 1, "ascii");
+  if (entry.linkname) writeTarString(header, 157, 100, entry.linkname);
+  header.write("ustar\0", 257, 6, "ascii");
+  header.write("00", 263, 2, "ascii");
+  header.write("0", 265, 1, "ascii");
+  header.write("0", 297, 1, "ascii");
+  let checksum = 0;
+  for (const byte of header) checksum += byte;
+  const checksumText = checksum.toString(8).padStart(6, "0").slice(-6);
+  header.write(`${checksumText}\0 `, 148, 8, "ascii");
+  const padding = Buffer.alloc((512 - (content.length % 512)) % 512, 0);
+  return [header, content, padding];
+}
+
+function writeTarGz(file, entries) {
+  const chunks = [];
+  for (const entry of entries) chunks.push(...tarHeader(entry));
+  chunks.push(Buffer.alloc(1024, 0));
+  fs.writeFileSync(file, zlib.gzipSync(Buffer.concat(chunks)));
+}
+
+function safePluginTarball(file) {
+  writeTarGz(file, [
+    { name: "codex-computer-use-x11/", type: "5" },
+    { name: "codex-computer-use-x11/bin/", type: "5" },
+    { name: "codex-computer-use-x11/.mcp.json", type: "0", content: '{"mcpServers":{"codex-computer-use-x11":{"command":"./bin/codex-computer-use-x11"}}}\n' },
+    { name: "codex-computer-use-x11/bin/codex-computer-use-x11", type: "0", mode: 0o755, content: "#!/bin/sh\nexit 0\n" },
+  ]);
+}
+
+function runStage(workspace, extraEnv = {}) {
+  return execFileSync("bash", [path.join(featureDir, "stage.sh")], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      SCRIPT_DIR: upstreamRepoRoot(),
+      INSTALL_DIR: path.join(workspace, "install"),
+      WORK_DIR: path.join(workspace, "work"),
+      ARCH: "x86_64",
+      CODEX_UPSTREAM_APP_DIR: path.join(workspace, "Codex.app"),
+      ...extraEnv,
+    },
+    stdio: "pipe",
+  });
+}
+
 function applyPatchTwice(patchFn, source) {
   const patched = patchFn(source);
   assert.equal(patchFn(patched), patched);
@@ -64,6 +138,72 @@ test("x11-ewmh-computer-use documents and pins v0.1.3 release artifact", () => {
   assert.equal(stage.includes(sha), true);
   assert.equal(readme.includes(url), true);
   assert.equal(readme.includes(sha), true);
+});
+
+
+test("x11-ewmh-computer-use default release fails fast on unsupported architectures", () => {
+  const workspace = tempDir("x11-ewmh-arch");
+  assert.throws(
+    () => runStage(workspace, { ARCH: "aarch64" }),
+    (error) => {
+      assert.match(String(error.stderr), /no default release artifact for ARCH=aarch64/);
+      return true;
+    },
+  );
+});
+
+test("x11-ewmh-computer-use validates tarball entries before extraction", () => {
+  const cases = [
+    {
+      name: "absolute",
+      entry: { name: "/tmp/evil", type: "0", content: "evil" },
+      message: /unsafe absolute path/,
+    },
+    {
+      name: "parent",
+      entry: { name: "../evil", type: "0", content: "evil" },
+      message: /unsafe parent path/,
+    },
+    {
+      name: "symlink",
+      entry: { name: "codex-computer-use-x11/bin/link", type: "2", linkname: "/tmp/evil" },
+      message: /unsupported symlink entry/,
+    },
+    {
+      name: "hardlink",
+      entry: { name: "codex-computer-use-x11/bin/link", type: "1", linkname: "codex-computer-use-x11/bin/codex-computer-use-x11" },
+      message: /unsupported hardlink entry/,
+    },
+  ];
+
+  for (const item of cases) {
+    const workspace = tempDir(`x11-ewmh-tar-${item.name}`);
+    const tarball = path.join(workspace, "malicious.tar.gz");
+    writeTarGz(tarball, [item.entry]);
+    assert.throws(
+      () => runStage(workspace, {
+        CODEX_X11_COMPUTER_USE_RELEASE_TARBALL: tarball,
+        CODEX_X11_COMPUTER_USE_RELEASE_SHA256: sha256(tarball),
+      }),
+      (error) => {
+        assert.match(String(error.stderr), item.message);
+        return true;
+      },
+    );
+  }
+});
+
+test("x11-ewmh-computer-use stages a validated safe release tarball", () => {
+  const workspace = tempDir("x11-ewmh-safe-tar");
+  const tarball = path.join(workspace, "safe.tar.gz");
+  safePluginTarball(tarball);
+  runStage(workspace, {
+    CODEX_X11_COMPUTER_USE_RELEASE_TARBALL: tarball,
+    CODEX_X11_COMPUTER_USE_RELEASE_SHA256: sha256(tarball),
+  });
+  const pluginDir = path.join(workspace, "install/resources/plugins/openai-bundled/plugins/codex-computer-use-x11");
+  assert.equal(fs.existsSync(path.join(pluginDir, ".mcp.json")), true);
+  assert.equal(fs.existsSync(path.join(pluginDir, "bin/codex-computer-use-x11")), true);
 });
 
 test("x11-ewmh-computer-use stays disabled until listed in features.json", () => {
@@ -91,6 +231,20 @@ test("x11-ewmh-computer-use plugin gate is idempotent and narrow", () => {
   const patched = applyPatchTwice(applyX11ComputerUsePluginGatePatch, source);
   assert.match(patched, /name:`codex-computer-use-x11`,isAvailable:\(\{platform:e\}\)=>e===`linux`/);
   assert.match(patched, /name:ft,isAvailable:\(\{features:e,platform:t\}\)=>t===`darwin`&&e\.computerUse/);
+});
+
+
+test("x11-ewmh-computer-use plugin gate surfaces upstream computerUse marker drift", () => {
+  const { applyX11ComputerUsePluginGatePatch } = require("./patches.js");
+  assert.throws(
+    () => applyX11ComputerUsePluginGatePatch("var Kr=[{name:`latex-tectonic`,isAvailable:()=>!0}];"),
+    /expected upstream \.computerUse plugin descriptor array/,
+  );
+});
+
+test("x11-ewmh-computer-use plugin gate descriptor stays optional", () => {
+  const { descriptors } = require("./patches.js");
+  assert.equal(descriptors[0].ciPolicy, "optional");
 });
 
 test("x11-ewmh-computer-use stage hook records marketplace entry and preserves computer-use", () => {


### PR DESCRIPTION
## What changed

Adds `linux-features/x11-ewmh-computer-use/` as a fully opt-in adapter for the standalone [`codex-computer-use-x11`](https://github.com/AlekseiSeleznev/codex-computer-use-x11) MCP plugin.

The feature:

- stays disabled by default and only activates when listed in `linux-features/features.json`;
- stages the v0.1.3 plugin artifact from a pinned release URL with SHA-256 verification;
- supports local source, local tarball, direct binary, and custom download override modes;
- adds a narrow plugin-gate patch descriptor for Linux only;
- keeps the existing bundled `computer-use` plugin and global doctor behavior unchanged;
- avoids submodules and keeps `codex-computer-use-x11` as the source of truth.

Release used by the default staging path:

- https://github.com/AlekseiSeleznev/codex-computer-use-x11/releases/tag/v0.1.3

## Why

This follows the direction from #389: use an optional `linux-features/` integration instead of rewriting the main Computer Use backend or adding a default bundled plugin.

## Validation

Ran locally from a clean `origin/main` worktree:

```bash
bash -n linux-features/x11-ewmh-computer-use/stage.sh
node --test linux-features/x11-ewmh-computer-use/test.js
node --test linux-features/*/test.js
```

All feature tests passed locally (`246` tests total for `linux-features/*/test.js`).
