### PR TITLE
Fix Linux plugin marketplace feature sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Plugin marketplace browsing now preserves upstream's `remote_plugin`
+  feature sync on Linux, so current app servers can load the remote OpenAI
+  curated catalog instead of falling back to only locally installed plugins.
 - The in-app updater no longer quits into a broken `pkexec` install path when a
   minimal window-manager session has no graphical polkit authentication agent;
   it keeps the rebuilt package ready and reports a terminal `sudo

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -591,11 +591,11 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
   }
 
   // 26.527.x builds the per-host feature enablement in a helper that copies the
-  // supported defaults, then unconditionally adds remote_plugin (n[vI]=t) — which
-  // the app-server rejects — and never includes remote_control. On Linux, force
-  // remote_control on and drop the unsupported remote_plugin entry before sync.
-  // The core Linux patch may already have removed the remote_plugin tail; compose
-  // with that sanitized shape instead of treating it as drift.
+  // supported defaults, then unconditionally adds remote_plugin (n[vI]=t), and
+  // never includes remote_control. Current app servers support remote_plugin and
+  // use it for remote marketplace data, so Linux only adds remote_control.
+  // Older core Linux patches may already have removed the remote_plugin tail;
+  // compose with that sanitized shape instead of treating it as drift.
   let patched = source;
   let changed = false;
   const enablementRegex =
@@ -606,7 +606,7 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
       const [, loopBlock, , , enablementVar, remotePluginVar, remotePluginValue] = match;
       const replacement =
         `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
-        `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar})` +
+        `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})` +
         `:(${enablementVar}[${remotePluginVar}]=${remotePluginValue},${enablementVar})}` +
         `function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
       patched = patched.replace(enablementRegex, replacement);

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -870,14 +870,16 @@ test("Linux remote-control load gate enables remote-control environment loading"
   assert.equal(applyLinuxRemoteControlLoadGatePatch(patched), patched);
 });
 
-test("Linux remote-control feature sync forces remote_control and drops remote_plugin on Linux", () => {
+test("Linux remote-control feature sync forces remote_control and preserves remote_plugin on Linux", () => {
   const source = syntheticAppMainFeatureSyncBundle();
   const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
 
   assert.notEqual(patched, source);
   assert.match(patched, /\.remote_control=!0/);
+  assert.match(patched, /n\[vI\]=t/);
   assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled/);
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)\?\(/);
+  assert.match(patched, /\?\(codexLinuxRemoteControlFeatureSyncEnabled\(arguments\[2\],arguments\[3\]\)&&\(n\.remote_control=!0\),n\[vI\]=t,n\)/);
   assert.match(patched, /:\(n\[vI\]=t,n\)\}/);
   assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
 });

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2860,6 +2860,20 @@ test("preserves supported dynamic remote_plugin in current app-server feature sy
   assert.match(patched, /n\[vI\]=t/);
 });
 
+test("preserves dynamic remote_plugin when the minified feature key contains regex syntax", () => {
+  const source = [
+    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],v$I=`remote_plugin`;",
+    "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
+    "return e[0]!==r?(a=()=>{let r=qF(n,!0);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
+    "function qF(e,t){let n={};for(let r of GF){let i=e[r];i!=null&&(n[r]=i)}return n[v$I]=t,n}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
+
+  assert.equal(patched, source);
+  assert.match(patched, /n\[v\$I\]=t/);
+});
+
 test("keeps already-sanitized dynamic app-server feature sync quiet", () => {
   const source = [
     "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],vI=`remote_plugin`;",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2808,7 +2808,7 @@ test("shows the profile dropdown settings route on Linux", () => {
 
 test("removes unsupported features from default app-server feature sync", () => {
   const source = [
-    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];",
+    "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`remote_plugin`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];",
     "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
     "return e[0]!==r?(a=()=>{let r=qF(n);qn(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:r}).catch(n=>{q.error(`Failed to sync experimental feature enablement`,{sensitive:{error:n}})})},o=[r],e[0]=r,e[1]=a,e[2]=o):(a=e[1],o=e[2]),null}",
     "function qF(e){let t={};for(let n of GF){let r=e[n];r!=null&&(t[n]=r)}return t}",
@@ -2818,7 +2818,7 @@ test("removes unsupported features from default app-server feature sync", () => 
 
   assert.match(
     patched,
-    /var GF=\[`apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`tool_call_mcp_elicitation`,`tool_suggest`\];/,
+    /var GF=\[`apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`remote_plugin`,`tool_call_mcp_elicitation`,`tool_suggest`\];/,
   );
   assert.doesNotMatch(patched, /`auth_elicitation`/);
   assert.doesNotMatch(patched, /`enable_mcp_apps`/);
@@ -2846,7 +2846,7 @@ test("patches the matched app-server feature sync array when an identical array 
   assert.match(patched, new RegExp(`function OF\\(\\)\\{return GF\\}${escapeRegExp(supportedFeatureArray)}function KF`));
 });
 
-test("removes unsupported dynamic extra from current app-server feature sync", () => {
+test("preserves supported dynamic remote_plugin in current app-server feature sync", () => {
   const source = [
     "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],vI=`remote_plugin`;",
     "function KF(){let e=(0,Z.c)(6),t=K(G),[n]=ts(`statsig_default_enable_features`),r=Lc(),i=Io(),a,o;",
@@ -2856,9 +2856,8 @@ test("removes unsupported dynamic extra from current app-server feature sync", (
 
   const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
 
-  assert.notEqual(patched, source);
-  assert.match(patched, /function qF\(e,t\)\{let n=\{\};for\(let r of GF\)\{let i=e\[r\];i!=null&&\(n\[r\]=i\)\}return n\}/);
-  assert.doesNotMatch(patched, /n\[vI\]=t/);
+  assert.equal(patched, source);
+  assert.match(patched, /n\[vI\]=t/);
 });
 
 test("keeps already-sanitized dynamic app-server feature sync quiet", () => {

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const {
+  escapeRegExp,
   findMatchingBrace,
 } = require("./shared.js");
 
@@ -489,7 +490,7 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
     if (dynamicBuilderExtraMatch != null) {
       const [, loopBlock, , , enablementVar, featureKeyVar] = dynamicBuilderExtraMatch;
       const featureKeyDeclaration = new RegExp(
-        `${featureKeyVar}=\`remote_plugin\``,
+        `${escapeRegExp(featureKeyVar)}=\`remote_plugin\``,
         "u",
       );
       if (featureKeyDeclaration.test(currentSource)) {

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -462,6 +462,7 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
     "mentions_v2",
     "plugins",
     "remote_control",
+    "remote_plugin",
     "tool_call_mcp_elicitation",
     "tool_suggest",
   ]);
@@ -486,7 +487,14 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
       /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\[([A-Za-z_$][\w$]*)\]=([A-Za-z_$][\w$]*),\4\}/u;
     const dynamicBuilderExtraMatch = currentSource.match(dynamicBuilderExtraRegex);
     if (dynamicBuilderExtraMatch != null) {
-      const [, loopBlock, , , enablementVar] = dynamicBuilderExtraMatch;
+      const [, loopBlock, , , enablementVar, featureKeyVar] = dynamicBuilderExtraMatch;
+      const featureKeyDeclaration = new RegExp(
+        `${featureKeyVar}=\`remote_plugin\``,
+        "u",
+      );
+      if (featureKeyDeclaration.test(currentSource)) {
+        return currentSource;
+      }
       return currentSource.replace(
         dynamicBuilderExtraRegex,
         `${loopBlock}return ${enablementVar}}`,


### PR DESCRIPTION
## Summary
- Preserve the upstream `remote_plugin` feature when Linux webview feature-sync patches add Linux-only feature flags.
- Keep the remote mobile feature patch from narrowing the supported feature list to `remote_control` only.
- Add regression tests for both the core webview patch and the optional remote mobile feature patch.

## Root Cause
After the upstream DMG started relying on the dynamic `remote_plugin` feature, the Linux feature-sync patches replaced that dynamic feature list instead of extending it. That disabled the remote plugin catalog path in the packaged Linux app, so the OpenAI Curated marketplace loaded only locally installed plugins.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/remote-mobile-control/test.js`
- `node --check scripts/patches/webview-assets.js`
- `node --check linux-features/remote-mobile-control/patch.js`
- `git diff --check upstream/main...HEAD`