### PR TITLE
fix: require unique persistent status panel needles

### DIFF
--- a/linux-features/persistent-status-panel/patch.js
+++ b/linux-features/persistent-status-panel/patch.js
@@ -5,6 +5,32 @@ const STORAGE_KEY = "codex-linux-persistent-status-panel-open";
 const statusStatePattern =
   /\{conversationId:[^,]+,threadId:[^,]+,rateLimit:[^,]+,onOpenChange:([A-Za-z_$][\w$]*)\}=e,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\),\[([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\]=\(0,([A-Za-z_$][\w$]*)\.useState\)\(!1\),/;
 
+function countOccurrences(source, needle) {
+  if (needle.length === 0) {
+    return 0;
+  }
+  let count = 0;
+  let index = 0;
+  while ((index = source.indexOf(needle, index)) !== -1) {
+    count += 1;
+    index += needle.length;
+  }
+  return count;
+}
+
+function requireUniqueNeedle(source, needle, description) {
+  const count = countOccurrences(source, needle);
+  if (count === 1) {
+    return true;
+  }
+  if (count === 0) {
+    console.warn(`WARN: Could not find ${description} - skipping persistent status panel patch`);
+  } else {
+    console.warn(`WARN: Found ${count} ${description} occurrences - skipping persistent status panel patch`);
+  }
+  return false;
+}
+
 function applyPersistentStatusPanelPatch(source) {
   if (source.includes(STORAGE_KEY)) {
     return source;
@@ -23,8 +49,11 @@ function applyPersistentStatusPanelPatch(source) {
   const [stateNeedle, onOpenChange, _intl, _isOpen, setIsOpen] = match;
   const openNeedle = `async()=>{${setIsOpen}(!0),${onOpenChange}?.(!0)}`;
   const closeNeedle = `()=>{${setIsOpen}(!1),${onOpenChange}?.(!1)}`;
-  if (!source.includes(openNeedle) || !source.includes(closeNeedle)) {
-    console.warn("WARN: Could not find Codex status panel handlers - skipping persistent status panel patch");
+  if (
+    !requireUniqueNeedle(source, stateNeedle, "Codex status panel state") ||
+    !requireUniqueNeedle(source, openNeedle, "Codex status panel open handler") ||
+    !requireUniqueNeedle(source, closeNeedle, "Codex status panel close handler")
+  ) {
     return source;
   }
 

--- a/linux-features/persistent-status-panel/test.js
+++ b/linux-features/persistent-status-panel/test.js
@@ -18,6 +18,19 @@ const {
 const composerSource =
   "function av(e){let t=(0,$.c)(26),{conversationId:n,threadId:r,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=(0,Z.useState)(!1),p;t[0]===s&&(p=1);let b,x;t[10]===o?(b=t[11],x=t[12]):(b=async()=>{l(!0),o?.(!0)},x=[o]);let y=s.formatMessage({id:`composer.statusSlashCommand.description`});if(!c)return null;let C;t[18]===o?C=t[19]:(C=()=>{l(!1),o?.(!1)});return C}";
 
+function captureWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => {
+    warnings.push(message);
+  };
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 function withFeatureConfig(enabled, fn) {
   const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "persistent-status-panel-"));
@@ -63,16 +76,43 @@ test("status panel preference survives component remounts", () => {
   assert.equal(applyPersistentStatusPanelPatch(patched), patched);
 });
 
+test("ambiguous status panel handler needles are unchanged", () => {
+  const ambiguousSource = composerSource.replace(
+    "let y=s.formatMessage",
+    "let extraOpen=async()=>{l(!0),o?.(!0)},extraClose=()=>{l(!1),o?.(!1)},y=s.formatMessage",
+  );
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPersistentStatusPanelPatch(ambiguousSource),
+  );
+
+  assert.equal(patched, ambiguousSource);
+  assert.deepEqual(warnings, [
+    "WARN: Found 2 Codex status panel open handler occurrences - skipping persistent status panel patch",
+  ]);
+});
+
+test("composer bundle with changed status state shape is unchanged", () => {
+  const changedStateSource = composerSource.replace(
+    "{conversationId:n,threadId:r,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=(0,Z.useState)(!1),",
+    "{threadId:r,conversationId:n,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=Z.useState(!1),",
+  );
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPersistentStatusPanelPatch(changedStateSource),
+  );
+
+  assert.equal(patched, changedStateSource);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find Codex status panel state - skipping persistent status panel patch",
+  ]);
+});
+
 test("unknown composer bundle is unchanged", () => {
-  const originalWarn = console.warn;
-  let warningCount = 0;
-  console.warn = () => {
-    warningCount += 1;
-  };
-  try {
-    assert.equal(applyPersistentStatusPanelPatch("unrelated bundle"), "unrelated bundle");
-    assert.equal(warningCount, 0);
-  } finally {
-    console.warn = originalWarn;
-  }
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPersistentStatusPanelPatch("unrelated bundle"),
+  );
+
+  assert.equal(patched, "unrelated bundle");
+  assert.deepEqual(warnings, []);
 });


### PR DESCRIPTION
## Summary

- Make the persistent status panel patch fail-soft unless the state/open/close needles are unique.
- Add regression coverage for duplicate handler shapes.
- Add drift coverage for composer bundles that still contain the status i18n marker but no longer match the expected state shape.

## Context

Follow-up to #557. The original feature was merged as an opt-in, disabled-by-default Linux feature. This PR hardens the patch against ambiguous minified handler needles and upstream bundle shape drift.

## Validation

- `node --test linux-features/persistent-status-panel/test.js`
- `git diff --check`