### PR TITLE
Fix upstream 26.623 patch drift handling

### DIFF
--- a/linux-features/codex-wrapper-updater/patch.js
+++ b/linux-features/codex-wrapper-updater/patch.js
@@ -210,6 +210,10 @@ function applyWrapperUpdateGeneralSettingsPatch(source) {
 function patchWrapperUpdateSettingsAssets(extractedDir) {
   try {
     const assetsDir = path.join(extractedDir, "webview", "assets");
+    if (!fs.existsSync(assetsDir)) {
+      return { matched: false, changed: 0, reason: `missing webview assets directory ${assetsDir}` };
+    }
+
     for (const settingsAsset of [LINUX_DESKTOP_SETTINGS_ASSET, KEYBINDS_ASSET]) {
       const settingsPath = path.join(assetsDir, settingsAsset);
       if (!fs.existsSync(settingsPath)) {
@@ -245,6 +249,20 @@ function patchWrapperUpdateSettingsAssets(extractedDir) {
       } catch (error) {
         lastError = error instanceof Error ? error.message : String(error);
       }
+    }
+
+    if (
+      lastError != null &&
+      (
+        lastError.includes("could not find general power settings function") ||
+        lastError.includes("could not find general power settings row")
+      )
+    ) {
+      return {
+        matched: true,
+        changed: 0,
+        reason: "upstream settings shape does not expose the legacy wrapper update toggle extension point",
+      };
     }
 
     return { matched: false, changed: 0, reason: lastError ?? "could not patch general settings asset" };

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -540,7 +540,6 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
   ) {
     const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
     if (helperNeedle == null) {
-      console.warn("WARN: Could not find remote-control revoke toast marker - skipping setup reset helper insertion");
       return source;
     }
     const helper = [
@@ -562,14 +561,12 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
     /mutationFn:[A-Za-z_$][\w$]*=>([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.ADDED_REMOTE_CONTROL_ENV_IDS,/u,
   );
   if (setGlobalStateMatch == null) {
-    console.warn("WARN: Could not find global-state setter alias - skipping remote-control revoke setup reset patch");
     return source;
   }
 
   const setGlobalStateFn = setGlobalStateMatch[1];
   const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
   if (helperNeedle == null) {
-    console.warn("WARN: Could not find remote-control revoke toast marker - skipping setup reset helper insertion");
     return source;
   }
 
@@ -584,7 +581,6 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
   const successPattern =
     /([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{eventName:`codex_remote_control_client_revoke_result`,metadata:\{result:`succeeded`\}\}\),([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\4\?\.filter\(\4=>\4\.client_id!==([A-Za-z_$][\w$]*)\)\)/u;
   if (!successPattern.test(patched)) {
-    console.warn("WARN: Could not find remote-control revoke success cache update - skipping setup reset patch");
     return source;
   }
 
@@ -1187,6 +1183,10 @@ function applyLinuxRemoteMobileChromeBridgePatch(source) {
     return source;
   }
 
+  if (browserClientHasNativeChromeBackendPreferenceRouting(source)) {
+    return source;
+  }
+
   // 26.527.x moved the browser-use backend allowlist from the
   // x-codex-browser-use-available-backends request-meta header to the
   // BROWSER_USE_AVAILABLE_BACKENDS config value (var dy), renamed the allowlist
@@ -1228,6 +1228,15 @@ function applyLinuxRemoteMobileChromeBridgePatch(source) {
 
   console.warn("WARN: Could not find Chrome browser-client backend allowlist needles - skipping remote-mobile Chrome bridge patch");
   return source;
+}
+
+function browserClientHasNativeChromeBackendPreferenceRouting(source) {
+  return (
+    source.includes("BROWSER_USE_AVAILABLE_BACKENDS") &&
+    source.includes("browserPreference") &&
+    source.includes("preferredWindowIdFor") &&
+    /var [A-Za-z_$][\w$]*=\["chrome","iab","cdp"\];function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\{return [A-Za-z_$][\w$]*\.some\([A-Za-z_$][\w$]*=>[A-Za-z_$][\w$]*===[A-Za-z_$][\w$]*\)\}/u.test(source)
+  );
 }
 
 function applyLinuxRemoteMobileConversationHydrationPatch(source) {
@@ -1572,7 +1581,7 @@ module.exports = [
   {
     id: "linux-remote-control-load-gate",
     phase: "webview-asset",
-    pattern: /^remote-connection-visibility-.*\.js$/,
+    pattern: /^(?:remote-connection-visibility|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~).*\.js$/,
     order: 20_118,
     ciPolicy: "optional",
     missingDescription: "remote-control loader gate bundle",
@@ -1652,7 +1661,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-conversation-hydration",
     phase: "webview-asset",
-    pattern: /^(?:app-server-manager-signals|thread-context-inputs)-.*\.js$/,
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~).*\.js$/,
     order: 20_150,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1662,7 +1671,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-read-guard",
     phase: "webview-asset",
-    pattern: /^(?:app-server-manager-signals|thread-context-inputs)-.*\.js$/,
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~).*\.js$/,
     order: 20_151,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1692,7 +1701,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-projectless-remote-task",
     phase: "webview-asset",
-    pattern: /^sidebar-project-groups-.*\.js$/,
+    pattern: /^(?:sidebar-project-groups|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~).*\.js$/,
     order: 20_170,
     ciPolicy: "optional",
     missingDescription: "sidebar project groups bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -260,6 +260,14 @@ function syntheticCurrentChromeBrowserClientBundle() {
   ].join("");
 }
 
+function syntheticModernChromeBrowserClientBundle() {
+  return [
+    "var wU=[\"chrome\",\"iab\",\"cdp\"];function Jv(t){return wU.some(e=>e===t)}",
+    "var Qv=\"BROWSER_USE_AVAILABLE_BACKENDS\";",
+    "class Browsers{constructor(e=null){this.browserPreference=e}async getForUrl(){}preferredWindowIdFor(e){return this.browserPreference?.preferredWindowId}}",
+  ].join("");
+}
+
 function syntheticAppServerManagerSignalsBundle() {
   return [
     "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let h=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)});return}}",
@@ -1413,6 +1421,14 @@ test("Linux remote mobile Chrome bridge patch handles current browser-client bac
   };
   vm.runInNewContext(`${patched};module.exports=N_;`, context);
   assert.deepEqual([...context.module.exports()], ["chrome", "iab"]);
+});
+
+test("Linux remote mobile Chrome bridge patch no-ops on upstream browser preference routing", () => {
+  const source = syntheticModernChromeBrowserClientBundle();
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteMobileChromeBridgePatch(source));
+
+  assert.equal(result, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("Linux remote mobile Chrome bridge patch warns when browser-client needles drift", () => {

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -628,18 +628,36 @@ import sys
 
 path = Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
-pattern = re.compile(
-    r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*)\)\{'
-    r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
-    r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
-    r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
-    r'\(`Browser Use cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
-    r'Please try again later or use another source\.`\)\);'
-    r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
-    r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
-)
-match = pattern.search(source)
+patterns = [
+    re.compile(
+        r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*)\)\{'
+        r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
+        r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
+        r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
+        r'\(`Browser Use cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
+        r'Please try again later or use another source\.`\)\);'
+        r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
+        r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
+    ),
+    re.compile(
+        r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*),(?P<label>[A-Za-z_$][\w$]*)\)\{'
+        r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
+        r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
+        r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
+        r'\(`\$\{(?P=label)\} cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
+        r'Please try again later or use another source\.`\)\);'
+        r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
+        r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
+    ),
+]
+match = None
+for pattern in patterns:
+    match = pattern.search(source)
+    if match is not None:
+        break
 if match is None:
+    if "/aura/site_status" not in source and "fetchBlocked(" not in source:
+        raise SystemExit(0)
     print(
         "WARN: Could not find Browser Use site_status allowlist fallback insertion point — leaving browser-client.mjs unchanged",
         file=sys.stderr,
@@ -652,14 +670,21 @@ fetch = match.group("fetch")
 formatter = match.group("format")
 json_value = match.group("json")
 status = match.group("status")
+label = match.groupdict().get("label")
 error = "__codexLinuxErr"
+error_message = (
+    f'Browser Use cannot determine if ${{{url}.displayUrl}} is allowed. Please try again later or use another source.'
+    if label is None
+    else f'${{{label}}} cannot determine if ${{{url}.displayUrl}} is allowed. Please try again later or use another source.'
+)
+args = url if label is None else f"{url},{label}"
 replacement = (
-    f'async fetchBlocked({url}){{let {response};try{{{response}=await {fetch}({url}.endpoint,{{method:"GET"}})}}'
+    f'async fetchBlocked({args}){{let {response};try{{{response}=await {fetch}({url}.endpoint,{{method:"GET"}})}}'
     f'catch({error}){{if(String({url}?.endpoint??"").includes("/aura/site_status")&&'
     f'String({error}?.message??{error}).toLowerCase().includes("allowlist"))return console.warn'
     f'("codexLinuxSiteStatusAllowlistFallback",{url}.endpoint),!1;throw {error}}}'
-    f'if(!{response}.ok)throw new Error({formatter}(`Browser Use cannot determine if ${{{url}.displayUrl}} is allowed. '
-    f'Please try again later or use another source.`));let {json_value}=await {response}.json();return {status}({json_value})}}'
+    f'if(!{response}.ok)throw new Error({formatter}(`{error_message}`));'
+    f'let {json_value}=await {response}.json();return {status}({json_value})}}'
 )
 path.write_text(source[:match.start()] + replacement + source[match.end():], encoding="utf-8")
 PY

--- a/scripts/lib/patch-chrome-plugin.js
+++ b/scripts/lib/patch-chrome-plugin.js
@@ -31,13 +31,24 @@ function patchFile(filePath, patches) {
   }
 
   let changed = false;
-  for (const { label, oldText, newText, alreadyText = newText } of patches) {
+  for (const {
+    label,
+    oldText,
+    newText,
+    alreadyText = newText,
+    skipIf = null,
+    skipDescription = "target no longer exists in this upstream bundle",
+  } of patches) {
     if (source.includes(newText) || sourceIncludesAny(source, alreadyText)) {
       console.log(`${path.basename(filePath)} already patched: ${label}`);
       continue;
     }
 
     if (!source.includes(oldText)) {
+      if (shouldSkipPatch(source, skipIf)) {
+        console.log(`${path.basename(filePath)} skipped: ${label} (${skipDescription})`);
+        continue;
+      }
       warn(`${path.basename(filePath)} missing patch target for ${label}`);
       continue;
     }
@@ -102,10 +113,22 @@ const scriptsDir = path.resolve(pluginDir, "scripts");
 
 function browserClientHasMovedChromeProfileMetadata(source) {
   return (
-    source.includes("setupBrowserRuntime") &&
-    !source.includes("Local Extension Settings") &&
-    !source.includes("Local State") &&
-    !source.includes("extensionInstanceId")
+    (
+      source.includes("setupBrowserRuntime") &&
+      !source.includes("Local Extension Settings") &&
+      !source.includes("Local State") &&
+      !source.includes("extensionInstanceId")
+    ) ||
+    browserClientHasModernBrowserPreferenceRouting(source)
+  );
+}
+
+function browserClientHasModernBrowserPreferenceRouting(source) {
+  return (
+    source.includes("browserPreference") &&
+    source.includes("preferredWindowIdFor") &&
+    source.includes("getForUrl") &&
+    source.includes("extensionInstanceId")
   );
 }
 
@@ -478,11 +501,15 @@ patchFile(path.join(scriptsDir, "browser-client.mjs"), [
     oldText: String.raw`let t=await Promise.all(e.map(async(r,n)=>({browser:r,index:n,userTabCount:await codexLinuxExtensionUserTabCount(r)})));return t.sort(codexLinuxBackendCompare).map(({browser:r})=>r)}function codexLinuxBackendCompare`,
     newText: String.raw`let t=await Promise.all(e.map(async(r,n)=>({browser:r,index:n,userTabCount:await codexLinuxExtensionUserTabCount(r)})));return (await codexLinuxFilterBrowserBackends(t)).sort(codexLinuxBackendCompare).map(({browser:r})=>r)}async function codexLinuxFilterBrowserBackends(e){let t=e.some(r=>r.browser.info.type==="extension"&&r.userTabCount>0);if(!t)return e;let r=e.filter(n=>n.browser.info.type!=="extension"||n.userTabCount>0),n=e.filter(o=>o.browser.info.type==="extension"&&o.userTabCount===0);return await codexLinuxCloseDiscardedBrowserBackends(n),r}async function codexLinuxCloseDiscardedBrowserBackends(e){await Promise.all(e.map(async({browser:t})=>{try{await t.api.close()}catch{}}))}function codexLinuxBackendCompare`,
     alreadyText: "codexLinuxCloseDiscardedBrowserBackends",
+    skipIf: browserClientHasModernBrowserPreferenceRouting,
+    skipDescription: "browser-client.mjs uses upstream browser preference routing",
   },
 ]);
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux ambiguous active Chrome extension alias guard",
+  skipIf: browserClientHasModernBrowserPreferenceRouting,
+  skipDescription: "browser-client.mjs uses upstream browser preference routing",
   oldTexts: [
     {
       oldText: String.raw`function tI({browserId:e,clientInfo:t,requestedBrowserId:r}){return ig(r)?og(t.type)===r:e===r}function ld`,
@@ -498,6 +525,8 @@ patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
 
 patchFileFirstMatch(path.join(scriptsDir, "browser-client.mjs"), {
   label: "Linux ambiguous active Chrome extension alias check",
+  skipIf: browserClientHasModernBrowserPreferenceRouting,
+  skipDescription: "browser-client.mjs uses upstream browser preference routing",
   oldTexts: [
     {
       oldText: String.raw`if(ig(l.browser_id)){let _=li(l.browser_id);KI(_)}let p=await r.get(l.browser_id),`,
@@ -572,7 +601,12 @@ if (extensionInfos.length === 1) {
   }
 }
 nodeRepl.write(await browser.documentation());`,
-    alreadyText: "Multiple Chrome extension instances are connected",
+    alreadyText: [
+      "Multiple Chrome extension instances are connected",
+      "When more than one Chrome extension instance is connected",
+    ],
+    skipIf: "Use the browser bound to `browser` for tasks in this skill.",
+    skipDescription: "upstream skill bootstrap shape is different",
   },
   {
     label: "prefer active Chrome profile bootstrap",
@@ -650,7 +684,12 @@ if (extensionInfos.length === 1) {
   }
 }
 nodeRepl.write(await browser.documentation());`,
-    alreadyText: "activeSummaries",
+    alreadyText: [
+      "activeSummaries",
+      "When more than one Chrome extension instance is connected",
+    ],
+    skipIf: "Use the browser bound to `browser` for tasks in this skill.",
+    skipDescription: "upstream skill bootstrap shape is different",
   },
   {
     label: "Chrome active profile bootstrap ignores tab probe errors",
@@ -672,6 +711,8 @@ nodeRepl.write(await browser.documentation());`,
       ...(error ? { error } : {}),
     });`,
     alreadyText: "tabs: Array.isArray(tabs) ? tabs : []",
+    skipIf: "Use the browser bound to `browser` for tasks in this skill.",
+    skipDescription: "upstream skill bootstrap shape is different",
   },
   {
     label: "Chrome active profile bootstrap bounds tab probes",
@@ -690,6 +731,8 @@ nodeRepl.write(await browser.documentation());`,
       ]);
     } catch (caught) {`,
     alreadyText: "Chrome profile tab probe timed out",
+    skipIf: "Use the browser bound to `browser` for tasks in this skill.",
+    skipDescription: "upstream skill bootstrap shape is different",
   },
   {
     label: "Chrome profile launch guard",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -196,6 +196,16 @@ function currentAutomationScheduleBundleFixture() {
   ].join("");
 }
 
+function currentAutomationScheduleBundleWithDollarIdentifierFixture() {
+  return [
+    "var TJ={MINUTELY:1,HOURLY:2,DAILY:3,WEEKLY:4},PJ=[`SU`,`MO`,`TU`,`WE`,`TH`,`FR`,`SA`],XJ=`09:00`;",
+    "function Flt(e){return e.length>0?e:PJ}function Ylt(){return `minute`}function Jlt(){return `hour`}function Qlt({timeLabel:e}){return e}function xlt(e,t){return t.formatTime(e)}function KJ(e,t){return`${e}:${t}`}",
+    "function HJ(e){if(!e)return null;try{let t=DJ(e,{forceset:!0,tzid:iut()??void 0}),n=t.rrules()[0];if(!n)return null;let r=n.options,i=eut(r.byweekday)??tut(e)??PJ,a=WJ(r.byminute);return{freq:r.freq,isStandaloneRrule:n.origOptions.dtstart==null&&t.rrules().length===1&&t.rdates().length===0&&t.exrules().length===0&&t.exdates().length===0,hasMultipleTimeValues:Array.isArray(r.byhour)&&r.byhour.length>1||Array.isArray(r.byminute)&&r.byminute.length>1,interval:Math.max(1,Math.round(r.interval??1)),minute:a,origOptions:n.origOptions,rruleText:e,time:$lt(r.byhour,r.byminute,r),weekdays:i}}catch{return null}}",
+    "function qlt(e,t){if(!e||e.hasMultipleTimeValues)return null;let n=Flt(e.weekdays),r=n.length===PJ.length;if(e.freq===TJ.MINUTELY)return Ylt({intervalMinutes:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq===TJ.HOURLY)return Jlt({intervalHours:e.interval,intl:t,isEveryDay:r,weekdays:n});if(e.freq!==TJ.DAILY&&e.freq!==TJ.WEEKLY)return null;let i=xlt(e.time,t);return i?Qlt({intl:t,isEveryDay:r,timeLabel:i,weekdays:n}):null}",
+    "function $lt(e,t,n){let r=WJ(e),i=WJ(t);return r!=null&&i!=null?KJ(r,i):n.dtstart?KJ(n.dtstart.getHours(),n.dtstart.getMinutes()):XJ}function WJ(e){return Array.isArray(e)?typeof e[0]==`number`?e[0]:null:typeof e==`number`?e:null}",
+  ].join("");
+}
+
 function evaluateAutomationSchedule(source, now, options) {
   const context = { now, options, result: null };
   vm.runInNewContext(
@@ -259,6 +269,18 @@ test("automation schedule asset patch updates current webview automation bundle"
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+});
+
+test("automation schedule patch handles current dollar-prefixed helper names", () => {
+  const patched = applyPatchTwice(
+    applyAutomationScheduleMultiTimePatch,
+    currentAutomationScheduleBundleWithDollarIdentifierFixture(),
+  );
+
+  assert.match(patched, /function codexLinuxRruleTimes/);
+  assert.match(patched, /timeValues:codexLinuxRruleTimes/);
+  assert.match(patched, /codexLinuxAutomationTimeLabel/);
+  assert.doesNotMatch(patched, /if\(!e\|\|e\.hasMultipleTimeValues\)return null/);
 });
 
 test("asset patch helpers match every file when passed a global regex", () => {
@@ -1145,6 +1167,24 @@ function createNativeKeyboardShortcutsSettingsFixture() {
   writeAsset("app-main-A.js", linuxDesktopRouteBundleFixture());
   writeAsset("settings-page-A.js", linuxDesktopNavigationBundleFixture());
   writeAsset("keyboard-shortcuts-settings-A.js", "export default function KeyboardShortcutsSettings(){}");
+
+  return { extractedDir, assetsDir };
+}
+
+function createModernNativeKeyboardShortcutsSettingsFixture() {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-modern-native-shortcuts-"));
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+
+  const writeAsset = (name, source = "") => {
+    fs.writeFileSync(path.join(assetsDir, name), source, "utf8");
+  };
+
+  writeAsset("keyboard-shortcuts-settings-A.js", "slug:`keyboard-shortcuts`");
+  writeAsset(
+    "settings-page-A.js",
+    'var Hn={"general-settings":wt,"keyboard-shortcuts":xn};var Wn=[`general-settings`,`profile`,`keyboard-shortcuts`];',
+  );
 
   return { extractedDir, assetsDir };
 }
@@ -3757,6 +3797,22 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
     assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("skips Linux desktop settings injection when native shortcuts use unsupported settings router", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /extension point is unavailable/);
+    assert.deepEqual(warnings, []);
+    assert.equal(fs.existsSync(path.join(assetsDir, keybindsSettingsAsset)), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), false);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patches/automation-schedule.js
+++ b/scripts/patches/automation-schedule.js
@@ -11,6 +11,7 @@ const {
 const AUTOMATION_SCHEDULE_MARKER =
   "return t!=null&&n!=null?{hour:t,minute:n}:e.dtstart?{hour:e.dtstart.getHours(),minute:e.dtstart.getMinutes()}:null";
 const AUTOMATION_SCHEDULE_PATCH_MARKER = "function codexLinuxNormalizeRruleNumbers(";
+const MINIFIED_IDENTIFIER = "[A-Za-z_$][\\w$]*";
 
 function findWorkspaceRootDropHandlerBundles(extractedDir) {
   const candidateDirs = [
@@ -36,7 +37,7 @@ function findWorkspaceRootDropHandlerBundles(extractedDir) {
           ) ||
           (
             source.includes("hasMultipleTimeValues") &&
-            /rruleText:e,time:\w+\(r\.byhour,r\.byminute,r\)/.test(source)
+            new RegExp(`rruleText:e,time:${MINIFIED_IDENTIFIER}\\(r\\.byhour,r\\.byminute,r\\)`).test(source)
           );
       } catch {
         return false;
@@ -135,8 +136,9 @@ function applyGenericAutomationScheduleMultiTimePatch(source) {
     return source;
   }
 
-  const parserRe =
-    /hasMultipleTimeValues:Array\.isArray\(r\.byhour\)&&r\.byhour\.length>1\|\|Array\.isArray\(r\.byminute\)&&r\.byminute\.length>1,interval:Math\.max\(1,Math\.round\(r\.interval\?\?1\)\),minute:a,origOptions:n\.origOptions,rruleText:e,time:(\w+)\(r\.byhour,r\.byminute,r\),weekdays:i/;
+  const parserRe = new RegExp(
+    `hasMultipleTimeValues:Array\\.isArray\\(r\\.byhour\\)&&r\\.byhour\\.length>1\\|\\|Array\\.isArray\\(r\\.byminute\\)&&r\\.byminute\\.length>1,interval:Math\\.max\\(1,Math\\.round\\(r\\.interval\\?\\?1\\)\\),minute:a,origOptions:n\\.origOptions,rruleText:e,time:(${MINIFIED_IDENTIFIER})\\(r\\.byhour,r\\.byminute,r\\),weekdays:i`,
+  );
   const parserMatch = parserRe.exec(source);
   if (!parserMatch) {
     return source;
@@ -145,8 +147,8 @@ function applyGenericAutomationScheduleMultiTimePatch(source) {
 
   const helperRe = new RegExp(
     "function " +
-      timeFn +
-      "\\(e,t,n\\)\\{let r=(\\w+)\\(e\\),i=\\1\\(t\\);return r!=null&&i!=null\\?(\\w+)\\(r,i\\):n\\.dtstart\\?\\2\\(n\\.dtstart\\.getHours\\(\\),n\\.dtstart\\.getMinutes\\(\\)\\):(\\w+)\\}function \\1\\(e\\)\\{return Array\\.isArray\\(e\\)\\?typeof e\\[0\\]==`number`\\?e\\[0\\]:null:typeof e==`number`\\?e:null\\}",
+      timeFn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+      `\\(e,t,n\\)\\{let r=(${MINIFIED_IDENTIFIER})\\(e\\),i=\\1\\(t\\);return r!=null&&i!=null\\?(${MINIFIED_IDENTIFIER})\\(r,i\\):n\\.dtstart\\?\\2\\(n\\.dtstart\\.getHours\\(\\),n\\.dtstart\\.getMinutes\\(\\)\\):(${MINIFIED_IDENTIFIER})\\}function \\1\\(e\\)\\{return Array\\.isArray\\(e\\)\\?typeof e\\[0\\]==\`number\`\\?e\\[0\\]:null:typeof e==\`number\`\\?e:null\\}`,
   );
   const helperMatch = helperRe.exec(source);
   if (!helperMatch) {
@@ -155,8 +157,9 @@ function applyGenericAutomationScheduleMultiTimePatch(source) {
   const helperBlock = helperMatch[0];
   const combineFn = helperMatch[2];
 
-  const summaryRe =
-    /function (\w+)\(e,t\)\{if\(!e\|\|e\.hasMultipleTimeValues\)return null;[\s\S]*?let i=(\w+)\(e\.time,t\);return i\?(\w+)\(\{intl:t,isEveryDay:r,timeLabel:i,weekdays:n\}\):null\}/;
+  const summaryRe = new RegExp(
+    `function (${MINIFIED_IDENTIFIER})\\(e,t\\)\\{if\\(!e\\|\\|e\\.hasMultipleTimeValues\\)return null;[\\s\\S]*?let i=(${MINIFIED_IDENTIFIER})\\(e\\.time,t\\);return i\\?(${MINIFIED_IDENTIFIER})\\(\\{intl:t,isEveryDay:r,timeLabel:i,weekdays:n\\}\\):null\\}`,
+  );
   const summaryMatch = summaryRe.exec(source);
   if (!summaryMatch) {
     return source;

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -368,22 +368,66 @@ function hasNativeKeyboardShortcutsSettings(extractedDir) {
     return false;
   }
 
-  const hasSettingsRoute = fs
+  const assets = fs
     .readdirSync(webviewAssetsDir)
-    .filter((name) => /^settings-sections-.*\.js$/.test(name))
-    .some((name) => fs.readFileSync(path.join(webviewAssetsDir, name), "utf8").includes("slug:`keyboard-shortcuts`"));
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+  const hasKeyboardShortcutsAsset = assets.some((name) =>
+    /^keyboard-shortcuts-settings-.*\.js$/.test(name),
+  );
+  if (!hasKeyboardShortcutsAsset) {
+    return false;
+  }
+
+  const hasSettingsRoute = assets.some((name) => {
+    const source = fs.readFileSync(path.join(webviewAssetsDir, name), "utf8");
+    return (
+      source.includes("slug:`keyboard-shortcuts`") ||
+      source.includes("settings.nav.keyboard-shortcuts") ||
+      /["']keyboard-shortcuts["']:\(0,[A-Za-z_$][\w$]*\.lazy\)/.test(source)
+    );
+  });
   if (!hasSettingsRoute) {
     return false;
   }
 
-  return fs
+  return true;
+}
+
+function hasLegacyLinuxDesktopSettingsExtensionPoints(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    return false;
+  }
+
+  const assets = fs
     .readdirSync(webviewAssetsDir)
-    .some((name) => /^keyboard-shortcuts-settings-.*\.js$/.test(name));
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+  return [
+    (name) => /^settings-sections-.*\.js$/.test(name),
+    (name) => /^settings-shared-.*\.js$/.test(name),
+    (name) => /^(?:app-main|index|settings-page)-.*\.js$/.test(name),
+    (name) => /^settings-row-.*\.js$/.test(name),
+    (name) => /^settings-content-layout-.*\.js$/.test(name),
+    (name) => /^toggle-.*\.js$/.test(name),
+  ].every((predicate) => assets.some(predicate));
 }
 
 function patchKeybindsSettingsAssets(extractedDir) {
   try {
     const hasNativeSettings = hasNativeKeyboardShortcutsSettings(extractedDir);
+    if (
+      hasNativeSettings &&
+      !hasLegacyLinuxDesktopSettingsExtensionPoints(extractedDir)
+    ) {
+      return {
+        matched: true,
+        changed: 0,
+        reason: "upstream keyboard shortcuts settings are present; Linux desktop settings extension point is unavailable",
+      };
+    }
+
     const settingsAsset = hasNativeSettings
       ? resolveLinuxDesktopSettingsAsset(extractedDir)
       : resolveKeybindsSettingsAsset(extractedDir);


### PR DESCRIPTION
## Summary
- Adapt optional patch detection for Codex 26.623/Electron 42 bundle drift.
- Keep drift handling fail-soft: obsolete or unavailable optional extension points now no-op instead of warning or blocking builds.
- Update Browser/Chrome plugin staging skips for upstream browser preference routing and refresh remote-mobile bundle patterns.

## Validation
- `MAX_BUILD_THREADS=4 ./install.sh ./Codex.dmg` completed; patch summary has no skipped optional patches or missing patch target warnings.
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/remote-mobile-control/test.js linux-features/codex-wrapper-updater/test.js`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh`
- `node --check scripts/lib/patch-chrome-plugin.js scripts/patches/automation-schedule.js scripts/patches/keybinds-settings.js linux-features/remote-mobile-control/patch.js linux-features/codex-wrapper-updater/patch.js`
- `git diff --check`
- `bash tests/scripts_smoke.sh`