### PR TITLE
[codex] Make workspace-root open targets optional on drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -806,7 +806,6 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
     "linux-tray",
-    "linux-workspace-root-open-targets",
   ]) {
     assert.equal(
       descriptors.find((descriptor) => descriptor.id === id)?.ciPolicy,
@@ -814,6 +813,11 @@ test("default core patch descriptors are grouped and unique", () => {
       `${id} should block upstream builds when it drifts`,
     );
   }
+  assert.equal(
+    descriptors.find((descriptor) => descriptor.id === "linux-workspace-root-open-targets")?.ciPolicy,
+    "optional",
+    "workspace-root open targets should not block app builds when upstream removes the File Manager insertion point",
+  );
 
   const descriptorOrder = new Map(descriptors.map((descriptor) => [descriptor.id, descriptor.order]));
   assert.ok(

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -9,7 +9,7 @@ const {
 
 const PATCH_MARKER = "codexLinuxWorkspaceRootOpenTarget";
 const MISSING_FILE_MANAGER_ACTION_REASON =
-  "Could not find workspace-root File Manager open action while Linux targets are enabled";
+  "Workspace-root File Manager open action is not present in this upstream build";
 
 function warn(message) {
   console.warn(`WARN: ${message} - skipping Linux workspace-root open targets patch`);
@@ -320,7 +320,7 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
     return {
       matched,
       changed,
-      status: "failed-required",
+      status: "skipped-target",
       reason: MISSING_FILE_MANAGER_ACTION_REASON,
     };
   }
@@ -331,7 +331,7 @@ module.exports = {
   id: "linux-workspace-root-open-targets",
   phase: "extracted-app",
   order: 2060,
-  ciPolicy: "required-upstream",
+  ciPolicy: "optional",
   apply: patchWorkspaceRootOpenTargets,
   status(result, warnings) {
     if (result?.status != null) {
@@ -339,11 +339,11 @@ module.exports = {
     }
     if (result?.changed) {
       return warnings.length > 0
-        ? { status: "failed-required", reason: warnings[0] }
+        ? { status: "applied-with-warnings", reason: warnings[0] }
         : "applied";
     }
     if (warnings.length > 0) {
-      return { status: "failed-required", reason: warnings[0] };
+      return { status: "skipped-optional", reason: warnings[0] };
     }
     return "already-applied";
   },

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -320,7 +320,7 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
     return {
       matched,
       changed,
-      status: "skipped-target",
+      status: "skipped-optional",
       reason: MISSING_FILE_MANAGER_ACTION_REASON,
     };
   }

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -191,7 +191,7 @@ test("workspace root open targets patch is not applicable without Linux targets"
   }
 });
 
-test("workspace root open targets patch skips when Linux targets are enabled but the File Manager chunk is absent", () => {
+test("workspace root open targets patch reports optional drift when Linux targets are enabled but the File Manager chunk is absent", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
   try {
     const buildDir = path.join(root, ".vite", "build");
@@ -222,11 +222,11 @@ test("workspace root open targets patch skips when Linux targets are enabled but
     assert.deepEqual(result, {
       matched: 0,
       changed: 0,
-      status: "skipped-target",
+      status: "skipped-optional",
       reason: expectedReason,
     });
     assert.deepEqual(workspaceRootOpenTargetsPatch.status(result, []), {
-      status: "skipped-target",
+      status: "skipped-optional",
       reason: expectedReason,
     });
   } finally {

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -191,7 +191,7 @@ test("workspace root open targets patch is not applicable without Linux targets"
   }
 });
 
-test("workspace root open targets patch fails required when Linux targets are enabled but the File Manager chunk drifted", () => {
+test("workspace root open targets patch skips when Linux targets are enabled but the File Manager chunk is absent", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
   try {
     const buildDir = path.join(root, ".vite", "build");
@@ -217,16 +217,16 @@ test("workspace root open targets patch fails required when Linux targets are en
     );
 
     const result = patchWorkspaceRootOpenTargets(root);
-    const expectedReason = "Could not find workspace-root File Manager open action while Linux targets are enabled";
+    const expectedReason = "Workspace-root File Manager open action is not present in this upstream build";
 
     assert.deepEqual(result, {
       matched: 0,
       changed: 0,
-      status: "failed-required",
+      status: "skipped-target",
       reason: expectedReason,
     });
     assert.deepEqual(workspaceRootOpenTargetsPatch.status(result, []), {
-      status: "failed-required",
+      status: "skipped-target",
       reason: expectedReason,
     });
   } finally {


### PR DESCRIPTION
## Summary
- make the workspace-root open-targets patch optional when upstream no longer contains the File Manager insertion point
- return skipped-target/skipped-optional instead of failing the full app patch flow
- update descriptor and focused patch tests for the new optional drift behavior

## Root cause
Latest upstream Codex Desktop builds can omit the File Manager workspace-root action chunk. The Linux wrapper treated that as required upstream drift, which blocked building otherwise usable Linux apps even though the open-targets enhancement can be skipped safely.

## Validation
- `node --test scripts/workspace-root-open-targets-patch.test.js scripts/patch-linux-window-ui.test.js`
- `git diff --check`