### PR TITLE
Fix v0.8.4: Removes fs4 crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.8.4] - 2026-06-20
+
 ### Added
 
 - The `make setup-native` Linux feature picker can now present a GUI checklist
@@ -68,6 +70,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- `codex-update-manager` no longer depends on the `fs4` crate for updater check
+  serialization. The updater now uses `std::fs::File::try_lock`, preserves the
+  existing non-blocking `check.lock` behavior when another check is active, and
+  adds regression coverage for `WouldBlock` lock contention semantics.
 - The avatar overlay is focusable on Linux so inline pet reply inputs can accept
   keyboard input after being clicked, while still staying above the main Codex
   window as an overlay.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,13 +518,12 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "chrono",
  "clap",
  "directories",
- "fs4",
  "futures-util",
  "notify-rust",
  "reqwest",
@@ -805,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -891,16 +890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1907,7 +1896,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2130,7 +2119,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2187,7 +2176,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2508,7 +2497,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3145,7 +3134,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3301,15 +3290,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 
 [dependencies]
@@ -9,7 +9,6 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 directories = "6.0.0"
 futures-util = "0.3.32"
-fs4 = "0.13.1"
 notify-rust = "4.18.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use chrono::{Duration as ChronoDuration, Utc};
-use fs4::fs_std::FileExt;
 use reqwest::Client;
 use serde::Deserialize;
 use std::{
@@ -265,13 +264,13 @@ fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
         .open(&lock_path)
         .with_context(|| format!("Failed to open {}", lock_path.display()))?;
 
-    match file.try_lock_exclusive() {
-        Ok(true) => {}
-        Ok(false) => {
+    match file.try_lock() {
+        Ok(()) => {}
+        Err(fs::TryLockError::WouldBlock) => {
             info!("skipping upstream check because another check is already active");
             return Ok(None);
         }
-        Err(error) => {
+        Err(fs::TryLockError::Error(error)) => {
             return Err(error).with_context(|| format!("Failed to lock {}", lock_path.display()));
         }
     }
@@ -2203,6 +2202,34 @@ mod tests {
         }
 
         assert!(reacquired_lock.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn std_file_try_lock_reports_would_block_for_second_holder() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let lock_path = temp.path().join("check.lock");
+        let first_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let second_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+
+        first_file.try_lock()?;
+        let second_attempt = second_file.try_lock();
+
+        assert!(matches!(
+            second_attempt,
+            Err(std::fs::TryLockError::WouldBlock)
+        ));
+        first_file.unlock()?;
         Ok(())
     }
 


### PR DESCRIPTION
This pull request updates the `codex-update-manager` to version 0.8.4 and removes its dependency on the `fs4` crate, switching to the standard library's file locking for updater check serialization. 

Dependency and Updater Improvements:
* Removed the `fs4` crate from `Cargo.toml` and replaced its usage in `app.rs` with `std::fs::File::try_lock`, simplifying dependencies and using the standard library for file locking. 
* Updated the version of `codex-update-manager` to 0.8.4 in `Cargo.toml`.

Testing and Reliability:
* Added a regression test to ensure that `try_lock` correctly reports `WouldBlock` when a second lock attempt is made, improving reliability of lock contention handling.

Documentation:
* Updated `CHANGELOG.md` to reflect the removal of the `fs4` dependency, the switch to `std::fs::File::try_lock`, and the addition of regression coverage for lock contention. 