### PR TITLE
Add frameless-titlebar Linux feature

### DIFF
--- a/linux-features/frameless-titlebar/README.md
+++ b/linux-features/frameless-titlebar/README.md
@@ -1,0 +1,49 @@
+# Frameless Titlebar
+
+This optional feature hides the Linux Electron titlebar overlay controls and
+removes the native menu chrome from the main Codex window. It is intended for
+Wayland compositors or window managers where compositor-managed decorations
+already provide the expected window controls, such as Hyprland setups.
+
+The default build leaves the existing Linux titlebar overlay behavior in place.
+Enable this only when the built-in Codex titlebar/buttons visually conflict
+with your desktop environment.
+
+Enable it by copying `linux-features/features.example.json` to
+`linux-features/features.json` and listing the feature id:
+
+```json
+{
+  "enabled": [
+    "frameless-titlebar"
+  ]
+}
+```
+
+Then rerun `./install.sh` or the native package build flow so the ASAR patches
+are regenerated with this feature enabled.
+
+## Testing
+
+Run the feature's unit tests from the repository root:
+
+```bash
+node --test linux-features/frameless-titlebar/test.js
+```
+
+For a manual check, enable the feature as above, rebuild, and launch the app:
+
+- The primary window should show no Electron-drawn titlebar overlay buttons
+  (minimize/maximize/close in the top-right corner) and no menu bar.
+- Window move, resize, and close/minimize/maximize should work through your
+  compositor's bindings (for example Hyprland's `bindm` mouse binds and
+  `killactive`/`fullscreen` dispatchers).
+- Changing the system dark/light theme must not crash the app or repaint a
+  titlebar strip; the patch removes all Linux `setTitleBarOverlay` calls,
+  which would otherwise throw on a window created without `titleBarOverlay`.
+
+## Known risks
+
+This removes Codex's Electron-provided Linux titlebar buttons.
+Window movement, resize, and close/minimize/maximize controls then depend on
+your compositor or desktop environment.

--- a/linux-features/frameless-titlebar/feature.json
+++ b/linux-features/frameless-titlebar/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "frameless-titlebar",
+  "title": "Frameless Titlebar",
+  "description": "Hide Linux titlebar overlay controls and native menu chrome for compositor-managed window decorations.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -37,15 +37,28 @@ function applyFramelessTitlebarBranchPatch(currentSource) {
   return patchedSource;
 }
 
-// The overlay sync method appears in three shapes depending on upstream and
-// core-patch vintage: the un-widened upstream form (first replace), the
-// current upstream form with a win32/linux gate but a plain overlay helper
-// body (second replace), and the form produced by the core
-// linux-native-titlebar patch with a codexLinuxTitleBarOverlay ternary body
-// (third replace). All three must collapse to the win32-only form.
+// The zoom path and the overlay sync method each appear in multiple shapes
+// depending on upstream and core-patch vintage. setWindowZoom: a plain
+// overlay helper body, or a codexLinuxTitleBarOverlay ternary body after the
+// core linux-native-titlebar patch. Overlay sync: the un-widened upstream
+// form, the current upstream form with a win32/linux gate but a plain
+// overlay helper body, and the core-patched form with a
+// codexLinuxTitleBarOverlay ternary body. All must collapse to win32-only.
 function applyFramelessTitlebarOverlaySyncPatch(currentSource) {
   let patchedSource = currentSource.replace(
     /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g,
+    (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
+      `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`,
+  );
+
+  const linuxZoomOverlayTernaryRegex = new RegExp(
+    "\\(process\\.platform===`win32`\\|\\|process\\.platform===`linux`\\)&&\\(this\\.windowZooms\\.set\\(([A-Za-z_$][\\w$]*)\\.id,([A-Za-z_$][\\w$]*)\\),\\1\\.setTitleBarOverlay\\(process\\.platform===`linux`\\?" +
+      escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
+      "\\([^)]*\\):([A-Za-z_$][\\w$]*)\\(\\2\\)\\)\\)",
+    "g",
+  );
+  patchedSource = patchedSource.replace(
+    linuxZoomOverlayTernaryRegex,
     (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
       `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`,
   );

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const LINUX_TITLEBAR_OVERLAY_HELPER = "codexLinuxTitleBarOverlay";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function applyFramelessTitlebarBranchPatch(currentSource) {
+  const primaryTitlebarRegex =
+    /case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\?\{titleBarStyle:`hiddenInset`,trafficLightPosition:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\}:\{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:\3\(\4\)\}:\1===`win32`(\|\|\1===`linux`)?\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(\4\)\}:\{titleBarStyle:`default`\};/g;
+  let patchedSource = currentSource;
+  let patchedTitlebar = false;
+
+  primaryTitlebarRegex.lastIndex = 0;
+  patchedSource = patchedSource.replace(
+    primaryTitlebarRegex,
+    (_match, platformAlias, opaqueWindowsAlias, trafficLightAlias, zoomAlias, _linuxInWin32Branch, overlayHelperAlias) => {
+      patchedTitlebar = true;
+      return `case\`primary\`:return ${platformAlias}===\`darwin\`?${opaqueWindowsAlias}?{titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:{vibrancy:\`menu\`,titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias})}:${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`}:{titleBarStyle:\`default\`};`;
+    },
+  );
+
+  const linuxOverlayRegex = new RegExp(
+    `([A-Za-z_$][\\w$]*)===\`linux\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\([^)]*\\)\\}:`,
+    "g",
+  );
+  patchedSource = patchedSource.replace(linuxOverlayRegex, (_match, platformAlias) => {
+    patchedTitlebar = true;
+    return `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`}:`;
+  });
+
+  if (!patchedTitlebar && !/===`linux`\?\{titleBarStyle:`hidden`\}/.test(patchedSource)) {
+    console.warn("WARN: Could not find primary BrowserWindow titlebar snippet - skipping frameless titlebar branch patch");
+  }
+
+  return patchedSource;
+}
+
+// The overlay sync method appears in three shapes depending on upstream and
+// core-patch vintage: the un-widened upstream form (first replace), the
+// current upstream form with a win32/linux gate but a plain overlay helper
+// body (second replace), and the form produced by the core
+// linux-native-titlebar patch with a codexLinuxTitleBarOverlay ternary body
+// (third replace). All three must collapse to the win32-only form.
+function applyFramelessTitlebarOverlaySyncPatch(currentSource) {
+  let patchedSource = currentSource.replace(
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g,
+    (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
+      `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`,
+  );
+
+  patchedSource = patchedSource.replace(
+    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\((?:\(process\.platform!==`win32`&&process\.platform!==`linux`\)|process\.platform!==`win32`&&process\.platform!==`linux`)\|\|\3!==`primary`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
+    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, overlayHelperAlias, electronAlias) =>
+      `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`,
+  );
+
+  return patchedSource.replace(
+    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(\(process\.platform!==`win32`&&process\.platform!==`linux`\)\|\|\3!==`primary`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\2\.id\)\):([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
+    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, windowsOverlayHelperAlias, electronAlias) =>
+      `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${windowsOverlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`,
+  );
+}
+
+function applyFramelessTitlebarMenuPatch(currentSource) {
+  const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
+  let patchedAny = false;
+  const patchedSource = currentSource.replace(menuRegex, (match, windowVar, offset) => {
+    const linuxPatch = `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),`;
+    const legacyLinuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
+    if (currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
+      return match;
+    }
+    if (currentSource.slice(Math.max(0, offset - legacyLinuxPatch.length), offset) === legacyLinuxPatch) {
+      patchedAny = true;
+      return match;
+    }
+    patchedAny = true;
+    return `${linuxPatch}${match}`;
+  });
+
+  const upgradedSource = patchedSource.replace(
+    /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+    (_match, windowVar) =>
+      `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+  );
+
+  if (!patchedAny && !currentSource.includes("setMenuBarVisibility(!1)")) {
+    const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(currentSource);
+    if (hasWindowsRemoveMenu) {
+      console.warn("WARN: Could not find window menu visibility snippet - skipping frameless titlebar menu patch");
+    }
+  }
+
+  return upgradedSource;
+}
+
+function applyFramelessTitlebarMainPatch(currentSource) {
+  return applyFramelessTitlebarMenuPatch(
+    applyFramelessTitlebarOverlaySyncPatch(
+      applyFramelessTitlebarBranchPatch(currentSource),
+    ),
+  );
+}
+
+function applyFramelessTitlebarWebviewPatch(currentSource) {
+  let patchedSource = currentSource.replace(
+    /applicationMenu:Object\.freeze\(\{left:0,right:\d+\}\)/g,
+    "applicationMenu:Object.freeze({left:0,right:0})",
+  );
+
+  const linuxApplicationMenuChrome = "case`win32`:case`linux`:return`application-menu`";
+  const linuxNativeChrome = "case`win32`:return`application-menu`;case`linux`:return`native`";
+  const foundApplicationMenuChrome = patchedSource.includes(linuxApplicationMenuChrome);
+  const hasNativeChrome = patchedSource.includes(linuxNativeChrome);
+  if (foundApplicationMenuChrome) {
+    patchedSource = patchedSource.split(linuxApplicationMenuChrome).join(linuxNativeChrome);
+  }
+
+  const linuxApplicationMenuBrowserGate =
+    "i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??l.applicationMenu:l.default";
+  const linuxNativeBrowserGate =
+    "i.includes(`win`)||r.includes(`windows`)?t??l.applicationMenu:l.default";
+  const foundApplicationMenuBrowserGate = patchedSource.includes(linuxApplicationMenuBrowserGate);
+  const hasNativeBrowserGate = patchedSource.includes(linuxNativeBrowserGate);
+  if (foundApplicationMenuBrowserGate) {
+    patchedSource = patchedSource.split(linuxApplicationMenuBrowserGate).join(linuxNativeBrowserGate);
+  }
+
+  const recognizedChromeMapping = foundApplicationMenuChrome || hasNativeChrome;
+  const recognizedBrowserGate = foundApplicationMenuBrowserGate || hasNativeBrowserGate;
+  if (!recognizedChromeMapping && !recognizedBrowserGate && currentSource.includes("applicationMenu:Object.freeze({left:0,right:")) {
+    console.warn("WARN: Could not find Linux window controls chrome mapping - skipping frameless webview chrome patch");
+  }
+
+  return patchedSource;
+}
+
+const patches = [
+  {
+    id: "main-process",
+    phase: "main-bundle",
+    order: 20_720,
+    ciPolicy: "optional",
+    apply: applyFramelessTitlebarMainPatch,
+  },
+  {
+    id: "webview-window-controls-layout",
+    phase: "webview-asset",
+    order: 20_730,
+    ciPolicy: "optional",
+    pattern: /^use-window-controls-safe-area-.*\.js$/,
+    missingDescription: "window controls safe-area bundle",
+    skipDescription: "frameless titlebar webview layout patch",
+    apply: applyFramelessTitlebarWebviewPatch,
+  },
+];
+
+module.exports = {
+  patches,
+  applyFramelessTitlebarBranchPatch,
+  applyFramelessTitlebarMainPatch,
+  applyFramelessTitlebarMenuPatch,
+  applyFramelessTitlebarOverlaySyncPatch,
+  applyFramelessTitlebarWebviewPatch,
+};

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -82,6 +82,23 @@ test("frameless-titlebar removes Linux overlay controls and menu chrome", () => 
   assert.doesNotMatch(patched, /process\.platform!==`linux`[^;]*setTitleBarOverlay/);
 });
 
+test("frameless-titlebar collapses the core-patched zoom overlay ternary", () => {
+  const source = [
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "function codexLinuxTitleBarOverlay(e=1){return{color:a.nativeTheme.shouldUseDarkColors?`#111111`:o2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(30*e)}}",
+    "setWindowZoom(e,t){let n=r.BrowserWindow.fromWebContents(e);n==null||this.windowAppearances.get(n.id)!==`primary`||(process.platform===`darwin`?n.setWindowButtonPosition(f6(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(t):b2(t))))}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyFramelessTitlebarMainPatch, source);
+
+  assert.match(
+    patched,
+    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(b2\(t\)\)\)/,
+  );
+  assert.doesNotMatch(patched, /setTitleBarOverlay\(process\.platform===`linux`/);
+  assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
+});
+
 test("frameless-titlebar maps Linux window controls chrome to native webview layout", () => {
   const source = [
     "var l=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+c,right:0}),modern:Object.freeze({left:76+c,right:0})}),applicationMenu:Object.freeze({left:0,right:138})});",

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  applyFramelessTitlebarMainPatch,
+  applyFramelessTitlebarWebviewPatch,
+} = require("./patch.js");
+
+function applyPatchTwice(patchFn, source) {
+  const patched = patchFn(source);
+  assert.equal(patchFn(patched), patched);
+  return patched;
+}
+
+function copyFeatureTo(featuresRoot) {
+  const featureDir = path.join(featuresRoot, "frameless-titlebar");
+  fs.mkdirSync(featureDir, { recursive: true });
+  for (const name of ["feature.json", "README.md", "patch.js"]) {
+    fs.copyFileSync(path.join(__dirname, name), path.join(featureDir, name));
+  }
+}
+
+test("frameless-titlebar stays disabled until listed in features.json", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "frameless-titlebar-feature-"));
+  try {
+    const featuresRoot = path.join(tempDir, "linux-features");
+    fs.mkdirSync(featuresRoot, { recursive: true });
+    copyFeatureTo(featuresRoot);
+    fs.writeFileSync(path.join(featuresRoot, "features.example.json"), '{"enabled":[]}\n');
+
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+
+    fs.writeFileSync(path.join(featuresRoot, "features.json"), '{"enabled":["frameless-titlebar"]}\n');
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      descriptors.map((descriptor) => descriptor.id).sort(),
+      [
+        "feature:frameless-titlebar:main-process",
+        "feature:frameless-titlebar:webview-window-controls-layout",
+      ],
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("frameless-titlebar removes Linux overlay controls and menu chrome", () => {
+  const source = [
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "function codexLinuxTitleBarOverlay(e=1){return{color:a.nativeTheme.shouldUseDarkColors?`#111111`:o2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(30*e)}}",
+    "case`primary`:return n===`darwin`?t?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r)}:{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r)}:n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r)}:n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay(r)}:{titleBarStyle:`default`};",
+    "setWindowZoom(e,t){let n=r.BrowserWindow.fromWebContents(e);n==null||this.windowAppearances.get(n.id)!==`primary`||(process.platform===`darwin`?n.setWindowButtonPosition(f6(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(b2(t))))}",
+    "installWindowsTitleBarOverlaySync(e,t){if((process.platform!==`win32`&&process.platform!==`linux`)||t!==`primary`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(this.windowZooms.get(e.id)):b2(this.windowZooms.get(e.id)))};return a.nativeTheme.on(`updated`,n),n(),()=>{a.nativeTheme.off(`updated`,n)}}",
+    "process.platform===`linux`&&k.setMenuBarVisibility(!1),process.platform===`win32`&&k.removeMenu(),",
+  ].join("");
+
+  const patched = applyPatchTwice(applyFramelessTitlebarMainPatch, source);
+
+  assert.match(patched, /n===`linux`\?\{titleBarStyle:`hidden`\}/);
+  assert.match(
+    patched,
+    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(b2\(t\)\)\)/,
+  );
+  assert.match(patched, /if\(process\.platform!==`win32`\|\|t!==`primary`\)return/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`&&\(k\.setMenuBarVisibility\(!1\),k\.removeMenu\?\.\(\)\),process\.platform===`win32`&&k\.removeMenu\(\),/,
+  );
+  assert.doesNotMatch(patched, /titleBarOverlay:codexLinuxTitleBarOverlay/);
+  assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
+  assert.doesNotMatch(patched, /process\.platform!==`linux`[^;]*setTitleBarOverlay/);
+});
+
+test("frameless-titlebar maps Linux window controls chrome to native webview layout", () => {
+  const source = [
+    "var l=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+c,right:0}),modern:Object.freeze({left:76+c,right:0})}),applicationMenu:Object.freeze({left:0,right:138})});",
+    "var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:138})});",
+    "function chrome(e){switch(e){case`win32`:case`linux`:return`application-menu`;default:return`native`}}",
+    "let inset=i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??l.applicationMenu:l.default;",
+  ].join("");
+
+  const patched = applyPatchTwice(applyFramelessTitlebarWebviewPatch, source);
+
+  assert.equal(
+    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/g) ?? []).length,
+    2,
+  );
+  assert.match(patched, /case`win32`:return`application-menu`;case`linux`:return`native`/);
+  assert.match(patched, /i\.includes\(`win`\)\|\|r\.includes\(`windows`\)\?t\?\?l\.applicationMenu:l\.default/);
+  assert.doesNotMatch(patched, /case`win32`:case`linux`:return`application-menu`/);
+  assert.doesNotMatch(patched, /right:138/);
+});


### PR DESCRIPTION
## What

Adds an opt-in `frameless-titlebar` Linux feature that hides the Electron titlebar overlay controls and native menu chrome on the main Codex window, for Wayland compositors / window managers where compositor-managed decorations already provide window controls (developed and tested on Hyprland).

Disabled by default per the feature contract; enabled via `linux-features/features.json`.

## Why

The native Linux titlebar overlay (#413, refined in #460) renders Electron-drawn window buttons that visually conflict with compositor-managed decorations on Hyprland — the overlay strip and buttons are redundant there and don't match the compositor theme.

## How

Two patch descriptors (orders 20720/20730, after the core `linux-native-titlebar` patch at order 85):

- **main-bundle**: collapses the Linux primary-window branch to `titleBarStyle: hidden` with no `titleBarOverlay`, removes all Linux `setTitleBarOverlay` call paths (zoom sync and nativeTheme sync — these throw on a window created without an overlay), and hides/removes the window menu. Handles the raw upstream shape, the current upstream shape, and the core-patched shape, and is idempotent.
- **webview-asset** (`use-window-controls-safe-area-*.js`): zeroes the window-controls safe-area inset and maps Linux chrome from `application-menu` to `native` so the UI doesn't reserve space for buttons that no longer exist.

## Testing

- `node --test linux-features/frameless-titlebar/test.js` (3 tests: loader gating, main-bundle transform + idempotency, webview transform + idempotency)
- Verified end-to-end with `make install-native` on Arch/Hyprland: no overlay buttons, no menu bar, window management via compositor bindings, dark/light theme flips clean.
- Dry-run against the real upstream bundle confirms only the intended call sites change and the patch is a no-op when re-applied.

## Note for the maintainer

While building this I noticed upstream renamed `installWindowsTitleBarOverlaySync` to `installApplicationMenuTitleBarOverlaySync`. The core `linux-native-titlebar` patch in `scripts/patches/main-process.js` only matches the old name, so its nativeTheme-sync portion silently no-ops on current upstream bundles (the warning is gated on the old name being present). That's independent of this PR but probably worth a core fix.

