### PR TITLE
Support fast mode selection when logged in with an API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ workarounds.
 | Copilot reasoning effort defaults | Opt-in | `copilot-reasoning-effort` | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | Example Linux Feature | Developer example | `example-feature` | [Docs](linux-features/example-feature/README.md) |
 | Open Target Discovery | Opt-in | `open-target-discovery` | [Docs](linux-features/open-target-discovery/README.md) |
+| API key service tier | Opt-in | `api-key-service-tier` | [Docs](linux-features/api-key-service-tier/README.md) |
 | Read Aloud button | Opt-in | `read-aloud` | [Docs](linux-features/read-aloud/README.md) |
 | Read Aloud MCP | Opt-in | `read-aloud-mcp` | [Docs](linux-features/read-aloud-mcp/README.md) |
 | Remote Control UI gates | Opt-in | `remote-control-ui` | [Docs](linux-features/remote-control-ui/README.md) |

--- a/linux-features/api-key-service-tier/README.md
+++ b/linux-features/api-key-service-tier/README.md
@@ -46,10 +46,11 @@ provider explicitly documents such a model alias.
 ## Behavior
 
 - API-key-authenticated hosts are allowed to show service-tier controls.
-- If the active model has no `serviceTiers` metadata, the UI synthesizes one
-  `fast` option so the selector can send `serviceTier: "fast"`.
+- If an API-key host's active model has no `serviceTiers` metadata, the UI
+  synthesizes one `fast` option so the selector can send
+  `serviceTier: "fast"`.
 - ChatGPT-authenticated hosts still use upstream account requirements for
-  official Fast mode.
+  official Fast mode and do not receive synthetic service-tier metadata.
 
 ## Risks
 

--- a/linux-features/api-key-service-tier/README.md
+++ b/linux-features/api-key-service-tier/README.md
@@ -1,0 +1,64 @@
+# API Key Service Tier
+
+This opt-in feature exposes the desktop Fast/service-tier selector when Codex
+is using API-key authentication with an OpenAI-compatible provider.
+
+It is intended for providers that wrap the OpenAI Responses API and understand
+Codex's `serviceTier` request setting. It does not grant OpenAI Fast mode
+credits and does not bypass ChatGPT-account entitlement checks for the official
+OpenAI service.
+
+## Enable
+
+Add the feature id to `linux-features/features.json`:
+
+```json
+{
+  "enabled": [
+    "api-key-service-tier"
+  ]
+}
+```
+
+Then rebuild the app:
+
+```bash
+./install.sh
+```
+
+Keep the model name as the upstream model name, for example:
+
+```toml
+model = "gpt-5"
+model_provider = "openai-compatible"
+service_tier = "fast"
+
+[model_providers.openai-compatible]
+name = "OpenAI-compatible"
+base_url = "https://provider.example/v1"
+wire_api = "responses"
+```
+
+Provider-specific API keys should be configured according to the provider's
+normal Codex setup. Do not encode the tier into the model name unless the
+provider explicitly documents such a model alias.
+
+## Behavior
+
+- API-key-authenticated hosts are allowed to show service-tier controls.
+- If the active model has no `serviceTiers` metadata, the UI synthesizes one
+  `fast` option so the selector can send `serviceTier: "fast"`.
+- ChatGPT-authenticated hosts still use upstream account requirements for
+  official Fast mode.
+
+## Risks
+
+The provider must accept and implement the `serviceTier` request setting. A
+provider that rejects unknown fields may return an API error; a provider that
+ignores unknown fields may show the UI without changing latency.
+
+## Test
+
+```bash
+node --test linux-features/api-key-service-tier/test.js
+```

--- a/linux-features/api-key-service-tier/feature.json
+++ b/linux-features/api-key-service-tier/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "api-key-service-tier",
+  "title": "API Key Service Tier",
+  "description": "Opt-in Fast/service-tier UI and request support for API-key authenticated OpenAI-compatible providers.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
+const PATCH_MARKER = "codexLinuxApiKeyFastTier";
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function applyApiKeyServiceTierGatePatch(source) {
+  const gateNeedle = new RegExp(
+    `(${JS_IDENT})=(${JS_IDENT})\\?\\.authMethod===\\\`chatgpt\\\`,` +
+      `(${JS_IDENT})=\\2\\?\\.authMethod\\?\\?null([\\s\\S]{0,500}?),` +
+      `d=\\1&&!(${JS_IDENT})&&(${JS_IDENT})!=null&&\\6\\?\\.requirements\\?\\.featureRequirements\\?\\.fast_mode!==!1`,
+    "g",
+  );
+
+  const patched = source.replace(
+    gateNeedle,
+    (_match, isChatGptVar, hostVar, authMethodVar, middle, loadingVar, requirementsVar) =>
+      `${isChatGptVar}=${hostVar}?.authMethod===\`chatgpt\`,` +
+      `${authMethodVar}=${hostVar}?.authMethod??null${middle},` +
+      `d=!${loadingVar}&&(${isChatGptVar}?${requirementsVar}!=null&&${requirementsVar}?.requirements?.featureRequirements?.fast_mode!==!1:${authMethodVar}===\`apikey\`)`,
+  );
+
+  if (patched !== source || source.includes(`${authMethodVarName(source)}===\`apikey\``)) {
+    return patched;
+  }
+
+  if (source.includes("featureRequirements?.fast_mode") && source.includes("authMethod===`chatgpt`")) {
+    warn("Could not find service tier auth gate", "API key service tier gate patch");
+  }
+  return source;
+}
+
+function authMethodVarName(source) {
+  return source.match(new RegExp(`(${JS_IDENT})=${JS_IDENT}\\?\\.authMethod\\?\\?null`))?.[1] ?? "__never";
+}
+
+function applyFallbackFastTierPatch(source) {
+  let patched = source;
+
+  if (!patched.includes(`function ${PATCH_MARKER}(`)) {
+    const fastResolverPattern = new RegExp(
+      `function (${JS_IDENT})\\(e\\)\\{return e\\?\\.serviceTiers\\?\\.find\\(e=>` +
+        `(${JS_IDENT})\\(e\\.id,e\\.name\\)===\\\`fast\\\`\\|\\|e\\.name\\.trim\\(\\)\\.toLowerCase\\(\\)===\\\`priority\\\`\\)\\?\\?null\\}`,
+    );
+    const fastResolverMatch = patched.match(fastResolverPattern);
+    if (fastResolverMatch != null) {
+      const helper =
+        `function ${PATCH_MARKER}(e){return e==null||e?.serviceTiers?.length?null:{id:\`fast\`,name:\`Fast\`,description:\`1.5x speed, increased usage\`}}`;
+      patched = patched.replace(fastResolverPattern, `${helper}${fastResolverMatch[0]}`);
+    }
+  }
+
+  const fastResolverPatch = new RegExp(
+    `function (${JS_IDENT})\\(e\\)\\{return e\\?\\.serviceTiers\\?\\.find\\(e=>` +
+      `(${JS_IDENT})\\(e\\.id,e\\.name\\)===\\\`fast\\\`\\|\\|e\\.name\\.trim\\(\\)\\.toLowerCase\\(\\)===\\\`priority\\\`\\)\\?\\?null\\}`,
+    "g",
+  );
+  patched = patched.replace(
+    fastResolverPatch,
+    `function $1(e){return e?.serviceTiers?.find(e=>$2(e.id,e.name)===\`fast\`||e.name.trim().toLowerCase()===\`priority\`)??${PATCH_MARKER}(e)}`,
+  );
+
+  const optionsPatch = new RegExp(
+    `\\.\\.\\.\\((${JS_IDENT})\\?\\.serviceTiers\\?\\?\\[\\]\\)\\.map\\((${JS_IDENT})=>\\(\\{` +
+      `description:(${JS_IDENT})\\(\\2\\),iconKind:(${JS_IDENT})\\(\\2\\.id,\\2\\.name\\),` +
+      `label:(${JS_IDENT})\\(\\2\\),tier:\\2,value:\\2\\.id\\}\\)\\)`,
+    "g",
+  );
+  patched = patched.replace(
+    optionsPatch,
+    `...(($1?.serviceTiers?.length?$1.serviceTiers:[${PATCH_MARKER}($1)]).filter(Boolean)).map($2=>({description:$3($2),iconKind:$4($2.id,$2.name),label:$5($2),tier:$2,value:$2.id}))`,
+  );
+
+  if (patched !== source || source.includes(PATCH_MARKER)) {
+    return patched;
+  }
+
+  if (source.includes("serviceTiers") && source.includes("defaultServiceTier")) {
+    warn("Could not find service tier option helpers", "API key fallback fast tier patch");
+  }
+  return source;
+}
+
+function applyApiKeyServiceTierPatch(source) {
+  return applyFallbackFastTierPatch(applyApiKeyServiceTierGatePatch(source));
+}
+
+const descriptors = [
+  {
+    id: "api-key-service-tier-ui",
+    phase: "webview-asset",
+    order: 20600,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~.*\.js$/,
+    missingDescription: "app main webview bundle",
+    skipDescription: "API key service tier UI patch",
+    apply: applyApiKeyServiceTierPatch,
+  },
+];
+
+module.exports = {
+  applyApiKeyServiceTierGatePatch,
+  applyFallbackFastTierPatch,
+  applyApiKeyServiceTierPatch,
+  descriptors,
+};

--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -2,6 +2,7 @@
 
 const JS_IDENT = "[A-Za-z_$][\\w$]*";
 const PATCH_MARKER = "codexLinuxApiKeyFastTier";
+const MODEL_MARKER = "codexLinuxApiKeyServiceTierModel";
 
 function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
@@ -37,6 +38,34 @@ function authMethodVarName(source) {
   return source.match(new RegExp(`(${JS_IDENT})=${JS_IDENT}\\?\\.authMethod\\?\\?null`))?.[1] ?? "__never";
 }
 
+function applyApiKeyModelMarkerPatch(source) {
+  if (new RegExp(`${MODEL_MARKER}:${JS_IDENT}===\\\`apikey\\\``).test(source)) {
+    return source;
+  }
+
+  const modelListPattern = new RegExp(
+    `(function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
+      `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
+      `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},useHiddenModels:${JS_IDENT}\\}\\)` +
+      `\\{[\\s\\S]{0,1800}?[,;]${JS_IDENT}=\\{\\.\\.\\.${JS_IDENT},supportedReasoningEfforts:${JS_IDENT})(\\})`,
+    "g",
+  );
+
+  const patched = source.replace(
+    modelListPattern,
+    (_match, prefix, authMethodVar, suffix) => `${prefix},${MODEL_MARKER}:${authMethodVar}===\`apikey\`${suffix}`,
+  );
+
+  if (patched !== source) {
+    return patched;
+  }
+
+  if (source.includes("list-models-for-host") && source.includes("supportedReasoningEfforts")) {
+    warn("Could not find model list mapping", "API key model service tier marker patch");
+  }
+  return source;
+}
+
 function applyFallbackFastTierPatch(source) {
   let patched = source;
 
@@ -48,7 +77,7 @@ function applyFallbackFastTierPatch(source) {
     const fastResolverMatch = patched.match(fastResolverPattern);
     if (fastResolverMatch != null) {
       const helper =
-        `function ${PATCH_MARKER}(e){return e==null||e?.serviceTiers?.length?null:{id:\`fast\`,name:\`Fast\`,description:\`1.5x speed, increased usage\`}}`;
+        `function ${PATCH_MARKER}(e){return e==null||e?.serviceTiers?.length||e?.${MODEL_MARKER}!==!0?null:{id:\`fast\`,name:\`Fast\`,description:\`1.5x speed, increased usage\`}}`;
       patched = patched.replace(fastResolverPattern, `${helper}${fastResolverMatch[0]}`);
     }
   }
@@ -85,7 +114,7 @@ function applyFallbackFastTierPatch(source) {
 }
 
 function applyApiKeyServiceTierPatch(source) {
-  return applyFallbackFastTierPatch(applyApiKeyServiceTierGatePatch(source));
+  return applyFallbackFastTierPatch(applyApiKeyModelMarkerPatch(applyApiKeyServiceTierGatePatch(source)));
 }
 
 const descriptors = [
@@ -102,6 +131,7 @@ const descriptors = [
 ];
 
 module.exports = {
+  applyApiKeyModelMarkerPatch,
   applyApiKeyServiceTierGatePatch,
   applyFallbackFastTierPatch,
   applyApiKeyServiceTierPatch,

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -11,6 +11,7 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  applyApiKeyModelMarkerPatch,
   applyApiKeyServiceTierPatch,
   applyApiKeyServiceTierGatePatch,
   applyFallbackFastTierPatch,
@@ -76,7 +77,16 @@ test("service tier auth gate allows API-key hosts while preserving ChatGPT requi
   assert.doesNotMatch(patched, /d=a&&!u&&c!=null/);
 });
 
-test("fallback fast tier is synthesized when model catalog has no service tiers", () => {
+test("model list entries are marked only when loaded for API-key hosts", () => {
+  const source =
+    "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+
+  const patched = applyPatchTwice(applyApiKeyModelMarkerPatch, source);
+
+  assert.match(patched, /o=\{\.\.\.n,supportedReasoningEfforts:a,codexLinuxApiKeyServiceTierModel:e===`apikey`\}/);
+});
+
+test("fallback fast tier is synthesized only for API-key model catalog entries", () => {
   const source = [
     "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
     "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
@@ -87,6 +97,7 @@ test("fallback fast tier is synthesized when model catalog has no service tiers"
   const patched = applyPatchTwice(applyFallbackFastTierPatch, source);
 
   assert.match(patched, /function codexLinuxApiKeyFastTier\(e\)/);
+  assert.match(patched, /e\?\.codexLinuxApiKeyServiceTierModel!==!0\?null/);
   assert.match(patched, /codexLinuxApiKeyFastTier\(e\)/);
   assert.match(patched, /\?e\.serviceTiers:\[codexLinuxApiKeyFastTier\(e\)\]\)\.filter\(Boolean\)\)\.map/);
   assert.doesNotMatch(patched, /\(e\?\.serviceTiers\?\?\[\]\)\.map/);
@@ -96,6 +107,7 @@ test("fallback fast tier is synthesized when model catalog has no service tiers"
 test("combined patch updates both service tier gate and fallback options", () => {
   const source = [
     "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}",
+    "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}",
     "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
     "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
     "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
@@ -104,5 +116,7 @@ test("combined patch updates both service tier gate and fallback options", () =>
   const patched = applyPatchTwice(applyApiKeyServiceTierPatch, source);
 
   assert.match(patched, /o===`apikey`/);
+  assert.match(patched, /codexLinuxApiKeyServiceTierModel:e===`apikey`/);
+  assert.match(patched, /e\?\.codexLinuxApiKeyServiceTierModel!==!0\?null/);
   assert.match(patched, /function codexLinuxApiKeyFastTier\(e\)/);
 });

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  applyApiKeyServiceTierPatch,
+  applyApiKeyServiceTierGatePatch,
+  applyFallbackFastTierPatch,
+  descriptors,
+} = require("./patch.js");
+
+function applyPatchTwice(patchFn, source) {
+  const once = patchFn(source);
+  assert.notEqual(once, source);
+  assert.equal(patchFn(once), once);
+  return once;
+}
+
+function withFeatureConfig(enabled, callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-service-tier-"));
+  const configPath = path.join(tempDir, "features.json");
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+
+  try {
+    fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+    process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+    return callback(path.resolve(__dirname, ".."));
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("api-key-service-tier stays disabled until listed in features.json", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withFeatureConfig(["api-key-service-tier"], (featuresRoot) => {
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      loaded.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+      [["feature:api-key-service-tier:api-key-service-tier-ui", "webview-asset", "optional"]],
+    );
+  });
+});
+
+test("descriptor is optional and targets app main webview chunks", () => {
+  assert.deepEqual(
+    descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+    [["api-key-service-tier-ui", "webview-asset", "optional"]],
+  );
+  assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), true);
+  assert.equal(descriptors[0].pattern.test("settings-page-abc.js"), false);
+});
+
+test("service tier auth gate allows API-key hosts while preserving ChatGPT requirements", () => {
+  const source =
+    "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}";
+
+  const patched = applyPatchTwice(applyApiKeyServiceTierGatePatch, source);
+
+  assert.match(patched, /d=!u&&\(a\?c!=null&&c\?\.requirements\?\.featureRequirements\?\.fast_mode!==!1:o===`apikey`\)/);
+  assert.doesNotMatch(patched, /d=a&&!u&&c!=null/);
+});
+
+test("fallback fast tier is synthesized when model catalog has no service tiers", () => {
+  const source = [
+    "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
+    "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
+    "function nEe(e,t,n){return e?.find(e=>e.model===t&&hQ(e,n))??null}",
+    "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyFallbackFastTierPatch, source);
+
+  assert.match(patched, /function codexLinuxApiKeyFastTier\(e\)/);
+  assert.match(patched, /codexLinuxApiKeyFastTier\(e\)/);
+  assert.match(patched, /\?e\.serviceTiers:\[codexLinuxApiKeyFastTier\(e\)\]\)\.filter\(Boolean\)\)\.map/);
+  assert.doesNotMatch(patched, /\(e\?\.serviceTiers\?\?\[\]\)\.map/);
+  assert.doesNotMatch(patched, /\)\?\?null\}function nEe/);
+});
+
+test("combined patch updates both service tier gate and fallback options", () => {
+  const source = [
+    "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}",
+    "function pQ(e,t){return t==null?null:t===`fast`?mQ(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
+    "function tEe(e){return[{description:yQ.standardDescription,iconKind:null,label:yQ.standardLabel,tier:null,value:null},...(e?.serviceTiers??[]).map(e=>({description:eEe(e),iconKind:fQ(e.id,e.name),label:$Te(e),tier:e,value:e.id}))]}",
+    "function mQ(e){return e?.serviceTiers?.find(e=>fQ(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyApiKeyServiceTierPatch, source);
+
+  assert.match(patched, /o===`apikey`/);
+  assert.match(patched, /function codexLinuxApiKeyFastTier\(e\)/);
+});


### PR DESCRIPTION
## Summary

Adds an opt-in Linux feature, `api-key-service-tier`, that exposes the Codex Desktop Fast/service-tier selector for API-key authenticated OpenAI-compatible providers.

The feature patches the app main webview bundle to allow service-tier controls when the active host is logged in with an API key. It preserves the upstream ChatGPT/OAuth entitlement check for official Fast mode, and synthesizes a `fast` service tier option when model metadata does not provide `serviceTiers`.

This feature is disabled by default and must be enabled through `linux-features/features.json`.

## Why

Codex Desktop currently gates the Fast/service-tier UI behind the ChatGPT auth path and upstream account requirements. That is appropriate for official ChatGPT/OAuth usage, but it prevents API-key authenticated OpenAI-compatible providers from exposing a `serviceTier` setting even when the provider supports Codex's `serviceTier` request field.

This keeps official account behavior unchanged while allowing API-key provider users to opt in explicitly.

## Changed Files

- `linux-features/api-key-service-tier/feature.json`
  - Registers the disabled-by-default feature and its patch descriptor entrypoint.

- `linux-features/api-key-service-tier/patch.js`
  - Allows the service-tier UI gate for `authMethod === "apikey"`.
  - Keeps ChatGPT/OAuth hosts on the upstream `fast_mode` entitlement check.
  - Synthesizes a fallback `fast` service tier option when model metadata has no `serviceTiers`.

- `linux-features/api-key-service-tier/README.md`
  - Documents enablement, config shape, behavior, risks, and validation.

- `linux-features/api-key-service-tier/test.js`
  - Covers descriptor loading, opt-in behavior, target matching, auth gate patching, fallback tier synthesis, and patch idempotency.

- `README.md`
  - Adds the feature to the Linux Features table.

## Behavior

When disabled, there is no behavior change.

When enabled:

- API-key authenticated hosts can show service-tier controls.
- Models without `serviceTiers` metadata get a synthesized `fast` UI option.
- ChatGPT/OAuth hosts still use the upstream account `fast_mode` entitlement check.
- Providers must still support the `serviceTier` request setting for this to have an effect.