### PR TITLE
fix(packaging): order libasound2t64 first to match other t64 deps

### DIFF
--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: Codex Desktop Linux Maintainers
-Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2 | libasound2t64, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, libasound2t64 | libasound2, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
 Recommends: zenity, kdialog
 Description: Codex Desktop for Linux
  Community-built Linux package for Codex Desktop generated from the macOS DMG.


### PR DESCRIPTION
The `Depends` line lists `libasound2 | libasound2t64` (non-t64 first), which is inconsistent with the other three t64 libraries that are already ordered t64-first (`libcups2t64 | libcups2`, `libglib2.0-0t64 | libglib2.0-0`, `libgtk-3-0t64 | libgtk-3-0`).

On Debian 13 (trixie) the real package is `libasound2t64`; `libasound2` is not provided, so the alternative still resolves — but listing the t64 variant first is the correct, consistent form and avoids the resolver preferring a non-existent/transitional name on mixed systems.

Verified: the package builds, installs, and runs on Debian 13 trixie with `libasound2t64 1.2.14-1` (upstream app `26.609.41114`, Electron `42.1.0`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
