### PR TITLE
[codex] Fix Linux Browser Use route liveness fallback

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -65,6 +65,7 @@ const {
 const {
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAboutDialogPatch,
+  applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,
@@ -182,6 +183,7 @@ module.exports = {
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
   applyLinuxBrowserUseNonLocalNavigationPatch,
+  applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxChromeNativeHostRuntimePatch,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -22,6 +22,7 @@ const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxBrowserUseIabVisibleOnCreatePatch,
+  applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxChromeNativeHostRuntimePatch,
   applyLinuxChromePluginAutoInstallPatch,
@@ -634,6 +635,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-chrome-plugin-auto-install",
     "linux-chrome-native-host-runtime",
     "browser-use-node-repl-approval",
+    "linux-browser-use-route-liveness",
     "linux-chrome-extension-status",
     "linux-remote-control-config-preservation",
     "linux-app-updater-menu",
@@ -3745,6 +3747,58 @@ test("patches later Browser Use navigation dispatches when an earlier one is alr
     2,
   );
   assert.doesNotMatch(patched, /browser-use-non-local-sites-allowed-changed`,\{allowed:p\}/);
+});
+
+test("falls back to the single live Linux Browser Use route window", () => {
+  const source =
+    "var kK=t.Ur(`browser-sidebar-manager`);" +
+    "function AK({ensureWindowState:e,windowId:t,windows:n}){let i=n.get(t)??null;if(i==null){let n=r.BrowserWindow.fromId(t);n!=null&&!n.isDestroyed()&&!n.webContents.isDestroyed()&&(i=e(n,n.webContents))}return i==null||i.window.isDestroyed()||i.owner.isDestroyed()?(kK().warning(`IAB_LIFECYCLE route window is not live`,{safe:{hasWindowState:i!=null,ownerDestroyed:i?.owner.isDestroyed()??null,windowDestroyed:i?.window.isDestroyed()??null,windowId:t},sensitive:{}}),null):i}";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseRouteLivenessPatch, source);
+
+  assert.match(patched, /function codexLinuxResolveLiveBrowserUseRouteWindow/);
+  assert.match(patched, /i==null&&\(i=codexLinuxResolveLiveBrowserUseRouteWindow\(e,t,n,r\)\);return/);
+  assert.equal((patched.match(/codexLinuxResolveLiveBrowserUseRouteWindow/g) || []).length, 2);
+
+  const webContents = { isDestroyed: () => false };
+  const window = { id: 7, isDestroyed: () => false, webContents };
+  const context = {
+    process: { platform: "linux" },
+    r: { BrowserWindow: { fromId: () => null, getAllWindows: () => [window] } },
+    t: { Ur: () => () => ({ warning: () => assert.fail("fallback should avoid warning") }) },
+  };
+  const result = vm.runInNewContext(
+    `${patched};AK({ensureWindowState:(window,owner)=>({owner,threads:new Map,window}),windowId:42,windows:new Map})`,
+    context,
+  );
+
+  assert.equal(result.window.id, 7);
+  assert.equal(result.owner, webContents);
+});
+
+test("keeps Browser Use route liveness fallback inactive when ambiguous", () => {
+  const source =
+    "var kK=t.Ur(`browser-sidebar-manager`);" +
+    "function AK({ensureWindowState:e,windowId:t,windows:n}){let i=n.get(t)??null;if(i==null){let n=r.BrowserWindow.fromId(t);n!=null&&!n.isDestroyed()&&!n.webContents.isDestroyed()&&(i=e(n,n.webContents))}return i==null||i.window.isDestroyed()||i.owner.isDestroyed()?(kK().warning(`IAB_LIFECYCLE route window is not live`,{safe:{hasWindowState:i!=null,ownerDestroyed:i?.owner.isDestroyed()??null,windowDestroyed:i?.window.isDestroyed()??null,windowId:t},sensitive:{}}),null):i}";
+  const patched = applyLinuxBrowserUseRouteLivenessPatch(source);
+  const webContents = { isDestroyed: () => false };
+  const windows = [
+    { id: 7, isDestroyed: () => false, webContents },
+    { id: 8, isDestroyed: () => false, webContents },
+  ];
+  let warnings = 0;
+  const context = {
+    process: { platform: "linux" },
+    r: { BrowserWindow: { fromId: () => null, getAllWindows: () => windows } },
+    t: { Ur: () => () => ({ warning: () => { warnings += 1; } }) },
+  };
+  const result = vm.runInNewContext(
+    `${patched};AK({ensureWindowState:(window,owner)=>({owner,window}),windowId:42,windows:new Map})`,
+    context,
+  );
+
+  assert.equal(result, null);
+  assert.equal(warnings, 1);
 });
 
 test("shows object-helper Computer Use plugin UI on Linux", () => {

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -2,6 +2,7 @@
 
 const {
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../main-process.js");
 const { applyLinuxChromePluginAutoInstallPatch } = require("../../../../chrome-plugin.js");
@@ -20,6 +21,13 @@ module.exports = [
     order: 160,
     ciPolicy: "optional",
     apply: applyBrowserUseNodeReplApprovalPatch,
+  },
+  {
+    id: "linux-browser-use-route-liveness",
+    phase: "main-bundle",
+    order: 170,
+    ciPolicy: "optional",
+    apply: applyLinuxBrowserUseRouteLivenessPatch,
   },
   {
     id: "linux-chrome-extension-status",

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -1293,6 +1293,45 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxBrowserUseRouteLivenessPatch(currentSource) {
+  if (currentSource.includes("codexLinuxResolveLiveBrowserUseRouteWindow")) {
+    return currentSource;
+  }
+
+  const routeWindowPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{ensureWindowState:([A-Za-z_$][\w$]*),windowId:([A-Za-z_$][\w$]*),windows:([A-Za-z_$][\w$]*)\}\)\{let ([A-Za-z_$][\w$]*)=\4\.get\(\3\)\?\?null;if\(\5==null\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.BrowserWindow\.fromId\(\3\);\6!=null&&!\6\.isDestroyed\(\)&&!\6\.webContents\.isDestroyed\(\)&&\(\5=\2\(\6,\6\.webContents\)\)\}return \5==null\|\|\5\.window\.isDestroyed\(\)\|\|\5\.owner\.isDestroyed\(\)\?\(([A-Za-z_$][\w$]*)\(\)\.warning\(`IAB_LIFECYCLE route window is not live`,\{safe:\{hasWindowState:\5!=null,ownerDestroyed:\5\?\.owner\.isDestroyed\(\)\?\?null,windowDestroyed:\5\?\.window\.isDestroyed\(\)\?\?null,windowId:\3\},sensitive:\{\}\}\),null\):\5\}/u;
+
+  const match = currentSource.match(routeWindowPattern);
+  if (match == null) {
+    if (
+      currentSource.includes("IAB_LIFECYCLE route window is not live") &&
+      currentSource.includes("BrowserWindow.fromId")
+    ) {
+      console.warn(
+        "WARN: Could not find Browser Use route liveness helper — skipping Linux route liveness fallback patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [
+    original,
+    functionName,
+    ensureWindowStateVar,
+    windowIdVar,
+    windowsVar,
+    stateVar,
+    browserWindowVar,
+    electronVar,
+    loggerVar,
+  ] = match;
+
+  const helper = `function codexLinuxResolveLiveBrowserUseRouteWindow(e,t,n,r){if(process.platform!==\`linux\`)return null;let i=[];try{for(let e of n.values())e!=null&&!e.window.isDestroyed()&&!e.owner.isDestroyed()&&i.push(e)}catch{}if(i.length===1)return i[0];let a=[];try{a=r.BrowserWindow.getAllWindows().filter(e=>e!=null&&!e.isDestroyed()&&!e.webContents.isDestroyed())}catch{return null}if(a.length!==1)return null;let o=a[0],s=n.get(o.id)??null;return s!=null&&!s.window.isDestroyed()&&!s.owner.isDestroyed()?s:e(o,o.webContents)}`;
+  const replacement = `${helper}function ${functionName}({ensureWindowState:${ensureWindowStateVar},windowId:${windowIdVar},windows:${windowsVar}}){let ${stateVar}=${windowsVar}.get(${windowIdVar})??null;if(${stateVar}==null){let ${browserWindowVar}=${electronVar}.BrowserWindow.fromId(${windowIdVar});${browserWindowVar}!=null&&!${browserWindowVar}.isDestroyed()&&!${browserWindowVar}.webContents.isDestroyed()&&(${stateVar}=${ensureWindowStateVar}(${browserWindowVar},${browserWindowVar}.webContents))}${stateVar}==null&&(${stateVar}=codexLinuxResolveLiveBrowserUseRouteWindow(${ensureWindowStateVar},${windowIdVar},${windowsVar},${electronVar}));return ${stateVar}==null||${stateVar}.window.isDestroyed()||${stateVar}.owner.isDestroyed()?(${loggerVar}().warning(\`IAB_LIFECYCLE route window is not live\`,{safe:{hasWindowState:${stateVar}!=null,ownerDestroyed:${stateVar}?.owner.isDestroyed()??null,windowDestroyed:${stateVar}?.window.isDestroyed()??null,windowId:${windowIdVar}},sensitive:{}}),null):${stateVar}}`;
+
+  return currentSource.replace(original, replacement);
+}
+
 function applyLinuxChromeExtensionStatusPatch(currentSource) {
   if (currentSource.includes("codexLinuxChromeProfileRoots")) {
     return currentSource;
@@ -1443,6 +1482,7 @@ function applyLinuxRemoteControlConfigPreservationPatch(currentSource) {
 
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
+  applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxAboutDialogPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExplicitIpcQuitPatch,


### PR DESCRIPTION
## Summary
- add a Linux-only fallback for Browser Use route window liveness when upstream cannot resolve the recorded window id
- keep the fallback conservative: use one live BrowserWindow/window state only, and preserve upstream behavior when multiple windows make the route ambiguous
- register the patch as an optional core main-bundle descriptor and cover it with regression tests

## Root cause
Issue #454 reports a reconnect loop where Browser Use route liveness returns false with hasWindowState=false even though the app window is still alive. In the fresh upstream 26.608.12217 bundle, the main-process route helper logs this exact IAB_LIFECYCLE route window is not live warning before downstream Browser Use/session teardown.

## Validation
- node --test scripts/patch-linux-window-ui.test.js
- verified applyLinuxBrowserUseRouteLivenessPatch changes the fresh main-CIL4OHS5.js bundle from upstream Codex.dmg

Addresses #454