### PR TITLE
fix(installer): ignore space-joined Electron helpers

### DIFF
--- a/scripts/lib/process-detection.sh
+++ b/scripts/lib/process-detection.sh
@@ -22,10 +22,16 @@ pid_is_current_user() {
 # all carry their role as a `--type=...` argv entry. Only the main app
 # process omits it, so we use this to skip orphaned helpers that survive
 # their parent and re-attach to systemd.
+cmdline_has_electron_helper_type() {
+    local cmdline_path="$1"
+    [ -r "$cmdline_path" ] || return 1
+    tr '\000' '\n' < "$cmdline_path" 2>/dev/null | grep -q '^--type=' && return 0
+    LC_ALL=C grep -a -q -- ' --type=' "$cmdline_path" 2>/dev/null
+}
+
 pid_is_electron_helper() {
     local pid="$1"
-    [ -r "/proc/$pid/cmdline" ] || return 1
-    tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null | grep -q '^--type='
+    cmdline_has_electron_helper_type "/proc/$pid/cmdline"
 }
 
 pid_matches_install_target() {
@@ -87,4 +93,3 @@ Close that app before rebuilding this install directory, or build into a separat
 Set CODEX_INSTALL_ALLOW_RUNNING=1 only if you intentionally want to overwrite a running app."
     fi
 }
-

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3269,6 +3269,25 @@ if (!launcher.includes('ln -sfnT "$target" "$link_path"')) {
 NODE
 }
 
+test_process_detection_helper_cmdline_shapes() {
+    info "Checking Electron helper process detection cmdline shapes"
+    local nul_cmdline="$TMP_DIR/electron-helper-nul.cmdline"
+    local space_cmdline="$TMP_DIR/electron-helper-space.cmdline"
+    local main_cmdline="$TMP_DIR/electron-main.cmdline"
+
+    printf '/opt/codex-desktop/electron\0--type=gpu-process\0--no-sandbox\0' > "$nul_cmdline"
+    printf '/opt/codex-desktop/electron --type=utility --no-sandbox' > "$space_cmdline"
+    printf '/opt/codex-desktop/electron --no-sandbox' > "$main_cmdline"
+
+    (
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/process-detection.sh"
+        cmdline_has_electron_helper_type "$nul_cmdline" || exit 1
+        cmdline_has_electron_helper_type "$space_cmdline" || exit 1
+        ! cmdline_has_electron_helper_type "$main_cmdline" || exit 1
+    ) || fail "Electron helper detection must handle NUL-separated and space-joined cmdline formats"
+}
+
 test_side_by_side_launcher_identity() {
     info "Checking side-by-side launcher identity"
     local workspace="$TMP_DIR/side-by-side-launcher"
@@ -5977,6 +5996,7 @@ main() {
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_template_sanity
+    test_process_detection_helper_cmdline_shapes
     test_webview_probe_equivalence
     test_side_by_side_launcher_identity
     test_linux_file_manager_patch_smoke


### PR DESCRIPTION
## Summary
- detect Electron helper processes from both NUL-separated and space-joined cmdline shapes
- keep installer running-app protection focused on the real main Electron process
- add smoke coverage for GPU/utility helper cmdline variants

## Why
On this machine a stale Codex GPU helper showed `/proc/<pid>/cmdline` as a space-joined command line. The installer then treated `--type=gpu-process` as the main app and refused to rebuild `codex-app`, even though no main process was running from that install dir.

## Testing
- `bash -n install.sh scripts/lib/process-detection.sh tests/scripts_smoke.sh`
- focused helper detection probe against live pid 421508: helper detected, no main process found
- synthetic `cmdline_has_electron_helper_type` probe for NUL-separated helper, space-joined helper, and main-process cmdlines
- `git diff --check`
- `bash tests/scripts_smoke.sh` reached and passed `Checking Electron helper process detection cmdline shapes`, then was stopped later because an existing user-local smoke scenario hung in `stat -c %s /home/igor/codex-desktop-linux/Codex.dmg` with `D/autofs_wait`; that hang is unrelated to this patch
