### PR TITLE
Add persistent Electron launch flags config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ not download or extract the DMG themselves. See
 | `/tmp` is mounted `noexec` | Set `TMPDIR` and `XDG_CACHE_HOME` to executable directories under `$HOME` |
 | Blank window or splash stuck | Check `~/.cache/codex-desktop/launcher.log` and whether port `5175` is already in use |
 | `CODEX_CLI_PATH` or CLI install error | Reopen the app or install `@openai/codex` manually |
-| Wayland / GPU / Vulkan hang | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` |
+| Wayland / GPU / Vulkan hang | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` or persistent launch flags |
 | Computer Use UI is hidden | Enable the UI opt-in; account/server rollouts may still hide upstream-gated parts |
 | Computer Use has no input backend | Check `/dev/uinput`, portal support, or `ydotoold` / `ydotool.service` |
 | Updater seems stuck | Check `codex-update-manager status --json` and service logs |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@
 | `nix run` exits with no window or terminal output | Check `~/.cache/codex-desktop/launcher.log`; the Nix package still requires a user-provided `codex` CLI |
 | `gh auth status` works in terminal but fails inside Codex Desktop | See [GitHub CLI auth in app-launched shells](github-cli-auth.md) |
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log` |
-| GPU / Vulkan / Wayland errors | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` |
+| GPU / Vulkan / Wayland errors | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` or persistent launch flags below |
 | Window flickering | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh`, then `./codex-app/start.sh --disable-gpu` if needed |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
@@ -20,6 +20,29 @@
 | `ConnectTimeoutError` for Electron headers | Re-run `make build-app`; the installer uses `https://artifacts.electronjs.org/headers/dist` by default |
 | Computer Use AT-SPI tree empty | Run `codex-computer-use-linux setup`, then restart the target app |
 | `codex-update-manager` keeps running after package removal | Run `systemctl --user disable --now codex-update-manager.service` and confirm `/opt/codex-desktop` is gone |
+
+## Persistent Launch Flags
+
+The launcher creates `~/.config/codex-desktop/electron-flags.conf` on first
+cold start. Uncomment one flag per line; blank lines and lines starting with
+`#` are ignored. Existing files are never overwritten.
+
+For KDE/Wayland rendering issues, try:
+
+```text
+--ozone-platform=x11
+```
+
+For native Wayland IME setups, try:
+
+```text
+--wayland
+--enable-wayland-ime
+--wayland-text-input-version=1
+```
+
+Restart Codex Desktop after changing this file. Warm-start launches reuse the
+running Electron process and will not pick up new flags.
 
 ## `/tmp` Mounted `noexec`
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -27,6 +27,7 @@ LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID"
 LOG_FILE="$LOG_DIR/launcher.log"
 APP_CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/$CODEX_LINUX_APP_ID"
 APP_SETTINGS_FILE="$APP_CONFIG_DIR/settings.json"
+USER_ELECTRON_FLAGS_FILE="$APP_CONFIG_DIR/electron-flags.conf"
 CODEX_LINUX_SETTINGS_FILE="$APP_SETTINGS_FILE"
 CODEX_LINUX_FEATURES_DIR="$SCRIPT_DIR/.codex-linux/features"
 export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR
@@ -228,6 +229,7 @@ Options:
 
 Default launch keeps Electron GPU enabled and lets Electron choose the platform.
 Extra flags are passed directly to Electron.
+Persistent launch flags: $USER_ELECTRON_FLAGS_FILE
 
 Environment:
   CODEX_LINUX_RENDERING_MODE=auto|default|wslg|wayland-gpu
@@ -1949,6 +1951,80 @@ scan_electron_rendering_arg() {
     esac
 }
 
+write_user_electron_flags_template() {
+    cat > "$USER_ELECTRON_FLAGS_FILE" <<'EOF'
+# Codex Desktop Linux launch flags.
+# Uncomment one flag per line. Existing files are never overwritten.
+# Lines starting with # and blank lines are ignored.
+# Shell syntax, quotes, variables, and inline comments are not evaluated.
+#
+# X11 / Wayland:
+# --x11
+# --wayland
+# --ozone-platform=x11
+# --ozone-platform=wayland
+# --ozone-platform-hint=auto
+#
+# Wayland / IME:
+# --enable-wayland-ime
+# --wayland-text-input-version=1
+#
+# GPU / rendering:
+# --safe-mode
+# --disable-gpu
+# --enable-gpu
+# --disable-gpu-compositing
+# --use-gl=angle
+# --use-gl=desktop
+# --use-angle=gl
+# --disable-features=Vulkan
+#
+# Accessibility:
+# --force-renderer-accessibility
+#
+# Wayland decorations:
+# --enable-features=WaylandWindowDecorations
+EOF
+}
+
+ensure_user_electron_flags_file() {
+    [ -n "${USER_ELECTRON_FLAGS_FILE:-}" ] || return 0
+    if [ -e "$USER_ELECTRON_FLAGS_FILE" ] || [ -L "$USER_ELECTRON_FLAGS_FILE" ]; then
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$USER_ELECTRON_FLAGS_FILE")"
+    if write_user_electron_flags_template; then
+        echo "Created persistent Electron flags template: $USER_ELECTRON_FLAGS_FILE"
+    else
+        echo "Could not create persistent Electron flags template: $USER_ELECTRON_FLAGS_FILE"
+        rm -f "$USER_ELECTRON_FLAGS_FILE" 2>/dev/null || true
+    fi
+}
+
+load_user_electron_flags() {
+    USER_ELECTRON_FLAGS=()
+    [ -n "${USER_ELECTRON_FLAGS_FILE:-}" ] || return 0
+    [ -f "$USER_ELECTRON_FLAGS_FILE" ] || return 0
+
+    local line
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+            ""|\#*) continue ;;
+            --)
+                echo "Ignoring unsupported separator in Electron flags file: $USER_ELECTRON_FLAGS_FILE"
+                continue
+                ;;
+        esac
+        USER_ELECTRON_FLAGS+=("$line")
+    done < "$USER_ELECTRON_FLAGS_FILE"
+
+    if [ "${#USER_ELECTRON_FLAGS[@]}" -gt 0 ]; then
+        echo "Loaded ${#USER_ELECTRON_FLAGS[@]} persistent Electron flag(s): $USER_ELECTRON_FLAGS_FILE"
+    fi
+}
+
 apply_electron_rendering_profile() {
     local requested_mode
     requested_mode="$(normalize_linux_rendering_mode)"
@@ -2242,7 +2318,9 @@ launch_electron() {
     cd "$SCRIPT_DIR"
     log_phase "electron_launch"
 
-    set_electron_defaults "$@"
+    ensure_user_electron_flags_file
+    load_user_electron_flags
+    set_electron_defaults "${USER_ELECTRON_FLAGS[@]}" "$@"
     build_electron_launch_args
 
     if [ "$WARM_START" -eq 1 ]; then

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2224,7 +2224,8 @@ set_electron_defaults() {
     apply_electron_rendering_profile
 }
 
-append_feature_electron_args() {
+load_feature_electron_args() {
+    FEATURE_ELECTRON_ARGS=()
     [ -n "${FEATURE_ELECTRON_ARGS_DIR:-}" ] || return 0
     [ -d "$FEATURE_ELECTRON_ARGS_DIR" ] || return 0
 
@@ -2238,7 +2239,7 @@ append_feature_electron_args() {
             case "$line" in
                 ""|\#*) continue ;;
             esac
-            ELECTRON_LAUNCH_ARGS+=("$line")
+            FEATURE_ELECTRON_ARGS+=("$line")
         done < "$args_file"
     done
 }
@@ -2286,7 +2287,6 @@ build_electron_launch_args() {
         ELECTRON_LAUNCH_ARGS+=(--enable-features=WaylandWindowDecorations)
     fi
 
-    append_feature_electron_args
 }
 
 configure_side_by_side_app_env() {
@@ -2319,8 +2319,9 @@ launch_electron() {
     log_phase "electron_launch"
 
     ensure_user_electron_flags_file
+    load_feature_electron_args
     load_user_electron_flags
-    set_electron_defaults "${USER_ELECTRON_FLAGS[@]}" "$@"
+    set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
     build_electron_launch_args
 
     if [ "$WARM_START" -eq 1 ]; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2208,6 +2208,10 @@ SCRIPT
     assert_contains "$launcher_stderr" "CODEX_WEBVIEW_PORT must be between 1 and 65535"
     assert_not_contains "$launcher_stderr" "integer expected"
 
+    XDG_CONFIG_HOME="$workspace/help-config" bash "$start_script" --help >"$launcher_stdout" 2>"$launcher_stderr"
+    assert_contains "$launcher_stdout" "electron-flags.conf"
+    assert_file_not_exists "$workspace/help-config/codex-desktop/electron-flags.conf"
+
     cat > "$launcher_probe_script" <<'SCRIPT'
 #!/bin/bash
 set -euo pipefail
@@ -2875,6 +2879,9 @@ set -Eeuo pipefail
 
 CODEX_LINUX_APP_ID="${CODEX_LINUX_APP_ID:-codex-desktop}"
 APP_STATE_DIR="${APP_STATE_DIR:-/tmp/codex-launcher-probe-state}"
+APP_CONFIG_DIR="${APP_CONFIG_DIR:-/tmp/codex-launcher-probe-config.$$}"
+USER_ELECTRON_FLAGS_FILE="${USER_ELECTRON_FLAGS_FILE:-$APP_CONFIG_DIR/electron-flags.conf}"
+FEATURE_ELECTRON_ARGS_DIR="${FEATURE_ELECTRON_ARGS_DIR:-}"
 
 print_state() {
     printf 'mode=%s wslg=%s ozone_platform=%s ozone_hint=%s gpu=%s gpu_arg=%s comp=%s gl_added=%s renderer_accessibility=%s launch=' \
@@ -2900,9 +2907,13 @@ print_state() {
 case "${1:-}" in
     probe)
         shift
-        set_electron_defaults "$@"
+        load_user_electron_flags
+        set_electron_defaults "${USER_ELECTRON_FLAGS[@]}" "$@"
         build_electron_launch_args
         print_state
+        ;;
+    ensure-template)
+        ensure_user_electron_flags_file
         ;;
     *)
         echo "Usage: $0 probe [launcher args...]" >&2
@@ -2924,6 +2935,35 @@ PY
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --ozone-platform=x11)"
     [[ "$output" == *"electron=<--ozone-platform=x11>"* ]] || fail "pass-through ozone platform must reach Electron: $output"
     [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "launcher must not add ozone hint when pass-through supplies an ozone platform: $output"
+
+    local user_flags_dir="$TMP_DIR/user-electron-flags"
+    local user_flags_file="$user_flags_dir/electron-flags.conf"
+    mkdir -p "$user_flags_dir"
+    printf '%s\n' \
+        '# --disable-gpu' \
+        '' \
+        '--ozone-platform=x11' \
+        '--enable-wayland-ime' \
+        '--use-gl=angle' > "$user_flags_file"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$user_flags_dir" USER_ELECTRON_FLAGS_FILE="$user_flags_file" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"<--ozone-platform=x11>"* ]] || fail "persistent flags file must set the Electron ozone platform: $output"
+    [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "persistent ozone platform must suppress the default ozone hint: $output"
+    [[ "$output" == *"electron=<--enable-wayland-ime><--use-gl=angle>"* ]] || fail "persistent flags file must pass non-launcher Electron args in order: $output"
+    [[ "$output" != *"<--disable-gpu>"* ]] || fail "commented persistent flags must be ignored: $output"
+
+    output="$(env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$user_flags_dir" USER_ELECTRON_FLAGS_FILE="$user_flags_file" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --use-gl=desktop)"
+    [[ "$output" == *"electron=<--enable-wayland-ime><--use-gl=angle><--use-gl=desktop>"* ]] || fail "explicit CLI Electron args must follow persistent file args: $output"
+
+    local template_dir="$TMP_DIR/user-electron-template"
+    local template_file="$template_dir/electron-flags.conf"
+    env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$template_dir" USER_ELECTRON_FLAGS_FILE="$template_file" "$launcher_probe" ensure-template >/dev/null
+    assert_file_exists "$template_file"
+    assert_contains "$template_file" "--x11"
+    assert_contains "$template_file" "--enable-wayland-ime"
+    printf '%s\n' '--wayland' > "$template_file"
+    env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$template_dir" USER_ELECTRON_FLAGS_FILE="$template_file" "$launcher_probe" ensure-template >/dev/null
+    [ "$(cat "$template_file")" = "--wayland" ] || fail "persistent flags template must not overwrite an existing file"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe)"
     [[ "$output" == *"mode=wayland-gpu"* && "$output" == *"ozone_platform=wayland"* && "$output" == *"gpu=1"* ]] || fail "wayland-gpu profile must force native Wayland with GPU enabled: $output"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2907,8 +2907,9 @@ print_state() {
 case "${1:-}" in
     probe)
         shift
+        load_feature_electron_args
         load_user_electron_flags
-        set_electron_defaults "${USER_ELECTRON_FLAGS[@]}" "$@"
+        set_electron_defaults "${FEATURE_ELECTRON_ARGS[@]}" "${USER_ELECTRON_FLAGS[@]}" "$@"
         build_electron_launch_args
         print_state
         ;;
@@ -2954,6 +2955,14 @@ PY
 
     output="$(env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$user_flags_dir" USER_ELECTRON_FLAGS_FILE="$user_flags_file" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe -- --use-gl=desktop)"
     [[ "$output" == *"electron=<--enable-wayland-ime><--use-gl=angle><--use-gl=desktop>"* ]] || fail "explicit CLI Electron args must follow persistent file args: $output"
+
+    local feature_args_dir="$TMP_DIR/feature-electron-args"
+    mkdir -p "$feature_args_dir"
+    printf '%s\n' '--ozone-platform=wayland' '--use-angle=gl' > "$feature_args_dir/feature"
+    output="$(env -i PATH="$PATH" HOME="$HOME" APP_CONFIG_DIR="$user_flags_dir" USER_ELECTRON_FLAGS_FILE="$user_flags_file" FEATURE_ELECTRON_ARGS_DIR="$feature_args_dir" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"<--ozone-platform=x11>"* ]] || fail "persistent flags file must override feature Electron platform args: $output"
+    [[ "$output" != *"<--ozone-platform=wayland>"* ]] || fail "feature Electron platform args must not survive after user override: $output"
+    [[ "$output" == *"electron=<--use-angle=gl><--enable-wayland-ime><--use-gl=angle>"* ]] || fail "feature, user, and CLI-independent Electron args must keep precedence order: $output"
 
     local template_dir="$TMP_DIR/user-electron-template"
     local template_file="$template_dir/electron-flags.conf"


### PR DESCRIPTION
## Summary
- add an app-scoped electron-flags.conf template under the user's XDG config directory
- load persistent launch flags before explicit CLI args so desktop-entry launches can keep Wayland/IME/GPU workarounds
- document the flags file in troubleshooting and cover creation/ordering behavior in smoke tests

Addresses #425.

## Tests
- bash -n launcher/start.sh.template
- bash -n tests/scripts_smoke.sh
- bash tests/scripts_smoke.sh
- git diff --check