### PR TITLE
Respect disabled updater service

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -84,6 +84,21 @@ codex-update-manager status --json
 `make service-enable` is meant for installed packages, not repo-only generated
 apps.
 
+To temporarily pause automatic package rebuilds and installs while keeping Codex
+Desktop usable, disable the user service:
+
+```bash
+systemctl --user disable --now codex-update-manager.service
+```
+
+Launching Codex Desktop and upgrading the package will not re-enable a disabled
+updater service. Re-enable updater behavior explicitly when you want automatic
+checks again:
+
+```bash
+systemctl --user enable --now codex-update-manager.service
+```
+
 ## Wrapper Updates
 
 Optional wrapper-update tracking can watch this repository's own Linux wrapper

--- a/packaging/linux/codex-desktop.install
+++ b/packaging/linux/codex-desktop.install
@@ -9,20 +9,27 @@ if [ -f "$DESKTOP_ENTRY_DOCTOR" ]; then
     . "$DESKTOP_ENTRY_DOCTOR"
 fi
 
-post_install() {
+codex_desktop_post_transaction_common() {
     if command -v update-desktop-database >/dev/null 2>&1; then
         update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
     fi
     if [ -f "$DESKTOP_ENTRY_DOCTOR" ]; then
         codex_desktop_repair_system_package_shadow_entries codex-desktop || true
     fi
+}
+
+post_install() {
+    codex_desktop_post_transaction_common
     if [ -f "$SERVICE_HELPER" ]; then
         codex_ensure_user_service_running || true
     fi
 }
 
 post_upgrade() {
-    post_install
+    codex_desktop_post_transaction_common
+    if [ -f "$SERVICE_HELPER" ]; then
+        codex_start_enabled_user_service || true
+    fi
 }
 
 pre_remove() {

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -68,7 +68,11 @@ fi
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
 if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
-    codex_ensure_user_service_running || true
+    if [ "${1:-0}" -eq 1 ]; then
+        codex_ensure_user_service_running || true
+    else
+        codex_start_enabled_user_service || true
+    fi
 fi
 %else
 CLEANUP_HELPER=/opt/__PACKAGE_NAME__/.codex-linux/codex-no-updater-transition-cleanup.sh

--- a/packaging/linux/codex-packaged-runtime.sh
+++ b/packaging/linux/codex-packaged-runtime.sh
@@ -39,12 +39,11 @@ codex_packaged_runtime_prelaunch_background() {
             YDOTOOL_SOCKET >/dev/null 2>&1 || true
     fi
 
-    if systemctl --user is-enabled codex-update-manager.service >/dev/null 2>&1; then
-        systemctl --user start codex-update-manager.service >/dev/null 2>&1 || true
-    else
-        systemctl --user enable --now codex-update-manager.service >/dev/null 2>&1 || true
+    if ! systemctl --user is-enabled codex-update-manager.service >/dev/null 2>&1; then
+        return 0
     fi
 
+    systemctl --user start codex-update-manager.service >/dev/null 2>&1 || true
     codex_packaged_runtime_trigger_update_check
 }
 

--- a/packaging/linux/codex-update-manager-user-service.sh
+++ b/packaging/linux/codex-update-manager-user-service.sh
@@ -51,6 +51,10 @@ codex_ensure_user_service_running() {
     codex_foreach_user_manager codex_ensure_one_user_service_running
 }
 
+codex_start_enabled_user_service() {
+    codex_foreach_user_manager codex_start_one_enabled_user_service
+}
+
 codex_ensure_one_user_service_running() {
     user_name="$1"
     runtime_dir="$2"
@@ -66,6 +70,22 @@ codex_ensure_one_user_service_running() {
         codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" start "$SERVICE_NAME" || true
     else
         codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" enable --now "$SERVICE_NAME" || true
+    fi
+}
+
+codex_start_one_enabled_user_service() {
+    user_name="$1"
+    runtime_dir="$2"
+    bus="$3"
+
+    codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" daemon-reload || true
+
+    if codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" is-active "$SERVICE_NAME"; then
+        return
+    fi
+
+    if codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" is-enabled "$SERVICE_NAME"; then
+        codex_run_systemctl_user "$user_name" "$runtime_dir" "$bus" start "$SERVICE_NAME" || true
     fi
 }
 

--- a/packaging/linux/codex-update-manager.postinst
+++ b/packaging/linux/codex-update-manager.postinst
@@ -6,7 +6,11 @@ DESKTOP_ENTRY_DOCTOR="/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor
 if [ -f "$SERVICE_HELPER" ]; then
     # shellcheck source=/opt/codex-desktop/update-builder/packaging/linux/codex-update-manager-user-service.sh
     . "$SERVICE_HELPER"
-    codex_ensure_user_service_running || true
+    if [ "${1:-}" = "configure" ] && [ -z "${2:-}" ]; then
+        codex_ensure_user_service_running || true
+    else
+        codex_start_enabled_user_service || true
+    fi
 fi
 if [ -f "$DESKTOP_ENTRY_DOCTOR" ]; then
     # shellcheck source=/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor.sh

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -325,7 +325,10 @@ SCRIPT
     assert_file_exists "$dist_dir/codex-desktop_2026.03.24.120000+deadbeef_amd64.deb"
     [ "$(cat "$capture_dir/dpkg-deb-threads")" = "6" ] \
         || fail "Expected MAX_BUILD_THREADS to reach dpkg-deb"
+    assert_file_exists "$pkg_root/DEBIAN/postinst"
     assert_file_exists "$pkg_root/DEBIAN/prerm"
+    assert_contains "$pkg_root/DEBIAN/postinst" "codex_ensure_user_service_running"
+    assert_contains "$pkg_root/DEBIAN/postinst" "codex_start_enabled_user_service"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=New Window"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=Check for Updates"
     assert_contains "$pkg_root/usr/share/applications/codex-desktop.desktop" "Name=Install Ready Update"
@@ -362,6 +365,8 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/plugins/openai-bundled/plugins/read-aloud/.mcp.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/.codex-linux/source-info.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
+    assert_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "is-enabled codex-update-manager.service"
+    assert_not_contains "$pkg_root/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "enable --now codex-update-manager.service"
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/packaging/linux/codex-desktop-entry-doctor.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/resources/node-runtime/bin/node"
@@ -767,6 +772,62 @@ SCRIPT
         _ "$helper"
 
     assert_file_not_exists "$service_link"
+}
+
+test_update_manager_service_helper_respects_disabled_service() {
+    info "Checking updater service helper respects disabled user service state"
+    local helper_log="$TMP_DIR/updater-service-helper.log"
+    local helper_state=""
+
+    # shellcheck source=packaging/linux/codex-update-manager-user-service.sh
+    . "$REPO_DIR/packaging/linux/codex-update-manager-user-service.sh"
+
+    codex_run_systemctl_user() {
+        local user_name="$1"
+        local runtime_dir="$2"
+        local bus="$3"
+        shift 3
+        printf '%s|%s|%s|%s\n' "$helper_state" "$user_name" "$runtime_dir" "$*" >> "$helper_log"
+
+        case "$*" in
+            "daemon-reload")
+                return 0
+                ;;
+            "is-active $SERVICE_NAME")
+                [ "$helper_state" = "active" ]
+                return
+                ;;
+            "is-enabled $SERVICE_NAME")
+                [ "$helper_state" = "enabled" ] || [ "$helper_state" = "active" ]
+                return
+                ;;
+            "start $SERVICE_NAME")
+                return 0
+                ;;
+            "enable --now $SERVICE_NAME")
+                return 0
+                ;;
+        esac
+
+        return 1
+    }
+
+    helper_state="disabled"
+    : > "$helper_log"
+    codex_start_one_enabled_user_service codexuser /run/user/1000 /run/user/1000/bus
+    assert_not_contains "$helper_log" "start $SERVICE_NAME"
+    assert_not_contains "$helper_log" "enable --now $SERVICE_NAME"
+
+    helper_state="enabled"
+    : > "$helper_log"
+    codex_start_one_enabled_user_service codexuser /run/user/1000 /run/user/1000/bus
+    assert_contains "$helper_log" "start $SERVICE_NAME"
+    assert_not_contains "$helper_log" "enable --now $SERVICE_NAME"
+
+    helper_state="disabled"
+    : > "$helper_log"
+    codex_ensure_one_user_service_running codexuser /run/user/1000 /run/user/1000/bus
+    assert_contains "$helper_log" "enable --now $SERVICE_NAME"
 }
 
 test_rpm_builder_smoke() {
@@ -3455,9 +3516,15 @@ EOF
     assert_contains "$REPO_DIR/updater/src/app.rs" "kdialog"
     assert_contains "$REPO_DIR/updater/src/app.rs" "zenity"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "CHROME_DESKTOP"
+    assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "is-enabled codex-update-manager.service"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager-launch-check"
     assert_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "codex-update-manager check-now --if-stale"
+    assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "enable --now codex-update-manager.service"
     assert_not_contains "$REPO_DIR/packaging/linux/codex-packaged-runtime.sh" "restart codex-update-manager.service"
+    assert_contains "$REPO_DIR/packaging/linux/codex-update-manager-user-service.sh" "codex_start_enabled_user_service"
+    assert_contains "$REPO_DIR/packaging/linux/codex-update-manager.postinst" "codex_start_enabled_user_service"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.install" "codex_start_enabled_user_service"
+    assert_contains "$REPO_DIR/packaging/linux/codex-desktop.spec" "codex_start_enabled_user_service"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" 'NODEJS_MAJOR="${NODEJS_MAJOR:-22}"'
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "apt_nodejs_candidate_major"
     assert_contains "$REPO_DIR/scripts/install-deps.sh" "Installing distro Node.js/npm candidate"
@@ -3606,7 +3673,7 @@ test_side_by_side_launcher_identity() {
     assert_contains "$app_dir/start.sh" 'LOG_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/$CODEX_LINUX_APP_ID"'
     XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" bash "$app_dir/start.sh" --help >"$help_log"
     assert_contains "$help_log" "Launches the Codex CUA Lab app."
-    assert_contains "$help_log" "codex-cua-lab/launcher.log"
+    assert_contains "$help_log" "codex-cua-lab/launcher"
 
     ln -s "$app_dir/start.sh" "$bin_dir/codex-cua-lab"
     XDG_CACHE_HOME="$workspace/cache" XDG_STATE_HOME="$workspace/state" XDG_RUNTIME_DIR="$workspace/runtime" bash "$bin_dir/codex-cua-lab" --help >"$symlink_help_log"
@@ -6255,6 +6322,7 @@ main() {
     test_deb_builder_respects_package_identity
     test_deb_builder_without_updater
     test_no_updater_cleanup_helper_removes_inactive_user_enablement
+    test_update_manager_service_helper_respects_disabled_service
     test_rpm_builder_smoke
     test_pacman_builder_without_updater_transition_hook
     test_appimage_builder_smoke


### PR DESCRIPTION
## Summary
- keep app launch from re-enabling `codex-update-manager.service` after a user disables it
- add a start-only-if-enabled helper for package upgrade/runtime paths while preserving fresh-install enablement
- document the supported temporary auto-update pause workflow

Fixes #568

## Tests
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh packaging/linux/codex-packaged-runtime.sh packaging/linux/codex-update-manager-user-service.sh packaging/linux/codex-update-manager.postinst packaging/linux/codex-desktop.install`
- `bash tests/scripts_smoke.sh`