### PR TITLE
fix: report missing run-app launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ rebuild-next:
 
 run-app:
 	@echo "[make] Launching local Electron app"
+	@[ -x "$(APP_DIR)/start.sh" ] || { echo "[make] Missing launcher: $(APP_DIR)/start.sh. Run make build-app first." >&2; exit 1; }
 	"$(APP_DIR)/start.sh"
 
 build-dev-app:

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1204,6 +1204,21 @@ test_make_install_reports_missing_native_packages() {
     done
 }
 
+test_make_run_app_reports_missing_launcher() {
+    info "Checking make run-app missing-launcher diagnostics"
+    local workspace="$TMP_DIR/make-run-app-missing"
+    local output_log="$workspace/run-app.log"
+
+    mkdir -p "$workspace"
+
+    if make -f "$REPO_DIR/Makefile" -C "$workspace" run-app >"$output_log" 2>&1; then
+        fail "make run-app should fail when codex-app/start.sh is missing"
+    fi
+
+    assert_contains "$output_log" "Missing launcher: $workspace/codex-app/start.sh. Run make build-app first."
+    assert_not_contains "$output_log" "No such file or directory"
+}
+
 test_make_build_app_uses_installer_download_flow_by_default() {
     info "Checking make build-app default DMG behavior"
     local workspace="$TMP_DIR/make-build-app"
@@ -6470,6 +6485,7 @@ main() {
     test_appimage_builder_smoke
     test_missing_input_failure
     test_make_install_reports_missing_native_packages
+    test_make_run_app_reports_missing_launcher
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
     test_installer_refreshes_stale_cached_dmg_metadata


### PR DESCRIPTION
## Summary

Improve the `make run-app` diagnostic when the generated launcher is missing.

Running `make run-app` before generating `codex-app/` currently falls through to a raw shell error because `codex-app/start.sh` does not exist yet. This adds a small guard with an actionable message.

## Changes

- Check that `codex-app/start.sh` exists and is executable before launching.
- Print a clear `Run make build-app first.` message when it is missing.
- Add a smoke test covering the missing-launcher diagnostic.

## Validation

- `bash -n tests/scripts_smoke.sh`
- `make -n run-app`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
