### PR TITLE
[codex] fix Computer Use settings path

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4808,11 +4808,13 @@ function withIsolatedHome(body) {
   const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousAppId = process.env.CODEX_APP_ID;
   const previousLinuxAppId = process.env.CODEX_LINUX_APP_ID;
+  const previousSettingsFile = process.env.CODEX_LINUX_SETTINGS_FILE;
   const previousFlag = process.env[COMPUTER_USE_UI_ENV_VAR];
   process.env.HOME = tempHome;
   delete process.env.XDG_CONFIG_HOME;
   delete process.env.CODEX_APP_ID;
   delete process.env.CODEX_LINUX_APP_ID;
+  delete process.env.CODEX_LINUX_SETTINGS_FILE;
   delete process.env[COMPUTER_USE_UI_ENV_VAR];
   try {
     return body(tempHome);
@@ -4836,6 +4838,11 @@ function withIsolatedHome(body) {
       delete process.env.CODEX_LINUX_APP_ID;
     } else {
       process.env.CODEX_LINUX_APP_ID = previousLinuxAppId;
+    }
+    if (previousSettingsFile == null) {
+      delete process.env.CODEX_LINUX_SETTINGS_FILE;
+    } else {
+      process.env.CODEX_LINUX_SETTINGS_FILE = previousSettingsFile;
     }
     if (previousFlag == null) {
       delete process.env[COMPUTER_USE_UI_ENV_VAR];
@@ -4878,6 +4885,24 @@ test("isComputerUseUiEnabled honours side-by-side CODEX_APP_ID settings", () => 
   withIsolatedHome((home) => {
     process.env.CODEX_APP_ID = "codex-cua-lab";
     writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "codex-cua-lab");
+    assert.equal(isComputerUseUiEnabled(), true);
+  });
+});
+
+test("isComputerUseUiEnabled prefers CODEX_LINUX_APP_ID settings", () => {
+  withIsolatedHome((home) => {
+    process.env.CODEX_LINUX_APP_ID = "codex-cua-lab";
+    process.env.CODEX_APP_ID = "codex-desktop";
+    writeSettingsFile(home, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "codex-cua-lab");
+    assert.equal(isComputerUseUiEnabled(), true);
+  });
+});
+
+test("isComputerUseUiEnabled honours CODEX_LINUX_SETTINGS_FILE", () => {
+  withIsolatedHome((home) => {
+    const settingsFile = path.join(home, "custom-settings.json");
+    fs.writeFileSync(settingsFile, JSON.stringify({ [COMPUTER_USE_UI_SETTINGS_KEY]: true }), "utf8");
+    process.env.CODEX_LINUX_SETTINGS_FILE = settingsFile;
     assert.equal(isComputerUseUiEnabled(), true);
   });
 });

--- a/scripts/patches/computer-use.js
+++ b/scripts/patches/computer-use.js
@@ -37,6 +37,10 @@ function readComputerUseUiSettingsFlag(env) {
 }
 
 function computerUseUiSettingsPath(env) {
+  const override = env.CODEX_LINUX_SETTINGS_FILE;
+  if (typeof override === "string" && override.length > 0) {
+    return override;
+  }
   const xdgConfig = env.XDG_CONFIG_HOME;
   const home = env.HOME;
   const configHome = (xdgConfig && xdgConfig.length > 0)
@@ -52,7 +56,7 @@ function computerUseUiSettingsPath(env) {
 }
 
 function computerUseUiSettingsAppId(env) {
-  const appId = env.CODEX_APP_ID || env.CODEX_LINUX_APP_ID || "codex-desktop";
+  const appId = env.CODEX_LINUX_APP_ID || env.CODEX_APP_ID || "codex-desktop";
   return /^[A-Za-z0-9._-]+$/.test(appId) ? appId : "codex-desktop";
 }
 


### PR DESCRIPTION
## Summary

Fix the build-time Computer Use UI settings reader so it resolves the same settings file that the Linux runtime writes.

## Root cause

The patched runtime persists Linux settings through `CODEX_LINUX_SETTINGS_FILE`, or through an app-specific config directory resolved with `CODEX_LINUX_APP_ID` before `CODEX_APP_ID`. The Computer Use UI opt-in reader used during patching only looked under the config directory and preferred `CODEX_APP_ID`, so side-by-side installs and explicit settings-file launches could write the opt-in flag successfully while the patcher still treated Computer Use UI as disabled.

## Changes

- Honor `CODEX_LINUX_SETTINGS_FILE` in `computerUseUiSettingsPath`.
- Prefer `CODEX_LINUX_APP_ID` before `CODEX_APP_ID`, matching launcher/runtime settings resolution.
- Add regression coverage for both settings-path cases and restore the env var in the isolated test helper.

## Verification

- `node --test --test-name-pattern "isComputerUseUiEnabled" scripts/patch-linux-window-ui.test.js`
- `node -c scripts/patches/computer-use.js`
- `node -c scripts/patch-linux-window-ui.test.js`
- `git diff --check --cached`