### PR TITLE
Fix primary focusable patch for current window shape

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2755,6 +2755,50 @@ test("forces Linux primary BrowserWindow to be focusable", () => {
   assert.doesNotMatch(patched, /show:l,parent:p,focusable:m/);
 });
 
+test("forces Linux primary BrowserWindow to be focusable for current boolean minified shape", () => {
+  const source = [
+    "async createWindow(e={}){let{title:n,width:i=1280,height:o=820,appearance:c=`primary`}=e,",
+    "M=new a.BrowserWindow({width:b,height:x,title:n??a.app.getName(),focusable:!1,",
+    "webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, null);
+
+  assert.match(
+    patched,
+    /focusable:process\.platform===`linux`&&c===`primary`\?!0:!1,webPreferences:k/,
+  );
+  assert.doesNotMatch(patched, /focusable:!1,webPreferences:k/);
+});
+
+test("keeps focusable destructuring valid while patching current boolean minified shape", () => {
+  const source = [
+    "async createWindow(e={}){let{title:n,width:i=1280,height:o=820,appearance:c=`primary`,",
+    "focusable:m}=e,M=new a.BrowserWindow({width:b,height:x,focusable:!1,",
+    "webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, null);
+
+  assert.match(patched, /appearance:c=`primary`,focusable:m\}=e/);
+  assert.match(
+    patched,
+    /new a\.BrowserWindow\(\{width:b,height:x,focusable:process\.platform===`linux`&&c===`primary`\?!0:!1,/,
+  );
+});
+
+test("fails loudly when primary BrowserWindow focusable shape cannot be patched", () => {
+  const source = [
+    "async createWindow(e={}){let{appearance:c=`primary`}=e,",
+    "M=new a.BrowserWindow({width:b,height:x,focusable:getFocusable(),webPreferences:k});}",
+  ].join("");
+
+  assert.throws(
+    () => applyLinuxWindowOptionsPatch(source, null),
+    /Could not patch primary BrowserWindow focusable option for Linux/,
+  );
+});
+
 test("patches remaining Linux window icon snippets when another window is already patched", () => {
   const iconAsset = "app-test.png";
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -108,6 +108,12 @@ function findCreateWindowAppearanceAlias(currentSource, matchIndex) {
   return appearanceAlias;
 }
 
+function hasPrimaryBrowserWindowFocusableCandidate(currentSource) {
+  return /createWindow\([^)]*\)\{let\{[^}]*appearance:[A-Za-z_$][\w$]*(?:=`primary`)?[^}]*\}=[\s\S]{0,3500}?new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{[\s\S]{0,2000}?focusable:/.test(
+    currentSource,
+  );
+}
+
 function applyLinuxPrimaryFocusablePatch(currentSource) {
   if (
     currentSource.includes("===`primary`?{focusable:!0}") ||
@@ -154,8 +160,30 @@ function applyLinuxPrimaryFocusablePatch(currentSource) {
     },
   );
 
-  if (!patchedAny && skippedAny && currentSource.includes("createWindow(")) {
-    console.warn("WARN: Could not derive primary BrowserWindow appearance alias — skipping Linux focusable patch");
+  const focusableCurrentShapeRegex =
+    /(new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{(?:(?!\}\);)[\s\S]){0,2000}?focusable:)(!?[A-Za-z_$][\w$]*|![01]|null),/g;
+  patchedSource = patchedSource.replace(
+    focusableCurrentShapeRegex,
+    (match, browserWindowPrefix, focusableExpression, offset) => {
+      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
+      if (appearanceAlias == null) {
+        skippedAny = true;
+        return match;
+      }
+      patchedAny = true;
+      return (
+        `${browserWindowPrefix}process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
+        `${focusableExpression},`
+      );
+    },
+  );
+
+  if (!patchedAny && skippedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
+    throw new Error("Could not derive primary BrowserWindow appearance alias for Linux focusable patch");
+  }
+
+  if (!patchedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
+    throw new Error("Could not patch primary BrowserWindow focusable option for Linux");
   }
 
   return patchedSource;


### PR DESCRIPTION
Summary
- Fix the Linux primary BrowserWindow focusable patch for the current minified `focusable:!1` shape.
- Make unpatched primary BrowserWindow focusable drift fail loudly instead of silently shipping a no-op patch.
- Add regression coverage for #616.

Tests
- node --test scripts/patch-linux-window-ui.test.js
- bash tests/scripts_smoke.sh
- git diff --check origin/main...HEAD

Closes #616