### PR TITLE
fix(browser): enable Browser Use gates on Linux

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -104,6 +104,8 @@ const {
 const {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppSunsetPatch,
+  applyLinuxBrowserUseAvailabilityPatch,
+  applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxConfigWriteVersionConflictPatch,
   applyLinuxI18nGatePatch,
   applyLinuxProfileSettingsMenuPatch,
@@ -173,6 +175,8 @@ module.exports = {
   applyLinuxAppUpdaterMenuPatch,
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyLinuxBrowserUseIabVisibleOnCreatePatch,
+  applyLinuxBrowserUseAvailabilityPatch,
+  applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxChromeNativeHostRuntimePatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -41,6 +41,8 @@ const {
   applyLinuxNativeTitlebarPatch,
   applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxAppSunsetPatch,
+  applyLinuxBrowserUseAvailabilityPatch,
+  applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
@@ -557,6 +559,8 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-set-icon",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
+    "linux-browser-use-availability",
+    "linux-browser-use-non-local-navigation",
     "linux-file-manager",
     "linux-tray",
     "linux-build-info-tray",
@@ -3065,6 +3069,33 @@ test("shows current use-is-plugins-enabled Computer Use UI on Linux", () => {
     patched,
     /let _=a&&i&&\(s===`linux`\|\|u&&\(o\|\|g\)\),v=_&&!o&&\(s===`linux`\|\|h\.enabled\)&&!h\.isLoading,y=_&&s!==`linux`&&h\.isLoading,b=_&&\(o\|\|s!==`linux`&&h\.isLoading\),x;/,
   );
+});
+
+test("enables Browser Use availability on Linux when only the Statsig gate is disabled", () => {
+  const source =
+    "function h(n){let r=(0,l.c)(13),{hostId:a}=n,s=t(c),d=i(`410262010`),f;r[0]===a?f=r[1]:(f={featureName:`browser_use`,hostId:a},r[0]=a,r[1]=f);let p=u(f),m=o(e.runCodexInWsl),h=p.enabled&&!p.isLoading,_=p.isLoading,v=m===!0,y;r[2]!==d||r[3]!==s||r[4]!==h||r[5]!==_||r[6]!==v?(y=g({isBrowserAgentGateEnabled:d,isBrowserSidebarEnabled:s,isBrowserUseEnabled:h,isLoading:_,runCodexInWsl:v,windowType:`electron`}),r[2]=d,r[3]=s,r[4]=h,r[5]=_,r[6]=v,r[7]=y):y=r[7];return y}";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseAvailabilityPatch, source);
+
+  assert.match(
+    patched,
+    /y=g\(\{isBrowserAgentGateEnabled:!0,isBrowserSidebarEnabled:s,isBrowserUseEnabled:h,isLoading:_,runCodexInWsl:v,windowType:`electron`\}\)/,
+  );
+  assert.match(patched, /isBrowserUseEnabled:h/);
+  assert.match(patched, /featureName:`browser_use`/);
+});
+
+test("allows Browser Use non-local navigation on Linux without the upstream rollout flag", () => {
+  const source =
+    "function mx(){let e=(0,Z.c)(20),t=q(Ss).value,n;e[0]===t?n=e[1]:(n=vs(t),e[0]=t,e[1]=n);let r=n,i=J(fl.activeTab$),a=J(Xn),o=ka(`3903563814`),s=ka(`2327881676`),c,l;e[2]!==i||e[3]!==r||e[4]!==a||e[5]!==t.pathname||e[6]!==t.search?(c=()=>{if(r==null)return;let e=ml(i,r);ci.dispatchMessage(`browser-sidebar-owner-sync`,{conversationId:r})},l=[i,r,a,t.pathname,t.search],e[2]=i,e[3]=r,e[4]=a,e[5]=t.pathname,e[6]=t.search,e[7]=c,e[8]=l):(c=e[7],l=e[8]),(0,$.useLayoutEffect)(c,l);let u,d;e[9]===o?(u=e[10],d=e[11]):(u=()=>{ux||ci.dispatchMessage(`browser-use-non-local-sites-allowed-changed`,{allowed:o})},d=[o],e[9]=o,e[10]=u,e[11]=d),(0,$.useEffect)(u,d);return null}";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseNonLocalNavigationPatch, source);
+
+  assert.match(
+    patched,
+    /dispatchMessage\(`browser-use-non-local-sites-allowed-changed`,\{allowed:!0\}\)/,
+  );
+  assert.match(patched, /ka\(`3903563814`\)/);
 });
 
 test("shows object-helper Computer Use plugin UI on Linux", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3098,6 +3098,20 @@ test("allows Browser Use non-local navigation on Linux without the upstream roll
   assert.match(patched, /ka\(`3903563814`\)/);
 });
 
+test("patches later Browser Use navigation dispatches when an earlier one is already patched", () => {
+  const source =
+    "function first(){let o=ka(`3903563814`);return()=>ci.dispatchMessage(`browser-use-non-local-sites-allowed-changed`,{allowed:!0})}" +
+    "function second(){let p=ka(`3903563814`);return()=>ci.dispatchMessage(`browser-use-non-local-sites-allowed-changed`,{allowed:p})}";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseNonLocalNavigationPatch, source);
+
+  assert.equal(
+    (patched.match(/browser-use-non-local-sites-allowed-changed`,\{allowed:!0\}/g) || []).length,
+    2,
+  );
+  assert.doesNotMatch(patched, /browser-use-non-local-sites-allowed-changed`,\{allowed:p\}/);
+});
+
 test("shows object-helper Computer Use plugin UI on Linux", () => {
   const source =
     "function m(e){return e===`macOS`||e===`windows`}" +

--- a/scripts/patches/core/all-linux/webview/browser-use-availability/patch.js
+++ b/scripts/patches/core/all-linux/webview/browser-use-availability/patch.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const {
+  applyLinuxBrowserUseAvailabilityPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = {
+  id: "linux-browser-use-availability",
+  phase: "webview-asset",
+  order: 1090,
+  ciPolicy: "optional",
+  pattern: /^(use-in-app-browser-use-availability|use-is-plugins-enabled)-.*\.js$/,
+  missingDescription: "Browser Use availability bundle",
+  skipDescription: "Linux Browser Use availability patch",
+  apply: applyLinuxBrowserUseAvailabilityPatch,
+};

--- a/scripts/patches/core/all-linux/webview/browser-use-navigation/patch.js
+++ b/scripts/patches/core/all-linux/webview/browser-use-navigation/patch.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const {
+  applyLinuxBrowserUseNonLocalNavigationPatch,
+} = require("../../../../webview-assets.js");
+
+module.exports = {
+  id: "linux-browser-use-non-local-navigation",
+  phase: "webview-asset",
+  order: 1091,
+  ciPolicy: "optional",
+  pattern: /^app-main-.*\.js$/,
+  missingDescription: "webview app main bundle",
+  skipDescription: "Linux Browser Use non-local navigation patch",
+  apply: applyLinuxBrowserUseNonLocalNavigationPatch,
+};

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -265,10 +265,6 @@ function applyLinuxBrowserUseNonLocalNavigationPatch(currentSource) {
   const statsigNeedle = "3903563814";
   let changed = false;
 
-  if (currentSource.includes(`${messageNeedle}\`,{allowed:!0}`)) {
-    return currentSource;
-  }
-
   const dispatchPattern =
     /((?:[A-Za-z_$][\w$]*=)?[A-Za-z_$][\w$]*\(`3903563814`\)[\s\S]{0,1800}?dispatchMessage\(`browser-use-non-local-sites-allowed-changed`,\{allowed:)([A-Za-z_$][\w$]*)(\}\))/g;
 
@@ -282,6 +278,10 @@ function applyLinuxBrowserUseNonLocalNavigationPatch(currentSource) {
 
   if (changed) {
     return patchedSource;
+  }
+
+  if (currentSource.includes(`${messageNeedle}\`,{allowed:!0}`)) {
+    return currentSource;
   }
 
   if (currentSource.includes(messageNeedle) && currentSource.includes(statsigNeedle)) {

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -212,6 +212,87 @@ function applyLinuxAppSunsetPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxBrowserUseAvailabilityPatch(currentSource) {
+  const browserUseFeatureNeedle = "featureName:`browser_use`";
+  const statsigNeedle = "410262010";
+  let changed = false;
+
+  const alreadyPatched = () =>
+    /featureName:`browser_use`[\s\S]{0,1400}?isBrowserAgentGateEnabled:!0,/.test(currentSource);
+
+  const gatePattern =
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\{isBrowserAgentGateEnabled:([A-Za-z_$][\w$]*),isBrowserSidebarEnabled:([A-Za-z_$][\w$]*),isBrowserUseEnabled:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*),runCodexInWsl:([A-Za-z_$][\w$]*),windowType:`electron`\}\)/g;
+
+  const patchedSource = currentSource.replace(
+    gatePattern,
+    (
+      match,
+      resultVar,
+      helperVar,
+      gateVar,
+      sidebarVar,
+      browserUseVar,
+      loadingVar,
+      wslVar,
+      offset,
+    ) => {
+      const contextStart = Math.max(0, offset - 1400);
+      const context = currentSource.slice(contextStart, offset + match.length);
+      if (!context.includes(browserUseFeatureNeedle) || !context.includes(statsigNeedle)) {
+        return match;
+      }
+
+      changed = true;
+      return `${resultVar}=${helperVar}({isBrowserAgentGateEnabled:!0,isBrowserSidebarEnabled:${sidebarVar},isBrowserUseEnabled:${browserUseVar},isLoading:${loadingVar},runCodexInWsl:${wslVar},windowType:\`electron\`})`;
+    },
+  );
+
+  if (changed || alreadyPatched()) {
+    return patchedSource;
+  }
+
+  if (currentSource.includes(browserUseFeatureNeedle) && currentSource.includes(statsigNeedle)) {
+    console.warn(
+      "WARN: Could not find Browser Use availability gate — skipping Linux Browser Use availability patch",
+    );
+  }
+
+  return currentSource;
+}
+
+function applyLinuxBrowserUseNonLocalNavigationPatch(currentSource) {
+  const messageNeedle = "browser-use-non-local-sites-allowed-changed";
+  const statsigNeedle = "3903563814";
+  let changed = false;
+
+  if (currentSource.includes(`${messageNeedle}\`,{allowed:!0}`)) {
+    return currentSource;
+  }
+
+  const dispatchPattern =
+    /((?:[A-Za-z_$][\w$]*=)?[A-Za-z_$][\w$]*\(`3903563814`\)[\s\S]{0,1800}?dispatchMessage\(`browser-use-non-local-sites-allowed-changed`,\{allowed:)([A-Za-z_$][\w$]*)(\}\))/g;
+
+  const patchedSource = currentSource.replace(
+    dispatchPattern,
+    (match, prefix, allowedVar, suffix) => {
+      changed = true;
+      return `${prefix}!0${suffix}`;
+    },
+  );
+
+  if (changed) {
+    return patchedSource;
+  }
+
+  if (currentSource.includes(messageNeedle) && currentSource.includes(statsigNeedle)) {
+    console.warn(
+      "WARN: Could not find Browser Use non-local navigation gate — skipping Linux Browser Use navigation patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
   const supportedFeatures = new Set([
     "apps",
@@ -1041,6 +1122,8 @@ function patchCommentPreloadBundle(extractedDir) {
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppServerFeatureEnablementPatch,
+  applyLinuxBrowserUseAvailabilityPatch,
+  applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxConfigWriteVersionConflictPatch,
   applyLinuxI18nGatePatch,
   applyLinuxProfileSettingsMenuPatch,


### PR DESCRIPTION
## Summary

Fix Browser Use availability on Linux when the upstream webview Statsig gates are disabled.

This adds Linux webview patches for two Browser Use gates:

- enable the in-app Browser Use availability path when only the Browser Use Statsig gate is disabled
- allow Browser Use to navigate to non-local URLs by syncing `browser-use-non-local-sites-allowed-changed` as enabled on Linux

Without this, Browser settings can show “Disabled by your organization or unavailable in your region”, and Browser Use navigation can fail with:

`Blocked browser navigation to non-local URL: https://www.baidu.com/`

## Local Environment

This was reproduced in a local Linux build with:

1. third-party API key authentication
2. third-party API base URL

The same account/API setup works in the macOS Codex GUI, so this appears to be a Linux wrapper/webview gating issue rather than an account, organization, or region restriction.

## Validation

```bash
codex-app/resources/node-runtime/bin/node --test scripts/patch-linux-window-ui.test.js