### PR TITLE
Fix Fedora dependency bootstrap missing g++

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ If you are installing dependencies manually on Fedora:
 
 ```bash
 # Fedora 41+
-sudo dnf install python3 7zip curl unzip rpm-build @development-tools
+sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools
 
 # Fedora < 41
-sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build
+sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++
 sudo dnf groupinstall 'Development Tools'
 ```
 

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -26,10 +26,10 @@ packages, and bootstraps Rust through `rustup` when needed.
 
 ```bash
 # Fedora 41+
-sudo dnf install python3 7zip curl unzip rpm-build @development-tools
+sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools
 
 # Fedora < 41
-sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build
+sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++
 sudo dnf groupinstall 'Development Tools'
 
 # openSUSE

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -296,9 +296,11 @@ install_apt() {
 
 install_dnf5() {
     info "Detected RPM-based distro (dnf5)"
-    # dnf5: 7zip provides /usr/bin/7z; @development-tools is the group syntax
+    # dnf5: 7zip provides /usr/bin/7z; @development-tools is the group syntax.
+    # Install make and gcc-c++ explicitly because the group may already be marked
+    # installed without providing the g++ executable required by install.sh.
     sudo dnf install -y \
-        python3 7zip curl unzip rpm-build \
+        python3 7zip curl unzip rpm-build make gcc-c++ \
         @development-tools
 }
 
@@ -307,7 +309,7 @@ install_dnf() {
     # Older dnf: 7z comes from p7zip + p7zip-plugins
     sudo dnf install -y \
         nodejs npm python3 \
-        p7zip p7zip-plugins curl unzip rpm-build
+        p7zip p7zip-plugins curl unzip rpm-build make gcc-c++
     sudo dnf groupinstall -y 'Development Tools'
 }
 
@@ -490,8 +492,8 @@ case "$DISTRO" in
         error "Unsupported package manager. Install manually:
   # Debian/Ubuntu: install Node.js 20+ with npm/npx from NodeSource, nvm, or another compatible source, then:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install python3 7zip curl unzip rpm-build @development-tools             # Fedora 41+ (dnf5)
-  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build      # Fedora <41 (dnf)
+  sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools             # Fedora 41+ (dnf5)
+  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S nodejs npm python p7zip curl unzip zstd base-devel                 # Arch
   sudo zypper install nodejs-default npm-default python3 p7zip-full curl unzip      # openSUSE

--- a/scripts/lib/install-helpers.sh
+++ b/scripts/lib/install-helpers.sh
@@ -20,8 +20,8 @@ Run the helper to install them automatically:
 
 Or install manually:
   sudo apt install python3 p7zip-full curl unzip build-essential                   # Debian/Ubuntu
-  sudo dnf install python3 7zip curl unzip rpm-build @development-tools             # Fedora 41+ (dnf5)
-  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build      # Fedora <41 (dnf)
+  sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools             # Fedora 41+ (dnf5)
+  sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++      # Fedora <41 (dnf)
     && sudo dnf groupinstall 'Development Tools'
   sudo pacman -S python p7zip curl unzip zstd base-devel                            # Arch
   sudo zypper install python3 p7zip-full curl unzip                                 # openSUSE

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1672,7 +1672,7 @@ test_native_shortcut_targets_compose_existing_flows() {
 }
 
 test_fedora_dependency_bootstrap_installs_rpmbuild() {
-    info "Checking Fedora dependency bootstrap includes rpmbuild"
+    info "Checking Fedora dependency bootstrap includes rpmbuild and C++ build tools"
     local install_deps="$REPO_DIR/scripts/install-deps.sh"
     local helper="$REPO_DIR/scripts/lib/install-helpers.sh"
     local readme="$REPO_DIR/README.md"
@@ -1681,13 +1681,17 @@ test_fedora_dependency_bootstrap_installs_rpmbuild() {
         || fail "install_dnf5 must install rpm-build for rpmbuild"
     awk '/^install_dnf\(\) \{/,/^}/' "$install_deps" | grep -q -- "rpm-build" \
         || fail "install_dnf must install rpm-build for rpmbuild"
+    awk '/^install_dnf5\(\) \{/,/^}/' "$install_deps" | grep -q -- "gcc-c++" \
+        || fail "install_dnf5 must install gcc-c++ for g++"
+    awk '/^install_dnf\(\) \{/,/^}/' "$install_deps" | grep -q -- "gcc-c++" \
+        || fail "install_dnf must install gcc-c++ for g++"
 
-    assert_contains "$install_deps" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
-    assert_contains "$install_deps" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build"
-    assert_contains "$helper" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
-    assert_contains "$helper" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build"
-    assert_contains "$readme" "sudo dnf install python3 7zip curl unzip rpm-build @development-tools"
-    assert_contains "$readme" "sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build"
+    assert_contains "$install_deps" "sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools"
+    assert_contains "$install_deps" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++"
+    assert_contains "$helper" "sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools"
+    assert_contains "$helper" "sudo dnf install nodejs npm python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++"
+    assert_contains "$readme" "sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools"
+    assert_contains "$readme" "sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++"
 }
 
 test_setup_native_wizard_noninteractive_feature_writer() {


### PR DESCRIPTION
## Summary
- Install make and gcc-c++ explicitly in Fedora dependency bootstrap paths.
- Update Fedora manual dependency docs and installer guidance.
- Extend smoke coverage to assert Fedora bootstrap includes the C++ compiler package.

## Why
On vanilla Fedora 44 KDE, scripts/install-deps.sh reported success with @development-tools installed, but install.sh still failed because g++ was unavailable. Installing gcc-c++ explicitly makes the bootstrap match the installer preflight.

## Validation
- bash -n install.sh
- bash -n scripts/lib/*.sh
- bash -n launcher/start.sh.template
- bash -n scripts/build-deb.sh
- bash -n scripts/build-rpm.sh
- bash -n scripts/build-pacman.sh
- bash -n scripts/build-appimage.sh
- bash tests/scripts_smoke.sh