### PR TITLE
Use validated DMG cache for fresh native builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ help:
 	@printf '  %-18s %s\n' "make rebuild-install" "Find a DMG, rebuild, and install into codex-app/"
 	@printf '  %-18s %s\n' "make inspect-upstream" "Inspect a DMG and write rebuild reports without changing codex-app/"
 	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/ (reuses cached Codex.dmg)"
-	@printf '  %-18s %s\n' "make build-app-fresh" "Remove cached Codex.dmg and regenerate codex-app/"
+	@printf '  %-18s %s\n' "make build-app-fresh" "Remove codex-app/ and rebuild with the validated DMG cache"
 	@printf '  %-18s %s\n' "make setup-native" "Guided setup summary and Linux feature config helper"
 	@printf '  %-18s %s\n' "make bootstrap-native" "Install deps, fresh-build, package, and install"
 	@printf '  %-18s %s\n' "make install-native" "Fresh-build, package, and install"
@@ -176,8 +176,8 @@ build-app:
 	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh "$(DMG)"
 
 build-app-fresh:
-	@echo "[make] Regenerating codex-app from fresh DMG"
-	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --fresh "$(DMG)"
+	@echo "[make] Regenerating codex-app with validated DMG cache"
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --fresh --reuse-dmg "$(DMG)"
 
 setup-native:
 	@echo "[make] Running guided native setup"

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -67,13 +67,16 @@ Equivalent direct commands:
 ```bash
 ./install.sh
 ./install.sh /path/to/Codex.dmg
-./install.sh --fresh
+./install.sh --fresh --reuse-dmg
 ```
 
 The default path stores upstream DMG headers, plus a hash of the upstream URL,
 next to `Codex.dmg` and refreshes the cached file when that upstream fingerprint
-changes. `--fresh` still forces a cache removal before rebuilding, and an
-explicit `DMG=/path/to/Codex.dmg` uses that file exactly.
+changes. `make build-app-fresh` removes the generated app but keeps using that
+validated DMG cache, so it only downloads again when the DMG is missing, has no
+metadata yet, or the upstream fingerprint changed. Direct `./install.sh --fresh`
+still forces a cache removal before rebuilding, and an explicit
+`DMG=/path/to/Codex.dmg` uses that file exactly.
 
 Run the generated app:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@
 | Window flickering, resize ghosting, or stale frame trails | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh`, then `./codex-app/start.sh --disable-gpu` if needed |
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
-| Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
+| Stale install / cached DMG | `make build-app-fresh` removes the generated app and reuses `Codex.dmg` only when cached metadata still matches upstream; run `./install.sh --fresh` to force a fresh DMG download |
 | Computer Use plugin invisible in UI | Enable the Computer Use UI opt-in; upstream server/account rollout can still hide some controls |
 | Computer Use `doctor` reports no input backend | Grant `/dev/uinput`, enable XDG RemoteDesktop portal, or start `ydotoold` / `ydotool.service` |
 | Computer Use `doctor` reports `ydotool_socket: Permission denied` | Adjust the daemon socket so users in the `input` group can use it |

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1239,6 +1239,7 @@ test_make_build_app_fresh_uses_installer_fresh_flow() {
     local first_line
     local second_line
     local third_line
+    local fourth_line
 
     mkdir -p "$workspace"
 
@@ -1258,9 +1259,11 @@ SCRIPT
     first_line="$(sed -n '1p' "$install_log")"
     second_line="$(sed -n '2p' "$install_log")"
     third_line="$(sed -n '3p' "$install_log")"
-    [ "$first_line" = "2" ] || fail "Expected make build-app-fresh to pass --fresh plus the default argument slot, got: $(cat "$install_log")"
+    fourth_line="$(sed -n '4p' "$install_log")"
+    [ "$first_line" = "3" ] || fail "Expected make build-app-fresh to pass --fresh, --reuse-dmg, plus the default argument slot, got: $(cat "$install_log")"
     [ "$second_line" = "--fresh" ] || fail "Expected make build-app-fresh to pass --fresh first, got: $(cat "$install_log")"
-    [ -z "$third_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
+    [ "$third_line" = "--reuse-dmg" ] || fail "Expected make build-app-fresh to pass --reuse-dmg after --fresh, got: $(cat "$install_log")"
+    [ -z "$fourth_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
 }
 
 test_installer_refreshes_stale_cached_dmg_metadata() {
@@ -1689,7 +1692,7 @@ test_native_shortcut_targets_compose_existing_flows() {
     local setup_log="$TMP_DIR/make-setup-native.log"
 
     make -n -C "$REPO_DIR" install-native >"$install_log"
-    assert_contains "$install_log" './install.sh --fresh'
+    assert_contains "$install_log" './install.sh --fresh --reuse-dmg'
     assert_contains "$install_log" 'Building native package'
     assert_contains "$install_log" 'Installing latest native package'
 


### PR DESCRIPTION
## Summary
- let `make build-app-fresh` keep the installer-managed DMG cache by passing `--reuse-dmg` after `--fresh`
- keep direct `./install.sh --fresh` as the explicit force-refresh path
- update docs and smoke coverage for the fresh native flow

Closes #589

## Testing
- `git diff --check`
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh`
- `bash tests/scripts_smoke.sh`