### PR TITLE
Fix Linux remote control toggle params

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -1175,10 +1175,17 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
   if (!patched.includes(REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER)) {
     const enabledForHostNullParamsPattern =
       /("set-remote-control-enabled-for-host":[A-Za-z_$][\w$]*\(\([A-Za-z_$][\w$]*,\{enabled:[A-Za-z_$][\w$]*\}\)=>[A-Za-z_$][\w$]*\.sendRequest\([A-Za-z_$][\w$]*\?`remoteControl\/enable`:`remoteControl\/disable`,)null(\)\))/u;
+    const beforeEnableForHostParamsPatch = patched;
     patched = patched.replace(
       enabledForHostNullParamsPattern,
       `$1void 0/*${REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER}*/$2`,
     );
+    if (
+      patched === beforeEnableForHostParamsPatch &&
+      patched.includes("set-remote-control-enabled-for-host")
+    ) {
+      console.warn("WARN: Could not find remote-control enable-for-host params needle - skipping Linux remote-control host params patch");
+    }
   }
 
   const markerIndex = patched.indexOf("[remote-connections/slingshot-gate-bridge]");

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -42,6 +42,7 @@ const REMOTE_MOBILE_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntime
 const REMOTE_MOBILE_UNKNOWN_TURN_MARKER = "codexLinuxRemoteMobileHydrateUnknownTurn";
 const REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER = "codexLinuxRemoteMobileNotificationQueue";
 const REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER = "codexLinuxRemoteControlEnablementBridge";
+const REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER = "codexLinuxRemoteControlEnableForHostParams";
 const REMOTE_CONTROL_AUTO_CONNECT_CLEANUP_MARKER = "codexLinuxRemoteControlAutoConnectCleanup";
 const REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER = "codexLinuxRemoteControlSelfAutoConnect";
 const REMOTE_MOBILE_ACTIVE_STATUS_MARKER = "codexLinuxRemoteMobileActiveStatus";
@@ -1169,12 +1170,22 @@ function applyLinuxRemoteControlStatusReadGuardPatch(source) {
 }
 
 function applyLinuxRemoteControlEnablementBridgePatch(source) {
-  const markerIndex = source.indexOf("[remote-connections/slingshot-gate-bridge]");
-  if (markerIndex < 0 || source.indexOf("set-remote-control-connections-enabled", markerIndex) < 0) {
-    return source;
+  let patched = source;
+
+  if (!patched.includes(REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER)) {
+    const enabledForHostNullParamsPattern =
+      /("set-remote-control-enabled-for-host":[A-Za-z_$][\w$]*\(\([A-Za-z_$][\w$]*,\{enabled:[A-Za-z_$][\w$]*\}\)=>[A-Za-z_$][\w$]*\.sendRequest\([A-Za-z_$][\w$]*\?`remoteControl\/enable`:`remoteControl\/disable`,)null(\)\))/u;
+    patched = patched.replace(
+      enabledForHostNullParamsPattern,
+      `$1void 0/*${REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER}*/$2`,
+    );
   }
 
-  let patched = source;
+  const markerIndex = patched.indexOf("[remote-connections/slingshot-gate-bridge]");
+  if (markerIndex < 0 || patched.indexOf("set-remote-control-connections-enabled", markerIndex) < 0) {
+    return patched;
+  }
+
   let region = patched.slice(markerIndex, markerIndex + 4_500);
 
   if (!patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER)) {
@@ -1188,7 +1199,7 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
 
     if (patchedRegion === region) {
       console.warn("WARN: Could not find remote-control enablement bridge needle - skipping Linux remote-control bridge patch");
-      return source;
+      return patched;
     }
 
     patched = patched.slice(0, markerIndex) + patchedRegion + patched.slice(markerIndex + region.length);

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -1682,6 +1682,15 @@ test("Linux remote-control enablement bridge omits params for current host toggl
   assert.equal(calls[0].params, undefined);
 });
 
+test("Linux remote-control enablement bridge warns when host toggle params needle drifts", () => {
+  const source =
+    "var handlers={\"set-remote-control-enabled-for-host\":pU((e,{enabled:t})=>e.sendRequest((t?`remoteControl/enable`:`remoteControl/disable`),null))};";
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteControlEnablementBridgePatch(source));
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("enable-for-host params needle")));
+});
+
 test("Linux remote-control enablement bridge migrates old auto-connect cleanup patch", () => {
   const source = syntheticAppMainEnablementBridgeBundle().replace(
     "$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -287,6 +287,14 @@ function syntheticAppMainEnablementBridgeBundle() {
   ].join("");
 }
 
+function syntheticCurrentAppMainEnablementBridgeBundle() {
+  return [
+    "var fH=`[remote-connections/slingshot-gate-bridge]`;",
+    "function mH(){let e=(0,Q.c)(6),{checkGate:t,isLoading:n}=eo(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||qt(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{Y.warning(`${fH} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,$.useEffect)(a,o),null}",
+    "var handlers={\"set-remote-control-enabled-for-host\":pU((e,{enabled:t})=>e.sendRequest(t?`remoteControl/enable`:`remoteControl/disable`,null))};",
+  ].join("");
+}
+
 function syntheticSelectedTabBundle() {
   return [
     "function nr(e,t){return e.displayName.localeCompare(t.displayName)}",
@@ -1646,6 +1654,32 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
   assert.equal(calls.length, 1);
   assert.equal(calls[0].method, "set-remote-control-connections-enabled");
   assert.equal(calls[0].params.enabled, true);
+});
+
+test("Linux remote-control enablement bridge omits params for current host toggle handler", async () => {
+  const source = syntheticCurrentAppMainEnablementBridgeBundle();
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlEnableForHostParams/);
+  assert.doesNotMatch(patched, /remoteControl\/disable`,null/);
+  assert.equal(applyLinuxRemoteControlEnablementBridgePatch(patched), patched);
+
+  const calls = [];
+  const context = {
+    pU: (handler) => handler,
+    host: {
+      sendRequest(method, params) {
+        calls.push({ method, params });
+        return Promise.resolve({ status: "enabled" });
+      },
+    },
+  };
+  await vm.runInNewContext(`${patched};handlers["set-remote-control-enabled-for-host"](host,{enabled:true});`, context);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "remoteControl/enable");
+  assert.equal(calls[0].params, undefined);
 });
 
 test("Linux remote-control enablement bridge migrates old auto-connect cleanup patch", () => {


### PR DESCRIPTION
## Summary
- Patch the current `set-remote-control-enabled-for-host` webview handler so Linux sends omitted params to `remoteControl/enable` and `remoteControl/disable` instead of `null`.
- Add a current-DMG-style remote-control fixture covering the handler shape introduced around 26.616.41845.
- Preserve the existing older enablement bridge behavior and idempotence.

## Validation
- `devcontainer exec --workspace-folder . sh -lc 'cd /workspaces/codex-desktop-linux-remote-pr && node --test linux-features/remote-mobile-control/test.js'`
- `devcontainer exec --workspace-folder . sh -lc 'cd /workspaces/codex-desktop-linux-remote-pr && node --test scripts/patch-linux-window-ui.test.js'`
- `git diff --check`