### PR TITLE
Preserve user Node path in desktop terminal

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -540,13 +540,9 @@ export_packaged_runtime_env() {
     fi
 }
 
-prepend_managed_node_runtime_to_path() {
+export_managed_node_runtime_env() {
     [ -x "$MANAGED_NODE_BIN_DIR/node" ] || return 0
 
-    case ":$PATH:" in
-        *":$MANAGED_NODE_BIN_DIR:"*) ;;
-        *) export PATH="$MANAGED_NODE_BIN_DIR:$PATH" ;;
-    esac
     export CODEX_MANAGED_NODE_RUNTIME_DIR="$SCRIPT_DIR/resources/node-runtime"
 }
 
@@ -2978,7 +2974,7 @@ hydrate_graphical_session_env
 configure_side_by_side_app_env
 export_feature_runtime_env
 load_packaged_runtime_helper
-prepend_managed_node_runtime_to_path
+export_managed_node_runtime_env
 source_feature_env_files
 register_url_scheme_handlers
 log_phase "initial_launch_state_refresh_start"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3742,6 +3742,8 @@ EOF
     assert_contains "$REPO_DIR/flake.nix" "https://static.crates.io/crates/"
     assert_contains "$REPO_DIR/flake.nix" "api/v1/crates/"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "MANAGED_NODE_BIN_DIR"
+    assert_not_contains "$REPO_DIR/launcher/start.sh.template" 'export PATH="$MANAGED_NODE_BIN_DIR:$PATH"'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'CODEX_BROWSER_USE_NODE_PATH="$MANAGED_NODE_BIN_DIR/node"'
     assert_contains "$REPO_DIR/updater/src/builder.rs" "managed_node_bin_dirs"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "stage_common_package_files"
     assert_contains "$REPO_DIR/scripts/build-rpm.sh" "PACKAGED_RUNTIME_SOURCE"


### PR DESCRIPTION
## Summary
- Stop prepending the packaged managed Node runtime to the global launcher PATH inherited by Electron.
- Keep managed Node available through CODEX_MANAGED_NODE_RUNTIME_DIR and explicit Browser Use / node_repl env vars.
- Add a smoke guard so the launcher does not leak resources/node-runtime/bin ahead of the user PATH again.

Fixes #623

## Tests/checks run
- bash -n launcher/start.sh.template
- bash -n tests/scripts_smoke.sh
- git diff --check
- bash tests/scripts_smoke.sh

## Notes
- This is a draft PR for review; it intentionally does not change managed Node packaging or Browser Use runtime resolution.