### PR TITLE
[codex] Fail builds on critical Linux patch drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -705,6 +705,19 @@ test("default core patch descriptors are grouped and unique", () => {
     descriptors.find((descriptor) => descriptor.id === "local-environment-action-modal-draft")?.ciPolicy,
     "optional",
   );
+  for (const id of [
+    "linux-window-options",
+    "linux-native-titlebar",
+    "linux-opaque-background",
+    "linux-avatar-overlay-mouse-passthrough",
+    "linux-tray",
+  ]) {
+    assert.equal(
+      descriptors.find((descriptor) => descriptor.id === id)?.ciPolicy,
+      "required-upstream",
+      `${id} should block upstream builds when it drifts`,
+    );
+  }
 
   const descriptorOrder = new Map(descriptors.map((descriptor) => [descriptor.id, descriptor.order]));
   assert.ok(
@@ -5040,16 +5053,20 @@ test("patchExtractedApp records a structured patch report", () => {
     assert.equal(report.iconAsset, "app-test.png");
     assert.equal(report.desktopName, "codex-desktop.desktop");
     assert.deepEqual(report.enabledFeatures, enabledLinuxFeatureIds());
-    // Browser/Computer Use integration drift is optional: the aggregate stays
-    // applied because no required main-bundle patch warned on this fixture.
+    // Browser/Computer Use integration drift is optional, but window-shell
+    // drift is critical: this partial fixture lacks the titlebar shape.
     assert.ok(
       report.patches.some(
         (patch) =>
           patch.name === "main-process-ui" &&
-          patch.status === "applied" &&
+          patch.status === "failed-required" &&
           patch.sourceKind === "core" &&
-          patch.warnings === undefined,
+          Array.isArray(patch.warnings) &&
+          patch.warnings.some((warning) => warning.includes("Linux native titlebar patch")),
       ),
+    );
+    assert.ok(
+      criticalFailuresFromReport(report).some((failure) => failure.name === "linux-native-titlebar"),
     );
     assert.ok(
       optionalDriftFromReport(report).some((drift) => drift.name === "linux-chrome-plugin-auto-install"),
@@ -5913,6 +5930,42 @@ test("patcher CLI --enforce-critical exits non-zero with an aggregated message",
       { encoding: "utf8" },
     );
     assert.equal(lenient.status, 0, lenient.stderr);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patcher CLI --enforce-critical treats window-shell drift as critical", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-critical-window-shell-cli-test-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    const reportPath = path.join(tempRoot, "reports", "patch-report.json");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), mainBundlePrefix);
+    fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(__dirname, "patch-linux-window-ui.js"),
+        "--enforce-critical",
+        "--report-json",
+        reportPath,
+        tempRoot,
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /linux-opaque-background \(failed-required\)/);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+    assert.ok(
+      criticalFailuresFromReport(report).some(
+        (failure) => failure.name === "linux-opaque-background" && failure.status === "failed-required",
+      ),
+    );
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -29,7 +29,7 @@ module.exports = [
     id: "linux-window-options",
     phase: "main-bundle",
     order: 50,
-    ciPolicy: "optional",
+    ciPolicy: "required-upstream",
     apply: (source, context) => applyLinuxWindowOptionsPatch(source, context.iconAsset),
   },
   {
@@ -43,7 +43,7 @@ module.exports = [
     id: "linux-native-titlebar",
     phase: "main-bundle",
     order: 85,
-    ciPolicy: "optional",
+    ciPolicy: "required-upstream",
     apply: applyLinuxNativeTitlebarPatch,
   },
   {
@@ -71,14 +71,14 @@ module.exports = [
     id: "linux-opaque-background",
     phase: "main-bundle",
     order: 80,
-    ciPolicy: "optional",
+    ciPolicy: "required-upstream",
     apply: applyLinuxOpaqueBackgroundPatch,
   },
   {
     id: "linux-avatar-overlay-mouse-passthrough",
     phase: "main-bundle",
     order: 90,
-    ciPolicy: "optional",
+    ciPolicy: "required-upstream",
     apply: applyLinuxAvatarOverlayMousePassthroughPatch,
   },
   {
@@ -92,7 +92,7 @@ module.exports = [
     id: "linux-tray",
     phase: "main-bundle",
     order: 110,
-    ciPolicy: "optional",
+    ciPolicy: "required-upstream",
     apply: (source, context) => applyLinuxTrayPatch(source, context.iconPathExpression),
   },
   {


### PR DESCRIPTION
Fixes #492

## Summary
- Add a `--validate-required` mode to the ASAR patcher and use it during real installer builds.
- Promote the critical Linux window/tray/opaque-background patch descriptors to `required-upstream`.
- Add coverage proving required patch drift makes the patcher exit non-zero while still writing a report.

## Impact
When upstream changes cause critical Linux patches to miss, install/rebuild flows now stop instead of packaging an app with transparent windows, missing tray support, or related shell regressions. Inspect-only flows can still produce reports for diagnosis.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash -n install.sh`
- `bash -n scripts/lib/*.sh`
- `bash -n launcher/start.sh.template`
- `bash -n scripts/build-deb.sh && bash -n scripts/build-rpm.sh && bash -n scripts/build-pacman.sh && bash -n scripts/build-appimage.sh`

## Notes
- `bash tests/scripts_smoke.sh` currently stops in `test_v8_nullptr_workaround_wraps_when_included_probe_fails` with exit 126 while invoking the generated fake CXX wrapper; this appears unrelated to this patcher change and occurs before the patcher-specific smoke coverage.