### PR TITLE
fix(launcher): surface curl diagnostics and restore the terminal CLI install prompt

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -248,6 +248,13 @@ HELP
     exit 0
 fi
 
+# Capture interactivity before stdout/stderr are redirected into the log;
+# [ -t 1 ] is always false after the exec below.
+LAUNCHER_INTERACTIVE_TERMINAL=0
+if [ -t 0 ] && [ -t 1 ]; then
+    LAUNCHER_INTERACTIVE_TERMINAL=1
+fi
+
 exec >>"$LOG_FILE" 2>&1
 
 echo "[$(date -Is)] Starting $CODEX_LINUX_APP_DISPLAY_NAME launcher"
@@ -1201,7 +1208,7 @@ run_cli_preflight_background() {
 }
 
 is_interactive_terminal() {
-    [ -t 0 ] && [ -t 1 ]
+    [ "$LAUNCHER_INTERACTIVE_TERMINAL" -eq 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]
 }
 
 run_gui_cli_prompt() {
@@ -1236,8 +1243,9 @@ prompt_install_missing_cli() {
     fi
 
     local reply=""
-    printf 'Codex CLI is not installed. Install it now? [Y/n] '
-    if ! read -r reply; then
+    # stdout is redirected into the launcher log, so prompt via the terminal.
+    printf 'Codex CLI is not installed. Install it now? [Y/n] ' >/dev/tty
+    if ! read -r reply </dev/tty; then
         return 1
     fi
 
@@ -1587,7 +1595,7 @@ verify_webview_origin() {
     local body err detail
     err=$(mktemp 2>/dev/null) || err="${TMPDIR:-/tmp}/codex-curl-err.$$"
     if ! body="$(curl --disable --noproxy 127.0.0.1,localhost --silent --show-error --fail --max-time 2 "$url" 2>"$err")"; then
-        detail=$(< "$err" 2>/dev/null)
+        detail=$(cat "$err" 2>/dev/null || true)
         rm -f "$err"
         echo "Webview origin validation failed for $url; ${detail:-curl exited non-zero with no diagnostic}" >&2
         return 1

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3172,6 +3172,8 @@ PY
     assert_contains "$REPO_DIR/flake.nix" ".tmp/bundled-marketplaces/openai-bundled"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Install it now? \\[Y/n\\]"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "is_interactive_terminal"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "LAUNCHER_INTERACTIVE_TERMINAL"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'detail=$(cat "$err" 2>/dev/null || true)'
     assert_contains "$REPO_DIR/updater/src/app.rs" "kdialog"
     assert_contains "$REPO_DIR/updater/src/app.rs" "zenity"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "CHROME_DESKTOP"


### PR DESCRIPTION
## What changed

Two launcher bugs in `launcher/start.sh.template` that hid information from terminal users:

1. **`verify_webview_origin` never surfaced the captured curl diagnostic.** The error file was read back with `detail=$(< "$err" 2>/dev/null)`. In bash, `$(< file)` only works as the *sole* element of a command substitution; with the extra redirection it becomes a null command and produces no output, so `detail` was always empty and every webview-origin failure logged the generic `curl exited non-zero with no diagnostic` fallback instead of the real cause (connect refused, timeout, HTTP status, ...) that the comment block above documents as the purpose of this code. Now reads with `cat`.

   Empirical check (bash 5.3):
   ```
   $ echo "connection refused" > f
   $ a=$(< f 2>/dev/null); echo "[$a]"
   []
   $ a=$(cat f 2>/dev/null || true); echo "[$a]"
   [connection refused]
   ```

2. **The interactive `Install Codex CLI now? [Y/n]` terminal prompt was unreachable.** The launcher redirects stdout/stderr into the log early (`exec >>"$LOG_FILE" 2>&1`), so the later `[ -t 1 ]` check in `is_interactive_terminal` was always false. Terminal launches with a missing CLI were routed to the GUI prompt path, or hard-exited when no update manager is installed — the elaborate `prompt_install_missing_cli` flow could never run (and its `printf` would have gone into the log file anyway). Interactivity is now captured before the redirect, and the prompt reads/writes via `/dev/tty`.

## Source-of-truth files

- `launcher/start.sh.template` (runtime launcher behavior)
- `tests/scripts_smoke.sh` (added template assertions)

## Validation

- `bash -n` on `install.sh`, `scripts/lib/*.sh`, `launcher/start.sh.template`, build scripts — clean
- `bash tests/scripts_smoke.sh` on this branch in Ubuntu (WSL): **All script smoke tests passed**
- Same suite passes identically on `main` (baseline)

## Notes / limitations

- Verified on Ubuntu under WSL2; not exercised against a real packaged install.
