### PR TITLE
[codex] Update documentation drift references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The current flow is:
   perform explicit feature-owned cleanup.
 - `Cargo.toml`
   Workspace root. Members currently are `computer-use-linux`,
-  `read-aloud-linux`, and `updater`.
+  `read-aloud-linux`, `record-replay-linux`, and `updater`.
 - `flake.nix` / `flake.lock`
   Nix flake that pins upstream DMG, Cargo dependency, and Node dependency
   hashes. Use `scripts/ci/update-nix-hashes.sh` to refresh pins.
@@ -201,8 +201,9 @@ Detailed contract: `linux-features/README.md` and
   patcher, and package builders.
 - Declarative `resources`, `runtimeHooks`, and `packageHooks` are preferred
   over ad hoc staging whenever possible.
-- Runtime hook types are `env`, `prelaunch`, `electronArgs`, `coldStart`, and
-  `afterExit`; they are staged under `codex-app/.codex-linux/`.
+- Runtime hook types are `env`, `prelaunch`, `electronArgs`, `launcher`,
+  `coldStart`, and `afterExit`; they are staged under
+  `codex-app/.codex-linux/`.
 - Declarative resources and runtime hooks are tracked in
   `.codex-linux/linux-features-staged.json` and removed on the next install
   when their owning feature is disabled.
@@ -278,7 +279,7 @@ update-builder bundle under `/opt/codex-desktop/update-builder`.
 The updater runs unprivileged and only escalates through `pkexec` for
 `install-deb`, `install-rpm`, or `install-pacman`.
 
-### Computer Use, Browser, And Read Aloud
+### Computer Use, Browser, Read Aloud, And Record & Replay
 
 - `computer-use-linux/`
   Rust crate for Linux Computer Use MCP, Chrome native messaging host, and the
@@ -299,13 +300,17 @@ The updater runs unprivileged and only escalates through `pkexec` for
   Bundled plugin manifests/resources staged into the Linux app.
 - `read-aloud-linux/`
   Rust MCP backend for optional Read Aloud support.
+- `record-replay-linux/`
+  Rust CLI and stdio MCP backend for the optional Record & Replay Linux
+  demo-to-skill workflow.
 - `linux-features/read-aloud/` and `linux-features/read-aloud-mcp/`
   Optional Linux features for Read Aloud patching/staging/integration. They are
-  two of ~16 opt-in features under `linux-features/` (e.g. `agent-workspace`,
-  `appshots`, `codex-wrapper-updater`, `conversation-mode`,
-  `copilot-reasoning-effort`, `frameless-titlebar`, `node-repl-reaper`,
-  `open-target-discovery`, `remote-control-ui`, `remote-mobile-control`,
-  `thorium-chrome-plugin`, `x11-ewmh-computer-use`,
+  two of 19 opt-in features under `linux-features/` (e.g. `agent-workspace`,
+  `api-key-service-tier`, `appshots`, `authenticated-proxy`,
+  `codex-wrapper-updater`, `conversation-mode`, `copilot-reasoning-effort`,
+  `frameless-titlebar`, `node-repl-reaper`, `open-target-discovery`,
+  `persistent-status-panel`, `record-and-replay`, `remote-control-ui`,
+  `remote-mobile-control`, `thorium-chrome-plugin`, `x11-ewmh-computer-use`,
   plus the `example-feature` template); all ship `feature.json` + `README.md`
   and are disabled by default.
 
@@ -368,12 +373,16 @@ package. The daily-driver flow remains `install.sh` plus a native package plus
   Linux feature framework contract.
 - `docs/linux-computer-use.md`
   Linux Computer Use backend, windowing, and desktop integration notes.
+- `docs/record-and-replay-linux.md`
+  Linux Record & Replay compatibility and tester acceptance notes.
 - `docs/nix.md`
   Nix flake, modules (`nix/`), and hash-pin workflow.
 - `docs/troubleshooting.md`
   Common install/runtime issues and diagnostics.
 - `docs/github-cli-auth.md`
   GitHub CLI authentication guidance.
+- `docs/wayland-input-focus-investigation.md`
+  Historical Wayland/X11 input-focus investigation for issue #569.
 - `docs/webview-server-evaluation.md`
   Decision record for the future local webview server model.
 
@@ -537,6 +546,8 @@ cargo check -p codex-computer-use-linux
 cargo test -p codex-computer-use-linux
 cargo check -p codex-read-aloud-linux
 cargo test -p codex-read-aloud-linux
+cargo check -p codex-record-replay-linux
+cargo test -p codex-record-replay-linux
 ```
 
 For package payload changes, build the relevant formats and inspect metadata:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ workarounds.
 | Experimental Remote Mobile Control | Opt-in | `remote-mobile-control` | [Docs](linux-features/remote-mobile-control/README.md) |
 | Thorium Chrome Plugin Support | Opt-in | `thorium-chrome-plugin` | [Docs](linux-features/thorium-chrome-plugin/README.md) |
 
+Additional opt-in features, including proxy, titlebar, process cleanup,
+status-panel, and X11 Computer Use adapters, are documented under
+`linux-features/`.
+
 Server-gated upstream features, such as model rollouts, are controlled by
 OpenAI per account. Rebuilding this wrapper does not unlock them.
 
@@ -236,6 +240,7 @@ Full list: [Troubleshooting](docs/troubleshooting.md).
 - [Architecture](docs/architecture.md)
 - [GitHub CLI auth in app-launched shells](docs/github-cli-auth.md)
 - [Linux Features architecture](docs/linux-features-architecture.md)
+- [Wayland input focus investigation](docs/wayland-input-focus-investigation.md)
 - [Webview server evaluation](docs/webview-server-evaluation.md)
 
 ## Disclaimer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,10 @@ cargo check -p codex-update-manager
 cargo test -p codex-update-manager
 cargo check -p codex-computer-use-linux
 cargo test -p codex-computer-use-linux
+cargo check -p codex-read-aloud-linux
+cargo test -p codex-read-aloud-linux
+cargo check -p codex-record-replay-linux
+cargo test -p codex-record-replay-linux
 make package
 ```
 

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -4,14 +4,17 @@
 
 You need:
 
-- `python3`, `7z` or `7zz`, `curl`, `unzip`, `make`, `g++`
+- `python3`, `7z` or `7zz`, `curl`, `unzip`, `tar`, `make`, `g++`
 - Rust toolchain with `cargo` for `codex-update-manager`,
-  `codex-computer-use-linux`, and the Chrome extension host binary
+  `codex-computer-use-linux`, the Chrome extension host binary, and optional
+  Rust-backed features such as Read Aloud MCP and Record & Replay
 
 The installer downloads a managed Linux Node.js runtime into
 `codex-app/resources/node-runtime` and uses it for `node`, `npm`, and `npx`
 during the build. Existing `nvm`, asdf, Volta, NodeSource, or nodejs.org
-installs are fine, but no longer required for this project.
+installs are fine, but no longer required for the generated app build. The
+dependency helper may still install or validate a distro Node.js toolchain on
+some bootstrap paths.
 
 Bootstrap dependencies:
 
@@ -26,18 +29,18 @@ packages, and bootstraps Rust through `rustup` when needed.
 
 ```bash
 # Fedora 41+
-sudo dnf install python3 7zip curl unzip rpm-build make gcc-c++ @development-tools
+sudo dnf install python3 7zip curl unzip tar rpm-build make gcc-c++ @development-tools
 
 # Fedora < 41
-sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++
+sudo dnf install python3 p7zip p7zip-plugins curl unzip tar rpm-build make gcc-c++
 sudo dnf groupinstall 'Development Tools'
 
 # openSUSE
-sudo zypper install python3 p7zip-full curl unzip
+sudo zypper install python3 p7zip-full curl unzip tar
 sudo zypper install -t pattern devel_basis
 
 # Arch / Manjaro
-sudo pacman -S --needed python p7zip curl unzip zstd base-devel
+sudo pacman -S --needed python p7zip curl unzip tar zstd base-devel
 
 # Rust toolchain
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -23,7 +23,7 @@ launcher, or a warm-start handoff to an already-running instance may not have
 your Nix profile on `PATH`, in which case Codex Desktop fails with
 `Unable to locate the Codex CLI binary. Set CODEX_CLI_PATH ...`. Pinning the CLI
 explicitly avoids this. The Home Manager and NixOS modules can do this for you
-via [`programs.codexDesktopLinux.cliPackage`](#home-manager--nixos-module),
+via [`programs.codexDesktopLinux.cliPackage`](#home-manager-nixos-module),
 which wraps the launcher so `CODEX_CLI_PATH` is always set.
 
 One direct upstream install path is the npm package:

--- a/docs/webview-server-evaluation.md
+++ b/docs/webview-server-evaluation.md
@@ -2,31 +2,38 @@
 
 ## Context
 
-The current launcher starts a local `python3 -m http.server "$CODEX_LINUX_WEBVIEW_PORT"` process for the extracted webview bundle. It waits for the configured port to become reachable before launching Electron, and exports `ELECTRON_RENDERER_URL` so side-by-side app IDs can use an isolated local origin.
+The current launcher starts the bundled `launcher/webview-server.py` helper
+with `python3 "$SCRIPT_DIR/.codex-linux/webview-server.py"
+"$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1` for the extracted webview
+bundle. It waits for the configured port to become reachable before launching
+Electron, validates the served origin, and exports `ELECTRON_RENDERER_URL` so
+side-by-side app IDs can use an isolated local origin.
 
 The extracted webview payload is a static bundle under `codex-app/content/webview` and is relatively large: about 35 MB across 693 files. The generated `index.html` references hashed assets through relative paths, so the app still expects a stable local origin.
 
 ## Options
 
-### 1. Keep Python and harden lifecycle handling
+### 1. Keep the bundled Python server
 
 What changes:
 
-- Keep `python3 -m http.server "$CODEX_LINUX_WEBVIEW_PORT"`
-- Keep improving the current process lifecycle and readiness behavior
-- Improve port-collision handling and logging
+- Keep `launcher/webview-server.py` as the webview static-file server
+- Keep lifecycle, readiness, adoption, and port-collision handling in the
+  launcher
+- Keep explicit no-store/no-cache response headers in the helper
 
 Benefits:
 
 - Lowest implementation risk
-- No packaging or runtime-binary changes
+- No new runtime-binary build or packaging step
 - Preserves the existing static-asset serving model
 
 Risks:
 
 - Python remains an external runtime dependency for the launcher path
 - Startup reliability still depends on a separate process being spawned correctly
-- Performance improvements are limited, because the server is still a generic Python HTTP server
+- Performance improvements are limited, because the helper still uses Python's
+  standard HTTP server stack
 
 ### 2. Ship a tiny Rust static-file server
 
@@ -69,22 +76,27 @@ Risks:
 
 ## Recommendation
 
-Keep Python for now, but harden the launcher lifecycle and readiness handling.
+Keep the bundled Python helper for now. Revisit a Rust helper only if startup
+or lifecycle evidence shows Python remains a bottleneck after the current
+readiness, ownership, and cache-header handling.
 
 Why this wins:
 
-- The current problem looks more like process orchestration than raw server throughput.
+- The historical problem looked more like process orchestration than raw server
+  throughput, and that now lives in launcher-side ownership/readiness logic.
 - The webview payload is static, so the launcher only needs a reliable local origin, not a high-performance application server.
 - This path preserves compatibility while leaving the door open for a Rust server later if evidence shows Python is still a bottleneck.
 
 ## Integration Points
 
-If we later implement the recommended hardening or a Rust server, the change points are:
+If we later replace the bundled Python helper with a Rust server, the change
+points are:
 
-- `install.sh` launcher generation
-- the local webview startup block around the configured webview port
+- `install.sh` staging for the webview helper
+- the launcher startup block around the configured webview port
 - packaging if a Rust server binary is added
-- launcher logging and cleanup logic around the PID file and `http.server` shutdown
+- launcher logging, ownership, adoption, and cleanup logic around the PID file
+  and helper shutdown
 
 ## Risks To Watch
 


### PR DESCRIPTION
## Summary
- Update AGENTS.md for the current Rust workspace, Linux feature hooks, docs list, and Record & Replay validation.
- Refresh build/architecture docs for current Rust-backed components, tar prerequisite, and webview helper behavior.
- Keep README changes short while pointing to the remaining opt-in Linux features and Wayland investigation note.

## Tests/checks
- `git diff --check`
- local markdown link and anchor check
- Linux feature README inventory check

## Notes
- Documentation-only change; no public APIs or runtime behavior changed.