### PR TITLE
fix(linux): prevent duplicate app instances (launcher detection + enforced bootstrap single-instance lock)

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1416,6 +1416,25 @@ find_running_app_pid() {
     return 1
 }
 
+pid_in_same_launch_instance() {
+    # The /proc scan matches by electron binary path, which side-by-side
+    # multi-launch instances share with the default app. Match instance
+    # identity via the process environment so the default app never adopts
+    # a side-by-side instance and vice versa. Substring checks on the
+    # newline-joined environ avoid grep -q pipelines, which can fail under
+    # pipefail when grep exits before the writer finishes.
+    local pid="$1"
+    local environ="/proc/$pid/environ"
+    local env_lines
+
+    env_lines=$'\n'"$(tr '\0' '\n' < "$environ" 2>/dev/null || true)"$'\n'
+    if [ "$MULTI_LAUNCH_ACTIVE" -eq 1 ]; then
+        [[ "$env_lines" == *$'\n'"CODEX_LINUX_INSTANCE_ID=$CODEX_LINUX_INSTANCE_ID"$'\n'* ]]
+    else
+        [[ "$env_lines" != *$'\n'"CODEX_LINUX_MULTI_LAUNCH=1"$'\n'* ]]
+    fi
+}
+
 discover_running_app_pid() {
     local pid
     local proc_exe
@@ -1424,7 +1443,7 @@ discover_running_app_pid() {
         [ -e "$proc_exe" ] || continue
         pid="${proc_exe#/proc/}"
         pid="${pid%/exe}"
-        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
+        if pid_matches_executable "$pid" "$SCRIPT_DIR/electron" && pid_in_same_launch_instance "$pid"; then
             echo "$pid"
             return 0
         fi
@@ -1446,7 +1465,12 @@ needs_cold_start() {
 }
 
 detect_warm_start() {
-    if RUNNING_APP_PID="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"; }; then
+    # Always fall back to the /proc scan: a hidden-to-tray instance can lose
+    # both its app.pid marker (clobbered by a failed duplicate launch) and its
+    # launch-action socket (runtime dir wiped, warm start disabled, or socket
+    # setup failed), and gating the scan on the socket made such an instance
+    # undetectable — every launch then cold-started a duplicate.
+    if RUNNING_APP_PID="$(find_running_app_pid)" || RUNNING_APP_PID="$(discover_running_app_pid)"; then
         echo "$RUNNING_APP_PID" > "$APP_PID_FILE"
         if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then
             WARM_START=0
@@ -1863,7 +1887,7 @@ reconcile_runtime_state() {
     local live_app_pid=""
     local webview_pid=""
 
-    if live_app_pid="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && live_app_pid="$(discover_running_app_pid)"; }; then
+    if live_app_pid="$(find_running_app_pid)" || live_app_pid="$(discover_running_app_pid)"; then
         echo "$live_app_pid" > "$APP_PID_FILE"
         return 0
     fi
@@ -2312,6 +2336,24 @@ cleanup_launcher() {
     fi
 }
 
+# Serialize the running-app detection -> Electron spawn -> app.pid write
+# critical section across concurrent launchers. Without this, two launches
+# racing through detection can both cold-start, and the loser's cleanup later
+# deletes the survivor's app.pid marker, making it undetectable. Fd 9 stays
+# open in this shell; the flock is released explicitly, so the fd leaking
+# into child processes does not extend the lock.
+acquire_launcher_lock() {
+    command -v flock >/dev/null 2>&1 || return 0
+    exec 9>"$APP_STATE_DIR/launcher.lock" || return 0
+    if ! flock -w 30 9; then
+        echo "WARN: timed out waiting for another launcher to finish; continuing unserialized"
+    fi
+}
+
+release_launcher_lock() {
+    flock -u 9 2>/dev/null || true
+}
+
 launch_electron() {
     cd "$SCRIPT_DIR"
     log_phase "electron_launch"
@@ -2323,6 +2365,7 @@ launch_electron() {
     build_electron_launch_args
 
     if [ "$WARM_START" -eq 1 ]; then
+        release_launcher_lock
         echo "Electron warm-start handoff: pid=$RUNNING_APP_PID rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED renderer_accessibility_forced=$ELECTRON_RENDERER_ACCESSIBILITY_FORCED"
         unset ELECTRON_RUN_AS_NODE
         "$SCRIPT_DIR/electron" "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}"
@@ -2338,6 +2381,7 @@ launch_electron() {
     else
         echo "$ELECTRON_PID" > "$APP_PID_FILE"
     fi
+    release_launcher_lock
     log_phase "electron_spawned"
 
     set +e
@@ -2355,6 +2399,7 @@ load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
 source_feature_env_files
 register_url_scheme_handlers
+acquire_launcher_lock
 reconcile_runtime_state
 detect_warm_start
 trap cleanup_launcher EXIT

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2354,6 +2354,13 @@ release_launcher_lock() {
     flock -u 9 2>/dev/null || true
 }
 
+refresh_launch_state() {
+    WARM_START=0
+    RUNNING_APP_PID=""
+    reconcile_runtime_state
+    detect_warm_start
+}
+
 launch_electron() {
     cd "$SCRIPT_DIR"
     log_phase "electron_launch"
@@ -2399,9 +2406,7 @@ load_packaged_runtime_helper
 prepend_managed_node_runtime_to_path
 source_feature_env_files
 register_url_scheme_handlers
-acquire_launcher_lock
-reconcile_runtime_state
-detect_warm_start
+refresh_launch_state
 trap cleanup_launcher EXIT
 
 if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
@@ -2426,7 +2431,7 @@ else
     log_phase "warm_start_ready"
 fi
 
-if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then
+if [ -z "${CODEX_CLI_PATH:-}" ]; then
     CODEX_CLI_PATH="$(find_codex_cli || true)"
     export CODEX_CLI_PATH
     log_phase "cli_lookup"
@@ -2483,6 +2488,11 @@ if needs_cold_start; then
     run_cold_start_hooks
 fi
 resolve_browser_use_runtime_env
+
+if needs_cold_start; then
+    acquire_launcher_lock
+    refresh_launch_state
+fi
 
 echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
 echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2309,16 +2309,80 @@ test("adds Linux single-instance lock and second-instance handoff", () => {
   assert.match(patched, /n\.app\.off\(`second-instance`,codexLinuxSecondInstanceHandler\)/);
 });
 
-test("lets explicit Linux multi-instance launches bypass the bootstrap single-instance lock", () => {
+test("forces the bootstrap single-instance lock on Linux even when upstream disables it", () => {
   const source =
     "var S=t.x({isMacOS:b,isPackaged:n.app.isPackaged});if(!(!S||n.app.requestSingleInstanceLock()))t.Jr().info(`Exiting second desktop instance`,{safe:{packaged:n.app.isPackaged,platform:process.platform}}),n.app.exit(0);else{let e=t.C(x);}";
   const patched = applyPatchTwice(applyLinuxMultiInstanceBootstrapPatch, source);
 
   assert.match(
     patched,
-    /if\(!\(!S\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|n\.app\.requestSingleInstanceLock\(\)\)\)/,
+    /if\(!\(process\.platform===`linux`\?process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|n\.app\.requestSingleInstanceLock\(\):!S\|\|n\.app\.requestSingleInstanceLock\(\)\)\)/,
   );
   assert.match(patched, /Exiting second desktop instance/);
+});
+
+test("upgrades the legacy guarded bootstrap single-instance lock to the enforced form", () => {
+  const source =
+    "var $=r.D({isMacOS:Z,isPackaged:e.app.isPackaged});if(!(!$||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||e.app.requestSingleInstanceLock()))t.Vr().info(`Exiting second desktop instance`,{}),e.app.exit(0);";
+  const patched = applyPatchTwice(applyLinuxMultiInstanceBootstrapPatch, source);
+
+  assert.match(
+    patched,
+    /if\(!\(process\.platform===`linux`\?process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|e\.app\.requestSingleInstanceLock\(\):!\$\|\|e\.app\.requestSingleInstanceLock\(\)\)\)/,
+  );
+  assert.ok(!patched.includes("&&process.env.CODEX_LINUX_MULTI_LAUNCH"));
+});
+
+test("enforced bootstrap lock takes the Linux lock with upstream flag off and exits the loser", () => {
+  const source =
+    "var S=t.x({isMacOS:b,isPackaged:n.app.isPackaged});if(!(!S||n.app.requestSingleInstanceLock()))n.app.exit(0);";
+  const patched = applyLinuxMultiInstanceBootstrapPatch(source);
+
+  const run = ({ lockResult, multiLaunch }) => {
+    const calls = { lock: 0, exit: 0 };
+    const t = { x: () => false };
+    const n = {
+      app: {
+        isPackaged: true,
+        requestSingleInstanceLock: () => {
+          calls.lock += 1;
+          return lockResult;
+        },
+        exit: () => {
+          calls.exit += 1;
+        },
+      },
+    };
+    const previous = process.env.CODEX_LINUX_MULTI_LAUNCH;
+    if (multiLaunch) {
+      process.env.CODEX_LINUX_MULTI_LAUNCH = "1";
+    } else {
+      delete process.env.CODEX_LINUX_MULTI_LAUNCH;
+    }
+    try {
+      new Function("t", "n", "b", patched)(t, n, false);
+    } finally {
+      if (previous == null) {
+        delete process.env.CODEX_LINUX_MULTI_LAUNCH;
+      } else {
+        process.env.CODEX_LINUX_MULTI_LAUNCH = previous;
+      }
+    }
+    return calls;
+  };
+
+  // process.platform is linux in CI and on dev machines for this repo.
+  const winner = run({ lockResult: true, multiLaunch: false });
+  assert.equal(winner.lock, 1);
+  assert.equal(winner.exit, 0);
+
+  const loser = run({ lockResult: false, multiLaunch: false });
+  assert.equal(loser.lock, 1);
+  assert.equal(loser.exit, 1);
+
+  const sideBySide = run({ lockResult: true, multiLaunch: true });
+  assert.equal(sideBySide.lock, 0);
+  assert.equal(sideBySide.exit, 0);
 });
 
 test("recognizes bootstrap-owned single-instance handoff in current bundles", () => {

--- a/scripts/patches/bootstrap.js
+++ b/scripts/patches/bootstrap.js
@@ -3,27 +3,46 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-function applyLinuxMultiInstanceBootstrapPatch(currentSource) {
-  const unguardedLock =
-    "if(!(!S||n.app.requestSingleInstanceLock()))";
-  const guardedLock =
-    "if(!(!S||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||n.app.requestSingleInstanceLock()))";
-  const dynamicGuardedLockRegex =
-    /if\(!\(!([A-Za-z_$][\w$]*)\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|([A-Za-z_$][\w$]*)\.app\.requestSingleInstanceLock\(\)\)\)/;
-  const dynamicUnguardedLockRegex =
-    /if\(!\(!([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.app\.requestSingleInstanceLock\(\)\)\)/;
+// Upstream gates the bootstrap single-instance lock behind a flag computed
+// from {isMacOS, isPackaged}, which is always false on Linux — so the stock
+// `!flag ||` short-circuit skips requestSingleInstanceLock() entirely and
+// Linux gets no duplicate-instance protection. Rewrite the gate so Linux
+// always takes the lock (unless an explicit CODEX_LINUX_MULTI_LAUNCH=1
+// side-by-side launch opts out) while other platforms keep upstream
+// semantics. Shapes handled, with minified variable names captured
+// dynamically (enabled flag, electron namespace):
+//   upstream:  if(!(!S||n.app.requestSingleInstanceLock()))
+//   legacy:    if(!(!S||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||n.app.requestSingleInstanceLock()))
+//   enforced:  if(!(process.platform===`linux`?process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||n.app.requestSingleInstanceLock():!S||n.app.requestSingleInstanceLock()))
+const enforcedLockRegex =
+  /if\(!\(process\.platform===`linux`\?process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|([A-Za-z_$][\w$]*)\.app\.requestSingleInstanceLock\(\):!([A-Za-z_$][\w$]*)\|\|\1\.app\.requestSingleInstanceLock\(\)\)\)/;
+const legacyGuardedLockRegex =
+  /if\(!\(!([A-Za-z_$][\w$]*)\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH===`1`\|\|([A-Za-z_$][\w$]*)\.app\.requestSingleInstanceLock\(\)\)\)/;
+const unguardedLockRegex =
+  /if\(!\(!([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.app\.requestSingleInstanceLock\(\)\)\)/;
 
-  if (currentSource.includes(guardedLock) || dynamicGuardedLockRegex.test(currentSource)) {
+function enforcedLockCondition(enabledVar, appVar) {
+  return (
+    "if(!(process.platform===`linux`?process.env.CODEX_LINUX_MULTI_LAUNCH===`1`||" +
+    `${appVar}.app.requestSingleInstanceLock():!${enabledVar}||` +
+    `${appVar}.app.requestSingleInstanceLock()))`
+  );
+}
+
+function applyLinuxMultiInstanceBootstrapPatch(currentSource) {
+  if (enforcedLockRegex.test(currentSource)) {
     return currentSource;
   }
-  if (currentSource.includes(unguardedLock)) {
-    return currentSource.replace(unguardedLock, guardedLock);
-  }
-  if (dynamicUnguardedLockRegex.test(currentSource)) {
+  if (legacyGuardedLockRegex.test(currentSource)) {
     return currentSource.replace(
-      dynamicUnguardedLockRegex,
-      (_match, enabledVar, appVar) =>
-        `if(!(!${enabledVar}||process.platform===\`linux\`&&process.env.CODEX_LINUX_MULTI_LAUNCH===\`1\`||${appVar}.app.requestSingleInstanceLock()))`,
+      legacyGuardedLockRegex,
+      (_match, enabledVar, appVar) => enforcedLockCondition(enabledVar, appVar),
+    );
+  }
+  if (unguardedLockRegex.test(currentSource)) {
+    return currentSource.replace(
+      unguardedLockRegex,
+      (_match, enabledVar, appVar) => enforcedLockCondition(enabledVar, appVar),
     );
   }
 
@@ -32,7 +51,7 @@ function applyLinuxMultiInstanceBootstrapPatch(currentSource) {
     currentSource.includes("Exiting second desktop instance")
   ) {
     console.warn(
-      "WARN: Could not find bootstrap single-instance lock — skipping Linux multi-instance bootstrap patch",
+      "WARN: Could not find bootstrap single-instance lock — Linux builds would allow unbounded duplicate instances",
     );
   }
   return currentSource;

--- a/scripts/patches/core/all-linux/extracted-app/bootstrap/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/bootstrap/patch.js
@@ -8,6 +8,9 @@ module.exports = {
   id: "linux-multi-instance-bootstrap-lock",
   phase: "extracted-app",
   order: 125,
-  ciPolicy: "optional",
+  // On bundles where bootstrap.js owns the single-instance lock, this is the
+  // only duplicate-instance protection Linux gets (the main-bundle patch
+  // defers to it), so a drifted needle must fail the build, not warn.
+  ciPolicy: "required-upstream",
   apply: patchLinuxMultiInstanceBootstrap,
 };

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2893,8 +2893,8 @@ if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permiss
     raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
 if not re.search(r'if needs_cold_start; then\s+clear_bundled_marketplace_tmp_cache\s+# The runtime marketplace is populated asynchronously.*?monitor_bundled_marketplace_tmp_permissions\s+sync_browser_use_bundled_plugin_cache\s+sync_chrome_bundled_plugin_cache\s+sync_computer_use_bundled_plugin_cache\s+sync_read_aloud_bundled_plugin_cache\s+run_cold_start_hooks\s+fi', runtime_body, re.S):
     raise SystemExit("bundled marketplace cleanup, plugin sync, and cold-start hooks must run only on cold start")
-if 'if needs_cold_start && [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
-    raise SystemExit("second-instance handoff must skip CLI lookup")
+if 'if [ -z "${CODEX_CLI_PATH:-}" ]; then' not in runtime_body:
+    raise SystemExit("launcher must run the cheap CLI lookup even for second-instance fallback")
 if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip missing-CLI failure")
 if '"$HOME/.bun/bin/codex"' not in source:
@@ -2950,8 +2950,10 @@ if 'pid_in_same_launch_instance "$pid"' not in discover_body:
 instance_match_body = source.split("pid_in_same_launch_instance() {", 1)[1].split("discover_running_app_pid() {", 1)[0]
 if 'CODEX_LINUX_INSTANCE_ID=$CODEX_LINUX_INSTANCE_ID' not in instance_match_body or 'CODEX_LINUX_MULTI_LAUNCH=1' not in instance_match_body:
     raise SystemExit("pid_in_same_launch_instance must match instance identity from the process environment")
-if 'acquire_launcher_lock\nreconcile_runtime_state\ndetect_warm_start' not in source:
-    raise SystemExit("launcher must serialize running-app detection behind the launcher lock")
+if 'refresh_launch_state\ntrap cleanup_launcher EXIT' not in source:
+    raise SystemExit("launcher must do an initial runtime-state refresh before warm-start IPC")
+if 'if needs_cold_start; then\n    acquire_launcher_lock\n    refresh_launch_state\nfi' not in source:
+    raise SystemExit("launcher must re-check runtime state under the launcher lock immediately before cold launch")
 if 'flock -w 30 9' not in source:
     raise SystemExit("launcher lock must use a bounded flock wait so a stuck launcher cannot block launches forever")
 if launch_body.count("release_launcher_lock") != 2:

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2860,8 +2860,10 @@ if 'Adopted concurrently-started verified webview server' not in source:
     raise SystemExit("launcher must tolerate a concurrent verified webview server winning the bind race")
 if 'RUNNING_APP_PID="$(find_running_app_pid)"' not in detect_body:
     raise SystemExit("detect_warm_start must record a pid-file running app even when warm start is disabled")
-if '[ -S "$LAUNCH_ACTION_SOCKET" ] && RUNNING_APP_PID="$(discover_running_app_pid)"' not in detect_body:
-    raise SystemExit("detect_warm_start must only use the expensive running-app scan when the launch socket exists")
+if 'RUNNING_APP_PID="$(find_running_app_pid)" || RUNNING_APP_PID="$(discover_running_app_pid)"' not in detect_body:
+    raise SystemExit("detect_warm_start must fall back to the running-app scan even when the launch socket is missing")
+if '[ -S "$LAUNCH_ACTION_SOCKET" ]' in detect_body:
+    raise SystemExit("detect_warm_start must not gate the running-app scan on launch socket existence; hidden instances can lose the socket")
 if not re.search(r'if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1; then.*?return 0', detect_body, re.S):
     raise SystemExit("detect_warm_start must not fail when warm start is disabled")
 if "preserving liveness marker for second-instance handoff" not in detect_body:
@@ -2934,7 +2936,7 @@ if ensure_body.find("stop_stale_webview_server") > ensure_body.find("is already 
     raise SystemExit("ensure_webview_server must try stale-server cleanup before foreign reachable-port failure")
 if "Keeping the live app untouched" not in ensure_body:
     raise SystemExit("ensure_webview_server must not stop a live app server when validation fails")
-if 'if live_app_pid="$(find_running_app_pid)" || { [ -S "$LAUNCH_ACTION_SOCKET" ] && live_app_pid="$(discover_running_app_pid)"; }; then' not in reconcile_body:
+if 'if live_app_pid="$(find_running_app_pid)" || live_app_pid="$(discover_running_app_pid)"; then' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must preserve runtime markers when a live app still exists")
 if 'rm -f "$LAUNCH_ACTION_SOCKET"' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must clear a stale launch-action socket when no live app exists")
@@ -2942,6 +2944,20 @@ if 'clear_stale_pid_file' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must still clear stale app.pid markers")
 if 'if [ -z "$webview_pid" ] || { ! pid_is_webview_server "$webview_pid" && ! pid_is_stale_webview_server "$webview_pid"; }; then' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must clear stale launcher webview ownership markers without touching valid orphaned servers")
+discover_body = source.split("discover_running_app_pid() {", 1)[1].split("running_app_is_active() {", 1)[0]
+if 'pid_in_same_launch_instance "$pid"' not in discover_body:
+    raise SystemExit("discover_running_app_pid must filter by launch instance so default and side-by-side apps never adopt each other")
+instance_match_body = source.split("pid_in_same_launch_instance() {", 1)[1].split("discover_running_app_pid() {", 1)[0]
+if 'CODEX_LINUX_INSTANCE_ID=$CODEX_LINUX_INSTANCE_ID' not in instance_match_body or 'CODEX_LINUX_MULTI_LAUNCH=1' not in instance_match_body:
+    raise SystemExit("pid_in_same_launch_instance must match instance identity from the process environment")
+if 'acquire_launcher_lock\nreconcile_runtime_state\ndetect_warm_start' not in source:
+    raise SystemExit("launcher must serialize running-app detection behind the launcher lock")
+if 'flock -w 30 9' not in source:
+    raise SystemExit("launcher lock must use a bounded flock wait so a stuck launcher cannot block launches forever")
+if launch_body.count("release_launcher_lock") != 2:
+    raise SystemExit("launch_electron must release the launcher lock on both the warm-start and cold-start paths")
+if launch_body.index("release_launcher_lock", launch_body.index('echo "$ELECTRON_PID" > "$APP_PID_FILE"')) > launch_body.index('wait "$ELECTRON_PID"'):
+    raise SystemExit("launch_electron must release the launcher lock after writing app.pid and before waiting on Electron")
 PY
     local launcher_probe
     local output


### PR DESCRIPTION
Two fixes for the duplicate-instance restart loop observed in production on SteamOS:

**1. Launcher: running-app detection survives lost markers** (`launcher/start.sh.template`)
- A hidden-to-tray instance could lose both its `app.pid` (clobbered by a failed duplicate launch's cleanup) and its launch-action socket; the `/proc` scan was gated on the socket existing, so the instance became undetectable and every launch cold-started a duplicate sharing the same user-data dir.
- The scan now always runs as fallback, filtered by instance identity from `/proc/<pid>/environ` so default and side-by-side multi-launch instances never adopt each other.
- The detection → spawn → `app.pid` write critical section is serialized with a bounded `flock`.

**2. Bootstrap: enforce the single-instance lock on Linux** (`scripts/patches/bootstrap.js`)
- Upstream gates `requestSingleInstanceLock()` behind a flag computed from `{isMacOS, isPackaged}` — always false on Linux — so packaged Linux builds ran with **no** duplicate-instance protection (verified: no `SingletonLock` in the profile dir while the app runs). The previous patch only added the multi-launch bypass and preserved the `!flag ||` short-circuit.
- The gate is rewritten to a platform ternary: Linux always takes the lock unless `CODEX_LINUX_MULTI_LAUNCH=1`; other platforms keep upstream semantics. Legacy-guarded bundles are upgraded in place.
- Patch promoted to `required-upstream` since main-process defers single-instance handling to bootstrap on current bundles.

Verified end-to-end on SteamOS against DMG 26.608.12217 and 26.609.30741: `SingletonLock` now appears in the profile dir, and a second launch with all launcher markers wiped rediscovers the live instance and hands off instead of duplicating. `node --test scripts/patch-linux-window-ui.test.js` (204 pass) and `tests/scripts_smoke.sh` launcher assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)