### PR TITLE
Update nix dmg hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-S7VSvxwZBL1m4oTTScRYKcWREORuSDLF1ps++vkQIT8=";
+          hash = "sha256-/tf+iJCNU/85Voi8PikcZPapQAXt3zP2NdfiLXznpu0=";
         };
 
-        codexVersion = "26.616.81150";
+        codexVersion = "26.623.31921";
         electronVersion = "42.1.0";
         electronPlatform =
           {


### PR DESCRIPTION
Updates the hash expected by the Nix flake for `26.623.31921`

This also should fix current [pipeline fail](https://github.com/ilysenko/codex-desktop-linux/actions/runs/28226272535/job/83618885587) in main.