### PR TITLE
Working on latest Codex app drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2193,8 +2193,8 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /Number\(d\)!==t\.width/);
   assert.doesNotMatch(patched, /let\[,l,u,d,f\]=c/);
   assert.doesNotMatch(patched, /this\.codexLinuxIsI3Session\(\)\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.pointerInteractive=!0,this\.mousePassthroughEnabled&&\(this\.mousePassthroughEnabled=!1\),e\.setIgnoreMouseEvents\(!1\);return\}/);
-  assert.match(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{/);
-  assert.match(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStartAvatarPassthroughRecovery\(\),/);
+  assert.match(patched, /if\(process\.platform===`linux`&&process\.env\.XDG_SESSION_TYPE!==`wayland`&&!process\.env\.WAYLAND_DISPLAY&&typeof e\.setShape==`function`\)\{/);
+  assert.match(patched, /if\(process\.platform===`linux`&&process\.env\.XDG_SESSION_TYPE!==`wayland`&&!process\.env\.WAYLAND_DISPLAY&&typeof e\.setShape==`function`\)\{this\.codexLinuxStartAvatarPassthroughRecovery\(\),/);
   assert.doesNotMatch(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),/);
   assert.doesNotMatch(patched, /typeof e\.setShape==`function`&&!this\.codexLinuxIsI3Session\(\)/);
   assert.match(patched, /if\(t==null\)return null/);
@@ -2208,7 +2208,8 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /this\.dragState!=null/);
   assert.match(patched, /this\.codexLinuxIsCursorInAvatarInteractiveRegion\(e\)/);
   assert.match(patched, /__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds\.width&&__codexY<=__codexBounds\.height/);
-  assert.match(patched, /return __codexHit\(t\.mascot\)\|\|__codexHit\(t\.tray\)\|\|__codexWindowHit/);
+  assert.match(patched, /return __codexHit\(t\.mascot\)\|\|__codexHit\(t\.tray\)/);
+  assert.doesNotMatch(patched, /return __codexHit\(t\.mascot\)\|\|__codexHit\(t\.tray\)\|\|__codexWindowHit/);
   assert.doesNotMatch(patched, /let r=r\.screen\.getCursorScreenPoint\(\)/);
   assert.match(patched, /catch\{t=!0\}/);
   assert.match(patched, /this\.pointerInteractive=t/);
@@ -2242,11 +2243,12 @@ test("keeps Linux avatar overlay above the app while reply inputs are focusable"
   );
 });
 
-test("Linux avatar overlay treats visible window content as interactive fallback", () => {
+test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,
     avatarOverlayBundleFixture(),
   );
+  const cursor = { x: 5843, y: 1036 };
   const context = {
     globalThis: {},
     process: {
@@ -2266,7 +2268,7 @@ test("Linux avatar overlay treats visible window content as interactive fallback
         getName: () => "Codex",
       },
       screen: {
-        getCursorScreenPoint: () => ({ x: 5765, y: 1088 }),
+        getCursorScreenPoint: () => cursor,
         getDisplayNearestPoint: () => ({ bounds: { x: 0, y: 0, width: 800, height: 600 } }),
       },
     },
@@ -2288,6 +2290,14 @@ test("Linux avatar overlay treats visible window content as interactive fallback
     }),
     true,
   );
+  cursor.x = 5765;
+  cursor.y = 1088;
+  assert.equal(
+    controller.codexLinuxIsCursorInAvatarInteractiveRegion({
+      getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
+    }),
+    false,
+  );
   assert.equal(
     controller.codexLinuxIsCursorInAvatarInteractiveRegion({
       getContentBounds: () => ({ x: 6000, y: 936, width: 100, height: 100 }),
@@ -2306,6 +2316,11 @@ test("Linux avatar overlay treats visible window content as interactive fallback
     { x: 57, y: 55, width: 276, height: 131 },
   ]);
   controller.pointerInteractive = true;
+  assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
+    { x: 220, y: 190, width: 113, height: 122 },
+    { x: 57, y: 55, width: 276, height: 131 },
+  ]);
+  controller.dragState = {};
   assert.deepEqual(serializeShape(controller.codexLinuxBuildAvatarInputShape(overlayWindow)), [
     { x: 0, y: 0, width: 356, height: 320 },
   ]);

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -836,6 +836,11 @@ test("fast-mode guard descriptor follows upstream service-tier bundle names", ()
   assert.ok(descriptor.pattern.test("read-service-tier-for-request-BJ8QN0Q7.js"));
   assert.ok(descriptor.pattern.test("use-service-tier-settings-DFXPADNF.js"));
   assert.ok(descriptor.pattern.test("app-server-manager-signals-BOGyjFm3.js"));
+  assert.ok(
+    descriptor.pattern.test(
+      "app-initial~app-main~remote-conversation-page~plugin-detail-page~new-thread-panel-page~appg~ijdupmx5-CdYgxe-b.js",
+    ),
+  );
   assert.equal(descriptor.pattern.test("service-tier-icons-CsNhab5W.js"), false);
 });
 
@@ -846,6 +851,11 @@ test("subagent nickname metadata descriptor follows upstream metadata bundle nam
 
   assert.ok(descriptor.pattern.test("app-server-manager-signals-BOGyjFm3.js"));
   assert.ok(descriptor.pattern.test("use-host-config-Dpd_LQBD.js"));
+  assert.ok(
+    descriptor.pattern.test(
+      "app-initial~app-main~remote-conversation-page~plugin-detail-page~new-thread-panel-page~appg~ijdupmx5-CdYgxe-b.js",
+    ),
+  );
   assert.equal(descriptor.pattern.test("thread-context-inputs-D5uMjcUB.js"), false);
 });
 
@@ -2349,6 +2359,30 @@ test("keeps avatar overlay interactivity working after native presentation drift
   assert.match(patched, /this\.setWindowBounds\(e,o\.windowBounds,n,r\),this\.sendLayoutToRenderer\(e,i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\),!t&&this\.isOpen\(\)&&\(this\.finishPendingPresentation\(\),this\.broadcastOpenState\(\)\)\}showWindowIfReady/);
   assert.match(patched, /this\.cancelMomentum\(\),this\.clearMovedWindowPersist\(\),this\.window=null/);
+});
+
+test("finds avatar overlay class when the route marker moves after the class body", () => {
+  const source = currentAvatarOverlayBundleFixture().replace(
+    "var rV=`/avatar-overlay`,",
+    "var rV=`/avatar-overlay-next`,",
+  ) + "let lateRoute=`/avatar-overlay`;";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(
+      applyLinuxAvatarOverlayMousePassthroughPatch,
+      source,
+    ),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(
+    patched,
+    /this\.dragState=new h2\(i==null\?`renderer`:`native`,c,l,a\.screen\.getDisplayNearestPoint\(s\)\.bounds\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/,
+  );
+  assert.match(
+    patched,
+    /this\.setWindowBounds\(e,o\.windowBounds,n,r\),this\.sendLayoutToRenderer\(e,i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/,
+  );
 });
 
 test("scopes avatar overlay method matching away from unrelated earlier classes", () => {
@@ -5956,6 +5990,22 @@ test("preserves real Electron Owl feature binding when available", () => {
 
   assert.equal(sandbox.enabled, true);
   assert.equal(sandbox.disabled, false);
+});
+
+test("accepts current Electron Owl feature binding null fallback", () => {
+  const source = [
+    "var Ve=`electron_common_owl_features`,Ge={parse:e=>e};",
+    "function st(e){return String(e?.message??e).includes(Ve)&&String(e?.message??e).includes(`No such binding was linked`)}",
+    "function Ze(e){let t=Qe();if(t==null)return!1;try{return t.isOwlFeatureEnabled(e)}catch(e){if(e instanceof Error&&e.message.startsWith(`Unsupported Owl feature:`))return!1;throw e}}",
+    "function Qe(){let e=process._linkedBinding;if(typeof e!=`function`)return null;let t;try{t=e.call(process,Ve)}catch(e){if(st(e))return null;throw e}return Ge.parse(t)}",
+  ].join("");
+
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxOwlFeatureBindingFallbackPatch, source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("patches Electron Owl feature binding fallback outside the main bundle", () => {

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -158,11 +158,11 @@ function replaceAvatarMethodText(source, method, replacement) {
 }
 
 function avatarCursorRegionPatch(electronVar) {
-  return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)||__codexWindowHit}`;
+  return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)}`;
 }
 
 function avatarInputShapePatch() {
-  return "codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null||this.pointerInteractive)return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
+  return "codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null)return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
 }
 
 function avatarApplyInputShapePatch() {
@@ -226,7 +226,7 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   const previousSetShapePolicyPatch =
     "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
   const setShapePolicyPatch =
-    "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
+    "if(process.platform===`linux`&&process.env.XDG_SESSION_TYPE!==`wayland`&&!process.env.WAYLAND_DISPLAY&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
   // previousShapeInteractivityNeedle embeds the older Stop-based policy block;
   // finalize it at build time so the replaceAll below only fires for trees
   // patched by an older wrapper, not on every fresh DMG.

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -52,7 +52,62 @@ function avatarOverlayRegionStart(source) {
   return stateMessageIndex === -1 ? 0 : stateMessageIndex;
 }
 
+function avatarOverlayMarkerIndices(source) {
+  const markers = [
+    "appearance:`avatarOverlay`",
+    "avatar-overlay-open-state-changed",
+  ];
+  const indices = [];
+  for (const marker of markers) {
+    let index = source.indexOf(marker);
+    while (index !== -1) {
+      indices.push(index);
+      index = source.indexOf(marker, index + marker.length);
+    }
+  }
+  return indices.sort((left, right) => left - right);
+}
+
+function findClassContainingIndex(source, index) {
+  const classRegex = /class(?:\s+[A-Za-z_$][\w$]*)?(?:\s+extends\s+[A-Za-z_$][\w$.]*)?\{/g;
+  let candidate = null;
+  let match;
+  while ((match = classRegex.exec(source)) != null) {
+    if (match.index > index) {
+      break;
+    }
+    const openIndex = match.index + match[0].length - 1;
+    const closeIndex = findMatchingBrace(source, openIndex);
+    if (closeIndex === -1) {
+      classRegex.lastIndex = match.index + "class".length;
+      continue;
+    }
+    if (openIndex <= index && index <= closeIndex) {
+      candidate = {
+        start: match.index,
+        end: closeIndex + 1,
+        text: source.slice(match.index, closeIndex + 1),
+      };
+      classRegex.lastIndex = match.index + "class".length;
+      continue;
+    }
+    classRegex.lastIndex = closeIndex + 1;
+  }
+  return candidate;
+}
+
 function findAvatarOverlayClass(source) {
+  for (const markerIndex of avatarOverlayMarkerIndices(source)) {
+    const markerClass = findClassContainingIndex(source, markerIndex);
+    if (
+      markerClass != null &&
+      (markerClass.text.includes("appearance:`avatarOverlay`") ||
+        markerClass.text.includes("avatar-overlay-open-state-changed"))
+    ) {
+      return markerClass;
+    }
+  }
+
   const classRegex = /class(?:\s+[A-Za-z_$][\w$]*)?(?:\s+extends\s+[A-Za-z_$][\w$.]*)?\{/g;
   classRegex.lastIndex = avatarOverlayRegionStart(source);
   let match;
@@ -60,7 +115,8 @@ function findAvatarOverlayClass(source) {
     const openIndex = match.index + match[0].length - 1;
     const closeIndex = findMatchingBrace(source, openIndex);
     if (closeIndex === -1) {
-      return null;
+      classRegex.lastIndex = match.index + "class".length;
+      continue;
     }
     const text = source.slice(match.index, closeIndex + 1);
     if (

--- a/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
+++ b/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
@@ -8,7 +8,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1040,
     ciPolicy: "required-upstream",
-    pattern: /^(?:use-is-fast-mode-enabled|read-service-tier-for-request|use-service-tier-settings|app-server-manager-signals)-.*\.js$/,
+    pattern: /^(?:(?:use-is-fast-mode-enabled|read-service-tier-for-request|use-service-tier-settings|app-server-manager-signals)-.*|app-initial~app-main~remote-conversation-page~plugin-detail-page~new-thread-panel-page~appg~.*)\.js$/,
     missingDescription: "fast-mode/service-tier availability bundle",
     skipDescription: "fast-mode model guard patch",
     apply: applyLinuxFastModeModelGuardPatch,

--- a/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
+++ b/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
@@ -10,7 +10,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "required-upstream",
-    pattern: /^(?:app-server-manager-signals|use-host-config)-.*\.js$/,
+    pattern: /^(?:(?:app-server-manager-signals|use-host-config)-.*|app-initial~app-main~remote-conversation-page~plugin-detail-page~new-thread-panel-page~appg~.*)\.js$/,
     missingDescription: "subagent metadata webview bundle",
     skipDescription: "subagent nickname metadata shape patch",
     apply: applySubagentNicknameMetadataPatch,

--- a/scripts/patches/main-process/misc.js
+++ b/scripts/patches/main-process/misc.js
@@ -172,6 +172,21 @@ function applyLinuxOwlFeatureBindingFallbackPatch(currentSource) {
     return currentSource;
   }
 
+  const safeNullLoaderRegex =
+    /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)return null;let ([A-Za-z_$][\w$]*);try\{\3=\2\.call\(process,(?:`electron_common_owl_features`|[A-Za-z_$][\w$]*)\)\}catch\(([A-Za-z_$][\w$]*)\)\{if\([A-Za-z_$][\w$]*\(\4\)\)return null;throw \4\}return [A-Za-z_$][\w$]*\.parse\(\3\)\}/u;
+  const safeNullLoaderMatch = currentSource.match(safeNullLoaderRegex);
+  if (safeNullLoaderMatch != null) {
+    const [, loaderFnName] = safeNullLoaderMatch;
+    const escapedLoaderFnName = loaderFnName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const safeNullConsumerRegex = new RegExp(
+      `let ([A-Za-z_$][\\w$]*)=${escapedLoaderFnName}\\(\\);if\\(\\1==null\\)return!1;try\\{return \\1\\.isOwlFeatureEnabled\\(`,
+      "u",
+    );
+    if (safeNullConsumerRegex.test(currentSource)) {
+      return currentSource;
+    }
+  }
+
   const loaderRegex =
     /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)throw Error\(`Owl feature binding is unavailable`\);return ([A-Za-z_$][\w$]*)\.parse\(\2\.call\(process,`electron_common_owl_features`\)\)\}/u;
   const match = currentSource.match(loaderRegex);


### PR DESCRIPTION
Fixes the latest upstream DMG drift found during fresh install.

Changes:
- Recognize the new avatar overlay class position when upstream moves the route marker.
- Treat the new Owl feature binding null fallback as already safe on Linux.
- Match the new app-initial/app-main webview chunk for fast-mode and subagent metadata patches.
- Add regression coverage for the new drift shapes.

Validation:
- node --test scripts/patch-linux-window-ui.test.js
- ./install.sh --fresh against latest DMG (Electron 42.1.0), no required patch failures