### PR TITLE
Make settings section-title patch tolerant of minified identifier drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -71,6 +71,8 @@ const {
 const {
   keybindsSettingsAsset,
   linuxDesktopSettingsAsset,
+  applyKeybindsSettingsSharedPatch,
+  applyLinuxDesktopSettingsSharedPatch,
 } = require("./patches/keybinds-settings.js");
 const {
   validateReport,
@@ -816,6 +818,17 @@ function settingsSharedBundleFixture() {
   return [
     '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},appearance:{id:`settings.nav.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`},',
     "function titleForSection(e){switch(e){case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`appearance`:return (0,d.jsx)(n,{id:`settings.section.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`})}}",
+  ].join("");
+}
+
+// Same bundle as settingsSharedBundleFixture() but with the minified JSX message
+// component bound to `r` instead of `n` (and the memo cache as `o[5]`), mirroring
+// the identifiers shipped in Codex 26.601.21317 (settings-shared-BibDzP9i.js).
+// The minifier picks these letters arbitrarily, so the patch must not hardcode them.
+function settingsSharedBundleWithDriftingJsxAliasFixture() {
+  return [
+    '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},appearance:{id:`settings.nav.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`},',
+    "function titleForSection(e){switch(e){case`general-settings`:{let e;return o[5]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(r,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),o[5]=e):e=o[5],e}case`appearance`:return (0,d.jsx)(r,{id:`settings.section.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`})}}",
   ].join("");
 }
 
@@ -2040,6 +2053,32 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }
+});
+
+test("adds the Linux desktop section title when the JSX message component identifier drifts", () => {
+  const patched = applyLinuxDesktopSettingsSharedPatch(
+    settingsSharedBundleWithDriftingJsxAliasFixture(),
+  );
+
+  // The injected case must reuse the bundle's actual identifiers (r / o[5]),
+  // not a hardcoded `n`, otherwise the section title renders blank.
+  assert.match(
+    patched,
+    /case`linux-desktop`:\{return \(0,d\.jsx\)\(r,\{id:`settings\.section\.linux-desktop`,defaultMessage:`Linux desktop`,description:`Title for Linux desktop settings section`\}\)\}/,
+  );
+  // The original general-settings case is preserved untouched.
+  assert.match(patched, /case`general-settings`:\{let e;return o\[5\]===Symbol\.for\(`react\.memo_cache_sentinel`\)/);
+});
+
+test("adds the keybinds section title when the JSX message component identifier drifts", () => {
+  const patched = applyKeybindsSettingsSharedPatch(
+    settingsSharedBundleWithDriftingJsxAliasFixture(),
+  );
+
+  assert.match(
+    patched,
+    /case`keybinds`:\{return \(0,d\.jsx\)\(r,\{id:`settings\.section\.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`\}\)\}/,
+  );
 });
 
 test("keeps local environment action modal inputs editable inside stored modal content", () => {

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -448,6 +448,29 @@ function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   throw new Error("Required Keybinds settings patch failed: could not add Linux desktop settings section");
 }
 
+// Inserts a new `titleForSection` switch case after the upstream
+// `general-settings` case. The minifier names the JSX factory, the message
+// component, and the memo-cache slot arbitrarily (e.g. `n` vs `r`, `t[2]` vs
+// `o[5]`) and these drift between upstream builds, so the identifiers are
+// captured from the matched block and reused in the injected case rather than
+// hardcoded. Returns null when the anchor case cannot be located.
+function injectSettingsSectionTitle(currentSource, { slug, defaultMessage, description }) {
+  const generalCasePattern =
+    /case`general-settings`:\{let ([A-Za-z_$][\w$]*);return ([A-Za-z_$][\w$]*)\[(\d+)\]===Symbol\.for\(`react\.memo_cache_sentinel`\)\?\(\1=\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*),\{id:`settings\.section\.general-settings`,defaultMessage:`General`,description:`Title for general settings section`\}\),\2\[\3\]=\1\):\1=\2\[\3\],\1\}/;
+  const match = currentSource.match(generalCasePattern);
+  if (match == null) {
+    return null;
+  }
+  const matchedBlock = match[0];
+  const jsxFactory = match[4];
+  const messageComponent = match[5];
+  const injectedCase =
+    `case\`${slug}\`:{return (0,${jsxFactory}.jsx)(${messageComponent},`
+    + `{id:\`settings.section.${slug}\`,defaultMessage:\`${defaultMessage}\`,description:\`${description}\`})}`;
+  const insertAt = match.index + matchedBlock.length;
+  return currentSource.slice(0, insertAt) + injectedCase + currentSource.slice(insertAt);
+}
+
 function applyKeybindsSettingsSharedPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -463,14 +486,15 @@ function applyKeybindsSettingsSharedPatch(currentSource) {
   }
 
   if (!patchedSource.includes("settings.section.keybinds")) {
-    const sectionNeedle =
-      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}";
-    const sectionPatch =
-      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`keybinds`:{return (0,d.jsx)(n,{id:`settings.section.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`})}";
-    if (!patchedSource.includes(sectionNeedle)) {
+    const next = injectSettingsSectionTitle(patchedSource, {
+      slug: "keybinds",
+      defaultMessage: "Keybinds",
+      description: "Title for keybinds settings section",
+    });
+    if (next == null) {
       throw new Error("Required Keybinds settings patch failed: could not add keybinds section title");
     }
-    patchedSource = patchedSource.replace(sectionNeedle, sectionPatch);
+    patchedSource = next;
   }
 
   return patchedSource;
@@ -491,14 +515,15 @@ function applyLinuxDesktopSettingsSharedPatch(currentSource) {
   }
 
   if (!patchedSource.includes("settings.section.linux-desktop")) {
-    const sectionNeedle =
-      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}";
-    const sectionPatch =
-      "case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}case`linux-desktop`:{return (0,d.jsx)(n,{id:`settings.section.linux-desktop`,defaultMessage:`Linux desktop`,description:`Title for Linux desktop settings section`})}";
-    if (!patchedSource.includes(sectionNeedle)) {
+    const next = injectSettingsSectionTitle(patchedSource, {
+      slug: "linux-desktop",
+      defaultMessage: "Linux desktop",
+      description: "Title for Linux desktop settings section",
+    });
+    if (next == null) {
       throw new Error("Required Keybinds settings patch failed: could not add Linux desktop section title");
     }
-    patchedSource = patchedSource.replace(sectionNeedle, sectionPatch);
+    patchedSource = next;
   }
 
   return patchedSource;


### PR DESCRIPTION
## What changed

`injectSettingsSectionTitle()` replaces the literal `titleForSection` section-title needle in both `applyKeybindsSettingsSharedPatch` and `applyLinuxDesktopSettingsSharedPatch`. Instead of matching a hardcoded minified snippet, it matches the upstream `general-settings` case with a regex, captures the JSX factory and message-component identifiers, and reuses them in the injected `keybinds` / `linux-desktop` case.

## Why

#405 added the Linux desktop settings page (System tray, Warm start, Compact prompt window, install-on-close) by injecting a new `titleForSection` switch case into the `settings-shared` bundle. The anchor `general-settings` case was matched with a literal needle that hardcoded the minified JSX message-component identifier (`n`) and memo-cache slot (`t[2]`).

Those identifiers are assigned arbitrarily by the upstream minifier and drift between builds. On Codex `26.601.21317` the component minifies to `r` (and the cache slot to `o[5]`), so the literal needle never matched. Because the patch is transactional, `applyLinuxDesktopSettingsSharedPatch` threw `could not add Linux desktop section title`, the whole optional patch was caught and skipped, and the Linux settings page silently disappeared from the UI — the behavior patches still applied (e.g. close-to-tray), but there was no longer any toggle to control them.

This mirrors the identifier-tolerant regex approach already used by the route/navigation patches in the same file.

## Source-of-truth files edited

- `scripts/patches/keybinds-settings.js` — the fix (real patch source, not generated output)
- `scripts/patch-linux-window-ui.test.js` — regression tests

## How it was tested

- Added a failing-first regression test: a `settings-shared` fixture whose identifiers drift (`r` / `o[5]`, mirroring `26.601.21317`). It reproduces the `could not add ... section title` throw on the old literal needle and passes with the regex. Covers both the keybinds and linux-desktop shared patches.
- `node --test scripts/patch-linux-window-ui.test.js` → 178/178 pass (was 176 before the 2 new tests; existing `n`-identifier tests still pass, so backward compatible).
- `node --check` on both edited files.
- End-to-end on real hardware (Pop!_OS 22.04, x11, `.deb`, Codex `26.601.21317`): rebuilt from the upstream DMG with no `Keybinds settings patch skipped` warning; `linux-desktop-settings-linux.js` is emitted; the injected case uses the bundle's real identifier `(0,d.jsx)(r,{id:\`settings.section.linux-desktop\`...})`; `settings-sections` registers `slug:\`linux-desktop\``. Built a `.deb`, installed it, and confirmed Settings → **Linux desktop** → Desktop integration → **System tray** appears and that toggling it off + relaunch makes closing the window quit the app instead of hiding to the tray.

## Environment limitations

- Verified only on a `deb` / Pop!_OS x11 build against Codex `26.601.21317`. The regex stays backward compatible with the previously-targeted `n`/`t[2]` minification, but I did not separately rebuild `.rpm`/pacman/Nix; the change is in shared patch logic exercised by all package paths, and the JS test suite covers both identifier variants.
- No updater crate (`updater/`) changes, so no version bump per the versioning rules.
- No documentation change — this restores the already-intended #405 behavior rather than changing documented behavior.

## Risks / follow-ups

- Low risk: the change only broadens an existing match; the existing literal-`n` test path is still green.
- Possible follow-up: the same literal-minified-snippet style is used in a few other needles in this file (route/nav already use tolerant regexes); if further drift surfaces they could get the same treatment, but that's out of scope here.

Fixes the regression for bundles described in #404 / #405.
