### PR TITLE
Fix Linux primary BrowserWindow focusability

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2637,6 +2637,27 @@ test("omits undefined BrowserWindow options in the current window manager bundle
   assert.doesNotMatch(patched, /minWidth:T\?\.width/);
 });
 
+test("forces Linux primary BrowserWindow to be focusable", () => {
+  const iconAsset = "app-test.png";
+  const source = [
+    "async createWindow(e={}){let{title:n,width:i=1280,height:o=820,appearance:c=`primary`,",
+    "show:l=!0,parent:p,focusable:m}=e,D={},M=new a.BrowserWindow({width:b,height:x,",
+    "...S===void 0||C===void 0?{}:{x:S,y:C},title:n??a.app.getName(),backgroundColor:A,",
+    "show:l,parent:p,focusable:m,",
+    "...process.platform===`win32`?{autoHideMenuBar:!0}:process.platform===`linux`?{icon:process.resourcesPath+`/../content/webview/assets/app-test.png`}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, iconAsset);
+
+  assert.match(
+    patched,
+    /show:l,\.\.\.p==null\?\{\}:\{parent:p\},\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m==null\?\{\}:\{focusable:m\}/,
+  );
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\},\.\.\.D/);
+  assert.doesNotMatch(patched, /show:l,parent:p,focusable:m/);
+});
+
 test("patches remaining Linux window icon snippets when another window is already patched", () => {
   const iconAsset = "app-test.png";
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -71,6 +71,7 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
   }
 
   patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
+  patchedSource = applyLinuxPrimaryFocusablePatch(patchedSource);
   return patchedSource;
 }
 
@@ -93,6 +94,71 @@ function applyDefinedBrowserWindowOptionsPatch(currentSource) {
     ) =>
       `show:${showAlias},...${parentAlias}==null?{}:{parent:${parentAlias}},...${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
   );
+}
+
+function findCreateWindowAppearanceAlias(currentSource, matchIndex) {
+  const prefix = currentSource.slice(Math.max(0, matchIndex - 3000), matchIndex);
+  const createWindowRegex =
+    /createWindow\([^)]*\)\{let\{[^}]*appearance:([A-Za-z_$][\w$]*)(?:=[^,}]+)?/g;
+  let match;
+  let appearanceAlias = null;
+  while ((match = createWindowRegex.exec(prefix)) != null) {
+    appearanceAlias = match[1];
+  }
+  return appearanceAlias;
+}
+
+function applyLinuxPrimaryFocusablePatch(currentSource) {
+  if (
+    currentSource.includes("===`primary`?{focusable:!0}") ||
+    currentSource.includes("===`primary`?!0:")
+  ) {
+    return currentSource;
+  }
+
+  let patchedAny = false;
+  let skippedAny = false;
+  const focusableSpreadRegex =
+    /\.\.\.([A-Za-z_$][\w$]*)==null\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`\?)/g;
+  let patchedSource = currentSource.replace(
+    focusableSpreadRegex,
+    (match, focusableAlias, platformOptions, offset) => {
+      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
+      if (appearanceAlias == null) {
+        skippedAny = true;
+        return match;
+      }
+      patchedAny = true;
+      return (
+        `...process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?{focusable:!0}:` +
+        `${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}`
+      );
+    },
+  );
+
+  const focusableDirectRegex =
+    /focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?)/g;
+  patchedSource = patchedSource.replace(
+    focusableDirectRegex,
+    (match, focusableAlias, platformOptions, offset) => {
+      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
+      if (appearanceAlias == null) {
+        skippedAny = true;
+        return match;
+      }
+      patchedAny = true;
+      return (
+        `focusable:process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
+        `${focusableAlias},${platformOptions}`
+      );
+    },
+  );
+
+  if (!patchedAny && skippedAny && currentSource.includes("createWindow(")) {
+    console.warn("WARN: Could not derive primary BrowserWindow appearance alias — skipping Linux focusable patch");
+  }
+
+  return patchedSource;
 }
 
 function applyLinuxNativeTitlebarPatch(currentSource) {


### PR DESCRIPTION
## Summary
- Force the primary Linux BrowserWindow to remain focusable while preserving non-primary focusable behavior.
- Add regression coverage for the current minified window manager bundle shape.

## Issue
Fixes #613
Issue: https://github.com/ilysenko/codex-desktop-linux/issues/613

## Tests
- node --test scripts/patch-linux-window-ui.test.js
- node --test scripts/patches/main-process/browser.test.js
