### PR TITLE
[codex] Fix AppShots availability patch

### DIFF
--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -12,16 +12,16 @@ function warn(message, patchName) {
 }
 
 function applyLinuxAppshotAvailabilityPatch(currentSource) {
-  if (currentSource.includes("===`linux`||") && currentSource.includes("===`macOS`&&")) {
+  if (currentSource.includes("!==`linux`&&(") && currentSource.includes("!==`macOS`||")) {
     return currentSource;
   }
 
   let changed = false;
   const patchedSource = currentSource.replace(
-    /return ([A-Za-z_$][\w$]*)===`macOS`&&([A-Za-z_$][\w$]*)/g,
-    (match, platformVar, flagVar) => {
+    /if\(([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)!==`macOS`\|\|!([A-Za-z_$][\w$]*)\(([^)]*?)\)\)return!1;/g,
+    (match, platformGetFn, platformAtomVar, flagGetFn, flagArgs) => {
       changed = true;
-      return `return ${platformVar}===\`linux\`||${platformVar}===\`macOS\`&&${flagVar}`;
+      return `if(${platformGetFn}(${platformAtomVar})!==\`linux\`&&(${platformGetFn}(${platformAtomVar})!==\`macOS\`||!${flagGetFn}(${flagArgs})))return!1;`;
     },
   );
 
@@ -37,7 +37,7 @@ function applyLinuxAppshotAvailabilityPatch(currentSource) {
 
 function applyLinuxAppshotMainProcessPatch(currentSource) {
   if (currentSource.includes(APPSHOT_HELPER_MARKER)) {
-    return repairLinuxAppshotRendererSender(currentSource);
+    return currentSource;
   }
 
   const sendMessageFn = findMessageForViewSendFunction(currentSource);
@@ -75,21 +75,6 @@ function applyLinuxAppshotMainProcessPatch(currentSource) {
 }
 
 function applyLinuxAppshotHotkeyPatch(currentSource) {
-  currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?`DoubleShift`:([A-Za-z_$][\w$]*)\);/g,
-    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar) =>
-      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
-  );
-  currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\);/g,
-    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar) =>
-      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});`,
-  );
-  currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*);let ([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:\1,isActive:\5!=null\}\)/g,
-    (match, configuredVar, globalStateVar, getterName, defaultHotkeyVar, registrationVar, stateFnVar, enabledVar) =>
-      `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null})`,
-  );
   currentSource = currentSource.replace(
     /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\),([A-Za-z_$][\w$]*)=\1===void 0\?([A-Za-z_$][\w$]*):\1,([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\4,isActive:\6!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\6\?\.unregister\(\),\6=null,!\8\|\|process\.platform!==`darwin`\|\|\4==null\)\{/g,
     (
@@ -184,15 +169,7 @@ function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
   }
 
   let changed = false;
-  let patchedSource = currentSource.replace(
-    /((?:var\s+|,)([A-Za-z_$][\w$]*)=typeof navigator!=`undefined`&&navigator\.userAgent\.includes\(`Linux`\)\?)\[[^\]]+\]:(\[\{hotkey:`DoubleCommand`,label:`[^`]+`\},\{hotkey:`DoubleOption`,label:`[^`]+`\},\{hotkey:`DoubleShift`,label:`[^`]+`\}\])(?=;)/,
-    (match, linuxPrefix, optionsVar, macOptions) => {
-      changed = true;
-      return `${linuxPrefix}${linuxOptions}:${macOptions}`;
-    },
-  );
-
-  patchedSource = patchedSource.replace(
+  const patchedSource = currentSource.replace(
     /((?:var\s+|,)([A-Za-z_$][\w$]*)=)(\[\{hotkey:`DoubleCommand`,label:`[^`]+`\},\{hotkey:`DoubleOption`,label:`[^`]+`\},\{hotkey:`DoubleShift`,label:`[^`]+`\}\])(?=;)/,
     (match, declarationPrefix, optionsVar, macOptions) => {
       changed = true;
@@ -208,19 +185,6 @@ function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
     warn("Could not find AppShots settings hotkey options", "Linux AppShots settings patch");
   }
   return currentSource;
-}
-
-function repairLinuxAppshotRendererSender(source) {
-  const sendMessageFn = findMessageForViewSendFunction(source);
-  if (sendMessageFn == null) {
-    return source;
-  }
-
-  return source.replace(
-    /function codexLinuxAppshotSend\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{try\{[A-Za-z_$][\w$]*\(\1,\{requestId:\2,type:`computer-use-capture-updated`,update:\3\}\)\}catch\{\}\}/,
-    (match, originVar, requestIdVar, updateVar) =>
-      `function codexLinuxAppshotSend(${originVar},${requestIdVar},${updateVar}){try{${sendMessageFn}(${originVar},{requestId:${requestIdVar},type:\`computer-use-capture-updated\`,update:${updateVar}})}catch{}}`,
-  );
 }
 
 function findMessageForViewSendFunction(source) {
@@ -301,7 +265,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^use-is-appshot-available-.*\.js$/,
+    pattern: /^appshot-availability-.*\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -27,8 +27,15 @@ function applyPatchTwice(patchFn, source) {
   return once;
 }
 
-function appshotAvailabilityBundleFixture() {
-  return "function t(n,r){return n===`macOS`&&r}";
+function appshotAvailabilityAtomBundleFixture() {
+  return [
+    "import{c as e,l as t,t as n}from\"./app-scope.js\";",
+    "import{v as r}from\"./app-server-manager-signals.js\";",
+    "import{f as i}from\"./statsig.js\";",
+    "import{n as a}from\"./platform.js\";",
+    "import{c as o}from\"./config-queries.js\";",
+    "var s=t(n,(e,{get:t})=>{if(t(a)!==`macOS`||!t(i,`1304276663`))return!1;let{data:n}=t(o,{hostId:e});return n!=null&&n.requirements?.allowAppshots!==!1}),c=e(n,({get:e})=>e(s,e(r)));export{s as n,c as t};",
+  ].join("");
 }
 
 function appshotMainProcessBundleFixture() {
@@ -67,13 +74,6 @@ function appshotSettingsBundleFixture() {
     "var O=d(),A=e(t(),1),j=n(),M=[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}];",
     "function N(){let{data:h}=l(`appshot-hotkey-state`,{queryConfig:{enabled:t}}),x=c(`appshot-set-hotkey`);let w=h?.configuredHotkey??null,E=M.find(e=>e.hotkey===w)??null;return E}",
   ].join("");
-}
-
-function previouslyPatchedAppshotSettingsBundleFixture() {
-  return appshotSettingsBundleFixture().replace(
-    "M=[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}]",
-    "M=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)?[{hotkey:`Ctrl+Alt+A`,label:`Ctrl + Alt + A`},{hotkey:`Alt+Shift+A`,label:`Alt + Shift + A`},{hotkey:`Ctrl+Shift+A`,label:`Ctrl + Shift + A`}]:[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}]",
-  );
 }
 
 test("appshots stays disabled until listed in features.json", () => {
@@ -116,6 +116,14 @@ test("appshots feature descriptors are optional", () => {
   assert.ok(descriptors.every((descriptor) => descriptor.ciPolicy == null));
 });
 
+test("appshots availability descriptor matches the current bundle", () => {
+  const descriptor = descriptors.find(
+    (descriptor) => descriptor.id === "linux-appshots-availability",
+  );
+
+  assert.ok(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"));
+});
+
 test("stages the Linux bare modifier monitor helper", () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
   const helperSource = fs.readFileSync(
@@ -146,13 +154,17 @@ test("stages the Linux bare modifier monitor helper", () => {
   execFileSync("bash", ["-n", path.join(__dirname, "bin", "bare-modifier-monitor")]);
 });
 
-test("enables AppShots availability on Linux", () => {
+test("enables AppShots availability atom on Linux", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotAvailabilityPatch,
-    appshotAvailabilityBundleFixture(),
+    appshotAvailabilityAtomBundleFixture(),
   );
 
-  assert.equal(patched, "function t(n,r){return n===`linux`||n===`macOS`&&r}");
+  assert.match(
+    patched,
+    /if\(t\(a\)!==`linux`&&\(t\(a\)!==`macOS`\|\|!t\(i,`1304276663`\)\)\)return!1;/,
+  );
+  assert.match(patched, /requirements\?\.allowAppshots!==!1/);
 });
 
 test("finds only the raw renderer message sender", () => {
@@ -288,37 +300,4 @@ test("shows Linux AppShots accelerator choices in settings", () => {
   assert.doesNotMatch(patched, /hotkey:`Ctrl\+Alt\+A`/);
   assert.match(patched, /hotkey:`DoubleCommand`,label:`\\u2318 \+ \\u2318`/);
   assert.match(patched, /hotkey:`DoubleShift`,label:`\\u21e7 \+ \\u21e7`/);
-});
-
-test("upgrades stale Linux AppShots settings accelerators", () => {
-  const patched = applyPatchTwice(
-    applyLinuxAppshotSettingsHotkeyPatch,
-    previouslyPatchedAppshotSettingsBundleFixture(),
-  );
-
-  assert.match(patched, /hotkey:`DoubleOption`,label:`Alt \+ Alt`/);
-  assert.match(patched, /hotkey:`DoubleShift`,label:`Shift \+ Shift`/);
-  assert.match(patched, /hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`/);
-  assert.doesNotMatch(patched, /Alt\+Super\+A/);
-  assert.doesNotMatch(patched, /Ctrl\+Alt\+A/);
-  assert.doesNotMatch(patched, /Alt\+Shift\+A/);
-  assert.doesNotMatch(patched, /Ctrl\+Shift\+A/);
-});
-
-test("repairs AppShots renderer updates in already-patched bundles", () => {
-  const patched = applyLinuxAppshotMainProcessPatch(appshotMainProcessBundleFixture());
-  const regressed = patched.replace(
-    "rS(e,{requestId:t,type:`computer-use-capture-updated`,update:n})",
-    "nS(e,{requestId:t,type:`computer-use-capture-updated`,update:n})",
-  );
-  const repaired = applyLinuxAppshotMainProcessPatch(regressed);
-
-  assert.match(
-    repaired,
-    /function codexLinuxAppshotSend\(e,t,n\)\{try\{rS\(e,\{requestId:t,type:`computer-use-capture-updated`,update:n\}\)\}catch\{\}\}/,
-  );
-  assert.doesNotMatch(
-    repaired,
-    /function codexLinuxAppshotSend\(e,t,n\)\{try\{nS\(e,\{requestId:t,type:`computer-use-capture-updated`,update:n\}\)\}catch\{\}\}/,
-  );
 });


### PR DESCRIPTION
## Summary

- update the AppShots availability patch to match the current appshot-availability bundle
- remove stale legacy AppShots compatibility paths from the optional feature patcher
- update focused AppShots feature tests for the current upstream bundle shape

## User-visible behavior

- AppShots availability can be enabled on Linux again when the appshots feature is enabled.

## Root cause

Upstream moved AppShots availability from the old use-is-appshot-available bundle shape to the current appshot-availability atom bundle, so the Linux feature descriptor no longer matched the asset that gates AppShots settings/UI availability.

## Validation

- node --test linux-features/appshots/test.js
- git diff --check
- ./install.sh ./Codex.dmg
