### PR TITLE
DMG 26.602.71036 Patch Drifts

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -788,7 +788,7 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
   const mutationRegex =
     /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.mutate\(\{hostId:\2\},\{onSuccess:\(\{state:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)\}\}\)\}/u;
   const localVersionRegex =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\((\d+)\),\{connection:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onEdit:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*),onLogoutConnection:([A-Za-z_$][\w$]*),onRemove:([A-Za-z_$][\w$]*),onShowDetails:([A-Za-z_$][\w$]*),onToggleConnection:([A-Za-z_$][\w$]*)\}=\2,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\6\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\((\d+)\),\{connection:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),([\s\S]*?)onAuthenticate:([A-Za-z_$][\w$]*),([\s\S]*?)onInstallCodex:([A-Za-z_$][\w$]*),([\s\S]*?)\}=\2,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\6\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
 
   const actionBuilderMatch = source.match(actionBuilderRegex);
   const actionCallMatch = source.match(actionCallRegex);
@@ -814,13 +814,11 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
     rowConnectionVar,
     rowDisabledVar,
     rowInstallPendingVar,
+    rowBetweenPendingAndAuth,
     rowAuthenticateVar,
-    rowEditVar,
+    rowBetweenAuthAndInstall,
     rowInstallVar,
-    rowLogoutVar,
-    rowRemoveVar,
-    rowShowDetailsVar,
-    rowToggleVar,
+    rowTrailingProps,
     rowFormatVar,
     rowFormatFn,
     rowAppServerVersionVar,
@@ -833,9 +831,8 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
   const localVersionReplacement =
     `function ${rowComponentFn}(${rowPropsVar}){let ${rowCacheVar}=(0,${rowCompilerVar}.c)(${rowCacheSize}),` +
     `{connection:${rowConnectionVar},disabled:${rowDisabledVar},installCodexPending:${rowInstallPendingVar},` +
-    `onAuthenticate:${rowAuthenticateVar},onEdit:${rowEditVar},onInstallCodex:${rowInstallVar},` +
-    `onLogoutConnection:${rowLogoutVar},onRemove:${rowRemoveVar},onShowDetails:${rowShowDetailsVar},` +
-    `onToggleConnection:${rowToggleVar}}=${rowPropsVar},${rowFormatVar}=${rowFormatFn}(),` +
+    `${rowBetweenPendingAndAuth}onAuthenticate:${rowAuthenticateVar},${rowBetweenAuthAndInstall}` +
+    `onInstallCodex:${rowInstallVar},${rowTrailingProps}}=${rowPropsVar},${rowFormatVar}=${rowFormatFn}(),` +
     `{appServerVersion:${rowAppServerVersionVar},error:${rowErrorVar},installedCodexVersion:${rowInstalledVersionVar},state:${rowStateVar}}=${rowConnectionStateFn}(${rowConnectionVar}.hostId),` +
     `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${rowConnectionStateFn}(\`local\`);` +
     `codexLinuxRemoteControlSshInstallDefaultRelease=codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??codexLinuxRemoteControlSshInstallDefaultRelease;` +
@@ -1060,10 +1057,12 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
   let patched = source;
 
   if (!patched.includes(REMOTE_MOBILE_THREAD_RUNTIME_MARKER)) {
-    const runtimeNeedle = "e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)";
     const runtimeReplacement =
-      `/*${REMOTE_MOBILE_THREAD_RUNTIME_MARKER}*/(e.resumeState===\`needs_resume\`||h?.type===\`active\`||h?.type===\`idle\`)&&(e.threadRuntimeStatus=h)`;
-    if (patched.includes(runtimeNeedle)) {
+      (_needle, conversationVar, runtimeVar) =>
+        `/*${REMOTE_MOBILE_THREAD_RUNTIME_MARKER}*/(${conversationVar}.resumeState===\`needs_resume\`||${runtimeVar}?.type===\`active\`||${runtimeVar}?.type===\`idle\`)&&(${conversationVar}.threadRuntimeStatus=${runtimeVar})`;
+    const runtimeNeedle =
+      /([A-Za-z_$][\w$]*)\.resumeState===`needs_resume`&&\(\1\.threadRuntimeStatus=([A-Za-z_$][\w$]*)\)/u;
+    if (runtimeNeedle.test(patched)) {
       patched = patched.replace(runtimeNeedle, runtimeReplacement);
     } else if (patched.includes("threadRuntimeStatus") && patched.includes("resumeState")) {
       console.warn("WARN: Could not find thread/list runtime-status needle - skipping remote mobile runtime-status patch");
@@ -1075,10 +1074,11 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
   // Re-implement hydrate-on-turn/started + queue-while-hydrating without the deleted routes.
   if (!patched.includes(REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER)) {
     const unknownTurnNeedle =
-      "if(!this.conversations.get(r)){z.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}";
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{z\.error\(`Received turn\/started for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
     const unknownTurnReplacement =
-      `if(!this.conversations.get(r)){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let i=this.codexLinuxRemoteMobilePendingNotifications??=new Map,a=i.get(r);a||(a=[],i.set(r,a)),a.push(n),z.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:r,queuedNotificationCount:a.length},sensitive:{}});let o=(s=0)=>this.readThread(r,{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(r)??[];if(!t){if(s<12){z.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:r,queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r),z.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:r,queuedNotificationCount:c.length},sensitive:{}});return}this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(r);for(let e of c)this.onNotification(e.method,e.params)}).catch(e=>{if(s<12){z.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:r,attempt:s+1},sensitive:{error:e}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(r),z.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:r},sensitive:{error:e}})});o();break}`;
-    if (patched.includes(unknownTurnNeedle)) {
+      (_needle, conversationIdVar) =>
+        `if(!this.conversations.get(${conversationIdVar})){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let i=this.codexLinuxRemoteMobilePendingNotifications??=new Map,a=i.get(${conversationIdVar});a||(a=[],i.set(${conversationIdVar},a)),a.push(n),z.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:a.length},sensitive:{}});let o=(s=0)=>this.readThread(${conversationIdVar},{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar})??[];if(!t){if(s<12){z.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),z.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length},sensitive:{}});return}this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar});for(let e of c)this.onNotification(e.method,e.params)}).catch(e=>{if(s<12){z.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:${conversationIdVar},attempt:s+1},sensitive:{error:e}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),z.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:${conversationIdVar}},sensitive:{error:e}})});o();break}`;
+    if (unknownTurnNeedle.test(patched)) {
       patched = patched.replace(unknownTurnNeedle, unknownTurnReplacement);
     } else if (patched.includes("Received turn/started for unknown conversation")) {
       console.warn("WARN: Could not find unknown turn/started needle - skipping remote mobile hydration patch");
@@ -1105,10 +1105,11 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
     }
 
     const turnCompletedNeedle =
-      "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}";
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{z\.error\(`Received turn\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
     const turnCompletedReplacement =
-      "if(!this.conversations.get(r)){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(r);if(o){o.push(n),z.warning(`Queueing turn/completed for hydrating conversation`,{safe:{conversationId:r,queuedNotificationCount:o.length},sensitive:{}});break}z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}";
-    if (patched.includes(turnCompletedNeedle)) {
+      (_needle, conversationIdVar) =>
+        `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),z.warning(\`Queueing turn/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}z.error(\`Received turn/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`;
+    if (turnCompletedNeedle.test(patched)) {
       patched = patched.replace(turnCompletedNeedle, turnCompletedReplacement);
     } else if (patched.includes("Received turn/completed for unknown conversation")) {
       console.warn("WARN: Could not find unknown turn/completed needle - skipping remote mobile turn queue patch");

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -1309,6 +1309,18 @@ test("Linux remote mobile conversation hydration patch retries transient and mis
   assert.match(patched, /Failed to hydrate conversation for turn\/started/);
 });
 
+test("Linux remote mobile conversation hydration patch warns when only part of the queue drifted", () => {
+  const source = syntheticAppServerManagerSignalsBundle().replace(
+    "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}",
+    "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{id:r},sensitive:{}});break}",
+  );
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteMobileConversationHydrationPatch(source));
+
+  assert.notEqual(result, source);
+  assert.match(result, /codexLinuxRemoteMobileHydrateUnknownTurn/);
+  assert.ok(warnings.some((warning) => warning.includes("unknown turn/completed needle")));
+});
+
 test("Linux remote-control status guard skips slow remote SSH status reads", async () => {
   const source = syntheticAppServerManagerStatusBundle();
   const patched = applyLinuxRemoteControlStatusReadGuardPatch(source);
@@ -1372,6 +1384,73 @@ test("Linux remote-control status guard skips slow remote SSH status reads", asy
   await new Promise((resolve) => setImmediate(resolve));
   assert.equal(localRequests, 1);
   assert.equal(values.get("local").status, "enabled");
+});
+
+test("Linux remote-control settings UX patch warns when SSH release handling drifts after partial patching", () => {
+  const source = (syntheticSettingsBundle() + syntheticSshInstallSettingsBundle()).replace(
+    "installedCodexVersion:h",
+    "installedVersion:h",
+  );
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteControlSettingsUxPatch(source));
+
+  assert.notEqual(result, source);
+  assert.match(result, /codexLinuxRemoteControlSettingsTabs/);
+  assert.ok(warnings.some((warning) => warning.includes("SSH install release needles")));
+});
+
+test("remote mobile feature patch report records feature metadata and partial warnings", () => {
+  withTempFeatureRoot(["remote-mobile-control"], (root) => {
+    const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-report-"));
+    try {
+      const buildDir = path.join(tempApp, ".vite", "build");
+      const assetsDir = path.join(tempApp, "webview", "assets");
+      fs.mkdirSync(buildDir, { recursive: true });
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(path.join(buildDir, "main.js"), syntheticCurrentMainBundle());
+      fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
+      fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
+      fs.writeFileSync(path.join(assetsDir, "remote-connection-visibility-test.js"), syntheticRemoteConnectionVisibilityBundle());
+      fs.writeFileSync(path.join(assetsDir, "app-main-test.js"), syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle() + syntheticAppMainActiveStatusBundle());
+      fs.writeFileSync(
+        path.join(assetsDir, "remote-connections-settings-test.js"),
+        (syntheticSettingsBundle() + syntheticSshInstallSettingsBundle()).replace(
+          "installedCodexVersion:h",
+          "installedVersion:h",
+        ),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, "app-server-manager-signals-test.js"),
+        syntheticAppServerManagerSignalsBundle().replace(
+          "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}",
+          "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{id:r},sensitive:{}});break}",
+        ) + syntheticAppServerManagerStatusBundle(),
+      );
+      fs.writeFileSync(path.join(assetsDir, "sidebar-project-groups-test.js"), syntheticSidebarProjectGroupsBundle());
+      fs.writeFileSync(path.join(assetsDir, "codex-mobile-setup-flow-test.js"), syntheticMobileSetupFlowCopyBundle());
+      fs.writeFileSync(path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"), syntheticMobileConnectedSettingsBundle());
+
+      const report = createPatchReport();
+      withFeatureRootEnv(root, () => patchExtractedApp(tempApp, { report }));
+
+      assert.deepEqual(report.enabledFeatures, ["remote-mobile-control"]);
+      const settingsPatch = report.patches.find(
+        (patch) => patch.name === "feature:remote-mobile-control:linux-remote-control-settings-ux",
+      );
+      assert.equal(settingsPatch.sourceKind, "feature");
+      assert.equal(settingsPatch.featureId, "remote-mobile-control");
+      assert.equal(settingsPatch.status, "applied-with-warnings");
+      assert.ok(settingsPatch.warnings.some((warning) => warning.includes("SSH install release needles")));
+
+      const hydrationPatch = report.patches.find(
+        (patch) => patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
+      );
+      assert.equal(hydrationPatch.sourceKind, "feature");
+      assert.equal(hydrationPatch.status, "applied-with-warnings");
+      assert.ok(hydrationPatch.warnings.some((warning) => warning.includes("unknown turn/completed needle")));
+    } finally {
+      fs.rmSync(tempApp, { recursive: true, force: true });
+    }
+  });
 });
 
 test("Linux remote mobile projectless remote task patch groups tasks without owner repo metadata", () => {

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -4,6 +4,40 @@
 # Sourced by install.sh. Do not run directly.
 # shellcheck shell=bash
 
+print_patch_report_summary() {
+    local patch_report="$1"
+    [ -f "$patch_report" ] || return 0
+
+    node - "$patch_report" "$SCRIPT_DIR/scripts/lib/patch-report.js" <<'NODE'
+const fs = require("node:fs");
+const reportPath = process.argv[2];
+const helperPath = process.argv[3];
+const { summarizePatchReport } = require(helperPath);
+
+const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+const summary = summarizePatchReport(report);
+const fmt = (counts) => Object.entries(counts).map(([k, v]) => `${k}=${v}`).join(", ") || "none";
+
+console.error("[INFO] inspect-upstream summary:");
+console.error(`  required core: ${fmt(summary.groups.requiredCore.statusCounts)}`);
+console.error(`  optional core: ${fmt(summary.groups.optionalCore.statusCounts)}`);
+
+if (summary.enabledFeatures.length === 0) {
+  console.error("  optional features: none enabled");
+} else {
+  console.error(`  enabled features: ${summary.enabledFeatures.join(", ")}`);
+  const featureEntries = Object.entries(summary.groups.optionalFeatures.byFeature);
+  if (featureEntries.length === 0) {
+    console.error("  optional feature drift: none");
+  } else {
+    for (const [featureId, featureSummary] of featureEntries) {
+      console.error(`  feature ${featureId}: ${fmt(featureSummary.statusCounts)}`);
+    }
+  }
+}
+NODE
+}
+
 # ---- Extract and patch app.asar ----
 patch_asar() {
     local app_dir="$1"
@@ -72,4 +106,5 @@ inspect_rebuild_candidate() {
 
     info "Patch report: $patch_report"
     info "Rebuild report: $rebuild_report"
+    print_patch_report_summary "$patch_report"
 }

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -35,7 +35,10 @@ function linuxFeaturesRoot(options = {}) {
   return defaultLinuxFeaturesRoot();
 }
 
-function linuxFeaturesConfigPath(featuresRoot) {
+function linuxFeaturesConfigPath(featuresRoot, options = {}) {
+  if (options.featuresConfigPath != null) {
+    return path.resolve(options.featuresConfigPath);
+  }
   if (process.env.CODEX_LINUX_FEATURES_CONFIG?.trim()) {
     return path.resolve(process.env.CODEX_LINUX_FEATURES_CONFIG.trim());
   }
@@ -105,7 +108,7 @@ function normalizeEnabledFeatureIds(value, sourcePath) {
 
 function enabledLinuxFeatureIds(options = {}) {
   const featuresRoot = linuxFeaturesRoot(options);
-  const configPath = linuxFeaturesConfigPath(featuresRoot);
+  const configPath = linuxFeaturesConfigPath(featuresRoot, options);
   if (!fs.existsSync(configPath)) {
     return [];
   }

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -365,6 +365,8 @@ function wrapFeaturePatchDescriptor(feature, descriptor, sourcePath, index, feat
     id: wrappedId,
     name: descriptor.name ?? wrappedId,
     ciPolicy: descriptor.ciPolicy ?? "optional",
+    sourceKind: "feature",
+    featureId: feature.id,
     order: descriptor.order ?? 20_000 + featureIndex * 100 + index * 10,
     sourcePath,
     apply: (target, context) => descriptor.apply(target, featureContext(context, feature)),

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -646,6 +646,8 @@ stage_common_package_files() {
     local root="$1"
     local app_root="$root/opt/$PACKAGE_NAME"
     local polkit_policy="$REPO_DIR/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy"
+    local tray_icon_source="$ICON_SOURCE"
+    local candidate
 
     if package_with_updater_enabled; then
         ensure_file_exists "$polkit_policy" "polkit policy"
@@ -665,7 +667,14 @@ stage_common_package_files() {
     rm -rf "$app_root"
     cp -aT "$APP_DIR" "$app_root"
     mkdir -p "$app_root/.codex-linux"
+    for candidate in "$app_root"/content/webview/assets/app-*.png; do
+        if [ -f "$candidate" ]; then
+            tray_icon_source="$candidate"
+            break
+        fi
+    done
     cp "$ICON_SOURCE" "$app_root/.codex-linux/$PACKAGE_NAME.png"
+    cp "$tray_icon_source" "$app_root/.codex-linux/$PACKAGE_NAME-tray.png"
     render_desktop_entry_doctor_helper "$app_root/.codex-linux/codex-desktop-entry-doctor.sh"
     render_desktop_entry "$root/usr/share/applications/$PACKAGE_NAME.desktop"
     cp "$ICON_SOURCE" "$root/usr/share/icons/hicolor/256x256/apps/$PACKAGE_NAME.png"

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -4,6 +4,10 @@ info() {
     echo "[INFO] $*" >&2
 }
 
+warn() {
+    echo "[WARN] $*" >&2
+}
+
 error() {
     echo "[ERROR] $*" >&2
     exit 1
@@ -646,8 +650,6 @@ stage_common_package_files() {
     local root="$1"
     local app_root="$root/opt/$PACKAGE_NAME"
     local polkit_policy="$REPO_DIR/packaging/linux/com.github.ilysenko.codex-desktop-linux.update.policy"
-    local tray_icon_source="$ICON_SOURCE"
-    local candidate
 
     if package_with_updater_enabled; then
         ensure_file_exists "$polkit_policy" "polkit policy"
@@ -667,14 +669,8 @@ stage_common_package_files() {
     rm -rf "$app_root"
     cp -aT "$APP_DIR" "$app_root"
     mkdir -p "$app_root/.codex-linux"
-    for candidate in "$app_root"/content/webview/assets/app-*.png; do
-        if [ -f "$candidate" ]; then
-            tray_icon_source="$candidate"
-            break
-        fi
-    done
     cp "$ICON_SOURCE" "$app_root/.codex-linux/$PACKAGE_NAME.png"
-    cp "$tray_icon_source" "$app_root/.codex-linux/$PACKAGE_NAME-tray.png"
+    cp "$(resolve_tray_icon_source "$app_root")" "$app_root/.codex-linux/$PACKAGE_NAME-tray.png"
     render_desktop_entry_doctor_helper "$app_root/.codex-linux/codex-desktop-entry-doctor.sh"
     render_desktop_entry "$root/usr/share/applications/$PACKAGE_NAME.desktop"
     cp "$ICON_SOURCE" "$root/usr/share/icons/hicolor/256x256/apps/$PACKAGE_NAME.png"
@@ -690,6 +686,31 @@ stage_common_package_files() {
             "$app_root/.codex-linux/codex-no-updater-transition-cleanup.sh"
     fi
     render_packaged_runtime_helper "$app_root/.codex-linux/codex-packaged-runtime.sh"
+}
+
+resolve_tray_icon_source() {
+    local app_root="$1"
+    local assets_dir="$app_root/content/webview/assets"
+    local -a candidates=()
+    local candidate
+
+    if [ -d "$assets_dir" ]; then
+        while IFS= read -r -d '' candidate; do
+            candidates+=("$candidate")
+        done < <(find "$assets_dir" -maxdepth 1 -type f -name 'app-*.png' -print0 | sort -z)
+    fi
+
+    if [ "${#candidates[@]}" -eq 1 ]; then
+        printf '%s\n' "${candidates[0]}"
+        return 0
+    fi
+
+    if [ "${#candidates[@]}" -gt 1 ]; then
+        warn "Multiple tray icon candidates found in $assets_dir; falling back to package icon"
+    else
+        warn "Could not resolve a unique tray icon in $assets_dir; falling back to package icon"
+    fi
+    printf '%s\n' "$ICON_SOURCE"
 }
 
 stage_update_builder_bundle() {

--- a/scripts/lib/patch-report.js
+++ b/scripts/lib/patch-report.js
@@ -11,6 +11,7 @@ function createPatchReport() {
     iconAsset: null,
     desktopName: null,
     linuxTarget: null,
+    enabledFeatures: [],
     patches: [],
   };
 }
@@ -53,14 +54,52 @@ function writePatchReport(reportPath, report) {
   fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
 }
 
-function patchStatusFromChange(changed, warnings) {
+function patchStatusFromChange(changed, warnings, ciPolicy = "optional") {
+  const required = ciPolicy === "required-upstream";
   if (changed) {
+    if (warnings.length > 0) {
+      return required ? "failed-required" : "applied-with-warnings";
+    }
     return "applied";
   }
   if (warnings.length > 0) {
-    return "skipped-optional";
+    return required ? "failed-required" : "skipped-optional";
   }
   return "already-applied";
+}
+
+function patchGroupForEntry(entry) {
+  if (entry.ciPolicy === "required-upstream") {
+    return "requiredCore";
+  }
+  return entry.sourceKind === "feature" ? "optionalFeatures" : "optionalCore";
+}
+
+function summarizePatchReport(report) {
+  const groups = {
+    requiredCore: { count: 0, statusCounts: {} },
+    optionalCore: { count: 0, statusCounts: {} },
+    optionalFeatures: { count: 0, statusCounts: {}, byFeature: {} },
+  };
+
+  for (const patch of report?.patches ?? []) {
+    const groupName = patchGroupForEntry(patch);
+    const group = groups[groupName];
+    group.count += 1;
+    group.statusCounts[patch.status] = (group.statusCounts[patch.status] ?? 0) + 1;
+
+    if (groupName === "optionalFeatures") {
+      const featureId = patch.featureId ?? "unknown-feature";
+      const featureGroup = group.byFeature[featureId] ??= { count: 0, statusCounts: {} };
+      featureGroup.count += 1;
+      featureGroup.statusCounts[patch.status] = (featureGroup.statusCounts[patch.status] ?? 0) + 1;
+    }
+  }
+
+  return {
+    enabledFeatures: Array.isArray(report?.enabledFeatures) ? [...report.enabledFeatures] : [],
+    groups,
+  };
 }
 
 module.exports = {
@@ -68,5 +107,6 @@ module.exports = {
   createPatchReport,
   patchStatusFromChange,
   recordPatch,
+  summarizePatchReport,
   writePatchReport,
 };

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -68,6 +68,7 @@ const {
   corePatchDescriptors,
   detectLinuxTargetContext,
   discoverCorePatchDescriptors,
+  enabledLinuxFeatureIds,
   linuxTargetSummary,
   normalizePatchDescriptors,
   parseOsRelease,
@@ -88,6 +89,9 @@ const {
   packageProfile,
   sourceInfo,
 } = require("./lib/build-info.js");
+const {
+  summarizePatchReport,
+} = require("./lib/patch-report.js");
 const {
   applyBrowserAnnotationScreenshotPatch,
   applyLocalEnvironmentActionModalDraftPatch,
@@ -1639,11 +1643,21 @@ test("patches remaining Linux window icon snippets when another window is alread
 
 test("adds Linux tray support including the platform guard", () => {
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
+  const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
   const patched = applyPatchTwice(applyLinuxTrayPatch, trayBundleFixture(), iconPathExpression);
 
   assert.match(
     patched,
     /process\.platform!==`win32`&&process\.platform!==`darwin`&&process\.platform!==`linux`\?null:/,
+  );
+  assert.match(
+    patched,
+    new RegExp(`nativeImage\\.createFromPath\\(${escapeRegExp(packagedTrayIconPathExpression)}\\)`),
+  );
+  assert.match(
+    patched,
+    new RegExp(`nativeImage\\.createFromPath\\(${escapeRegExp(packagedAppIconPathExpression)}\\)`),
   );
   assert.match(
     patched,
@@ -1672,6 +1686,22 @@ test("adds Linux tray support including the platform guard", () => {
     /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
   );
   assert.doesNotMatch(patched, /process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)/);
+});
+
+test("adds Linux tray support even when About dialog already uses the bundled icon path", () => {
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
+  const source = [
+    trayBundleFixture(),
+    "async function bZ(){let t=process.execPath;return process.platform===`linux`?Promise.resolve((()=>{let __codexLinuxAboutIcon=n.nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`);return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):n.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, iconPathExpression);
+
+  assert.match(
+    patched,
+    new RegExp(`nativeImage\\.createFromPath\\(${escapeRegExp(packagedTrayIconPathExpression)}\\)`),
+  );
 });
 
 test("adds Linux build information to the tray menu", () => {
@@ -3978,11 +4008,44 @@ test("patchExtractedApp records a structured patch report", () => {
     assert.equal(report.mainBundle, "main.js");
     assert.equal(report.iconAsset, "app-test.png");
     assert.equal(report.desktopName, "codex-desktop.desktop");
-    assert.ok(report.patches.some((patch) => patch.name === "main-process-ui" && patch.status === "applied"));
+    assert.deepEqual(report.enabledFeatures, enabledLinuxFeatureIds());
+    assert.ok(
+      report.patches.some(
+        (patch) =>
+          patch.name === "main-process-ui" &&
+          patch.status === "failed-required" &&
+          patch.sourceKind === "core" &&
+          Array.isArray(patch.warnings) &&
+          patch.warnings.length > 0,
+      ),
+    );
     assert.ok(report.patches.some((patch) => patch.name === "keybinds-settings" && patch.status === "skipped-optional"));
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("patch report summary separates required core, optional core, and optional feature drift", () => {
+  const summary = summarizePatchReport({
+    enabledFeatures: ["remote-mobile-control"],
+    patches: [
+      { name: "main-process-ui", status: "applied", sourceKind: "core", ciPolicy: "required-upstream" },
+      { name: "linux-app-updater-bridge", status: "skipped-optional", sourceKind: "core", ciPolicy: "optional" },
+      {
+        name: "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
+        status: "applied-with-warnings",
+        sourceKind: "feature",
+        featureId: "remote-mobile-control",
+        ciPolicy: "optional",
+      },
+    ],
+  });
+
+  assert.deepEqual(summary.enabledFeatures, ["remote-mobile-control"]);
+  assert.deepEqual(summary.groups.requiredCore.statusCounts, { applied: 1 });
+  assert.deepEqual(summary.groups.optionalCore.statusCounts, { "skipped-optional": 1 });
+  assert.deepEqual(summary.groups.optionalFeatures.statusCounts, { "applied-with-warnings": 1 });
+  assert.equal(summary.groups.optionalFeatures.byFeature["remote-mobile-control"].count, 1);
 });
 
 test("patch report marks missing required webview assets as required failures", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -106,6 +106,7 @@ const {
   applyLinuxWindowControlsSafeAreaPatch,
 } = require("./patches/webview-assets.js");
 const { patchAssetFiles } = require("./patches/shared.js");
+const { featurePatchDescriptors } = require("./patches/registry.js");
 
 const mainBundlePrefix =
   "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
@@ -4020,6 +4021,107 @@ test("patchExtractedApp records a structured patch report", () => {
       ),
     );
     assert.ok(report.patches.some((patch) => patch.name === "keybinds-settings" && patch.status === "skipped-optional"));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("feature patch descriptors honor explicit feature config overrides", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-patch-override-"));
+  try {
+    const featuresRoot = path.join(tempRoot, "linux-features");
+    const featureDir = path.join(featuresRoot, "temp-feature");
+    const featureConfigPath = path.join(tempRoot, "custom-features.json");
+    fs.mkdirSync(featureDir, { recursive: true });
+    fs.writeFileSync(path.join(featuresRoot, "features.example.json"), JSON.stringify({ enabled: [] }));
+    fs.writeFileSync(
+      path.join(featureDir, "feature.json"),
+      JSON.stringify({
+        id: "temp-feature",
+        title: "Temp Feature",
+        defaultEnabled: false,
+        entrypoints: { patches: "./patch.js" },
+      }),
+    );
+    fs.writeFileSync(path.join(featureDir, "README.md"), "# Temp Feature\n");
+    fs.writeFileSync(
+      path.join(featureDir, "patch.js"),
+      [
+        "\"use strict\";",
+        "module.exports=[{",
+        "id:\"temp-feature-main-bundle\",",
+        "phase:\"main-bundle\",",
+        "ciPolicy:\"optional\",",
+        "apply:(source)=>source",
+        "}];",
+      ].join("\n"),
+    );
+    fs.writeFileSync(featureConfigPath, JSON.stringify({ enabled: ["temp-feature"] }));
+
+    const descriptors = featurePatchDescriptors({ featuresRoot, featuresConfigPath: featureConfigPath });
+    assert.ok(descriptors.some((descriptor) => descriptor.id === "feature:temp-feature:temp-feature-main-bundle"));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patchExtractedApp report honors explicit feature config overrides", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-feature-override-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    const featuresRoot = path.join(tempRoot, "linux-features");
+    const featureDir = path.join(featuresRoot, "temp-feature");
+    const featureConfigPath = path.join(tempRoot, "custom-features.json");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.mkdirSync(featureDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      [
+        mainBundlePrefix,
+        "process.platform===`win32`&&k.removeMenu(),",
+        "codexTempFeatureDisabled()",
+      ].join(""),
+    );
+    fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
+    fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
+    fs.writeFileSync(path.join(featuresRoot, "features.example.json"), JSON.stringify({ enabled: [] }));
+    fs.writeFileSync(
+      path.join(featureDir, "feature.json"),
+      JSON.stringify({
+        id: "temp-feature",
+        title: "Temp Feature",
+        defaultEnabled: false,
+        entrypoints: { patches: "./patch.js" },
+      }),
+    );
+    fs.writeFileSync(path.join(featureDir, "README.md"), "# Temp Feature\n");
+    fs.writeFileSync(
+      path.join(featureDir, "patch.js"),
+      [
+        "\"use strict\";",
+        "module.exports=[{",
+        "id:\"temp-feature-main-bundle\",",
+        "phase:\"main-bundle\",",
+        "ciPolicy:\"optional\",",
+        "apply:(source)=>source.includes(\"codexTempFeatureDisabled()\")?source.replace(\"codexTempFeatureDisabled()\",\"codexTempFeatureEnabled()\"):(source)",
+        "}];",
+      ].join("\n"),
+    );
+    fs.writeFileSync(featureConfigPath, JSON.stringify({ enabled: ["temp-feature"] }));
+
+    const report = createPatchReport();
+    patchExtractedApp(tempRoot, { report, featuresRoot, featuresConfigPath: featureConfigPath });
+
+    assert.deepEqual(report.enabledFeatures, ["temp-feature"]);
+    assert.ok(
+      report.patches.some(
+        (patch) =>
+          patch.name === "feature:temp-feature:temp-feature-main-bundle" && patch.status === "applied",
+      ),
+    );
+    assert.match(fs.readFileSync(path.join(buildDir, "main.js"), "utf8"), /codexTempFeatureEnabled\(\)/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -39,6 +39,7 @@ function normalizeDescriptor(descriptor, sourcePath = null, index = 0) {
     id,
     name: descriptor.name ?? id,
     phase: descriptor.phase ?? "main-bundle",
+    sourceKind: descriptor.sourceKind ?? (descriptor.featureId != null ? "feature" : "core"),
     order: descriptor.order ?? 10_000 + index,
     sourcePath,
   };
@@ -131,13 +132,7 @@ function descriptorFailureStatus(descriptor) {
 }
 
 function patchStatusFromDescriptorChange(descriptor, changed, warnings) {
-  if (changed) {
-    return "applied";
-  }
-  if (warnings.length > 0) {
-    return descriptorFailureStatus(descriptor);
-  }
-  return "already-applied";
+  return patchStatusFromChange(changed, warnings, descriptor.ciPolicy);
 }
 
 function normalizeDescriptorStatus(descriptor, status) {
@@ -148,9 +143,16 @@ function normalizeDescriptorStatus(descriptor, status) {
 }
 
 function recordDescriptorPatch(report, descriptor, status, reason, context) {
+  const warnings = Array.isArray(context?.reportWarnings) && context.reportWarnings.length > 0
+    ? { warnings: [...context.reportWarnings] }
+    : {};
   recordPatch(report, descriptor.id, normalizeDescriptorStatus(descriptor, status), reason, {
     phase: descriptor.phase,
     targetSummary: patchTargetSummary(descriptor, context),
+    ciPolicy: descriptor.ciPolicy ?? "optional",
+    sourceKind: descriptor.sourceKind ?? "core",
+    ...(descriptor.featureId != null ? { featureId: descriptor.featureId } : {}),
+    ...warnings,
   });
 }
 
@@ -171,6 +173,7 @@ function descriptorEnabled(descriptor, context) {
 function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
   let patched = source;
   const warnings = [];
+  const coreWarnings = [];
   for (const descriptor of descriptors.filter((patch) => patch.phase === "main-bundle")) {
     if (!descriptorAppliesTo(descriptor, context)) {
       recordDescriptorPatch(report, descriptor, SKIPPED_TARGET, null, context);
@@ -184,6 +187,10 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
     const result = captureWarnings(() => descriptor.apply(patched, context));
     patched = result.value;
     warnings.push(...result.warnings);
+    if ((descriptor.sourceKind ?? "core") === "core") {
+      coreWarnings.push(...result.warnings);
+    }
+    context.reportWarnings = result.warnings;
     recordDescriptorPatch(
       report,
       descriptor,
@@ -191,8 +198,9 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
       result.warnings[0] ?? null,
       context,
     );
+    delete context.reportWarnings;
   }
-  return { patchedSource: patched, warnings };
+  return { patchedSource: patched, warnings, coreWarnings };
 }
 
 function defaultWebviewMissingWarning(extractedDir, descriptor) {
@@ -234,7 +242,9 @@ function applyWebviewAssetPatchDescriptors(extractedDir, descriptors, context, r
     const { value: result, warnings } = captureWarnings(() =>
       patchAssetFiles(extractedDir, pattern, (source) => descriptor.apply(source, context), missingWarning),
     );
+    context.reportWarnings = warnings;
     recordAssetDescriptorPatch(report, descriptor, result, warnings, context);
+    delete context.reportWarnings;
   }
 }
 
@@ -249,10 +259,11 @@ function applyExtractedAppPatchDescriptors(extractedDir, descriptors, context, r
     }
 
     const { value: result, warnings } = captureWarnings(() => descriptor.apply(extractedDir, context));
+    context.reportWarnings = warnings;
     const statusResult = typeof descriptor.status === "function"
       ? descriptor.status(result, warnings, context)
       : result?.changed != null
-        ? patchStatusFromChange(Boolean(result.changed), warnings)
+        ? patchStatusFromChange(Boolean(result.changed), warnings, descriptor.ciPolicy)
         : "applied";
     const status = typeof statusResult === "object" && statusResult != null
       ? statusResult.status
@@ -261,6 +272,7 @@ function applyExtractedAppPatchDescriptors(extractedDir, descriptors, context, r
       ? statusResult.reason
       : result?.reason ?? warnings[0] ?? null;
     recordDescriptorPatch(report, descriptor, status, reason, context);
+    delete context.reportWarnings;
   }
 }
 

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -648,6 +648,8 @@ function applyLinuxExplicitIpcQuitPatch(currentSource) {
 function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   let patchedSource = currentSource;
   const electronVar = requireName(currentSource, "electron") ?? "n";
+  const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
+  const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
 
   const trayGuardNeedle =
     "process.platform!==`win32`&&process.platform!==`darwin`?null:";
@@ -671,8 +673,11 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     const trayIconNeedle =
       `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
     const trayIconPatch =
-      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}if(process.platform===\`linux\`){let e=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!e.isEmpty())return{defaultIcon:e,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
-    if (patchedSource.includes(`nativeImage.createFromPath(${iconPathExpression})`)) {
+      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}if(process.platform===\`linux\`){let e=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!e.isEmpty())return{defaultIcon:e,chronicleRunningIcon:null};let t=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null};let r=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!r.isEmpty())return{defaultIcon:r,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
+    if (
+      patchedSource.includes(`nativeImage.createFromPath(${packagedTrayIconPathExpression})`) ||
+      patchedSource.includes(`nativeImage.createFromPath(${packagedAppIconPathExpression})`)
+    ) {
       // Already patched.
     } else if (patchedSource.includes(trayIconNeedle)) {
       patchedSource = patchedSource.replace(trayIconNeedle, trayIconPatch);
@@ -682,7 +687,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
       patchedSource = patchedSource.replace(
         /for\(let ([A-Za-z_$][\w$]*) of ([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(\1\);if\(!\3\.isEmpty\(\)\)return\{defaultIcon:\3,chronicleRunningIcon:null\}\}return\{defaultIcon:await \4\.app\.getFileIcon\(process\.execPath,\{size:process\.platform===`win32`\?`small`:`normal`\}\),chronicleRunningIcon:null\}\}/,
         (_match, iconPathVar, candidatesVar, imageVar, electronAlias) =>
-          `for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let ${iconPathVar}=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!${iconPathVar}.isEmpty())return{defaultIcon:${iconPathVar},chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`,
+          `for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let ${iconPathVar}=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!${iconPathVar}.isEmpty())return{defaultIcon:${iconPathVar},chronicleRunningIcon:null};let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`,
       );
     } else {
       console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -13,6 +13,7 @@ const {
 } = require("../lib/linux-target-context.js");
 const {
   loadLinuxFeaturePatchDescriptors,
+  enabledLinuxFeatureIds,
 } = require("../lib/linux-features.js");
 const {
   findIconAsset,
@@ -38,6 +39,14 @@ const EXTRACTED_APP_WEBVIEW_SPLIT_ORDER = 2020;
 const CUSTOM_PATCH_POLICIES = [
   { name: "main-process-ui", ciPolicy: REQUIRED_UPSTREAM, phase: "main-bundle" },
 ];
+
+function recordMainProcessUiPatch(report, status, reason = null) {
+  recordPatch(report, "main-process-ui", status, reason, {
+    phase: "main-bundle",
+    ciPolicy: REQUIRED_UPSTREAM,
+    sourceKind: "core",
+  });
+}
 
 function normalizeDiscoveredCorePatchDescriptors(options = {}) {
   const root = options.corePatchRoot ?? CORE_PATCH_ROOT;
@@ -112,6 +121,9 @@ function patchExtractedApp(extractedDir, options = {}) {
   ]);
 
   setReportLinuxTarget(report, baseContext.linux);
+  if (report != null) {
+    report.enabledFeatures = enabledLinuxFeatureIds();
+  }
 
   const main = findMainBundle(extractedDir);
   if (report != null) {
@@ -121,7 +133,7 @@ function patchExtractedApp(extractedDir, options = {}) {
   if (main == null) {
     const reason = `Could not find main bundle in ${path.join(extractedDir, ".vite", "build")}`;
     console.warn(`WARN: ${reason} — skipping main-process UI patches`);
-    recordPatch(report, "main-process-ui", "failed-required", reason);
+    recordMainProcessUiPatch(report, "failed-required", reason);
   }
 
   const iconAsset = findIconAsset(extractedDir);
@@ -143,15 +155,21 @@ function patchExtractedApp(extractedDir, options = {}) {
   if (main != null) {
     const target = path.join(main.buildDir, main.mainBundle);
     const source = fs.readFileSync(target, "utf8");
-    const { patchedSource, warnings } = applyMainBundlePatches(source, assetContext, report);
+    const { patchedSource, warnings, coreWarnings } = applyMainBundlePatches(source, assetContext, report);
     if (patchedSource !== source) {
       fs.writeFileSync(target, patchedSource, "utf8");
     }
     recordPatch(
       report,
       "main-process-ui",
-      patchStatusFromChange(patchedSource !== source, warnings),
-      warnings[0] ?? null,
+      patchStatusFromChange(patchedSource !== source, coreWarnings, REQUIRED_UPSTREAM),
+      coreWarnings[0] ?? null,
+      {
+        phase: "main-bundle",
+        ciPolicy: REQUIRED_UPSTREAM,
+        sourceKind: "core",
+        ...(coreWarnings.length > 0 ? { warnings: [...coreWarnings] } : {}),
+      },
     );
   }
 

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -61,8 +61,15 @@ function legacyCorePatchDescriptors(options = {}) {
   return corePatchDescriptors(options);
 }
 
-function featurePatchDescriptors() {
-  return normalizePatchDescriptors(loadLinuxFeaturePatchDescriptors());
+function featurePatchDescriptors(options = {}) {
+  return normalizePatchDescriptors(loadLinuxFeaturePatchDescriptors(options));
+}
+
+function featurePatchOptions(options = {}) {
+  return {
+    ...(options.featuresRoot != null ? { featuresRoot: options.featuresRoot } : {}),
+    ...(options.featuresConfigPath != null ? { featuresConfigPath: options.featuresConfigPath } : {}),
+  };
 }
 
 function createMainBundleContext(iconAsset, options = {}) {
@@ -75,6 +82,7 @@ function createMainBundleContext(iconAsset, options = {}) {
     linux,
     linuxTarget: linux,
     corePatchRoot: options.corePatchRoot,
+    featurePatchOptions: featurePatchOptions(options),
   };
 }
 
@@ -100,7 +108,7 @@ function mainBundlePatchDescriptors(context) {
   return normalizePatchDescriptors([
     ...corePatchDescriptors({ corePatchRoot: context.corePatchRoot })
       .filter((patch) => patch.phase === "main-bundle"),
-    ...featurePatchDescriptors().filter((patch) => patch.phase === "main-bundle"),
+    ...featurePatchDescriptors(context.featurePatchOptions).filter((patch) => patch.phase === "main-bundle"),
   ]);
 }
 
@@ -115,14 +123,15 @@ function patchMainBundleSource(source, iconAsset, options = {}) {
 function patchExtractedApp(extractedDir, options = {}) {
   const report = options.report ?? null;
   const baseContext = createMainBundleContext(null, options);
+  const featuresOptions = featurePatchOptions(options);
   const patchDescriptors = normalizePatchDescriptors([
     ...corePatchDescriptors({ corePatchRoot: options.corePatchRoot }),
-    ...featurePatchDescriptors(),
+    ...featurePatchDescriptors(featuresOptions),
   ]);
 
   setReportLinuxTarget(report, baseContext.linux);
   if (report != null) {
-    report.enabledFeatures = enabledLinuxFeatureIds();
+    report.enabledFeatures = enabledLinuxFeatureIds(featuresOptions);
   }
 
   const main = findMainBundle(extractedDir);
@@ -211,7 +220,7 @@ function allPatchPolicies(options = {}) {
       phase,
       appliesTo,
     })),
-    ...featurePatchDescriptors().map(({ id, name, ciPolicy, phase, appliesTo }) => ({
+    ...featurePatchDescriptors(featurePatchOptions(options)).map(({ id, name, ciPolicy, phase, appliesTo }) => ({
       name: name ?? id,
       ciPolicy,
       phase,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -194,6 +194,85 @@ JSON
     assert_mode "$private_file" "600"
 }
 
+test_stage_common_package_files_resolves_tray_icon_deterministically() {
+    info "Checking stage_common_package_files tray icon resolution"
+    local workspace="$TMP_DIR/package-common-tray"
+    local app_dir="$workspace/app"
+    local root="$workspace/root"
+    local output_log="$workspace/output.log"
+    local icon_source="$workspace/icon-source.png"
+    local tray_output="$root/opt/codex-desktop/.codex-linux/codex-desktop-tray.png"
+    local package_icon="$root/opt/codex-desktop/.codex-linux/codex-desktop.png"
+
+    mkdir -p "$workspace" "$root"
+    make_fake_app "$app_dir"
+    mkdir -p "$app_dir/content/webview/assets"
+    printf '%s\n' 'package-icon' > "$icon_source"
+    printf '%s\n' 'upstream-tray' > "$app_dir/content/webview/assets/app-main.png"
+
+    (
+        export APP_DIR="$app_dir"
+        export PACKAGE_NAME="codex-desktop"
+        export PACKAGE_WITH_UPDATER=0
+        export ICON_SOURCE="$icon_source"
+        export DESKTOP_TEMPLATE="$REPO_DIR/packaging/linux/codex-desktop.desktop"
+        export PACKAGED_RUNTIME_SOURCE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/package-common.sh"
+        stage_common_package_files "$root"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$package_icon"
+    assert_file_exists "$tray_output"
+    cmp -s "$icon_source" "$package_icon" || fail "Expected package icon copy to come from ICON_SOURCE"
+    cmp -s "$app_dir/content/webview/assets/app-main.png" "$tray_output" \
+        || fail "Expected tray icon copy to come from the unique upstream asset"
+    assert_not_contains "$output_log" "falling back to package icon"
+}
+
+test_stage_common_package_files_tray_icon_fallbacks_when_ambiguous_or_missing() {
+    info "Checking stage_common_package_files tray icon fallback behavior"
+    local workspace="$TMP_DIR/package-common-tray-fallback"
+    local icon_source="$workspace/icon-source.png"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    printf '%s\n' 'package-icon' > "$icon_source"
+
+    for scenario in ambiguous missing; do
+        local app_dir="$workspace/$scenario-app"
+        local root="$workspace/$scenario-root"
+        local tray_output="$root/opt/codex-desktop/.codex-linux/codex-desktop-tray.png"
+
+        mkdir -p "$root"
+        make_fake_app "$app_dir"
+        mkdir -p "$app_dir/content/webview/assets"
+        if [ "$scenario" = "ambiguous" ]; then
+            printf '%s\n' 'upstream-a' > "$app_dir/content/webview/assets/app-alpha.png"
+            printf '%s\n' 'upstream-b' > "$app_dir/content/webview/assets/app-beta.png"
+        fi
+
+        (
+            export APP_DIR="$app_dir"
+            export PACKAGE_NAME="codex-desktop"
+            export PACKAGE_WITH_UPDATER=0
+            export ICON_SOURCE="$icon_source"
+            export DESKTOP_TEMPLATE="$REPO_DIR/packaging/linux/codex-desktop.desktop"
+            export PACKAGED_RUNTIME_SOURCE="$REPO_DIR/packaging/linux/codex-packaged-runtime.sh"
+            # shellcheck disable=SC1091
+            source "$REPO_DIR/scripts/lib/package-common.sh"
+            stage_common_package_files "$root"
+        ) >>"$output_log" 2>&1
+
+        assert_file_exists "$tray_output"
+        cmp -s "$icon_source" "$tray_output" \
+            || fail "Expected tray icon fallback to come from ICON_SOURCE for $scenario"
+    done
+
+    assert_contains "$output_log" "Multiple tray icon candidates found"
+    assert_contains "$output_log" "Could not resolve a unique tray icon"
+}
+
 test_deb_builder_smoke() {
     info "Running Debian packaging smoke test"
     local workspace="$TMP_DIR/deb"
@@ -4033,7 +4112,10 @@ NODE
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform!==`linux`' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath' '3'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath+`/../.codex-linux/codex-desktop.png`)' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`)' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`)&&!this.isAppQuitting' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'setLinuxTrayContextMenu(){' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`' '1'

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -32,6 +32,7 @@ const PROMPT_INSTALL_CLI_NO_BACKEND_EXIT_CODE: i32 = 11;
 const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
     "budgie-polkit",
     "cinnamon-polkit",
+    "cosmic-osd",
     "gnome-shell",
     "hyprpolkitagent",
     "io.elementary.desktop.agent-polkit",
@@ -2581,6 +2582,7 @@ mod tests {
         assert!(process_text_matches_polkit_auth_agent(
             "/usr/lib/polkit-gnome-authentication-agent-1"
         ));
+        assert!(process_text_matches_polkit_auth_agent("cosmic-osd"));
         assert!(process_text_matches_polkit_auth_agent(
             "gnome-shell --wayland"
         ));


### PR DESCRIPTION
This pull request updates the latest DMG patch drift handling and adds some extra hardening to make future upstream drifts easier to detect.

## What changed

### Patch reporting improvements

- Added `print_patch_report_summary` to `asar-patch.sh` to print a human-readable summary of patch results during build/inspection.
- Patch reports now include `enabledFeatures`.
- Feature patch metadata is now recorded with `sourceKind: "feature"` and `featureId`.

### Feature patching/config improvements

- `linuxFeaturesConfigPath` and `enabledLinuxFeatureIds` now support overriding the feature config path through options, which makes them more flexible across different environments.

### Test coverage

- Added tests to verify warnings are emitted when patch needles partially drift.
- Added coverage to ensure patch reports correctly record warnings and feature metadata in those scenarios.

### UX and error reporting

- Added a `warn` helper to `package-common.sh`.
- Improved tray icon resolution so it now warns and falls back gracefully when a unique tray icon cannot be resolved.
- `stage_common_package_files` now uses the resolved tray icon for packaging.

### Patch matching hardening

- Updated several patch application paths to use regex-based matching for better resilience against upstream code drift.
- Added warnings when expected code patterns are not found.

## Why this matters

These changes make the patching and packaging flow more robust, easier to inspect, and easier to debug when upstream changes introduce partial patch failures or drift.