### PR TITLE
[codex] Document latest DMG pull request policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+**IMPORTANT: THIS PROJECT SUPPORTS ONLY THE LATEST UPSTREAM `CODEX.DMG`. WHEN FIXING UPSTREAM DRIFT, REMOVE OLD DRIFT WORKAROUNDS IN THE SAME PULL REQUEST. DO NOT KEEP LEGACY DMG SHAPES, FALLBACK PATCH PATHS, OR VERSION-SPECIFIC COMPATIBILITY ZOOS AROUND. THE CODE SHOULD TARGET THE CURRENT DMG SO REVIEW, VALIDATION, AND DIAGNOSTICS DO NOT HAVE TO GUESS WHICH UPSTREAM VERSION FAILED.**
+
 # Contributing to Codex Desktop for Linux
 
 Thanks for your interest in contributing to Codex Desktop for Linux. This project adapts the official macOS Codex Desktop DMG into a runnable Linux app, packages it for multiple Linux distributions, and maintains a local Rust update manager for future rebuilds.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Before opening a pull request, read [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md).
+
 # Codex Desktop for Linux
 
 Unofficial Linux build wrapper for [OpenAI Codex Desktop](https://openai.com/codex/).
@@ -9,8 +11,7 @@ The project builds native `.deb`, `.rpm`, and `.pkg.tar.zst` packages, supports
 local AppImage self-builds and Nix, and can install a local update manager that
 rebuilds future Linux packages from newer upstream DMGs.
 
-Before opening a pull request, read [CONTRIBUTING.md](CONTRIBUTING.md). For
-implementation details, see [AGENTS.md](AGENTS.md).
+For implementation details, see [AGENTS.md](AGENTS.md).
 
 ## Install By Platform
 


### PR DESCRIPTION
## Summary
- move the pull request CONTRIBUTING notice to the top of README.md
- add an explicit latest-upstream-DMG-only policy at the top of CONTRIBUTING.md
- clarify that upstream drift fixes should remove old drift workarounds instead of keeping legacy compatibility paths

## Validation
- `git diff --check`

## Notes
- docs-only change
