### PR TITLE
[codex] Use versioned DMG URL in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,12 +79,12 @@
           cp ${./scripts/lib/native-modules.sh} "$out/scripts/lib/native-modules.sh"
         '';
 
+        codexVersion = "26.623.31921";
         codexDmg = pkgs.fetchurl {
-          url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
+          url = "https://persistent.oaistatic.com/codex-app-prod/Codex-${codexVersion}-arm64.dmg";
           hash = "sha256-/tf+iJCNU/85Voi8PikcZPapQAXt3zP2NdfiLXznpu0=";
         };
 
-        codexVersion = "26.623.31921";
         electronVersion = "42.1.0";
         electronPlatform =
           {


### PR DESCRIPTION
Refs #573.

## Summary
- switch the flake's `codexDmg` fetch URL from the floating `Codex.dmg` path to the versioned DMG path derived from `codexVersion`
- keep the existing hash and package behavior unchanged

## Validation
- `git diff --check`
- `python3` assertion that `flake.nix` now wires the DMG URL to `${codexVersion}`
- `curl -I -sSfL https://persistent.oaistatic.com/codex-app-prod/Codex-26.623.31921-arm64.dmg`

## Notes
- `nix` is not installed in the local automation environment, so this was validated as a narrow pinning change rather than with a full flake evaluation.
