### PR TITLE
Restore Linux desktop build info settings

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1200,10 +1200,34 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
     fs.writeFileSync(path.join(assetsDir, name), source, "utf8");
   };
 
+  writeAsset("chunk-A.js", "");
+  writeAsset(
+    "jsx-runtime-A.js",
+    'import{s as s}from"./chunk-A.js";function n(){return{}}function t(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}react.transitional.element;export{n,t};',
+  );
+  writeAsset(
+    "setting-storage-A.js",
+    'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
+  );
+  writeAsset("toggle-A.js", "export{t};");
+  writeAsset(
+    "settings-row-A.js",
+    "function a(e){let{label:t,description:n,control:r}=e;return null}export{a as r};",
+  );
+  writeAsset("settings-content-layout-A.js", "export{n,r,t};");
+  writeAsset("settings-group-A.js", "export{n,t};");
+  writeAsset("settings-surface-A.js", "export{t};");
   writeAsset("keyboard-shortcuts-settings-A.js", "slug:`keyboard-shortcuts`");
   writeAsset(
     "settings-page-A.js",
-    'var Hn={"general-settings":wt,"keyboard-shortcuts":xn};var Wn=[`general-settings`,`profile`,`keyboard-shortcuts`];',
+    [
+      'var Zn={"general-settings":(0,Ya.lazy)(()=>Pr(()=>import(`./general-settings-A.js`),[],import.meta.url)),"keyboard-shortcuts":(0,Ya.lazy)(()=>Pr(()=>import(`./keyboard-shortcuts-settings-A.js`),[],import.meta.url))};',
+      'var Hn={"general-settings":wt,"keyboard-shortcuts":xn};',
+      "var Wn=[`general-settings`,`profile`,`keyboard-shortcuts`];",
+      "var Qn=[{key:`app`,slugs:[`general-settings`,`profile`,`keyboard-shortcuts`]}];",
+      "function visible(e){switch(e.slug){case`general-settings`:case`agent`:case`personalization`:return!0;case`keyboard-shortcuts`:return!0}}",
+      "function loading(H){let W=!1;if(H)bb0:switch(H.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:W=!1;break bb0;case`keyboard-shortcuts`:W=!1;break bb0}return W}",
+    ].join(""),
   );
 
   return { extractedDir, assetsDir };
@@ -3863,17 +3887,32 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
   }
 });
 
-test("skips Linux desktop settings injection when native shortcuts use unsupported settings router", () => {
+test("adds Linux desktop settings when native shortcuts use a consolidated settings bundle", () => {
   const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
   try {
     const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
 
     assert.equal(result.matched, true);
-    assert.equal(result.changed, 0);
-    assert.match(result.reason, /extension point is unavailable/);
+    assert.ok(result.changed >= 2);
+    assert.match(result.reason, /upstream keyboard shortcuts settings are present/);
     assert.deepEqual(warnings, []);
     assert.equal(fs.existsSync(path.join(assetsDir, keybindsSettingsAsset)), false);
-    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), true);
+
+    const linuxDesktopSource = fs.readFileSync(
+      path.join(assetsDir, linuxDesktopSettingsAsset),
+      "utf8",
+    );
+    assert.match(linuxDesktopSource, /Linux desktop/);
+    assert.match(linuxDesktopSource, /Build information/);
+    assert.match(linuxDesktopSource, /codex-linux-get-build-info/);
+
+    const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
+    assert.match(settingsPageSource, /linux-desktop-settings-linux\.js/);
+    assert.match(settingsPageSource, /"linux-desktop":[A-Za-z_$][\w$]*,"general-settings"/);
+    assert.match(settingsPageSource, /=\[`general-settings`,`linux-desktop`,`profile`/);
+    assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
+    assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -321,6 +321,36 @@ function collectRequiredAssetPatches(extractedDir, filenamePattern, patchFn, des
   });
 }
 
+function collectOptionalAssetPatches(extractedDir, filenamePattern, patchFn) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    return [];
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => filenamePattern.test(name))
+    .sort();
+
+  const patches = [];
+  for (const candidate of candidates) {
+    const filePath = path.join(webviewAssetsDir, candidate);
+    const currentSource = fs.readFileSync(filePath, "utf8");
+    try {
+      patches.push({
+        filePath,
+        currentSource,
+        patchedSource: patchFn(currentSource),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`WARN: Optional Keybinds settings patch skipped for ${candidate}: ${message}`);
+    }
+  }
+
+  return patches;
+}
+
 function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -394,40 +424,9 @@ function hasNativeKeyboardShortcutsSettings(extractedDir) {
   return true;
 }
 
-function hasLegacyLinuxDesktopSettingsExtensionPoints(extractedDir) {
-  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
-  if (!fs.existsSync(webviewAssetsDir)) {
-    return false;
-  }
-
-  const assets = fs
-    .readdirSync(webviewAssetsDir)
-    .filter((name) => name.endsWith(".js"))
-    .sort();
-  return [
-    (name) => /^settings-sections-.*\.js$/.test(name),
-    (name) => /^settings-shared-.*\.js$/.test(name),
-    (name) => /^(?:app-main|index|settings-page)-.*\.js$/.test(name),
-    (name) => /^settings-row-.*\.js$/.test(name),
-    (name) => /^settings-content-layout-.*\.js$/.test(name),
-    (name) => /^toggle-.*\.js$/.test(name),
-  ].every((predicate) => assets.some(predicate));
-}
-
 function patchKeybindsSettingsAssets(extractedDir) {
   try {
     const hasNativeSettings = hasNativeKeyboardShortcutsSettings(extractedDir);
-    if (
-      hasNativeSettings &&
-      !hasLegacyLinuxDesktopSettingsExtensionPoints(extractedDir)
-    ) {
-      return {
-        matched: true,
-        changed: 0,
-        reason: "upstream keyboard shortcuts settings are present; Linux desktop settings extension point is unavailable",
-      };
-    }
-
     const settingsAsset = hasNativeSettings
       ? resolveLinuxDesktopSettingsAsset(extractedDir)
       : resolveKeybindsSettingsAsset(extractedDir);
@@ -435,34 +434,40 @@ function patchKeybindsSettingsAssets(extractedDir) {
     const previousSettingsSource = settingsAssetExists
       ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
-    const patches = [
-      ...collectRequiredAssetPatches(
-        extractedDir,
-        /^settings-sections-.*\.js$/,
-        hasNativeSettings
-          ? applyLinuxDesktopSettingsSectionsPatch
-          : applyKeybindsSettingsSectionsPatch,
-        "settings sections bundle",
-      ),
-      ...collectRequiredAssetPatches(
-        extractedDir,
-        /^settings-shared-.*\.js$/,
-        hasNativeSettings
-          ? applyLinuxDesktopSettingsSharedPatch
-          : applyKeybindsSettingsSharedPatch,
-        "settings shared bundle",
-      ),
-      ...(
-        hasNativeSettings
-          ? collectLinuxDesktopRouteAndNavigationPatches(extractedDir)
-          : collectRequiredAssetPatches(
-              extractedDir,
-              /^index-.*\.js$/,
-              applyKeybindsSettingsIndexPatch,
-              "webview index bundle",
-            )
-      ),
-    ];
+    const patches = hasNativeSettings
+      ? [
+          ...collectOptionalAssetPatches(
+            extractedDir,
+            /^settings-sections-.*\.js$/,
+            applyLinuxDesktopSettingsSectionsPatch,
+          ),
+          ...collectOptionalAssetPatches(
+            extractedDir,
+            /^settings-shared-.*\.js$/,
+            applyLinuxDesktopSettingsSharedPatch,
+          ),
+          ...collectLinuxDesktopRouteAndNavigationPatches(extractedDir),
+        ]
+      : [
+          ...collectRequiredAssetPatches(
+            extractedDir,
+            /^settings-sections-.*\.js$/,
+            applyKeybindsSettingsSectionsPatch,
+            "settings sections bundle",
+          ),
+          ...collectRequiredAssetPatches(
+            extractedDir,
+            /^settings-shared-.*\.js$/,
+            applyKeybindsSettingsSharedPatch,
+            "settings shared bundle",
+          ),
+          ...collectRequiredAssetPatches(
+            extractedDir,
+            /^index-.*\.js$/,
+            applyKeybindsSettingsIndexPatch,
+            "webview index bundle",
+          ),
+        ];
 
     fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
     let changed = previousSettingsSource !== settingsAsset.source ? 1 : 0;


### PR DESCRIPTION
## Summary
- restore Linux desktop settings generation when upstream native Keyboard Shortcuts uses a consolidated settings bundle
- stop requiring legacy settings section/shared bundles for the Linux desktop build-info page
- add regression coverage that verifies the generated Linux desktop page still includes build information and IPC hooks

## Root cause
The native Keyboard Shortcuts path returned early when the old Linux desktop settings extension-point assets were missing. Newer upstream settings bundles can still support the Linux desktop route and generated page without those legacy helper bundles, so the early return removed the section that exposed version/build metadata.

## Validation
- node --test scripts/patch-linux-window-ui.test.js
- node --check scripts/patches/keybinds-settings.js
- node --check scripts/patch-linux-window-ui.test.js
- git diff --check