### PR TITLE
Document Nix Codex CLI requirement

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -11,6 +11,24 @@ bot refreshes the upstream `Codex.dmg` hash and verifies the Nix package outputs
 in `main`. If you hit a hash mismatch right after an upstream release, wait for
 the next bot run and retry.
 
+## Codex CLI Requirement
+
+The Nix package does not install the Codex CLI for you. Before first launch,
+make sure the `codex` command is available in your user environment, or set
+`CODEX_CLI_PATH` to the binary you want Codex Desktop to use.
+
+One option is the upstream npm package:
+
+```bash
+npm i -g @openai/codex
+```
+
+If `nix run` appears to do nothing, check the launcher log first:
+
+```bash
+sed -n '1,220p' ~/.cache/codex-desktop/launcher.log
+```
+
 ## Feature Outputs
 
 Flakes do not include the git-ignored `linux-features/features.json` opt-in

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,7 @@
 | `ERR_CONNECTION_REFUSED` on the webview port | Ensure `python3` works and the configured port is free |
 | Stuck on Codex logo splash | Check `~/.cache/codex-desktop/launcher.log`; another process may be serving the webview port |
 | `CODEX_CLI_PATH` error | Reopen the app to retry automatic CLI install, or install manually with `npm i -g @openai/codex` / `npm i -g --prefix ~/.local @openai/codex` |
+| `nix run` exits with no window or terminal output | Check `~/.cache/codex-desktop/launcher.log`; the Nix package still requires a user-provided `codex` CLI |
 | `gh auth status` works in terminal but fails inside Codex Desktop | See [GitHub CLI auth in app-launched shells](github-cli-auth.md) |
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log` |
 | GPU / Vulkan / Wayland errors | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` |


### PR DESCRIPTION
## What changed

- Added a Nix docs section explaining that the flake does not install the Codex CLI.
- Documented that users should make `codex` available themselves or set `CODEX_CLI_PATH`.
- Added a troubleshooting row for `nix run` appearing to do nothing while the launcher writes the real error to `~/.cache/codex-desktop/launcher.log`.

## Why

Issue #395 shows that Nix users can hit a silent-looking launch failure when the app starts successfully but stops at CLI lookup because the Codex CLI is missing. This was not the upstream patch drift fixed in #397; it is a Nix docs/UX gap.

## Validation

- `git diff --check`