### PR TITLE
[codex] Preserve enabled local features during wrapper updates

### DIFF
--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -373,6 +373,57 @@ apply_source_overlay() {
     done < <(source_repo_overlay_remove_paths "$base_ref")
 }
 
+copy_enabled_local_features() {
+    local config_path source_local_root target_local_root feature_id source_dir target_dir
+
+    config_path="${CODEX_LINUX_FEATURES_CONFIG:-}"
+    if [ -z "$config_path" ] && [ -f "$SOURCE_REPO_DIR/linux-features/features.json" ]; then
+        config_path="$SOURCE_REPO_DIR/linux-features/features.json"
+    fi
+
+    [ -f "$config_path" ] || return 0
+    source_local_root="$SOURCE_REPO_DIR/linux-features/local"
+    [ -d "$source_local_root" ] || return 0
+
+    target_local_root="$MANAGED_REPO_DIR/linux-features/local"
+    while IFS= read -r feature_id; do
+        [ -n "$feature_id" ] || continue
+        source_dir="$source_local_root/$feature_id"
+        [ -f "$source_dir/feature.json" ] || continue
+
+        # If the fetched wrapper gained a real top-level feature with this id,
+        # prefer the upstream feature and do not create a duplicate local id.
+        [ ! -f "$MANAGED_REPO_DIR/linux-features/$feature_id/feature.json" ] || continue
+
+        target_dir="$target_local_root/$feature_id"
+        mkdir -p "$(dirname "$target_dir")"
+        rm -rf "$target_dir"
+        cp -a "$source_dir" "$target_dir"
+    done < <(python3 - "$config_path" <<'PY'
+import json
+import re
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+except Exception:
+    raise SystemExit(0)
+
+seen = set()
+for item in config.get("enabled", []):
+    if not isinstance(item, str):
+        continue
+    if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", item):
+        continue
+    if item in seen:
+        continue
+    seen.add(item)
+    print(item)
+PY
+)
+}
+
 prepare_build_repo() {
     local branch managed_ref
 
@@ -397,6 +448,7 @@ prepare_build_repo() {
     git -C "$MANAGED_REPO_DIR" reset --hard "$managed_ref" >/dev/null
     git -C "$MANAGED_REPO_DIR" clean -fdx >/dev/null
     apply_source_overlay
+    copy_enabled_local_features
     BUILD_REPO_DIR="$MANAGED_REPO_DIR"
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5061,6 +5061,86 @@ test_user_local_install_preserves_persisted_x11_preference_on_refresh() {
     assert_contains "$preference_file" "CODEX_USER_LOCAL_OZONE_PLATFORM=auto"
 }
 
+test_user_local_prepare_build_repo_copies_enabled_local_features() {
+    info "Checking user-local managed checkout stages enabled local features"
+    local workspace="$TMP_DIR/user-local-local-features"
+    local origin_repo="$workspace/origin.git"
+    local source_repo="$workspace/source"
+    local managed_repo="$workspace/xdg-data/codex-desktop-linux/managed-repo"
+    local install_env="$workspace/install.env"
+    local feature_config="$workspace/linux-features.json"
+    local staged_local_feature="$managed_repo/linux-features/local/local-tool"
+
+    mkdir -p "$workspace"
+    git init --bare --initial-branch=main "$origin_repo" >/dev/null
+    git clone "$origin_repo" "$source_repo" >/dev/null 2>&1
+    git -C "$source_repo" config user.name "Smoke Test"
+    git -C "$source_repo" config user.email "smoke@example.com"
+
+    mkdir -p "$source_repo/linux-features/repo-feature"
+    printf '%s\n' '# Linux Features' > "$source_repo/linux-features/README.md"
+    printf '%s\n' '{"enabled":[]}' > "$source_repo/linux-features/features.example.json"
+    printf '%s\n' '{"id":"repo-feature","title":"Repo Feature"}' \
+        > "$source_repo/linux-features/repo-feature/feature.json"
+    printf '%s\n' '# Repo Feature' > "$source_repo/linux-features/repo-feature/README.md"
+    git -C "$source_repo" add linux-features
+    git -C "$source_repo" commit -m "base" >/dev/null
+    git -C "$source_repo" push -u origin main >/dev/null
+
+    mkdir -p "$source_repo/linux-features/local/local-tool/nested"
+    mkdir -p "$source_repo/linux-features/local/repo-feature"
+    printf '%s\n' '{"id":"local-tool","title":"Local Tool"}' \
+        > "$source_repo/linux-features/local/local-tool/feature.json"
+    printf '%s\n' '# Local Tool' > "$source_repo/linux-features/local/local-tool/README.md"
+    printf '%s\n' 'payload' > "$source_repo/linux-features/local/local-tool/nested/payload.txt"
+    ln -s nested/payload.txt "$source_repo/linux-features/local/local-tool/payload-link"
+    printf '%s\n' '{"id":"repo-feature","title":"Local Repo Feature"}' \
+        > "$source_repo/linux-features/local/repo-feature/feature.json"
+    cat > "$feature_config" <<'JSON'
+{
+  "enabled": [
+    "local-tool",
+    "repo-feature",
+    "missing-local",
+    "bad id"
+  ]
+}
+JSON
+
+    (
+        export HOME="$workspace/home"
+        export XDG_DATA_HOME="$workspace/xdg-data"
+        export XDG_STATE_HOME="$workspace/xdg-state"
+        export CODEX_LINUX_FEATURES_CONFIG="$feature_config"
+        mkdir -p "$HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME"
+
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh"
+
+        INSTALL_CONFIG_FILE="$install_env"
+        cat > "$INSTALL_CONFIG_FILE" <<EOF
+SOURCE_REPO_DIR=$(printf '%q' "$source_repo")
+MANAGED_REPO_DIR=$(printf '%q' "$managed_repo")
+REPO_ORIGIN_URL=$(printf '%q' "$origin_repo")
+REPO_DEFAULT_BRANCH=$(printf '%q' "main")
+OPT_ROOT=$(printf '%q' "$workspace/opt")
+EOF
+
+        prepare_build_repo
+    )
+
+    assert_file_exists "$staged_local_feature/feature.json"
+    [ "$(cat "$staged_local_feature/nested/payload.txt")" = "payload" ] \
+        || fail "Expected local feature nested payload to be copied"
+    [ -L "$staged_local_feature/payload-link" ] \
+        || fail "Expected local feature symlink to be preserved"
+    [ "$(readlink "$staged_local_feature/payload-link")" = "nested/payload.txt" ] \
+        || fail "Expected local feature symlink target to be preserved"
+    assert_file_not_exists "$managed_repo/linux-features/local/repo-feature/feature.json"
+    assert_file_not_exists "$managed_repo/linux-features/local/missing-local/feature.json"
+    assert_file_exists "$managed_repo/linux-features/repo-feature/feature.json"
+}
+
 test_user_local_prepare_build_repo_updates_existing_single_branch_fetch_refspec() {
     info "Checking user-local managed checkout can switch branches after a single-branch clone"
     local workspace="$TMP_DIR/user-local-single-branch-refspec"
@@ -5396,6 +5476,7 @@ main() {
     test_desktop_entry_doctor_repairs_only_legacy_generated_entries
     test_user_local_install_from_update_defers_record_only_metadata
     test_user_local_install_preserves_persisted_x11_preference_on_refresh
+    test_user_local_prepare_build_repo_copies_enabled_local_features
     test_user_local_prepare_build_repo_updates_existing_single_branch_fetch_refspec
     test_user_local_prepare_build_repo_handles_deleted_overlay_paths
     test_user_local_prepare_build_repo_removes_rename_source_paths

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -14,8 +14,11 @@
 //!   remain in place for a later retry.
 
 use anyhow::{Context, Result};
+use serde_json::Value;
 use std::{
-    os::unix::fs::PermissionsExt,
+    collections::HashSet,
+    fs,
+    os::unix::fs::{self as unix_fs, PermissionsExt},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -165,6 +168,7 @@ async fn apply_user_local(
         .map(Path::to_path_buf)
         .unwrap_or_else(|| app_dir.clone());
     let wrapper_src = ensure_wrapper_source(config, paths, candidate_commit)?;
+    stage_enabled_local_features(config, &wrapper_src, feature_config.as_deref())?;
     let install_sh = wrapper_src.join("install.sh");
     if !install_sh.is_file() {
         anyhow::bail!(
@@ -194,6 +198,133 @@ async fn apply_user_local(
 /// then the installed builder bundle's preserved feature config.
 fn effective_feature_config(config: &RuntimeConfig) -> Option<PathBuf> {
     crate::config::effective_feature_config_path(config)
+}
+
+fn valid_feature_id(id: &str) -> bool {
+    let mut bytes = id.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return false;
+    }
+    bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+fn enabled_feature_ids_from_config(config_path: &Path) -> Vec<String> {
+    let content = match fs::read_to_string(config_path) {
+        Ok(content) => content,
+        Err(error) => {
+            warn!(path = %config_path.display(), error = %error, "could not read Linux feature config");
+            return Vec::new();
+        }
+    };
+    let value = match serde_json::from_str::<Value>(&content) {
+        Ok(value) => value,
+        Err(error) => {
+            warn!(path = %config_path.display(), error = %error, "could not parse Linux feature config");
+            return Vec::new();
+        }
+    };
+    let Some(enabled) = value.get("enabled").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    let mut ids = Vec::new();
+    for item in enabled {
+        let Some(id) = item.as_str() else {
+            continue;
+        };
+        if !valid_feature_id(id) || !seen.insert(id.to_string()) {
+            continue;
+        }
+        ids.push(id.to_string());
+    }
+    ids
+}
+
+fn copy_dir_all(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).with_context(|| format!("Failed to create {}", target.display()))?;
+    for entry in
+        fs::read_dir(source).with_context(|| format!("Failed to read {}", source.display()))?
+    {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)
+            .with_context(|| format!("Failed to stat {}", source_path.display()))?;
+        let file_type = metadata.file_type();
+        if file_type.is_dir() {
+            copy_dir_all(&source_path, &target_path)?;
+        } else if file_type.is_symlink() {
+            let link_target = fs::read_link(&source_path)
+                .with_context(|| format!("Failed to read symlink {}", source_path.display()))?;
+            unix_fs::symlink(&link_target, &target_path).with_context(|| {
+                format!(
+                    "Failed to copy symlink {} to {}",
+                    source_path.display(),
+                    target_path.display()
+                )
+            })?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &target_path).with_context(|| {
+                format!(
+                    "Failed to copy {} to {}",
+                    source_path.display(),
+                    target_path.display()
+                )
+            })?;
+            fs::set_permissions(&target_path, metadata.permissions()).with_context(|| {
+                format!("Failed to set permissions on {}", target_path.display())
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn stage_enabled_local_features(
+    config: &RuntimeConfig,
+    wrapper_src: &Path,
+    feature_config: Option<&Path>,
+) -> Result<()> {
+    let Some(feature_config) = feature_config else {
+        return Ok(());
+    };
+    if !feature_config.is_file() {
+        return Ok(());
+    }
+
+    let source_local_root = config.builder_bundle_root.join("linux-features/local");
+    if !source_local_root.is_dir() {
+        return Ok(());
+    }
+
+    let target_features_root = wrapper_src.join("linux-features");
+    for id in enabled_feature_ids_from_config(feature_config) {
+        let source_dir = source_local_root.join(&id);
+        if !source_dir.join("feature.json").is_file() {
+            continue;
+        }
+
+        // If the fetched wrapper gained a real top-level feature with this id,
+        // prefer the upstream feature and avoid creating a duplicate manifest.
+        if target_features_root
+            .join(&id)
+            .join("feature.json")
+            .is_file()
+        {
+            continue;
+        }
+
+        let target_dir = target_features_root.join("local").join(&id);
+        if target_dir.exists() {
+            fs::remove_dir_all(&target_dir)
+                .with_context(|| format!("Failed to remove {}", target_dir.display()))?;
+        }
+        copy_dir_all(&source_dir, &target_dir)?;
+    }
+    Ok(())
 }
 
 fn user_local_update_helper() -> Option<PathBuf> {
@@ -235,6 +366,8 @@ async fn apply_packaged(
     }
 
     let wrapper_src = ensure_wrapper_source(config, paths, candidate_commit)?;
+    let feature_config = effective_feature_config(config);
+    stage_enabled_local_features(config, &wrapper_src, feature_config.as_deref())?;
     let dmg_path = cached_or_downloaded_dmg(config, state, paths).await?;
 
     // The package version must remain monotonic (timestamp+dmghash), so derive
@@ -445,6 +578,109 @@ mod tests {
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
         }
+    }
+
+    fn write_local_feature(root: &Path, id: &str) {
+        let feature_dir = root.join("builder/linux-features/local").join(id);
+        std::fs::create_dir_all(feature_dir.join("nested")).unwrap();
+        std::fs::write(
+            feature_dir.join("feature.json"),
+            format!(
+                r#"{{
+  "id": "{id}",
+  "title": "Local Feature",
+  "description": "Local test feature",
+  "defaultEnabled": false,
+  "entrypoints": {{}}
+}}"#
+            ),
+        )
+        .unwrap();
+        std::fs::write(feature_dir.join("README.md"), "# Local Feature\n").unwrap();
+        std::fs::write(feature_dir.join("nested/payload.txt"), "payload\n").unwrap();
+        unix_fs::symlink("nested/payload.txt", feature_dir.join("payload-link")).unwrap();
+    }
+
+    #[test]
+    fn stages_enabled_local_features_into_wrapper_source() {
+        let root = tempdir().unwrap();
+        let config = test_config(root.path());
+        let wrapper_src = root.path().join("wrapper-src");
+        let feature_config = root.path().join("linux-features.json");
+        write_local_feature(root.path(), "model-provider-switcher");
+        std::fs::create_dir_all(wrapper_src.join("linux-features")).unwrap();
+        std::fs::write(
+            &feature_config,
+            r#"{"enabled":["agent-workspace","model-provider-switcher","missing-local"]}"#,
+        )
+        .unwrap();
+
+        stage_enabled_local_features(&config, &wrapper_src, Some(&feature_config)).unwrap();
+
+        assert!(wrapper_src
+            .join("linux-features/local/model-provider-switcher/feature.json")
+            .is_file());
+        assert_eq!(
+            std::fs::read_to_string(
+                wrapper_src.join("linux-features/local/model-provider-switcher/nested/payload.txt")
+            )
+            .unwrap(),
+            "payload\n"
+        );
+        assert_eq!(
+            std::fs::read_link(
+                wrapper_src.join("linux-features/local/model-provider-switcher/payload-link")
+            )
+            .unwrap(),
+            PathBuf::from("nested/payload.txt")
+        );
+        assert!(!wrapper_src
+            .join("linux-features/local/missing-local/feature.json")
+            .exists());
+    }
+
+    #[test]
+    fn local_feature_staging_does_not_duplicate_upstream_features() {
+        let root = tempdir().unwrap();
+        let config = test_config(root.path());
+        let wrapper_src = root.path().join("wrapper-src");
+        let feature_config = root.path().join("linux-features.json");
+        write_local_feature(root.path(), "model-provider-switcher");
+        std::fs::create_dir_all(wrapper_src.join("linux-features/model-provider-switcher"))
+            .unwrap();
+        std::fs::write(
+            wrapper_src.join("linux-features/model-provider-switcher/feature.json"),
+            r#"{"id":"model-provider-switcher"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &feature_config,
+            r#"{"enabled":["model-provider-switcher"]}"#,
+        )
+        .unwrap();
+
+        stage_enabled_local_features(&config, &wrapper_src, Some(&feature_config)).unwrap();
+
+        assert!(!wrapper_src
+            .join("linux-features/local/model-provider-switcher/feature.json")
+            .exists());
+    }
+
+    #[test]
+    fn malformed_feature_config_does_not_block_local_feature_staging() {
+        let root = tempdir().unwrap();
+        let config = test_config(root.path());
+        let wrapper_src = root.path().join("wrapper-src");
+        let feature_config = root.path().join("linux-features.json");
+        write_local_feature(root.path(), "model-provider-switcher");
+        std::fs::create_dir_all(wrapper_src.join("linux-features")).unwrap();
+        std::fs::write(&feature_config, "{not json").unwrap();
+
+        stage_enabled_local_features(&config, &wrapper_src, Some(&feature_config)).unwrap();
+
+        assert!(!wrapper_src
+            .join("linux-features/local/model-provider-switcher/feature.json")
+            .exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- stage enabled `linux-features/local/<id>` directories into fetched wrapper sources before wrapper rebuilds
- apply the same preservation path to packaged rebuilds and user-local helper managed checkouts
- keep upstream top-level feature ids authoritative, so a future built-in feature is not duplicated as local

## Root Cause
Wrapper updates rebuild from a freshly fetched wrapper source. If the current install had an enabled local Linux feature, the saved feature config still referenced that id, but the fetched source did not contain `linux-features/local/<id>`. `scripts/lib/linux-features.js` then rejected the enabled id and the wrapper update stayed pending.

## Validation
- `cargo fmt --all --check`
- `bash -n contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh tests/scripts_smoke.sh`
- `git diff --check`
- `cargo test -p codex-update-manager wrapper_apply`
- `bash tests/scripts_smoke.sh`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-update-manager`