### PR TITLE
[codex] Fix updater daemon state reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -139,6 +139,40 @@ fn sync_and_persist(
     persist_if_changed(paths, state, &original_state)
 }
 
+fn reload_state_from_disk(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let previous_status = state.status.clone();
+    let previous_candidate_version = state.candidate_version.clone();
+    let previous_waiting_auto_install = state.waiting_for_app_exit_auto_install;
+
+    let loaded =
+        PersistedState::load_or_default(&paths.state_file, effective_auto_install(config))?;
+    let mut refreshed = loaded.clone();
+    sync_runtime_state(config, &mut refreshed);
+    persist_if_changed(paths, &refreshed, &loaded)?;
+
+    if previous_status != refreshed.status
+        || previous_candidate_version != refreshed.candidate_version
+        || previous_waiting_auto_install != refreshed.waiting_for_app_exit_auto_install
+    {
+        info!(
+            previous_status = ?previous_status,
+            status = ?refreshed.status,
+            previous_candidate_version = previous_candidate_version.as_deref(),
+            candidate_version = refreshed.candidate_version.as_deref(),
+            previous_waiting_auto_install,
+            waiting_auto_install = refreshed.waiting_for_app_exit_auto_install,
+            "reloaded updater state from disk"
+        );
+    }
+
+    *state = refreshed;
+    Ok(())
+}
+
 fn normalize_workspace_dir_and_persist(
     state: &mut PersistedState,
     paths: &RuntimePaths,
@@ -312,10 +346,10 @@ async fn run_daemon(
     info!("daemon initialized");
 
     time::sleep(Duration::from_secs(config.initial_check_delay_seconds)).await;
-    if let Err(error) = run_check_cycle(config, state, paths).await {
+    if let Err(error) = run_check_cycle_from_disk(config, state, paths).await {
         error!(?error, "initial check failed");
     }
-    if let Err(error) = reconcile_pending_install(config, state, paths).await {
+    if let Err(error) = reconcile_pending_install_from_disk(config, state, paths).await {
         error!(?error, "initial reconciliation failed");
     }
 
@@ -332,12 +366,12 @@ async fn run_daemon(
 
         tokio::select! {
             _ = check_interval.tick() => {
-                if let Err(error) = run_check_cycle(config, state, paths).await {
+                if let Err(error) = run_check_cycle_from_disk(config, state, paths).await {
                     error!(?error, "periodic check failed");
                 }
             }
             _ = reconcile_interval.tick() => {
-                if let Err(error) = reconcile_pending_install(config, state, paths).await {
+                if let Err(error) = reconcile_pending_install_from_disk(config, state, paths).await {
                     error!(?error, "pending install reconciliation failed");
                 }
             }
@@ -781,6 +815,15 @@ fn run_actionable_notification_prompt() -> Result<bool> {
     }
 }
 
+async fn run_check_cycle_from_disk(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    reload_state_from_disk(config, state, paths)?;
+    run_check_cycle(config, state, paths).await
+}
+
 async fn run_check_cycle(
     config: &RuntimeConfig,
     state: &mut PersistedState,
@@ -916,6 +959,15 @@ async fn run_check_cycle(
     }
 
     Ok(())
+}
+
+async fn reconcile_pending_install_from_disk(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    reload_state_from_disk(config, state, paths)?;
+    reconcile_pending_install(config, state, paths).await
 }
 
 async fn reconcile_pending_install(
@@ -2101,6 +2153,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn daemon_check_cycle_reloads_pending_state_written_by_another_process() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let mut config = test_config(temp.path());
+        config.dmg_url = "https://invalid.example/Codex.dmg".to_string();
+
+        let mut on_disk = PersistedState::new(true);
+        on_disk.status = UpdateStatus::WaitingForAppExit;
+        on_disk.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
+        on_disk.waiting_for_app_exit_auto_install = true;
+        on_disk.save(&paths.state_file)?;
+
+        let mut stale_daemon_state = PersistedState::new(true);
+        stale_daemon_state.status = UpdateStatus::Idle;
+
+        run_check_cycle_from_disk(&config, &mut stale_daemon_state, &paths).await?;
+
+        assert_eq!(stale_daemon_state.status, UpdateStatus::WaitingForAppExit);
+        assert!(stale_daemon_state.waiting_for_app_exit_auto_install);
+        assert_eq!(stale_daemon_state.last_check_at, None);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn run_check_cycle_ignores_downloaded_dmg_already_installed() -> Result<()> {
         let server = MockServer::start().await;
         let body = b"codex-dmg-test-payload";
@@ -2409,6 +2486,63 @@ mod tests {
         assert_eq!(state.status, UpdateStatus::WaitingForAppExit);
         assert!(state.waiting_for_app_exit_auto_install);
         assert!(!install_auth_retry_is_blocked(&state));
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_reconcile_reloads_waiting_state_written_by_another_process() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let runtime = tokio::runtime::Runtime::new()?;
+        let previous_no_agent = std::env::var_os("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT");
+        std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT", "1");
+
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+
+        let package_path = temp.path().join("dist/codex.deb");
+        std::fs::create_dir_all(
+            package_path
+                .parent()
+                .expect("package path should have parent"),
+        )?;
+        std::fs::write(&package_path, b"deb")?;
+
+        let mut on_disk = PersistedState::new(true);
+        on_disk.status = UpdateStatus::WaitingForAppExit;
+        on_disk.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
+        on_disk.waiting_for_app_exit_auto_install = true;
+        on_disk.artifact_paths.package_path = Some(package_path);
+        on_disk.save(&paths.state_file)?;
+
+        let mut stale_daemon_state = PersistedState::new(true);
+        stale_daemon_state.status = UpdateStatus::Idle;
+
+        let result = runtime.block_on(reconcile_pending_install_from_disk(
+            &config,
+            &mut stale_daemon_state,
+            &paths,
+        ));
+
+        if let Some(value) = previous_no_agent {
+            std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT", value);
+        } else {
+            std::env::remove_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT");
+        }
+
+        result?;
+        assert_eq!(stale_daemon_state.status, UpdateStatus::ReadyToInstall);
+        assert!(!stale_daemon_state.waiting_for_app_exit_auto_install);
+        assert!(stale_daemon_state
+            .error_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("No graphical polkit authentication agent"));
+
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.status, UpdateStatus::ReadyToInstall);
+        assert!(!persisted.waiting_for_app_exit_auto_install);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- reload persisted updater state from disk before daemon check and reconcile cycles
- keep auto-install state synchronized when another updater process writes a pending candidate
- bump codex-update-manager to 0.8.5

## Why
The daemon could keep stale in-memory state after another update/check process persisted `waiting_for_app_exit`. If the desktop app exited after that, the daemon might never notice the pending install state and would not advance the update.

## Source of truth
- `updater/src/app.rs`
- `updater/Cargo.toml`
- `Cargo.lock`

## Validation
- `cargo fmt --package codex-update-manager --check`
- `git diff --check`
- `CARGO_HOME=/home/mohit/.cache/cargo cargo check -p codex-update-manager`
- `CARGO_HOME=/home/mohit/.cache/cargo cargo test -p codex-update-manager`
