### PR TITLE
Updater v0.8.3: Polkit detection enhance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -433,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1512,14 +1512,16 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.12"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -1582,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.14.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2c9bc1689653cfbc04400b8719f2562638ff9c545bbd48cc58c657a14526df"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -2026,9 +2028,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -2281,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2328,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2604,9 +2606,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "codex-update-manager"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde"] }
-clap = { version = "4.6.0", features = ["derive"] }
+chrono = { version = "0.4.45", features = ["clock", "serde"] }
+clap = { version = "4.6.1", features = ["derive"] }
 directories = "6.0.0"
 futures-util = "0.3.32"
 fs4 = "0.13.1"
-notify-rust = "4.14.0"
-reqwest = { version = "0.13.2", default-features = false, features = ["http2", "rustls", "stream"] }
+notify-rust = "4.18.0"
+reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
-semver = "1.0.27"
+serde_json = "1.0.150"
+semver = "1.0.28"
 sha2 = "0.11.0"
-tokio = { version = "1.51.1", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "signal", "time"] }
+tokio = { version = "1.52.3", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "signal", "time"] }
 toml = "1.1.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["fmt"] }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -656,7 +656,7 @@ fn prompt_install_cli(
         return Ok(PromptInstallCliOutcome::Cancelled);
     }
 
-    if !has_graphical_session() {
+    if !has_interactive_graphical_session() {
         return Ok(PromptInstallCliOutcome::NoBackend);
     }
 
@@ -687,12 +687,17 @@ fn recently_dismissed_cli_prompt(state: &PersistedState) -> bool {
     })
 }
 
-fn has_graphical_session() -> bool {
+fn has_interactive_graphical_session() -> bool {
     let has_display =
         std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some();
     let has_dbus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some()
         || std::env::var_os("XDG_RUNTIME_DIR").is_some();
     has_display && has_dbus
+}
+
+fn has_user_session_bus_for_polkit() -> bool {
+    std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some()
+        || std::env::var_os("XDG_RUNTIME_DIR").is_some()
 }
 
 fn prefers_kdialog() -> bool {
@@ -1647,7 +1652,7 @@ fn graphical_polkit_auth_agent_is_likely_available() -> bool {
     if std::env::var_os("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT").is_some() {
         return true;
     }
-    if !has_graphical_session() {
+    if !has_user_session_bus_for_polkit() {
         return false;
     }
     polkit_auth_agent_process_is_running()
@@ -2784,6 +2789,43 @@ mod tests {
         assert!(!process_text_matches_polkit_auth_agent(
             "/usr/bin/ssh-agent -D"
         ));
+    }
+
+    #[test]
+    fn user_session_bus_for_polkit_allows_user_service_env_without_display() {
+        let _env_guard = crate::test_util::env_lock();
+        let original_display = std::env::var_os("DISPLAY");
+        let original_wayland_display = std::env::var_os("WAYLAND_DISPLAY");
+        let original_dbus_session_bus_address = std::env::var_os("DBUS_SESSION_BUS_ADDRESS");
+        let original_xdg_runtime_dir = std::env::var_os("XDG_RUNTIME_DIR");
+
+        std::env::remove_var("DISPLAY");
+        std::env::remove_var("WAYLAND_DISPLAY");
+        std::env::set_var("DBUS_SESSION_BUS_ADDRESS", "unix:path=/run/user/1000/bus");
+        std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
+
+        assert!(has_user_session_bus_for_polkit());
+
+        if let Some(value) = original_display {
+            std::env::set_var("DISPLAY", value);
+        } else {
+            std::env::remove_var("DISPLAY");
+        }
+        if let Some(value) = original_wayland_display {
+            std::env::set_var("WAYLAND_DISPLAY", value);
+        } else {
+            std::env::remove_var("WAYLAND_DISPLAY");
+        }
+        if let Some(value) = original_dbus_session_bus_address {
+            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", value);
+        } else {
+            std::env::remove_var("DBUS_SESSION_BUS_ADDRESS");
+        }
+        if let Some(value) = original_xdg_runtime_dir {
+            std::env::set_var("XDG_RUNTIME_DIR", value);
+        } else {
+            std::env::remove_var("XDG_RUNTIME_DIR");
+        }
     }
 
     #[test]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -2794,10 +2794,12 @@ mod tests {
     #[test]
     fn user_session_bus_for_polkit_allows_user_service_env_without_display() {
         let _env_guard = crate::test_util::env_lock();
-        let original_display = std::env::var_os("DISPLAY");
-        let original_wayland_display = std::env::var_os("WAYLAND_DISPLAY");
-        let original_dbus_session_bus_address = std::env::var_os("DBUS_SESSION_BUS_ADDRESS");
-        let original_xdg_runtime_dir = std::env::var_os("XDG_RUNTIME_DIR");
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "DISPLAY",
+            "WAYLAND_DISPLAY",
+            "DBUS_SESSION_BUS_ADDRESS",
+            "XDG_RUNTIME_DIR",
+        ]);
 
         std::env::remove_var("DISPLAY");
         std::env::remove_var("WAYLAND_DISPLAY");
@@ -2805,27 +2807,6 @@ mod tests {
         std::env::set_var("XDG_RUNTIME_DIR", "/run/user/1000");
 
         assert!(has_user_session_bus_for_polkit());
-
-        if let Some(value) = original_display {
-            std::env::set_var("DISPLAY", value);
-        } else {
-            std::env::remove_var("DISPLAY");
-        }
-        if let Some(value) = original_wayland_display {
-            std::env::set_var("WAYLAND_DISPLAY", value);
-        } else {
-            std::env::remove_var("WAYLAND_DISPLAY");
-        }
-        if let Some(value) = original_dbus_session_bus_address {
-            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", value);
-        } else {
-            std::env::remove_var("DBUS_SESSION_BUS_ADDRESS");
-        }
-        if let Some(value) = original_xdg_runtime_dir {
-            std::env::set_var("XDG_RUNTIME_DIR", value);
-        } else {
-            std::env::remove_var("XDG_RUNTIME_DIR");
-        }
     }
 
     #[test]
@@ -2874,15 +2855,16 @@ mod tests {
         };
         paths.ensure_dirs()?;
 
-        let original_display = std::env::var_os("DISPLAY");
-        let original_wayland_display = std::env::var_os("WAYLAND_DISPLAY");
-        let original_dbus_session_bus_address = std::env::var_os("DBUS_SESSION_BUS_ADDRESS");
-        let original_xdg_runtime_dir = std::env::var_os("XDG_RUNTIME_DIR");
-        let original_path = std::env::var_os("PATH");
-        let original_home = std::env::var_os("HOME");
-        let original_nvm_dir = std::env::var_os("NVM_DIR");
-        let original_skip_system_cli_lookup =
-            std::env::var_os("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "DISPLAY",
+            "WAYLAND_DISPLAY",
+            "DBUS_SESSION_BUS_ADDRESS",
+            "XDG_RUNTIME_DIR",
+            "PATH",
+            "HOME",
+            "NVM_DIR",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+        ]);
 
         std::env::remove_var("DISPLAY");
         std::env::remove_var("WAYLAND_DISPLAY");
@@ -2900,47 +2882,6 @@ mod tests {
         state.cli_path = Some(invalid_cli_path);
 
         let outcome = prompt_install_cli(&mut state, &paths, None)?;
-
-        if let Some(value) = original_display {
-            std::env::set_var("DISPLAY", value);
-        } else {
-            std::env::remove_var("DISPLAY");
-        }
-        if let Some(value) = original_wayland_display {
-            std::env::set_var("WAYLAND_DISPLAY", value);
-        } else {
-            std::env::remove_var("WAYLAND_DISPLAY");
-        }
-        if let Some(value) = original_dbus_session_bus_address {
-            std::env::set_var("DBUS_SESSION_BUS_ADDRESS", value);
-        } else {
-            std::env::remove_var("DBUS_SESSION_BUS_ADDRESS");
-        }
-        if let Some(value) = original_xdg_runtime_dir {
-            std::env::set_var("XDG_RUNTIME_DIR", value);
-        } else {
-            std::env::remove_var("XDG_RUNTIME_DIR");
-        }
-        if let Some(value) = original_path {
-            std::env::set_var("PATH", value);
-        } else {
-            std::env::remove_var("PATH");
-        }
-        if let Some(value) = original_home {
-            std::env::set_var("HOME", value);
-        } else {
-            std::env::remove_var("HOME");
-        }
-        if let Some(value) = original_nvm_dir {
-            std::env::set_var("NVM_DIR", value);
-        } else {
-            std::env::remove_var("NVM_DIR");
-        }
-        if let Some(value) = original_skip_system_cli_lookup {
-            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", value);
-        } else {
-            std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
-        }
 
         assert_eq!(outcome, PromptInstallCliOutcome::NoBackend);
         Ok(())

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -767,10 +767,10 @@ mod tests {
     use crate::{
         config::RuntimePaths,
         state::{CliStatus, PersistedState},
-        test_util::env_lock,
+        test_util::{env_lock, EnvRestoreGuard},
     };
     use chrono::Utc;
-    use std::{ffi::OsString, fs, os::unix::fs::PermissionsExt, path::Path};
+    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
     use tempfile::tempdir;
 
     fn write_executable_script(path: &Path, contents: &str) -> Result<()> {
@@ -789,33 +789,6 @@ mod tests {
             cache_dir: root.join("cache"),
             state_dir: root.join("state"),
             config_dir: root.join("config"),
-        }
-    }
-
-    struct EnvRestoreGuard {
-        saved: Vec<(&'static str, Option<OsString>)>,
-    }
-
-    impl EnvRestoreGuard {
-        fn capture(keys: &[&'static str]) -> Self {
-            Self {
-                saved: keys
-                    .iter()
-                    .map(|key| (*key, std::env::var_os(key)))
-                    .collect(),
-            }
-        }
-    }
-
-    impl Drop for EnvRestoreGuard {
-        fn drop(&mut self) {
-            for (key, value) in &self.saved {
-                if let Some(value) = value {
-                    std::env::set_var(key, value);
-                } else {
-                    std::env::remove_var(key);
-                }
-            }
         }
     }
 

--- a/updater/src/test_util.rs
+++ b/updater/src/test_util.rs
@@ -64,6 +64,9 @@ mod tests {
         });
 
         assert_eq!(std::env::var_os("DISPLAY"), original_display);
-        assert_eq!(std::env::var_os("WAYLAND_DISPLAY"), original_wayland_display);
+        assert_eq!(
+            std::env::var_os("WAYLAND_DISPLAY"),
+            original_wayland_display
+        );
     }
 }

--- a/updater/src/test_util.rs
+++ b/updater/src/test_util.rs
@@ -18,3 +18,52 @@ pub(crate) fn env_lock() -> MutexGuard<'static, ()> {
         .lock()
         .unwrap_or_else(|err| err.into_inner())
 }
+
+pub(crate) struct EnvRestoreGuard {
+    saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvRestoreGuard {
+    pub(crate) fn capture(keys: &[&'static str]) -> Self {
+        Self {
+            saved: keys
+                .iter()
+                .map(|key| (*key, std::env::var_os(key)))
+                .collect(),
+        }
+    }
+}
+
+impl Drop for EnvRestoreGuard {
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            if let Some(value) = value {
+                std::env::set_var(key, value);
+            } else {
+                std::env::remove_var(key);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{env_lock, EnvRestoreGuard};
+
+    #[test]
+    fn env_restore_guard_restores_variables_after_panic() {
+        let _env_guard = env_lock();
+        let original_display = std::env::var_os("DISPLAY");
+        let original_wayland_display = std::env::var_os("WAYLAND_DISPLAY");
+
+        let _ = std::panic::catch_unwind(|| {
+            let _restore_env = EnvRestoreGuard::capture(&["DISPLAY", "WAYLAND_DISPLAY"]);
+            std::env::set_var("DISPLAY", ":panic-test");
+            std::env::remove_var("WAYLAND_DISPLAY");
+            panic!("intentional panic to verify env restoration");
+        });
+
+        assert_eq!(std::env::var_os("DISPLAY"), original_display);
+        assert_eq!(std::env::var_os("WAYLAND_DISPLAY"), original_wayland_display);
+    }
+}


### PR DESCRIPTION
This pull request updates dependencies and refines how the application detects graphical and user session environments, especially for polkit (policy kit) support. The main focus is on improving session detection logic, clarifying function responsibilities, and adding targeted tests.

Dependency updates:

* Updated versions for several dependencies in `Cargo.toml`, including `chrono`, `clap`, `notify-rust`, `reqwest`, `serde_json`, `semver`, and `tokio` for bug fixes and compatibility.

Session detection improvements:

* Renamed `has_graphical_session` to `has_interactive_graphical_session` to clarify its purpose, and updated all call sites to use the new name.
* Introduced a new function `has_user_session_bus_for_polkit`, which checks for a user session bus environment and is now used in polkit agent detection. 

Testing:

* Added a unit test to verify that `has_user_session_bus_for_polkit` returns true when the appropriate environment variables are set, even without a display.