### PR TITLE
Fix upstream drift for latest Codex Desktop release

### DIFF
--- a/linux-features/codex-wrapper-updater/patch.js
+++ b/linux-features/codex-wrapper-updater/patch.js
@@ -7,6 +7,7 @@ const { linuxSettingsKeys, requireName } = require("../../scripts/patches/shared
 const HANDLER_NAME = "codex-linux-wrapper-updater";
 const RUNTIME_VERSION = "codex-wrapper-updater-v3";
 const KEYBINDS_ASSET = "keybinds-settings-linux.js";
+const LINUX_DESKTOP_SETTINGS_ASSET = "linux-desktop-settings-linux.js";
 const WRAPPER_UPDATES_SETTING_KEY = linuxSettingsKeys.wrapperUpdates;
 const FEATURE_PICKER_ON_UPDATE_SETTING_KEY = linuxSettingsKeys.featurePickerOnUpdate;
 
@@ -209,14 +210,17 @@ function applyWrapperUpdateGeneralSettingsPatch(source) {
 function patchWrapperUpdateSettingsAssets(extractedDir) {
   try {
     const assetsDir = path.join(extractedDir, "webview", "assets");
-    const keybindsPath = path.join(assetsDir, KEYBINDS_ASSET);
-    if (fs.existsSync(keybindsPath)) {
-      const current = fs.readFileSync(keybindsPath, "utf8");
+    for (const settingsAsset of [LINUX_DESKTOP_SETTINGS_ASSET, KEYBINDS_ASSET]) {
+      const settingsPath = path.join(assetsDir, settingsAsset);
+      if (!fs.existsSync(settingsPath)) {
+        continue;
+      }
+      const current = fs.readFileSync(settingsPath, "utf8");
       const patched = applyWrapperUpdateSettingsPatch(current);
       if (patched === current) {
         return { matched: true, changed: 0 };
       }
-      fs.writeFileSync(keybindsPath, patched, "utf8");
+      fs.writeFileSync(settingsPath, patched, "utf8");
       return { matched: true, changed: 1 };
     }
 
@@ -224,7 +228,7 @@ function patchWrapperUpdateSettingsAssets(extractedDir) {
       .readdirSync(assetsDir)
       .filter((name) => /^general-settings-.*\.js$/.test(name));
     if (generalSettingsAssets.length === 0) {
-      return { matched: false, changed: 0, reason: `${KEYBINDS_ASSET} and general settings asset are not present` };
+      return { matched: false, changed: 0, reason: `${LINUX_DESKTOP_SETTINGS_ASSET}, ${KEYBINDS_ASSET}, and general settings asset are not present` };
     }
 
     let lastError = null;

--- a/linux-features/codex-wrapper-updater/test.js
+++ b/linux-features/codex-wrapper-updater/test.js
@@ -132,6 +132,32 @@ test("settings asset patch skips re-exported general settings bundles", () => {
   }
 });
 
+test("settings asset patch prefers generated Linux desktop settings bundle", () => {
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-wrapper-updater-linux-desktop-settings-"));
+  const assetsDir = path.join(appDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const linuxDesktopSettings =
+    `var KEYS={autoUpdateOnExit:"codex-linux-auto-update-on-exit"};` +
+    `function Settings(){return $.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})}`;
+  const generalSettings = `function Br(){return null}`;
+  fs.writeFileSync(path.join(assetsDir, "linux-desktop-settings-linux.js"), linuxDesktopSettings);
+  fs.writeFileSync(path.join(assetsDir, "general-settings-z.js"), generalSettings);
+
+  try {
+    assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), { matched: true, changed: 1 });
+    assert.match(
+      fs.readFileSync(path.join(assetsDir, "linux-desktop-settings-linux.js"), "utf8"),
+      /Check for Codex Desktop Linux updates/,
+    );
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"),
+      generalSettings,
+    );
+  } finally {
+    fs.rmSync(appDir, { recursive: true, force: true });
+  }
+});
+
 test("feature exposes optional patches and declarative apply hooks when enabled", () => {
   withTempFeatureConfig(["codex-wrapper-updater"], () => {
     assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot }), ["codex-wrapper-updater"]);

--- a/scripts/lib/linux-update-bridge-patch.js
+++ b/scripts/lib/linux-update-bridge-patch.js
@@ -196,7 +196,15 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
   const messageDispatcherVar = bridgeHandlersSearchSource.match(
     /([A-Za-z_$][\w$]*)\.sendMessageToAllRegisteredWindows\(\{type:`app-update-ready-changed`/,
   )?.[1] ?? null;
-  if (messageDispatcherVar == null) {
+  const appUpdateStateBroadcasterVar = bridgeHandlersSearchSource.match(
+    /([A-Za-z_$][\w$]*)\.broadcastAppUpdateState\(\)/,
+  )?.[1] ?? null;
+  const sendCallback = messageDispatcherVar == null
+    ? appUpdateStateBroadcasterVar == null
+      ? null
+      : `send:()=>${appUpdateStateBroadcasterVar}.broadcastAppUpdateState()`
+    : `send:e=>${messageDispatcherVar}.sendMessageToAllRegisteredWindows(e)`;
+  if (sendCallback == null) {
     console.warn("WARN: Could not identify current updater window message dispatcher - skipping Linux updater bridge patch");
     return currentSource;
   }
@@ -208,7 +216,7 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
       patchedSource = patchedSource.replace(
         legacyBridgeRegex,
         (_match, quitControllerVar, quitFactoryVar, quitFnVar, electronBindingVar) =>
-          `let ${quitControllerVar}=${quitFactoryVar}(),${quitFnVar}=()=>{${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),${electronBindingVar}.app.quit()},codexLinuxPackageUpdateBridge=process.platform===\`linux\`?codexLinuxCreatePackageUpdateManager({allowQuit:()=>${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),send:e=>${messageDispatcherVar}.sendMessageToAllRegisteredWindows(e)}):null;codexLinuxPackageUpdateBridge!=null&&(${sparkleVar}=codexLinuxPackageUpdateBridge.manager,${quitFnVar}=codexLinuxPackageUpdateBridge.quitForUpdate,setInterval(()=>codexLinuxPackageUpdateBridge.refresh(),3e4).unref?.());`,
+          `let ${quitControllerVar}=${quitFactoryVar}(),${quitFnVar}=()=>{${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),${electronBindingVar}.app.quit()},codexLinuxPackageUpdateBridge=process.platform===\`linux\`?codexLinuxCreatePackageUpdateManager({allowQuit:()=>${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),${sendCallback}}):null;codexLinuxPackageUpdateBridge!=null&&(${sparkleVar}=codexLinuxPackageUpdateBridge.manager,${quitFnVar}=codexLinuxPackageUpdateBridge.quitForUpdate,setInterval(()=>codexLinuxPackageUpdateBridge.refresh(),3e4).unref?.());`,
       );
     } else {
       const currentBridgeRegex =
@@ -220,7 +228,7 @@ function applyCurrentBootstrapUpdaterBridgePatch(currentSource) {
       }
       const [bridgeDeclaration, quitControllerVar, quitFactoryVar, preservedVar, quitFnVar] = currentBridgeMatch;
       const bridgeSetup =
-        `${bridgeDeclaration}codexLinuxPackageUpdateBridge=process.platform===\`linux\`?codexLinuxCreatePackageUpdateManager({allowQuit:()=>${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),send:e=>${messageDispatcherVar}.sendMessageToAllRegisteredWindows(e)}):null;codexLinuxPackageUpdateBridge!=null&&(${sparkleVar}=codexLinuxPackageUpdateBridge.manager,${quitFnVar}=codexLinuxPackageUpdateBridge.quitForUpdate,setInterval(()=>codexLinuxPackageUpdateBridge.refresh(),3e4).unref?.());`;
+        `${bridgeDeclaration}codexLinuxPackageUpdateBridge=process.platform===\`linux\`?codexLinuxCreatePackageUpdateManager({allowQuit:()=>${quitControllerVar}.allowQuitTemporarilyForUpdateInstall(),${sendCallback}}):null;codexLinuxPackageUpdateBridge!=null&&(${sparkleVar}=codexLinuxPackageUpdateBridge.manager,${quitFnVar}=codexLinuxPackageUpdateBridge.quitForUpdate,setInterval(()=>codexLinuxPackageUpdateBridge.refresh(),3e4).unref?.());`;
       patchedSource = patchedSource.replace(currentBridgeRegex, bridgeSetup);
     }
   }

--- a/scripts/lib/patch-chrome-plugin.js
+++ b/scripts/lib/patch-chrome-plugin.js
@@ -8,6 +8,19 @@ function warn(message) {
   process.stderr.write(`WARN: ${message}\n`);
 }
 
+function sourceIncludesAny(source, texts) {
+  return (Array.isArray(texts) ? texts : [texts]).some(
+    (text) => typeof text === "string" && text.length > 0 && source.includes(text),
+  );
+}
+
+function shouldSkipPatch(source, skipIf) {
+  if (typeof skipIf === "function") {
+    return skipIf(source);
+  }
+  return sourceIncludesAny(source, skipIf);
+}
+
 function patchFile(filePath, patches) {
   let source;
   try {
@@ -19,7 +32,7 @@ function patchFile(filePath, patches) {
 
   let changed = false;
   for (const { label, oldText, newText, alreadyText = newText } of patches) {
-    if (source.includes(newText) || source.includes(alreadyText)) {
+    if (source.includes(newText) || sourceIncludesAny(source, alreadyText)) {
       console.log(`${path.basename(filePath)} already patched: ${label}`);
       continue;
     }
@@ -39,7 +52,14 @@ function patchFile(filePath, patches) {
   }
 }
 
-function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText = newText }) {
+function patchFileFirstMatch(filePath, {
+  label,
+  oldTexts,
+  newText,
+  alreadyText = newText,
+  skipIf = null,
+  skipDescription = "target no longer exists in this upstream bundle",
+}) {
   let source;
   try {
     source = fs.readFileSync(filePath, "utf8");
@@ -61,6 +81,10 @@ function patchFileFirstMatch(filePath, { label, oldTexts, newText, alreadyText =
 
   const match = candidates.find((candidate) => source.includes(candidate.oldText));
   if (!match) {
+    if (shouldSkipPatch(source, skipIf)) {
+      console.log(`${path.basename(filePath)} skipped: ${label} (${skipDescription})`);
+      return;
+    }
     warn(`${path.basename(filePath)} missing patch target for ${label}`);
     return;
   }
@@ -75,6 +99,20 @@ if (!pluginDir) {
 }
 
 const scriptsDir = path.resolve(pluginDir, "scripts");
+
+function browserClientHasMovedChromeProfileMetadata(source) {
+  return (
+    source.includes("setupBrowserRuntime") &&
+    !source.includes("Local Extension Settings") &&
+    !source.includes("Local State") &&
+    !source.includes("extensionInstanceId")
+  );
+}
+
+const legacyBrowserClientChromeProfileSkip = {
+  skipIf: browserClientHasMovedChromeProfileMetadata,
+  skipDescription: "Chrome profile metadata now lives outside browser-client.mjs",
+};
 
 const linuxExtensionAwareUserDataFallback = `  const linuxChromeUserDataDirectory = path.join(os.homedir(), ".config", "google-chrome");
   const linuxChromiumUserDataDirectory = path.join(os.homedir(), ".config", "chromium");
@@ -330,6 +368,7 @@ ${linuxNativeHostManifestFallback}
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux Chrome profile roots",
+  ...legacyBrowserClientChromeProfileSkip,
   oldTexts: [
     {
       oldText: String.raw`var Tc=GF(VF(),WF()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
@@ -351,12 +390,17 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       oldText: String.raw`var $c=Nj(Oj(),Mj()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
       newText: String.raw`var $c=Nj(Oj(),Mj()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>Mj()==="linux"?[Nj(Oj(),".config","BraveSoftware","Brave-Browser"),Nj(Oj(),".config","google-chrome"),Nj(Oj(),".config","chromium")]:[$c];`,
     },
+    {
+      oldText: String.raw`var cd=d$(p$(),f$()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome");`,
+      newText: String.raw`var cd=d$(p$(),f$()==="win32"?"AppData\\Local\\Google\\Chrome\\User Data":"Library/Application Support/Google/Chrome"),codexLinuxChromeUserDataDirectories=()=>f$()==="linux"?[d$(p$(),".config","BraveSoftware","Brave-Browser"),d$(p$(),".config","google-chrome"),d$(p$(),".config","chromium")]:[cd];`,
+    },
   ],
   alreadyText: "codexLinuxChromeUserDataDirectories",
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux Chrome profile metadata lookup",
+  ...legacyBrowserClientChromeProfileSkip,
   oldTexts: [
     {
       oldText: String.raw`var IS=async(t,e)=>{let r=Gf(Tc,t,"Local Extension Settings",e);if(!XF(r))return null;let n=await JF(Gf(QF(),"codex"));await ZF(r,n,{recursive:!0}),await kS(Gf(n,"LOCK"));let o=new KF(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await kS(n,{force:!0,recursive:!0})}}`,
@@ -374,12 +418,17 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       oldText: String.raw`var bk=async(e,t)=>{let r=Ih($c,e,"Local Extension Settings",t);if(!jj(r))return null;let n=await Uj(Ih(qj(),"codex"));await Lj(r,n,{recursive:!0}),await gk(Ih(n,"LOCK"));let o=new Fj(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await gk(n,{force:!0,recursive:!0})}}`,
       newText: String.raw`var bk=async(e,t,r=$c)=>{let n=Ih(r,e,"Local Extension Settings",t);if(!jj(n))return null;let o=await Uj(Ih(qj(),"codex"));await Lj(n,o,{recursive:!0}),await gk(Ih(o,"LOCK"));let i=new Fj(o,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await i.open();let s=await i.get("extensionInstanceId");if(!s)return null;let a=JSON.parse(s);return typeof a!="string"?null:a}finally{await i.close(),await gk(o,{force:!0,recursive:!0})}}`,
     },
+    {
+      oldText: String.raw`var ak=async(e,t)=>{let r=Zh(cd,e,"Local Extension Settings",t);if(!y$(r))return null;let n=await b$(Zh(_$(),"codex"));await g$(r,n,{recursive:!0}),await sk(Zh(n,"LOCK"));let o=new m$(n,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await o.open();let i=await o.get("extensionInstanceId");if(!i)return null;let s=JSON.parse(i);return typeof s!="string"?null:s}finally{await o.close(),await sk(n,{force:!0,recursive:!0})}}`,
+      newText: String.raw`var ak=async(e,t,r=cd)=>{let n=Zh(r,e,"Local Extension Settings",t);if(!y$(n))return null;let o=await b$(Zh(_$(),"codex"));await g$(n,o,{recursive:!0}),await sk(Zh(o,"LOCK"));let i=new m$(o,{createIfMissing:!1,keyEncoding:"utf8",valueEncoding:"utf8"});try{await i.open();let s=await i.get("extensionInstanceId");if(!s)return null;let a=JSON.parse(s);return typeof a!="string"?null:a}finally{await i.close(),await sk(o,{force:!0,recursive:!0})}}`,
+    },
   ],
   alreadyText: "async(t,e,r=Tc)",
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux Chrome profile instance matching",
+  ...legacyBrowserClientChromeProfileSkip,
   oldTexts: [
     {
       oldText: String.raw`rO=async(t,e)=>(await nO(t)).find(o=>o.instanceId===e)||null,nO=async t=>{let e=await oO();return await Promise.all(e.map(async r=>({...r,instanceId:await IS(r.id,t).catch(n=>(ee(n),null))})))},oO=async()=>{let t=tO(Tc,"Local State"),e=JSON.parse(await eO(t,"utf8"));return e.profile.profiles_order.map((r,n)=>{let o=e.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:e.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}`,
@@ -397,12 +446,17 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
       oldText: String.raw`Wj=async(e,t)=>(await Hj(e)).find(o=>o.instanceId===t)||null,Hj=async e=>{let t=await Vj();return await Promise.all(t.map(async r=>({...r,instanceId:await bk(r.id,e).catch(n=>(ue(n),null))})))},Vj=async()=>{let e=zj($c,"Local State"),t=JSON.parse(await $j(e,"utf8"));return t.profile.profiles_order.map((r,n)=>{let o=t.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:t.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}`,
       newText: String.raw`Wj=async(e,t)=>{let r=(await Hj(e)).filter(n=>n.instanceId===t);return r.length===1?r[0]:null},Hj=async e=>{let t=[];for(let r of codexLinuxChromeUserDataDirectories())try{let n=await Vj(r);t.push(...await Promise.all(n.map(async o=>({...o,userDataDir:r,instanceId:await bk(o.id,e,r).catch(i=>(ue(i),null))}))))}catch(n){ue(n)}return t},Vj=async r=>{let n=zj(r,"Local State"),o=JSON.parse(await $j(n,"utf8"));return o.profile.profiles_order.map((i,s)=>{let a=o.profile.info_cache[i];return a?{id:i,name:a.name,isLastUsed:o.profile.last_used===i,orderingIndex:s,avatarUrl:a.avatar_icon}:null}).filter(i=>!!i)}`,
     },
+    {
+      oldText: String.raw`S$=async(e,t)=>(await v$(e)).find(o=>o.instanceId===t)||null,v$=async e=>{let t=await E$();return await Promise.all(t.map(async r=>({...r,instanceId:await ak(r.id,e).catch(n=>(ue(n),null))})))},E$=async()=>{let e=x$(cd,"Local State"),t=JSON.parse(await w$(e,"utf8"));return t.profile.profiles_order.map((r,n)=>{let o=t.profile.info_cache[r];return o?{id:r,name:o.name,isLastUsed:t.profile.last_used===r,orderingIndex:n,avatarUrl:o.avatar_icon}:null}).filter(r=>!!r)}`,
+      newText: String.raw`S$=async(e,t)=>{let r=(await v$(e)).filter(n=>n.instanceId===t);return r.length===1?r[0]:null},v$=async e=>{let t=[];for(let r of codexLinuxChromeUserDataDirectories())try{let n=await E$(r);t.push(...await Promise.all(n.map(async o=>({...o,userDataDir:r,instanceId:await ak(o.id,e,r).catch(i=>(ue(i),null))}))))}catch(n){ue(n)}return t},E$=async r=>{let n=x$(r,"Local State"),o=JSON.parse(await w$(n,"utf8"));return o.profile.profiles_order.map((i,s)=>{let a=o.profile.info_cache[i];return a?{id:i,name:a.name,isLastUsed:o.profile.last_used===i,orderingIndex:s,avatarUrl:a.avatar_icon}:null}).filter(i=>!!i)}`,
+    },
   ],
   alreadyText: "r.length===1?r[0]:null",
 });
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux Chrome active profile backend ordering",
+  ...legacyBrowserClientChromeProfileSkip,
   oldTexts: [
     {
       oldText: String.raw`d9=async e=>{let t=ST(),r=e.filter(o=>o.info.type==="iab"),n=p9(r,t);return await Promise.all(r.filter(o=>!n.includes(o)).map(async({api:o})=>o.close())),[...e.filter(o=>o.info.type!=="iab"),...n]},p9=(e,t)=>t==null?[]:e.filter(r=>r.info.metadata?.codexSessionId===t);`,
@@ -415,6 +469,10 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
     {
       oldText: String.raw`Kj=async(e,{codexSessionId:t})=>{let r=ap(Ey),n=e.filter(i=>i.info.type==="iab"),o=Jj(n,t,r);return await Promise.all(n.filter(i=>!o.includes(i)).map(async({api:i})=>i.close())),[...e.filter(i=>i.info.type!=="iab"),...o]},Jj=(e,t,r)=>t==null?[]:e.filter(n=>n.info.metadata?.codexSessionId===t&&(r==null||n.info.metadata.codexAppBuildFlavor===r));`,
       newText: String.raw`Kj=async(e,{codexSessionId:t})=>{let r=ap(Ey),n=e.filter(i=>i.info.type==="iab"),o=Jj(n,t,r);await Promise.all(n.filter(i=>!o.includes(i)).map(async({api:i})=>i.close()));let s=[...e.filter(i=>i.info.type!=="iab"),...o];return await codexLinuxRankBrowserBackends(s)},Jj=(e,t,r)=>t==null?[]:e.filter(n=>n.info.metadata?.codexSessionId===t&&(r==null||n.info.metadata.codexAppBuildFlavor===r));async function codexLinuxRankBrowserBackends(e){if(Mj()!=="linux")return e;let t=await Promise.all(e.map(async(r,n)=>({browser:r,index:n,userTabCount:await codexLinuxExtensionUserTabCount(r)})));return t.sort(codexLinuxBackendCompare).map(({browser:r})=>r)}function codexLinuxBackendCompare(e,t){let r=e.browser.info.type==="extension",n=t.browser.info.type==="extension";return!r||!n?e.index-t.index:codexLinuxExtensionBackendScore(t)-codexLinuxExtensionBackendScore(e)||e.index-t.index}async function codexLinuxExtensionUserTabCount(e){if(e.info.type!=="extension")return-1;try{let t=await Promise.race([e.api.getUserTabs(),new Promise((r,n)=>setTimeout(()=>n(new Error("Chrome profile tab probe timed out")),750))]);return Array.isArray(t)?t.length:0}catch(t){return ue(t),0}}function codexLinuxExtensionBackendScore(e){let t=e.userTabCount>0?1e4+e.userTabCount:0,r=e.browser.info.metadata??{};r.profileIsLastUsed==="true"&&(t+=100);let n=Number(r.profileOrdering);return Number.isFinite(n)?t-n:t}`,
+    },
+    {
+      oldText: String.raw`A$=async(e,{codexSessionId:t})=>{let r=Gu(Vy),n=e.filter(i=>i.info.type==="iab"),o=k$(n,t,r);return await Promise.all(n.filter(i=>!o.includes(i)).map(async({api:i})=>i.close())),[...e.filter(i=>i.info.type!=="iab"),...o]},k$=(e,t,r)=>t==null?[]:e.filter(n=>n.info.metadata?.codexSessionId===t&&(r==null||n.info.metadata.codexAppBuildFlavor===r));`,
+      newText: String.raw`A$=async(e,{codexSessionId:t})=>{let r=Gu(Vy),n=e.filter(i=>i.info.type==="iab"),o=k$(n,t,r);await Promise.all(n.filter(i=>!o.includes(i)).map(async({api:i})=>i.close()));let s=[...e.filter(i=>i.info.type!=="iab"),...o];return await codexLinuxRankBrowserBackends(s)},k$=(e,t,r)=>t==null?[]:e.filter(n=>n.info.metadata?.codexSessionId===t&&(r==null||n.info.metadata.codexAppBuildFlavor===r));async function codexLinuxRankBrowserBackends(e){if(f$()!=="linux")return e;let t=await Promise.all(e.map(async(r,n)=>({browser:r,index:n,userTabCount:await codexLinuxExtensionUserTabCount(r)})));return t.sort(codexLinuxBackendCompare).map(({browser:r})=>r)}function codexLinuxBackendCompare(e,t){let r=e.browser.info.type==="extension",n=t.browser.info.type==="extension";return!r||!n?e.index-t.index:codexLinuxExtensionBackendScore(t)-codexLinuxExtensionBackendScore(e)||e.index-t.index}async function codexLinuxExtensionUserTabCount(e){if(e.info.type!=="extension")return-1;try{let t=await Promise.race([e.api.getUserTabs(),new Promise((r,n)=>setTimeout(()=>n(new Error("Chrome profile tab probe timed out")),750))]);return Array.isArray(t)?t.length:0}catch(t){return ue(t),0}}function codexLinuxExtensionBackendScore(e){let t=e.userTabCount>0?1e4+e.userTabCount:0,r=e.browser.info.metadata??{};r.profileIsLastUsed==="true"&&(t+=100);let n=Number(r.profileOrdering);return Number.isFinite(n)?t-n:t}`,
     },
   ],
   alreadyText: "codexLinuxRankBrowserBackends",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -77,6 +77,7 @@ const {
 const {
   keybindsSettingsAsset,
   linuxDesktopSettingsAsset,
+  applyLinuxDesktopSettingsSectionsPatch,
   applyKeybindsSettingsSharedPatch,
   applyLinuxDesktopSettingsSharedPatch,
 } = require("./patches/keybinds-settings.js");
@@ -161,6 +162,16 @@ function automationScheduleBundleFixture() {
   ].join("");
 }
 
+function currentAutomationScheduleBundleFixture() {
+  return [
+    "var K={MINUTELY:1,HOURLY:2,DAILY:3,WEEKLY:4},q=[`SU`,`MO`,`TU`,`WE`,`TH`,`FR`,`SA`],X=Array.from(q),Ht=[`MO`,`TU`,`WE`,`TH`,`FR`],Ut=[`SA`,`SU`],Wt=`09:00`,Gt=`MO`,Kt=new Set([`freq`,`interval`,`dtstart`,`tzid`]),qt=new Set([...Kt,`byweekday`,`byminute`]),Jt=new Set([...qt,`byhour`]);",
+    "function Mt(e,t){return t.formatTime(e)}function Y(e,t){return e.length===t.length}function on(e){return e.length>0?e:X}function Sn(){return `minute`}function xn(){return `hour`}function wn({timeLabel:e}){return e}",
+    "function Tn(e,t,n){let r=En(e),i=En(t);return r!=null&&i!=null?Mn(r,i):n.dtstart?Mn(n.dtstart.getHours(),n.dtstart.getMinutes()):Wt}function En(e){return Array.isArray(e)?typeof e[0]==`number`?e[0]:null:typeof e==`number`?e:null}",
+    "function $(e){let t=yt(e,{forceset:!0,tzid:Nn()??void 0}),n=t.rrules()[0],r=n.options,i=Dn(r.byweekday)??On(e)??X,a=En(r.byminute);return{freq:r.freq,isStandaloneRrule:n.origOptions.dtstart==null&&t.rrules().length===1&&t.rdates().length===0&&t.exrules().length===0&&t.exdates().length===0,hasMultipleTimeValues:Array.isArray(r.byhour)&&r.byhour.length>1||Array.isArray(r.byminute)&&r.byminute.length>1,interval:Math.max(1,Math.round(r.interval??1)),minute:a,origOptions:n.origOptions,rruleText:e,time:Tn(r.byhour,r.byminute,r),weekdays:i}}",
+    "function bn(e,t){if(!e||e.hasMultipleTimeValues)return null;let n=on(e.weekdays),r=n.length===q.length;if(e.freq===K.MINUTELY)return Sn({intervalMinutes:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq===K.HOURLY)return xn({intervalHours:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq!==K.DAILY&&e.freq!==K.WEEKLY)return null;let i=Mt(e.time,t);return i?wn({intl:t,isEveryDay:r,timeLabel:i,weekdays:n}):null}",
+  ].join("");
+}
+
 function evaluateAutomationSchedule(source, now, options) {
   const context = { now, options, result: null };
   vm.runInNewContext(
@@ -201,6 +212,25 @@ test("automation schedule asset patch updates workspace-root bundle", () => {
     assert.deepEqual(patchAutomationScheduleAssets(tempRoot), { matched: 1, changed: 1 });
     const patched = fs.readFileSync(bundlePath, "utf8");
     assert.match(patched, /function codexLinuxRruleTimes/);
+    assert.deepEqual(patchAutomationScheduleAssets(tempRoot), { matched: 1, changed: 0 });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("automation schedule asset patch updates current webview automation bundle", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-automation-schedule-current-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+    const bundlePath = path.join(assetsDir, "automation-schedule-test.js");
+    fs.writeFileSync(bundlePath, currentAutomationScheduleBundleFixture(), "utf8");
+
+    assert.deepEqual(patchAutomationScheduleAssets(tempRoot), { matched: 1, changed: 1 });
+    const patched = fs.readFileSync(bundlePath, "utf8");
+    assert.match(patched, /function codexLinuxRruleTimes/);
+    assert.match(patched, /timeValues:codexLinuxRruleTimes/);
+    assert.match(patched, /codexLinuxAutomationTimeLabel/);
     assert.deepEqual(patchAutomationScheduleAssets(tempRoot), { matched: 1, changed: 0 });
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
@@ -291,6 +321,24 @@ test("subagent nickname metadata patch accepts session metadata shape", () => {
     source: "Pepper Potts",
     role: "worker",
   });
+});
+
+test("subagent nickname metadata patch accepts current upstream patched aliases", () => {
+  const source = [
+    "function P(e){return e}",
+    "function jo(e){if(e==null||typeof e==`string`)return null;let t=Mo(e);return t==null?null:No(t)}",
+    "function Mo(e){return`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null}",
+    "function No(e){return typeof e==`string`?Po():`thread_spawn`in e?{parentThreadId:P(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Po()}",
+    "function Po(){return{parentThreadId:null,depth:null,agentNickname:null,agentRole:null}}",
+    "function Fo(e){return e==null?null:Io(e.agentNickname)??Io(e.agent_nickname)??Io(jo(e.source)?.agentNickname)}",
+    "function Io(e){if(e==null)return null;let t=e.trim();return t.length===0?null:t}",
+  ].join("");
+  const { value, warnings } = captureWarns(() =>
+    applySubagentNicknameMetadataPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("Linux target context parses distro, package, and desktop details", () => {
@@ -980,6 +1028,18 @@ function currentBootstrapUpdaterBundleWithParametrizedQuitFixture() {
   ].join("");
 }
 
+function currentBootstrapUpdaterBundleWithAppUpdateStateBroadcastFixture() {
+  return [
+    "let r=require(`electron`),i=require(`node:path`),o=require(`node:fs`),u=require(`node:child_process`);",
+    "var g6={enabled:!1,running:!1,state:`disabled`};",
+    "async function v6(){",
+    "let{startedAtMs:e,buildFlavor:i,desktopSentry:o,sparkleManager:s,setSparkleBridgeHandlers:c,setSecondInstanceArgsHandler:l}=n.k(),d=n.P.shouldIncludeSparkle(i,process.platform,process.env)||process.platform===`linux`;",
+    "let ee=FZ(),P=null,te=e=>{if(e?.quitImmediately===!1){ee.allowQuitTemporarilyForUpdateInstall();return}ee.allowQuitTemporarilyForUpdateInstall(),r.app.quit()};let F=F3({}),oe=iZ({}),se=oe.getWindowContext();",
+    "c({onDownloadProgressChanged:()=>{se.broadcastAppUpdateState()},onInstallProgressChanged:()=>{T&&se.broadcastAppUpdateState()},onUpdateReadyChanged:()=>{se.broadcastAppUpdateState()},onUpdateLifecycleStateChanged:()=>{se.broadcastAppUpdateState()},onRelaunchNoticeChanged:()=>{se.broadcastAppUpdateState()},onInstallUpdatesRequested:e=>{te(e)},isTrustedIpcEvent:M});",
+    "}",
+  ].join("");
+}
+
 function avatarOverlayBundleFixture() {
   return [
     "let u=require(`node:child_process`);",
@@ -996,6 +1056,26 @@ function avatarOverlayBundleFixture() {
     "showWindow(e){if(e.isDestroyed())return;let t=this.isOpen();e.moveTop(),e.showInactive(),!t&&this.isOpen()&&this.broadcastOpenState()}broadcastOpenState(){this.windowManager.sendMessageToAllRegisteredWindows({type:`avatar-overlay-open-state-changed`,isOpen:this.isOpen()})}",
     "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}",
     "refreshCursorAtCurrentMousePosition(e){if(e.isDestroyed())return;let t=n.screen.getCursorScreenPoint(),r=e.getContentBounds(),i=t.x-r.x,a=t.y-r.y;i<0||a<0||i>r.width||a>r.height||e.webContents.sendInputEvent({type:`mouseMove`,x:i,y:a,movementX:0,movementY:0})}",
+    "};",
+  ].join("");
+}
+
+function currentAvatarOverlayBundleFixture() {
+  return [
+    "let r=require(`electron`),f=require(`node:child_process`);",
+    "var rV=`/avatar-overlay`,zB={width:356,height:320},oV={width:112,height:121},u1={width:0,height:0},l1={width:276,height:131};",
+    "var fV=class{window=null;rendererReady=!1;layout=null;mascotSize=oV;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;windowStagedForNativePresentation=!1;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1}};",
+    "constructor(e,t){this.windowManager=e,this.globalState=t}",
+    "isOpen(){let e=this.window;return e!=null&&!e.isDestroyed()&&e.isVisible()&&!this.windowStagedForNativePresentation}",
+    "startDrag(e,{pointerWindowX:t,pointerWindowY:n}){let i=this.window;if(i==null||i.isDestroyed()||i.webContents.id!==e)return;this.cancelMomentum(),this.clearDetachedDisplayRestore();let a=this.getLayout(i);this.dragState={pointerAnchorX:t-a.mascot.left,pointerAnchorY:n-a.mascot.top,hasMoved:!1,displayBounds:r.screen.getDisplayNearestPoint(r.screen.getCursorScreenPoint()).bounds},process.platform===`linux`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())}",
+    "moveDrag(e){return e}",
+    "endDrag(e){let t=this.window;t==null||t.isDestroyed()||t.webContents.id!==e||(this.dragState?.hasMoved&&this.moveDragToCurrentCursor(t),this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0}),process.platform===`linux`&&this.applyPointerInteractivityPolicy())}",
+    "setElementSize(e,{isTrayVisible:t,mascot:n,tray:r}){let i=this.window;i==null||i.isDestroyed()||i.webContents.id!==e||(this.cancelMomentum(),this.layoutMode=t==null?`native`:`legacy`,this.mascotSize=n,this.traySize=r,this.applyLatestElementSizes(i),this.stageWindowForNativePresentation(i),this.showWindowIfReady(i))}",
+    "applyLatestElementSizes(e){this.anchor={...this.anchor,width:this.mascotSize.width,height:this.mascotSize.height},this.applyLayout(e)}",
+    "async createWindow(e){let t=await this.windowManager.createWindow({title:r.app.getName(),width:zB.width,height:zB.height,appearance:`avatarOverlay`,focusable:!1,show:!1,initialRoute:rV});return this.window=t,this.compositionHost.setOverlayWindow(t),this.rendererReady=this.windowManager.isWebContentsReady(t.webContents.id),this.dragState=null,this.layout=null,this.mascotSize=oV,this.mousePassthroughEnabled=!1,this.traySize=null,t.on(`closed`,()=>{this.window===t&&(this.cancelMomentum(),this.clearMovedWindowPersist(),this.window=null,this.dragState=null,this.layout=null,this.rendererReady=!1,this.pointerInteractive=!1,this.mousePassthroughEnabled=!1,this.compositionHost.setOverlayWindow(null),this.broadcastOpenState())}),t}",
+    "applyLayout(e,t=this.getCurrentDisplay(),n=!1,r=!0){if(e.isDestroyed())return;let a=UB({anchor:this.anchor,displayBounds:t.bounds,mascotSize:this.mascotSize,previousPlacement:this.placement,traySize:this.traySize??(this.layoutMode===`native`?u1:l1)});this.anchor=a.anchor,this.layout=a,this.placement=a.placement,this.setWindowBounds(e,a.windowBounds,n,r),this.sendLayoutToRenderer(e)}getLayout(e){if(this.layout??this.applyLayout(e),this.layout==null)throw Error(`Expected avatar overlay layout`);return this.layout}",
+    "showWindow(e){if(e.isDestroyed())return;let t=this.isOpen();this.windowStagedForNativePresentation&&=(e.setOpacity(1),!1),e.moveTop(),e.showInactive(),!t&&this.isOpen()&&this.broadcastOpenState()}showWindowIfReady(e){!this.rendererReady||this.initialPresentationState!==`ready`||(this.showWindow(e),this.applyPointerInteractivityPolicy())}stageWindowForNativePresentation(e){e.isDestroyed()||this.applyPointerInteractivityPolicy()}broadcastOpenState(){this.windowManager.sendMessageToAllRegisteredWindows({type:`avatar-overlay-open-state-changed`,isOpen:this.isOpen()})}",
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}refreshCursorAtCurrentMousePosition(e){let t=r.screen.getCursorScreenPoint()}",
     "};",
   ].join("");
 }
@@ -1236,6 +1316,17 @@ test("uses the frameless native Codex titlebar for primary Linux windows", () =>
   assert.doesNotMatch(patched, /n===`win32`\|\|n===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:b2\(r\)\}/);
 });
 
+test("recognizes current Linux native titlebar literal color as already patched", () => {
+  const source =
+    "function T3({appearance:e,opaqueWindowSurfaceEnabled:t,platform:n,windowZoom:r=1}){switch(e){case`primary`:return n===`darwin`?t?{titleBarStyle:`hiddenInset`,trafficLightPosition:a3(r)}:{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:a3(r)}:n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:o3(r)}:n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:{color:r.nativeTheme.shouldUseDarkColors?`#111111`:K4,symbolColor:r.nativeTheme.shouldUseDarkColors?i3:r3,height:Math.round(30*r)}}:{titleBarStyle:`default`}}}";
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxNativeTitlebarPatch, source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
+});
+
 test("updates the Linux native titlebar overlay when nativeTheme changes", () => {
   const source = [
     "function A2(e){return e===`avatarOverlay`}",
@@ -1321,6 +1412,16 @@ test("patches remaining tooltip collision middleware when another copy is alread
     (patched.match(/padding:\{top:44,right:8,bottom:8,left:8\}/g) ?? []).length,
     6,
   );
+  assert.doesNotMatch(patched, /[,(]\{padding:8\}/);
+});
+
+test("keeps tooltip collision padding after middleware alias drift", () => {
+  const source =
+    "middleware:[o({mainAxis:ne,crossAxis:t}),l({padding:8}),u({padding:8}),d({padding:8,apply({availableWidth:e,availableHeight:t,elements:n,rects:r}){n.floating.style.setProperty(`--radix-tooltip-trigger-width`,`1px`)}})]";
+
+  const patched = applyPatchTwice(applyLinuxTooltipWindowControlsCollisionPatch, source);
+
+  assert.match(patched, /o\(\{mainAxis:ne,crossAxis:t\}\),l\(\{padding:\{top:44,right:8,bottom:8,left:8\}\}\),u\(\{padding:\{top:44,right:8,bottom:8,left:8\}\}\),d\(\{padding:\{top:44,right:8,bottom:8,left:8\},apply/);
   assert.doesNotMatch(patched, /[,(]\{padding:8\}/);
 });
 
@@ -1594,6 +1695,23 @@ test("keeps avatar overlay layout sync working after layout alias drift", () => 
   );
 });
 
+test("keeps avatar overlay interactivity working after native presentation drift", () => {
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(
+      applyLinuxAvatarOverlayMousePassthroughPatch,
+      currentAvatarOverlayBundleFixture(),
+    ),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(patched, /this\.applyLatestElementSizes\(i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
+  assert.match(patched, /this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.compositionHost\.setOverlayWindow\(t\)/);
+  assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`&&this\.codexLinuxIsI3Session\(\)\?this\.traySize:this\.traySize\?\?\(this\.layoutMode===`native`\?u1:l1\)/);
+  assert.match(patched, /this\.setWindowBounds\(e,a\.windowBounds,n,r\),this\.sendLayoutToRenderer\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
+  assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\),!t&&this\.isOpen\(\)&&this\.broadcastOpenState\(\)\}showWindowIfReady/);
+  assert.match(patched, /this\.cancelMomentum\(\),this\.clearMovedWindowPersist\(\),this\.window=null/);
+});
+
 test("adds Linux window icon handling when an icon asset is available", () => {
   const iconAsset = "app-test.png";
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
@@ -1847,6 +1965,27 @@ test("makes About dialog prefer the bundled Linux icon asset", () => {
   assert.match(patched, /i==null\|\|i\.isEmpty\(\)\?null:i\.resize\(/);
   assert.match(patched, /windowIcon:i\?\?null/);
   assert.doesNotThrow(() => new Function(patched));
+});
+
+test("upgrades partially patched About dialog icon fallbacks after alias drift", () => {
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const source = [
+    "let r=require(`electron`),n={T:()=>null};",
+    "var UZ=`codex.aboutDialog.title`,eQ=72;",
+    "async function dQ(){let e=process.platform===`darwin`,t=e?n.T():process.execPath,[i,a]=await Promise.all([",
+    "process.platform===`linux`?null:e?tT(t):null,",
+    "process.platform===`linux`?Promise.resolve((()=>{let __codexLinuxAboutIcon=r.nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`);return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):r.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
+    "]);return{htmlIconDataUrl:i??(a.isEmpty()?null:a.resize({width:eQ,height:eQ,quality:`best`}).toDataURL()),windowIcon:a}}",
+    "let f={windowIcon:null},x={...f.windowIcon.isEmpty()?{}:{icon:f.windowIcon}};",
+  ].join("");
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxAboutDialogPatch, source, iconPathExpression),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(patched, /a==null\|\|a\.isEmpty\(\)\?null:a\.resize\(/);
+  assert.match(patched, /windowIcon:a\?\?null/);
+  assert.match(patched, /f\.windowIcon==null\|\|f\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:f\.windowIcon\}/);
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {
@@ -2418,6 +2557,16 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
   }
 });
 
+test("adds Linux desktop section to current native Keyboard Shortcuts sections bundle", () => {
+  const source =
+    "var e=[`general-settings`,`profile`,`keyboard-shortcuts`,`account`],t=`general-settings`,n=function(){},r=[{slug:`general-settings`},{slug:`profile`},{slug:`appearance`},{slug:`keyboard-shortcuts`}];";
+
+  const patched = applyPatchTwice(applyLinuxDesktopSettingsSectionsPatch, source);
+
+  assert.match(patched, /e=\[`general-settings`,`linux-desktop`,`profile`,`keyboard-shortcuts`/);
+  assert.match(patched, /r=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`profile`\}/);
+});
+
 test("adds the Linux desktop section title when the JSX message component identifier drifts", () => {
   const patched = applyLinuxDesktopSettingsSharedPatch(
     settingsSharedBundleWithDriftingJsxAliasFixture(),
@@ -2459,6 +2608,23 @@ test("keeps local environment action modal inputs editable inside stored modal c
   assert.match(patched, /codexLinuxUpdateActionDraft\(\{command:e\}\)/);
   assert.match(patched, /t\[67\]!==codexLinuxActionDraft\.name/);
   assert.match(patched, /var _d=_t\(`local-env-recent-actions-by-key`,\{\}\);function Ml\(\)\{return n\.name\+n\.command\+n\.icon\}/);
+});
+
+test("keeps local environment action modal inputs editable after component alias drift", () => {
+  const source = [
+    "function Existing(){return (0,Z.useState)(!1)}",
+    "function lf(e){let t=(0,X.c)(101),{action:n,configPath:r,environment:i,hostConfig:a,onOpenSettings:o,onRunAction:s,onSaved:c,onUpdate:l,workspaceRoot:u}=e,d=on(),f=v(),p=w(`local-environment-config-save`),g,y,j;if(t[0]!==n||t[7]!==l){let label={id:`threadPage.runAction.setup.commandLabel`},desc={id:`settings.localEnvironments.actions.add.description`},A={ariaLabel:`a`,icon:null,value:n.icon},N=`local`,P=n.name.trim(),F=P,I=n.command.trim(),L=I;y=F.length===0||L.length===0||p.isPending,g=`local-env-action-name-${n.id}`;let R;t[36]!==n?(R=e=>{if(e.preventDefault(),y)return;let t=i.environment,o={...n,command:L,name:F},l={command:L,icon:n.icon,name:F,...n.platform?{platform:n.platform}:{}},d=mu({actions:[...vu(t.actions??[]),o]});p.mutate({configPath:r,hostId:a.id,raw:d},{onSuccess:()=>{c(),s(l)}})},t[36]=n,t[49]=R):R=t[49],j=n.command;let z=e=>{l({icon:e.value})},M=e=>{l({name:e.target.value})},V=e=>{l({command:e})};return {label,desc,g,j,z,M,V}}return null}",
+  ].join("");
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLocalEnvironmentActionModalDraftPatch, source),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(patched, /\[codexLinuxActionDraft,codexLinuxSetActionDraft\]=\(0,Z\.useState\)\(\(\)=>n\)/);
+  assert.match(patched, /\{\.\.\.codexLinuxActionDraft,command:L,name:F\}/);
+  assert.match(patched, /codexLinuxActionDraft\.name\.trim\(\)/);
+  assert.match(patched, /codexLinuxUpdateActionDraft\(\{command:e\}\)/);
 });
 
 test("skips local environment action modal patch when a critical replacement needle drifts", () => {
@@ -2535,6 +2701,28 @@ test("allows explicit locale overrides through the settings language row i18n ga
     /i=re\(`72216192`\)\?\.get\(`enable_i18n`,!0\),s=H\(t\.localeOverride\);i=i\|\|s!=null;if\(!i\)/,
   );
   assert.equal((patched.match(/H\(t\.localeOverride\)/g) ?? []).length, 1);
+});
+
+test("recognizes current app i18n provider gate as already patched", () => {
+  const source =
+    "function MI(e){let t=(0,Q.c)(21),{children:n}=e,{data:r}=p(AI),i=d(m),a=yo(`72216192`),o;t[0]===a?o=t[1]:(o=a?.get(`enable_i18n`,!1),t[0]=a,t[1]=o);let c=a?.get(`locale_source`,`IDE`),l=za(G.localeOverride),s=o||l!=null,u=r?.ideLocale;return s?u:n}";
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxI18nGatePatch, source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("recognizes current settings language row i18n gate as already patched", () => {
+  const source =
+    "function Jn(){let e=(0,Z.c)(48),t=a(s),n=P(),r=oe(`72216192`)?.get(`enable_i18n`,!0),[i,o]=(0,Q.useState)(``),c=W(_.localeOverride);r=r||c!=null;let l;if(!r)return null;return l}";
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxI18nGatePatch, source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("shows the profile dropdown settings route on Linux", () => {
@@ -2764,6 +2952,20 @@ test("adds Linux package updater to current bootstrap updater wiring after callb
   assert.match(patched, /s=codexLinuxPackageUpdateBridge\.manager/);
   assert.match(patched, /ne=codexLinuxPackageUpdateBridge\.quitForUpdate/);
   assert.match(patched, /send:e=>M\.sendMessageToAllRegisteredWindows\(e\)/);
+});
+
+test("adds Linux package updater to current bootstrap updater wiring after broadcast drift", () => {
+  const patched = applyPatchTwice(
+    applyLinuxAppUpdaterBridgePatch,
+    currentBootstrapUpdaterBundleWithAppUpdateStateBroadcastFixture(),
+  );
+
+  assert.match(patched, /function codexLinuxCreatePackageUpdateManager\(/);
+  assert.match(patched, /codexLinuxPackageUpdateBridge=process\.platform===`linux`/);
+  assert.match(patched, /send:\(\)=>se\.broadcastAppUpdateState\(\)/);
+  assert.match(patched, /s=codexLinuxPackageUpdateBridge\.manager/);
+  assert.match(patched, /te=codexLinuxPackageUpdateBridge\.quitForUpdate/);
+  assert.doesNotMatch(patched, /send:e=>se\.sendMessageToAllRegisteredWindows/);
 });
 
 test("adds Linux package updater to current bootstrap updater wiring when dispatcher is farther away", () => {
@@ -4460,6 +4662,17 @@ test("persistent rate limit footer uses existing account signal without dropdown
   assert.doesNotMatch(patched, /codexLinuxUseRateLimitStatus/);
   assert.doesNotMatch(patched, /codex-linux-rate-limit-footer/);
   assert.equal((patched.match(/Rate limits remaining/g) || []).length, 1);
+});
+
+test("persistent rate limit footer descriptor ignores external footer chunks", () => {
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "composer-persistent-rate-limit-footer",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.pattern.test("composer-D1QtVouy.js"), true);
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(descriptor.pattern.test("composer-external-footer-0Iw5VZtp.js"), false);
 });
 
 test("persistent rate limit footer skips current footer group when conversation id is missing", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -118,6 +118,8 @@ const opaqueBackgroundBundleWithDriftingGw =
   "var cM=`#00000000`,lM=`#000000`,uM=`#f9f9f9`;function OM(e){return e===`avatarOverlay`||e===`browserCommentPopup`}function jM({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!OM(t)?n?{backgroundColor:r?lM:uM,backgroundMaterial:`none`}:{backgroundColor:cM,backgroundMaterial:`mica`}:{backgroundColor:cM,backgroundMaterial:null}}function gw(e){return e.page==null?e.snapshot.url:mw(e.page)}";
 const currentOpaqueBackgroundBundle =
   "var QK=`#00000000`,$K=`#000000`,eq=`#f9f9f9`;function vq(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`}function xq({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!vq(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?$K:eq,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!vq(t)?{backgroundColor:QK,backgroundMaterial:`mica`}:{backgroundColor:QK,backgroundMaterial:null}}";
+const currentOpaqueWindowSurfaceBackgroundBundle =
+  "var W4=`#00000000`,G4=`#000000`,K4=`#f9f9f9`;function g3(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`||e===`hud`}function S3({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?G4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!g3(t)?{backgroundColor:W4,backgroundMaterial:`mica`}:{backgroundColor:W4,backgroundMaterial:null}}";
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -715,6 +717,19 @@ function chromeNativeHostRuntimeBundleFixture() {
     "function Ic(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`codex.exe`:`codex`})}",
     "function Qp(e){let t=Ic(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`]),n=Fc(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`electron`,`bin`,process.platform===`win32`?`node.exe`:`node`]),r=Pc(e.resourcesPath)??$p(e.devRuntimeRepoRoot,[`electron`,`bin`,process.platform===`win32`?`node_repl.exe`:`node_repl`]),i=[t==null?`codex`:null,n==null?`node`:null,r==null?`node_repl`:null].filter(e=>e!=null);if(i.length>0)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}: ${i.join(`, `)} (resourcesPath: ${e.resourcesPath}).`);if(t==null||n==null||r==null)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`);return{codexCliPath:t,nodePath:n,nodeReplPath:r}}",
     "function $p(e,t){if(e==null)return null;let n=(0,r.join)(e,...t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
+  ].join("");
+}
+
+function currentChromeNativeHostRuntimeBundleFixture() {
+  return [
+    "let r=require(`node:path`),o=require(`node:fs`);",
+    "function Mc({resourcesPath:e,executableName:t}){if(!e)return null;let n=(0,r.join)(e,t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
+    "function Oj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node_repl.exe`:`node_repl`})}",
+    "function kj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`node.exe`:`node`})}",
+    "function Nj(e){return Mc({resourcesPath:e,executableName:process.platform===`win32`?`codex.exe`:`codex`})}",
+    "function QL(e){let t=Nj(e.resourcesPath)??$L(e.devRuntimeRepoRoot,[`extension`,`bin`,process.platform===`win32`?`codex.exe`:`codex`]),n=kj(e.resourcesPath),r=Oj(e.resourcesPath),i=[t==null?`codex`:null,n==null?`node`:null,r==null?`node_repl`:null].filter(e=>e!=null);if(i.length>0)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}: ${i.join(`, `)} (resourcesPath: ${e.resourcesPath}).`);if(t==null||n==null||r==null)throw Error(`Missing bundled Electron runtime required to sync Chrome native host resources for ${e.nativeHostName}.`);return{codexCliPath:t,nodePath:n,nodeModuleDirs:Aj(e.resourcesPath),nodeReplPath:r}}",
+    "function $L(e,t){if(e==null)return null;let n=(0,r.join)(e,...t);try{return(0,o.statSync)(n).isFile()?n:null}catch{return null}}",
+    "function Aj(e){return []}",
   ].join("");
 }
 
@@ -1370,6 +1385,16 @@ test("patches current BrowserWindow background helper shape for Linux opaque bac
   assert.match(patched, /vq\(e\).*hotkeyWindowThread/);
 });
 
+test("patches current opaque window surface background helper shape for Linux", () => {
+  const patched = applyPatchTwice(applyLinuxOpaqueBackgroundPatch, currentOpaqueWindowSurfaceBackgroundBundle);
+
+  assert.match(
+    patched,
+    /:e===`linux`&&!g3\(t\)\?\{backgroundColor:r\?G4:K4,backgroundMaterial:null\}:e===`win32`&&!g3\(t\)\?/,
+  );
+  assert.match(patched, /opaqueWindowSurfaceEnabled:n/);
+});
+
 test("patches current webview opaque window default bundle shapes", () => {
   const resolvedThemeSource =
     "function oe(e,t){let n=o[t];return{accent:p(e?.accent)??n.accent,contrast:se(e?.contrast,n.contrast),fonts:le(e?.fonts),ink:p(e?.ink)??n.ink,opaqueWindows:e?.opaqueWindows??n.opaqueWindows,semanticColors:ue(e?.semanticColors,n.semanticColors),surface:p(e?.surface)??n.surface}}";
@@ -1687,6 +1712,23 @@ test("adds Linux tray support including the platform guard", () => {
     /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
   );
   assert.doesNotMatch(patched, /process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)/);
+});
+
+test("uses collision-proof Linux tray icon variables when Electron alias is r", () => {
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const source = [
+    "let r=require(`electron`),i=require(`node:path`);",
+    "async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let t=await Ww(e.buildFlavor,e.repoRoot),i=new r.Tray(t.defaultIcon);return i})()))}",
+    "async function Ww(e,t){if(process.platform===`darwin`){return null}let n=process.platform===`win32`?`.ico`:`.png`,a=Nw(e,process.platform),o=[...r.app.isPackaged?[(0,i.join)(process.resourcesPath,`${a}${n}`)]:[],(0,i.join)(t,`electron`,`src`,`icons`,`${a}${n}`)];for(let e of o){let t=r.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await r.app.getFileIcon(process.execPath,{size:process.platform===`win32`?`small`:`normal`}),chronicleRunningIcon:null}}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxTrayPatch, source, iconPathExpression);
+
+  assert.doesNotMatch(patched, /let r=r\.nativeImage/);
+  assert.match(
+    patched,
+    /let __codexLinuxUpstreamTrayIcon=r\.nativeImage\.createFromPath\(process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/app-test\.png`\)/,
+  );
 });
 
 test("adds Linux tray support even when About dialog already uses the bundled icon path", () => {
@@ -3096,6 +3138,53 @@ test("uses Linux managed runtime paths for Chrome native host sync", () => {
   });
 });
 
+test("uses Linux managed runtime paths for current Chrome native host sync shape", () => {
+  const patched = applyPatchTwice(
+    applyLinuxChromeNativeHostRuntimePatch,
+    currentChromeNativeHostRuntimeBundleFixture(),
+  );
+  const files = new Set([
+    "/opt/codex/resources/node-runtime/bin/node",
+    "/opt/codex/resources/node_repl",
+    "/home/josh/.local/bin/codex",
+  ]);
+
+  const result = vm.runInNewContext(
+    `${patched};QL({resourcesPath:"/opt/codex/resources",devRuntimeRepoRoot:null,nativeHostName:"com.openai.codexextension"});`,
+    {
+      require(moduleName) {
+        if (moduleName === "node:path") {
+          return path;
+        }
+        if (moduleName === "node:fs") {
+          return {
+            statSync(filePath) {
+              if (!files.has(filePath)) {
+                throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+              }
+              return { isFile: () => true };
+            },
+          };
+        }
+        return require(moduleName);
+      },
+      process: {
+        platform: "linux",
+        env: {
+          CODEX_CLI_PATH: "/home/josh/.local/bin/codex",
+        },
+      },
+    },
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(result)), {
+    codexCliPath: "/home/josh/.local/bin/codex",
+    nodeModuleDirs: [],
+    nodePath: "/opt/codex/resources/node-runtime/bin/node",
+    nodeReplPath: "/opt/codex/resources/node_repl",
+  });
+});
+
 test("reports drifted Chrome native host runtime resolver as required upstream failure", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-chrome-runtime-drift-"));
   try {
@@ -4228,6 +4317,60 @@ test("patch report summary separates required core, optional core, and optional 
   assert.deepEqual(summary.groups.optionalCore.statusCounts, { "skipped-optional": 1 });
   assert.deepEqual(summary.groups.optionalFeatures.statusCounts, { "applied-with-warnings": 1 });
   assert.equal(summary.groups.optionalFeatures.byFeature["remote-mobile-control"].count, 1);
+});
+
+test("main-process-ui aggregate ignores optional main-bundle drift warnings", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-patch-report-optional-main-drift-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    const coreRoot = path.join(tempRoot, "core-patches");
+    const requiredPatchDir = path.join(coreRoot, "all-linux", "main-process", "required-test");
+    const optionalPatchDir = path.join(coreRoot, "all-linux", "main-process", "optional-test");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(requiredPatchDir, { recursive: true });
+    fs.mkdirSync(optionalPatchDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), "codexRequiredPatchOff()");
+    fs.writeFileSync(
+      path.join(requiredPatchDir, "patch.js"),
+      [
+        "\"use strict\";",
+        "module.exports=[{",
+        "id:\"required-main-bundle-test\",",
+        "phase:\"main-bundle\",",
+        "ciPolicy:\"required-upstream\",",
+        "apply:(source)=>source.replace(\"codexRequiredPatchOff()\",\"codexRequiredPatchOn()\")",
+        "}];",
+      ].join("\n"),
+    );
+    fs.writeFileSync(
+      path.join(optionalPatchDir, "patch.js"),
+      [
+        "\"use strict\";",
+        "module.exports=[{",
+        "id:\"optional-background-avatar-drift-test\",",
+        "phase:\"main-bundle\",",
+        "ciPolicy:\"optional\",",
+        "apply:(source)=>{console.warn(\"WARN: optional background/avatar drift\"); return source;}",
+        "}];",
+      ].join("\n"),
+    );
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report, corePatchRoot: coreRoot }));
+
+    const optionalPatch = report.patches.find((patch) => patch.name === "optional-background-avatar-drift-test");
+    const aggregate = report.patches.find((patch) => patch.name === "main-process-ui");
+    assert.equal(optionalPatch.status, "skipped-optional");
+    assert.equal(aggregate.status, "applied");
+    assert.equal(aggregate.warnings, undefined);
+    assert.ok(
+      !validateReport(report, "upstream-build").some((failure) =>
+        failure.startsWith("main-process-ui:"),
+      ),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("patch report marks missing required webview assets as required failures", () => {

--- a/scripts/patches/automation-schedule.js
+++ b/scripts/patches/automation-schedule.js
@@ -13,16 +13,27 @@ const AUTOMATION_SCHEDULE_MARKER =
 const AUTOMATION_SCHEDULE_PATCH_MARKER = "function codexLinuxNormalizeRruleNumbers(";
 
 function findWorkspaceRootDropHandlerBundles(extractedDir) {
-  const buildDir = path.join(extractedDir, ".vite", "build");
-  return readDirectoryNames(buildDir)
-    .filter((name) => name.endsWith(".js"))
-    .sort()
-    .map((name) => path.join(buildDir, name))
+  const candidateDirs = [
+    path.join(extractedDir, ".vite", "build"),
+    path.join(extractedDir, "webview", "assets"),
+  ];
+  return candidateDirs
+    .flatMap((dir) =>
+      readDirectoryNames(dir)
+        .filter((name) => name.endsWith(".js"))
+        .sort()
+        .map((name) => path.join(dir, name)),
+    )
     .filter((candidate) => {
       try {
         const source = fs.readFileSync(candidate, "utf8");
         return source.includes(AUTOMATION_SCHEDULE_MARKER) ||
-          source.includes(AUTOMATION_SCHEDULE_PATCH_MARKER);
+          source.includes(AUTOMATION_SCHEDULE_PATCH_MARKER) ||
+          (
+            /^automation-schedule-.*\.js$/.test(path.basename(candidate)) &&
+            source.includes("hasMultipleTimeValues") &&
+            source.includes("function Tn(")
+          );
       } catch {
         return false;
       }
@@ -100,6 +111,10 @@ function applyAutomationScheduleMultiTimePatch(source) {
 
   const block = findAutomationScheduleHelperBlock(source);
   if (block == null) {
+    const currentPatched = applyCurrentAutomationScheduleMultiTimePatch(source);
+    if (currentPatched !== source) {
+      return currentPatched;
+    }
     console.warn("WARN: Could not find automation schedule helper block — skipping RRULE multi-time patch");
     return source;
   }
@@ -107,10 +122,49 @@ function applyAutomationScheduleMultiTimePatch(source) {
   return source.slice(0, block.start) + automationScheduleReplacement(block) + source.slice(block.end);
 }
 
+function applyCurrentAutomationScheduleMultiTimePatch(source) {
+  if (
+    !source.includes("hasMultipleTimeValues") ||
+    !source.includes("function Tn(") ||
+    !source.includes("function bn(")
+  ) {
+    return source;
+  }
+
+  let patchedSource = source;
+  const helperNeedle =
+    "function Tn(e,t,n){let r=En(e),i=En(t);return r!=null&&i!=null?Mn(r,i):n.dtstart?Mn(n.dtstart.getHours(),n.dtstart.getMinutes()):Wt}function En(e){return Array.isArray(e)?typeof e[0]==`number`?e[0]:null:typeof e==`number`?e:null}";
+  const helperPatch =
+    `${helperNeedle}function codexLinuxNormalizeRruleNumbers(e,t,n){let r=Array.isArray(e)?e:[e];return Array.from(new Set(r.filter(e=>typeof e==\`number\`&&Number.isInteger(e)&&e>=t&&e<=n))).sort((e,t)=>e-t)}function codexLinuxRruleTimes(e,t,n){let r=codexLinuxNormalizeRruleNumbers(e,0,23),i=codexLinuxNormalizeRruleNumbers(t,0,59);n.dtstart&&(r.length!==0||(r=[n.dtstart.getHours()]),i.length!==0||(i=[n.dtstart.getMinutes()]));let a=[];for(let e of r)for(let t of i)a.push(Mn(e,t));return Array.from(new Set(a)).sort()}function codexLinuxAutomationTimeLabel(e,t){let n=Array.isArray(e.timeValues)&&e.timeValues.length>0?e.timeValues:[e.time],r=n.map(e=>Mt(e,t)).filter(Boolean);return r.length===0?null:typeof t.formatList==\`function\`?t.formatList(r,{type:\`conjunction\`}):r.join(\`, \`)}`;
+  if (!patchedSource.includes(helperNeedle)) {
+    return source;
+  }
+  patchedSource = patchedSource.replace(helperNeedle, helperPatch);
+
+  const parserNeedle =
+    "hasMultipleTimeValues:Array.isArray(r.byhour)&&r.byhour.length>1||Array.isArray(r.byminute)&&r.byminute.length>1,interval:Math.max(1,Math.round(r.interval??1)),minute:a,origOptions:n.origOptions,rruleText:e,time:Tn(r.byhour,r.byminute,r),weekdays:i";
+  const parserPatch =
+    "hasMultipleTimeValues:codexLinuxRruleTimes(r.byhour,r.byminute,r).length>1,interval:Math.max(1,Math.round(r.interval??1)),minute:a,origOptions:n.origOptions,rruleText:e,time:Tn(r.byhour,r.byminute,r),timeValues:codexLinuxRruleTimes(r.byhour,r.byminute,r),weekdays:i";
+  if (!patchedSource.includes(parserNeedle)) {
+    return source;
+  }
+  patchedSource = patchedSource.replace(parserNeedle, parserPatch);
+
+  const summaryNeedle =
+    "function bn(e,t){if(!e||e.hasMultipleTimeValues)return null;let n=on(e.weekdays),r=n.length===q.length;if(e.freq===K.MINUTELY)return Sn({intervalMinutes:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq===K.HOURLY)return xn({intervalHours:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq!==K.DAILY&&e.freq!==K.WEEKLY)return null;let i=Mt(e.time,t);return i?wn({intl:t,isEveryDay:r,timeLabel:i,weekdays:n}):null}";
+  const summaryPatch =
+    "function bn(e,t){if(!e)return null;let n=on(e.weekdays),r=n.length===q.length;if(e.freq===K.MINUTELY)return Sn({intervalMinutes:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq===K.HOURLY)return xn({intervalHours:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq!==K.DAILY&&e.freq!==K.WEEKLY)return null;let i=codexLinuxAutomationTimeLabel(e,t);return i?wn({intl:t,isEveryDay:r,timeLabel:i,weekdays:n}):null}";
+  if (!patchedSource.includes(summaryNeedle)) {
+    return source;
+  }
+  patchedSource = patchedSource.replace(summaryNeedle, summaryPatch);
+  return patchedSource;
+}
+
 function patchAutomationScheduleAssets(extractedDir) {
   const candidates = findWorkspaceRootDropHandlerBundles(extractedDir);
   if (candidates.length === 0) {
-    const reason = `Could not find workspace-root-drop-handler bundle in ${path.join(extractedDir, ".vite", "build")}`;
+    const reason = `Could not find automation schedule bundle in ${path.join(extractedDir, ".vite", "build")} or ${path.join(extractedDir, "webview", "assets")}`;
     console.warn(`WARN: ${reason} — skipping RRULE multi-time patch`);
     return { matched: 0, changed: 0, reason };
   }

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -109,10 +109,14 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     /displayBounds:([A-Za-z_$][\w$]*)\.screen\.getDisplayNearestPoint\(\1\.screen\.getCursorScreenPoint\(\)\)\.bounds\}\}moveDrag\(e\)\{/;
   const previousStartDragAfterStateRegex =
     /displayBounds:([A-Za-z_$][\w$]*)\.screen\.getDisplayNearestPoint\(\1\.screen\.getCursorScreenPoint\(\)\)\.bounds\},this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\}moveDrag\(e\)\{/;
+  const currentStartDragPatchRegex =
+    /displayBounds:([A-Za-z_$][\w$]*)\.screen\.getDisplayNearestPoint\(\1\.screen\.getCursorScreenPoint\(\)\)\.bounds\},process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)\}moveDrag\(e\)\{/;
   if (patchedSource.includes(previousStartDragPatch)) {
     patchedSource = patchedSource.replace(previousStartDragPatch, originalStartDragPrefix);
   }
-  if (previousStartDragAfterStateRegex.test(patchedSource)) {
+  if (currentStartDragPatchRegex.test(patchedSource)) {
+    // Already patched.
+  } else if (previousStartDragAfterStateRegex.test(patchedSource)) {
     patchedSource = patchedSource.replace(previousStartDragAfterStateRegex, startDragPatch);
   } else if (patchedSource.includes(previousStartDragAfterStatePatch)) {
     patchedSource = patchedSource.replace(previousStartDragAfterStatePatch, startDragPatch);
@@ -150,15 +154,15 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
 
   const setElementSizeMethod = findAvatarMethod(
     patchedSource,
-    /setElementSize\([A-Za-z_$][\w$]*,\{mascot:[A-Za-z_$][\w$]*,tray:[A-Za-z_$][\w$]*\}\)\{/,
+    /setElementSize\([A-Za-z_$][\w$]*,\{(?:[^{}]*,)?mascot:[A-Za-z_$][\w$]*,tray:[A-Za-z_$][\w$]*(?:,[^{}]*)?\}\)\{/,
   );
   if (setElementSizeMethod != null) {
     if (
-      !/this\.applyLayout\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(setElementSizeMethod.text)
+      !/this\.(?:applyLayout|applyLatestElementSizes)\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(setElementSizeMethod.text)
     ) {
       const patchedMethod = setElementSizeMethod.text.replace(
-        /this\.applyLayout\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
-        "this.applyLayout($1),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+        /this\.(applyLayout|applyLatestElementSizes)\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
+        "this.$1($2),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
       );
       if (patchedMethod !== setElementSizeMethod.text) {
         patchedSource =
@@ -176,17 +180,15 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     );
   }
 
-  if (
-    !patchedSource.includes("this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.rendererReady")
-  ) {
+  if (!patchedSource.includes("this.codexLinuxAvatarCompositorHintsApplied=!1")) {
     patchedSource = patchedSource.replace(
-      /return this\.window=([A-Za-z_$][\w$]*),this\.rendererReady=this\.windowManager\.isWebContentsReady\(\1\.webContents\.id\),/,
-      "return this.window=$1,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.rendererReady=this.windowManager.isWebContentsReady($1.webContents.id),",
+      /return this\.window=([A-Za-z_$][\w$]*),/,
+      "return this.window=$1,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,",
     );
   }
 
   const i3TrayFallbackRegex =
-    /traySize:this\.traySize\?\?([A-Za-z_$][\w$]*)\}\);this\.anchor=/;
+    /traySize:this\.traySize\?\?([A-Za-z_$][\w$]*|\([^{};]*?\))\}\);this\.anchor=/;
   const i3TrayFallbackPatch =
     "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1});this.anchor=";
   if (
@@ -204,11 +206,11 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   }
 
   const currentApplyLayoutPatchRegex =
-    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)?)\),this\.sendLayoutToRenderer\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}getLayout\(e\)\{/;
+    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}getLayout\(e\)\{/;
   const previousApplyLayoutPatchRegex =
-    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)?)\),this\.sendLayoutToRenderer\(e\),this\.codexLinuxSyncAvatarPointerInteractivity\(e\)&&this\.applyPointerInteractivityPolicy\(\)\}getLayout\(e\)\{/;
+    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(e\),this\.codexLinuxSyncAvatarPointerInteractivity\(e\)&&this\.applyPointerInteractivityPolicy\(\)\}getLayout\(e\)\{/;
   const applyLayoutRegex =
-    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)?)\),this\.sendLayoutToRenderer\(e\)\}getLayout\(e\)\{/;
+    /this\.setWindowBounds\(e,([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(e\)\}getLayout\(e\)\{/;
   if (currentApplyLayoutPatchRegex.test(patchedSource)) {
     // Already patched.
   } else if (previousApplyLayoutPatchRegex.test(patchedSource)) {
@@ -240,6 +242,10 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     "e.moveTop(),e.showInactive(),process.platform===`linux`&&this.applyPointerInteractivityPolicy(),!t&&this.isOpen()&&this.broadcastOpenState()}broadcastOpenState(){";
   const previousShowWindowPatch =
     "e.moveTop(),e.showInactive(),process.platform===`linux`&&this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy(),!t&&this.isOpen()&&this.broadcastOpenState()}broadcastOpenState(){";
+  const currentShowWindowRegex =
+    /e\.moveTop\(\),e\.showInactive\(\),(![A-Za-z_$][\w$]*&&this\.isOpen\(\)&&this\.broadcastOpenState\(\)\}showWindowIfReady\([A-Za-z_$][\w$]*\)\{)/;
+  const currentShowWindowPatchRegex =
+    /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\),![A-Za-z_$][\w$]*&&this\.isOpen\(\)&&this\.broadcastOpenState\(\)\}showWindowIfReady\([A-Za-z_$][\w$]*\)\{/;
   if (patchedSource.includes(previousShowWindowCompositorPatch)) {
     patchedSource = patchedSource.replace(previousShowWindowCompositorPatch, showWindowPatch);
   } else if (patchedSource.includes(previousShowWindowPatch)) {
@@ -248,6 +254,13 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     patchedSource = patchedSource.replace(previousShowWindowI3Patch, showWindowPatch);
   } else if (patchedSource.includes(showWindowNeedle)) {
     patchedSource = patchedSource.replace(showWindowNeedle, showWindowPatch);
+  } else if (currentShowWindowPatchRegex.test(patchedSource)) {
+    // Already patched.
+  } else if (currentShowWindowRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      currentShowWindowRegex,
+      "e.moveTop(),e.showInactive(),process.platform===`linux`&&this.codexLinuxApplyAvatarCompositorHints(e),process.platform===`linux`&&this.applyPointerInteractivityPolicy(),$1",
+    );
   } else if (
     patchedSource.includes("avatar-overlay") &&
     !patchedSource.includes(showWindowPatch)
@@ -258,13 +271,13 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   }
 
   const closedPatchRegex =
-    /this\.window===[A-Za-z_$][\w$]*&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\),this\.window=null,/;
+    /this\.window===[A-Za-z_$][\w$]*&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\),[\s\S]*?this\.window=null,/;
   if (closedPatchRegex.test(patchedSource)) {
     // Already patched.
-  } else if (/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),this\.window=null,/.test(patchedSource)) {
+  } else if (/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/.test(patchedSource)) {
     patchedSource = patchedSource.replace(
-      /this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),this\.window=null,/,
-      "this.window===$1&&(this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.cancelMomentum(),this.window=null,",
+      /this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/,
+      "this.window===$1&&(this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.cancelMomentum(),$2this.window=null,",
     );
   } else if (
     patchedSource.includes("avatar-overlay") &&

--- a/scripts/patches/chrome-plugin.js
+++ b/scripts/patches/chrome-plugin.js
@@ -133,7 +133,31 @@ function applyLinuxChromeNativeHostRuntimePatch(currentSource) {
   const runtimeResolverRegex =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?([A-Za-z_$][\w$]*)\(\2\.devRuntimeRepoRoot,\[`extension`,`bin`,process\.platform===`win32`\?`codex\.exe`:`codex`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?\5\(\2\.devRuntimeRepoRoot,\[`electron`,`bin`,process\.platform===`win32`\?`node\.exe`:`node`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?\5\(\2\.devRuntimeRepoRoot,\[`electron`,`bin`,process\.platform===`win32`\?`node_repl\.exe`:`node_repl`\]\),/;
   const match = currentSource.match(runtimeResolverRegex);
-  if (match == null) {
+  if (match != null) {
+    const [
+      originalPrefix,
+      resolverName,
+      configVar,
+      codexVar,
+      codexResourceFn,
+      devRuntimeFn,
+      nodeVar,
+      nodeResourceFn,
+      nodeReplVar,
+      nodeReplResourceFn,
+    ] = match;
+    const helper =
+      `function codexLinuxChromeNativeHostRuntimeFile(e,t){if(process.platform!==\`linux\`||e==null)return null;for(let n of t){let t=(0,${pathVar}.join)(e,...n);try{if((0,${fsVar}.statSync)(t).isFile())return t}catch{}}return null}function codexLinuxChromeNativeHostRuntimeEnv(e){if(process.platform!==\`linux\`)return null;let t=process.env[e];if(t==null||t.length===0)return null;try{return(0,${fsVar}.statSync)(t).isFile()?t:null}catch{return null}}function codexLinuxChromeNativeHostRuntimePath(e){if(process.platform!==\`linux\`)return null;for(let t of(process.env.PATH??\`\`).split(\`:\`)){if(t.length===0)continue;let n=(0,${pathVar}.join)(t,e);try{if((0,${fsVar}.statSync)(n).isFile())return n}catch{}}return null}`;
+    const replacement =
+      `${helper}function ${resolverName}(${configVar}){let ${codexVar}=${codexResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_CLI_PATH\`)??codexLinuxChromeNativeHostRuntimePath(\`codex\`)??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`extension\`,\`bin\`,process.platform===\`win32\`?\`codex.exe\`:\`codex\`]),${nodeVar}=${nodeResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_BROWSER_USE_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeEnv(\`NODE_REPL_NODE_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[\`node-runtime\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node.exe\`:\`node\`]),${nodeReplVar}=${nodeReplResourceFn}(${configVar}.resourcesPath)??codexLinuxChromeNativeHostRuntimeEnv(\`CODEX_NODE_REPL_PATH\`)??codexLinuxChromeNativeHostRuntimeFile(${configVar}.resourcesPath,[[process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]])??${devRuntimeFn}(${configVar}.devRuntimeRepoRoot,[\`electron\`,\`bin\`,process.platform===\`win32\`?\`node_repl.exe\`:\`node_repl\`]),`;
+
+    return currentSource.replace(originalPrefix, replacement);
+  }
+
+  const currentRuntimeResolverRegex =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\)\?\?([A-Za-z_$][\w$]*)\(\2\.devRuntimeRepoRoot,\[`extension`,`bin`,process\.platform===`win32`\?`codex\.exe`:`codex`\]\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\.resourcesPath\),/;
+  const currentMatch = currentSource.match(currentRuntimeResolverRegex);
+  if (currentMatch == null) {
     console.warn(
       "WARN: Could not identify Chrome native host runtime resolver shape — skipping Linux runtime path patch",
     );
@@ -151,7 +175,7 @@ function applyLinuxChromeNativeHostRuntimePatch(currentSource) {
     nodeResourceFn,
     nodeReplVar,
     nodeReplResourceFn,
-  ] = match;
+  ] = currentMatch;
   const helper =
     `function codexLinuxChromeNativeHostRuntimeFile(e,t){if(process.platform!==\`linux\`||e==null)return null;for(let n of t){let t=(0,${pathVar}.join)(e,...n);try{if((0,${fsVar}.statSync)(t).isFile())return t}catch{}}return null}function codexLinuxChromeNativeHostRuntimeEnv(e){if(process.platform!==\`linux\`)return null;let t=process.env[e];if(t==null||t.length===0)return null;try{return(0,${fsVar}.statSync)(t).isFile()?t:null}catch{return null}}function codexLinuxChromeNativeHostRuntimePath(e){if(process.platform!==\`linux\`)return null;for(let t of(process.env.PATH??\`\`).split(\`:\`)){if(t.length===0)continue;let n=(0,${pathVar}.join)(t,e);try{if((0,${fsVar}.statSync)(n).isFile())return n}catch{}}return null}`;
   const replacement =

--- a/scripts/patches/core/all-linux/webview/rate-limits/patch.js
+++ b/scripts/patches/core/all-linux/webview/rate-limits/patch.js
@@ -10,7 +10,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^composer-.*\.js$/,
+    pattern: /^composer-(?!external-footer).*\.js$/,
     missingDescription: "composer bundle",
     skipDescription: "persistent composer rate limit footer patch",
     apply: applyPersistentRateLimitFooterPatch,

--- a/scripts/patches/engine.js
+++ b/scripts/patches/engine.js
@@ -174,6 +174,7 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
   let patched = source;
   const warnings = [];
   const coreWarnings = [];
+  const requiredCoreWarnings = [];
   for (const descriptor of descriptors.filter((patch) => patch.phase === "main-bundle")) {
     if (!descriptorAppliesTo(descriptor, context)) {
       recordDescriptorPatch(report, descriptor, SKIPPED_TARGET, null, context);
@@ -189,6 +190,9 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
     warnings.push(...result.warnings);
     if ((descriptor.sourceKind ?? "core") === "core") {
       coreWarnings.push(...result.warnings);
+      if (descriptor.ciPolicy === REQUIRED_UPSTREAM) {
+        requiredCoreWarnings.push(...result.warnings);
+      }
     }
     context.reportWarnings = result.warnings;
     recordDescriptorPatch(
@@ -200,7 +204,7 @@ function applyMainBundlePatchDescriptors(source, descriptors, context, report) {
     );
     delete context.reportWarnings;
   }
-  return { patchedSource: patched, warnings, coreWarnings };
+  return { patchedSource: patched, warnings, coreWarnings, requiredCoreWarnings };
 }
 
 function defaultWebviewMissingWarning(extractedDir, descriptor) {

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -424,29 +424,48 @@ function applyKeybindsSettingsSectionsPatch(currentSource) {
 function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   let patchedSource = currentSource;
 
-  if (patchedSource.includes("slug:`linux-desktop`")) {
+  if (
+    patchedSource.includes("slug:`linux-desktop`") &&
+    /=\[`general-settings`,`linux-desktop`/.test(patchedSource)
+  ) {
     return patchedSource;
   }
 
-  const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
-  const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`linux-desktop`},";
-  if (patchedSource.includes(sectionsNeedle)) {
-    return patchedSource.replace(sectionsNeedle, sectionsPatch);
+  if (!/=\[`general-settings`,`linux-desktop`/.test(patchedSource)) {
+    const orderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
+    if (orderPattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(orderPattern, "$1`linux-desktop`,");
+    }
   }
 
-  const currentNeedle = "n=[{slug:e},{slug:`appearance`}";
-  if (patchedSource.includes(currentNeedle)) {
-    return patchedSource.replace(currentNeedle, "n=[{slug:e},{slug:`linux-desktop`},{slug:`appearance`}");
+  if (!patchedSource.includes("slug:`linux-desktop`")) {
+    const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
+    const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`linux-desktop`},";
+    if (patchedSource.includes(sectionsNeedle)) {
+      patchedSource = patchedSource.replace(sectionsNeedle, sectionsPatch);
+    } else {
+      const currentNeedle = "n=[{slug:e},{slug:`appearance`}";
+      if (patchedSource.includes(currentNeedle)) {
+        patchedSource = patchedSource.replace(currentNeedle, "n=[{slug:e},{slug:`linux-desktop`},{slug:`appearance`}");
+      } else {
+        const literalNeedle = "n=[{slug:`general-settings`},{slug:`appearance`}";
+        if (patchedSource.includes(literalNeedle)) {
+          patchedSource = patchedSource.replace(literalNeedle, "n=[{slug:`general-settings`},{slug:`linux-desktop`},{slug:`appearance`}");
+        } else {
+          const generalFirstPattern = /([A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},)/;
+          if (generalFirstPattern.test(patchedSource)) {
+            patchedSource = patchedSource.replace(generalFirstPattern, "$1{slug:`linux-desktop`},");
+          }
+        }
+      }
+    }
   }
 
-  const literalNeedle = "n=[{slug:`general-settings`},{slug:`appearance`}";
-  if (patchedSource.includes(literalNeedle)) {
-    return patchedSource.replace(literalNeedle, "n=[{slug:`general-settings`},{slug:`linux-desktop`},{slug:`appearance`}");
-  }
-
-  const generalFirstPattern = /(n=\[\{slug:`general-settings`\},)/;
-  if (generalFirstPattern.test(patchedSource)) {
-    return patchedSource.replace(generalFirstPattern, "$1{slug:`linux-desktop`},");
+  if (
+    patchedSource.includes("slug:`linux-desktop`") &&
+    (/=\[`general-settings`,`linux-desktop`/.test(patchedSource) || !/[A-Za-z_$][\w$]*=\[`general-settings`,/.test(currentSource))
+  ) {
+    return patchedSource;
   }
 
   throw new Error("Required Keybinds settings patch failed: could not add Linux desktop settings section");

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -94,7 +94,7 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
 
 function applyLinuxNativeTitlebarPatch(currentSource) {
   const patchedPrimaryTitlebarRegex =
-    /===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\{color:([A-Za-z_$][\w$]*)\.nativeTheme\.shouldUseDarkColors\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),symbolColor:\1\.nativeTheme\.shouldUseDarkColors\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),height:Math\.round\(((?:[A-Za-z_$][\w$]*|\d+(?:\.\d+)?)?)\*[A-Za-z_$][\w$]*\)\}\}/;
+    /===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\{color:([A-Za-z_$][\w$]*)\.nativeTheme\.shouldUseDarkColors\?(?:`#[0-9A-Fa-f]{6}`|[A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),symbolColor:\1\.nativeTheme\.shouldUseDarkColors\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),height:Math\.round\(((?:[A-Za-z_$][\w$]*|\d+(?:\.\d+)?)?)\*[A-Za-z_$][\w$]*\)\}\}/;
   const alreadyPatchedTitlebarMatch = currentSource.match(patchedPrimaryTitlebarRegex);
 
   const primaryTitlebarRegex =
@@ -136,10 +136,11 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
     primaryTitlebarRegex.lastIndex = 0;
     patchedSource = patchedSource.replace(primaryTitlebarRegex, replacement);
   } else {
-    [, electronAlias, darkBackgroundAlias, lightBackgroundAlias, lightSymbolAlias, darkSymbolAlias, overlayHeightAlias] =
+    [, electronAlias, lightBackgroundAlias, lightSymbolAlias, darkSymbolAlias, overlayHeightAlias] =
       alreadyPatchedTitlebarMatch;
+    darkBackgroundAlias = "`#111111`";
     patchedSource = patchedSource.replace(
-      /(===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\{color:[A-Za-z_$][\w$]*\.nativeTheme\.shouldUseDarkColors\?)[A-Za-z_$][\w$]*(:[A-Za-z_$][\w$]*,symbolColor:)/,
+      /(===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\{color:[A-Za-z_$][\w$]*\.nativeTheme\.shouldUseDarkColors\?)(?:`#[0-9A-Fa-f]{6}`|[A-Za-z_$][\w$]*)(:[A-Za-z_$][\w$]*,symbolColor:)/,
       "$1`#111111`$2",
     );
   }
@@ -387,9 +388,14 @@ function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {
   const alreadyUsesBundledIcon =
     iconPathExpression != null &&
     currentSource.includes(`nativeImage.createFromPath(${iconPathExpression})`);
+  const aboutHtmlIconNullSafeRegex =
+    /[A-Za-z_$][\w$]*==null\|\|([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/;
+  const aboutWindowIconNullSafeRegex =
+    /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon==null\|\|\1\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/;
   const alreadyNullSafe =
-    currentSource.includes("windowIcon==null||d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}") &&
-    currentSource.includes("i==null||i.isEmpty()?null:i.resize(");
+    aboutWindowIconNullSafeRegex.test(currentSource) &&
+    aboutHtmlIconNullSafeRegex.test(currentSource) &&
+    /windowIcon:[A-Za-z_$][\w$]*\?\?null\}/.test(currentSource);
   if (alreadyUsesBundledIcon && alreadyNullSafe) {
     return currentSource;
   }
@@ -419,9 +425,15 @@ process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.
   }
 
   patchedSource = patchedSource
-    .replace("i.isEmpty()?null:i.resize(", "i==null||i.isEmpty()?null:i.resize(")
-    .replace("windowIcon:i}", "windowIcon:i??null}")
-    .replace("windowIcon.isEmpty()?{}:{icon:d.windowIcon}", "windowIcon==null||d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}");
+    .replace(
+      /([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/g,
+      "$1==null||$1.isEmpty()?null:$1.resize(",
+    )
+    .replace(/windowIcon:([A-Za-z_$][\w$]*)\}/g, "windowIcon:$1??null}")
+    .replace(
+      /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/g,
+      "...$1.windowIcon==null||$1.windowIcon.isEmpty()?{}:{icon:$1.windowIcon}",
+    );
 
   if (patchedSource !== currentSource) {
     return patchedSource;

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -328,6 +328,28 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
     return currentSource;
   }
 
+  const currentSurfaceFuncParamRegex =
+    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
+  const currentSurfaceFuncMatch = currentSource.match(currentSurfaceFuncParamRegex);
+  if (currentSurfaceFuncMatch != null) {
+    const [, platformParam, appearanceParam, , darkColorsParam, darkVarFromReturn, lightVarFromReturn, transparentAppearancePredicate] =
+      currentSurfaceFuncMatch;
+    const win32Needle =
+      `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
+    const linuxBgPrefix =
+      `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVarFromReturn}:${lightVarFromReturn},backgroundMaterial:null}:`;
+
+    if (currentSource.includes(linuxBgPrefix)) {
+      return currentSource;
+    }
+    if (currentSource.includes(win32Needle)) {
+      return currentSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
+    }
+
+    console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
+    return currentSource;
+  }
+
   const funcParamRegex =
     /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
   const funcMatch = currentSource.match(funcParamRegex);
@@ -714,7 +736,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     const trayIconNeedle =
       `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
     const trayIconPatch =
-      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}if(process.platform===\`linux\`){let e=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!e.isEmpty())return{defaultIcon:e,chronicleRunningIcon:null};let t=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null};let r=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!r.isEmpty())return{defaultIcon:r,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
+      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`;
     if (
       patchedSource.includes(`nativeImage.createFromPath(${packagedTrayIconPathExpression})`) ||
       patchedSource.includes(`nativeImage.createFromPath(${packagedAppIconPathExpression})`)
@@ -728,7 +750,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
       patchedSource = patchedSource.replace(
         /for\(let ([A-Za-z_$][\w$]*) of ([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(\1\);if\(!\3\.isEmpty\(\)\)return\{defaultIcon:\3,chronicleRunningIcon:null\}\}return\{defaultIcon:await \4\.app\.getFileIcon\(process\.execPath,\{size:process\.platform===`win32`\?`small`:`normal`\}\),chronicleRunningIcon:null\}\}/,
         (_match, iconPathVar, candidatesVar, imageVar, electronAlias) =>
-          `for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let ${iconPathVar}=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!${iconPathVar}.isEmpty())return{defaultIcon:${iconPathVar},chronicleRunningIcon:null};let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`,
+          `for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:process.platform===\`win32\`?\`small\`:\`normal\`}),chronicleRunningIcon:null}}`,
       );
     } else {
       console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");

--- a/scripts/patches/registry.js
+++ b/scripts/patches/registry.js
@@ -164,20 +164,20 @@ function patchExtractedApp(extractedDir, options = {}) {
   if (main != null) {
     const target = path.join(main.buildDir, main.mainBundle);
     const source = fs.readFileSync(target, "utf8");
-    const { patchedSource, warnings, coreWarnings } = applyMainBundlePatches(source, assetContext, report);
+    const { patchedSource, requiredCoreWarnings } = applyMainBundlePatches(source, assetContext, report);
     if (patchedSource !== source) {
       fs.writeFileSync(target, patchedSource, "utf8");
     }
     recordPatch(
       report,
       "main-process-ui",
-      patchStatusFromChange(patchedSource !== source, coreWarnings, REQUIRED_UPSTREAM),
-      coreWarnings[0] ?? null,
+      patchStatusFromChange(patchedSource !== source, requiredCoreWarnings, REQUIRED_UPSTREAM),
+      requiredCoreWarnings[0] ?? null,
       {
         phase: "main-bundle",
         ciPolicy: REQUIRED_UPSTREAM,
         sourceKind: "core",
-        ...(coreWarnings.length > 0 ? { warnings: [...coreWarnings] } : {}),
+        ...(requiredCoreWarnings.length > 0 ? { warnings: [...requiredCoreWarnings] } : {}),
       },
     );
   }

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -3,6 +3,10 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
+const {
+  findMatchingBrace,
+} = require("./shared.js");
+
 // Webview asset patches target hashed browser chunks copied out of app.asar.
 // They stay fail-soft because upstream chunk names and minified symbols drift.
 const LINUX_SAFE_MONOSPACE_FONT_STACK =
@@ -220,12 +224,21 @@ function applyLinuxTooltipWindowControlsCollisionPatch(currentSource) {
   const patchedMiddleware =
     `middleware:[a({mainAxis:C,crossAxis:t}),c({${currentPadding}}),l({${currentPadding}}),u({${currentPadding},apply({availableWidth:e,availableHeight:t,elements:n,rects:r})`;
 
-  if (currentSource.includes(defaultMiddleware)) {
-    return currentSource.split(defaultMiddleware).join(patchedMiddleware);
+  let patchedSource = currentSource;
+  if (patchedSource.includes(defaultMiddleware)) {
+    patchedSource = patchedSource.split(defaultMiddleware).join(patchedMiddleware);
   }
 
-  if (currentSource.includes(currentPadding)) {
-    return currentSource;
+  const middlewarePattern =
+    /middleware:\[([A-Za-z_$][\w$]*)\(\{mainAxis:([^{}]*?),crossAxis:([^{}]*?)\}\),([A-Za-z_$][\w$]*)\(\{padding:8\}\),([A-Za-z_$][\w$]*)\(\{padding:8\}\),([A-Za-z_$][\w$]*)\(\{padding:8,apply\(\{availableWidth:([A-Za-z_$][\w$]*),availableHeight:([A-Za-z_$][\w$]*),elements:([A-Za-z_$][\w$]*),rects:([A-Za-z_$][\w$]*)\}\)/g;
+  patchedSource = patchedSource.replace(
+    middlewarePattern,
+    (_match, offsetAlias, mainAxis, crossAxis, shiftAlias, flipAlias, sizeAlias, availableWidth, availableHeight, elements, rects) =>
+      `middleware:[${offsetAlias}({mainAxis:${mainAxis},crossAxis:${crossAxis}}),${shiftAlias}({${currentPadding}}),${flipAlias}({${currentPadding}}),${sizeAlias}({${currentPadding},apply({availableWidth:${availableWidth},availableHeight:${availableHeight},elements:${elements},rects:${rects}})`,
+  );
+
+  if (patchedSource !== currentSource || patchedSource.includes(currentPadding)) {
+    return patchedSource;
   }
 
   if (currentSource.includes("middleware:[") && currentSource.includes("availableWidth")) {
@@ -235,6 +248,37 @@ function applyLinuxTooltipWindowControlsCollisionPatch(currentSource) {
   }
 
   return currentSource;
+}
+
+function findLocalEnvironmentActionModalFunction(currentSource) {
+  const componentPattern =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(\d+\),\{action:([A-Za-z_$][\w$]*),[^{}]*onUpdate:([A-Za-z_$][\w$]*),workspaceRoot:([A-Za-z_$][\w$]*)\}=\2,/g;
+  let match;
+  while ((match = componentPattern.exec(currentSource)) != null) {
+    const openBrace = currentSource.indexOf("{", match.index);
+    const closeBrace = findMatchingBrace(currentSource, openBrace);
+    if (closeBrace === -1) {
+      continue;
+    }
+    const text = currentSource.slice(match.index, closeBrace + 1);
+    if (
+      text.includes("settings.localEnvironments.actions.add.description") &&
+      text.includes("threadPage.runAction.setup.commandLabel") &&
+      text.includes(`local-env-action-name-\${${match[5]}.id}`)
+    ) {
+      return {
+        start: match.index,
+        end: closeBrace + 1,
+        text,
+        paramVar: match[2],
+        cacheVar: match[3],
+        actionVar: match[5],
+        updateVar: match[6],
+        workspaceVar: match[7],
+      };
+    }
+  }
+  return null;
 }
 
 function applyLinuxThreadSidePanelNativeTooltipPatch(currentSource) {
@@ -495,6 +539,10 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
 }
 
 function applyLinuxI18nGatePatch(currentSource) {
+  const alreadyPatchedI18nGateRegexes = [
+    /([A-Za-z_$][\w$]*)=[^;]*?\.get\(`enable_i18n`,!1\)[^;]*;let [^;]*,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.localeOverride\),[A-Za-z_$][\w$]*=\1\|\|\2!=null/u,
+    /([A-Za-z_$][\w$]*)=[^;]*?\.get\(`enable_i18n`,!0\)[^;]*,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.localeOverride\);\1=\1\|\|\2!=null;/u,
+  ];
   let patchedSource = currentSource.replace(
     /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\?\.get\(`enable_i18n`,!1\)(?:,[^;]+?)?);let ([A-Za-z_$][\w$]*)=\1,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\?\.get\(`locale_source`,`IDE`\)),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.localeOverride\)/g,
     (
@@ -546,7 +594,11 @@ function applyLinuxI18nGatePatch(currentSource) {
     },
   );
 
-  if (currentSource.includes("enable_i18n") && patchedSource === currentSource) {
+  if (
+    currentSource.includes("enable_i18n") &&
+    patchedSource === currentSource &&
+    !alreadyPatchedI18nGateRegexes.some((regex) => regex.test(currentSource))
+  ) {
     console.warn("WARN: Could not find i18n gate needle — skipping Linux i18n gate patch");
   }
 
@@ -598,15 +650,16 @@ function applyLinuxConfigWriteVersionConflictPatch(currentSource) {
 
 function applySubagentNicknameMetadataPatch(currentSource) {
   let patchedSource = currentSource;
-  const sourceShapePatchedMarker = "`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null";
-  const nicknamePatchedMarker =
-    "Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)";
+  const sourceShapePatchedRegex =
+    /`subAgent`in ([A-Za-z_$][\w$]*)\?\1\.subAgent:`subagent`in \1\?\1\.subagent:null/u;
+  const nicknamePatchedRegex =
+    /([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.agentNickname\)\?\?\1\(\2\.agent_nickname\)\?\?\1\([A-Za-z_$][\w$]*\(\2\.source\)\?\.agentNickname\)/u;
 
   const sourceShapeNeedle =
     "function Mi(e){return`subAgent`in e?e.subAgent:null}function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}";
   const sourceShapePatch =
     "function Mi(e){return`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null}function Ni(e){return typeof e==`string`?Pi():`thread_spawn`in e?{parentThreadId:j(e.thread_spawn.parent_thread_id),depth:e.thread_spawn.depth,agentNickname:e.thread_spawn.agent_nickname,agentRole:e.thread_spawn.agent_role}:Pi()}";
-  if (patchedSource.includes(sourceShapePatchedMarker)) {
+  if (sourceShapePatchedRegex.test(patchedSource)) {
     // Already patched.
   } else if (patchedSource.includes(sourceShapeNeedle)) {
     patchedSource = patchedSource.replace(sourceShapeNeedle, sourceShapePatch);
@@ -625,7 +678,7 @@ function applySubagentNicknameMetadataPatch(currentSource) {
     "function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(B(e.source)?.agentNickname)}";
   const nicknamePatch =
     "function Xl(e){return e==null?null:Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)}";
-  if (patchedSource.includes(nicknamePatchedMarker)) {
+  if (nicknamePatchedRegex.test(patchedSource)) {
     // Already patched.
   } else if (patchedSource.includes(nicknameNeedle)) {
     patchedSource = patchedSource.replace(nicknameNeedle, nicknamePatch);
@@ -642,7 +695,7 @@ function applySubagentNicknameMetadataPatch(currentSource) {
 
   if (
     patchedSource === currentSource &&
-    !(currentSource.includes(sourceShapePatchedMarker) && currentSource.includes(nicknamePatchedMarker)) &&
+    !(sourceShapePatchedRegex.test(currentSource) && nicknamePatchedRegex.test(currentSource)) &&
     (currentSource.includes("agentNickname") ||
       currentSource.includes("agent_nickname") ||
       currentSource.includes("thread_spawn"))
@@ -666,28 +719,23 @@ function applyLocalEnvironmentActionModalDraftPatch(currentSource) {
     return currentSource;
   }
 
-  const functionStart = currentSource.indexOf("function gd(e){");
-  if (functionStart === -1) {
+  const modalFunction = findLocalEnvironmentActionModalFunction(currentSource);
+  if (modalFunction == null) {
     console.warn(
       "WARN: Could not find local environment action modal component — skipping action input patch",
     );
     return currentSource;
   }
 
-  const functionEnd = currentSource.indexOf("var _d=", functionStart);
-  if (functionEnd === -1) {
-    console.warn(
-      "WARN: Could not find local environment action modal component boundary — skipping action input patch",
-    );
-    return currentSource;
-  }
-
-  const beforeFunction = currentSource.slice(0, functionStart);
-  const afterFunction = currentSource.slice(functionEnd);
-  let patchedFunction = currentSource.slice(functionStart, functionEnd);
-  const stateNeedle = "workspaceRoot:u}=e,d=Gt()";
+  const beforeFunction = currentSource.slice(0, modalFunction.start);
+  const afterFunction = currentSource.slice(modalFunction.end);
+  let patchedFunction = modalFunction.text;
+  const reactVar =
+    currentSource.match(/\(0,([A-Za-z_$][\w$]*)\.useState\)\(/)?.[1] ?? "Q";
+  const { actionVar, cacheVar, paramVar, updateVar, workspaceVar } = modalFunction;
+  const stateNeedle = `workspaceRoot:${workspaceVar}}=${paramVar},`;
   const statePatch =
-    "workspaceRoot:u}=e,[codexLinuxActionDraft,codexLinuxSetActionDraft]=(0,Q.useState)(()=>n),codexLinuxUpdateActionDraft=e=>(codexLinuxSetActionDraft(t=>({...t,...e})),l(e)),d=Gt()";
+    `workspaceRoot:${workspaceVar}}=${paramVar},[codexLinuxActionDraft,codexLinuxSetActionDraft]=(0,${reactVar}.useState)(()=>${actionVar}),codexLinuxUpdateActionDraft=codexLinuxPatch=>(codexLinuxSetActionDraft(codexLinuxDraft=>({...codexLinuxDraft,...codexLinuxPatch})),${updateVar}(codexLinuxPatch)),`;
   const requiredReplacements = [
     {
       needle: stateNeedle,
@@ -695,46 +743,55 @@ function applyLocalEnvironmentActionModalDraftPatch(currentSource) {
       description: "draft state insertion point",
     },
     {
-      needle: "if(t[0]!==n||",
-      replacement: "if(t[0]!==codexLinuxActionDraft||t[0]!==n||",
+      needle: `if(${cacheVar}[0]!==${actionVar}||`,
+      replacement: `if(${cacheVar}[0]!==codexLinuxActionDraft||${cacheVar}[0]!==${actionVar}||`,
       description: "modal memo guard",
     },
     {
-      needle: "{...n,command:I,name:P}",
-      replacement: "{...codexLinuxActionDraft,command:I,name:P}",
-      description: "saved action payload",
-    },
-    {
-      needle: "n.icon",
+      needle: `${actionVar}.icon`,
       replacement: "codexLinuxActionDraft.icon",
       description: "icon draft references",
     },
     {
-      needle: "n.name",
+      needle: `${actionVar}.name`,
       replacement: "codexLinuxActionDraft.name",
       description: "name draft references",
     },
     {
-      needle: "n.command",
+      needle: `${actionVar}.command`,
       replacement: "codexLinuxActionDraft.command",
       description: "command draft references",
     },
     {
-      needle: "l({icon:e.value})",
+      needle: `${updateVar}({icon:e.value})`,
       replacement: "codexLinuxUpdateActionDraft({icon:e.value})",
       description: "icon update callback",
     },
     {
-      needle: "l({name:e.target.value})",
+      needle: `${updateVar}({name:e.target.value})`,
       replacement: "codexLinuxUpdateActionDraft({name:e.target.value})",
       description: "name update callback",
     },
     {
-      needle: "l({command:e})",
+      needle: `${updateVar}({command:e})`,
       replacement: "codexLinuxUpdateActionDraft({command:e})",
       description: "command update callback",
     },
   ];
+
+  const savedPayloadPattern = new RegExp(
+    String.raw`\{\.\.\.${actionVar},command:([A-Za-z_$][\w$]*),name:([A-Za-z_$][\w$]*)\}`,
+  );
+  if (!savedPayloadPattern.test(patchedFunction)) {
+    console.warn(
+      "WARN: Could not find local environment action modal saved action payload — skipping action input patch",
+    );
+    return currentSource;
+  }
+  patchedFunction = patchedFunction.replace(
+    savedPayloadPattern,
+    "{...codexLinuxActionDraft,command:$1,name:$2}",
+  );
 
   const missingReplacement = requiredReplacements.find(
     ({ needle }) => !patchedFunction.includes(needle),

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3774,6 +3774,16 @@ JS
     assert_contains "$browser_client" 'async(e,t,r=$c)'
     assert_contains "$browser_client" "instanceId:await bk(o.id,e,r)"
     assert_contains "$browser_client" "codexLinuxRankBrowserBackends"
+
+    cat > "$browser_client" <<'JS'
+async function sye({globals:e}){return e}export{sye as setupBrowserRuntime};
+JS
+    local patch_log="$workspace/current-browser-client.log"
+    node "$REPO_DIR/scripts/lib/patch-chrome-plugin.js" "$chrome_dir" >"$patch_log" 2>&1
+    assert_not_contains "$patch_log" "browser-client.mjs missing patch target for Linux Chrome profile roots"
+    assert_not_contains "$patch_log" "browser-client.mjs missing patch target for Linux Chrome profile metadata lookup"
+    assert_not_contains "$patch_log" "browser-client.mjs missing patch target for Linux Chrome profile instance matching"
+    assert_not_contains "$patch_log" "browser-client.mjs missing patch target for Linux Chrome active profile backend ordering"
 }
 
 test_chrome_marketplace_fallback_synthesis() {


### PR DESCRIPTION
## Summary

Fixes latest upstream Codex Desktop drift for the Linux repackaging flow. The patch registry and Chrome plugin staging now handle the current upstream bundle shapes without required patch failures or stale `missing patch target` noise.

## Scope

- Updated ASAR patch helpers for current upstream minifier and bundle drift.
- Made optional/background-avatar-adjacent patch paths idempotent/fail-soft where upstream already has the Linux-compatible shape.
- Fixed current webview drift for automation schedules, local environment action drafts, settings sections, tooltips, updater bridge, subagent metadata, About dialog, native titlebar, and i18n gate detection.
- Updated Chrome plugin browser-client patching for the current alias family so Linux profile roots, profile metadata lookup, instance matching, and backend ranking are patched again.
- Added regression coverage for the new upstream shapes and focused Chrome plugin smoke coverage.

## Progress

- [x] Open tracking PR before starting the investigation.
- [x] Rebuild from a fresh upstream download.
- [x] Identify the failing patch/test surface.
- [x] Implement and validate the fix.
- [x] Push final drift fixes to this PR.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` — 218/218 passed.
- `node --test linux-features/codex-wrapper-updater/test.js` — 10/10 passed.
- Focused `test_chrome_browser_client_profile_root_variants` smoke check passed.
- `node --check scripts/lib/patch-chrome-plugin.js` passed.
- `bash -n tests/scripts_smoke.sh` passed.
- Fresh install from `/tmp/codex-upstream-ci/Codex.dmg` completed successfully into `/tmp/codex-driftfix-install-bIJjYS/codex-app`.
- Patch report validation passed with `bad-count=0` and `Required patch validation passed for profile upstream-build`.

## Notes

The only warnings left in the fresh install output are the known 7z DMG extraction symlink warnings; the app bundle is found and the build continues normally.