### PR TITLE
Remove Linux window menus

### DIFF
--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -78,35 +78,32 @@ function applyFramelessTitlebarOverlaySyncPatch(currentSource) {
 
 function applyFramelessTitlebarMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(menuRegex, (match, windowVar, offset) => {
-    const linuxPatch = `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),`;
-    const legacyLinuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
-    if (currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
-      return match;
-    }
-    if (currentSource.slice(Math.max(0, offset - legacyLinuxPatch.length), offset) === legacyLinuxPatch) {
-      patchedAny = true;
+  let patchedSource = currentSource
+    .replace(
+      /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+    )
+    .replace(
+      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+    );
+  let patchedAny = patchedSource !== currentSource;
+  patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
+    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.removeMenu(),`;
+    if (source.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
       return match;
     }
     patchedAny = true;
     return `${linuxPatch}${match}`;
   });
 
-  const upgradedSource = patchedSource.replace(
-    /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-    (_match, windowVar) =>
-      `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-  );
-
-  if (!patchedAny && !currentSource.includes("setMenuBarVisibility(!1)")) {
-    const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(currentSource);
-    if (hasWindowsRemoveMenu) {
-      console.warn("WARN: Could not find window menu visibility snippet - skipping frameless titlebar menu patch");
-    }
+  const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
+  const hasLinuxRemoveMenu = /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
+  if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
+    console.warn("WARN: Could not find window menu visibility snippet - skipping frameless titlebar menu patch");
   }
 
-  return upgradedSource;
+  return patchedSource;
 }
 
 function applyFramelessTitlebarMainPatch(currentSource) {

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -12,6 +12,7 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
   applyFramelessTitlebarMainPatch,
+  applyFramelessTitlebarMenuPatch,
   applyFramelessTitlebarWebviewPatch,
 } = require("./patch.js");
 
@@ -75,11 +76,23 @@ test("frameless-titlebar removes Linux overlay controls and menu chrome", () => 
   assert.match(patched, /if\(process\.platform!==`win32`\|\|t!==`primary`\)return/);
   assert.match(
     patched,
-    /process\.platform===`linux`&&\(k\.setMenuBarVisibility\(!1\),k\.removeMenu\?\.\(\)\),process\.platform===`win32`&&k\.removeMenu\(\),/,
+    /process\.platform===`linux`&&k\.removeMenu\(\),process\.platform===`win32`&&k\.removeMenu\(\),/,
   );
+  assert.doesNotMatch(patched, /setMenuBarVisibility/);
   assert.doesNotMatch(patched, /titleBarOverlay:codexLinuxTitleBarOverlay/);
   assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
   assert.doesNotMatch(patched, /process\.platform!==`linux`[^;]*setTitleBarOverlay/);
+});
+
+test("frameless-titlebar leaves core Linux removeMenu patch idempotent", () => {
+  const source =
+    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),";
+
+  const patched = applyPatchTwice(applyFramelessTitlebarMenuPatch, source);
+
+  assert.equal(patched, source);
+  assert.equal((patched.match(/process\.platform===`linux`&&k\.removeMenu\(\),/g) ?? []).length, 1);
+  assert.doesNotMatch(patched, /setMenuBarVisibility/);
 });
 
 test("frameless-titlebar collapses the core-patched zoom overlay ternary", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2170,38 +2170,51 @@ test("removes native title tooltip from the thread side panel toolbar action", (
   assert.doesNotMatch(patched, /title:i/);
 });
 
-test("adds Linux menu hiding next to Windows removeMenu calls", () => {
+test("removes the Linux menu next to Windows removeMenu calls", () => {
   const source = "process.platform===`win32`&&k.removeMenu(),";
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
 
   assert.equal(
     patched,
-    "process.platform===`linux`&&k.setMenuBarVisibility(!1),process.platform===`win32`&&k.removeMenu(),",
+    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),",
   );
 });
 
 test("patches remaining Windows menu snippets when another copy is already Linux-patched", () => {
   const windowsMenuSnippet = "process.platform===`win32`&&k.removeMenu(),";
-  const linuxMenuPatch = "process.platform===`linux`&&k.setMenuBarVisibility(!1),";
+  const linuxMenuPatch = "process.platform===`linux`&&k.removeMenu(),";
   const source = `${linuxMenuPatch}${windowsMenuSnippet}function createSecondWindow(){${windowsMenuSnippet}}`;
 
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
 
-  assert.equal((patched.match(/setMenuBarVisibility\(!1\)/g) ?? []).length, 2);
+  assert.equal((patched.match(/removeMenu\(\)/g) ?? []).length, 4);
   assert.match(
     patched,
-    /function createSecondWindow\(\)\{process\.platform===`linux`&&k\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
+    /function createSecondWindow\(\)\{process\.platform===`linux`&&k\.removeMenu\(\),process\.platform===`win32`&&k\.removeMenu\(\),\}/,
   );
 });
 
-test("recognizes the frameless-titlebar upgraded menu snippet as already applied", () => {
+test("upgrades legacy Linux menu snippets to remove the menu", () => {
   const source =
     "process.platform===`linux`&&(k.setMenuBarVisibility(!1),k.removeMenu?.()),process.platform===`win32`&&k.removeMenu(),";
 
   const patched = applyPatchTwice(applyLinuxMenuPatch, source);
 
+  assert.equal(
+    patched,
+    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),",
+  );
+  assert.doesNotMatch(patched, /setMenuBarVisibility/);
+});
+
+test("recognizes the Linux removeMenu snippet as already applied", () => {
+  const source =
+    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),";
+
+  const patched = applyPatchTwice(applyLinuxMenuPatch, source);
+
   assert.equal(patched, source);
-  assert.equal((patched.match(/setMenuBarVisibility\(!1\)/g) ?? []).length, 1);
+  assert.equal((patched.match(/process\.platform===`linux`&&k\.removeMenu\(\),/g) ?? []).length, 1);
 });
 
 test("recognizes already-applied Linux opaque background patch", () => {
@@ -6648,7 +6661,7 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
   assert.match(patched, /codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0/);
   assert.match(patched, /n\.app\.on\(`before-quit`,codexLinuxBeforeQuitHandler\)/);
-  assert.match(patched, /process\.platform===`linux`&&k\.setMenuBarVisibility\(!1\)/);
+  assert.match(patched, /process\.platform===`linux`&&k\.removeMenu\(\)/);
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(
     patched,

--- a/scripts/patches/main-process/window.js
+++ b/scripts/patches/main-process/window.js
@@ -343,28 +343,29 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
 
 function applyLinuxMenuPatch(currentSource) {
   const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(menuRegex, (match, windowVar, offset) => {
-    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setMenuBarVisibility(!1),`;
-    // The frameless-titlebar feature upgrades the inserted snippet to also
-    // call removeMenu?.(); treat that form as already applied so re-running
-    // the pipeline over feature-patched output stays idempotent.
-    const upgradedLinuxPatch = `process.platform===\`linux\`&&(${windowVar}.setMenuBarVisibility(!1),${windowVar}.removeMenu?.()),`;
-    if (
-      currentSource.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch ||
-      currentSource.slice(Math.max(0, offset - upgradedLinuxPatch.length), offset) === upgradedLinuxPatch
-    ) {
+  let patchedSource = currentSource
+    .replace(
+      /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+    )
+    .replace(
+      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+    );
+  let patchedAny = patchedSource !== currentSource;
+  patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
+    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.removeMenu(),`;
+    if (source.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
       return match;
     }
     patchedAny = true;
     return `${linuxPatch}${match}`;
   });
 
-  if (!patchedAny && !currentSource.includes("setMenuBarVisibility(!1)")) {
-    const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(currentSource);
-    if (hasWindowsRemoveMenu) {
-      console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
-    }
+  const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
+  const hasLinuxRemoveMenu = /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
+  if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
+    console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
   }
 
   return patchedSource;

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4712,7 +4712,8 @@ test_linux_file_manager_patch_smoke() {
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_contains "$extracted/.vite/build/main-test.js" 'detect:()=>`linux-file-manager`'
     assert_contains "$extracted/.vite/build/main-test.js" 'linux:{label:`File Manager`'
-    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.setMenuBarVisibility(!1),'
+    assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&D.removeMenu(),process.platform===`win32`&&D.removeMenu(),'
+    assert_not_contains "$extracted/.vite/build/main-test.js" 'D.setMenuBarVisibility(!1)'
     assert_contains "$extracted/.vite/build/main-test.js" '&&D.setIcon('
     assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" '`subAgent`in e?e.subAgent:`subagent`in e?e.subagent:null'
     assert_contains "$extracted/webview/assets/app-server-manager-signals-test.js" 'Zl(e.agentNickname)??Zl(e.agent_nickname)??Zl(B(e.source)?.agentNickname)'


### PR DESCRIPTION
Hi,

This follows up on #633 after it was closed. That PR pointed at the right Linux UX problem, and this keeps the work moving with a narrower implementation.

On Linux we were only hiding the BrowserWindow menu with `setMenuBarVisibility(false)`. Hidden menus can still leave accelerators active even though the menu is not visible, which is the behavior users can hit with accidental window closes. This changes the Linux patch to remove the window menu with `removeMenu()`, matching the existing Windows path.

I also updated the `frameless-titlebar` feature patch so it recognizes the new core Linux `removeMenu()` snippet and does not re-add the older `setMenuBarVisibility(false)` branch.

This does not carry over the global `before-input-event` Ctrl+W guard from #633. The menu path is narrower, and it avoids blocking renderer or editor shortcuts.

Validation run locally:

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/frameless-titlebar/test.js`
- `timeout 300 bash tests/scripts_smoke.sh`
- `make check && make test`
- `git diff --check HEAD~1..HEAD`
