### PR TITLE
[codex] Guard read aloud settings nav icon

### DIFF
--- a/docs/wayland-input-focus-investigation.md
+++ b/docs/wayland-input-focus-investigation.md
@@ -1,0 +1,164 @@
+# Wayland/X11 composer input dead — root-cause investigation (issue #569)
+
+Date: 2026-06-26
+Investigated live on: Ubuntu 25.10, GNOME, Wayland session (Electron 42.1.0 /
+Chromium 148, Codex 26.623.31921).
+
+## Symptom
+
+App opens, UI is clickable (model selector, "Full Access" dropdown, buttons all
+work), but the **main composer text input cannot be focused or typed into**.
+User observation that cracked the case: *clicking the Codex window does not give
+it keyboard focus — keystrokes keep going to the previously-focused window (the
+terminal). The window "looks like a modal" / never focuses.*
+
+## How it was diagnosed (empirical, not guesswork)
+
+The installed app was launched with Chrome DevTools Protocol enabled:
+
+```
+./codex-app/start.sh -- --remote-debugging-port=9222 --remote-allow-origins=*
+```
+
+and inspected over CDP (see `scratchpad/cdp*.py`). Then the real X11 window was
+inspected with `xprop` / `xwininfo` (works because under XWayland the Electron
+window is a real X11 window).
+
+### Finding 1 — the editor/DOM is completely healthy
+Via CDP `Runtime.evaluate` on the page:
+- `document.activeElement` is already `DIV.ProseMirror`.
+- `.ProseMirror` has `contenteditable="true"`, `isContentEditable=true`,
+  `-webkit-user-modify: read-write`, `pointer-events: auto`, not
+  disabled/readonly, `-webkit-app-region: no-drag`.
+
+➡️ The "app renders the composer non-editable / focus-blocked" theory is
+**false**. The composer is fully editable and is the active element.
+
+### Finding 2 — the renderer never has focus
+- `document.hasFocus()` === **false** while the window is visible.
+- Main-process logs confirm it: `rendererWindowFocused=false`.
+
+### Finding 3 — forcing renderer focus shows a caret but does NOT enable typing
+Via CDP `Emulation.setFocusEmulationEnabled({enabled:true})`:
+- `document.hasFocus()` flips to **true**, `.ProseMirror` gains the
+  `ProseMirror-focused` class, a caret appears.
+- BUT real hardware keystrokes still do not enter text (user confirmed: "I saw
+  the cursor but couldn't type").
+
+### Finding 4 — the editor accepts input through the browser process
+Via CDP:
+- `Input.insertText("CDP_INSERT_OK")` → text appears.
+- `Input.dispatchKeyEvent` for "KEY9" → text appears.
+
+`Input.dispatchKeyEvent` injects at the Electron **browser-process** level,
+bypassing the OS/compositor. It works. So the editor is fine; the break is
+between the **OS/compositor and Electron** — real keyboard events never reach
+the window.
+
+### Finding 5 (root cause) — the window is override-redirect / unmanaged
+`xprop` on the real Codex window (under XWayland):
+
+```
+WM_CLASS            = "codex-desktop", "codex-desktop"
+WM_NAME             = "Codex"
+_NET_WM_WINDOW_TYPE = _NET_WM_WINDOW_TYPE_NORMAL
+_NET_WM_STATE       = _NET_WM_STATE_SKIP_PAGER, _NET_WM_STATE_SKIP_TASKBAR
+WM_HINTS            = not found            <-- no input hint
+Override Redirect State: yes               <-- THE BUG
+Map State: IsViewable
+```
+
+`Override Redirect State: yes` means the window **bypasses the window manager**.
+The WM does not manage it, does not route keyboard focus to it, does not list it
+in the taskbar, and clicking it does not activate it. That explains every
+symptom at once:
+- mouse works (pointer events go to the window under the cursor regardless of WM),
+- keyboard goes wherever the WM thinks focus is (the terminal),
+- `document.hasFocus()` is permanently false,
+- identical breakage on Wayland and X11 (the cause is in window creation, not the
+  backend).
+
+### Finding 6 — why the window is override-redirect
+The 26.623 upstream bundle builds the primary `BrowserWindow` options as a flat
+object with **explicit** (non-spread) keys:
+
+```
+show:l, parent:p, focusable:m, ...platformOpts,
+backgroundMaterial:bm??void 0, ...appearanceOpts,
+minWidth:sz?.width, minHeight:sz?.height, webPreferences:wp
+```
+
+When `parent` / `focusable` / `backgroundMaterial` / `minimumSize` are
+undefined, these become literal `parent:undefined`, `focusable:undefined`,
+`backgroundMaterial:void 0`, `minWidth:undefined` options. Electron/Chromium on
+Linux mishandles those explicit-undefined options and creates an **unmanaged
+(override-redirect)** window. Confirmed: the installed patched `app.asar`
+contains exactly one such options object (`show:l,parent:p,focusable:m,...`).
+
+## The fix — PR #578 ("Fix X11 BrowserWindow option handling")
+
+PR #578 (`fix/x11-browserwindow-options`, Fixes #576) rewrites those options to
+**conditional spreads**, so an undefined option is simply absent:
+
+```
+show:l,
+...p==null?{}:{parent:p},
+...m==null?{}:{focusable:m},
+...platformOpts,
+...bm==null?{}:{backgroundMaterial:bm},
+...appearanceOpts,
+...sz==null?{}:{minWidth:sz.width,minHeight:sz.height},
+webPreferences:wp
+```
+
+PR author verified on Zorin OS/X11 that the rebuilt window is **managed by the
+WM, exposes WM_STATE, and supports move/minimize/maximize**. That is precisely
+the override-redirect → managed transition we need. Once the window is managed it
+receives real WM keyboard focus, `document.hasFocus()` becomes true on click, and
+real keystrokes reach the (already-healthy) composer.
+
+Implementation: `applyDefinedBrowserWindowOptionsPatch()` in
+`scripts/patches/main-process/window.js`.
+
+## Why every earlier attempt failed (and looked plausible)
+
+All earlier hypotheses targeted layers that were not broken:
+
+1. **Avatar-overlay focus-trap patches (#575/#577, commit 77c353d)** — overlay
+   was not the cause; the main window itself was unmanaged. No change.
+2. **`linux-editable-no-drag` CSS** — composer already had
+   `-webkit-app-region: no-drag`; CSS was never the blocker. No change.
+3. **Main-process `electron-window-focus-request` → BrowserWindow.focus() /
+   webContents.focus()** — you cannot focus an override-redirect window via the
+   WM; `.focus()` is a no-op for an unmanaged surface. No change.
+4. **Removing Wayland auto `--disable-gpu-compositing`** — unrelated to focus;
+   reverted (GPU path adds other problems). No change.
+5. **Disabling the Linux titlebar overlay / native-titlebar experiment** — the
+   override-redirect comes from the window *options*, not the titlebar style, so
+   reverting the titlebar changed nothing. No change.
+6. **`Emulation.setFocusEmulationEnabled` (renderer focus emulation)** — fixes
+   the *renderer's* focus state (caret appears, `document.hasFocus()`=true) but
+   not the *OS-level* keyboard routing, because the window still has no WM
+   keyboard focus. Cursor appears, typing still dead.
+
+The unifying reason: real keyboard input is delivered by the window manager to
+the focused managed window. An override-redirect window is never given that
+focus, so no renderer- or app-level change can make hardware keys arrive.
+
+## Verification checklist after applying #578
+
+1. Rebuild: `./install.sh ./Codex.dmg`.
+2. Launch and inspect the window with `xprop` (under XWayland) — expect
+   `Override Redirect State: no` and a present `WM_STATE` / `WM_HINTS`.
+3. Click the window: `document.hasFocus()` should become true on its own (no
+   emulation needed).
+4. Type in the composer — text should appear. (Confirmed by user.)
+
+## Reusable diagnostics (in scratchpad)
+
+- `cdp.py '<js>'` — evaluate JS in the live page over CDP.
+- `cdp_focus_test.py` — toggle `setFocusEmulationEnabled` and read focus state.
+- `cdp_keylog_native.py` — log real keydown events + composer text (no emulation).
+- `xprop -id <win> WM_CLASS WM_NAME _NET_WM_WINDOW_TYPE _NET_WM_STATE WM_HINTS` +
+  `xwininfo -id <win> | grep -i "override"` — confirm managed vs override-redirect.
+</content>

--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -458,49 +458,73 @@ function detectSettingsPageJsxRuntime(source) {
   return iconMatch?.[2] ?? "Z";
 }
 
-function readAloudSettingsNavIconSource(jsxVar = "Z") {
-  return `codexLinuxReadAloudSettingsIcon=e=>(0,${jsxVar}.jsxs)(\`svg\`,{width:16,height:16,viewBox:\`0 0 16 16\`,fill:\`none\`,xmlns:\`http://www.w3.org/2000/svg\`,...e,children:[(0,${jsxVar}.jsx)(\`path\`,{d:\`M7.25 3.25 4.35 5.7H2.75A1.25 1.25 0 0 0 1.5 6.95v2.1c0 .69.56 1.25 1.25 1.25h1.6l2.9 2.45c.5.42 1.25.06 1.25-.59V3.84c0-.65-.75-1.01-1.25-.59Z\`,fill:\`currentColor\`}),(0,${jsxVar}.jsx)(\`path\`,{d:\`M10.25 6.1a2.7 2.7 0 0 1 0 3.8\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`}),(0,${jsxVar}.jsx)(\`path\`,{d:\`M12.25 4.45a5.05 5.05 0 0 1 0 7.1\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`})]})`;
+function readAloudSettingsNavIconExpression(jsxVar = "Z", fallbackIcon = null) {
+  const customIcon = `(0,${jsxVar}.jsxs)(\`svg\`,{width:16,height:16,viewBox:\`0 0 16 16\`,fill:\`none\`,xmlns:\`http://www.w3.org/2000/svg\`,...e,children:[(0,${jsxVar}.jsx)(\`path\`,{d:\`M7.25 3.25 4.35 5.7H2.75A1.25 1.25 0 0 0 1.5 6.95v2.1c0 .69.56 1.25 1.25 1.25h1.6l2.9 2.45c.5.42 1.25.06 1.25-.59V3.84c0-.65-.75-1.01-1.25-.59Z\`,fill:\`currentColor\`}),(0,${jsxVar}.jsx)(\`path\`,{d:\`M10.25 6.1a2.7 2.7 0 0 1 0 3.8\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`}),(0,${jsxVar}.jsx)(\`path\`,{d:\`M12.25 4.45a5.05 5.05 0 0 1 0 7.1\`,stroke:\`currentColor\`,strokeWidth:1.2,strokeLinecap:\`round\`})]})`;
+  if (fallbackIcon == null) {
+    return `(e=>${customIcon})`;
+  }
+  return `(e=>{try{return ${customIcon}}catch(t){return ${fallbackIcon}(e)}})`;
+}
+
+function hasReadAloudSettingsIconDeclaration(source) {
+  return /(?:^|[;\n])\s*(?:var|let|const)\s+codexLinuxReadAloudSettingsIcon(?:[=,;])/.test(source);
+}
+
+function declareLegacyReadAloudSettingsIconIfNeeded(source) {
+  if (
+    !source.includes("codexLinuxReadAloudSettingsIcon=e=>") ||
+    hasReadAloudSettingsIconDeclaration(source)
+  ) {
+    return source;
+  }
+  let insertionIndex = 0;
+  while (source.startsWith("import", insertionIndex)) {
+    const statementEnd = source.indexOf(";", insertionIndex);
+    if (statementEnd === -1) {
+      break;
+    }
+    insertionIndex = statementEnd + 1;
+  }
+  return `${source.slice(0, insertionIndex)}var codexLinuxReadAloudSettingsIcon;${source.slice(insertionIndex)}`;
 }
 
 function applySettingsPageNavPatch(source) {
-  let patched = source;
-  if (!patched.includes("codexLinuxReadAloudSettingsIcon=e=>")) {
-    const iconSource = readAloudSettingsNavIconSource(detectSettingsPageJsxRuntime(patched));
-    if (patched.includes(",pe={")) {
-      patched = patched.replace(",pe={", `,${iconSource},pe={`);
-    } else {
-      const iconMapMatch = patched.match(
-        /(?:var |let |const |,)[A-Za-z_$][\w$]*=\{(?=[^;\n]*"general-settings":)(?=[^;\n]*"computer-use":)[^;\n]*\}/,
-      );
-      if (iconMapMatch != null) {
-        const index = iconMapMatch.index ?? 0;
-        if (iconMapMatch[0].startsWith(",")) {
-          patched = `${patched.slice(0, index)},${iconSource}${patched.slice(index)}`;
-        } else {
-          const keyword = iconMapMatch[0].match(/^(var |let |const )/)?.[1] ?? "var ";
-          patched = `${patched.slice(0, index)}${keyword}${iconSource};${patched.slice(index)}`;
-        }
-      } else {
-        patched = patched.replace(
-          /,([A-Za-z_$][\w$]*)=\{"general-settings":/,
-          `,${iconSource},$1={"general-settings":`,
-        );
-      }
-    }
-  }
-  if (!patched.includes(`"read-aloud-settings":codexLinuxReadAloudSettingsIcon`)) {
+  let patched = declareLegacyReadAloudSettingsIconIfNeeded(source);
+  const jsxVar = detectSettingsPageJsxRuntime(patched);
+  const staleReadAloudIconRegex =
+    /("computer-use":([A-Za-z_$][\w$]*),"read-aloud-settings":)(codexLinuxReadAloudSettingsIcon|[A-Za-z_$][\w$]*)(,"local-environments")/;
+  if (staleReadAloudIconRegex.test(patched)) {
+    patched = patched.replace(
+      staleReadAloudIconRegex,
+      (_match, prefix, computerUseIcon, _staleIcon, suffix) =>
+        `${prefix}${readAloudSettingsNavIconExpression(jsxVar, computerUseIcon)}${suffix}`,
+    );
+  } else if (!patched.includes(`"read-aloud-settings":`)) {
     const iconMapRegex =
-      /("browser-use":[A-Za-z_$][\w$]*,"computer-use":[A-Za-z_$][\w$]*,)(?!"read-aloud-settings":)/;
+      /("browser-use":[A-Za-z_$][\w$]*,"computer-use":([A-Za-z_$][\w$]*),)(?!"read-aloud-settings":)/;
     if (iconMapRegex.test(patched)) {
-      patched = patched.replace(iconMapRegex, '$1"read-aloud-settings":codexLinuxReadAloudSettingsIcon,');
+      patched = patched.replace(
+        iconMapRegex,
+        (_match, prefix, computerUseIcon) =>
+          `${prefix}"read-aloud-settings":${readAloudSettingsNavIconExpression(
+            jsxVar,
+            computerUseIcon,
+          )},`,
+      );
     } else {
       patched = patched.replace(
         `"computer-use":oe,"local-environments"`,
-        `"computer-use":oe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments"`,
+        `"computer-use":oe,"read-aloud-settings":${readAloudSettingsNavIconExpression(
+          jsxVar,
+          "oe",
+        )},"local-environments"`,
       );
       patched = patched.replace(
         `"computer-use":oe,"read-aloud-settings":G,"local-environments"`,
-        `"computer-use":oe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments"`,
+        `"computer-use":oe,"read-aloud-settings":${readAloudSettingsNavIconExpression(
+          jsxVar,
+          "oe",
+        )},"local-environments"`,
       );
     }
   }

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -1135,8 +1135,12 @@ test("settings nav patches add a visible read aloud section after computer use",
     "case`computer-use`:z=k.isLoading||m.isLoading;break bb0;",
   ].join("");
   const patchedPage = twice(applySettingsPageNavPatch, page);
-  assert.match(patchedPage, /codexLinuxReadAloudSettingsIcon=e=>/);
-  assert.match(patchedPage, /"read-aloud-settings":codexLinuxReadAloudSettingsIcon/);
+  assert.doesNotMatch(patchedPage, /codexLinuxReadAloudSettingsIcon=e=>/);
+  assert.match(
+    patchedPage,
+    /"read-aloud-settings":\(e=>\{try\{return \(0,Z\.jsxs\)\(`svg`,/,
+  );
+  assert.match(patchedPage, /catch\(t\)\{return oe\(e\)\}\}\)/);
   assert.match(patchedPage, /`computer-use`,`read-aloud-settings`,`data-controls`/);
   assert.match(patchedPage, /`computer-use`,`read-aloud-settings`,`local-environments`/);
   assert.match(patchedPage, /case`read-aloud-settings`:return!0;case`computer-use`/);
@@ -1152,12 +1156,13 @@ test("settings nav patch adds the read aloud icon to the current settings page i
     "case`computer-use`:z=D.isLoading||h.isLoading;break bb0;",
   ].join("");
   const patched = twice(applySettingsPageNavPatch, page);
-  assert.match(patched, /codexLinuxReadAloudSettingsIcon=e=>\(0,\$\.jsxs\)/);
-  assert.doesNotMatch(patched, /codexLinuxReadAloudSettingsIcon=e=>\(0,Z\.jsxs\)/);
+  assert.doesNotMatch(patched, /codexLinuxReadAloudSettingsIcon=e=>/);
   assert.match(
     patched,
-    /"browser-use":me,"computer-use":fe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments":pe/,
+    /"browser-use":me,"computer-use":fe,"read-aloud-settings":\(e=>\{try\{return \(0,\$\.jsxs\)\(`svg`,/,
   );
+  assert.match(patched, /catch\(t\)\{return fe\(e\)\}\}\),"local-environments":pe/);
+  assert.doesNotMatch(patched, /\(0,Z\.jsxs\)/);
   assert.match(patched, /`computer-use`,`read-aloud-settings`,`data-controls`/);
   assert.match(patched, /case`read-aloud-settings`:return!0;case`computer-use`/);
   assert.match(patched, /case`read-aloud-settings`:z=!1;break bb0;case`computer-use`/);
@@ -1182,7 +1187,7 @@ test("settings nav patch adds read aloud visibility before drifted computer-use 
   );
 });
 
-test("settings nav patch defines the read aloud icon before var icon maps", () => {
+test("settings nav patch repairs stale read aloud icon references in var icon maps", () => {
   const page = [
     "var $=i();",
     "var codexLinuxAgentWorkspaceSettingsIcon=e=>(0,$.jsxs)(`svg`,{children:[]});",
@@ -1193,13 +1198,36 @@ test("settings nav patch defines the read aloud icon before var icon maps", () =
     "case`computer-use`:I=T.isLoading||g.isLoading;break bb0;",
   ].join("");
   const patched = twice(applySettingsPageNavPatch, page);
-  assert.match(patched, /var codexLinuxReadAloudSettingsIcon=e=>\(0,\$\.jsxs\)/);
-  assert.ok(
-    patched.indexOf("codexLinuxReadAloudSettingsIcon=e=>") <
-      patched.indexOf('"read-aloud-settings":codexLinuxReadAloudSettingsIcon'),
+  assert.doesNotMatch(patched, /codexLinuxReadAloudSettingsIcon=e=>/);
+  assert.match(
+    patched,
+    /"computer-use":De,"read-aloud-settings":\(e=>\{try\{return \(0,\$\.jsxs\)\(`svg`,/,
   );
+  assert.match(patched, /catch\(t\)\{return De\(e\)\}\}\),"local-environments":Oe/);
   assert.match(patched, /case`read-aloud-settings`:return!0;case`computer-use`/);
   assert.match(patched, /case`read-aloud-settings`:I=!1;break bb0;case`computer-use`/);
+});
+
+test("settings nav patch declares legacy read aloud icon assignments before they can throw", () => {
+  const page = [
+    'import{n as e}from"./rolldown-runtime.js";',
+    "var $=i(),Hn,Xn=e((()=>{Hn=null,codexLinuxReadAloudSettingsIcon=e=>(0,$.jsxs)(`svg`,{children:[]}),Hn={\"browser-use\":me,\"computer-use\":fe,\"read-aloud-settings\":codexLinuxReadAloudSettingsIcon,\"local-environments\":pe}}));",
+    "xe=[`browser-use`,`computer-use`,`data-controls`];",
+    "Se=[{slugs:[`browser-use`,`computer-use`,`local-environments`]}];",
+    "case`computer-use`:return A;",
+    "case`computer-use`:z=D.isLoading||h.isLoading;break bb0;",
+  ].join("");
+  const patched = twice(applySettingsPageNavPatch, page);
+  assert.match(
+    patched,
+    /^import\{n as e\}from"\.\/rolldown-runtime\.js";var codexLinuxReadAloudSettingsIcon;/,
+  );
+  assert.match(patched, /codexLinuxReadAloudSettingsIcon=e=>\(0,\$\.jsxs\)/);
+  assert.match(
+    patched,
+    /"computer-use":fe,"read-aloud-settings":\(e=>\{try\{return \(0,\$\.jsxs\)\(`svg`,/,
+  );
+  assert.match(patched, /catch\(t\)\{return fe\(e\)\}\}\),"local-environments":pe/);
 });
 
 test("app route patch wires read aloud settings to the generated page export", () => {
@@ -1356,7 +1384,7 @@ test("settings asset patch creates a first-class read aloud settings section", (
     assert.deepEqual(applySettingsAssetPatch(root), { matched: true, changed: 0 });
     assert.match(
       fs.readFileSync(path.join(assets, "settings-page-current.js"), "utf8"),
-      /"read-aloud-settings":codexLinuxReadAloudSettingsIcon/,
+      /"read-aloud-settings":\(e=>\{try\{return \(0,Z\.jsxs\)\(`svg`,/,
     );
     assert.match(
       fs.readFileSync(path.join(assets, "app-main-current.js"), "utf8"),


### PR DESCRIPTION
## Summary
- patch the Read Aloud settings nav icon inline instead of relying on an undeclared generated symbol
- repair stale Read Aloud icon map references with a safe fallback to the existing Computer Use icon
- declare legacy generated icon assignments before they can throw during module initialization
- add the Wayland/X11 input-focus investigation notes

## Root cause
The Read Aloud Linux feature patched the settings page icon map to reference codexLinuxReadAloudSettingsIcon. In current upstream chunks the generated assignment could land inside a strict-mode expression statement, so loading Settings/Profile could throw ReferenceError before the route rendered.

## Validation
- node --test linux-features/read-aloud/test.js
- sanity checked the current generated settings-page asset: stale reference is repaired, legacy assignment is declared, and a safe fallback is present