### PR TITLE
Add optional UI tweaks feature

### DIFF
--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -38,6 +38,25 @@ git-ignored `linux-features/features.json` file:
 }
 ```
 
+Feature developers can also define user-overridable settings. Keep shipped
+defaults in tracked `feature.json`, and read user-specific overrides from the
+git-ignored `features.json` file under `settings.<feature-id>`:
+
+```json
+{
+  "enabled": ["my-feature"],
+  "settings": {
+    "my-feature": {
+      "option": "local value"
+    }
+  }
+}
+```
+
+Patch descriptors receive this object as `context.feature.settings`. Treat it
+as optional, validate the shape inside the feature, warn on invalid values, and
+fall back to manifest defaults rather than failing the build.
+
 ## Lifecycle
 
 The build pipeline loads enabled features in these phases:
@@ -54,8 +73,9 @@ The build pipeline loads enabled features in these phases:
 
 Native packages copy the configured feature root into the packaged
 `update-builder` bundle, including `linux-features/local/`, and write a
-sanitized `features.json` containing only the enabled ids. Local auto-updates
-therefore rebuild with the same opt-in features.
+sanitized `features.json` containing the enabled ids plus settings for enabled
+features. Local auto-updates therefore rebuild with the same opt-in features
+and user-specific feature settings.
 
 Declarative staged files are tracked in
 `.codex-linux/linux-features-staged.json`. On the next install, the framework

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -27,7 +27,8 @@ same opt-in features across auto-updates.
 
 Feature-specific local settings can live in the same gitignored file under
 `settings.<feature-id>`. Keep tracked `feature.json` files as shipped defaults;
-do not edit them for personal preferences:
+do not edit them for personal preferences. Feature patch descriptors receive
+this object as `context.feature.settings`:
 
 ```json
 {

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -21,9 +21,32 @@ building packages, then list the feature ids you want:
 `features.json` is ignored by git so local choices do not leak into commits.
 Feature choices are read during the install/build pipeline; if you change this
 file after an app has already been generated, rerun the install/build step.
-Native packages preserve the enabled feature id list in the packaged
-update-builder bundle, so `codex-update-manager` rebuilds keep the same opt-in
-features across auto-updates.
+Native packages preserve the enabled feature id list and settings in the
+packaged update-builder bundle, so `codex-update-manager` rebuilds keep the
+same opt-in features across auto-updates.
+
+Feature-specific local settings can live in the same gitignored file under
+`settings.<feature-id>`. Keep tracked `feature.json` files as shipped defaults;
+do not edit them for personal preferences:
+
+```json
+{
+  "enabled": [
+    "ui-tweaks"
+  ],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "sidebar": {
+          "projectName": {
+            "style": "font-weight: 700 !important; padding-top: 0.25rem;"
+          }
+        }
+      }
+    }
+  }
+}
+```
 
 Feature directories can be tracked repository features at `linux-features/<id>/`
 or private user-local features at `linux-features/local/<id>/`. The

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -69,9 +69,11 @@ Config keys:
 
 - `enabled`: `true` applies the tweak, `false` keeps the feature enabled but
   skips this specific tweak.
-- `style`: CSS declaration string inserted into the project-name rule. The
-  default is `font-weight: 700 !important; padding-top: 0.25rem;`, so project
-  names are bold with a small top offset and no color is forced.
+- `style`: CSS declaration list inserted into the project-name rule, such as
+  `font-weight: 800 !important; color: red;`. It is not arbitrary CSS; unsafe
+  syntax that could escape the scoped rule warns and falls back to the default.
+  The default is `font-weight: 700 !important; padding-top: 0.25rem;`, so
+  project names are bold with a small top offset and no color is forced.
 
 ## Drift Behavior
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -21,12 +21,36 @@ Enable it in the local, gitignored feature config:
 
 ## Settings
 
-This feature keeps tweak settings in `feature.json` under the `tweaks` object.
+Tracked defaults live in `feature.json`, but local preferences should not be
+edited there. Put user-specific overrides in the gitignored
+`linux-features/features.json` file under `settings.ui-tweaks`.
+
+Example local config:
+
+```json
+{
+  "enabled": ["ui-tweaks"],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "sidebar": {
+          "projectName": {
+            "style": "font-weight: 800 !important; color: red;"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 Each tweak documents its own config keys below.
 
 ### `sidebar.projectName`
 
 Styles project names in the left sidebar project list.
+
+Tracked default in `feature.json`:
 
 ```json
 {
@@ -34,7 +58,7 @@ Styles project names in the left sidebar project list.
     "sidebar": {
       "projectName": {
         "enabled": true,
-        "style": "font-weight: 700 !important;"
+        "style": "font-weight: 700 !important; padding-top: 0.25rem;"
       }
     }
   }
@@ -46,8 +70,8 @@ Config keys:
 - `enabled`: `true` applies the tweak, `false` keeps the feature enabled but
   skips this specific tweak.
 - `style`: CSS declaration string inserted into the project-name rule. The
-  default is `font-weight: 700 !important;`, so project names are bold only and
-  no color is forced.
+  default is `font-weight: 700 !important; padding-top: 0.25rem;`, so project
+  names are bold with a small top offset and no color is forced.
 
 ## Drift Behavior
 

--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -1,0 +1,68 @@
+# UI Tweaks
+
+`ui-tweaks` is an optional Linux feature for small Codex Desktop UI
+customizations. It is disabled by default and is intended as a shared place for
+future visual tweaks that are useful to some Linux users but should not affect
+the baseline app.
+
+Enable it in the local, gitignored feature config:
+
+```json
+{
+  "enabled": ["ui-tweaks"]
+}
+```
+
+## Tweaks
+
+| Tweak | Patch module | What it does | Settings |
+| --- | --- | --- | --- |
+| `sidebar.projectName` | `patches/sidebar-project-name.js` | Styles project names in the left sidebar project list. It does not style `Projects` / `Chats` section headings and does not style chat rows. | `tweaks.sidebar.projectName.enabled`, `tweaks.sidebar.projectName.style` |
+
+## Settings
+
+This feature keeps tweak settings in `feature.json` under the `tweaks` object.
+Each tweak documents its own config keys below.
+
+### `sidebar.projectName`
+
+Styles project names in the left sidebar project list.
+
+```json
+{
+  "tweaks": {
+    "sidebar": {
+      "projectName": {
+        "enabled": true,
+        "style": "font-weight: 700 !important;"
+      }
+    }
+  }
+}
+```
+
+Config keys:
+
+- `enabled`: `true` applies the tweak, `false` keeps the feature enabled but
+  skips this specific tweak.
+- `style`: CSS declaration string inserted into the project-name rule. The
+  default is `font-weight: 700 !important;`, so project names are bold only and
+  no color is forced.
+
+## Drift Behavior
+
+The patches are fail-soft. If upstream bundle markers drift, the feature writes
+a `WARN` message and leaves the asset unchanged. Invalid style values also warn
+and fall back to the default bold style. The feature should not block install,
+rebuild, or packaging flows.
+
+## Adding Tweaks
+
+Add each tweak as a focused module under `patches/`, register it from `patch.js`,
+document its JSON settings here, and add coverage in `test.js`.
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/ui-tweaks/test.js
+```

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -1,0 +1,17 @@
+{
+  "id": "ui-tweaks",
+  "title": "UI Tweaks",
+  "description": "Optional UI customization patches for Codex Desktop Linux.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "tweaks": {
+    "sidebar": {
+      "projectName": {
+        "enabled": true,
+        "style": "font-weight: 700 !important; padding-top: 0.25rem;"
+      }
+    }
+  }
+}

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const sidebarProjectName = require("./patches/sidebar-project-name.js");
+
+function patchesFrom(...modules) {
+  return modules.flatMap((moduleExports) =>
+    Array.isArray(moduleExports?.patches) ? moduleExports.patches : [],
+  );
+}
+
+module.exports = {
+  patches: patchesFrom(sidebarProjectName),
+};

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -1,9 +1,12 @@
 "use strict";
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
+const PROJECTS_SIDEBAR_ASSET_PATTERN =
+  /^app-initial~app-main~remote-conversation-page~projects-index-page-[^.]+\.js$/;
 const PROJECT_NAME_SELECTOR = ".group\\/folder-row .min-w-0.truncate.pr-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
+const UNSAFE_PROJECT_NAME_STYLE_PATTERN = /[{}@<>]|\r|\n|\/\*|\*\/|\burl\s*\(/i;
 
 const SIDEBAR_PROJECT_NAME_MARKERS = [
   "sidebarElectron.projectsNavLink",
@@ -28,6 +31,10 @@ function sidebarProjectNameStyleRuntimeSource(style = DEFAULT_PROJECT_NAME_STYLE
     `function install(){if(typeof document==="undefined")return;const target=document.head||document.documentElement;if(!target)return;let style=document.getElementById(STYLE_ID);if(style){style.textContent!==CSS&&(style.textContent=CSS);return}style=document.createElement("style");style.id=STYLE_ID;style.textContent=CSS;target.appendChild(style)}`,
     `document.readyState==="loading"&&document.addEventListener("DOMContentLoaded",install,{once:true});install();})();`,
   ].join("");
+}
+
+function isSafeProjectNameStyle(style) {
+  return !UNSAFE_PROJECT_NAME_STYLE_PATTERN.test(style);
 }
 
 function sidebarProjectNameConfig(context) {
@@ -60,6 +67,13 @@ function normalizedProjectNameStyle(context) {
     return { enabled: true, style: DEFAULT_PROJECT_NAME_STYLE };
   }
 
+  if (!isSafeProjectNameStyle(style)) {
+    console.warn(
+      "WARN: ui-tweaks sidebar project name style must be a safe CSS declaration list - using default bold style",
+    );
+    return { enabled: true, style: DEFAULT_PROJECT_NAME_STYLE };
+  }
+
   return { enabled: true, style };
 }
 
@@ -84,7 +98,7 @@ function applySidebarProjectNameStylePatch(source, context = {}) {
     }
 
     if (!looksLikeSidebarProjectBundle(source)) {
-      if (hasPartialSidebarProjectMarkers(source)) {
+      if (context.warnOnMissingMarkers === true || hasPartialSidebarProjectMarkers(source)) {
         warn("Could not find current sidebar project name markers");
       }
       return source;
@@ -103,15 +117,17 @@ const patches = [
     phase: "webview-asset",
     order: 20_790,
     ciPolicy: "optional",
-    pattern: /^(?:app-initial~app-main~remote-conversation-page~projects-index-page|projects-index-page).*\.js$/,
+    pattern: PROJECTS_SIDEBAR_ASSET_PATTERN,
     missingDescription: "projects sidebar bundle",
     skipDescription: "ui-tweaks sidebar project name style patch",
-    apply: applySidebarProjectNameStylePatch,
+    apply: (source, context = {}) =>
+      applySidebarProjectNameStylePatch(source, { ...context, warnOnMissingMarkers: true }),
   },
 ];
 
 module.exports = {
   DEFAULT_PROJECT_NAME_STYLE,
+  PROJECTS_SIDEBAR_ASSET_PATTERN,
   PROJECT_NAME_SELECTOR,
   RUNTIME_MARKER,
   STYLE_ID,

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important;";
+const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
 const PROJECT_NAME_SELECTOR = ".group\\/folder-row .min-w-0.truncate.pr-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
@@ -31,7 +31,12 @@ function sidebarProjectNameStyleRuntimeSource(style = DEFAULT_PROJECT_NAME_STYLE
 }
 
 function sidebarProjectNameConfig(context) {
-  return context?.feature?.manifest?.tweaks?.sidebar?.projectName ?? {};
+  const defaults = context?.feature?.manifest?.tweaks?.sidebar?.projectName;
+  const settings = context?.feature?.settings?.tweaks?.sidebar?.projectName;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
 }
 
 function normalizedProjectNameStyle(context) {

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -1,0 +1,118 @@
+"use strict";
+
+const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important;";
+const PROJECT_NAME_SELECTOR = ".group\\/folder-row .min-w-0.truncate.pr-1";
+const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
+const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
+
+const SIDEBAR_PROJECT_NAME_MARKERS = [
+  "sidebarElectron.projectsNavLink",
+  "group/folder-row",
+  "className:`min-w-0 truncate pr-1`",
+];
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping ui-tweaks sidebar project name patch`);
+}
+
+function sidebarProjectNameCss(style = DEFAULT_PROJECT_NAME_STYLE) {
+  return `${PROJECT_NAME_SELECTOR}{${style}}`;
+}
+
+function sidebarProjectNameStyleRuntimeSource(style = DEFAULT_PROJECT_NAME_STYLE) {
+  const css = sidebarProjectNameCss(style);
+  return [
+    `;(()=>{const ${RUNTIME_MARKER}=true;`,
+    `const STYLE_ID=${JSON.stringify(STYLE_ID)};`,
+    `const CSS=${JSON.stringify(css)};`,
+    `function install(){if(typeof document==="undefined")return;const target=document.head||document.documentElement;if(!target)return;let style=document.getElementById(STYLE_ID);if(style){style.textContent!==CSS&&(style.textContent=CSS);return}style=document.createElement("style");style.id=STYLE_ID;style.textContent=CSS;target.appendChild(style)}`,
+    `document.readyState==="loading"&&document.addEventListener("DOMContentLoaded",install,{once:true});install();})();`,
+  ].join("");
+}
+
+function sidebarProjectNameConfig(context) {
+  return context?.feature?.manifest?.tweaks?.sidebar?.projectName ?? {};
+}
+
+function normalizedProjectNameStyle(context) {
+  const config = sidebarProjectNameConfig(context);
+  if (config.enabled === false) {
+    return { enabled: false, style: DEFAULT_PROJECT_NAME_STYLE };
+  }
+
+  if (config.style == null) {
+    return { enabled: true, style: DEFAULT_PROJECT_NAME_STYLE };
+  }
+
+  if (typeof config.style !== "string") {
+    console.warn("WARN: ui-tweaks sidebar project name style must be a string - using default bold style");
+    return { enabled: true, style: DEFAULT_PROJECT_NAME_STYLE };
+  }
+
+  const style = config.style.trim();
+  if (style.length === 0) {
+    console.warn("WARN: ui-tweaks sidebar project name style is empty - using default bold style");
+    return { enabled: true, style: DEFAULT_PROJECT_NAME_STYLE };
+  }
+
+  return { enabled: true, style };
+}
+
+function looksLikeSidebarProjectBundle(source) {
+  return SIDEBAR_PROJECT_NAME_MARKERS.every((marker) => source.includes(marker));
+}
+
+function hasPartialSidebarProjectMarkers(source) {
+  return SIDEBAR_PROJECT_NAME_MARKERS.some((marker) => source.includes(marker));
+}
+
+function applySidebarProjectNameStylePatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+
+    const { enabled, style } = normalizedProjectNameStyle(context);
+    if (!enabled || source.includes(RUNTIME_MARKER) || source.includes(STYLE_ID)) {
+      return source;
+    }
+
+    if (!looksLikeSidebarProjectBundle(source)) {
+      if (hasPartialSidebarProjectMarkers(source)) {
+        warn("Could not find current sidebar project name markers");
+      }
+      return source;
+    }
+
+    return `${source}\n${sidebarProjectNameStyleRuntimeSource(style)}`;
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+const patches = [
+  {
+    id: "sidebar-project-name-style",
+    phase: "webview-asset",
+    order: 20_790,
+    ciPolicy: "optional",
+    pattern: /^(?:app-initial~app-main~remote-conversation-page~projects-index-page|projects-index-page).*\.js$/,
+    missingDescription: "projects sidebar bundle",
+    skipDescription: "ui-tweaks sidebar project name style patch",
+    apply: applySidebarProjectNameStylePatch,
+  },
+];
+
+module.exports = {
+  DEFAULT_PROJECT_NAME_STYLE,
+  PROJECT_NAME_SELECTOR,
+  RUNTIME_MARKER,
+  STYLE_ID,
+  applySidebarProjectNameStylePatch,
+  normalizedProjectNameStyle,
+  patches,
+  sidebarProjectNameCss,
+  sidebarProjectNameStyleRuntimeSource,
+};

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -13,10 +13,12 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
   DEFAULT_PROJECT_NAME_STYLE,
+  PROJECTS_SIDEBAR_ASSET_PATTERN,
   PROJECT_NAME_SELECTOR,
   RUNTIME_MARKER,
   STYLE_ID,
   applySidebarProjectNameStylePatch,
+  patches,
   sidebarProjectNameCss,
 } = require("./patches/sidebar-project-name.js");
 
@@ -79,6 +81,18 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
   }
 });
 
+test("sidebar project descriptor targets only the current project sidebar asset", () => {
+  assert.match(
+    "app-initial~app-main~remote-conversation-page~projects-index-page-By2_tGIM.js",
+    PROJECTS_SIDEBAR_ASSET_PATTERN,
+  );
+  assert.doesNotMatch("projects-index-page-TFjtVwC4.js", PROJECTS_SIDEBAR_ASSET_PATTERN);
+  assert.doesNotMatch(
+    "app-initial~app-main~remote-conversation-page~projects-index-page~hotkey-window-thread-page~hc7acb17-B7QwUDa9.js",
+    PROJECTS_SIDEBAR_ASSET_PATTERN,
+  );
+});
+
 test("patch injects sidebar project-name stylesheet runtime once", () => {
   const context = {
     feature: {
@@ -112,6 +126,23 @@ test("patch injects sidebar project-name stylesheet runtime once", () => {
     patched.includes(JSON.stringify(sidebarProjectNameCss("font-weight: 800 !important; color: red;"))),
   );
   assert.equal((patched.match(new RegExp(STYLE_ID, "g")) ?? []).length, 1);
+});
+
+test("feature manifest defaults reach descriptor context through the feature loader", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-tweaks-manifest-defaults-"));
+  try {
+    const featuresRoot = path.join(tempDir, "linux-features");
+    fs.mkdirSync(featuresRoot, { recursive: true });
+    copyFeatureTo(featuresRoot);
+    fs.writeFileSync(path.join(featuresRoot, "features.json"), '{"enabled":["ui-tweaks"]}\n');
+
+    const [descriptor] = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    const patched = descriptor.apply(projectBundleFixture(), {});
+
+    assert.match(patched, /font-weight: 700 !important; padding-top: 0.25rem;/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("default project name style is bold with top padding and no forced color", () => {
@@ -185,7 +216,10 @@ test("invalid feature settings warn and fall back to defaults", () => {
 
 test("patch skips unrelated assets", () => {
   const source = "console.log('not the sidebar');";
-  assert.equal(applySidebarProjectNameStylePatch(source), source);
+  const { value, warnings } = withCapturedWarns(() => applySidebarProjectNameStylePatch(source));
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("drift warning returns source unchanged", () => {
@@ -195,6 +229,16 @@ test("drift warning returns source unchanged", () => {
   ].join("");
 
   const { value, warnings } = withCapturedWarns(() => applySidebarProjectNameStylePatch(source));
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^WARN: Could not find current sidebar project name markers/);
+});
+
+test("target asset drift warning returns source unchanged when all markers are missing", () => {
+  const source = "console.log('projects sidebar bundle drifted');";
+
+  const { value, warnings } = withCapturedWarns(() => patches[0].apply(source, {}));
 
   assert.equal(value, source);
   assert.equal(warnings.length, 1);
@@ -233,4 +277,30 @@ test("invalid and empty styles warn and fall back without throwing", () => {
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /^WARN: ui-tweaks sidebar project name style/);
   }
+});
+
+test("unsafe styles warn, stay scoped, and fall back to the default", () => {
+  const unsafeStyle = "font-weight:700;} body{display:none} /*";
+  const { value, warnings } = withCapturedWarns(() =>
+    applySidebarProjectNameStylePatch(projectBundleFixture(), {
+      feature: {
+        settings: {
+          tweaks: {
+            sidebar: {
+              projectName: {
+                style: unsafeStyle,
+              },
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  assert.match(value, new RegExp(STYLE_ID));
+  assert.match(value, /font-weight: 700 !important; padding-top: 0.25rem;/);
+  assert.doesNotMatch(value, /body\{display:none\}/);
+  assert.equal(value.includes(unsafeStyle), false);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^WARN: ui-tweaks sidebar project name style must be a safe CSS declaration list/);
 });

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -86,6 +86,15 @@ test("patch injects sidebar project-name stylesheet runtime once", () => {
         tweaks: {
           sidebar: {
             projectName: {
+              style: DEFAULT_PROJECT_NAME_STYLE,
+            },
+          },
+        },
+      },
+      settings: {
+        tweaks: {
+          sidebar: {
+            projectName: {
               style: "font-weight: 800 !important; color: red;",
             },
           },
@@ -105,12 +114,73 @@ test("patch injects sidebar project-name stylesheet runtime once", () => {
   assert.equal((patched.match(new RegExp(STYLE_ID, "g")) ?? []).length, 1);
 });
 
-test("default project name style is bold-only", () => {
+test("default project name style is bold with top padding and no forced color", () => {
   const featureJson = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
   assert.equal(featureJson.tweaks.sidebar.projectName.style, DEFAULT_PROJECT_NAME_STYLE);
   assert.match(DEFAULT_PROJECT_NAME_STYLE, /font-weight:\s*700\s*!important/);
+  assert.match(DEFAULT_PROJECT_NAME_STYLE, /padding-top:\s*0\.25rem/);
   assert.doesNotMatch(DEFAULT_PROJECT_NAME_STYLE, /color/i);
   assert.doesNotMatch(sidebarProjectNameCss(DEFAULT_PROJECT_NAME_STYLE), /#000|black/i);
+});
+
+test("feature settings override the tracked defaults through features.json", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-tweaks-settings-"));
+  try {
+    const featuresRoot = path.join(tempDir, "linux-features");
+    fs.mkdirSync(featuresRoot, { recursive: true });
+    copyFeatureTo(featuresRoot);
+    fs.writeFileSync(
+      path.join(featuresRoot, "features.json"),
+      `${JSON.stringify(
+        {
+          enabled: ["ui-tweaks"],
+          settings: {
+            "ui-tweaks": {
+              tweaks: {
+                sidebar: {
+                  projectName: {
+                    style: "font-weight: 800 !important; color: red;",
+                  },
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const [descriptor] = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    const patched = descriptor.apply(projectBundleFixture(), {});
+
+    assert.match(patched, /font-weight: 800 !important; color: red;/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("invalid feature settings warn and fall back to defaults", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-tweaks-invalid-settings-"));
+  try {
+    const featuresRoot = path.join(tempDir, "linux-features");
+    fs.mkdirSync(featuresRoot, { recursive: true });
+    copyFeatureTo(featuresRoot);
+    fs.writeFileSync(
+      path.join(featuresRoot, "features.json"),
+      '{"enabled":["ui-tweaks"],"settings":{"ui-tweaks":false}}\n',
+    );
+
+    const { value: descriptors, warnings } = withCapturedWarns(() =>
+      loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+    );
+    const patched = descriptors[0].apply(projectBundleFixture(), {});
+
+    assert.match(warnings.join("\n"), /WARN: Linux feature 'ui-tweaks' settings/);
+    assert.match(patched, /font-weight: 700 !important; padding-top: 0.25rem;/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("patch skips unrelated assets", () => {
@@ -140,6 +210,15 @@ test("invalid and empty styles warn and fall back without throwing", () => {
             tweaks: {
               sidebar: {
                 projectName: {
+                  style: DEFAULT_PROJECT_NAME_STYLE,
+                },
+              },
+            },
+          },
+          settings: {
+            tweaks: {
+              sidebar: {
+                projectName: {
                   style: badStyle,
                 },
               },
@@ -150,7 +229,7 @@ test("invalid and empty styles warn and fall back without throwing", () => {
     );
 
     assert.match(value, new RegExp(STYLE_ID));
-    assert.match(value, /font-weight: 700 !important;/);
+    assert.match(value, /font-weight: 700 !important; padding-top: 0.25rem;/);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /^WARN: ui-tweaks sidebar project name style/);
   }

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  discoverLinuxFeatureManifests,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  DEFAULT_PROJECT_NAME_STYLE,
+  PROJECT_NAME_SELECTOR,
+  RUNTIME_MARKER,
+  STYLE_ID,
+  applySidebarProjectNameStylePatch,
+  sidebarProjectNameCss,
+} = require("./patches/sidebar-project-name.js");
+
+function projectBundleFixture() {
+  return [
+    "function Hd(){return {id:`sidebarElectron.projectsNavLink`,defaultMessage:`Projects`}}",
+    "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
+    "let V=(0,Iy.jsx)(`span`,{className:`min-w-0 truncate pr-1`,children:p});return [j,V]}",
+  ].join("");
+}
+
+function applyPatchTwice(source, context) {
+  const patched = applySidebarProjectNameStylePatch(source, context);
+  assert.equal(applySidebarProjectNameStylePatch(patched, context), patched);
+  return patched;
+}
+
+function copyFeatureTo(featuresRoot) {
+  const featureDir = path.join(featuresRoot, "ui-tweaks");
+  fs.mkdirSync(featureDir, { recursive: true });
+  for (const name of ["feature.json", "README.md", "patch.js"]) {
+    fs.copyFileSync(path.join(__dirname, name), path.join(featureDir, name));
+  }
+  fs.cpSync(path.join(__dirname, "patches"), path.join(featureDir, "patches"), { recursive: true });
+}
+
+function withCapturedWarns(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+test("ui-tweaks is discoverable and disabled until listed in features.json", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ui-tweaks-feature-"));
+  try {
+    const featuresRoot = path.join(tempDir, "linux-features");
+    fs.mkdirSync(featuresRoot, { recursive: true });
+    copyFeatureTo(featuresRoot);
+    fs.writeFileSync(path.join(featuresRoot, "features.example.json"), '{"enabled":[]}\n');
+
+    const manifests = discoverLinuxFeatureManifests({ featuresRoot });
+    assert.equal(manifests.length, 1);
+    assert.equal(manifests[0].id, "ui-tweaks");
+    assert.equal(manifests[0].manifest.defaultEnabled, false);
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+
+    fs.writeFileSync(path.join(featuresRoot, "features.json"), '{"enabled":["ui-tweaks"]}\n');
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+      [["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"]],
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("patch injects sidebar project-name stylesheet runtime once", () => {
+  const context = {
+    feature: {
+      manifest: {
+        tweaks: {
+          sidebar: {
+            projectName: {
+              style: "font-weight: 800 !important; color: red;",
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const patched = applyPatchTwice(projectBundleFixture(), context);
+
+  assert.match(patched, new RegExp(STYLE_ID));
+  assert.match(patched, new RegExp(RUNTIME_MARKER));
+  assert.match(patched, /font-weight: 800 !important; color: red;/);
+  assert.ok(
+    patched.includes(JSON.stringify(sidebarProjectNameCss("font-weight: 800 !important; color: red;"))),
+  );
+  assert.equal((patched.match(new RegExp(STYLE_ID, "g")) ?? []).length, 1);
+});
+
+test("default project name style is bold-only", () => {
+  const featureJson = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
+  assert.equal(featureJson.tweaks.sidebar.projectName.style, DEFAULT_PROJECT_NAME_STYLE);
+  assert.match(DEFAULT_PROJECT_NAME_STYLE, /font-weight:\s*700\s*!important/);
+  assert.doesNotMatch(DEFAULT_PROJECT_NAME_STYLE, /color/i);
+  assert.doesNotMatch(sidebarProjectNameCss(DEFAULT_PROJECT_NAME_STYLE), /#000|black/i);
+});
+
+test("patch skips unrelated assets", () => {
+  const source = "console.log('not the sidebar');";
+  assert.equal(applySidebarProjectNameStylePatch(source), source);
+});
+
+test("drift warning returns source unchanged", () => {
+  const source = [
+    "function Hd(){return {id:`sidebarElectron.projectsNavLink`,defaultMessage:`Projects`}}",
+    "function row(){let j=Pn(`group/folder-row group relative flex`);return j}",
+  ].join("");
+
+  const { value, warnings } = withCapturedWarns(() => applySidebarProjectNameStylePatch(source));
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^WARN: Could not find current sidebar project name markers/);
+});
+
+test("invalid and empty styles warn and fall back without throwing", () => {
+  for (const badStyle of [42, "   "]) {
+    const { value, warnings } = withCapturedWarns(() =>
+      applySidebarProjectNameStylePatch(projectBundleFixture(), {
+        feature: {
+          manifest: {
+            tweaks: {
+              sidebar: {
+                projectName: {
+                  style: badStyle,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    assert.match(value, new RegExp(STYLE_ID));
+    assert.match(value, /font-weight: 700 !important;/);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /^WARN: ui-tweaks sidebar project name style/);
+  }
+});

--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -793,15 +793,17 @@ def discover_features(root):
         }
     return dict(sorted(features.items()))
 
-def read_enabled_ids(path):
+def read_feature_config(path):
     if not path.exists():
         fallback = features_root / "features.example.json"
         if fallback.exists():
-            data = read_json(fallback, "Linux features example config") or {}
+            return read_json(fallback, "Linux features example config") or {}
         else:
-            return []
+            return {}
     else:
-        data = read_json(path, "Linux features config") or {}
+        return read_json(path, "Linux features config") or {}
+
+def read_enabled_ids(data, path):
     enabled = data.get("enabled", [])
     if not isinstance(enabled, list):
         die(f"Linux features config {path} must contain an enabled array")
@@ -819,7 +821,10 @@ def csv(ids):
     return ", ".join(ids) if ids else "none"
 
 features = discover_features(features_root)
-current = read_enabled_ids(config_path)
+config_data = read_feature_config(config_path)
+if not isinstance(config_data, dict):
+    die(f"Linux features config {config_path} must be a JSON object")
+current = read_enabled_ids(config_data, config_path)
 
 if output_mode == "tsv":
     # Machine-readable discovery for the GUI feature picker: one
@@ -863,7 +868,9 @@ for feature_id in final:
 
 if apply_changes and (enable or disable):
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps({"enabled": final}, indent=2) + "\n")
+    updated_config = dict(config_data)
+    updated_config["enabled"] = final
+    config_path.write_text(json.dumps(updated_config, indent=2) + "\n")
     print(f"[setup] Updated Linux feature config: {config_path}")
 elif not config_path.exists():
     print(f"[setup] Linux feature config: {config_path} (not created yet)")

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -63,6 +63,24 @@ function readJsonFile(filePath, label) {
   }
 }
 
+function readLinuxFeaturesConfig(options = {}) {
+  const featuresRoot = linuxFeaturesRoot(options);
+  const configPath = linuxFeaturesConfigPath(featuresRoot, options);
+  if (!fs.existsSync(configPath)) {
+    return { config: null, configPath };
+  }
+
+  const config = readJsonFile(configPath, "Linux features config");
+  if (config == null) {
+    return { config: null, configPath };
+  }
+  if (typeof config !== "object" || Array.isArray(config)) {
+    console.warn(`WARN: Linux features config ${configPath} must be a JSON object`);
+    return { config: null, configPath };
+  }
+  return { config, configPath };
+}
+
 function assertFeatureId(value, label) {
   if (typeof value !== "string" || !FEATURE_ID_PATTERN.test(value)) {
     throw new Error(`${label} must match ${FEATURE_ID_PATTERN}`);
@@ -112,18 +130,59 @@ function normalizeEnabledFeatureIds(value, sourcePath) {
   return ids;
 }
 
-function enabledLinuxFeatureIds(options = {}) {
-  const featuresRoot = linuxFeaturesRoot(options);
-  const configPath = linuxFeaturesConfigPath(featuresRoot, options);
-  if (!fs.existsSync(configPath)) {
-    return [];
+function normalizeLinuxFeatureSettings(value, sourcePath) {
+  if (value == null) {
+    return {};
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    console.warn(`WARN: Linux features config ${sourcePath} settings must be an object`);
+    return {};
   }
 
-  const config = readJsonFile(configPath, "Linux features config");
-  if (config == null) {
-    return [];
+  const settings = {};
+  for (const [rawId, rawSettings] of Object.entries(value)) {
+    if (typeof rawId !== "string" || !FEATURE_ID_PATTERN.test(rawId)) {
+      console.warn(`WARN: Invalid Linux feature settings id in ${sourcePath}: ${String(rawId)}`);
+      continue;
+    }
+    const id = LEGACY_FEATURE_ID_ALIASES.get(rawId) ?? rawId;
+    if (rawSettings == null || typeof rawSettings !== "object" || Array.isArray(rawSettings)) {
+      console.warn(`WARN: Linux feature '${rawId}' settings in ${sourcePath} must be an object`);
+      continue;
+    }
+    settings[id] = rawSettings;
   }
-  return normalizeEnabledFeatureIds(config.enabled, configPath);
+  return settings;
+}
+
+function linuxFeaturesConfig(options = {}) {
+  const { config, configPath } = readLinuxFeaturesConfig(options);
+  if (config == null) {
+    return { enabled: [], settings: {}, configPath };
+  }
+  return {
+    enabled: normalizeEnabledFeatureIds(config.enabled, configPath),
+    settings: normalizeLinuxFeatureSettings(config.settings, configPath),
+    configPath,
+  };
+}
+
+function enabledLinuxFeatureIds(options = {}) {
+  return linuxFeaturesConfig(options).enabled;
+}
+
+function enabledLinuxFeaturesConfig(options = {}) {
+  const { enabled, settings } = linuxFeaturesConfig(options);
+  const filteredSettings = {};
+  for (const id of enabled) {
+    if (Object.prototype.hasOwnProperty.call(settings, id)) {
+      filteredSettings[id] = settings[id];
+    }
+  }
+  if (Object.keys(filteredSettings).length === 0) {
+    return { enabled };
+  }
+  return { enabled, settings: filteredSettings };
 }
 
 function isDirectory(filePath) {
@@ -249,14 +308,15 @@ function validateEnabledFeatureDependencies(features) {
 function loadEnabledLinuxFeatures(options = {}) {
   const featuresRoot = linuxFeaturesRoot(options);
   const available = linuxFeatureManifestMap({ ...options, featuresRoot });
+  const config = linuxFeaturesConfig({ ...options, featuresRoot });
   const features = [];
   const missing = [];
-  for (const id of enabledLinuxFeatureIds({ ...options, featuresRoot })) {
+  for (const id of config.enabled) {
     const feature = available.get(id);
     if (feature == null) {
       missing.push(id);
     } else {
-      features.push(feature);
+      features.push({ ...feature, settings: config.settings[id] ?? {} });
     }
   }
   if (missing.length > 0) {
@@ -823,6 +883,7 @@ if (require.main === module) {
 module.exports = {
   disabledLinuxFeatureCleanupHooks,
   discoverLinuxFeatureManifests,
+  enabledLinuxFeaturesConfig,
   enabledLinuxFeatureIds,
   enabledLinuxFeatureInstallPlan,
   enabledLinuxFeaturePackageHooks,

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -68,16 +68,16 @@ const path = require("node:path");
 
 const helperPath = path.resolve(process.argv[2]);
 const targetPath = path.resolve(process.argv[3]);
-const { enabledLinuxFeatureIds } = require(helperPath);
+const { enabledLinuxFeaturesConfig } = require(helperPath);
 
-const enabled = enabledLinuxFeatureIds();
-if (enabled.length === 0) {
+const config = enabledLinuxFeaturesConfig();
+if (config.enabled.length === 0) {
   fs.rmSync(targetPath, { force: true });
   process.exit(0);
 }
 
 fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-fs.writeFileSync(targetPath, `${JSON.stringify({ enabled }, null, 2)}\n`);
+fs.writeFileSync(targetPath, `${JSON.stringify(config, null, 2)}\n`);
 NODE
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -490,6 +490,19 @@ test_update_builder_preserves_enabled_linux_features_config() {
     "example-feature",
     "local-tool"
   ],
+  "settings": {
+    "example-feature": {
+      "tweaks": {
+        "enabled": true
+      }
+    },
+    "disabled-feature": {
+      "should": "not be packaged"
+    },
+    "local-tool": {
+      "mode": "local"
+    }
+  },
   "localComment": "should not be packaged"
 }
 JSON
@@ -512,13 +525,29 @@ JSON
     assert_file_exists "$staged_local_manifest"
     assert_contains "$staged_config" "example-feature"
     assert_contains "$staged_config" "local-tool"
+    assert_contains "$staged_config" "tweaks"
+    assert_contains "$staged_config" "mode"
     assert_not_contains "$staged_config" "localComment"
+    assert_not_contains "$staged_config" "disabled-feature"
 
     node - "$staged_config" <<'NODE' || fail "Expected staged Linux features config to be sanitized"
 const fs = require("node:fs");
 const configPath = process.argv[2];
 const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
-if (JSON.stringify(config) !== JSON.stringify({ enabled: ["example-feature", "local-tool"] })) {
+const expected = {
+  enabled: ["example-feature", "local-tool"],
+  settings: {
+    "example-feature": {
+      tweaks: {
+        enabled: true,
+      },
+    },
+    "local-tool": {
+      mode: "local",
+    },
+  },
+};
+if (JSON.stringify(config) !== JSON.stringify(expected)) {
   process.exit(1);
 }
 NODE
@@ -1843,7 +1872,22 @@ test_setup_native_wizard_noninteractive_feature_writer() {
 
     make_wizard_feature_root "$features_root"
     cat > "$config" <<'JSON'
-{"enabled":["conversation-mode"]}
+{
+  "enabled": [
+    "conversation-mode"
+  ],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "sidebar": {
+          "projectName": {
+            "style": "font-weight: 700 !important; padding-top: 0.25rem;"
+          }
+        }
+      }
+    }
+  }
+}
 JSON
 
     CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
@@ -1855,6 +1899,13 @@ JSON
         bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$output_log"
 
     assert_json_enabled_equals "$config" '["remote-mobile-control","read-aloud"]'
+    node - "$config" <<'NODE' || fail "Expected setup-native wizard to preserve Linux feature settings"
+const fs = require("node:fs");
+const config = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (config.settings?.["ui-tweaks"]?.tweaks?.sidebar?.projectName?.style !== "font-weight: 700 !important; padding-top: 0.25rem;") {
+  process.exit(1);
+}
+NODE
     assert_contains "$output_log" "remote-mobile-control"
     assert_contains "$output_log" "read-aloud"
     assert_contains "$output_log" "Manual-update native package mode selected"


### PR DESCRIPTION
## Summary
- Add a disabled-by-default `ui-tweaks` Linux feature for small UI customization patches.
- Add the first modular tweak, `sidebar.projectName`, with CSS defaults in `feature.json` and local overrides from gitignored `linux-features/features.json` settings.
- Extend the Linux feature config flow so per-feature settings are passed to patches and preserved through bootstrap edits and update-builder packaging.
- Document available sub-tweaks, settings, drift behavior, and how future tweaks should be registered.

## Tests/checks run
- `node --test linux-features/ui-tweaks/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`

## Notes
- The sidebar project-name default is `font-weight: 700 !important; padding-top: 0.25rem;` and does not force a color.
- The patch is fail-soft: drift or invalid style config emits `WARN` and leaves the app bundle unchanged or falls back to the default style.
- Local ignored `linux-features/features.json` is still only for testing/user preferences and is not part of this PR.