### PR TITLE
fix: suppress launcher notice fd warnings

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -300,7 +300,7 @@ launcher_notice() {
 
     echo "$message"
     if [ -n "${LAUNCHER_EARLY_STDERR_FD:-}" ]; then
-        printf '%s\n' "$message" >&"$LAUNCHER_EARLY_STDERR_FD" 2>/dev/null || true
+        printf '%s\n' "$message" 2>/dev/null 1>&"$LAUNCHER_EARLY_STDERR_FD" || true
     fi
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3432,6 +3432,8 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" "ADOPTED_WEBVIEW_PID"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "Reusing webview server pid="
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_cold_start_hooks"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" '2>/dev/null 1>&"\$LAUNCHER_EARLY_STDERR_FD" || true'
+    assert_not_contains "$REPO_DIR/launcher/start.sh.template" '>&"\$LAUNCHER_EARLY_STDERR_FD" 2>/dev/null || true'
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/feature.json" '"stageHook": "./stage.sh"'
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "cold-start.d"
     assert_contains "$REPO_DIR/linux-features/remote-mobile-control/stage.sh" "remote-mobile-control"


### PR DESCRIPTION
Hi,

This fixes the launcher notice fallback that ShellCheck reports as SC2261. The previous redirection order sent stdout to the duplicated early-stderr FD before applying `2>/dev/null`, so a stale or closed FD could still print a redirection warning from what is meant to be a best-effort fallback.

The launcher now applies the stderr suppression before redirecting stdout to the saved FD. Valid-FD behavior stays the same, and the stale-FD path stays quiet. I also added a smoke guard so the template keeps that order.

Checks run locally:

- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `shellcheck -s bash -S error launcher/start.sh.template`
- `shellcheck -S error tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- launcher FD behavior harness, valid FD matches and stale FD is suppressed
- `node --check` on 110 JS files
- `node --test` on 24 Node test files, 717 tests passed
- `make check`
- `make test`, 189 tests passed
- `cargo test --workspace --all-targets` with isolated runtime dirs
- `cargo clippy --workspace --all-targets -- -D warnings` with isolated runtime dirs
