### PR TITLE
Fix Linux open target discovery

### DIFF
--- a/linux-features/open-target-discovery/feature.json
+++ b/linux-features/open-target-discovery/feature.json
@@ -4,6 +4,6 @@
   "description": "Adds opt-in Linux terminal and editor opener discovery, plus richer file manager launching.",
   "defaultEnabled": false,
   "entrypoints": {
-    "mainBundlePatch": "./patch.js"
+    "patchDescriptors": "./patch.js"
   }
 }

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -334,7 +334,7 @@ function applyIdeDiscoveryPatch(currentSource, deps) {
     `function codexLinuxKnownIdeDesktopDuplicate(e){let t=new Set([\`cursor\`,\`code\`,\`codium\`,\`code-insiders\`,\`windsurf\`,\`antigravity\`,\`zed\`,\`zeditor\`,\`zedit\`,\`zed-cli\`,\`idea\`,\`webstorm\`,\`pycharm\`,\`goland\`,\`clion\`,\`rustrover\`,\`rider\`,\`phpstorm\`,\`studio\`,\`studio.sh\`]);return t.has(e.base)&&codexLinuxFindExecutable(e.base)!=null}` +
     `function codexLinuxDesktopIdeIcon(e,t){let n=\`\${e.Name||\`\`} \${e.Id||\`\`} \${t.base||\`\`}\`.toLowerCase();for(let[e,t]of [[\`cursor\`,\`apps/cursor.png\`],[\`code-insiders\`,\`apps/vscode-insiders.png\`],[\`vscode\`,\`apps/vscode.png\`],[\`visual studio code\`,\`apps/vscode.png\`],[\`codium\`,\`apps/vscode.png\`],[\`zed\`,\`apps/zed.png\`],[\`sublime\`,\`apps/sublime-text.png\`],[\`emacs\`,\`apps/emacs.png\`],[\`intellij\`,\`apps/intellij.png\`],[\`webstorm\`,\`apps/webstorm.svg\`],[\`pycharm\`,\`apps/pycharm.png\`],[\`goland\`,\`apps/goland.png\`],[\`clion\`,\`apps/clion.png\`],[\`rustrover\`,\`apps/rustrover.png\`],[\`rider\`,\`apps/rider.png\`],[\`phpstorm\`,\`apps/phpstorm.png\`],[\`android studio\`,\`apps/android-studio.png\`],[\`windsurf\`,\`apps/windsurf.png\`],[\`antigravity\`,\`apps/antigravity.png\`]])if(n.includes(e))return t;return\`apps/terminal.png\`}` +
     `function codexLinuxIconSearchRoots(){let e=process.env.HOME||\`/nonexistent\`,t=process.env.XDG_DATA_HOME&&(0,${pathVar}.isAbsolute)(process.env.XDG_DATA_HOME)?process.env.XDG_DATA_HOME:(0,${pathVar}.join)(e,\`.local/share\`),n=(process.env.XDG_DATA_DIRS&&process.env.XDG_DATA_DIRS.length>0?process.env.XDG_DATA_DIRS:\`/usr/local/share:/usr/share\`).split(\`:\`).filter(Boolean),r=[(0,${pathVar}.join)(t,\`icons\`),(0,${pathVar}.join)(e,\`.icons\`),...n.map(e=>(0,${pathVar}.join)(e,\`icons\`)),(0,${pathVar}.join)(t,\`pixmaps\`),...n.map(e=>(0,${pathVar}.join)(e,\`pixmaps\`)),(0,${pathVar}.join)(e,\`.local/share/flatpak/exports/share/icons\`),(0,${pathVar}.join)(e,\`.local/share/flatpak/exports/share/pixmaps\`),\`/var/lib/flatpak/exports/share/icons\`,\`/var/lib/flatpak/exports/share/pixmaps\`,\`/var/lib/snapd/desktop/icons\`],a=new Set;return r.filter(e=>e&&(0,${pathVar}.isAbsolute)(e)&&!a.has(e)&&(a.add(e),!0))}` +
-    `function codexLinuxFindIconFile(e,t,n=0){if(n>6)return null;try{for(let r of (0,${fsVar}.readdirSync)(e,{withFileTypes:!0})){let a=(0,${pathVar}.join)(e,r.name);if(r.isDirectory()){let e=codexLinuxFindIconFile(a,t,n+1);if(e)return e}else if(r.isFile()&&r.name.replace(/\\.(png|svg|xpm)$/iu,\`\`)===t&&/\\.(png|svg|xpm)$/iu.test(r.name))return a}}catch{}return null}` +
+    `function codexLinuxFindIconFile(e,t,n=0){if(n>6)return null;try{for(let r of (0,${fsVar}.readdirSync)(e,{withFileTypes:!0})){let a=(0,${pathVar}.join)(e,r.name);if(r.isDirectory()){let e=codexLinuxFindIconFile(a,t,n+1);if(e)return e}else if((r.isFile()||r.isSymbolicLink())&&r.name.replace(/\\.(png|svg|xpm)$/iu,\`\`)===t&&/\\.(png|svg|xpm)$/iu.test(r.name))return a}}catch{}return null}` +
     `function codexLinuxDesktopIconPath(e){let t=(e.Icon||\`\`).trim();if(!t)return null;if((0,${pathVar}.isAbsolute)(t)){try{if((0,${fsVar}.existsSync)(t))return t}catch{}return null}let n=t.replace(/\\.(png|svg|xpm)$/iu,\`\`),r=[\`png\`,\`svg\`,\`xpm\`];for(let e of codexLinuxIconSearchRoots())for(let t of r){let r=(0,${pathVar}.join)(e,\`\${n}.\${t}\`);try{if((0,${fsVar}.existsSync)(r))return r}catch{}}for(let e of codexLinuxIconSearchRoots()){let t=codexLinuxFindIconFile(e,n);if(t)return t}return null}` +
     `function codexLinuxDesktopIdeId(e){let t=(e.Id||e.Name||e.Exec||\`app\`).toLowerCase().replace(/\\.desktop$/u,\`\`).replace(/[^a-z0-9]+/gu,\`-\`).replace(/^-|-$/gu,\`\`).slice(0,64)||\`app\`;return\`linux-desktop-\${t}\`}` +
     `function codexLinuxUniqueDesktopIdeId(e,t){let n=codexLinuxDesktopIdeId(e),r=n,i=2;for(;t.has(r);)r=\`\${n}-\${i++}\`;return t.add(r),r}` +
@@ -428,21 +428,47 @@ function applyLinuxIconPathResolutionPatch(currentSource) {
     }
   }
 
+  if (!patchedSource.includes("codexLinuxOpenTargetIconPath(e,t)")) {
+    const fallbackNeedle = "r=e.iconPath?e.iconPath(t):t";
+    if (patchedSource.includes(fallbackNeedle)) {
+      patchedSource = patchedSource.replace(
+        fallbackNeedle,
+        "r=codexLinuxOpenTargetIconPath(e,t)",
+      );
+    } else {
+      warn("Could not find open target icon command fallback");
+    }
+  }
+
   if (!patchedSource.includes("codexLinuxOpenTargetIconImage(")) {
     const resolverMatch = patchedSource.match(
       /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.toLowerCase\(\)\.endsWith\(`\.lnk`\)\?await ([A-Za-z_$][\w$]*)\(\2\):await ([A-Za-z_$][\w$]*)\.app\.getFileIcon\(\2,\{size:`normal`\}\);return!\1\|\|\1\.isEmpty\(\)\?([A-Za-z_$][\w$]*):\1\.toDataURL\(\)/u,
     );
     if (resolverMatch != null) {
       const [resolverNeedle, imageVar, pathArg, lnkResolver, electronVar, fallbackVar] = resolverMatch;
+      const emptyPathNeedle = `if(!${pathArg})return ${fallbackVar};`;
+      if (patchedSource.includes(emptyPathNeedle)) {
+        patchedSource = patchedSource.replace(
+          emptyPathNeedle,
+          `if(!${pathArg})return codexLinuxOpenTargetIconDataUrl(null,${fallbackVar});`,
+        );
+      } else if (!patchedSource.includes(`codexLinuxOpenTargetIconDataUrl(null,${fallbackVar})`)) {
+        warn("Could not find open target icon empty-path fallback");
+      }
       patchedSource = patchedSource.replace(
         resolverNeedle,
-        `let ${imageVar}=codexLinuxOpenTargetIconImage(${pathArg})??(${pathArg}.toLowerCase().endsWith(\`.lnk\`)?await ${lnkResolver}(${pathArg}):await ${electronVar}.app.getFileIcon(${pathArg},{size:\`normal\`}));return!${imageVar}||${imageVar}.isEmpty()?${fallbackVar}:${imageVar}.toDataURL()`,
+        `let ${imageVar}=await codexLinuxOpenTargetIconImage(${pathArg});${imageVar}=${imageVar}??(${pathArg}.toLowerCase().endsWith(\`.lnk\`)?await ${lnkResolver}(${pathArg}):await ${electronVar}.app.getFileIcon(${pathArg},{size:\`normal\`}));return!${imageVar}||${imageVar}.isEmpty()?${fallbackVar}:${imageVar}.toDataURL()`,
       );
       const resolverIndex = patchedSource.lastIndexOf("async function ", resolverMatch.index);
       if (resolverIndex >= 0) {
         patchedSource =
           patchedSource.slice(0, resolverIndex) +
-          `function codexLinuxOpenTargetIconImage(e){if(process.platform!==\`linux\`||typeof e!==\`string\`||!/\\.(png|svg|jpe?g|bmp|ico)$/iu.test(e))return null;try{let t=${electronVar}.nativeImage.createFromPath(e);return t.isEmpty()?null:t}catch{return null}}` +
+          `function codexLinuxOpenTargetIconPath(e,t){if(process.platform===\`linux\`)return typeof e?.iconPath===\`function\`?e.iconPath(t):null;return e?.iconPath?e.iconPath(t):t}` +
+          `var codexLinuxOpenTargetSvgIconCache=new Map;` +
+          `function codexLinuxOpenTargetBundledIconPath(e){if(process.platform!==\`linux\`||typeof e!==\`string\`||!/\\.svg$/iu.test(e)||e.startsWith(\`data:\`)||e.startsWith(\`file:\`)||e.startsWith(\`/\`))return null;try{let t=require(\`node:path\`),n=require(\`node:fs\`),r=[t.join(process.resourcesPath,\`../content/webview\`,e),t.join(process.resourcesPath,\`app.asar/webview\`,e)];for(let e of r)if(n.existsSync(e))return e}catch{}return null}` +
+          `async function codexLinuxOpenTargetRasterizeSvg(e,t){if(typeof ${electronVar}.BrowserWindow!==\`function\`)return null;let _codexWindow=new ${electronVar}.BrowserWindow({show:!1,width:64,height:64,transparent:!0,frame:!1,webPreferences:{offscreen:!0,nodeIntegration:!1,contextIsolation:!0,sandbox:!0}});try{let r=\`data:image/svg+xml;charset=utf-8,\${encodeURIComponent(e)}\`,i=\`data:text/html;charset=utf-8,\${encodeURIComponent(\`<!doctype html><html><body style="margin:0;background:transparent;width:64px;height:64px;overflow:hidden"><img src="\${r}" style="width:64px;height:64px;display:block"></body></html>\`)}\`;await _codexWindow.loadURL(i);let a=await _codexWindow.webContents.capturePage({x:0,y:0,width:64,height:64});return a.isEmpty()?null:a}catch{return null}finally{try{_codexWindow.destroy()}catch{}}}` +
+          `async function codexLinuxOpenTargetIconDataUrl(e,t){let r=e??codexLinuxOpenTargetBundledIconPath(t),n=await codexLinuxOpenTargetIconImage(r);return n&&!n.isEmpty()?n.toDataURL():t}` +
+          `async function codexLinuxOpenTargetIconImage(e){if(process.platform!==\`linux\`||typeof e!==\`string\`)return null;if(codexLinuxOpenTargetSvgIconCache.has(e))return codexLinuxOpenTargetSvgIconCache.get(e);let _codexExt=e.match(/\\.([a-z0-9]+)$/iu)?.[1]?.toLowerCase(),_codexMime={png:\`image/png\`,svg:\`image/svg+xml\`,jpg:\`image/jpeg\`,jpeg:\`image/jpeg\`,bmp:\`image/bmp\`,ico:\`image/x-icon\`,xpm:\`image/x-xpixmap\`}[_codexExt];if(!_codexMime)return null;if(_codexExt===\`svg\`){let _codexPromise=(async()=>{try{let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return t}catch{}try{let t=require(\`node:fs\`).readFileSync(e,\`utf8\`);return await codexLinuxOpenTargetRasterizeSvg(t,e)}catch{return null}})();codexLinuxOpenTargetSvgIconCache.set(e,_codexPromise);return _codexPromise}try{let _codexData=require(\`node:fs\`).readFileSync(e);return{isEmpty:()=>_codexData.length===0,toDataURL:()=>\`data:\${_codexMime};base64,\${_codexData.toString(\`base64\`)}\`}}catch{}try{let _codexImage=${electronVar}.nativeImage.createFromPath(e);return _codexImage.isEmpty()?null:_codexImage}catch{return null}}` +
           patchedSource.slice(resolverIndex);
       } else {
         warn("Could not find open target icon resolver declaration");
@@ -452,7 +478,153 @@ function applyLinuxIconPathResolutionPatch(currentSource) {
     }
   }
 
-  return patchedSource;
+  return applyLinuxIconSummaryResolutionPatch(patchedSource);
+}
+
+function applyLinuxIconSummaryResolutionPatch(currentSource) {
+  if (!currentSource.includes("codexLinuxOpenTargetIconImage(")) {
+    return currentSource;
+  }
+  if (currentSource.includes("codexLinuxOpenTargetSummaryIcon(")) {
+    return currentSource;
+  }
+
+  const summaryMatch = currentSource.match(
+    /function ([A-Za-z_$][\w$]*)\(e\)\{return e\.map\(\(\{id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a\}\)=>\(\{id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a\}\)\)\}/u,
+  );
+  if (summaryMatch == null) {
+    warn("Could not find open target icon summary mapper");
+    return currentSource;
+  }
+
+  const [needle, summaryFn] = summaryMatch;
+  const replacement =
+    `function codexLinuxOpenTargetSummaryIconDataUrl(e,t){let n=e??codexLinuxOpenTargetBundledIconPath(t);if(process.platform!==\`linux\`||typeof n!==\`string\`)return t;let r=n.match(/\\.([a-z0-9]+)$/iu)?.[1]?.toLowerCase(),i={png:\`image/png\`,svg:\`image/svg+xml\`,jpg:\`image/jpeg\`,jpeg:\`image/jpeg\`,bmp:\`image/bmp\`,ico:\`image/x-icon\`,xpm:\`image/x-xpixmap\`}[r];if(!i)return t;try{if(r===\`svg\`){let e=require(\`node:fs\`).readFileSync(n,\`utf8\`);return \`data:image/svg+xml;charset=utf-8,\${encodeURIComponent(e)}\`}let e=require(\`node:fs\`).readFileSync(n);return \`data:\${i};base64,\${e.toString(\`base64\`)}\`}catch{return t}}` +
+    `function codexLinuxOpenTargetSummaryIcon(e){if(process.platform!==\`linux\`)return e.icon;try{return codexLinuxOpenTargetSummaryIconDataUrl(codexLinuxOpenTargetIconPath(e,null),e.icon)}catch{return e.icon}}` +
+    `function ${summaryFn}(e){return e.map(e=>({id:e.id,label:e.label,icon:codexLinuxOpenTargetSummaryIcon(e),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}))}`;
+
+  return currentSource.replace(needle, replacement);
+}
+
+function applyOpenInTargetRegistryCommandPatch(currentSource) {
+  if (currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
+    return currentSource;
+  }
+
+  const insertionIndex = currentSource.indexOf("async function");
+  if (insertionIndex === -1) {
+    warn("Could not find insertion point for Linux open target registry helper");
+    return currentSource;
+  }
+
+  const helper =
+    "async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==`linux`)return;let n=iP(e).find(e=>e.id===t);return typeof n?.detect===`function`?await n.detect(IN):null}";
+  return currentSource.slice(0, insertionIndex) + helper + currentSource.slice(insertionIndex);
+}
+
+function applyOpenInTargetCommandPatch(currentSource) {
+  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource);
+  if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e)")) {
+    return currentSource;
+  }
+
+  const needles = [
+    "async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}",
+    "async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});return t}",
+  ];
+  const replacement =
+    "async getOpenInTargetCommand(e){let t=await codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e);if(process.platform===`linux`){if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}if(this.requestOpenInWorker==null)return;let{command:n}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(n==null)throw Error(`Open target \"${e}\" is not available`);return n}";
+
+  for (const needle of needles) {
+    if (currentSource.includes(needle)) {
+      return currentSource.replace(needle, replacement);
+    }
+  }
+
+  if (currentSource.includes("getOpenInTargetCommand")) {
+    warn("Could not find getOpenInTargetCommand worker fallback");
+  }
+  return currentSource;
+}
+
+function applyOpenInTargetsBridgeDetectionPatch(currentSource) {
+  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource);
+  if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e)")) {
+    return currentSource;
+  }
+
+  const needle =
+    "openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:JN(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:";
+  const replacement =
+    "openInTargets:{detectTarget:async({target:e})=>{let t=await codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e);if(process.platform===`linux`)return{available:t!=null};if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:n}=await this.options.requestOpenInWorker({method:`get-target-command`,params:JN(this.options.settingsStore,e)});return{available:n!=null}},loadTargetIcon:";
+
+  if (!currentSource.includes(needle)) {
+    if (currentSource.includes("openInTargets:{detectTarget")) {
+      warn("Could not find open-in bridge target detection");
+    }
+    return currentSource;
+  }
+  return currentSource.replace(needle, replacement);
+}
+
+function applyOpenInTargetExecutePatch(currentSource) {
+  if (currentSource.includes("targets:iP(e)")) {
+    return currentSource;
+  }
+
+  const needle =
+    "async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c})}";
+  const replacement =
+    "async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c,targets:iP(e)})}";
+
+  if (!currentSource.includes(needle)) {
+    if (currentSource.includes("async function ZN(")) {
+      warn("Could not find open-in target execution helper");
+    }
+    return currentSource;
+  }
+  return currentSource.replace(needle, replacement);
+}
+
+function applyOpenInTargetsDirectoryModePatch(currentSource) {
+  const helper = "function codexLinuxOpenTargetIsDirectory(";
+  const directoryNeedle =
+    "g=d||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[]";
+  const directoryReplacement =
+    "w=f!=null&&codexLinuxOpenTargetIsDirectory(f),g=d||w||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[]";
+
+  if (currentSource.includes(helper)) {
+    return currentSource;
+  }
+  if (!currentSource.includes('"open-in-targets":async')) {
+    return currentSource;
+  }
+  if (!currentSource.includes(directoryNeedle)) {
+    warn("Could not find open-in-targets path mode expression");
+    return currentSource;
+  }
+
+  const helperSource =
+    `function codexLinuxOpenTargetIsDirectory(e){if(process.platform!==\`linux\`||typeof e!==\`string\`)return!1;try{return(0,codexLinuxNodeFs().existsSync)(e)&&(0,codexLinuxNodeFs().statSync)(e).isDirectory()}catch{return!1}}`;
+  const patchedSource = helperSource + currentSource;
+  return patchedSource.replace(directoryNeedle, directoryReplacement);
+}
+
+function applyNativeOpenTargetSelectionPatch(currentSource) {
+  if (currentSource.includes("function codexLinuxDirectoryOpenTarget(")) {
+    return currentSource;
+  }
+
+  const original =
+    "function e({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}";
+  const patched =
+    "function codexLinuxDirectoryOpenTarget(e){return e?.available===!0&&(e.kind===`editor`||e.kind===`terminal`)}function e({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`||codexLinuxDirectoryOpenTarget(e));let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}";
+
+  if (!currentSource.includes(original)) {
+    warn("Could not find native open-target selection logic");
+    return currentSource;
+  }
+  return currentSource.replace(original, patched);
 }
 
 function applyMainBundlePatch(currentSource) {
@@ -476,9 +648,39 @@ function applyMainBundlePatch(currentSource) {
   patchedSource = applyTerminalDiscoveryPatch(patchedSource, deps);
   patchedSource = applyIdeDiscoveryPatch(patchedSource, deps);
   patchedSource = applyLinuxIconPathResolutionPatch(patchedSource);
+  patchedSource = applyOpenInTargetRegistryCommandPatch(patchedSource);
+  patchedSource = applyOpenInTargetCommandPatch(patchedSource);
+  patchedSource = applyOpenInTargetsBridgeDetectionPatch(patchedSource);
+  patchedSource = applyOpenInTargetExecutePatch(patchedSource);
+  patchedSource = applyOpenInTargetsDirectoryModePatch(patchedSource);
   return patchedSource;
 }
 
 module.exports = {
+  applyNativeOpenTargetSelectionPatch,
   applyMainBundlePatch,
+  applyOpenInTargetRegistryCommandPatch,
+  applyOpenInTargetExecutePatch,
+  applyOpenInTargetCommandPatch,
+  applyOpenInTargetsBridgeDetectionPatch,
+  applyOpenInTargetsDirectoryModePatch,
+  descriptors: [
+    {
+      id: "main-bundle-open-target-discovery",
+      phase: "main-bundle",
+      order: 20500,
+      ciPolicy: "optional",
+      apply: applyMainBundlePatch,
+    },
+    {
+      id: "webview-native-open-target-selection",
+      phase: "webview-asset",
+      order: 20520,
+      ciPolicy: "optional",
+      pattern: /^open-target-selection-.*\.js$/,
+      missingDescription: "open target selection webview bundle",
+      skipDescription: "native open-target selection patch",
+      apply: applyNativeOpenTargetSelectionPatch,
+    },
+  ],
 };

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -8,7 +8,15 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const { pathToFileURL } = require("node:url");
-const { applyMainBundlePatch } = require("./patch.js");
+const {
+  applyMainBundlePatch,
+  applyNativeOpenTargetSelectionPatch,
+  applyOpenInTargetCommandPatch,
+  applyOpenInTargetExecutePatch,
+  applyOpenInTargetRegistryCommandPatch,
+  applyOpenInTargetsBridgeDetectionPatch,
+  applyOpenInTargetsDirectoryModePatch,
+} = require("./patch.js");
 const {
   enabledLinuxFeatureIds,
   loadLinuxFeatureMainBundlePatches,
@@ -37,6 +45,18 @@ const iconResolverBundle =
   "async function c_(e,t,a){return e===`win32`?Promise.all(t.map(async e=>{let t=a?.get(e.id)??null,r=e.iconPath?e.iconPath(t):t;return{id:e.id,label:e.label,icon:await d_(r,e.icon),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}})):l_(t)}function l_(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}async function d_(e,t){if(!e)return t;try{let r=e.toLowerCase().endsWith(`.lnk`)?await f_(e):await n.app.getFileIcon(e,{size:`normal`});return!r||r.isEmpty()?t:r.toDataURL()}catch(e){return t}}async function f_(e){return n.nativeImage.createFromPath(e)}";
 const currentIconResolverBundle =
   "async function VN(e,t,n){return e===`win32`?Promise.all(t.map(async e=>{let t=n?.get(e.id)??null,r=e.iconPath?e.iconPath(t):t;return{id:e.id,label:e.label,icon:await WN(r,e.icon),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}})):HN(t)}function HN(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}async function WN(e,t){if(!e)return t;try{let r=e.toLowerCase().endsWith(`.lnk`)?await UN(e):await n.app.getFileIcon(e,{size:`normal`});return!r||r.isEmpty()?t:r.toDataURL()}catch(e){return t}}async function UN(e){return n.nativeImage.createFromPath(e)}";
+const openInCommandBundle =
+  "async function JN(){}function iP(e){return e.targets}var IN={};class App{constructor(){this.requestOpenInWorker=async()=>({command:`worker-command`});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});return t}}";
+const currentOpenInCommandBundle =
+  "async function JN(){}function iP(e){return e.targets}var IN={};class App{constructor(){this.requestOpenInWorker=async()=>({command:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
+const openInBridgeBundle =
+  "async function JN(){}function iP(e){return e.targets}var IN={};var bridge={options:{settingsStore:{targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]},requestOpenInWorker:async()=>({command:`worker-command`})},openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:JN(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
+const openInExecuteBundle =
+  "function iP(e){return e.targets}async function BN(e,t,n){return n}async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c})}";
+const openInTargetsBundle =
+  '"open-in-targets":async({cwd:e,deferEnrichment:n=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();let[c,l]=await Promise.all([XN(s),YN(s)]),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&_F(u)&&!t.Ta(o.hostConfig),f=u==null||d||t.Ta(o.hostConfig)?null:this.resolveOpenFilePath(this.mapAgentPathToLocalPath(u,o.hostConfig)??u,this.mapAgentPathToLocalPath(e,o.hostConfig)??this.getWorkspaceRoot()),p=oj(o.hostConfig,c,l),m=new Set(p),h=tP(s,e,m),g=d||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}';
+const openTargetSelectionBundle =
+  "function e({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}function t({preferredTarget:t,targets:n,availableTargets:r,includeHiddenTargets:i=!0,mode:a=`editor`}){let o=e({targets:n,availableTargets:r,includeHiddenTargets:i,mode:a});return o.length===0?null:t?o.find(e=>e.target===t)??o[0]??null:o[0]??null}function n(e){return e.appPath==null&&e.kind===`editor`}export{e as n,t as r,n as t};";
 
 function applyPatchTwice(patchFn, source, ...args) {
   const patched = patchFn(source, ...args);
@@ -715,23 +735,56 @@ test("open-target discovery uses desktop entry icons when available", () => {
   });
 });
 
+test("open-target discovery follows symlinked desktop entry icons", () => {
+  withTempDir((tmp) => {
+    const dataHome = path.join(tmp, "share");
+    const appsDir = path.join(dataHome, "applications");
+    const iconDir = path.join(dataHome, "icons", "hicolor", "128x128", "apps");
+    const targetIconPath = path.join(tmp, "flatpak-app", "export", "icons", "hicolor", "128x128", "apps", "com.example.Agent.png");
+    const symlinkIconPath = path.join(iconDir, "com.example.Agent.png");
+    const editorCommand = makeExecutable(path.join(tmp, "flatpak", "exports", "bin"), "com.example.Agent");
+    fs.mkdirSync(appsDir, { recursive: true });
+    fs.mkdirSync(iconDir, { recursive: true });
+    fs.mkdirSync(path.dirname(targetIconPath), { recursive: true });
+    fs.writeFileSync(targetIconPath, "png");
+    fs.symlinkSync(targetIconPath, symlinkIconPath);
+    fs.writeFileSync(
+      path.join(appsDir, "com.example.Agent.desktop"),
+      [
+        "[Desktop Entry]",
+        "Type=Application",
+        "Name=Flatpak Agent",
+        `Exec=${editorCommand} %U`,
+        "Icon=com.example.Agent",
+        "Categories=Development;",
+      ].join("\n"),
+    );
+
+    const targets = evaluatePatched(
+      openTargetsBundle,
+      { HOME: tmp, PATH: path.join(tmp, "bin"), XDG_DATA_HOME: dataHome, XDG_DATA_DIRS: path.join(tmp, "empty") },
+      "Xg.flatMap((target)=>{let platform=target.platforms.linux;return platform?[{label:platform.label,iconPath:platform.iconPath?.()}]:[]})",
+    );
+    const agent = targets.find((target) => target.label === "Flatpak Agent");
+
+    assert.ok(agent);
+    assert.equal(agent.iconPath, symlinkIconPath);
+  });
+});
+
 test("open-target discovery resolves iconPath on Linux", async () => {
   const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${iconResolverBundle}`);
-  const iconPath = "/tmp/codex-icon.png";
-  const image = {
-    isEmpty: () => false,
-    toDataURL: () => "data:image/png;base64,codex",
-  };
+  const iconPath = path.join(os.tmpdir(), "codex-open-target-icon.png");
+  fs.writeFileSync(iconPath, "codex");
   const electron = {
     app: {
       getFileIcon: async () => {
-        throw new Error("should prefer nativeImage for image files");
+        throw new Error("should prefer direct data URL for image files");
       },
     },
     nativeImage: {
-      createFromPath: (target) => {
-        assert.equal(target, iconPath);
-        return image;
+      createFromPath: () => {
+        throw new Error("should not need nativeImage for image files");
       },
     },
   };
@@ -751,26 +804,29 @@ test("open-target discovery resolves iconPath on Linux", async () => {
     targets,
   );
 
-  assert.equal(result[0].icon, "data:image/png;base64,codex");
+  assert.equal(result[0].icon, `data:image/png;base64,${Buffer.from("codex").toString("base64")}`);
+  fs.rmSync(iconPath, { force: true });
 });
 
 test("open-target discovery resolves iconPath on current upstream bundle shape", async () => {
   const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
-  const iconPath = "/tmp/codex-current-icon.svg";
-  const image = {
-    isEmpty: () => false,
-    toDataURL: () => "data:image/svg+xml;base64,codex",
-  };
+  const iconPath = path.join(os.tmpdir(), "codex-current-open-target-icon.svg");
+  fs.writeFileSync(iconPath, "<svg/>");
+  let nativeImageUsed = false;
   const electron = {
     app: {
       getFileIcon: async () => {
-        throw new Error("should prefer nativeImage for image files");
+        throw new Error("should not need getFileIcon for image files");
       },
     },
     nativeImage: {
       createFromPath: (target) => {
+        nativeImageUsed = true;
         assert.equal(target, iconPath);
-        return image;
+        return {
+          isEmpty: () => false,
+          toDataURL: () => "data:image/png;base64,converted-svg",
+        };
       },
     },
   };
@@ -792,7 +848,343 @@ test("open-target discovery resolves iconPath on current upstream bundle shape",
     targets,
   );
 
-  assert.equal(result[0].icon, "data:image/svg+xml;base64,codex");
+  assert.equal(nativeImageUsed, true);
+  assert.equal(result[0].icon, "data:image/png;base64,converted-svg");
+  fs.rmSync(iconPath, { force: true });
+});
+
+test("open-target discovery rasterizes undecodable SVG iconPath", async () => {
+  const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+  const iconPath = path.join(os.tmpdir(), "codex-current-open-target-empty-svg.svg");
+  const svg = "<svg><rect width=\"16\" height=\"16\" /></svg>";
+  fs.writeFileSync(iconPath, svg);
+  const electron = {
+    app: {
+      getFileIcon: async () => {
+        throw new Error("should not fall back to file type icons for SVG iconPath");
+      },
+    },
+    nativeImage: {
+      createFromPath: (target) => {
+        assert.equal(target, iconPath);
+        return { isEmpty: () => true };
+      },
+    },
+    BrowserWindow: class {
+      webContents = {
+        capturePage: async () => ({
+          isEmpty: () => false,
+          toDataURL: () => "data:image/png;base64,rasterized-svg",
+          getSize: () => ({ width: 64, height: 64 }),
+        }),
+      };
+      async loadURL(url) {
+        assert.match(url, /^data:text\/html;charset=utf-8,/);
+      }
+      destroy() {}
+    },
+  };
+  const targets = [
+    {
+      id: "linux-desktop-agent",
+      label: "Agent",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      iconPath: () => iconPath,
+    },
+  ];
+
+  const result = await new Function("require", "process", `${patched};return VN('linux', arguments[2], new Map());`)(
+    (name) => (name === "electron" ? electron : require(name)),
+    { platform: "linux", env: {} },
+    targets,
+  );
+
+  assert.equal(result[0].icon, "data:image/png;base64,rasterized-svg");
+  fs.rmSync(iconPath, { force: true });
+});
+
+test("open-target discovery keeps built-in icons for Linux targets without iconPath", async () => {
+  const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+  const commandPath = path.join(os.tmpdir(), "codex-current-open-target-command");
+  fs.writeFileSync(commandPath, "binary");
+  const electron = {
+    app: {
+      getFileIcon: async () => {
+        throw new Error("should not inspect command paths for Linux targets without iconPath");
+      },
+    },
+    nativeImage: {
+      createFromPath: () => {
+        throw new Error("should not inspect command paths for Linux targets without iconPath");
+      },
+    },
+  };
+  const targets = [
+    {
+      id: "webstorm",
+      label: "WebStorm",
+      icon: "apps/webstorm.svg",
+      kind: "editor",
+    },
+  ];
+
+  const result = await new Function("require", "process", `${patched};return VN('linux', arguments[2], arguments[3]);`)(
+    (name) => (name === "electron" ? electron : require(name)),
+    { platform: "linux", env: {} },
+    targets,
+    new Map([["webstorm", commandPath]]),
+  );
+
+  assert.equal(result[0].icon, "apps/webstorm.svg");
+  fs.rmSync(commandPath, { force: true });
+});
+
+test("open-target discovery preserves bundled SVG fallback icons in Linux open menus", async () => {
+  withTempDir(async (tmp) => {
+    const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+    const electron = {
+      app: {
+        getFileIcon: async () => {
+          throw new Error("should not inspect command paths for Linux targets without iconPath");
+        },
+      },
+      nativeImage: {
+        createFromPath: () => {
+          throw new Error("should not convert bundled fallback icons");
+        },
+      },
+    };
+    const targets = [
+      {
+        id: "webstorm",
+        label: "WebStorm",
+        icon: "apps/webstorm.svg",
+        kind: "editor",
+      },
+    ];
+
+    const result = await new Function("require", "process", `${patched};return VN('linux', arguments[2], new Map());`)(
+      (name) => (name === "electron" ? electron : require(name)),
+      { platform: "linux", env: {} },
+      targets,
+    );
+
+    assert.equal(result[0].icon, "apps/webstorm.svg");
+  });
+});
+
+test("open-target discovery rasterizes bundled SVG fallback icons when available", async () => {
+  withTempDir(async (tmp) => {
+    const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+    const resourcesPath = path.join(tmp, "resources");
+    const bundledIconPath = path.join(resourcesPath, "app.asar", "webview", "apps", "webstorm.svg");
+    fs.mkdirSync(path.dirname(bundledIconPath), { recursive: true });
+    fs.writeFileSync(bundledIconPath, "<svg><rect width=\"16\" height=\"16\" /></svg>");
+    const electron = {
+      app: {
+        getFileIcon: async () => {
+          throw new Error("should not inspect command paths for bundled fallback icons");
+        },
+      },
+      nativeImage: {
+        createFromPath: (target) => {
+          assert.equal(target, bundledIconPath);
+          return { isEmpty: () => true };
+        },
+      },
+      BrowserWindow: class {
+        webContents = {
+          capturePage: async () => ({
+            isEmpty: () => false,
+            toDataURL: () => "data:image/png;base64,bundled-webstorm",
+            getSize: () => ({ width: 64, height: 64 }),
+          }),
+        };
+        async loadURL(url) {
+          assert.match(url, /^data:text\/html;charset=utf-8,/);
+        }
+        destroy() {}
+      },
+    };
+    const targets = [
+      {
+        id: "webstorm",
+        label: "WebStorm",
+        icon: "apps/webstorm.svg",
+        kind: "editor",
+      },
+    ];
+
+    const result = await new Function("require", "process", `${patched};return VN('linux', arguments[2], new Map());`)(
+      (name) => (name === "electron" ? electron : require(name)),
+      { platform: "linux", env: {}, resourcesPath },
+      targets,
+    );
+
+    assert.equal(result[0].icon, "data:image/png;base64,bundled-webstorm");
+  });
+});
+
+test("open-target discovery resolves iconPath in Linux target summaries", async () => {
+  const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+  const iconPath = path.join(os.tmpdir(), "codex-current-open-target-summary-icon.png");
+  fs.writeFileSync(iconPath, "summary");
+  const electron = {
+    app: {
+      getFileIcon: async () => {
+        throw new Error("should prefer direct data URL for Linux summaries");
+      },
+    },
+    nativeImage: {
+      createFromPath: () => {
+        throw new Error("should not need nativeImage for PNG summaries");
+      },
+    },
+  };
+  const targets = [
+    {
+      id: "linux-desktop-agent",
+      label: "Agent",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      iconPath: () => iconPath,
+    },
+  ];
+
+  assert.match(patched, /function codexLinuxOpenTargetSummaryIcon/);
+  const result = new Function("require", "process", `${patched};return HN(arguments[2]);`)(
+    (name) => (name === "electron" ? electron : require(name)),
+    { platform: "linux", env: {} },
+    targets,
+  );
+
+  assert.equal(Array.isArray(result), true);
+  assert.equal(result[0].icon, `data:image/png;base64,${Buffer.from("summary").toString("base64")}`);
+  fs.rmSync(iconPath, { force: true });
+});
+
+test("open-target discovery resolves SVG iconPath in Linux target summaries", async () => {
+  const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
+  const iconPath = path.join(os.tmpdir(), "codex-current-open-target-summary-icon.svg");
+  const svg = "<svg><rect width=\"16\" height=\"16\" /></svg>";
+  fs.writeFileSync(iconPath, svg);
+  const electron = {
+    app: {
+      getFileIcon: async () => {
+        throw new Error("should prefer direct SVG data URL for Linux summaries");
+      },
+    },
+    nativeImage: {
+      createFromPath: () => {
+        throw new Error("summary mapping should stay synchronous");
+      },
+    },
+  };
+  const targets = [
+    {
+      id: "linux-desktop-agent",
+      label: "Agent",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      iconPath: () => iconPath,
+    },
+  ];
+
+  const result = new Function("require", "process", `${patched};return HN(arguments[2]);`)(
+    (name) => (name === "electron" ? electron : require(name)),
+    { platform: "linux", env: {} },
+    targets,
+  );
+
+  assert.equal(Array.isArray(result), true);
+  assert.equal(result[0].icon, `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`);
+  fs.rmSync(iconPath, { force: true });
+});
+
+test("open-target discovery uses main registry for Linux command lookup", async () => {
+  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, openInCommandBundle);
+  const app = new Function(`${patched};return new App();`)();
+
+  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
+  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
+  await assert.rejects(() => app.getOpenInTargetCommand("missing"), /not available/);
+});
+
+test("open-target discovery patches current command lookup shape", async () => {
+  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, currentOpenInCommandBundle);
+  const app = new Function(`${patched};return new App();`)();
+
+  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
+  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
+});
+
+test("open-target discovery bridge detection uses main registry on Linux", async () => {
+  const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, openInBridgeBundle);
+  const options = {
+    settingsStore: {
+      targets: [
+        { id: "linux-desktop-agent", detect: async () => "main-command" },
+        { id: "missing", detect: async () => null },
+      ],
+    },
+    requestOpenInWorker: async () => ({ command: "worker-command" }),
+  };
+  const bridge = new Function(`${patched};return bridge;`).call({ options });
+
+  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "linux-desktop-agent" }), {
+    available: true,
+  });
+  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "missing" }), {
+    available: false,
+  });
+  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "vscode" }), {
+    available: false,
+  });
+});
+
+test("open-target discovery inserts shared Linux registry command helper", async () => {
+  const patched = applyPatchTwice(applyOpenInTargetRegistryCommandPatch, openInCommandBundle);
+  const command = await new Function(`${patched};return codexLinuxOpenTargetRegistryCommand({targets:[{id:'kate',detect:async()=>'/usr/bin/kate'}]}, 'kate');`)();
+
+  assert.match(patched, /async function codexLinuxOpenTargetRegistryCommand/);
+  assert.equal(command, "/usr/bin/kate");
+});
+
+test("open-target discovery passes main registry into open execution", () => {
+  const patched = applyPatchTwice(applyOpenInTargetExecutePatch, openInExecuteBundle);
+
+  assert.match(patched, /targets:iP\(e\)/);
+});
+
+test("open-target discovery treats directories as native open targets", () => {
+  const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, openInTargetsBundle);
+
+  assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
+  assert.match(patched, /w=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
+});
+
+test("open-target discovery native selector includes available directory-capable targets", () => {
+  const patched = applyPatchTwice(applyNativeOpenTargetSelectionPatch, openTargetSelectionBundle)
+    .replace(/export\{[^}]+\};/u, "return {selectTargets:e,selectTarget:t,isEditor:n};");
+  const { selectTargets } = new Function(patched)();
+  const targets = [
+    { target: "fileManager", appPath: "/usr/bin/dolphin" },
+    { target: "systemDefault", appPath: "/usr/share/applications/kate.desktop" },
+    { target: "terminal", available: true, kind: "terminal" },
+    { target: "vscode", available: true, kind: "editor" },
+    { target: "linux-desktop-kate", available: true, kind: "editor" },
+    { target: "linux-desktop-hidden", available: false, kind: "editor" },
+  ];
+
+  assert.deepEqual(
+    selectTargets({
+      targets,
+      availableTargets: targets.map((target) => target.target),
+      mode: "native",
+    }).map((target) => target.target),
+    ["fileManager", "systemDefault", "terminal", "vscode", "linux-desktop-kate"],
+  );
 });
 
 test("open-target discovery respects hidden desktop entry overrides", () => {
@@ -931,7 +1323,10 @@ test("open-target discovery participates in feature loading and patch reports", 
         assert.match(patched, /linux:\{label:`Terminal`/);
         assert.match(patched, /\.\.\.codexLinuxDiscoveredIdeTargets\(\)/);
         assert.ok(
-          report.patches.some((patch) => patch.name === "feature:open-target-discovery" && patch.status === "applied"),
+          report.patches.some((patch) =>
+            patch.name === "feature:open-target-discovery:main-bundle-open-target-discovery" &&
+            patch.status === "applied",
+          ),
         );
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The `open-target-discovery` Linux feature was only extending part of Codex Desktop's open-target pipeline. On current upstream builds, the main process, renderer bridge, and open-target selection bundle can each observe or enrich targets through different code paths. As a result, Linux targets discovered from `.desktop` files could appear in one place but be filtered out, marked unavailable, fail to launch, or lose their application icons in another.

This patch keeps the feature optional, but makes its Linux opener model consistent across the affected paths:

- registers discovered Linux open targets through the main open-target registry
- makes command lookup, bridge detection, and open execution consult that registry before falling back to upstream static target handling
- patches the open-target selection bundle so directory openers and native selectors receive the same Linux target set
- resolves `.desktop` launch and icon handling for both the top selector and native right-click Open with menu

## Before / After

### Before

Project-directory opener could collapse to only File Manager, so editors and terminals discovered on Linux were not available from the top selector.

<img width="479" height="731" alt="img_v3_0212u_b3e84f08-9f03-4969-b690-491771eb79fg" src="https://github.com/user-attachments/assets/c1336046-0e01-4f86-a2c1-8fed0f791b15" />

File open selector listed some dynamic desktop-entry targets, but several icons fell back to generic file or terminal icons.

<img width="463" height="1493" alt="img_v3_0212u_ad5c5cee-7793-4d9d-96eb-e063454def0g" src="https://github.com/user-attachments/assets/55bf6711-67ae-4b86-8100-0eee6410d4a0" />

### After

Project-directory selector lists available Linux editors, terminals, File Manager, and discovered desktop-entry openers.

<img width="582" height="1397" alt="image" src="https://github.com/user-attachments/assets/e1535dfa-bd49-44f5-a845-5d7ce5065cc6" />

File open selector preserves application icons for built-in targets and discovered desktop entries.

<img width="995" height="1501" alt="image" src="https://github.com/user-attachments/assets/0bdac2aa-10ad-459b-87c5-10a1d269a4a6" />

Right-click Open with uses the same resolved targets and application icons.

<img width="1402" height="2010" alt="image" src="https://github.com/user-attachments/assets/9c20334f-ef56-47e0-85cc-94256e876373" />

## Verification

- `node --check linux-features/open-target-discovery/patch.js`
- `node --test linux-features/open-target-discovery/test.js`
- Manually verified in the Linux desktop app:
  - project-directory opener lists discovered Linux targets
  - file open selector preserves application icons
  - right-click Open with menu preserves application icons
