### PR TITLE
Restore Linux desktop settings with native shortcuts

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -48,8 +48,12 @@ const {
   applyKeybindsSettingsIndexPatch,
   applyKeybindsSettingsSectionsPatch,
   applyKeybindsSettingsSharedPatch,
+  applyLinuxDesktopSettingsIndexPatch,
+  applyLinuxDesktopSettingsSectionsPatch,
+  applyLinuxDesktopSettingsSharedPatch,
   applyLinuxKeybindOverridesRuntimePatch,
   patchKeybindsSettingsAssets,
+  resolveLinuxDesktopSettingsAsset,
   resolveKeybindsSettingsAsset,
 } = require("./patches/keybinds-settings.js");
 const {
@@ -160,6 +164,9 @@ module.exports = {
   applyKeybindsSettingsIndexPatch,
   applyKeybindsSettingsSectionsPatch,
   applyKeybindsSettingsSharedPatch,
+  applyLinuxDesktopSettingsIndexPatch,
+  applyLinuxDesktopSettingsSectionsPatch,
+  applyLinuxDesktopSettingsSharedPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
@@ -225,5 +232,6 @@ module.exports = {
   patchMainBundleSource,
   patchPackageJson,
   resolveDesktopName,
+  resolveLinuxDesktopSettingsAsset,
   resolveKeybindsSettingsAsset,
 };

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -18,6 +18,7 @@ const {
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
+  applyLinuxDesktopSettingsIndexPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxBrowserUseIabVisibleOnCreatePatch,
@@ -56,6 +57,7 @@ const {
   patchExtractedApp,
   patchPackageJson,
   patchLinuxAppUpdaterBridge,
+  patchKeybindsSettingsAssets,
   patchAutomationScheduleAssets,
   createPatchReport,
   corePatchDescriptors,
@@ -66,6 +68,10 @@ const {
   parseOsRelease,
   resolveDesktopName,
 } = require("./patch-linux-window-ui.js");
+const {
+  keybindsSettingsAsset,
+  linuxDesktopSettingsAsset,
+} = require("./patches/keybinds-settings.js");
 const {
   validateReport,
 } = require("./ci/validate-patch-report.js");
@@ -804,6 +810,70 @@ function keybindsIndexBundleWithLazyAliasDriftFixture() {
     "(0,Z.lazy)(()=>s(",
     "(0,R.lazy)(()=>q(",
   );
+}
+
+function settingsSharedBundleFixture() {
+  return [
+    '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},appearance:{id:`settings.nav.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`},',
+    "function titleForSection(e){switch(e){case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`appearance`:return (0,d.jsx)(n,{id:`settings.section.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`})}}",
+  ].join("");
+}
+
+function linuxDesktopRouteBundleFixture() {
+  return [
+    "var DE={",
+    '"read-aloud-settings":(0,$.lazy)(()=>Xr(()=>import(`./general-settings-read.js`),[],import.meta.url)),',
+    '"general-settings":(0,$.lazy)(()=>Xr(()=>import(`./general-settings-A.js`),[],import.meta.url)),',
+    "profile:(0,$.lazy)(()=>Xr(()=>import(`./profile-A.js`),[],import.meta.url)),",
+    '"keyboard-shortcuts":(0,$.lazy)(()=>Xr(()=>import(`./keyboard-shortcuts-settings-A.js`),[],import.meta.url))',
+    "};",
+  ].join("");
+}
+
+function linuxDesktopNavigationBundleFixture() {
+  return [
+    'var ye={"general-settings":q,profile:ee,"keyboard-shortcuts":ve,appearance:le};',
+    "var xe=[`general-settings`,`profile`,`appearance`,`keyboard-shortcuts`];",
+    "var Se=[{key:`app`,slugs:[`general-settings`,`profile`,`appearance`]},{key:`connection`,slugs:[`agent`,`keyboard-shortcuts`}]}];",
+    "function visible(e){switch(e.slug){case`appearance`:return!0;case`general-settings`:case`agent`:case`personalization`:return!0;case`keyboard-shortcuts`:return!0}}",
+    "function loading(H){let W=!1;if(H)bb0:switch(H.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:W=!1;break bb0;case`keyboard-shortcuts`:W=!1;break bb0}return W}",
+  ].join("");
+}
+
+function createNativeKeyboardShortcutsSettingsFixture() {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-native-shortcuts-"));
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+
+  const writeAsset = (name, source = "") => {
+    fs.writeFileSync(path.join(assetsDir, name), source, "utf8");
+  };
+
+  writeAsset("chunk-A.js", "");
+  writeAsset(
+    "jsx-runtime-A.js",
+    'import{s as s}from"./chunk-A.js";function n(){return{}}function t(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}react.transitional.element;export{n,t};',
+  );
+  writeAsset(
+    "setting-storage-A.js",
+    'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
+  );
+  writeAsset("general-settings-A.js", "hotkey-window-hotkey-state");
+  writeAsset("toggle-A.js", "export{t};");
+  writeAsset("settings-row-A.js", "export{n};");
+  writeAsset("settings-content-layout-A.js", "export{n,r,t};");
+  writeAsset("settings-group-A.js", "export{n,t};");
+  writeAsset("settings-surface-A.js", "export{t};");
+  writeAsset(
+    "settings-sections-A.js",
+    "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`appearance`},{slug:`keyboard-shortcuts`}];",
+  );
+  writeAsset("settings-shared-A.js", settingsSharedBundleFixture());
+  writeAsset("app-main-A.js", linuxDesktopRouteBundleFixture());
+  writeAsset("settings-page-A.js", linuxDesktopNavigationBundleFixture());
+  writeAsset("keyboard-shortcuts-settings-A.js", "export default function KeyboardShortcutsSettings(){}");
+
+  return { extractedDir, assetsDir };
 }
 
 function appSunsetBundleFixture() {
@@ -1904,6 +1974,72 @@ test("adds Keybinds settings route with current lazy and preload aliases", () =>
     /var i_e=\{keybinds:\(0,R\.lazy\)\(\(\)=>q\(\(\)=>import\(`\.\/keybinds-settings-linux\.js`\)/,
   );
   assert.doesNotMatch(patched, /keybinds:\(0,Z\.lazy\)\(\(\)=>s\(/);
+});
+
+test("adds Linux desktop settings route when upstream owns Keyboard Shortcuts", () => {
+  const patched = applyPatchTwice(
+    applyLinuxDesktopSettingsIndexPatch,
+    keybindsIndexBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /var i_e=\{"linux-desktop":\(0,Z\.lazy\)\(\(\)=>s\(\(\)=>import\(`\.\/linux-desktop-settings-linux\.js`\)/,
+  );
+  assert.match(patched, /var Kge=\{"linux-desktop":xh,"general-settings":xh,/);
+  assert.match(patched, /qge=\[`general-settings`,`linux-desktop`,`appearance`/);
+  assert.match(patched, /slugs:\[`general-settings`,`linux-desktop`,`appearance`/);
+  assert.match(patched, /case`linux-desktop`:return l===`electron`/);
+  assert.match(patched, /case`linux-desktop`:k=!1;break bb0;/);
+  assert.doesNotMatch(patched, /codexLinuxKeybindOverridesRuntime/);
+});
+
+test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () => {
+  const { extractedDir, assetsDir } = createNativeKeyboardShortcutsSettingsFixture();
+  try {
+    const result = patchKeybindsSettingsAssets(extractedDir);
+
+    assert.equal(result.matched, true);
+    assert.ok(result.changed >= 4);
+    assert.match(result.reason, /upstream keyboard shortcuts settings are present/);
+    assert.equal(fs.existsSync(path.join(assetsDir, keybindsSettingsAsset)), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), true);
+
+    const linuxDesktopSource = fs.readFileSync(
+      path.join(assetsDir, linuxDesktopSettingsAsset),
+      "utf8",
+    );
+    assert.match(linuxDesktopSource, /Linux desktop/);
+    assert.match(linuxDesktopSource, /Compact prompt window/);
+    assert.match(linuxDesktopSource, /System tray/);
+    assert.match(linuxDesktopSource, /Warm start/);
+    assert.match(linuxDesktopSource, /Install updates when you close Codex/);
+    assert.match(linuxDesktopSource, /codex-linux-system-tray-enabled/);
+    assert.match(linuxDesktopSource, /codex-linux-auto-update-on-exit/);
+    assert.match(linuxDesktopSource, /import\{z as __post\}from"\.\/setting-storage-A\.js"/);
+
+    assert.match(
+      fs.readFileSync(path.join(assetsDir, "settings-sections-A.js"), "utf8"),
+      /slug:`linux-desktop`/,
+    );
+    assert.match(
+      fs.readFileSync(path.join(assetsDir, "settings-shared-A.js"), "utf8"),
+      /settings\.nav\.linux-desktop/,
+    );
+    const appMainSource = fs.readFileSync(path.join(assetsDir, "app-main-A.js"), "utf8");
+    assert.match(appMainSource, /linux-desktop-settings-linux\.js/);
+    assert.doesNotMatch(appMainSource, /keybinds-settings-linux\.js/);
+    const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
+    assert.match(settingsPageSource, /"linux-desktop":q,"general-settings":q/);
+    assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
+    assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
+
+    const secondResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(secondResult.matched, true);
+    assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
 });
 
 test("keeps local environment action modal inputs editable inside stored modal content", () => {

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const {
+  findCodexRequestWebviewAsset,
   findImportedAsset,
   findRequiredWebviewAsset,
   linuxSettingsKeys,
@@ -11,6 +12,7 @@ const {
 // Keybind settings are transactional: either all dependent webview assets are
 // updated together, or the patch logs a warning and leaves the app usable.
 const keybindsSettingsAsset = "keybinds-settings-linux.js";
+const linuxDesktopSettingsAsset = "linux-desktop-settings-linux.js";
 const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
 
 function buildKeybindsSettingsSource({
@@ -19,6 +21,7 @@ function buildKeybindsSettingsSource({
   reactExportName = "t",
   jsxRuntimeAsset,
   vscodeApiAsset,
+  vscodeApiExportName = "n",
   hotkeySettingsAsset,
   toggleAsset,
   settingsRowAsset,
@@ -134,10 +137,33 @@ function buildKeybindsSettingsSource({
     },
   ];
 
-  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{n as __post}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},DEFAULT_SHORTCUTS=${JSON.stringify(defaultShortcuts)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
+  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},DEFAULT_SHORTCUTS=${JSON.stringify(defaultShortcuts)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
 }
 
-function resolveKeybindsSettingsAsset(extractedDir) {
+function buildLinuxDesktopSettingsSource({
+  chunkAsset,
+  reactAsset,
+  reactExportName = "t",
+  jsxRuntimeAsset,
+  vscodeApiAsset,
+  vscodeApiExportName = "n",
+  toggleAsset,
+  settingsRowAsset,
+  settingsPageAsset,
+  settingsPageExportName = "t",
+  settingsSectionAsset,
+  settingsSectionExportName = "r",
+  settingsGroupAsset,
+  settingsGroupExportName = "n",
+}) {
+  const reactImport = reactAsset === jsxRuntimeAsset
+    ? `import{${reactExportName} as __reactFactory,t as __jsxFactory}from"./${jsxRuntimeAsset}";`
+    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";`;
+
+  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{t as Toggle}from"./${toggleAsset}";import{n as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}};function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}function LinuxDesktopSettings(){return $.jsx(SettingsPage,{title:"Linux desktop",subtitle:"Launcher, tray, prompt window, and update behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Desktop integration"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]})]})})}export{LinuxDesktopSettings,LinuxDesktopSettings as default};\n//# sourceMappingURL=${linuxDesktopSettingsAsset}.map\n`;
+}
+
+function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings = true } = {}) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
     throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
@@ -151,13 +177,16 @@ function resolveKeybindsSettingsAsset(extractedDir) {
     : findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
   const reactExportName = jsxExportsReactFactory ? "n" : "t";
   const chunkAsset = findImportedAsset(webviewAssetsDir, reactAsset, "React shared chunk asset");
-  const vscodeApiAsset = findRequiredWebviewAsset(webviewAssetsDir, /^vscode-api-.*\.js$/, "vscode://codex", "VS Code API asset");
-  const hotkeySettingsAsset = findRequiredWebviewAsset(
-    webviewAssetsDir,
-    /^general-settings-.*\.js$/,
-    "hotkey-window-hotkey-state",
-    "hotkey settings asset",
-  );
+  const { assetName: vscodeApiAsset, exportName: vscodeApiExportName } =
+    findCodexRequestWebviewAsset(webviewAssetsDir);
+  const hotkeySettingsAsset = includeHotkeySettings
+    ? findRequiredWebviewAsset(
+        webviewAssetsDir,
+        /^general-settings-.*\.js$/,
+        "hotkey-window-hotkey-state",
+        "hotkey settings asset",
+      )
+    : null;
   const toggleAsset = findRequiredWebviewAsset(webviewAssetsDir, /^toggle-.*\.js$/, null, "toggle asset");
   const settingsRowAsset = findRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset");
   const settingsLayoutAsset = findRequiredWebviewAsset(
@@ -174,26 +203,45 @@ function resolveKeybindsSettingsAsset(extractedDir) {
     .readdirSync(webviewAssetsDir)
     .filter((name) => /^settings-surface-.*\.js$/.test(name))
     .sort()[0] ?? null;
-  const filePath = path.join(webviewAssetsDir, keybindsSettingsAsset);
 
   return {
-    filePath,
-    source: buildKeybindsSettingsSource({
-      chunkAsset,
-      reactAsset,
-      reactExportName,
-      jsxRuntimeAsset,
-      vscodeApiAsset,
-      hotkeySettingsAsset,
-      toggleAsset,
-      settingsRowAsset,
-      settingsPageAsset: settingsLayoutAsset,
-      settingsPageExportName: "t",
-      settingsSectionAsset: settingsGroupCandidate ?? settingsLayoutAsset,
-      settingsSectionExportName: settingsGroupCandidate == null ? "r" : "t",
-      settingsGroupAsset: settingsSurfaceCandidate ?? settingsLayoutAsset,
-      settingsGroupExportName: settingsSurfaceCandidate == null ? "n" : "t",
-    }),
+    chunkAsset,
+    reactAsset,
+    reactExportName,
+    jsxRuntimeAsset,
+    vscodeApiAsset,
+    vscodeApiExportName,
+    hotkeySettingsAsset,
+    toggleAsset,
+    settingsRowAsset,
+    settingsPageAsset: settingsLayoutAsset,
+    settingsPageExportName: "t",
+    settingsSectionAsset: settingsGroupCandidate ?? settingsLayoutAsset,
+    settingsSectionExportName: settingsGroupCandidate == null ? "r" : "t",
+    settingsGroupAsset: settingsSurfaceCandidate ?? settingsLayoutAsset,
+    settingsGroupExportName: settingsSurfaceCandidate == null ? "n" : "t",
+  };
+}
+
+function resolveKeybindsSettingsAsset(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  const dependencies = resolveSettingsAssetDependencies(extractedDir);
+
+  return {
+    filePath: path.join(webviewAssetsDir, keybindsSettingsAsset),
+    source: buildKeybindsSettingsSource(dependencies),
+  };
+}
+
+function resolveLinuxDesktopSettingsAsset(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  const dependencies = resolveSettingsAssetDependencies(extractedDir, {
+    includeHotkeySettings: false,
+  });
+
+  return {
+    filePath: path.join(webviewAssetsDir, linuxDesktopSettingsAsset),
+    source: buildLinuxDesktopSettingsSource(dependencies),
   };
 }
 
@@ -222,6 +270,47 @@ function collectRequiredAssetPatches(extractedDir, filenamePattern, patchFn, des
   });
 }
 
+function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^(?:app-main|index|settings-page)-.*\.js$/.test(name))
+    .sort();
+
+  let routeMatched = false;
+  let navigationMatched = false;
+  const patches = [];
+  for (const candidate of candidates) {
+    const filePath = path.join(webviewAssetsDir, candidate);
+    const currentSource = fs.readFileSync(filePath, "utf8");
+    let patchedSource = currentSource;
+    if (isSettingsRouteBundleSource(currentSource)) {
+      routeMatched = true;
+      patchedSource = applyLinuxDesktopSettingsRoutePatch(patchedSource);
+    }
+    if (isSettingsNavigationBundleSource(currentSource)) {
+      navigationMatched = true;
+      patchedSource = applyLinuxDesktopSettingsNavigationPatch(patchedSource);
+    }
+    if (patchedSource !== currentSource) {
+      patches.push({ filePath, currentSource, patchedSource });
+    }
+  }
+
+  if (!routeMatched) {
+    throw new Error("Required Keybinds settings patch failed: could not find Linux desktop settings route bundle");
+  }
+  if (!navigationMatched) {
+    throw new Error("Required Keybinds settings patch failed: could not find Linux desktop settings navigation bundle");
+  }
+
+  return patches;
+}
+
 function hasNativeKeyboardShortcutsSettings(extractedDir) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -242,50 +331,59 @@ function hasNativeKeyboardShortcutsSettings(extractedDir) {
 }
 
 function patchKeybindsSettingsAssets(extractedDir) {
-  if (hasNativeKeyboardShortcutsSettings(extractedDir)) {
-    return {
-      matched: true,
-      changed: 0,
-      reason: "upstream keyboard shortcuts settings are present",
-    };
-  }
-
   try {
-    const keybindsAsset = resolveKeybindsSettingsAsset(extractedDir);
-    const keybindsAssetExists = fs.existsSync(keybindsAsset.filePath);
-    const previousKeybindsSource = keybindsAssetExists
-      ? fs.readFileSync(keybindsAsset.filePath, "utf8")
+    const hasNativeSettings = hasNativeKeyboardShortcutsSettings(extractedDir);
+    const settingsAsset = hasNativeSettings
+      ? resolveLinuxDesktopSettingsAsset(extractedDir)
+      : resolveKeybindsSettingsAsset(extractedDir);
+    const settingsAssetExists = fs.existsSync(settingsAsset.filePath);
+    const previousSettingsSource = settingsAssetExists
+      ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
     const patches = [
       ...collectRequiredAssetPatches(
         extractedDir,
         /^settings-sections-.*\.js$/,
-        applyKeybindsSettingsSectionsPatch,
+        hasNativeSettings
+          ? applyLinuxDesktopSettingsSectionsPatch
+          : applyKeybindsSettingsSectionsPatch,
         "settings sections bundle",
       ),
       ...collectRequiredAssetPatches(
         extractedDir,
         /^settings-shared-.*\.js$/,
-        applyKeybindsSettingsSharedPatch,
+        hasNativeSettings
+          ? applyLinuxDesktopSettingsSharedPatch
+          : applyKeybindsSettingsSharedPatch,
         "settings shared bundle",
       ),
-      ...collectRequiredAssetPatches(
-        extractedDir,
-        /^index-.*\.js$/,
-        applyKeybindsSettingsIndexPatch,
-        "webview index bundle",
+      ...(
+        hasNativeSettings
+          ? collectLinuxDesktopRouteAndNavigationPatches(extractedDir)
+          : collectRequiredAssetPatches(
+              extractedDir,
+              /^index-.*\.js$/,
+              applyKeybindsSettingsIndexPatch,
+              "webview index bundle",
+            )
       ),
     ];
 
-    fs.writeFileSync(keybindsAsset.filePath, keybindsAsset.source, "utf8");
-    let changed = previousKeybindsSource !== keybindsAsset.source ? 1 : 0;
+    fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
+    let changed = previousSettingsSource !== settingsAsset.source ? 1 : 0;
     for (const patch of patches) {
       if (patch.patchedSource !== patch.currentSource) {
         fs.writeFileSync(patch.filePath, patch.patchedSource, "utf8");
         changed += 1;
       }
     }
-    return { matched: true, changed };
+    return hasNativeSettings
+      ? {
+          matched: true,
+          changed,
+          reason: "upstream keyboard shortcuts settings are present; added Linux desktop settings",
+        }
+      : { matched: true, changed };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`WARN: Keybinds settings patch skipped: ${message}`);
@@ -319,6 +417,37 @@ function applyKeybindsSettingsSectionsPatch(currentSource) {
   throw new Error("Required Keybinds settings patch failed: could not add keybinds settings section");
 }
 
+function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (patchedSource.includes("slug:`linux-desktop`")) {
+    return patchedSource;
+  }
+
+  const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
+  const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`linux-desktop`},";
+  if (patchedSource.includes(sectionsNeedle)) {
+    return patchedSource.replace(sectionsNeedle, sectionsPatch);
+  }
+
+  const currentNeedle = "n=[{slug:e},{slug:`appearance`}";
+  if (patchedSource.includes(currentNeedle)) {
+    return patchedSource.replace(currentNeedle, "n=[{slug:e},{slug:`linux-desktop`},{slug:`appearance`}");
+  }
+
+  const literalNeedle = "n=[{slug:`general-settings`},{slug:`appearance`}";
+  if (patchedSource.includes(literalNeedle)) {
+    return patchedSource.replace(literalNeedle, "n=[{slug:`general-settings`},{slug:`linux-desktop`},{slug:`appearance`}");
+  }
+
+  const generalFirstPattern = /(n=\[\{slug:`general-settings`\},)/;
+  if (generalFirstPattern.test(patchedSource)) {
+    return patchedSource.replace(generalFirstPattern, "$1{slug:`linux-desktop`},");
+  }
+
+  throw new Error("Required Keybinds settings patch failed: could not add Linux desktop settings section");
+}
+
 function applyKeybindsSettingsSharedPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -340,6 +469,34 @@ function applyKeybindsSettingsSharedPatch(currentSource) {
       "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`keybinds`:{return (0,d.jsx)(n,{id:`settings.section.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`})}";
     if (!patchedSource.includes(sectionNeedle)) {
       throw new Error("Required Keybinds settings patch failed: could not add keybinds section title");
+    }
+    patchedSource = patchedSource.replace(sectionNeedle, sectionPatch);
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxDesktopSettingsSharedPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!patchedSource.includes("settings.nav.linux-desktop")) {
+    const navNeedle =
+      '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},';
+    const navPatch =
+      '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},"linux-desktop":{id:`settings.nav.linux-desktop`,defaultMessage:`Linux desktop`,description:`Title for Linux desktop settings section`},';
+    if (!patchedSource.includes(navNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop nav label");
+    }
+    patchedSource = patchedSource.replace(navNeedle, navPatch);
+  }
+
+  if (!patchedSource.includes("settings.section.linux-desktop")) {
+    const sectionNeedle =
+      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}";
+    const sectionPatch =
+      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`linux-desktop`:{return (0,d.jsx)(n,{id:`settings.section.linux-desktop`,defaultMessage:`Linux desktop`,description:`Title for Linux desktop settings section`})}";
+    if (!patchedSource.includes(sectionNeedle)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop section title");
     }
     patchedSource = patchedSource.replace(sectionNeedle, sectionPatch);
   }
@@ -426,13 +583,134 @@ function applyKeybindsSettingsIndexPatch(currentSource) {
   return applyLinuxKeybindOverridesRuntimePatch(patchedSource);
 }
 
+function isSettingsRouteBundleSource(currentSource) {
+  return currentSource.includes(linuxDesktopSettingsAsset)
+    || /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource);
+}
+
+function isSettingsNavigationBundleSource(currentSource) {
+  return (
+    /[A-Za-z_$][\w$]*=\{[^;]*"linux-desktop":[A-Za-z_$][\w$]*,/.test(currentSource)
+    && currentSource.includes("slugs:[`general-settings`,`linux-desktop`")
+  ) || (
+    /[A-Za-z_$][\w$]*=\{[^;]*"general-settings":[A-Za-z_$][\w$]*,/.test(currentSource)
+    && /[A-Za-z_$][\w$]*=\[`general-settings`,/.test(currentSource)
+    && currentSource.includes("slugs:[`general-settings`,")
+  );
+}
+
+function applyLinuxDesktopSettingsRoutePatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!patchedSource.includes(`${linuxDesktopSettingsAsset}`)) {
+    const routePattern = /var ([A-Za-z_$][\w$]*)=\{([^;]*?)"general-settings":(?=\(0,([A-Za-z_$][\w$]*)\.lazy\)\(\(\)=>([A-Za-z_$][\w$]*)\()/;
+    if (!routePattern.test(patchedSource)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop route");
+    }
+    patchedSource = patchedSource.replace(
+      routePattern,
+      (_match, routeMap, beforeGeneralSettings, lazyAlias, preloadAlias) =>
+        `var ${routeMap}={"linux-desktop":(0,${lazyAlias}.lazy)(()=>${preloadAlias}(()=>import(\`./${linuxDesktopSettingsAsset}\`),[],import.meta.url)),${beforeGeneralSettings}"general-settings":`,
+    );
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxDesktopSettingsNavigationPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!/[,{]"linux-desktop":[A-Za-z_$][\w$]*,"general-settings":/.test(patchedSource)) {
+    const iconPattern = /([A-Za-z_$][\w$]*=\{)"general-settings":([A-Za-z_$][\w$]*),/;
+    if (!iconPattern.test(patchedSource)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop icon");
+    }
+    patchedSource = patchedSource.replace(
+      iconPattern,
+      (_match, prefix, icon) => `${prefix}"linux-desktop":${icon},"general-settings":${icon},`,
+    );
+  }
+
+  if (!/=\[`general-settings`,`linux-desktop`/.test(patchedSource)) {
+    const orderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
+    if (!orderPattern.test(patchedSource)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop nav order");
+    }
+    patchedSource = patchedSource.replace(orderPattern, "$1`linux-desktop`,");
+  }
+
+  if (!patchedSource.includes("slugs:[`general-settings`,`linux-desktop`")) {
+    const groupPattern = /(slugs:\[`general-settings`,)(?!`linux-desktop`)/;
+    if (!groupPattern.test(patchedSource)) {
+      throw new Error("Required Keybinds settings patch failed: could not add Linux desktop nav group");
+    }
+    patchedSource = patchedSource.replace(groupPattern, "$1`linux-desktop`,");
+  }
+
+  if (
+    !patchedSource.includes("case`linux-desktop`:return l===`electron`")
+    && !patchedSource.includes("case`linux-desktop`:case`general-settings`:case`agent`:case`personalization`:return!0;")
+  ) {
+    const visibilityNeedle =
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;";
+    const visibilityPatch =
+      "case`linux-desktop`:return l===`electron`;case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;";
+    if (!patchedSource.includes(visibilityNeedle)) {
+      const currentVisibilityNeedle =
+        "case`general-settings`:case`agent`:case`personalization`:return!0;";
+      const currentVisibilityPatch =
+        "case`linux-desktop`:case`general-settings`:case`agent`:case`personalization`:return!0;";
+      if (!patchedSource.includes(currentVisibilityNeedle)) {
+        throw new Error("Required Keybinds settings patch failed: could not add Linux desktop visibility");
+      }
+      patchedSource = patchedSource.replace(currentVisibilityNeedle, currentVisibilityPatch);
+    } else {
+      patchedSource = patchedSource.replace(visibilityNeedle, visibilityPatch);
+    }
+  }
+
+  if (!/case`linux-desktop`:[A-Za-z_$][\w$]*=!1;break [A-Za-z_$][\w$]*;/.test(patchedSource)) {
+    const redirectNeedle =
+      "case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;";
+    const redirectPatch =
+      "case`linux-desktop`:k=!1;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;";
+    if (patchedSource.includes(redirectNeedle)) {
+      patchedSource = patchedSource.replace(redirectNeedle, redirectPatch);
+    } else {
+      const currentLoadingPattern = /(case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:([A-Za-z_$][\w$]*)=!1;break ([A-Za-z_$][\w$]*);)/;
+      if (currentLoadingPattern.test(patchedSource)) {
+        patchedSource = patchedSource.replace(
+          currentLoadingPattern,
+          (_match, existingCases, loadingAlias, breakLabel) =>
+            `case\`linux-desktop\`:${loadingAlias}=!1;break ${breakLabel};${existingCases}`,
+        );
+      }
+    }
+  }
+
+  return patchedSource;
+}
+
+function applyLinuxDesktopSettingsIndexPatch(currentSource) {
+  return applyLinuxDesktopSettingsNavigationPatch(
+    applyLinuxDesktopSettingsRoutePatch(currentSource),
+  );
+}
+
 module.exports = {
   applyKeybindsSettingsIndexPatch,
   applyKeybindsSettingsSectionsPatch,
   applyKeybindsSettingsSharedPatch,
+  applyLinuxDesktopSettingsIndexPatch,
+  applyLinuxDesktopSettingsNavigationPatch,
+  applyLinuxDesktopSettingsRoutePatch,
+  applyLinuxDesktopSettingsSectionsPatch,
+  applyLinuxDesktopSettingsSharedPatch,
   applyLinuxKeybindOverridesRuntimePatch,
   keybindsSettingsAsset,
+  linuxDesktopSettingsAsset,
   linuxKeybindOverridesKey,
   patchKeybindsSettingsAssets,
+  resolveLinuxDesktopSettingsAsset,
   resolveKeybindsSettingsAsset,
 };


### PR DESCRIPTION
## Summary

Fixes #404.

When upstream Codex ships its own native Keyboard Shortcuts settings page, the Linux wrapper used to skip the injected Keybinds page entirely. That avoided duplicating upstream shortcuts, but it also removed the Linux-only controls from the UI.

This PR keeps the native upstream Keyboard Shortcuts page intact and adds a small dedicated Linux desktop settings page for the Linux-only toggles:

- Compact prompt window
- System tray
- Warm start
- Install updates when you close Codex

The patcher now handles both older combined settings bundles and the current split bundle layout where route registration, navigation metadata, and section metadata live in different assets. It also uses the shared Codex request asset discovery so current `setting-storage-*.js` bundles work as well as older `vscode-api-*.js` bundles.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- Manual real-bundle copy check: first patch run changes 5 files; second patch run is idempotent with `changed: 0`.
