### PR TITLE
Hide Linux titlebar menu chrome

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1302,7 +1302,7 @@ test("patches remaining explicit quit handlers when another copy is already patc
   );
 });
 
-test("uses the frameless native Codex titlebar for primary Linux windows", () => {
+test("uses a hidden native titlebar overlay for primary Linux windows", () => {
   const source = [
     "function A2(e){return e===`avatarOverlay`}",
     "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
@@ -1313,7 +1313,7 @@ test("uses the frameless native Codex titlebar for primary Linux windows", () =>
 
   assert.match(
     patched,
-    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:a\.nativeTheme\.shouldUseDarkColors\?`#111111`:o2,symbolColor:a\.nativeTheme\.shouldUseDarkColors\?v2:_2,height:Math\.round\(30\*e\)\}\}/,
+    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:`rgba\(0,0,0,0\)`,symbolColor:`rgba\(0,0,0,0\)`,height:1\}\}/,
   );
   assert.match(
     patched,
@@ -1336,7 +1336,7 @@ test("uses a module-scoped Linux native titlebar helper when aliases shadow Elec
 
   assert.match(
     value,
-    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:r\.nativeTheme\.shouldUseDarkColors\?`#111111`:K4,symbolColor:r\.nativeTheme\.shouldUseDarkColors\?i3:r3,height:Math\.round\(30\*e\)\}\}/,
+    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:`rgba\(0,0,0,0\)`,symbolColor:`rgba\(0,0,0,0\)`,height:1\}\}/,
   );
   assert.match(
     value,
@@ -1368,40 +1368,60 @@ test("updates the Linux native titlebar overlay when nativeTheme changes", () =>
   assert.doesNotMatch(patched, /data-codex-window-type/);
 });
 
-test("adds a right-side safe area for Linux window controls in application menu chrome", () => {
+test("maps Linux window controls chrome to native webview layout", () => {
   const source = [
     "var l=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+c,right:0}),modern:Object.freeze({left:76+c,right:0})}),applicationMenu:Object.freeze({left:0,right:0})});",
     "var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
+    "function chrome(e){switch(e){case`win32`:case`linux`:return`application-menu`;default:return`native`}}",
+    "let inset=i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??l.applicationMenu:l.default;",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source);
 
   assert.equal(
-    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:138\}\)/g) ?? []).length,
+    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/g) ?? []).length,
     2,
   );
-  assert.doesNotMatch(
-    patched,
-    /applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/,
-  );
+  assert.match(patched, /case`win32`:return`application-menu`;case`linux`:return`native`/);
+  assert.match(patched, /i\.includes\(`win`\)\|\|r\.includes\(`windows`\)\?t\?\?l\.applicationMenu:l\.default/);
+  assert.doesNotMatch(patched, /case`win32`:case`linux`:return`application-menu`/);
+  assert.doesNotMatch(patched, /i\.includes\(`win`\)\|\|r\.includes\(`windows`\)\|\|i\.includes\(`linux`\)\?t\?\?l\.applicationMenu:l\.default/);
 });
 
-test("patches remaining Linux window controls safe areas when another copy is already patched", () => {
+test("patches remaining Linux window controls chrome snippets when another copy is already patched", () => {
   const source = [
-    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:138})});",
+    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
+    "function patched(e){switch(e){case`win32`:return`application-menu`;case`linux`:return`native`;default:return`native`}}",
     "var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
+    "function unpatched(e){switch(e){case`win32`:case`linux`:return`application-menu`;default:return`native`}}",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source);
 
   assert.equal(
-    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:138\}\)/g) ?? []).length,
+    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/g) ?? []).length,
     2,
   );
-  assert.doesNotMatch(
-    patched,
-    /applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/,
+  assert.equal(
+    (patched.match(/case`win32`:return`application-menu`;case`linux`:return`native`/g) ?? []).length,
+    2,
   );
+  assert.doesNotMatch(patched, /case`win32`:case`linux`:return`application-menu`/);
+});
+
+test("warns when Linux window controls chrome mapping drifts", () => {
+  const source =
+    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});function chrome(e){return e===`linux`?`application-menu`:`native`}";
+
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find Linux window controls chrome mapping — skipping Linux native chrome layout patch",
+    "WARN: Could not find Linux window controls chrome mapping — skipping Linux native chrome layout patch",
+  ]);
 });
 
 test("keeps tooltips out of the Linux window controls titlebar area", () => {
@@ -1462,13 +1482,13 @@ test("adds Linux menu hiding next to Windows removeMenu calls", () => {
 
   assert.equal(
     patched,
-    "process.platform===`linux`&&k.setMenuBarVisibility(!1),process.platform===`win32`&&k.removeMenu(),",
+    "process.platform===`linux`&&(k.setMenuBarVisibility(!1),k.removeMenu?.()),process.platform===`win32`&&k.removeMenu(),",
   );
 });
 
 test("patches remaining Windows menu snippets when another copy is already Linux-patched", () => {
   const windowsMenuSnippet = "process.platform===`win32`&&k.removeMenu(),";
-  const linuxMenuPatch = "process.platform===`linux`&&k.setMenuBarVisibility(!1),";
+  const linuxMenuPatch = "process.platform===`linux`&&(k.setMenuBarVisibility(!1),k.removeMenu?.()),";
   const source = `${linuxMenuPatch}${windowsMenuSnippet}function createSecondWindow(){${windowsMenuSnippet}}`;
 
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
@@ -1476,7 +1496,7 @@ test("patches remaining Windows menu snippets when another copy is already Linux
   assert.equal((patched.match(/setMenuBarVisibility\(!1\)/g) ?? []).length, 2);
   assert.match(
     patched,
-    /function createSecondWindow\(\)\{process\.platform===`linux`&&k\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
+    /function createSecondWindow\(\)\{process\.platform===`linux`&&\(k\.setMenuBarVisibility\(!1\),k\.removeMenu\?\.\(\)\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
   );
 });
 
@@ -4239,7 +4259,10 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
   assert.match(patched, /codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0/);
   assert.match(patched, /n\.app\.on\(`before-quit`,codexLinuxBeforeQuitHandler\)/);
-  assert.match(patched, /process\.platform===`linux`&&k\.setMenuBarVisibility\(!1\)/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`&&\(k\.setMenuBarVisibility\(!1\),k\.removeMenu\?\.\(\)\)/,
+  );
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(
     patched,

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -9,7 +9,8 @@ const {
   requireName,
 } = require("./shared.js");
 
-const LINUX_TITLEBAR_OVERLAY_HEIGHT = 30;
+const LINUX_TITLEBAR_OVERLAY_COLOR = "`rgba(0,0,0,0)`";
+const LINUX_TITLEBAR_OVERLAY_HEIGHT = 1;
 const LINUX_TITLEBAR_OVERLAY_HELPER = "codexLinuxTitleBarOverlay";
 
 function linuxTitlebarOverlayHelperSource(
@@ -18,7 +19,7 @@ function linuxTitlebarOverlayHelperSource(
   lightSymbolAlias,
   darkSymbolAlias,
 ) {
-  return `function ${LINUX_TITLEBAR_OVERLAY_HELPER}(e=1){return{color:${electronAlias}.nativeTheme.shouldUseDarkColors?\`#111111\`:${lightBackgroundAlias},symbolColor:${electronAlias}.nativeTheme.shouldUseDarkColors?${lightSymbolAlias}:${darkSymbolAlias},height:Math.round(${LINUX_TITLEBAR_OVERLAY_HEIGHT}*e)}}`;
+  return `function ${LINUX_TITLEBAR_OVERLAY_HELPER}(e=1){return{color:${LINUX_TITLEBAR_OVERLAY_COLOR},symbolColor:${LINUX_TITLEBAR_OVERLAY_COLOR},height:${LINUX_TITLEBAR_OVERLAY_HEIGHT}}}`;
 }
 
 function ensureLinuxTitlebarOverlayHelper(source, anchorText, helperSource) {
@@ -127,9 +128,7 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
   const helperFunctionRegex = new RegExp(
     'function ' +
       escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
-      '\\([^)]*\\)\\{return\\{color:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?`#111111`:([A-Za-z_$][\\w$]*),symbolColor:\\1\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(' +
-      LINUX_TITLEBAR_OVERLAY_HEIGHT +
-      '\\*[A-Za-z_$][\\w$]*\\)\\}\\}',
+      '\\([^)]*\\)\\{return\\{color:`rgba\\(0,0,0,0\\)`,symbolColor:`rgba\\(0,0,0,0\\)`,height:1\\}\\}',
   );
   const helperFunctionMatch = currentSource.match(helperFunctionRegex);
 
@@ -184,7 +183,7 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
       return currentSource;
     }
   } else if (helperFunctionMatch != null) {
-    [, electronAlias, lightBackgroundAlias, lightSymbolAlias, darkSymbolAlias] = helperFunctionMatch;
+    electronAlias = requireName(currentSource, "electron");
   } else {
     console.warn("WARN: Could not derive Linux titleBarOverlay helper aliases — skipping Linux native titlebar patch");
     return currentSource;
@@ -196,6 +195,13 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
       `setTitleBarOverlay\\(process\\.platform===\`linux\`\\?${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\(`,
     ).test(patchedSource)
   ) {
+    return patchedSource;
+  }
+
+  if (electronAlias == null) {
+    if (patchedSource.includes("installWindowsTitleBarOverlaySync")) {
+      console.warn("WARN: Could not derive Electron alias — skipping Linux native titlebar sync patch");
+    }
     return patchedSource;
   }
 
@@ -257,13 +263,24 @@ function applyLinuxMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
   let patchedAny = false;
   const patchedSource = currentSource.replace(menuRegex, (match, windowVar, offset) => {
-    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
+    const linuxPatch = `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),`;
+    const legacyLinuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
     if (currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
+      return match;
+    }
+    if (currentSource.slice(Math.max(0, offset - legacyLinuxPatch.length), offset) === legacyLinuxPatch) {
+      patchedAny = true;
       return match;
     }
     patchedAny = true;
     return `${linuxPatch}${match}`;
   });
+
+  const upgradedSource = patchedSource.replace(
+    /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+    (_match, windowVar) =>
+      `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+  );
 
   if (!patchedAny && !currentSource.includes("setMenuBarVisibility(!1)")) {
     const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(currentSource);
@@ -272,7 +289,7 @@ function applyLinuxMenuPatch(currentSource) {
     }
   }
 
-  return patchedSource;
+  return upgradedSource;
 }
 
 function applyLinuxSetIconPatch(currentSource, iconAsset) {

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -12,7 +12,7 @@ const {
 const LINUX_SAFE_MONOSPACE_FONT_STACK =
   "\"Noto Sans Mono\", \"DejaVu Sans Mono\", \"Liberation Mono\", \"Ubuntu Mono\", ui-monospace, \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace";
 const LINUX_TOOLTIP_COLLISION_PADDING_TOP = 44;
-const LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT = 138;
+const LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT = 0;
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -201,21 +201,45 @@ function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
 function applyLinuxWindowControlsSafeAreaPatch(currentSource) {
   const currentInset = `applicationMenu:Object.freeze({left:0,right:${LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT}})`;
   const defaultInset = "applicationMenu:Object.freeze({left:0,right:0})";
-  if (currentSource.includes(defaultInset)) {
-    return currentSource.split(defaultInset).join(currentInset);
+  const hasWindowControlsInset = currentSource.includes("applicationMenu:Object.freeze({left:0,right:");
+  let patchedSource = currentSource;
+
+  if (patchedSource.includes(defaultInset)) {
+    patchedSource = patchedSource.split(defaultInset).join(currentInset);
   }
 
-  if (currentSource.includes(currentInset)) {
-    return currentSource;
+  const linuxApplicationMenuChrome = "case`win32`:case`linux`:return`application-menu`";
+  const linuxNativeChrome = "case`win32`:return`application-menu`;case`linux`:return`native`";
+  const foundApplicationMenuChrome = patchedSource.includes(linuxApplicationMenuChrome);
+  const hasNativeChrome = patchedSource.includes(linuxNativeChrome);
+  if (foundApplicationMenuChrome) {
+    patchedSource = patchedSource.split(linuxApplicationMenuChrome).join(linuxNativeChrome);
   }
 
-  if (currentSource.includes("applicationMenu:Object.freeze({left:0,right:")) {
+  const linuxApplicationMenuBrowserGate =
+    "i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??l.applicationMenu:l.default";
+  const linuxNativeBrowserGate =
+    "i.includes(`win`)||r.includes(`windows`)?t??l.applicationMenu:l.default";
+  const foundApplicationMenuBrowserGate = patchedSource.includes(linuxApplicationMenuBrowserGate);
+  const hasNativeBrowserGate = patchedSource.includes(linuxNativeBrowserGate);
+  if (foundApplicationMenuBrowserGate) {
+    patchedSource = patchedSource.split(linuxApplicationMenuBrowserGate).join(linuxNativeBrowserGate);
+  }
+
+  const recognizedChromeMapping = foundApplicationMenuChrome || hasNativeChrome;
+  const recognizedBrowserGate = foundApplicationMenuBrowserGate || hasNativeBrowserGate;
+
+  if (recognizedChromeMapping || recognizedBrowserGate) {
+    return patchedSource;
+  }
+
+  if (hasWindowControlsInset) {
     console.warn(
-      "WARN: Could not find Linux window controls safe-area insertion point — skipping safe-area patch",
+      "WARN: Could not find Linux window controls chrome mapping — skipping Linux native chrome layout patch",
     );
   }
 
-  return currentSource;
+  return patchedSource;
 }
 
 function applyLinuxTooltipWindowControlsCollisionPatch(currentSource) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3931,7 +3931,7 @@ test_linux_file_manager_patch_smoke() {
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>`linux-file-manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
-    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.setMenuBarVisibility(!1),'
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&(D.setMenuBarVisibility(!1),D.removeMenu?.()),'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
     assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" '`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null'
     assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" 'Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)'


### PR DESCRIPTION
## Summary

- hide the Linux primary-window titlebar overlay by keeping Electron's `titleBarOverlay` object but making it transparent and 1px tall
- strengthen Linux menu suppression by calling both `setMenuBarVisibility(false)` and `removeMenu?.()` next to the existing Windows `removeMenu()` path
- map Linux webview window chrome back to `native` instead of `application-menu`, so the renderer no longer reserves application-menu/window-control chrome space

## Why

Recent Codex Desktop builds can show a Linux app/menu decoration row or a visible top-right Electron titlebar overlay. Removing the overlay object entirely, or switching the window to `frame: false`, can crash the Linux build. Keeping the overlay API present while making it visually transparent avoids that crash path while removing the unwanted chrome.

## Validation

- `node --check scripts/patches/main-process.js`
- `node --check scripts/patches/webview-assets.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `tests/scripts_smoke.sh`

This behavior was also verified manually through a Nix/Home Manager override against Codex Desktop `26.602.71036` on Linux.
