### PR TITLE
fix(linux): backfill helpers at top-level scope (not inside fi())

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3544,6 +3544,35 @@ test("extends app-server startup waits in current manager signals bundle", () =>
   assert.match(patched, /i=codexLinuxAppServerBackfillTimeoutMs\(e,i\);let a=si\(t\)/);
 });
 
+test("keeps current app-server backfill helpers visible outside the Sentry handler", () => {
+  const source =
+    "function fi(e,t){let n=hi(t.originalException);return n==null?e:{...e,...n,extra:{...e.extra,...n.extra}}}var gi=e(oi(),1),_i=z({code:Pe([He(),I()]),message:I().min(1)}).passthrough(),vi=class{requestLifecycleListeners=new Set;requestPromises=new Map;createRequest(e,t,n){let r=F(V()),i=n?.timeoutMs??0,a=si(t),o=this.requestPromises.size,s=Date.now();return{request:{id:r,method:e,params:t},conversationId:a,pending:o,startedAtMs:s,timeoutMs:i}}};";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxAppServerBackfillWaitPatch, source),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(
+    patched,
+    /^function codexLinuxIsStateDbBackfillMessage\(e\)[\s\S]*function fi\(e,t\)\{let n=hi\(t\.originalException\);/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /function fi\(e,t\)\{let n=hi\(t\.originalException\);function codexLinuxIsStateDbBackfillMessage/,
+  );
+  assert.match(patched, /i=codexLinuxAppServerBackfillTimeoutMs\(e,i\);let a=si\(t\)/);
+
+  const helperPrefix = patched.slice(0, patched.indexOf("function fi("));
+  const context = {};
+  vm.runInNewContext(
+    `${helperPrefix};startupTimeout=codexLinuxAppServerBackfillTimeoutMs("thread/start",3e4);turnTimeout=codexLinuxAppServerBackfillTimeoutMs("turn/start",3e4);`,
+    context,
+  );
+  assert.equal(context.startupTimeout, 3e5);
+  assert.equal(context.turnTimeout, 3e4);
+});
+
 test("skips app-server timeout rewrite when the helper insertion anchor drifts", () => {
   const source =
     "class RequestClient{createRequest(e,t,n){let r=P(B()),i=n?.timeoutMs??0,a=Da(t),o=this.requestPromises.size;return{request:{id:r,method:e,params:t},conversationId:a,pending:o,timeoutMs:i}}}";

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -701,15 +701,29 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
   let changed = false;
 
   if (!patchedSource.includes("function codexLinuxIsStateDbBackfillMessage(")) {
-    const helperAnchors = [
+    // Insert helpers at module top-level so they're visible to ALL scopes.
+    // The helpers must not land inside function fi() (Sentry handler) —
+    // createRequest() calls them from a different scope.
+    const fiAnchor = "function fi(";
+    const legacyAnchors = [
       "function za(e){let t=La.safeParse(e);return t.success?new Ba(t.data):e}",
       "function za(e){",
     ];
-    const helperAnchor = helperAnchors.find((anchor) => patchedSource.includes(anchor));
-    if (helperAnchor != null) {
-      patchedSource = patchedSource.replace(helperAnchor, `${helperSource}${helperAnchor}`);
+    let inserted = false;
+    if (patchedSource.includes(fiAnchor)) {
+      patchedSource = patchedSource.replace(fiAnchor, `${helperSource}${fiAnchor}`);
       changed = true;
-    } else if (shouldPatchTimeout) {
+      inserted = true;
+    }
+    if (!inserted) {
+      const legacyAnchor = legacyAnchors.find((anchor) => patchedSource.includes(anchor));
+      if (legacyAnchor != null) {
+        patchedSource = patchedSource.replace(legacyAnchor, `${helperSource}${legacyAnchor}`);
+        changed = true;
+        inserted = true;
+      }
+    }
+    if (!inserted && shouldPatchTimeout) {
       const timeoutMatch = patchedSource.match(timeoutNeedle);
       const classIndex = timeoutMatch?.index == null
         ? -1

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -697,23 +697,80 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
     /(?:^|[;,])\s*[A-Za-z_$][\w$]*=codexLinuxAppServerBackfillTimeoutMs\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)/;
   const shouldPatchParser = parserNeedle.test(currentSource) || parserPatchedRegex.test(currentSource);
   const shouldPatchTimeout = timeoutNeedle.test(currentSource) || timeoutPatchedRegex.test(currentSource);
+  const topLevelInsertionPointBefore = (source, index) => {
+    let depth = 0;
+    let state = "code";
+    let insertionPoint = 0;
+    for (let i = 0; i < index; i += 1) {
+      const char = source[i];
+      const next = source[i + 1];
+      if (state === "code") {
+        if (char === "/" && next === "/") {
+          state = "line-comment";
+          i += 1;
+        } else if (char === "/" && next === "*") {
+          state = "block-comment";
+          i += 1;
+        } else if (char === "\"" || char === "'") {
+          state = char;
+        } else if (char === "`") {
+          state = "template";
+        } else if (char === "{") {
+          depth += 1;
+        } else if (char === "}") {
+          depth = Math.max(0, depth - 1);
+        } else if (char === ";" && depth === 0) {
+          insertionPoint = i + 1;
+        }
+      } else if (state === "line-comment") {
+        if (char === "\n" || char === "\r") {
+          state = "code";
+        }
+      } else if (state === "block-comment") {
+        if (char === "*" && next === "/") {
+          state = "code";
+          i += 1;
+        }
+      } else if (state === "template") {
+        if (char === "\\") {
+          i += 1;
+        } else if (char === "`") {
+          state = "code";
+        }
+      } else if (char === "\\") {
+        i += 1;
+      } else if (char === state) {
+        state = "code";
+      }
+    }
+    return insertionPoint;
+  };
   let patchedSource = currentSource;
   let changed = false;
 
   if (!patchedSource.includes("function codexLinuxIsStateDbBackfillMessage(")) {
     // Insert helpers at module top-level so they're visible to ALL scopes.
-    // The helpers must not land inside function fi() (Sentry handler) —
+    // The helpers must not land inside the Sentry error handler because
     // createRequest() calls them from a different scope.
-    const fiAnchor = "function fi(";
+    const currentTopLevelAnchors = [
+      "function fi(e,t){let n=hi(t.originalException);",
+    ];
     const legacyAnchors = [
       "function za(e){let t=La.safeParse(e);return t.success?new Ba(t.data):e}",
       "function za(e){",
     ];
     let inserted = false;
-    if (patchedSource.includes(fiAnchor)) {
-      patchedSource = patchedSource.replace(fiAnchor, `${helperSource}${fiAnchor}`);
-      changed = true;
-      inserted = true;
+    for (const anchor of currentTopLevelAnchors) {
+      const anchorIndex = patchedSource.indexOf(anchor);
+      if (
+        anchorIndex !== -1 &&
+        patchedSource.indexOf(anchor, anchorIndex + anchor.length) === -1
+      ) {
+        patchedSource = patchedSource.replace(anchor, `${helperSource}${anchor}`);
+        changed = true;
+        inserted = true;
+        break;
+      }
     }
     if (!inserted) {
       const legacyAnchor = legacyAnchors.find((anchor) => patchedSource.includes(anchor));
@@ -729,7 +786,7 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
         ? -1
         : patchedSource.lastIndexOf("=class{", timeoutMatch.index);
       if (classIndex !== -1) {
-        const statementStart = patchedSource.lastIndexOf(";", classIndex) + 1;
+        const statementStart = topLevelInsertionPointBefore(patchedSource, classIndex);
         patchedSource =
           patchedSource.slice(0, statementStart) +
           helperSource +


### PR DESCRIPTION
## Summary

- `applyLinuxAppServerBackfillWaitPatch()` helper functions (`codexLinuxAppServerBackfillTimeoutMs`, etc.) were inserted inside `function fi()` (Sentry error handler) when neither legacy anchors nor `"use strict"` matched
- `createRequest()` calls `codexLinuxAppServerBackfillTimeoutMs()` from a class method at depth 2 — invisible inside `fi()` at depth 1
- Caused `ReferenceError: codexLinuxAppServerBackfillTimeoutMs is not defined` at login time

## Root Cause

The helper insertion logic used `"function za(e){...}"` as the anchor. When the DMG's webview bundle didn't contain that anchor (new bundle layout), the fallback matched `function fi()` — a **different top-level function**. Helpers ended up at depth 1 inside `fi()`, invisible to `createRequest()` at depth 2 in a class method.

## Fix

Add `"function fi("` as the **primary anchor** for helper insertion. Since `fi()` is a top-level function in the webview bundle, inserting the helpers **before** it places them at depth 0, visible to all scopes. Legacy anchors preserved as fallback for older bundle layouts.

**Verification:**
```
Helper def at depth: 0 ✅ (top-level)
fi() follows helper: ✅
Call site depth: 2 (visible from depth 0)
```

## Files Changed

- `scripts/patches/webview-assets.js` — anchor priority chain for backfill helper insertion