### PR TITLE
feat: add opt-in persistent status panel feature

### DIFF
--- a/linux-features/persistent-status-panel/README.md
+++ b/linux-features/persistent-status-panel/README.md
@@ -1,0 +1,16 @@
+# Persistent Status Panel
+
+Keeps the Codex `/status` panel open across thread switches and app restarts
+until it is explicitly closed. The existing panel continues to own chat ID,
+context usage, and rate-limit rendering.
+
+Enable it in `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["persistent-status-panel"]
+}
+```
+
+The webview patch is optional, fail-soft, and idempotent. If the upstream
+composer bundle changes shape, the patch warns and leaves the bundle unchanged.

--- a/linux-features/persistent-status-panel/feature.json
+++ b/linux-features/persistent-status-panel/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "persistent-status-panel",
+  "title": "Persistent Status Panel",
+  "description": "Keep the Codex /status panel open across thread switches and app restarts until explicitly closed.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/persistent-status-panel/patch.js
+++ b/linux-features/persistent-status-panel/patch.js
@@ -1,0 +1,61 @@
+"use strict";
+
+const STORAGE_KEY = "codex-linux-persistent-status-panel-open";
+
+const statusStatePattern =
+  /\{conversationId:[^,]+,threadId:[^,]+,rateLimit:[^,]+,onOpenChange:([A-Za-z_$][\w$]*)\}=e,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\),\[([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\]=\(0,([A-Za-z_$][\w$]*)\.useState\)\(!1\),/;
+
+function applyPersistentStatusPanelPatch(source) {
+  if (source.includes(STORAGE_KEY)) {
+    return source;
+  }
+
+  if (!source.includes("composer.statusSlashCommand.description")) {
+    return source;
+  }
+
+  const match = source.match(statusStatePattern);
+  if (!match) {
+    console.warn("WARN: Could not find Codex status panel state - skipping persistent status panel patch");
+    return source;
+  }
+
+  const [stateNeedle, onOpenChange, _intl, _isOpen, setIsOpen] = match;
+  const openNeedle = `async()=>{${setIsOpen}(!0),${onOpenChange}?.(!0)}`;
+  const closeNeedle = `()=>{${setIsOpen}(!1),${onOpenChange}?.(!1)}`;
+  if (!source.includes(openNeedle) || !source.includes(closeNeedle)) {
+    console.warn("WARN: Could not find Codex status panel handlers - skipping persistent status panel patch");
+    return source;
+  }
+
+  const statePatch = stateNeedle.replace(
+    ".useState)(!1),",
+    `.useState)(()=>{try{return localStorage.getItem(\`${STORAGE_KEY}\`)===\`1\`}catch{return!1}}),`,
+  );
+  const openPatch = `async()=>{try{localStorage.setItem(\`${STORAGE_KEY}\`,\`1\`)}catch{}${setIsOpen}(!0),${onOpenChange}?.(!0)}`;
+  const closePatch = `()=>{try{localStorage.removeItem(\`${STORAGE_KEY}\`)}catch{}${setIsOpen}(!1),${onOpenChange}?.(!1)}`;
+
+  return source
+    .replace(stateNeedle, statePatch)
+    .replace(openNeedle, openPatch)
+    .replace(closeNeedle, closePatch);
+}
+
+const patches = [
+  {
+    id: "composer-status-state",
+    phase: "webview-asset",
+    order: 20_800,
+    ciPolicy: "optional",
+    pattern: /^composer-.*\.js$/,
+    missingDescription: "composer status panel bundle",
+    skipDescription: "persistent status panel patch",
+    apply: applyPersistentStatusPanelPatch,
+  },
+];
+
+module.exports = {
+  STORAGE_KEY,
+  applyPersistentStatusPanelPatch,
+  patches,
+};

--- a/linux-features/persistent-status-panel/test.js
+++ b/linux-features/persistent-status-panel/test.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  STORAGE_KEY,
+  applyPersistentStatusPanelPatch,
+} = require("./patch.js");
+
+const composerSource =
+  "function av(e){let t=(0,$.c)(26),{conversationId:n,threadId:r,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=(0,Z.useState)(!1),p;t[0]===s&&(p=1);let b,x;t[10]===o?(b=t[11],x=t[12]):(b=async()=>{l(!0),o?.(!0)},x=[o]);let y=s.formatMessage({id:`composer.statusSlashCommand.description`});if(!c)return null;let C;t[18]===o?C=t[19]:(C=()=>{l(!1),o?.(!1)});return C}";
+
+function withFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "persistent-status-panel-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }));
+    return fn();
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("feature is disabled until selected", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+  withFeatureConfig([], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot })
+        .some((descriptor) => descriptor.id === "feature:persistent-status-panel:composer-status-state"),
+      false,
+    );
+  });
+  withFeatureConfig(["persistent-status-panel"], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot })
+        .some((descriptor) => descriptor.id === "feature:persistent-status-panel:composer-status-state"),
+      true,
+    );
+  });
+});
+
+test("status panel preference survives component remounts", () => {
+  const patched = applyPersistentStatusPanelPatch(composerSource);
+
+  assert.notEqual(patched, composerSource);
+  assert.match(patched, new RegExp(`localStorage\\.getItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
+  assert.match(patched, new RegExp(`localStorage\\.setItem\\(\\\`${STORAGE_KEY}\\\`,\\\`1\\\`\\)`));
+  assert.match(patched, new RegExp(`localStorage\\.removeItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
+  assert.equal(applyPersistentStatusPanelPatch(patched), patched);
+});
+
+test("unknown composer bundle is unchanged", () => {
+  const originalWarn = console.warn;
+  let warningCount = 0;
+  console.warn = () => {
+    warningCount += 1;
+  };
+  try {
+    assert.equal(applyPersistentStatusPanelPatch("unrelated bundle"), "unrelated bundle");
+    assert.equal(warningCount, 0);
+  } finally {
+    console.warn = originalWarn;
+  }
+});


### PR DESCRIPTION
## Summary

- Add an opt-in `persistent-status-panel` Linux feature.
- Keep the Codex `/status` panel open across thread switches and app restarts until explicitly closed.
- Leave the existing status panel rendering unchanged.

## Behavior

The feature is disabled by default. When enabled, it stores the explicit open/closed preference in `localStorage` and applies it when the composer remounts.

The patch is fail-soft and idempotent. If the upstream composer bundle changes shape, it warns and leaves the bundle unchanged.

## Validation

- `git diff --check origin/main...HEAD`
- `node --test linux-features/persistent-status-panel/test.js`

Also checked broader suites locally:

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`

These broader suites currently fail on `origin/main` as well, so the failures appear unrelated to this feature.

## Manual testing

Used locally with `persistent-status-panel` enabled to keep `/status` visible across Codex Desktop session switches and restarts.