### PR TITLE
Fix Linux file manager target in worker registry

### DIFF
--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -78,6 +78,7 @@ const {
   applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
+  applyLinuxWorkerFileManagerPatch,
   applyLinuxMenuPatch,
   applyLinuxNativeTitlebarPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
@@ -94,6 +95,7 @@ const {
   applyLinuxWindowOptionsPatch,
   applyLinuxXdgDocumentsDirPatch,
   patchLinuxOwlFeatureBindingFallbackAssets,
+  patchLinuxWorkerFileManagerTarget,
 } = require("./patches/main-process.js");
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
@@ -227,6 +229,7 @@ module.exports = {
   applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
+  applyLinuxWorkerFileManagerPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxKeybindOverridesRuntimePatch,
   applyLinuxLaunchActionArgsPatch,
@@ -275,6 +278,7 @@ module.exports = {
   patchLinuxAppUpdaterBridge,
   patchLinuxChromeNativeHostRuntimeAssets,
   patchLinuxOwlFeatureBindingFallbackAssets,
+  patchLinuxWorkerFileManagerTarget,
   patchProjectlessDocumentsAssets,
   patchMainBundleSource,
   patchPackageJson,

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -43,6 +43,7 @@ const {
   applyLinuxExplicitTrayQuitPatch,
   applyLinuxFileManagerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
+  applyLinuxWorkerFileManagerPatch,
   applyLinuxQuitGuardPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,
@@ -131,6 +132,8 @@ const { featurePatchDescriptors } = require("./patches/registry.js");
 
 const mainBundlePrefix =
   "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
+const workerBundlePrefix =
+  "let i=require(`node:path`),o=require(`node:fs`);";
 const fileManagerBundle =
   "var lu=jl({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>il(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:uu,args:e=>il(e),open:async({path:e})=>du(e)}});function uu(){}";
 const alreadyOpaqueBackgroundBundle =
@@ -691,6 +694,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-browser-use-external-availability",
     "linux-chat-search-hydration",
     "linux-file-manager",
+    "linux-worker-file-manager",
     "linux-tray",
     "linux-build-info-tray",
     "linux-single-instance",
@@ -1211,6 +1215,93 @@ test("adds Linux file manager support without relying on exact minified variable
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
   assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+});
+
+test("adds Linux file manager support to the worker open target registry", () => {
+  const source = `${workerBundlePrefix}${fileManagerBundle}`;
+
+  const patched = applyPatchTwice(applyLinuxWorkerFileManagerPatch, source);
+
+  assert.match(patched, /linux:\{label:`File Manager`/);
+  assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
+  assert.match(patched, /o\.existsSync\(t\)/);
+  assert.match(patched, /i\.dirname\(t\)/);
+  assert.doesNotMatch(patched, /open:async\(\{path:e\}\)=>\{let [^}]*require\(`node:fs`\)/);
+  assert.match(patched, /import\(`electron`\)\)\.shell\.openPath\(t\)/);
+});
+
+test("patchExtractedApp patches worker file manager support", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-worker-file-manager-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      [
+        mainBundlePrefix,
+        "process.platform===`win32`&&k.removeMenu(),",
+        alreadyOpaqueBackgroundBundle,
+        fileManagerBundle,
+        trayBundleFixture(),
+        singleInstanceBundleFixture(),
+      ].join(""),
+    );
+    fs.writeFileSync(path.join(buildDir, "worker.js"), `${workerBundlePrefix}${fileManagerBundle}`);
+    fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const worker = fs.readFileSync(path.join(buildDir, "worker.js"), "utf8");
+    assert.match(worker, /linux:\{label:`File Manager`/);
+    assert.match(worker, /o\.existsSync\(t\)/);
+    assert.match(worker, /i\.dirname\(t\)/);
+    assert.doesNotMatch(worker, /open:async\(\{path:e\}\)=>\{let [^}]*require\(`node:fs`\)/);
+    assert.match(worker, /import\(`electron`\)\)\.shell\.openPath\(t\)/);
+    assert.equal(
+      report.patches.find((patch) => patch.name === "linux-worker-file-manager")?.status,
+      "applied",
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patchExtractedApp reports worker file manager patch drift", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-worker-file-manager-drift-"));
+  try {
+    const buildDir = path.join(tempRoot, ".vite", "build");
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      [
+        mainBundlePrefix,
+        "process.platform===`win32`&&k.removeMenu(),",
+        alreadyOpaqueBackgroundBundle,
+        fileManagerBundle,
+        trayBundleFixture(),
+        singleInstanceBundleFixture(),
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(buildDir, "worker.js"),
+      "const workerRegistry={target:`other`,note:`id:`fileManager``};",
+    );
+    fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(tempRoot, { report }));
+
+    const workerPatch = report.patches.find((patch) => patch.name === "linux-worker-file-manager");
+    assert.equal(workerPatch?.status, "skipped-optional");
+    assert.equal(workerPatch?.reason, "fileManager target found but patchable block not found");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("uses XDG user documents directory for projectless Codex folders on Linux", () => {

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -10,6 +10,7 @@ const {
   applyLinuxResizeRepaintPatch,
   applyLinuxOpaqueBackgroundPatch,
   applyLinuxFileManagerPatch,
+  patchLinuxWorkerFileManagerTarget,
   applyLinuxBuildInfoTrayPatch,
   applyLinuxTrayPatch,
   applyLinuxSingleInstancePatch,
@@ -87,6 +88,22 @@ module.exports = [
     order: 100,
     ciPolicy: "optional",
     apply: applyLinuxFileManagerPatch,
+  },
+  {
+    id: "linux-worker-file-manager",
+    phase: "extracted-app",
+    order: 101,
+    ciPolicy: "optional",
+    apply: patchLinuxWorkerFileManagerTarget,
+    status: (result, warnings) => {
+      if (result?.changed) {
+        return warnings.length > 0 ? "applied-with-warnings" : "applied";
+      }
+      if (warnings.length > 0 || result?.matched === 0 || result?.reason != null) {
+        return { status: "skipped-optional", reason: result?.reason ?? warnings[0] };
+      }
+      return "already-applied";
+    },
   },
   {
     id: "linux-tray",

--- a/scripts/patches/main-process/misc.js
+++ b/scripts/patches/main-process/misc.js
@@ -56,6 +56,84 @@ function applyLinuxFileManagerPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxWorkerFileManagerPatch(currentSource) {
+  const block = findCallBlock(currentSource, "id:`fileManager`");
+  if (block == null) {
+    console.warn("Failed to apply Linux Worker File Manager Patch");
+    return currentSource;
+  }
+
+  if (block.text.includes("linux:{")) {
+    return currentSource;
+  }
+
+  const fsVar = requireName(currentSource, "node:fs");
+  const pathVar = requireName(currentSource, "node:path");
+  if (fsVar == null || pathVar == null) {
+    console.warn("Failed to apply Linux Worker File Manager Patch");
+    return currentSource;
+  }
+
+  const insertionPoint = block.text.lastIndexOf("}});");
+  if (insertionPoint === -1) {
+    console.warn("Failed to apply Linux Worker File Manager Patch");
+    return currentSource;
+  }
+
+  const linuxFileManager =
+    `,linux:{label:\`File Manager\`,icon:\`apps/file-explorer.png\`,detect:()=>\`linux-file-manager\`,args:e=>[e],open:async({path:e})=>{let t=e;for(;;){try{if(${fsVar}.existsSync(t))break}catch{}let e=${pathVar}.dirname(t);if(e===t)break;t=e}try{${fsVar}.existsSync(t)&&${fsVar}.statSync(t).isFile()&&(t=${pathVar}.dirname(t))}catch{}let i=await(await import(\`electron\`)).shell.openPath(t);if(i)throw Error(i)}}`;
+
+  const patchedBlock =
+    block.text.slice(0, insertionPoint + 1) +
+    linuxFileManager +
+    block.text.slice(insertionPoint + 1);
+  const patchedSource =
+    currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
+
+  const patchedBlockCheck = patchedSource.slice(block.start, block.start + patchedBlock.length);
+  if (
+    !patchedBlockCheck.includes("linux:{label:`File Manager`") ||
+    !patchedBlockCheck.includes("detect:()=>`linux-file-manager`") ||
+    !patchedBlockCheck.includes("import(`electron`)).shell.openPath(t)")
+  ) {
+    console.warn("Failed to apply Linux Worker File Manager Patch");
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
+function patchLinuxWorkerFileManagerTarget(extractedDir) {
+  const workerPath = path.join(extractedDir, ".vite", "build", "worker.js");
+  if (!fs.existsSync(workerPath)) {
+    console.warn(
+      `WARN: Could not find worker bundle at ${workerPath} — skipping Linux Worker File Manager Patch`,
+    );
+    return { matched: 0, changed: 0, reason: "worker bundle not found" };
+  }
+
+  const source = fs.readFileSync(workerPath, "utf8");
+  const patchedSource = applyLinuxWorkerFileManagerPatch(source);
+  if (patchedSource === source) {
+    const hasTarget = source.includes("id:`fileManager`");
+    const hasLinuxTarget = source.includes("linux:{label:`File Manager`");
+    const hasPatchableBlock = findCallBlock(source, "id:`fileManager`") != null;
+    return {
+      matched: hasPatchableBlock ? 1 : 0,
+      changed: 0,
+      reason: !hasTarget
+        ? "fileManager target not found"
+        : hasLinuxTarget
+          ? null
+          : hasPatchableBlock
+            ? "fileManager target found but Linux worker patch was not applied"
+            : "fileManager target found but patchable block not found",
+    };
+  }
+  fs.writeFileSync(workerPath, patchedSource, "utf8");
+  return { matched: 1, changed: 1 };
+}
+
 function applyLinuxGitOriginsSourceFallbackPatch(currentSource) {
   const fallbackSource = "linux_git_origins_missing_source_fallback";
   if (currentSource.includes(`source:\`${fallbackSource}\`,requestKind:`)) {
@@ -286,7 +364,9 @@ module.exports = {
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,
   applyLinuxOwlFeatureBindingFallbackPatch,
+  applyLinuxWorkerFileManagerPatch,
   patchLinuxOwlFeatureBindingFallbackAssets,
+  patchLinuxWorkerFileManagerTarget,
   applyLinuxRemoteControlConfigPreservationPatch,
   applyLinuxXdgDocumentsDirPatch,
 };


### PR DESCRIPTION
Fixes #545.

## Summary

- add a core extracted-app patch for `.vite/build/worker.js`
- inject the missing Linux `fileManager` target into the worker open-target registry
- add regression coverage for the direct worker patch and the `patchExtractedApp` path

## Notes

The existing Linux file manager patch covers the main bundle, but current Codex.app builds also have a separate open-target registry in `worker.js`. That worker-side `fileManager` target only had `darwin` and `win32`, so Linux could still hit `Unknown open target "fileManager"` from the worker path.

## Validation

```bash
node --test scripts/patch-linux-window-ui.test.js
```

Result: 292 passed, 0 failed.
