### PR TITLE
fix: sync restored persistent status panel layout state

### DIFF
--- a/linux-features/persistent-status-panel/patch.js
+++ b/linux-features/persistent-status-panel/patch.js
@@ -46,7 +46,7 @@ function applyPersistentStatusPanelPatch(source) {
     return source;
   }
 
-  const [stateNeedle, onOpenChange, _intl, _isOpen, setIsOpen] = match;
+  const [stateNeedle, onOpenChange, _intl, isOpen, setIsOpen, reactVar] = match;
   const openNeedle = `async()=>{${setIsOpen}(!0),${onOpenChange}?.(!0)}`;
   const closeNeedle = `()=>{${setIsOpen}(!1),${onOpenChange}?.(!1)}`;
   if (
@@ -64,10 +64,18 @@ function applyPersistentStatusPanelPatch(source) {
   const openPatch = `async()=>{try{localStorage.setItem(\`${STORAGE_KEY}\`,\`1\`)}catch{}${setIsOpen}(!0),${onOpenChange}?.(!0)}`;
   const closePatch = `()=>{try{localStorage.removeItem(\`${STORAGE_KEY}\`)}catch{}${setIsOpen}(!1),${onOpenChange}?.(!1)}`;
 
-  return source
+  let patchedSource = source
     .replace(stateNeedle, statePatch)
     .replace(openNeedle, openPatch)
     .replace(closeNeedle, closePatch);
+  const stateIndex = patchedSource.indexOf(statePatch);
+  const declarationEndIndex = stateIndex === -1 ? -1 : patchedSource.indexOf(";", stateIndex + statePatch.length);
+  if (declarationEndIndex === -1) {
+    console.warn("WARN: Could not find Codex status panel state declaration end - skipping persistent status panel patch");
+    return source;
+  }
+  const restoreEffect = `(0,${reactVar}.useEffect)(()=>{${isOpen}&&${onOpenChange}?.(!0)},[${isOpen},${onOpenChange}]);`;
+  return `${patchedSource.slice(0, declarationEndIndex + 1)}${restoreEffect}${patchedSource.slice(declarationEndIndex + 1)}`;
 }
 
 const patches = [

--- a/linux-features/persistent-status-panel/test.js
+++ b/linux-features/persistent-status-panel/test.js
@@ -76,6 +76,16 @@ test("status panel preference survives component remounts", () => {
   assert.equal(applyPersistentStatusPanelPatch(patched), patched);
 });
 
+test("restored status panel state notifies composer layout", () => {
+  const patched = applyPersistentStatusPanelPatch(composerSource);
+
+  assert.match(patched, /\(0,Z\.useEffect\)\(\(\)=>\{c&&o\?\.\(!0\)\},\[c,o\]\);/);
+  assert.match(
+    patched,
+    /\(0,Z\.useState\)\(\(\)=>\{try\{return localStorage\.getItem\(`codex-linux-persistent-status-panel-open`\)===`1`\}catch\{return!1\}\}\),p;\(0,Z\.useEffect\)/,
+  );
+});
+
 test("ambiguous status panel handler needles are unchanged", () => {
   const ambiguousSource = composerSource.replace(
     "let y=s.formatMessage",


### PR DESCRIPTION
## Summary

Fixes a lifecycle edge case in the optional `persistent-status-panel` Linux feature.

With the current upstream composer lifecycle, restoring the status panel's local open state from `localStorage` is not enough to keep the parent composer layout marked as open. After switching threads, the status panel component can restore itself as open, while the parent layout state still treats the panel as closed, causing the panel to disappear.

This change adds a small restore-time effect after the patched status state declaration:

- restore `isOpen` from `localStorage` as before
- call `onOpenChange(true)` when the restored state is open
- keep the existing open / close handlers responsible for updating `localStorage`
- preserve fail-soft behavior if the upstream bundle shape drifts

## Validation

- `node --test linux-features/persistent-status-panel/test.js`
- rebuilt the Linux app with `persistent-status-panel` enabled
- rebuilt and installed local `.deb`
- verified the installed `/opt/codex-desktop` bundle contains the layout-sync patch
- manually verified on Ubuntu 22.04 / GNOME X11 using the `.deb` install path:
  - open `/status`
  - switch thread
  - status panel remains open
