### PR TITLE
fix(linux): log tray setup failures

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1801,6 +1801,11 @@ test("adds Linux tray support for current minified window and startup identifier
     patched,
     /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
+  assert.match(
+    patched,
+    /catch\(e\)\{O=!1;process\.platform===`linux`&&console\.warn\(`\[codex-linux\] Failed to set up system tray`,e\)\}/,
+  );
+  assert.equal((patched.match(/\[codex-linux\] Failed to set up system tray/g) ?? []).length, 1);
 });
 
 test("scopes dynamic tray startup matching to the tray initializer", () => {
@@ -1822,6 +1827,11 @@ test("scopes dynamic tray startup matching to the tray initializer", () => {
     patched,
     /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
+  assert.match(patched, /catch\(e\)\{A=!1\}\};U&&startOther\(\);/);
+  assert.match(
+    patched,
+    /catch\(e\)\{O=!1;process\.platform===`linux`&&console\.warn\(`\[codex-linux\] Failed to set up system tray`,e\)\}/,
+  );
 });
 
 test("migrates Linux tray startup patch to tolerate missing settings helper", () => {
@@ -1835,6 +1845,28 @@ test("migrates Linux tray startup patch to tolerate missing settings helper", ()
   assert.match(
     patched,
     /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
+  );
+  assert.match(
+    patched,
+    /catch\(e\)\{O=!1;process\.platform===`linux`&&console\.warn\(`\[codex-linux\] Failed to set up system tray`,e\)\}/,
+  );
+});
+
+test("logs Linux tray setup failures when the catch body contains nested objects", () => {
+  const source = [
+    "async function s4(e){let t=await l4(e.buildFlavor,e.repoRoot),n=new a.Tray(t.defaultIcon);return n}",
+    "let _e=async()=>{k=!0;try{await s4({buildFlavor:o,repoRoot:M.repoRoot})}catch(e){k=!1,v.reportNonFatal(e instanceof Error?e:`Failed to set up tray`,{kind:`tray-setup-failed`,tags:{errorType:`tray-setup-failed`}}),N.ensureWindow()}};D&&_e();",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
+
+  assert.match(
+    patched,
+    /\(D\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&_e\(\);/,
+  );
+  assert.match(
+    patched,
+    /N\.ensureWindow\(\);process\.platform===`linux`&&console\.warn\(`\[codex-linux\] Failed to set up system tray`,e\)\}/,
   );
 });
 

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -434,7 +434,7 @@ function findDynamicTraySetup(source) {
   while ((match = setupRegex.exec(source)) != null) {
     const [, setupFn, factoryFn] = match;
     if (isTrayFactoryFunction(source, factoryFn)) {
-      return { setupFn, index: match.index };
+      return { setupFn, factoryFn, index: match.index };
     }
   }
   return null;
@@ -444,6 +444,47 @@ function findDynamicTrayStartupCall(source, setupFn, startIndex) {
   const startupRegex = new RegExp(`([A-Za-z_$][\\w$]*)&&${escapeRegExp(setupFn)}\\(\\);`, "g");
   startupRegex.lastIndex = startIndex;
   return startupRegex.exec(source);
+}
+
+function addDynamicTraySetupFailureLogging(source, traySetup) {
+  const logMessage = "[codex-linux] Failed to set up system tray";
+  if (traySetup == null || source.includes(logMessage)) {
+    return source;
+  }
+
+  const openIndex = source.indexOf("{", traySetup.index);
+  if (openIndex === -1) {
+    return source;
+  }
+  const closeIndex = findMatchingBrace(source, openIndex);
+  if (closeIndex === -1) {
+    return source;
+  }
+
+  const body = source.slice(openIndex, closeIndex + 1);
+  if (!body.includes(`await ${traySetup.factoryFn}(`)) {
+    return source;
+  }
+
+  const catchRegex = /catch\(([A-Za-z_$][\w$]*)\)\{/;
+  const catchMatch = body.match(catchRegex);
+  if (catchMatch == null) {
+    return source;
+  }
+
+  const [, errorVar] = catchMatch;
+  const catchOpenIndex = catchMatch.index + catchMatch[0].length - 1;
+  const catchCloseIndex = findMatchingBrace(body, catchOpenIndex);
+  if (catchCloseIndex === -1) {
+    return source;
+  }
+
+  const catchBody = body.slice(catchOpenIndex + 1, catchCloseIndex);
+  const separator = catchBody.trim().length === 0 || /[;,]$/.test(catchBody.trim()) ? "" : ";";
+  const linuxWarning = `${separator}process.platform===\`linux\`&&console.warn(\`${logMessage}\`,${errorVar})`;
+  const patchedBody =
+    `${body.slice(0, catchCloseIndex)}${linuxWarning}${body.slice(catchCloseIndex)}`;
+  return `${source.slice(0, openIndex)}${patchedBody}${source.slice(closeIndex + 1)}`;
 }
 
 function applyLinuxQuitGuardPatch(currentSource) {
@@ -839,6 +880,20 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
       console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
     }
   }
+
+  const traySetupForDiagnostics = findDynamicTraySetup(patchedSource);
+  const sourceWithTrayDiagnostics = addDynamicTraySetupFailureLogging(
+    patchedSource,
+    traySetupForDiagnostics,
+  );
+  if (
+    traySetupForDiagnostics != null &&
+    sourceWithTrayDiagnostics === patchedSource &&
+    !patchedSource.includes("[codex-linux] Failed to set up system tray")
+  ) {
+    console.warn("WARN: Could not find tray setup catch handler — skipping Linux tray diagnostics patch");
+  }
+  patchedSource = sourceWithTrayDiagnostics;
 
   return patchedSource;
 }


### PR DESCRIPTION
## Summary
- add a Linux-only warning inside the dynamic tray startup catch so failed `new Tray(...)` paths are visible in logs
- keep tray behavior unchanged; this only reports the exception when Linux tray setup throws
- cover the current minified tray wrapper and keep unrelated async startup wrappers untouched

## Notes
- The packaged tray/app icon fallback mentioned in #435 is already present on current `main` via #434.
- This PR addresses the remaining blind spot from #435: if Electron tray setup fails before KDE StatusNotifier registration, the failure should no longer be silent.

Refs #435

## Testing
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`