### PR TITLE
fix(linux): stub Owl feature binding to fix startup crash

### DIFF
--- a/scripts/patches/core/all-linux/extracted-app/owl-feature-binding/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/owl-feature-binding/patch.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// Codex 26.616.x+ reads an internal "Owl" feature-flag set through a native
+// binding that only exists in OpenAI's private Electron build:
+//   function Q(){let e=process._linkedBinding;...;return G.parse(e.call(process,`electron_common_owl_features`))}
+// On stock upstream Electron (what this wrapper rebuilds against) that binding
+// is absent, so the call throws "No such binding was linked:
+// electron_common_owl_features" the moment the main bundle imports — the app
+// dies at bootstrap-import-main with a "Codex failed to start" dialog.
+//
+// The accessor is the sole consumer of the binding; its only used member is
+// isOwlFeatureEnabled(name). Rewrite the function body to return a stub that
+// reports every Owl feature as disabled, dropping the binding call entirely.
+// Owl-gated features default off; everything else is untouched. The file-based
+// owl-feature-bootstrap-cache path is independent and keeps working.
+//
+// Minified identifiers (the function name and the schema-parser name) change
+// every build, so anchor on the stable string literals and structural shape,
+// and preserve the captured function name so existing callers still resolve.
+const OWL_BINDING_REGEX =
+  /function (\w+)\(\)\{let \w+=process\._linkedBinding;if\(typeof \w+!=`function`\)throw [\w.]*Error\(`Owl feature binding is unavailable`\);return \w+\.parse\(\w+\.call\(process,`electron_common_owl_features`\)\)\}/;
+
+const OWL_BINDING_LITERAL = "electron_common_owl_features";
+
+function stubOwlAccessor(source) {
+  return source.replace(
+    OWL_BINDING_REGEX,
+    (_match, fnName) => `function ${fnName}(){return{isOwlFeatureEnabled:()=>!1}}`,
+  );
+}
+
+function patchLinuxOwlFeatureBinding(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  if (!fs.existsSync(buildDir)) {
+    return { changed: false, reason: ".vite/build not found" };
+  }
+
+  let changedFiles = 0;
+  let sawLiteral = false;
+  for (const name of fs.readdirSync(buildDir).sort()) {
+    if (!name.endsWith(".js")) {
+      continue;
+    }
+    const target = path.join(buildDir, name);
+    const source = fs.readFileSync(target, "utf8");
+    if (!source.includes(OWL_BINDING_LITERAL)) {
+      continue;
+    }
+    sawLiteral = true;
+    const patched = stubOwlAccessor(source);
+    if (patched !== source) {
+      fs.writeFileSync(target, patched, "utf8");
+      changedFiles += 1;
+    }
+  }
+
+  if (changedFiles === 0) {
+    if (sawLiteral) {
+      console.warn(
+        "WARN: Owl feature binding accessor shape changed — owl stub NOT applied; " +
+          "app will crash with 'No such binding was linked: electron_common_owl_features'",
+      );
+    }
+    // No literal anywhere: upstream dropped the Owl binding — nothing to do.
+    return { changed: false };
+  }
+
+  return { changed: true };
+}
+
+module.exports = {
+  id: "linux-owl-feature-binding-stub",
+  phase: "extracted-app",
+  order: 130,
+  // Optional so a future shape drift warns instead of hard-failing the whole
+  // build; the post-install verification step is the real safety net.
+  ciPolicy: "optional",
+  apply: patchLinuxOwlFeatureBinding,
+};


### PR DESCRIPTION
## Summary

Adds a patch that stubs OpenAI's internal "Owl" feature-flag binding so the rebuilt Linux app stops crashing on startup. Fixes #520.

Codex `26.616.x+` reads Owl flags through a native binding `electron_common_owl_features` that exists only in OpenAI's private Electron build. On the stock Electron this wrapper rebuilds against, the binding is absent, so the accessor throws **`No such binding was linked: electron_common_owl_features`** at `bootstrap-import-main` and the app dies with a "Codex failed to start" dialog.

The accessor is the binding's sole consumer and its only used member is `isOwlFeatureEnabled(name)`. This rewrites the function body to a stub returning `{ isOwlFeatureEnabled: () => false }`, dropping the binding call entirely. Owl-gated features default off; everything else is untouched. The file-based owl-feature-bootstrap-cache path is independent and keeps working.

## Why an extracted-app patch (not main-bundle)

The workaround posted in #520 targets `process.binding('electron_common_owl_features')` with a `main-bundle` patch. On current builds that misses, because:

- the real call is `process._linkedBinding(...)`, and
- the accessor lives in a **content-hashed chunk** (`workspace-root-drop-handler-*.js`), not the main bundle.

So this patch runs in the `extracted-app` phase and scans every `.vite/build/*.js`, patching whichever chunk contains the binding literal.

## Implementation notes

- Anchored on the stable string literals + structural shape; minified identifiers change every build, so the captured function name is preserved so existing callers still resolve.
- `ciPolicy: "optional"` so a future shape drift emits a loud warning (`owl stub NOT applied; app will crash...`) instead of hard-failing the whole build — the post-install launch is the real safety net.
- No-op when the literal is absent (i.e. once upstream drops the binding).

## Validation

- `make build-app DMG=./Codex.dmg` then `make rpm` + install: patch-report shows `linux-owl-feature-binding-stub` = `applied`; repacked `app.asar` has the stub and zero `electron_common_owl_features` references.
- Installed build launches cleanly on Fedora 44 / stock Electron 42.1.0 — no bootstrap/owl error, all windows load.

> Orthogonal to #518, which fixes the `linux-tray` / `subagent-nickname-metadata-shape` patch drift the same issue reports. This PR only addresses the Owl binding crash.
