### PR TITLE
fix(contrib): resolve the cached Codex.dmg where install.sh actually caches it

### DIFF
--- a/contrib/user-local-install/files/.local/bin/codex-desktop-update
+++ b/contrib/user-local-install/files/.local/bin/codex-desktop-update
@@ -37,7 +37,9 @@ log() {
 }
 
 if [ "$record_only" -eq 1 ]; then
-    extract_icon
+    # Icon extraction is best-effort: without a usable cached Codex.dmg it
+    # must not abort metadata recording under set -e.
+    extract_icon || log "Icon extraction skipped: no usable cached Codex.dmg."
     record_metadata
     log "Metadata refreshed."
     exit 0
@@ -109,7 +111,8 @@ fi
 
 if [ "$dmg_changed" -eq 1 ]; then
     log "Refreshing cached Codex.dmg..."
-    rm -f "$DMG_FILE"
+    dmg_file="$(cached_dmg_file)"
+    rm -f "$dmg_file" "$dmg_file.metadata"
 fi
 
 log "Rebuilding wrapper..."
@@ -129,7 +132,7 @@ log "Rebuilding wrapper..."
         ./install.sh
 )
 
-extract_icon
+extract_icon || log "Icon extraction skipped: no usable cached Codex.dmg."
 record_metadata
 
 if command -v update-desktop-database >/dev/null 2>&1; then

--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
 APP_DIR="${OPT_ROOT}/codex-app"
-DMG_FILE="${OPT_ROOT}/Codex.dmg"
 DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
@@ -58,6 +57,12 @@ effective_repo_dir() {
         return 0
     fi
     printf '%s\n' "$SOURCE_REPO_DIR"
+}
+
+# install.sh caches the upstream DMG next to itself in the build repo
+# checkout, never under $OPT_ROOT.
+cached_dmg_file() {
+    printf '%s/Codex.dmg\n' "$(effective_repo_dir)"
 }
 
 current_repo_head() {
@@ -464,11 +469,12 @@ header_value() {
 
 extract_icon() {
     ensure_layout
-    local tmp_dir
+    local dmg_file tmp_dir
+    dmg_file="$(cached_dmg_file)"
     tmp_dir="$(mktemp -d)"
     trap 'rm -rf "$tmp_dir"' RETURN
 
-    7z e -y "$DMG_FILE" "Codex Installer/Codex.app/Contents/Resources/electron.icns" "-o${tmp_dir}" >/dev/null
+    7z e -y "$dmg_file" "Codex Installer/Codex.app/Contents/Resources/electron.icns" "-o${tmp_dir}" >/dev/null
     python3 - "$tmp_dir/electron.icns" "$ICON_PATH" <<'PY'
 from PIL import Image
 import sys
@@ -485,7 +491,7 @@ record_metadata() {
     ensure_layout
     load_install_config
 
-    local build_repo_dir repo_head source_repo_head_value source_overlay_sha dmg_sha256 dmg_size electron_version dmg_headers dmg_etag dmg_last_modified dmg_content_length build_time repo_origin
+    local build_repo_dir repo_head source_repo_head_value source_overlay_sha dmg_file dmg_sha256 dmg_size electron_version dmg_headers dmg_etag dmg_last_modified dmg_content_length build_time repo_origin
     build_repo_dir="$(effective_repo_dir)"
 
     if [ -d "$build_repo_dir/.git" ]; then
@@ -495,8 +501,14 @@ record_metadata() {
         repo_head="unavailable"
         repo_origin="unavailable"
     fi
-    dmg_sha256="$(sha256sum "$DMG_FILE" | awk '{ print $1 }')"
-    dmg_size="$(stat -c '%s' "$DMG_FILE")"
+    dmg_file="$(cached_dmg_file)"
+    if [ -f "$dmg_file" ]; then
+        dmg_sha256="$(sha256sum "$dmg_file" | awk '{ print $1 }')"
+        dmg_size="$(stat -c '%s' "$dmg_file")"
+    else
+        dmg_sha256="unavailable"
+        dmg_size="unavailable"
+    fi
     electron_version="$(cat "$APP_DIR/version")"
     build_time="$(date -Iseconds)"
     source_repo_head_value="$(source_repo_head 2>/dev/null || true)"


### PR DESCRIPTION
## What changed

The user-local helpers (`contrib/user-local-install`) looked for the cached DMG at `$OPT_ROOT/Codex.dmg`, but nothing ever writes the DMG there: `install.sh` caches it next to itself in the build repo checkout (`CACHED_DMG_PATH="$SCRIPT_DIR/Codex.dmg"` in `scripts/lib/install-helpers.sh`), and `CODEX_INSTALL_ROOT` only relocates the generated app directory.

Consequences in the update flow (`codex-desktop-update`):

- After every successful rebuild, `extract_icon` ran `7z` on a nonexistent file, so `set -euo pipefail` aborted the script **before** `record_metadata`.
- The weekly `codex-desktop-update.timer` unit therefore failed on every run.
- Because metadata never refreshed, `codex-desktop-check-update` kept reporting a pending update forever.
- The `Refreshing cached Codex.dmg...` step deleted the wrong path, so it never actually forced a refresh.

Fix:

- Resolve the cache via the effective build repo dir (`cached_dmg_file()` on top of the existing `effective_repo_dir()`), so icon extraction and DMG metadata work against the DMG that install.sh actually cached.
- Treat icon extraction as best-effort at the `codex-desktop-update` call sites (`extract_icon || log ...`), so a missing/unusable DMG can no longer abort the script before `record_metadata`. The extraction is still *attempted* every time, preserving the behavior the smoke suite pins.
- Record `DMG_SHA256` / `DMG_SIZE` as `unavailable` when no cached DMG exists (same convention as `repo_head`); `codex-desktop-version` already prints these fields defensively.
- Delete the real cache plus its `.metadata` sidecar when a DMG refresh is forced.

## Source-of-truth files

- `contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh`
- `contrib/user-local-install/files/.local/bin/codex-desktop-update`

## Validation

- `bash -n` on all contrib scripts — clean
- `bash tests/scripts_smoke.sh` on this branch in Ubuntu (WSL): **All script smoke tests passed**, including the user-local overlay/refresh suites and `test_user_local_install_from_update_defers_record_only_metadata`
- Functional repro in a sandbox `$HOME`: sourcing the fixed `common.sh`, `cached_dmg_file` resolves into the build repo dir; the tolerated `extract_icon` failure no longer aborts under `set -e`; `record_metadata` completes and writes `DMG_SHA256/DMG_SIZE=unavailable` when no DMG is cached

## Notes / limitations

- Not exercised against a real `~/.local` install with the systemd timer; the failure mechanics and fix were verified by sourcing the helpers in a sandboxed `$HOME` plus the smoke suite.
