### PR TITLE
[codex] Harden remote download and update paths

### DIFF
--- a/linux-features/read-aloud/install-kokoro-runtime.sh
+++ b/linux-features/read-aloud/install-kokoro-runtime.sh
@@ -8,6 +8,37 @@ voices="${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES:-$data_home/kokoro/voices-v1.0.bi
 model_url="${CODEX_LINUX_READ_ALOUD_KOKORO_MODEL_URL:-https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/kokoro-v1.0.onnx}"
 voices_url="${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES_URL:-https://huggingface.co/zijuncheng/kokoro_model_v1.0/resolve/main/voices-v1.0.bin}"
 
+truthy_env_value() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+expected_sha_for_target() {
+    local target="$1"
+    case "$target" in
+        "$model") printf '%s\n' "${CODEX_LINUX_READ_ALOUD_KOKORO_MODEL_SHA256:-}" ;;
+        "$voices") printf '%s\n' "${CODEX_LINUX_READ_ALOUD_KOKORO_VOICES_SHA256:-}" ;;
+        *) printf '%s\n' "" ;;
+    esac
+}
+
+verify_download_sha256() {
+    local target="$1"
+    local expected_sha
+    expected_sha="$(expected_sha_for_target "$target")"
+    if [ -z "$expected_sha" ]; then
+        echo "Refusing to download $(basename "$target") without an expected SHA256" >&2
+        exit 1
+    fi
+    if ! printf '%s  %s\n' "$expected_sha" "$target" | sha256sum -c - >/dev/null 2>&1; then
+        rm -f "$target"
+        echo "Checksum mismatch for $target" >&2
+        exit 1
+    fi
+}
+
 choose_python() {
     local candidate
     for candidate in "${PYTHON:-}" python3.12 python3.13 python3.11 python3.10 python3; do
@@ -54,6 +85,7 @@ PY
     fi
 
     mv "$tmp" "$target"
+    verify_download_sha256 "$target"
 }
 
 python_bin="$(choose_python || true)"
@@ -64,18 +96,34 @@ python_bin="$(choose_python || true)"
 
 mkdir -p "$(dirname "$venv")"
 
+if ! truthy_env_value "${CODEX_LINUX_READ_ALOUD_ALLOW_NETWORK_INSTALL:-0}"; then
+    echo "Read Aloud network runtime install requires explicit CODEX_LINUX_READ_ALOUD_ALLOW_NETWORK_INSTALL=1" >&2
+    exit 1
+fi
+
+requirements_file="${CODEX_LINUX_READ_ALOUD_PIP_REQUIREMENTS:-}"
+if [ -z "$requirements_file" ]; then
+    echo "Refusing to install Python packages without hashed requirements." >&2
+    echo "Set CODEX_LINUX_READ_ALOUD_PIP_REQUIREMENTS to a pip requirements file using --hash entries." >&2
+    exit 1
+fi
+[ -f "$requirements_file" ] || {
+    echo "Read Aloud requirements file not found: $requirements_file" >&2
+    exit 1
+}
+
 if command -v uv >/dev/null 2>&1; then
     if [ ! -x "$venv/bin/python" ]; then
         uv venv --python "$python_bin" "$venv"
     fi
-    uv pip install --python "$venv/bin/python" 'kokoro-onnx>=0.5.0' 'numpy>=2.0.2'
+    uv pip install --python "$venv/bin/python" --require-hashes -r "$requirements_file"
 else
     if [ ! -x "$venv/bin/python" ]; then
         "$python_bin" -m venv "$venv"
     fi
     "$venv/bin/python" -m ensurepip --upgrade
     "$venv/bin/python" -m pip install --upgrade pip
-    "$venv/bin/python" -m pip install 'kokoro-onnx>=0.5.0' 'numpy>=2.0.2'
+    "$venv/bin/python" -m pip install --require-hashes -r "$requirements_file"
 fi
 
 echo "Kokoro runtime installed at $venv" >&2

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -163,6 +163,10 @@ remote_mobile_control_main() {
             echo "Remote mobile control standalone runtime auto-install disabled by CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED"
             return 0
         fi
+        if ! truthy_env_value "${CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL:-0}"; then
+            echo "Remote mobile control standalone runtime auto-install requires explicit CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL=1"
+            return 0
+        fi
         if ! install_remote_mobile_control_runtime "$codex_home"; then
             echo "Remote mobile control is enabled, but the standalone Codex daemon runtime could not be installed at $standalone_codex"
             echo "Brew or another CLI can remain the interactive Codex CLI; remote mobile control uses CODEX_REMOTE_CONTROL_CODEX_PATH separately."

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -395,7 +395,8 @@ bootstrap_7zz() {
         install_dir="/usr/local/bin"
     fi
 
-    # Try pinned versions newest-first with HEAD verification — no HTML parsing
+    # Try pinned versions newest-first with HEAD verification — no HTML parsing.
+    # The archive is accepted only when the caller provides an expected SHA256.
     local -a versions=(2600 2500 2409)
     local version="" url="" candidate_url
     for candidate in "${versions[@]}"; do
@@ -413,6 +414,15 @@ Tried versions: ${versions[*]}
 Install 7zz manually from https://www.7-zip.org/download.html and ensure it is on your PATH."
     fi
 
+    local expected_sha="${SEVENZIP_BOOTSTRAP_SHA256:-}"
+    if [ -z "$expected_sha" ] && [ -n "${SEVENZIP_BOOTSTRAP_SHA256_FILE:-}" ]; then
+        expected_sha="$(awk '{print $1; exit}' "$SEVENZIP_BOOTSTRAP_SHA256_FILE")"
+    fi
+    if [ -z "$expected_sha" ]; then
+        error "Refusing to install 7zz ${version} without an expected SHA256.
+Set SEVENZIP_BOOTSTRAP_SHA256 or SEVENZIP_BOOTSTRAP_SHA256_FILE for $url."
+    fi
+
     local tmpdir
     tmpdir="$(mktemp -d)"
     # shellcheck disable=SC2064
@@ -420,6 +430,9 @@ Install 7zz manually from https://www.7-zip.org/download.html and ensure it is o
 
     info "Downloading 7zz ${version} from $url"
     curl -fL --progress-bar -o "$tmpdir/7z.tar.xz" "$url"
+    if ! printf '%s  %s\n' "$expected_sha" "$tmpdir/7z.tar.xz" | sha256sum -c - >/dev/null 2>&1; then
+        error "7zz archive checksum mismatch"
+    fi
     tar -C "$tmpdir" -xf "$tmpdir/7z.tar.xz" 7zz
 
     if [ "$install_dir" = "/usr/local/bin" ]; then
@@ -456,8 +469,30 @@ install_rust() {
         return
     fi
 
-    info "Installing Rust toolchain via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    local rustup_arch rustup_url rustup_tmp expected_sha
+    case "$ARCH" in
+        x86_64)  rustup_arch="x86_64-unknown-linux-gnu" ;;
+        aarch64) rustup_arch="aarch64-unknown-linux-gnu" ;;
+        armv7l)  rustup_arch="armv7-unknown-linux-gnueabihf" ;;
+        *)       error "Unsupported rustup architecture: $ARCH" ;;
+    esac
+
+    expected_sha="${RUSTUP_INIT_SHA256:-}"
+    [ -n "$expected_sha" ] || error "Refusing to install Rust via network without RUSTUP_INIT_SHA256.
+Install cargo through your distro package manager, or set RUSTUP_INIT_SHA256 for rustup-init ${rustup_arch}."
+
+    rustup_url="${RUSTUP_INIT_URL:-https://static.rust-lang.org/rustup/dist/${rustup_arch}/rustup-init}"
+    rustup_tmp="$(mktemp)"
+    # shellcheck disable=SC2064
+    trap "rm -f '$rustup_tmp'" RETURN
+
+    info "Installing Rust toolchain via verified rustup-init..."
+    curl --proto '=https' --tlsv1.2 -sSf "$rustup_url" -o "$rustup_tmp"
+    if ! printf '%s  %s\n' "$expected_sha" "$rustup_tmp" | sha256sum -c - >/dev/null 2>&1; then
+        error "rustup-init checksum mismatch"
+    fi
+    chmod 0755 "$rustup_tmp"
+    "$rustup_tmp" -y
 
     # Make cargo available in this shell session
     # shellcheck source=/dev/null

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -8,6 +8,7 @@
 DEFAULT_DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
 DMG_URL="${CODEX_UPSTREAM_DMG_URL:-$DEFAULT_DMG_URL}"
 DMG_REMOTE_FINGERPRINT=""
+DMG_EXPECTED_SHA256="${CODEX_UPSTREAM_DMG_SHA256:-}"
 
 redact_dmg_url() {
     local dmg_url="$1"
@@ -48,6 +49,30 @@ validate_dmg_url() {
             error "Upstream DMG URL must be an HTTPS URL: $(redact_dmg_url "$dmg_url")"
             ;;
     esac
+}
+
+truthy_dmg_env_value() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+verify_dmg_sha256_policy() {
+    local dmg_path="$1"
+
+    if [ -z "$DMG_EXPECTED_SHA256" ]; then
+        if truthy_dmg_env_value "${CODEX_ALLOW_UNVERIFIED_DMG:-0}"; then
+            warn "Accepting unverified Codex DMG because CODEX_ALLOW_UNVERIFIED_DMG=1"
+            return 0
+        fi
+        error "Refusing to use Codex DMG without CODEX_UPSTREAM_DMG_SHA256.
+Set CODEX_UPSTREAM_DMG_SHA256 to the expected SHA256, or CODEX_ALLOW_UNVERIFIED_DMG=1 for a local manual override."
+    fi
+
+    if ! printf '%s  %s\n' "$DMG_EXPECTED_SHA256" "$dmg_path" | sha256sum -c - >/dev/null 2>&1; then
+        error "Codex DMG checksum mismatch: $dmg_path"
+    fi
 }
 
 dmg_url_cache_key() {
@@ -179,6 +204,7 @@ get_dmg() {
     if [ -s "$dmg_dest" ]; then
         DMG_REMOTE_FINGERPRINT=""
         if cached_dmg_is_fresh "$dmg_dest" "$metadata_path" "$DMG_URL"; then
+            verify_dmg_sha256_policy "$dmg_dest"
             info "Using cached DMG: $dmg_dest ($(du -h "$dmg_dest" | cut -f1))"
             echo "$dmg_dest"
             return
@@ -210,6 +236,7 @@ get_dmg() {
         error "Download produced empty file. Download manually and place as: $dmg_dest"
     fi
 
+    verify_dmg_sha256_policy "$tmp_dest"
     mv "$tmp_dest" "$dmg_dest"
     write_cached_dmg_metadata "$metadata_path" "$download_fingerprint"
     info "Saved: $dmg_dest ($(du -h "$dmg_dest" | cut -f1))"

--- a/scripts/lib/native-modules.sh
+++ b/scripts/lib/native-modules.sh
@@ -284,6 +284,38 @@ install_native_modules_from_source() {
 }
 
 # ---- Download Linux Electron ----
+electron_zip_sha256() {
+    local electron_arch="$1"
+    local key
+    key="$(printf '%s_%s' "$ELECTRON_VERSION" "$electron_arch" | tr '.-' '__')"
+
+    if [ -n "${CODEX_ELECTRON_ZIP_SHA256:-}" ]; then
+        printf '%s\n' "$CODEX_ELECTRON_ZIP_SHA256"
+        return 0
+    fi
+
+    eval "printf '%s\n' \"\${CODEX_ELECTRON_ZIP_SHA256_${key}:-}\""
+}
+
+verify_electron_zip_sha256() {
+    local zip_path="$1"
+    local electron_arch="$2"
+    local expected_sha
+    local version_key
+
+    expected_sha="$(electron_zip_sha256 "$electron_arch")"
+    version_key="$(printf '%s_%s' "$ELECTRON_VERSION" "$electron_arch" | tr '.-' '__')"
+    if [ -z "$expected_sha" ]; then
+        error "No SHA256 configured for Electron v${ELECTRON_VERSION} linux-${electron_arch}.
+Set CODEX_ELECTRON_ZIP_SHA256 or CODEX_ELECTRON_ZIP_SHA256_${version_key} before downloading Electron archives."
+    fi
+
+    if ! printf '%s  %s\n' "$expected_sha" "$zip_path" | sha256sum -c - >/dev/null 2>&1; then
+        rm -f "$zip_path"
+        error "Electron runtime checksum mismatch; removed archive: $zip_path"
+    fi
+}
+
 download_electron() {
     info "Downloading Electron v${ELECTRON_VERSION} for Linux..."
 
@@ -298,6 +330,7 @@ download_electron() {
     local electron_zip="electron-v${ELECTRON_VERSION}-linux-${electron_arch}.zip"
     if [ -n "${CODEX_ELECTRON_ZIP_SOURCE:-}" ]; then
         [ -f "$CODEX_ELECTRON_ZIP_SOURCE" ] || error "CODEX_ELECTRON_ZIP_SOURCE does not exist: $CODEX_ELECTRON_ZIP_SOURCE"
+        verify_electron_zip_sha256 "$CODEX_ELECTRON_ZIP_SOURCE" "$electron_arch"
         info "Using Electron runtime archive: $CODEX_ELECTRON_ZIP_SOURCE"
         cp "$CODEX_ELECTRON_ZIP_SOURCE" "$WORK_DIR/electron.zip"
         mkdir -p "$INSTALL_DIR"
@@ -326,6 +359,7 @@ download_electron() {
     else
         info "Using cached Electron archive: $cached_zip"
     fi
+    verify_electron_zip_sha256 "$cached_zip" "$electron_arch"
 
     cp "$cached_zip" "$WORK_DIR/electron.zip"
     mkdir -p "$INSTALL_DIR"

--- a/updater/src/wrapper.rs
+++ b/updater/src/wrapper.rs
@@ -286,6 +286,17 @@ pub fn resolve_remote(config_remote: &str, bundle_root: &Path) -> String {
     origin_url(bundle_root).unwrap_or_else(|| "origin".to_string())
 }
 
+pub fn remote_is_trusted(remote: &str) -> bool {
+    let trimmed = remote.trim();
+    matches!(
+        trimmed,
+        "https://github.com/ilysenko/codex-desktop-linux"
+            | "https://github.com/ilysenko/codex-desktop-linux.git"
+            | "git@github.com:ilysenko/codex-desktop-linux.git"
+            | "ssh://git@github.com/ilysenko/codex-desktop-linux.git"
+    )
+}
+
 /// Queries the remote head commit for `branch` via `git ls-remote`.
 ///
 /// `remote` may be a configured remote name (`origin`) or an explicit URL. When
@@ -296,6 +307,9 @@ pub fn fetch_remote_head(repo: &Path, remote: &str, branch: &str) -> Option<Stri
     } else {
         remote.to_string()
     };
+    if !remote_is_trusted(&resolved_remote) {
+        return None;
+    }
     let output = git_capture(repo, &["ls-remote", &resolved_remote, branch])?;
     // ls-remote prints "<sha>\t<ref>"; take the first whitespace-delimited field.
     output
@@ -318,6 +332,9 @@ fn fetch_objects(repo: &Path, remote: &str, branch: &str) -> bool {
     } else {
         remote.to_string()
     };
+    if !remote_is_trusted(&resolved_remote) {
+        return false;
+    }
     // `git fetch <remote> <branch>` updates FETCH_HEAD and objects only.
     git_status(repo, &["fetch", "--quiet", &resolved_remote, branch])
         .is_some_and(|status| status.success())

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -409,6 +409,9 @@ pub(crate) fn ensure_wrapper_source(
     candidate_commit: Option<&str>,
 ) -> Result<PathBuf> {
     let remote = wrapper::resolve_remote(&config.wrapper_remote, &config.builder_bundle_root);
+    if !wrapper::remote_is_trusted(&remote) {
+        anyhow::bail!("refusing wrapper update from untrusted remote: {remote}");
+    }
     let branch = if config.wrapper_branch.trim().is_empty() {
         "main"
     } else {


### PR DESCRIPTION
## Summary

This PR hardens several remote download and update paths that previously trusted HTTPS or configured remotes without an explicit integrity/policy gate.

Changes include:
- require SHA256 verification for downloaded or locally supplied Electron Linux runtime archives
- require SHA256 verification for 7zz bootstrap archives and replace `curl | sh` rustup with verified `rustup-init`
- gate remote-mobile-control runtime auto-install behind explicit opt-in
- require explicit opt-in, hashed Python requirements, and SHA256 checks for Read Aloud model assets
- restrict wrapper updates to the trusted upstream repository before detecting or applying updates
- require `CODEX_UPSTREAM_DMG_SHA256` for Codex.dmg, with an explicit local override for unverified manual use

## Security impact

These changes reduce supply-chain exposure from unauthenticated archive acceptance, implicit network installers, and arbitrary wrapper update remotes.

## Validation

Validated locally with shell syntax checks only:

```bash
bash -n scripts/install-deps.sh scripts/lib/dmg.sh scripts/lib/native-modules.sh linux-features/remote-mobile-control/cold-start-hook.sh linux-features/read-aloud/install-kokoro-runtime.sh
```

I did not run Node/Rust test suites because this review was performed in the context of auditing a suspicious checkout and those tests execute repository/dependency code.