### PR TITLE
[codex] Fix Linux avatar overlay reply focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The avatar overlay is focusable on Linux so inline pet reply inputs can accept
+  keyboard input after being clicked.
 - Plugin marketplace browsing now preserves upstream's `remote_plugin`
   feature sync on Linux, so current app servers can load the remote OpenAI
   curated catalog instead of falling back to only locally installed plugins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - The avatar overlay is focusable on Linux so inline pet reply inputs can accept
-  keyboard input after being clicked.
+  keyboard input after being clicked, while still staying above the main Codex
+  window as an overlay.
 - Plugin marketplace browsing now preserves upstream's `remote_plugin`
   feature sync on Linux, so current app servers can load the remote OpenAI
   curated catalog instead of falling back to only locally installed plugins.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1816,7 +1816,7 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /this\.window===t&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
 });
 
-test("makes Linux avatar overlay focusable for inline reply inputs", () => {
+test("keeps Linux avatar overlay above the app while reply inputs are focusable", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,
     avatarOverlayBundleFixture(),
@@ -1824,7 +1824,7 @@ test("makes Linux avatar overlay focusable for inline reply inputs", () => {
 
   assert.match(
     patched,
-    /appearance:`avatarOverlay`,focusable:process\.platform===`linux`\?!0:!1,show:!1/,
+    /appearance:`avatarOverlay`,alwaysOnTop:process\.platform===`linux`,skipTaskbar:process\.platform===`linux`,focusable:process\.platform===`linux`\?!0:!1,show:!1/,
   );
   assert.doesNotMatch(patched, /appearance:`avatarOverlay`,focusable:!1,show:!1/);
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1816,6 +1816,25 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /this\.window===t&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
 });
 
+test("makes Linux avatar overlay focusable for inline reply inputs", () => {
+  const patched = applyPatchTwice(
+    applyLinuxAvatarOverlayMousePassthroughPatch,
+    avatarOverlayBundleFixture(),
+  );
+
+  assert.match(
+    patched,
+    /appearance:`avatarOverlay`,focusable:process\.platform===`linux`\?!0:!1,show:!1/,
+  );
+  assert.doesNotMatch(patched, /appearance:`avatarOverlay`,focusable:!1,show:!1/);
+
+  const nonAvatarSource = "async createWindow(){return this.windowManager.createWindow({appearance:`main`,focusable:!1,show:!1})}";
+  assert.equal(
+    applyPatchTwice(applyLinuxAvatarOverlayMousePassthroughPatch, nonAvatarSource),
+    nonAvatarSource,
+  );
+});
+
 test("Linux avatar overlay treats visible window content as interactive fallback", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -44,15 +44,21 @@ function avatarApplyInputShapePatch() {
   return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
 }
 
-function patchAvatarOverlayFocusable(source) {
-  const focusablePatch = "appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1";
-  if (source.includes(focusablePatch)) {
+function patchAvatarOverlayWindowOptions(source) {
+  const windowOptionsPatch =
+    "appearance:`avatarOverlay`,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
+  if (source.includes(windowOptionsPatch)) {
     return source;
   }
-  return source.replace(
-    "appearance:`avatarOverlay`,focusable:!1",
-    focusablePatch,
-  );
+  return source
+    .replace(
+      "appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1",
+      windowOptionsPatch,
+    )
+    .replace(
+      "appearance:`avatarOverlay`,focusable:!1",
+      windowOptionsPatch,
+    );
 }
 
 function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
@@ -134,9 +140,9 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   }
   patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
   const beforeFocusablePatch = patchedSource;
-  patchedSource = patchAvatarOverlayFocusable(patchedSource);
+  patchedSource = patchAvatarOverlayWindowOptions(patchedSource);
   recordStrategy(
-    "avatar-focusable",
+    "avatar-window-options",
     patchedSource === beforeFocusablePatch
       ? patchedSource.includes("appearance:`avatarOverlay`") ? "already-applied" : "none"
       : "upstream",

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -44,6 +44,17 @@ function avatarApplyInputShapePatch() {
   return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
 }
 
+function patchAvatarOverlayFocusable(source) {
+  const focusablePatch = "appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1";
+  if (source.includes(focusablePatch)) {
+    return source;
+  }
+  return source.replace(
+    "appearance:`avatarOverlay`,focusable:!1",
+    focusablePatch,
+  );
+}
+
 function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
   let patched = source;
   patched = replaceAvatarMethod(
@@ -122,6 +133,14 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     );
   }
   patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
+  const beforeFocusablePatch = patchedSource;
+  patchedSource = patchAvatarOverlayFocusable(patchedSource);
+  recordStrategy(
+    "avatar-focusable",
+    patchedSource === beforeFocusablePatch
+      ? patchedSource.includes("appearance:`avatarOverlay`") ? "already-applied" : "none"
+      : "upstream",
+  );
 
   const startDragPatch =
     `displayBounds:${electronVar}.screen.getDisplayNearestPoint(${electronVar}.screen.getCursorScreenPoint()).bounds},process.platform===\`linux\`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())}moveDrag(e){`;


### PR DESCRIPTION
## Summary

- make the avatar overlay focusable on Linux so inline reply inputs accept keyboard input
- keep the focusable Linux overlay above the main Codex window with Linux-only overlay window options
- add regression coverage for the reply-input and overlay stacking behavior

## Root cause

The Linux avatar overlay was still created as non-focusable, which lets it receive mouse interactions but prevents the inline reply input from reliably accepting keyboard input. Making it focusable fixes typing, but on Linux it also removes the implicit window-manager behavior that kept the old non-focusable overlay above the app, so the patch adds explicit Linux-only overlay options for that case.

## Validation

- `node --test --test-name-pattern "avatar overlay|keeps Linux avatar overlay above" scripts/patch-linux-window-ui.test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
