### PR TITLE
fix(patches): align Computer Use settings resolution and quit-guard insertion

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1144,6 +1144,25 @@ test("adds the Linux quit guard when only the Electron require is recognizable",
   assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
 });
 
+test("keeps a leading use strict directive ahead of the quit guard fallback", () => {
+  const source =
+    '"use strict";const e=require(`./app-session.js`);let t=require(`electron`);class WindowManager{}';
+
+  const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
+
+  assert.match(patched, /^"use strict";let codexLinuxQuitInProgress=!1/);
+  assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
+});
+
+test("warns and skips the quit guard when no Electron require exists", () => {
+  const source = "const e=1;";
+
+  const { value, warnings } = captureWarns(() => applyLinuxQuitGuardPatch(source));
+
+  assert.equal(value, source);
+  assert.match(warnings.join("\n"), /quit guard insertion point/);
+});
+
 test("upgrades the legacy Linux quit guard helper when re-patching older bundles", () => {
   const source =
     "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);let codexLinuxQuitInProgress=!1,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;var x=1;";
@@ -4046,11 +4065,13 @@ function withIsolatedHome(body) {
   const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousAppId = process.env.CODEX_APP_ID;
   const previousLinuxAppId = process.env.CODEX_LINUX_APP_ID;
+  const previousSettingsFile = process.env.CODEX_LINUX_SETTINGS_FILE;
   const previousFlag = process.env[COMPUTER_USE_UI_ENV_VAR];
   process.env.HOME = tempHome;
   delete process.env.XDG_CONFIG_HOME;
   delete process.env.CODEX_APP_ID;
   delete process.env.CODEX_LINUX_APP_ID;
+  delete process.env.CODEX_LINUX_SETTINGS_FILE;
   delete process.env[COMPUTER_USE_UI_ENV_VAR];
   try {
     return body(tempHome);
@@ -4116,6 +4137,24 @@ test("isComputerUseUiEnabled honours side-by-side CODEX_APP_ID settings", () => 
   withIsolatedHome((home) => {
     process.env.CODEX_APP_ID = "codex-cua-lab";
     writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "codex-cua-lab");
+    assert.equal(isComputerUseUiEnabled(), true);
+  });
+});
+
+test("isComputerUseUiEnabled prefers CODEX_LINUX_APP_ID like the runtime settings writer", () => {
+  withIsolatedHome((home) => {
+    process.env.CODEX_LINUX_APP_ID = "codex-cua-lab";
+    process.env.CODEX_APP_ID = "codex-desktop";
+    writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "codex-cua-lab");
+    assert.equal(isComputerUseUiEnabled(), true);
+  });
+});
+
+test("isComputerUseUiEnabled honours CODEX_LINUX_SETTINGS_FILE", () => {
+  withIsolatedHome((home) => {
+    const settingsFile = path.join(home, "custom-settings.json");
+    fs.writeFileSync(settingsFile, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "utf8");
+    process.env.CODEX_LINUX_SETTINGS_FILE = settingsFile;
     assert.equal(isComputerUseUiEnabled(), true);
   });
 });

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -37,6 +37,12 @@ function readComputerUseUiSettingsFlag(env) {
 }
 
 function computerUseUiSettingsPath(env) {
+  // Mirror the runtime codexLinuxSettingsPath() resolution so this build-time
+  // reader finds the same settings.json the patched app writes the flag to.
+  const override = env.CODEX_LINUX_SETTINGS_FILE;
+  if (typeof override === "string" && override.length > 0) {
+    return override;
+  }
   const xdgConfig = env.XDG_CONFIG_HOME;
   const home = env.HOME;
   const configHome = (xdgConfig && xdgConfig.length > 0)
@@ -52,7 +58,7 @@ function computerUseUiSettingsPath(env) {
 }
 
 function computerUseUiSettingsAppId(env) {
-  const appId = env.CODEX_APP_ID || env.CODEX_LINUX_APP_ID || "codex-desktop";
+  const appId = env.CODEX_LINUX_APP_ID || env.CODEX_APP_ID || "codex-desktop";
   return /^[A-Za-z0-9._-]+$/.test(appId) ? appId : "codex-desktop";
 }
 

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -599,12 +599,17 @@ function applyLinuxQuitGuardPatch(currentSource) {
   }
 
   if (patchedSource.includes("require(`electron`)")) {
-    return `${quitGuardSuffix}${patchedSource}`;
+    // Insert after a leading "use strict" so prepending the helper does not
+    // demote the directive to a plain expression and de-strict the bundle.
+    const insertAt = patchedSource.startsWith('"use strict";')
+      ? '"use strict";'.length
+      : patchedSource.startsWith("'use strict';")
+        ? "'use strict';".length
+        : 0;
+    return `${patchedSource.slice(0, insertAt)}${quitGuardSuffix}${patchedSource.slice(insertAt)}`;
   }
 
-  if (patchedSource.includes("require(`electron`)") && patchedSource.includes("require(`node:path`)")) {
-    console.warn("WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch");
-  }
+  console.warn("WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch");
 
   return patchedSource;
 }


### PR DESCRIPTION
## What changed

Two core ASAR patch fixes.

1. **`computer-use.js` resolved the settings identity inversely to the runtime that writes the flag.** `computerUseUiSettingsAppId` used `CODEX_APP_ID || CODEX_LINUX_APP_ID`, while every other resolver in the repo — including the injected `codexLinuxSettingsAppId()` runtime that *persists* `codex-linux-computer-use-ui-enabled`, plus `codexLinuxWrapAppId`, `codexLinuxReadAloudSettingsAppId`, `bootstrap-wizard.sh`, `apply-pending.sh`, and the updater's documented resolution order (`updater/src/config.rs`) — uses `CODEX_LINUX_APP_ID || CODEX_APP_ID`. With side-by-side app identities (e.g. `make build-dev-app`, where the repo's own tests set the two vars to different values) the build-time reader checked a different `settings.json` than the one the running app writes, silently ignoring the persisted Computer Use UI opt-in. The reader now also honours `CODEX_LINUX_SETTINGS_FILE`, like the runtime `codexLinuxSettingsPath()` it mirrors.

2. **`applyLinuxQuitGuardPatch`'s last-resort fallback de-stricted the main bundle, and its drift warning was dead code.** The fallback prepended the quit-guard helper at byte 0; the `.vite/build` bundles start with `"use strict";`, and a statement before the directive demotes it to a plain expression, switching the whole bundle to sloppy mode. The helper is now inserted after a leading directive (the same technique the other helper-injection patches use). The "could not find insertion point" warning was guarded by a condition that the preceding `return` made unreachable; it now actually fires when no anchor exists.

## Source-of-truth files

- `scripts/patches/computer-use.js`
- `scripts/patches/main-process.js`
- `scripts/patch-linux-window-ui.test.js` (new coverage)

## Validation (Ubuntu/WSL, node 22)

- `node --test scripts/patch-linux-window-ui.test.js`: **222/222 pass** (218 baseline + 4 new: LINUX-first app-id precedence, `CODEX_LINUX_SETTINGS_FILE` override, use-strict-preserving fallback insertion, warning on missing anchor)
- `node --test linux-features/*/test.js`: all pass
- Baseline on `main`: 218/218 pass, so no regressions

## Notes / limitations

- The existing fallback test ("adds the Linux quit guard when only the Electron require is recognizable") still passes unchanged — insertion at byte 0 is preserved for sources without a directive.
