### PR TITLE
[codex] Force opaque Linux window surfaces

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -122,7 +122,7 @@ const opaqueBackgroundBundleWithDriftingGw =
 const currentOpaqueBackgroundBundle =
   "var QK=`#00000000`,$K=`#000000`,eq=`#f9f9f9`;function vq(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`}function xq({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!vq(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?$K:eq,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!vq(t)?{backgroundColor:QK,backgroundMaterial:`mica`}:{backgroundColor:QK,backgroundMaterial:null}}";
 const currentOpaqueWindowSurfaceBackgroundBundle =
-  "var W4=`#00000000`,G4=`#000000`,K4=`#f9f9f9`;function g3(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`||e===`hud`}function S3({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?G4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!g3(t)?{backgroundColor:W4,backgroundMaterial:`mica`}:{backgroundColor:W4,backgroundMaterial:null}}";
+  "var W4=`#00000000`,G4=`#000000`,K4=`#f9f9f9`;function g3(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`||e===`hud`}function v3({appearance:e,opaqueWindowsEnabled:t,platform:n}){return t&&!g3(e)&&(n===`darwin`||n===`win32`)}function S3({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?G4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!g3(t)?{backgroundColor:W4,backgroundMaterial:`mica`}:{backgroundColor:W4,backgroundMaterial:null}}class k3{isOpaqueWindowsEnabled(){return theme?.opaqueWindows===!0}shouldUseOpaqueWindowSurface(e,t,n){return this.shouldAlwaysUseOpaqueWindowSurface(e)}shouldAlwaysUseOpaqueWindowSurface(e){return v3({appearance:e,opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!BA()&&!g3(e)}}";
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -1515,6 +1515,10 @@ test("patches current opaque window surface background helper shape for Linux", 
   assert.match(
     patched,
     /:e===`linux`&&!g3\(t\)\?\{backgroundColor:r\?G4:K4,backgroundMaterial:null\}:e===`win32`&&!g3\(t\)\?/,
+  );
+  assert.match(
+    patched,
+    /shouldAlwaysUseOpaqueWindowSurface\(e\)\{return process\.platform===`linux`&&!g3\(e\)\|\|v3\(\{appearance:e,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!BA\(\)&&!g3\(e\)\}/,
   );
   assert.match(patched, /opaqueWindowSurfaceEnabled:n/);
 });

--- a/scripts/patches/main-process.js
+++ b/scripts/patches/main-process.js
@@ -379,29 +379,52 @@ function applyLinuxResizeRepaintPatch(currentSource) {
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  if (
-    currentSource.includes("===`linux`&&!OM(") ||
-    /===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(currentSource)
+  let patchedSource = currentSource;
+  const shouldAlwaysOpaqueSurfaceRegex =
+    /shouldAlwaysUseOpaqueWindowSurface\(([A-Za-z_$][\w$]*)\)\{return\s*([A-Za-z_$][\w$]*)\(\{appearance:\1,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!([A-Za-z_$][\w$]*)\(\)&&!([A-Za-z_$][\w$]*)\(\1\)\}/u;
+  const shouldAlwaysOpaqueSurfaceMatch = patchedSource.match(shouldAlwaysOpaqueSurfaceRegex);
+  if (shouldAlwaysOpaqueSurfaceMatch != null) {
+    const [
+      match,
+      appearanceParam,
+      opaqueSurfaceHelper,
+      nativeSurfaceCapabilityHelper,
+      transparentAppearancePredicate,
+    ] = shouldAlwaysOpaqueSurfaceMatch;
+    const replacement =
+      `shouldAlwaysUseOpaqueWindowSurface(${appearanceParam}){return process.platform===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})||${opaqueSurfaceHelper}({appearance:${appearanceParam},opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!${nativeSurfaceCapabilityHelper}()&&!${transparentAppearancePredicate}(${appearanceParam})}`;
+    patchedSource = patchedSource.replace(match, replacement);
+  } else if (
+    /shouldAlwaysUseOpaqueWindowSurface\([A-Za-z_$][\w$]*\)\{return\s*process\.platform===`linux`&&!/.test(patchedSource)
   ) {
-    return currentSource;
+    // Already patched.
+  } else if (patchedSource.includes("shouldAlwaysUseOpaqueWindowSurface(")) {
+    console.warn("WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch");
+  }
+
+  if (
+    patchedSource.includes("===`linux`&&!OM(") ||
+    /===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(patchedSource)
+  ) {
+    return patchedSource;
   }
 
   const colorConstRegex =
     /([A-Za-z_$][\w$]*)=`#00000000`,([A-Za-z_$][\w$]*)=`#000000`,([A-Za-z_$][\w$]*)=`#f9f9f9`/;
-  const colorMatch = currentSource.match(colorConstRegex);
+  const colorMatch = patchedSource.match(colorConstRegex);
 
   if (!colorMatch) {
     console.warn(
       "WARN: Could not find color constants (#00000000, #000000, #f9f9f9) — skipping background patch",
     );
-    return currentSource;
+    return patchedSource;
   }
 
   const [, transparentVar, darkVar, lightVar] = colorMatch;
 
   const currentFuncParamRegex =
     /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3&&!([A-Za-z_$][\w$]*)\(\2\)&&\(\1===`darwin`\|\|\1===`win32`\)\?/;
-  const currentFuncMatch = currentSource.match(currentFuncParamRegex);
+  const currentFuncMatch = patchedSource.match(currentFuncParamRegex);
   if (currentFuncMatch != null) {
     const [, platformParam, appearanceParam, , darkColorsParam, transparentAppearancePredicate] =
       currentFuncMatch;
@@ -410,20 +433,20 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
     const linuxBgPrefix =
       `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:`;
 
-    if (currentSource.includes(linuxBgPrefix)) {
-      return currentSource;
+    if (patchedSource.includes(linuxBgPrefix)) {
+      return patchedSource;
     }
-    if (currentSource.includes(win32Needle)) {
-      return currentSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
+    if (patchedSource.includes(win32Needle)) {
+      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
     }
 
     console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-    return currentSource;
+    return patchedSource;
   }
 
   const currentSurfaceFuncParamRegex =
     /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
-  const currentSurfaceFuncMatch = currentSource.match(currentSurfaceFuncParamRegex);
+  const currentSurfaceFuncMatch = patchedSource.match(currentSurfaceFuncParamRegex);
   if (currentSurfaceFuncMatch != null) {
     const [, platformParam, appearanceParam, , darkColorsParam, darkVarFromReturn, lightVarFromReturn, transparentAppearancePredicate] =
       currentSurfaceFuncMatch;
@@ -432,24 +455,24 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
     const linuxBgPrefix =
       `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVarFromReturn}:${lightVarFromReturn},backgroundMaterial:null}:`;
 
-    if (currentSource.includes(linuxBgPrefix)) {
-      return currentSource;
+    if (patchedSource.includes(linuxBgPrefix)) {
+      return patchedSource;
     }
-    if (currentSource.includes(win32Needle)) {
-      return currentSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
+    if (patchedSource.includes(win32Needle)) {
+      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
     }
 
     console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-    return currentSource;
+    return patchedSource;
   }
 
   const funcParamRegex =
     /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
-  const funcMatch = currentSource.match(funcParamRegex);
+  const funcMatch = patchedSource.match(funcParamRegex);
 
   if (funcMatch == null) {
     console.warn("WARN: Could not find BrowserWindow background function signature — skipping background patch");
-    return currentSource;
+    return patchedSource;
   }
 
   const [, platformParam, appearanceParam, darkColorsParam, transparentAppearancePredicate] =
@@ -461,15 +484,15 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
   const bgReplacement =
     `backgroundMaterial:\`mica\`}:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
 
-  if (currentSource.includes(bgNeedle)) {
-    return currentSource.replace(bgNeedle, bgReplacement);
+  if (patchedSource.includes(bgNeedle)) {
+    return patchedSource.replace(bgNeedle, bgReplacement);
   }
-  if (currentSource.includes(oldLinuxBgPatch)) {
-    return currentSource.replace(oldLinuxBgPatch, bgReplacement);
+  if (patchedSource.includes(oldLinuxBgPatch)) {
+    return patchedSource.replace(oldLinuxBgPatch, bgReplacement);
   }
 
   console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-  return currentSource;
+  return patchedSource;
 }
 
 function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {


### PR DESCRIPTION
## Summary
- Force normal Linux windows to use the opaque surface path in the main process.
- Keep transparent/excluded appearances such as overlays and HUD windows out of the forced Linux path.
- Extend the opaque-window regression fixture so the current upstream surface predicate is covered.

## Root cause
The webview patch defaulted Linux renderer state toward `electron-opaque`, but the main process still computed `opaqueWindowSurfaceEnabled` as false on Linux because upstream only enabled that surface path for macOS/Windows. The renderer then received `electron-window-opaque-surface-changed=false` and could remove the opaque class, leaving sidebar/menu transparency artifacts on affected compositors.

Fixes #459.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js` (221/221)
- `node --test linux-features/*/test.js` (264/264)
- `git diff --check`
- In-memory verification against the current extracted `main-CIL4OHS5.js` bundle confirmed both the Linux opaque background branch and the Linux opaque surface predicate are inserted.

`bash tests/scripts_smoke.sh` was started but stopped after it hung outside this patch on `stat -c %s Codex.dmg` inside the user-local metadata smoke path (`autofs_wait`).
