### PR TITLE
Fix X11 BrowserWindow option handling

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2607,6 +2607,24 @@ test("adds Linux window icon handling to current Linux autoHideMenuBar options",
   assert.match(patched, new RegExp(`icon:${escapeRegExp(iconPathExpression)}`));
 });
 
+test("omits undefined BrowserWindow options in the current window manager bundle", () => {
+  const iconAsset = "app-test.png";
+  const source = [
+    "let M=new a.BrowserWindow({width:b,height:x,...S===void 0||C===void 0?{}:{x:S,y:C},",
+    "title:n??a.app.getName(),backgroundColor:A,show:l,parent:p,focusable:m,",
+    "...process.platform===`win32`?{autoHideMenuBar:!0}:process.platform===`linux`?{icon:process.resourcesPath+`/../content/webview/assets/app-test.png`}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k});",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, iconAsset);
+
+  assert.match(patched, /show:l,\.\.\.p==null\?\{\}:\{parent:p\},\.\.\.m==null\?\{\}:\{focusable:m\}/);
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\},\.\.\.D,\.\.\.T==null\?\{\}:\{minWidth:T\.width,minHeight:T\.height\},webPreferences:k/);
+  assert.doesNotMatch(patched, /show:l,parent:p,focusable:m/);
+  assert.doesNotMatch(patched, /backgroundMaterial:j\?\?void 0/);
+  assert.doesNotMatch(patched, /minWidth:T\?\.width/);
+});
+
 test("patches remaining Linux window icon snippets when another window is already patched", () => {
   const iconAsset = "app-test.png";
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -36,47 +36,63 @@ function ensureLinuxTitlebarOverlayHelper(source, anchorText, helperSource) {
 // Main-process patches adapt Electron shell behavior: windows, tray, menu,
 // single-instance handling, file manager integration, and packaged runtime glue.
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
-  if (iconAsset == null) {
-    return currentSource;
-  }
-
-  const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
-  const iconPathNeedle = `icon:${iconPathExpression}`;
-  const setIconNeedle = `setIcon(${iconPathExpression})`;
-  const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
-
-  const windowOptionsNeedle = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
-  const currentLinuxAutoHideMenuBarNeedle =
-    "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
-  const legacyLinuxSystemTitlebarNeedle =
-    `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
-  const windowOptionsReplacement =
-    `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
-
   let patchedSource = currentSource;
-  if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
-    patchedSource = patchedSource.split(legacyLinuxSystemTitlebarNeedle).join(windowOptionsReplacement);
+
+  if (iconAsset != null) {
+    const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
+    const iconPathNeedle = `icon:${iconPathExpression}`;
+    const setIconNeedle = `setIcon(${iconPathExpression})`;
+    const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
+
+    const windowOptionsNeedle = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+    const currentLinuxAutoHideMenuBarNeedle =
+      "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
+    const legacyLinuxSystemTitlebarNeedle =
+      `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
+    const windowOptionsReplacement =
+      `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
+
+    if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
+      patchedSource = patchedSource.split(legacyLinuxSystemTitlebarNeedle).join(windowOptionsReplacement);
+    }
+
+    if (patchedSource.includes(windowOptionsNeedle)) {
+      patchedSource = patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
+    } else if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
+      patchedSource = patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
+    } else if (
+      patchedSource === currentSource &&
+      !patchedSource.includes(iconPathNeedle) &&
+      !patchedSource.includes(setIconNeedle) &&
+      !readyToShowSetIconInsertionPattern.test(patchedSource)
+    ) {
+      console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
+    }
   }
 
-  if (patchedSource.includes(windowOptionsNeedle)) {
-    return patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
-  }
+  patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
+  return patchedSource;
+}
 
-  if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
-    return patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
-  }
+function applyDefinedBrowserWindowOptionsPatch(currentSource) {
+  const browserWindowOptionsRegex =
+    /show:([A-Za-z_$][\w$]*),parent:([A-Za-z_$][\w$]*),focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?\{autoHideMenuBar:!0\}:process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/[^`]+`\}:\{\},)backgroundMaterial:([A-Za-z_$][\w$]*)\?\?void 0,\.\.\.([A-Za-z_$][\w$]*),minWidth:([A-Za-z_$][\w$]*)\?\.width,minHeight:\7\?\.height,webPreferences:([A-Za-z_$][\w$]*)/g;
 
-  if (
-    patchedSource !== currentSource ||
-    patchedSource.includes(iconPathNeedle) ||
-    patchedSource.includes(setIconNeedle) ||
-    readyToShowSetIconInsertionPattern.test(patchedSource)
-  ) {
-    return patchedSource;
-  }
-
-  console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
-  return currentSource;
+  return currentSource.replace(
+    browserWindowOptionsRegex,
+    (
+      _match,
+      showAlias,
+      parentAlias,
+      focusableAlias,
+      platformOptions,
+      backgroundMaterialAlias,
+      appearanceOptionsAlias,
+      minimumSizeAlias,
+      webPreferencesAlias,
+    ) =>
+      `show:${showAlias},...${parentAlias}==null?{}:{parent:${parentAlias}},...${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
+  );
 }
 
 function applyLinuxNativeTitlebarPatch(currentSource) {


### PR DESCRIPTION
## Summary
- restore conditional BrowserWindow option spreading for parent, focusable, backgroundMaterial, and minimumSize in the current 26.623 window manager bundle
- keep the Linux icon window option patch active while applying the undefined-option cleanup independently
- add regression coverage for the current minified BrowserWindow option shape

Fixes #576.

## Validation
- node --test scripts/patch-linux-window-ui.test.js
- make check
- built a 26.623.31921 lab app from the fixed branch
- verified the rebuilt app.asar uses conditional option spreads instead of explicit undefined BrowserWindow options
- verified on Zorin OS/X11 that the fixed lab window is managed by the window manager, exposes WM_STATE, and supports move/minimize/maximize actions
