### PR TITLE
Block Wayland avatar overlay focus traps

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2607,6 +2607,24 @@ test("adds Linux window icon handling to current Linux autoHideMenuBar options",
   assert.match(patched, new RegExp(`icon:${escapeRegExp(iconPathExpression)}`));
 });
 
+test("omits undefined BrowserWindow options in the current window manager bundle", () => {
+  const iconAsset = "app-test.png";
+  const source = [
+    "let M=new a.BrowserWindow({width:b,height:x,...S===void 0||C===void 0?{}:{x:S,y:C},",
+    "title:n??a.app.getName(),backgroundColor:A,show:l,parent:p,focusable:m,",
+    "...process.platform===`win32`?{autoHideMenuBar:!0}:process.platform===`linux`?{icon:process.resourcesPath+`/../content/webview/assets/app-test.png`}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k});",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, iconAsset);
+
+  assert.match(patched, /show:l,\.\.\.p==null\?\{\}:\{parent:p\},\.\.\.m==null\?\{\}:\{focusable:m\}/);
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\},\.\.\.D,\.\.\.T==null\?\{\}:\{minWidth:T\.width,minHeight:T\.height\},webPreferences:k/);
+  assert.doesNotMatch(patched, /show:l,parent:p,focusable:m/);
+  assert.doesNotMatch(patched, /backgroundMaterial:j\?\?void 0/);
+  assert.doesNotMatch(patched, /minWidth:T\?\.width/);
+});
+
 test("patches remaining Linux window icon snippets when another window is already patched", () => {
   const iconAsset = "app-test.png";
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2189,6 +2189,14 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /getSwitchValue\(`ozone-platform`\)/);
   assert.match(patched, /return e===`x11`\|\|e===``&&!process\.env\.WAYLAND_DISPLAY/);
   assert.doesNotMatch(patched, /XDG_SESSION_TYPE/);
+  assert.match(
+    patched,
+    /process\.platform===`linux`&&\(this\.codexLinuxIsAvatarShapeBackend\(\)\?\(this\.codexLinuxStartAvatarPassthroughRecovery\(\),this\.codexLinuxSyncAvatarPointerInteractivity\(e\)\):\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.pointerInteractive=!1\)\);/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /process\.platform===`linux`&&\(this\.codexLinuxStartAvatarPassthroughRecovery\(\),this\.codexLinuxSyncAvatarPointerInteractivity\(e\)\);/,
+  );
   assert.doesNotMatch(patched, /if\(process\.platform===`linux`&&typeof e\.setShape==`function`\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),/);
   assert.doesNotMatch(patched, /typeof e\.setShape==`function`&&!this\.codexLinuxIsI3Session\(\)/);
   assert.match(patched, /if\(t==null\)return null/);
@@ -2324,6 +2332,19 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
   context.process.env.WAYLAND_DISPLAY = "wayland-0";
   assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
   assert.equal(controller.codexLinuxApplyAvatarInputShape(overlayWindow), false);
+  const ignoreMouseEvents = [];
+  controller.window = {
+    isDestroyed: () => false,
+    setIgnoreMouseEvents(ignore, options) {
+      ignoreMouseEvents.push({ ignore, options });
+    },
+  };
+  controller.pointerInteractive = true;
+  controller.mousePassthroughEnabled = false;
+  controller.applyPointerInteractivityPolicy();
+  assert.equal(controller.pointerInteractive, false);
+  assert.equal(ignoreMouseEvents.at(-1)?.ignore, true);
+  assert.equal(ignoreMouseEvents.at(-1)?.options?.forward, true);
   let setShapeCalls = 0;
   ozonePlatform = "x11";
   assert.equal(controller.codexLinuxIsAvatarShapeBackend(), true);
@@ -2359,6 +2380,104 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
     }),
     false,
   );
+});
+
+test("Linux avatar composition surfaces cannot take keyboard focus on Wayland", () => {
+  const compositionSurfaceSource = [
+    "function I(e){a?.orderSurfaces(bp(D?.slots??[]));for(let t of e.visibleSurfaceIds){let e=v.get(t);e!=null&&(e.window.setOpacity(1),e.keyboardInteractive?(e.window.setFocusable(!0),e.window.setIgnoreMouseEvents(!1)):e.window.showInactive(),te(e))}}",
+    "function te(e){if(e==null||!e.visible||!e.attached||e.preparation.id!==S)return;e.window.show(),e.window.setFocusable(!0),e.window.setIgnoreMouseEvents(!1),e.keyboardInteractive=!0;let t=!1,n=()=>{t||!e.keyboardInteractive||(t=!0,p?.(e.window))};e.window.isFocused()||e.window.once(`focus`,n),o(),e.window.focus(),e.window.webContents.focus(),e.window.isFocused()&&n(),S=null}",
+    "function ce(e,t){let n=v.get(e);if(!t){S===e&&(S=null),n!=null&&(n.keyboardInteractive=!1),ue();return}n?.keyboardInteractive||S===e||(S=e,te(n))}",
+    "function ue(){for(let[e,t]of v){let n=e===C;t.window.setFocusable(t.keyboardInteractive||n),n?(t.window.setIgnoreMouseEvents(!1),de(t)):t.window.setIgnoreMouseEvents(!0,{forward:!0})}}",
+    "function create(){throw Error(`Missing avatar overlay composition surface: ${n}`)}",
+  ].join("");
+  const patched = applyPatchTwice(
+    applyLinuxAvatarOverlayMousePassthroughPatch,
+    compositionSurfaceSource,
+  );
+
+  assert.match(patched, /function codexLinuxAvatarOverlaySurfacesCanFocus\(\)\{/);
+  assert.match(patched, /e\.keyboardInteractive&&codexLinuxAvatarOverlaySurfacesCanFocus\(\)\?/);
+  assert.match(patched, /function te\(e\)\{if\(!codexLinuxAvatarOverlaySurfacesCanFocus\(\)\)return;/);
+  assert.match(
+    patched,
+    /function ce\(e,t\)\{process\.platform===`linux`&&!codexLinuxAvatarOverlaySurfacesCanFocus\(\)&&\(t=!1\);/,
+  );
+  assert.match(
+    patched,
+    /t\.window\.setFocusable\(codexLinuxAvatarOverlaySurfacesCanFocus\(\)&&\(t\.keyboardInteractive\|\|n\)\)/,
+  );
+
+  const events = [];
+  let ozonePlatform = "wayland";
+  const context = {
+    process: { platform: "linux", env: { WAYLAND_DISPLAY: "wayland-0" } },
+    n: { app: { commandLine: { getSwitchValue: () => ozonePlatform } } },
+    a: { app: { commandLine: { getSwitchValue: () => ozonePlatform } } },
+    bp: () => [],
+    D: null,
+    C: null,
+    S: null,
+    p: null,
+    o() {
+      events.push("flush");
+    },
+    de() {
+      events.push("mouse");
+    },
+    v: new Map(),
+  };
+  const makeSurface = () => ({
+    visible: true,
+    attached: true,
+    keyboardInteractive: false,
+    preparation: { id: "composer" },
+    window: {
+      setOpacity(value) {
+        events.push(["opacity", value]);
+      },
+      setFocusable(value) {
+        events.push(["focusable", value]);
+      },
+      setIgnoreMouseEvents(ignore, options) {
+        events.push(["ignore", ignore, options ?? null]);
+      },
+      showInactive() {
+        events.push("showInactive");
+      },
+      show() {
+        events.push("show");
+      },
+      isFocused: () => false,
+      once(eventName) {
+        events.push(["once", eventName]);
+      },
+      focus() {
+        events.push("focus");
+      },
+      webContents: {
+        focus() {
+          events.push("webContents.focus");
+        },
+      },
+    },
+  });
+  context.v.set("composer", makeSurface());
+  vm.runInNewContext(`${patched};globalThis.api={I,ce,ue};`, context);
+
+  context.api.ce("composer", true);
+  assert.deepEqual(events.filter((event) => event === "focus" || event === "webContents.focus"), []);
+  assert.deepEqual(events.filter((event) => Array.isArray(event) && event[0] === "focusable").at(-1), [
+    "focusable",
+    false,
+  ]);
+
+  events.length = 0;
+  ozonePlatform = "x11";
+  context.process.env.WAYLAND_DISPLAY = "wayland-0";
+  context.v.set("composer", makeSurface());
+  context.api.ce("composer", true);
+  assert.ok(events.includes("focus"));
+  assert.ok(events.includes("webContents.focus"));
 });
 
 test("keeps avatar overlay layout sync working after layout alias drift", () => {

--- a/scripts/patches/avatar-overlay.js
+++ b/scripts/patches/avatar-overlay.js
@@ -117,6 +117,10 @@ function avatarApplyInputShapePatch() {
   return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`||typeof this.codexLinuxIsAvatarShapeBackend==`function`&&!this.codexLinuxIsAvatarShapeBackend())return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
 }
 
+function avatarShapeBackendPredicate(electronVar) {
+  return `if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY`;
+}
+
 function patchAvatarOverlayWindowOptions(source) {
   const windowOptionsPatch =
     "appearance:`avatarOverlay`,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
@@ -154,6 +158,54 @@ function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
   return patched;
 }
 
+function applyLinuxAvatarOverlayCompositionSurfaceFocusPatch(currentSource, electronVar) {
+  let patchedSource = currentSource;
+  if (
+    !patchedSource.includes("Missing avatar overlay composition surface") &&
+    !patchedSource.includes("setSurfaceKeyboardInteraction:")
+  ) {
+    return patchedSource;
+  }
+
+  const helperName = "codexLinuxAvatarOverlaySurfacesCanFocus";
+  const helperSource = `function ${helperName}(){${avatarShapeBackendPredicate(electronVar)}}`;
+
+  if (!patchedSource.includes(`function ${helperName}()`)) {
+    const insertionNeedle = "function I(e){a?.orderSurfaces";
+    if (patchedSource.includes(insertionNeedle)) {
+      patchedSource = patchedSource.replace(insertionNeedle, `${helperSource}${insertionNeedle}`);
+    } else if (patchedSource.includes("function te(e){if(e==null||!e.visible||!e.attached")) {
+      patchedSource = patchedSource.replace(
+        "function te(e){",
+        `${helperSource}function te(e){`,
+      );
+    }
+  }
+
+  if (!patchedSource.includes(`function ${helperName}()`)) {
+    return patchedSource;
+  }
+
+  patchedSource = patchedSource.replace(
+    "e.keyboardInteractive?(e.window.setFocusable(!0),e.window.setIgnoreMouseEvents(!1)):e.window.showInactive(),te(e)",
+    `e.keyboardInteractive&&${helperName}()?(e.window.setFocusable(!0),e.window.setIgnoreMouseEvents(!1)):(e.window.setFocusable(!1),e.window.showInactive()),te(e)`,
+  );
+  patchedSource = patchedSource.replace(
+    "function te(e){if(e==null||!e.visible||!e.attached||e.preparation.id!==S)return;",
+    `function te(e){if(!${helperName}())return;if(e==null||!e.visible||!e.attached||e.preparation.id!==S)return;`,
+  );
+  patchedSource = patchedSource.replace(
+    "function ce(e,t){let n=v.get(e);if(!t){",
+    `function ce(e,t){process.platform===\`linux\`&&!${helperName}()&&(t=!1);let n=v.get(e);if(!t){`,
+  );
+  patchedSource = patchedSource.replace(
+    "t.window.setFocusable(t.keyboardInteractive||n),n?(t.window.setIgnoreMouseEvents(!1),de(t)):t.window.setIgnoreMouseEvents(!0,{forward:!0})",
+    `t.window.setFocusable(${helperName}()&&(t.keyboardInteractive||n)),n?(t.window.setIgnoreMouseEvents(!1),de(t)):t.window.setIgnoreMouseEvents(!0,{forward:!0})`,
+  );
+
+  return patchedSource;
+}
+
 function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   let patchedSource = currentSource;
   const electronVar = requireName(currentSource, "electron") ?? "n";
@@ -167,7 +219,9 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
       ? "codexLinuxApplyAvatarCompositorHints(e){}"
       : `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,l,h,d,f]=c;if(Number(l)!==t.x||Number(h)!==t.y||Number(d)!==t.width||Number(f)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
   const shapeBackendMethod =
-    `codexLinuxIsAvatarShapeBackend(){if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY}`;
+    `codexLinuxIsAvatarShapeBackend(){${avatarShapeBackendPredicate(electronVar)}}`;
+  const nonShapeFallbackPolicy =
+    "process.platform===`linux`&&(this.codexLinuxIsAvatarShapeBackend()?(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e)):(this.codexLinuxStopAvatarPassthroughRecovery(),this.pointerInteractive=!1));";
 
   const interactivityNeedle =
     "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}refreshCursorAtCurrentMousePosition(e){";
@@ -185,7 +239,11 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
       "codexLinuxStopAvatarPassthroughRecovery(){",
       `${i3SessionMethod}${compositorHintsMethod}${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
     )
-    .replaceAll(previousSetShapePolicyPatch, setShapePolicyPatch);
+    .replaceAll(previousSetShapePolicyPatch, setShapePolicyPatch)
+    .replace(
+      "process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));",
+      nonShapeFallbackPolicy,
+    );
 
   if (!patchedSource.includes("codexLinuxIsI3Session")) {
     if (patchedSource.includes(interactivityNeedle)) {
@@ -223,6 +281,11 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     );
   }
   patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
+  patchedSource = patchedSource.replace(
+    "process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));",
+    nonShapeFallbackPolicy,
+  );
+  patchedSource = applyLinuxAvatarOverlayCompositionSurfaceFocusPatch(patchedSource, electronVar);
   const beforeFocusablePatch = patchedSource;
   patchedSource = patchAvatarOverlayWindowOptions(patchedSource);
   recordStrategy(

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -36,47 +36,63 @@ function ensureLinuxTitlebarOverlayHelper(source, anchorText, helperSource) {
 // Main-process patches adapt Electron shell behavior: windows, tray, menu,
 // single-instance handling, file manager integration, and packaged runtime glue.
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
-  if (iconAsset == null) {
-    return currentSource;
-  }
-
-  const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
-  const iconPathNeedle = `icon:${iconPathExpression}`;
-  const setIconNeedle = `setIcon(${iconPathExpression})`;
-  const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
-
-  const windowOptionsNeedle = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
-  const currentLinuxAutoHideMenuBarNeedle =
-    "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
-  const legacyLinuxSystemTitlebarNeedle =
-    `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
-  const windowOptionsReplacement =
-    `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
-
   let patchedSource = currentSource;
-  if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
-    patchedSource = patchedSource.split(legacyLinuxSystemTitlebarNeedle).join(windowOptionsReplacement);
+
+  if (iconAsset != null) {
+    const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
+    const iconPathNeedle = `icon:${iconPathExpression}`;
+    const setIconNeedle = `setIcon(${iconPathExpression})`;
+    const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
+
+    const windowOptionsNeedle = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+    const currentLinuxAutoHideMenuBarNeedle =
+      "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
+    const legacyLinuxSystemTitlebarNeedle =
+      `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
+    const windowOptionsReplacement =
+      `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
+
+    if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
+      patchedSource = patchedSource.split(legacyLinuxSystemTitlebarNeedle).join(windowOptionsReplacement);
+    }
+
+    if (patchedSource.includes(windowOptionsNeedle)) {
+      patchedSource = patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
+    } else if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
+      patchedSource = patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
+    } else if (
+      patchedSource === currentSource &&
+      !patchedSource.includes(iconPathNeedle) &&
+      !patchedSource.includes(setIconNeedle) &&
+      !readyToShowSetIconInsertionPattern.test(patchedSource)
+    ) {
+      console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
+    }
   }
 
-  if (patchedSource.includes(windowOptionsNeedle)) {
-    return patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
-  }
+  patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
+  return patchedSource;
+}
 
-  if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
-    return patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
-  }
+function applyDefinedBrowserWindowOptionsPatch(currentSource) {
+  const browserWindowOptionsRegex =
+    /show:([A-Za-z_$][\w$]*),parent:([A-Za-z_$][\w$]*),focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?\{autoHideMenuBar:!0\}:process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/[^`]+`\}:\{\},)backgroundMaterial:([A-Za-z_$][\w$]*)\?\?void 0,\.\.\.([A-Za-z_$][\w$]*),minWidth:([A-Za-z_$][\w$]*)\?\.width,minHeight:\7\?\.height,webPreferences:([A-Za-z_$][\w$]*)/g;
 
-  if (
-    patchedSource !== currentSource ||
-    patchedSource.includes(iconPathNeedle) ||
-    patchedSource.includes(setIconNeedle) ||
-    readyToShowSetIconInsertionPattern.test(patchedSource)
-  ) {
-    return patchedSource;
-  }
-
-  console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
-  return currentSource;
+  return currentSource.replace(
+    browserWindowOptionsRegex,
+    (
+      _match,
+      showAlias,
+      parentAlias,
+      focusableAlias,
+      platformOptions,
+      backgroundMaterialAlias,
+      appearanceOptionsAlias,
+      minimumSizeAlias,
+      webPreferencesAlias,
+    ) =>
+      `show:${showAlias},...${parentAlias}==null?{}:{parent:${parentAlias}},...${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
+  );
 }
 
 function applyLinuxNativeTitlebarPatch(currentSource) {


### PR DESCRIPTION
## Summary
- disable avatar overlay passthrough recovery on Linux backends where the overlay cannot safely use X11 input shaping
- gate new 26.623 avatar composition surface keyboard/focus paths behind the same X11 ozone backend check
- add regression coverage for Wayland vs explicit --ozone-platform=x11 overlay focus behavior

Follow-up for #569 and #575.

## Validation
- node --test --test-name-pattern 'avatar' scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js
- ./install.sh ./Codex.dmg
- verified rebuilt app.asar contains the non-shape recovery guard and composition-surface focus guards
- patch report: 0 failed-required patches