### PR TITLE
[codex] Preserve active remote mobile CLI symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The opt-in `remote-mobile-control` cold-start hook no longer removes
+  `~/.local/bin/codex` when the launcher is actively using that symlink as
+  `CODEX_CLI_PATH`.
 - The in-app updater no longer quits into a broken `pkexec` install path when a
   minimal window-manager session has no graphical polkit authentication agent;
   it keeps the rebuilt package ready and reports a terminal `sudo

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -13,6 +13,8 @@ cleanup_remote_mobile_control_interactive_symlink() {
     local home_dir="${HOME:-}"
     local user_codex=""
     local resolved_user_codex=""
+    local active_cli_path=""
+    local resolved_active_cli_path=""
     local standalone_root=""
 
     [ -n "$home_dir" ] || return 0
@@ -25,6 +27,15 @@ cleanup_remote_mobile_control_interactive_symlink() {
 
     case "$resolved_user_codex" in
         "$standalone_root"/*)
+            active_cli_path="${CODEX_CLI_PATH:-}"
+            if [ -n "$active_cli_path" ]; then
+                resolved_active_cli_path="$(readlink -f "$active_cli_path" 2>/dev/null || true)"
+                if [ "$active_cli_path" = "$user_codex" ] ||
+                    { [ -n "$resolved_active_cli_path" ] && [ "$resolved_active_cli_path" = "$resolved_user_codex" ]; }; then
+                    echo "Preserved active CODEX_CLI_PATH symlink: $user_codex -> $resolved_user_codex"
+                    return 0
+                fi
+            fi
             if rm -f "$user_codex"; then
                 echo "Removed remote mobile control standalone symlink from interactive PATH: $user_codex -> $resolved_user_codex"
             fi

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -474,6 +474,64 @@ test("remote mobile cold-start hook removes leaked standalone codex symlink from
   }
 });
 
+test("remote mobile cold-start hook preserves active CODEX_CLI_PATH standalone symlink", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "bin", "codex");
+    const userCodex = path.join(home, ".local", "bin", "codex");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(path.dirname(userCodex), { recursive: true });
+    fs.writeFileSync(standaloneCodex, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(standaloneCodex, 0o755);
+    fs.symlinkSync(standaloneCodex, userCodex);
+
+    const result = runColdStartHook({
+      CODEX_CLI_PATH: userCodex,
+      CODEX_HOME: codexHome,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readlinkSync(userCodex), standaloneCodex);
+    assert.match(result.stdout, /Preserved active CODEX_CLI_PATH symlink/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook preserves symlink resolving to active CODEX_CLI_PATH", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "bin", "codex");
+    const userCodex = path.join(home, ".local", "bin", "codex");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(path.dirname(userCodex), { recursive: true });
+    fs.writeFileSync(standaloneCodex, "#!/usr/bin/env sh\nexit 0\n");
+    fs.chmodSync(standaloneCodex, 0o755);
+    fs.symlinkSync(standaloneCodex, userCodex);
+
+    const result = runColdStartHook({
+      CODEX_CLI_PATH: standaloneCodex,
+      CODEX_HOME: codexHome,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readlinkSync(userCodex), standaloneCodex);
+    assert.match(result.stdout, /Preserved active CODEX_CLI_PATH symlink/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("remote mobile cold-start hook preserves user codex symlinks outside the standalone runtime", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
   try {


### PR DESCRIPTION
## Summary
- Preserve `~/.local/bin/codex` when the remote-mobile-control cold-start hook sees that the launcher is actively using it as `CODEX_CLI_PATH`.
- Keep the existing cleanup for leaked standalone symlinks when they are not active.
- Add regression tests for both the direct symlink path and the resolved-target path.

## Root Cause
The launcher resolves `CODEX_CLI_PATH` before running cold-start hooks. If `remote-mobile-control` is enabled and `~/.local/bin/codex` points into the standalone runtime, the cold-start hook can remove that symlink after the launcher has selected it. Electron then starts with a stale CLI path, which matches the failure reported in #467.

## Validation
- `node --test linux-features/remote-mobile-control/test.js --test-name-pattern='cold-start hook'`
- `bash -n linux-features/remote-mobile-control/cold-start-hook.sh`
- `git diff --check`

Related: #467