### PR TITLE
nix: wrap launcher to bake CODEX_CLI_PATH via cliPackage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   bundled plugin registry so the app keeps `read-aloud` installed, and the
   launcher syncs the plugin cache so new Codex windows expose the MCP tools
   through the same auto-install path as Computer Use.
+- The Home Manager and NixOS modules gained a
+  `programs.codexDesktopLinux.cliPackage` option that wraps the installed Codex
+  Desktop launcher (and its `.desktop` entry) so it always starts with
+  `CODEX_CLI_PATH` pointing at the chosen CLI. Because the path is baked into the
+  launcher instead of exported as a session variable, Codex Desktop reliably
+  finds the Codex CLI regardless of how it is launched (graphical autostart,
+  application launcher, terminal, or warm-start handoff), even when the Nix
+  profile is not on the graphical session `PATH`, and the change takes effect on
+  the next app launch with no re-login. When unset it falls back to
+  `remoteControl.package` if the remote-control service is enabled. This avoids
+  the `Unable to locate the Codex CLI binary. Set CODEX_CLI_PATH ...` startup
+  failure.
 
 ### Fixed
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -18,6 +18,14 @@ repository does not install or maintain the CLI for you; it only needs a
 working `codex` binary. Put `codex` on your user `PATH`, or set
 `CODEX_CLI_PATH` to the exact binary that Codex Desktop should launch.
 
+Relying on `PATH` alone is fragile: a graphical autostart entry, an application
+launcher, or a warm-start handoff to an already-running instance may not have
+your Nix profile on `PATH`, in which case Codex Desktop fails with
+`Unable to locate the Codex CLI binary. Set CODEX_CLI_PATH ...`. Pinning the CLI
+explicitly avoids this. The Home Manager and NixOS modules can do this for you
+via [`programs.codexDesktopLinux.cliPackage`](#home-manager--nixos-module),
+which wraps the launcher so `CODEX_CLI_PATH` is always set.
+
 One direct upstream install path is the npm package:
 
 ```bash
@@ -93,9 +101,24 @@ in
     codexCli
   ];
 
-  programs.codexDesktopLinux.enable = true;
+  programs.codexDesktopLinux = {
+    enable = true;
+    # Bake CODEX_CLI_PATH into the launcher so the Desktop app always finds this
+    # CLI, even when launched from a graphical session that lacks the profile on
+    # PATH.
+    cliPackage = codexCli;
+  };
 }
 ```
+
+Setting `cliPackage` wraps the installed Codex Desktop launcher (and its
+`.desktop` entry) so it always starts with `CODEX_CLI_PATH` pointing at the
+package's `codex` binary. Because the value is baked into the launcher rather
+than exported as a session variable, it works for graphical, terminal, and
+warm-start launches and takes effect on the next app launch — no re-login
+required. An explicit `CODEX_CLI_PATH` already in the environment still wins. If
+you enable `remoteControl` but leave `cliPackage` unset, the module reuses
+`remoteControl.package` automatically.
 
 For a NixOS module, use the same package in `environment.systemPackages`
 instead of `home.packages`.
@@ -122,11 +145,15 @@ Pinning `github:sadjow/codex-cli-nix` to a release tag or commit is
 recommended for fully reproducible configurations.
 
 If your graphical session does not put the selected profile on `PATH`, set
-`CODEX_CLI_PATH` to the Nix-built CLI binary:
+`cliPackage` so the launcher is wrapped with `CODEX_CLI_PATH`:
 
 ```nix
 {
-  home.sessionVariables.CODEX_CLI_PATH = "${codexCli}/bin/codex";
+  # Preferred: wrap the launcher so CODEX_CLI_PATH is always set.
+  programs.codexDesktopLinux.cliPackage = codexCli;
+
+  # Manual fallback if you are not using the module (needs a re-login to apply):
+  # home.sessionVariables.CODEX_CLI_PATH = "${codexCli}/bin/codex";
 }
 ```
 

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -19,7 +19,47 @@ let
       "codex-desktop-computer-use-ui"
     else
       "codex-desktop";
-  desktopPackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  basePackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  codexCliPackage =
+    if cfg.cliPackage != null then
+      cfg.cliPackage
+    else if remoteCfg.enable then
+      remoteCfg.package
+    else
+      null;
+  codexCliPath = if codexCliPackage != null then lib.getExe' codexCliPackage "codex" else null;
+  # Thin wrapper that bakes CODEX_CLI_PATH into the launcher. The `.desktop`
+  # entry shipped by the package launches `<pkg>/bin/codex-desktop` by absolute
+  # path, so wrapping that binary (and repointing the desktop entry at the
+  # wrapper) makes Codex Desktop locate the CLI no matter how it is started --
+  # graphical autostart, application launcher, terminal, or a warm-start handoff
+  # to an already-running instance -- without depending on the session/login
+  # `PATH` and without requiring a re-login for a config change to take effect.
+  # `--set-default` leaves an explicit `CODEX_CLI_PATH` in the environment in
+  # control, so users can still override the launched CLI.
+  withCodexCliPath =
+    base:
+    pkgs.symlinkJoin {
+      name = "${base.name}-codex-cli-path";
+      paths = [ base ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        if [ -e "$out/bin/codex-desktop" ]; then
+          rm -f "$out/bin/codex-desktop"
+          makeWrapper "${base}/bin/codex-desktop" "$out/bin/codex-desktop" \
+            --set-default CODEX_CLI_PATH "${codexCliPath}"
+        fi
+        desktopFile="$out/share/applications/codex-desktop.desktop"
+        if [ -e "$desktopFile" ]; then
+          target="$(readlink -f "$desktopFile")"
+          rm -f "$desktopFile"
+          substitute "$target" "$desktopFile" \
+            --replace-fail "${base}/bin/codex-desktop" "$out/bin/codex-desktop"
+        fi
+      '';
+      meta = base.meta or { };
+    };
+  desktopPackage = if codexCliPath != null then withCodexCliPath basePackage else basePackage;
   codexHome =
     if remoteCfg.codexHome != null then remoteCfg.codexHome else "${config.home.homeDirectory}/.codex";
   remoteControlPath = lib.makeSearchPath "bin" (
@@ -52,6 +92,30 @@ in
         this flake's package variants from
         {option}`programs.codexDesktopLinux.computerUseUi.enable` and
         {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+      '';
+    };
+
+    cliPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      defaultText = lib.literalExpression "pkgs.codex";
+      example = lib.literalExpression "pkgs.codex";
+      description = ''
+        Codex CLI package that Codex Desktop should launch. When set, the
+        installed Codex Desktop launcher (and its `.desktop` entry) is wrapped so
+        it always starts with {env}`CODEX_CLI_PATH` pointing at this package's
+        `codex` binary. This lets Codex Desktop locate the CLI regardless of how
+        it is started — graphical autostart, application launcher, terminal, or a
+        warm-start handoff to an already-running instance — without depending on
+        the session/login {env}`PATH` and without requiring a re-login for the
+        setting to take effect. An explicit {env}`CODEX_CLI_PATH` already in the
+        environment still wins.
+
+        When unset, the module falls back to
+        {option}`programs.codexDesktopLinux.remoteControl.package` if
+        {option}`programs.codexDesktopLinux.remoteControl.enable` is set;
+        otherwise the launcher is left unwrapped and Codex Desktop relies on
+        discovering `codex` on {env}`PATH`.
       '';
     };
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -19,7 +19,47 @@ let
       "codex-desktop-computer-use-ui"
     else
       "codex-desktop";
-  desktopPackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  basePackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  codexCliPackage =
+    if cfg.cliPackage != null then
+      cfg.cliPackage
+    else if remoteCfg.enable then
+      remoteCfg.package
+    else
+      null;
+  codexCliPath = if codexCliPackage != null then lib.getExe' codexCliPackage "codex" else null;
+  # Thin wrapper that bakes CODEX_CLI_PATH into the launcher. The `.desktop`
+  # entry shipped by the package launches `<pkg>/bin/codex-desktop` by absolute
+  # path, so wrapping that binary (and repointing the desktop entry at the
+  # wrapper) makes Codex Desktop locate the CLI no matter how it is started --
+  # graphical autostart, application launcher, terminal, or a warm-start handoff
+  # to an already-running instance -- without depending on the session/login
+  # `PATH` and without requiring a re-login for a config change to take effect.
+  # `--set-default` leaves an explicit `CODEX_CLI_PATH` in the environment in
+  # control, so users can still override the launched CLI.
+  withCodexCliPath =
+    base:
+    pkgs.symlinkJoin {
+      name = "${base.name}-codex-cli-path";
+      paths = [ base ];
+      nativeBuildInputs = [ pkgs.makeWrapper ];
+      postBuild = ''
+        if [ -e "$out/bin/codex-desktop" ]; then
+          rm -f "$out/bin/codex-desktop"
+          makeWrapper "${base}/bin/codex-desktop" "$out/bin/codex-desktop" \
+            --set-default CODEX_CLI_PATH "${codexCliPath}"
+        fi
+        desktopFile="$out/share/applications/codex-desktop.desktop"
+        if [ -e "$desktopFile" ]; then
+          target="$(readlink -f "$desktopFile")"
+          rm -f "$desktopFile"
+          substitute "$target" "$desktopFile" \
+            --replace-fail "${base}/bin/codex-desktop" "$out/bin/codex-desktop"
+        fi
+      '';
+      meta = base.meta or { };
+    };
+  desktopPackage = if codexCliPath != null then withCodexCliPath basePackage else basePackage;
   remoteControlPath = lib.makeSearchPath "bin" (
     [
       "/run/current-system/sw"
@@ -50,6 +90,30 @@ in
         this flake's package variants from
         {option}`programs.codexDesktopLinux.computerUseUi.enable` and
         {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+      '';
+    };
+
+    cliPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      defaultText = lib.literalExpression "pkgs.codex";
+      example = lib.literalExpression "pkgs.codex";
+      description = ''
+        Codex CLI package that Codex Desktop should launch. When set, the
+        installed Codex Desktop launcher (and its `.desktop` entry) is wrapped so
+        it always starts with {env}`CODEX_CLI_PATH` pointing at this package's
+        `codex` binary. This lets Codex Desktop locate the CLI regardless of how
+        it is started — graphical autostart, application launcher, terminal, or a
+        warm-start handoff to an already-running instance — without depending on
+        the session/login {env}`PATH` and without requiring a re-login for the
+        setting to take effect. An explicit {env}`CODEX_CLI_PATH` already in the
+        environment still wins.
+
+        When unset, the module falls back to
+        {option}`programs.codexDesktopLinux.remoteControl.package` if
+        {option}`programs.codexDesktopLinux.remoteControl.enable` is set;
+        otherwise the launcher is left unwrapped and Codex Desktop relies on
+        discovering `codex` on {env}`PATH`.
       '';
     };
 


### PR DESCRIPTION
## Problem

Codex Desktop resolves the local Codex CLI from `CODEX_CLI_PATH` first, then a bundled `resources/bin/codex`. The Nix package ships **neither**, so it depends on the launcher's `find_codex_cli` (cold start only) finding `codex` on `PATH`.

Graphical autostart entries, application launchers, and **warm-start handoffs** to an already-running instance don't carry the Nix profile on `PATH`, and the warm-start path explicitly logs `Using CODEX_CLI_PATH=warm-start-skip`. A long-running instance started without a resolvable CLI then fails on every new app-server connection with:

```
Unable to locate the Codex CLI binary. Set CODEX_CLI_PATH or ensure the Electron resources include bin/codex.
```

Today this is documentation-only (`docs/nix.md` tells users to set `CODEX_CLI_PATH` by hand). Related: #395.

## Change

Add a `programs.codexDesktopLinux.cliPackage` option to the Home Manager and NixOS modules. When set, the module wraps the installed launcher with a thin `makeWrapper` layer that does `--set-default CODEX_CLI_PATH <pkg>/bin/codex`, and repoints the package's `.desktop` entry (which launches `<pkg>/bin/codex-desktop` by absolute path) at the wrapper.

The CLI path is **baked into the launcher**, not exported as a session variable, so it:
- works for graphical, terminal, and warm-start launches alike;
- takes effect on the next app launch — **no re-login required**;
- still lets an explicit `CODEX_CLI_PATH` in the environment win (`--set-default`).

The wrapper is a cheap `symlinkJoin` layer; it does not rebuild the Electron payload.

- Default `null` preserves current PATH-based behavior (launcher left unwrapped).
- When unset but `remoteControl.enable = true`, it reuses `remoteControl.package` so the desktop and the remote-control service share one CLI.
- Docs + CHANGELOG updated.

> Re: the earlier auto-review note about also setting `systemd.user.sessionVariables` in the NixOS module — that no longer applies. The first revision wired `CODEX_CLI_PATH` through `environment.sessionVariables`, which (a) needs a re-login to apply and (b) splits the GUI/login-shell vs systemd-user surfaces. This revision drops the session-variable approach entirely in favor of the launcher wrapper, so there is no env-propagation surface to mirror.

## Validation

- `nix-instantiate --parse` on both module files.
- Built the `symlinkJoin` wrapper over a real package store path and confirmed `bin/codex-desktop` becomes `export CODEX_CLI_PATH=${CODEX_CLI_PATH-'.../codex'}; exec <base>/bin/codex-desktop "$@"` and that both `.desktop` `Exec=` lines (main + "New Window") now point at the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)