### PR TITLE
Fix avatar overlay hit testing inside window bounds

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1743,9 +1743,11 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.doesNotMatch(patched, /let\[,l,u,d,f\]=c/);
   assert.doesNotMatch(patched, /this\.codexLinuxIsI3Session\(\)\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.pointerInteractive=!0,this\.mousePassthroughEnabled&&\(this\.mousePassthroughEnabled=!1\),e\.setIgnoreMouseEvents\(!1\);return\}/);
   assert.match(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{/);
+  assert.match(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStartAvatarPassthroughRecovery\(\),/);
+  assert.doesNotMatch(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),/);
   assert.doesNotMatch(patched, /typeof e\.setShape==`function`&&!this\.codexLinuxIsI3Session\(\)/);
   assert.match(patched, /if\(t==null\)return null/);
-  assert.match(patched, /if\(t==null\)return!1;let n=JSON\.stringify\(t\)/);
+  assert.match(patched, /try\{let t=this\.codexLinuxBuildAvatarInputShape\(e\);if\(t==null\)return!1;let n=JSON\.stringify\(t\)/);
   assert.match(patched, /e\.setShape\(t\),this\.codexLinuxAvatarInputShapeKey=n;return!0/);
   assert.match(patched, /return\[i\(t\.mascot\),i\(t\.tray\)\]\.filter\(Boolean\)/);
   assert.match(patched, /process\.platform!==`linux`/);
@@ -1754,6 +1756,9 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.doesNotMatch(patched, /typeof e\.setShape==`function`\)return;this\.codexLinuxAvatarPassthroughRecoveryTimer=setInterval/);
   assert.match(patched, /this\.dragState!=null/);
   assert.match(patched, /this\.codexLinuxIsCursorInAvatarInteractiveRegion\(e\)/);
+  assert.match(patched, /__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds\.width&&__codexY<=__codexBounds\.height/);
+  assert.match(patched, /return __codexHit\(t\.mascot\)\|\|__codexHit\(t\.tray\)\|\|__codexWindowHit/);
+  assert.doesNotMatch(patched, /let r=r\.screen\.getCursorScreenPoint\(\)/);
   assert.match(patched, /catch\{t=!0\}/);
   assert.match(patched, /this\.pointerInteractive=t/);
   assert.match(patched, /displayBounds:n\.screen\.getDisplayNearestPoint\(n\.screen\.getCursorScreenPoint\(\)\)\.bounds\},process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)\}moveDrag\(e\)/);
@@ -1765,6 +1770,95 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.doesNotMatch(patched, /codexLinuxRecoverAvatarPointerInteractivity/);
   assert.match(patched, /this\.window===t&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
+});
+
+test("Linux avatar overlay treats visible window content as interactive fallback", () => {
+  const patched = applyPatchTwice(
+    applyLinuxAvatarOverlayMousePassthroughPatch,
+    avatarOverlayBundleFixture(),
+  );
+  const context = {
+    globalThis: {},
+    process: {
+      env: {},
+      pid: 123,
+      platform: "linux",
+    },
+    require(moduleName) {
+      assert.equal(moduleName, "node:child_process");
+      return { execFile() {} };
+    },
+    pV(bounds) {
+      return bounds;
+    },
+    n: {
+      app: {
+        getName: () => "Codex",
+      },
+      screen: {
+        getCursorScreenPoint: () => ({ x: 5765, y: 1088 }),
+        getDisplayNearestPoint: () => ({ bounds: { x: 0, y: 0, width: 800, height: 600 } }),
+      },
+    },
+  };
+  vm.runInNewContext(`${patched};globalThis.AvatarOverlayController=fV;`, context);
+
+  const controller = new context.globalThis.AvatarOverlayController(
+    { sendMessageToAllRegisteredWindows() {} },
+    { set() {} },
+  );
+  controller.layout = {
+    mascot: { left: 220, top: 190, width: 113, height: 122 },
+    tray: { left: 57, top: 55, width: 276, height: 131 },
+  };
+
+  assert.equal(
+    controller.codexLinuxIsCursorInAvatarInteractiveRegion({
+      getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
+    }),
+    true,
+  );
+  assert.equal(
+    controller.codexLinuxIsCursorInAvatarInteractiveRegion({
+      getContentBounds: () => ({ x: 6000, y: 936, width: 100, height: 100 }),
+    }),
+    false,
+  );
+
+  const overlayWindow = {
+    isDestroyed: () => false,
+    getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
+    setShape() {},
+  };
+  const serializeShape = (shape) => JSON.parse(JSON.stringify(shape));
+  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
+    { x: 220, y: 190, width: 113, height: 122 },
+    { x: 57, y: 55, width: 276, height: 131 },
+  ]);
+  controller.pointerInteractive = true;
+  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
+    { x: 0, y: 0, width: 356, height: 320 },
+  ]);
+  assert.equal(
+    controller.codexLinuxApplyAvatarInputShape({
+      isDestroyed: () => false,
+      getContentBounds: () => {
+        throw new Error("drift");
+      },
+      setShape() {},
+    }),
+    false,
+  );
+  assert.equal(
+    controller.codexLinuxApplyAvatarInputShape({
+      isDestroyed: () => false,
+      getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
+      setShape() {
+        throw new Error("unsupported");
+      },
+    }),
+    false,
+  );
 });
 
 test("keeps avatar overlay layout sync working after layout alias drift", () => {

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -23,6 +23,46 @@ function findAvatarMethod(source, signatureRegex) {
   };
 }
 
+function replaceAvatarMethod(source, signatureRegex, replacement) {
+  const method = findAvatarMethod(source, signatureRegex);
+  if (method == null || method.text === replacement) {
+    return source;
+  }
+  return source.slice(0, method.start) + replacement + source.slice(method.end);
+}
+
+function avatarCursorRegionPatch(electronVar) {
+  return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)||__codexWindowHit}`;
+}
+
+function avatarInputShapePatch() {
+  return "codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null||this.pointerInteractive)return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
+}
+
+function avatarApplyInputShapePatch() {
+  return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
+}
+
+function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
+  let patched = source;
+  patched = replaceAvatarMethod(
+    patched,
+    /codexLinuxBuildAvatarInputShape\(e\)\{/,
+    avatarInputShapePatch(),
+  );
+  patched = replaceAvatarMethod(
+    patched,
+    /codexLinuxApplyAvatarInputShape\(e\)\{/,
+    avatarApplyInputShapePatch(),
+  );
+  patched = replaceAvatarMethod(
+    patched,
+    /codexLinuxIsCursorInAvatarInteractiveRegion\(e\)\{/,
+    avatarCursorRegionPatch(electronVar),
+  );
+  return patched;
+}
+
 function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   let patchedSource = currentSource;
   const electronVar = requireName(currentSource, "electron") ?? "n";
@@ -53,6 +93,10 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     "if(process.platform===`linux`&&this.codexLinuxIsI3Session()){this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.pointerInteractive=!0,this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1),e.setIgnoreMouseEvents(!1);return}";
   const previousI3SetShapeGuardPatch =
     "if(process.platform===`linux`&&typeof e.setShape==`function`&&!this.codexLinuxIsI3Session()){";
+  const previousSetShapePolicyPatch =
+    "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
+  const setShapePolicyPatch =
+    "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
 
   if (!patchedSource.includes("codexLinuxIsI3Session")) {
     if (patchedSource.includes(interactivityNeedle)) {
@@ -91,9 +135,8 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
       "if(process.platform===`linux`&&typeof e.setShape==`function`){",
     );
   }
-  if (electronVar !== "n" && patchedSource.includes("codexLinuxIsCursorInAvatarInteractiveRegion")) {
-    patchedSource = patchedSource.replaceAll("let r=n.screen.getCursorScreenPoint()", `let r=${electronVar}.screen.getCursorScreenPoint()`);
-  }
+  patchedSource = patchedSource.replaceAll(previousSetShapePolicyPatch, setShapePolicyPatch);
+  patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
 
   const previousStartDragPatch =
     "startDrag(e,{pointerWindowX:t,pointerWindowY:r}){let i=this.window;if(i==null||i.isDestroyed()||i.webContents.id!==e)return;this.pointerInteractive=!0,this.applyPointerInteractivityPolicy(),this.cancelMomentum();";


### PR DESCRIPTION
## Summary
- keep the Linux avatar overlay recovery polling active when Electron `setShape()` is available
- treat cursor positions inside the overlay window bounds as interactive fallback when mascot/tray rectangles miss visible content
- make the injected input-shape path fail-soft so `getContentBounds()` or `setShape()` failures fall back instead of breaking launch

Fixes #464.

## Validation
- `node --check scripts/patches/avatar-overlay.js && node --check scripts/patch-linux-window-ui.test.js`
- `git diff --check`
- `node --test scripts/patch-linux-window-ui.test.js`
- dry-run against the current generated `codex-app/resources/app.asar` confirmed `__codexWindowHit` is inserted and the old alias-shadowed `let r=r.screen...` form is removed

## Note
- `bash tests/scripts_smoke.sh` was started, but stopped after it hung in an unrelated user-local smoke step on `stat -c %s /home/igor/codex-desktop-linux/Codex.dmg` while refreshing metadata.