### PR TITLE
Fix Codex Desktop 26.616 patch and bootstrap drift

### DIFF
--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -120,11 +120,44 @@ function escapeRegExp(value) {
 
 const JS_IDENT = "[A-Za-z_$][\\w$]*";
 
+function objectPropVar(objectSource, name, fallback) {
+  return objectSource.match(new RegExp(`(?:^|,)\\s*${escapeRegExp(name)}:(${JS_IDENT})(?:,|$)`))?.[1] ?? fallback;
+}
+
+function currentComposerBinding(source) {
+  const bindingPattern = new RegExp(
+    `\\{([^{}]*)\\}\\s*=\\s*${JS_IDENT}\\s*,\\s*` +
+      `\\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\\}\\s*=\\s*(${JS_IDENT})`,
+    "g",
+  );
+  for (const match of source.matchAll(bindingPattern)) {
+    const propsObject = match[1];
+    const voiceControlsObject = match[2];
+    const voiceControlsVar = match[3];
+    if (objectPropVar(propsObject, "voiceControls", null) !== voiceControlsVar) {
+      continue;
+    }
+    const requiredProps = ["conversationId", "isResponseInProgress", "onStop", "submitBlockReason"];
+    if (requiredProps.every((name) => objectPropVar(propsObject, name, null) != null)) {
+      return { propsObject, voiceControlsObject, voiceControlsVar };
+    }
+  }
+  return null;
+}
+
 function voiceControlsObjectVar(source) {
+  const currentBinding = currentComposerBinding(source);
+  if (currentBinding != null) {
+    return currentBinding.voiceControlsVar;
+  }
   return source.match(/voiceControls:([A-Za-z_$][\w$]*)/)?.[1] ?? "z";
 }
 
 function voiceControlVar(source, name, fallback) {
+  const currentBinding = currentComposerBinding(source);
+  if (currentBinding != null) {
+    return objectPropVar(currentBinding.voiceControlsObject, name, fallback);
+  }
   const voiceControlsVar = voiceControlsObjectVar(source);
   const match = source.match(
     new RegExp(`\\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\\}=${escapeRegExp(voiceControlsVar)}`),
@@ -132,11 +165,15 @@ function voiceControlVar(source, name, fallback) {
   if (!match) {
     return fallback;
   }
-  return match[1].match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`))?.[1] ?? fallback;
+  return objectPropVar(match[1], name, fallback);
 }
 
 function composerPropVar(source, name, fallback) {
-  return source.match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`))?.[1] ?? fallback;
+  const currentBinding = currentComposerBinding(source);
+  if (currentBinding == null) {
+    return fallback;
+  }
+  return objectPropVar(currentBinding.propsObject, name, fallback);
 }
 
 function composerPropVars(source) {

--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -125,21 +125,25 @@ function objectPropVar(objectSource, name, fallback) {
 }
 
 function currentComposerBinding(source) {
-  const bindingPattern = new RegExp(
-    `\\{([^{}]*)\\}\\s*=\\s*${JS_IDENT}\\s*,\\s*` +
-      `\\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\\}\\s*=\\s*(${JS_IDENT})`,
-    "g",
-  );
-  for (const match of source.matchAll(bindingPattern)) {
-    const propsObject = match[1];
-    const voiceControlsObject = match[2];
-    const voiceControlsVar = match[3];
-    if (objectPropVar(propsObject, "voiceControls", null) !== voiceControlsVar) {
+  const propsPattern = new RegExp(`\\{([^{}]*voiceControls:${JS_IDENT}[^{}]*)\\}\\s*=\\s*${JS_IDENT}`, "g");
+  for (const propsMatch of source.matchAll(propsPattern)) {
+    const propsObject = propsMatch[1];
+    const voiceControlsVar = objectPropVar(propsObject, "voiceControls", null);
+    if (voiceControlsVar == null) {
       continue;
     }
     const requiredProps = ["conversationId", "isResponseInProgress", "onStop", "submitBlockReason"];
-    if (requiredProps.every((name) => objectPropVar(propsObject, name, null) != null)) {
-      return { propsObject, voiceControlsObject, voiceControlsVar };
+    if (!requiredProps.every((name) => objectPropVar(propsObject, name, null) != null)) {
+      continue;
+    }
+    const voiceControlsPattern = new RegExp(
+      `\\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\\}\\s*=\\s*${escapeRegExp(voiceControlsVar)}`,
+      "g",
+    );
+    voiceControlsPattern.lastIndex = propsMatch.index + propsMatch[0].length;
+    const voiceControlsMatch = voiceControlsPattern.exec(source);
+    if (voiceControlsMatch != null) {
+      return { propsObject, voiceControlsObject: voiceControlsMatch[1], voiceControlsVar };
     }
   }
   return null;
@@ -272,6 +276,9 @@ function applyComposerControlPatch(source) {
   const togglePattern = new RegExp(
     `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${escapeRegExp(props.conversationId)},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${escapeRegExp(props.onStop)},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${escapeRegExp(props.isResponseInProgress)},isDictationSupported:${JS_IDENT}\\}\\)`,
   );
+  const anyTogglePattern = new RegExp(
+    `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${JS_IDENT},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${JS_IDENT},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${JS_IDENT},isDictationSupported:${JS_IDENT}\\}\\)`,
+  );
   const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars, props)}})`;
   if (legacyClickPattern.test(patched)) {
     patched = patched.replace(
@@ -285,6 +292,8 @@ function applyComposerControlPatch(source) {
     );
   } else if (togglePattern.test(patched)) {
     patched = patched.replace(togglePattern, toggleCall);
+  } else if (anyTogglePattern.test(patched)) {
+    patched = patched.replace(anyTogglePattern, toggleCall);
   } else if (!patched.includes("codexLinuxConversationToggle")) {
     warn("Could not find composer voice button click handler", "conversation mode composer control patch");
   }

--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -180,7 +180,18 @@ function composerPropVar(source, name, fallback) {
   return objectPropVar(currentBinding.propsObject, name, fallback);
 }
 
+function isLegacyComposerControlShape(source) {
+  return (
+    new RegExp(`\\{\\s*voiceControls:${JS_IDENT}\\s*\\}\\s*=\\s*${JS_IDENT}`).test(source) &&
+    source.includes("F===`empty-message`&&!A") &&
+    source.includes("ue.isAvailable&&ue.phase!==`active`")
+  );
+}
+
 function composerPropVars(source) {
+  if (currentComposerBinding(source) == null && !isLegacyComposerControlShape(source)) {
+    return null;
+  }
   return {
     conversationId: composerPropVar(source, "conversationId", "v"),
     isResponseInProgress: composerPropVar(source, "isResponseInProgress", "A"),
@@ -236,32 +247,36 @@ function applyComposerControlPatch(source) {
   let patched = source;
   const vars = composerVoiceVars(patched);
   const props = composerPropVars(patched);
-  const visiblePattern = new RegExp(
-    `let (${JS_IDENT})=(${JS_IDENT}),(${JS_IDENT})=${escapeRegExp(props.submitBlockReason)}` +
-      '===`empty-message`' +
-      `&&!${escapeRegExp(props.isResponseInProgress)}&&\\((?:(${JS_IDENT})&&)?` +
-      `${escapeRegExp(vars.threadRealtime)}\\.isAvailable&&${escapeRegExp(vars.threadRealtime)}\\.phase!==` +
-      '`active`' +
-      `\\|\\|(${JS_IDENT})\\),(${JS_IDENT})=(${JS_IDENT})\\((${JS_IDENT}),` +
-      '`composer\\.startVoiceMode`' +
-      "\\)",
-  );
-  const visibleMatch = patched.match(visiblePattern);
-  if (visibleMatch && !patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
-    const labelVar = visibleMatch[1];
-    const labelSrc = visibleMatch[2];
-    const visVar = visibleMatch[3];
-    const existingRealtimeAvailable = visibleMatch[4] == null ? "" : `${visibleMatch[4]}&&`;
-    const realtimeAvailable = visibleMatch[5] || vars.isNewRealtimeConversationAvailable;
-    const shortcutResultVar = visibleMatch[6];
-    const shortcutFn = visibleMatch[7];
-    const shortcutArg = visibleMatch[8];
-    patched = patched.replace(
-      visiblePattern,
-      `let ${labelVar}=${labelSrc};globalThis.codexLinuxConversationSync?.(${props.conversationId},{${composerSyncPayload(vars, props)}});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(${props.conversationId})===!0,${visVar}=codexLinuxConversationActive||${props.submitBlockReason}===\`empty-message\`&&!${props.isResponseInProgress}&&((${props.conversationId}&&globalThis.codexLinuxConversationAvailable?.())||${existingRealtimeAvailable}${vars.threadRealtime}.isAvailable&&${vars.threadRealtime}.phase!==\`active\`||${realtimeAvailable}),${shortcutResultVar}=${shortcutFn}(${shortcutArg},\`composer.startVoiceMode\`)`,
+  if (props == null) {
+    warn("Could not resolve composer prop aliases", "conversation mode composer control patch");
+  } else {
+    const visiblePattern = new RegExp(
+      `let (${JS_IDENT})=(${JS_IDENT}),(${JS_IDENT})=${escapeRegExp(props.submitBlockReason)}` +
+        '===`empty-message`' +
+        `&&!${escapeRegExp(props.isResponseInProgress)}&&\\((?:(${JS_IDENT})&&)?` +
+        `${escapeRegExp(vars.threadRealtime)}\\.isAvailable&&${escapeRegExp(vars.threadRealtime)}\\.phase!==` +
+        '`active`' +
+        `\\|\\|(${JS_IDENT})\\),(${JS_IDENT})=(${JS_IDENT})\\((${JS_IDENT}),` +
+        '`composer\\.startVoiceMode`' +
+        "\\)",
     );
-  } else if (!patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
-    warn("Could not find composer voice button visibility gate", "conversation mode composer control patch");
+    const visibleMatch = patched.match(visiblePattern);
+    if (visibleMatch && !patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
+      const labelVar = visibleMatch[1];
+      const labelSrc = visibleMatch[2];
+      const visVar = visibleMatch[3];
+      const existingRealtimeAvailable = visibleMatch[4] == null ? "" : `${visibleMatch[4]}&&`;
+      const realtimeAvailable = visibleMatch[5] || vars.isNewRealtimeConversationAvailable;
+      const shortcutResultVar = visibleMatch[6];
+      const shortcutFn = visibleMatch[7];
+      const shortcutArg = visibleMatch[8];
+      patched = patched.replace(
+        visiblePattern,
+        `let ${labelVar}=${labelSrc};globalThis.codexLinuxConversationSync?.(${props.conversationId},{${composerSyncPayload(vars, props)}});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(${props.conversationId})===!0,${visVar}=codexLinuxConversationActive||${props.submitBlockReason}===\`empty-message\`&&!${props.isResponseInProgress}&&((${props.conversationId}&&globalThis.codexLinuxConversationAvailable?.())||${existingRealtimeAvailable}${vars.threadRealtime}.isAvailable&&${vars.threadRealtime}.phase!==\`active\`||${realtimeAvailable}),${shortcutResultVar}=${shortcutFn}(${shortcutArg},\`composer.startVoiceMode\`)`,
+      );
+    } else if (!patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
+      warn("Could not find composer voice button visibility gate", "conversation mode composer control patch");
+    }
   }
 
   const threadRealtime = escapeRegExp(vars.threadRealtime);
@@ -273,27 +288,31 @@ function applyComposerControlPatch(source) {
   const currentClickPattern = new RegExp(
     `([A-Za-z_$][\\w$]*)=\\(\\)=>\\{if\\(${threadRealtime}\\.phase===\`starting\`\\|\\|${threadRealtime}\\.phase===\`active\`\\)\\{${threadRealtime}\\.stopRealtime\\(\\);return\\}if\\(${threadRealtime}\\.isAvailable\\)\\{${threadRealtime}\\.phase===\`inactive\`&&${currentStartRealtimeConversation}\\(\\);return\\}${currentStartRealtimeConversation}\\(\\)\\}`,
   );
-  const togglePattern = new RegExp(
-    `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${escapeRegExp(props.conversationId)},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${escapeRegExp(props.onStop)},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${escapeRegExp(props.isResponseInProgress)},isDictationSupported:${JS_IDENT}\\}\\)`,
-  );
   const anyTogglePattern = new RegExp(
     `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${JS_IDENT},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${JS_IDENT},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${JS_IDENT},isDictationSupported:${JS_IDENT}\\}\\)`,
   );
-  const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars, props)}})`;
-  if (legacyClickPattern.test(patched)) {
-    patched = patched.replace(
-      legacyClickPattern,
-      `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.threadRealtime}.startRealtime(\`composer_button_existing_thread\`);return}${vars.startNewRealtimeConversation}()}`,
+  if (props != null) {
+    const togglePattern = new RegExp(
+      `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${escapeRegExp(props.conversationId)},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${escapeRegExp(props.onStop)},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${escapeRegExp(props.isResponseInProgress)},isDictationSupported:${JS_IDENT}\\}\\)`,
     );
-  } else if (currentClickPattern.test(patched)) {
-    patched = patched.replace(
-      currentClickPattern,
-      `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.startRealtimeConversation}();return}${vars.startRealtimeConversation}()}`,
-    );
-  } else if (togglePattern.test(patched)) {
-    patched = patched.replace(togglePattern, toggleCall);
-  } else if (anyTogglePattern.test(patched)) {
-    patched = patched.replace(anyTogglePattern, toggleCall);
+    const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars, props)}})`;
+    if (legacyClickPattern.test(patched)) {
+      patched = patched.replace(
+        legacyClickPattern,
+        `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.threadRealtime}.startRealtime(\`composer_button_existing_thread\`);return}${vars.startNewRealtimeConversation}()}`,
+      );
+    } else if (currentClickPattern.test(patched)) {
+      patched = patched.replace(
+        currentClickPattern,
+        `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.startRealtimeConversation}();return}${vars.startRealtimeConversation}()}`,
+      );
+    } else if (togglePattern.test(patched)) {
+      patched = patched.replace(togglePattern, toggleCall);
+    } else if (anyTogglePattern.test(patched)) {
+      patched = patched.replace(anyTogglePattern, toggleCall);
+    } else if (!patched.includes("codexLinuxConversationToggle")) {
+      warn("Could not find composer voice button click handler", "conversation mode composer control patch");
+    }
   } else if (!patched.includes("codexLinuxConversationToggle")) {
     warn("Could not find composer voice button click handler", "conversation mode composer control patch");
   }

--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -118,47 +118,75 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
+
+function voiceControlsObjectVar(source) {
+  return source.match(/voiceControls:([A-Za-z_$][\w$]*)/)?.[1] ?? "z";
+}
+
 function voiceControlVar(source, name, fallback) {
-  const match = source.match(/\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\}=z/);
+  const voiceControlsVar = voiceControlsObjectVar(source);
+  const match = source.match(
+    new RegExp(`\\{([^{}]*startDictation:[^{}]*stopDictation:[^{}]*threadRealtime:[^{}]*)\\}=${escapeRegExp(voiceControlsVar)}`),
+  );
   if (!match) {
     return fallback;
   }
   return match[1].match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`))?.[1] ?? fallback;
 }
 
+function composerPropVar(source, name, fallback) {
+  return source.match(new RegExp(`${name}:([A-Za-z_$][\\w$]*)`))?.[1] ?? fallback;
+}
+
+function composerPropVars(source) {
+  return {
+    conversationId: composerPropVar(source, "conversationId", "v"),
+    isResponseInProgress: composerPropVar(source, "isResponseInProgress", "A"),
+    onStop: composerPropVar(source, "onStop", "P"),
+    submitBlockReason: composerPropVar(source, "submitBlockReason", "F"),
+  };
+}
+
 function composerVoiceVars(source) {
+  const startRealtimeConversation = voiceControlVar(source, "startRealtimeConversation", null);
   return {
     isDictating: voiceControlVar(source, "isDictating", "J"),
     isDictationSupported: voiceControlVar(source, "isDictationSupported", "q"),
     isTranscribing: voiceControlVar(source, "isTranscribing", "re"),
     isNewRealtimeConversationAvailable: voiceControlVar(source, "isNewRealtimeConversationAvailable", "J"),
     startDictation: voiceControlVar(source, "startDictation", "se"),
-    startNewRealtimeConversation: voiceControlVar(source, "startNewRealtimeConversation", "ce"),
+    startRealtimeConversation: startRealtimeConversation ?? "ce",
+    startNewRealtimeConversation: voiceControlVar(
+      source,
+      "startNewRealtimeConversation",
+      startRealtimeConversation ?? "ce",
+    ),
     stopDictation: voiceControlVar(source, "stopDictation", "le"),
     threadRealtime: voiceControlVar(source, "threadRealtime", "ue"),
   };
 }
 
-function composerSyncPayload(vars) {
+function composerSyncPayload(vars, props) {
   return [
-    "isResponseInProgress:A",
+    `isResponseInProgress:${props.isResponseInProgress}`,
     `isDictating:${vars.isDictating}`,
     `isTranscribing:${vars.isTranscribing}`,
     `startDictation:${vars.startDictation}`,
     `stopDictation:${vars.stopDictation}`,
-    "onStop:P",
+    `onStop:${props.onStop}`,
   ].join(",");
 }
 
-function composerTogglePayload(vars) {
+function composerTogglePayload(vars, props) {
   return [
-    "conversationId:v",
+    `conversationId:${props.conversationId}`,
     `startDictation:${vars.startDictation}`,
     `stopDictation:${vars.stopDictation}`,
-    "onStop:P",
+    `onStop:${props.onStop}`,
     `isDictating:${vars.isDictating}`,
     `isTranscribing:${vars.isTranscribing}`,
-    "isResponseInProgress:A",
+    `isResponseInProgress:${props.isResponseInProgress}`,
     `isDictationSupported:${vars.isDictationSupported}`,
   ].join(",");
 }
@@ -166,38 +194,57 @@ function composerTogglePayload(vars) {
 function applyComposerControlPatch(source) {
   let patched = source;
   const vars = composerVoiceVars(patched);
-  const visiblePattern =
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=F===`empty-message`&&!A&&\((?:v&&globalThis\.codexLinuxConversationAvailable\?\.\(\)\|\|)?([A-Za-z_$][\w$]*)\.isAvailable&&\4\.phase!==`active`\|\|([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`composer\.startVoiceMode`\)/;
+  const props = composerPropVars(patched);
+  const visiblePattern = new RegExp(
+    `let (${JS_IDENT})=(${JS_IDENT}),(${JS_IDENT})=${escapeRegExp(props.submitBlockReason)}` +
+      '===`empty-message`' +
+      `&&!${escapeRegExp(props.isResponseInProgress)}&&\\((?:(${JS_IDENT})&&)?` +
+      `${escapeRegExp(vars.threadRealtime)}\\.isAvailable&&${escapeRegExp(vars.threadRealtime)}\\.phase!==` +
+      '`active`' +
+      `\\|\\|(${JS_IDENT})\\),(${JS_IDENT})=(${JS_IDENT})\\((${JS_IDENT}),` +
+      '`composer\\.startVoiceMode`' +
+      "\\)",
+  );
   const visibleMatch = patched.match(visiblePattern);
-  if (visibleMatch && !patched.includes("codexLinuxConversationSync?.(v")) {
+  if (visibleMatch && !patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
     const labelVar = visibleMatch[1];
     const labelSrc = visibleMatch[2];
     const visVar = visibleMatch[3];
-    const threadRealtime = visibleMatch[4];
+    const existingRealtimeAvailable = visibleMatch[4] == null ? "" : `${visibleMatch[4]}&&`;
     const realtimeAvailable = visibleMatch[5] || vars.isNewRealtimeConversationAvailable;
     const shortcutResultVar = visibleMatch[6];
     const shortcutFn = visibleMatch[7];
     const shortcutArg = visibleMatch[8];
     patched = patched.replace(
       visiblePattern,
-      `let ${labelVar}=${labelSrc};globalThis.codexLinuxConversationSync?.(v,{${composerSyncPayload(vars)}});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(v)===!0,${visVar}=codexLinuxConversationActive||F===\`empty-message\`&&!A&&((v&&globalThis.codexLinuxConversationAvailable?.())||${threadRealtime}.isAvailable&&${threadRealtime}.phase!==\`active\`||${realtimeAvailable}),${shortcutResultVar}=${shortcutFn}(${shortcutArg},\`composer.startVoiceMode\`)`,
+      `let ${labelVar}=${labelSrc};globalThis.codexLinuxConversationSync?.(${props.conversationId},{${composerSyncPayload(vars, props)}});let codexLinuxConversationActive=globalThis.codexLinuxConversationIsActive?.(${props.conversationId})===!0,${visVar}=codexLinuxConversationActive||${props.submitBlockReason}===\`empty-message\`&&!${props.isResponseInProgress}&&((${props.conversationId}&&globalThis.codexLinuxConversationAvailable?.())||${existingRealtimeAvailable}${vars.threadRealtime}.isAvailable&&${vars.threadRealtime}.phase!==\`active\`||${realtimeAvailable}),${shortcutResultVar}=${shortcutFn}(${shortcutArg},\`composer.startVoiceMode\`)`,
     );
-  } else if (!patched.includes("codexLinuxConversationSync?.(v")) {
+  } else if (!patched.includes(`codexLinuxConversationSync?.(${props.conversationId}`)) {
     warn("Could not find composer voice button visibility gate", "conversation mode composer control patch");
   }
 
   const threadRealtime = escapeRegExp(vars.threadRealtime);
   const startNewRealtimeConversation = escapeRegExp(vars.startNewRealtimeConversation);
-  const clickPattern = new RegExp(
+  const legacyClickPattern = new RegExp(
     `([A-Za-z_$][\\w$]*)=\\(\\)=>\\{if\\(${threadRealtime}\\.phase===\`starting\`\\|\\|${threadRealtime}\\.phase===\`active\`\\)\\{${threadRealtime}\\.stopRealtime\\(\\);return\\}if\\(${threadRealtime}\\.isAvailable\\)\\{${threadRealtime}\\.phase===\`inactive\`&&${threadRealtime}\\.startRealtime\\(\`composer_button_existing_thread\`\\);return\\}${startNewRealtimeConversation}\\(\\)\\}`,
   );
-  const togglePattern =
-    /codexLinuxConversationToggle\?\.\(\{conversationId:v,startDictation:[A-Za-z_$][\w$]*,stopDictation:[A-Za-z_$][\w$]*,onStop:P,isDictating:[A-Za-z_$][\w$]*,isTranscribing:[A-Za-z_$][\w$]*,isResponseInProgress:A,isDictationSupported:[A-Za-z_$][\w$]*\}\)/;
-  const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars)}})`;
-  if (clickPattern.test(patched)) {
+  const currentStartRealtimeConversation = escapeRegExp(vars.startRealtimeConversation);
+  const currentClickPattern = new RegExp(
+    `([A-Za-z_$][\\w$]*)=\\(\\)=>\\{if\\(${threadRealtime}\\.phase===\`starting\`\\|\\|${threadRealtime}\\.phase===\`active\`\\)\\{${threadRealtime}\\.stopRealtime\\(\\);return\\}if\\(${threadRealtime}\\.isAvailable\\)\\{${threadRealtime}\\.phase===\`inactive\`&&${currentStartRealtimeConversation}\\(\\);return\\}${currentStartRealtimeConversation}\\(\\)\\}`,
+  );
+  const togglePattern = new RegExp(
+    `codexLinuxConversationToggle\\?\\.\\(\\{conversationId:${escapeRegExp(props.conversationId)},startDictation:${JS_IDENT},stopDictation:${JS_IDENT},onStop:${escapeRegExp(props.onStop)},isDictating:${JS_IDENT},isTranscribing:${JS_IDENT},isResponseInProgress:${escapeRegExp(props.isResponseInProgress)},isDictationSupported:${JS_IDENT}\\}\\)`,
+  );
+  const toggleCall = `codexLinuxConversationToggle?.({${composerTogglePayload(vars, props)}})`;
+  if (legacyClickPattern.test(patched)) {
     patched = patched.replace(
-      clickPattern,
+      legacyClickPattern,
       `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.threadRealtime}.startRealtime(\`composer_button_existing_thread\`);return}${vars.startNewRealtimeConversation}()}`,
+    );
+  } else if (currentClickPattern.test(patched)) {
+    patched = patched.replace(
+      currentClickPattern,
+      `$1=()=>{if(globalThis.${toggleCall})return;if(${vars.threadRealtime}.phase===\`starting\`||${vars.threadRealtime}.phase===\`active\`){${vars.threadRealtime}.stopRealtime();return}if(${vars.threadRealtime}.isAvailable){${vars.threadRealtime}.phase===\`inactive\`&&${vars.startRealtimeConversation}();return}${vars.startRealtimeConversation}()}`,
     );
   } else if (togglePattern.test(patched)) {
     patched = patched.replace(togglePattern, toggleCall);
@@ -225,6 +272,14 @@ function applyComposerControlPatch(source) {
 }
 
 function applyDictationEndpointPatch(source) {
+  if (
+    !source.includes("global-dictation-record-history-item") &&
+    !source.includes("navigator.mediaDevices.getUserMedia({audio:{channelCount:1}})") &&
+    !source.includes("new MediaRecorder")
+  ) {
+    return source;
+  }
+
   let patched = source;
   const getUserMediaNeedle = "navigator.mediaDevices.getUserMedia({audio:{channelCount:1}})";
   if (patched.includes(getUserMediaNeedle)) {
@@ -232,6 +287,15 @@ function applyDictationEndpointPatch(source) {
       getUserMediaNeedle,
       "navigator.mediaDevices.getUserMedia({audio:{channelCount:1,echoCancellation:!0,noiseSuppression:!0,autoGainControl:!0}})",
     );
+  } else {
+    const currentMicConstraintsPattern =
+      /([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\{channelCount:1\}\)/u;
+    if (currentMicConstraintsPattern.test(patched)) {
+      patched = patched.replace(
+        currentMicConstraintsPattern,
+        "$1=await $2({channelCount:1,echoCancellation:!0,noiseSuppression:!0,autoGainControl:!0})",
+      );
+    }
   }
 
   const cleanupNeedle = "r&&(r.ondataavailable=null,r.onstop=null),m.current=null,D();";
@@ -241,7 +305,16 @@ function applyDictationEndpointPatch(source) {
       "r?.codexLinuxConversationCleanup?.(),r&&(r.ondataavailable=null,r.onstop=null),m.current=null,D();",
     );
   } else if (!patched.includes("codexLinuxConversationCleanup")) {
-    warn("Could not find dictation cleanup point", "conversation mode dictation endpoint patch");
+    const currentCleanupPattern =
+      /([A-Za-z_$][\w$]*)&&\(\1\.ondataavailable=null,\1\.onstop=null\),([A-Za-z_$][\w$]*)\.current=null,([A-Za-z_$][\w$]*)\(\);/u;
+    if (currentCleanupPattern.test(patched)) {
+      patched = patched.replace(
+        currentCleanupPattern,
+        "$1?.codexLinuxConversationCleanup?.(),$1&&($1.ondataavailable=null,$1.onstop=null),$2.current=null,$3();",
+      );
+    } else {
+      warn("Could not find dictation cleanup point", "conversation mode dictation endpoint patch");
+    }
   }
 
   const recorderNeedle =
@@ -252,7 +325,18 @@ function applyDictationEndpointPatch(source) {
       "t.ondataavailable=e=>{e.data.size>0&&g.current.push(e.data)},t.onstop=()=>{A()},t.codexLinuxConversationCleanup=globalThis.codexLinuxConversationEndpoint?.({stream:e,stop:()=>a(`send`),isActive:()=>m.current===t&&t.state!==`inactive`}),t.start(),l(!0)",
     );
   } else if (!patched.includes("codexLinuxConversationEndpoint")) {
-    warn("Could not find dictation recorder start point", "conversation mode dictation endpoint patch");
+    const currentActionRef = patched.match(/let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\.current\?\?`insert`/)?.[1] ?? "w";
+    const currentRecorderPattern =
+      /let ([A-Za-z_$][\w$]*)=new MediaRecorder\(([A-Za-z_$][\w$]*)\);if\(([A-Za-z_$][\w$]*)\.current=\1,([A-Za-z_$][\w$]*)\.current=\[\],\1\.ondataavailable=([A-Za-z_$][\w$]*)=>\{\5\.data\.size>0&&\4\.current\.push\(\5\.data\)\},\1\.onstop=\(\)=>\{([A-Za-z_$][\w$]*)\(\)\},\1\.start\(\),([A-Za-z_$][\w$]*)\(!0\)/u;
+    if (currentRecorderPattern.test(patched)) {
+      patched = patched.replace(
+        currentRecorderPattern,
+        (_needle, recorderVar, streamVar, recorderRefVar, chunksRefVar, dataVar, finishFn, activeSetterVar) =>
+          `let ${recorderVar}=new MediaRecorder(${streamVar});if(${recorderRefVar}.current=${recorderVar},${chunksRefVar}.current=[],${recorderVar}.ondataavailable=${dataVar}=>{${dataVar}.data.size>0&&${chunksRefVar}.current.push(${dataVar}.data)},${recorderVar}.onstop=()=>{${finishFn}()},${recorderVar}.codexLinuxConversationCleanup=globalThis.codexLinuxConversationEndpoint?.({stream:${streamVar},stop:()=>{${currentActionRef}.current=\`send\`;${recorderVar}.state!==\`inactive\`&&${recorderVar}.stop()},isActive:()=>${recorderRefVar}.current===${recorderVar}&&${recorderVar}.state!==\`inactive\`}),${recorderVar}.start(),${activeSetterVar}(!0)`,
+      );
+    } else {
+      warn("Could not find dictation recorder start point", "conversation mode dictation endpoint patch");
+    }
   }
 
   const globalStopNeedle = "p.current!==e.sessionId||(p.current=null,o(`insert`))";
@@ -271,7 +355,16 @@ function applyDictationEndpointPatch(source) {
       "i.length>0&&e!==`discard`&&globalThis.codexLinuxConversationShouldSendTranscript?.(i,e)!==!1&&(j.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:i}),e===`send`?n.onTranscriptSend(i):n.onTranscriptInsert(i))",
     );
   } else if (!patched.includes("codexLinuxConversationShouldSendTranscript")) {
-    warn("Could not find dictation transcript send point", "conversation mode transcript dedupe patch");
+    const currentTranscriptPattern =
+      /([A-Za-z_$][\w$]*)\.length>0&&\(([A-Za-z_$][\w$]*)\.getInstance\(\)\.dispatchMessage\(`global-dictation-record-history-item`,\{text:\1\}\),([A-Za-z_$][\w$]*)===`send`\?([A-Za-z_$][\w$]*)\.onTranscriptSend\(\1\):\4\.onTranscriptInsert\(\1\)\)/u;
+    if (currentTranscriptPattern.test(patched)) {
+      patched = patched.replace(
+        currentTranscriptPattern,
+        "$1.length>0&&$3!==`discard`&&globalThis.codexLinuxConversationShouldSendTranscript?.($1,$3)!==!1&&($2.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:$1}),$3===`send`?$4.onTranscriptSend($1):$4.onTranscriptInsert($1))",
+      );
+    } else {
+      warn("Could not find dictation transcript send point", "conversation mode transcript dedupe patch");
+    }
   }
 
   return patched;
@@ -333,7 +426,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20690,
       ciPolicy: "optional",
-      pattern: /^browser-sidebar-comment-light-dismiss-.*\.js$/,
+      pattern: /^(?:browser-sidebar-comment-light-dismiss|use-dictation(?!-hotkey))-.*\.js$/,
       missingDescription: "composer dictation bundle",
       skipDescription: "conversation mode dictation endpoint patch",
       apply: applyDictationEndpointPatch,

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -91,6 +91,10 @@ const composerControlSource =
 const currentComposerControlSource =
   "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
 
+const currentComposerControlSourceWithDecoyProps =
+  "function decoy(e){let{conversationId:badId,isResponseInProgress:badProgress,onStop:badStop,submitBlockReason:badReason,voiceControls:badVoiceControls}=e;return badId||badProgress||badStop||badReason||badVoiceControls}" +
+  currentComposerControlSource;
+
 const halfPatchedCurrentComposerControlSource =
   "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:te,isTranscribing:re,isResponseInProgress:A,isDictationSupported:q}))return;if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
 
@@ -1739,6 +1743,22 @@ test("composer control patch follows the current composer voiceControls shape", 
   assert.match(patched, /\|\|ue\.isAvailable&&ue\.phase!==`active`\|\|te/);
   assert.doesNotMatch(patched, /isDictating:te/);
   assert.doesNotMatch(patched, /isDictationSupported:q/);
+});
+
+test("composer control patch scopes current composer props to the composer binding", () => {
+  const patched = twice(applyComposerControlPatch, currentComposerControlSourceWithDecoyProps);
+  assert.match(
+    patched,
+    /codexLinuxConversationSync\?\.\(v,\{isResponseInProgress:A,isDictating:J,isTranscribing:re,startDictation:se,stopDictation:le,onStop:P\}\)/,
+  );
+  assert.match(
+    patched,
+    /codexLinuxConversationToggle\?\.\(\{conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:J,isTranscribing:re,isResponseInProgress:A,isDictationSupported:ee\}\)/,
+  );
+  assert.doesNotMatch(patched, /codexLinuxConversationSync\?\.\(badId/);
+  assert.doesNotMatch(patched, /codexLinuxConversationToggle\?\.\(\{conversationId:badId/);
+  assert.doesNotMatch(patched, /codexLinuxConversationSync\?\.\([^)]*\{[^}]*isResponseInProgress:badProgress/);
+  assert.doesNotMatch(patched, /codexLinuxConversationToggle\?\.\([^)]*onStop:badStop/);
 });
 
 test("composer control patch repairs bundles where only the click handler was patched", () => {

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -89,14 +89,17 @@ const composerControlSource =
   "function mz(e){let {voiceControls:z}=e;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||J),He=si(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};let e=G.formatMessage({id:`composer.realtime.start.aria`,defaultMessage:`Start realtime voice`,description:`Aria label for the button that starts realtime voice mode in the composer`});let n=G.formatMessage({id:`composer.realtime.start.tooltip`,defaultMessage:`Start realtime voice`,description:`Tooltip for the button that starts realtime voice mode in the composer`});}";
 
 const currentComposerControlSource =
-  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
+  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,I=h===void 0?!1:h,L=mu(),R=fu(L,tg),x=fu(L,eg),{enterBehavior:B}=Ul(),V=Wt(),{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
 
 const currentComposerControlSourceWithDecoyProps =
   "function decoy(e){let{conversationId:badId,isResponseInProgress:badProgress,onStop:badStop,submitBlockReason:badReason,voiceControls:badVoiceControls}=e;return badId||badProgress||badStop||badReason||badVoiceControls}" +
   currentComposerControlSource;
 
 const halfPatchedCurrentComposerControlSource =
-  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:te,isTranscribing:re,isResponseInProgress:A,isDictationSupported:q}))return;if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
+  "function hz(e){let{conversationId:v,isResponseInProgress:A,onStop:P,submitBlockReason:F,voiceControls:z}=e,I=h===void 0?!1:h,L=mu(),R=fu(L,tg),x=fu(L,eg),{enterBehavior:B}=Ul(),V=Wt(),{canRetryDictation:K,dictationShortcutLabel:q,isDictating:J,isDictationSupported:ee,isNewRealtimeConversationAvailable:te,isRealtimeSubmitStarting:ne,isTranscribing:re,startDictation:se,startNewRealtimeConversation:ce,stopDictation:le,threadRealtime:ue}=z;let Be=ze,Ve=F===`empty-message`&&!A&&(ue.isAvailable&&ue.phase!==`active`||te),He=oi(fc,`composer.startVoiceMode`),Ue;Ue=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:se,stopDictation:le,onStop:P,isDictating:te,isTranscribing:re,isResponseInProgress:A,isDictationSupported:q}))return;if(ue.phase===`starting`||ue.phase===`active`){ue.stopRealtime();return}if(ue.isAvailable){ue.phase===`inactive`&&ue.startRealtime(`composer_button_existing_thread`);return}ce()};}";
+
+const halfPatchedCurrentComposerControlSourceWithFallbackAliases =
+  "function hz(e){let{conversationId:l,isResponseInProgress:T,onStop:k,submitBlockReason:A,voiceControls:F}=e,I=h===void 0?!1:h,L=mu(),R=fu(L,tg),z=fu(L,eg),{enterBehavior:B}=Ul(),V=Wt(),{canRetryDictation:ee,dictationShortcutLabel:te,isDictating:ne,isDictationSupported:re,isNewRealtimeConversationAvailable:ae,isRealtimeSubmitStarting:U,isTranscribing:W,startDictation:oe,startRealtimeConversation:se,stopDictation:ce,threadRealtime:J}=F;let Fe=Pe,Ie=A===`empty-message`&&!T&&(J.isAvailable&&J.phase!==`active`||ae),Le=a(Po,`composer.startVoiceMode`),Re;Re=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:oe,stopDictation:ce,onStop:P,isDictating:ne,isTranscribing:W,isResponseInProgress:A,isDictationSupported:re}))return;if(J.phase===`starting`||J.phase===`active`){J.stopRealtime();return}if(J.isAvailable){J.phase===`inactive`&&se();return}se()};}";
 
 const assistantRenderSource =
   "return (0,$.jsx)(Ov,{item:n,alwaysShowActions:M,assistantCopyText:p,turnId:m,after:g,conversationId:o,cwd:u,renderCodeBlocksAsWritingBlocks:V})";
@@ -1767,6 +1770,22 @@ test("composer control patch repairs bundles where only the click handler was pa
   assert.match(patched, /isDictationSupported:ee/);
   assert.doesNotMatch(patched, /isDictating:te/);
   assert.doesNotMatch(patched, /isDictationSupported:q/);
+});
+
+test("composer control patch repairs stale fallback aliases in existing toggle payloads", () => {
+  const patched = twice(applyComposerControlPatch, halfPatchedCurrentComposerControlSourceWithFallbackAliases);
+  assert.match(
+    patched,
+    /codexLinuxConversationSync\?\.\(l,\{isResponseInProgress:T,isDictating:ne,isTranscribing:W,startDictation:oe,stopDictation:ce,onStop:k\}\)/,
+  );
+  assert.match(
+    patched,
+    /codexLinuxConversationToggle\?\.\(\{conversationId:l,startDictation:oe,stopDictation:ce,onStop:k,isDictating:ne,isTranscribing:W,isResponseInProgress:T,isDictationSupported:re\}\)/,
+  );
+  assert.match(patched, /codexLinuxConversationActive=globalThis\.codexLinuxConversationIsActive/);
+  assert.doesNotMatch(patched, /conversationId:v,startDictation:oe/);
+  assert.doesNotMatch(patched, /onStop:P/);
+  assert.doesNotMatch(patched, /isResponseInProgress:A,isDictationSupported:re/);
 });
 
 test("composer patch ignores adjacent composer chunks", () => {

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -101,6 +101,9 @@ const halfPatchedCurrentComposerControlSource =
 const halfPatchedCurrentComposerControlSourceWithFallbackAliases =
   "function hz(e){let{conversationId:l,isResponseInProgress:T,onStop:k,submitBlockReason:A,voiceControls:F}=e,I=h===void 0?!1:h,L=mu(),R=fu(L,tg),z=fu(L,eg),{enterBehavior:B}=Ul(),V=Wt(),{canRetryDictation:ee,dictationShortcutLabel:te,isDictating:ne,isDictationSupported:re,isNewRealtimeConversationAvailable:ae,isRealtimeSubmitStarting:U,isTranscribing:W,startDictation:oe,startRealtimeConversation:se,stopDictation:ce,threadRealtime:J}=F;let Fe=Pe,Ie=A===`empty-message`&&!T&&(J.isAvailable&&J.phase!==`active`||ae),Le=a(Po,`composer.startVoiceMode`),Re;Re=()=>{if(globalThis.codexLinuxConversationToggle?.({conversationId:v,startDictation:oe,stopDictation:ce,onStop:P,isDictating:ne,isTranscribing:W,isResponseInProgress:A,isDictationSupported:re}))return;if(J.phase===`starting`||J.phase===`active`){J.stopRealtime();return}if(J.isAvailable){J.phase===`inactive`&&se();return}se()};}";
 
+const driftedCurrentComposerControlSource =
+  "function hz(e){let{conversationId:l,isResponseInProgress:T,onStop:k,submitBlockReason:A,voiceControls:F}=e,I=h===void 0?!1:h,L=mu(),R=fu(L,tg),z=fu(L,eg),{enterBehavior:B}=Ul(),V=Wt(),{canRetryDictation:ee,dictationShortcutLabel:te,isDictating:ne,isDictationSupported:re,isNewRealtimeConversationAvailable:ae,isRealtimeSubmitStarting:U,isTranscribing:W,startDictation:oe,startRealtimeConversation:se,stopDictation:ce,threadRealtime:J}=M;let Fe=Pe,Ie=A===`empty-message`&&!T&&(J.isAvailable&&J.phase!==`active`||ae),Le=a(Po,`composer.startVoiceMode`),Re;Re=()=>{if(J.phase===`starting`||J.phase===`active`){J.stopRealtime();return}if(J.isAvailable){J.phase===`inactive`&&se();return}se()};}";
+
 const assistantRenderSource =
   "return (0,$.jsx)(Ov,{item:n,alwaysShowActions:M,assistantCopyText:p,turnId:m,after:g,conversationId:o,cwd:u,renderCodeBlocksAsWritingBlocks:V})";
 
@@ -1786,6 +1789,19 @@ test("composer control patch repairs stale fallback aliases in existing toggle p
   assert.doesNotMatch(patched, /conversationId:v,startDictation:oe/);
   assert.doesNotMatch(patched, /onStop:P/);
   assert.doesNotMatch(patched, /isResponseInProgress:A,isDictationSupported:re/);
+});
+
+test("composer control patch skips current payloads when scoped aliases drift", () => {
+  const { value: patched, warnings } = captureWarns(() =>
+    twice(applyComposerControlPatch, driftedCurrentComposerControlSource),
+  );
+  assert.equal(patched, driftedCurrentComposerControlSource);
+  assert.match(warnings.join("\n"), /Could not resolve composer prop aliases/);
+  assert.match(warnings.join("\n"), /Could not find composer voice button click handler/);
+  assert.doesNotMatch(patched, /codexLinuxConversationSync/);
+  assert.doesNotMatch(patched, /codexLinuxConversationToggle/);
+  assert.doesNotMatch(patched, /conversationId:v/);
+  assert.doesNotMatch(patched, /onStop:P/);
 });
 
 test("composer patch ignores adjacent composer chunks", () => {

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -33,10 +33,30 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
   }
 
   const copilotSavePatchMarker = "copilot-default-reasoning-effort`,";
+  const copilotAsyncSaveRegex =
+    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2,\{throwOnFailure:!0\}\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)(throw Error\(`Model settings host is unavailable`\);|return;)/;
   const copilotSaveRegex =
     /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)return;/;
   if (patchedSource.includes(copilotSavePatchMarker)) {
     // Already patched.
+  } else if (copilotAsyncSaveRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      copilotAsyncSaveRegex,
+      (
+        _match,
+        updateConversationVar,
+        modelArgVar,
+        effortArgVar,
+        isCopilotVar,
+        persistStateVar,
+        stateScopeVar,
+        loggerVar,
+        configVar,
+        hostReadyVar,
+        unavailableTail,
+      ) =>
+        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){await ${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar},{throwOnFailure:!0});await ${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar},{throwOnFailure:!0});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})${unavailableTail}`,
+    );
   } else if (copilotSaveRegex.test(patchedSource)) {
     patchedSource = patchedSource.replace(
       copilotSaveRegex,

--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -253,17 +253,43 @@ function detectReactAlias(source) {
   return "X";
 }
 
+function settingsRowAlias(source) {
+  return importAlias(source, "settings-row", "r") ?? importAlias(source, "settings-row", "n") ?? "J";
+}
+
+function formatHookAlias(source) {
+  return importAlias(source, "lib", "l") ?? importAlias(source, "lib", "c") ?? "N";
+}
+
+function formattedMessageAlias(source) {
+  return importAlias(source, "lib", "s") ?? importAlias(source, "lib", "o") ?? "P";
+}
+
+function currentSettingsAliasesNeedRefresh(source) {
+  const jsx = detectJsxAlias(source);
+  const settingsRow = settingsRowAlias(source);
+  const formatHook = formatHookAlias(source);
+  const formattedMessage = formattedMessageAlias(source);
+  return !(
+    source.includes(`(0,${jsx}.jsx)(${settingsRow},{label:l,`) &&
+    source.includes(`c=${formatHook}();`) &&
+    source.includes("codexLinuxReadAloudChooseFolderLabel=c.formatMessage") &&
+    source.includes(`(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.label\``) &&
+    source.includes(`(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.readAloud.title\``)
+  );
+}
+
 function currentGeneralSettingsReadAloudBlockSource(source) {
   const jsx = detectJsxAlias(source);
   const react = detectReactAlias(source);
   const settingsPage = importAlias(source, "settings-content-layout", "t") ?? "St";
-  const settingsRow = importAlias(source, "settings-row", "n") ?? "K";
+  const settingsRow = settingsRowAlias(source);
   const toggle = importAlias(source, "toggle", "t") ?? "G";
-  const formatHook = importAlias(source, "lib", "c") ?? "F";
-  const formattedMessage = importAlias(source, "lib", "o") ?? "I";
+  const formatHook = formatHookAlias(source);
+  const formattedMessage = formattedMessageAlias(source);
   const postGlobalState = importAlias(source, "vscode-api", "n") ?? "k";
 
-  return `/*${CURRENT_SETTINGS_BLOCK_MARKER}*/function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let[e,t]=(0,${react}.useState)(!1),[n,r]=(0,${react}.useState)(1.05),[i,a]=(0,${react}.useState)(!0),[o,s]=(0,${react}.useState)(null),c=${formatHook}();(0,${react}.useEffect)(()=>{let e=!0;return a(!0),Promise.all([${postGlobalState}(\`get-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)}}}),${postGlobalState}(\`get-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)}}})]).then(([n,i])=>{e&&(t(n?.value===!0),r(codexLinuxReadAloudPaceValue(i?.value??1.05)),s(null))}).catch(t=>{e&&s(t instanceof Error?t.message:String(t))}).finally(()=>{e&&a(!1)}),()=>{e=!1}},[]);let l=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),u=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`}),d=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),f=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),p=c.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),m=c.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),h=c.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),g=c.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),_=c.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),v=e=>{let n=e;t(n),s(null),${postGlobalState}(\`set-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)},value:n}}).catch(e=>{t(!n),s(e instanceof Error?e.message:String(e))})},y=e=>{let t=codexLinuxReadAloudPaceValue(e.currentTarget.value);r(t),s(null),${postGlobalState}(\`set-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)},value:t}}).catch(e=>{s(e instanceof Error?e.message:String(e))})},b=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,x=(0,${jsx}.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:n,disabled:i,onChange:y,"aria-label":g,className:\`h-2 w-36 accent-token-text-primary\`}),(0,${jsx}.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${n.toFixed(2)}x\`})]}),C=o?(0,${jsx}.jsx)(\`div\`,{className:\`text-sm text-token-text-secondary\`,children:o}):null;return(0,${jsx}.jsxs)(${jsx}.Fragment,{children:[(0,${jsx}.jsx)(${settingsRow},{label:l,description:(0,${jsx}.jsxs)(${jsx}.Fragment,{children:[u,C]}),control:(0,${jsx}.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(${toggle},{checked:e===!0,disabled:i,onChange:v,ariaLabel:p}),e?(0,${jsx}.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:m}),(0,${jsx}.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:h}),(0,${jsx}.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:_,"aria-label":_,children:\`?\`})]}):null]})}),e?(0,${jsx}.jsx)(${settingsRow},{label:d,description:f,control:x}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,${jsx}.jsx)(${settingsPage},{title:(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),subtitle:(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.readAloud.subtitle\`,defaultMessage:\`Listen to assistant responses with a local Kokoro voice.\`,description:\`Subtitle for Linux read aloud settings section\`}),children:(0,${jsx}.jsx)(\`div\`,{className:\`max-w-3xl\`,children:(0,${jsx}.jsx)(codexLinuxReadAloudSettingsRow,{})})})}`;
+  return `/*${CURRENT_SETTINGS_BLOCK_MARKER}*/function codexLinuxReadAloudPaceValue(e){let t=Number(e);return Number.isFinite(t)?Math.min(1.4,Math.max(.7,Math.round(t*20)/20)):1.05}function codexLinuxReadAloudSettingsRow(){let[e,t]=(0,${react}.useState)(!1),[n,r]=(0,${react}.useState)(1.05),[i,a]=(0,${react}.useState)(!0),[o,s]=(0,${react}.useState)(null),c=${formatHook}();(0,${react}.useEffect)(()=>{let e=!0;return a(!0),Promise.all([${postGlobalState}(\`get-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)}}}),${postGlobalState}(\`get-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)}}})]).then(([n,i])=>{e&&(t(n?.value===!0),r(codexLinuxReadAloudPaceValue(i?.value??1.05)),s(null))}).catch(t=>{e&&s(t instanceof Error?t.message:String(t))}).finally(()=>{e&&a(!1)}),()=>{e=!1}},[]);let l=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),u=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.description\`,defaultMessage:\`Show a read aloud button under assistant responses. If the Kokoro voice files are missing, choose a local folder or download them.\`,description:\`Description for Linux read aloud setting\`}),d=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),f=(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.general.readAloud.pace.description\`,defaultMessage:\`Adjust the read aloud speed\`,description:\`Description for Linux read aloud pace setting\`}),codexLinuxReadAloudToggleLabel=c.formatMessage({id:\`settings.general.readAloud.label\`,defaultMessage:\`Read aloud responses\`,description:\`Label for Linux read aloud setting\`}),codexLinuxReadAloudChooseFolderLabel=c.formatMessage({id:\`settings.general.readAloud.chooseFolder\`,defaultMessage:\`Choose folder\`,description:\`Button label for choosing an existing Kokoro model folder\`}),codexLinuxReadAloudDownloadVoiceLabel=c.formatMessage({id:\`settings.general.readAloud.downloadVoice\`,defaultMessage:\`Download voice\`,description:\`Button label for downloading the Kokoro voice model\`}),codexLinuxReadAloudPaceLabel=c.formatMessage({id:\`settings.general.readAloud.pace.label\`,defaultMessage:\`Speech pace\`,description:\`Label for Linux read aloud pace setting\`}),codexLinuxReadAloudHelpLabel=c.formatMessage({id:\`settings.general.readAloud.help\`,defaultMessage:\`Choose folder expects kokoro-v1.0.onnx and voices-v1.0.bin. Download voice creates a managed Python runtime and downloads the Kokoro files from Hugging Face.\`,description:\`Help text for Linux read aloud setup actions\`}),v=e=>{let n=e;t(n),s(null),${postGlobalState}(\`set-global-state\`,{params:{key:${JSON.stringify(SETTINGS_KEY)},value:n}}).catch(e=>{t(!n),s(e instanceof Error?e.message:String(e))})},y=e=>{let t=codexLinuxReadAloudPaceValue(e.currentTarget.value);r(t),s(null),${postGlobalState}(\`set-global-state\`,{params:{key:${JSON.stringify(KOKORO_SPEED_KEY)},value:t}}).catch(e=>{s(e instanceof Error?e.message:String(e))})},b=\`rounded-md border border-token-border px-2 py-1 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60\`,x=(0,${jsx}.jsxs)(\`div\`,{className:\`flex items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(\`input\`,{type:\`range\`,min:.7,max:1.4,step:.05,value:n,disabled:i,onChange:y,"aria-label":codexLinuxReadAloudPaceLabel,className:\`h-2 w-36 accent-token-text-primary\`}),(0,${jsx}.jsx)(\`span\`,{className:\`w-12 text-right text-sm text-token-text-secondary\`,children:\`\${n.toFixed(2)}x\`})]}),C=o?(0,${jsx}.jsx)(\`div\`,{className:\`text-sm text-token-text-secondary\`,children:o}):null;return(0,${jsx}.jsxs)(${jsx}.Fragment,{children:[(0,${jsx}.jsx)(${settingsRow},{label:l,description:(0,${jsx}.jsxs)(${jsx}.Fragment,{children:[u,C]}),control:(0,${jsx}.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(${toggle},{checked:e===!0,disabled:i,onChange:v,ariaLabel:codexLinuxReadAloudToggleLabel}),e?(0,${jsx}.jsxs)(\`div\`,{className:\`flex flex-wrap items-center justify-end gap-2\`,children:[(0,${jsx}.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`choose-folder\`,e.currentTarget),children:codexLinuxReadAloudChooseFolderLabel}),(0,${jsx}.jsx)(\`button\`,{type:\`button\`,className:b,onClick:e=>globalThis.${SETUP_MARKER}?.(\`download\`,e.currentTarget),children:codexLinuxReadAloudDownloadVoiceLabel}),(0,${jsx}.jsx)(\`span\`,{className:\`inline-flex h-7 w-7 select-none items-center justify-center rounded-full border border-token-border text-sm text-token-text-secondary\`,title:codexLinuxReadAloudHelpLabel,"aria-label":codexLinuxReadAloudHelpLabel,children:\`?\`})]}):null]})}),e?(0,${jsx}.jsx)(${settingsRow},{label:d,description:f,control:x}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,${jsx}.jsx)(${settingsPage},{title:(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.readAloud.title\`,defaultMessage:\`Read Aloud\`,description:\`Title for Linux read aloud settings section\`}),subtitle:(0,${jsx}.jsx)(${formattedMessage},{id:\`settings.readAloud.subtitle\`,defaultMessage:\`Listen to assistant responses with a local Kokoro voice.\`,description:\`Subtitle for Linux read aloud settings section\`}),children:(0,${jsx}.jsx)(\`div\`,{className:\`max-w-3xl\`,children:(0,${jsx}.jsx)(codexLinuxReadAloudSettingsRow,{})})})}`;
 }
 
 function exportedGeneralSettingsFunctionName(source) {
@@ -286,10 +312,15 @@ function replaceExistingGeneralSettingsReadAloudRow(source, functionName, blockS
     return source;
   }
   const paceStart = source.indexOf("function codexLinuxReadAloudPaceValue(");
-  const start = paceStart !== -1 && paceStart < rowStart ? paceStart : rowStart;
+  let start = paceStart !== -1 && paceStart < rowStart ? paceStart : rowStart;
   const end = source.indexOf(`function ${functionName}(){`, rowStart);
   if (end === -1) {
     return source;
+  }
+  const marker = `/*${CURRENT_SETTINGS_BLOCK_MARKER}*/`;
+  const markerStart = source.lastIndexOf(marker, start);
+  if (markerStart !== -1 && source.slice(markerStart + marker.length, start).trim() === "") {
+    start = markerStart;
   }
   return `${source.slice(0, start)}${blockSource}${source.slice(end)}`;
 }
@@ -318,8 +349,13 @@ function applyGeneralSettingsPatch(source) {
       functionName !== "Gn" &&
       patched.includes("function codexLinuxReadAloudSettingsPage") &&
       !patched.includes(CURRENT_SETTINGS_BLOCK_MARKER);
+    const needsCurrentSettingsAliasRefresh =
+      functionName !== "Gn" &&
+      patched.includes(CURRENT_SETTINGS_BLOCK_MARKER) &&
+      currentSettingsAliasesNeedRefresh(patched);
     if (
       needsCurrentAliasRefresh ||
+      needsCurrentSettingsAliasRefresh ||
       !patched.includes(KOKORO_SPEED_KEY) ||
       !patched.includes("settings.general.readAloud.chooseFolder") ||
       !patched.includes("settings.general.readAloud.help") ||

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -962,28 +962,39 @@ test("general settings patch follows current export map instead of stale Gn alia
   const source = [
     'import{s as e}from"./src-BRBmN298.js";',
     'import{t as xt}from"./settings-content-layout-Dm8iYKt_.js";',
-    'import{n as q}from"./settings-row-xI_5tNBH.js";',
-    'import{t as K}from"./toggle-Cl52yCxI.js";',
-    'import{c as F,o as I}from"./lib-MoKmYgcO.js";',
-    'import{n as k}from"./vscode-api-DjORcpSo.js";',
+    'import{a as st,r as K,t as ct}from"./dropdown-CTBRoADH.js";',
+    'import{r as J}from"./settings-row-FLzCWFCC.js";',
+    'import{t as Tg}from"./toggle-Cl52yCxI.js";',
+    'import{i as M,l as N,s as P}from"./lib-MoKmYgcO.js";',
+    'import{t as F}from"./clsx-DF17mjDp.js";',
+    'import{n as I,y as L}from"./app-shell-state-Dq2x034T.js";',
+    'import{n as m}from"./vscode-api-DjORcpSo.js";',
     'import{n as v,t as y}from"./jsx-runtime-CiQ1k8xo.js";',
     'import{t as St}from"./sun-BbSktlDj.js";',
     'import{a as U,i as W}from"./setting-storage-CwKZnsvR.js";',
     'import{n as wt}from"./external-agent-import-step-CfOKFuct.js";',
     "var Q=e(v(),1),$=y();",
     "function Gn(){return (0,$.jsx)(K,{label:`Service tier`})}",
-    "function nr(){return (0,$.jsxs)(q,{className:`gap-2`,children:[x,(0,$.jsx)(q.Content,{children:(0,$.jsxs)(wt,{children:[v,y,b]})})]})}",
+    "function nr(){return (0,$.jsx)(J,{label:`General`})}",
     "export{or as i,ar as n,nr as r,Tr as t};",
   ].join("");
   const patched = twice(applyGeneralSettingsPatch, source);
   assert.match(patched, /codexLinuxReadAloudSettingsAliasesV2/);
   assert.match(patched, /function codexLinuxReadAloudSettingsPage\(\)\{return\(0,\$\.jsx\)\(xt/);
-  assert.match(patched, /\(0,\$\.jsx\)\(q,\{label:l/);
-  assert.match(patched, /\(0,\$\.jsx\)\(K,\{checked:e===!0/);
+  assert.match(patched, /\(0,\$\.jsx\)\(J,\{label:l/);
+  assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(K,\{label:l/);
+  assert.match(patched, /\(0,\$\.jsx\)\(Tg,\{checked:e===!0/);
+  assert.match(patched, /c=N\(\);/);
+  assert.match(patched, /\(0,\$\.jsx\)\(P,\{id:`settings\.general\.readAloud\.label`/);
+  assert.match(patched, /\(0,\$\.jsx\)\(P,\{id:`settings\.readAloud\.title`/);
+  assert.doesNotMatch(patched, /c=F\(\);/);
+  assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(I,\{id:`settings\.(general\.readAloud|readAloud)\./);
   assert.match(patched, /\(0,Q\.useState\)\(!1\)/);
-  assert.match(patched, /k\(`get-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled"\}\}\)/);
-  assert.match(patched, /k\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled",value:n\}\}\)/);
-  assert.match(patched, /k\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-kokoro-speed",value:t\}\}\)/);
+  assert.match(patched, /m\(`get-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled"\}\}\)/);
+  assert.match(patched, /m\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-enabled",value:n\}\}\)/);
+  assert.match(patched, /m\(`set-global-state`,\{params:\{key:"codex-linux-read-aloud-kokoro-speed",value:t\}\}\)/);
+  assert.match(patched, /codexLinuxReadAloudChooseFolderLabel=c\.formatMessage/);
+  assert.doesNotMatch(patched, /m=c\.formatMessage/);
   assert.doesNotMatch(patched, /set-setting|get-setting/);
   assert.doesNotMatch(patched, /let e=S\(D\),t=F\(\),n=\{key:"codex-linux-read-aloud-enabled",default:!1\}/);
   assert.doesNotMatch(patched, /U\(e,n,t\)/);
@@ -1000,10 +1011,13 @@ test("general settings patch upgrades a stale current read aloud settings page",
   const source = [
     'import{s as e}from"./src-BRBmN298.js";',
     'import{t as xt}from"./settings-content-layout-Dm8iYKt_.js";',
-    'import{n as q}from"./settings-row-xI_5tNBH.js";',
-    'import{t as K}from"./toggle-Cl52yCxI.js";',
-    'import{c as F,o as I}from"./lib-MoKmYgcO.js";',
-    'import{n as k}from"./vscode-api-DjORcpSo.js";',
+    'import{a as st,r as K,t as ct}from"./dropdown-CTBRoADH.js";',
+    'import{r as J}from"./settings-row-FLzCWFCC.js";',
+    'import{t as Tg}from"./toggle-Cl52yCxI.js";',
+    'import{i as M,l as N,s as P}from"./lib-MoKmYgcO.js";',
+    'import{t as F}from"./clsx-DF17mjDp.js";',
+    'import{n as I,y as L}from"./app-shell-state-Dq2x034T.js";',
+    'import{n as m}from"./vscode-api-DjORcpSo.js";',
     'import{n as v,t as y}from"./jsx-runtime-CiQ1k8xo.js";',
     'import{t as St}from"./sun-BbSktlDj.js";',
     'import{a as U,i as W}from"./setting-storage-CwKZnsvR.js";',
@@ -1011,7 +1025,7 @@ test("general settings patch upgrades a stale current read aloud settings page",
     "var Q=e(v(),1),$=y();",
     "function Gn(){return (0,$.jsx)(K,{label:`Service tier`})}",
     "function codexLinuxReadAloudPaceValue(e){return 1.05}function codexLinuxReadAloudSettingsRow(){return `codex-linux-read-aloud-enabled codex-linux-read-aloud-kokoro-speed settings.general.readAloud.chooseFolder settings.general.readAloud.help`}function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(St,{children:(0,$.jsx)(W,{electron:!0,children:(0,$.jsx)(wt,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})})})}",
-    "function nr(){return (0,$.jsx)(q,{label:`General`})}",
+    "function nr(){return (0,$.jsx)(J,{label:`General`})}",
     "export{or as i,ar as n,nr as r,Tr as t,codexLinuxReadAloudSettingsPage as ReadAloudSettings};",
   ].join("");
   const patched = twice(applyGeneralSettingsPatch, source);
@@ -1019,7 +1033,43 @@ test("general settings patch upgrades a stale current read aloud settings page",
   assert.equal((patched.match(/function codexLinuxReadAloudSettingsPage/g) ?? []).length, 1);
   assert.match(patched, /codexLinuxReadAloudSettingsAliasesV2/);
   assert.match(patched, /function codexLinuxReadAloudSettingsPage\(\)\{return\(0,\$\.jsx\)\(xt/);
+  assert.match(patched, /c=N\(\);/);
+  assert.match(patched, /\(0,\$\.jsx\)\(P,\{id:`settings\.readAloud\.title`/);
   assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(St,\{children:\(0,\$\.jsx\)\(W/);
+});
+
+test("general settings patch refreshes a current read aloud row with a stale settings-row alias", () => {
+  const source = [
+    'import{s as e}from"./src-BRBmN298.js";',
+    'import{t as xt}from"./settings-content-layout-Dm8iYKt_.js";',
+    'import{a as st,r as K,t as ct}from"./dropdown-CTBRoADH.js";',
+    'import{r as J}from"./settings-row-FLzCWFCC.js";',
+    'import{t as Tg}from"./toggle-Cl52yCxI.js";',
+    'import{i as M,l as N,s as P}from"./lib-MoKmYgcO.js";',
+    'import{t as F}from"./clsx-DF17mjDp.js";',
+    'import{n as I,y as L}from"./app-shell-state-Dq2x034T.js";',
+    'import{n as m}from"./vscode-api-DjORcpSo.js";',
+    'import{n as v,t as y}from"./jsx-runtime-CiQ1k8xo.js";',
+    "var Q=e(v(),1),$=y();",
+    "function Gn(){return (0,$.jsx)(K,{label:`Service tier`})}",
+    "/*codexLinuxReadAloudSettingsAliasesV2*/function codexLinuxReadAloudPaceValue(e){return 1.05}function codexLinuxReadAloudSettingsRow(){let e=!0,l=`codex-linux-read-aloud-enabled`,d=`codex-linux-read-aloud-kokoro-speed`;return(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(K,{label:l,description:`settings.general.readAloud.chooseFolder settings.general.readAloud.help`,control:null}),e?(0,$.jsx)(K,{label:d,description:`settings.general.readAloud.help`,control:null}):null]})}function codexLinuxReadAloudSettingsPage(){return(0,$.jsx)(xt,{children:(0,$.jsx)(codexLinuxReadAloudSettingsRow,{})})}",
+    "function nr(){return (0,$.jsx)(J,{label:`General`})}",
+    "export{or as i,ar as n,nr as r,Tr as t,codexLinuxReadAloudSettingsPage as ReadAloudSettings};",
+  ].join("");
+  const patched = twice(applyGeneralSettingsPatch, source);
+  assert.equal((patched.match(/function codexLinuxReadAloudSettingsRow/g) ?? []).length, 1);
+  assert.equal((patched.match(/function codexLinuxReadAloudSettingsPage/g) ?? []).length, 1);
+  assert.equal((patched.match(/codexLinuxReadAloudSettingsAliasesV2/g) ?? []).length, 1);
+  assert.match(patched, /codexLinuxReadAloudSettingsAliasesV2/);
+  assert.match(patched, /\(0,\$\.jsx\)\(J,\{label:l/);
+  assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(K,\{label:l/);
+  assert.match(patched, /\(0,\$\.jsx\)\(Tg,\{checked:e===!0/);
+  assert.match(patched, /c=N\(\);/);
+  assert.match(patched, /\(0,\$\.jsx\)\(P,\{id:`settings\.general\.readAloud\.label`/);
+  assert.doesNotMatch(patched, /c=F\(\);/);
+  assert.doesNotMatch(patched, /\(0,\$\.jsx\)\(I,\{id:`settings\.(general\.readAloud|readAloud)\./);
+  assert.match(patched, /codexLinuxReadAloudChooseFolderLabel=c\.formatMessage/);
+  assert.doesNotMatch(patched, /m=c\.formatMessage/);
 });
 
 test("general settings wrapper re-exports the read aloud settings page", () => {

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -523,6 +523,41 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
     return source;
   }
 
+  const currentStateKeysVar = source.match(/([A-Za-z_$][\w$]*)\.CODEX_MOBILE_SETUP_COMPLETED/u)?.[1] ?? null;
+  const currentStateSetterVar =
+    source.match(/([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.keepRemoteControlAwakeWhilePluggedIn,/u)?.[1] ??
+    null;
+  const currentScopeMatch = source.match(
+    /function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\{let [A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.c\)\(\d+\),[\s\S]*?([A-Za-z_$][\w$]*)=a\(s\)[\s\S]*?`local_remote_control_client_id`[\s\S]*?onRevoked:[A-Za-z_$][\w$]*=>\{[A-Za-z_$][\w$]*\.setData[\s\S]*?onRevokeResult:/u,
+  );
+  const currentLocalRevokePattern =
+    /onRevoked:([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\3\?\.filter\(\3=>\3\.clientId!==\1\)\),\2\.invalidate\(\)\},onRevokeResult:/u;
+  if (
+    currentStateKeysVar != null &&
+    currentStateSetterVar != null &&
+    currentScopeMatch != null &&
+    currentLocalRevokePattern.test(source)
+  ) {
+    const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
+    if (helperNeedle == null) {
+      console.warn("WARN: Could not find remote-control revoke toast marker - skipping setup reset helper insertion");
+      return source;
+    }
+    const helper = [
+      `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n,r,i){`,
+      "let a=e?.filter(e=>(e.clientId??e.client_id)!==t);",
+      "return a?.length===0&&i(n,r.CODEX_MOBILE_SETUP_COMPLETED,!1),a",
+      "}",
+    ].join("");
+    return source
+      .replace(helperNeedle, `${helper}${helperNeedle}`)
+      .replace(
+        currentLocalRevokePattern,
+        (_needle, clientIdVar, querySnapshotVar, dataVar) =>
+          `onRevoked:${clientIdVar}=>{${querySnapshotVar}.setData(${dataVar}=>${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(${dataVar},${clientIdVar},${currentScopeMatch[1]},${currentStateKeysVar},${currentStateSetterVar})),${querySnapshotVar}.invalidate()},onRevokeResult:`,
+      );
+  }
+
   const setGlobalStateMatch = source.match(
     /mutationFn:[A-Za-z_$][\w$]*=>([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.ADDED_REMOTE_CONTROL_ENV_IDS,/u,
   );
@@ -540,7 +575,7 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
 
   const helper = [
     `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n){`,
-    "let r=e?.filter(e=>e.client_id!==t);",
+    "let r=e?.filter(e=>(e.client_id??e.clientId)!==t);",
     `return r?.length===0&&${setGlobalStateFn}(n,\`codex-mobile-has-connected-device\`,!1),r`,
     "}",
   ].join("");
@@ -770,17 +805,28 @@ function applyLinuxRemoteControlSshInstallActionPatch(source) {
   }
 
   const actionGateRegex =
-    /let ([A-Za-z_$][\w$]*)=!([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,/u;
+    /let ([A-Za-z_$][\w$]*)=([^;]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,/u;
   const match = source.match(actionGateRegex);
-  if (match == null) {
+  if (match != null) {
+    const [, gateVar, , , renderedActionVar, connectionActionVar, renderActionFn] = match;
+    return source.replace(
+      actionGateRegex,
+      `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1;${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
+    );
+  }
+
+  const currentActionGateRegex =
+    /let ([A-Za-z_$][\w$]*)=([^;,]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\),([\s\S]*?)([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\6\.action,/u;
+  const currentMatch = source.match(currentActionGateRegex);
+  if (currentMatch == null) {
     console.warn("WARN: Could not find remote-control SSH install action gate - skipping Linux install action patch");
     return source;
   }
 
-  const [, gateVar, , , renderedActionVar, connectionActionVar, renderActionFn] = match;
+  const [, gateVar, , , betweenGateAndAction, renderedActionVar, connectionActionVar, renderActionFn] = currentMatch;
   return source.replace(
-    actionGateRegex,
-    `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1;${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
+    currentActionGateRegex,
+    `let ${gateVar}=/*${REMOTE_CONTROL_SSH_INSTALL_ACTION_MARKER}*/!1,${betweenGateAndAction}${renderedActionVar}=${connectionActionVar}==null?null:${renderActionFn}({action:${connectionActionVar}.action,`,
   );
 }
 
@@ -793,18 +839,114 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
   }
 
   const actionBuilderRegex =
-    /function ([A-Za-z_$][\w$]*)\(\{action:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)\{if\(\2==null\)return null;switch\(\2\.kind\)\{case`install-codex`:return\{disabled:\3,label:\2\.label,loading:\5,loadingLabel:\2\.loadingLabel,renderInElectronOnly:!0,tooltipText:\2\.tooltipText,onClick:\(\)=>\7\(\4\)\}/u;
+    /function ([A-Za-z_$][\w$]*)\(\{action:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)(?:,onRestart:([A-Za-z_$][\w$]*))?\}\)\{if\(\2==null\)return null;switch\(\2\.kind\)\{case`install-codex`:return\{disabled:\3,label:\2\.label,loading:\5,loadingLabel:\2\.loadingLabel,renderInElectronOnly:!0,tooltipText:\2\.tooltipText,onClick:\(\)=>\7\(\4\)\}/u;
   const actionCallRegex =
-    /let ([A-Za-z_$][\w$]*)=!([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
+    /let ([A-Za-z_$][\w$]*)=([^;]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\);([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\5\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),(?:onRestart:([A-Za-z_$][\w$]*),)?onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
   const mutationRegex =
     /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.mutate\(\{hostId:\2\},\{onSuccess:\(\{state:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)\}\}\)\}/u;
   const localVersionRegex =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\((\d+)\),\{connection:([A-Za-z_$][\w$]*),disabled:([A-Za-z_$][\w$]*),installCodexPending:([A-Za-z_$][\w$]*),([\s\S]*?)onAuthenticate:([A-Za-z_$][\w$]*),([\s\S]*?)onInstallCodex:([A-Za-z_$][\w$]*),([\s\S]*?)\}=\2,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\6\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
+  const currentActionCallRegex =
+    /let ([A-Za-z_$][\w$]*)=([^;,]+?)&&\(([A-Za-z_$][\w$]*)\?\.code===`remote-codex-not-found`\|\|\3\?\.code===`update-required`\),([\s\S]*?)([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)==null\|\|\1\?null:([A-Za-z_$][\w$]*)\(\{action:\6\.action,disabled:([A-Za-z_$][\w$]*),hostId:([A-Za-z_$][\w$]*)\.hostId,installCodexPending:([A-Za-z_$][\w$]*),(?:onRestart:([A-Za-z_$][\w$]*),)?onAuthenticate:([A-Za-z_$][\w$]*),onInstallCodex:([A-Za-z_$][\w$]*)\}\)/u;
+  const currentLocalVersionRegex =
+    /\{appServerVersion:([A-Za-z_$][\w$]*),error:([A-Za-z_$][\w$]*),installedCodexVersion:([A-Za-z_$][\w$]*),state:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.hostId\),([A-Za-z_$][\w$]*)=\6\.displayName/u;
 
   const actionBuilderMatch = source.match(actionBuilderRegex);
   const actionCallMatch = source.match(actionCallRegex);
   const mutationMatch = source.match(mutationRegex);
   const localVersionMatch = source.match(localVersionRegex);
+  const currentActionCallMatch = source.match(currentActionCallRegex);
+  const currentLocalVersionMatch = source.match(currentLocalVersionRegex);
+  if (
+    actionBuilderMatch != null &&
+    mutationMatch != null &&
+    currentActionCallMatch != null &&
+    currentLocalVersionMatch != null
+  ) {
+    const [
+      ,
+      builderFn,
+      builderActionVar,
+      builderDisabledVar,
+      builderHostVar,
+      builderPendingVar,
+      builderAuthVar,
+      builderInstallVar,
+      builderRestartVar,
+    ] = actionBuilderMatch;
+    const builderRestartPart = builderRestartVar == null ? "" : `,onRestart:${builderRestartVar}`;
+    const actionBuilderReplacement =
+      `function ${builderFn}({action:${builderActionVar},disabled:${builderDisabledVar},hostId:${builderHostVar},installCodexPending:${builderPendingVar},` +
+      `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}${builderRestartPart}}){` +
+      `if(${builderActionVar}==null)return null;switch(${builderActionVar}.kind){case\`install-codex\`:return{disabled:${builderDisabledVar},label:${builderActionVar}.label,loading:${builderPendingVar},` +
+      `loadingLabel:${builderActionVar}.loadingLabel,renderInElectronOnly:!0,tooltipText:${builderActionVar}.tooltipText,onClick:()=>${builderInstallVar}(${builderHostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
+
+    const [
+      ,
+      gateVar,
+      gateExpression,
+      errorVar,
+      betweenGateAndAction,
+      renderedActionVar,
+      connectionActionVar,
+      renderActionFn,
+      disabledVar,
+      connectionVar,
+      pendingVar,
+      restartVar,
+      authenticateVar,
+      installVar,
+    ] = currentActionCallMatch;
+    const restartPart = restartVar == null ? "" : `onRestart:${restartVar},`;
+    const actionCallReplacement =
+      `let ${gateVar}=${gateExpression}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`),` +
+      `${betweenGateAndAction}${renderedActionVar}=${connectionActionVar}==null||${gateVar}?null:${renderActionFn}({action:${connectionActionVar}.action,disabled:${disabledVar},hostId:${connectionVar}.hostId,` +
+      `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),${restartPart}onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
+
+    const [
+      ,
+      currentAppServerVersionVar,
+      currentErrorVar,
+      currentInstalledVersionVar,
+      currentStateVar,
+      currentConnectionStateFn,
+      currentConnectionVar,
+      currentDisplayNameVar,
+    ] = currentLocalVersionMatch;
+    const currentLocalVersionReplacement =
+      `{appServerVersion:${currentAppServerVersionVar},error:${currentErrorVar},installedCodexVersion:${currentInstalledVersionVar},state:${currentStateVar}}=${currentConnectionStateFn}(${currentConnectionVar}.hostId),` +
+      `{appServerVersion:codexLinuxRemoteControlSshInstallLocalVersion}=${currentConnectionStateFn}(\`local\`);` +
+      `codexLinuxRemoteControlSshInstallDefaultRelease=codexLinuxRemoteControlValidRelease(codexLinuxRemoteControlSshInstallLocalVersion)??codexLinuxRemoteControlSshInstallDefaultRelease;` +
+      `let ${currentDisplayNameVar}=${currentConnectionVar}.displayName`;
+
+    const [
+      ,
+      mutationHandlerVar,
+      mutationHostVar,
+      mutationVar,
+      mutationStateVar,
+      mutationErrorVar,
+      syncStateFn,
+    ] = mutationMatch;
+    const mutationReplacement =
+      `${mutationHandlerVar}=(${mutationHostVar},codexLinuxRemoteControlSshInstallTargetRelease)=>{` +
+      `let codexLinuxRemoteControlSshInstallRequest={hostId:${mutationHostVar}},` +
+      `codexLinuxRemoteControlSshInstallResolvedRelease=codexLinuxRemoteControlSshInstallTargetRelease??codexLinuxRemoteControlSshInstallDefaultRelease;` +
+      `codexLinuxRemoteControlSshInstallResolvedRelease!=null&&(codexLinuxRemoteControlSshInstallRequest.release=codexLinuxRemoteControlSshInstallResolvedRelease),` +
+      `${mutationVar}.mutate(codexLinuxRemoteControlSshInstallRequest,{onSuccess:({state:${mutationStateVar},error:${mutationErrorVar}})=>{${syncStateFn}(${mutationHostVar},${mutationStateVar},${mutationErrorVar})}})}`;
+
+    const helper = [
+      "let codexLinuxRemoteControlSshInstallDefaultRelease=null;",
+      "function codexLinuxRemoteControlValidRelease(e){return typeof e==`string`&&e.trim().length>0?e.trim():null}",
+      `function ${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(e){return e?.code===\`update-required\`?codexLinuxRemoteControlValidRelease(e.minRequiredVersion):null}`,
+    ].join("");
+
+    return helper + source
+      .replace(currentLocalVersionRegex, currentLocalVersionReplacement)
+      .replace(actionBuilderRegex, actionBuilderReplacement)
+      .replace(currentActionCallRegex, actionCallReplacement)
+      .replace(mutationRegex, mutationReplacement);
+  }
   if (
     actionBuilderMatch == null ||
     actionCallMatch == null ||
@@ -858,10 +1000,12 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
     builderPendingVar,
     builderAuthVar,
     builderInstallVar,
+    builderRestartVar,
   ] = actionBuilderMatch;
+  const builderRestartPart = builderRestartVar == null ? "" : `,onRestart:${builderRestartVar}`;
   const actionBuilderReplacement =
     `function ${builderFn}({action:${builderActionVar},disabled:${builderDisabledVar},hostId:${builderHostVar},installCodexPending:${builderPendingVar},` +
-    `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}}){` +
+    `installCodexRelease:codexLinuxRemoteControlSshInstallReleaseTarget,onAuthenticate:${builderAuthVar},onInstallCodex:${builderInstallVar}${builderRestartPart}}){` +
     `if(${builderActionVar}==null)return null;switch(${builderActionVar}.kind){case\`install-codex\`:return{disabled:${builderDisabledVar},label:${builderActionVar}.label,loading:${builderPendingVar},` +
     `loadingLabel:${builderActionVar}.loadingLabel,renderInElectronOnly:!0,tooltipText:${builderActionVar}.tooltipText,onClick:()=>${builderInstallVar}(${builderHostVar},codexLinuxRemoteControlSshInstallReleaseTarget)}`;
 
@@ -876,13 +1020,15 @@ function applyLinuxRemoteControlSshInstallReleasePatch(source) {
     disabledVar,
     connectionVar,
     pendingVar,
+    restartVar,
     authenticateVar,
     installVar,
   ] = actionCallMatch;
+  const restartPart = restartVar == null ? "" : `onRestart:${restartVar},`;
   const actionCallReplacement =
-    `let ${gateVar}=!${loadGateVar}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`);` +
+    `let ${gateVar}=${loadGateVar}&&(${errorVar}?.code===\`remote-codex-not-found\`||${errorVar}?.code===\`update-required\`);` +
     `${renderedActionVar}=${connectionActionVar}==null||${gateVar}?null:${renderActionFn}({action:${connectionActionVar}.action,disabled:${disabledVar},hostId:${connectionVar}.hostId,` +
-    `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
+    `installCodexPending:${pendingVar},installCodexRelease:${REMOTE_CONTROL_SSH_INSTALL_RELEASE_MARKER}(${errorVar}),${restartPart}onAuthenticate:${authenticateVar},onInstallCodex:${installVar}})`;
 
   const [
     ,
@@ -1054,14 +1200,34 @@ function applyLinuxRemoteMobileChromeBridgePatch(source) {
   const currentBackendReplacement =
     "function _y(){let e=Su(dy);return codexLinuxRemoteMobileBrowserBackends(e==null?null:vy(e))}";
 
-  if (!source.includes(backendNeedle) || !source.includes(currentBackendNeedle)) {
-    console.warn("WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch");
-    return source;
+  if (source.includes(backendNeedle) && source.includes(currentBackendNeedle)) {
+    return source
+      .replace(backendNeedle, backendReplacement)
+      .replace(currentBackendNeedle, currentBackendReplacement);
   }
 
-  return source
-    .replace(backendNeedle, backendReplacement)
-    .replace(currentBackendNeedle, currentBackendReplacement);
+  const backendAllowlistPattern =
+    /var ([A-Za-z_$][\w$]*)=\["chrome","iab","cdp"\];function ([A-Za-z_$][\w$]*)\(e\)\{return \1\.some\(t=>t===e\)\}/u;
+  const readerPattern =
+    /function ([A-Za-z_$][\w$]*)\(\)\{let e=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\);return e==null\?null:([A-Za-z_$][\w$]*)\(e\)\.filter\(([A-Za-z_$][\w$]*)\)\}/u;
+  const allowlistMatch = source.match(backendAllowlistPattern);
+  const readerMatch = source.match(readerPattern);
+  if (allowlistMatch != null && readerMatch != null && readerMatch[5] === allowlistMatch[2]) {
+    const [, allowlistVar, allowlistFn] = allowlistMatch;
+    const [, readerFn, envReaderFn, backendsEnvVar, parseBackendsFn] = readerMatch;
+    return source
+      .replace(
+        backendAllowlistPattern,
+        `var ${allowlistVar}=["chrome","iab","cdp"];function ${allowlistFn}(e){return ${allowlistVar}.some(t=>t===e)}function codexLinuxRemoteMobileBrowserBackends(e){if(e==null)return null;if(!Array.isArray(e))return[];let t=e.filter(${allowlistFn});return typeof process!=\`undefined\`&&process.platform===\`linux\`&&!t.includes(\`chrome\`)?[\`chrome\`,...t]:t}`,
+      )
+      .replace(
+        readerPattern,
+        `function ${readerFn}(){let e=${envReaderFn}(${backendsEnvVar});return codexLinuxRemoteMobileBrowserBackends(e==null?null:${parseBackendsFn}(e))}`,
+      );
+  }
+
+  console.warn("WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch");
+  return source;
 }
 
 function applyLinuxRemoteMobileConversationHydrationPatch(source) {
@@ -1075,6 +1241,12 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       /([A-Za-z_$][\w$]*)\.resumeState===`needs_resume`&&\(\1\.threadRuntimeStatus=([A-Za-z_$][\w$]*)\)/u;
     if (runtimeNeedle.test(patched)) {
       patched = patched.replace(runtimeNeedle, runtimeReplacement);
+    } else if (
+      patched.includes("threadRuntimeStatus:e.threadRuntimeStatus") &&
+      patched.includes("t===`needs_resume`?n?.type===`active`")
+    ) {
+      // Current upstream preserves threadRuntimeStatus on thread summaries and
+      // already treats active needs-resume threads as live in the sidebar model.
     } else if (patched.includes("threadRuntimeStatus") && patched.includes("resumeState")) {
       console.warn("WARN: Could not find thread/list runtime-status needle - skipping remote mobile runtime-status patch");
     }
@@ -1085,10 +1257,10 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
   // Re-implement hydrate-on-turn/started + queue-while-hydrating without the deleted routes.
   if (!patched.includes(REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER)) {
     const unknownTurnNeedle =
-      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{z\.error\(`Received turn\/started for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received turn\/started for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
     const unknownTurnReplacement =
-      (_needle, conversationIdVar) =>
-        `if(!this.conversations.get(${conversationIdVar})){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let i=this.codexLinuxRemoteMobilePendingNotifications??=new Map,a=i.get(${conversationIdVar});a||(a=[],i.set(${conversationIdVar},a)),a.push(n),z.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:a.length},sensitive:{}});let o=(s=0)=>this.readThread(${conversationIdVar},{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar})??[];if(!t){if(s<12){z.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),z.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length},sensitive:{}});return}this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar});for(let e of c)this.onNotification(e.method,e.params)}).catch(e=>{if(s<12){z.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:${conversationIdVar},attempt:s+1},sensitive:{error:e}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),z.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:${conversationIdVar}},sensitive:{error:e}})});o();break}`;
+      (_needle, conversationIdVar, loggerVar) =>
+        `if(!this.conversations.get(${conversationIdVar})){/*${REMOTE_MOBILE_UNKNOWN_TURN_MARKER}*//*${REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER}*/let i=this.codexLinuxRemoteMobilePendingNotifications??=new Map,a=i.get(${conversationIdVar});a||(a=[],i.set(${conversationIdVar},a)),a.push(n),${loggerVar}.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:a.length},sensitive:{}});let o=(s=0)=>this.readThread(${conversationIdVar},{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar})??[];if(!t){if(s<12){${loggerVar}.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),${loggerVar}.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length},sensitive:{}});return}this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar});for(let e of c)this.onNotification(e.method,e.params)}).catch(e=>{if(s<12){${loggerVar}.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:${conversationIdVar},attempt:s+1},sensitive:{error:e}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),${loggerVar}.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:${conversationIdVar}},sensitive:{error:e}})});o();break}`;
     if (unknownTurnNeedle.test(patched)) {
       patched = patched.replace(unknownTurnNeedle, unknownTurnReplacement);
     } else if (patched.includes("Received turn/started for unknown conversation")) {
@@ -1096,30 +1268,34 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
     }
 
     const itemStartedNeedle =
-      "if(!this.conversations.get(a)){z.error(`Received item/started for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}";
-    const itemStartedReplacement =
-      "if(!this.conversations.get(a)){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(a);if(o){o.push(n),z.warning(`Queueing item/started for hydrating conversation`,{safe:{conversationId:a,queuedNotificationCount:o.length},sensitive:{}});break}z.error(`Received item/started for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}";
-    if (patched.includes(itemStartedNeedle)) {
-      patched = patched.replace(itemStartedNeedle, itemStartedReplacement);
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received item\/started for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
+    if (itemStartedNeedle.test(patched)) {
+      patched = patched.replace(
+        itemStartedNeedle,
+        (_needle, conversationIdVar, loggerVar) =>
+          `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing item/started for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received item/started for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`,
+      );
     } else if (patched.includes("Received item/started for unknown conversation")) {
       console.warn("WARN: Could not find unknown item/started needle - skipping remote mobile item queue patch");
     }
 
     const itemCompletedNeedle =
-      "if(!this.conversations.get(a)){z.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}";
-    const itemCompletedReplacement =
-      "if(!this.conversations.get(a)){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(a);if(o){o.push(n),z.warning(`Queueing item/completed for hydrating conversation`,{safe:{conversationId:a,queuedNotificationCount:o.length},sensitive:{}});break}z.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}";
-    if (patched.includes(itemCompletedNeedle)) {
-      patched = patched.replace(itemCompletedNeedle, itemCompletedReplacement);
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received item\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
+    if (itemCompletedNeedle.test(patched)) {
+      patched = patched.replace(
+        itemCompletedNeedle,
+        (_needle, conversationIdVar, loggerVar) =>
+          `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing item/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received item/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`,
+      );
     } else if (patched.includes("Received item/completed for unknown conversation")) {
       console.warn("WARN: Could not find unknown item/completed needle - skipping remote mobile item queue patch");
     }
 
     const turnCompletedNeedle =
-      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{z\.error\(`Received turn\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
+      /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received turn\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
     const turnCompletedReplacement =
-      (_needle, conversationIdVar) =>
-        `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),z.warning(\`Queueing turn/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}z.error(\`Received turn/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`;
+      (_needle, conversationIdVar, loggerVar) =>
+        `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing turn/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received turn/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`;
     if (turnCompletedNeedle.test(patched)) {
       patched = patched.replace(turnCompletedNeedle, turnCompletedReplacement);
     } else if (patched.includes("Received turn/completed for unknown conversation")) {
@@ -1135,10 +1311,43 @@ function applyLinuxRemoteControlStatusReadGuardPatch(source) {
     return source;
   }
 
+  const replacementForDirectStatusRead = (match) => {
+    const [
+      needle,
+      functionName,
+      storeVar,
+      clientVar,
+      hostVar,
+      generationVar,
+      generationFn,
+      initialValueVar,
+      statusAtomVar,
+      notificationParamsVar,
+      isCurrentFn,
+      readResultVar,
+      errorVar,
+      loggerVar,
+    ] = match;
+    const replacement =
+      `function ${REMOTE_CONTROL_STATUS_READ_GUARD_MARKER}(e){return !(typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)&&typeof e==\`string\`&&e.startsWith(\`remote-ssh\`))}` +
+      `function ${functionName}(${storeVar},${clientVar}){let ${hostVar}=${clientVar}.getHostId(),${generationVar}=${generationFn}(${storeVar},${hostVar}),${initialValueVar}=${storeVar}.get(${statusAtomVar},${hostVar});` +
+      `${clientVar}.addNotificationCallback(\`remoteControl/status/changed\`,({params:${notificationParamsVar}})=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},${notificationParamsVar})});` +
+      `if(!${REMOTE_CONTROL_STATUS_READ_GUARD_MARKER}(${hostVar})){${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},{status:\`disabled\`,available:!1,accessRequired:!1});return}` +
+      `${clientVar}.sendRequest(\`remoteControl/status/read\`,void 0).then(${readResultVar}=>{${storeVar}.get(${statusAtomVar},${hostVar})===${initialValueVar}&&${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},${readResultVar})}).catch(${errorVar}=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${loggerVar}.error(\`Failed to read remote-control status\`,{safe:{},sensitive:{error:${errorVar}}})})}`;
+    return source.replace(needle, replacement);
+  };
+
   const statusReadPattern =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\3\.getHostId\(\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\4\),([A-Za-z_$][\w$]*)=\2\.get\(([A-Za-z_$][\w$]*),\4\);\3\.addNotificationCallback\(`remoteControl\/status\/changed`,\(\{params:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)&&\2\.set\(\8,\4,\9\)\}\),\3\.sendRequest\(`remoteControl\/status\/read`,void 0\)\.then\(([A-Za-z_$][\w$]*)=>\{\2\.get\(\8,\4\)===\7&&\10\(\2,\4,\5\)&&\2\.set\(\8,\4,\11\)\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{\10\(\2,\4,\5\)&&([A-Za-z_$][\w$]*)\.error\(`Failed to read remote-control status`,\{safe:\{\},sensitive:\{error:\12\}\}\)\}\)\}/u;
   const match = source.match(statusReadPattern);
-  if (match == null) {
+  if (match != null) {
+    return replacementForDirectStatusRead(match);
+  }
+
+  const helperStatusReadPattern =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=\3\.getHostId\(\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\4\),([A-Za-z_$][\w$]*)=\2\.get\(([A-Za-z_$][\w$]*),\4\);\3\.addNotificationCallback\(`remoteControl\/status\/changed`,\(\{params:([A-Za-z_$][\w$]*)\}\)=>\{([A-Za-z_$][\w$]*)\(\2,\4,\5\)&&([A-Za-z_$][\w$]*)\(\2,\4,\9\)\}\),\3\.sendRequest\(`remoteControl\/status\/read`,void 0\)\.then\(([A-Za-z_$][\w$]*)=>\{\2\.get\(\8,\4\)===\7&&\10\(\2,\4,\5\)&&\11\(\2,\4,\12\)\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{\10\(\2,\4,\5\)&&([A-Za-z_$][\w$]*)\.error\(`Failed to read remote-control status`,\{safe:\{\},sensitive:\{error:\13\}\}\)\}\)\}/u;
+  const helperMatch = source.match(helperStatusReadPattern);
+  if (helperMatch == null) {
     console.warn("WARN: Could not find remote-control status read needle - skipping Linux remote-control status guard patch");
     return source;
   }
@@ -1155,16 +1364,17 @@ function applyLinuxRemoteControlStatusReadGuardPatch(source) {
     statusAtomVar,
     notificationParamsVar,
     isCurrentFn,
+    statusSetterFn,
     readResultVar,
     errorVar,
     loggerVar,
-  ] = match;
+  ] = helperMatch;
   const replacement =
     `function ${REMOTE_CONTROL_STATUS_READ_GUARD_MARKER}(e){return !(typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)&&typeof e==\`string\`&&e.startsWith(\`remote-ssh\`))}` +
     `function ${functionName}(${storeVar},${clientVar}){let ${hostVar}=${clientVar}.getHostId(),${generationVar}=${generationFn}(${storeVar},${hostVar}),${initialValueVar}=${storeVar}.get(${statusAtomVar},${hostVar});` +
-    `${clientVar}.addNotificationCallback(\`remoteControl/status/changed\`,({params:${notificationParamsVar}})=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},${notificationParamsVar})});` +
-    `if(!${REMOTE_CONTROL_STATUS_READ_GUARD_MARKER}(${hostVar})){${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},{status:\`disabled\`,available:!1,accessRequired:!1});return}` +
-    `${clientVar}.sendRequest(\`remoteControl/status/read\`,void 0).then(${readResultVar}=>{${storeVar}.get(${statusAtomVar},${hostVar})===${initialValueVar}&&${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${storeVar}.set(${statusAtomVar},${hostVar},${readResultVar})}).catch(${errorVar}=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${loggerVar}.error(\`Failed to read remote-control status\`,{safe:{},sensitive:{error:${errorVar}}})})}`;
+    `${clientVar}.addNotificationCallback(\`remoteControl/status/changed\`,({params:${notificationParamsVar}})=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${statusSetterFn}(${storeVar},${hostVar},${notificationParamsVar})});` +
+    `if(!${REMOTE_CONTROL_STATUS_READ_GUARD_MARKER}(${hostVar})){${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${statusSetterFn}(${storeVar},${hostVar},{status:\`disabled\`,available:!1,accessRequired:!1});return}` +
+    `${clientVar}.sendRequest(\`remoteControl/status/read\`,void 0).then(${readResultVar}=>{${storeVar}.get(${statusAtomVar},${hostVar})===${initialValueVar}&&${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${statusSetterFn}(${storeVar},${hostVar},${readResultVar})}).catch(${errorVar}=>{${isCurrentFn}(${storeVar},${hostVar},${generationVar})&&${loggerVar}.error(\`Failed to read remote-control status\`,{safe:{},sensitive:{error:${errorVar}}})})}`;
 
   return source.replace(needle, replacement);
 }
@@ -1196,13 +1406,22 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
   let region = patched.slice(markerIndex, markerIndex + 4_500);
 
   if (!patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER)) {
+    const currentBridgePattern =
+      /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(6\),\{checkGate:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*);\2\[0\]===\4\?\7=\2\[1\]:\(\7=\4\(`1042620455`\),\2\[0\]=\4,\2\[1\]=\7\);let ([A-Za-z_$][\w$]*)=\7,([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return /u;
+    let patchedRegion = region.replace(
+      currentBridgePattern,
+      (_needle, functionName, cacheVar, compilerVar, checkGateVar, isLoadingVar, gateHookVar, gateValueVar, enabledVar, callbackVar, depsVar) =>
+        `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(6),{checkGate:${checkGateVar},isLoading:${isLoadingVar}}=${gateHookVar}(),${gateValueVar};${cacheVar}[0]===${checkGateVar}?${gateValueVar}=${cacheVar}[1]:(${gateValueVar}=${checkGateVar}(\`1042620455\`),${cacheVar}[0]=${checkGateVar},${cacheVar}[1]=${gateValueVar});let ${enabledVar}=${gateValueVar}||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return `,
+    );
     const bridgePattern =
       /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return \2\[0\]===\4\?/u;
-    const patchedRegion = region.replace(
-      bridgePattern,
-      (_needle, functionName, cacheVar, compilerVar, enabledVar, gateVar, callbackVar, depsVar) =>
-        `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(3),${enabledVar}=${gateVar}()||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return ${cacheVar}[0]===${enabledVar}?`,
-    );
+    if (patchedRegion === region) {
+      patchedRegion = region.replace(
+        bridgePattern,
+        (_needle, functionName, cacheVar, compilerVar, enabledVar, gateVar, callbackVar, depsVar) =>
+          `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(3),${enabledVar}=${gateVar}()||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return ${cacheVar}[0]===${enabledVar}?`,
+      );
+    }
 
     if (patchedRegion === region) {
       console.warn("WARN: Could not find remote-control enablement bridge needle - skipping Linux remote-control bridge patch");
@@ -1221,9 +1440,9 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
     `${desktopHostRequestFn}(\`set-remote-control-connections-enabled\`,{params:{enabled:${enabledVar}}}).then(async e=>{if(${enabledVar}&&typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){let t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null;if(t.length===0)try{let e=await ${desktopHostRequestFn}(\`refresh-remote-control-connections\`,{params:{}});t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=n??e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_refresh_failed\`,{safe:{},sensitive:{error:e}})}if(n==null)try{let e=await ${desktopHostRequestFn}(\`get-global-state\`,{params:{key:\`electron-local-remote-control-installation-id\`}});n=e?.value??e?.state?.value??e?.globalState?.[\`electron-local-remote-control-installation-id\`]??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_identity_failed\`,{safe:{},sensitive:{error:e}})}let r=t.filter(e=>typeof e?.hostId==\`string\`&&e.hostId.startsWith(\`remote-control:\`)),i=new Set(r.filter(e=>n!=null&&(e.installationId??e.installation_id)===n).map(e=>e.hostId));await Promise.all(r.map(e=>${desktopHostRequestFn}(\`set-remote-connection-auto-connect\`,{params:{hostId:e.hostId,autoConnect:i.has(e.hostId)}}).catch(t=>{${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_failed\`,{safe:{hostId:e.hostId,autoConnect:i.has(e.hostId)},sensitive:{error:t}})})))}}/*${REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER}*/).catch(${errorVar}=>{${loggerVar}.warning(\`\${${logPrefixVar}} sync_failed\`,{safe:{enabled:${enabledVar}},sensitive:{error:${errorVar}}})})`;
 
   const previousAutoConnectCleanupPattern =
-    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.then\(async ([A-Za-z_$][\w$]*)=>\{[\s\S]*?\/\*codexLinuxRemoteControlAutoConnectCleanup\*\/\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{enabled:\2\},sensitive:\{error:\4\}\}\)\}\)/u;
+    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.then\(async ([A-Za-z_$][\w$]*)=>\{[\s\S]*?\/\*codexLinuxRemoteControlAutoConnectCleanup\*\/\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{(?:enabled|slingshotEnabled):\2\},sensitive:\{error:\4\}\}\)\}\)/u;
   const selfAutoConnectPattern =
-    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{enabled:\2\},sensitive:\{error:\3\}\}\)\}\)/u;
+    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{(?:enabled|slingshotEnabled):\2\},sensitive:\{error:\3\}\}\)\}\)/u;
   let selfAutoConnectRegion = region.replace(
     previousAutoConnectCleanupPattern,
     (_needle, desktopHostRequestFn, enabledVar, _resultVar, errorVar, loggerVar, logPrefixVar) =>
@@ -1249,11 +1468,17 @@ function applyLinuxRemoteMobileActiveStatusPatch(source) {
   if (source.includes(REMOTE_MOBILE_ACTIVE_STATUS_MARKER)) {
     return source;
   }
+  if (
+    source.includes("e.resumeState===`needs_resume`?e.threadRuntimeStatus:null") &&
+    source.includes("?`running`:e.hasUnreadTurn?`review`:`idle`")
+  ) {
+    return source;
+  }
 
   const statusPattern =
     /function ([A-Za-z_$][\w$]*)\(\{latestTurnStatus:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),streamRole:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{return \4==null\?\3===`needs_resume`\?`needs-resume`:`read-only`:\4\.role===`follower`\?`follower`:\5\?\.type===`active`\|\|\2===`inProgress`\?`active`:`inactive`\}/u;
   if (!statusPattern.test(source)) {
-    if (source.includes("threadRuntimeStatus") && source.includes("needs-resume")) {
+    if (source.includes("latestTurnStatus:") && source.includes("streamRole:") && source.includes("threadRuntimeStatus:")) {
       console.warn("WARN: Could not find active-status renderer needle - skipping remote mobile active-status patch");
     }
     return source;
@@ -1274,7 +1499,7 @@ function applyLinuxRemoteMobileProjectlessRemoteTaskPatch(source) {
   }
 
   const fallbackPattern =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\5\);if\(!\7\)\{([A-Za-z_$][\w$]*)\.warning\(`No owner repo found for remote task`,\{safe:\{taskId:\2\.task\.id\},sensitive:\{\}\}\);return\}/u;
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\5\);if\(!\7\)\{(?:([A-Za-z_$][\w$]*)\.has\(\2\.task\.id\)\|\|\(\9\.add\(\2\.task\.id\),)?([A-Za-z_$][\w$]*)\.warning\(`No owner repo found for remote task`,\{safe:\{taskId:\2\.task\.id\},sensitive:\{\}\}\)(?:\))?;return\}/u;
   const match = source.match(fallbackPattern);
   if (match == null) {
     console.warn("WARN: Could not find remote task owner-repo grouping needle - skipping projectless remote task patch");
@@ -1427,7 +1652,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-conversation-hydration",
     phase: "webview-asset",
-    pattern: /^app-server-manager-signals-.*\.js$/,
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs)-.*\.js$/,
     order: 20_150,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1437,7 +1662,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-read-guard",
     phase: "webview-asset",
-    pattern: /^app-server-manager-signals-.*\.js$/,
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs)-.*\.js$/,
     order: 20_151,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1457,7 +1682,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-active-status",
     phase: "webview-asset",
-    pattern: /^app-main-.*\.js$/,
+    pattern: /^(?:app-main|avatar-overlay-realtime-voice-button)-.*\.js$/,
     order: 20_160,
     ciPolicy: "optional",
     missingDescription: "app main bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -251,6 +251,15 @@ function syntheticChromeBrowserClientBundle() {
   ].join("");
 }
 
+function syntheticCurrentChromeBrowserClientBundle() {
+  return [
+    "var CN=[\"chrome\",\"iab\",\"cdp\"];function m_(e){return CN.some(t=>t===e)}",
+    "var y_=\"BROWSER_USE_AVAILABLE_BACKENDS\";",
+    "function nl(e){return globalThis[e]??null}function F_(e){return Array.isArray(e)?e:String(e).split(\",\")}",
+    "function N_(){let e=nl(y_);return e==null?null:F_(e).filter(m_)}",
+  ].join("");
+}
+
 function syntheticAppServerManagerSignalsBundle() {
   return [
     "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let h=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)});return}}",
@@ -1385,6 +1394,24 @@ test("Linux remote mobile Chrome bridge patch preserves Chrome when backends con
     process: { platform: "linux" },
   };
   vm.runInNewContext(`${patched};module.exports=_y;`, context);
+  assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
+});
+
+test("Linux remote mobile Chrome bridge patch handles current browser-client backend allowlist shape", () => {
+  const source = syntheticCurrentChromeBrowserClientBundle();
+  const patched = applyLinuxRemoteMobileChromeBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteMobileBrowserBackends/);
+  assert.match(patched, /function N_\(\)\{let e=nl\(y_\);return codexLinuxRemoteMobileBrowserBackends/);
+  assert.equal(applyLinuxRemoteMobileChromeBridgePatch(patched), patched);
+
+  const context = {
+    BROWSER_USE_AVAILABLE_BACKENDS: ["iab"],
+    module: { exports: {} },
+    process: { platform: "linux" },
+  };
+  vm.runInNewContext(`${patched};module.exports=N_;`, context);
   assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
 });
 

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -217,6 +217,113 @@ get_dmg() {
 }
 
 # ---- Extract app from DMG ----
+path_is_within_root() {
+    local root="$1"
+    local candidate="$2"
+    local root_real
+    local candidate_real
+
+    root_real="$(realpath -m "$root")" || return 1
+    candidate_real="$(realpath -m "$candidate")" || return 1
+
+    case "$candidate_real" in
+        "$root_real"|"$root_real"/*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+repair_7z_dangerous_link_path_warnings() {
+    local extract_dir="$1"
+    local app_dir="$2"
+    local seven_log="$3"
+    local dangerous_count=0
+    local repaired_count=0
+    local failed_count=0
+    local other_error_count=0
+    local line
+    local payload
+    local link_rel
+    local link_target
+    local link_path
+    local link_parent
+    local target_path
+
+    while IFS= read -r line; do
+        case "$line" in
+            "ERROR: Dangerous link path was ignored : "*)
+                dangerous_count=$((dangerous_count + 1))
+                payload="${line#ERROR: Dangerous link path was ignored : }"
+                link_rel="${payload% : *}"
+                link_target="${payload##* : }"
+
+                if [ "$link_rel" = "$payload" ] || [ -z "$link_rel" ] || [ -z "$link_target" ]; then
+                    failed_count=$((failed_count + 1))
+                    continue
+                fi
+
+                case "$link_target" in
+                    /*)
+                        failed_count=$((failed_count + 1))
+                        continue
+                        ;;
+                esac
+
+                link_path="$extract_dir/$link_rel"
+                link_parent="$(dirname "$link_path")"
+                target_path="$link_parent/$link_target"
+
+                if ! path_is_within_root "$app_dir" "$link_path" \
+                        || ! path_is_within_root "$app_dir" "$target_path"; then
+                    failed_count=$((failed_count + 1))
+                    continue
+                fi
+
+                if [ ! -e "$target_path" ] && [ ! -L "$target_path" ]; then
+                    failed_count=$((failed_count + 1))
+                    continue
+                fi
+
+                if [ -e "$link_path" ] || [ -L "$link_path" ]; then
+                    if [ -L "$link_path" ] && [ "$(readlink "$link_path")" = "$link_target" ]; then
+                        repaired_count=$((repaired_count + 1))
+                        continue
+                    fi
+                    if [ -s "$link_path" ]; then
+                        failed_count=$((failed_count + 1))
+                        continue
+                    fi
+                    if ! rm -f "$link_path"; then
+                        failed_count=$((failed_count + 1))
+                        continue
+                    fi
+                fi
+
+                if ln -s "$link_target" "$link_path"; then
+                    repaired_count=$((repaired_count + 1))
+                else
+                    failed_count=$((failed_count + 1))
+                fi
+                ;;
+            ERROR:*)
+                other_error_count=$((other_error_count + 1))
+                ;;
+        esac
+    done <"$seven_log"
+
+    if [ "$dangerous_count" -eq 0 ] \
+            || [ "$failed_count" -ne 0 ] \
+            || [ "$other_error_count" -ne 0 ]; then
+        return 1
+    fi
+
+    printf '%s\n' "$repaired_count"
+    return 0
+}
+
 extract_dmg() {
     local dmg_path="$1"
     info "Extracting DMG with 7z..."
@@ -237,8 +344,15 @@ extract_dmg() {
 
     if [ "$seven_zip_status" -ne 0 ]; then
         if [ -n "$app_dir" ]; then
-            warn "7z exited with code $seven_zip_status but app bundle was found; continuing"
-            warn "$(tail -n 5 "$seven_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')"
+            local repaired_link_count=""
+            if repaired_link_count="$(repair_7z_dangerous_link_path_warnings "$extract_dir" "$app_dir" "$seven_log")"; then
+                local warning_word="warnings"
+                [ "$repaired_link_count" = "1" ] && warning_word="warning"
+                info "7z reported $repaired_link_count safe package symlink $warning_word; repaired and continuing"
+            else
+                warn "7z exited with code $seven_zip_status but app bundle was found; continuing"
+                warn "$(tail -n 5 "$seven_log" | tr '\n' ' ' | sed 's/[[:space:]]\+/ /g')"
+            fi
         else
             cat "$seven_log" >&2
             error "Failed to extract DMG"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1376,6 +1376,140 @@ EOF
     assert_contains "$invalid_url/output.log" "Upstream DMG URL must be an HTTPS URL"
 }
 
+test_extract_dmg_repairs_safe_7z_link_warnings() {
+    info "Checking DMG extraction repairs safe 7z package symlink warnings"
+    local workspace="$TMP_DIR/dmg-dangerous-link-paths"
+    local bin_dir="$workspace/bin"
+    local work_dir="$workspace/work"
+    local output_log="$workspace/output.log"
+    local app_dir="$work_dir/dmg-extract/Codex Installer/Codex.app"
+    local node_modules="$app_dir/Contents/Resources/cua_node/lib/node_modules"
+    local actual
+
+    mkdir -p "$bin_dir" "$work_dir"
+    printf '%s' "fake dmg payload" >"$workspace/Codex.dmg"
+
+    cat >"$bin_dir/7z" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+out=""
+for arg in "$@"; do
+    case "$arg" in
+        -o*)
+            out="${arg#-o}"
+            ;;
+    esac
+done
+[ -n "$out" ] || exit 2
+
+app="$out/Codex Installer/Codex.app"
+node_modules="$app/Contents/Resources/cua_node/lib/node_modules"
+mkdir -p \
+    "$node_modules/.bin" \
+    "$node_modules/@oai/sky/bin/linux" \
+    "$node_modules/opencollective-postinstall" \
+    "$node_modules/pixelmatch/bin" \
+    "$node_modules/playwright" \
+    "$node_modules/playwright-core" \
+    "$node_modules/semver/bin" \
+    "$node_modules/sharp/node_modules/.bin" \
+    "$node_modules/tesseract.js/node_modules/.bin"
+
+printf '%s\n' "target" >"$node_modules/opencollective-postinstall/index.js"
+printf '%s\n' "target" >"$node_modules/pixelmatch/bin/pixelmatch"
+printf '%s\n' "target" >"$node_modules/playwright/cli.js"
+printf '%s\n' "target" >"$node_modules/playwright-core/cli.js"
+printf '%s\n' "target" >"$node_modules/semver/bin/semver.js"
+printf '%s\n' "target" >"$node_modules/@oai/sky/bin/linux/sky_linux_arm64"
+printf '%s\n' "target" >"$node_modules/@oai/sky/bin/linux/sky_linux_x64"
+
+: >"$node_modules/.bin/opencollective-postinstall"
+: >"$node_modules/.bin/pixelmatch"
+: >"$node_modules/.bin/playwright"
+: >"$node_modules/.bin/playwright-core"
+: >"$node_modules/.bin/semver"
+: >"$node_modules/.bin/sky_linux_arm64"
+: >"$node_modules/.bin/sky_linux_x64"
+: >"$node_modules/tesseract.js/node_modules/.bin/opencollective-postinstall"
+: >"$node_modules/sharp/node_modules/.bin/semver"
+
+cat <<'LOG'
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/opencollective-postinstall : ../opencollective-postinstall/index.js
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/pixelmatch : ../pixelmatch/bin/pixelmatch
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/playwright : ../playwright/cli.js
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/playwright-core : ../playwright-core/cli.js
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/semver : ../semver/bin/semver.js
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/sky_linux_arm64 : ../@oai/sky/bin/linux/sky_linux_arm64
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/.bin/sky_linux_x64 : ../@oai/sky/bin/linux/sky_linux_x64
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/tesseract.js/node_modules/.bin/opencollective-postinstall : ../../../opencollective-postinstall/index.js
+ERROR: Dangerous link path was ignored : Codex Installer/Codex.app/Contents/Resources/cua_node/lib/node_modules/sharp/node_modules/.bin/semver : ../../../semver/bin/semver.js
+
+Sub items Errors: 9
+
+Archives with Errors: 1
+
+Sub items Errors: 9
+LOG
+exit 2
+SCRIPT
+    chmod +x "$bin_dir/7z"
+
+    REPO_DIR="$REPO_DIR" \
+    WORK_DIR="$work_dir" \
+    SEVEN_ZIP_CMD="$bin_dir/7z" \
+    TEST_DMG_PATH="$workspace/Codex.dmg" \
+        bash <<'SCRIPT' >"$output_log" 2>&1
+set -Eeuo pipefail
+
+info() { echo "[INFO] $*" >&2; }
+warn() { echo "[WARN] $*" >&2; }
+error() { echo "[ERROR] $*" >&2; exit 1; }
+
+# shellcheck disable=SC1091
+source "$REPO_DIR/scripts/lib/dmg.sh"
+
+app_dir="$(extract_dmg "$TEST_DMG_PATH")"
+[ "$(basename "$app_dir")" = "Codex.app" ]
+SCRIPT
+
+    assert_contains "$output_log" "7z reported 9 safe package symlink warnings; repaired and continuing"
+    assert_not_contains "$output_log" "7z exited with code"
+    assert_not_contains "$output_log" "Sub items Errors"
+
+    [ -L "$node_modules/.bin/opencollective-postinstall" ] || fail "Expected repaired opencollective-postinstall symlink"
+    [ "$(readlink "$node_modules/.bin/opencollective-postinstall")" = "../opencollective-postinstall/index.js" ] \
+        || fail "Unexpected opencollective-postinstall symlink target"
+    [ -L "$node_modules/.bin/pixelmatch" ] || fail "Expected repaired pixelmatch symlink"
+    [ "$(readlink "$node_modules/.bin/pixelmatch")" = "../pixelmatch/bin/pixelmatch" ] \
+        || fail "Unexpected pixelmatch symlink target"
+    [ -L "$node_modules/.bin/playwright" ] || fail "Expected repaired playwright symlink"
+    [ "$(readlink "$node_modules/.bin/playwright")" = "../playwright/cli.js" ] \
+        || fail "Unexpected playwright symlink target"
+    [ -L "$node_modules/.bin/playwright-core" ] || fail "Expected repaired playwright-core symlink"
+    [ "$(readlink "$node_modules/.bin/playwright-core")" = "../playwright-core/cli.js" ] \
+        || fail "Unexpected playwright-core symlink target"
+    [ -L "$node_modules/.bin/semver" ] || fail "Expected repaired semver symlink"
+    [ "$(readlink "$node_modules/.bin/semver")" = "../semver/bin/semver.js" ] \
+        || fail "Unexpected semver symlink target"
+    [ -L "$node_modules/.bin/sky_linux_arm64" ] || fail "Expected repaired sky_linux_arm64 symlink"
+    [ "$(readlink "$node_modules/.bin/sky_linux_arm64")" = "../@oai/sky/bin/linux/sky_linux_arm64" ] \
+        || fail "Unexpected sky_linux_arm64 symlink target"
+    [ -L "$node_modules/.bin/sky_linux_x64" ] || fail "Expected repaired sky_linux_x64 symlink"
+    [ "$(readlink "$node_modules/.bin/sky_linux_x64")" = "../@oai/sky/bin/linux/sky_linux_x64" ] \
+        || fail "Unexpected sky_linux_x64 symlink target"
+    [ -L "$node_modules/tesseract.js/node_modules/.bin/opencollective-postinstall" ] \
+        || fail "Expected repaired nested opencollective-postinstall symlink"
+    [ "$(readlink "$node_modules/tesseract.js/node_modules/.bin/opencollective-postinstall")" = "../../../opencollective-postinstall/index.js" ] \
+        || fail "Unexpected nested opencollective-postinstall symlink target"
+    [ -L "$node_modules/sharp/node_modules/.bin/semver" ] || fail "Expected repaired nested semver symlink"
+    [ "$(readlink "$node_modules/sharp/node_modules/.bin/semver")" = "../../../semver/bin/semver.js" ] \
+        || fail "Unexpected nested semver symlink target"
+
+    actual="$(find "$node_modules" -path '*/.bin/*' -type l | wc -l | tr -d ' ')"
+    [ "$actual" = "9" ] || fail "Expected 9 repaired symlinks, found $actual"
+}
+
 test_fresh_install_removes_cached_dmg_metadata() {
     info "Checking --fresh removes cached DMG metadata"
     local workspace="$TMP_DIR/fresh-dmg-metadata"
@@ -6056,6 +6190,7 @@ main() {
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
     test_installer_refreshes_stale_cached_dmg_metadata
+    test_extract_dmg_repairs_safe_7z_link_warnings
     test_fresh_install_removes_cached_dmg_metadata
     test_rebuild_candidate_uses_validated_default_dmg
     test_native_shortcut_targets_compose_existing_flows


### PR DESCRIPTION
## Summary

Fix Linux wrapper drift against the current upstream Codex Desktop DMG (`26.616.51431`, Electron `42.1.0`). The affected areas were enabled correctly, but upstream chunk names, minified exports, renderer shapes, and DMG packaging changed enough that optional descriptors warned/skipped, Read Aloud settings crashed, and fresh bootstrap extraction reported a 7z warning for safe in-app package symlinks.

Fixes #537.
Fixes #538.
Fixes #539.
Fixes #541.
Fixes #542.

## What changed

### remote-mobile-control

- Retarget app-server manager/status descriptors from only `app-server-manager-signals-*` to current `thread-context-inputs-*` chunks as well.
- Update conversation hydration to capture the current logger alias instead of assuming the old minified binding.
- Support the current status read path that writes through a helper setter, while preserving the older direct `store.set` shape.
- Support current remote-control settings/revoke setup reset shapes, including local mobile setup state keyed by `CODEX_MOBILE_SETUP_COMPLETED`.
- Support the current SSH install/release settings flow with the newer restart callback shape.
- Support the current enablement bridge hook shape using `checkGate/isLoading` and the current `slingshotEnabled` safe payload.
- Treat the current avatar active-status shape as already compatible when upstream already preserves active runtime status.
- Support the current projectless remote task duplicate-warning guard.
- Update the staged Chrome bridge patch for the current bundled browser-client allowlist aliases (`CN`/`m_`/`N_`) while retaining the older `e2`/`ly`/`_y` path.
- Add fixture coverage for the current Chrome browser-client shape.

### conversation-mode

- Derive composer prop and `voiceControls` aliases dynamically rather than assuming previous minified names.
- Scope composer prop alias extraction to the current composer binding so unrelated same-name props earlier in the bundle cannot poison generated payloads.
- Support the real current composer bundle shape where the props destructure and `voiceControls` destructure are separated by intermediate assignments.
- Repair stale existing `codexLinuxConversationToggle` payload aliases during idempotent reapplication.
- Preserve the legacy `v`/`A`/`P`/`F` composer prop fallbacks only for a detected legacy voiceControls-only composer shape.
- Skip current-bundle payload emission with warnings when scoped composer aliases cannot be resolved, so future drift degrades to a skipped optional patch instead of injected out-of-scope identifiers.
- Support the current voice button click shape that calls `startRealtimeConversation()`.
- Retarget dictation endpoint patching to `use-dictation-*`, while excluding adjacent `use-dictation-hotkey-*` chunks.
- Support the current microphone helper, cleanup, recorder setup, and transcript send shapes.
- No-op on matching legacy-adjacent chunks that do not contain dictation endpoint markers.

### copilot-reasoning-effort

- Add support for the current async Copilot default model writer using `{throwOnFailure:!0}`.
- Persist `copilot-default-reasoning-effort` alongside `copilot-default-model` for that current writer path.

### read-aloud

- Resolve the current `general-settings-*` import map instead of assuming stale aliases.
- Prefer the current `settings-row` `r` export over the unrelated current dropdown `r` export, preventing invalid JSX and React error #130 in the Read Aloud settings route.
- Prefer the current `lib` `l`/`s` exports for the intl hook and `FormattedMessage`, while retaining compatibility with older `c`/`o` aliases.
- Refresh existing generated Read Aloud settings blocks when their aliases or generated label locals are stale.
- Stop generating one-letter label locals that can shadow current minified imports such as the `vscode-api` post helper alias `m`.
- Add regression coverage for the current bundle alias layout and stale generated row refresh.

### DMG extraction

- Handle the current upstream DMG's 7z `Dangerous link path was ignored` diagnostics for safe `cua_node/lib/node_modules/.bin` package symlinks.
- Recreate only relative symlinks whose link path and resolved target both stay inside the extracted `Codex.app` bundle and whose target exists.
- Downgrade that verified safe case to an info log; keep the existing warning/failure path for missing targets, absolute targets, paths escaping the app bundle, or any other 7z `ERROR:` diagnostics.
- Add shell smoke coverage for the nine current safe package-bin symlinks.

## Behavior before

`make bootstrap-native` completed but produced optional feature warnings like:

```text
feature:remote-mobile-control:linux-remote-control-settings-ux: applied-with-warnings
feature:remote-mobile-control:linux-remote-control-client-revoke-setup-reset: skipped-optional
feature:remote-mobile-control:linux-remote-mobile-conversation-hydration: skipped-optional
feature:remote-mobile-control:linux-remote-control-status-read-guard: skipped-optional
feature:remote-mobile-control:linux-remote-control-enablement-bridge: applied-with-warnings
feature:remote-mobile-control:linux-remote-mobile-active-status: skipped-optional
feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task: skipped-optional
feature:copilot-reasoning-effort:settings: applied-with-warnings
feature:conversation-mode:dictation-endpoint: skipped-optional
feature:conversation-mode:composer-control: applied-with-warnings
```

The `remote-mobile-control` stage hook also warned:

```text
WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch
```

With `read-aloud` enabled, opening **File > Settings > Read Aloud** rendered the generic error screen. The renderer log included Read Aloud settings errors such as:

```text
errorMessage="Minified React error #130"
```

and stale partially refreshed generated rows could also fail with:

```text
errorMessage="m is not a function"
```

Fresh bootstrap DMG extraction also warned even though the app bundle was found:

```text
[INFO] Extracting DMG with 7z...
[WARN] 7z exited with code 2 but app bundle was found; continuing
[WARN] Sub items Errors: 9 Archives with Errors: 1 Sub items Errors: 9
```

Raw 7z output showed those nine subitem errors were relative package-bin symlinks under `Codex.app/Contents/Resources/cua_node/lib/node_modules`, not the documented harmless `/Applications` DMG link case.

## Behavior after

The generated patch report for the same current upstream DMG reports:

```text
feature:remote-mobile-control:linux-remote-control-settings-ux: applied
feature:remote-mobile-control:linux-remote-control-client-revoke-setup-reset: applied
feature:remote-mobile-control:linux-remote-mobile-conversation-hydration: applied
feature:remote-mobile-control:linux-remote-control-status-read-guard: applied
feature:remote-mobile-control:linux-remote-control-enablement-bridge: applied
feature:remote-mobile-control:linux-remote-mobile-active-status: already-applied
feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task: applied
feature:copilot-reasoning-effort:settings: applied
feature:conversation-mode:dictation-endpoint: applied
feature:conversation-mode:composer-control: applied
```

The `remote-mobile-control` stage hook now prints:

```text
Remote mobile Chrome bridge patch applied
```

The Read Aloud settings page now generates against the current `general-settings-*` aliases and loads through `initialRoute=/settings/read-aloud-settings` without a Read Aloud renderer error boundary.

Fresh DMG extraction now repairs the verified safe package-bin symlinks and logs:

```text
[INFO] Saved: /home/bcdonadio/oss/codex-desktop-linux/Codex.dmg (72M)
[INFO] Extracting DMG with 7z...
[INFO] 7z reported 9 safe package symlink warnings; repaired and continuing
[INFO] Found: Codex.app
[INFO] Detected Electron version from package.json: 42.1.0
```

## Follow-up Notes

The final `conversation-mode:composer-control` warning seen during follow-up validation was not a new upstream issue. It was a direct follow-up to this PR's earlier composer-control fix and is covered by #538.

The first follow-up root cause was that the review-driven scoped composer binding matcher required the props destructure and `voiceControls` destructure to be adjacent. In the real current `composer-*` bundle they are separated by intermediate assignments, so idempotent reapplication could still warn and leave stale fallback aliases in an existing toggle payload. The patch now keeps alias extraction scoped while finding the later matching `voiceControls` destructure for the same props object and repairing stale toggle payload aliases.

A later review thread correctly pointed out that the current-shape path could still fall back to legacy `v`/`A`/`P`/`F` aliases when the scoped current binding could not be resolved. That is now guarded: legacy fallbacks are only used for a detected legacy composer shape, and current-shape drift now warns/skips payload emission instead of producing JavaScript that may reference out-of-scope identifiers.

Issue #542 was opened for the DMG extraction warning because it is a distinct upstream DMG packaging shape from the repo-documented harmless `/Applications` symlink warning.

## Validation

Environment used for validation:

- Fedora Linux 44 Workstation
- GNOME on Wayland
- RPM package profile and generated dev app profile
- Upstream DMG app version: `26.616.51431`
- Electron version: `42.1.0`
- 7z version: `26.01`

Commands run:

```bash
node --check linux-features/remote-mobile-control/patch.js
node --check linux-features/conversation-mode/patch.js
node --check linux-features/copilot-reasoning-effort/patch.js
node --check linux-features/read-aloud/patch.js
node --test linux-features/remote-mobile-control/test.js linux-features/conversation-mode/test.js linux-features/copilot-reasoning-effort/test.js linux-features/read-aloud/test.js
node --test linux-features/conversation-mode/test.js
bash -n install.sh
bash -n scripts/lib/*.sh
bash -n tests/scripts_smoke.sh
git diff --check
bash tests/scripts_smoke.sh
make bootstrap-native
make build-app
rpm -q codex-desktop
```

Additional direct composer replay was used against the generated current asset:

```bash
node -e 'const fs=require("fs"); const {applyComposerControlPatch}=require("./linux-features/conversation-mode/patch.js"); const s=fs.readFileSync("codex-app/content/webview/assets/composer-CCuv6v-2.js","utf8"); applyComposerControlPatch(s);'
```

Read Aloud route smoke:

```bash
CODEX_MULTI_LAUNCH_PORT_RANGE=5185-5185 \
CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE=1 \
ELECTRON_RENDERER_URL='http://127.0.0.1:5185/?initialRoute=/settings/read-aloud-settings' \
./codex-app/start.sh --new-instance
```

Results:

- latest focused combined feature run: 153 passed
- `remote-mobile-control` focused suite: passed
- `conversation-mode` focused suite: passed, including separated composer binding, stale toggle alias, and scoped-alias drift regression coverage
- `copilot-reasoning-effort` focused suite: passed
- `read-aloud` focused suite: passed
- `bash tests/scripts_smoke.sh` passed, including DMG extraction symlink repair coverage
- latest `make bootstrap-native` completed, built and installed `codex-desktop-2026.06.21.224241-1.fc41.x86_64`
- earlier `make bootstrap-native` completed, built and installed `codex-desktop-2026.06.21.222003-1.fc41.x86_64`
- earlier `make bootstrap-native` completed, built `dist/codex-desktop-2026.06.21.211813-1.x86_64.rpm`, and installed `codex-desktop-2026.06.21.211813-1.fc41.x86_64`
- latest generated patch report includes `feature:conversation-mode:composer-control: applied` with no warning
- latest bootstrap DMG extraction logs the repaired safe symlink info line instead of the original 7z warning
- `make build-app` regenerated the app with Read Aloud descriptors applied
- route smoke loaded `general-settings-D4nmDUYi.js` and `general-settings-Bit-KX17.js`; after the fix, the latest launch segment had no Read Aloud renderer `error boundary`
- generated artifacts such as `codex-app/`, `dist/`, and `Codex.dmg` were used for validation only and are not committed

Note: a full `node --test linux-features/*/test.js` sweep was also attempted while validating this branch, but it currently exposes an unrelated existing Thorium fixture failure in `linux-features/thorium-chrome-plugin/test.js` (`Thorium stage hook upgrades a core Linux-patched Chrome plugin`). The focused suites for this PR's touched feature areas pass.

## Not validated

I validated this on Fedora/RPM with GNOME Wayland. I did not run `.deb`, pacman, Nix, or updater rebuild validation locally. The touched JavaScript feature patches are distro-neutral; the DMG symlink repair path is covered by `scripts_smoke.sh`, but maintainer-side validation on other packaging paths would still be useful.