### PR TITLE
Add Linux workspace root Open In targets

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -740,6 +740,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-git-origins-source-fallback",
     "linux-xdg-documents-dir",
     "linux-projectless-xdg-documents-dir",
+    "linux-workspace-root-open-targets",
     "linux-i18n-gate",
     "linux-profile-settings-menu",
     "automation-schedule-multi-time-rrule",
@@ -796,6 +797,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
     "linux-tray",
+    "linux-workspace-root-open-targets",
   ]) {
     assert.equal(
       descriptors.find((descriptor) => descriptor.id === id)?.ciPolicy,

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -8,6 +8,8 @@ const {
 } = require("../../../../shared.js");
 
 const PATCH_MARKER = "codexLinuxWorkspaceRootOpenTarget";
+const MISSING_FILE_MANAGER_ACTION_REASON =
+  "Could not find workspace-root File Manager open action while Linux targets are enabled";
 
 function warn(message) {
   console.warn(`WARN: ${message} - skipping Linux workspace-root open targets patch`);
@@ -315,7 +317,12 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
   }
 
   if (matched === 0) {
-    return { matched, changed };
+    return {
+      matched,
+      changed,
+      status: "failed-required",
+      reason: MISSING_FILE_MANAGER_ACTION_REASON,
+    };
   }
   return { matched, changed };
 }

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -1,0 +1,300 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  findMainBundle,
+} = require("../../../../shared.js");
+
+const PATCH_MARKER = "codexLinuxWorkspaceRootOpenTarget";
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping Linux workspace-root open targets patch`);
+}
+
+function findMatching(source, openIndex, openChar, closeChar) {
+  let depth = 0;
+  const stack = [{ type: "code" }];
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const top = stack[stack.length - 1];
+
+    if (top.type === "string") {
+      if (top.escaped) {
+        top.escaped = false;
+      } else if (char === "\\") {
+        top.escaped = true;
+      } else if (char === top.quote) {
+        stack.pop();
+      }
+      continue;
+    }
+
+    if (top.type === "template") {
+      if (top.escaped) {
+        top.escaped = false;
+      } else if (char === "\\") {
+        top.escaped = true;
+      } else if (char === "`") {
+        stack.pop();
+      } else if (char === "$" && source[index + 1] === "{") {
+        stack.push({ type: "templateExpression", depth: 1 });
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "\"" || char === "'") {
+      stack.push({ type: "string", quote: char, escaped: false });
+      continue;
+    }
+    if (char === "`") {
+      stack.push({ type: "template", escaped: false });
+      continue;
+    }
+
+    if (top.type === "templateExpression") {
+      if (char === "{") {
+        top.depth += 1;
+      } else if (char === "}") {
+        top.depth -= 1;
+        if (top.depth === 0) {
+          stack.pop();
+        }
+      }
+      continue;
+    }
+
+    if (char === openChar) {
+      depth += 1;
+    } else if (char === closeChar) {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function enabledWorkspaceRootTargets(mainSource) {
+  const targets = [];
+  if (
+    mainSource.includes("id:`vscode`") &&
+    (
+      mainSource.includes("linuxDetect:()=>codexLinuxOpenTargetExecutable(`code`)") ||
+      mainSource.includes("codexLinuxIdePlatform(`vscode`") ||
+      mainSource.includes("function codexLinuxIdeCommand(")
+    )
+  ) {
+    targets.push({ id: "vscode", label: "VS Code" });
+  }
+  if (mainSource.includes("id:`zed`") && mainSource.includes("linux:{label:`Zed`")) {
+    targets.push({ id: "zed", label: "Zed" });
+  }
+  if (mainSource.includes("id:`terminal`") && mainSource.includes("linux:{label:`Terminal`")) {
+    targets.push({ id: "terminal", label: "Terminal" });
+  }
+  return targets;
+}
+
+function findItemAssignment(source, onSelectName, searchStart) {
+  const pattern =
+    /([A-Za-z_$][\w$]*)=[^;]*?\(0,([A-Za-z_$][\w$]*)\.jsx\)\(([A-Za-z_$][\w$]*)\.Item,\{/g;
+  let match = null;
+  const prefix = source.slice(0, searchStart);
+  for (let next; (next = pattern.exec(prefix)) != null;) {
+    match = next;
+  }
+  if (match == null) {
+    return null;
+  }
+
+  const valueStart = source.indexOf("=", match.index) + 1;
+  const firstParenStart = source.indexOf("(", valueStart);
+  const firstParenEnd = findMatching(source, firstParenStart, "(", ")");
+  const callParenStart = firstParenEnd + 1;
+  if (source[callParenStart] !== "(") {
+    return null;
+  }
+  const callParenEnd = findMatching(source, callParenStart, "(", ")");
+  if (callParenEnd === -1) {
+    return null;
+  }
+
+  const valuePrefix = source.slice(valueStart, firstParenStart);
+  const value = source.slice(firstParenStart, callParenEnd + 1);
+  if (!value.includes(`onSelect:${onSelectName}`)) {
+    return null;
+  }
+
+  return {
+    start: match.index,
+    end: callParenEnd + 1,
+    itemVar: match[1],
+    jsxVar: match[2],
+    menuVar: match[3],
+    value,
+    valuePrefix,
+  };
+}
+
+function onSelectNameCandidates(source, callbackName, searchStart) {
+  const names = new Set([callbackName]);
+  const tail = source.slice(searchStart);
+  let added = true;
+  while (added) {
+    added = false;
+    for (const name of [...names]) {
+      const pattern = new RegExp(
+        `(?:^|[;,])\\s*(?:var\\s+|let\\s+|const\\s+)?([A-Za-z_$][\\w$]*)=${escapeRegExp(name)}(?=[,;])`,
+        "g",
+      );
+      for (let match; (match = pattern.exec(tail)) != null;) {
+        if (!names.has(match[1])) {
+          names.add(match[1]);
+          added = true;
+        }
+      }
+    }
+  }
+  return [...names];
+}
+
+function openTargetItem({ jsxVar, menuVar, openFn, pathVar, cwdVar, openFileVar, closeVar, target }) {
+  return `(0,${jsxVar}.jsx)(${menuVar}.Item,{key:\`${PATCH_MARKER}:${target.id}\`,onSelect:()=>{${openFn}({path:${pathVar},cwd:${cwdVar},target:\`${target.id}\`,openFile:${openFileVar}.mutate}),${closeVar}(!1)},children:\`${target.label}\`})`;
+}
+
+function applyWorkspaceRootOpenTargetsPatch(currentSource, targets) {
+  if (currentSource.includes(PATCH_MARKER)) {
+    return currentSource;
+  }
+  if (targets.length === 0) {
+    warn("Could not find Linux editor or terminal open targets in the main bundle");
+    return currentSource;
+  }
+
+  const openCallPattern = /([A-Za-z_$][\w$]*)\(\{path:([A-Za-z_$][\w$]*),cwd:([A-Za-z_$][\w$]*),target:`fileManager`,openFile:([A-Za-z_$][\w$]*)\.mutate\}\)/u;
+  const openCallMatch = currentSource.match(openCallPattern);
+  if (openCallMatch == null) {
+    warn("Could not find workspace-root File Manager open action");
+    return currentSource;
+  }
+
+  const [openCall, openFn, pathVar, cwdVar, openFileVar] = openCallMatch;
+  const callbackPattern = /([A-Za-z_$][\w$]*)=\(\)=>\{/g;
+  let callbackMatch = null;
+  const callbackSearchSource = currentSource.slice(0, openCallMatch.index);
+  for (let next; (next = callbackPattern.exec(callbackSearchSource)) != null;) {
+    callbackMatch = next;
+  }
+  if (callbackMatch == null) {
+    warn("Could not identify workspace-root File Manager callback");
+    return currentSource;
+  }
+
+  const [, onSelectName] = callbackMatch;
+  const callbackBraceIndex = currentSource.indexOf("{", callbackMatch.index);
+  const callbackEnd = findMatching(currentSource, callbackBraceIndex, "{", "}");
+  if (callbackEnd === -1 || callbackEnd < openCallMatch.index) {
+    warn("Could not parse workspace-root File Manager callback body");
+    return currentSource;
+  }
+
+  const callbackBodyAfterOpen = currentSource.slice(openCallMatch.index + openCall.length, callbackEnd);
+  const closeVar = callbackBodyAfterOpen.match(/,([A-Za-z_$][\w$]*)\(!1\)/u)?.[1] ?? null;
+  if (closeVar == null) {
+    warn("Could not identify workspace-root dropdown close callback");
+    return currentSource;
+  }
+
+  let item = null;
+  for (const candidateName of onSelectNameCandidates(currentSource, onSelectName, callbackEnd)) {
+    const onSelectIndex = currentSource.indexOf(`onSelect:${candidateName}`, callbackEnd);
+    if (onSelectIndex === -1) {
+      continue;
+    }
+    item = findItemAssignment(currentSource, candidateName, onSelectIndex);
+    if (item != null) {
+      break;
+    }
+  }
+  if (item == null) {
+    warn("Could not parse workspace-root File Manager menu item");
+    return currentSource;
+  }
+
+  const targetItems = targets.map((target) =>
+    openTargetItem({
+      jsxVar: item.jsxVar,
+      menuVar: item.menuVar,
+      openFn,
+      pathVar,
+      cwdVar,
+      openFileVar,
+      closeVar,
+      target,
+    }),
+  );
+  const replacement =
+    `${item.itemVar}=${item.valuePrefix}(0,${item.jsxVar}.jsxs)(${item.jsxVar}.Fragment,{children:[` +
+    `${targetItems.join(",")},${item.value}]})`;
+
+  return currentSource.slice(0, item.start) + replacement + currentSource.slice(item.end);
+}
+
+function patchWorkspaceRootOpenTargets(extractedDir) {
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(assetsDir)) {
+    return { matched: 0, changed: 0 };
+  }
+
+  const main = findMainBundle(extractedDir);
+  if (main == null) {
+    return { matched: 0, changed: 0 };
+  }
+
+  const mainSource = fs.readFileSync(path.join(main.buildDir, main.mainBundle), "utf8");
+  const targets = enabledWorkspaceRootTargets(mainSource);
+  let matched = 0;
+  let changed = 0;
+
+  for (const name of fs.readdirSync(assetsDir)) {
+    if (!/^(?:app-main-.*|app-initial~app-main~.*projects-index.*)\.js$/u.test(name)) {
+      continue;
+    }
+    const filePath = path.join(assetsDir, name);
+    const source = fs.readFileSync(filePath, "utf8");
+    if (!source.includes("target:`fileManager`")) {
+      continue;
+    }
+    matched += 1;
+    const patched = applyWorkspaceRootOpenTargetsPatch(source, targets);
+    if (patched !== source) {
+      fs.writeFileSync(filePath, patched, "utf8");
+      changed += 1;
+    }
+  }
+
+  if (matched === 0) {
+    return { matched, changed };
+  }
+  return { matched, changed };
+}
+
+module.exports = {
+  id: "linux-workspace-root-open-targets",
+  phase: "extracted-app",
+  order: 2060,
+  ciPolicy: "optional",
+  apply: patchWorkspaceRootOpenTargets,
+  applyWorkspaceRootOpenTargetsPatch,
+  enabledWorkspaceRootTargets,
+};

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -96,6 +96,16 @@ function enabledWorkspaceRootTargets(mainSource) {
   ) {
     targets.push({ id: "vscode", label: "VS Code" });
   }
+  if (
+    mainSource.includes("id:`vscodeInsiders`") &&
+    (
+      mainSource.includes("linuxDetect:()=>codexLinuxOpenTargetExecutable(`code-insiders`)") ||
+      mainSource.includes("codexLinuxIdePlatform(`vscodeInsiders`") ||
+      mainSource.includes("function codexLinuxIdeCommand(")
+    )
+  ) {
+    targets.push({ id: "vscodeInsiders", label: "VS Code Insiders" });
+  }
   if (mainSource.includes("id:`zed`") && mainSource.includes("linux:{label:`Zed`")) {
     targets.push({ id: "zed", label: "Zed" });
   }
@@ -173,81 +183,94 @@ function openTargetItem({ jsxVar, menuVar, openFn, pathVar, cwdVar, openFileVar,
 }
 
 function applyWorkspaceRootOpenTargetsPatch(currentSource, targets) {
-  if (currentSource.includes(PATCH_MARKER)) {
-    return currentSource;
-  }
   if (targets.length === 0) {
-    warn("Could not find Linux editor or terminal open targets in the main bundle");
     return currentSource;
   }
 
-  const openCallPattern = /([A-Za-z_$][\w$]*)\(\{path:([A-Za-z_$][\w$]*),cwd:([A-Za-z_$][\w$]*),target:`fileManager`,openFile:([A-Za-z_$][\w$]*)\.mutate\}\)/u;
-  const openCallMatch = currentSource.match(openCallPattern);
-  if (openCallMatch == null) {
+  const openCallPattern = /([A-Za-z_$][\w$]*)\(\{path:([A-Za-z_$][\w$]*),cwd:([A-Za-z_$][\w$]*),target:`fileManager`,openFile:([A-Za-z_$][\w$]*)\.mutate\}\)/gu;
+  const edits = [];
+  let matchedOpenCall = false;
+  for (const openCallMatch of currentSource.matchAll(openCallPattern)) {
+    matchedOpenCall = true;
+    const [openCall, openFn, pathVar, cwdVar, openFileVar] = openCallMatch;
+    const callbackPattern = /([A-Za-z_$][\w$]*)=\(\)=>\{/g;
+    let callbackMatch = null;
+    const callbackSearchSource = currentSource.slice(0, openCallMatch.index);
+    for (let next; (next = callbackPattern.exec(callbackSearchSource)) != null;) {
+      callbackMatch = next;
+    }
+    if (callbackMatch == null) {
+      warn("Could not identify workspace-root File Manager callback");
+      continue;
+    }
+
+    const [, onSelectName] = callbackMatch;
+    const callbackBraceIndex = currentSource.indexOf("{", callbackMatch.index);
+    const callbackEnd = findMatching(currentSource, callbackBraceIndex, "{", "}");
+    if (callbackEnd === -1 || callbackEnd < openCallMatch.index) {
+      warn("Could not parse workspace-root File Manager callback body");
+      continue;
+    }
+
+    const callbackBodyAfterOpen = currentSource.slice(openCallMatch.index + openCall.length, callbackEnd);
+    const closeVar = callbackBodyAfterOpen.match(/,([A-Za-z_$][\w$]*)\(!1\)/u)?.[1] ?? null;
+    if (closeVar == null) {
+      warn("Could not identify workspace-root dropdown close callback");
+      continue;
+    }
+
+    let item = null;
+    for (const candidateName of onSelectNameCandidates(currentSource, onSelectName, callbackEnd)) {
+      const onSelectIndex = currentSource.indexOf(`onSelect:${candidateName}`, callbackEnd);
+      if (onSelectIndex === -1) {
+        continue;
+      }
+      item = findItemAssignment(currentSource, candidateName, onSelectIndex);
+      if (item != null) {
+        break;
+      }
+    }
+    if (item == null) {
+      warn("Could not parse workspace-root File Manager menu item");
+      continue;
+    }
+    if (item.value.includes(PATCH_MARKER) || edits.some((edit) => edit.start === item.start && edit.end === item.end)) {
+      continue;
+    }
+
+    const targetItems = targets.map((target) =>
+      openTargetItem({
+        jsxVar: item.jsxVar,
+        menuVar: item.menuVar,
+        openFn,
+        pathVar,
+        cwdVar,
+        openFileVar,
+        closeVar,
+        target,
+      }),
+    );
+    const replacement =
+      `${item.itemVar}=${item.valuePrefix}(0,${item.jsxVar}.jsxs)(${item.jsxVar}.Fragment,{children:[` +
+      `${targetItems.join(",")},${item.value}]})`;
+
+    edits.push({ start: item.start, end: item.end, replacement });
+  }
+
+  if (!matchedOpenCall) {
     warn("Could not find workspace-root File Manager open action");
     return currentSource;
   }
-
-  const [openCall, openFn, pathVar, cwdVar, openFileVar] = openCallMatch;
-  const callbackPattern = /([A-Za-z_$][\w$]*)=\(\)=>\{/g;
-  let callbackMatch = null;
-  const callbackSearchSource = currentSource.slice(0, openCallMatch.index);
-  for (let next; (next = callbackPattern.exec(callbackSearchSource)) != null;) {
-    callbackMatch = next;
-  }
-  if (callbackMatch == null) {
-    warn("Could not identify workspace-root File Manager callback");
+  if (edits.length === 0) {
     return currentSource;
   }
 
-  const [, onSelectName] = callbackMatch;
-  const callbackBraceIndex = currentSource.indexOf("{", callbackMatch.index);
-  const callbackEnd = findMatching(currentSource, callbackBraceIndex, "{", "}");
-  if (callbackEnd === -1 || callbackEnd < openCallMatch.index) {
-    warn("Could not parse workspace-root File Manager callback body");
-    return currentSource;
-  }
-
-  const callbackBodyAfterOpen = currentSource.slice(openCallMatch.index + openCall.length, callbackEnd);
-  const closeVar = callbackBodyAfterOpen.match(/,([A-Za-z_$][\w$]*)\(!1\)/u)?.[1] ?? null;
-  if (closeVar == null) {
-    warn("Could not identify workspace-root dropdown close callback");
-    return currentSource;
-  }
-
-  let item = null;
-  for (const candidateName of onSelectNameCandidates(currentSource, onSelectName, callbackEnd)) {
-    const onSelectIndex = currentSource.indexOf(`onSelect:${candidateName}`, callbackEnd);
-    if (onSelectIndex === -1) {
-      continue;
-    }
-    item = findItemAssignment(currentSource, candidateName, onSelectIndex);
-    if (item != null) {
-      break;
-    }
-  }
-  if (item == null) {
-    warn("Could not parse workspace-root File Manager menu item");
-    return currentSource;
-  }
-
-  const targetItems = targets.map((target) =>
-    openTargetItem({
-      jsxVar: item.jsxVar,
-      menuVar: item.menuVar,
-      openFn,
-      pathVar,
-      cwdVar,
-      openFileVar,
-      closeVar,
-      target,
-    }),
-  );
-  const replacement =
-    `${item.itemVar}=${item.valuePrefix}(0,${item.jsxVar}.jsxs)(${item.jsxVar}.Fragment,{children:[` +
-    `${targetItems.join(",")},${item.value}]})`;
-
-  return currentSource.slice(0, item.start) + replacement + currentSource.slice(item.end);
+  return edits
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (patched, edit) => patched.slice(0, edit.start) + edit.replacement + patched.slice(edit.end),
+      currentSource,
+    );
 }
 
 function patchWorkspaceRootOpenTargets(extractedDir) {
@@ -263,6 +286,14 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
 
   const mainSource = fs.readFileSync(path.join(main.buildDir, main.mainBundle), "utf8");
   const targets = enabledWorkspaceRootTargets(mainSource);
+  if (targets.length === 0) {
+    return {
+      matched: 0,
+      changed: 0,
+      status: "skipped-target",
+      reason: "No Linux editor or terminal open targets are enabled",
+    };
+  }
   let matched = 0;
   let changed = 0;
 
@@ -293,8 +324,22 @@ module.exports = {
   id: "linux-workspace-root-open-targets",
   phase: "extracted-app",
   order: 2060,
-  ciPolicy: "optional",
+  ciPolicy: "required-upstream",
   apply: patchWorkspaceRootOpenTargets,
+  status(result, warnings) {
+    if (result?.status != null) {
+      return { status: result.status, reason: result.reason ?? null };
+    }
+    if (result?.changed) {
+      return warnings.length > 0
+        ? { status: "failed-required", reason: warnings[0] }
+        : "applied";
+    }
+    if (warnings.length > 0) {
+      return { status: "failed-required", reason: warnings[0] };
+    }
+    return "already-applied";
+  },
   applyWorkspaceRootOpenTargetsPatch,
   enabledWorkspaceRootTargets,
 };

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -7,11 +7,12 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
+const workspaceRootOpenTargetsPatch = require("./patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js");
 const {
   apply: patchWorkspaceRootOpenTargets,
   applyWorkspaceRootOpenTargetsPatch,
   enabledWorkspaceRootTargets,
-} = require("./patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js");
+} = workspaceRootOpenTargetsPatch;
 
 test("workspace root dropdown adds Linux open targets alongside File Manager", () => {
   const mainSource = [
@@ -184,6 +185,49 @@ test("workspace root open targets patch is not applicable without Linux targets"
       changed: 0,
       status: "skipped-target",
       reason: "No Linux editor or terminal open targets are enabled",
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workspace root open targets patch fails required when Linux targets are enabled but the File Manager chunk drifted", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
+  try {
+    const buildDir = path.join(root, ".vite", "build");
+    const assetsDir = path.join(root, "webview", "assets");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      [
+        "function codexLinuxIdeCommand(){}",
+        "var lM={id:`vscode`};",
+        "var wN={id:`zed`,platforms:{linux:{label:`Zed`}}};",
+      ].join(""),
+    );
+    fs.writeFileSync(
+      path.join(assetsDir, "app-main-current.js"),
+      [
+        "function CurrentWorkspaceMenu(){",
+        "let _=`/tmp/project`,a=()=>{},x=A(`open-file`);",
+        "return (0,$.jsx)(di.Item,{onSelect:a,children:`Project`})",
+        "}",
+      ].join(""),
+    );
+
+    const result = patchWorkspaceRootOpenTargets(root);
+    const expectedReason = "Could not find workspace-root File Manager open action while Linux targets are enabled";
+
+    assert.deepEqual(result, {
+      matched: 0,
+      changed: 0,
+      status: "failed-required",
+      reason: expectedReason,
+    });
+    assert.deepEqual(workspaceRootOpenTargetsPatch.status(result, []), {
+      status: "failed-required",
+      reason: expectedReason,
     });
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  apply: patchWorkspaceRootOpenTargets,
+  applyWorkspaceRootOpenTargetsPatch,
+  enabledWorkspaceRootTargets,
+} = require("./patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js");
+
+test("workspace root dropdown adds Linux open targets alongside File Manager", () => {
+  const mainSource = [
+    "function codexLinuxIdeCommand(){}",
+    "var lM={id:`vscode`};",
+    "var wN={id:`zed`,platforms:{linux:{label:`Zed`}}};",
+    "var Hj={id:`terminal`,platforms:{linux:{label:`Terminal`}}};",
+  ].join("");
+  const source = [
+    "function WorkspaceRootMenu(){",
+    "let t=[],a=()=>{},v=`/tmp/project`,S=Zt(`open-file`),C;",
+    "t[7]!==v||t[8]!==a||t[9]!==S?",
+    "(C=()=>{if(v==null)return;let e=lr(v);El({path:v,cwd:e,target:`fileManager`,openFile:S.mutate}),a(!1)},t[7]=v,t[8]=a,t[9]=S,t[10]=C):C=t[10];",
+    "let T;t[11]!==C?(T=(0,Z.jsx)(uv.Item,{LeftIcon:iy,onSelect:C,children:`File Manager`}),t[11]=C,t[12]=T):T=t[12];",
+    "return (0,Z.jsxs)(Z.Fragment,{children:[T]})",
+    "}",
+  ].join("");
+
+  const targets = enabledWorkspaceRootTargets(mainSource);
+  const patched = applyWorkspaceRootOpenTargetsPatch(source, targets);
+
+  assert.deepEqual(targets, [
+    { id: "vscode", label: "VS Code" },
+    { id: "zed", label: "Zed" },
+    { id: "terminal", label: "Terminal" },
+  ]);
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
+  assert.match(patched, /target:`vscode`/);
+  assert.match(patched, /target:`zed`/);
+  assert.match(patched, /target:`terminal`/);
+  assert.match(patched, /target:`fileManager`/);
+  assert.equal(applyWorkspaceRootOpenTargetsPatch(patched, targets), patched);
+});
+
+test("workspace root dropdown follows aliased File Manager callbacks", () => {
+  const targets = [
+    { id: "vscode", label: "VS Code" },
+    { id: "zed", label: "Zed" },
+    { id: "terminal", label: "Terminal" },
+  ];
+  const source = [
+    "function CurrentWorkspaceMenu(){",
+    "let _=`/tmp/project`,a=()=>{},x=A(`open-file`),C,w,E;",
+    "C=()=>{if(_==null)return;let e=S(_);Ta({path:_,cwd:e,target:`fileManager`,openFile:x.mutate}),a(!1)};",
+    "w=C;",
+    "E=_==null?null:(0,$.jsx)(di.Item,{LeftIcon:em,onSelect:w,children:(0,$.jsx)(Gh,{platform:m})});",
+    "return (0,$.jsxs)($.Fragment,{children:[E]})",
+    "}",
+  ].join("");
+
+  const patched = applyWorkspaceRootOpenTargetsPatch(source, targets);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
+  assert.match(patched, /onSelect:\(\)=>\{Ta\(\{path:_,cwd:e,target:`vscode`,openFile:x\.mutate\}\),a\(!1\)\}/);
+  assert.match(patched, /target:`fileManager`,openFile:x\.mutate/);
+  assert.match(patched, /\(0,\$\.jsx\)\(di\.Item,\{LeftIcon:em,onSelect:w/);
+  assert.equal(applyWorkspaceRootOpenTargetsPatch(patched, targets), patched);
+});
+
+test("workspace root open targets patch scans current shared app main project chunks", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
+  try {
+    const buildDir = path.join(root, ".vite", "build");
+    const assetsDir = path.join(root, "webview", "assets");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(buildDir, "main.js"),
+      [
+        "function codexLinuxIdeCommand(){}",
+        "var lM={id:`vscode`};",
+        "var wN={id:`zed`,platforms:{linux:{label:`Zed`}}};",
+        "var Hj={id:`terminal`,platforms:{linux:{label:`Terminal`}}};",
+      ].join(""),
+    );
+    fs.writeFileSync(path.join(assetsDir, "app-main-current.js"), "console.log(`shell`);");
+    const sharedChunkName = "app-initial~app-main~remote-conversation-page~projects-index-page-current.js";
+    fs.writeFileSync(
+      path.join(assetsDir, sharedChunkName),
+      [
+        "function CurrentWorkspaceMenu(){",
+        "let _=`/tmp/project`,a=()=>{},x=A(`open-file`),C,w,E;",
+        "C=()=>{if(_==null)return;let e=S(_);Ta({path:_,cwd:e,target:`fileManager`,openFile:x.mutate}),a(!1)};",
+        "w=C;",
+        "E=_==null?null:(0,$.jsx)(di.Item,{LeftIcon:em,onSelect:w,children:(0,$.jsx)(Gh,{platform:m})});",
+        "return (0,$.jsxs)($.Fragment,{children:[E]})",
+        "}",
+      ].join(""),
+    );
+
+    const result = patchWorkspaceRootOpenTargets(root);
+    const patched = fs.readFileSync(path.join(assetsDir, sharedChunkName), "utf8");
+
+    assert.equal(result.changed, 1);
+    assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
+    assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
+    assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -17,6 +17,7 @@ test("workspace root dropdown adds Linux open targets alongside File Manager", (
   const mainSource = [
     "function codexLinuxIdeCommand(){}",
     "var lM={id:`vscode`};",
+    "var iN={id:`vscodeInsiders`};",
     "var wN={id:`zed`,platforms:{linux:{label:`Zed`}}};",
     "var Hj={id:`terminal`,platforms:{linux:{label:`Terminal`}}};",
   ].join("");
@@ -35,17 +36,51 @@ test("workspace root dropdown adds Linux open targets alongside File Manager", (
 
   assert.deepEqual(targets, [
     { id: "vscode", label: "VS Code" },
+    { id: "vscodeInsiders", label: "VS Code Insiders" },
     { id: "zed", label: "Zed" },
     { id: "terminal", label: "Terminal" },
   ]);
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
+  assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscodeInsiders/);
   assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
   assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
   assert.match(patched, /target:`vscode`/);
+  assert.match(patched, /target:`vscodeInsiders`/);
   assert.match(patched, /target:`zed`/);
   assert.match(patched, /target:`terminal`/);
   assert.match(patched, /target:`fileManager`/);
+  assert.equal(applyWorkspaceRootOpenTargetsPatch(patched, targets), patched);
+});
+
+test("workspace root dropdown patches every File Manager item in a shared chunk", () => {
+  const targets = [
+    { id: "vscode", label: "VS Code" },
+    { id: "zed", label: "Zed" },
+  ];
+  const source = [
+    "function FirstWorkspaceRootMenu(){",
+    "let a=()=>{},v=`/tmp/one`,S=Zt(`open-file`),C,T;",
+    "C=()=>{if(v==null)return;let e=lr(v);El({path:v,cwd:e,target:`fileManager`,openFile:S.mutate}),a(!1)};",
+    "T=(0,Z.jsx)(uv.Item,{LeftIcon:iy,onSelect:C,children:`File Manager`});",
+    "return T",
+    "}",
+    "function SecondWorkspaceRootMenu(){",
+    "let b=()=>{},p=`/tmp/two`,M=Qt(`open-file`),D,U;",
+    "D=()=>{if(p==null)return;let c=lr(p);Op({path:p,cwd:c,target:`fileManager`,openFile:M.mutate}),b(!1)};",
+    "U=(0,Z.jsx)(uv.Item,{LeftIcon:iy,onSelect:D,children:`File Manager`});",
+    "return U",
+    "}",
+  ].join("");
+
+  const patched = applyWorkspaceRootOpenTargetsPatch(source, targets);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(/codexLinuxWorkspaceRootOpenTarget:vscode/g) ?? []).length, 2);
+  assert.equal((patched.match(/codexLinuxWorkspaceRootOpenTarget:zed/g) ?? []).length, 2);
+  assert.equal((patched.match(/target:`vscode`/g) ?? []).length, 2);
+  assert.equal((patched.match(/target:`zed`/g) ?? []).length, 2);
+  assert.equal((patched.match(/target:`fileManager`/g) ?? []).length, 2);
   assert.equal(applyWorkspaceRootOpenTargetsPatch(patched, targets), patched);
 });
 
@@ -89,6 +124,7 @@ test("workspace root open targets patch scans current shared app main project ch
       [
         "function codexLinuxIdeCommand(){}",
         "var lM={id:`vscode`};",
+        "var iN={id:`vscodeInsiders`};",
         "var wN={id:`zed`,platforms:{linux:{label:`Zed`}}};",
         "var Hj={id:`terminal`,platforms:{linux:{label:`Terminal`}}};",
       ].join(""),
@@ -113,8 +149,42 @@ test("workspace root open targets patch scans current shared app main project ch
 
     assert.equal(result.changed, 1);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
+    assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscodeInsiders/);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("workspace root open targets patch is not applicable without Linux targets", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
+  try {
+    const buildDir = path.join(root, ".vite", "build");
+    const assetsDir = path.join(root, "webview", "assets");
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), "var lM={id:`vscode`};");
+    fs.writeFileSync(
+      path.join(assetsDir, "app-main-current.js"),
+      [
+        "function CurrentWorkspaceMenu(){",
+        "let _=`/tmp/project`,a=()=>{},x=A(`open-file`),C,E;",
+        "C=()=>{if(_==null)return;let e=S(_);Ta({path:_,cwd:e,target:`fileManager`,openFile:x.mutate}),a(!1)};",
+        "E=(0,$.jsx)(di.Item,{LeftIcon:em,onSelect:C,children:`File Manager`});",
+        "return E",
+        "}",
+      ].join(""),
+    );
+
+    const result = patchWorkspaceRootOpenTargets(root);
+
+    assert.deepEqual(result, {
+      matched: 0,
+      changed: 0,
+      status: "skipped-target",
+      reason: "No Linux editor or terminal open targets are enabled",
+    });
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- add a core Linux patch for workspace-root "Open in" targets
- inject VS Code, VS Code Insiders, Zed, terminal, and file-manager project menu entries from the Linux open-target registry
- tolerate aliased callback handlers and current shared app-main project index chunks

## Validation

- `node --test scripts/workspace-root-open-targets-patch.test.js`

## Notes

This brings the project/workspace-root Open In menu in line with the file-level Open In Linux integration.
