### PR TITLE
[codex] Keep Linux Chrome plugin available

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2820,7 +2820,7 @@ test("auto-installs the current Chrome plugin gate shape", () => {
 
   assert.match(
     patched,
-    /\{forceReload:!0,installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,features:t\}\)=>t\.externalBrowserUseAllowed&&\$n\(e\)\}/,
+    /\{forceReload:!0,installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,features:t\}\)=>process\.platform===`linux`\|\|\(t\.externalBrowserUseAllowed&&\$n\(e\)\)\}/,
   );
   assert.match(patched, /name:xt,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,env:t,features:n\}\)=>Ar\(e,t\)&&n\.externalBrowserUseAllowed/);
   assert.match(patched, /name:dt,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,env:t,features:n\}\)=>jr\(e,t\)&&n\.externalBrowserUseAllowed/);
@@ -2904,10 +2904,24 @@ test("reports drifted Chrome native host runtime resolver as required upstream f
   }
 });
 
-test("keeps an already auto-installed Chrome plugin gate unchanged", () => {
+test("adds Linux availability to an already auto-installed Chrome plugin gate", () => {
   const source = currentPluginGateBundleFixture().replace(
     "{forceReload:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:",
     "{forceReload:!0,installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:",
+  );
+
+  const patched = applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source);
+
+  assert.match(
+    patched,
+    /installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,features:t\}\)=>process\.platform===`linux`\|\|\(t\.externalBrowserUseAllowed&&\$n\(e\)\)/,
+  );
+});
+
+test("keeps a fully Linux-enabled Chrome plugin gate unchanged", () => {
+  const source = currentPluginGateBundleFixture().replace(
+    "{forceReload:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:({buildFlavor:e,features:t})=>t.externalBrowserUseAllowed&&$n(e)}",
+    "{forceReload:!0,installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:({buildFlavor:e,features:t})=>process.platform===`linux`||(t.externalBrowserUseAllowed&&$n(e))}",
   );
 
   assert.equal(applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source), source);
@@ -2920,6 +2934,7 @@ test("handles literal Chrome plugin gate names", () => {
   const patched = applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source);
 
   assert.match(patched, /installWhenMissing:!0,name:'chrome'/);
+  assert.match(patched, /process\.platform===`linux`\|\|\(t\.externalBrowserUseAllowed\)/);
   assert.doesNotMatch(patched, /installWhenMissing:!0,name:'chrome-internal'/);
 });
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2927,6 +2927,23 @@ test("keeps a fully Linux-enabled Chrome plugin gate unchanged", () => {
   assert.equal(applyPatchTwice(applyLinuxChromePluginAutoInstallPatch, source), source);
 });
 
+test("does not treat unrelated Linux platform checks as Chrome plugin availability", () => {
+  const source = currentPluginGateBundleFixture()
+    .replace(
+      "{forceReload:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:",
+      "{forceReload:!0,installWhenMissing:!0,name:ut,syncInstallStateWithChromeExtension:!0,isAvailable:",
+    )
+    .replace(
+      "({buildFlavor:e,features:t})=>t.externalBrowserUseAllowed&&$n(e)}",
+      "function({features:t}){return t.externalBrowserUseAllowed}}",
+    ) + "var __codexOtherLinuxPatch=process.platform===`linux`;";
+
+  assert.throws(
+    () => applyLinuxChromePluginAutoInstallPatch(source),
+    /Required Linux Chrome plugin auto-install patch failed/,
+  );
+});
+
 test("handles literal Chrome plugin gate names", () => {
   const source =
     "var Kr=[{forceReload:!0,name:'chrome',isEnabled:({features:t})=>t.externalBrowserUseAllowed},{forceReload:!0,name:'chrome-internal',isEnabled:({features:t})=>t.externalBrowserUseAllowed}];";

--- a/scripts/patches/chrome-plugin.js
+++ b/scripts/patches/chrome-plugin.js
@@ -17,16 +17,23 @@ function isChromeNameExpr(nameExpr, chromeNameVar) {
     nameExpr === chromeNameVar;
 }
 
-function hasChromeAutoInstall(source, chromeNameVar) {
+function chromeNamePatterns(chromeNameVar) {
   const namePatterns = [String.raw`\`chrome\``, "\"chrome\"", "'chrome'"];
   if (chromeNameVar != null) {
     namePatterns.push(chromeNameVar);
   }
-  return new RegExp(String.raw`installWhenMissing:!0,name:(?:${namePatterns.join("|")})`).test(source);
+  return namePatterns;
 }
 
 function hasLinuxChromeAvailability(source) {
   return source.includes("process.platform===`linux`");
+}
+
+function hasChromeAutoInstallWithLinuxAvailability(source, chromeNameVar) {
+  const namePatterns = chromeNamePatterns(chromeNameVar);
+  return new RegExp(
+    String.raw`\{(?=[^{}]*installWhenMissing:!0)(?=[^{}]*name:(?:${namePatterns.join("|")}))(?=[^{}]*process\.platform===\`linux\`)[^{}]*(?:isEnabled|isAvailable):[^{}]*\}`,
+  ).test(source);
 }
 
 function applyLinuxChromePluginAutoInstallPatch(currentSource) {
@@ -86,10 +93,7 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
     return patched;
   }
 
-  if (
-    hasChromeAutoInstall(currentSource, chromeNameVar) &&
-    hasLinuxChromeAvailability(currentSource)
-  ) {
+  if (hasChromeAutoInstallWithLinuxAvailability(currentSource, chromeNameVar)) {
     return currentSource;
   }
 

--- a/scripts/patches/chrome-plugin.js
+++ b/scripts/patches/chrome-plugin.js
@@ -25,6 +25,10 @@ function hasChromeAutoInstall(source, chromeNameVar) {
   return new RegExp(String.raw`installWhenMissing:!0,name:(?:${namePatterns.join("|")})`).test(source);
 }
 
+function hasLinuxChromeAvailability(source) {
+  return source.includes("process.platform===`linux`");
+}
+
 function applyLinuxChromePluginAutoInstallPatch(currentSource) {
   if (!hasChromePluginLiteral(currentSource)) {
     console.warn(
@@ -62,12 +66,19 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
       }
 
       sawChromeGate = true;
-      if (installWhenMissing != null || prefix.includes("installWhenMissing:!0")) {
+      const hasInstallWhenMissing = installWhenMissing != null ||
+        prefix.includes("installWhenMissing:!0");
+      const hasLinuxAvailability = hasLinuxChromeAvailability(expression);
+      if (hasInstallWhenMissing && hasLinuxAvailability) {
         sawAlreadyInstalledGate = true;
         return gateSource;
       }
 
-      return `{${prefix}installWhenMissing:!0,name:${nameExpr},${middleFields}${availabilityProp}:({${paramsText}})=>${expression}${migrateSuffix}}`;
+      const installWhenMissingField = hasInstallWhenMissing ? (installWhenMissing ?? "") : "installWhenMissing:!0,";
+      const availabilityExpression = hasLinuxAvailability
+        ? expression
+        : `process.platform===\`linux\`||(${expression})`;
+      return `{${prefix}${installWhenMissingField}name:${nameExpr},${middleFields}${availabilityProp}:({${paramsText}})=>${availabilityExpression}${migrateSuffix}}`;
     },
   );
 
@@ -75,7 +86,10 @@ function applyLinuxChromePluginAutoInstallPatch(currentSource) {
     return patched;
   }
 
-  if (hasChromeAutoInstall(currentSource, chromeNameVar)) {
+  if (
+    hasChromeAutoInstall(currentSource, chromeNameVar) &&
+    hasLinuxChromeAvailability(currentSource)
+  ) {
     return currentSource;
   }
 


### PR DESCRIPTION
## Summary

- Keep the bundled Chrome plugin available on Linux even when upstream `externalBrowserUseAllowed` is false.
- Preserve upstream Chrome availability gating on non-Linux platforms.
- Add regression coverage for the auto-installed Chrome gate and idempotent Linux-enabled gates.

## Root Cause

The Linux launcher staged the Chrome plugin resources and native host, but the app's bundled-plugin marketplace resolver still filtered Chrome out when upstream `externalBrowserUseAllowed` was false. That left only `computer-use` in the runtime marketplace, causing Chrome to be uninstalled and its native host manifest to be removed.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh`
- Locally verified the patched gate against the installed ASAR shape before rebasing.
- Previously built `nix build .#codex-desktop-computer-use-ui-remote-mobile-control` successfully with the patch.
