### PR TITLE
fix: allow address reuse and daemonize threads in webview server

### DIFF
--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -52,6 +52,11 @@ class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
         super().end_headers()
 
 
+class CodexHTTPServer(http.server.ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
 handler = functools.partial(CodexWebviewHandler, directory=".")
-with http.server.ThreadingHTTPServer((bind, port), handler) as httpd:
+with CodexHTTPServer((bind, port), handler) as httpd:
     httpd.serve_forever()


### PR DESCRIPTION
This change ensures the webview backend server can be restarted immediately by enabling SO_REUSEADDR, which prevents 'Address already in use' errors caused by sockets remaining in a TIME_WAIT state. Additionally, daemon_threads is enabled to ensure request threads do not block process termination, improving overall reliability and handling of rapid application restarts.