### PR TITLE
[codex] Keep rate limit footer visible in current composer

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4788,7 +4788,7 @@ test("persistent rate limit footer uses existing account signal without dropdown
   assert.equal((patched.match(/Rate limits remaining/g) || []).length, 1);
 });
 
-test("persistent rate limit footer descriptor ignores external footer chunks", () => {
+test("persistent rate limit footer descriptor includes external footer chunks", () => {
   const descriptor = corePatchDescriptors().find(
     (candidate) => candidate.id === "composer-persistent-rate-limit-footer",
   );
@@ -4796,7 +4796,7 @@ test("persistent rate limit footer descriptor ignores external footer chunks", (
   assert.ok(descriptor);
   assert.equal(descriptor.pattern.test("composer-D1QtVouy.js"), true);
   descriptor.pattern.lastIndex = 0;
-  assert.equal(descriptor.pattern.test("composer-external-footer-0Iw5VZtp.js"), false);
+  assert.equal(descriptor.pattern.test("composer-external-footer-0Iw5VZtp.js"), true);
 });
 
 test("persistent rate limit footer skips current footer group when conversation id is missing", () => {
@@ -4947,8 +4947,103 @@ test("persistent rate limit footer adapts to current composer permissions footer
   );
   assert.match(
     patched,
-    /\(0,Q\.jsx\)\(Sm,\{conversationId:f,hostId:C,cwdOverride:w\}\),f==null\?null:\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:f\}\),\(0,Q\.jsx\)\(Rm,\{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0\}\)/,
+    /\(0,Q\.jsx\)\(Sm,\{conversationId:f,hostId:C,cwdOverride:w\}\),\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:f\}\),\(0,Q\.jsx\)\(Rm,\{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0\}\)/,
   );
+});
+
+test("persistent rate limit footer adapts to current external composer footer shape", () => {
+  const source = [
+    "var R=Hr();",
+    "function Me(e){let t=(0,Te.c)(176),{variant:n,composerMode:r,conversationId:s}=e,I=n===void 0?`default`:n,V=null,H=null,U=H??s,Ze=H??s,Ht=`project`,Lt=`mode`,$=`cloud`;",
+    "let Ut=I===`home`?Ht:Lt,Wt=V?.type===`cloud`?$:null,Gt=I===`home`?Lt:Ht,Kt;t[158]!==Ut||t[159]!==Wt||t[160]!==Gt?(Kt=(0,R.jsxs)(`div`,{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:[Ut,Wt,Gt]}),t[158]=Ut,t[159]=Wt,t[160]=Gt,t[161]=Kt):Kt=t[161];return Kt}",
+    "export{Me as ComposerExternalFooter};",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal((patched.match(/function codexLinuxRateLimitFooter/g) || []).length, 1);
+  assert.match(patched, /function codexLinuxRateLimitFooter\(\)\{try\{return\(0,R\.jsx\)/);
+  assert.match(patched, /children:`Usage limits`/);
+  assert.match(
+    patched,
+    /Kt=\(0,R\.jsxs\)\(`div`,\{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:\[Ut,\(0,R\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:Ze\}\),Wt,Gt\]\}\)/,
+  );
+  assert.doesNotMatch(patched, /t\[158\]!==Ut\|\|t\[159\]!==Wt\|\|t\[160\]!==Gt\?\(Kt=/);
+});
+
+test("persistent rate limit footer adapts to follow-up composer inline controls", () => {
+  const source = [
+    "var $=qt();var Q=Hr();",
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{return(0,Q.jsx)(`span`,{children:`Usage limits`})}catch(e){return null}}",
+    "var Pp=Object.assign(Fp,{FooterInlineControls:Wp});",
+    "function Wp(e){let t=(0,$.c)(6),{children:n,gap:r,ref:i}=e,a=(r===void 0?`compact`:r)===`compact`?`gap-1`:`gap-[5px]`,o;t[0]===a?o=t[1]:(o=J(`flex min-w-0 items-center`,a),t[0]=a,t[1]=o);let s;return t[2]!==n||t[3]!==i||t[4]!==o?(s=(0,Q.jsx)(`div`,{ref:i,className:o,children:n}),t[2]=n,t[3]=i,t[4]=o,t[5]=s):s=t[5],s}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal((patched.match(/function codexLinuxRateLimitFooter/g) || []).length, 1);
+  assert.match(
+    patched,
+    /s=\(0,Q\.jsxs\)\(`div`,\{ref:i,className:o,children:\[n,\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:null\}\)\]\}\),s\}/,
+  );
+  assert.doesNotMatch(patched, /t\[2\]!==n\|\|t\[3\]!==i\|\|t\[4\]!==o\?\(s=/);
+});
+
+test("persistent rate limit footer adapts to latest composer footer controls without conversation guard", () => {
+  const source = [
+    "var $=qt();var Q=Hr();",
+    "function Mm(e){let t=(0,$.c)(12),{addContextButton:n,conversationId:s}=e,Ke=null,qe;t[0]!==n||t[1]!==Ke?(qe=(0,Q.jsxs)(Pp.FooterInlineControls,{gap:`normal`,children:[n,Ke]}),t[0]=n,t[1]=Ke,t[2]=qe):qe=t[2];return qe}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.match(patched, /function codexLinuxRateLimitFooter\(\{conversationId:e\}\)/);
+  assert.match(patched, /selectedModel:r\}\)\.filter\(og\)\.slice\(0,2\);s\.length===0&&\(s=da\(a,\{activeLimitName:o,selectedModel:null\}\)\.filter\(og\)\.slice\(0,2\)\)/);
+  assert.match(patched, /children:`Usage limits`/);
+  assert.match(patched, /catch\(e\)\{return\(0,Q\.jsx\)\(`span`,\{className:`composer-footer__label--sm[^`]+`,children:`Usage limits`\}\)\}/);
+  assert.match(
+    patched,
+    /FooterInlineControls,\{gap:`normal`,children:\[n,\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:s\}\),Ke\]\}/,
+  );
+  assert.doesNotMatch(patched, /s==null\?null:\(0,Q\.jsx\)\(codexLinuxRateLimitFooter/);
+});
+
+test("persistent rate limit footer migrates latest composer footer away from conversation guard", () => {
+  const oldHelper =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);if(s.length===0)return null;let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return null}}";
+  const source = [
+    "var $=qt();var Q=Hr();",
+    oldHelper,
+    "function Mm(e){let t=(0,$.c)(12),{addContextButton:n,conversationId:s}=e,Ke=null,qe;t[0]!==n||t[1]!==Ke?(qe=(0,Q.jsxs)(Pp.FooterInlineControls,{gap:`normal`,children:[n,s==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:s}),Ke]}),t[0]=n,t[1]=Ke,t[2]=qe):qe=t[2];return qe}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal((patched.match(/function codexLinuxRateLimitFooter/g) || []).length, 1);
+  assert.match(patched, /selectedModel:null/);
+  assert.match(patched, /children:`Usage limits`/);
+  assert.match(
+    patched,
+    /FooterInlineControls,\{gap:`normal`,children:\[n,\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:s\}\),Ke\]\}/,
+  );
+  assert.doesNotMatch(patched, /s==null\?null:\(0,Q\.jsx\)\(codexLinuxRateLimitFooter/);
+});
+
+test("persistent rate limit footer migrates latest model fallback to visible fallback", () => {
+  const oldHelper =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);s.length===0&&(s=da(a,{activeLimitName:o,selectedModel:null}).filter(og).slice(0,2));if(s.length===0)return null;let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return null}}";
+  const source = [
+    "var $=qt();var Q=Hr();",
+    oldHelper,
+    "function Mm(e){let t=(0,$.c)(12),{addContextButton:n,conversationId:s}=e,Ke=null,qe;t[0]!==n||t[1]!==Ke?(qe=(0,Q.jsxs)(Pp.FooterInlineControls,{gap:`normal`,children:[n,(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:s}),Ke]}),t[0]=n,t[1]=Ke,t[2]=qe):qe=t[2];return qe}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyPersistentRateLimitFooterPatch, source);
+
+  assert.equal((patched.match(/function codexLinuxRateLimitFooter/g) || []).length, 1);
+  assert.match(patched, /children:`Usage limits`/);
+  assert.match(patched, /catch\(e\)\{return\(0,Q\.jsx\)\(`span`,\{className:`composer-footer__label--sm[^`]+`,children:`Usage limits`\}\)\}/);
+  assert.doesNotMatch(patched, /if\(s\.length===0\)return null/);
 });
 
 test("patcher CLI writes --report-json output", () => {

--- a/scripts/patches/core/all-linux/webview/rate-limits/patch.js
+++ b/scripts/patches/core/all-linux/webview/rate-limits/patch.js
@@ -10,7 +10,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^composer-(?!external-footer).*\.js$/,
+    pattern: /^composer-(?:external-footer-.*|(?!(?:external-footer)).*)\.js$/,
     missingDescription: "composer bundle",
     skipDescription: "persistent composer rate limit footer patch",
     apply: applyPersistentRateLimitFooterPatch,

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -1008,8 +1008,101 @@ function detectLatestComposerFooterControls(source) {
     footerControlsNeedle:
       `FooterInlineControls,{gap:\`normal\`,children:[${firstChildVar},${secondChildVar}]}`,
     footerControlsPatch:
-      `FooterInlineControls,{gap:\`normal\`,children:[${firstChildVar},${conversationIdVar}==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:${conversationIdVar}}),${secondChildVar}]}`,
+      `FooterInlineControls,{gap:\`normal\`,children:[${firstChildVar},(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:${conversationIdVar}}),${secondChildVar}]}`,
   };
+}
+
+function detectCurrentComposerExternalFooterGroup(source) {
+  const groupRegex =
+    /let ([A-Za-z_$][\w$]*)=I===`home`\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=V\?\.type===`cloud`\?([A-Za-z_$][\w$]*):null,([A-Za-z_$][\w$]*)=I===`home`\?\3:\2,([A-Za-z_$][\w$]*);t\[(\d+)\]!==\1\|\|t\[(\d+)\]!==\4\|\|t\[(\d+)\]!==\6\?\(\7=\(0,([A-Za-z_$][\w$]*)\.jsxs\)\(`div`,\{className:`flex min-w-0 flex-1 flex-nowrap items-center gap-1`,children:\[\1,\4,\6\]\}\),t\[\8\]=\1,t\[\9\]=\4,t\[\10\]=\6,t\[(\d+)\]=\7\):\7=t\[(\d+)\]/;
+  const match = source.match(groupRegex);
+  if (match == null || match.index == null) {
+    return null;
+  }
+
+  const [
+    needle,
+    firstChildVar,
+    homeChildVar,
+    defaultChildVar,
+    secondChildVar,
+    cloudChildVar,
+    thirdChildVar,
+    groupVar,
+    firstCacheIndex,
+    secondCacheIndex,
+    thirdCacheIndex,
+    jsxAlias,
+    groupCacheSetIndex,
+    groupCacheReadIndex,
+  ] = match;
+  if (
+    firstCacheIndex == null ||
+    secondCacheIndex == null ||
+    thirdCacheIndex == null
+  ) {
+    return null;
+  }
+  if (groupCacheSetIndex !== groupCacheReadIndex) {
+    return null;
+  }
+  const functionStart = source.lastIndexOf("function ", match.index);
+  if (functionStart === -1) {
+    return null;
+  }
+  const functionName = source.slice(functionStart).match(/^function ([A-Za-z_$][\w$]*)\(e\)\{/)?.[1];
+  if (functionName == null) {
+    return null;
+  }
+  const conversationIdVar = detectComposerFooterConversationIdVar(source, needle);
+  if (conversationIdVar == null) {
+    return null;
+  }
+
+  return {
+    needle,
+    patch:
+      `let ${firstChildVar}=I===\`home\`?${homeChildVar}:${defaultChildVar},${secondChildVar}=V?.type===\`cloud\`?${cloudChildVar}:null,${thirdChildVar}=I===\`home\`?${defaultChildVar}:${homeChildVar},${groupVar};${groupVar}=(0,${jsxAlias}.jsxs)(\`div\`,{className:\`flex min-w-0 flex-1 flex-nowrap items-center gap-1\`,children:[${firstChildVar},(0,${jsxAlias}.jsx)(codexLinuxRateLimitFooter,{conversationId:${conversationIdVar}}),${secondChildVar},${thirdChildVar}]})`,
+    insertionNeedle: `function ${functionName}(e){`,
+    jsxAlias,
+  };
+}
+
+function patchComposerFooterInlineControlsComponent(source) {
+  const markerMatch = source.match(/FooterInlineControls:([A-Za-z_$][\w$]*)/);
+  const functionName = markerMatch?.[1] ?? null;
+  if (functionName == null) {
+    return source;
+  }
+
+  const functionNeedle = `function ${functionName}(e){`;
+  const functionStart = source.indexOf(functionNeedle);
+  if (functionStart === -1) {
+    return source;
+  }
+  const openingBrace = functionStart + functionNeedle.length - 1;
+  const closingBrace = findMatchingBrace(source, openingBrace);
+  if (closingBrace === -1) {
+    return source;
+  }
+
+  const functionSource = source.slice(functionStart, closingBrace + 1);
+  if (functionSource.includes("codexLinuxRateLimitFooter")) {
+    return source;
+  }
+
+  const tailRegex =
+    /let ([A-Za-z_$][\w$]*);return t\[2\]!==([A-Za-z_$][\w$]*)\|\|t\[3\]!==([A-Za-z_$][\w$]*)\|\|t\[4\]!==([A-Za-z_$][\w$]*)\?\(\1=\(0,([A-Za-z_$][\w$]*)\.jsx\)\(`div`,\{ref:\3,className:\4,children:\2\}\),t\[2\]=\2,t\[3\]=\3,t\[4\]=\4,t\[5\]=\1\):\1=t\[5\],\1\}$/;
+  const patchedFunctionSource = functionSource.replace(
+    tailRegex,
+    "let $1;return $1=(0,$5.jsxs)(`div`,{ref:$3,className:$4,children:[$2,(0,$5.jsx)(codexLinuxRateLimitFooter,{conversationId:null})]}),$1}",
+  );
+
+  if (patchedFunctionSource === functionSource) {
+    return source;
+  }
+
+  return source.slice(0, functionStart) + patchedFunctionSource + source.slice(closingBrace + 1);
 }
 
 function detectCurrentPermissionsRateLimitFooterSymbols(source) {
@@ -1047,6 +1140,7 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
   let patchedSource = currentSource;
   const currentSymbols = detectCurrentRateLimitFooterSymbols(currentSource);
   const latestFooterControls = detectLatestComposerFooterControls(currentSource);
+  const currentExternalFooterGroup = detectCurrentComposerExternalFooterGroup(currentSource);
   const currentPermissionsFooterSymbols = detectCurrentPermissionsRateLimitFooterSymbols(currentSource);
   const currentComposerStatusNeedle =
     "function zg(e){";
@@ -1065,6 +1159,7 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
     currentSource.includes("(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w})") ||
     currentPermissionsControlsNeedle.test(currentSource) ||
     latestFooterControls != null ||
+    currentExternalFooterGroup != null ||
     (currentSource.includes(currentComposerStatusNeedle) &&
       currentSource.includes(currentComposerFooterCallNeedle));
   const homeFooterGroupNeedle =
@@ -1094,6 +1189,15 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
     ? null
     : `function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,Z.c)(22),{activeMode:n}=Bi(e),r=n?.settings.model??null,{data:i}=ci(${currentSymbols.accountSignalVar}),a=i===void 0?null:i,o=Ro(a),s=Zo(a),c=Xo(Jo(o,{activeLimitName:s,selectedModel:r})).slice(0,2);c.length===0&&(c=Xo(Jo(o,{activeLimitName:s,selectedModel:null})).slice(0,2));if(c.length===0)return null;let l;t[0]===Symbol.for(\`react.memo_cache_sentinel\`)?(l=(0,Q.jsx)(X,{id:\`composer.linuxRateLimitFooter.tooltip\`,defaultMessage:\`Rate limits remaining\`,description:\`Tooltip for compact footer rate limit status\`}),t[0]=l):l=t[0];let u;if(t[1]!==c){u=c.map((e,t)=>{let n=No(e.bucket.usedPercent??0);return(0,Q.jsxs)(\`span\`,{className:\`flex items-center gap-1 whitespace-nowrap\`,children:[t>0?(0,Q.jsx)(\`span\`,{className:\`text-token-input-placeholder-foreground\`,children:\`/\`}):null,(0,Q.jsx)(\`span\`,{children:(0,Q.jsx)(${currentSymbols.durationComponent},{minutes:e.bucket.windowDurationMins,variant:\`summary\`})}),(0,Q.jsx)(\`span\`,{className:\`font-medium text-token-text-primary\`,children:Do(n)})]},e.key)}),t[1]=c,t[2]=u}else u=t[2];let d;t[3]!==u?(d=(0,Q.jsx)(\`span\`,{className:\`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10\`,children:u}),t[3]=u,t[4]=d):d=t[4];let f;return t[5]!==l||t[6]!==d?(f=(0,Q.jsx)(nc,{tooltipContent:l,children:d}),t[5]=l,t[6]=d,t[7]=f):f=t[7],f}catch(e){return null}}`;
   const latestFooterFunction =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);s.length===0&&(s=da(a,{activeLimitName:o,selectedModel:null}).filter(og).slice(0,2));if(s.length===0)return(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:`Usage limits`});let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:`Usage limits`})}}";
+  const previousLatestFooterFunctionWithVisibleFallback =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);s.length===0&&(s=da(a,{activeLimitName:o,selectedModel:null}).filter(og).slice(0,2));if(s.length===0)return(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:`Usage limits`});let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return null}}";
+  const currentExternalFooterFunction = currentExternalFooterGroup == null
+    ? null
+    : `function codexLinuxRateLimitFooter(){try{return(0,${currentExternalFooterGroup.jsxAlias}.jsx)(\`span\`,{className:\`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10\`,children:\`Usage limits\`})}catch(e){return null}}`;
+  const previousLatestFooterFunctionWithModelFallback =
+    "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);s.length===0&&(s=da(a,{activeLimitName:o,selectedModel:null}).filter(og).slice(0,2));if(s.length===0)return null;let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return null}}";
+  const previousLatestFooterFunction =
     "function codexLinuxRateLimitFooter({conversationId:e}){try{let t=(0,$.c)(8),{activeMode:n}=or(e),r=n?.settings.model??null,{data:i}=St(ue),a=ma(i),o=la(i),s=da(a,{activeLimitName:o,selectedModel:r}).filter(og).slice(0,2);if(s.length===0)return null;let c=ht(),l;if(t[0]!==s||t[1]!==c){l=s.map(e=>`${Xh(e.bucket.windowDurationMins??null,c)} ${c.formatNumber(Sa(e.bucket.usedPercent??0),{maximumFractionDigits:0})}%`).join(` / `),t[0]=s,t[1]=c,t[2]=l}else l=t[2];let u;return t[3]!==l?(u=(0,Q.jsx)(`span`,{className:`composer-footer__label--sm inline-flex shrink-0 items-center gap-1.5 rounded-full border border-token-border-light bg-token-main-surface-primary/80 px-2 py-1 text-xs text-token-text-secondary shadow-sm dark:border-white/10`,children:l}),t[3]=l,t[4]=u):u=t[4],u}catch(e){return null}}";
   const currentPermissionsFooterFunction = currentPermissionsFooterSymbols == null
     ? null
@@ -1105,6 +1209,11 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
       patchedSource = patchedSource.replace(
         latestFooterControls.insertionNeedle,
         `${latestFooterFunction}${latestFooterControls.insertionNeedle}`,
+      );
+    } else if (currentExternalFooterGroup != null && currentExternalFooterFunction != null) {
+      patchedSource = patchedSource.replace(
+        currentExternalFooterGroup.insertionNeedle,
+        `${currentExternalFooterFunction}${currentExternalFooterGroup.insertionNeedle}`,
       );
     } else if (currentSymbols != null && currentFooterFunction != null) {
       patchedSource = patchedSource.replace(
@@ -1162,6 +1271,21 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
     return currentSource;
   }
 
+  if (patchedSource.includes(previousLatestFooterFunction)) {
+    patchedSource = patchedSource.replace(previousLatestFooterFunction, latestFooterFunction);
+  }
+  if (patchedSource.includes(previousLatestFooterFunctionWithModelFallback)) {
+    patchedSource = patchedSource.replace(previousLatestFooterFunctionWithModelFallback, latestFooterFunction);
+  }
+  if (patchedSource.includes(previousLatestFooterFunctionWithVisibleFallback)) {
+    patchedSource = patchedSource.replace(previousLatestFooterFunctionWithVisibleFallback, latestFooterFunction);
+  }
+
+  patchedSource = patchedSource.replace(
+    /([A-Za-z_$][\w$]*)==null\?null:\(0,Q\.jsx\)\(codexLinuxRateLimitFooter,\{conversationId:\1\}\)/g,
+    "(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:$1})",
+  );
+
   if (
     latestFooterControls != null &&
     !patchedSource.includes(`codexLinuxRateLimitFooter,{conversationId:${latestFooterControls.conversationIdVar}}`) &&
@@ -1170,6 +1294,15 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
     patchedSource = patchedSource.replace(
       latestFooterControls.footerControlsNeedle,
       latestFooterControls.footerControlsPatch,
+    );
+  }
+
+  patchedSource = patchComposerFooterInlineControlsComponent(patchedSource);
+
+  if (currentExternalFooterGroup != null && patchedSource.includes(currentExternalFooterGroup.needle)) {
+    patchedSource = patchedSource.replace(
+      currentExternalFooterGroup.needle,
+      currentExternalFooterGroup.patch,
     );
   }
 
@@ -1225,14 +1358,14 @@ function applyPersistentRateLimitFooterPatch(currentSource) {
   const permissionsControlsNeedle =
     "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})";
   const permissionsControlsPatch =
-    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),f==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})";
+    "(0,Q.jsx)(nz,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)(vz,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})";
   if (patchedSource.includes(permissionsControlsNeedle)) {
     patchedSource = patchedSource.replace(permissionsControlsNeedle, permissionsControlsPatch);
   }
   if (currentPermissionsControlsNeedle.test(patchedSource)) {
     patchedSource = patchedSource.replace(
       currentPermissionsControlsNeedle,
-      "(0,Q.jsx)($1,{conversationId:f,hostId:C,cwdOverride:w}),f==null?null:(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)($2,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})",
+      "(0,Q.jsx)($1,{conversationId:f,hostId:C,cwdOverride:w}),(0,Q.jsx)(codexLinuxRateLimitFooter,{conversationId:f}),(0,Q.jsx)($2,{conversationId:f,hasGoal:y,isGoalActionAvailable:b,onClearGoal:x,showDivider:!0})",
     );
   }
 


### PR DESCRIPTION
## Summary

- keeps the Linux rate-limit footer visible in the current composer bundles, including restored chats and new chats
- patches current external footer chunks instead of skipping them
- adds a visible `Usage limits` fallback when upstream limit data/model lookup is unavailable instead of returning `null`
- avoids caching the injected footer inside stale composer footer memo entries where the active chat can change

## Root Cause

The previous patch still missed current composer footer paths after upstream bundle drift. In restored/follow-up chats, the footer helper could throw or have no matching limit rows and return `null`, so the injected footer disappeared even though the patch had applied. External composer footer chunks were also excluded from the descriptor scan.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js --test-name-pattern='persistent rate limit footer'` passed: 226/226
- patched the installed `/opt/codex-desktop` app locally and restarted with fresh Electron caches
- visually verified the real desktop app with screenshots in all four states:
  - new chat inside a project
  - restored/existing project chat
  - restored/existing projectless chat
  - new projectless chat
- DOM checks for each screenshot reported `Usage limits` visible in the live app
