### PR TITLE
fix: harden AppShots FIFO setup

### DIFF
--- a/linux-features/appshots/bin/bare-modifier-monitor
+++ b/linux-features/appshots/bin/bare-modifier-monitor
@@ -156,8 +156,8 @@ if [ -z "$keyboard_ids" ]; then
     exit 1
 fi
 
-event_fifo="$(mktemp -u "${TMPDIR:-/tmp}/codex-bare-modifier.XXXXXX")"
-mkfifo "$event_fifo"
+event_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-bare-modifier.XXXXXX")"
+event_fifo="$event_dir/events"
 monitor_pids=()
 
 cleanup() {
@@ -176,10 +176,12 @@ cleanup() {
     done
     wait "${monitor_pids[@]:-}" >/dev/null 2>&1 || true
     rm -f "$event_fifo"
+    rmdir "$event_dir" 2>/dev/null || true
 }
 trap cleanup EXIT
 trap 'cleanup; exit 143' INT TERM
 
+mkfifo "$event_fifo"
 exec 4<>"$event_fifo"
 
 for device_id in $keyboard_ids; do

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -151,6 +151,14 @@ test("stages the Linux bare modifier monitor helper and Wayland portal hook", ()
   assert.equal(electronArgsSource.trim(), "--enable-features=GlobalShortcutsPortal");
   assert.match(helperSource, /xinput test "\$device_id"/);
   assert.match(helperSource, /stdbuf -oL/);
+  assert.doesNotMatch(helperSource, /\bmktemp\s+-u\b/);
+  assert.match(
+    helperSource,
+    /event_dir="\$\(mktemp -d "\$\{TMPDIR:-\/tmp\}\/codex-bare-modifier\.XXXXXX"\)"/,
+  );
+  assert.match(helperSource, /event_fifo="\$event_dir\/events"/);
+  assert.match(helperSource, /mkfifo "\$event_fifo"/);
+  assert.match(helperSource, /rmdir "\$event_dir" 2>\/dev\/null \|\| true/);
   assert.match(helperSource, /exec 4<>"\$event_fifo"/);
   assert.match(helperSource, /pkill -TERM -P "\$pid"/);
   assert.match(helperSource, /while read -r pending code <&3; do/);


### PR DESCRIPTION
Hi,

This tightens the AppShots bare modifier helper by avoiding `mktemp -u` for the event FIFO path. The helper now creates a private temp directory with `mktemp -d`, places the FIFO inside it, and removes the directory during cleanup.

That avoids the small race where a path is printed but not reserved before `mkfifo` runs. The AppShots test now keeps this tempdir/FIFO contract covered.

Checks run locally:

- `node --check` on 110 JS files
- `node --test` on 24 Node test files, 717 tests passed
- `node --test linux-features/appshots/test.js`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- `cargo test --workspace --all-targets` with isolated runtime dirs
- `cargo clippy --workspace --all-targets -- -D warnings` with isolated runtime dirs
- `bash -n` on the shell entrypoints and the AppShots helper
- `shellcheck -S error` on the shell scripts and the AppShots helper
