### PR TITLE
fix(updater): rollback block identity, zero-interval panic, atomic DMG cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -318,8 +318,7 @@ async fn run_daemon(
         error!(?error, "initial reconciliation failed");
     }
 
-    let mut check_interval =
-        time::interval(Duration::from_secs(config.check_interval_hours * 3600));
+    let mut check_interval = time::interval(check_interval_period(config.check_interval_hours));
     let mut reconcile_interval = time::interval(Duration::from_secs(RECONCILE_INTERVAL_SECONDS));
     check_interval.tick().await;
     reconcile_interval.tick().await;
@@ -835,7 +834,7 @@ async fn run_check_cycle(
             .rollback_blocked_candidate_version
             .as_deref()
             .is_some_and(|blocked| {
-                installed_version_matches_candidate(blocked, &downloaded.candidate_version)
+                candidate_matches_rolled_back_version(blocked, &downloaded.candidate_version)
             })
         {
             state.status = UpdateStatus::Idle;
@@ -1216,6 +1215,33 @@ fn installed_version_matches_candidate(installed: &str, candidate: &str) -> bool
         Some(std::cmp::Ordering::Equal) => true,
         Some(_) => false,
         None => installed == candidate,
+    }
+}
+
+/// `tokio::time::interval` panics on a zero period; clamp a hand-edited
+/// `check_interval_hours = 0` to the smallest supported cadence.
+fn check_interval_period(check_interval_hours: u64) -> Duration {
+    Duration::from_secs(check_interval_hours.max(1).saturating_mul(3600))
+}
+
+fn version_dmg_short_hash(version: &str) -> Option<&str> {
+    version
+        .split_once('+')
+        .map(|(_, short_hash)| short_hash)
+        .filter(|short_hash| !short_hash.is_empty())
+}
+
+/// Returns true when a downloaded candidate is the same upstream DMG as a
+/// previously rolled-back install. Generated versions embed the download
+/// timestamp, so the `+<dmg-sha8>` suffix is the only identity that survives
+/// a re-download of the same DMG.
+fn candidate_matches_rolled_back_version(blocked: &str, candidate: &str) -> bool {
+    match (
+        version_dmg_short_hash(blocked),
+        version_dmg_short_hash(candidate),
+    ) {
+        (Some(blocked_hash), Some(candidate_hash)) => blocked_hash == candidate_hash,
+        _ => installed_version_matches_candidate(blocked, candidate),
     }
 }
 
@@ -1654,6 +1680,35 @@ mod tests {
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
         }
+    }
+
+    #[test]
+    fn rollback_block_matches_same_dmg_across_redownload_timestamps() {
+        // The timestamp segments differ between the original download and a
+        // later re-download of the same DMG; only the +sha8 suffix is stable.
+        assert!(candidate_matches_rolled_back_version(
+            "2026.05.04.131500+abcdef12",
+            "2026.06.10.083355+abcdef12"
+        ));
+        assert!(!candidate_matches_rolled_back_version(
+            "2026.05.04.131500+abcdef12",
+            "2026.06.10.083355+12345678"
+        ));
+        // Versions without a DMG hash fall back to version comparison.
+        assert!(candidate_matches_rolled_back_version(
+            "2026.05.04.131500",
+            "2026.05.04.131500"
+        ));
+        assert!(!candidate_matches_rolled_back_version(
+            "2026.05.04.131500",
+            "2026.06.10.083355"
+        ));
+    }
+
+    #[test]
+    fn check_interval_period_clamps_zero_hours() {
+        assert_eq!(check_interval_period(0), Duration::from_secs(3600));
+        assert_eq!(check_interval_period(6), Duration::from_secs(6 * 3600));
     }
 
     #[test]

--- a/updater/src/upstream.rs
+++ b/updater/src/upstream.rs
@@ -80,39 +80,60 @@ pub async fn download_dmg(
         .await
         .with_context(|| format!("Failed to create {}", destination_dir.display()))?;
 
+    // Stream into a sidecar file and rename on success so a failed
+    // re-download cannot truncate the previously cached DMG that pending
+    // installs and wrapper rebuilds still reference through state.
     let destination = destination_dir.join("Codex.dmg");
-    let mut file = File::create(&destination)
-        .await
-        .with_context(|| format!("Failed to create {}", destination.display()))?;
+    let partial = destination_dir.join("Codex.dmg.part");
 
-    let response = client
-        .get(dmg_url)
-        .send()
-        .await
-        .with_context(|| format!("Failed GET request for {dmg_url}"))?
-        .error_for_status()
-        .with_context(|| format!("GET request for {dmg_url} returned an error status"))?;
-
-    let mut hasher = Sha256::new();
-    let mut stream = response.bytes_stream();
-
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.with_context(|| format!("Failed downloading {dmg_url}"))?;
-        file.write_all(&chunk)
+    let download_result: Result<String> = async {
+        let mut file = File::create(&partial)
             .await
-            .with_context(|| format!("Failed writing {}", destination.display()))?;
-        hasher.update(&chunk);
+            .with_context(|| format!("Failed to create {}", partial.display()))?;
+
+        let response = client
+            .get(dmg_url)
+            .send()
+            .await
+            .with_context(|| format!("Failed GET request for {dmg_url}"))?
+            .error_for_status()
+            .with_context(|| format!("GET request for {dmg_url} returned an error status"))?;
+
+        let mut hasher = Sha256::new();
+        let mut stream = response.bytes_stream();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.with_context(|| format!("Failed downloading {dmg_url}"))?;
+            file.write_all(&chunk)
+                .await
+                .with_context(|| format!("Failed writing {}", partial.display()))?;
+            hasher.update(&chunk);
+        }
+
+        file.flush()
+            .await
+            .with_context(|| format!("Failed flushing {}", partial.display()))?;
+
+        Ok(hasher
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>())
     }
+    .await;
 
-    file.flush()
+    let sha256 = match download_result {
+        Ok(sha256) => sha256,
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&partial).await;
+            return Err(error);
+        }
+    };
+
+    tokio::fs::rename(&partial, &destination)
         .await
-        .with_context(|| format!("Failed flushing {}", destination.display()))?;
+        .with_context(|| format!("Failed to move {} into place", partial.display()))?;
 
-    let sha256 = hasher
-        .finalize()
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
     let candidate_version = derive_candidate_version(&sha256, version_timestamp)?;
 
     Ok(DownloadedDmg {
@@ -198,6 +219,37 @@ mod tests {
             "678cd508ffe0071e217020a7a4eecbebe25362c022ac78c13a5ae87b7a3a0c92"
         );
         assert_eq!(downloaded.candidate_version, "2026.03.24.120000+678cd508");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_download_preserves_existing_cached_dmg() -> Result<()> {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/Codex.dmg"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let client = Client::builder().build()?;
+        let temp = tempdir()?;
+        let cached = temp.path().join("Codex.dmg");
+        tokio::fs::write(&cached, b"previously-cached-dmg").await?;
+
+        let result = download_dmg(
+            &client,
+            &format!("{}/Codex.dmg", server.uri()),
+            temp.path(),
+            Utc.with_ymd_and_hms(2026, 3, 24, 12, 0, 0).unwrap(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            tokio::fs::read(&cached).await?,
+            b"previously-cached-dmg".to_vec()
+        );
+        assert!(!temp.path().join("Codex.dmg.part").exists());
         Ok(())
     }
 


### PR DESCRIPTION
## What changed

Three correctness fixes in the Rust update manager, plus a patch version bump to 0.8.3.

1. **The rollback block could never match, so a rolled-back bad update was auto-reinstalled on the failed-check retry path.** Generated candidate versions are `{download-timestamp}+{dmg-sha8}` (`derive_candidate_version`). `installed_version_matches_candidate` strips everything after `+`/`-` and compares only the four timestamp segments — which are *download times* and always differ between the originally installed download and a later re-download of the same DMG. `Ordering::Equal` was structurally unreachable, making the `rollback_blocked_candidate_version` guard dead code. On the `Failed`-status retry path (`retrying_failed_update`, which deliberately bypasses both the headers-fingerprint guard and the `dmg_sha256` guard), any transient check error after a rollback caused the same bad DMG to be rebuilt under a fresh version and auto-reinstalled — exactly what the guard, its log line, and its error message exist to prevent. The new `candidate_matches_rolled_back_version` compares the `+sha8` DMG identity, falling back to the old comparison for versions without a hash suffix.

2. **`check_interval_hours = 0` in `config.toml` panicked the daemon.** `tokio::time::interval` asserts a non-zero period (``"`period` must be non-zero"``), and the user-editable config value was multiplied straight into it, killing the reconcile loop right after the initial check. The new `check_interval_period` clamps to a 1-hour minimum (and saturates the multiply).

3. **A failed re-download corrupted the cached DMG in place.** `download_dmg` truncated `downloads/Codex.dmg` via `File::create` *before* sending the GET, so a mid-stream failure left a partial file at the exact path that `state.artifact_paths.dmg_path` still references — and `wrapper_apply::cached_or_downloaded_dmg` reuses it via a bare `exists()` check, feeding a truncated DMG into wrapper rebuilds. Downloads now stream into `Codex.dmg.part` and rename into place on success; the sidecar is removed on failure.

## Source-of-truth files

- `updater/src/app.rs`, `updater/src/upstream.rs`
- `updater/Cargo.toml` (0.8.2 → 0.8.3, patch bump per the repo versioning rules), `Cargo.lock`

## Validation (Ubuntu/WSL)

- `cargo fmt -p codex-update-manager -- --check` — clean
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings` — clean
- `cargo test -p codex-update-manager` — 169 passed; the 3 failures (`feature_picker::tests::{dont_ask_sentinel_writes_setting, selection_preserves_unknown_existing_feature_ids, selection_writes_feature_config_outside_wrapper_src}`) fail identically on `main` in my environment (env-specific, unrelated to this change)
- New tests: `rollback_block_matches_same_dmg_across_redownload_timestamps`, `check_interval_period_clamps_zero_hours`, `failed_download_preserves_existing_cached_dmg` (asserts a 500 response leaves the previously cached DMG intact and no `.part` behind); existing `downloads_dmg_and_hashes_contents` still passes

## Notes / limitations

- Persisted state is unchanged (`rollback_blocked_candidate_version` keeps its existing format); only the comparison is fixed, so no state migration is needed.
