### PR TITLE
Add AUR packaging workflow

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -34,13 +34,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolve source ref
+        id: source-ref
+        env:
+          SOURCE_REF_INPUT: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          source_ref="${SOURCE_REF_INPUT:-$GITHUB_SHA}"
+          resolved="$(git rev-parse "${source_ref}^{commit}")"
+          echo "source_ref=$resolved" >> "$GITHUB_OUTPUT"
+
       - name: Render and validate in Arch Linux
         run: |
           set -euo pipefail
           docker run --rm \
             -e AUR_PKGNAME="$AUR_PKGNAME" \
             -e AUR_SOURCE_REPO="$AUR_SOURCE_REPO" \
-            -e AUR_SOURCE_REF="${{ inputs.source_ref || github.sha }}" \
+            -e AUR_SOURCE_REF="${{ steps.source-ref.outputs.source_ref }}" \
             -e AUR_PKGVER="${{ inputs.pkgver }}" \
             -e AUR_DMG_URL="$AUR_DMG_URL" \
             -e AUR_PUBLISH="${{ inputs.publish }}" \
@@ -50,25 +60,36 @@ jobs:
             bash -lc '
               set -euo pipefail
               pacman -Syu --noconfirm --needed curl git
+              useradd -m builder
+              chown -R builder:builder /work
 
-              if [ -z "${AUR_PKGVER:-}" ]; then
-                AUR_PKGVER="$(date -u +%Y.%m.%d.%H%M%S)"
-                export AUR_PKGVER
-              fi
+              runuser -u builder -- env \
+                AUR_PKGNAME="$AUR_PKGNAME" \
+                AUR_SOURCE_REPO="$AUR_SOURCE_REPO" \
+                AUR_SOURCE_REF="$AUR_SOURCE_REF" \
+                AUR_PKGVER="$AUR_PKGVER" \
+                AUR_DMG_URL="$AUR_DMG_URL" \
+                AUR_PUBLISH="$AUR_PUBLISH" \
+                bash -lc '"'"'
+                  set -euo pipefail
 
-              if [ "${AUR_PUBLISH:-false}" = "true" ]; then
-                archive_url="${AUR_SOURCE_REPO}/archive/${AUR_SOURCE_REF}.tar.gz"
-                AUR_SOURCE_SHA256="$(curl -fsSL "$archive_url" | sha256sum | cut -d" " -f1)"
-                AUR_DMG_SHA256="$(curl -fL --retry 3 "$AUR_DMG_URL" | sha256sum | cut -d" " -f1)"
-                export AUR_SOURCE_SHA256 AUR_DMG_SHA256
-              fi
+                  if [ -z "${AUR_PKGVER:-}" ]; then
+                    AUR_PKGVER="$(date -u +%Y.%m.%d.%H%M%S)"
+                    export AUR_PKGVER
+                  fi
 
-              AUR_DIR=/work/dist/aur ./scripts/aur/render-aur-package.sh
-              cd /work/dist/aur
-              makepkg --printsrcinfo > .SRCINFO
-              test -s PKGBUILD
-              test -s .SRCINFO
-              grep -q "^pkgname = ${AUR_PKGNAME}$" .SRCINFO
+                  if [ "${AUR_PUBLISH:-false}" = "true" ]; then
+                    AUR_DMG_SHA256="$(curl -fL --retry 3 "$AUR_DMG_URL" | sha256sum | cut -d" " -f1)"
+                    export AUR_DMG_SHA256
+                  fi
+
+                  AUR_DIR=/work/dist/aur ./scripts/aur/render-aur-package.sh
+                  cd /work/dist/aur
+                  makepkg --printsrcinfo > .SRCINFO
+                  test -s PKGBUILD
+                  test -s .SRCINFO
+                  grep -q "^pkgname = ${AUR_PKGNAME}$" .SRCINFO
+                '"'"'
             '
 
       - name: Upload rendered AUR files

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -48,13 +48,15 @@ jobs:
           echo "source_ref=$resolved" >> "$GITHUB_OUTPUT"
 
       - name: Render and validate in Arch Linux
+        env:
+          AUR_PKGVER_INPUT: ${{ inputs.pkgver }}
         run: |
           set -euo pipefail
           docker run --rm \
             -e AUR_PKGNAME="$AUR_PKGNAME" \
             -e AUR_SOURCE_REPO="$AUR_SOURCE_REPO" \
             -e AUR_SOURCE_REF="${{ steps.source-ref.outputs.source_ref }}" \
-            -e AUR_PKGVER="${{ inputs.pkgver }}" \
+            -e AUR_PKGVER="$AUR_PKGVER_INPUT" \
             -e AUR_DMG_URL="$AUR_DMG_URL" \
             -e AUR_PUBLISH="${{ inputs.publish }}" \
             -e AUR_NODE_VERSION="$AUR_NODE_VERSION" \

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,123 @@
+name: Publish AUR Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      pkgver:
+        description: AUR pkgver override, without hyphens
+        required: false
+        type: string
+      source_ref:
+        description: Git ref or commit to package
+        required: false
+        type: string
+      publish:
+        description: Push changes to aur.archlinux.org
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  AUR_PKGNAME: codex-desktop-linux
+  AUR_SOURCE_REPO: https://github.com/ilysenko/codex-desktop-linux
+  AUR_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+
+jobs:
+  aur:
+    name: Render AUR Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Render and validate in Arch Linux
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e AUR_PKGNAME="$AUR_PKGNAME" \
+            -e AUR_SOURCE_REPO="$AUR_SOURCE_REPO" \
+            -e AUR_SOURCE_REF="${{ inputs.source_ref || github.sha }}" \
+            -e AUR_PKGVER="${{ inputs.pkgver }}" \
+            -e AUR_DMG_URL="$AUR_DMG_URL" \
+            -e AUR_PUBLISH="${{ inputs.publish }}" \
+            -v "$PWD:/work" \
+            -w /work \
+            archlinux:base-devel \
+            bash -lc '
+              set -euo pipefail
+              pacman -Syu --noconfirm --needed curl git
+
+              if [ -z "${AUR_PKGVER:-}" ]; then
+                AUR_PKGVER="$(date -u +%Y.%m.%d.%H%M%S)"
+                export AUR_PKGVER
+              fi
+
+              if [ "${AUR_PUBLISH:-false}" = "true" ]; then
+                archive_url="${AUR_SOURCE_REPO}/archive/${AUR_SOURCE_REF}.tar.gz"
+                AUR_SOURCE_SHA256="$(curl -fsSL "$archive_url" | sha256sum | cut -d" " -f1)"
+                AUR_DMG_SHA256="$(curl -fL --retry 3 "$AUR_DMG_URL" | sha256sum | cut -d" " -f1)"
+                export AUR_SOURCE_SHA256 AUR_DMG_SHA256
+              fi
+
+              AUR_DIR=/work/dist/aur ./scripts/aur/render-aur-package.sh
+              cd /work/dist/aur
+              makepkg --printsrcinfo > .SRCINFO
+              test -s PKGBUILD
+              test -s .SRCINFO
+              grep -q "^pkgname = ${AUR_PKGNAME}$" .SRCINFO
+            '
+
+      - name: Upload rendered AUR files
+        uses: actions/upload-artifact@v4
+        with:
+          name: aur-package
+          path: |
+            dist/aur/PKGBUILD
+            dist/aur/.SRCINFO
+            dist/aur/*.install
+
+      - name: Configure AUR SSH
+        if: inputs.publish == true
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_KNOWN_HOSTS: ${{ secrets.AUR_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          test -n "$AUR_SSH_PRIVATE_KEY"
+          install -m 0700 -d "$HOME/.ssh"
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > "$HOME/.ssh/aur"
+          chmod 0600 "$HOME/.ssh/aur"
+          if [ -n "$AUR_KNOWN_HOSTS" ]; then
+            printf '%s\n' "$AUR_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          else
+            ssh-keyscan aur.archlinux.org > "$HOME/.ssh/known_hosts"
+          fi
+          cat > "$HOME/.ssh/config" <<'SSH'
+Host aur.archlinux.org
+  IdentityFile ~/.ssh/aur
+  User aur
+  IdentitiesOnly yes
+SSH
+          chmod 0600 "$HOME/.ssh/config"
+
+      - name: Publish to AUR
+        if: inputs.publish == true
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/aur-codex-desktop-linux
+          git clone "ssh://aur@aur.archlinux.org/${AUR_PKGNAME}.git" /tmp/aur-codex-desktop-linux
+          cp dist/aur/PKGBUILD dist/aur/.SRCINFO dist/aur/*.install /tmp/aur-codex-desktop-linux/
+          cd /tmp/aur-codex-desktop-linux
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- PKGBUILD .SRCINFO *.install; then
+            echo "No AUR package changes to publish."
+            exit 0
+          fi
+          git add PKGBUILD .SRCINFO *.install
+          git commit -m "Update ${AUR_PKGNAME}"
+          git push

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -24,6 +24,9 @@ env:
   AUR_PKGNAME: codex-desktop-linux
   AUR_SOURCE_REPO: https://github.com/ilysenko/codex-desktop-linux
   AUR_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+  AUR_NODE_VERSION: v22.22.2
+  AUR_ELECTRON_VERSION: 42.1.0
+  AUR_BROWSER_RUNTIME_VERSION: 26.426.12240
 
 jobs:
   aur:
@@ -54,6 +57,9 @@ jobs:
             -e AUR_PKGVER="${{ inputs.pkgver }}" \
             -e AUR_DMG_URL="$AUR_DMG_URL" \
             -e AUR_PUBLISH="${{ inputs.publish }}" \
+            -e AUR_NODE_VERSION="$AUR_NODE_VERSION" \
+            -e AUR_ELECTRON_VERSION="$AUR_ELECTRON_VERSION" \
+            -e AUR_BROWSER_RUNTIME_VERSION="$AUR_BROWSER_RUNTIME_VERSION" \
             -v "$PWD:/work" \
             -w /work \
             archlinux:base-devel \
@@ -63,6 +69,17 @@ jobs:
               useradd -m builder
               chown -R builder:builder /work
 
+              if [ "${AUR_PUBLISH:-false}" = "true" ]; then
+                AUR_NODE_X64_SHA256="$(curl -fsSL "https://nodejs.org/dist/${AUR_NODE_VERSION}/node-${AUR_NODE_VERSION}-linux-x64.tar.xz" | sha256sum | cut -d" " -f1)"
+                AUR_NODE_ARM64_SHA256="$(curl -fsSL "https://nodejs.org/dist/${AUR_NODE_VERSION}/node-${AUR_NODE_VERSION}-linux-arm64.tar.xz" | sha256sum | cut -d" " -f1)"
+                AUR_ELECTRON_X64_SHA256="$(curl -fsSL "https://github.com/electron/electron/releases/download/v${AUR_ELECTRON_VERSION}/electron-v${AUR_ELECTRON_VERSION}-linux-x64.zip" | sha256sum | cut -d" " -f1)"
+                AUR_ELECTRON_ARM64_SHA256="$(curl -fsSL "https://github.com/electron/electron/releases/download/v${AUR_ELECTRON_VERSION}/electron-v${AUR_ELECTRON_VERSION}-linux-arm64.zip" | sha256sum | cut -d" " -f1)"
+                AUR_BROWSER_RUNTIME_X64_SHA256="$(curl -fsSL "https://persistent.oaistatic.com/codex-primary-runtime/${AUR_BROWSER_RUNTIME_VERSION}/codex-primary-runtime-linux-x64-${AUR_BROWSER_RUNTIME_VERSION}.tar.xz" | sha256sum | cut -d" " -f1)"
+                export AUR_NODE_X64_SHA256 AUR_NODE_ARM64_SHA256
+                export AUR_ELECTRON_X64_SHA256 AUR_ELECTRON_ARM64_SHA256
+                export AUR_BROWSER_RUNTIME_X64_SHA256
+              fi
+
               runuser -u builder -- env \
                 AUR_PKGNAME="$AUR_PKGNAME" \
                 AUR_SOURCE_REPO="$AUR_SOURCE_REPO" \
@@ -70,6 +87,14 @@ jobs:
                 AUR_PKGVER="$AUR_PKGVER" \
                 AUR_DMG_URL="$AUR_DMG_URL" \
                 AUR_PUBLISH="$AUR_PUBLISH" \
+                AUR_NODE_VERSION="$AUR_NODE_VERSION" \
+                AUR_NODE_X64_SHA256="${AUR_NODE_X64_SHA256:-SKIP}" \
+                AUR_NODE_ARM64_SHA256="${AUR_NODE_ARM64_SHA256:-SKIP}" \
+                AUR_ELECTRON_VERSION="$AUR_ELECTRON_VERSION" \
+                AUR_ELECTRON_X64_SHA256="${AUR_ELECTRON_X64_SHA256:-SKIP}" \
+                AUR_ELECTRON_ARM64_SHA256="${AUR_ELECTRON_ARM64_SHA256:-SKIP}" \
+                AUR_BROWSER_RUNTIME_VERSION="$AUR_BROWSER_RUNTIME_VERSION" \
+                AUR_BROWSER_RUNTIME_X64_SHA256="${AUR_BROWSER_RUNTIME_X64_SHA256:-SKIP}" \
                 bash -lc '"'"'
                   set -euo pipefail
 

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -78,11 +78,6 @@ jobs:
                     export AUR_PKGVER
                   fi
 
-                  if [ "${AUR_PUBLISH:-false}" = "true" ]; then
-                    AUR_DMG_SHA256="$(curl -fL --retry 3 "$AUR_DMG_URL" | sha256sum | cut -d" " -f1)"
-                    export AUR_DMG_SHA256
-                  fi
-
                   AUR_DIR=/work/dist/aur ./scripts/aur/render-aur-package.sh
                   cd /work/dist/aur
                   makepkg --printsrcinfo > .SRCINFO
@@ -135,10 +130,10 @@ SSH
           cd /tmp/aur-codex-desktop-linux
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- PKGBUILD .SRCINFO *.install; then
+          git add PKGBUILD .SRCINFO *.install
+          if git diff --cached --quiet -- PKGBUILD .SRCINFO *.install; then
             echo "No AUR package changes to publish."
             exit 0
           fi
-          git add PKGBUILD .SRCINFO *.install
           git commit -m "Update ${AUR_PKGNAME}"
           git push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           bash -n scripts/build-rpm.sh
           bash -n scripts/build-pacman.sh
           bash -n scripts/build-appimage.sh
+          bash -n scripts/aur/render-aur-package.sh
           bash -n scripts/ci/update-nix-hashes.sh
           bash -n scripts/ci/validate-nix-pins.sh
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman aur aur-srcinfo appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -84,6 +84,8 @@ help:
 	@printf '  %-18s %s\n' "make deb" "Build the Debian package into dist/"
 	@printf '  %-18s %s\n' "make rpm" "Build the RPM package into dist/ (Fedora/openSUSE)"
 	@printf '  %-18s %s\n' "make pacman" "Build the pacman package into dist/ (Arch)"
+	@printf '  %-18s %s\n' "make aur" "Render AUR PKGBUILD files into dist/aur/"
+	@printf '  %-18s %s\n' "make aur-srcinfo" "Render AUR files and generate dist/aur/.SRCINFO"
 	@printf '  %-18s %s\n' "make appimage" "Build the AppImage into dist/ (local self-build)"
 	@printf '  %-18s %s\n' "make package" "Build native package (auto-detects deb, rpm, or pacman)"
 	@printf '  %-18s %s\n' "make install" "Install the latest generated native package"
@@ -126,6 +128,7 @@ help:
 	@printf '  %s\n' "MAX_BUILD_THREADS=8 make install-native"
 	@printf '  %s\n' "MAX_BUILD_THREADS=8 make rpm"
 	@printf '  %s\n' "make pacman PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
+	@printf '  %s\n' "AUR_PKGVER=2026.03.24 make aur-srcinfo"
 	@printf '  %s\n' "make appimage PACKAGE_VERSION=2026.03.24.220723+88f07cd3"
 	@printf '  %s\n' "make install"
 	@printf '  %s\n\n' "make service-enable"
@@ -240,6 +243,14 @@ rpm: maybe-build-updater
 pacman: maybe-build-updater
 	@echo "[make] Building pacman package"
 	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" PACKAGE_WITH_UPDATER="$(PACKAGE_WITH_UPDATER)" ./scripts/build-pacman.sh
+
+aur:
+	@echo "[make] Rendering AUR package files"
+	./scripts/aur/render-aur-package.sh
+
+aur-srcinfo: aur
+	@echo "[make] Generating AUR .SRCINFO"
+	cd dist/aur && makepkg --printsrcinfo > .SRCINFO
 
 appimage:
 	@echo "[make] Building AppImage"

--- a/docs/aur-packaging.md
+++ b/docs/aur-packaging.md
@@ -48,3 +48,37 @@ Configure these GitHub secrets:
 The `Publish AUR Package` workflow renders `PKGBUILD`, generates `.SRCINFO`,
 clones the AUR Git repository, copies the generated files, and pushes only when
 the rendered package metadata changed.
+
+## Publish After Merge
+
+After this workflow exists on the default branch, a maintainer can publish or
+update the AUR package manually:
+
+1. Create the AUR package repository once, if it does not already exist:
+
+   ```bash
+   git clone ssh://aur@aur.archlinux.org/codex-desktop-linux.git
+   ```
+
+   The first successful push from the workflow can populate the empty AUR Git
+   repository with `PKGBUILD`, `.SRCINFO`, and `codex-desktop-linux.install`.
+
+2. Add an SSH private key that can push to the AUR package as the
+   `AUR_SSH_PRIVATE_KEY` GitHub Actions secret. The matching public key must be
+   registered on the maintainer's AUR account.
+
+3. Optionally add `AUR_KNOWN_HOSTS`. If omitted, the workflow runs
+   `ssh-keyscan aur.archlinux.org` during setup.
+
+4. Open GitHub Actions in the repository and run `Publish AUR Package`
+   manually with `publish` set to `true`.
+
+5. Set `pkgver` when publishing a specific package version. If omitted, the
+   workflow uses a UTC timestamp in `YYYY.MM.DD.HHMMSS` format.
+
+6. Set `source_ref` when publishing a specific commit or tag. If omitted, the
+   workflow packages the workflow run's commit SHA.
+
+The workflow calculates source checksums only when `publish=true`. Local
+rendering keeps `SKIP` checksums so contributors can generate and inspect AUR
+metadata without downloading all sources.

--- a/docs/aur-packaging.md
+++ b/docs/aur-packaging.md
@@ -19,6 +19,9 @@ The generated `PKGBUILD` downloads:
 
 - this repository archive at `AUR_SOURCE_REF`
 - the upstream `Codex.dmg`
+- the managed Node.js runtime archive
+- the matching Linux Electron runtime archive
+- the Browser Use `node_repl` fallback runtime archive on `x86_64`
 
 It then runs `install.sh` during `build()` and stages a no-updater package
 during `package()`. The AUR package intentionally sets
@@ -44,13 +47,16 @@ mutable ref or a slash-containing archive directory name.
 regenerate tarball compression bytes for the same commit. Keep
 `AUR_DMG_SHA256=SKIP` because the Codex DMG URL is the stable upstream download
 location for this project and package refreshes are handled by publishing a new
-AUR revision.
+AUR revision. Local rendering also defaults the runtime archive hashes to
+`SKIP`; the GitHub Actions publisher computes those runtime hashes before
+publishing.
 
 This AUR package intentionally runs the same networked build flow as the rest
-of this repository. During `build()`, `install.sh` can download the managed Node
-runtime, Electron runtime, npm rebuild inputs, and bundled plugin fallback
-resources. Listing every transient build input in AUR `source=()` would require
-a larger source-cache mode that this repository does not currently have.
+of this repository, but the largest runtime archives that already have local
+override hooks are declared in AUR `source=()` and passed into `install.sh`.
+During `build()`, `install.sh` can still download npm rebuild inputs for native
+modules. Listing every transient npm input in AUR `source=()` would require a
+larger source-cache mode that this repository does not currently have.
 
 Publishing to AUR requires an SSH key registered with `aur.archlinux.org`.
 Configure these GitHub secrets:
@@ -93,8 +99,10 @@ update the AUR package manually:
    omitted, the workflow uses the workflow run's commit SHA. The workflow
    resolves the value to a full commit SHA before rendering `PKGBUILD`.
 
-The workflow keeps source checksums as `SKIP` so contributors can generate and
-inspect AUR metadata without downloading all sources. The GitHub source archive
-checksum stays `SKIP` because GitHub-generated tarball bytes are not stable
-enough for a durable AUR checksum. The DMG checksum also stays `SKIP`; package
-freshness is handled by rerunning the publish workflow for a new AUR revision.
+The workflow keeps the GitHub source archive and DMG checksums as `SKIP` so
+contributors can generate and inspect AUR metadata without downloading those
+sources. It calculates checksums for the declared runtime archives when
+`publish=true`. The GitHub source archive checksum stays `SKIP` because
+GitHub-generated tarball bytes are not stable enough for a durable AUR
+checksum. The DMG checksum also stays `SKIP`; package freshness is handled by
+rerunning the publish workflow for a new AUR revision.

--- a/docs/aur-packaging.md
+++ b/docs/aur-packaging.md
@@ -1,0 +1,50 @@
+# AUR Packaging
+
+This repository keeps AUR packaging separate from the local pacman package
+builder.
+
+The local pacman builder, `scripts/build-pacman.sh`, packages an already staged
+`codex-app/` directory. That is useful for local native packages and CI
+fixtures, but it is not a valid AUR source package because its generated
+`PKGBUILD` copies from a temporary staging directory.
+
+The AUR flow renders a standalone source package under `dist/aur/`:
+
+```bash
+make aur
+make aur-srcinfo
+```
+
+The generated `PKGBUILD` downloads:
+
+- this repository archive at `AUR_SOURCE_REF`
+- the upstream `Codex.dmg`
+
+It then runs `install.sh` during `build()` and stages a no-updater package
+during `package()`. The AUR package intentionally sets
+`PACKAGE_WITH_UPDATER=0`; updates should be handled by pacman and the user's
+AUR helper, not by the bundled `codex-update-manager`.
+
+The AUR `makedepends` include Arch's `7zip` package because current upstream
+DMGs are APFS images and the installer rejects old p7zip extractors.
+
+Useful overrides:
+
+```bash
+AUR_PKGVER=2026.06.05 make aur
+AUR_SOURCE_REF="$(git rev-parse HEAD)" make aur
+AUR_SOURCE_SHA256=<repo-archive-sha256> AUR_DMG_SHA256=<dmg-sha256> make aur
+```
+
+`AUR_SOURCE_SHA256` and `AUR_DMG_SHA256` default to `SKIP` for local rendering.
+The GitHub Actions publisher can calculate both values before publishing.
+
+Publishing to AUR requires an SSH key registered with `aur.archlinux.org`.
+Configure these GitHub secrets:
+
+- `AUR_SSH_PRIVATE_KEY`
+- optional `AUR_KNOWN_HOSTS`
+
+The `Publish AUR Package` workflow renders `PKGBUILD`, generates `.SRCINFO`,
+clones the AUR Git repository, copies the generated files, and pushes only when
+the rendered package metadata changed.

--- a/docs/aur-packaging.md
+++ b/docs/aur-packaging.md
@@ -33,11 +33,17 @@ Useful overrides:
 ```bash
 AUR_PKGVER=2026.06.05 make aur
 AUR_SOURCE_REF="$(git rev-parse HEAD)" make aur
-AUR_SOURCE_SHA256=<repo-archive-sha256> AUR_DMG_SHA256=<dmg-sha256> make aur
+AUR_DMG_SHA256=<dmg-sha256> make aur
 ```
 
+`AUR_SOURCE_REF` must be a full 40-character commit SHA. Resolve tags or
+branches before rendering so the published AUR package does not depend on a
+mutable ref or a slash-containing archive directory name.
+
 `AUR_SOURCE_SHA256` and `AUR_DMG_SHA256` default to `SKIP` for local rendering.
-The GitHub Actions publisher can calculate both values before publishing.
+Keep `AUR_SOURCE_SHA256=SKIP` for GitHub-generated source archives because
+GitHub may regenerate tarball compression bytes for the same commit. The GitHub
+Actions publisher calculates the DMG checksum before publishing.
 
 Publishing to AUR requires an SSH key registered with `aur.archlinux.org`.
 Configure these GitHub secrets:
@@ -76,9 +82,12 @@ update the AUR package manually:
 5. Set `pkgver` when publishing a specific package version. If omitted, the
    workflow uses a UTC timestamp in `YYYY.MM.DD.HHMMSS` format.
 
-6. Set `source_ref` when publishing a specific commit or tag. If omitted, the
-   workflow packages the workflow run's commit SHA.
+6. Set `source_ref` when publishing a specific commit, tag, or branch. If
+   omitted, the workflow uses the workflow run's commit SHA. The workflow
+   resolves the value to a full commit SHA before rendering `PKGBUILD`.
 
-The workflow calculates source checksums only when `publish=true`. Local
+The workflow calculates the DMG checksum only when `publish=true`. Local
 rendering keeps `SKIP` checksums so contributors can generate and inspect AUR
-metadata without downloading all sources.
+metadata without downloading all sources. The GitHub source archive checksum
+stays `SKIP` because GitHub-generated tarball bytes are not stable enough for a
+durable AUR checksum.

--- a/docs/aur-packaging.md
+++ b/docs/aur-packaging.md
@@ -33,17 +33,24 @@ Useful overrides:
 ```bash
 AUR_PKGVER=2026.06.05 make aur
 AUR_SOURCE_REF="$(git rev-parse HEAD)" make aur
-AUR_DMG_SHA256=<dmg-sha256> make aur
 ```
 
 `AUR_SOURCE_REF` must be a full 40-character commit SHA. Resolve tags or
 branches before rendering so the published AUR package does not depend on a
 mutable ref or a slash-containing archive directory name.
 
-`AUR_SOURCE_SHA256` and `AUR_DMG_SHA256` default to `SKIP` for local rendering.
-Keep `AUR_SOURCE_SHA256=SKIP` for GitHub-generated source archives because
-GitHub may regenerate tarball compression bytes for the same commit. The GitHub
-Actions publisher calculates the DMG checksum before publishing.
+`AUR_SOURCE_SHA256` and `AUR_DMG_SHA256` default to `SKIP`. Keep
+`AUR_SOURCE_SHA256=SKIP` for GitHub-generated source archives because GitHub may
+regenerate tarball compression bytes for the same commit. Keep
+`AUR_DMG_SHA256=SKIP` because the Codex DMG URL is the stable upstream download
+location for this project and package refreshes are handled by publishing a new
+AUR revision.
+
+This AUR package intentionally runs the same networked build flow as the rest
+of this repository. During `build()`, `install.sh` can download the managed Node
+runtime, Electron runtime, npm rebuild inputs, and bundled plugin fallback
+resources. Listing every transient build input in AUR `source=()` would require
+a larger source-cache mode that this repository does not currently have.
 
 Publishing to AUR requires an SSH key registered with `aur.archlinux.org`.
 Configure these GitHub secrets:
@@ -86,8 +93,8 @@ update the AUR package manually:
    omitted, the workflow uses the workflow run's commit SHA. The workflow
    resolves the value to a full commit SHA before rendering `PKGBUILD`.
 
-The workflow calculates the DMG checksum only when `publish=true`. Local
-rendering keeps `SKIP` checksums so contributors can generate and inspect AUR
-metadata without downloading all sources. The GitHub source archive checksum
-stays `SKIP` because GitHub-generated tarball bytes are not stable enough for a
-durable AUR checksum.
+The workflow keeps source checksums as `SKIP` so contributors can generate and
+inspect AUR metadata without downloading all sources. The GitHub source archive
+checksum stays `SKIP` because GitHub-generated tarball bytes are not stable
+enough for a durable AUR checksum. The DMG checksum also stays `SKIP`; package
+freshness is handled by rerunning the publish workflow for a new AUR revision.

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,9 @@ main() {
     app_dir=$(extract_dmg "$dmg_path")
 
     detect_electron_version "$app_dir"
+    if [ -n "${CODEX_EXPECTED_ELECTRON_VERSION:-}" ] && [ "$ELECTRON_VERSION" != "$CODEX_EXPECTED_ELECTRON_VERSION" ]; then
+        error "Detected Electron version $ELECTRON_VERSION does not match expected $CODEX_EXPECTED_ELECTRON_VERSION"
+    fi
     if [ "$INSPECT_ONLY" -eq 1 ]; then
         inspect_rebuild_candidate "$app_dir" "$dmg_path"
         return 0

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -54,6 +54,9 @@ install="${pkgname}.install"
 _source_ref="__SOURCE_REF__"
 _dmg_url="__DMG_URL__"
 _repo_dir="codex-desktop-linux-${_source_ref}"
+_node_version="__NODE_VERSION__"
+_electron_version="__ELECTRON_VERSION__"
+_browser_runtime_version="__BROWSER_RUNTIME_VERSION__"
 
 source=(
     "${_repo_dir}.tar.gz::__SOURCE_REPO__/archive/${_source_ref}.tar.gz"
@@ -63,6 +66,49 @@ sha256sums=(
     '__SOURCE_SHA256__'
     '__DMG_SHA256__'
 )
+source_x86_64=(
+    "node-${_node_version}-linux-x64.tar.xz::https://nodejs.org/dist/${_node_version}/node-${_node_version}-linux-x64.tar.xz"
+    "electron-v${_electron_version}-linux-x64.zip::https://github.com/electron/electron/releases/download/v${_electron_version}/electron-v${_electron_version}-linux-x64.zip"
+    "codex-primary-runtime-linux-x64-${_browser_runtime_version}.tar.xz::https://persistent.oaistatic.com/codex-primary-runtime/${_browser_runtime_version}/codex-primary-runtime-linux-x64-${_browser_runtime_version}.tar.xz"
+)
+sha256sums_x86_64=(
+    '__NODE_X64_SHA256__'
+    '__ELECTRON_X64_SHA256__'
+    '__BROWSER_RUNTIME_X64_SHA256__'
+)
+source_aarch64=(
+    "node-${_node_version}-linux-arm64.tar.xz::https://nodejs.org/dist/${_node_version}/node-${_node_version}-linux-arm64.tar.xz"
+    "electron-v${_electron_version}-linux-arm64.zip::https://github.com/electron/electron/releases/download/v${_electron_version}/electron-v${_electron_version}-linux-arm64.zip"
+)
+sha256sums_aarch64=(
+    '__NODE_ARM64_SHA256__'
+    '__ELECTRON_ARM64_SHA256__'
+)
+
+prepare() {
+    rm -rf "${srcdir}/aur-node-runtime"
+    mkdir -p "${srcdir}/aur-node-runtime"
+
+    case "${CARCH}" in
+        x86_64)
+            tar -xJf "${srcdir}/node-${_node_version}-linux-x64.tar.xz" \
+                -C "${srcdir}/aur-node-runtime" --strip-components=1
+            rm -rf "${srcdir}/aur-browser-use-runtime"
+            mkdir -p "${srcdir}/aur-browser-use-runtime"
+            tar -xJf "${srcdir}/codex-primary-runtime-linux-x64-${_browser_runtime_version}.tar.xz" \
+                -C "${srcdir}/aur-browser-use-runtime" \
+                codex-primary-runtime/dependencies/bin/node_repl
+            ;;
+        aarch64)
+            tar -xJf "${srcdir}/node-${_node_version}-linux-arm64.tar.xz" \
+                -C "${srcdir}/aur-node-runtime" --strip-components=1
+            ;;
+        *)
+            echo "Unsupported architecture: ${CARCH}" >&2
+            return 1
+            ;;
+    esac
+}
 
 build() {
     cd "${srcdir}/${_repo_dir}"
@@ -71,6 +117,17 @@ build() {
     export CODEX_LINUX_SOURCE_COMMIT="${_source_ref}"
     export CODEX_LINUX_SOURCE_BRANCH=""
     export CODEX_LINUX_SOURCE_DESCRIBE="${pkgver}-${pkgrel}"
+    export CODEX_MANAGED_NODE_SOURCE="${srcdir}/aur-node-runtime"
+
+    case "${CARCH}" in
+        x86_64)
+            export CODEX_ELECTRON_ZIP_SOURCE="${srcdir}/electron-v${_electron_version}-linux-x64.zip"
+            export CODEX_LINUX_NODE_REPL_SOURCE="${srcdir}/aur-browser-use-runtime/codex-primary-runtime/dependencies/bin/node_repl"
+            ;;
+        aarch64)
+            export CODEX_ELECTRON_ZIP_SOURCE="${srcdir}/electron-v${_electron_version}-linux-arm64.zip"
+            ;;
+    esac
 
     ./install.sh "${srcdir}/Codex.dmg"
 }

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -90,6 +90,7 @@ package() {
     # shellcheck source=/dev/null
     . "$PWD/scripts/lib/package-common.sh"
 
+    ensure_app_layout
     stage_common_package_files "$pkgdir"
     write_launcher_stub "$pkgdir"
     run_linux_feature_package_hooks "$pkgdir" "pacman"

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -118,6 +118,7 @@ build() {
     export CODEX_LINUX_SOURCE_BRANCH=""
     export CODEX_LINUX_SOURCE_DESCRIBE="${pkgver}-${pkgrel}"
     export CODEX_MANAGED_NODE_SOURCE="${srcdir}/aur-node-runtime"
+    export CODEX_EXPECTED_ELECTRON_VERSION="${_electron_version}"
 
     case "${CARCH}" in
         x86_64)

--- a/packaging/aur/PKGBUILD.template
+++ b/packaging/aur/PKGBUILD.template
@@ -1,0 +1,98 @@
+# Maintainer: Codex Desktop Linux Maintainers
+
+pkgname=__AUR_PKGNAME__
+pkgver=__PKGVER__
+pkgrel=__PKGREL__
+pkgdesc="Codex Desktop for Linux, community-built from the macOS DMG"
+arch=('x86_64' 'aarch64')
+url="https://github.com/ilysenko/codex-desktop-linux"
+license=('MIT')
+depends=(
+    'python'
+    'curl'
+    'alsa-lib'
+    'at-spi2-core'
+    'atk'
+    'cairo'
+    'dbus'
+    'glib2'
+    'gtk3'
+    'libcups'
+    'libdrm'
+    'libx11'
+    'libxcb'
+    'libxcomposite'
+    'libxdamage'
+    'libxext'
+    'libxfixes'
+    'libxkbcommon'
+    'libxrandr'
+    'mesa'
+    'nspr'
+    'nss'
+    'pango'
+)
+makedepends=(
+    'cargo'
+    'gcc'
+    'git'
+    'make'
+    '7zip'
+    'unzip'
+)
+optdepends=(
+    'nodejs>=22.22.0: optional override for the bundled managed Node.js runtime'
+    'npm: optional override for Codex CLI install/update flows'
+    'zenity: GTK dialog fallback when the Codex CLI is missing'
+    'kdialog: KDE dialog fallback when the Codex CLI is missing'
+)
+provides=('codex-desktop')
+conflicts=('codex-desktop')
+options=(!debug !strip)
+install="${pkgname}.install"
+
+_source_ref="__SOURCE_REF__"
+_dmg_url="__DMG_URL__"
+_repo_dir="codex-desktop-linux-${_source_ref}"
+
+source=(
+    "${_repo_dir}.tar.gz::__SOURCE_REPO__/archive/${_source_ref}.tar.gz"
+    "Codex.dmg::${_dmg_url}"
+)
+sha256sums=(
+    '__SOURCE_SHA256__'
+    '__DMG_SHA256__'
+)
+
+build() {
+    cd "${srcdir}/${_repo_dir}"
+
+    export CODEX_LINUX_SOURCE_REMOTE="__SOURCE_REPO__"
+    export CODEX_LINUX_SOURCE_COMMIT="${_source_ref}"
+    export CODEX_LINUX_SOURCE_BRANCH=""
+    export CODEX_LINUX_SOURCE_DESCRIBE="${pkgver}-${pkgrel}"
+
+    ./install.sh "${srcdir}/Codex.dmg"
+}
+
+package() {
+    cd "${srcdir}/${_repo_dir}"
+
+    export REPO_DIR="$PWD"
+    export APP_DIR="$PWD/codex-app"
+    export PACKAGE_NAME="codex-desktop"
+    export PACKAGE_VERSION="${pkgver}-${pkgrel}"
+    export PACKAGE_WITH_UPDATER=0
+    export DESKTOP_TEMPLATE="$PWD/packaging/linux/codex-desktop.desktop"
+    export ICON_SOURCE="$PWD/assets/codex.png"
+    export PACKAGED_RUNTIME_SOURCE="$PWD/packaging/linux/codex-packaged-runtime.sh"
+
+    # shellcheck source=/dev/null
+    . "$PWD/scripts/lib/package-common.sh"
+
+    stage_common_package_files "$pkgdir"
+    write_launcher_stub "$pkgdir"
+    run_linux_feature_package_hooks "$pkgdir" "pacman"
+    normalize_package_payload_permissions "$pkgdir"
+    restore_linux_feature_payload_permissions "$pkgdir"
+}

--- a/packaging/aur/codex-desktop-linux.install
+++ b/packaging/aur/codex-desktop-linux.install
@@ -1,0 +1,34 @@
+CLEANUP_HELPER="/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh"
+DESKTOP_ENTRY_DOCTOR="/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor.sh"
+
+codex_no_updater_cleanup_if_present() {
+    if [ -f "$CLEANUP_HELPER" ]; then
+        # shellcheck source=/opt/codex-desktop/.codex-linux/codex-no-updater-transition-cleanup.sh
+        . "$CLEANUP_HELPER"
+        codex_no_updater_cleanup_update_manager_service || true
+    fi
+}
+
+codex_desktop_repair_if_present() {
+    if [ -f "$DESKTOP_ENTRY_DOCTOR" ]; then
+        # shellcheck source=/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor.sh
+        . "$DESKTOP_ENTRY_DOCTOR"
+        codex_desktop_repair_system_package_shadow_entries codex-desktop || true
+    fi
+}
+
+post_install() {
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
+    fi
+    codex_desktop_repair_if_present
+    codex_no_updater_cleanup_if_present
+}
+
+post_upgrade() {
+    post_install
+}
+
+pre_remove() {
+    codex_no_updater_cleanup_if_present
+}

--- a/scripts/aur/render-aur-package.sh
+++ b/scripts/aur/render-aur-package.sh
@@ -31,6 +31,17 @@ validate_pkgver() {
     esac
 }
 
+validate_source_ref() {
+    case "$1" in
+        [0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F])
+            return 0
+            ;;
+        *)
+            error "AUR_SOURCE_REF must be a full 40-character commit SHA. Resolve tags or branches before rendering."
+            ;;
+    esac
+}
+
 derive_pkgver() {
     local version
     version="$(git -C "$REPO_DIR" describe --tags --always --dirty 2>/dev/null || true)"
@@ -78,6 +89,7 @@ main() {
         AUR_PKGVER="$(derive_pkgver)"
     fi
     validate_pkgver "$AUR_PKGVER"
+    validate_source_ref "$AUR_SOURCE_REF"
 
     mkdir -p "$AUR_DIR"
     render_template "$REPO_DIR/packaging/aur/PKGBUILD.template" "$AUR_DIR/PKGBUILD"

--- a/scripts/aur/render-aur-package.sh
+++ b/scripts/aur/render-aur-package.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+AUR_DIR="${AUR_DIR:-$REPO_DIR/dist/aur}"
+AUR_PKGNAME="${AUR_PKGNAME:-codex-desktop-linux}"
+AUR_PKGREL="${AUR_PKGREL:-1}"
+AUR_SOURCE_REPO="${AUR_SOURCE_REPO:-https://github.com/ilysenko/codex-desktop-linux}"
+AUR_SOURCE_REF="${AUR_SOURCE_REF:-$(git -C "$REPO_DIR" rev-parse HEAD)}"
+AUR_SOURCE_SHA256="${AUR_SOURCE_SHA256:-SKIP}"
+AUR_DMG_URL="${AUR_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+AUR_DMG_SHA256="${AUR_DMG_SHA256:-SKIP}"
+AUR_PKGVER="${AUR_PKGVER:-}"
+
+error() {
+    echo "[ERROR] $*" >&2
+    exit 1
+}
+
+sed_escape_replacement() {
+    printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+validate_pkgver() {
+    case "$1" in
+        ""|*[-:[:space:]]*)
+            error "AUR_PKGVER must be non-empty and cannot contain hyphens, colons, or whitespace"
+            ;;
+    esac
+}
+
+derive_pkgver() {
+    local version
+    version="$(git -C "$REPO_DIR" describe --tags --always --dirty 2>/dev/null || true)"
+    version="${version#v}"
+    version="${version//-/.}"
+    version="${version//+/.}"
+    version="${version//_/.}"
+    version="${version//[^A-Za-z0-9.]/.}"
+    version="${version#.}"
+    version="${version%.}"
+    if [ -z "$version" ]; then
+        version="$(date -u +%Y.%m.%d.%H%M%S)"
+    fi
+    printf '%s\n' "$version"
+}
+
+render_template() {
+    local template="$1"
+    local target="$2"
+    local aur_pkgname aur_pkgver aur_pkgrel source_repo source_ref source_sha dmg_url dmg_sha
+
+    aur_pkgname="$(sed_escape_replacement "$AUR_PKGNAME")"
+    aur_pkgver="$(sed_escape_replacement "$AUR_PKGVER")"
+    aur_pkgrel="$(sed_escape_replacement "$AUR_PKGREL")"
+    source_repo="$(sed_escape_replacement "$AUR_SOURCE_REPO")"
+    source_ref="$(sed_escape_replacement "$AUR_SOURCE_REF")"
+    source_sha="$(sed_escape_replacement "$AUR_SOURCE_SHA256")"
+    dmg_url="$(sed_escape_replacement "$AUR_DMG_URL")"
+    dmg_sha="$(sed_escape_replacement "$AUR_DMG_SHA256")"
+
+    sed \
+        -e "s/__AUR_PKGNAME__/$aur_pkgname/g" \
+        -e "s/__PKGVER__/$aur_pkgver/g" \
+        -e "s/__PKGREL__/$aur_pkgrel/g" \
+        -e "s|__SOURCE_REPO__|$source_repo|g" \
+        -e "s/__SOURCE_REF__/$source_ref/g" \
+        -e "s/__SOURCE_SHA256__/$source_sha/g" \
+        -e "s|__DMG_URL__|$dmg_url|g" \
+        -e "s/__DMG_SHA256__/$dmg_sha/g" \
+        "$template" > "$target"
+}
+
+main() {
+    if [ -z "$AUR_PKGVER" ]; then
+        AUR_PKGVER="$(derive_pkgver)"
+    fi
+    validate_pkgver "$AUR_PKGVER"
+
+    mkdir -p "$AUR_DIR"
+    render_template "$REPO_DIR/packaging/aur/PKGBUILD.template" "$AUR_DIR/PKGBUILD"
+    cp "$REPO_DIR/packaging/aur/codex-desktop-linux.install" "$AUR_DIR/$AUR_PKGNAME.install"
+
+    echo "[INFO] Rendered AUR package files in $AUR_DIR" >&2
+    printf '%s\n' "$AUR_DIR"
+}
+
+main "$@"

--- a/scripts/aur/render-aur-package.sh
+++ b/scripts/aur/render-aur-package.sh
@@ -20,7 +20,7 @@ error() {
 }
 
 sed_escape_replacement() {
-    printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+    printf '%s' "$1" | sed -e 's/[\/&|]/\\&/g'
 }
 
 validate_pkgver() {

--- a/scripts/aur/render-aur-package.sh
+++ b/scripts/aur/render-aur-package.sh
@@ -13,6 +13,14 @@ AUR_SOURCE_SHA256="${AUR_SOURCE_SHA256:-SKIP}"
 AUR_DMG_URL="${AUR_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
 AUR_DMG_SHA256="${AUR_DMG_SHA256:-SKIP}"
 AUR_PKGVER="${AUR_PKGVER:-}"
+AUR_NODE_VERSION="${AUR_NODE_VERSION:-v22.22.2}"
+AUR_NODE_X64_SHA256="${AUR_NODE_X64_SHA256:-SKIP}"
+AUR_NODE_ARM64_SHA256="${AUR_NODE_ARM64_SHA256:-SKIP}"
+AUR_ELECTRON_VERSION="${AUR_ELECTRON_VERSION:-42.1.0}"
+AUR_ELECTRON_X64_SHA256="${AUR_ELECTRON_X64_SHA256:-SKIP}"
+AUR_ELECTRON_ARM64_SHA256="${AUR_ELECTRON_ARM64_SHA256:-SKIP}"
+AUR_BROWSER_RUNTIME_VERSION="${AUR_BROWSER_RUNTIME_VERSION:-26.426.12240}"
+AUR_BROWSER_RUNTIME_X64_SHA256="${AUR_BROWSER_RUNTIME_X64_SHA256:-SKIP}"
 
 error() {
     echo "[ERROR] $*" >&2
@@ -62,6 +70,8 @@ render_template() {
     local template="$1"
     local target="$2"
     local aur_pkgname aur_pkgver aur_pkgrel source_repo source_ref source_sha dmg_url dmg_sha
+    local node_version node_x64_sha node_arm64_sha electron_version electron_x64_sha electron_arm64_sha
+    local browser_runtime_version browser_runtime_x64_sha
 
     aur_pkgname="$(sed_escape_replacement "$AUR_PKGNAME")"
     aur_pkgver="$(sed_escape_replacement "$AUR_PKGVER")"
@@ -71,6 +81,14 @@ render_template() {
     source_sha="$(sed_escape_replacement "$AUR_SOURCE_SHA256")"
     dmg_url="$(sed_escape_replacement "$AUR_DMG_URL")"
     dmg_sha="$(sed_escape_replacement "$AUR_DMG_SHA256")"
+    node_version="$(sed_escape_replacement "$AUR_NODE_VERSION")"
+    node_x64_sha="$(sed_escape_replacement "$AUR_NODE_X64_SHA256")"
+    node_arm64_sha="$(sed_escape_replacement "$AUR_NODE_ARM64_SHA256")"
+    electron_version="$(sed_escape_replacement "$AUR_ELECTRON_VERSION")"
+    electron_x64_sha="$(sed_escape_replacement "$AUR_ELECTRON_X64_SHA256")"
+    electron_arm64_sha="$(sed_escape_replacement "$AUR_ELECTRON_ARM64_SHA256")"
+    browser_runtime_version="$(sed_escape_replacement "$AUR_BROWSER_RUNTIME_VERSION")"
+    browser_runtime_x64_sha="$(sed_escape_replacement "$AUR_BROWSER_RUNTIME_X64_SHA256")"
 
     sed \
         -e "s/__AUR_PKGNAME__/$aur_pkgname/g" \
@@ -81,6 +99,14 @@ render_template() {
         -e "s/__SOURCE_SHA256__/$source_sha/g" \
         -e "s|__DMG_URL__|$dmg_url|g" \
         -e "s/__DMG_SHA256__/$dmg_sha/g" \
+        -e "s/__NODE_VERSION__/$node_version/g" \
+        -e "s/__NODE_X64_SHA256__/$node_x64_sha/g" \
+        -e "s/__NODE_ARM64_SHA256__/$node_arm64_sha/g" \
+        -e "s/__ELECTRON_VERSION__/$electron_version/g" \
+        -e "s/__ELECTRON_X64_SHA256__/$electron_x64_sha/g" \
+        -e "s/__ELECTRON_ARM64_SHA256__/$electron_arm64_sha/g" \
+        -e "s/__BROWSER_RUNTIME_VERSION__/$browser_runtime_version/g" \
+        -e "s/__BROWSER_RUNTIME_X64_SHA256__/$browser_runtime_x64_sha/g" \
         "$template" > "$target"
 }
 


### PR DESCRIPTION
## Summary

Adds an AUR packaging path alongside the existing local pacman package builder.

- Adds an AUR PKGBUILD template and install hook for `codex-desktop-linux`
- Adds `scripts/aur/render-aur-package.sh` plus `make aur` and `make aur-srcinfo`
- Adds a manual GitHub Actions workflow to render, validate, and optionally publish AUR metadata
- Declares the managed Node, Electron, and Browser Use runtime archives as AUR sources and passes them into the existing installer through local-source overrides
- Documents local AUR testing and post-merge publishing setup
- Extends CI shell syntax checks to cover the new renderer

Closes https://github.com/ilysenko/codex-desktop-linux/issues/402

The AUR package builds from the upstream repository source URL, `https://github.com/ilysenko/codex-desktop-linux`. This PR does not change `codex-update-manager`; it only omits the updater from the AUR package payload so Arch users update through pacman/AUR helpers instead.

## How maintainers publish to AUR after merge

Publishing is not automatic until the workflow is run manually with `publish=true`.

1. Create the AUR package repository once, if it does not already exist:

   ```bash
   git clone ssh://aur@aur.archlinux.org/codex-desktop-linux.git
   ```

   The first successful workflow push can populate the empty AUR Git repository with `PKGBUILD`, `.SRCINFO`, and `codex-desktop-linux.install`.

2. Add an SSH private key that can push to the AUR package as the `AUR_SSH_PRIVATE_KEY` GitHub Actions secret. The matching public key must be registered on the maintainer's AUR account.

3. Optionally add `AUR_KNOWN_HOSTS`. If omitted, the workflow runs `ssh-keyscan aur.archlinux.org` during setup.

4. Open GitHub Actions in this repository and run `Publish AUR Package` manually with `publish` set to `true`.

5. Optionally set `pkgver` for a specific package version. If omitted, the workflow uses a UTC timestamp in `YYYY.MM.DD.HHMMSS` format.

6. Optionally set `source_ref` for a specific commit, tag, or branch. If omitted, the workflow uses the workflow run's commit SHA. The workflow resolves this value to a full commit SHA before rendering `PKGBUILD`.

The workflow keeps the GitHub source archive and DMG checksums as `SKIP`, while computing checksums for declared runtime archives when `publish=true`. GitHub-generated source archives can be regenerated with different compressed bytes, and the Codex DMG is consumed from the stable upstream download URL. Package freshness is handled by rerunning the publish workflow for a new AUR revision.

The AUR build now declares the large runtime archives that already have installer override hooks: managed Node, Electron, and Browser Use `node_repl` on x86_64. The remaining networked part is npm rebuild inputs for native modules; making those source-declared would require a larger npm/cache mode outside this PR.

## Validation

- `bash -n install.sh`
- `bash -n scripts/aur/render-aur-package.sh`
- `make aur-srcinfo AUR_PKGVER=2026.06.05`
- `AUR_SOURCE_REF=refs/tags/v1 AUR_PKGVER=2026.06.05 ./scripts/aur/render-aur-package.sh` fails with the expected full-SHA validation error
- Full local AUR-style build with `makepkg -si --needed --noconfirm`
- Installed resulting package with `pacman -U dist/aur/codex-desktop-linux-2026.06.05-1-x86_64.pkg.tar.zst` after removing the previous `codex-desktop` package