### PR TITLE
[codex] Invalidate stale DMG cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.dmg
+*.dmg.metadata
 node_modules/
 __pycache__/
 *.py[cod]

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -70,6 +70,11 @@ Equivalent direct commands:
 ./install.sh --fresh
 ```
 
+The default path stores upstream DMG headers, plus a hash of the upstream URL,
+next to `Codex.dmg` and refreshes the cached file when that upstream fingerprint
+changes. `--fresh` still forces a cache removal before rebuilding, and an
+explicit `DMG=/path/to/Codex.dmg` uses that file exactly.
+
 Run the generated app:
 
 ```bash

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -54,6 +54,26 @@ dmg_url_cache_key() {
     printf '%s' "$1" | sha256sum | awk '{print $1}'
 }
 
+cached_dmg_metadata_url_sha256() {
+    local metadata_path="$1"
+
+    awk -F= '$1 == "url_sha256" { print $2; exit }' "$metadata_path" 2>/dev/null || true
+}
+
+cached_dmg_metadata_matches_url() {
+    local metadata_path="$1"
+    local dmg_url="$2"
+    local cached_url_sha256
+    local expected_url_sha256
+
+    [ -s "$metadata_path" ] || return 1
+
+    cached_url_sha256="$(cached_dmg_metadata_url_sha256 "$metadata_path")"
+    expected_url_sha256="$(dmg_url_cache_key "$dmg_url")"
+
+    [ -n "$cached_url_sha256" ] && [ "$cached_url_sha256" = "$expected_url_sha256" ]
+}
+
 fetch_dmg_remote_fingerprint() {
     local dmg_url="$1"
     local headers_file="$WORK_DIR/dmg-headers.txt"
@@ -112,8 +132,13 @@ cached_dmg_is_fresh() {
     local remote_fingerprint
 
     if ! remote_fingerprint="$(fetch_dmg_remote_fingerprint "$dmg_url")"; then
-        warn "Could not check upstream DMG metadata; using cached DMG"
-        return 0
+        if cached_dmg_metadata_matches_url "$metadata_path" "$dmg_url"; then
+            warn "Could not check upstream DMG metadata; using cached DMG for matching URL"
+            return 0
+        fi
+
+        warn "Could not check upstream DMG metadata; cached DMG URL metadata does not match current URL"
+        return 1
     fi
     DMG_REMOTE_FINGERPRINT="$remote_fingerprint"
 

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -5,31 +5,186 @@
 # shellcheck shell=bash
 
 # ---- Download or find Codex DMG ----
+DEFAULT_DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+DMG_URL="${CODEX_UPSTREAM_DMG_URL:-$DEFAULT_DMG_URL}"
+DMG_REMOTE_FINGERPRINT=""
+
+redact_dmg_url() {
+    local dmg_url="$1"
+    local scheme="${dmg_url%%://*}"
+    local remainder="${dmg_url#*://}"
+    local authority="${remainder%%/*}"
+    local path=""
+
+    if [ "$remainder" != "$authority" ]; then
+        path="${remainder#"$authority"}"
+    fi
+
+    if [[ "$authority" == *@* ]]; then
+        authority="redacted@${authority##*@}"
+    fi
+
+    if [[ "$path" == *\?* ]]; then
+        path="${path%%\?*}?REDACTED"
+    elif [[ "$path" == *\#* ]]; then
+        path="${path%%\#*}#REDACTED"
+    fi
+
+    printf '%s://%s%s\n' "$scheme" "$authority" "$path"
+}
+
+validate_dmg_url() {
+    local dmg_url="$1"
+
+    case "$dmg_url" in
+        https://*)
+            ;;
+        "")
+            error "Upstream DMG URL must not be empty"
+            ;;
+        *)
+            error "Upstream DMG URL must be an HTTPS URL: $(redact_dmg_url "$dmg_url")"
+            ;;
+    esac
+}
+
+dmg_url_cache_key() {
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+}
+
+fetch_dmg_remote_fingerprint() {
+    local dmg_url="$1"
+    local headers_file="$WORK_DIR/dmg-headers.txt"
+    local url_sha256
+
+    url_sha256="$(dmg_url_cache_key "$dmg_url")"
+
+    if ! curl -fsSLI --max-time 10 --connect-timeout 5 -- "$dmg_url" >"$headers_file"; then
+        return 1
+    fi
+
+    awk -v url_sha256="$url_sha256" '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            key = line
+            sub(/:.*/, "", key)
+            key = tolower(key)
+            value = line
+            sub(/^[^:]+:[[:space:]]*/, "", value)
+        }
+        key ~ /^http\// {
+            etag = ""
+            last_modified = ""
+            content_length = ""
+            next
+        }
+        key == "etag" {
+            etag = value
+            next
+        }
+        key == "last-modified" {
+            last_modified = value
+            next
+        }
+        key == "content-length" {
+            content_length = value
+            next
+        }
+        END {
+            if (etag == "" && last_modified == "" && content_length == "") {
+                exit 1
+            }
+            print "url_sha256=" url_sha256
+            print "etag=" etag
+            print "last_modified=" last_modified
+            print "content_length=" content_length
+        }
+    ' "$headers_file"
+}
+
+cached_dmg_is_fresh() {
+    local dmg_dest="$1"
+    local metadata_path="$2"
+    local dmg_url="$3"
+    local remote_fingerprint
+
+    if ! remote_fingerprint="$(fetch_dmg_remote_fingerprint "$dmg_url")"; then
+        warn "Could not check upstream DMG metadata; using cached DMG"
+        return 0
+    fi
+    DMG_REMOTE_FINGERPRINT="$remote_fingerprint"
+
+    if [ ! -s "$metadata_path" ]; then
+        warn "Cached DMG has no upstream metadata; refreshing once to seed the cache"
+        return 1
+    fi
+
+    if [ "$(cat "$metadata_path")" = "$remote_fingerprint" ]; then
+        return 0
+    fi
+
+    warn "Cached DMG metadata differs from upstream; refreshing"
+    return 1
+}
+
+write_cached_dmg_metadata() {
+    local metadata_path="$1"
+    local remote_fingerprint="$2"
+
+    if [ -n "$remote_fingerprint" ]; then
+        printf '%s\n' "$remote_fingerprint" >"$metadata_path"
+    else
+        rm -f "$metadata_path"
+        warn "Could not record upstream DMG metadata"
+    fi
+}
+
 get_dmg() {
     local dmg_dest="$CACHED_DMG_PATH"
+    local metadata_path="$CACHED_DMG_METADATA_PATH"
+    local download_fingerprint=""
+    local tmp_dest="$dmg_dest.part"
 
-    # Reuse existing DMG
+    validate_dmg_url "$DMG_URL"
+
+    # Reuse existing DMG only when it still matches upstream metadata.
     if [ -s "$dmg_dest" ]; then
-        info "Using cached DMG: $dmg_dest ($(du -h "$dmg_dest" | cut -f1))"
-        echo "$dmg_dest"
-        return
+        DMG_REMOTE_FINGERPRINT=""
+        if cached_dmg_is_fresh "$dmg_dest" "$metadata_path" "$DMG_URL"; then
+            info "Using cached DMG: $dmg_dest ($(du -h "$dmg_dest" | cut -f1))"
+            echo "$dmg_dest"
+            return
+        fi
+
+        download_fingerprint="$DMG_REMOTE_FINGERPRINT"
+        info "Refreshing stale cached DMG: $dmg_dest"
+    fi
+
+    if [ -z "$download_fingerprint" ]; then
+        if ! download_fingerprint="$(fetch_dmg_remote_fingerprint "$DMG_URL")"; then
+            warn "Could not record upstream DMG metadata"
+            download_fingerprint=""
+        fi
     fi
 
     info "Downloading Codex Desktop DMG..."
-    local dmg_url="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
-    info "URL: $dmg_url"
+    info "URL: $(redact_dmg_url "$DMG_URL")"
 
+    rm -f "$tmp_dest"
     if ! curl -L --progress-bar --max-time 600 --connect-timeout 30 \
-            -o "$dmg_dest" "$dmg_url"; then
-        rm -f "$dmg_dest"
+            -o "$tmp_dest" -- "$DMG_URL"; then
+        rm -f "$tmp_dest"
         error "Download failed. Download manually and place as: $dmg_dest"
     fi
 
-    if [ ! -s "$dmg_dest" ]; then
-        rm -f "$dmg_dest"
+    if [ ! -s "$tmp_dest" ]; then
+        rm -f "$tmp_dest"
         error "Download produced empty file. Download manually and place as: $dmg_dest"
     fi
 
+    mv "$tmp_dest" "$dmg_dest"
+    write_cached_dmg_metadata "$metadata_path" "$download_fingerprint"
     info "Saved: $dmg_dest ($(du -h "$dmg_dest" | cut -f1))"
     echo "$dmg_dest"
 }

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -13,7 +13,9 @@ redact_dmg_url() {
     local dmg_url="$1"
     local scheme="${dmg_url%%://*}"
     local remainder="${dmg_url#*://}"
-    local authority="${remainder%%/*}"
+
+    # Authority ends at the first '/', '?', or '#', whichever comes first.
+    local authority="${remainder%%[/?#]*}"
     local path=""
 
     if [ "$remainder" != "$authority" ]; then

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -36,6 +36,7 @@ trap cleanup EXIT
 trap 'error "Failed at line $LINENO (exit code $?)"' ERR
 
 CACHED_DMG_PATH="$SCRIPT_DIR/Codex.dmg"
+CACHED_DMG_METADATA_PATH="$CACHED_DMG_PATH.metadata"
 FRESH_INSTALL=0
 REUSE_CACHED_DMG=1
 PROVIDED_DMG_PATH=""
@@ -51,7 +52,7 @@ Converts the official macOS Codex Desktop app to run on Linux.
 Options:
   -h, --help     Show this help message and exit
   --fresh        Remove existing install directory and cached DMG before building
-  --reuse-dmg    Reuse cached Codex.dmg if present (default)
+  --reuse-dmg    Reuse cached Codex.dmg when upstream metadata still matches (default)
   --inspect      Inspect the DMG and write patch/rebuild reports without installing
   --report-dir DIR
                  Directory for --inspect reports (default: ./dist-next/rebuild)
@@ -146,9 +147,11 @@ prepare_install() {
         rm -rf "$INSTALL_DIR"
     fi
 
-    if [ "$FRESH_INSTALL" -eq 1 ] && [ "$REUSE_CACHED_DMG" -ne 1 ] && [ -f "$CACHED_DMG_PATH" ]; then
-        info "Removing cached DMG: $CACHED_DMG_PATH"
+    if [ "$FRESH_INSTALL" -eq 1 ] && [ "$REUSE_CACHED_DMG" -ne 1 ] \
+            && { [ -e "$CACHED_DMG_PATH" ] || [ -e "$CACHED_DMG_METADATA_PATH" ]; }; then
+        info "Removing cached DMG and metadata: $CACHED_DMG_PATH"
         rm -f "$CACHED_DMG_PATH"
+        rm -f "$CACHED_DMG_METADATA_PATH"
     fi
 }
 

--- a/scripts/rebuild-candidate.sh
+++ b/scripts/rebuild-candidate.sh
@@ -9,7 +9,7 @@ usage() {
 Usage: scripts/rebuild-candidate.sh [--install] [path/to/Codex.dmg]
 
 Runs the safe rebuild flow:
-  1. Find Codex.dmg in this repository, unless a DMG path is given.
+  1. Use the installer-managed Codex.dmg cache, unless a DMG path is given.
   2. Inspect the DMG and write reports.
   3. Build a side-by-side candidate in codex-app-next/.
   4. With --install, move the candidate into codex-app/ and keep a backup.
@@ -65,29 +65,11 @@ REBUILD_REPORT="$REPORT_DIR/rebuild-report.json"
 
 resolve_dmg_path() {
     local explicit_path="$1"
-    local -a candidates=()
 
     if [ -n "$explicit_path" ]; then
         [ -f "$explicit_path" ] || error "DMG not found: $explicit_path"
         realpath "$explicit_path"
         return 0
-    fi
-
-    if [ -f "$REPO_DIR/Codex.dmg" ]; then
-        realpath "$REPO_DIR/Codex.dmg"
-        return 0
-    fi
-
-    mapfile -d '' candidates < <(find "$REPO_DIR" -maxdepth 1 -type f -name '*.dmg' -print0 | sort -z)
-    if [ "${#candidates[@]}" -eq 1 ]; then
-        realpath "${candidates[0]}"
-        return 0
-    fi
-
-    if [ "${#candidates[@]}" -gt 1 ]; then
-        printf '[rebuild][ERROR] Multiple DMG files found. Pass one explicitly:\n' >&2
-        printf '  %s\n' "${candidates[@]}" >&2
-        exit 1
     fi
 
     echo ""
@@ -164,11 +146,18 @@ if [ -n "$DMG_PATH" ]; then
     dmg_args=("$DMG_PATH")
     info "Using DMG: $DMG_PATH"
 else
-    info "No local DMG found; installer will reuse or download Codex.dmg"
+    info "No explicit DMG given; installer will validate, reuse, or download Codex.dmg"
 fi
 
 info "1/2 Inspecting upstream DMG"
 "$REPO_DIR/install.sh" --inspect --report-dir "$REPORT_DIR" "${dmg_args[@]}"
+
+if [ -z "$DMG_PATH" ]; then
+    DMG_PATH="$REPO_DIR/Codex.dmg"
+    [ -f "$DMG_PATH" ] || error "Installer did not produce cached DMG: $DMG_PATH"
+    dmg_args=("$DMG_PATH")
+    info "Using validated DMG for build: $DMG_PATH"
+fi
 
 info "2/2 Building side-by-side candidate"
 CODEX_INSTALL_DIR="$NEXT_APP_DIR" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1252,6 +1252,27 @@ EOF
     assert_not_contains "$head_failure/curl.log" "GET"
     assert_contains "$head_failure/output.log" "Could not check upstream DMG metadata"
 
+    local head_failure_mismatched_url="$workspace/head-failure-mismatched-url"
+    mkdir -p "$head_failure_mismatched_url"
+    printf '%s' "old" >"$head_failure_mismatched_url/Codex.dmg"
+    cat >"$head_failure_mismatched_url/Codex.dmg.metadata" <<EOF
+url_sha256=$url_sha256
+etag=old-etag
+last_modified=Thu, 04 Jun 2026 00:00:00 GMT
+content_length=3
+EOF
+    if run_dmg_cache_case "$head_failure_mismatched_url" "$head_failure_mismatched_url/output.log" \
+        CODEX_UPSTREAM_DMG_URL="https://example.com/Codex.dmg" \
+        TEST_HEAD_FAIL=1 \
+        TEST_GET_FAIL=1
+    then
+        fail "Expected HEAD failure with mismatched cached URL metadata to attempt refresh and fail"
+    fi
+    [ "$(cat "$head_failure_mismatched_url/Codex.dmg")" = "old" ] || fail "Expected failed mismatched-URL refresh to preserve old DMG"
+    assert_contains "$head_failure_mismatched_url/Codex.dmg.metadata" "etag=old-etag"
+    assert_contains "$head_failure_mismatched_url/curl.log" "GET"
+    assert_contains "$head_failure_mismatched_url/output.log" "cached DMG URL metadata does not match current URL"
+
     local secret_url="$workspace/secret-url"
     mkdir -p "$secret_url"
     run_dmg_cache_case "$secret_url" "$secret_url/output.log" \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1087,6 +1087,269 @@ SCRIPT
     [ -z "$third_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
 }
 
+test_installer_refreshes_stale_cached_dmg_metadata() {
+    info "Checking installer DMG cache freshness metadata branches"
+    local workspace="$TMP_DIR/dmg-cache-refresh"
+    local bin_dir="$workspace/bin"
+    local url="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    local url_sha256
+
+    url_sha256="$(printf '%s' "$url" | sha256sum | awk '{print $1}')"
+
+    mkdir -p "$bin_dir"
+
+    cat >"$bin_dir/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+is_head=0
+for arg in "$@"; do
+    if [ "$arg" = "-fsSLI" ]; then
+        is_head=1
+    fi
+done
+
+if [ "$is_head" -eq 1 ]; then
+    printf '%s\n' "HEAD" >> "$TEST_CURL_LOG"
+    if [ "${TEST_HEAD_FAIL:-0}" = "1" ]; then
+        exit 22
+    fi
+    printf 'HTTP/2 200\r\n'
+    [ -z "${TEST_ETAG:-}" ] || printf 'ETag: %s\r\n' "$TEST_ETAG"
+    [ -z "${TEST_LAST_MODIFIED:-}" ] || printf 'Last-Modified: %s\r\n' "$TEST_LAST_MODIFIED"
+    [ -z "${TEST_CONTENT_LENGTH:-}" ] || printf 'Content-Length: %s\r\n' "$TEST_CONTENT_LENGTH"
+    printf '\r\n'
+    exit 0
+fi
+
+printf '%s\n' "GET" >> "$TEST_CURL_LOG"
+if [ "${TEST_GET_FAIL:-0}" = "1" ]; then
+    exit 23
+fi
+
+out=""
+while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-o" ]; then
+        shift
+        out="$1"
+    fi
+    shift || true
+done
+
+[ -n "$out" ] || exit 2
+printf '%s' "${TEST_DOWNLOAD_CONTENT:-new}" >"$out"
+SCRIPT
+    chmod +x "$bin_dir/curl"
+
+    run_dmg_cache_case() {
+        local source_dir="$1"
+        local output_log="$2"
+        shift 2
+
+        mkdir -p "$source_dir"
+        : >"$source_dir/curl.log"
+        env "$@" \
+            PATH="$bin_dir:$PATH" \
+            TEST_SOURCE_DIR="$source_dir" \
+            TEST_CURL_LOG="$source_dir/curl.log" \
+            REPO_DIR="$REPO_DIR" \
+            bash <<'SCRIPT' >"$output_log" 2>&1
+set -Eeuo pipefail
+
+SCRIPT_DIR="$TEST_SOURCE_DIR"
+WORK_DIR="$(mktemp -d)"
+# shellcheck disable=SC1091
+source "$REPO_DIR/scripts/lib/install-helpers.sh"
+# shellcheck disable=SC1091
+source "$REPO_DIR/scripts/lib/dmg.sh"
+
+dmg_path="$(get_dmg)"
+[ "$dmg_path" = "$TEST_SOURCE_DIR/Codex.dmg" ]
+SCRIPT
+    }
+
+    local no_metadata="$workspace/no-metadata"
+    mkdir -p "$no_metadata"
+    printf '%s' "old" >"$no_metadata/Codex.dmg"
+    run_dmg_cache_case "$no_metadata" "$no_metadata/output.log" \
+        TEST_ETAG=fresh-etag \
+        TEST_LAST_MODIFIED="Thu, 04 Jun 2026 00:00:00 GMT" \
+        TEST_CONTENT_LENGTH=3 \
+        TEST_DOWNLOAD_CONTENT=new
+    [ "$(cat "$no_metadata/Codex.dmg")" = "new" ] || fail "Expected missing-metadata cache to refresh"
+    assert_contains "$no_metadata/Codex.dmg.metadata" "etag=fresh-etag"
+    assert_contains "$no_metadata/Codex.dmg.metadata" "url_sha256=$url_sha256"
+    assert_contains "$no_metadata/output.log" "Cached DMG has no upstream metadata"
+    assert_contains "$no_metadata/output.log" "Refreshing stale cached DMG"
+
+    local matching="$workspace/matching"
+    mkdir -p "$matching"
+    printf '%s' "old" >"$matching/Codex.dmg"
+    cat >"$matching/Codex.dmg.metadata" <<EOF
+url_sha256=$url_sha256
+etag=same-etag
+last_modified=Thu, 04 Jun 2026 00:00:00 GMT
+content_length=3
+EOF
+    run_dmg_cache_case "$matching" "$matching/output.log" \
+        TEST_ETAG=same-etag \
+        TEST_LAST_MODIFIED="Thu, 04 Jun 2026 00:00:00 GMT" \
+        TEST_CONTENT_LENGTH=3 \
+        TEST_DOWNLOAD_CONTENT=downloaded
+    [ "$(cat "$matching/Codex.dmg")" = "old" ] || fail "Expected matching metadata to reuse cache"
+    assert_not_contains "$matching/curl.log" "GET"
+    assert_contains "$matching/output.log" "Using cached DMG"
+
+    local differing="$workspace/differing"
+    mkdir -p "$differing"
+    printf '%s' "old" >"$differing/Codex.dmg"
+    cat >"$differing/Codex.dmg.metadata" <<EOF
+url_sha256=$url_sha256
+etag=old-etag
+last_modified=Thu, 04 Jun 2026 00:00:00 GMT
+content_length=3
+EOF
+    run_dmg_cache_case "$differing" "$differing/output.log" \
+        TEST_ETAG=fresh-etag \
+        TEST_LAST_MODIFIED="Thu, 04 Jun 2026 00:00:00 GMT" \
+        TEST_CONTENT_LENGTH=3 \
+        TEST_DOWNLOAD_CONTENT=new
+    [ "$(cat "$differing/Codex.dmg")" = "new" ] || fail "Expected differing metadata to refresh cache"
+    assert_contains "$differing/curl.log" "GET"
+
+    local failed_get="$workspace/failed-get"
+    mkdir -p "$failed_get"
+    printf '%s' "old" >"$failed_get/Codex.dmg"
+    cat >"$failed_get/Codex.dmg.metadata" <<EOF
+url_sha256=$url_sha256
+etag=old-etag
+last_modified=Thu, 04 Jun 2026 00:00:00 GMT
+content_length=3
+EOF
+    if run_dmg_cache_case "$failed_get" "$failed_get/output.log" \
+        TEST_ETAG=fresh-etag \
+        TEST_LAST_MODIFIED="Thu, 04 Jun 2026 00:00:00 GMT" \
+        TEST_CONTENT_LENGTH=3 \
+        TEST_GET_FAIL=1
+    then
+        fail "Expected failed replacement download to fail the refresh"
+    fi
+    [ "$(cat "$failed_get/Codex.dmg")" = "old" ] || fail "Expected failed refresh to preserve old DMG"
+    assert_contains "$failed_get/Codex.dmg.metadata" "etag=old-etag"
+    assert_file_not_exists "$failed_get/Codex.dmg.part"
+
+    local head_failure="$workspace/head-failure"
+    mkdir -p "$head_failure"
+    printf '%s' "old" >"$head_failure/Codex.dmg"
+    cat >"$head_failure/Codex.dmg.metadata" <<EOF
+url_sha256=$url_sha256
+etag=old-etag
+last_modified=Thu, 04 Jun 2026 00:00:00 GMT
+content_length=3
+EOF
+    run_dmg_cache_case "$head_failure" "$head_failure/output.log" TEST_HEAD_FAIL=1
+    [ "$(cat "$head_failure/Codex.dmg")" = "old" ] || fail "Expected HEAD failure to preserve cache"
+    assert_not_contains "$head_failure/curl.log" "GET"
+    assert_contains "$head_failure/output.log" "Could not check upstream DMG metadata"
+
+    local secret_url="$workspace/secret-url"
+    mkdir -p "$secret_url"
+    run_dmg_cache_case "$secret_url" "$secret_url/output.log" \
+        CODEX_UPSTREAM_DMG_URL="https://user:secret@example.com/Codex.dmg?token=topsecret#fragsecret" \
+        TEST_ETAG=opaque-etag \
+        TEST_CONTENT_LENGTH=3 \
+        TEST_DOWNLOAD_CONTENT=new
+    [ "$(cat "$secret_url/Codex.dmg")" = "new" ] || fail "Expected HTTPS override URL to download"
+    assert_contains "$secret_url/output.log" "URL: https://redacted@example.com/Codex.dmg?REDACTED"
+    assert_not_contains "$secret_url/output.log" "topsecret"
+    assert_not_contains "$secret_url/output.log" "fragsecret"
+    assert_not_contains "$secret_url/Codex.dmg.metadata" "topsecret"
+    assert_not_contains "$secret_url/Codex.dmg.metadata" "fragsecret"
+
+    local invalid_url="$workspace/invalid-url"
+    mkdir -p "$invalid_url"
+    if run_dmg_cache_case "$invalid_url" "$invalid_url/output.log" \
+        CODEX_UPSTREAM_DMG_URL="file:///tmp/Codex.dmg"
+    then
+        fail "Expected non-HTTPS upstream DMG URL to fail"
+    fi
+    assert_contains "$invalid_url/output.log" "Upstream DMG URL must be an HTTPS URL"
+}
+
+test_fresh_install_removes_cached_dmg_metadata() {
+    info "Checking --fresh removes cached DMG metadata"
+    local workspace="$TMP_DIR/fresh-dmg-metadata"
+    local source_dir="$workspace/source"
+
+    mkdir -p "$source_dir"
+    printf '%s' "metadata" >"$source_dir/Codex.dmg.metadata"
+
+    TEST_SOURCE_DIR="$source_dir" REPO_DIR="$REPO_DIR" bash <<'SCRIPT'
+set -Eeuo pipefail
+
+SCRIPT_DIR="$TEST_SOURCE_DIR"
+WORK_DIR="$(mktemp -d)"
+INSTALL_DIR="$TEST_SOURCE_DIR/codex-app"
+# shellcheck disable=SC1091
+source "$REPO_DIR/scripts/lib/install-helpers.sh"
+
+FRESH_INSTALL=1
+REUSE_CACHED_DMG=0
+prepare_install
+SCRIPT
+
+    assert_file_not_exists "$source_dir/Codex.dmg"
+    assert_file_not_exists "$source_dir/Codex.dmg.metadata"
+}
+
+test_rebuild_candidate_uses_validated_default_dmg() {
+    info "Checking rebuild-candidate default DMG validation flow"
+    local workspace="$TMP_DIR/rebuild-candidate-dmg"
+    local repo="$workspace/repo"
+    local explicit_dmg="$workspace/explicit.dmg"
+    local explicit_realpath
+    local first_line
+    local second_line
+
+    mkdir -p "$repo/scripts"
+    cp "$REPO_DIR/scripts/rebuild-candidate.sh" "$repo/scripts/rebuild-candidate.sh"
+    printf '%s' "cached" >"$repo/Codex.dmg"
+    printf '%s' "explicit" >"$explicit_dmg"
+    explicit_realpath="$(realpath "$explicit_dmg")"
+
+    cat >"$repo/install.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+{
+    printf 'CALL:'
+    for arg in "$@"; do
+        printf '<%s>' "$arg"
+    done
+    printf '\n'
+} >> "$TEST_REBUILD_LOG"
+SCRIPT
+    chmod +x "$repo/install.sh"
+
+    TEST_REBUILD_LOG="$workspace/default.log" \
+    CODEX_NEXT_APP_DIR="$workspace/next" \
+    REBUILD_REPORT_DIR="$workspace/report" \
+        bash "$repo/scripts/rebuild-candidate.sh" >"$workspace/default.out" 2>&1
+    first_line="$(sed -n '1p' "$workspace/default.log")"
+    second_line="$(sed -n '2p' "$workspace/default.log")"
+    [[ "$first_line" != *"Codex.dmg"* ]] || fail "Default inspect should let installer validate the cache: $first_line"
+    [[ "$second_line" == *"<$repo/Codex.dmg>"* ]] || fail "Default build should pin the validated cache: $second_line"
+    assert_contains "$workspace/default.out" "Using validated DMG for build"
+
+    TEST_REBUILD_LOG="$workspace/explicit.log" \
+    CODEX_NEXT_APP_DIR="$workspace/next-explicit" \
+    REBUILD_REPORT_DIR="$workspace/report-explicit" \
+        bash "$repo/scripts/rebuild-candidate.sh" "$explicit_dmg" >"$workspace/explicit.out" 2>&1
+    first_line="$(sed -n '1p' "$workspace/explicit.log")"
+    second_line="$(sed -n '2p' "$workspace/explicit.log")"
+    [[ "$first_line" == *"<$explicit_realpath>"* ]] || fail "Explicit inspect should receive explicit DMG: $first_line"
+    [[ "$second_line" == *"<$explicit_realpath>"* ]] || fail "Explicit build should receive explicit DMG: $second_line"
+}
+
 test_native_shortcut_targets_compose_existing_flows() {
     info "Checking native install/update shortcut targets"
     local install_log="$TMP_DIR/make-install-native.log"
@@ -5329,6 +5592,9 @@ main() {
     test_make_install_reports_missing_native_packages
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
+    test_installer_refreshes_stale_cached_dmg_metadata
+    test_fresh_install_removes_cached_dmg_metadata
+    test_rebuild_candidate_uses_validated_default_dmg
     test_native_shortcut_targets_compose_existing_flows
     test_fedora_dependency_bootstrap_installs_rpmbuild
     test_setup_native_wizard_noninteractive_feature_writer


### PR DESCRIPTION
## Summary

- Store upstream `Codex.dmg` HEAD metadata and the upstream URL hash next to the installer cache, then refresh the cached DMG when that fingerprint changes.
- Preserve the previous cached DMG if a refresh download fails, redact override URLs in logs/metadata, and remove the metadata sidecar during `--fresh` rebuilds.
- Let `scripts/rebuild-candidate.sh` use the installer-managed cache by default, while preserving explicit `DMG=/path/to/Codex.dmg` behavior.

## Why

The default rebuild path could silently reuse an old `Codex.dmg`. `rebuild-candidate.sh` also resolved and passed the local `Codex.dmg` explicitly, which bypassed any installer-side chance to refresh it. That made it possible to rebuild a Linux app while believing it was based on the current upstream DMG, even when the local cache was stale.

## Source Of Truth

- `scripts/lib/dmg.sh`
- `scripts/lib/install-helpers.sh`
- `scripts/rebuild-candidate.sh`
- `tests/scripts_smoke.sh`
- `docs/build-and-packaging.md`

## Validation

- `bash -n install.sh scripts/lib/*.sh scripts/rebuild-candidate.sh launcher/start.sh.template tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- `cargo test -p codex-update-manager`

No matching open issue or PR was found for `DMG cache`, `cached DMG`, or `Codex.dmg`.