### PR TITLE
Fix AppShots Wayland shortcuts

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2263,6 +2263,41 @@ scan_electron_rendering_arg() {
     esac
 }
 
+add_electron_enable_features() {
+    local raw="$1"
+    local feature
+    local existing
+    local IFS=,
+    local parts=()
+
+    read -r -a parts <<< "$raw"
+    for feature in "${parts[@]}"; do
+        feature="${feature#"${feature%%[![:space:]]*}"}"
+        feature="${feature%"${feature##*[![:space:]]}"}"
+        [ -n "$feature" ] || continue
+        for existing in "${ELECTRON_ENABLE_FEATURES[@]}"; do
+            [ "$existing" != "$feature" ] || continue 2
+        done
+        ELECTRON_ENABLE_FEATURES+=("$feature")
+    done
+}
+
+electron_enable_features_arg() {
+    local joined=""
+    local feature
+
+    for feature in "${ELECTRON_ENABLE_FEATURES[@]}"; do
+        if [ -z "$joined" ]; then
+            joined="$feature"
+        else
+            joined="$joined,$feature"
+        fi
+    done
+
+    [ -n "$joined" ] || return 1
+    printf '%s\n' "--enable-features=$joined"
+}
+
 write_user_electron_flags_template() {
     cat > "$USER_ELECTRON_FLAGS_FILE" <<'EOF'
 # Codex Desktop Linux launch flags.
@@ -2465,12 +2500,20 @@ set_electron_defaults() {
     ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED=0
     ELECTRON_RENDERER_ACCESSIBILITY_FORCED=0
     ELECTRON_ARGS=()
+    ELECTRON_ENABLE_FEATURES=()
     local passthrough=0
 
     while [ "$#" -gt 0 ]; do
         if [ "$passthrough" -eq 1 ]; then
-            ELECTRON_ARGS+=("$1")
-            scan_electron_rendering_arg "$1"
+            case "$1" in
+                --enable-features=*)
+                    add_electron_enable_features "${1#--enable-features=}"
+                    ;;
+                *)
+                    ELECTRON_ARGS+=("$1")
+                    scan_electron_rendering_arg "$1"
+                    ;;
+            esac
             shift
             continue
         fi
@@ -2510,6 +2553,9 @@ set_electron_defaults() {
                 ELECTRON_OZONE_HINT="${1#--ozone-platform-hint=}"
                 ELECTRON_OZONE_PLATFORM=""
                 ELECTRON_PLATFORM_EXPLICIT=1
+                ;;
+            --enable-features=*)
+                add_electron_enable_features "${1#--enable-features=}"
                 ;;
             *)
                 ELECTRON_ARGS+=("$1")
@@ -2564,6 +2610,8 @@ load_feature_electron_args() {
 }
 
 build_electron_launch_args() {
+    local enable_features_arg
+
     ELECTRON_LAUNCH_ARGS=(
         --no-sandbox
         --class="$CODEX_LINUX_APP_ID"
@@ -2603,7 +2651,11 @@ build_electron_launch_args() {
     fi
 
     if [ "$ELECTRON_OZONE_PLATFORM" = "wayland" ]; then
-        ELECTRON_LAUNCH_ARGS+=(--enable-features=WaylandWindowDecorations)
+        add_electron_enable_features "WaylandWindowDecorations"
+    fi
+
+    if enable_features_arg="$(electron_enable_features_arg)"; then
+        ELECTRON_LAUNCH_ARGS+=("$enable_features_arg")
     fi
 
 }

--- a/linux-features/appshots/README.md
+++ b/linux-features/appshots/README.md
@@ -35,13 +35,16 @@ Privacy and correctness constraints:
   intersect the captured image.
 - Global hotkeys are disabled by default on Linux until the user chooses one in
   AppShots settings. The dropdown mirrors upstream's bare-modifier choices where
-  they are practical on Linux (`Alt + Alt` and `Shift + Shift`) and keeps
-  `Ctrl+Super+A` as a non-bare fallback.
+  they are practical on X11 (`Alt + Alt` and `Shift + Shift`) and keeps
+  `Ctrl+Super+A` as a non-bare fallback on both X11 and Wayland.
 - `Alt + Alt` and `Shift + Shift` are backed by a feature-local
   `bare-modifier-monitor` helper staged into `resources/native/`. It requires
   the left and right modifier keycodes, so tapping only one physical modifier
   twice does not trigger AppShots. It uses `xinput` and `xmodmap`, so it is
   expected to work on X11 sessions and fail closed elsewhere.
+- On Wayland, the feature stages an Electron args hook that enables
+  `GlobalShortcutsPortal`, and the settings dropdown hides the X11-only bare
+  modifier shortcuts.
 
 Run the feature self-test:
 

--- a/linux-features/appshots/electron-args
+++ b/linux-features/appshots/electron-args
@@ -1,0 +1,1 @@
+--enable-features=GlobalShortcutsPortal

--- a/linux-features/appshots/feature.json
+++ b/linux-features/appshots/feature.json
@@ -12,5 +12,12 @@
       "target": "resources/native/bare-modifier-monitor",
       "mode": "0755"
     }
-  ]
+  ],
+  "runtimeHooks": {
+    "electronArgs": {
+      "source": "electron-args",
+      "name": "electron-args",
+      "mode": "0644"
+    }
+  }
 }

--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -1,9 +1,12 @@
 "use strict";
 
 const APPSHOT_HELPER_MARKER = "codexLinuxAppshotStartCapture";
-const LINUX_APPSHOT_HOTKEYS = [
+const LINUX_APPSHOT_X11_HOTKEYS = [
   { hotkey: "DoubleOption", label: "Alt + Alt" },
   { hotkey: "DoubleShift", label: "Shift + Shift" },
+  { hotkey: "Ctrl+Super+A", label: "Ctrl + Super + A" },
+];
+const LINUX_APPSHOT_WAYLAND_HOTKEYS = [
   { hotkey: "Ctrl+Super+A", label: "Ctrl + Super + A" },
 ];
 
@@ -75,6 +78,8 @@ function applyLinuxAppshotMainProcessPatch(currentSource) {
 }
 
 function applyLinuxAppshotHotkeyPatch(currentSource) {
+  let changed = false;
+
   currentSource = currentSource.replace(
     /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\),([A-Za-z_$][\w$]*)=\1===void 0\?([A-Za-z_$][\w$]*):\1,([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\4,isActive:\6!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\6\?\.unregister\(\),\6=null,!\8\|\|process\.platform!==`darwin`\|\|\4==null\)\{/g,
     (
@@ -89,30 +94,41 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
       enabledVar,
       reconcileFnVar,
     ) => {
-      return `let ${storedVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`),${configuredVar}=${storedVar}===void 0?(process.platform===\`linux\`?null:${defaultHotkeyVar}):${storedVar},${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
+      changed = true;
+      return `let ${storedVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`),${configuredVar}=${storedVar}===void 0?(process.platform===\`linux\`?null:${defaultHotkeyVar}):${storedVar},${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null,linuxWayland:codexLinuxAppshotIsWayland()}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
     },
   );
   currentSource = currentSource.replace(
     /return ([A-Za-z_$][\w$]*)\.length===1\?([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\2\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/g,
-    (match, partsVar, platformVar, supportedBareModifierFn, hotkeyVar) =>
-      `return ${partsVar}.length===1?(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)?${supportedBareModifierFn}(${hotkeyVar},${platformVar})?null:\`This shortcut key is not supported.\`:\`Choose a shortcut with Ctrl or Alt plus another key.\`:\`Use Ctrl, Alt, or Command when combining with another key.\``,
+    (match, partsVar, platformVar, supportedBareModifierFn, hotkeyVar) => {
+      changed = true;
+      return `return ${partsVar}.length===1?(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)?${supportedBareModifierFn}(${hotkeyVar},${platformVar})?null:\`This shortcut key is not supported.\`:\`Choose a shortcut with Ctrl or Alt plus another key.\`:\`Use Ctrl, Alt, or Command when combining with another key.\``;
+    },
+  );
+  currentSource = currentSource.replace(
+    /new Set\(\[\.\.\.([A-Za-z_$][\w$]*),`shift`\]\)/g,
+    (match, baseModifiersVar) => {
+      changed = true;
+      return `new Set([...${baseModifiersVar},\`shift\`,\`super\`,\`meta\`,\`win\`])`;
+    },
   );
 
   if (
     currentSource.includes("process.platform===`linux`?null") &&
     currentSource.includes("process.platform!==`darwin`&&process.platform!==`linux`") &&
-    currentSource.includes("===`linux`)&&") &&
-    currentSource.includes("if(process.platform!==`darwin`&&process.platform!==`linux`)return null")
+    currentSource.includes("!codexLinuxAppshotIsWayland()") &&
+    currentSource.includes("if(process.platform!==`darwin`&&process.platform!==`linux`)return null") &&
+    currentSource.includes("codexLinuxAppshotIsWayland") &&
+    currentSource.includes("`super`,`meta`,`win`")
   ) {
     return currentSource;
   }
 
-  let changed = false;
   let patchedSource = currentSource.replace(
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=process\.platform\)\{return \3===`darwin`&&([A-Za-z_$][\w$]*)\(\2\)!=null\}/g,
     (match, fnName, hotkeyVar, platformVar, modifierFn) => {
       changed = true;
-      return `function ${fnName}(${hotkeyVar},${platformVar}=process.platform){return (${platformVar}===\`darwin\`||${platformVar}===\`linux\`)&&${modifierFn}(${hotkeyVar})!=null}`;
+      return `function ${fnName}(${hotkeyVar},${platformVar}=process.platform){return (${platformVar}===\`darwin\`||${platformVar}===\`linux\`&&!codexLinuxAppshotIsWayland())&&${modifierFn}(${hotkeyVar})!=null}`;
     },
   );
 
@@ -138,7 +154,7 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
       reconcileFnVar,
     ) => {
       changed = true;
-      return `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
+      return `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null,linuxWayland:codexLinuxAppshotIsWayland()}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
     },
   );
 
@@ -151,7 +167,7 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
   );
 
   if (changed) {
-    return patchedSource;
+    return withLinuxAppshotWaylandHelper(patchedSource);
   }
 
   if (currentSource.includes("appshotHotkey") || currentSource.includes("appshot-hotkey-state")) {
@@ -161,21 +177,43 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
 }
 
 function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
-  const linuxOptions = `[${LINUX_APPSHOT_HOTKEYS.map(
+  const linuxX11Options = `[${LINUX_APPSHOT_X11_HOTKEYS.map(
     (option) => `{hotkey:\`${option.hotkey}\`,label:\`${option.label}\`}`,
   ).join(",")}]`;
-  if (currentSource.includes(`navigator.userAgent.includes(\`Linux\`)?${linuxOptions}:`)) {
+  const linuxWaylandOptions = `[${LINUX_APPSHOT_WAYLAND_HOTKEYS.map(
+    (option) => `{hotkey:\`${option.hotkey}\`,label:\`${option.label}\`}`,
+  ).join(",")}]`;
+  if (currentSource.includes("codexLinuxAppshotHotkeyOptions")) {
+    return currentSource;
+  }
+
+  const stateDataVar = currentSource.match(/\{data:([A-Za-z_$][\w$]*)\}=/)?.[1] ?? null;
+  if (stateDataVar == null) {
+    if (currentSource.includes("appshot-hotkey-state") || currentSource.includes("DoubleCommand")) {
+      warn("Could not find AppShots settings state binding", "Linux AppShots settings hotkey patch");
+    }
     return currentSource;
   }
 
   let changed = false;
-  const patchedSource = currentSource.replace(
+  let optionsVarName = null;
+  let patchedSource = currentSource.replace(
     /((?:var\s+|,)([A-Za-z_$][\w$]*)=)(\[\{hotkey:`DoubleCommand`,label:`[^`]+`\},\{hotkey:`DoubleOption`,label:`[^`]+`\},\{hotkey:`DoubleShift`,label:`[^`]+`\}\])(?=;)/,
     (match, declarationPrefix, optionsVar, macOptions) => {
       changed = true;
-      return `${declarationPrefix}typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)?${linuxOptions}:${macOptions}`;
+      optionsVarName = optionsVar;
+      const helper =
+        `codexLinuxAppshotHotkeyOptions=e=>typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)?e?.linuxWayland?${linuxWaylandOptions}:${linuxX11Options}:${optionsVar}`;
+      return `${declarationPrefix}${macOptions},${helper}`;
     },
   );
+
+  if (changed && optionsVarName != null) {
+    const escapedOptionsVarName = escapeRegExp(optionsVarName);
+    patchedSource = patchedSource
+      .replace(new RegExp(`\\b${escapedOptionsVarName}\\.find\\(`, "g"), `codexLinuxAppshotHotkeyOptions(${stateDataVar}).find(`)
+      .replace(new RegExp(`\\b${escapedOptionsVarName}\\.map\\(`, "g"), `codexLinuxAppshotHotkeyOptions(${stateDataVar}).map(`);
+  }
 
   if (changed) {
     return patchedSource;
@@ -185,6 +223,17 @@ function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
     warn("Could not find AppShots settings hotkey options", "Linux AppShots settings patch");
   }
   return currentSource;
+}
+
+function linuxAppshotWaylandHelperSource() {
+  return "function codexLinuxAppshotIsWayland(){return process.platform===`linux`&&((process.env.XDG_SESSION_TYPE||``).toLowerCase()===`wayland`||!!process.env.WAYLAND_DISPLAY)}";
+}
+
+function withLinuxAppshotWaylandHelper(source) {
+  if (source.includes("function codexLinuxAppshotIsWayland")) {
+    return source;
+  }
+  return `${linuxAppshotWaylandHelperSource()}${source}`;
 }
 
 function findMessageForViewSendFunction(source) {

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -52,6 +52,7 @@ function appshotMainProcessBundleFixture() {
 function appshotHotkeyMainBundleFixture() {
   return [
     "var uG=`DoubleCommand`,dG=6e4;",
+    "var SO=new Set([`cmdorctrl`,`command`,`cmd`,`control`,`ctrl`,`alt`,`option`]),CO=new Set([...SO,`shift`]);",
     "function rw(e,t=process.platform){return t===`darwin`&&aw(e)!=null}",
     "function QC(e,t,r=`press`){if(process.platform!==`darwin`)return null;let i=aw(e);return i==null?null:KC(e,t,r)}",
     "function bw(e,t,r){if(iw(e))return rw(e)?QC(e,t,r?.bareModifierTrigger):null;let i=Ew(e),a=()=>{t.onPressed()},o=n.globalShortcut.register(i,a);return o?{handlesRelease:!1,unregister:()=>{n.globalShortcut.unregister(i)}}:null}",
@@ -62,6 +63,7 @@ function appshotHotkeyMainBundleFixture() {
 function appshotHotkeyStoredMainBundleFixture() {
   return [
     "var bX=`DoubleCommand`,xX=6e4;",
+    "var JE=new Set([`cmdorctrl`,`command`,`cmd`,`control`,`ctrl`,`alt`,`option`]),LE=new Set([...JE,`shift`]);",
     "function CE(e,t=process.platform){return t===`darwin`&&TE(e)!=null}",
     "function vE(e,t,n=`press`){if(process.platform!==`darwin`)return null;let r=TE(e);return r==null?null:DE(r,t,n)}",
     "function HE(e,t=process.platform){let n=GE(e);if(CE(e,t))return null;if(n.some(wE))return n.length===1?t===`darwin`?CE(e,t)?null:`This shortcut key is not supported.`:`Choose a shortcut with Ctrl or Alt plus another key.`:`Use Ctrl, Alt, or Command when combining with another key.`;return null}",
@@ -72,7 +74,7 @@ function appshotHotkeyStoredMainBundleFixture() {
 function appshotSettingsBundleFixture() {
   return [
     "var O=d(),A=e(t(),1),j=n(),M=[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}];",
-    "function N(){let{data:h}=l(`appshot-hotkey-state`,{queryConfig:{enabled:t}}),x=c(`appshot-set-hotkey`);let w=h?.configuredHotkey??null,E=M.find(e=>e.hotkey===w)??null;return E}",
+    "function N(){let{data:h}=l(`appshot-hotkey-state`,{queryConfig:{enabled:t}}),x=c(`appshot-set-hotkey`);let w=h?.configuredHotkey??null,y=M.map(e=>e.label).join(`,`),E=M.find(e=>e.hotkey===w)??null;return E??y}",
   ].join("");
 }
 
@@ -124,12 +126,13 @@ test("appshots availability descriptor matches the current bundle", () => {
   assert.ok(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"));
 });
 
-test("stages the Linux bare modifier monitor helper", () => {
+test("stages the Linux bare modifier monitor helper and Wayland portal hook", () => {
   const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
   const helperSource = fs.readFileSync(
     path.join(__dirname, "bin", "bare-modifier-monitor"),
     "utf8",
   );
+  const electronArgsSource = fs.readFileSync(path.join(__dirname, "electron-args"), "utf8");
 
   assert.deepEqual(manifest.resources, [
     {
@@ -138,6 +141,14 @@ test("stages the Linux bare modifier monitor helper", () => {
       mode: "0755",
     },
   ]);
+  assert.deepEqual(manifest.runtimeHooks, {
+    electronArgs: {
+      source: "electron-args",
+      name: "electron-args",
+      mode: "0644",
+    },
+  });
+  assert.equal(electronArgsSource.trim(), "--enable-features=GlobalShortcutsPortal");
   assert.match(helperSource, /xinput test "\$device_id"/);
   assert.match(helperSource, /stdbuf -oL/);
   assert.match(helperSource, /exec 4<>"\$event_fifo"/);
@@ -227,18 +238,23 @@ test("enables AppShots hotkeys and bare modifiers on Linux", () => {
 
   assert.match(
     patched,
-    /function rw\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`\)&&aw\(e\)!=null\}/,
+    /function codexLinuxAppshotIsWayland\(\)\{return process\.platform===`linux`&&\(\(process\.env\.XDG_SESSION_TYPE\|\|``\)\.toLowerCase\(\)===`wayland`\|\|!!process\.env\.WAYLAND_DISPLAY\)\}/,
+  );
+  assert.match(
+    patched,
+    /function rw\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&aw\(e\)!=null\}/,
   );
   assert.match(
     patched,
     /function QC\(e,t,r=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
   );
+  assert.match(patched, /new Set\(\[\.\.\.SO,`shift`,`super`,`meta`,`win`\]\)/);
   assert.match(patched, /appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:uG\)/);
   assert.doesNotMatch(patched, /process\.platform===`linux`\?`DoubleShift`/);
   assert.doesNotMatch(patched, /process\.platform===`linux`&&i!=null&&iw\(i\)&&\(i=null\)/);
   assert.match(
     patched,
-    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\)/,
+    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:i,isActive:a!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
   );
   assert.match(
     patched,
@@ -262,12 +278,17 @@ test("enables Linux AppShots hotkeys for stored upstream controller shape", () =
 
   assert.match(
     patched,
-    /function CE\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`\)&&TE\(e\)!=null\}/,
+    /function codexLinuxAppshotIsWayland\(\)\{return process\.platform===`linux`&&\(\(process\.env\.XDG_SESSION_TYPE\|\|``\)\.toLowerCase\(\)===`wayland`\|\|!!process\.env\.WAYLAND_DISPLAY\)\}/,
+  );
+  assert.match(
+    patched,
+    /function CE\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&TE\(e\)!=null\}/,
   );
   assert.match(
     patched,
     /function vE\(e,t,n=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
   );
+  assert.match(patched, /new Set\(\[\.\.\.JE,`shift`,`super`,`meta`,`win`\]\)/);
   assert.match(
     patched,
     /return n\.length===1\?\(t===`darwin`\|\|t===`linux`\)\?CE\(e,t\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/,
@@ -278,7 +299,7 @@ test("enables Linux AppShots hotkeys for stored upstream controller shape", () =
   );
   assert.match(
     patched,
-    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\)/,
+    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:a,isActive:o!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
   );
   assert.match(
     patched,
@@ -293,6 +314,15 @@ test("shows Linux AppShots accelerator choices in settings", () => {
   );
 
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.match(patched, /codexLinuxAppshotHotkeyOptions=e=>/);
+  assert.match(
+    patched,
+    /e\?\.linuxWayland\?\[\{hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`\}\]:\[\{hotkey:`DoubleOption`,label:`Alt \+ Alt`\}/,
+  );
+  assert.match(patched, /codexLinuxAppshotHotkeyOptions\(h\)\.find/);
+  assert.match(patched, /codexLinuxAppshotHotkeyOptions\(h\)\.map/);
+  assert.doesNotMatch(patched, /\bM\.find\(/);
+  assert.doesNotMatch(patched, /\bM\.map\(/);
   assert.match(patched, /hotkey:`DoubleOption`,label:`Alt \+ Alt`/);
   assert.match(patched, /hotkey:`DoubleShift`,label:`Shift \+ Shift`/);
   assert.match(patched, /hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`/);

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3153,6 +3153,13 @@ PY
     [[ "$output" == *"<--ozone-platform=wayland>"* && "$output" == *"<--enable-features=WaylandWindowDecorations>"* ]] || fail "wayland-gpu profile must add Wayland launch args: $output"
     [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu profile must skip renderer accessibility by default: $output"
 
+    local portal_feature_args_dir="$TMP_DIR/portal-feature-electron-args"
+    mkdir -p "$portal_feature_args_dir"
+    printf '%s\n' '--enable-features=GlobalShortcutsPortal' '--enable-features=GlobalShortcutsPortal' > "$portal_feature_args_dir/appshots"
+    output="$(env -i PATH="$PATH" HOME="$HOME" FEATURE_ELECTRON_ARGS_DIR="$portal_feature_args_dir" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe)"
+    [[ "$output" == *"<--enable-features=GlobalShortcutsPortal,WaylandWindowDecorations>"* ]] || fail "feature and Wayland Electron feature flags must be merged: $output"
+    [[ "$output" != *"electron=<--enable-features=GlobalShortcutsPortal>"* ]] || fail "merged Electron feature flags must not remain in pass-through args: $output"
+
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu CODEX_FORCE_RENDERER_ACCESSIBILITY=1 "$launcher_probe" probe)"
     [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "CODEX_FORCE_RENDERER_ACCESSIBILITY=1 must force renderer accessibility under wayland-gpu: $output"
 


### PR DESCRIPTION
## Summary
- enable Electron's GlobalShortcutsPortal for the opt-in AppShots feature
- treat Super/Meta/Win as shortcut modifiers so Ctrl+Super+A validates on Linux
- hide X11-only bare modifier shortcuts from the AppShots settings dropdown on Wayland
- merge Electron --enable-features flags so feature hooks and Wayland decorations can coexist

## Root cause
The upstream hotkey validator did not count Super/Meta/Win as modifiers, so Ctrl+Super+A was rejected as having two non-modifier keys. The AppShots feature also offered X11 bare-modifier shortcuts on Wayland, where the helper cannot observe them, and did not enable Electron's global shortcuts portal.

Fixes #500

## Checks
- node --test linux-features/appshots/test.js
- node --test scripts/patch-linux-window-ui.test.js
- bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh
- bash tests/scripts_smoke.sh
- node --test linux-features/*/test.js