### PR TITLE
Fix Linux About dialog icon handling

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -64,6 +64,7 @@ const {
 } = require("./patches/launch-actions.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxAboutDialogPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
@@ -171,6 +172,7 @@ module.exports = {
   applyLinuxDesktopSettingsIndexPatch,
   applyLinuxDesktopSettingsSectionsPatch,
   applyLinuxDesktopSettingsSharedPatch,
+  applyLinuxAboutDialogPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -27,6 +27,7 @@ const {
   applyLinuxChromePluginAutoInstallPatch,
   applyLinuxAppUpdaterBridgePatch,
   applyLinuxAppUpdaterMenuPatch,
+  applyLinuxAboutDialogPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,
@@ -557,6 +558,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-explicit-tray-quit",
     "linux-explicit-ipc-quit",
     "linux-window-options",
+    "linux-about-dialog",
     "linux-native-titlebar",
     "linux-menu",
     "linux-multi-instance-bootstrap-lock",
@@ -1707,6 +1709,28 @@ test("adds Linux build information to the app Help menu", () => {
     patched,
     /\{role:`help`,id:e\.bn\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],\{label:`Codex Documentation`/,
   );
+});
+
+test("makes About dialog prefer the bundled Linux icon asset", () => {
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const source = [
+    "let a=require(`electron`),r={T:()=>null,V:()=>({formatMessage:({defaultMessage:e})=>e})},t={dt:()=>null,Kr:()=>null};",
+    "var $X=`codex.aboutDialog.title`,eZ=`About {appName}`,tZ=`codex.aboutDialog.ok`,nZ=`codex.aboutDialog.versionLine`,rZ=`Version {version}`,iZ=`codex.aboutDialog.versionLineWithDate`,aZ=`Version {version} • Released {releaseDate}`,oZ=`codex.aboutDialog.buildInfoLabel`,sZ=`Build information`,cZ=380,lZ=360,uZ=72,pZ=null;",
+    "async function bZ(){let e=process.platform===`darwin`,t=e?r.T():process.execPath,[n,i]=await Promise.all([e?Fw(t):null,a.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`})]);return{htmlIconDataUrl:n??(i.isEmpty()?null:i.resize({width:uZ,height:uZ,quality:`best`}).toDataURL()),windowIcon:i}}",
+    "let d={windowIcon:null},q={...d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}};",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAboutDialogPatch, source, iconPathExpression);
+
+  assert.match(
+    patched,
+    new RegExp(`nativeImage\\.createFromPath\\(${escapeRegExp(iconPathExpression)}\\)`),
+  );
+  assert.match(patched, /process\.platform===`linux`\?null:e\?Fw\(t\):null/);
+  assert.match(patched, /windowIcon==null\|\|d\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:d\.windowIcon\}/);
+  assert.match(patched, /i==null\|\|i\.isEmpty\(\)\?null:i\.resize\(/);
+  assert.match(patched, /windowIcon:i\?\?null/);
+  assert.doesNotThrow(() => new Function(patched));
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const {
+  applyLinuxAboutDialogPatch,
   applyLinuxWindowOptionsPatch,
   applyLinuxNativeTitlebarPatch,
   applyLinuxMenuPatch,
@@ -16,6 +17,13 @@ const {
 const { applyLinuxAvatarOverlayMousePassthroughPatch } = require("../../../../avatar-overlay.js");
 
 module.exports = [
+  {
+    id: "linux-about-dialog",
+    phase: "main-bundle",
+    order: 55,
+    ciPolicy: "optional",
+    apply: (source, context) => applyLinuxAboutDialogPatch(source, context.iconPathExpression),
+  },
   {
     id: "linux-window-options",
     phase: "main-bundle",

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -357,6 +357,58 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {
+  if (!currentSource.includes("codex.aboutDialog.title")) {
+    return currentSource;
+  }
+
+  const alreadyUsesBundledIcon =
+    iconPathExpression != null &&
+    currentSource.includes(`nativeImage.createFromPath(${iconPathExpression})`);
+  const alreadyNullSafe =
+    currentSource.includes("windowIcon==null||d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}") &&
+    currentSource.includes("i==null||i.isEmpty()?null:i.resize(");
+  if (alreadyUsesBundledIcon && alreadyNullSafe) {
+    return currentSource;
+  }
+
+  let patchedSource = currentSource;
+  if (iconPathExpression != null) {
+    const aboutIconPromiseRegex =
+      /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\]/;
+    patchedSource = patchedSource.replace(
+      aboutIconPromiseRegex,
+      `[
+process.platform===\`linux\`?null:$1?$2($3):null,
+process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4.app.getFileIcon($5,{size:process.platform===\`win32\`?\`large\`:\`normal\`}).catch(()=>null)
+]`,
+    );
+  } else {
+    const patchedGetFileIconRegex =
+      /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\.catch\(\(\)=>null\)/;
+    if (!patchedGetFileIconRegex.test(patchedSource)) {
+      const getFileIconRegex =
+        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)/;
+      patchedSource = patchedSource.replace(
+        getFileIconRegex,
+        "$1.app.getFileIcon($2,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
+      );
+    }
+  }
+
+  patchedSource = patchedSource
+    .replace("i.isEmpty()?null:i.resize(", "i==null||i.isEmpty()?null:i.resize(")
+    .replace("windowIcon:i}", "windowIcon:i??null}")
+    .replace("windowIcon.isEmpty()?{}:{icon:d.windowIcon}", "windowIcon==null||d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}");
+
+  if (patchedSource !== currentSource) {
+    return patchedSource;
+  }
+
+  console.warn("WARN: Could not patch About dialog icon fallback for Linux");
+  return currentSource;
+}
+
 function findNamedFunctionBody(source, functionName) {
   const functionMatch = source.match(
     new RegExp(`(?:async\\s+)?function\\s+${escapeRegExp(functionName)}\\([^)]*\\)\\{`),
@@ -1159,6 +1211,7 @@ function applyLinuxRemoteControlConfigPreservationPatch(currentSource) {
 
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxAboutDialogPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
   applyLinuxExplicitQuitPromptBypassPatch,


### PR DESCRIPTION
## What changed

On Linux the About dialog showed no icon, or could crash with an uncaught promise rejection. This PR wires up a proper bundled icon path for Linux and adds null-safety guards on the icon return values so the dialog renders correctly regardless of which code path is taken.

## Why it changed

The upstream About-dialog helper (`bZ` in the minified main bundle) unconditionally calls `app.getFileIcon` and then calls `.isEmpty()` on the result without guarding against `null`. On Linux:

1. `app.getFileIcon` can reject on some desktop environments, leaving the icon promise unresolved or throwing.
2. The `windowIcon` field propagated downstream without a null check, so `d.windowIcon.isEmpty()` threw when the icon was `null`.
3. No bundled Linux asset was ever supplied to the dialog — the function only tried macOS thumbnail (`Fw`) or the system file-icon API, both of which are no-ops or failures on Linux.

The patch (`applyLinuxAboutDialogPatch`) addresses all three:
- On Linux it short-circuits the macOS-only `Fw` call to `null`.
- It replaces the `app.getFileIcon` call with `nativeImage.createFromPath(iconPathExpression)` pointing at the bundled `content/webview/assets/app-test.png` asset, wrapped in an IIFE that returns `null` on an empty image instead of propagating an empty `NativeImage`.
- It guards `i.isEmpty()` → `i==null||i.isEmpty()` and `d.windowIcon.isEmpty()` → `d.windowIcon==null||d.windowIcon.isEmpty()` and `windowIcon:i}` → `windowIcon:i??null}` throughout the downstream spread.
- `getFileIcon` on non-Linux paths gets `.catch(()=>null)` so a rejection no longer propagates.

The patch is `ciPolicy: "optional"` (fail-soft): if the minified bundle changes shape the dialog silently falls back to its previous behavior rather than breaking startup.

## Source-of-truth files changed

- `scripts/patches/main-process.js` — new `applyLinuxAboutDialogPatch` function
- `scripts/patches/core/all-linux/main-process/window-shell/patch.js` — registers the patch descriptor (`id: "linux-about-dialog"`, phase `main-bundle`, order 55)
- `scripts/patch-linux-window-ui.js` — imports and re-exports `applyLinuxAboutDialogPatch`
- `scripts/patch-linux-window-ui.test.js` — adds the patch to the uniqueness registry test and adds a focused unit test covering the icon-path substitution, null-safe guards, and idempotency

## Validation

```
node scripts/patch-linux-window-ui.test.js
```

All tests pass, including the new `"makes About dialog prefer the bundled Linux icon asset"` case. The test covers:
- `nativeImage.createFromPath(...)` substitution present in patched output
- `process.platform===\`linux\`?null:...` short-circuit for the macOS thumbnail call
- `windowIcon==null||d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}` null guard
- `i==null||i.isEmpty()?null:i.resize(` null guard
- `windowIcon:i??null` coalescing
- Idempotency (patch applied twice produces identical output)
- Output is valid JavaScript (`new Function(patched)` does not throw)

## Limitations / follow-up

- The icon asset path (`content/webview/assets/app-test.png`) is resolved at patch time from `context.iconPathExpression`; if the upstream DMG renames the asset this patch will silently fall back. A follow-up could add a CI assertion that the asset path resolves.
- Patch is `optional` policy; if the minified signature drifts significantly only the null-safety guards (string-replace based) will still apply.