### PR TITLE
[codex] fix Linux XDG documents directory

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -64,6 +64,10 @@ const {
   applyLinuxTrayCloseSettingPatch,
 } = require("./patches/launch-actions.js");
 const {
+  applyLinuxProjectlessXdgDocumentsDirPatch,
+  patchProjectlessDocumentsAssets,
+} = require("./patches/projectless-documents.js");
+const {
   applyBrowserUseNodeReplApprovalPatch,
   applyLinuxAboutDialogPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
@@ -87,6 +91,7 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxXdgDocumentsDirPatch,
 } = require("./patches/main-process.js");
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
@@ -226,6 +231,7 @@ module.exports = {
   applyLinuxMenuPatch,
   applyLinuxNativeTitlebarPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
+  applyLinuxProjectlessXdgDocumentsDirPatch,
   applyLinuxMultiInstanceBootstrapPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
@@ -241,6 +247,7 @@ module.exports = {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxXdgDocumentsDirPatch,
   applySubagentNicknameMetadataPatch,
   createPatchReport,
   corePatchDescriptors,
@@ -264,6 +271,7 @@ module.exports = {
   patchLinuxMultiInstanceBootstrap,
   patchLinuxAppUpdaterBridge,
   patchLinuxChromeNativeHostRuntimeAssets,
+  patchProjectlessDocumentsAssets,
   patchMainBundleSource,
   patchPackageJson,
   resolveDesktopName,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -54,6 +54,7 @@ const {
   applyLinuxAppSunsetPatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
+  applyLinuxProjectlessXdgDocumentsDirPatch,
   applyLinuxBrowserUseNonLocalNavigationPatch,
   applyLinuxAppServerBackfillWaitPatch,
   applyLinuxOpaqueBackgroundPatch,
@@ -68,12 +69,14 @@ const {
   applyLinuxTrayPatch,
   applyLinuxWillQuitDrainTimeoutPatch,
   applyLinuxWindowOptionsPatch,
+  applyLinuxXdgDocumentsDirPatch,
   applySubagentNicknameMetadataPatch,
   isComputerUseUiEnabled,
   patchMainBundleSource,
   patchExtractedApp,
   patchPackageJson,
   patchLinuxAppUpdaterBridge,
+  patchProjectlessDocumentsAssets,
   patchKeybindsSettingsAssets,
   patchAutomationScheduleAssets,
   createPatchReport,
@@ -666,6 +669,8 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-launch-actions",
     "linux-hotkey-window-prewarm",
     "linux-git-origins-source-fallback",
+    "linux-xdg-documents-dir",
+    "linux-projectless-xdg-documents-dir",
     "linux-i18n-gate",
     "linux-profile-settings-menu",
     "automation-schedule-multi-time-rrule",
@@ -1128,6 +1133,100 @@ test("adds Linux file manager support without relying on exact minified variable
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
   assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+});
+
+test("uses XDG user documents directory for projectless Codex folders on Linux", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-xdg-documents-"));
+  try {
+    const configDir = path.join(tempRoot, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "user-dirs.dirs"),
+      'XDG_DOCUMENTS_DIR="$HOME/My\\ Documents"\n',
+      "utf8",
+    );
+
+    const source = [
+      "let i={default:require(`node:path`)},o=require(`node:fs`);",
+      "function ST(e,t,n){let r=CT(n),i=r.resolve(e),a=r.resolve(t);return n===`win32`?i.toLowerCase()===a.toLowerCase():i===a}",
+      "function CT(e){return e===`win32`?i.default.win32:i.default.posix}",
+      "function vT({desktopPaths:e,homeDir:t,platform:n}){return ST(t,e.getPath(`home`),n)?e.getPath(`documents`):CT(n).join(t,`Documents`)}",
+    ].join("");
+
+    const patched = applyPatchTwice(applyLinuxXdgDocumentsDirPatch, source);
+    const context = {
+      home: "/home/example",
+      process: { env: { XDG_CONFIG_HOME: configDir } },
+      require,
+      result: null,
+    };
+
+    vm.runInNewContext(
+      `${patched};result=vT({desktopPaths:{getPath:e=>e===\`home\`?home:e===\`documents\`?home+\`/Documents\`:null},homeDir:home,platform:\`linux\`});`,
+      context,
+    );
+
+    assert.match(patched, /codexLinuxXdgDocumentsDir/);
+    assert.match(patched, /`\$1`/);
+    assert.equal(context.result, "/home/example/My Documents");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("uses XDG user documents directory for generated projectless workspaces", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-projectless-xdg-documents-"));
+  try {
+    const configDir = path.join(tempRoot, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, "user-dirs.dirs"),
+      'XDG_DOCUMENTS_DIR="$HOME/My\\ Documents"\n',
+      "utf8",
+    );
+
+    const source =
+      "function Mb({homeDirectory:e,path:t}){return t.join(e,`Documents`,`Codex`)}function Lb({homeDirectory:e,path:t}){return Mb({homeDirectory:e,path:t})}function Rb(e){return e}";
+    const patched = applyPatchTwice(applyLinuxProjectlessXdgDocumentsDirPatch, source);
+    const context = {
+      home: "/home/example",
+      process: { platform: "linux", env: { XDG_CONFIG_HOME: configDir } },
+      require,
+      result: null,
+    };
+
+    vm.runInNewContext(
+      `${patched};result=Mb({homeDirectory:home,path:require(\`node:path\`).posix});`,
+      context,
+    );
+
+    assert.match(patched, /codexLinuxProjectlessDocumentsDir/);
+    assert.match(patched, /`\$1`/);
+    assert.equal(context.result, "/home/example/My Documents/Codex");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("projectless documents asset patch updates Vite build bundle", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-projectless-xdg-asset-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    const bundlePath = path.join(buildDir, "src-test.js");
+    fs.writeFileSync(
+      bundlePath,
+      "function Mb({homeDirectory:e,path:t}){return t.join(e,`Documents`,`Codex`)}async function Lb(){throw Error(`Projectless thread directory must be a real directory`)}",
+      "utf8",
+    );
+
+    assert.deepEqual(patchProjectlessDocumentsAssets(tempRoot), { matched: 1, changed: 1 });
+    const patched = fs.readFileSync(bundlePath, "utf8");
+    assert.match(patched, /function codexLinuxProjectlessDocumentsDir/);
+    assert.deepEqual(patchProjectlessDocumentsAssets(tempRoot), { matched: 1, changed: 0 });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("preserves user-enabled remote_control config on Linux", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1229,6 +1229,36 @@ test("projectless documents asset patch updates Vite build bundle", () => {
   }
 });
 
+test("projectless documents descriptor surfaces resolver drift as skipped optional", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-projectless-xdg-drift-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), mainBundlePrefix, "utf8");
+    fs.writeFileSync(
+      path.join(buildDir, "src-test.js"),
+      "function Mb({homeDirectory:e,path:t}){return t.resolve(e,`Documents`,`Codex`)}async function Lb(){throw Error(`Projectless thread directory must be a real directory`)}",
+      "utf8",
+    );
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const patch = report.patches.find((patch) =>
+      patch.name === "linux-projectless-xdg-documents-dir",
+    );
+    assert.equal(patch.status, "skipped-optional");
+    assert.match(patch.reason, /projectless documents directory resolver/);
+    assert.ok(
+      patch.warnings.some((warning) =>
+        warning.includes("projectless documents directory resolver"),
+      ),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("preserves user-enabled remote_control config on Linux", () => {
   const source = [
     "async function mV({codexHome:e,hostConfig:n,logger:r=t.Jr()}){if(n.kind===`local`)try{await hV(i.default.join(e??t.Rr({hostConfig:n,preferWsl:t.Kr(n)}),pV))&&r.info(`Removed remote_control from config before app-server start`)}catch(e){r.warning(`Failed to remove remote_control before app-server start`,{safe:{},sensitive:{error:e}})}}",

--- a/scripts/patches/core/all-linux/extracted-app/projectless-xdg-documents/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/projectless-xdg-documents/patch.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const { patchProjectlessDocumentsAssets } = require("../../../../projectless-documents.js");
+
+module.exports = {
+  id: "linux-projectless-xdg-documents-dir",
+  phase: "extracted-app",
+  order: 245,
+  ciPolicy: "optional",
+  apply: patchProjectlessDocumentsAssets,
+  status: (result, warnings) => ({
+    status: result?.changed
+      ? "applied"
+      : result?.matched
+        ? "already-applied"
+        : "skipped-optional",
+    reason: result?.reason ?? warnings[0] ?? null,
+  }),
+};

--- a/scripts/patches/core/all-linux/extracted-app/projectless-xdg-documents/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/projectless-xdg-documents/patch.js
@@ -11,9 +11,11 @@ module.exports = {
   status: (result, warnings) => ({
     status: result?.changed
       ? "applied"
-      : result?.matched
-        ? "already-applied"
-        : "skipped-optional",
+      : warnings.length > 0
+        ? "skipped-optional"
+        : result?.matched
+          ? "already-applied"
+          : "skipped-optional",
     reason: result?.reason ?? warnings[0] ?? null,
   }),
 };

--- a/scripts/patches/core/all-linux/main-process/xdg-documents/patch.js
+++ b/scripts/patches/core/all-linux/main-process/xdg-documents/patch.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const { applyLinuxXdgDocumentsDirPatch } = require("../../../../main-process.js");
+
+module.exports = {
+  id: "linux-xdg-documents-dir",
+  phase: "main-bundle",
+  order: 245,
+  ciPolicy: "optional",
+  apply: applyLinuxXdgDocumentsDirPatch,
+};

--- a/scripts/patches/main-process/misc.js
+++ b/scripts/patches/main-process/misc.js
@@ -111,6 +111,56 @@ function applyLinuxRemoteControlConfigPreservationPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxXdgDocumentsDirPatch(currentSource) {
+  if (currentSource.includes("codexLinuxXdgDocumentsDir")) {
+    return currentSource;
+  }
+
+  const fsVar = requireName(currentSource, "node:fs");
+  if (fsVar == null) {
+    console.warn("WARN: Could not find fs require — skipping Linux XDG documents dir patch");
+    return currentSource;
+  }
+
+  const documentsDirRegex =
+    /function ([A-Za-z_$][\w$]*)\(\{desktopPaths:([A-Za-z_$][\w$]*),homeDir:([A-Za-z_$][\w$]*),platform:([A-Za-z_$][\w$]*)\}\)\{return ([A-Za-z_$][\w$]*)\(\3,\2\.getPath\(`home`\),\4\)\?\2\.getPath\(`documents`\):([A-Za-z_$][\w$]*)\(\4\)\.join\(\3,`Documents`\)\}/u;
+  const match = currentSource.match(documentsDirRegex);
+  if (match == null) {
+    if (
+      currentSource.includes("getPath(`documents`)") &&
+      currentSource.includes(".join(") &&
+      currentSource.includes("`Documents`")
+    ) {
+      console.warn(
+        "WARN: Could not find documents directory resolver — skipping Linux XDG documents dir patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [, fnName, desktopPathsVar, homeDirVar, platformVar, sameHomeFn, pathFactoryFn] = match;
+  const helper = [
+    "function codexLinuxXdgDocumentsDir({fs:e,homeDir:t,path:n}){try{",
+    "let r=process.env.XDG_CONFIG_HOME?.trim(),i=r&&n.isAbsolute(r)?n.join(r,`user-dirs.dirs`):n.join(t,`.config`,`user-dirs.dirs`);",
+    "if(!e.existsSync(i))return null;",
+    "let a=e.readFileSync(i,`utf8`).match(/^XDG_DOCUMENTS_DIR=([\"'])(.*)\\1/m);",
+    "if(a==null)return null;",
+    "let o=a[2].replace(/\\\\(.)/g,`$1`);",
+    "if(o===`$HOME`)return t;",
+    "if(o.startsWith(`$HOME/`))return n.join(t,o.slice(6));",
+    "if(o.startsWith(`~/`))return n.join(t,o.slice(2));",
+    "return n.isAbsolute(o)?o:n.join(t,o)",
+    "}catch{return null}}",
+  ].join("");
+  const patchedFn =
+    `${helper}function ${fnName}({desktopPaths:${desktopPathsVar},homeDir:${homeDirVar},platform:${platformVar}}){` +
+    `if(${platformVar}===\`linux\`){let __codexLinuxDocumentsDir=codexLinuxXdgDocumentsDir({fs:${fsVar},homeDir:${homeDirVar},path:${pathFactoryFn}(${platformVar})});` +
+    "if(__codexLinuxDocumentsDir!=null)return __codexLinuxDocumentsDir}" +
+    `return ${sameHomeFn}(${homeDirVar},${desktopPathsVar}.getPath(\`home\`),${platformVar})?${desktopPathsVar}.getPath(\`documents\`):${pathFactoryFn}(${platformVar}).join(${homeDirVar},\`Documents\`)}`;
+
+  return currentSource.replace(documentsDirRegex, () => patchedFn);
+}
+
 function applyLinuxLocalAppServerFeatureEnablementHandlerPatch(currentSource) {
   const method = "set-local-app-server-feature-enablement";
   const handler =
@@ -168,4 +218,5 @@ module.exports = {
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
   applyLinuxRemoteControlConfigPreservationPatch,
+  applyLinuxXdgDocumentsDirPatch,
 };

--- a/scripts/patches/projectless-documents.js
+++ b/scripts/patches/projectless-documents.js
@@ -1,0 +1,96 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  readDirectoryNames,
+} = require("./shared.js");
+
+const PROJECTLESS_DOCUMENTS_MARKER = "function codexLinuxProjectlessDocumentsDir(";
+
+function xdgDocumentsHelperSource() {
+  return [
+    "function codexLinuxProjectlessDocumentsDir({homeDirectory:e,path:t}){try{",
+    "if(process.platform!==`linux`)return t.join(e,`Documents`,`Codex`);",
+    "let n=process.env.XDG_CONFIG_HOME?.trim(),r=n&&t.isAbsolute(n)?t.join(n,`user-dirs.dirs`):t.join(e,`.config`,`user-dirs.dirs`);",
+    "if(!require(`node:fs`).existsSync(r))return t.join(e,`Documents`,`Codex`);",
+    "let i=require(`node:fs`).readFileSync(r,`utf8`).match(/^XDG_DOCUMENTS_DIR=([\"'])(.*)\\1/m);",
+    "if(i==null)return t.join(e,`Documents`,`Codex`);",
+    "let a=i[2].replace(/\\\\(.)/g,`$1`),o=a===`$HOME`?e:a.startsWith(`$HOME/`)?t.join(e,a.slice(6)):a.startsWith(`~/`)?t.join(e,a.slice(2)):t.isAbsolute(a)?a:t.join(e,a);",
+    "return t.join(o,`Codex`)",
+    "}catch{return t.join(e,`Documents`,`Codex`)}}",
+  ].join("");
+}
+
+function applyLinuxProjectlessXdgDocumentsDirPatch(source) {
+  if (source.includes(PROJECTLESS_DOCUMENTS_MARKER)) {
+    return source;
+  }
+
+  const resolverRegex =
+    /function ([A-Za-z_$][\w$]*)\(\{homeDirectory:([A-Za-z_$][\w$]*),path:([A-Za-z_$][\w$]*)\}\)\{return \3\.join\(\2,`Documents`,`Codex`\)\}/u;
+  const match = source.match(resolverRegex);
+  if (match == null) {
+    if (
+      source.includes("`Documents`,`Codex`") &&
+      source.includes("Projectless thread directory")
+    ) {
+      console.warn(
+        "WARN: Could not find projectless documents directory resolver — skipping Linux projectless XDG documents patch",
+      );
+    }
+    return source;
+  }
+
+  const [, fnName, homeDirectoryVar, pathVar] = match;
+  const patchedResolver =
+    `${xdgDocumentsHelperSource()}function ${fnName}({homeDirectory:${homeDirectoryVar},path:${pathVar}}){return codexLinuxProjectlessDocumentsDir({homeDirectory:${homeDirectoryVar},path:${pathVar}})}`;
+  return source.replace(resolverRegex, () => patchedResolver);
+}
+
+function findProjectlessBundles(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  return readDirectoryNames(buildDir)
+    .filter((name) => name.endsWith(".js"))
+    .sort()
+    .map((name) => path.join(buildDir, name))
+    .filter((candidate) => {
+      try {
+        const source = fs.readFileSync(candidate, "utf8");
+        return source.includes(PROJECTLESS_DOCUMENTS_MARKER) ||
+          (
+            source.includes("`Documents`,`Codex`") &&
+            source.includes("Projectless thread directory")
+          );
+      } catch {
+        return false;
+      }
+    });
+}
+
+function patchProjectlessDocumentsAssets(extractedDir) {
+  const candidates = findProjectlessBundles(extractedDir);
+  if (candidates.length === 0) {
+    const reason = `Could not find projectless documents bundle in ${path.join(extractedDir, ".vite", "build")}`;
+    console.warn(`WARN: ${reason} — skipping Linux projectless XDG documents patch`);
+    return { matched: 0, changed: 0, reason };
+  }
+
+  let changed = 0;
+  for (const candidate of candidates) {
+    const source = fs.readFileSync(candidate, "utf8");
+    const patched = applyLinuxProjectlessXdgDocumentsDirPatch(source);
+    if (patched !== source) {
+      fs.writeFileSync(candidate, patched, "utf8");
+      changed += 1;
+    }
+  }
+
+  return { matched: candidates.length, changed };
+}
+
+module.exports = {
+  applyLinuxProjectlessXdgDocumentsDirPatch,
+  patchProjectlessDocumentsAssets,
+};


### PR DESCRIPTION
## Summary

- add a Linux XDG-aware documents directory resolver for main-process document path lookups
- patch the projectless workspace bundle so generated Codex folders use `$XDG_DOCUMENTS_DIR/Codex` instead of hardcoded `$HOME/Documents/Codex`
- add regression coverage for XDG parsing, projectless bundle patching, and escaped `user-dirs.dirs` values

## Root Cause

Projectless threads ultimately create their generated workspace through a shared `.vite/build/src-*.js` bundle. That bundle hardcoded `path.join(homeDirectory, `Documents`, `Codex`)`, so localized Linux desktops created an extra English `~/Documents` directory even when `~/.config/user-dirs.dirs` points documents to `~/文档`, `~/Dokumente`, etc.

## Validation

- `node scripts/patch-linux-window-ui.test.js`
- rebuilt and installed a local Debian package with `make install-native`
- verified the installed patch report contains `linux-xdg-documents-dir` and `linux-projectless-xdg-documents-dir`
