### PR TITLE
fix(build): portable awk header matching and correct stderr redirects

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -64,9 +64,11 @@ jobs:
 
           curl -fsSLI "$UPSTREAM_DMG_URL" > "$headers_file"
 
-          last_modified="$(awk 'BEGIN{IGNORECASE=1} /^last-modified:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
-          etag="$(awk 'BEGIN{IGNORECASE=1} /^etag:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); gsub(/"/,""); print; exit}' "$headers_file")"
-          content_length="$(awk 'BEGIN{IGNORECASE=1} /^content-length:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+          # Match header names case-insensitively without gawk's IGNORECASE,
+          # which is a no-op under mawk (the default awk on ubuntu runners).
+          last_modified="$(awk 'tolower($0) ~ /^last-modified:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+          etag="$(awk 'tolower($0) ~ /^etag:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); gsub(/"/,""); print; exit}' "$headers_file")"
+          content_length="$(awk 'tolower($0) ~ /^content-length:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
 
           if [ -z "$last_modified" ]; then
             last_modified="unknown"

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -452,9 +452,11 @@ capture_upstream_metadata() {
     local etag="no-etag"
     local content_length="unknown"
     if curl -fsSLI "$UPSTREAM_DMG_URL" > "$headers_file"; then
-        last_modified="$(awk 'BEGIN{IGNORECASE=1} /^last-modified:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
-        etag="$(awk 'BEGIN{IGNORECASE=1} /^etag:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); gsub(/"/,""); print; exit}' "$headers_file")"
-        content_length="$(awk 'BEGIN{IGNORECASE=1} /^content-length:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+        # Match header names case-insensitively without gawk's IGNORECASE,
+        # which is a no-op under mawk (the default awk in the CI containers).
+        last_modified="$(awk 'tolower($0) ~ /^last-modified:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
+        etag="$(awk 'tolower($0) ~ /^etag:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); gsub(/"/,""); print; exit}' "$headers_file")"
+        content_length="$(awk 'tolower($0) ~ /^content-length:/ {sub(/\r$/,""); sub(/^[^:]+: /,""); print; exit}' "$headers_file")"
     fi
     rm -f "$headers_file"
 

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -227,8 +227,8 @@ build_native_modules() {
         "$ELECTRON_REBUILD_PACKAGE" \
         "$ELECTRON_REBUILD_NODE_ABI_PACKAGE" \
         --save-dev \
-        --ignore-scripts 2>&1 >&2
-    npm install "better-sqlite3@$bs3_build_ver" "node-pty@$npty_ver" --ignore-scripts 2>&1 >&2
+        --ignore-scripts >&2
+    npm install "better-sqlite3@$bs3_build_ver" "node-pty@$npty_ver" --ignore-scripts >&2
     patch_better_sqlite3_for_v8_external_pointer_api "$build_dir/node_modules/better-sqlite3"
 
     info "Compiling for Electron v$ELECTRON_VERSION (this takes ~1 min)..."
@@ -239,7 +239,7 @@ build_native_modules() {
         npm_config_disturl="$ELECTRON_HEADERS_URL" \
         NPM_CONFIG_DISTURL="$ELECTRON_HEADERS_URL" \
         "${native_build_env[@]}" \
-        node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" "${electron_rebuild_mode_args[@]}" 2>&1 >&2
+        node "$build_dir/node_modules/@electron/rebuild/lib/cli.js" -v "$ELECTRON_VERSION" --force --dist-url "$ELECTRON_HEADERS_URL" "${electron_rebuild_mode_args[@]}" >&2
 
     info "Native modules built successfully"
 


### PR DESCRIPTION
## What changed

Two small build/CI plumbing fixes.

1. **Upstream DMG metadata capture silently degraded to `unknown` under mawk.** `capture_upstream_metadata` in `scripts/ci/container-entrypoint.sh` and the equivalent step in `.github/workflows/upstream-build-app.yml` matched HTTP response headers with `awk 'BEGIN{IGNORECASE=1} /^last-modified:/ ...'`. `IGNORECASE` is a gawk extension; under mawk — the default `awk` in the `ubuntu:24.04` CI container and on ubuntu runners — it is an inert variable, and real responses send capitalized `Last-Modified` / `ETag` / `Content-Length`, so all three lookups returned empty and the recorded metadata fell back to `unknown` / `no-etag`. Now matches on `tolower($0)`, like the equivalent parser in `scripts/lib/dmg.sh`.

   Verified against real mawk:
   ```
   mawk old IGNORECASE etag: []
   mawk new tolower etag:    [abc]
   ```

2. **`2>&1 >&2` in `scripts/lib/native-modules.sh` did the opposite of intent.** Redirections apply left to right: `2>&1` points stderr at current stdout, then `>&2` points stdout at the (already-redirected) stderr — net effect, stderr merges *into stdout* and stdout is unchanged. The evident intent (keep npm/electron-rebuild chatter on stderr, the convention everywhere else in the install pipeline) is `>&2`.

## Source-of-truth files

- `scripts/ci/container-entrypoint.sh`
- `.github/workflows/upstream-build-app.yml`
- `scripts/lib/native-modules.sh`

## Validation

- `bash -n` across install/lib/launcher/build/ci scripts — clean
- `bash tests/scripts_smoke.sh` on this branch in Ubuntu (WSL): **All script smoke tests passed**
- mawk comparison above run against `mawk 1.3.4` on Ubuntu (WSL)

## Notes / limitations

- Impact of (1) is limited to CI metadata/reporting (cache keys still work since they hash whatever values were captured); (2) is stream classification only — no caller currently parses install.sh stdout.
