### PR TITLE
fix(read-aloud): repair settings route patch

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -212,7 +212,7 @@ function generalSettingsReadAloudBlockSource() {
 }
 
 function currentGeneralSettingsReadAloudBlockSource() {
-  return `function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let[e,t]=(0,X.useState)(!1),[n,r]=(0,X.useState)(1.05),[i,a]=(0,X.useState)(!0),[o,s]=(0,X.useState)(null),c=x();(0,X.useEffect)(()=>{let e=!0;return a(!0),Promise.all([N(\`get-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)}}}),N(\`get-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)}}})]).then(([n,i])=>{e&&(t(n?.value===!0),r(codexLinuxReadAloudPaceValue(i?.value??1.05)),s(null))}).catch(t=>{e&&s(t instanceof Error?t.message:String(t))}).finally(()=>{e&&a(!1)}),()=>{e=!1}},[]);let l=(0,$.jsx)(w,{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),u=(0,$.jsx)(w,{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`});o&&(u=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[u,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:o})]}));let d=c.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),f=c.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),p=c.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),m=c.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),h=c.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),g=e=>{let n=e;t(n),s(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)},value:n}}).catch(e=>{t(!n),s(e instanceof Error?e.message:String(e))})},_=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,v=e=>{let t=codexLinuxReadAloudPaceValue(e.currentTarget.value);r(t),N(\`set-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)},value:t}}).catch(e=>{s(e instanceof Error?e.message:String(e))})};return(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(J,{label:l,description:u,control:(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(q,{checked:e===!0,disabled:i,onChange:g,ariaLabel:d}),e?(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(\`button\`,{type:\`button\`,className:_,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:f}),(0,$.jsx)(\`button\`,{type:\`button\`,className:_,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:p}),(0,$.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:h,"aria-label":h,children:\`?\`})]}):null]})}),e?(0,$.jsx)(J,{label:(0,$.jsx)(w,{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),description:(0,$.jsx)(w,{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),control:(0,$.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,$.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:n,disabled:i,onChange:v,"aria-label":m,className:\`h-2 w-36 accent-token-text-primary\`}),(0,$.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${n.toFixed(2)}x\`})]})}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(vt,{title:(0,$.jsx)(w,{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),children:(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)(Y,{children:[(0,$.jsx)(Y.Header,{title:(0,$.jsx)(w,{id:\`settings.readAloud.voice.title\`,defaultMessage:\`Voice\`,description:\`Title for Linux read aloud voice settings group\`})}),(0,$.jsx)(Y.Content,{children:(0,$.jsx)(bt,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})})]})})})}`;
+  return `function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let[e,t]=(0,X.useState)(!1),[n,r]=(0,X.useState)(1.05),[i,a]=(0,X.useState)(!0),[o,s]=(0,X.useState)(null),c=F();(0,X.useEffect)(()=>{let e=!0;return a(!0),Promise.all([k(\`get-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)}}}),k(\`get-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)}}})]).then(([n,i])=>{e&&(t(n?.value===!0),r(codexLinuxReadAloudPaceValue(i?.value??1.05)),s(null))}).catch(t=>{e&&s(t instanceof Error?t.message:String(t))}).finally(()=>{e&&a(!1)}),()=>{e=!1}},[]);let l=(0,$.jsx)(I,{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),u=(0,$.jsx)(I,{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`}),d=(0,$.jsx)(I,{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),f=(0,$.jsx)(I,{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),p=c.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),m=c.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),h=c.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),g=c.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),_=c.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),v=e=>{let n=e;t(n),s(null),k(\`set-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)},value:n}}).catch(e=>{t(!n),s(e instanceof Error?e.message:String(e))})},y=e=>{let t=codexLinuxReadAloudPaceValue(e.currentTarget.value);r(t),s(null),k(\`set-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)},value:t}}).catch(e=>{s(e instanceof Error?e.message:String(e))})},b=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,x=(0,$.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,$.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:n,disabled:i,onChange:y,"aria-label":g,className:\`h-2 w-36 accent-token-text-primary\`}),(0,$.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${n.toFixed(2)}x\`})]}),C=o?(0,$.jsx)(\`div\`,{className:\`text-sm text-token-text-secondary\`,children:o}):null;return(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(K,{label:l,description:(0,$.jsxs)($.Fragment,{children:[u,C]}),control:(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(G,{checked:e===!0,disabled:i,onChange:v,ariaLabel:p}),e?(0,$.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,$.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:m}),(0,$.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:h}),(0,$.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:_,"aria-label":_,children:\`?\`})]}):null]})}),e?(0,$.jsx)(K,{label:d,description:f,control:x}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(St,{title:(0,$.jsx)(I,{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),subtitle:(0,$.jsx)(I,{id:\`settings.readAloud.subtitle\`,defaultMessage:\`Listen to assistant responses with a local Kokoro voice.\`,description:\`Subtitle for Linux read aloud settings section\`}),children:(0,$.jsx)(W,{electron:!0,children:(0,$.jsxs)(q,{children:[(0,$.jsx)(q.Header,{title:(0,$.jsx)(I,{id:\`settings.readAloud.voice.title\`,defaultMessage:\`Voice\`,description:\`Title for Linux read aloud voice settings group\`})}),(0,$.jsx)(q.Content,{children:(0,$.jsx)(wt,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})})]})})})}`;
 }
 
 function exportedGeneralSettingsFunctionName(source) {
@@ -229,18 +229,18 @@ function exportedGeneralSettingsFunctionName(source) {
   return null;
 }
 
-function replaceExistingGeneralSettingsReadAloudRow(source) {
+function replaceExistingGeneralSettingsReadAloudRow(source, functionName, blockSource) {
   const rowStart = source.indexOf("function codexLinuxReadAloudSettingsRow(){");
   if (rowStart === -1) {
     return source;
   }
   const paceStart = source.indexOf("function codexLinuxReadAloudPaceValue(");
   const start = paceStart !== -1 && paceStart < rowStart ? paceStart : rowStart;
-  const end = source.indexOf("function Gn(){", rowStart);
+  const end = source.indexOf(`function ${functionName}(){`, rowStart);
   if (end === -1) {
     return source;
   }
-  return `${source.slice(0, start)}${generalSettingsReadAloudBlockSource()}${source.slice(end)}`;
+  return `${source.slice(0, start)}${blockSource}${source.slice(end)}`;
 }
 
 function removeGeneralSettingsRowPlacement(source) {
@@ -250,7 +250,7 @@ function removeGeneralSettingsRowPlacement(source) {
 }
 
 function applyGeneralSettingsPatch(source) {
-  const functionName = source.includes("function Gn(){") ? "Gn" : exportedGeneralSettingsFunctionName(source);
+  const functionName = exportedGeneralSettingsFunctionName(source) ?? (source.includes("function Gn(){") ? "Gn" : null);
   if (functionName == null) {
     return source;
   }
@@ -269,7 +269,7 @@ function applyGeneralSettingsPatch(source) {
       !patched.includes("settings.general.readAloud.help") ||
       !patched.includes("function codexLinuxReadAloudSettingsPage")
     ) {
-      patched = replaceExistingGeneralSettingsReadAloudRow(patched);
+      patched = replaceExistingGeneralSettingsReadAloudRow(patched, functionName, blockSource);
     }
   } else {
     patched = patched.replace(functionNeedle, `${blockSource}${functionNeedle}`);
@@ -308,11 +308,23 @@ function applyGeneralSettingsWrapperPatch(source) {
   if (correctWrapperPattern.test(source)) {
     return source;
   }
-  return source.replace(
-    /import\{r as ([A-Za-z_$][\w$]*)\}from"(\.\/general-settings-[^"]+\.js)";export\{\1 as GeneralSettings(?:,\1 as ReadAloudSettings)?\};/,
-    (_match, generalAlias, innerAsset) =>
-      wrapperSource(generalAlias, "codexLinuxReadAloudSettings", innerAsset),
+  const wrapperRegex =
+    /import\{r as ([A-Za-z_$][\w$]*)\}from"(\.\/general-settings-[^"]+\.js)";/;
+  const wrapperMatch = source.match(wrapperRegex);
+  if (wrapperMatch == null) {
+    return source;
+  }
+  const [, generalAlias, innerAsset] = wrapperMatch;
+  const readAloudAlias = "codexLinuxReadAloudSettings";
+  const exportRegex = new RegExp(
+    `export\\{${generalAlias} as GeneralSettings(?:,${generalAlias} as ReadAloudSettings)?\\};`,
   );
+  if (!exportRegex.test(source)) {
+    return source;
+  }
+  return source
+    .replace(wrapperRegex, `import{r as ${generalAlias},ReadAloudSettings as ${readAloudAlias}}from"${innerAsset}";`)
+    .replace(exportRegex, `export{${generalAlias} as GeneralSettings,${readAloudAlias} as ReadAloudSettings};`);
 }
 
 function applySettingsSectionsNavPatch(source) {

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -840,6 +840,30 @@ test("general settings patch exports read aloud from the current inner chunk", (
   assert.match(patched, /export\{ir as i,rr as n,\$n as r,Cr as t,codexLinuxReadAloudSettingsPage as ReadAloudSettings\}/);
 });
 
+test("general settings patch follows current export map instead of stale Gn aliases", () => {
+  const source = [
+    "function Gn(){return (0,$.jsx)(K,{label:`Service tier`})}",
+    "function nr(){return (0,$.jsxs)(q,{className:`gap-2`,children:[x,(0,$.jsx)(q.Content,{children:(0,$.jsxs)(wt,{children:[v,y,b]})})]})}",
+    "export{or as i,ar as n,nr as r,Tr as t};",
+  ].join("");
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.match(patched, /function codexLinuxReadAloudSettingsPage\(\)\{return\(0,\$\.jsx\)\(St/);
+  assert.match(patched, /\(0,\$\.jsx\)\(W,\{electron:!0/);
+  assert.match(patched, /q\.Header/);
+  assert.match(patched, /q\.Content/);
+  assert.match(patched, /\(0,\$\.jsx\)\(wt,\{children:\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow,\{\}\)\}/);
+  assert.match(patched, /k\(`get-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled"\}\}\)/);
+  assert.match(patched, /k\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled",value:n\}\}\)/);
+  assert.match(patched, /k\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-kokoro-speed",value:t\}\}\)/);
+  assert.doesNotMatch(patched, /set-setting|get-setting/);
+  assert.doesNotMatch(patched, /let e=S\(D\),t=F\(\),n=\{key:"codex-linux-read-aloud-enabled",default:!1\}/);
+  assert.doesNotMatch(patched, /U\(e,n,t\)/);
+  assert.doesNotMatch(patched, /function codexLinuxReadAloudSettingsPage\(\)\{return\(0,\$\.jsx\)\(pt/);
+  assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(ht,\{children:\(0,\$\.jsx\)\(codexLinuxReadAloudSettingsRow/);
+  assert.ok(patched.indexOf("function codexLinuxReadAloudSettingsRow") > patched.indexOf("function Gn(){"));
+  assert.ok(patched.indexOf("function codexLinuxReadAloudSettingsRow") < patched.indexOf("function nr(){"));
+});
+
 test("general settings wrapper re-exports the read aloud settings page", () => {
   const source = 'import{r as e}from"./general-settings-Bvwhh0-i.js";export{e as GeneralSettings};';
   const patched = twice(applyGeneralSettingsWrapperPatch, source);
@@ -858,6 +882,18 @@ test("general settings wrapper preserves an existing read aloud import", () => {
   assert.equal(patched, source);
   assert.match(patched, /ReadAloudSettings as t/);
   assert.doesNotMatch(patched, /e as GeneralSettings,e as ReadAloudSettings/);
+});
+
+test("general settings wrapper re-exports read aloud when side-effect imports split the wrapper", () => {
+  const source =
+    'import"./src-BRBmN298.js";import{r as e}from"./general-settings-DobuGNrH.js";import"./general-settings.search-BiUmOZih.js";export{e as GeneralSettings};';
+  const patched = twice(applyGeneralSettingsWrapperPatch, source);
+  assert.match(
+    patched,
+    /import\{r as e,ReadAloudSettings as codexLinuxReadAloudSettings\}from"\.\/general-settings-DobuGNrH\.js"/,
+  );
+  assert.match(patched, /import"\.\/general-settings\.search-BiUmOZih\.js";/);
+  assert.match(patched, /export\{e as GeneralSettings,codexLinuxReadAloudSettings as ReadAloudSettings\}/);
 });
 
 test("settings nav patches add a visible read aloud section after computer use", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1719,6 +1719,42 @@ test("persists Linux settings under the effective side-by-side app id", () => {
   }
 });
 
+test("persists Linux settings with current setGlobalStateValue handler shape", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-settings-current-shape-"));
+  try {
+    const settingsFile = path.join(tempRoot, "config", "codex-desktop", "settings.json");
+    const patched = applyPatchTwice(applyLinuxSettingsPersistencePatch, currentSettingsPersistenceBundleFixture());
+
+    assert.match(patched, /var s=`\.codex-global-state\.json`;function codexLinuxSettingsAppId/);
+    assert.match(patched, /var c=`config\.toml`/);
+    assert.match(patched, /this\.setGlobalStateValue\(a,b,c\),codexLinuxPersistSettingsState\(a,b\)/);
+    runSettingsPersistence(
+      patched,
+      {
+        CODEX_LINUX_SETTINGS_FILE: settingsFile,
+        HOME: path.join(tempRoot, "home"),
+      },
+      "codex-linux-read-aloud-enabled",
+      true,
+    );
+    runSettingsPersistence(
+      patched,
+      {
+        CODEX_LINUX_SETTINGS_FILE: settingsFile,
+        HOME: path.join(tempRoot, "home"),
+      },
+      "codex-linux-read-aloud-kokoro-speed",
+      1.15,
+    );
+
+    const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
+    assert.equal(settings["codex-linux-read-aloud-enabled"], true);
+    assert.equal(settings["codex-linux-read-aloud-kokoro-speed"], 1.15);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("migrates already-patched Linux settings persistence away from codex-desktop", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-settings-migrate-"));
   try {
@@ -1740,6 +1776,20 @@ test("migrates already-patched Linux settings persistence away from codex-deskto
     assert.equal(
       JSON.parse(fs.readFileSync(path.join(xdgConfig, "codex-cua-lab", "settings.json"), "utf8"))["codex-linux-prompt-window-enabled"],
       false,
+    );
+    runSettingsPersistence(
+      patched,
+      {
+        CODEX_LINUX_APP_ID: "codex-cua-lab",
+        XDG_CONFIG_HOME: xdgConfig,
+      },
+      "codex-linux-read-aloud-enabled",
+      true,
+    );
+
+    assert.equal(
+      JSON.parse(fs.readFileSync(path.join(xdgConfig, "codex-cua-lab", "settings.json"), "utf8"))["codex-linux-read-aloud-enabled"],
+      true,
     );
     assert.equal(fs.existsSync(path.join(xdgConfig, "codex-desktop", "settings.json")), false);
   } finally {

--- a/scripts/patches/launch-actions.js
+++ b/scripts/patches/launch-actions.js
@@ -17,6 +17,10 @@ const {
 const linuxQuitStateHelpers =
   "let codexLinuxQuitInProgress=!1,codexLinuxExplicitQuitApproved=!1,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxPrepareForExplicitQuit=()=>{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress()},codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0,codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0,";
 
+function persistedLinuxSettingsKeysSource() {
+  return `[${Object.values(linuxSettingsKeys).map((key) => `\`${key}\``).join(",")}]`;
+}
+
 function applyLinuxSettingsPersistencePatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -32,7 +36,7 @@ function applyLinuxSettingsPersistencePatch(currentSource) {
     const fsVar = inferModuleAlias(patchedSource, "node:fs");
     const stateFileHelperSource =
       (stateFileVar) =>
-        `var ${stateFileVar}=\`.codex-global-state.json\`;function codexLinuxSettingsAppId(){let e=process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||\`codex-desktop\`;return/^[A-Za-z0-9._-]+$/.test(e)?e:\`codex-desktop\`}function codexLinuxSettingsPath(){let e=process.env.CODEX_LINUX_SETTINGS_FILE;if(typeof e===\`string\`&&e.length>0)return e;let t=process.env.XDG_CONFIG_HOME||process.env.HOME&&${pathVar}.join(process.env.HOME,\`.config\`);return t?${pathVar}.join(t,codexLinuxSettingsAppId(),\`settings.json\`):null}function codexLinuxReadSettingsFile(){let e=codexLinuxSettingsPath();if(!e||!${fsVar}.existsSync(e))return{};try{let t=${fsVar}.readFileSync(e,\`utf8\`),n=JSON.parse(t);return n&&typeof n===\`object\`&&!Array.isArray(n)?n:{}}catch(e){return{}}}function codexLinuxPersistSettingsState(e,t){if(process.platform!==\`linux\`||![${Object.values(linuxSettingsKeys).map((key) => `\`${key}\``).join(",")}].includes(e))return;try{let n=codexLinuxSettingsPath();if(!n)return;let r=codexLinuxReadSettingsFile();t===void 0?delete r[e]:r[e]=t,${fsVar}.mkdirSync(${pathVar}.dirname(n),{recursive:!0,mode:448}),${fsVar}.writeFileSync(n,JSON.stringify(r,null,2)+\`\\n\`,\`utf8\`)}catch(e){}}`;
+        `var ${stateFileVar}=\`.codex-global-state.json\`;function codexLinuxSettingsAppId(){let e=process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||\`codex-desktop\`;return/^[A-Za-z0-9._-]+$/.test(e)?e:\`codex-desktop\`}function codexLinuxSettingsPath(){let e=process.env.CODEX_LINUX_SETTINGS_FILE;if(typeof e===\`string\`&&e.length>0)return e;let t=process.env.XDG_CONFIG_HOME||process.env.HOME&&${pathVar}.join(process.env.HOME,\`.config\`);return t?${pathVar}.join(t,codexLinuxSettingsAppId(),\`settings.json\`):null}function codexLinuxReadSettingsFile(){let e=codexLinuxSettingsPath();if(!e||!${fsVar}.existsSync(e))return{};try{let t=${fsVar}.readFileSync(e,\`utf8\`),n=JSON.parse(t);return n&&typeof n===\`object\`&&!Array.isArray(n)?n:{}}catch(e){return{}}}function codexLinuxPersistSettingsState(e,t){if(process.platform!==\`linux\`||!${persistedLinuxSettingsKeysSource()}.includes(e))return;try{let n=codexLinuxSettingsPath();if(!n)return;let r=codexLinuxReadSettingsFile();t===void 0?delete r[e]:r[e]=t,${fsVar}.mkdirSync(${pathVar}.dirname(n),{recursive:!0,mode:448}),${fsVar}.writeFileSync(n,JSON.stringify(r,null,2)+\`\\n\`,\`utf8\`)}catch(e){}}`;
     const stateFileCommaRegex = /var ([A-Za-z_$][\w$]*)=`\.codex-global-state\.json`,/;
     const stateFileSemicolonRegex = /var ([A-Za-z_$][\w$]*)=`\.codex-global-state\.json`;/;
     if (pathVar == null || fsVar == null) {
@@ -63,7 +67,13 @@ function applyLinuxSettingsPersistencePatch(currentSource) {
     );
   }
 
-  if (/"set-global-state":async\(\{key:[A-Za-z_$][\w$]*,value:[A-Za-z_$][\w$]*,origin:[A-Za-z_$][\w$]*\}\)=>\(this\.globalState\.set\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\),codexLinuxPersistSettingsState\(/.test(patchedSource)) {
+  const settingsKeysGuard = `!${persistedLinuxSettingsKeysSource()}.includes(e)`;
+  if (!patchedSource.includes(settingsKeysGuard)) {
+    const oldSettingsKeysGuardRegex = /!\[[^\]]*`codex-linux-[^`]+`[^\]]*\]\.includes\(e\)/;
+    patchedSource = patchedSource.replace(oldSettingsKeysGuardRegex, settingsKeysGuard);
+  }
+
+  if (/"set-global-state":async\(\{key:[A-Za-z_$][\w$]*,value:[A-Za-z_$][\w$]*,origin:[A-Za-z_$][\w$]*\}\)=>\([\s\S]{0,300}?codexLinuxPersistSettingsState\(/.test(patchedSource)) {
     return patchedSource;
   }
   if (/"set-global-state":async\(\{key:[A-Za-z_$][\w$]*,value:[A-Za-z_$][\w$]*,origin:[A-Za-z_$][\w$]*\}\)=>\(this\.setGlobalStateValue\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\),codexLinuxPersistSettingsState\(/.test(patchedSource)) {

--- a/scripts/patches/shared.js
+++ b/scripts/patches/shared.js
@@ -10,6 +10,8 @@ const CLOSE_GATE_PREFIX_LOOKBACK = 8000;
 const HANDLER_PREFIX_LOOKBACK = 12000;
 
 const linuxSettingsKeys = {
+  readAloud: "codex-linux-read-aloud-enabled",
+  readAloudKokoroSpeed: "codex-linux-read-aloud-kokoro-speed",
   promptWindow: "codex-linux-prompt-window-enabled",
   systemTray: "codex-linux-system-tray-enabled",
   warmStart: "codex-linux-warm-start-enabled",


### PR DESCRIPTION
## Summary
- re-export the Read Aloud settings route from split general-settings wrappers
- follow the current General settings export map instead of stale minifier aliases
- persist Read Aloud custom keys through global-state IPC and mirror them into launcher settings

## Tests
- node --test linux-features/read-aloud/test.js
- node --test --test-name-pattern "persists Linux settings|migrates already-patched Linux settings" scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check