### PR TITLE
Realign Linux patches to upstream 26.623 bundle (#567)

### DIFF
--- a/scripts/patches/automation-schedule.js
+++ b/scripts/patches/automation-schedule.js
@@ -33,6 +33,10 @@ function findWorkspaceRootDropHandlerBundles(extractedDir) {
             /^automation-schedule-.*\.js$/.test(path.basename(candidate)) &&
             source.includes("hasMultipleTimeValues") &&
             source.includes("function Tn(")
+          ) ||
+          (
+            source.includes("hasMultipleTimeValues") &&
+            /rruleText:e,time:\w+\(r\.byhour,r\.byminute,r\)/.test(source)
           );
       } catch {
         return false;
@@ -115,11 +119,77 @@ function applyAutomationScheduleMultiTimePatch(source) {
     if (currentPatched !== source) {
       return currentPatched;
     }
+    const genericPatched = applyGenericAutomationScheduleMultiTimePatch(source);
+    if (genericPatched !== source) {
+      return genericPatched;
+    }
     console.warn("WARN: Could not find automation schedule helper block — skipping RRULE multi-time patch");
     return source;
   }
 
   return source.slice(0, block.start) + automationScheduleReplacement(block) + source.slice(block.end);
+}
+
+function applyGenericAutomationScheduleMultiTimePatch(source) {
+  if (source.includes("function codexLinuxNormalizeRruleNumbers(")) {
+    return source;
+  }
+
+  const parserRe =
+    /hasMultipleTimeValues:Array\.isArray\(r\.byhour\)&&r\.byhour\.length>1\|\|Array\.isArray\(r\.byminute\)&&r\.byminute\.length>1,interval:Math\.max\(1,Math\.round\(r\.interval\?\?1\)\),minute:a,origOptions:n\.origOptions,rruleText:e,time:(\w+)\(r\.byhour,r\.byminute,r\),weekdays:i/;
+  const parserMatch = parserRe.exec(source);
+  if (!parserMatch) {
+    return source;
+  }
+  const timeFn = parserMatch[1];
+
+  const helperRe = new RegExp(
+    "function " +
+      timeFn +
+      "\\(e,t,n\\)\\{let r=(\\w+)\\(e\\),i=\\1\\(t\\);return r!=null&&i!=null\\?(\\w+)\\(r,i\\):n\\.dtstart\\?\\2\\(n\\.dtstart\\.getHours\\(\\),n\\.dtstart\\.getMinutes\\(\\)\\):(\\w+)\\}function \\1\\(e\\)\\{return Array\\.isArray\\(e\\)\\?typeof e\\[0\\]==`number`\\?e\\[0\\]:null:typeof e==`number`\\?e:null\\}",
+  );
+  const helperMatch = helperRe.exec(source);
+  if (!helperMatch) {
+    return source;
+  }
+  const helperBlock = helperMatch[0];
+  const combineFn = helperMatch[2];
+
+  const summaryRe =
+    /function (\w+)\(e,t\)\{if\(!e\|\|e\.hasMultipleTimeValues\)return null;[\s\S]*?let i=(\w+)\(e\.time,t\);return i\?(\w+)\(\{intl:t,isEveryDay:r,timeLabel:i,weekdays:n\}\):null\}/;
+  const summaryMatch = summaryRe.exec(source);
+  if (!summaryMatch) {
+    return source;
+  }
+  const summaryBlock = summaryMatch[0];
+  const labelFn = summaryMatch[2];
+
+  const helperPatch =
+    helperBlock +
+    "function codexLinuxNormalizeRruleNumbers(e,t,n){let r=Array.isArray(e)?e:[e];return Array.from(new Set(r.filter(e=>typeof e==`number`&&Number.isInteger(e)&&e>=t&&e<=n))).sort((e,t)=>e-t)}" +
+    "function codexLinuxRruleTimes(e,t,n){let r=codexLinuxNormalizeRruleNumbers(e,0,23),i=codexLinuxNormalizeRruleNumbers(t,0,59);n.dtstart&&(r.length!==0||(r=[n.dtstart.getHours()]),i.length!==0||(i=[n.dtstart.getMinutes()]));let a=[];for(let e of r)for(let t of i)a.push(" +
+    combineFn +
+    "(e,t));return Array.from(new Set(a)).sort()}" +
+    "function codexLinuxAutomationTimeLabel(e,t){let n=Array.isArray(e.timeValues)&&e.timeValues.length>0?e.timeValues:[e.time],r=n.map(e=>" +
+    labelFn +
+    "(e,t)).filter(Boolean);return r.length===0?null:typeof t.formatList==`function`?t.formatList(r,{type:`conjunction`}):r.join(`, `)}";
+
+  const parserPatch =
+    "hasMultipleTimeValues:codexLinuxRruleTimes(r.byhour,r.byminute,r).length>1,interval:Math.max(1,Math.round(r.interval??1)),minute:a,origOptions:n.origOptions,rruleText:e,time:" +
+    timeFn +
+    "(r.byhour,r.byminute,r),timeValues:codexLinuxRruleTimes(r.byhour,r.byminute,r),weekdays:i";
+
+  const summaryPatch = summaryBlock
+    .replace("if(!e||e.hasMultipleTimeValues)return null;", "if(!e)return null;")
+    .replace(
+      "let i=" + labelFn + "(e.time,t);",
+      "let i=codexLinuxAutomationTimeLabel(e,t);",
+    );
+
+  let patched = source.replace(helperBlock, () => helperPatch);
+  patched = patched.replace(parserMatch[0], () => parserPatch);
+  patched = patched.replace(summaryBlock, () => summaryPatch);
+  return patched;
 }
 
 function applyCurrentAutomationScheduleMultiTimePatch(source) {

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -60,7 +60,11 @@ function findAvatarOverlayClass(source) {
     const openIndex = match.index + match[0].length - 1;
     const closeIndex = findMatchingBrace(source, openIndex);
     if (closeIndex === -1) {
-      return null;
+      // findMatchingBrace cannot balance this class (e.g. it contains a regex
+      // literal with an unbalanced brace). Skip it and keep scanning instead of
+      // aborting — the avatar overlay class may appear later in the bundle.
+      classRegex.lastIndex = openIndex + 1;
+      continue;
     }
     const text = source.slice(match.index, closeIndex + 1);
     if (

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -1,7 +1,8 @@
 "use strict";
 
+const { patchStatusFromChange } = require("../../../../../lib/patch-report.js");
 const {
-  applyBrowserUseNodeReplApprovalPatch,
+  applyBrowserUseNodeReplApprovalAssets,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../main-process.js");
@@ -17,10 +18,20 @@ module.exports = [
   },
   {
     id: "browser-use-node-repl-approval",
-    phase: "main-bundle",
+    phase: "extracted-app",
     order: 160,
     ciPolicy: "optional",
-    apply: applyBrowserUseNodeReplApprovalPatch,
+    apply: applyBrowserUseNodeReplApprovalAssets,
+    status: (result, warnings) => ({
+      status:
+        result?.matched === 0
+          ? "skipped-optional"
+          : patchStatusFromChange(Boolean(result?.changed), warnings, "optional"),
+      reason:
+        result?.matched === 0
+          ? "Browser Use node_repl mcp config bundle not found"
+          : warnings[0] ?? null,
+    }),
   },
   {
     id: "linux-browser-use-route-liveness",

--- a/scripts/patches/core/all-linux/webview/browser-use-availability/patch.js
+++ b/scripts/patches/core/all-linux/webview/browser-use-availability/patch.js
@@ -9,7 +9,7 @@ module.exports = {
   phase: "webview-asset",
   order: 1090,
   ciPolicy: "optional",
-  pattern: /^(use-in-app-browser-use-availability|use-is-plugins-enabled)-.*\.js$/,
+  pattern: /^(?:use-in-app-browser-use-availability-|use-is-plugins-enabled-|app-initial~app-main~).*\.js$/,
   missingDescription: "Browser Use availability bundle",
   skipDescription: "Linux Browser Use availability patch",
   apply: applyLinuxBrowserUseAvailabilityPatch,

--- a/scripts/patches/core/all-linux/webview/browser-use-external-availability/patch.js
+++ b/scripts/patches/core/all-linux/webview/browser-use-external-availability/patch.js
@@ -9,7 +9,7 @@ module.exports = {
   phase: "webview-asset",
   order: 1092,
   ciPolicy: "optional",
-  pattern: /^(use-is-plugins-enabled|use-in-app-browser-use-availability)-.*\.js$/,
+  pattern: /^(?:use-is-plugins-enabled|use-in-app-browser-use-availability)-.*\.js$|^app-initial~app-main~.*\.js$/,
   missingDescription: "external Browser Use availability bundle",
   skipDescription: "Linux external Browser Use availability patch",
   apply: applyLinuxBrowserUseExternalAvailabilityPatch,

--- a/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
+++ b/scripts/patches/core/all-linux/webview/fast-mode-guard/patch.js
@@ -8,7 +8,10 @@ module.exports = [
     phase: "webview-asset",
     order: 1040,
     ciPolicy: "required-upstream",
-    pattern: /^(?:use-is-fast-mode-enabled|read-service-tier-for-request|use-service-tier-settings|app-server-manager-signals)-.*\.js$/,
+    // Older DMGs emit granular hook chunks; 26.623+ merges service-tier code
+    // into the shared `app-initial~app-main~…` bundle (and switched to optional
+    // chaining, so the guard is a no-op there). Match both shapes.
+    pattern: /^(?:use-is-fast-mode-enabled|read-service-tier-for-request|use-service-tier-settings|app-server-manager-signals|app-initial~app-main~).*\.js$/,
     missingDescription: "fast-mode/service-tier availability bundle",
     skipDescription: "fast-mode model guard patch",
     apply: applyLinuxFastModeModelGuardPatch,

--- a/scripts/patches/core/all-linux/webview/font-settings/patch.js
+++ b/scripts/patches/core/all-linux/webview/font-settings/patch.js
@@ -8,7 +8,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^font-settings-.*\.js$/,
+    pattern: /^(?:font-settings-.*|app-initial~app-main~remote-conversation-page~.*)\.js$/,
     missingDescription: "font settings bundle",
     skipDescription: "Linux monospace font stack patch",
     apply: applyLinuxSafeMonospaceFontStackPatch,

--- a/scripts/patches/core/all-linux/webview/profile-settings-menu/patch.js
+++ b/scripts/patches/core/all-linux/webview/profile-settings-menu/patch.js
@@ -8,7 +8,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^profile-dropdown-.*\.js$/,
+    pattern: /^(?:profile-dropdown-.*|app-initial~app-main~automations-page-.*)\.js$/,
     missingDescription: "profile dropdown webview bundle",
     skipDescription: "Linux profile settings menu patch",
     apply: applyLinuxProfileSettingsMenuPatch,

--- a/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
+++ b/scripts/patches/core/all-linux/webview/subagent-metadata/patch.js
@@ -10,7 +10,10 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "required-upstream",
-    pattern: /^(?:app-server-manager-signals|use-host-config)-.*\.js$/,
+    // Older DMGs emit granular hook chunks; 26.623+ merges them into the shared
+    // `app-initial~app-main~…` bundle. Match both so the patch keeps targeting
+    // the chunk that actually carries the subagent metadata module.
+    pattern: /^(?:app-server-manager-signals|use-host-config|app-initial~app-main~).*\.js$/,
     missingDescription: "subagent metadata webview bundle",
     skipDescription: "subagent nickname metadata shape patch",
     apply: applySubagentNicknameMetadataPatch,

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -44,7 +44,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1030,
     ciPolicy: "optional",
-    pattern: /^(diff-view-mode|use-resolved-theme-variant)-.*\.js$/,
+    pattern: /^(diff-view-mode|use-resolved-theme-variant)-.*\.js$|^app-initial~app-main~.*projects-index-page~app~.*\.js$/,
     missingDescription: "resolved theme bundle",
     skipDescription: "translucent sidebar default patch",
     apply: applyLinuxOpaqueWindowsDefaultPatch,
@@ -54,7 +54,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1040,
     ciPolicy: "optional",
-    pattern: /^use-window-controls-safe-area-.*\.js$/,
+    pattern: /^(?:use-window-controls-safe-area-|app-initial~app-main~remote-conversation-page~new-thread-panel-page~projects-index-page~app~).*\.js$/,
     missingDescription: "window controls safe-area bundle",
     skipDescription: "Linux window controls safe-area patch",
     apply: applyLinuxWindowControlsSafeAreaPatch,
@@ -64,7 +64,10 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^tooltip-.*\.js$/,
+    // 26.623 merged the tooltip floating-ui middleware into the shared
+    // `app-initial~app-main~…` bundle; keep matching the old granular
+    // `tooltip-*` chunk and add the merged bundle so the patch keeps landing.
+    pattern: /^(?:tooltip-|app-initial~app-main~).*\.js$/,
     missingDescription: "tooltip bundle",
     skipDescription: "Linux tooltip titlebar collision patch",
     apply: applyLinuxTooltipWindowControlsCollisionPatch,

--- a/scripts/patches/main-process/browser.js
+++ b/scripts/patches/main-process/browser.js
@@ -1,5 +1,8 @@
 "use strict";
 
+const fs = require("node:fs");
+const path = require("node:path");
+
 const {
   requireName,
 } = require("../shared.js");
@@ -41,6 +44,23 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     (_match, runtimeFactoryVar, runtimeFactoryMethod, configPrefix, nodeReplPathVar, comma) => {
       patchedAnyCurrentRuntimeConfig = true;
       return `${runtimeFactoryVar}.${runtimeFactoryMethod}({${configPrefix}nodeReplPath:${nodeReplPathVar}${comma}tools:{js:{approval_mode:\`approve\`}},`;
+    },
+  );
+
+  // 26.623+: the browser-use node_repl mcp server config is emitted as a
+  // standalone object literal `{args:[],command:VAR,env:VAR,startup_timeout_sec:120}`
+  // (env is now a hoisted variable, not the old inline `env:{...}` literal) inside
+  // a separate `src-*.js` chunk. Insert the js auto-approval there.
+  const mcpServerConfigRegex =
+    /(\[`mcp_servers\.\$\{[A-Za-z_$][\w$]*\}`\]:\{args:\[\],command:[A-Za-z_$][\w$]*,env:[A-Za-z_$][\w$]*,)(startup_timeout_sec:120\})/g;
+  const mcpServerConfigAlreadyApprovedRegex =
+    /\[`mcp_servers\.\$\{[A-Za-z_$][\w$]*\}`\]:\{args:\[\],command:[A-Za-z_$][\w$]*,env:[A-Za-z_$][\w$]*,tools:\{js:\{approval_mode:`approve`\}\},startup_timeout_sec:120\}/;
+  let patchedAnyMcpServerConfig = false;
+  patchedSource = patchedSource.replace(
+    mcpServerConfigRegex,
+    (_match, configPrefix, configSuffix) => {
+      patchedAnyMcpServerConfig = true;
+      return `${configPrefix}tools:{js:{approval_mode:\`approve\`}},${configSuffix}`;
     },
   );
 
@@ -94,7 +114,8 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   if (
     !patchedTrustedHashes &&
     !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(") &&
-    patchedSource.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S")
+    patchedSource.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S") &&
+    /trustedBrowserClientSha256s:[^,{}]+\|\|/.test(patchedSource)
   ) {
     console.warn(
       "WARN: Could not find Browser Use trusted hash insertion point — skipping Linux Browser Use trusted hash patch",
@@ -103,9 +124,12 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
 
   if (
     patchedSource === currentSource &&
+    patchedSource.includes("startup_timeout_sec:120") &&
     !patchedSource.includes(approvalPatch) &&
     !patchedAnyCurrentRuntimeConfig &&
     !currentRuntimeConfigAlreadyApprovedRegex.test(patchedSource) &&
+    !patchedAnyMcpServerConfig &&
+    !mcpServerConfigAlreadyApprovedRegex.test(patchedSource) &&
     !patchedTrustedHashes &&
     !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(")
   ) {
@@ -115,6 +139,50 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   }
 
   return patchedSource;
+}
+
+// 26.623+: the node_repl mcp config (and the NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S
+// trusted-hash code) was re-chunked out of the main bundle into a sibling
+// `.vite/build/src-*.js` chunk. Scan every build chunk that carries either marker so
+// the approval patch reaches whichever chunk now hosts the config.
+function applyBrowserUseNodeReplApprovalAssets(extractedDir) {
+  const buildDir = path.join(extractedDir, ".vite", "build");
+  if (!fs.existsSync(buildDir)) {
+    return { matched: 0, changed: 0 };
+  }
+
+  const candidates = fs
+    .readdirSync(buildDir)
+    .filter((name) => name.endsWith(".js"))
+    .sort()
+    .map((name) => path.join(buildDir, name))
+    .filter((candidate) => {
+      try {
+        const source = fs.readFileSync(candidate, "utf8");
+        return (
+          source.includes("startup_timeout_sec:120") ||
+          source.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S")
+        );
+      } catch {
+        return false;
+      }
+    });
+
+  let changed = 0;
+  const pendingWrites = [];
+  for (const candidate of candidates) {
+    const currentSource = fs.readFileSync(candidate, "utf8");
+    const patchedSource = applyBrowserUseNodeReplApprovalPatch(currentSource);
+    if (patchedSource !== currentSource) {
+      changed += 1;
+      pendingWrites.push({ filePath: candidate, patchedSource });
+    }
+  }
+  for (const { filePath, patchedSource } of pendingWrites) {
+    fs.writeFileSync(filePath, patchedSource, "utf8");
+  }
+
+  return { matched: candidates.length, changed };
 }
 
 function applyLinuxBrowserUseRouteLivenessPatch(currentSource) {
@@ -252,6 +320,7 @@ function applyLinuxChromeExtensionStatusPatch(currentSource) {
 
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
+  applyBrowserUseNodeReplApprovalAssets,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
 };

--- a/scripts/patches/main-process/misc.js
+++ b/scripts/patches/main-process/misc.js
@@ -176,6 +176,21 @@ function applyLinuxOwlFeatureBindingFallbackPatch(currentSource) {
     /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \2!=`function`\)throw Error\(`Owl feature binding is unavailable`\);return ([A-Za-z_$][\w$]*)\.parse\(\2\.call\(process,`electron_common_owl_features`\)\)\}/u;
   const match = currentSource.match(loaderRegex);
   if (match == null) {
+    // 26.623+ rewrote the loader to natively return null when the binding is
+    // unavailable (`process._linkedBinding` missing) and to swallow the
+    // "No such binding was linked" error — exactly the Linux fallback this
+    // patch injected. When that native-safe shape is present there is nothing
+    // to patch, so stand down silently instead of failing the required patch.
+    const upstreamReturnsNullOnMissingBinding =
+      /let ([A-Za-z_$][\w$]*)=process\._linkedBinding;if\(typeof \1!=`function`\)return null;/u.test(
+        currentSource,
+      );
+    if (
+      upstreamReturnsNullOnMissingBinding &&
+      currentSource.includes("No such binding was linked:")
+    ) {
+      return currentSource;
+    }
     console.warn(
       "WARN: Could not find Owl feature binding loader - skipping Linux Owl feature fallback patch",
     );

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -511,6 +511,23 @@ process.platform===\`linux\`?null:$1?$2($3):null,
 process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4.app.getFileIcon($5,{size:process.platform===\`win32\`?\`large\`:\`normal\`}).catch(()=>null)
 ]`,
     );
+    if (patchedSource === currentSource) {
+      // 26.623 reshaped the about icon promise array: the non-win32 size
+      // ternary collapsed to {size:`normal`} and a win32 nativeImage branch was
+      // added — [t?k_(i):null,n?a.nativeImage.createFromPath(i):a.app.getFileIcon(i,{size:`normal`})].
+      // Without this branch the Linux-safe icon (and the .catch on getFileIcon)
+      // never apply, so a getFileIcon rejection on Linux makes the About window
+      // builder throw before its try/catch and the dialog never opens.
+      const aboutIconPromiseRegex26623 =
+        /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(([^()]+)\):([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\]/;
+      patchedSource = patchedSource.replace(
+        aboutIconPromiseRegex26623,
+        `[
+process.platform===\`linux\`?null:$1?$2($3):null,
+process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$5.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4?$5.nativeImage.createFromPath($6):$7.app.getFileIcon($8,{size:\`normal\`}).catch(()=>null)
+]`,
+      );
+    }
   } else {
     const patchedGetFileIconRegex =
       /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\.catch\(\(\)=>null\)/;
@@ -521,6 +538,20 @@ process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.
         getFileIconRegex,
         "$1.app.getFileIcon($2,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
       );
+    }
+    if (patchedSource === currentSource) {
+      // 26.623 fallback (no bundled icon): just make the reshaped getFileIcon
+      // call rejection-proof so the About window builder cannot throw on Linux.
+      const patchedGetFileIconRegex26623 =
+        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\.catch\(\(\)=>null\)/;
+      if (!patchedGetFileIconRegex26623.test(patchedSource)) {
+        const getFileIconRegex26623 =
+          /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)/;
+        patchedSource = patchedSource.replace(
+          getFileIconRegex26623,
+          "$1.app.getFileIcon($2,{size:`normal`}).catch(()=>null)",
+        );
+      }
     }
   }
 

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -545,7 +545,7 @@ function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
   const availabilityPattern =
     /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`chrome-extension`\|\|([A-Za-z_$][\w$]*)&&\1\.enabled&&!\1\.isLoading,([A-Za-z_$][\w$]*)=\5===`chrome-extension`\?!1:\1\.isLoading,/g;
 
-  const patchedSource = currentSource.replace(
+  let patchedSource = currentSource.replace(
     availabilityPattern,
     (
       match,
@@ -568,6 +568,22 @@ function applyLinuxBrowserUseExternalAvailabilityPatch(currentSource) {
       return `let ${featureQueryVar}=${featureQueryFn}(${featureQueryArg}),${availableVar}=${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)||${statsigVar}&&${featureQueryVar}.enabled&&!${featureQueryVar}.isLoading,${loadingVar}=${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?!1:${featureQueryVar}.isLoading,`;
     },
   );
+
+  if (!changed) {
+    // 26.623 refactored the inline availability gate into a status-string helper:
+    //   function X({isExternalBrowserUseFeatureEnabled:e,isExternalBrowserUseFeatureLoading:t,
+    //     isExternalBrowserUseGateEnabled:n,windowType:r}){return r===`chrome-extension`?`available`:...}
+    // Treat Linux like chrome-extension so the resolved status is `available`.
+    const statusFnPattern =
+      /(function [A-Za-z_$][\w$]*\(\{isExternalBrowserUseFeatureEnabled:[A-Za-z_$][\w$]*,isExternalBrowserUseFeatureLoading:[A-Za-z_$][\w$]*,isExternalBrowserUseGateEnabled:[A-Za-z_$][\w$]*,windowType:([A-Za-z_$][\w$]*)\}\)\{return )\2===`chrome-extension`\?`available`:/;
+    patchedSource = patchedSource.replace(
+      statusFnPattern,
+      (match, prefix, windowTypeVar) => {
+        changed = true;
+        return `${prefix}${windowTypeVar}===\`chrome-extension\`||navigator.userAgent.includes(\`Linux\`)?\`available\`:`;
+      },
+    );
+  }
 
   if (changed || alreadyPatched()) {
     return patchedSource;
@@ -1018,9 +1034,11 @@ function applySubagentNicknameMetadataPatch(currentSource) {
   if (
     patchedSource === currentSource &&
     !(sourceShapePatchedRegex.test(currentSource) && nicknamePatchedRegex.test(currentSource)) &&
-    (currentSource.includes("agentNickname") ||
-      currentSource.includes("agent_nickname") ||
-      currentSource.includes("thread_spawn"))
+    // `thread_spawn` uniquely marks the subagent metadata module. Other webview
+    // chunks reference `agentNickname` without carrying these needles, so gate
+    // the warning on `thread_spawn` to avoid false drift alarms when the patch
+    // pattern matches the shared bundle alongside unrelated chunks.
+    currentSource.includes("thread_spawn")
   ) {
     console.warn("WARN: Could not find subagent nickname metadata needles — skipping metadata shape patch");
   }
@@ -1231,6 +1249,13 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
       "Ze=(qe?A?.kind===`comment`?ge:[]:Xe==null?ge:ge.filter(e=>e.id!==Xe.id)).flatMap";
     const electron42CommentPreloadMarkersPatch =
       "Ze=(qe?A?.kind===`comment`?Ke:[]:Xe==null?ge:ge.filter(e=>e.id!==Xe.id)).flatMap";
+    // 26.623 refactored the marker-list computation into imperative form and
+    // adopted the screenshot fix natively: when a comment is selected it now
+    // assigns `it=rt?[j.annotation]:ye`, i.e. only the selected comment's marker
+    // is shown in screenshot mode. Detect that native-safe shape so we skip the
+    // patch without warning.
+    const nativeCommentPreloadMarkersRegex =
+      /([A-Za-z_$][\w$]*)\?\.kind===`comment`\?([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\?\[\1\.annotation\]:([A-Za-z_$][\w$]*):\3\|\|[A-Za-z_$][\w$]*\?\2=\[\]:[A-Za-z_$][\w$]*!=null&&\(\2=\4\.filter\(e=>e\.id!==[A-Za-z_$][\w$]*\.id\)\)/;
     if (patchedSource.includes(currentMarkersPatch)) {
       // Already patched.
     } else if (patchedSource.includes(currentSelectedMarkersPatch)) {
@@ -1267,6 +1292,9 @@ function applyBrowserAnnotationScreenshotPatch(currentSource) {
         electron42CommentPreloadMarkersNeedle,
         electron42CommentPreloadMarkersPatch,
       );
+    } else if (nativeCommentPreloadMarkersRegex.test(patchedSource)) {
+      // Already native: upstream now scopes screenshot markers to the selected
+      // comment, so no marker patch is required for this build.
     } else {
       console.warn("WARN: Could not find browser annotation screenshot markers — skipping screenshot marker patch");
     }


### PR DESCRIPTION
## Summary

Fixes #567.

Upstream Codex Desktop jumped from app version **26.616 → 26.623.31921**. vite re-chunked the webview (granular per-hook chunks were merged into shared `app-initial~app-main~…` bundles) and refactored several main-process code paths, so a batch of patch anchors no longer matched. `install.sh` aborted with the **5 required-patch failures** reported in #567, and silently skipped ~11 optional patches.

This PR re-anchors those patches to the 26.623 bundle. After it, `install.sh` completes with **0 failed patches**. Every pattern/anchor is **backward-compatible** with older DMGs (old chunk names are kept as alternatives).

## Critical fixes (the 5 `failed-required` patches in #567)

| Patch | Root cause in 26.623 | Fix |
|---|---|---|
| `linux-avatar-overlay-mouse-passthrough` + `main-process-ui` | `findAvatarOverlayClass` aborted its class scan when `findMatchingBrace` hit an unrelated regex-containing class (`class e extends Array{…}`, an SSH-config parser) **before** reaching the avatar class | Skip a class whose braces can't be balanced and keep scanning instead of bailing. The avatar class itself balances fine, so all avatar sub-patches re-apply. |
| `linux-owl-feature-binding-fallback` | Upstream now natively returns `null` on a missing owl binding and swallows `"No such binding was linked"` — the exact fallback this patch injected | Detect the native-safe loader shape and stand down silently → `already-applied`. |
| `linux-fast-mode-model-guard` | Upstream removed `additionalSpeedTiers` and moved to optional chaining; the crash the guard protected against no longer exists | Broaden the pattern to the merged bundle; it no-ops → `already-applied`. |
| `subagent-nickname-metadata-shape` | Content still present but relocated to the merged bundle | Repoint the pattern (backward-compatible) and gate the drift warning on `thread_spawn` so it doesn't false-fire on sibling chunks that also reference `agentNickname`. |

## Optional patches realigned to 26.623

- **`browser-use-node-repl-approval`** — the node_repl mcp-server config moved out of `main--*.js` into a sibling `.vite/build/src-*.js` chunk and was reshaped (`env` hoisted to a variable). Added an extracted-app scanner (mirroring the `owl-feature-binding` precedent) plus the new anchor; warnings are needle-gated so non-target chunks don't false-fail.
- **`automation-schedule-multi-time-rrule`, `browser-annotation-screenshot`, `opaque-window-default-resolved-theme`, `linux-window-controls-safe-area`, `linux-tooltip-window-controls-collision`, `linux-safe-monospace-font-stack`, `linux-browser-use-availability`, `linux-browser-use-external-availability`** — repointed patterns/anchors to the merged `app-initial~app-main~…` bundle (external-availability also got a new status-string-helper anchor). All keep the old chunk names as alternatives.
- **`linux-profile-settings-menu`** — the feature-flag gate (`4166894088`) was removed upstream; the settings menu item is now built unconditionally, so the patch is natively satisfied → `already-applied`.

## About-dialog fix (separate 26.623 drift, found while verifying)

`linux-about-dialog`: the about-icon promise array was reshaped (the non-win32 size ternary collapsed to `{size:`normal`}` and a win32 `nativeImage.createFromPath` branch was added), so the Linux-safe icon branch + `.catch(()=>null)` no longer applied. Because the about-window builder `await`s the icon promise **outside** its `try/catch`, an `app.getFileIcon` rejection on Linux made the builder throw before showing the window — **the About dialog never opened**. Added a 26.623 anchor so the Linux bundled-icon branch applies again (so `getFileIcon` isn't called on Linux and the builder can't reject).

## Not included

`keybinds-settings` remains `skipped-optional` (it's `ciPolicy: optional`, so it does not block install). 26.623's move to shared mega-bundles broke **all** of its required-asset lookups, and it *synthesizes* a `keybinds-settings-linux.js` ESM module whose `import { X as … } from "./chunk.js"` lines need the new minified export aliases rediscovered — a wrong alias yields a runtime white-screen that can only be confirmed by launching Electron, not by a static harness. That's beyond a statically-verifiable re-anchor and is best tracked separately. Impact: the Linux keybinds settings page + custom-accelerator runtime are missing on 26.623 until reimplemented.

## Verification

- `install.sh` completes against the 26.623 DMG: patch report shows **0 `failed`**, **0 `applied-with-warnings`**; only `keybinds-settings` is `skipped-optional`.
- `node --test scripts/patch-linux-window-ui.test.js scripts/patches/main-process/browser.test.js scripts/lib/patch-chrome-plugin.test.js` → **302 passed, 0 failed**.
- Each re-anchored patch was verified by applying it against the real extracted 26.623 bundle (target chunk changes as intended / correct no-op, **0 warnings** across all matched chunks). The fully patched main bundle passes `node --check`.

> Note: validated on x86_64 (Ubuntu). The anchors are arch-independent (they key on minified bundle content, not packaging), so this should resolve the pacman/Arch native-updater path in #567 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
