### PR TITLE
fix(linux): prevent IAB_LIFECYCLE sidebar rebound loop (windowId-based lookup)

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3956,7 +3956,7 @@ test("patches later Browser Use navigation dispatches when an earlier one is alr
   assert.doesNotMatch(patched, /browser-use-non-local-sites-allowed-changed`,\{allowed:p\}/);
 });
 
-test("falls back to the single live Linux Browser Use route window", () => {
+test("resolves the requested live Linux Browser Use route window by id", () => {
   const source =
     "var kK=t.Ur(`browser-sidebar-manager`);" +
     "function AK({ensureWindowState:e,windowId:t,windows:n}){let i=n.get(t)??null;if(i==null){let n=r.BrowserWindow.fromId(t);n!=null&&!n.isDestroyed()&&!n.webContents.isDestroyed()&&(i=e(n,n.webContents))}return i==null||i.window.isDestroyed()||i.owner.isDestroyed()?(kK().warning(`IAB_LIFECYCLE route window is not live`,{safe:{hasWindowState:i!=null,ownerDestroyed:i?.owner.isDestroyed()??null,windowDestroyed:i?.window.isDestroyed()??null,windowId:t},sensitive:{}}),null):i}";
@@ -3967,20 +3967,67 @@ test("falls back to the single live Linux Browser Use route window", () => {
   assert.match(patched, /i==null&&\(i=codexLinuxResolveLiveBrowserUseRouteWindow\(e,t,n,r\)\);return/);
   assert.equal((patched.match(/codexLinuxResolveLiveBrowserUseRouteWindow/g) || []).length, 2);
 
-  const webContents = { isDestroyed: () => false };
-  const window = { id: 7, isDestroyed: () => false, webContents };
+  const requestedWebContents = { isDestroyed: () => false };
+  const unrelatedWebContents = { isDestroyed: () => false };
+  const requestedWindow = { id: 42, isDestroyed: () => false, webContents: requestedWebContents };
+  const unrelatedWindow = { id: 7, isDestroyed: () => false, webContents: unrelatedWebContents };
+  let warnings = 0;
+  let getAllWindowsCalls = 0;
   const context = {
     process: { platform: "linux" },
-    r: { BrowserWindow: { fromId: () => null, getAllWindows: () => [window] } },
-    t: { Ur: () => () => ({ warning: () => assert.fail("fallback should avoid warning") }) },
+    r: {
+      BrowserWindow: {
+        fromId: (id) => (id === 42 ? requestedWindow : null),
+        getAllWindows: () => {
+          getAllWindowsCalls += 1;
+          return [unrelatedWindow];
+        },
+      },
+    },
+    t: { Ur: () => () => ({ warning: () => { warnings += 1; } }) },
   };
   const result = vm.runInNewContext(
     `${patched};AK({ensureWindowState:(window,owner)=>({owner,threads:new Map,window}),windowId:42,windows:new Map})`,
     context,
   );
 
-  assert.equal(result.window.id, 7);
-  assert.equal(result.owner, webContents);
+  assert.equal(result.window.id, 42);
+  assert.equal(result.owner, requestedWebContents);
+  assert.equal(warnings, 0);
+  assert.equal(getAllWindowsCalls, 0);
+});
+
+test("does not fall back to an unrelated single live Linux Browser Use route window", () => {
+  const source =
+    "var kK=t.Ur(`browser-sidebar-manager`);" +
+    "function AK({ensureWindowState:e,windowId:t,windows:n}){let i=n.get(t)??null;if(i==null){let n=r.BrowserWindow.fromId(t);n!=null&&!n.isDestroyed()&&!n.webContents.isDestroyed()&&(i=e(n,n.webContents))}return i==null||i.window.isDestroyed()||i.owner.isDestroyed()?(kK().warning(`IAB_LIFECYCLE route window is not live`,{safe:{hasWindowState:i!=null,ownerDestroyed:i?.owner.isDestroyed()??null,windowDestroyed:i?.window.isDestroyed()??null,windowId:t},sensitive:{}}),null):i}";
+
+  const patched = applyPatchTwice(applyLinuxBrowserUseRouteLivenessPatch, source);
+  const webContents = { isDestroyed: () => false };
+  const unrelatedWindow = { id: 7, isDestroyed: () => false, webContents };
+  let warnings = 0;
+  let getAllWindowsCalls = 0;
+  const context = {
+    process: { platform: "linux" },
+    r: {
+      BrowserWindow: {
+        fromId: () => null,
+        getAllWindows: () => {
+          getAllWindowsCalls += 1;
+          return [unrelatedWindow];
+        },
+      },
+    },
+    t: { Ur: () => () => ({ warning: () => { warnings += 1; } }) },
+  };
+  const result = vm.runInNewContext(
+    `${patched};AK({ensureWindowState:(window,owner)=>({owner,window}),windowId:42,windows:new Map})`,
+    context,
+  );
+
+  assert.equal(result, null);
+  assert.equal(warnings, 1);
+  assert.equal(getAllWindowsCalls, 0);
 });
 
 test("keeps Browser Use route liveness fallback inactive when ambiguous", () => {

--- a/scripts/patches/main-process/browser.js
+++ b/scripts/patches/main-process/browser.js
@@ -126,7 +126,11 @@ function applyLinuxBrowserUseRouteLivenessPatch(currentSource) {
     loggerVar,
   ] = match;
 
-  const helper = `function codexLinuxResolveLiveBrowserUseRouteWindow(e,t,n,r){if(process.platform!==\`linux\`)return null;let i=[];try{for(let e of n.values())e!=null&&!e.window.isDestroyed()&&!e.owner.isDestroyed()&&i.push(e)}catch{}if(i.length===1)return i[0];let a=[];try{a=r.BrowserWindow.getAllWindows().filter(e=>e!=null&&!e.isDestroyed()&&!e.webContents.isDestroyed())}catch{return null}if(a.length!==1)return null;let o=a[0],s=n.get(o.id)??null;return s!=null&&!s.window.isDestroyed()&&!s.owner.isDestroyed()?s:e(o,o.webContents)}`;
+  // Fix: use windowId-based lookup instead of "first live" heuristic.
+  // The old heuristic returned arbitrary live windows that may not match
+  // the requested windowId, causing IAB_LIFECYCLE rebound loops where the
+  // sidebar webview was created, destroyed, and re-created in a cycle.
+  const helper = `function codexLinuxResolveLiveBrowserUseRouteWindow(e,t,n,r){if(process.platform!==\`linux\`)return null;let o=r.BrowserWindow.fromId(t);if(o!=null&&!o.isDestroyed()&&!o.webContents.isDestroyed())return e(o,o.webContents);let s=n.get(t)??null;return s!=null&&!s.window.isDestroyed()&&!s.owner.isDestroyed()?s:null}`;
   const replacement = `${helper}function ${functionName}({ensureWindowState:${ensureWindowStateVar},windowId:${windowIdVar},windows:${windowsVar}}){let ${stateVar}=${windowsVar}.get(${windowIdVar})??null;if(${stateVar}==null){let ${browserWindowVar}=${electronVar}.BrowserWindow.fromId(${windowIdVar});${browserWindowVar}!=null&&!${browserWindowVar}.isDestroyed()&&!${browserWindowVar}.webContents.isDestroyed()&&(${stateVar}=${ensureWindowStateVar}(${browserWindowVar},${browserWindowVar}.webContents))}${stateVar}==null&&(${stateVar}=codexLinuxResolveLiveBrowserUseRouteWindow(${ensureWindowStateVar},${windowIdVar},${windowsVar},${electronVar}));return ${stateVar}==null||${stateVar}.window.isDestroyed()||${stateVar}.owner.isDestroyed()?(${loggerVar}().warning(\`IAB_LIFECYCLE route window is not live\`,{safe:{hasWindowState:${stateVar}!=null,ownerDestroyed:${stateVar}?.owner.isDestroyed()??null,windowDestroyed:${stateVar}?.window.isDestroyed()??null,windowId:${windowIdVar}},sensitive:{}}),null):${stateVar}}`;
 
   return currentSource.replace(original, replacement);


### PR DESCRIPTION
## Problem
`codexLinuxResolveLiveBrowserUseRouteWindow()` uses a "first live window" heuristic instead of matching the requested `windowId`. During Electron startup when the main window is the only one, this eagerly binds to it, then hidden windows appear and IAB_LIFECYCLE enters a destroy+recreate rebound loop → sidebar text overlap/ghosting.

Fixes #485

## Change
Replace the heuristic with a direct `BrowserWindow.fromId(windowId)` lookup — the function now correctly uses the `windowId` parameter it was already receiving:

- **Old**: iterate `getAllWindows()` → if exactly 1 → force bind (regardless of windowId)
- **New**: `fromId(windowId)` → if live → create state from it; otherwise check state map by id

## Tested
- Ubuntu 24.04 LTS, X11, Electron 42.1.0, AMD Phoenix3 GPU
- Before: sidebar text overlap/ghosting, IAB_LIFECYCLE rebound loop in logs
- After: sidebar renders correctly, clean IAB_LIFECYCLE init (registered once, no rebounds)
- Browser Use functionality preserved (route window lookup still works)