### PR TITLE
[codex] Sync embedded computer-use-linux v0.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI_PACKAGE_VERSION: 2026.04.28.000000+ci${{ github.run_number }}
 
 jobs:

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -22,6 +22,7 @@ jobs:
       NIX_CONFIG: experimental-features = nix-command flakes
       CACHIX_CACHE_NAME: codex-desktop-linux
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -29,6 +29,7 @@ permissions:
   contents: read
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
   UPSTREAM_DMG_PATH: /tmp/codex-upstream-ci/Codex.dmg
   DMG_CACHE_SCHEMA_VERSION: v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "codex-computer-use-linux"
-version = "0.2.3-linux-alpha1"
+version = "0.2.5-linux-alpha1"
 dependencies = [
  "anyhow",
  "atspi",
@@ -1373,6 +1373,8 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3814,6 +3816,21 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
 
 [[package]]
 name = "zvariant"

--- a/computer-use-linux/Cargo.toml
+++ b/computer-use-linux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-computer-use-linux"
-version = "0.2.3-linux-alpha1"
+version = "0.2.5-linux-alpha1"
 edition = "2021"
 
 [[bin]]
@@ -18,7 +18,7 @@ base64 = "0.22.1"
 cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "160b086", default-features = false, features = ["client"] }
 evdev = "0.13.2"
 futures-util = "0.3.32"
-image = { version = "0.25", default-features = false, features = ["png"] }
+image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 libc = "0.2"
 rmcp = { version = "1.5.0", features = ["transport-io"] }
 schemars = "1.0"

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
                 .nth(3)
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
-            let cap = screenshot::capture_screenshot().await?;
+            let cap = screenshot::capture_screenshot_raw().await?;
             eprintln!("desktop logical size: {}x{}", cap.width, cap.height);
             let mut p = abs_pointer::AbsPointer::create(cap.width as i32, cap.height as i32)?;
             p.click(x, y, abs_pointer::PointerButton::Left, 1)?;
@@ -87,6 +87,17 @@ async fn main() -> Result<()> {
                 serde_json::to_string_pretty(&serde_json::json!({
                     "mime_type": capture.mime_type,
                     "source": capture.source,
+                    "width": capture.width,
+                    "height": capture.height,
+                    "coordinate_width": capture.coordinate_width,
+                    "coordinate_height": capture.coordinate_height,
+                    "scale": capture.scale,
+                    "resized": capture.resized,
+                    "bytes": capture.bytes,
+                    "original_bytes": capture.original_bytes,
+                    "max_bytes": capture.max_bytes,
+                    "format": capture.format,
+                    "quality": capture.quality,
                     "data_url_length": capture.data_url.len()
                 }))
                 .context("failed to serialize screenshot report")?

--- a/computer-use-linux/src/screenshot.rs
+++ b/computer-use-linux/src/screenshot.rs
@@ -2,11 +2,14 @@ use crate::diagnostics::hydrate_session_bus_env;
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
 use futures_util::StreamExt;
+use image::codecs::jpeg::JpegEncoder;
+use image::imageops::FilterType;
 use schemars::JsonSchema;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs,
+    io::Cursor,
     path::{Path, PathBuf},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -19,13 +22,81 @@ use zbus::{
 const PORTAL_REQUEST_INTERFACE: &str = "org.freedesktop.portal.Request";
 const PORTAL_REQUEST_PATH_NAMESPACE: &str = "/org/freedesktop/portal/desktop/request";
 
+pub const DEFAULT_SCREENSHOT_MAX_DIMENSION: u32 = 1920;
+pub const DEFAULT_SCREENSHOT_MAX_BYTES: usize = 2 * 1024 * 1024;
+pub const ABSOLUTE_SCREENSHOT_MAX_DIMENSION: u32 = 4096;
+pub const ABSOLUTE_SCREENSHOT_MAX_BYTES: usize = 4 * 1024 * 1024;
+pub const DEFAULT_SCREENSHOT_JPEG_QUALITY: u8 = 80;
+pub const MIN_SCREENSHOT_JPEG_QUALITY: u8 = 1;
+pub const MAX_SCREENSHOT_JPEG_QUALITY: u8 = 95;
+const MIN_SCREENSHOT_MAX_BYTES: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct RawScreenshotCapture {
+    pub mime_type: String,
+    pub bytes: Vec<u8>,
+    pub source: String,
+    pub width: u32,
+    pub height: u32,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct ScreenshotCapture {
     pub mime_type: String,
     pub data_url: String,
     pub source: String,
+    /// Width of the returned image payload.
     pub width: u32,
+    /// Height of the returned image payload.
     pub height: u32,
+    /// Coordinate-space width before payload downscaling.
+    pub coordinate_width: u32,
+    /// Coordinate-space height before payload downscaling.
+    pub coordinate_height: u32,
+    /// Returned pixels per coordinate-space pixel.
+    pub scale: f32,
+    pub resized: bool,
+    pub bytes: usize,
+    pub original_bytes: usize,
+    pub max_bytes: usize,
+    pub format: ScreenshotOutputFormat,
+    pub quality: Option<u8>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ScreenshotPayloadOptions {
+    pub max_width: Option<u32>,
+    pub max_height: Option<u32>,
+    pub max_bytes: Option<usize>,
+    pub scale: Option<f32>,
+    pub format: Option<ScreenshotOutputFormat>,
+    pub quality: Option<u8>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ScreenshotOutputFormat {
+    Png,
+    Jpeg,
+}
+
+impl ScreenshotOutputFormat {
+    fn mime_type(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedScreenshotPayloadOptions {
+    max_width: u32,
+    max_height: u32,
+    max_bytes: usize,
+    scale: f32,
+    format: ScreenshotOutputFormat,
+    quality: u8,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,7 +105,43 @@ enum ScreenshotCleanup {
     Preserve,
 }
 
-pub async fn capture_screenshot() -> Result<ScreenshotCapture> {
+impl ScreenshotPayloadOptions {
+    fn resolve(self) -> ResolvedScreenshotPayloadOptions {
+        let max_width = self
+            .max_width
+            .unwrap_or(DEFAULT_SCREENSHOT_MAX_DIMENSION)
+            .clamp(1, ABSOLUTE_SCREENSHOT_MAX_DIMENSION);
+        let max_height = self
+            .max_height
+            .unwrap_or(DEFAULT_SCREENSHOT_MAX_DIMENSION)
+            .clamp(1, ABSOLUTE_SCREENSHOT_MAX_DIMENSION);
+        let max_bytes = self
+            .max_bytes
+            .unwrap_or(DEFAULT_SCREENSHOT_MAX_BYTES)
+            .clamp(MIN_SCREENSHOT_MAX_BYTES, ABSOLUTE_SCREENSHOT_MAX_BYTES);
+        let scale = self
+            .scale
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .unwrap_or(1.0)
+            .min(1.0);
+        let format = self.format.unwrap_or(ScreenshotOutputFormat::Png);
+        let quality = self
+            .quality
+            .unwrap_or(DEFAULT_SCREENSHOT_JPEG_QUALITY)
+            .clamp(MIN_SCREENSHOT_JPEG_QUALITY, MAX_SCREENSHOT_JPEG_QUALITY);
+
+        ResolvedScreenshotPayloadOptions {
+            max_width,
+            max_height,
+            max_bytes,
+            scale,
+            format,
+            quality,
+        }
+    }
+}
+
+pub async fn capture_screenshot_raw() -> Result<RawScreenshotCapture> {
     hydrate_session_bus_env();
 
     match capture_with_gnome_shell().await {
@@ -48,7 +155,67 @@ pub async fn capture_screenshot() -> Result<ScreenshotCapture> {
     }
 }
 
-async fn capture_with_gnome_shell() -> Result<ScreenshotCapture> {
+pub async fn capture_screenshot() -> Result<ScreenshotCapture> {
+    let raw = capture_screenshot_raw().await?;
+    prepare_screenshot_payload(raw, ScreenshotPayloadOptions::default())
+}
+
+pub fn prepare_screenshot_payload(
+    raw: RawScreenshotCapture,
+    options: ScreenshotPayloadOptions,
+) -> Result<ScreenshotCapture> {
+    if raw.bytes.is_empty() {
+        bail!("screenshot file was empty");
+    }
+    let (coordinate_width, coordinate_height) = png_dimensions(&raw.bytes)?;
+    let original_bytes = raw.bytes.len();
+    let options = options.resolve();
+    let (target_width, target_height) =
+        target_dimensions(coordinate_width, coordinate_height, options);
+
+    let (bytes, width, height) = if options.format == ScreenshotOutputFormat::Png
+        && target_width == coordinate_width
+        && target_height == coordinate_height
+        && original_bytes <= options.max_bytes
+    {
+        (raw.bytes, coordinate_width, coordinate_height)
+    } else {
+        encode_screenshot_to_fit_bytes(
+            &raw.bytes,
+            coordinate_width,
+            coordinate_height,
+            target_width,
+            target_height,
+            options,
+        )?
+    };
+
+    let encoded = STANDARD.encode(&bytes);
+    let scale = if coordinate_width == 0 {
+        1.0
+    } else {
+        width as f32 / coordinate_width as f32
+    };
+
+    Ok(ScreenshotCapture {
+        mime_type: options.format.mime_type().to_string(),
+        data_url: format!("data:{};base64,{encoded}", options.format.mime_type()),
+        source: raw.source,
+        width,
+        height,
+        coordinate_width,
+        coordinate_height,
+        scale,
+        resized: width != coordinate_width || height != coordinate_height,
+        bytes: bytes.len(),
+        original_bytes,
+        max_bytes: options.max_bytes,
+        format: options.format,
+        quality: (options.format == ScreenshotOutputFormat::Jpeg).then_some(options.quality),
+    })
+}
+
+async fn capture_with_gnome_shell() -> Result<RawScreenshotCapture> {
     let connection = zbus::Connection::session()
         .await
         .context("failed to connect to session bus")?;
@@ -86,7 +253,7 @@ async fn capture_with_gnome_shell() -> Result<ScreenshotCapture> {
     .await
 }
 
-async fn capture_with_portal() -> Result<ScreenshotCapture> {
+async fn capture_with_portal() -> Result<RawScreenshotCapture> {
     let connection = zbus::Connection::session()
         .await
         .context("failed to connect to session bus")?;
@@ -181,7 +348,7 @@ async fn read_png_as_capture(
     path: PathBuf,
     source: &str,
     cleanup: ScreenshotCleanup,
-) -> Result<ScreenshotCapture> {
+) -> Result<RawScreenshotCapture> {
     let result = read_png_as_capture_inner(&path, source);
     if let ScreenshotCleanup::DeletePath(path) = cleanup {
         let _ = fs::remove_file(path);
@@ -189,21 +356,124 @@ async fn read_png_as_capture(
     result
 }
 
-fn read_png_as_capture_inner(path: &Path, source: &str) -> Result<ScreenshotCapture> {
+fn read_png_as_capture_inner(path: &Path, source: &str) -> Result<RawScreenshotCapture> {
     let bytes = fs::read(path)
         .with_context(|| format!("failed to read screenshot file {}", path.display()))?;
     if bytes.is_empty() {
         bail!("screenshot file was empty: {}", path.display());
     }
     let (width, height) = png_dimensions(&bytes)?;
-    let encoded = STANDARD.encode(bytes);
-    Ok(ScreenshotCapture {
+    Ok(RawScreenshotCapture {
         mime_type: "image/png".to_string(),
-        data_url: format!("data:image/png;base64,{encoded}"),
+        bytes,
         source: source.to_string(),
         width,
         height,
     })
+}
+
+fn target_dimensions(
+    width: u32,
+    height: u32,
+    options: ResolvedScreenshotPayloadOptions,
+) -> (u32, u32) {
+    let width_scale = options.max_width as f64 / width as f64;
+    let height_scale = options.max_height as f64 / height as f64;
+    let scale = f64::from(options.scale)
+        .min(width_scale)
+        .min(height_scale)
+        .min(1.0);
+
+    let target_width = ((width as f64 * scale).round() as u32).clamp(1, width);
+    let target_height = ((height as f64 * scale).round() as u32).clamp(1, height);
+    (target_width, target_height)
+}
+
+fn encode_screenshot_to_fit_bytes(
+    raw: &[u8],
+    original_width: u32,
+    original_height: u32,
+    mut target_width: u32,
+    mut target_height: u32,
+    options: ResolvedScreenshotPayloadOptions,
+) -> Result<(Vec<u8>, u32, u32)> {
+    let img = image::load_from_memory_with_format(raw, image::ImageFormat::Png)
+        .context("failed to decode screenshot PNG for encoding")?;
+
+    loop {
+        let bytes = if options.format == ScreenshotOutputFormat::Png
+            && target_width == original_width
+            && target_height == original_height
+        {
+            raw.to_vec()
+        } else {
+            let output = if target_width == original_width && target_height == original_height {
+                img.clone()
+            } else {
+                img.resize_exact(target_width, target_height, FilterType::Lanczos3)
+            };
+            encode_image(&output, options)?
+        };
+
+        if bytes.len() <= options.max_bytes {
+            return Ok((bytes, target_width, target_height));
+        }
+
+        if target_width == 1 && target_height == 1 {
+            bail!(
+                "screenshot payload is {} bytes at 1x1, over max_bytes {}",
+                bytes.len(),
+                options.max_bytes
+            );
+        }
+
+        (target_width, target_height) = next_dimensions_for_byte_cap(
+            target_width,
+            target_height,
+            bytes.len(),
+            options.max_bytes,
+        );
+    }
+}
+
+fn encode_image(
+    img: &image::DynamicImage,
+    options: ResolvedScreenshotPayloadOptions,
+) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match options.format {
+        ScreenshotOutputFormat::Png => {
+            img.write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+                .context("failed to encode screenshot PNG")?;
+        }
+        ScreenshotOutputFormat::Jpeg => {
+            let rgb = img.to_rgb8();
+            JpegEncoder::new_with_quality(&mut out, options.quality)
+                .encode_image(&rgb)
+                .context("failed to encode screenshot JPEG")?;
+        }
+    }
+    Ok(out)
+}
+
+fn next_dimensions_for_byte_cap(
+    width: u32,
+    height: u32,
+    encoded_bytes: usize,
+    max_bytes: usize,
+) -> (u32, u32) {
+    let shrink = ((max_bytes as f64 / encoded_bytes as f64).sqrt() * 0.9).clamp(0.1, 0.95);
+    let mut next_width = ((width as f64 * shrink).floor() as u32).max(1);
+    let mut next_height = ((height as f64 * shrink).floor() as u32).max(1);
+
+    if next_width >= width && width > 1 {
+        next_width = width - 1;
+    }
+    if next_height >= height && height > 1 {
+        next_height = height - 1;
+    }
+
+    (next_width, next_height)
 }
 
 fn cleanup_gnome_requested_path(path: &Path) {
@@ -255,13 +525,13 @@ fn percent_decode(value: &str) -> String {
 
 fn temp_png_path(source: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
-        "codex-computer-use-{source}-{}.png",
+        "computer-use-linux-{source}-{}.png",
         unique_suffix()
     ))
 }
 
 fn request_token() -> String {
-    format!("codex_{}", unique_suffix().replace('-', "_"))
+    format!("computer_use_linux_{}", unique_suffix().replace('-', "_"))
 }
 
 fn unique_suffix() -> String {
@@ -277,7 +547,10 @@ mod tests {
     use super::*;
 
     fn test_path(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!("codex-screenshot-test-{name}-{}", unique_suffix()))
+        std::env::temp_dir().join(format!(
+            "computer-use-linux-screenshot-test-{name}-{}",
+            unique_suffix()
+        ))
     }
 
     fn valid_png(width: u32, height: u32) -> Vec<u8> {
@@ -291,6 +564,41 @@ mod tests {
         png
     }
 
+    fn solid_png(width: u32, height: u32) -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(width, height, image::Rgba([24, 96, 160, 255]));
+        encode_test_png(img)
+    }
+
+    fn noisy_png(width: u32, height: u32) -> Vec<u8> {
+        let mut img = image::RgbaImage::new(width, height);
+        for (x, y, pixel) in img.enumerate_pixels_mut() {
+            let r = ((x * 31 + y * 17) % 256) as u8;
+            let g = ((x * 13 + y * 47) % 256) as u8;
+            let b = ((x * 97 + y * 7) % 256) as u8;
+            *pixel = image::Rgba([r, g, b, 255]);
+        }
+        encode_test_png(img)
+    }
+
+    fn encode_test_png(img: image::RgbaImage) -> Vec<u8> {
+        let mut out = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut Cursor::new(&mut out), image::ImageFormat::Png)
+            .unwrap();
+        out
+    }
+
+    fn raw_capture(bytes: Vec<u8>) -> RawScreenshotCapture {
+        let (width, height) = png_dimensions(&bytes).unwrap();
+        RawScreenshotCapture {
+            mime_type: "image/png".to_string(),
+            bytes,
+            source: "test".to_string(),
+            width,
+            height,
+        }
+    }
+
     #[test]
     fn decodes_file_uri_percent_escapes() {
         assert_eq!(
@@ -302,7 +610,7 @@ mod tests {
     #[test]
     fn request_token_is_portal_safe() {
         let token = request_token();
-        assert!(token.starts_with("codex_"));
+        assert!(token.starts_with("computer_use_linux_"));
         assert!(token.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
     }
 
@@ -311,6 +619,92 @@ mod tests {
         let png = valid_png(3840, 1080);
 
         assert_eq!(png_dimensions(&png).unwrap(), (3840, 1080));
+    }
+
+    #[test]
+    fn default_payload_downscales_long_edge() {
+        let capture =
+            prepare_screenshot_payload(raw_capture(solid_png(4000, 1000)), Default::default())
+                .unwrap();
+
+        assert_eq!((capture.width, capture.height), (1920, 480));
+        assert_eq!(
+            (capture.coordinate_width, capture.coordinate_height),
+            (4000, 1000)
+        );
+        assert!(capture.resized);
+        assert!(capture.bytes <= DEFAULT_SCREENSHOT_MAX_BYTES);
+        assert!(capture.data_url.starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn larger_bounded_request_can_keep_more_detail() {
+        let capture = prepare_screenshot_payload(
+            raw_capture(solid_png(3000, 1000)),
+            ScreenshotPayloadOptions {
+                max_width: Some(3000),
+                max_height: Some(3000),
+                max_bytes: Some(DEFAULT_SCREENSHOT_MAX_BYTES),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!((capture.width, capture.height), (3000, 1000));
+        assert_eq!(
+            (capture.coordinate_width, capture.coordinate_height),
+            (3000, 1000)
+        );
+        assert!(!capture.resized);
+    }
+
+    #[test]
+    fn byte_cap_downscales_until_payload_fits() {
+        let capture = prepare_screenshot_payload(
+            raw_capture(noisy_png(512, 512)),
+            ScreenshotPayloadOptions {
+                max_width: Some(512),
+                max_height: Some(512),
+                max_bytes: Some(20_000),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(capture.bytes <= 20_000);
+        assert!(capture.width < 512);
+        assert_eq!(
+            (capture.coordinate_width, capture.coordinate_height),
+            (512, 512)
+        );
+        assert!(capture.resized);
+    }
+
+    #[test]
+    fn jpeg_format_compresses_when_requested() {
+        let capture = prepare_screenshot_payload(
+            raw_capture(noisy_png(512, 512)),
+            ScreenshotPayloadOptions {
+                max_width: Some(512),
+                max_height: Some(512),
+                max_bytes: Some(DEFAULT_SCREENSHOT_MAX_BYTES),
+                format: Some(ScreenshotOutputFormat::Jpeg),
+                quality: Some(60),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(capture.mime_type, "image/jpeg");
+        assert_eq!(capture.format, ScreenshotOutputFormat::Jpeg);
+        assert_eq!(capture.quality, Some(60));
+        assert_eq!((capture.width, capture.height), (512, 512));
+        assert_eq!(
+            (capture.coordinate_width, capture.coordinate_height),
+            (512, 512)
+        );
+        assert!(capture.bytes < capture.original_bytes);
+        assert!(capture.data_url.starts_with("data:image/jpeg;base64,"));
     }
 
     #[tokio::test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -463,24 +463,54 @@ impl ComputerUseLinux {
         )
     )]
     async fn click(&self, Parameters(mut params): Parameters<ClickParams>) -> Json<ActionOutput> {
-        let received = Some(serde_json::json!(params));
+        let received = Some(serde_json::json!(params.clone()));
         // Raise the target window first (if specified) so the click lands on the
         // intended app rather than whatever is stacked on top at that pixel.
-        if let Some(target) = params.window_target() {
-            let _ = focus_window_target(&target).await;
+        let window_target = params.window_target();
+        if params.relative == Some(true) && window_target.is_none() {
+            return Json(ActionOutput {
+                ok: false,
+                implemented: true,
+                action: "click".to_string(),
+                message: "Relative coordinate clicks require a window target.".to_string(),
+                received,
+            });
+        }
+        if let Some(target) = window_target {
+            let focus = match self.focus_target_for_input(&target).await {
+                Ok(focus) => focus,
+                Err(message) => {
+                    return Json(ActionOutput {
+                        ok: false,
+                        implemented: true,
+                        action: "click".to_string(),
+                        message,
+                        received,
+                    });
+                }
+            };
             tokio::time::sleep(std::time::Duration::from_millis(120)).await;
             // Window-relative coordinates: translate by the window's top-left so
             // the agent can click the pixel it saw in a window-cropped screenshot.
             if params.relative == Some(true) {
-                if let (Some(rx), Some(ry)) = (params.x, params.y) {
-                    if let Ok(windows) = list_windows().await {
-                        if let Ok(window) = resolve_window_target(&windows, &target) {
-                            if let Some(bounds) = &window.bounds {
-                                params.x = Some(bounds.x.unwrap_or(0) + rx);
-                                params.y = Some(bounds.y.unwrap_or(0) + ry);
-                            }
-                        }
-                    }
+                let Some(focus) = focus.as_ref() else {
+                    return Json(ActionOutput {
+                        ok: false,
+                        implemented: true,
+                        action: "click".to_string(),
+                        message: "Relative coordinate clicks require verified target-window focus."
+                            .to_string(),
+                        received,
+                    });
+                };
+                if let Err(message) = apply_window_relative_click_coordinates(&mut params, focus) {
+                    return Json(ActionOutput {
+                        ok: false,
+                        implemented: true,
+                        action: "click".to_string(),
+                        message,
+                        received,
+                    });
                 }
             }
         }
@@ -2368,6 +2398,36 @@ fn window_crop_rect(bounds: &crate::windowing::WindowBounds) -> Option<(i32, i32
     Some((x, y, bounds.width, bounds.height))
 }
 
+fn apply_window_relative_click_coordinates(
+    params: &mut ClickParams,
+    focus: &WindowFocusResult,
+) -> std::result::Result<(), String> {
+    let (relative_x, relative_y) = params
+        .x
+        .zip(params.y)
+        .ok_or_else(|| "Relative coordinate clicks require both x and y.".to_string())?;
+    let bounds = focus.requested_window.bounds.as_ref().ok_or_else(|| {
+        "Relative coordinate clicks require resolved target-window bounds.".to_string()
+    })?;
+    if bounds.width == 0 || bounds.height == 0 {
+        return Err(
+            "Relative coordinate clicks require non-empty target-window bounds.".to_string(),
+        );
+    }
+    let (origin_x, origin_y) = bounds.x.zip(bounds.y).ok_or_else(|| {
+        "Relative coordinate clicks require target-window bounds with an origin.".to_string()
+    })?;
+    let x = origin_x
+        .checked_add(relative_x)
+        .ok_or_else(|| "Relative click x coordinate overflowed.".to_string())?;
+    let y = origin_y
+        .checked_add(relative_y)
+        .ok_or_else(|| "Relative click y coordinate overflowed.".to_string())?;
+    params.x = Some(x);
+    params.y = Some(y);
+    Ok(())
+}
+
 /// Crop a PNG image to `(x, y, w, h)` (clamped to the image), returning the
 /// re-encoded PNG and the actual cropped dimensions.
 fn crop_png(
@@ -3003,6 +3063,88 @@ mod tests {
             backend: GNOME_SHELL_EXTENSION_BACKEND.to_string(),
             terminal: None,
         }
+    }
+
+    fn focus_result_with_bounds(bounds: Option<WindowBounds>) -> WindowFocusResult {
+        let mut requested_window = window_info(
+            42,
+            Some("Target"),
+            Some("target-app"),
+            Some("target-app"),
+            Some(4242),
+        );
+        requested_window.bounds = bounds;
+        let mut focused_window = requested_window.clone();
+        focused_window.focused = true;
+        WindowFocusResult {
+            requested_window,
+            focused_window: Some(focused_window),
+            exact_window_focused: true,
+            app_focused: true,
+            backend: GNOME_SHELL_EXTENSION_BACKEND.to_string(),
+            note: "test focus".to_string(),
+        }
+    }
+
+    #[test]
+    fn relative_click_coordinates_use_verified_window_bounds() {
+        let focus = focus_result_with_bounds(Some(WindowBounds {
+            x: Some(100),
+            y: Some(200),
+            width: 800,
+            height: 600,
+        }));
+        let mut params = ClickParams {
+            x: Some(7),
+            y: Some(9),
+            relative: Some(true),
+            ..Default::default()
+        };
+
+        apply_window_relative_click_coordinates(&mut params, &focus).unwrap();
+
+        assert_eq!((params.x, params.y), (Some(107), Some(209)));
+    }
+
+    #[test]
+    fn relative_click_coordinates_require_window_bounds_origin() {
+        let focus = focus_result_with_bounds(Some(WindowBounds {
+            x: None,
+            y: Some(200),
+            width: 800,
+            height: 600,
+        }));
+        let mut params = ClickParams {
+            x: Some(7),
+            y: Some(9),
+            relative: Some(true),
+            ..Default::default()
+        };
+
+        let error = apply_window_relative_click_coordinates(&mut params, &focus).unwrap_err();
+
+        assert!(error.contains("bounds with an origin"));
+        assert_eq!((params.x, params.y), (Some(7), Some(9)));
+    }
+
+    #[test]
+    fn relative_click_coordinates_require_xy() {
+        let focus = focus_result_with_bounds(Some(WindowBounds {
+            x: Some(100),
+            y: Some(200),
+            width: 800,
+            height: 600,
+        }));
+        let mut params = ClickParams {
+            x: Some(7),
+            relative: Some(true),
+            ..Default::default()
+        };
+
+        let error = apply_window_relative_click_coordinates(&mut params, &focus).unwrap_err();
+
+        assert!(error.contains("both x and y"));
+        assert_eq!((params.x, params.y), (Some(7), None));
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -11,7 +11,10 @@ use crate::remote_desktop::{
     type_text_with_keysyms, PointerButton, PortalKeyboardSession, PortalPointerSession,
     ScrollDirection,
 };
-use crate::screenshot::{capture_screenshot, ScreenshotCapture};
+use crate::screenshot::{
+    capture_screenshot_raw, prepare_screenshot_payload, RawScreenshotCapture, ScreenshotCapture,
+    ScreenshotOutputFormat, ScreenshotPayloadOptions,
+};
 use crate::windowing::registry;
 use crate::windows::{
     focus_window_target, focused_window, list_windows, resolve_window_target,
@@ -211,7 +214,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "get_app_state",
-        description = "Start an app use session if needed, then get screenshot and accessibility state for a Linux app.",
+        description = "Start an app use session if needed, then get a size-bounded screenshot and accessibility state for a Linux app. Screenshot results include coordinate_width, coordinate_height, scale, format, and quality when the returned image is downscaled or compressed; callers can request jpeg/quality for compression before resizing.",
         annotations(
             read_only_hint = true,
             destructive_hint = false,
@@ -229,11 +232,15 @@ impl ComputerUseLinux {
         let max_nodes = params.max_nodes.unwrap_or(120).clamp(1, 500);
         let max_depth = params.max_depth.unwrap_or(12).min(12);
         let include_screenshot = params.include_screenshot.unwrap_or(true);
+        let screenshot_options = params.screenshot_options();
         let app_filter = self
             .resolve_accessibility_app_filter(&params, window_context.as_ref())
             .await;
         let (screenshot, screenshot_error) = if include_screenshot {
-            match capture_screenshot().await {
+            match capture_screenshot_raw()
+                .await
+                .and_then(|raw| prepare_screenshot_payload(raw, screenshot_options))
+            {
                 Ok(capture) => (Some(capture), None),
                 Err(error) => (None, Some(error.to_string())),
             }
@@ -312,7 +319,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "screenshot",
-        description = "Capture the screen and return it as a viewable image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped to just that window, so you see the app on its own rather than the whole desktop. Returns the PNG image plus a short caption (dimensions, source, and crop bounds).",
+        description = "Capture the screen and return it as a viewable, size-bounded image. Optionally target a window (window_id/pid/wm_class/title/app_id): the window is raised to the front and the image is cropped before any resize. Returns the image plus a short caption with returned dimensions, coordinate dimensions, scale, format, quality, source, and crop bounds; callers can request jpeg/quality for compression before resizing.",
         annotations(
             read_only_hint = false,
             destructive_hint = false,
@@ -345,44 +352,63 @@ impl ComputerUseLinux {
             }
         }
 
-        let capture = capture_screenshot()
+        let raw_capture = capture_screenshot_raw()
             .await
             .map_err(|e| ErrorData::internal_error(format!("screenshot failed: {e}"), None))?;
-        let raw =
-            decode_data_url(&capture.data_url).map_err(|e| ErrorData::internal_error(e, None))?;
 
-        let (png, width, height, cropped) = match crop.as_ref().and_then(window_crop_rect) {
-            Some((x, y, w, h)) => match crop_png(&raw, x, y, w, h) {
-                Ok((bytes, cw, ch)) => (bytes, cw, ch, true),
+        let (capture, cropped) = match crop.as_ref().and_then(window_crop_rect) {
+            Some((x, y, w, h)) => match crop_png(&raw_capture.bytes, x, y, w, h) {
+                Ok((bytes, cw, ch)) => (
+                    RawScreenshotCapture {
+                        mime_type: raw_capture.mime_type.clone(),
+                        bytes,
+                        source: raw_capture.source.clone(),
+                        width: cw,
+                        height: ch,
+                    },
+                    true,
+                ),
                 // If cropping fails, fall back to the full frame rather than erroring.
-                Err(_) => (raw, capture.width, capture.height, false),
+                Err(_) => (raw_capture, false),
             },
-            None => (raw, capture.width, capture.height, false),
+            None => (raw_capture, false),
         };
+        let capture =
+            prepare_screenshot_payload(capture, params.screenshot_options()).map_err(|e| {
+                ErrorData::internal_error(format!("screenshot resize failed: {e}"), None)
+            })?;
 
-        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &png);
         let caption = serde_json::json!({
-            "width": width,
-            "height": height,
+            "width": capture.width,
+            "height": capture.height,
+            "coordinate_width": capture.coordinate_width,
+            "coordinate_height": capture.coordinate_height,
+            "scale": capture.scale,
+            "resized": capture.resized,
+            "bytes": capture.bytes,
+            "original_bytes": capture.original_bytes,
+            "max_bytes": capture.max_bytes,
+            "format": capture.format,
+            "quality": capture.quality,
             "source": capture.source,
             "cropped_to_window": cropped,
             "window_title": window_label,
         });
         Ok(CallToolResult::success(vec![
-            Content::image(b64, "image/png".to_string()),
+            Content::image(data_url_payload(&capture.data_url), capture.mime_type),
             Content::text(caption.to_string()),
         ]))
     }
 
     /// Lazily create the uinput absolute pointer, sizing its ABS range to the
     /// logical desktop (the portal screenshot dimensions). Returns `false` if it
-    /// can't be created or is disabled via `CODEX_COMPUTER_USE_DISABLE_ABS_POINTER`.
+    /// can't be created or is disabled via `CU_DISABLE_ABS_POINTER` (or the
+    /// Codex embedded-build alias).
     async fn ensure_abs_pointer(&self) -> bool {
-        if env::var("CODEX_COMPUTER_USE_DISABLE_ABS_POINTER")
-            .ok()
-            .as_deref()
-            == Some("1")
-        {
+        if env_flag_enabled_any(&[
+            "CU_DISABLE_ABS_POINTER",
+            "CODEX_COMPUTER_USE_DISABLE_ABS_POINTER",
+        ]) {
             return false;
         }
         if self
@@ -393,7 +419,7 @@ impl ComputerUseLinux {
         {
             return true;
         }
-        let Ok(cap) = crate::screenshot::capture_screenshot().await else {
+        let Ok(cap) = capture_screenshot_raw().await else {
             return false;
         };
         match crate::abs_pointer::AbsPointer::create(cap.width as i32, cap.height as i32) {
@@ -428,7 +454,7 @@ impl ComputerUseLinux {
 
     #[tool(
         name = "click",
-        description = "Click an element by index, semantic selector, or pixel coordinates from screenshot.",
+        description = "Click an element by index, semantic selector, or desktop coordinate pixels from screenshot metadata.",
         annotations(
             read_only_hint = false,
             destructive_hint = true,
@@ -436,8 +462,28 @@ impl ComputerUseLinux {
             open_world_hint = true
         )
     )]
-    async fn click(&self, Parameters(params): Parameters<ClickParams>) -> Json<ActionOutput> {
+    async fn click(&self, Parameters(mut params): Parameters<ClickParams>) -> Json<ActionOutput> {
         let received = Some(serde_json::json!(params));
+        // Raise the target window first (if specified) so the click lands on the
+        // intended app rather than whatever is stacked on top at that pixel.
+        if let Some(target) = params.window_target() {
+            let _ = focus_window_target(&target).await;
+            tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+            // Window-relative coordinates: translate by the window's top-left so
+            // the agent can click the pixel it saw in a window-cropped screenshot.
+            if params.relative == Some(true) {
+                if let (Some(rx), Some(ry)) = (params.x, params.y) {
+                    if let Ok(windows) = list_windows().await {
+                        if let Ok(window) = resolve_window_target(&windows, &target) {
+                            if let Some(bounds) = &window.bounds {
+                                params.x = Some(bounds.x.unwrap_or(0) + rx);
+                                params.y = Some(bounds.y.unwrap_or(0) + ry);
+                            }
+                        }
+                    }
+                }
+            }
+        }
         let target = match self.resolve_click_target(&params) {
             Ok(target) => target,
             Err(message) => {
@@ -992,8 +1038,12 @@ impl ComputerUseLinux {
 
 #[tool_handler(
     name = "codex-computer-use-linux",
-    version = "0.2.3-linux-alpha1",
-    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through registered Linux window backends when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, and send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available, and send layout-safe literal type_text through KDE clipboard integration on Plasma Wayland or through portal keysyms on other Wayland sessions before falling back to ydotool. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
+    // NOTE: keep in lockstep with Cargo.toml + package.json on every release.
+    // The rmcp tool_handler macro only accepts a string literal here, so this
+    // can't be env!("CARGO_PKG_VERSION"); the MCP safety check (CI) fails the
+    // build if it drifts from the Cargo version.
+    version = "0.2.5-linux-alpha1",
+    instructions = "Begin every turn that uses Computer Use by calling get_app_state. If diagnostics report disabled GNOME accessibility, call setup_accessibility before asking the user to retry. Use list_windows/focused_window before targeted keyboard input. If diagnostics report windowing.can_list_windows=false on GNOME, call setup_window_targeting to install the optional GNOME Shell extension backend, then ask the user to log out and back in if the setup report says a shell reload is required. This Linux backend can capture size-bounded screenshots through GNOME Shell or XDG Desktop Portal, read AT-SPI trees with action/value metadata, invoke native AT-SPI actions, set AT-SPI values or editable text, list/focus compositor windows through registered Linux window backends when the session permits it, attach best-effort terminal tty/process metadata to terminal windows, send coordinate or element-targeted click/scroll/drag input through the Wayland remote desktop portal when available, and send layout-safe literal type_text through KDE clipboard integration on Plasma Wayland or through portal keysyms on other Wayland sessions before falling back to ydotool. Screenshot results include width/height for the returned image plus coordinate_width/coordinate_height and scale for desktop coordinate conversion; request more detail with max_width, max_height, max_bytes, format=jpeg, quality, or a smaller target/crop instead of relying on unbounded screenshots. Tools with readOnlyHint=false may mutate local desktop or application state; hosts should require approval for actions that can submit, delete, send, purchase, or overwrite data. For element-targeted actions, prefer element_index from the latest get_app_state result; click, perform_action, and set_value can also use semantic role/name/text/states selectors when the target is unique. type_text and press_key accept optional window_id, pid, app_id, wm_class, title, tty, terminal_pid, terminal_command, or terminal_cwd selectors and refuse targeted input if focus cannot be verified."
 )]
 impl ServerHandler for ComputerUseLinux {}
 
@@ -1078,11 +1128,10 @@ struct ActivateWindowOutput {
     focus: Option<WindowFocusResult>,
     error: Option<String>,
     permissions_hint: Option<String>,
-    // Debug-only echo of the request. `serde_json::Value` serializes to a
-    // non-object schema (schemars emits the boolean schema `true`), which strict
-    // MCP clients reject in `outputSchema` — one invalid tool fails the whole
-    // `tools/list`. Keep it in the runtime response (serde) but omit it from the
-    // generated schema.
+    // Echo of the request for debugging. `serde_json::Value` has no fixed JSON
+    // schema, which strict MCP clients (Claude Code) reject in `outputSchema` —
+    // and one invalid tool fails the whole tool list. Keep it in the runtime
+    // response (serde) but omit it from the generated schema.
     #[schemars(skip)]
     received: Option<serde_json::Value>,
 }
@@ -1122,6 +1171,25 @@ struct GetAppStateParams {
     max_depth: Option<u32>,
     #[serde(default)]
     include_screenshot: Option<bool>,
+    /// Maximum returned screenshot width in pixels (default 1920, hard-capped).
+    #[serde(default)]
+    max_width: Option<u32>,
+    /// Maximum returned screenshot height in pixels (default 1920, hard-capped).
+    #[serde(default)]
+    max_height: Option<u32>,
+    /// Maximum returned screenshot image bytes before base64 (default 2 MiB, hard-capped).
+    #[serde(default)]
+    max_bytes: Option<usize>,
+    /// Additional downscale factor from 0.0 to 1.0, applied before max dimensions.
+    #[serde(default)]
+    scale: Option<f32>,
+    /// Output image format (default png). Use jpeg with quality to trade exact pixels for smaller payloads.
+    #[serde(default)]
+    format: Option<ScreenshotOutputFormat>,
+    /// JPEG quality from 1 to 95 (default 80). Ignored for png.
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 95))]
+    quality: Option<u8>,
 }
 
 impl GetAppStateParams {
@@ -1136,6 +1204,92 @@ impl GetAppStateParams {
             app_id: self.app_id.clone(),
             wm_class: self.wm_class.clone(),
             title: self.title.clone(),
+        }
+    }
+
+    fn screenshot_options(&self) -> ScreenshotPayloadOptions {
+        ScreenshotPayloadOptions {
+            max_width: self.max_width,
+            max_height: self.max_height,
+            max_bytes: self.max_bytes,
+            scale: self.scale,
+            format: self.format,
+            quality: self.quality,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
+struct ScreenshotParams {
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    /// Raise the targeted window before capture (default true). Ignored without
+    /// a window target.
+    #[serde(default)]
+    raise_window: Option<bool>,
+    /// Capture the whole desktop even when a window is targeted (default false).
+    #[serde(default)]
+    full_screen: Option<bool>,
+    /// Maximum returned screenshot width in pixels (default 1920, hard-capped).
+    #[serde(default)]
+    max_width: Option<u32>,
+    /// Maximum returned screenshot height in pixels (default 1920, hard-capped).
+    #[serde(default)]
+    max_height: Option<u32>,
+    /// Maximum returned screenshot image bytes before base64 (default 2 MiB, hard-capped).
+    #[serde(default)]
+    max_bytes: Option<usize>,
+    /// Additional downscale factor from 0.0 to 1.0, applied before max dimensions.
+    #[serde(default)]
+    scale: Option<f32>,
+    /// Output image format (default png). Use jpeg with quality to trade exact pixels for smaller payloads.
+    #[serde(default)]
+    format: Option<ScreenshotOutputFormat>,
+    /// JPEG quality from 1 to 95 (default 80). Ignored for png.
+    #[serde(default)]
+    #[schemars(range(min = 1, max = 95))]
+    quality: Option<u8>,
+}
+
+impl ScreenshotParams {
+    fn window_target(&self) -> Option<WindowTarget> {
+        if self.window_id.is_none()
+            && self.pid.is_none()
+            && self.app_id.is_none()
+            && self.wm_class.is_none()
+            && self.title.is_none()
+        {
+            return None;
+        }
+        Some(WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: None,
+            terminal_pid: None,
+            terminal_command: None,
+            terminal_cwd: None,
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.title.clone(),
+        })
+    }
+
+    fn screenshot_options(&self) -> ScreenshotPayloadOptions {
+        ScreenshotPayloadOptions {
+            max_width: self.max_width,
+            max_height: self.max_height,
+            max_bytes: self.max_bytes,
+            scale: self.scale,
+            format: self.format,
+            quality: self.quality,
         }
     }
 }
@@ -1176,9 +1330,50 @@ struct ClickParams {
     button: Option<String>,
     #[serde(default)]
     click_count: Option<u32>,
+    // Optional window target: when set, the window is raised/focused before the
+    // click so a coordinate click reliably lands on the intended app rather than
+    // whatever window happens to be stacked on top at that pixel.
+    #[serde(default)]
+    window_id: Option<u64>,
+    #[serde(default)]
+    pid: Option<u32>,
+    #[serde(default)]
+    app_id: Option<String>,
+    #[serde(default)]
+    wm_class: Option<String>,
+    #[serde(default)]
+    window_title: Option<String>,
+    /// Interpret `x`/`y` as relative to the targeted window's top-left corner
+    /// (the same coordinate space as a window-cropped `screenshot`). Requires a
+    /// window target; ignored otherwise.
+    #[serde(default)]
+    relative: Option<bool>,
 }
 
 impl ClickParams {
+    /// A window target if any window-identifying field was supplied.
+    fn window_target(&self) -> Option<WindowTarget> {
+        if self.window_id.is_none()
+            && self.pid.is_none()
+            && self.app_id.is_none()
+            && self.wm_class.is_none()
+            && self.window_title.is_none()
+        {
+            return None;
+        }
+        Some(WindowTarget {
+            window_id: self.window_id,
+            pid: self.pid,
+            tty: None,
+            terminal_pid: None,
+            terminal_command: None,
+            terminal_cwd: None,
+            app_id: self.app_id.clone(),
+            wm_class: self.wm_class.clone(),
+            title: self.window_title.clone(),
+        })
+    }
+
     fn selector(&self) -> ElementSelector<'_> {
         ElementSelector {
             role: self.role.as_deref(),
@@ -1351,11 +1546,9 @@ struct ActionOutput {
     implemented: bool,
     action: String,
     message: String,
-    // Debug-only echo of the request. `serde_json::Value` serializes to a
-    // non-object schema (schemars emits the boolean schema `true`), which strict
-    // MCP clients reject in `outputSchema` — one invalid tool fails the whole
-    // `tools/list`. Keep it in the runtime response (serde) but omit it from the
-    // generated schema.
+    // See ActivateWindowOutput: kept in the response, omitted from the schema
+    // because `serde_json::Value` produces a non-object schema strict MCP
+    // clients reject.
     #[schemars(skip)]
     received: Option<serde_json::Value>,
 }
@@ -1368,29 +1561,52 @@ impl ComputerUseLinux {
             .is_some_and(|value| value.eq_ignore_ascii_case("wayland"))
     }
 
+    // The Wayland remote-desktop portal is now a *fallback* for input: when a
+    // working `ydotoold` socket is present we prefer ydotool, because it injects
+    // input without a permission prompt. GNOME refuses to persist remote-desktop
+    // grants (`org.freedesktop.portal.Error: Remote desktop sessions cannot
+    // persist`), so the portal would otherwise re-prompt on every new session.
+    // `COMPUTER_USE_LINUX_FORCE_YDOTOOL_*=1` always uses ydotool;
+    // `COMPUTER_USE_LINUX_FORCE_PORTAL_*=1` always uses the portal. The
+    // `CODEX_COMPUTER_USE_*` names are accepted for the embedded Codex app
+    // bundle so downstream can share this source without local string patches.
     fn should_prefer_portal_pointer_backend(&self) -> bool {
-        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_POINTER")
-            .ok()
-            .as_deref()
-            != Some("1")
-            && self.is_wayland_session()
+        if env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_YDOTOOL_POINTER",
+            "CODEX_COMPUTER_USE_FORCE_YDOTOOL_POINTER",
+        ]) {
+            return false;
+        }
+        if env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_PORTAL_POINTER",
+            "CODEX_COMPUTER_USE_FORCE_PORTAL_POINTER",
+        ]) {
+            return self.is_wayland_session();
+        }
+        self.is_wayland_session() && ydotool_socket().is_none()
     }
 
     fn should_prefer_portal_keyboard_backend(&self) -> bool {
-        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
-            .ok()
-            .as_deref()
-            != Some("1")
-            && self.is_wayland_session()
-            && !self.is_kde_wayland_session()
+        if env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD",
+            "CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD",
+        ]) {
+            return false;
+        }
+        if env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_PORTAL_KEYBOARD",
+            "CODEX_COMPUTER_USE_FORCE_PORTAL_KEYBOARD",
+        ]) {
+            return self.is_wayland_session() && !self.is_kde_wayland_session();
+        }
+        self.is_wayland_session() && !self.is_kde_wayland_session() && ydotool_socket().is_none()
     }
 
     fn should_prefer_kde_clipboard_text_backend(&self) -> bool {
-        env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
-            .ok()
-            .as_deref()
-            != Some("1")
-            && self.is_kde_wayland_session()
+        !env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD",
+            "CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD",
+        ]) && self.is_kde_wayland_session()
     }
 
     fn is_kde_wayland_session(&self) -> bool {
@@ -1441,11 +1657,10 @@ impl ComputerUseLinux {
     }
 
     async fn ensure_portal_keyboard_session(&self) -> Result<Option<PortalKeyboardSession>> {
-        if env::var("CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD")
-            .ok()
-            .as_deref()
-            == Some("1")
-            || !self.is_wayland_session()
+        if env_flag_enabled_any(&[
+            "COMPUTER_USE_LINUX_FORCE_YDOTOOL_KEYBOARD",
+            "CODEX_COMPUTER_USE_FORCE_YDOTOOL_KEYBOARD",
+        ]) || !self.is_wayland_session()
         {
             return Ok(None);
         }
@@ -2124,58 +2339,22 @@ fn env_contains(key: &str, needle: &str) -> bool {
         .is_some_and(|value| value.to_ascii_lowercase().contains(needle))
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
-struct ScreenshotParams {
-    #[serde(default)]
-    window_id: Option<u64>,
-    #[serde(default)]
-    pid: Option<u32>,
-    #[serde(default)]
-    app_id: Option<String>,
-    #[serde(default)]
-    wm_class: Option<String>,
-    #[serde(default)]
-    title: Option<String>,
-    /// Raise the targeted window before capture (default true). Ignored without
-    /// a window target.
-    #[serde(default)]
-    raise_window: Option<bool>,
-    /// Capture the whole desktop even when a window is targeted (default false).
-    #[serde(default)]
-    full_screen: Option<bool>,
+/// True when an environment variable is set to `"1"` (an explicit on switch).
+fn env_flag_enabled(key: &str) -> bool {
+    env::var(key).ok().as_deref() == Some("1")
 }
 
-impl ScreenshotParams {
-    fn window_target(&self) -> Option<WindowTarget> {
-        if self.window_id.is_none()
-            && self.pid.is_none()
-            && self.app_id.is_none()
-            && self.wm_class.is_none()
-            && self.title.is_none()
-        {
-            return None;
-        }
-        Some(WindowTarget {
-            window_id: self.window_id,
-            pid: self.pid,
-            tty: None,
-            terminal_pid: None,
-            terminal_command: None,
-            terminal_cwd: None,
-            app_id: self.app_id.clone(),
-            wm_class: self.wm_class.clone(),
-            title: self.title.clone(),
-        })
-    }
+fn env_flag_enabled_any(keys: &[&str]) -> bool {
+    keys.iter().any(|key| env_flag_enabled(key))
 }
 
-/// Decode the base64 payload of a `data:` URL (or a bare base64 string) to bytes.
-fn decode_data_url(data_url: &str) -> std::result::Result<Vec<u8>, String> {
-    use base64::Engine;
-    let b64 = data_url.split_once(',').map(|(_, b)| b).unwrap_or(data_url);
-    base64::engine::general_purpose::STANDARD
-        .decode(b64)
-        .map_err(|e| format!("invalid screenshot base64: {e}"))
+/// Return the base64 payload of a `data:` URL (or the original string if bare).
+fn data_url_payload(data_url: &str) -> String {
+    data_url
+        .split_once(',')
+        .map(|(_, payload)| payload)
+        .unwrap_or(data_url)
+        .to_string()
 }
 
 /// Convert a window's bounds into a crop rectangle, if it has a usable origin
@@ -2447,9 +2626,9 @@ async fn run_kde_clipboard_paste_text(
         (Ok(_), Err(restore_error)) => Ok(format!(
             "Action pasted through KDE clipboard integration. Warning: previous KDE clipboard contents could not be restored: {restore_error}"
         )),
-        (Err(error), Err(restore_error)) => Err(KdeClipboardPasteError::after_portal_input(format!(
-            "{error}; previous KDE clipboard contents could not be restored: {restore_error}"
-        ))),
+        (Err(error), Err(restore_error)) => Err(KdeClipboardPasteError::after_portal_input(
+            format!("{error}; previous KDE clipboard contents could not be restored: {restore_error}"),
+        )),
     }
 }
 
@@ -2759,6 +2938,43 @@ mod tests {
             description: "Clicks the element".to_string(),
             keybinding: String::new(),
         }
+    }
+
+    fn solid_png(width: u32, height: u32) -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(width, height, image::Rgba([32, 128, 192, 255]));
+        let mut out = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut std::io::Cursor::new(&mut out), image::ImageFormat::Png)
+            .unwrap();
+        out
+    }
+
+    #[test]
+    fn window_crop_happens_before_screenshot_payload_resize() {
+        let (cropped, width, height) = crop_png(&solid_png(400, 200), 50, 20, 200, 100).unwrap();
+        let capture = prepare_screenshot_payload(
+            RawScreenshotCapture {
+                mime_type: "image/png".to_string(),
+                bytes: cropped,
+                source: "test".to_string(),
+                width,
+                height,
+            },
+            ScreenshotPayloadOptions {
+                max_width: Some(100),
+                max_height: Some(100),
+                max_bytes: Some(1024 * 1024),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            (capture.coordinate_width, capture.coordinate_height),
+            (200, 100)
+        );
+        assert_eq!((capture.width, capture.height), (100, 50));
+        assert!(capture.resized);
     }
 
     fn window_info(


### PR DESCRIPTION
## Summary
- sync embedded `codex-computer-use-linux` to the standalone `computer-use-linux` v0.2.5 screenshot payload behavior
- add bounded PNG/JPEG screenshot payload controls and coordinate metadata to `get_app_state` / `screenshot`
- opt JavaScript GitHub Actions into Node 24 runtime while keeping existing job Node 24 setup

Tracks agent-sh/computer-use-linux#19.

## Validation
- `cargo fmt --check -p codex-computer-use-linux`
- `cargo check -p codex-computer-use-linux --all-targets`
- `cargo test -p codex-computer-use-linux`
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `node --test linux-features/agent-workspace/test.js`
- `cargo build -p codex-computer-use-linux`
- `node /home/avifenesh/projects/computer-use-linux/scripts/zod-check/check.mjs --command target/debug/codex-computer-use-linux`
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `git diff --check`