### PR TITLE
[codex] Add configurable updater cleanup for generated artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ dependencies = [
  "clap",
  "directories",
  "futures-util",
+ "libc",
  "notify-rust",
  "reqwest",
  "semver",

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -35,6 +35,27 @@ Runtime files:
 ~/.local/state/codex-desktop/app.pid
 ```
 
+## Generated Artifact Cleanup
+
+The updater always prunes unreferenced updater workspaces under
+`~/.cache/codex-update-manager/workspaces`. Local checkout build output such as
+`dist/`, `target/`, and `codex-app/` is cleaned only when explicitly enabled.
+
+Example:
+
+```toml
+[generated_artifact_cleanup]
+enabled = true
+min_free_bytes = 10737418240 # 10 GiB
+roots = ["/home/mohit/Github/codex-desktop-linux"]
+entries = ["dist", "target", "codex-app"]
+```
+
+If `roots` is omitted, the updater uses `builder_bundle_root`. Cleanup only runs
+when the filesystem containing a root has less than `min_free_bytes` available.
+Every entry must be a relative top-level name, and the updater only cleans roots
+that look like this wrapper repository or packaged update-builder.
+
 ## Rollback
 
 If a rebuilt update installs but the previous retained package was better,

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { version = "0.4.45", features = ["clock", "serde"] }
 clap = { version = "4.6.1", features = ["derive"] }
 directories = "6.0.0"
 futures-util = "0.3.32"
+libc = "0.2.178"
 notify-rust = "4.18.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["http2", "rustls", "stream"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -202,6 +202,31 @@ fn maybe_prune_workspace_cache(workspace_root: &Path, state: &PersistedState) {
     }
 }
 
+fn maybe_prune_generated_artifacts(config: &RuntimeConfig) {
+    match cache_cleanup::prune_generated_artifacts(
+        &config.generated_artifact_cleanup,
+        &config.builder_bundle_root,
+    ) {
+        Ok(summary) if summary.pruned_paths > 0 => {
+            info!(
+                inspected_roots = summary.inspected_roots,
+                pruned_paths = summary.pruned_paths,
+                bytes_removed = summary.bytes_removed,
+                "pruned generated wrapper artifacts"
+            );
+        }
+        Ok(_) => {}
+        Err(error) => {
+            warn!(?error, "failed to prune generated wrapper artifacts");
+        }
+    }
+}
+
+fn maybe_prune_caches(config: &RuntimeConfig, state: &PersistedState) {
+    maybe_prune_workspace_cache(&config.workspace_root, state);
+    maybe_prune_generated_artifacts(config);
+}
+
 fn clear_wrapper_update_candidate_and_persist(
     state: &mut PersistedState,
     paths: &RuntimePaths,
@@ -353,7 +378,7 @@ async fn run_daemon(
     complete_current_dmg_update_if_already_installed(config, state, paths)?;
     codex_cli::reconcile_if_present(state, paths)?;
     normalize_workspace_dir_and_persist(state, paths)?;
-    maybe_prune_workspace_cache(&config.workspace_root, state);
+    maybe_prune_caches(config, state);
     maybe_notify_cli_missing(state, paths, config.notifications)?;
     if packaged_runtime_removed(config) {
         info!("packaged app files are gone; stopping updater daemon");
@@ -413,7 +438,7 @@ async fn run_check_now(
     complete_current_dmg_update_if_already_installed(config, state, paths)?;
     codex_cli::reconcile_if_present(state, paths)?;
     normalize_workspace_dir_and_persist(state, paths)?;
-    maybe_prune_workspace_cache(&config.workspace_root, state);
+    maybe_prune_caches(config, state);
     maybe_notify_cli_missing(state, paths, config.notifications)?;
     if if_stale && upstream_check_is_fresh(config, state) {
         if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
@@ -960,7 +985,7 @@ async fn run_check_cycle(
             .clone()
             .expect("candidate version should be set before local build");
         builder::build_update(config, state, paths, &candidate_version, &downloaded.path).await?;
-        maybe_prune_workspace_cache(&config.workspace_root, state);
+        maybe_prune_caches(config, state);
         maybe_notify_update_ready(state, paths, config.notifications)?;
         Ok(())
     }
@@ -968,7 +993,7 @@ async fn run_check_cycle(
 
     if let Err(error) = result {
         mark_failed_and_persist(state, paths, error.to_string())?;
-        maybe_prune_workspace_cache(&config.workspace_root, state);
+        maybe_prune_caches(config, state);
         let _ = notify_failure(config, state, paths, &error);
         return Err(error);
     }
@@ -1861,6 +1886,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         }
     }
 
@@ -1898,6 +1924,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(true);
@@ -2135,6 +2162,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2175,6 +2203,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         for status in [
@@ -2377,6 +2406,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(true);
@@ -2436,6 +2466,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2501,6 +2532,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(true);
@@ -2630,6 +2662,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(true);
@@ -2699,6 +2732,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2759,6 +2793,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(true);
@@ -2826,6 +2861,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2889,6 +2925,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);
@@ -2939,6 +2976,7 @@ mod tests {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
 
         let mut state = PersistedState::new(false);

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -725,6 +725,7 @@ fi
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         };
         let dmg_path = temp.path().join("Codex.dmg");
         fs::write(&dmg_path, b"dmg")?;

--- a/updater/src/cache_cleanup.rs
+++ b/updater/src/cache_cleanup.rs
@@ -1,11 +1,15 @@
-//! Cleanup helpers for updater-managed build workspaces.
+//! Cleanup helpers for updater-managed build workspaces and opt-in generated
+//! wrapper checkout artifacts.
 
+use crate::config::GeneratedArtifactCleanupConfig;
 use crate::state::{PersistedState, UpdateStatus};
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use std::{
     collections::BTreeSet,
-    fs,
-    path::{Path, PathBuf},
+    ffi::CString,
+    fs, mem,
+    os::unix::ffi::OsStrExt,
+    path::{Component, Path, PathBuf},
 };
 
 const HEAVY_WORKSPACE_DIRS: &[&str] = &["builder", "codex-app", "dist"];
@@ -13,6 +17,14 @@ const HEAVY_WORKSPACE_DIRS: &[&str] = &["builder", "codex-app", "dist"];
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct CleanupSummary {
     pub pruned_workspaces: usize,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct GeneratedArtifactCleanupSummary {
+    pub inspected_roots: usize,
+    pub skipped_roots: usize,
+    pub pruned_paths: usize,
+    pub bytes_removed: u64,
 }
 
 pub fn prune_unreferenced_workspaces(
@@ -54,6 +66,51 @@ pub fn prune_unreferenced_workspaces(
 
         if pruned {
             summary.pruned_workspaces += 1;
+        }
+    }
+
+    Ok(summary)
+}
+
+pub fn prune_generated_artifacts(
+    cleanup: &GeneratedArtifactCleanupConfig,
+    default_root: &Path,
+) -> Result<GeneratedArtifactCleanupSummary> {
+    if !cleanup.enabled {
+        return Ok(GeneratedArtifactCleanupSummary::default());
+    }
+
+    let entries = cleanup_entries(cleanup)?;
+    let mut summary = GeneratedArtifactCleanupSummary::default();
+    for root in cleanup_roots(cleanup, default_root) {
+        if !root.is_dir() {
+            summary.skipped_roots += 1;
+            continue;
+        }
+        if !looks_like_wrapper_root(&root) {
+            summary.skipped_roots += 1;
+            continue;
+        }
+
+        summary.inspected_roots += 1;
+        let available_bytes = available_disk_bytes(&root)
+            .with_context(|| format!("Failed to read free space for {}", root.display()))?;
+        if cleanup.min_free_bytes > 0 && available_bytes >= cleanup.min_free_bytes {
+            summary.skipped_roots += 1;
+            continue;
+        }
+
+        for entry in &entries {
+            let target = root.join(entry);
+            if !target.exists() && fs::symlink_metadata(&target).is_err() {
+                continue;
+            }
+
+            let bytes = path_size(&target).unwrap_or(0);
+            remove_path(&target)
+                .with_context(|| format!("Failed to remove {}", target.display()))?;
+            summary.pruned_paths += 1;
+            summary.bytes_removed = summary.bytes_removed.saturating_add(bytes);
         }
     }
 
@@ -150,9 +207,80 @@ fn directory_is_empty(path: &Path) -> Result<bool> {
         .is_none())
 }
 
+fn cleanup_roots(
+    cleanup: &GeneratedArtifactCleanupConfig,
+    default_root: &Path,
+) -> BTreeSet<PathBuf> {
+    if cleanup.roots.is_empty() {
+        BTreeSet::from([default_root.to_path_buf()])
+    } else {
+        cleanup.roots.iter().cloned().collect()
+    }
+}
+
+fn cleanup_entries(cleanup: &GeneratedArtifactCleanupConfig) -> Result<Vec<PathBuf>> {
+    let mut entries = Vec::new();
+    for entry in &cleanup.entries {
+        if entry.as_os_str().is_empty() || entry.is_absolute() {
+            bail!("generated artifact cleanup entries must be relative top-level names");
+        }
+        let mut components = entry.components();
+        if !matches!(components.next(), Some(Component::Normal(_))) || components.next().is_some() {
+            bail!("generated artifact cleanup entries must be relative top-level names");
+        }
+        entries.push(entry.clone());
+    }
+    Ok(entries)
+}
+
+fn looks_like_wrapper_root(root: &Path) -> bool {
+    root.join("install.sh").is_file()
+        && root.join("scripts/build-deb.sh").is_file()
+        && root.join("scripts/build-pacman.sh").is_file()
+}
+
+fn available_disk_bytes(path: &Path) -> Result<u64> {
+    let c_path = CString::new(path.as_os_str().as_bytes())
+        .with_context(|| format!("Path contains interior NUL: {}", path.display()))?;
+    let mut stat: libc::statvfs = unsafe { mem::zeroed() };
+    let result = unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("statvfs failed for {}", path.display()));
+    }
+
+    Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64))
+}
+
+fn path_size(path: &Path) -> Result<u64> {
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("Failed to stat {}", path.display()))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(metadata.len());
+    }
+
+    let mut total = metadata.len();
+    for entry in fs::read_dir(path).with_context(|| format!("Failed to read {}", path.display()))? {
+        let entry = entry?;
+        total = total.saturating_add(path_size(&entry.path())?);
+    }
+    Ok(total)
+}
+
+fn remove_path(path: &Path) -> Result<()> {
+    let metadata =
+        fs::symlink_metadata(path).with_context(|| format!("Failed to stat {}", path.display()))?;
+    if metadata.is_dir() && !metadata.file_type().is_symlink() {
+        fs::remove_dir_all(path).with_context(|| format!("Failed to remove {}", path.display()))
+    } else {
+        fs::remove_file(path).with_context(|| format!("Failed to remove {}", path.display()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::GeneratedArtifactCleanupConfig;
     use crate::state::{ArtifactPaths, PersistedState, UpdateStatus};
     use anyhow::Result;
     use std::{fs, path::PathBuf};
@@ -171,6 +299,141 @@ mod tests {
         fs::write(workspace.join("reports/rebuild-report.json"), b"{}")?;
         fs::write(workspace.join("metadata.json"), b"{}")?;
         Ok(workspace)
+    }
+
+    fn create_wrapper_root(root: &std::path::Path) -> Result<()> {
+        fs::create_dir_all(root.join("scripts"))?;
+        fs::write(root.join("install.sh"), b"#!/bin/bash\n")?;
+        fs::write(root.join("scripts/build-deb.sh"), b"#!/bin/bash\n")?;
+        fs::write(root.join("scripts/build-pacman.sh"), b"#!/bin/bash\n")?;
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_is_disabled_by_default() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_wrapper_root(temp.path())?;
+        fs::create_dir_all(temp.path().join("dist"))?;
+        fs::write(temp.path().join("dist/pkg.deb"), b"pkg")?;
+
+        let summary =
+            prune_generated_artifacts(&GeneratedArtifactCleanupConfig::default(), temp.path())?;
+
+        assert_eq!(summary.pruned_paths, 0);
+        assert!(temp.path().join("dist/pkg.deb").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_removes_known_artifacts_below_threshold() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_wrapper_root(temp.path())?;
+        fs::create_dir_all(temp.path().join("dist"))?;
+        fs::create_dir_all(temp.path().join("target"))?;
+        fs::create_dir_all(temp.path().join("codex-app"))?;
+        fs::write(temp.path().join("dist/pkg.deb"), b"pkg")?;
+        fs::write(temp.path().join("target/build.txt"), b"target")?;
+        fs::write(temp.path().join("codex-app/app.txt"), b"app")?;
+        fs::write(temp.path().join("Codex.dmg"), b"dmg")?;
+
+        let cleanup = GeneratedArtifactCleanupConfig {
+            enabled: true,
+            min_free_bytes: u64::MAX,
+            roots: Vec::new(),
+            entries: GeneratedArtifactCleanupConfig::default().entries,
+        };
+        let summary = prune_generated_artifacts(&cleanup, temp.path())?;
+
+        assert_eq!(summary.inspected_roots, 1);
+        assert_eq!(summary.pruned_paths, 3);
+        assert!(summary.bytes_removed > 0);
+        assert!(!temp.path().join("dist").exists());
+        assert!(!temp.path().join("target").exists());
+        assert!(!temp.path().join("codex-app").exists());
+        assert!(temp.path().join("Codex.dmg").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_skips_when_free_space_is_sufficient() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_wrapper_root(temp.path())?;
+        fs::create_dir_all(temp.path().join("dist"))?;
+        fs::write(temp.path().join("dist/pkg.deb"), b"pkg")?;
+
+        let cleanup = GeneratedArtifactCleanupConfig {
+            enabled: true,
+            min_free_bytes: 1,
+            roots: Vec::new(),
+            entries: GeneratedArtifactCleanupConfig::default().entries,
+        };
+        let summary = prune_generated_artifacts(&cleanup, temp.path())?;
+
+        assert_eq!(summary.pruned_paths, 0);
+        assert!(temp.path().join("dist/pkg.deb").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_skips_non_wrapper_roots() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::create_dir_all(temp.path().join("dist"))?;
+        fs::write(temp.path().join("dist/pkg.deb"), b"pkg")?;
+
+        let cleanup = GeneratedArtifactCleanupConfig {
+            enabled: true,
+            min_free_bytes: u64::MAX,
+            roots: Vec::new(),
+            entries: GeneratedArtifactCleanupConfig::default().entries,
+        };
+        let summary = prune_generated_artifacts(&cleanup, temp.path())?;
+
+        assert_eq!(summary.pruned_paths, 0);
+        assert_eq!(summary.skipped_roots, 1);
+        assert!(temp.path().join("dist/pkg.deb").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_rejects_unsafe_entries() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_wrapper_root(temp.path())?;
+        for entry in [
+            PathBuf::from("../outside"),
+            PathBuf::from("dist/pkg.deb"),
+            PathBuf::from("/tmp/dist"),
+        ] {
+            let cleanup = GeneratedArtifactCleanupConfig {
+                enabled: true,
+                min_free_bytes: u64::MAX,
+                roots: Vec::new(),
+                entries: vec![entry],
+            };
+
+            let error = prune_generated_artifacts(&cleanup, temp.path()).unwrap_err();
+
+            assert!(error.to_string().contains("top-level names"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn generated_artifact_cleanup_can_remove_configured_files() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        create_wrapper_root(temp.path())?;
+        fs::write(temp.path().join("Codex.dmg"), b"dmg")?;
+
+        let cleanup = GeneratedArtifactCleanupConfig {
+            enabled: true,
+            min_free_bytes: u64::MAX,
+            roots: Vec::new(),
+            entries: vec![PathBuf::from("Codex.dmg")],
+        };
+        let summary = prune_generated_artifacts(&cleanup, temp.path())?;
+
+        assert_eq!(summary.pruned_paths, 1);
+        assert!(!temp.path().join("Codex.dmg").exists());
+        Ok(())
     }
 
     #[test]

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -8,6 +8,43 @@ use std::{fs, path::PathBuf};
 const SERVICE_NAME: &str = "codex-update-manager";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// Optional cleanup for generated wrapper checkout artifacts such as `dist/`
+/// and `target/`. Disabled by default; when enabled, cleanup only runs if the
+/// filesystem containing a configured root is below `min_free_bytes`.
+pub struct GeneratedArtifactCleanupConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_generated_artifact_cleanup_min_free_bytes")]
+    pub min_free_bytes: u64,
+    #[serde(default)]
+    pub roots: Vec<PathBuf>,
+    #[serde(default = "default_generated_artifact_cleanup_entries")]
+    pub entries: Vec<PathBuf>,
+}
+
+impl Default for GeneratedArtifactCleanupConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            min_free_bytes: default_generated_artifact_cleanup_min_free_bytes(),
+            roots: Vec::new(),
+            entries: default_generated_artifact_cleanup_entries(),
+        }
+    }
+}
+
+fn default_generated_artifact_cleanup_min_free_bytes() -> u64 {
+    10 * 1024 * 1024 * 1024
+}
+
+fn default_generated_artifact_cleanup_entries() -> Vec<PathBuf> {
+    ["codex-app", "codex-app-next", "dist", "dist-next", "target"]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 /// Runtime configuration values that control how the updater behaves on Linux.
 pub struct RuntimeConfig {
     pub dmg_url: String,
@@ -30,6 +67,11 @@ pub struct RuntimeConfig {
     /// Branch to track for wrapper updates.
     #[serde(default = "default_wrapper_branch")]
     pub wrapper_branch: String,
+    /// Optional cleanup for generated wrapper checkout artifacts. This is
+    /// intentionally opt-in so users keep manual build output unless they
+    /// configure cleanup.
+    #[serde(default)]
+    pub generated_artifact_cleanup: GeneratedArtifactCleanupConfig,
 }
 
 fn default_wrapper_branch() -> String {
@@ -110,6 +152,7 @@ impl RuntimeConfig {
             enable_wrapper_updates: false,
             wrapper_remote: String::new(),
             wrapper_branch: default_wrapper_branch(),
+            generated_artifact_cleanup: GeneratedArtifactCleanupConfig::default(),
         }
     }
 
@@ -443,6 +486,21 @@ mod tests {
         assert!(config.auto_install_on_app_exit);
         assert_eq!(config.workspace_root, paths.cache_dir);
         assert!(config.builder_bundle_root.is_absolute());
+        assert!(!config.generated_artifact_cleanup.enabled);
+        assert_eq!(
+            config.generated_artifact_cleanup.min_free_bytes,
+            10 * 1024 * 1024 * 1024
+        );
+        assert_eq!(
+            config.generated_artifact_cleanup.entries,
+            vec![
+                PathBuf::from("codex-app"),
+                PathBuf::from("codex-app-next"),
+                PathBuf::from("dist"),
+                PathBuf::from("dist-next"),
+                PathBuf::from("target"),
+            ]
+        );
         Ok(())
     }
 
@@ -469,6 +527,12 @@ notifications = false
 workspace_root = "/tmp/codex-workspaces"
 builder_bundle_root = "/tmp/codex-builder"
 app_executable_path = "/opt/codex-desktop/electron"
+
+[generated_artifact_cleanup]
+enabled = true
+min_free_bytes = 2147483648
+roots = ["/home/mohit/Github/codex-desktop-linux"]
+entries = ["dist", "target", "Codex.dmg"]
 "#,
         )?;
 
@@ -489,6 +553,20 @@ app_executable_path = "/opt/codex-desktop/electron"
         assert_eq!(
             config.app_executable_path,
             PathBuf::from("/opt/codex-desktop/electron")
+        );
+        assert!(config.generated_artifact_cleanup.enabled);
+        assert_eq!(config.generated_artifact_cleanup.min_free_bytes, 2147483648);
+        assert_eq!(
+            config.generated_artifact_cleanup.roots,
+            vec![PathBuf::from("/home/mohit/Github/codex-desktop-linux")]
+        );
+        assert_eq!(
+            config.generated_artifact_cleanup.entries,
+            vec![
+                PathBuf::from("dist"),
+                PathBuf::from("target"),
+                PathBuf::from("Codex.dmg"),
+            ]
         );
         Ok(())
     }

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -577,6 +577,7 @@ mod tests {
             enable_wrapper_updates: true,
             wrapper_remote: String::new(),
             wrapper_branch: "main".to_string(),
+            generated_artifact_cleanup: Default::default(),
         }
     }
 


### PR DESCRIPTION
## Summary
- Add opt-in generated artifact cleanup to `codex-update-manager`.
- Prune configured top-level generated entries such as `dist`, `target`, and `codex-app` only when the containing filesystem is below `min_free_bytes`.
- Keep existing updater workspace pruning, add safety checks for wrapper/update-builder roots, and document the config.

## Why
Manual/native package builds can leave large ignored outputs in the wrapper checkout. On this machine, generated package output under `dist/` had filled the root filesystem. The updater already cleans its own rebuild workspaces; this adds a configurable guardrail for local generated outputs without deleting source or arbitrary paths.

## Safety
- Disabled by default.
- Threshold-based; `min_free_bytes = 0` can force cleanup.
- Entries must be relative top-level names.
- Roots must look like this wrapper repo or packaged update-builder (`install.sh`, `scripts/build-deb.sh`, `scripts/build-pacman.sh`).
- Default entries are generated directories only: `codex-app`, `codex-app-next`, `dist`, `dist-next`, and `target`. Files such as `Codex.dmg` are removed only if explicitly configured.

## Validation
- `cargo fmt -p codex-update-manager`
- `git diff --check`
- `CARGO_HOME=/home/mohit/.cache/cargo cargo test -p codex-update-manager`