### PR TITLE
[codex] Fix app-server feature sync sanitization

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -809,6 +809,20 @@ test("default core patch descriptors are grouped and unique", () => {
   );
 });
 
+test("app-server feature enablement descriptor matches current app-main chunks", () => {
+  const descriptor = corePatchDescriptors().find(
+    (descriptor) => descriptor.id === "linux-app-server-feature-enablement",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.pattern.test("app-main-DxUcMyo0.js"), true);
+  assert.equal(
+    descriptor.pattern.test("app-initial~app-main~automations-page-BfqUlSo6.js"),
+    true,
+  );
+  assert.equal(descriptor.pattern.test("experimental-feature-visibility-Bvp90zWX.js"), false);
+});
+
 test("patch descriptors reject unsupported ciPolicy values", () => {
   assert.throws(
     () =>
@@ -1553,6 +1567,8 @@ test("registers local app-server feature enablement in internal and Electron han
   assert.match(patched, /"set-local-app-server-feature-enablement":async/);
   assert.match(patched, /local_app_server_feature_enablement/);
   assert.match(patched, /local_remote_control_enabled/);
+  assert.match(patched, /`mentions_v2`/);
+  assert.match(patched, /`tool_search`/);
   assert.match(patched, /enablement/);
   assert.equal(
     (patched.match(/set-local-app-server-feature-enablement/g) ?? []).length,
@@ -4005,11 +4021,11 @@ test("removes unsupported features from default app-server feature sync", () => 
 
   assert.match(
     patched,
-    /var GF=\[`apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`remote_plugin`,`tool_call_mcp_elicitation`,`tool_suggest`\];/,
+    /var GF=\[`apps`,`memories`,`mentions_v2`,`plugins`,`remote_control`,`remote_plugin`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`\];/,
   );
   assert.doesNotMatch(patched, /`auth_elicitation`/);
   assert.doesNotMatch(patched, /`enable_mcp_apps`/);
-  assert.doesNotMatch(patched, /`tool_search`/);
+  assert.match(patched, /`tool_search`/);
   assert.doesNotMatch(patched, /,te\]/);
 });
 
@@ -4017,7 +4033,7 @@ test("patches the matched app-server feature sync array when an identical array 
   const unsupportedFeatureArray =
     "var GF=[`apps`,`auth_elicitation`,`enable_mcp_apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`,te];";
   const supportedFeatureArray =
-    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`];";
+    "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_search`,`tool_suggest`];";
   const source = [
     unsupportedFeatureArray,
     "function OF(){return GF}",
@@ -4059,6 +4075,22 @@ test("sanitizes unsupported features in current dynamic app-server feature sync"
 
   assert.match(patched, /var BV=\[`memories`,`tool_suggest`\],VV=`4218407052`,HV=`remote_plugin`/);
   assert.match(patched, /n\[HV\]=t,n/);
+  assert.doesNotMatch(patched, /`apps_mcp_path_override`/);
+  assert.doesNotMatch(patched, /`auth_elicitation`/);
+});
+
+test("sanitizes unsupported features in assignment-style dynamic app-server feature sync", () => {
+  const source = [
+    "function iae(e,t){let n={};for(let t of k7){let r=e[t];r!=null&&(n[t]=r)}return n[j7]=t,n}",
+    "var E7,D7,O7,k7,A7,j7,aae=e((()=>{E7=s(),k7=[`apps_mcp_path_override`,`auth_elicitation`,`memories`,`tool_suggest`],A7=`4218407052`,j7=`remote_plugin`}));",
+    "function rae(){let e=(0,E7.c)(7),t=M(J),[n]=Y_(`statsig_default_enable_features`),r=Kd(A7),i=Kh(),a=rt(),o,s;",
+    "return e[0]!==i||e[1]!==r||e[2]!==n||e[3]!==a||e[4]!==t?(o=()=>{let e=new Map,o=()=>{if(vd(`set-default-feature-overrides`,{overrides:n??null}),n==null)return;let i=iae(n,r),o=t.get(Kp),s=new Set(t.get(nm).filter(e=>e===o||pm(t,e).state===`connected`));for(let t of e.keys())s.has(t)||e.delete(t);let c=t.get(nm).filter(e=>s.has(e)).flatMap(t=>(0,D7.default)(e.get(t),i)?[]:(e.set(t,i),[vd(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:i}).catch(n=>{e.delete(t),l.error(`Failed to sync experimental feature enablement`,{safe:{hostId:t},sensitive:{error:n}})})]));c.length!==0&&Promise.all(c).then(()=>{a.invalidateQueries({queryKey:$te})})};return o(),i.addRegistryCallback(o)},s=[i,r,n,a,t],e[0]=i,e[1]=r,e[2]=n,e[3]=a,e[4]=t,e[5]=o,e[6]=s):(o=e[5],s=e[6]),(0,O7.useEffect)(o,s),null}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
+
+  assert.match(patched, /k7=\[`memories`,`tool_suggest`\]/);
+  assert.match(patched, /n\[j7\]=t,n/);
   assert.doesNotMatch(patched, /`apps_mcp_path_override`/);
   assert.doesNotMatch(patched, /`auth_elicitation`/);
 });

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4095,6 +4095,22 @@ test("sanitizes unsupported features in assignment-style dynamic app-server feat
   assert.doesNotMatch(patched, /`auth_elicitation`/);
 });
 
+test("does not sanitize assignment-style feature arrays inside longer identifiers", () => {
+  const source = [
+    "var Xk7=[`apps_mcp_path_override`,`auth_elicitation`];",
+    "function iae(e,t){let n={};for(let t of k7){let r=e[t];r!=null&&(n[t]=r)}return n[j7]=t,n}",
+    "var E7,D7,O7,k7,A7,j7,aae=e((()=>{E7=s(),k7=[`apps_mcp_path_override`,`auth_elicitation`,`memories`,`tool_suggest`],A7=`4218407052`,j7=`remote_plugin`}));",
+    "function rae(){let e=(0,E7.c)(7),t=M(J),[n]=Y_(`statsig_default_enable_features`),r=Kd(A7),i=Kh(),a=rt(),o,s;",
+    "return e[0]!==i||e[1]!==r||e[2]!==n||e[3]!==a||e[4]!==t?(o=()=>{let e=new Map,o=()=>{if(vd(`set-default-feature-overrides`,{overrides:n??null}),n==null)return;let i=iae(n,r),o=t.get(Kp),s=new Set(t.get(nm).filter(e=>e===o||pm(t,e).state===`connected`));for(let t of e.keys())s.has(t)||e.delete(t);let c=t.get(nm).filter(e=>s.has(e)).flatMap(t=>(0,D7.default)(e.get(t),i)?[]:(e.set(t,i),[vd(`set-experimental-feature-enablement-for-host`,{hostId:t,enablement:i}).catch(n=>{e.delete(t),l.error(`Failed to sync experimental feature enablement`,{safe:{hostId:t},sensitive:{error:n}})})]));c.length!==0&&Promise.all(c).then(()=>{a.invalidateQueries({queryKey:$te})})};return o(),i.addRegistryCallback(o)},s=[i,r,n,a,t],e[0]=i,e[1]=r,e[2]=n,e[3]=a,e[4]=t,e[5]=o,e[6]=s):(o=e[5],s=e[6]),(0,O7.useEffect)(o,s),null}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerFeatureEnablementPatch, source);
+
+  assert.match(patched, /Xk7=\[`apps_mcp_path_override`,`auth_elicitation`\]/);
+  assert.match(patched, /,k7=\[`memories`,`tool_suggest`\]/);
+  assert.match(patched, /n\[j7\]=t,n/);
+});
+
 test("preserves dynamic remote_plugin when the minified feature key contains regex syntax", () => {
   const source = [
     "var GF=[`apps`,`memories`,`plugins`,`tool_call_mcp_elicitation`,`tool_suggest`],v$I=`remote_plugin`;",

--- a/scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js
@@ -10,7 +10,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1040,
     ciPolicy: "optional",
-    pattern: /^(app-main|index)-.*\.js$/,
+    pattern: /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/,
     missingDescription: "webview app main bundle",
     skipDescription: "app-server feature enablement compatibility patch",
     apply: applyLinuxAppServerFeatureEnablementPatch,

--- a/scripts/patches/main-process/misc.js
+++ b/scripts/patches/main-process/misc.js
@@ -324,8 +324,19 @@ function applyLinuxXdgDocumentsDirPatch(currentSource) {
 
 function applyLinuxLocalAppServerFeatureEnablementHandlerPatch(currentSource) {
   const method = "set-local-app-server-feature-enablement";
+  const featureKeys = [
+    "remote_control",
+    "remote_plugin",
+    "memories",
+    "mentions_v2",
+    "tool_search",
+    "tool_suggest",
+    "tool_call_mcp_elicitation",
+    "plugins",
+    "apps",
+  ];
   const handler =
-    "async e=>{let t=e?.params??e??{},n={},r=(e,t)=>{typeof t===`boolean`&&(n[e]=t)};if(t.enablement&&typeof t.enablement===`object`)for(let[e,n]of Object.entries(t.enablement))r(e,n);let i=t.featureName??t.feature_name??t.name??t.feature??null,a=t.enabled;i!=null&&r(i,a);for(let e of[`remote_control`,`remote_plugin`,`memories`,`tool_suggest`,`tool_call_mcp_elicitation`,`plugins`,`apps`])r(e,t[e]);let o=this.sharedObjectRepository?.get?.(`local_app_server_feature_enablement`)??{};return this.sharedObjectRepository?.set?.(`local_app_server_feature_enablement`,{...o,...n}),Object.prototype.hasOwnProperty.call(n,`remote_control`)&&this.sharedObjectRepository?.set?.(`local_remote_control_enabled`,n.remote_control),{enabled:n}}";
+    `async e=>{let t=e?.params??e??{},n={},r=(e,t)=>{typeof t===\`boolean\`&&(n[e]=t)};if(t.enablement&&typeof t.enablement===\`object\`)for(let[e,n]of Object.entries(t.enablement))r(e,n);let i=t.featureName??t.feature_name??t.name??t.feature??null,a=t.enabled;i!=null&&r(i,a);for(let e of[${featureKeys.map((key) => `\`${key}\``).join(",")}])r(e,t[e]);let o=this.sharedObjectRepository?.get?.(\`local_app_server_feature_enablement\`)??{};return this.sharedObjectRepository?.set?.(\`local_app_server_feature_enablement\`,{...o,...n}),Object.prototype.hasOwnProperty.call(n,\`remote_control\`)&&this.sharedObjectRepository?.set?.(\`local_remote_control_enabled\`,n.remote_control),{enabled:n}}`;
   let patchedSource = currentSource;
 
   if (!patchedSource.includes(`methods:[\`${method}\`]`)) {

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -631,19 +631,22 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
 
   function sanitizeFeatureArrayDeclaration(source, arrayVar) {
     const arrayDeclarationRegex = new RegExp(
-      `((?:var\\s+)?${escapeRegExp(arrayVar)}=\\[)([^\\]]*?)(\\])`,
+      `(^|[^\\w$])((?:var\\s+)?${escapeRegExp(arrayVar)}=\\[)([^\\]]*?)(\\])`,
       "u",
     );
     const match = source.match(arrayDeclarationRegex);
     if (match == null) {
       return source;
     }
-    const [, prefix, featureArrayItems, suffix] = match;
+    const [, boundary, prefix, featureArrayItems, suffix] = match;
     const supportedFeatureArrayItems = sanitizeFeatureArrayItems(featureArrayItems);
     if (supportedFeatureArrayItems === featureArrayItems) {
       return source;
     }
-    return source.replace(arrayDeclarationRegex, `${prefix}${supportedFeatureArrayItems}${suffix}`);
+    return source.replace(
+      arrayDeclarationRegex,
+      `${boundary}${prefix}${supportedFeatureArrayItems}${suffix}`,
+    );
   }
 
   const featureArrayRegex =

--- a/scripts/patches/webview-assets.js
+++ b/scripts/patches/webview-assets.js
@@ -607,6 +607,7 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
     "remote_control",
     "remote_plugin",
     "tool_call_mcp_elicitation",
+    "tool_search",
     "tool_suggest",
   ]);
   const defaultFeaturesMarker = "statsig_default_enable_features";
@@ -630,7 +631,7 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
 
   function sanitizeFeatureArrayDeclaration(source, arrayVar) {
     const arrayDeclarationRegex = new RegExp(
-      `(var\\s+${escapeRegExp(arrayVar)}=\\[)([^\\]]*?)(\\])`,
+      `((?:var\\s+)?${escapeRegExp(arrayVar)}=\\[)([^\\]]*?)(\\])`,
       "u",
     );
     const match = source.match(arrayDeclarationRegex);


### PR DESCRIPTION
## Summary

Fix the Linux app-server feature enablement compatibility patch so current webview chunks stop leaking unsupported feature keys to the local app-server.

## What Changed

- Match current `app-initial~app-main~*.js` webview chunks for the app-server feature sync patch.
- Sanitize both `var featureList=[...]` and current assignment-style `featureList=[...]` arrays.
- Preserve supported feature keys such as `tool_search` and `mentions_v2` in the sanitizer and local bridge.
- Add regression tests for the current chunk pattern and assignment-style dynamic feature sync shape.

## Why

Current upstream webview assets can include `auth_elicitation` and `apps_mcp_path_override` in the feature sync array, but the local app-server rejects those feature keys. The existing Linux compatibility patch missed the current chunk name and assignment-style array, so unsupported keys were still sent and app-backed plugin/tool materialization could fail.

## Source Of Truth Files

- `scripts/patches/webview-assets.js`
- `scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js`
- `scripts/patches/main-process/misc.js`
- `scripts/patch-linux-window-ui.test.js`

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --check scripts/patches/webview-assets.js`
- `node --check scripts/patches/main-process/misc.js`
- `node --check scripts/patches/core/all-linux/webview/app-server-feature-enablement/patch.js`
