### PR TITLE
Fix Linux desktop settings for current webview bundles

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1255,6 +1255,87 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
   return { extractedDir, assetsDir };
 }
 
+// Mirrors Codex 26.623.42026, where the lazy settings route map was hoisted out of
+// `settings-page-*.js` into a hashed `app-initial~app-main~*.js` concatenation chunk
+// (assigned as a bare `X={...}` inside an IIFE body, no `var` keyword). The
+// `settings-page-*.js` bundle then carries only the icon map, nav order, slug
+// groups, and visibility/loading switches. This is the layout that rendered the
+// Linux desktop nav entry with the page component injected as its icon.
+function createSplitRouteNativeKeyboardShortcutsSettingsFixture() {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-split-route-shortcuts-"));
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+
+  const writeAsset = (name, source = "") => {
+    fs.writeFileSync(path.join(assetsDir, name), source, "utf8");
+  };
+
+  writeAsset("rolldown-runtime-A.js", "function n(e){return e}function s(e){return e}export{n,s};");
+  writeAsset(
+    "shared-runtime-A.js",
+    'import{s as s}from"./rolldown-runtime-A.js";function jsxFactory(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}function reactFactory(){return{useState(){},useCallback(){},useEffect(){}}}function memoCache(){}export{jsxFactory as I,memoCache as L,reactFactory as R};',
+  );
+  writeAsset(
+    "setting-storage-A.js",
+    'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
+  );
+  writeAsset("toggle-A.js", "export{t};");
+  writeAsset(
+    "settings-row-A.js",
+    "function a(e){let{label:t,description:n,control:r}=e;return null}export{a as r};",
+  );
+  writeAsset("settings-content-layout-A.js", "export{n,r,t};");
+  writeAsset("settings-group-A.js", "export{n,t};");
+  writeAsset("settings-surface-A.js", "export{t};");
+  writeAsset(
+    "keyboard-shortcuts-settings-A.js",
+    [
+      'import{n as __module,s as __toESM}from"./rolldown-runtime-A.js";',
+      'import{I as __jsxFactory,L as __memoCache,R as __reactFactory}from"./shared-runtime-A.js";',
+      "function KeyboardShortcutsSettings(){let t=(0,React.useState)(null);return (0,$.jsx)(`div`,{children:t})}",
+      "var React,$;__module(()=>{React=__toESM(__reactFactory(),1),$=__jsxFactory()})();",
+      "slug:`keyboard-shortcuts`;export{KeyboardShortcutsSettings};",
+    ].join(""),
+  );
+  // The icon/navigation bundle: no lazy route map lives here, only the slug -> icon
+  // component map plus the order, group, visibility, and loading metadata.
+  writeAsset(
+    "settings-page-A.js",
+    [
+      'var Hn={"general-settings":wt,"keyboard-shortcuts":xn};',
+      "var Wn=[`general-settings`,`profile`,`keyboard-shortcuts`];",
+      "var Qn=[{key:`app`,slugs:[`general-settings`,`profile`,`keyboard-shortcuts`]}];",
+      "function visible(e){switch(e.slug){case`general-settings`:case`agent`:case`personalization`:return!0;case`keyboard-shortcuts`:return!0}}",
+      "function loading(H){let W=!1;if(H)bb0:switch(H.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:W=!1;break bb0;case`keyboard-shortcuts`:W=!1;break bb0}return W}",
+    ].join(""),
+  );
+  // The hoisted lazy route map, assigned as a bare `FW={...}` inside an IIFE body.
+  writeAsset(
+    "app-initial~app-main~automations-page-A.js",
+    [
+      "var Bn,Ya,Pr,FW,Xn=e((()=>{Bn=s(),Ya=t(f(),1),Pr=o(),",
+      'FW={"general-settings":(0,Ya.lazy)(()=>Pr(()=>import(`./general-settings-A.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([1,2]))),',
+      '"keyboard-shortcuts":(0,Ya.lazy)(()=>Pr(()=>import(`./keyboard-shortcuts-settings-A.js`).then(e=>({default:e.KeyboardShortcutsSettings})),__vite__mapDeps([3])))}',
+      "}));",
+    ].join(""),
+  );
+  writeAsset(
+    "app-initial~app-main~page~remote-conversation-page~new-thread-panel-page~settings-page~shared-A.js",
+    settingsSharedBundleFixture(),
+  );
+  writeAsset(
+    "app-initial~app-main~remote-conversation-page~settings-page~hotkey-window-thread-page~mcp-s-A.js",
+    [
+      "var c,l=e((()=>{c=`general-settings.import.profile.keyboard-shortcuts.codex-micro.appshots.appearance.pets.agent.git-settings.data-controls.cloud-settings.cloud-environments.code-review.personalization.usage.browser-use.computer-use.local-environments.worktrees.environments.mcp-settings.hooks-settings.connections.plugins-settings.skills-settings`.split(`.`)})),u,d,f,p=e((()=>{",
+      "l(),u=`general-settings`,d=function(e){return e.String=`string`,e.Array=`array`,e.Record=`record`,e}({}),",
+      "f=[{slug:`general-settings`},{slug:`import`},{slug:`profile`},{slug:`appearance`},{slug:`pets`},{slug:`appshots`},{slug:`git-settings`},{slug:`connections`},{slug:`cloud-settings`},{slug:`cloud-environments`},{slug:`code-review`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`keyboard-shortcuts`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`},{slug:`hooks-settings`},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}]",
+      "}));",
+    ].join(""),
+  );
+
+  return { extractedDir, assetsDir };
+}
+
 function appSunsetBundleFixture() {
   return [
     "function IT(){return null}",
@@ -3898,10 +3979,11 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     assert.match(appMainSource, /linux-desktop-settings-linux\.js/);
     assert.doesNotMatch(appMainSource, /keybinds-settings-linux\.js/);
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
-    assert.match(
-      settingsPageSource,
-      /"linux-desktop":codexLinuxDesktopSettings,"general-settings":q/,
-    );
+    // The navigation bundle owns the icon map: linux-desktop must reuse the
+    // general-settings icon, never the lazy page component (the route lives in
+    // app-main-A.js). Injecting the page component here renders a broken nav icon.
+    assert.match(settingsPageSource, /"linux-desktop":q,"general-settings":q/);
+    assert.doesNotMatch(settingsPageSource, /"linux-desktop":codexLinuxDesktopSettings/);
     assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
     assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
 
@@ -3963,6 +4045,46 @@ test("adds Linux desktop settings when native shortcuts use a consolidated setti
     );
     assert.match(splitSectionsSource, /general-settings\.linux-desktop\.import\.profile\.keyboard-shortcuts/);
     assert.match(splitSectionsSource, /\{slug:`linux-desktop`\},\{slug:`import`\}/);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("adds Linux desktop settings when the lazy route map is hoisted into a separate app chunk", () => {
+  const { extractedDir, assetsDir } = createSplitRouteNativeKeyboardShortcutsSettingsFixture();
+  try {
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.ok(result.changed >= 3);
+    assert.deepEqual(warnings, []);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), true);
+
+    // The icon/navigation bundle must reuse the general-settings icon for the new
+    // entry and must NOT receive the lazy page component as a nav icon (the bug
+    // that rendered a broken floating "Linux desktop" box over the settings page).
+    const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
+    assert.match(settingsPageSource, /"linux-desktop":wt,"general-settings":wt/);
+    assert.doesNotMatch(settingsPageSource, /linux-desktop-settings-linux\.js/);
+    assert.doesNotMatch(settingsPageSource, /codexLinuxDesktopSettings/);
+    assert.match(settingsPageSource, /=\[`general-settings`,`linux-desktop`,`profile`/);
+    assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
+    assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
+
+    // The lazy route is registered in the hoisted app chunk, reusing the bundle's
+    // own lazy/preload aliases against the bare (no `var`) map assignment.
+    const routeChunkSource = fs.readFileSync(
+      path.join(assetsDir, "app-initial~app-main~automations-page-A.js"),
+      "utf8",
+    );
+    assert.match(
+      routeChunkSource,
+      /"linux-desktop":\(0,Ya\.lazy\)\(\(\)=>Pr\(\(\)=>import\(`\.\/linux-desktop-settings-linux\.js`\),\[\],import\.meta\.url\)\),"general-settings":/,
+    );
+
+    const secondResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(secondResult.matched, true);
+    assert.equal(secondResult.changed, 0);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -22,7 +22,6 @@ const {
   COMPUTER_USE_UI_ENV_VAR,
   COMPUTER_USE_UI_SETTINGS_KEY,
   applyAutomationScheduleMultiTimePatch,
-  applyKeybindsSettingsIndexPatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseInstallFlowPatch,
   applyLinuxNativeDesktopAppsHandlerPatch,
@@ -97,7 +96,6 @@ const {
   keybindsSettingsAsset,
   linuxDesktopSettingsAsset,
   applyLinuxDesktopSettingsSectionsPatch,
-  applyKeybindsSettingsSharedPatch,
   applyLinuxDesktopSettingsSharedPatch,
 } = require("./patches/keybinds-settings.js");
 const {
@@ -129,7 +127,10 @@ const {
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
 } = require("./patches/webview-assets.js");
-const { patchAssetFiles } = require("./patches/shared.js");
+const {
+  findCodexRequestWebviewAsset,
+  patchAssetFiles,
+} = require("./patches/shared.js");
 const { featurePatchDescriptors } = require("./patches/registry.js");
 
 const mainBundlePrefix =
@@ -1104,13 +1105,6 @@ function keybindsIndexBundleFixture() {
     "switch(e){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;}",
     "switch(e){case`usage`:k=g;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;}",
   ].join("");
-}
-
-function keybindsIndexBundleWithLazyAliasDriftFixture() {
-  return keybindsIndexBundleFixture().replaceAll(
-    "(0,Z.lazy)(()=>s(",
-    "(0,R.lazy)(()=>q(",
-  );
 }
 
 function settingsSharedBundleFixture() {
@@ -3889,34 +3883,6 @@ test("inserts native desktop app icon handler before a final native apps handler
   assert.deepEqual(JSON.parse(JSON.stringify(linuxIcon)), { iconSmall: "" });
 });
 
-test("adds Keybinds settings route after upstream minified variable drift", () => {
-  const patched = applyPatchTwice(applyKeybindsSettingsIndexPatch, keybindsIndexBundleFixture());
-
-  assert.match(
-    patched,
-    /var i_e=\{keybinds:\(0,Z\.lazy\)\(\(\)=>s\(\(\)=>import\(`\.\/keybinds-settings-linux\.js`\)/,
-  );
-  assert.match(patched, /var Kge=\{keybinds:xh,"general-settings":xh,/);
-  assert.match(patched, /qge=\[`general-settings`,`keybinds`,`appearance`/);
-  assert.match(patched, /slugs:\[`general-settings`,`keybinds`,`appearance`/);
-  assert.match(patched, /case`keybinds`:return l===`electron`/);
-  assert.match(patched, /case`keybinds`:k=!1;break bb0;/);
-  assert.match(patched, /codexLinuxKeybindOverridesRuntime/);
-});
-
-test("adds Keybinds settings route with current lazy and preload aliases", () => {
-  const patched = applyPatchTwice(
-    applyKeybindsSettingsIndexPatch,
-    keybindsIndexBundleWithLazyAliasDriftFixture(),
-  );
-
-  assert.match(
-    patched,
-    /var i_e=\{keybinds:\(0,R\.lazy\)\(\(\)=>q\(\(\)=>import\(`\.\/keybinds-settings-linux\.js`\)/,
-  );
-  assert.doesNotMatch(patched, /keybinds:\(0,Z\.lazy\)\(\(\)=>s\(/);
-});
-
 test("adds Linux desktop settings route when upstream owns Keyboard Shortcuts", () => {
   const patched = applyPatchTwice(
     applyLinuxDesktopSettingsIndexPatch,
@@ -3933,6 +3899,45 @@ test("adds Linux desktop settings route when upstream owns Keyboard Shortcuts", 
   assert.match(patched, /case`linux-desktop`:return l===`electron`/);
   assert.match(patched, /case`linux-desktop`:k=!1;break bb0;/);
   assert.doesNotMatch(patched, /codexLinuxKeybindOverridesRuntime/);
+});
+
+test("finds a unique current Codex request API asset outside legacy vscode-api chunks", () => {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-request-api-"));
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  try {
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(assetsDir, "app-initial~settings-page-A.js"),
+      'function requestCodex(...args){let[request]=args,{params:params,select:select,signal:signal,source:source}=request??{};return rawCodex("method",params,select,signal,source)}async function rawCodex(method,params,select,signal,source){return transport.post(`vscode://codex/${method}`,params,source,signal)}export{requestCodex as R};',
+      "utf8",
+    );
+
+    assert.deepEqual(findCodexRequestWebviewAsset(assetsDir), {
+      assetName: "app-initial~settings-page-A.js",
+      exportName: "R",
+    });
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("fails loudly when current Codex request API asset detection is ambiguous", () => {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-request-api-ambiguous-"));
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  const requestSource =
+    'function requestCodex(...args){let[request]=args,{params:params,select:select,signal:signal,source:source}=request??{};return rawCodex("method",params,select,signal,source)}async function rawCodex(method,params,select,signal,source){return transport.post(`vscode://codex/${method}`,params,source,signal)}export{requestCodex as R};';
+  try {
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(path.join(assetsDir, "app-a.js"), requestSource, "utf8");
+    fs.writeFileSync(path.join(assetsDir, "app-b.js"), requestSource, "utf8");
+
+    assert.throws(
+      () => findCodexRequestWebviewAsset(assetsDir),
+      /found multiple Codex request API assets \(app-a\.js, app-b\.js\)/,
+    );
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
 });
 
 test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () => {
@@ -3990,6 +3995,67 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
     assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("skips old Keybinds settings generation when native Keyboard Shortcuts are missing", () => {
+  const { extractedDir, assetsDir } = createNativeKeyboardShortcutsSettingsFixture();
+  try {
+    fs.rmSync(path.join(assetsDir, "keyboard-shortcuts-settings-A.js"));
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, false);
+    assert.match(result.reason, /current upstream Keyboard Shortcuts settings route is missing/);
+    assert.ok(warnings.some((warning) => warning.includes("current upstream Keyboard Shortcuts settings route is missing")));
+    assert.equal(fs.existsSync(path.join(assetsDir, keybindsSettingsAsset)), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), false);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("writes only missing Linux settings fallback components after required checks pass", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    fs.rmSync(path.join(assetsDir, "settings-row-A.js"));
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.deepEqual(warnings, []);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-row-linux.js")), true);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-page-linux.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-section-linux.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-group-linux.js")), false);
+    assert.match(
+      fs.readFileSync(path.join(assetsDir, linuxDesktopSettingsAsset), "utf8"),
+      /import\{n as SettingsRow\}from"\.\/linux-settings-row-linux\.js"/,
+    );
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("does not leave generated Linux settings fallbacks when later current-DMG route checks fail", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    fs.rmSync(path.join(assetsDir, "settings-row-A.js"));
+    fs.writeFileSync(
+      path.join(assetsDir, "settings-page-A.js"),
+      "settings.nav.keyboard-shortcuts;var icons={\"general-settings\":wt,\"keyboard-shortcuts\":xn};",
+      "utf8",
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, false);
+    assert.match(result.reason, /could not find Linux desktop settings route bundle/);
+    assert.ok(warnings.some((warning) => warning.includes("could not find Linux desktop settings route bundle")));
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-row-linux.js")), false);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }
@@ -4113,17 +4179,6 @@ test("adds the Linux desktop section title when the JSX message component identi
   );
   // The original general-settings case is preserved untouched.
   assert.match(patched, /case`general-settings`:\{let e;return o\[5\]===Symbol\.for\(`react\.memo_cache_sentinel`\)/);
-});
-
-test("adds the keybinds section title when the JSX message component identifier drifts", () => {
-  const patched = applyKeybindsSettingsSharedPatch(
-    settingsSharedBundleWithDriftingJsxAliasFixture(),
-  );
-
-  assert.match(
-    patched,
-    /case`keybinds`:\{return \(0,d\.jsx\)\(r,\{id:`settings\.section\.keybinds`,defaultMessage:`Keybinds`,description:`Title for keybinds settings section`\}\)\}/,
-  );
 });
 
 test("keeps local environment action modal inputs editable inside stored modal content", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1167,8 +1167,8 @@ function createNativeKeyboardShortcutsSettingsFixture() {
     'import{s as s}from"./chunk-A.js";function n(){return{}}function t(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}react.transitional.element;export{n,t};',
   );
   writeAsset(
-    "setting-storage-A.js",
-    'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
+    "shared-app-A.js",
+    'function requestCodex(...args){let[method,request]=args,{params:params,select:select,signal:signal,source:source}=request??{};return rawCodex(method,params,select,signal,source)}async function rawCodex(method,params,select,signal,source){let result=(await transport.post(`vscode://codex/${method}`,JSON.stringify(params),headers(source),signal)).body;return select?select(result):result}export{requestCodex as z};',
   );
   writeAsset("general-settings-A.js", "hotkey-window-hotkey-state");
   writeAsset("toggle-A.js", "export{t};");
@@ -1200,10 +1200,10 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
     fs.writeFileSync(path.join(assetsDir, name), source, "utf8");
   };
 
-  writeAsset("chunk-A.js", "");
+  writeAsset("rolldown-runtime-A.js", "function n(e){return e}function s(e){return e}export{n,s};");
   writeAsset(
-    "jsx-runtime-A.js",
-    'import{s as s}from"./chunk-A.js";function n(){return{}}function t(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}react.transitional.element;export{n,t};',
+    "shared-runtime-A.js",
+    'import{s as s}from"./rolldown-runtime-A.js";function jsxFactory(){return{jsx(){},jsxs(){},Fragment:"Fragment"}}function reactFactory(){return{useState(){},useCallback(){},useEffect(){}}}function memoCache(){}export{jsxFactory as I,memoCache as L,reactFactory as R};',
   );
   writeAsset(
     "setting-storage-A.js",
@@ -1217,7 +1217,16 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
   writeAsset("settings-content-layout-A.js", "export{n,r,t};");
   writeAsset("settings-group-A.js", "export{n,t};");
   writeAsset("settings-surface-A.js", "export{t};");
-  writeAsset("keyboard-shortcuts-settings-A.js", "slug:`keyboard-shortcuts`");
+  writeAsset(
+    "keyboard-shortcuts-settings-A.js",
+    [
+      'import{n as __module,s as __toESM}from"./rolldown-runtime-A.js";',
+      'import{I as __jsxFactory,L as __memoCache,R as __reactFactory}from"./shared-runtime-A.js";',
+      "function KeyboardShortcutsSettings(){let t=(0,React.useState)(null);return (0,$.jsx)(`div`,{children:t})}",
+      "var React,$;__module(()=>{React=__toESM(__reactFactory(),1),$=__jsxFactory()})();",
+      "slug:`keyboard-shortcuts`;export{KeyboardShortcutsSettings};",
+    ].join(""),
+  );
   writeAsset(
     "settings-page-A.js",
     [
@@ -1227,6 +1236,19 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
       "var Qn=[{key:`app`,slugs:[`general-settings`,`profile`,`keyboard-shortcuts`]}];",
       "function visible(e){switch(e.slug){case`general-settings`:case`agent`:case`personalization`:return!0;case`keyboard-shortcuts`:return!0}}",
       "function loading(H){let W=!1;if(H)bb0:switch(H.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:W=!1;break bb0;case`keyboard-shortcuts`:W=!1;break bb0}return W}",
+    ].join(""),
+  );
+  writeAsset(
+    "app-initial~app-main~page~remote-conversation-page~new-thread-panel-page~settings-page~shared-A.js",
+    settingsSharedBundleFixture(),
+  );
+  writeAsset(
+    "app-initial~app-main~remote-conversation-page~settings-page~hotkey-window-thread-page~mcp-s-A.js",
+    [
+      "var c,l=e((()=>{c=`general-settings.import.profile.keyboard-shortcuts.codex-micro.appshots.appearance.pets.agent.git-settings.data-controls.cloud-settings.cloud-environments.code-review.personalization.usage.browser-use.computer-use.local-environments.worktrees.environments.mcp-settings.hooks-settings.connections.plugins-settings.skills-settings`.split(`.`)})),u,d,f,p=e((()=>{",
+      "l(),u=`general-settings`,d=function(e){return e.String=`string`,e.Array=`array`,e.Record=`record`,e}({}),",
+      "f=[{slug:`general-settings`},{slug:`import`},{slug:`profile`},{slug:`appearance`},{slug:`pets`},{slug:`appshots`},{slug:`git-settings`},{slug:`connections`},{slug:`cloud-settings`},{slug:`cloud-environments`},{slug:`code-review`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`keyboard-shortcuts`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`},{slug:`hooks-settings`},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}]",
+      "}));",
     ].join(""),
   );
 
@@ -3855,13 +3877,14 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     assert.match(linuxDesktopSource, /Build information/);
     assert.match(linuxDesktopSource, /Linux source commit/);
     assert.match(linuxDesktopSource, /Copy commit/);
-    assert.match(linuxDesktopSource, /Open commit/);
+    assert.match(linuxDesktopSource, /Open on GitHub/);
+    assert.doesNotMatch(linuxDesktopSource, /Source commit URL/);
     assert.match(linuxDesktopSource, /href:url/);
     assert.match(linuxDesktopSource, /codex-linux-get-build-info/);
     assert.match(linuxDesktopSource, /codex-linux-system-tray-enabled/);
     assert.match(linuxDesktopSource, /codex-linux-auto-update-on-exit/);
     assert.match(linuxDesktopSource, /import\{r as SettingsRow\}from"\.\/settings-row-A\.js"/);
-    assert.match(linuxDesktopSource, /import\{z as __post\}from"\.\/setting-storage-A\.js"/);
+    assert.match(linuxDesktopSource, /import\{z as __post\}from"\.\/shared-app-A\.js"/);
 
     assert.match(
       fs.readFileSync(path.join(assetsDir, "settings-sections-A.js"), "utf8"),
@@ -3875,7 +3898,10 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     assert.match(appMainSource, /linux-desktop-settings-linux\.js/);
     assert.doesNotMatch(appMainSource, /keybinds-settings-linux\.js/);
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
-    assert.match(settingsPageSource, /"linux-desktop":q,"general-settings":q/);
+    assert.match(
+      settingsPageSource,
+      /"linux-desktop":codexLinuxDesktopSettings,"general-settings":q/,
+    );
     assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
     assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
 
@@ -3906,6 +3932,10 @@ test("adds Linux desktop settings when native shortcuts use a consolidated setti
     assert.match(linuxDesktopSource, /Linux desktop/);
     assert.match(linuxDesktopSource, /Build information/);
     assert.match(linuxDesktopSource, /codex-linux-get-build-info/);
+    assert.match(linuxDesktopSource, /Open on GitHub/);
+    assert.match(linuxDesktopSource, /href:url/);
+    assert.doesNotMatch(linuxDesktopSource, /Source commit URL/);
+    assert.match(linuxDesktopSource, /import\{R as __reactFactory,I as __jsxFactory\}from"\.\/shared-runtime-A\.js"/);
 
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
     assert.match(settingsPageSource, /linux-desktop-settings-linux\.js/);
@@ -3913,6 +3943,26 @@ test("adds Linux desktop settings when native shortcuts use a consolidated setti
     assert.match(settingsPageSource, /=\[`general-settings`,`linux-desktop`,`profile`/);
     assert.match(settingsPageSource, /slugs:\[`general-settings`,`linux-desktop`,`profile`/);
     assert.match(settingsPageSource, /case`linux-desktop`:case`general-settings`/);
+
+    const splitSharedSource = fs.readFileSync(
+      path.join(
+        assetsDir,
+        "app-initial~app-main~page~remote-conversation-page~new-thread-panel-page~settings-page~shared-A.js",
+      ),
+      "utf8",
+    );
+    assert.match(splitSharedSource, /settings\.nav\.linux-desktop/);
+    assert.match(splitSharedSource, /settings\.section\.linux-desktop/);
+
+    const splitSectionsSource = fs.readFileSync(
+      path.join(
+        assetsDir,
+        "app-initial~app-main~remote-conversation-page~settings-page~hotkey-window-thread-page~mcp-s-A.js",
+      ),
+      "utf8",
+    );
+    assert.match(splitSectionsSource, /general-settings\.linux-desktop\.import\.profile\.keyboard-shortcuts/);
+    assert.match(splitSectionsSource, /\{slug:`linux-desktop`\},\{slug:`import`\}/);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -524,9 +524,13 @@ function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
     throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
   }
 
+  // Newer builds split the lazy settings route map out of `app-main-*.js`/`index-*.js`
+  // into hashed concatenation chunks named `app-initial~app-main~*.js` (e.g. the
+  // automations-page chunk), while the icon/navigation metadata stays in
+  // `settings-page-*.js`. Scan all three so the route map is always discoverable.
   const candidates = fs
     .readdirSync(webviewAssetsDir)
-    .filter((name) => /^(?:app-main|index)-.*\.js$/.test(name) || /settings-page.*\.js$/.test(name))
+    .filter((name) => /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/.test(name) || /settings-page.*\.js$/.test(name))
     .sort();
 
   let routeMatched = false;
@@ -903,9 +907,13 @@ function applyKeybindsSettingsIndexPatch(currentSource) {
 }
 
 function isSettingsRouteBundleSource(currentSource) {
+  // Only treat a chunk as the route map when general-settings is wired to a lazy
+  // page component (or the Linux desktop route is already present). The previous
+  // `"general-settings":ID,...,"keyboard-shortcuts":ID` heuristic also matched the
+  // icon map (slug -> SVG component), which caused the route patch to inject the
+  // settings page component as a navigation icon and render a broken nav entry.
   return currentSource.includes(linuxDesktopSettingsAsset)
-    || /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource)
-    || /"general-settings":[A-Za-z_$][\w$]*,[^}]*"keyboard-shortcuts":[A-Za-z_$][\w$]*/.test(currentSource);
+    || /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource);
 }
 
 function isSettingsSectionsMetadataBundleSource(currentSource) {
@@ -938,15 +946,23 @@ function applyLinuxDesktopSettingsRoutePatch(currentSource) {
   let patchedSource = currentSource;
 
   if (!patchedSource.includes(`${linuxDesktopSettingsAsset}`)) {
-    const routePattern = /var ([A-Za-z_$][\w$]*)=\{([^;]*?)"general-settings":(?=\(0,([A-Za-z_$][\w$]*)\.lazy\)\(\(\)=>([A-Za-z_$][\w$]*)\()/;
+    // The route map is `var X={...}` in older bundles but a bare `X={...}` inside an
+    // IIFE body (`...,X={"general-settings":(0,Y.lazy)(...)`) in newer split chunks,
+    // so the `var` keyword is optional and preserved when present.
+    const routePattern = /(var )?([A-Za-z_$][\w$]*)=\{([^;]*?)"general-settings":(?=\(0,([A-Za-z_$][\w$]*)\.lazy\)\(\(\)=>([A-Za-z_$][\w$]*)\()/;
     const directRoutePattern = /((?:var )?[A-Za-z_$][\w$]*=\{)([^;}]*?)"general-settings":(?=[A-Za-z_$][\w$]*,)/;
+    // A navigation/icon bundle (it carries the `slugs:[`general-settings`,...]`
+    // group array) also exposes a `{"general-settings":ID,...}` map, but those IDs
+    // are SVG icon components, not route targets. Never apply the direct-route
+    // fallback there or the page component is injected as a nav icon.
+    const isNavigationBundle = /slugs:\[`general-settings`/.test(patchedSource);
     if (routePattern.test(patchedSource)) {
       patchedSource = patchedSource.replace(
         routePattern,
-        (_match, routeMap, beforeGeneralSettings, lazyAlias, preloadAlias) =>
-          `var ${routeMap}={"linux-desktop":(0,${lazyAlias}.lazy)(()=>${preloadAlias}(()=>import(\`./${linuxDesktopSettingsAsset}\`),[],import.meta.url)),${beforeGeneralSettings}"general-settings":`,
+        (_match, varKeyword, routeMap, beforeGeneralSettings, lazyAlias, preloadAlias) =>
+          `${varKeyword ?? ""}${routeMap}={"linux-desktop":(0,${lazyAlias}.lazy)(()=>${preloadAlias}(()=>import(\`./${linuxDesktopSettingsAsset}\`),[],import.meta.url)),${beforeGeneralSettings}"general-settings":`,
       );
-    } else if (directRoutePattern.test(patchedSource)) {
+    } else if (!isNavigationBundle && directRoutePattern.test(patchedSource)) {
       patchedSource = `import{LinuxDesktopSettings as codexLinuxDesktopSettings}from"./${linuxDesktopSettingsAsset}";${patchedSource}`;
       patchedSource = patchedSource.replace(
         directRoutePattern,

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -286,39 +286,30 @@ function tryFindRequiredWebviewAsset(webviewAssetsDir, namePattern, requiredCont
   }
 }
 
-function writeLinuxSettingsFallbackComponents(webviewAssetsDir, { jsxRuntimeAsset, jsxRuntimeExportName }) {
+function linuxSettingsFallbackComponents({ jsxRuntimeAsset, jsxRuntimeExportName }) {
   const jsxImport = `import{${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";var $=__jsxFactory();`;
-  const rowAsset = "linux-settings-row-linux.js";
-  const sectionAsset = "linux-settings-section-linux.js";
-  const groupAsset = "linux-settings-group-linux.js";
-  const pageAsset = "linux-settings-page-linux.js";
-
-  fs.writeFileSync(
-    path.join(webviewAssetsDir, rowAsset),
-    `${jsxImport}function n({label,description,control}){return $.jsxs("div",{className:"flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between",children:[$.jsxs("div",{className:"min-w-0 flex-1",children:[$.jsx("div",{className:"text-sm font-medium text-token-text-primary",children:label}),$.jsx("div",{className:"mt-1 text-sm text-token-text-secondary",children:description})]}),$.jsx("div",{className:"shrink-0",children:control})]})}export{n};\n`,
-  );
-  fs.writeFileSync(
-    path.join(webviewAssetsDir, sectionAsset),
-    `${jsxImport}function n({children,className}){return $.jsx("section",{className:className??"flex flex-col gap-2",children})}n.Header=function({title}){return $.jsx("h3",{className:"text-base font-medium text-token-text-primary",children:title})};n.Content=function({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light rounded-lg border border-token-border-light bg-token-main-surface-primary",children})};export{n};\n`,
-  );
-  fs.writeFileSync(
-    path.join(webviewAssetsDir, groupAsset),
-    `${jsxImport}function n({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light",children})}export{n};\n`,
-  );
-  fs.writeFileSync(
-    path.join(webviewAssetsDir, pageAsset),
-    `${jsxImport}function t({title,subtitle,children}){return $.jsxs("div",{className:"mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6",children:[$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("h2",{className:"text-xl font-semibold text-token-text-primary",children:title}),subtitle?$.jsx("p",{className:"text-sm text-token-text-secondary",children:subtitle}):null]}),children]})}export{t};\n`,
-  );
 
   return {
-    settingsRowAsset: rowAsset,
-    settingsRowExportName: "n",
-    settingsPageAsset: pageAsset,
-    settingsPageExportName: "t",
-    settingsSectionAsset: sectionAsset,
-    settingsSectionExportName: "n",
-    settingsGroupAsset: groupAsset,
-    settingsGroupExportName: "n",
+    settingsRow: {
+      assetName: "linux-settings-row-linux.js",
+      exportName: "n",
+      source: `${jsxImport}function n({label,description,control}){return $.jsxs("div",{className:"flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between",children:[$.jsxs("div",{className:"min-w-0 flex-1",children:[$.jsx("div",{className:"text-sm font-medium text-token-text-primary",children:label}),$.jsx("div",{className:"mt-1 text-sm text-token-text-secondary",children:description})]}),$.jsx("div",{className:"shrink-0",children:control})]})}export{n};\n`,
+    },
+    settingsSection: {
+      assetName: "linux-settings-section-linux.js",
+      exportName: "n",
+      source: `${jsxImport}function n({children,className}){return $.jsx("section",{className:className??"flex flex-col gap-2",children})}n.Header=function({title}){return $.jsx("h3",{className:"text-base font-medium text-token-text-primary",children:title})};n.Content=function({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light rounded-lg border border-token-border-light bg-token-main-surface-primary",children})};export{n};\n`,
+    },
+    settingsGroup: {
+      assetName: "linux-settings-group-linux.js",
+      exportName: "n",
+      source: `${jsxImport}function n({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light",children})}export{n};\n`,
+    },
+    settingsPage: {
+      assetName: "linux-settings-page-linux.js",
+      exportName: "t",
+      source: `${jsxImport}function t({title,subtitle,children}){return $.jsxs("div",{className:"mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6",children:[$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("h2",{className:"text-xl font-semibold text-token-text-primary",children:title}),subtitle?$.jsx("p",{className:"text-sm text-token-text-secondary",children:subtitle}):null]}),children]})}export{t};\n`,
+    },
   };
 }
 
@@ -367,19 +358,34 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
         "hotkey settings asset",
       )
     : null;
-  const fallbackComponents = writeLinuxSettingsFallbackComponents(webviewAssetsDir, {
+  const fallbackComponents = linuxSettingsFallbackComponents({
     jsxRuntimeAsset,
     jsxRuntimeExportName,
   });
-  const settingsRowAsset = tryFindRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset")
-    ?? fallbackComponents.settingsRowAsset;
-  const settingsRowSource = fs.readFileSync(path.join(webviewAssetsDir, settingsRowAsset), "utf8");
-  const settingsLayoutAsset = tryFindRequiredWebviewAsset(
+  const generatedAssets = [];
+  const useFallbackComponent = (componentName) => {
+    const component = fallbackComponents[componentName];
+    generatedAssets.push({
+      filePath: path.join(webviewAssetsDir, component.assetName),
+      source: component.source,
+    });
+    return component;
+  };
+
+  const settingsRowCandidate = tryFindRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset");
+  const settingsRowFallback = settingsRowCandidate == null ? useFallbackComponent("settingsRow") : null;
+  const settingsRowAsset = settingsRowCandidate ?? settingsRowFallback.assetName;
+  const settingsRowSource = settingsRowCandidate == null
+    ? settingsRowFallback.source
+    : fs.readFileSync(path.join(webviewAssetsDir, settingsRowAsset), "utf8");
+  const settingsLayoutCandidate = tryFindRequiredWebviewAsset(
     webviewAssetsDir,
     /^settings-content-layout-.*\.js$/,
     null,
     "settings content layout asset",
-  ) ?? fallbackComponents.settingsPageAsset;
+  );
+  const settingsLayoutFallback = settingsLayoutCandidate == null ? useFallbackComponent("settingsPage") : null;
+  const settingsLayoutAsset = settingsLayoutCandidate ?? settingsLayoutFallback.assetName;
   const settingsGroupCandidate = fs
     .readdirSync(webviewAssetsDir)
     .filter((name) => /^settings-group-.*\.js$/.test(name))
@@ -388,6 +394,8 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     .readdirSync(webviewAssetsDir)
     .filter((name) => /^settings-surface-.*\.js$/.test(name))
     .sort()[0] ?? null;
+  const settingsSectionFallback = settingsGroupCandidate == null ? useFallbackComponent("settingsSection") : null;
+  const settingsGroupFallback = settingsSurfaceCandidate == null ? useFallbackComponent("settingsGroup") : null;
 
   return {
     chunkAsset,
@@ -401,11 +409,12 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     settingsRowAsset,
     settingsRowExportName: inferSettingsRowExportName(settingsRowSource),
     settingsPageAsset: settingsLayoutAsset,
-    settingsPageExportName: "t",
-    settingsSectionAsset: settingsGroupCandidate ?? fallbackComponents.settingsSectionAsset,
-    settingsSectionExportName: settingsGroupCandidate == null ? fallbackComponents.settingsSectionExportName : "t",
-    settingsGroupAsset: settingsSurfaceCandidate ?? fallbackComponents.settingsGroupAsset,
-    settingsGroupExportName: settingsSurfaceCandidate == null ? fallbackComponents.settingsGroupExportName : "t",
+    settingsPageExportName: settingsLayoutFallback == null ? "t" : settingsLayoutFallback.exportName,
+    settingsSectionAsset: settingsGroupCandidate ?? settingsSectionFallback.assetName,
+    settingsSectionExportName: settingsGroupCandidate == null ? settingsSectionFallback.exportName : "t",
+    settingsGroupAsset: settingsSurfaceCandidate ?? settingsGroupFallback.assetName,
+    settingsGroupExportName: settingsSurfaceCandidate == null ? settingsGroupFallback.exportName : "t",
+    generatedAssets,
   };
 }
 
@@ -416,6 +425,7 @@ function resolveKeybindsSettingsAsset(extractedDir) {
   return {
     filePath: path.join(webviewAssetsDir, keybindsSettingsAsset),
     source: buildKeybindsSettingsSource(dependencies),
+    generatedAssets: dependencies.generatedAssets,
   };
 }
 
@@ -428,6 +438,7 @@ function resolveLinuxDesktopSettingsAsset(extractedDir) {
   return {
     filePath: path.join(webviewAssetsDir, linuxDesktopSettingsAsset),
     source: buildLinuxDesktopSettingsSource(dependencies),
+    generatedAssets: dependencies.generatedAssets,
   };
 }
 
@@ -597,64 +608,49 @@ function hasNativeKeyboardShortcutsSettings(extractedDir) {
 
 function patchKeybindsSettingsAssets(extractedDir) {
   try {
-    const hasNativeSettings = hasNativeKeyboardShortcutsSettings(extractedDir);
-    const settingsAsset = hasNativeSettings
-      ? resolveLinuxDesktopSettingsAsset(extractedDir)
-      : resolveKeybindsSettingsAsset(extractedDir);
+    if (!hasNativeKeyboardShortcutsSettings(extractedDir)) {
+      throw new Error("Required Keybinds settings patch failed: current upstream Keyboard Shortcuts settings route is missing");
+    }
+
+    const settingsAsset = resolveLinuxDesktopSettingsAsset(extractedDir);
     const settingsAssetExists = fs.existsSync(settingsAsset.filePath);
     const previousSettingsSource = settingsAssetExists
       ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
-    const patches = hasNativeSettings
-      ? [
-          ...collectOptionalMatchingAssetPatches(
-            extractedDir,
-            isSettingsSectionsMetadataBundleSource,
-            applyLinuxDesktopSettingsSectionsPatch,
-          ),
-          ...collectOptionalMatchingAssetPatches(
-            extractedDir,
-            isSettingsSharedMetadataBundleSource,
-            applyLinuxDesktopSettingsSharedPatch,
-          ),
-          ...collectLinuxDesktopRouteAndNavigationPatches(extractedDir),
-        ]
-      : [
-          ...collectRequiredAssetPatches(
-            extractedDir,
-            /^settings-sections-.*\.js$/,
-            applyKeybindsSettingsSectionsPatch,
-            "settings sections bundle",
-          ),
-          ...collectRequiredAssetPatches(
-            extractedDir,
-            /^settings-shared-.*\.js$/,
-            applyKeybindsSettingsSharedPatch,
-            "settings shared bundle",
-          ),
-          ...collectRequiredAssetPatches(
-            extractedDir,
-            /^index-.*\.js$/,
-            applyKeybindsSettingsIndexPatch,
-            "webview index bundle",
-          ),
-        ];
+    const patches = [
+      ...collectOptionalMatchingAssetPatches(
+        extractedDir,
+        isSettingsSectionsMetadataBundleSource,
+        applyLinuxDesktopSettingsSectionsPatch,
+      ),
+      ...collectOptionalMatchingAssetPatches(
+        extractedDir,
+        isSettingsSharedMetadataBundleSource,
+        applyLinuxDesktopSettingsSharedPatch,
+      ),
+      ...collectLinuxDesktopRouteAndNavigationPatches(extractedDir),
+    ];
 
+    const generatedWrites = (settingsAsset.generatedAssets ?? []).filter((generatedAsset) =>
+      !fs.existsSync(generatedAsset.filePath) ||
+        fs.readFileSync(generatedAsset.filePath, "utf8") !== generatedAsset.source
+    );
+    for (const generatedAsset of generatedWrites) {
+      fs.writeFileSync(generatedAsset.filePath, generatedAsset.source, "utf8");
+    }
     fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
-    let changed = previousSettingsSource !== settingsAsset.source ? 1 : 0;
+    let changed = generatedWrites.length + (previousSettingsSource !== settingsAsset.source ? 1 : 0);
     for (const patch of patches) {
       if (patch.patchedSource !== patch.currentSource) {
         fs.writeFileSync(patch.filePath, patch.patchedSource, "utf8");
         changed += 1;
       }
     }
-    return hasNativeSettings
-      ? {
-          matched: true,
-          changed,
-          reason: "upstream keyboard shortcuts settings are present; added Linux desktop settings",
-        }
-      : { matched: true, changed };
+    return {
+      matched: true,
+      changed,
+      reason: "upstream keyboard shortcuts settings are present; added Linux desktop settings",
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`WARN: Keybinds settings patch skipped: ${message}`);

--- a/scripts/patches/keybinds-settings.js
+++ b/scripts/patches/keybinds-settings.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const {
+  escapeRegExp,
   findCodexRequestWebviewAsset,
   findImportedAsset,
   findRequiredWebviewAsset,
@@ -16,7 +17,11 @@ const linuxDesktopSettingsAsset = "linux-desktop-settings-linux.js";
 const linuxKeybindOverridesKey = "codex-linux-keybind-overrides";
 
 function linuxBuildInfoPanelSource() {
-  return `function codexLinuxBuildInfoValue(value,fallback="unknown"){return typeof value=="string"&&value.trim().length>0?value:Array.isArray(value)&&value.length>0?value.join(", "):value==null?fallback:String(value)}function codexLinuxBuildInfoRows(payload){let info=payload?.info;if(!info)return [["Metadata file",codexLinuxBuildInfoValue(payload?.path,"not found")]];let target=info.linuxTarget??{},distro=target.distro??{},dmg=info.upstreamDmg??{},source=info.source??{},features=info.linuxFeatures?.enabled??[],profile=info.packageProfile??{},commit=source.commit||source.shortCommit||"",commitValue=commit?source.dirty?\`\${commit} (dirty)\`:commit:"unknown",distroValue=distro.prettyName||[distro.id,distro.versionId].filter(Boolean).join(" ")||"unknown";return [["Metadata file",codexLinuxBuildInfoValue(payload?.path)],["Linux package profile",codexLinuxBuildInfoValue(profile.label)],["Distro",distroValue],["Package manager",codexLinuxBuildInfoValue(target.packageManager??profile.packageManager)],["Package format",codexLinuxBuildInfoValue(target.packageFormat??profile.format)],["Enabled features",features.length>0?features.join(", "):"none"],["Upstream app version",codexLinuxBuildInfoValue(dmg.appVersion)],["Upstream DMG SHA256",codexLinuxBuildInfoValue(dmg.sha256)],["Electron",codexLinuxBuildInfoValue(info.electronVersion)],["Linux source commit",commitValue,payload?.commitUrl],["Source commit URL",codexLinuxBuildInfoValue(payload?.commitUrl,null)],["Source branch",codexLinuxBuildInfoValue(source.branch)],["Generated",codexLinuxBuildInfoValue(info.generatedAt)]].filter(row=>row[1]!=null)}function LinuxBuildInfoPanel(){let[data,setData]=React.useState(null),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null),[copied,setCopied]=React.useState(!1),load=React.useCallback(()=>{setIsLoading(!0),setError(null),__post("codex-linux-get-build-info",{}).then(result=>setData(result)).catch(err=>setError(err instanceof Error?err.message:String(err))).finally(()=>setIsLoading(!1))},[]);React.useEffect(()=>{load()},[load]);let info=data?.info,commit=info?.source?.commit||"",commitUrl=data?.commitUrl||"",copyCommit=()=>{if(!commit)return;let fail=err=>setError(err instanceof Error?err.message:String(err));navigator.clipboard?.writeText?navigator.clipboard.writeText(commit).then(()=>{setCopied(!0),setTimeout(()=>setCopied(!1),1500)}).catch(fail):fail("Clipboard API is unavailable")},openCommit=()=>{commitUrl&&__post("codex-linux-open-build-info-commit",{}).catch(err=>setError(err instanceof Error?err.message:String(err)))},showDetails=()=>__post("codex-linux-show-build-info",{}).catch(err=>setError(err instanceof Error?err.message:String(err))),buttonClass="h-8 rounded-md border border-token-border-default px-3 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60",rows=codexLinuxBuildInfoRows(data),description=isLoading?$.jsx("span",{children:"Loading build metadata..."}):$.jsxs("div",{className:"flex flex-col gap-1 text-sm",children:[...rows.map(([label,value,url])=>{let valueNode=url?$.jsx("a",{href:url,onClick:event=>{event.preventDefault(),openCommit()},className:"select-text break-all rounded bg-token-bg-secondary px-1 py-0.5 font-mono text-xs text-token-text-primary underline underline-offset-2",children:value}):$.jsx("code",{className:"select-text break-all rounded bg-token-bg-secondary px-1 py-0.5 font-mono text-xs text-token-text-primary",children:value});return $.jsxs("div",{className:"flex flex-col gap-0.5",children:[$.jsx("span",{className:"text-token-text-tertiary",children:label}),valueNode]},label)}),error?$.jsx("span",{className:"text-token-error-foreground",children:error}):null,copied?$.jsx("span",{className:"text-token-text-secondary",children:"Commit copied"}):null]});return $.jsx(SettingsRow,{label:"Build information",description,control:$.jsxs("div",{className:"flex flex-wrap items-center justify-end gap-2",children:[$.jsx("button",{type:"button",className:buttonClass,disabled:!commit,onClick:copyCommit,children:"Copy commit"}),$.jsx("button",{type:"button",className:buttonClass,disabled:!commitUrl,onClick:openCommit,children:"Open commit"}),$.jsx("button",{type:"button",className:buttonClass,disabled:isLoading,onClick:load,children:"Refresh"}),$.jsx("button",{type:"button",className:buttonClass,onClick:showDetails,children:"Details"})]})})}`;
+  return `function codexLinuxBuildInfoValue(value,fallback="unknown"){return typeof value=="string"&&value.trim().length>0?value:Array.isArray(value)&&value.length>0?value.join(", "):value==null?fallback:String(value)}function codexLinuxBuildInfoRows(payload){let info=payload?.info;if(!info)return [["Metadata file",codexLinuxBuildInfoValue(payload?.path,"not found")]];let target=info.linuxTarget??{},distro=target.distro??{},dmg=info.upstreamDmg??{},source=info.source??{},features=info.linuxFeatures?.enabled??[],profile=info.packageProfile??{},commit=source.commit||source.shortCommit||"",commitValue=commit?source.dirty?\`\${commit} (dirty)\`:commit:"unknown",distroValue=distro.prettyName||[distro.id,distro.versionId].filter(Boolean).join(" ")||"unknown";return [["Metadata file",codexLinuxBuildInfoValue(payload?.path)],["Linux package profile",codexLinuxBuildInfoValue(profile.label)],["Linux source commit",commitValue,payload?.commitUrl],["Source branch",codexLinuxBuildInfoValue(source.branch)],["Generated",codexLinuxBuildInfoValue(info.generatedAt)],["Distro",distroValue],["Package manager",codexLinuxBuildInfoValue(target.packageManager??profile.packageManager)],["Package format",codexLinuxBuildInfoValue(target.packageFormat??profile.format)],["Enabled features",features.length>0?features.join(", "):"none"],["Upstream app version",codexLinuxBuildInfoValue(dmg.appVersion)],["Electron",codexLinuxBuildInfoValue(info.electronVersion)],["Upstream DMG SHA256",codexLinuxBuildInfoValue(dmg.sha256)]].filter(row=>row[1]!=null)}function LinuxBuildInfoPanel(){let[data,setData]=React.useState(null),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null),[copied,setCopied]=React.useState(!1),load=React.useCallback(()=>{setIsLoading(!0),setError(null),__post("codex-linux-get-build-info",{}).then(result=>setData(result)).catch(err=>setError(err instanceof Error?err.message:String(err))).finally(()=>setIsLoading(!1))},[]);React.useEffect(()=>{load()},[load]);let info=data?.info,commit=info?.source?.commit||"",commitUrl=data?.commitUrl||"",copyCommit=()=>{if(!commit)return;let fail=err=>setError(err instanceof Error?err.message:String(err));navigator.clipboard?.writeText?navigator.clipboard.writeText(commit).then(()=>{setCopied(!0),setTimeout(()=>setCopied(!1),1500)}).catch(fail):fail("Clipboard API is unavailable")},openCommit=()=>{commitUrl&&__post("codex-linux-open-build-info-commit",{}).catch(err=>setError(err instanceof Error?err.message:String(err)))},showDetails=()=>__post("codex-linux-show-build-info",{}).catch(err=>setError(err instanceof Error?err.message:String(err))),buttonClass="h-8 rounded-md border border-token-border-default px-3 text-sm text-token-text-primary hover:bg-token-surface-secondary disabled:opacity-60",rows=codexLinuxBuildInfoRows(data),description=isLoading?$.jsx("span",{children:"Loading build metadata..."}):$.jsxs("div",{className:"flex flex-col gap-2 text-sm",children:[$.jsx("dl",{className:"grid gap-x-4 gap-y-2 rounded-md border border-token-border-default bg-token-bg-secondary p-3 sm:grid-cols-[150px_minmax(0,1fr)]",children:rows.map(([label,value,url])=>{let valueNode=url?$.jsx("a",{href:url,title:url,onClick:event=>{event.preventDefault(),openCommit()},className:"select-text break-all rounded bg-token-bg-primary px-1.5 py-0.5 font-mono text-xs text-token-text-primary underline decoration-token-text-tertiary underline-offset-2 hover:decoration-token-text-primary",children:value}):$.jsx("code",{className:"select-text break-all rounded bg-token-bg-primary px-1.5 py-0.5 font-mono text-xs text-token-text-primary",children:value});return $.jsxs(React.Fragment,{children:[$.jsx("dt",{className:"text-token-text-tertiary",children:label}),$.jsx("dd",{className:"min-w-0",children:valueNode})]},label)})}),error?$.jsx("span",{className:"text-token-error-foreground",children:error}):null,copied?$.jsx("span",{className:"text-token-text-secondary",children:"Commit copied"}):null]});return $.jsx(SettingsRow,{label:"Build information",description,control:$.jsxs("div",{className:"flex flex-wrap items-center justify-end gap-2",children:[$.jsx("button",{type:"button",className:buttonClass,disabled:!commit,onClick:copyCommit,children:"Copy commit"}),$.jsx("button",{type:"button",className:buttonClass,disabled:!commitUrl,onClick:openCommit,children:"Open on GitHub"}),$.jsx("button",{type:"button",className:buttonClass,disabled:isLoading,onClick:load,children:"Refresh"}),$.jsx("button",{type:"button",className:buttonClass,onClick:showDetails,children:"Details"})]})})}`;
+}
+
+function linuxSwitchComponentSource() {
+  return `function LinuxSwitch({checked,disabled,onChange,ariaLabel}){let track=checked?"bg-token-text-primary":"bg-token-bg-secondary border border-token-border-default",knob=checked?"translate-x-4 bg-token-bg-primary":"translate-x-0 bg-token-text-tertiary";return $.jsx("button",{type:"button",role:"switch","aria-checked":!!checked,"aria-label":ariaLabel,disabled,onClick:()=>{disabled||onChange(!checked)},className:"relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors "+track+" disabled:opacity-50",children:$.jsx("span",{className:"inline-block h-5 w-5 rounded-full transition-transform "+knob})})}`;
 }
 
 function buildKeybindsSettingsSource({
@@ -24,10 +29,10 @@ function buildKeybindsSettingsSource({
   reactAsset,
   reactExportName = "t",
   jsxRuntimeAsset,
+  jsxRuntimeExportName = "t",
   vscodeApiAsset,
   vscodeApiExportName = "n",
   hotkeySettingsAsset,
-  toggleAsset,
   settingsRowAsset,
   settingsRowExportName = "n",
   settingsPageAsset,
@@ -38,8 +43,8 @@ function buildKeybindsSettingsSource({
   settingsGroupExportName = "n",
 }) {
   const reactImport = reactAsset === jsxRuntimeAsset
-    ? `import{${reactExportName} as __reactFactory,t as __jsxFactory}from"./${jsxRuntimeAsset}";`
-    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";`;
+    ? `import{${reactExportName} as __reactFactory,${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";`
+    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";`;
   const defaultShortcuts = {
     copyConversationPath: "CmdOrCtrl+Alt+Shift+C",
     copyDeeplink: "CmdOrCtrl+Alt+L",
@@ -142,7 +147,7 @@ function buildKeybindsSettingsSource({
     },
   ];
 
-  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{t as Toggle}from"./${toggleAsset}";import{${settingsRowExportName} as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},DEFAULT_SHORTCUTS=${JSON.stringify(defaultShortcuts)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}${linuxBuildInfoPanelSource()}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."}),$.jsx(LinuxBuildInfoPanel,{})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
+  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{i as HotkeyWindowHotkeyRow}from"./${hotkeySettingsAsset}";import{${settingsRowExportName} as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}},KEYBIND_OVERRIDES_KEY=${JSON.stringify(linuxKeybindOverridesKey)},DEFAULT_SHORTCUTS=${JSON.stringify(defaultShortcuts)},KEYBIND_GROUPS=${JSON.stringify(keybindGroups)};function normalizeOverrides(value){if(!value||typeof value!="object"||Array.isArray(value))return{};return Object.fromEntries(Object.entries(value).filter(([key,accelerator])=>typeof key=="string"&&typeof accelerator=="string"&&accelerator.trim().length>0).map(([key,accelerator])=>[key,accelerator.trim()]))}function readLocalOverrides(){try{return normalizeOverrides(JSON.parse(localStorage.getItem(KEYBIND_OVERRIDES_KEY)||"{}"))}catch{return{}}}function writeLocalOverrides(next){try{localStorage.setItem(KEYBIND_OVERRIDES_KEY,JSON.stringify(next)),window.dispatchEvent(new CustomEvent("codex-linux-keybind-overrides-changed",{detail:next}))}catch{}}function useKeybindOverrides(){let[overrides,setOverrides]=React.useState(()=>readLocalOverrides()),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;__post("get-global-state",{params:{key:KEYBIND_OVERRIDES_KEY}}).then(result=>{if(!alive)return;let next=normalizeOverrides(result?.value);Object.keys(next).length>0?(setOverrides(next),writeLocalOverrides(next)):setOverrides(readLocalOverrides());setError(null)}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))});return()=>{alive=!1}},[]);let update=React.useCallback((actionId,accelerator)=>{setOverrides(previous=>{let next={...previous},defaultValue=typeof DEFAULT_SHORTCUTS[actionId]=="string"?DEFAULT_SHORTCUTS[actionId]:"",trimmed=String(accelerator??"").trim();trimmed.length===0||trimmed===defaultValue?delete next[actionId]:next[actionId]=trimmed;writeLocalOverrides(next);__post("set-global-state",{params:{key:KEYBIND_OVERRIDES_KEY,value:next}}).then(()=>setError(null)).catch(err=>setError(err instanceof Error?err.message:String(err)));return next})},[]);return{overrides,error,update}}function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}${linuxSwitchComponentSource()}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(LinuxSwitch,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}${linuxBuildInfoPanelSource()}function normalizeCapturedKey(key){let map={" ":"Space",ArrowUp:"Up",ArrowDown:"Down",ArrowLeft:"Left",ArrowRight:"Right",Escape:"Esc",",":",",".":".","/":"/","\\\\":"\\\\","[":"[","]":"]",";":";","'":"'","-":"-","=":"=","+":"Plus"};if(map[key])return map[key];if(/^.$/.test(key))return key.toUpperCase();return key}function formatAcceleratorForInput(event){if(!(event.ctrlKey||event.altKey||event.metaKey))return null;if(["Control","Shift","Alt","Meta"].includes(event.key))return null;let parts=[];event.ctrlKey&&parts.push("Ctrl");event.altKey&&parts.push("Alt");event.shiftKey&&parts.push("Shift");event.metaKey&&parts.push("Command");let key=normalizeCapturedKey(event.key);return key?[...parts,key].join("+"):null}function ShortcutInput({value,defaultValue,changed,onChange}){let[draft,setDraft]=React.useState(value);React.useEffect(()=>setDraft(value),[value]);let commit=next=>onChange(String(next??"").trim());return $.jsxs("div",{className:"flex min-w-[260px] items-center justify-end gap-2",children:[$.jsx("input",{className:"h-8 w-[190px] rounded-md border border-token-border-default bg-token-bg-primary px-2 text-sm text-token-text-primary outline-none focus:border-token-border-strong","data-codex-keybind-input":!0,value:draft,placeholder:defaultValue,onChange:event=>{setDraft(event.target.value),onChange(event.target.value)},onBlur:()=>commit(draft),onKeyDown:event=>{if(event.key==="Escape"){setDraft(value);return}if(event.key==="Enter"){event.preventDefault(),commit(draft);return}let captured=formatAcceleratorForInput(event);captured&&(event.preventDefault(),setDraft(captured),onChange(captured))}}),$.jsx("button",{type:"button",className:"h-8 rounded-md border border-token-border-default px-2 text-xs text-token-text-secondary disabled:opacity-40",disabled:!changed,onClick:()=>onChange(""),children:"Reset"})]})}function KeybindRow({action,overrides,update}){let defaultValue=typeof DEFAULT_SHORTCUTS[action.id]=="string"?DEFAULT_SHORTCUTS[action.id]:action.defaultAccelerator??"",hasOverride=Object.prototype.hasOwnProperty.call(overrides,action.id),value=hasOverride?overrides[action.id]:defaultValue,changed=hasOverride&&value!==defaultValue,description=$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:action.description}),$.jsxs("span",{className:"text-token-text-tertiary",children:["Default: ",defaultValue||"Unassigned"]})]});return $.jsx(SettingsRow,{label:action.label,description,control:$.jsx(ShortcutInput,{value,defaultValue,changed,onChange:next=>update(action.id,next)})})}function KeybindGroup({group,overrides,update}){return $.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:group.title}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:group.actions.map(action=>$.jsx(KeybindRow,{action,overrides,update},action.id))})})]},group.title)}function KeybindsSettings(){let{overrides,error,update}=useKeybindOverrides();return $.jsx(SettingsPage,{title:"Keybinds",subtitle:"App shortcuts and Linux desktop behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"App shortcuts"}),error?$.jsx("div",{className:"px-1 text-sm text-token-error-foreground",children:error}):null]}),...KEYBIND_GROUPS.map(group=>$.jsx(KeybindGroup,{group,overrides,update},group.title)),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(HotkeyWindowHotkeyRow,{}),$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Linux desktop"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."}),$.jsx(LinuxBuildInfoPanel,{})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]})]})})}export{KeybindsSettings,KeybindsSettings as default};\n//# sourceMappingURL=${keybindsSettingsAsset}.map\n`;
 }
 
 function buildLinuxDesktopSettingsSource({
@@ -150,9 +155,9 @@ function buildLinuxDesktopSettingsSource({
   reactAsset,
   reactExportName = "t",
   jsxRuntimeAsset,
+  jsxRuntimeExportName = "t",
   vscodeApiAsset,
   vscodeApiExportName = "n",
-  toggleAsset,
   settingsRowAsset,
   settingsRowExportName = "n",
   settingsPageAsset,
@@ -163,10 +168,10 @@ function buildLinuxDesktopSettingsSource({
   settingsGroupExportName = "n",
 }) {
   const reactImport = reactAsset === jsxRuntimeAsset
-    ? `import{${reactExportName} as __reactFactory,t as __jsxFactory}from"./${jsxRuntimeAsset}";`
-    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{t as __jsxFactory}from"./${jsxRuntimeAsset}";`;
+    ? `import{${reactExportName} as __reactFactory,${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";`
+    : `import{${reactExportName} as __reactFactory}from"./${reactAsset}";import{${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";`;
 
-  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{t as Toggle}from"./${toggleAsset}";import{${settingsRowExportName} as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}};function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(Toggle,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}${linuxBuildInfoPanelSource()}function LinuxDesktopSettings(){return $.jsx(SettingsPage,{title:"Linux desktop",subtitle:"Launcher, tray, prompt window, and update behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Desktop integration"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Build"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxBuildInfoPanel,{})})})]})]})})}export{LinuxDesktopSettings,LinuxDesktopSettings as default};\n//# sourceMappingURL=${linuxDesktopSettingsAsset}.map\n`;
+  return `import{s as __toESM}from"./${chunkAsset}";${reactImport}import{${vscodeApiExportName} as __post}from"./${vscodeApiAsset}";import{${settingsRowExportName} as SettingsRow}from"./${settingsRowAsset}";import{${settingsSectionExportName} as SettingsSection}from"./${settingsSectionAsset}";import{${settingsGroupExportName} as SettingsGroup}from"./${settingsGroupAsset}";import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";var React=__toESM(__reactFactory(),1),$=__jsxFactory(),KEYS={promptWindow:${JSON.stringify(linuxSettingsKeys.promptWindow)},systemTray:${JSON.stringify(linuxSettingsKeys.systemTray)},warmStart:${JSON.stringify(linuxSettingsKeys.warmStart)},autoUpdateOnExit:${JSON.stringify(linuxSettingsKeys.autoUpdateOnExit)}};function useLinuxSetting(key,defaultValue){let[value,setValue]=React.useState(defaultValue),[isLoading,setIsLoading]=React.useState(!0),[error,setError]=React.useState(null);React.useEffect(()=>{let alive=!0;setIsLoading(!0);__post("get-global-state",{params:{key}}).then(result=>{alive&&(setValue(result?.value??defaultValue),setError(null))}).catch(err=>{alive&&setError(err instanceof Error?err.message:String(err))}).finally(()=>{alive&&setIsLoading(!1)});return()=>{alive=!1}},[key,defaultValue]);let update=React.useCallback(next=>{let previous=value;setValue(next);setError(null);__post("set-global-state",{params:{key,value:next}}).catch(err=>{setValue(previous);setError(err instanceof Error?err.message:String(err))})},[key,value]);return{value,isLoading,error,update}}${linuxSwitchComponentSource()}function LinuxToggle({settingKey,label,description,defaultValue=!0}){let{value,isLoading,error,update}=useLinuxSetting(settingKey,defaultValue),details=error?$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("span",{children:description}),$.jsx("span",{className:"text-token-error-foreground",children:error})]}):description;return $.jsx(SettingsRow,{label,description:details,control:$.jsx(LinuxSwitch,{checked:value,disabled:isLoading,onChange:update,ariaLabel:label})})}${linuxBuildInfoPanelSource()}function LinuxDesktopSettings(){return $.jsx(SettingsPage,{title:"Linux desktop",subtitle:"Launcher, tray, prompt window, and update behavior.",children:$.jsxs("div",{className:"flex flex-col gap-6",children:[$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Global shortcuts"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.promptWindow,label:"Compact prompt window",description:"Allow --prompt-chat and --hotkey-window to open the compact prompt window and keep it prewarmed."})})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Desktop integration"}),$.jsx(SettingsSection.Content,{children:$.jsxs(SettingsGroup,{children:[$.jsx(LinuxToggle,{settingKey:KEYS.systemTray,label:"System tray",description:"Show the Codex system tray icon and keep the app available from the tray."}),$.jsx(LinuxToggle,{settingKey:KEYS.warmStart,label:"Warm start",description:"Use the running app for launch actions instead of starting a fresh Electron instance."})]})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Updates"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxToggle,{settingKey:KEYS.autoUpdateOnExit,label:"Install updates when you close Codex",description:"When on, a ready update waits for Codex to close and then installs. When off, updates wait until you click Update."})})})]}),$.jsxs(SettingsSection,{className:"gap-2",children:[$.jsx(SettingsSection.Header,{title:"Build"}),$.jsx(SettingsSection.Content,{children:$.jsx(SettingsGroup,{children:$.jsx(LinuxBuildInfoPanel,{})})})]})]})})}export{LinuxDesktopSettings,LinuxDesktopSettings as default};\n//# sourceMappingURL=${linuxDesktopSettingsAsset}.map\n`;
 }
 
 function inferSettingsRowExportName(source) {
@@ -212,19 +217,145 @@ function inferSettingsRowExportName(source) {
   return "n";
 }
 
+function importBindings(source) {
+  const bindings = new Map();
+  const importPattern = /import\{([^}]*)\}from"\.\/([^"]+)"/g;
+  let match;
+  while ((match = importPattern.exec(source)) != null) {
+    const [, specifiers, assetName] = match;
+    for (const rawSpecifier of specifiers.split(",")) {
+      const specifier = rawSpecifier.trim();
+      if (specifier.length === 0) {
+        continue;
+      }
+      const aliased = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+      if (aliased != null) {
+        bindings.set(aliased[2], { assetName, exportName: aliased[1] });
+      } else {
+        bindings.set(specifier, { assetName, exportName: specifier });
+      }
+    }
+  }
+  return bindings;
+}
+
+function inferRuntimeDependenciesFromSettingsSource(source) {
+  const jsxLocal = source.match(/\(0,([A-Za-z_$][\w$]*)\.jsx\)/)?.[1] ?? null;
+  const reactLocal = source.match(/\(0,([A-Za-z_$][\w$]*)\.useState\)/)?.[1] ?? null;
+  if (jsxLocal == null || reactLocal == null) {
+    return null;
+  }
+
+  const jsxFactoryLocal = source.match(
+    new RegExp(`${escapeRegExp(jsxLocal)}=([A-Za-z_$][\\w$]*)\\(\\)`),
+  )?.[1] ?? null;
+  const reactFactoryLocal = source.match(
+    new RegExp(`${escapeRegExp(reactLocal)}=[A-Za-z_$][\\w$]*\\(([A-Za-z_$][\\w$]*)\\(\\),1\\)`),
+  )?.[1] ?? null;
+  if (jsxFactoryLocal == null || reactFactoryLocal == null) {
+    return null;
+  }
+
+  const bindings = importBindings(source);
+  const jsxBinding = bindings.get(jsxFactoryLocal);
+  const reactBinding = bindings.get(reactFactoryLocal);
+  if (jsxBinding == null || reactBinding == null) {
+    return null;
+  }
+
+  return {
+    jsxRuntimeAsset: jsxBinding.assetName,
+    jsxRuntimeExportName: jsxBinding.exportName,
+    reactAsset: reactBinding.assetName,
+    reactExportName: reactBinding.exportName,
+  };
+}
+
+function findNativeKeyboardShortcutsSettingsAsset(webviewAssetsDir) {
+  return fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^keyboard-shortcuts-settings-.*\.js$/.test(name))
+    .sort()[0] ?? null;
+}
+
+function tryFindRequiredWebviewAsset(webviewAssetsDir, namePattern, requiredContent, description) {
+  try {
+    return findRequiredWebviewAsset(webviewAssetsDir, namePattern, requiredContent, description);
+  } catch {
+    return null;
+  }
+}
+
+function writeLinuxSettingsFallbackComponents(webviewAssetsDir, { jsxRuntimeAsset, jsxRuntimeExportName }) {
+  const jsxImport = `import{${jsxRuntimeExportName} as __jsxFactory}from"./${jsxRuntimeAsset}";var $=__jsxFactory();`;
+  const rowAsset = "linux-settings-row-linux.js";
+  const sectionAsset = "linux-settings-section-linux.js";
+  const groupAsset = "linux-settings-group-linux.js";
+  const pageAsset = "linux-settings-page-linux.js";
+
+  fs.writeFileSync(
+    path.join(webviewAssetsDir, rowAsset),
+    `${jsxImport}function n({label,description,control}){return $.jsxs("div",{className:"flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between",children:[$.jsxs("div",{className:"min-w-0 flex-1",children:[$.jsx("div",{className:"text-sm font-medium text-token-text-primary",children:label}),$.jsx("div",{className:"mt-1 text-sm text-token-text-secondary",children:description})]}),$.jsx("div",{className:"shrink-0",children:control})]})}export{n};\n`,
+  );
+  fs.writeFileSync(
+    path.join(webviewAssetsDir, sectionAsset),
+    `${jsxImport}function n({children,className}){return $.jsx("section",{className:className??"flex flex-col gap-2",children})}n.Header=function({title}){return $.jsx("h3",{className:"text-base font-medium text-token-text-primary",children:title})};n.Content=function({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light rounded-lg border border-token-border-light bg-token-main-surface-primary",children})};export{n};\n`,
+  );
+  fs.writeFileSync(
+    path.join(webviewAssetsDir, groupAsset),
+    `${jsxImport}function n({children}){return $.jsx("div",{className:"flex flex-col divide-y divide-token-border-light",children})}export{n};\n`,
+  );
+  fs.writeFileSync(
+    path.join(webviewAssetsDir, pageAsset),
+    `${jsxImport}function t({title,subtitle,children}){return $.jsxs("div",{className:"mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-6",children:[$.jsxs("div",{className:"flex flex-col gap-1",children:[$.jsx("h2",{className:"text-xl font-semibold text-token-text-primary",children:title}),subtitle?$.jsx("p",{className:"text-sm text-token-text-secondary",children:subtitle}):null]}),children]})}export{t};\n`,
+  );
+
+  return {
+    settingsRowAsset: rowAsset,
+    settingsRowExportName: "n",
+    settingsPageAsset: pageAsset,
+    settingsPageExportName: "t",
+    settingsSectionAsset: sectionAsset,
+    settingsSectionExportName: "n",
+    settingsGroupAsset: groupAsset,
+    settingsGroupExportName: "n",
+  };
+}
+
 function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings = true } = {}) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
     throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
   }
 
-  const jsxRuntimeAsset = findRequiredWebviewAsset(webviewAssetsDir, /^jsx-runtime-.*\.js$/, "react.transitional.element", "JSX runtime asset");
-  const jsxRuntimeSource = fs.readFileSync(path.join(webviewAssetsDir, jsxRuntimeAsset), "utf8");
-  const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
-  const reactAsset = jsxExportsReactFactory
-    ? jsxRuntimeAsset
-    : findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
-  const reactExportName = jsxExportsReactFactory ? "n" : "t";
+  let runtimeDependencies = null;
+  const nativeKeyboardShortcutsAsset = findNativeKeyboardShortcutsSettingsAsset(webviewAssetsDir);
+  if (nativeKeyboardShortcutsAsset != null) {
+    const source = fs.readFileSync(path.join(webviewAssetsDir, nativeKeyboardShortcutsAsset), "utf8");
+    runtimeDependencies = inferRuntimeDependenciesFromSettingsSource(source);
+  }
+
+  let jsxRuntimeAsset;
+  let jsxRuntimeExportName;
+  let reactAsset;
+  let reactExportName;
+  if (runtimeDependencies != null) {
+    ({
+      jsxRuntimeAsset,
+      jsxRuntimeExportName,
+      reactAsset,
+      reactExportName,
+    } = runtimeDependencies);
+  } else {
+    jsxRuntimeAsset = findRequiredWebviewAsset(webviewAssetsDir, /^jsx-runtime-.*\.js$/, "react.transitional.element", "JSX runtime asset");
+    const jsxRuntimeSource = fs.readFileSync(path.join(webviewAssetsDir, jsxRuntimeAsset), "utf8");
+    const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
+    reactAsset = jsxExportsReactFactory
+      ? jsxRuntimeAsset
+      : findRequiredWebviewAsset(webviewAssetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
+    reactExportName = jsxExportsReactFactory ? "n" : "t";
+    jsxRuntimeExportName = "t";
+  }
   const chunkAsset = findImportedAsset(webviewAssetsDir, reactAsset, "React shared chunk asset");
   const { assetName: vscodeApiAsset, exportName: vscodeApiExportName } =
     findCodexRequestWebviewAsset(webviewAssetsDir);
@@ -236,15 +367,19 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
         "hotkey settings asset",
       )
     : null;
-  const toggleAsset = findRequiredWebviewAsset(webviewAssetsDir, /^toggle-.*\.js$/, null, "toggle asset");
-  const settingsRowAsset = findRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset");
+  const fallbackComponents = writeLinuxSettingsFallbackComponents(webviewAssetsDir, {
+    jsxRuntimeAsset,
+    jsxRuntimeExportName,
+  });
+  const settingsRowAsset = tryFindRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset")
+    ?? fallbackComponents.settingsRowAsset;
   const settingsRowSource = fs.readFileSync(path.join(webviewAssetsDir, settingsRowAsset), "utf8");
-  const settingsLayoutAsset = findRequiredWebviewAsset(
+  const settingsLayoutAsset = tryFindRequiredWebviewAsset(
     webviewAssetsDir,
     /^settings-content-layout-.*\.js$/,
     null,
     "settings content layout asset",
-  );
+  ) ?? fallbackComponents.settingsPageAsset;
   const settingsGroupCandidate = fs
     .readdirSync(webviewAssetsDir)
     .filter((name) => /^settings-group-.*\.js$/.test(name))
@@ -259,18 +394,18 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     reactAsset,
     reactExportName,
     jsxRuntimeAsset,
+    jsxRuntimeExportName,
     vscodeApiAsset,
     vscodeApiExportName,
     hotkeySettingsAsset,
-    toggleAsset,
     settingsRowAsset,
     settingsRowExportName: inferSettingsRowExportName(settingsRowSource),
     settingsPageAsset: settingsLayoutAsset,
     settingsPageExportName: "t",
-    settingsSectionAsset: settingsGroupCandidate ?? settingsLayoutAsset,
-    settingsSectionExportName: settingsGroupCandidate == null ? "r" : "t",
-    settingsGroupAsset: settingsSurfaceCandidate ?? settingsLayoutAsset,
-    settingsGroupExportName: settingsSurfaceCandidate == null ? "n" : "t",
+    settingsSectionAsset: settingsGroupCandidate ?? fallbackComponents.settingsSectionAsset,
+    settingsSectionExportName: settingsGroupCandidate == null ? fallbackComponents.settingsSectionExportName : "t",
+    settingsGroupAsset: settingsSurfaceCandidate ?? fallbackComponents.settingsGroupAsset,
+    settingsGroupExportName: settingsSurfaceCandidate == null ? fallbackComponents.settingsGroupExportName : "t",
   };
 }
 
@@ -351,6 +486,38 @@ function collectOptionalAssetPatches(extractedDir, filenamePattern, patchFn) {
   return patches;
 }
 
+function collectOptionalMatchingAssetPatches(extractedDir, predicate, patchFn) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    return [];
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+
+  const patches = [];
+  for (const candidate of candidates) {
+    const filePath = path.join(webviewAssetsDir, candidate);
+    const currentSource = fs.readFileSync(filePath, "utf8");
+    if (!predicate(currentSource)) {
+      continue;
+    }
+    try {
+      patches.push({
+        filePath,
+        currentSource,
+        patchedSource: patchFn(currentSource),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`WARN: Optional Keybinds settings patch skipped for ${candidate}: ${message}`);
+    }
+  }
+
+  return patches;
+}
 function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -359,7 +526,7 @@ function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
 
   const candidates = fs
     .readdirSync(webviewAssetsDir)
-    .filter((name) => /^(?:app-main|index|settings-page)-.*\.js$/.test(name))
+    .filter((name) => /^(?:app-main|index)-.*\.js$/.test(name) || /settings-page.*\.js$/.test(name))
     .sort();
 
   let routeMatched = false;
@@ -436,14 +603,14 @@ function patchKeybindsSettingsAssets(extractedDir) {
       : null;
     const patches = hasNativeSettings
       ? [
-          ...collectOptionalAssetPatches(
+          ...collectOptionalMatchingAssetPatches(
             extractedDir,
-            /^settings-sections-.*\.js$/,
+            isSettingsSectionsMetadataBundleSource,
             applyLinuxDesktopSettingsSectionsPatch,
           ),
-          ...collectOptionalAssetPatches(
+          ...collectOptionalMatchingAssetPatches(
             extractedDir,
-            /^settings-shared-.*\.js$/,
+            isSettingsSharedMetadataBundleSource,
             applyLinuxDesktopSettingsSharedPatch,
           ),
           ...collectLinuxDesktopRouteAndNavigationPatches(extractedDir),
@@ -522,7 +689,8 @@ function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
 
   if (
     patchedSource.includes("slug:`linux-desktop`") &&
-    /=\[`general-settings`,`linux-desktop`/.test(patchedSource)
+    (/=\[`general-settings`,`linux-desktop`/.test(patchedSource)
+      || /`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/.test(patchedSource))
   ) {
     return patchedSource;
   }
@@ -531,6 +699,13 @@ function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
     const orderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
     if (orderPattern.test(patchedSource)) {
       patchedSource = patchedSource.replace(orderPattern, "$1`linux-desktop`,");
+    }
+  }
+
+  if (!/`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/.test(patchedSource)) {
+    const splitOrderPattern = /(`general-settings\.)(?!linux-desktop\.)([^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\))/;
+    if (splitOrderPattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(splitOrderPattern, "$1linux-desktop.$2");
     }
   }
 
@@ -729,7 +904,23 @@ function applyKeybindsSettingsIndexPatch(currentSource) {
 
 function isSettingsRouteBundleSource(currentSource) {
   return currentSource.includes(linuxDesktopSettingsAsset)
-    || /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource);
+    || /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource)
+    || /"general-settings":[A-Za-z_$][\w$]*,[^}]*"keyboard-shortcuts":[A-Za-z_$][\w$]*/.test(currentSource);
+}
+
+function isSettingsSectionsMetadataBundleSource(currentSource) {
+  return (
+    currentSource.includes("slug:`general-settings`")
+    && currentSource.includes("slug:`keyboard-shortcuts`")
+  ) || (
+    /[A-Za-z_$][\w$]*=`general-settings`/.test(currentSource)
+    && currentSource.includes("slug:`keyboard-shortcuts`")
+  ) || /`general-settings\.[^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\)/.test(currentSource);
+}
+
+function isSettingsSharedMetadataBundleSource(currentSource) {
+  return currentSource.includes('"general-settings":{id:`settings.nav.general-settings`')
+    || currentSource.includes("id:`settings.section.general-settings`,defaultMessage:`General`");
 }
 
 function isSettingsNavigationBundleSource(currentSource) {
@@ -748,14 +939,23 @@ function applyLinuxDesktopSettingsRoutePatch(currentSource) {
 
   if (!patchedSource.includes(`${linuxDesktopSettingsAsset}`)) {
     const routePattern = /var ([A-Za-z_$][\w$]*)=\{([^;]*?)"general-settings":(?=\(0,([A-Za-z_$][\w$]*)\.lazy\)\(\(\)=>([A-Za-z_$][\w$]*)\()/;
-    if (!routePattern.test(patchedSource)) {
+    const directRoutePattern = /((?:var )?[A-Za-z_$][\w$]*=\{)([^;}]*?)"general-settings":(?=[A-Za-z_$][\w$]*,)/;
+    if (routePattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        routePattern,
+        (_match, routeMap, beforeGeneralSettings, lazyAlias, preloadAlias) =>
+          `var ${routeMap}={"linux-desktop":(0,${lazyAlias}.lazy)(()=>${preloadAlias}(()=>import(\`./${linuxDesktopSettingsAsset}\`),[],import.meta.url)),${beforeGeneralSettings}"general-settings":`,
+      );
+    } else if (directRoutePattern.test(patchedSource)) {
+      patchedSource = `import{LinuxDesktopSettings as codexLinuxDesktopSettings}from"./${linuxDesktopSettingsAsset}";${patchedSource}`;
+      patchedSource = patchedSource.replace(
+        directRoutePattern,
+        (_match, prefix, beforeGeneralSettings) =>
+          `${prefix}"linux-desktop":codexLinuxDesktopSettings,${beforeGeneralSettings}"general-settings":`,
+      );
+    } else {
       throw new Error("Required Keybinds settings patch failed: could not add Linux desktop route");
     }
-    patchedSource = patchedSource.replace(
-      routePattern,
-      (_match, routeMap, beforeGeneralSettings, lazyAlias, preloadAlias) =>
-        `var ${routeMap}={"linux-desktop":(0,${lazyAlias}.lazy)(()=>${preloadAlias}(()=>import(\`./${linuxDesktopSettingsAsset}\`),[],import.meta.url)),${beforeGeneralSettings}"general-settings":`,
-    );
   }
 
   return patchedSource;

--- a/scripts/patches/shared.js
+++ b/scripts/patches/shared.js
@@ -196,6 +196,7 @@ function findCodexRequestWebviewAsset(webviewAssetsDir) {
     .sort()
     .filter((name) => !settingStorageCandidates.includes(name));
   const modernCandidates = [...settingStorageCandidates, ...allRequestCandidates];
+  const matches = [];
   for (const candidate of modernCandidates) {
     const source = readWebviewAsset(webviewAssetsDir, candidate);
     if (!source.includes("vscode://codex/")) {
@@ -203,8 +204,18 @@ function findCodexRequestWebviewAsset(webviewAssetsDir) {
     }
     const exportName = findCodexRequestExportName(source);
     if (exportName != null) {
-      return { assetName: candidate, exportName };
+      matches.push({ assetName: candidate, exportName });
     }
+  }
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Required Keybinds settings patch failed: found multiple Codex request API assets (${matches.map(({ assetName }) => assetName).join(", ")})`,
+    );
+  }
+
+  if (matches.length === 1) {
+    return matches[0];
   }
 
   throw new Error("Required Keybinds settings patch failed: could not find Codex request API asset");

--- a/scripts/patches/shared.js
+++ b/scripts/patches/shared.js
@@ -149,14 +149,27 @@ function findExportedAlias(source, localName) {
 }
 
 function findCodexRequestExportName(source) {
-  const match = source.match(
+  let match = source.match(
     /async function\s+([A-Za-z_$][\w$]*)\(\.\.\.[^)]+\)\{let\[[^\]]+\]=[^;]+,\{params:[^}]+source:[^}]+\}=[^;]+;return\s+[A-Za-z_$][\w$]*\([^)]*\)\}/,
   );
-  if (match == null) {
-    return null;
+  if (match != null) {
+    return findExportedAlias(source, match[1]);
   }
 
-  return findExportedAlias(source, match[1]);
+  match = source.match(
+    /function\s+([A-Za-z_$][\w$]*)\(\.\.\.[^)]+\)\{let\[[^\]]+\]=[^;]+,\{params:[^}]+select:[^}]+signal:[^}]+source:[^}]+\}=[^;]+;return\s+([A-Za-z_$][\w$]*)\([^)]*\)\}/,
+  );
+  if (match != null) {
+    const [, wrapperName, rawRequestName] = match;
+    const rawRequestPattern = new RegExp(
+      `async function\\s+${rawRequestName}\\([^)]*\\)\\{[\\s\\S]{0,600}?vscode://codex/`,
+    );
+    if (rawRequestPattern.test(source)) {
+      return findExportedAlias(source, wrapperName);
+    }
+  }
+
+  return null;
 }
 
 function findCodexRequestWebviewAsset(webviewAssetsDir) {
@@ -173,10 +186,16 @@ function findCodexRequestWebviewAsset(webviewAssetsDir) {
     return { assetName: legacyAsset, exportName: "n" };
   }
 
-  const modernCandidates = fs
+  const settingStorageCandidates = fs
     .readdirSync(webviewAssetsDir)
     .filter((name) => regexpTest(/^setting-storage-.*\.js$/, name))
     .sort();
+  const allRequestCandidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => regexpTest(/\.js$/, name))
+    .sort()
+    .filter((name) => !settingStorageCandidates.includes(name));
+  const modernCandidates = [...settingStorageCandidates, ...allRequestCandidates];
   for (const candidate of modernCandidates) {
     const source = readWebviewAsset(webviewAssetsDir, candidate);
     if (!source.includes("vscode://codex/")) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4819,7 +4819,7 @@ NODE
 }
 
 test_keybinds_settings_tab_patch_smoke() {
-    info "Checking Keybinds settings tab patch behavior"
+    info "Checking Linux desktop settings tab patch behavior"
     local workspace="$TMP_DIR/keybinds-settings-patch"
     local extracted="$workspace/extracted"
     local output_log="$workspace/output.log"
@@ -4828,135 +4828,45 @@ test_keybinds_settings_tab_patch_smoke() {
     make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let t={join(){}};let a={existsSync(){return true},statSync(){return {isFile(){return false}}}};let n={shell:{openPath(){return ""},showItemInFolder(){}}};...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
 
     cat > "$extracted/webview/assets/settings-sections-test.js" <<'JS'
-var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`appearance`},{slug:`git-settings`},{slug:`connections`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:t},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}],r=t;export{n,t as r,e as t};
+var e=[`general-settings`,`profile`,`keyboard-shortcuts`,`account`],t=`general-settings`,n=function(){},r=[{slug:`general-settings`},{slug:`profile`},{slug:`appearance`},{slug:`keyboard-shortcuts`}];
 JS
     cat > "$extracted/webview/assets/settings-shared-test.js" <<'JS'
-import{t as d}from"./jsx-runtime-ebkFq_df.js";var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},appearance:{id:`settings.nav.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`appearance`:{let e;return t[1]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.appearance`,defaultMessage:`Appearance`,description:`Title for appearance settings section`}),t[1]=e):e=t[1],e}case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
+import{t as d}from"./jsx-runtime-test.js";var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},"keyboard-shortcuts":{id:`settings.nav.keyboard-shortcuts`,defaultMessage:`Keyboard shortcuts`,description:`Title for keyboard shortcuts settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`keyboard-shortcuts`:{let e;return t[1]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.keyboard-shortcuts`,defaultMessage:`Keyboard shortcuts`,description:`Title for keyboard shortcuts settings section`}),t[1]=e):e=t[1],e}case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
 JS
     cat > "$extracted/webview/assets/index-test.js" <<'JS'
-var Xge={"general-settings":xh,appearance:Pf,agent:gU},H7={},Zge=[`general-settings`,`appearance`,`agent`,`personalization`,`mcp-settings`,`connections`,`git-settings`,`local-environments`,`worktrees`,`browser-use`,`computer-use`,`data-controls`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];function n_e(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:case`agent`:case`personalization`:case`mcp-settings`:return!0}};if(O)bb0:switch(D.slug){case`usage`:k=g;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;}}function s_e(e){let{slug:n}=e,r=c_e[n];return (0,$.jsx)(r,{})}var c_e={"general-settings":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DZbwMmWz.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([4]),import.meta.url)),appearance:(0,Z.lazy)(()=>s(()=>import(`./appearance-settings-D4xYjo5o.js`).then(e=>({default:e.AppearanceSettings})),__vite__mapDeps([56]),import.meta.url)),agent:(0,Z.lazy)(()=>Promise.resolve({default:l_e}))};
+var Xge={"general-settings":xh,"keyboard-shortcuts":ks,appearance:Pf,agent:gU},H7={},Zge=[`general-settings`,`profile`,`keyboard-shortcuts`,`appearance`,`agent`,`personalization`,`mcp-settings`,`connections`,`git-settings`,`local-environments`,`worktrees`,`browser-use`,`computer-use`,`data-controls`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`profile`,`keyboard-shortcuts`,`appearance`,`connections`,`git-settings`,`usage`]}];function n_e(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:case`agent`:case`personalization`:case`keyboard-shortcuts`:case`mcp-settings`:return!0}};if(O)bb0:switch(D.slug){case`usage`:k=g;break bb0;case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:case`keyboard-shortcuts`:k=!1;break bb0;}}function s_e(e){let{slug:n}=e,r=c_e[n];return (0,$.jsx)(r,{})}var c_e={"general-settings":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DZbwMmWz.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([4]),import.meta.url)),"keyboard-shortcuts":(0,Z.lazy)(()=>s(()=>import(`./keyboard-shortcuts-settings-test.js`),[],import.meta.url)),appearance:(0,Z.lazy)(()=>s(()=>import(`./appearance-settings-D4xYjo5o.js`).then(e=>({default:e.AppearanceSettings})),__vite__mapDeps([56]),import.meta.url)),agent:(0,Z.lazy)(()=>Promise.resolve({default:l_e}))};
+JS
+    cat > "$extracted/webview/assets/keyboard-shortcuts-settings-test.js" <<'JS'
+slug:`keyboard-shortcuts`;export default function KeyboardShortcutsSettings(){}
 JS
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_file_exists "$extracted/webview/assets/keybinds-settings-linux.js"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "function KeybindsSettings"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "HotkeyWindowHotkeyRow"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "DEFAULT_SHORTCUTS"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-keybind-overrides"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "function ShortcutInput"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "data-codex-keybind-input"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "newThread"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "openFolder"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "toggleTerminal"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "toggleDiffPanel"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "thread9"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+Alt+N"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+Shift+O"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+G"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+J"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+Alt+Shift+C"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "navigateBack"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "navigateForward"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "CmdOrCtrl+Shift+K"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "Ctrl+\`"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "newWindow"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "openThreadOverlay"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "openAvatarOverlay"
-    assert_not_contains "$extracted/webview/assets/keybinds-settings-linux.js" "toggleTraceRecording"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-system-tray-enabled"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-warm-start-enabled"
-    assert_contains "$extracted/webview/assets/keybinds-settings-linux.js" "codex-linux-prompt-window-enabled"
-    assert_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`'
-    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.nav.keybinds"
-    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.section.keybinds"
-    assert_contains "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js"
-    assert_contains "$extracted/webview/assets/index-test.js" "keybinds:xh"
-    assert_contains "$extracted/webview/assets/index-test.js" 'Zge=\[`general-settings`,`keybinds`'
-    assert_contains "$extracted/webview/assets/index-test.js" 'slugs:\[`general-settings`,`keybinds`'
-    assert_contains "$extracted/webview/assets/index-test.js" 'case`keybinds`:return l===`electron`'
-    assert_contains "$extracted/webview/assets/index-test.js" "codexLinuxKeybindOverridesRuntime"
-    assert_contains "$extracted/webview/assets/index-test.js" "codex-linux-keybind-overrides"
-    assert_contains "$extracted/webview/assets/index-test.js" "go-to-thread-index"
-    assert_contains "$extracted/webview/assets/index-test.js" "newThreadAlt"
-    assert_contains "$extracted/webview/assets/index-test.js" "new-chat"
-    assert_contains "$extracted/webview/assets/index-test.js" "toggle-terminal"
-    assert_contains "$extracted/webview/assets/index-test.js" "toggle-diff-panel"
-    assert_contains "$extracted/webview/assets/index-test.js" "isShortcutCaptureTarget"
-    assert_contains "$extracted/webview/assets/index-test.js" "data-codex-keybind-input"
-    assert_not_contains "$extracted/webview/assets/index-test.js" "isEditableTarget(event))return"
-    assert_not_contains "$extracted/webview/assets/index-test.js" "ac(id)"
-
-    node - "$extracted/webview/assets/index-test.js" <<'NODE'
-const fs = require("fs");
-const vm = require("vm");
-const file = process.argv[2];
-const source = fs.readFileSync(file, "utf8");
-const marker = ";function codexLinuxKeybindOverridesRuntime()";
-const start = source.indexOf(marker);
-if (start === -1) throw new Error("missing runtime patch");
-const runtime = source
-  .slice(start)
-  .replace("codexLinuxKeybindOverridesRuntime();", "globalThis.codexLinuxKeybindOverridesRuntime=codexLinuxKeybindOverridesRuntime;");
-const listeners = {};
-const calls = [];
-class FakeElement {
-  constructor(isKeybindInput = false) {
-    this.isKeybindInput = isKeybindInput;
-  }
-  closest(selector) {
-    return selector === "[data-codex-keybind-input]" && this.isKeybindInput ? this : null;
-  }
-}
-const context = {
-  window: { addEventListener: (event, fn) => (listeners[event] ??= []).push(fn) },
-  Element: FakeElement,
-  navigator: { platform: "Linux x86_64" },
-  localStorage: { getItem: () => JSON.stringify({ toggleFileTreePanel: "Ctrl+E" }) },
-  Ct: { toggleFileTreePanel: "Command+Shift+E" },
-  E: {
-    dispatchHostMessage: (message) => calls.push(message),
-    dispatchMessage: () => {},
-  },
-  globalThis: null,
-};
-context.globalThis = context;
-vm.runInNewContext(runtime, context);
-context.codexLinuxKeybindOverridesRuntime();
-const makeEvent = (target) => ({
-  defaultPrevented: false,
-  repeat: false,
-  target,
-  ctrlKey: true,
-  altKey: false,
-  shiftKey: false,
-  metaKey: false,
-  key: "e",
-  preventDefault() {
-    this.defaultPrevented = true;
-  },
-  stopPropagation() {
-    this.stopped = true;
-  },
-});
-const composerEvent = makeEvent(new FakeElement(false));
-listeners.keydown[0](composerEvent);
-if (calls.length !== 1 || calls[0].type !== "toggle-file-tree-panel" || !composerEvent.defaultPrevented) {
-  throw new Error("Ctrl+E override did not dispatch from composer-like target");
-}
-const keybindInputEvent = makeEvent(new FakeElement(true));
-listeners.keydown[0](keybindInputEvent);
-if (calls.length !== 1 || keybindInputEvent.defaultPrevented) {
-  throw new Error("keybind capture input should not dispatch runtime override");
-}
-NODE
+    assert_file_exists "$extracted/webview/assets/linux-desktop-settings-linux.js"
+    [ ! -f "$extracted/webview/assets/keybinds-settings-linux.js" ] || fail "Old Keybinds settings asset should not be written for current native Keyboard Shortcuts"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "function LinuxDesktopSettings"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "Linux desktop"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "System tray"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "Warm start"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "Build information"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-system-tray-enabled"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-warm-start-enabled"
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-prompt-window-enabled"
+    assert_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`linux-desktop`'
+    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.nav.linux-desktop"
+    assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.section.linux-desktop"
+    assert_contains "$extracted/webview/assets/index-test.js" "linux-desktop-settings-linux.js"
+    assert_contains "$extracted/webview/assets/index-test.js" '"linux-desktop":'
+    assert_contains "$extracted/webview/assets/index-test.js" 'Zge=\[`general-settings`,`linux-desktop`'
+    assert_contains "$extracted/webview/assets/index-test.js" 'slugs:\[`general-settings`,`linux-desktop`'
+    assert_contains "$extracted/webview/assets/index-test.js" 'case`linux-desktop`:return l===`electron`'
+    assert_not_contains "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js"
+    assert_not_contains "$extracted/webview/assets/index-test.js" "codexLinuxKeybindOverridesRuntime"
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
-    assert_occurrence_count "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`' '1'
-    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.nav.keybinds" '1'
-    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.section.keybinds" '1'
-    assert_occurrence_count "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js" '1'
-    assert_occurrence_count "$extracted/webview/assets/index-test.js" "keybinds:xh" '1'
-    assert_occurrence_count "$extracted/webview/assets/index-test.js" "function codexLinuxKeybindOverridesRuntime" '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-sections-test.js" 'slug:`linux-desktop`' '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.nav.linux-desktop" '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.section.linux-desktop" '1'
+    assert_occurrence_count "$extracted/webview/assets/index-test.js" "linux-desktop-settings-linux.js" '1'
 }
 
 test_keybinds_settings_patch_warns_on_bundle_shape_miss() {
@@ -4968,22 +4878,28 @@ test_keybinds_settings_patch_warns_on_bundle_shape_miss() {
     mkdir -p "$workspace"
     make_fake_extracted_asar "$extracted" 'let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};let t={join(){}};let a={existsSync(){return true},statSync(){return {isFile(){return false}}}};let n={shell:{openPath(){return ""},showItemInFolder(){}}};...process.platform===`win32`?{autoHideMenuBar:!0}:{},process.platform===`win32`&&D.removeMenu(),foo)}),D.once(`ready-to-show`,()=>{var sa=Mi({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>ai(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:ca,args:e=>ai(e),open:async({path:e})=>la(e)}});function ca(){let e=1;return e}async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showItemInFolder(t);return}let r=t??e,i=await n.shell.openPath(r);if(i)throw Error(i)}function ua(e){return e}var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});async function Wa(e){return e}'
     rm "$extracted/webview/assets/settings-row-test.js"
+    cat > "$extracted/webview/assets/keyboard-shortcuts-settings-test.js" <<'JS'
+slug:`keyboard-shortcuts`;export default function KeyboardShortcutsSettings(){}
+JS
     cat > "$extracted/webview/assets/settings-sections-test.js" <<'JS'
-var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`appearance`}],r=t;export{n,t as r,e as t};
+var e=[`general-settings`,`profile`,`keyboard-shortcuts`],t=`general-settings`,n=[{slug:`general-settings`},{slug:`keyboard-shortcuts`}];
 JS
     cat > "$extracted/webview/assets/settings-shared-test.js" <<'JS'
-var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
+var c={"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},"keyboard-shortcuts":{id:`settings.nav.keyboard-shortcuts`,defaultMessage:`Keyboard shortcuts`,description:`Title for keyboard shortcuts settings section`}};function m(e){let t=(0,u.c)(17),{slug:r}=e;switch(r){case`general-settings`:{let e;return t[2]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`,description:`Title for general settings section`}),t[2]=e):e=t[2],e}}}
 JS
     cat > "$extracted/webview/assets/index-test.js" <<'JS'
-var Xge={"general-settings":xh,appearance:Pf},H7={},Zge=[`general-settings`,`appearance`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];function n_e(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:return!0}};if(O)bb0:switch(D.slug){case`appearance`:case`general-settings`:k=!1;break bb0;}}var c_e={"general-settings":(0,Z.lazy)(()=>s(()=>import(`./general-settings-DZbwMmWz.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([4]),import.meta.url))};
+var Xge={"general-settings":xh,appearance:Pf},H7={},Zge=[`general-settings`,`appearance`],Qge=[{key:`app`,heading:H7.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]}];
 JS
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_contains "$output_log" "WARN: Keybinds settings patch skipped"
-    assert_contains "$output_log" "could not find settings row asset"
-    [ ! -f "$extracted/webview/assets/keybinds-settings-linux.js" ] || fail "Keybinds asset should not be written when bundle shape is missing"
-    assert_not_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`keybinds`'
-    assert_not_contains "$extracted/webview/assets/index-test.js" "keybinds-settings-linux.js"
+    assert_contains "$output_log" "could not add Linux desktop visibility"
+    [ ! -f "$extracted/webview/assets/linux-desktop-settings-linux.js" ] || fail "Linux desktop settings asset should not be written when route bundle is missing"
+    [ ! -f "$extracted/webview/assets/linux-settings-row-linux.js" ] || fail "Fallback row asset should not be written when route bundle is missing"
+    [ ! -f "$extracted/webview/assets/linux-settings-section-linux.js" ] || fail "Fallback section asset should not be written when route bundle is missing"
+    [ ! -f "$extracted/webview/assets/linux-settings-group-linux.js" ] || fail "Fallback group asset should not be written when route bundle is missing"
+    assert_not_contains "$extracted/webview/assets/settings-sections-test.js" 'slug:`linux-desktop`'
+    assert_not_contains "$extracted/webview/assets/index-test.js" "linux-desktop-settings-linux.js"
 }
 
 test_browser_annotation_screenshot_patch_smoke() {


### PR DESCRIPTION
## Summary
- restore Linux desktop settings injection for current webview route-map bundles
- detect the current Codex request helper shape outside setting-storage chunks
- generate fallback settings layout components when upstream no longer ships the previous settings row/layout assets

## Validation
- node --check scripts/patches/shared.js
- node --check scripts/patches/keybinds-settings.js
- node --check scripts/patch-linux-window-ui.test.js
- node --test --test-name-pattern "Linux desktop" scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js
- git diff --check
- smoke-tested against installed Nix webview bundle; keybinds-settings report is applied and linux-desktop-settings-linux.js is generated