### PR TITLE
Add Skysight OCR with RapidOCR fallback

### DIFF
--- a/docs/linux-chronicle-skysight.md
+++ b/docs/linux-chronicle-skysight.md
@@ -33,6 +33,84 @@ cadence-limited `*-6h-*.md` rollups. Exclusion rules suppress matching
 window/app/accessibility evidence and record suppression counts instead of
 copying excluded content into resources.
 
+## Local OCR
+
+Linux Chronicle OCR is local-only and optional. In `auto` backend mode,
+Skysight prefers RapidOCR through Python + ONNXRuntime when those packages are
+available, then falls back to the Tesseract CLI. Both backends run after the
+screenshot privacy gate passes and append recognized text plus bounding boxes
+to `*.ocr.jsonl`.
+
+When OCR is disabled or unavailable, Skysight still writes the Chronicle OCR
+history contract with `runs_ocr=false`, empty `normalized_text`, and an
+explicit `ocr_status` such as `disabled`, `backend_unavailable`, or
+`required_backend_unavailable`. This is a truthful local capability status, not
+Apple Vision parity.
+
+OCR never runs before screenshot/domain/window exclusions. If screenshot
+evidence is suppressed, no OCR attempt is made. If recognized OCR text matches
+an exclusion value before persistence, the OCR row is kept but text and
+observations are stripped and `ocr_status` becomes
+`suppressed_by_exclusion_text`. Rolling markdown resources summarize OCR
+status, paths, and byte counts; they do not dump raw OCR text by default.
+
+RapidOCR/ONNXRuntime is the preferred advanced backend for screen OCR because
+it is local, fast on CPU, and generally stronger than classic OCR on rendered
+UI screenshots. Tesseract remains the fallback baseline because it is broadly
+packaged, offline, and emits word boxes through TSV without Python packages.
+
+### OCR Backend Direction
+
+`auto` is the default Linux Chronicle OCR backend selection. It chooses
+RapidOCR/ONNXRuntime first when available and falls back to Tesseract. That
+keeps continuous screen memory privacy-preserving and useful without making
+model packages mandatory for every Linux install.
+
+The backend boundary should stay pluggable. Current and future OCR stacks:
+
+- RapidOCR/ONNXRuntime is the preferred optional advanced provider. It
+  packages PaddleOCR-style models for fast offline deployment, supports local
+  CPU inference, and keeps the default feature from depending on the larger
+  PaddlePaddle/PyTorch runtime stack.
+- PaddleOCR remains the upstream model family to watch for accuracy and model
+  refreshes. Its PP-OCR deployment paths cover broad multilingual scene OCR and
+  acceleration through OpenVINO, ONNX Runtime, TensorRT, and native inference
+  paths.
+- Surya is attractive for document-heavy workflows that need layout, reading
+  order, tables, and OCR together, but its current model stack and inference
+  server requirements are heavier than a per-minute desktop-memory default.
+- EasyOCR is easy to try and multilingual, but it is older and PyTorch-heavy
+  compared with current PaddleOCR and Surya options.
+- docTR is a clean deep-learning document OCR library, but it is less focused
+  on lightweight desktop screenshot memory than the options above.
+
+The practical target is therefore: keep `auto` as the default, prefer
+`rapidocr-python` when available, preserve `tesseract-cli` as fallback, and
+never make model downloads or GPU frameworks mandatory for the base Chronicle
+feature.
+
+Runtime controls:
+
+```bash
+CODEX_SKYSIGHT_OCR=auto|enabled|required|disabled
+CODEX_CHRONICLE_OCR=auto|enabled|required|disabled
+CODEX_SKYSIGHT_OCR_BACKEND=auto|rapidocr|tesseract
+CODEX_CHRONICLE_OCR_BACKEND=auto|rapidocr|tesseract
+CODEX_SKYSIGHT_RAPIDOCR_PYTHON=/path/to/python3
+CODEX_CHRONICLE_RAPIDOCR_PYTHON=/path/to/python3
+CODEX_SKYSIGHT_RAPIDOCR_LANG=ch
+CODEX_CHRONICLE_RAPIDOCR_LANG=ch
+CODEX_SKYSIGHT_TESSERACT_PATH=/path/to/tesseract
+CODEX_CHRONICLE_TESSERACT_PATH=/path/to/tesseract
+CODEX_SKYSIGHT_OCR_LANG=eng
+CODEX_SKYSIGHT_OCR_PSM=11
+CODEX_SKYSIGHT_OCR_TIMEOUT_MS=10000
+```
+
+For RapidOCR, the selected Python environment must be able to import
+`rapidocr`, `onnxruntime`, and OpenCV. On minimal Debian/Ubuntu containers this
+may also require the system package that provides `libGL.so.1`.
+
 ## Verification After Rebuild
 
 1. Run `node --test linux-features/record-and-replay/test.js`.

--- a/docs/record-and-replay-linux.md
+++ b/docs/record-and-replay-linux.md
@@ -80,6 +80,23 @@ The memory resources follow rolling-window semantics: `*-10min-*.md` summaries
 cover recent segment windows, while `*-6h-*.md` rollups are cadence-limited and
 reuse the current rollup until the next six-hour window is due.
 
+Linux Chronicle OCR is implemented as optional local backends. In `auto` mode,
+Skysight prefers RapidOCR through Python + ONNXRuntime when available, then
+falls back to the Tesseract CLI. Skysight reports OCR mode, backend selection,
+availability, language, version, dependency hints, and errors through
+`skysight status`, provider readiness events, and the Linux Chronicle bridge.
+Missing OCR dependencies are non-fatal unless `CODEX_SKYSIGHT_OCR=required`;
+in non-required modes Skysight continues writing Chronicle-shaped `.ocr.jsonl`
+rows with `runs_ocr=false`, empty `normalized_text`, and an explicit
+unavailable/disabled status.
+
+OCR is downstream of privacy gating. Screenshot suppression prevents OCR, and
+recognized text that matches an exclusion value is stripped before it can be
+persisted to `.ocr.jsonl` or summarized. Markdown resources include OCR
+status/count/path/truncation summaries only; raw OCR text is not copied into
+durable resources by default. RapidOCR is the preferred advanced screen OCR
+provider; Tesseract remains the safe local fallback.
+
 After rebuilding the feature, Josh can verify the branch with:
 
 1. `node --test linux-features/record-and-replay/test.js`

--- a/linux-features/record-and-replay/README.md
+++ b/linux-features/record-and-replay/README.md
@@ -44,6 +44,12 @@ Cargo and copies the release binary into `resources/native/`, the staged plugin
 - Skysight segment directories contain `events.jsonl`, `metadata.json`, and
   bounded artifacts such as diagnostics, screenshots, window metadata, and
   AT-SPI/accessibility evidence when available.
+- Runs optional local-only Chronicle OCR through RapidOCR/ONNXRuntime when
+  available, with Tesseract CLI fallback. Missing OCR dependencies are
+  non-fatal unless OCR is marked required, and are surfaced in
+  `skysight status`, provider readiness, and `.ocr.jsonl` rows.
+- Applies screenshot exclusions before OCR and strips recognized text before
+  persistence if it matches an exclusion value.
 - Writes rolling 10-minute markdown summaries and cadence-limited 6-hour
   rollups instead of treating every snapshot as a fresh six-hour window.
 - Writes a structured `backend_catalog` into the bundle manifest and a matching

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -96,7 +96,7 @@ function applyRecordReplayPluginGatePatch(currentSource) {
 
 function recordReplayBridgeSource({ childProcessVar, fsVar, pathVar }) {
   return [
-    `"chronicle-permissions":async()=>{let e=await codexLinuxChronicleSidecarControlStateAsync(),t=e.enabled===!0?"granted":"unknown";return{accessibility:t,screenRecording:t,chronicleSidecarPresent:e.enabled===!0,chronicleSidecarProcessState:e.state??"disabled"}}`,
+    `"chronicle-permissions":async()=>{let e=await codexLinuxChronicleSidecarControlStateAsync(),t=e.enabled===!0?"granted":"unknown";return{accessibility:t,screenRecording:t,chronicleSidecarPresent:e.enabled===!0,chronicleSidecarProcessState:e.state??"disabled",chronicleOcrAvailable:e.chronicleOcrAvailable===!0,chronicleOcrStatus:e.chronicleOcrStatus??"unknown",chronicleOcrBackend:e.chronicleOcrBackend??null,chronicleOcrLanguage:e.chronicleOcrLanguage??null}}`,
     `"getChronicleSidecarControlState":async()=>codexLinuxChronicleSidecarControlStateAsync()`,
     `"toggleChronicleSidecar":async()=>codexLinuxChronicleToggleSidecar()`,
     `"linux-record-replay-doctor":async()=>codexLinuxRecordReplayRun([${JSON.stringify("doctor")}],15000)`,
@@ -141,7 +141,7 @@ ${recordReplayChronicleHelperSource({ childProcessVar })}`;
 
 function recordReplayChronicleHelperSource({ childProcessVar }) {
   return `function codexLinuxRecordReplayRunSync(e,t){let n=codexLinuxRecordReplayBin();try{let r=${childProcessVar}.execFileSync(n,e,{encoding:"utf8",timeout:t,maxBuffer:16777216});return{ok:!0,command:n,args:e,stdout:r||"",stderr:"",json:codexLinuxRecordReplayParse(r)}}catch(r){let a=typeof r?.stdout==="string"?r.stdout:r?.stdout?String(r.stdout):"",o=typeof r?.stderr==="string"?r.stderr:r?.stderr?String(r.stderr):"";return{ok:!1,command:n,args:e,message:r instanceof Error?r.message:String(r),code:r?.status??r?.code??null,stdout:a,stderr:o,json:codexLinuxRecordReplayParse(a)}}}
-function codexLinuxChronicleControlStateFromSkysight(e){let t=e?.json&&typeof e.json==="object"?e.json:null;if(!e?.ok&&t==null)return{enabled:!1,running:!1,state:"disabled"};let n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused",o=n==="running"&&r&&!a;return{enabled:!0,running:o,state:o?"running":"stopped",skysight:t}}
+function codexLinuxChronicleControlStateFromSkysight(e){let t=e?.json&&typeof e.json==="object"?e.json:null;if(!e?.ok&&t==null)return{enabled:!1,running:!1,state:"disabled"};let n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused",o=n==="running"&&r&&!a;return{enabled:!0,running:o,state:o?"running":"stopped",skysight:t,chronicleOcrAvailable:t?.ocr_available===!0||t?.ocrAvailable===!0,chronicleOcrStatus:t?.ocr_status??t?.ocrStatus??"unknown",chronicleOcrBackend:t?.ocr_backend??t?.ocrBackend??null,chronicleOcrLanguage:t?.ocr_language??t?.ocrLanguage??null}}
 function codexLinuxChronicleSidecarControlState(){return codexLinuxChronicleControlStateFromSkysight(codexLinuxRecordReplayRunSync(["skysight","status"],3000))}
 async function codexLinuxChronicleSidecarControlStateAsync(){return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","status"],5000))}
 function codexLinuxChronicleSummaryAgentArgs(e){return e===!0?["--summary-agent","enabled"]:e===!1?["--summary-agent","disabled"]:[]}

--- a/linux-features/record-and-replay/plugin-template/skills/record-and-replay/SKILL.md
+++ b/linux-features/record-and-replay/plugin-template/skills/record-and-replay/SKILL.md
@@ -24,8 +24,11 @@ client, implemented by the Rust `codex-record-replay-linux` backend.
    point-in-time local activity summary. Use `skysight_pause` and
    `skysight_resume` to stop or continue Chronicle-compatible resources
    without losing the active session, and use `skysight_status` to find the
-   resource paths. Respect `skysight_list_exclusions` and update exclusions
-   before recording sensitive apps or domains.
+   resource paths and local OCR availability. Respect
+   `skysight_list_exclusions` and update exclusions before recording sensitive
+   apps or domains. Treat OCR as local screen evidence metadata; do not copy raw
+   OCR text into durable skill drafts unless it is necessary for the reusable
+   workflow and safe to retain.
 3. Call `event_stream_start` with a short `goal` when matching the upstream
    Record & Replay flow, or `start` when you need Linux-specific options. The
    Linux app should show the active Record & Replay recording HUD while the

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -151,6 +151,9 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.match(patched, /"chronicle-permissions":async/);
   assert.match(patched, /chronicleSidecarPresent/);
   assert.match(patched, /chronicleSidecarProcessState/);
+  assert.match(patched, /chronicleOcrAvailable/);
+  assert.match(patched, /chronicleOcrStatus/);
+  assert.match(patched, /chronicleOcrBackend/);
   assert.match(patched, /"getChronicleSidecarControlState":async/);
   assert.match(patched, /"toggleChronicleSidecar":async/);
   assert.match(patched, /codexLinuxChronicleControlStateFromSkysight/);
@@ -224,6 +227,15 @@ test("record-and-replay Chronicle helpers map Skysight status into upstream side
   assert.equal(state.enabled, true);
   assert.equal(state.running, true);
   assert.equal(state.state, "running");
+
+  const ocrState = vm.runInNewContext(
+    `${helperSource};codexLinuxChronicleControlStateFromSkysight({ok:true,json:{state:"running",is_running:true,ocr_available:true,ocr_status:"completed",ocr_backend:"tesseract-cli",ocr_language:"eng"}})`,
+    context,
+  );
+  assert.equal(ocrState.chronicleOcrAvailable, true);
+  assert.equal(ocrState.chronicleOcrStatus, "completed");
+  assert.equal(ocrState.chronicleOcrBackend, "tesseract-cli");
+  assert.equal(ocrState.chronicleOcrLanguage, "eng");
 
   const paused = vm.runInNewContext(
     `${helperSource};codexLinuxChronicleControlStateFromSkysight({ok:true,json:{state:"paused",is_running:true,paused:true}})`,

--- a/record-replay-linux/src/lib.rs
+++ b/record-replay-linux/src/lib.rs
@@ -5,6 +5,7 @@ pub mod draft_prompt;
 pub mod event_stream;
 pub mod manifest;
 pub mod mcp;
+mod ocr;
 mod process_identity;
 mod process_reaper;
 pub mod recorder;

--- a/record-replay-linux/src/mcp.rs
+++ b/record-replay-linux/src/mcp.rs
@@ -1020,6 +1020,10 @@ mod tests {
     fn status_value_includes_suppressed_events_path() {
         let temp = tempfile::tempdir().unwrap();
         let session_dir = temp.path().join("session");
+        let previous = std::env::var_os("CODEX_RECORD_REPLAY_STATUS_PATH");
+        let status_path = temp.path().join("status.json");
+        std::env::set_var("CODEX_RECORD_REPLAY_STATUS_PATH", &status_path);
+
         let server = RecordReplayLinux::default();
         server.set_active_session(Some(session_dir.clone()));
         let value = server.status_value("status");
@@ -1033,6 +1037,11 @@ mod tests {
                     .as_ref()
             )
         );
+
+        match previous {
+            Some(path) => std::env::set_var("CODEX_RECORD_REPLAY_STATUS_PATH", path),
+            None => std::env::remove_var("CODEX_RECORD_REPLAY_STATUS_PATH"),
+        }
     }
 
     #[test]

--- a/record-replay-linux/src/ocr.rs
+++ b/record-replay-linux/src/ocr.rs
@@ -1,0 +1,1543 @@
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const DEFAULT_TESSERACT: &str = "tesseract";
+const DEFAULT_RAPIDOCR_PYTHON: &str = "python3";
+const DEFAULT_LANGUAGE: &str = "eng";
+const DEFAULT_RAPIDOCR_LANGUAGE: &str = "ch";
+const DEFAULT_PSM: &str = "11";
+const DEFAULT_TIMEOUT_MS: u64 = 10_000;
+const TESSERACT_BACKEND_NAME: &str = "tesseract-cli";
+const RAPIDOCR_BACKEND_NAME: &str = "rapidocr-python";
+const AUTO_BACKEND_NAME: &str = "auto";
+const RAPIDOCR_JSON_PREFIX: &str = "__CODEX_RAPIDOCR_JSON__";
+const MAX_OCR_OBSERVATIONS: usize = 200;
+const MAX_OCR_NORMALIZED_TEXT_BYTES: usize = 32 * 1024;
+const MAX_OCR_CANDIDATE_TEXT_BYTES: usize = 512;
+
+const RAPIDOCR_CHECK_SCRIPT: &str = r#"
+import importlib.metadata as metadata
+import json
+import sys
+
+try:
+    import onnxruntime  # noqa: F401
+    from rapidocr import RapidOCR
+
+    lang_type = sys.argv[1] if len(sys.argv) > 1 else "ch"
+    engine = RapidOCR(params={"Rec.lang_type": lang_type})
+    payload = {
+        "rapidocr": metadata.version("rapidocr"),
+        "onnxruntime": metadata.version("onnxruntime"),
+        "lang_type": str(getattr(engine.cfg.Rec, "lang_type", lang_type)),
+    }
+    print("__CODEX_RAPIDOCR_JSON__" + json.dumps(payload, ensure_ascii=False))
+except Exception as exc:
+    payload = {"error": f"{type(exc).__name__}: {exc}"}
+    print("__CODEX_RAPIDOCR_JSON__" + json.dumps(payload, ensure_ascii=False))
+    raise
+"#;
+
+const RAPIDOCR_RUN_SCRIPT: &str = r#"
+import json
+import sys
+
+from rapidocr import RapidOCR
+
+def as_list(value):
+    if value is None:
+        return []
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return list(value)
+
+if len(sys.argv) != 3:
+    raise SystemExit("expected rapidocr language and image path arguments")
+lang_type = sys.argv[1]
+image_path = sys.argv[2]
+engine = RapidOCR(params={"Rec.lang_type": lang_type})
+result = engine(image_path)
+payload = {
+    "boxes": as_list(getattr(result, "boxes", None)),
+    "txts": as_list(getattr(result, "txts", None)),
+    "scores": as_list(getattr(result, "scores", None)),
+    "elapse": getattr(result, "elapse", None),
+    "lang_type": str(getattr(engine.cfg.Rec, "lang_type", lang_type)),
+}
+print("__CODEX_RAPIDOCR_JSON__" + json.dumps(payload, ensure_ascii=False))
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OcrMode {
+    Auto,
+    Enabled,
+    Required,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OcrBackendPreference {
+    Auto,
+    RapidOcr,
+    Tesseract,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OcrPolicy {
+    pub(crate) mode: OcrMode,
+    pub(crate) backend_preference: OcrBackendPreference,
+    tesseract_executable: PathBuf,
+    rapidocr_python: PathBuf,
+    pub(crate) language: String,
+    pub(crate) rapidocr_language: String,
+    pub(crate) page_segmentation_mode: String,
+    pub(crate) timeout: Duration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OcrReadiness {
+    pub(crate) enabled: bool,
+    pub(crate) available: bool,
+    pub(crate) backend: String,
+    pub(crate) status: String,
+    pub(crate) language: String,
+    pub(crate) version: Option<String>,
+    pub(crate) dependency_hint: Option<String>,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct OcrFrameResult {
+    #[serde(skip)]
+    pub(crate) runs_ocr: bool,
+    #[serde(skip)]
+    pub(crate) status: String,
+    #[serde(skip)]
+    pub(crate) backend: String,
+    #[serde(skip)]
+    pub(crate) language: String,
+    #[serde(skip)]
+    pub(crate) backend_version: Option<String>,
+    #[serde(skip)]
+    pub(crate) normalized_text: String,
+    #[serde(skip)]
+    pub(crate) dependency_hint: Option<String>,
+    #[serde(skip)]
+    pub(crate) error: Option<String>,
+    #[serde(skip)]
+    pub(crate) duration_ms: u128,
+    #[serde(skip)]
+    pub(crate) truncated: bool,
+    #[serde(skip)]
+    pub(crate) suppressed_text_observation_count: usize,
+    #[serde(skip)]
+    pub(crate) observations: Vec<OcrObservation>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct OcrObservation {
+    #[serde(rename = "boundingBox")]
+    pub(crate) bounding_box: NormalizedBoundingBox,
+    #[serde(rename = "pixelBoundingBox")]
+    pub(crate) pixel_bounding_box: PixelBoundingBox,
+    #[serde(rename = "topCandidates")]
+    pub(crate) top_candidates: Vec<OcrCandidate>,
+    pub(crate) normalized_text: String,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct NormalizedBoundingBox {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) width: f64,
+    pub(crate) height: f64,
+    pub(crate) coordinate_space: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(crate) struct PixelBoundingBox {
+    pub(crate) x: u32,
+    pub(crate) y: u32,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) coordinate_space: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub(crate) struct OcrCandidate {
+    pub(crate) text: String,
+    pub(crate) confidence: f64,
+}
+
+#[derive(Debug, Clone)]
+struct TsvWord {
+    page: String,
+    block: String,
+    paragraph: String,
+    line: String,
+    left: u32,
+    top: u32,
+    width: u32,
+    height: u32,
+    confidence: f64,
+    text: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RapidOcrVersions {
+    rapidocr: Option<String>,
+    onnxruntime: Option<String>,
+    lang_type: Option<String>,
+    error: Option<String>,
+}
+
+impl OcrPolicy {
+    pub(crate) fn from_env() -> Self {
+        let mode = env_value("CODEX_SKYSIGHT_OCR")
+            .or_else(|| env_value("CODEX_CHRONICLE_OCR"))
+            .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "disabled" | "off" | "false" | "0" => OcrMode::Disabled,
+                "enabled" | "on" | "true" | "1" => OcrMode::Enabled,
+                "required" | "require" => OcrMode::Required,
+                _ => OcrMode::Auto,
+            })
+            .unwrap_or(OcrMode::Auto);
+        let backend_preference = env_value("CODEX_SKYSIGHT_OCR_BACKEND")
+            .or_else(|| env_value("CODEX_CHRONICLE_OCR_BACKEND"))
+            .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+                "rapidocr" | "rapidocr-python" | "rapid-ocr" => OcrBackendPreference::RapidOcr,
+                "tesseract" | "tesseract-cli" => OcrBackendPreference::Tesseract,
+                _ => OcrBackendPreference::Auto,
+            })
+            .unwrap_or(OcrBackendPreference::Auto);
+        let tesseract_executable = env_value("CODEX_SKYSIGHT_TESSERACT_PATH")
+            .or_else(|| env_value("CODEX_CHRONICLE_TESSERACT_PATH"))
+            .unwrap_or_else(|| DEFAULT_TESSERACT.to_string());
+        let rapidocr_python = env_value("CODEX_SKYSIGHT_RAPIDOCR_PYTHON")
+            .or_else(|| env_value("CODEX_CHRONICLE_RAPIDOCR_PYTHON"))
+            .unwrap_or_else(|| DEFAULT_RAPIDOCR_PYTHON.to_string());
+        let language =
+            env_value("CODEX_SKYSIGHT_OCR_LANG").unwrap_or_else(|| DEFAULT_LANGUAGE.to_string());
+        let rapidocr_language = env_value("CODEX_SKYSIGHT_RAPIDOCR_LANG")
+            .or_else(|| env_value("CODEX_CHRONICLE_RAPIDOCR_LANG"))
+            .unwrap_or_else(|| DEFAULT_RAPIDOCR_LANGUAGE.to_string());
+        let page_segmentation_mode =
+            env_value("CODEX_SKYSIGHT_OCR_PSM").unwrap_or_else(|| DEFAULT_PSM.to_string());
+        let timeout_ms = env_value("CODEX_SKYSIGHT_OCR_TIMEOUT_MS")
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_TIMEOUT_MS);
+
+        Self {
+            mode,
+            backend_preference,
+            tesseract_executable: PathBuf::from(tesseract_executable),
+            rapidocr_python: PathBuf::from(rapidocr_python),
+            language,
+            rapidocr_language,
+            page_segmentation_mode,
+            timeout: Duration::from_millis(timeout_ms),
+        }
+    }
+
+    pub(crate) fn backend_name(&self) -> &'static str {
+        match self.backend_preference {
+            OcrBackendPreference::Auto => AUTO_BACKEND_NAME,
+            OcrBackendPreference::RapidOcr => RAPIDOCR_BACKEND_NAME,
+            OcrBackendPreference::Tesseract => TESSERACT_BACKEND_NAME,
+        }
+    }
+
+    pub(crate) fn mode_name(&self) -> &'static str {
+        match self.mode {
+            OcrMode::Auto => "auto",
+            OcrMode::Enabled => "enabled",
+            OcrMode::Required => "required",
+            OcrMode::Disabled => "disabled",
+        }
+    }
+
+    pub(crate) fn readiness(&self) -> OcrReadiness {
+        if self.mode == OcrMode::Disabled {
+            return OcrReadiness {
+                enabled: false,
+                available: false,
+                backend: self.backend_name().to_string(),
+                status: "disabled".to_string(),
+                language: self.language.clone(),
+                version: None,
+                dependency_hint: None,
+                error: None,
+            };
+        }
+
+        match self.backend_preference {
+            OcrBackendPreference::RapidOcr => self.rapidocr_readiness(),
+            OcrBackendPreference::Tesseract => self.tesseract_readiness(),
+            OcrBackendPreference::Auto => {
+                let rapidocr = self.rapidocr_readiness();
+                if rapidocr.available {
+                    return rapidocr;
+                }
+                let tesseract = self.tesseract_readiness();
+                if tesseract.available {
+                    return tesseract;
+                }
+                OcrReadiness {
+                    enabled: true,
+                    available: false,
+                    backend: AUTO_BACKEND_NAME.to_string(),
+                    status: "backend_unavailable".to_string(),
+                    language: self.language.clone(),
+                    version: None,
+                    dependency_hint: Some(auto_dependency_hint(&self.language)),
+                    error: Some(format!(
+                        "RapidOCR unavailable: {}; Tesseract unavailable: {}",
+                        rapidocr
+                            .error
+                            .unwrap_or_else(|| rapidocr.status.to_string()),
+                        tesseract
+                            .error
+                            .unwrap_or_else(|| tesseract.status.to_string())
+                    )),
+                }
+            }
+        }
+    }
+
+    fn rapidocr_readiness(&self) -> OcrReadiness {
+        let child = Command::new(&self.rapidocr_python)
+            .arg("-c")
+            .arg(RAPIDOCR_CHECK_SCRIPT)
+            .arg(&self.rapidocr_language)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+        let output = match child {
+            Ok(child) => match wait_with_output_timeout(child, self.timeout) {
+                Ok(output) => output,
+                Err(error) => {
+                    return OcrReadiness {
+                        enabled: true,
+                        available: false,
+                        backend: RAPIDOCR_BACKEND_NAME.to_string(),
+                        status: "backend_unavailable".to_string(),
+                        language: self.rapidocr_language.clone(),
+                        version: None,
+                        dependency_hint: Some(rapidocr_dependency_hint()),
+                        error: Some(error.to_string()),
+                    };
+                }
+            },
+            Err(error) => {
+                return OcrReadiness {
+                    enabled: true,
+                    available: false,
+                    backend: RAPIDOCR_BACKEND_NAME.to_string(),
+                    status: "backend_unavailable".to_string(),
+                    language: self.rapidocr_language.clone(),
+                    version: None,
+                    dependency_hint: Some(rapidocr_dependency_hint()),
+                    error: Some(error.to_string()),
+                };
+            }
+        };
+
+        if !output.status.success() {
+            return OcrReadiness {
+                enabled: true,
+                available: false,
+                backend: RAPIDOCR_BACKEND_NAME.to_string(),
+                status: "backend_unavailable".to_string(),
+                language: self.rapidocr_language.clone(),
+                version: None,
+                dependency_hint: Some(rapidocr_dependency_hint()),
+                error: Some(
+                    parse_rapidocr_versions(&output)
+                        .ok()
+                        .and_then(|versions| versions.error)
+                        .unwrap_or_else(|| format!("RapidOCR check exited with {}", output.status)),
+                ),
+            };
+        }
+
+        match parse_rapidocr_versions(&output) {
+            Ok(versions) => OcrReadiness {
+                enabled: true,
+                available: true,
+                backend: RAPIDOCR_BACKEND_NAME.to_string(),
+                status: "available".to_string(),
+                language: versions
+                    .lang_type
+                    .unwrap_or_else(|| self.rapidocr_language.clone()),
+                version: Some(format!(
+                    "rapidocr {}; onnxruntime {}",
+                    versions.rapidocr.unwrap_or_else(|| "unknown".to_string()),
+                    versions
+                        .onnxruntime
+                        .unwrap_or_else(|| "unknown".to_string())
+                )),
+                dependency_hint: None,
+                error: None,
+            },
+            Err(error) => OcrReadiness {
+                enabled: true,
+                available: false,
+                backend: RAPIDOCR_BACKEND_NAME.to_string(),
+                status: "backend_unavailable".to_string(),
+                language: self.rapidocr_language.clone(),
+                version: None,
+                dependency_hint: Some(rapidocr_dependency_hint()),
+                error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn tesseract_readiness(&self) -> OcrReadiness {
+        match Command::new(&self.tesseract_executable)
+            .arg("--version")
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let version = stdout.lines().next().map(str::trim).map(str::to_string);
+                OcrReadiness {
+                    enabled: true,
+                    available: true,
+                    backend: TESSERACT_BACKEND_NAME.to_string(),
+                    status: "available".to_string(),
+                    language: self.language.clone(),
+                    version,
+                    dependency_hint: None,
+                    error: None,
+                }
+            }
+            Ok(output) => OcrReadiness {
+                enabled: true,
+                available: false,
+                backend: TESSERACT_BACKEND_NAME.to_string(),
+                status: "backend_unavailable".to_string(),
+                language: self.language.clone(),
+                version: None,
+                dependency_hint: Some(tesseract_dependency_hint(&self.language)),
+                error: Some(format!("tesseract --version exited with {}", output.status)),
+            },
+            Err(error) => OcrReadiness {
+                enabled: true,
+                available: false,
+                backend: TESSERACT_BACKEND_NAME.to_string(),
+                status: "backend_unavailable".to_string(),
+                language: self.language.clone(),
+                version: None,
+                dependency_hint: Some(tesseract_dependency_hint(&self.language)),
+                error: Some(error.to_string()),
+            },
+        }
+    }
+}
+
+impl OcrFrameResult {
+    fn skipped(readiness: &OcrReadiness) -> Self {
+        Self {
+            runs_ocr: false,
+            status: readiness.status.clone(),
+            backend: readiness.backend.clone(),
+            language: readiness.language.clone(),
+            backend_version: readiness.version.clone(),
+            normalized_text: String::new(),
+            dependency_hint: readiness.dependency_hint.clone(),
+            error: readiness.error.clone(),
+            duration_ms: 0,
+            truncated: false,
+            suppressed_text_observation_count: 0,
+            observations: Vec::new(),
+        }
+    }
+
+    fn failure(readiness: &OcrReadiness, status: &str, duration_ms: u128, error: String) -> Self {
+        Self {
+            runs_ocr: true,
+            status: status.to_string(),
+            backend: readiness.backend.clone(),
+            language: readiness.language.clone(),
+            backend_version: readiness.version.clone(),
+            normalized_text: String::new(),
+            dependency_hint: None,
+            error: Some(error),
+            duration_ms,
+            truncated: false,
+            suppressed_text_observation_count: 0,
+            observations: Vec::new(),
+        }
+    }
+
+    fn required_unavailable(readiness: &OcrReadiness) -> Self {
+        Self {
+            runs_ocr: false,
+            status: "required_backend_unavailable".to_string(),
+            backend: readiness.backend.clone(),
+            language: readiness.language.clone(),
+            backend_version: readiness.version.clone(),
+            normalized_text: String::new(),
+            dependency_hint: readiness.dependency_hint.clone(),
+            error: Some(
+                readiness
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "required OCR backend is unavailable".to_string()),
+            ),
+            duration_ms: 0,
+            truncated: false,
+            suppressed_text_observation_count: 0,
+            observations: Vec::new(),
+        }
+    }
+
+    pub(crate) fn apply_text_exclusions(&mut self, exclusion_values: &[String]) {
+        if self.normalized_text.trim().is_empty() {
+            return;
+        }
+        if !exclusion_values
+            .iter()
+            .filter(|value| !value.trim().is_empty())
+            .any(|value| contains_case_insensitive(&self.normalized_text, value))
+        {
+            return;
+        }
+
+        self.status = "suppressed_by_exclusion_text".to_string();
+        self.suppressed_text_observation_count = self.observations.len();
+        self.normalized_text.clear();
+        self.observations.clear();
+    }
+
+    fn apply_persistence_limits(&mut self) {
+        if self.observations.len() > MAX_OCR_OBSERVATIONS {
+            self.observations.truncate(MAX_OCR_OBSERVATIONS);
+            self.truncated = true;
+        }
+
+        let mut truncated_text = false;
+        for observation in &mut self.observations {
+            truncated_text |= truncate_string_to_bytes(
+                &mut observation.normalized_text,
+                MAX_OCR_CANDIDATE_TEXT_BYTES,
+            );
+            for candidate in &mut observation.top_candidates {
+                truncated_text |=
+                    truncate_string_to_bytes(&mut candidate.text, MAX_OCR_CANDIDATE_TEXT_BYTES);
+            }
+        }
+        if truncated_text {
+            self.truncated = true;
+        }
+
+        if !self.observations.is_empty() {
+            self.normalized_text = self
+                .observations
+                .iter()
+                .map(|observation| observation.normalized_text.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
+        if truncate_string_to_bytes(&mut self.normalized_text, MAX_OCR_NORMALIZED_TEXT_BYTES) {
+            self.truncated = true;
+        }
+    }
+
+    pub(crate) fn to_json_line(
+        &self,
+        captured_at: &str,
+        frame_index: u64,
+        persisted_frame_path: &Path,
+        latest_frame_path: &Path,
+        display_id: &str,
+    ) -> Value {
+        let mut value = json!({
+            "schema_version": 1,
+            "captured_at": captured_at,
+            "frame_index": frame_index,
+            "persisted_frame_path": persisted_frame_path,
+            "latest_frame_path": latest_frame_path,
+            "display_id": display_id,
+            "normalized_text": self.normalized_text,
+            "normalized_text_bytes": self.normalized_text.len(),
+            "runs_ocr": self.runs_ocr,
+            "ocr_status": self.status,
+            "ocr_backend": self.backend,
+            "language": self.language,
+            "duration_ms": self.duration_ms,
+            "truncated": self.truncated,
+            "observations": self.observations,
+        });
+        if let Some(version) = &self.backend_version {
+            value["ocr_backend_version"] = json!(version);
+        }
+        if let Some(hint) = &self.dependency_hint {
+            value["dependency_hint"] = json!(hint);
+        }
+        if let Some(error) = &self.error {
+            value["error"] = json!(error);
+        }
+        if self.suppressed_text_observation_count > 0 {
+            value["suppressed_text_observation_count"] =
+                json!(self.suppressed_text_observation_count);
+        }
+        value
+    }
+
+    #[cfg(test)]
+    fn completed_for_test(text: &str) -> Self {
+        Self {
+            runs_ocr: true,
+            status: "completed".to_string(),
+            backend: "tesseract-cli".to_string(),
+            language: "eng".to_string(),
+            backend_version: None,
+            normalized_text: text.to_string(),
+            dependency_hint: None,
+            error: None,
+            duration_ms: 1,
+            truncated: false,
+            suppressed_text_observation_count: 0,
+            observations: vec![OcrObservation {
+                bounding_box: NormalizedBoundingBox {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 1.0,
+                    height: 1.0,
+                    coordinate_space: "vision-normalized-bottom-left",
+                },
+                pixel_bounding_box: PixelBoundingBox {
+                    x: 0,
+                    y: 0,
+                    width: 1,
+                    height: 1,
+                    coordinate_space: "pixel-top-left",
+                },
+                top_candidates: vec![OcrCandidate {
+                    text: text.to_string(),
+                    confidence: 1.0,
+                }],
+                normalized_text: text.to_string(),
+            }],
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn recognize_frame(
+    policy: &OcrPolicy,
+    frame_path: &Path,
+    image_width: u32,
+    image_height: u32,
+    exclusion_values: &[String],
+) -> OcrFrameResult {
+    let readiness = policy.readiness();
+    recognize_frame_with_readiness(
+        policy,
+        &readiness,
+        frame_path,
+        image_width,
+        image_height,
+        exclusion_values,
+    )
+}
+
+pub(crate) fn recognize_frame_with_readiness(
+    policy: &OcrPolicy,
+    readiness: &OcrReadiness,
+    frame_path: &Path,
+    image_width: u32,
+    image_height: u32,
+    exclusion_values: &[String],
+) -> OcrFrameResult {
+    if policy.mode == OcrMode::Disabled {
+        return OcrFrameResult::skipped(readiness);
+    }
+    if !readiness.available {
+        return if policy.mode == OcrMode::Required {
+            OcrFrameResult::required_unavailable(readiness)
+        } else {
+            OcrFrameResult::skipped(readiness)
+        };
+    }
+
+    let started = Instant::now();
+    match recognize_frame_inner(policy, readiness, frame_path, image_width, image_height) {
+        Ok(mut result) => {
+            result.backend_version = readiness.version.clone();
+            result.apply_text_exclusions(exclusion_values);
+            result.apply_persistence_limits();
+            result
+        }
+        Err(error) => OcrFrameResult::failure(
+            readiness,
+            if started.elapsed() >= policy.timeout {
+                "timeout"
+            } else {
+                "error"
+            },
+            started.elapsed().as_millis(),
+            error.to_string(),
+        ),
+    }
+}
+
+fn recognize_frame_inner(
+    policy: &OcrPolicy,
+    readiness: &OcrReadiness,
+    frame_path: &Path,
+    image_width: u32,
+    image_height: u32,
+) -> Result<OcrFrameResult> {
+    match readiness.backend.as_str() {
+        RAPIDOCR_BACKEND_NAME => {
+            recognize_frame_rapidocr(policy, frame_path, image_width, image_height)
+        }
+        TESSERACT_BACKEND_NAME => {
+            recognize_frame_tesseract(policy, frame_path, image_width, image_height)
+        }
+        backend => anyhow::bail!("OCR backend `{backend}` is not runnable"),
+    }
+}
+
+fn recognize_frame_tesseract(
+    policy: &OcrPolicy,
+    frame_path: &Path,
+    image_width: u32,
+    image_height: u32,
+) -> Result<OcrFrameResult> {
+    let started = Instant::now();
+    let temp_dir = frame_path
+        .parent()
+        .unwrap_or_else(|| Path::new("/tmp"))
+        .join(format!(".ocr-{}-{}", std::process::id(), unique_nanos()));
+    crate::secure_fs::create_private_dir_all(&temp_dir)?;
+    let output_base = temp_dir.join("frame");
+    let mut child = Command::new(&policy.tesseract_executable)
+        .arg(frame_path)
+        .arg(&output_base)
+        .arg("-l")
+        .arg(&policy.language)
+        .arg("--psm")
+        .arg(&policy.page_segmentation_mode)
+        .arg("tsv")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to start {}", policy.tesseract_executable.display()))?;
+
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= policy.timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = fs::remove_dir_all(&temp_dir);
+            anyhow::bail!(
+                "tesseract timed out after {} ms",
+                policy.timeout.as_millis()
+            );
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    if !status.success() {
+        let _ = fs::remove_dir_all(&temp_dir);
+        anyhow::bail!("tesseract exited with {status}");
+    }
+
+    let tsv_path = output_base.with_extension("tsv");
+    let tsv = fs::read_to_string(&tsv_path)
+        .with_context(|| format!("failed to read {}", tsv_path.display()))?;
+    let observations = observations_from_tsv(&tsv, image_width, image_height)?;
+    let normalized_text = observations
+        .iter()
+        .map(|observation| observation.normalized_text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    Ok(OcrFrameResult {
+        runs_ocr: true,
+        status: "completed".to_string(),
+        backend: TESSERACT_BACKEND_NAME.to_string(),
+        language: policy.language.clone(),
+        backend_version: None,
+        normalized_text,
+        dependency_hint: None,
+        error: None,
+        duration_ms: started.elapsed().as_millis(),
+        truncated: false,
+        suppressed_text_observation_count: 0,
+        observations,
+    })
+}
+
+fn recognize_frame_rapidocr(
+    policy: &OcrPolicy,
+    frame_path: &Path,
+    image_width: u32,
+    image_height: u32,
+) -> Result<OcrFrameResult> {
+    let started = Instant::now();
+    let child = Command::new(&policy.rapidocr_python)
+        .arg("-c")
+        .arg(RAPIDOCR_RUN_SCRIPT)
+        .arg(&policy.rapidocr_language)
+        .arg(frame_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start {}", policy.rapidocr_python.display()))?;
+    let output = wait_with_output_timeout(child, policy.timeout)?;
+    if !output.status.success() {
+        anyhow::bail!("RapidOCR exited with {}", output.status);
+    }
+
+    let payload = parse_rapidocr_json_line(&output)?;
+    let observations = observations_from_rapidocr_json(&payload, image_width, image_height)?;
+    let normalized_text = observations
+        .iter()
+        .map(|observation| observation.normalized_text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    Ok(OcrFrameResult {
+        runs_ocr: true,
+        status: "completed".to_string(),
+        backend: RAPIDOCR_BACKEND_NAME.to_string(),
+        language: policy.rapidocr_language.clone(),
+        backend_version: None,
+        normalized_text,
+        dependency_hint: None,
+        error: None,
+        duration_ms: started.elapsed().as_millis(),
+        truncated: false,
+        suppressed_text_observation_count: 0,
+        observations,
+    })
+}
+
+fn observations_from_tsv(
+    tsv: &str,
+    image_width: u32,
+    image_height: u32,
+) -> Result<Vec<OcrObservation>> {
+    let mut lines = tsv.lines();
+    let Some(header) = lines.next() else {
+        return Ok(Vec::new());
+    };
+    let columns = header.split('\t').collect::<Vec<_>>();
+    let index = |name: &str| {
+        columns
+            .iter()
+            .position(|column| *column == name)
+            .with_context(|| format!("missing TSV column {name}"))
+    };
+    let level_idx = index("level")?;
+    let page_idx = index("page_num")?;
+    let block_idx = index("block_num")?;
+    let paragraph_idx = index("par_num")?;
+    let line_idx = index("line_num")?;
+    let left_idx = index("left")?;
+    let top_idx = index("top")?;
+    let width_idx = index("width")?;
+    let height_idx = index("height")?;
+    let confidence_idx = index("conf")?;
+    let text_idx = index("text")?;
+
+    let mut words = Vec::new();
+    for line in lines {
+        let fields = line.split('\t').collect::<Vec<_>>();
+        if fields.len() <= text_idx || fields.get(level_idx) != Some(&"5") {
+            continue;
+        }
+        let text = fields[text_idx].trim();
+        if text.is_empty() {
+            continue;
+        }
+        words.push(TsvWord {
+            page: fields[page_idx].to_string(),
+            block: fields[block_idx].to_string(),
+            paragraph: fields[paragraph_idx].to_string(),
+            line: fields[line_idx].to_string(),
+            left: parse_u32(fields[left_idx]),
+            top: parse_u32(fields[top_idx]),
+            width: parse_u32(fields[width_idx]),
+            height: parse_u32(fields[height_idx]),
+            confidence: parse_confidence(fields[confidence_idx]),
+            text: text.to_string(),
+        });
+    }
+
+    let mut observations = Vec::new();
+    let mut current_key: Option<(String, String, String, String)> = None;
+    let mut current_words: Vec<TsvWord> = Vec::new();
+    for word in words {
+        let key = (
+            word.page.clone(),
+            word.block.clone(),
+            word.paragraph.clone(),
+            word.line.clone(),
+        );
+        if current_key
+            .as_ref()
+            .is_some_and(|existing| *existing != key)
+        {
+            observations.push(observation_from_words(
+                &current_words,
+                image_width,
+                image_height,
+            ));
+            current_words.clear();
+        }
+        current_key = Some(key);
+        current_words.push(word);
+    }
+    if !current_words.is_empty() {
+        observations.push(observation_from_words(
+            &current_words,
+            image_width,
+            image_height,
+        ));
+    }
+
+    Ok(observations)
+}
+
+fn observation_from_words(
+    words: &[TsvWord],
+    image_width: u32,
+    image_height: u32,
+) -> OcrObservation {
+    let x1 = words.iter().map(|word| word.left).min().unwrap_or(0);
+    let y1 = words.iter().map(|word| word.top).min().unwrap_or(0);
+    let x2 = words
+        .iter()
+        .map(|word| word.left.saturating_add(word.width))
+        .max()
+        .unwrap_or(x1);
+    let y2 = words
+        .iter()
+        .map(|word| word.top.saturating_add(word.height))
+        .max()
+        .unwrap_or(y1);
+    let width = x2.saturating_sub(x1);
+    let height = y2.saturating_sub(y1);
+    let text = words
+        .iter()
+        .map(|word| word.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let confidence = if words.is_empty() {
+        0.0
+    } else {
+        words.iter().map(|word| word.confidence).sum::<f64>() / words.len() as f64
+    };
+
+    OcrObservation {
+        bounding_box: NormalizedBoundingBox {
+            x: if image_width == 0 {
+                0.0
+            } else {
+                x1 as f64 / image_width as f64
+            },
+            y: if image_height == 0 {
+                0.0
+            } else {
+                1.0 - (y2 as f64 / image_height as f64)
+            },
+            width: if image_width == 0 {
+                0.0
+            } else {
+                width as f64 / image_width as f64
+            },
+            height: if image_height == 0 {
+                0.0
+            } else {
+                height as f64 / image_height as f64
+            },
+            coordinate_space: "vision-normalized-bottom-left",
+        },
+        pixel_bounding_box: PixelBoundingBox {
+            x: x1,
+            y: y1,
+            width,
+            height,
+            coordinate_space: "pixel-top-left",
+        },
+        top_candidates: vec![OcrCandidate {
+            text: text.clone(),
+            confidence,
+        }],
+        normalized_text: text,
+    }
+}
+
+fn observations_from_rapidocr_json(
+    payload: &Value,
+    image_width: u32,
+    image_height: u32,
+) -> Result<Vec<OcrObservation>> {
+    let boxes = payload
+        .get("boxes")
+        .and_then(Value::as_array)
+        .context("RapidOCR output missing boxes")?;
+    let txts = payload
+        .get("txts")
+        .and_then(Value::as_array)
+        .context("RapidOCR output missing txts")?;
+    let scores = payload
+        .get("scores")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut observations = Vec::new();
+    for (index, text_value) in txts.iter().enumerate() {
+        let text = text_value
+            .as_str()
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+            .unwrap_or_default();
+        if text.is_empty() {
+            continue;
+        }
+        let Some(box_value) = boxes.get(index) else {
+            continue;
+        };
+        let Some((x1, y1, x2, y2)) = rapidocr_box_bounds(box_value) else {
+            continue;
+        };
+        let confidence = scores
+            .get(index)
+            .and_then(Value::as_f64)
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        observations.push(observation_from_rect(
+            x1,
+            y1,
+            x2,
+            y2,
+            image_width,
+            image_height,
+            text,
+            confidence,
+        ));
+    }
+
+    Ok(observations)
+}
+
+fn rapidocr_box_bounds(value: &Value) -> Option<(f64, f64, f64, f64)> {
+    let points = value.as_array()?;
+    let mut xs = Vec::new();
+    let mut ys = Vec::new();
+    for point in points {
+        let coordinates = point.as_array()?;
+        let x = coordinates.first()?.as_f64()?;
+        let y = coordinates.get(1)?.as_f64()?;
+        if x.is_finite() && y.is_finite() {
+            xs.push(x);
+            ys.push(y);
+        }
+    }
+    if xs.is_empty() || ys.is_empty() {
+        return None;
+    }
+    Some((
+        xs.iter().copied().fold(f64::INFINITY, f64::min),
+        ys.iter().copied().fold(f64::INFINITY, f64::min),
+        xs.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+        ys.iter().copied().fold(f64::NEG_INFINITY, f64::max),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn observation_from_rect(
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    image_width: u32,
+    image_height: u32,
+    text: &str,
+    confidence: f64,
+) -> OcrObservation {
+    let max_x = if image_width == 0 {
+        f64::MAX
+    } else {
+        image_width as f64
+    };
+    let max_y = if image_height == 0 {
+        f64::MAX
+    } else {
+        image_height as f64
+    };
+    let x1 = x1.clamp(0.0, max_x);
+    let y1 = y1.clamp(0.0, max_y);
+    let x2 = x2.clamp(x1, max_x);
+    let y2 = y2.clamp(y1, max_y);
+    let pixel_x = x1.floor() as u32;
+    let pixel_y = y1.floor() as u32;
+    let pixel_width = x2.ceil().saturating_sub_f64(x1.floor());
+    let pixel_height = y2.ceil().saturating_sub_f64(y1.floor());
+    let text = text.to_string();
+
+    OcrObservation {
+        bounding_box: NormalizedBoundingBox {
+            x: if image_width == 0 {
+                0.0
+            } else {
+                x1 / image_width as f64
+            },
+            y: if image_height == 0 {
+                0.0
+            } else {
+                1.0 - (y2 / image_height as f64)
+            },
+            width: if image_width == 0 {
+                0.0
+            } else {
+                (x2 - x1) / image_width as f64
+            },
+            height: if image_height == 0 {
+                0.0
+            } else {
+                (y2 - y1) / image_height as f64
+            },
+            coordinate_space: "vision-normalized-bottom-left",
+        },
+        pixel_bounding_box: PixelBoundingBox {
+            x: pixel_x,
+            y: pixel_y,
+            width: pixel_width,
+            height: pixel_height,
+            coordinate_space: "pixel-top-left",
+        },
+        top_candidates: vec![OcrCandidate {
+            text: text.clone(),
+            confidence,
+        }],
+        normalized_text: text,
+    }
+}
+
+fn env_value(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn rapidocr_dependency_hint() -> String {
+    "Install Python packages `rapidocr` and `onnxruntime` plus the OpenCV runtime dependency `libGL.so.1`, or set CODEX_SKYSIGHT_OCR_BACKEND=tesseract".to_string()
+}
+
+fn tesseract_dependency_hint(language: &str) -> String {
+    format!("Install tesseract and traineddata for language `{language}`")
+}
+
+fn auto_dependency_hint(language: &str) -> String {
+    format!(
+        "{}; fallback: {}",
+        rapidocr_dependency_hint(),
+        tesseract_dependency_hint(language)
+    )
+}
+
+fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {
+    haystack
+        .to_ascii_lowercase()
+        .contains(&needle.to_ascii_lowercase())
+}
+
+fn truncate_string_to_bytes(value: &mut String, max_bytes: usize) -> bool {
+    if value.len() <= max_bytes {
+        return false;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    true
+}
+
+trait SaturatingSubF64 {
+    fn saturating_sub_f64(self, rhs: f64) -> u32;
+}
+
+impl SaturatingSubF64 for f64 {
+    fn saturating_sub_f64(self, rhs: f64) -> u32 {
+        if !self.is_finite() || !rhs.is_finite() || self <= rhs {
+            return 0;
+        }
+        (self - rhs).min(u32::MAX as f64) as u32
+    }
+}
+
+fn wait_with_output_timeout(mut child: Child, timeout: Duration) -> Result<Output> {
+    let started = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            return child
+                .wait_with_output()
+                .context("failed to collect OCR output");
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("OCR process timed out after {} ms", timeout.as_millis());
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn parse_rapidocr_versions(output: &Output) -> Result<RapidOcrVersions> {
+    let payload = parse_rapidocr_json_line(output)?;
+    serde_json::from_value(payload).context("failed to parse RapidOCR version payload")
+}
+
+fn parse_rapidocr_json_line(output: &Output) -> Result<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout
+        .lines()
+        .rev()
+        .find_map(|line| line.strip_prefix(RAPIDOCR_JSON_PREFIX))
+        .context("RapidOCR JSON payload was not found on stdout")?;
+    serde_json::from_str(line).context("failed to parse RapidOCR JSON payload")
+}
+
+fn parse_u32(value: &str) -> u32 {
+    value
+        .parse::<i64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .unwrap_or(0) as u32
+}
+
+fn parse_confidence(value: &str) -> f64 {
+    value
+        .parse::<f64>()
+        .ok()
+        .filter(|value| *value >= 0.0)
+        .map(|value| (value / 100.0).min(1.0))
+        .unwrap_or(0.0)
+}
+
+fn unique_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    #[test]
+    fn policy_defaults_to_auto_backend_preference() {
+        let _guard = env_lock();
+        clear_ocr_env();
+
+        let policy = OcrPolicy::from_env();
+
+        assert_eq!(policy.mode, OcrMode::Auto);
+        assert_eq!(policy.backend_preference, OcrBackendPreference::Auto);
+        assert_eq!(policy.backend_name(), "auto");
+        assert_eq!(policy.language, "eng");
+        assert_eq!(policy.rapidocr_language, "ch");
+        assert_eq!(policy.page_segmentation_mode, "11");
+        assert_eq!(policy.timeout.as_secs(), 10);
+    }
+
+    #[test]
+    fn rapidocr_run_script_requires_language_and_image_path() {
+        assert!(RAPIDOCR_RUN_SCRIPT.contains("len(sys.argv) != 3"));
+        assert!(RAPIDOCR_RUN_SCRIPT.contains("expected rapidocr language and image path"));
+        assert!(!RAPIDOCR_RUN_SCRIPT.contains("else sys.argv[1]"));
+    }
+
+    #[test]
+    fn missing_backend_reports_unavailable_without_requiring_host_dependency() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        std::env::set_var("CODEX_SKYSIGHT_OCR", "enabled");
+        std::env::set_var("CODEX_SKYSIGHT_OCR_BACKEND", "tesseract");
+        std::env::set_var(
+            "CODEX_SKYSIGHT_TESSERACT_PATH",
+            "/definitely/missing/tesseract",
+        );
+
+        let policy = OcrPolicy::from_env();
+        let readiness = policy.readiness();
+
+        assert!(readiness.enabled);
+        assert!(!readiness.available);
+        assert_eq!(readiness.status, "backend_unavailable");
+        assert!(readiness.dependency_hint.is_some());
+    }
+
+    #[test]
+    fn required_mode_marks_missing_backend_as_required_failure() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        std::env::set_var("CODEX_SKYSIGHT_OCR", "required");
+        std::env::set_var("CODEX_SKYSIGHT_OCR_BACKEND", "tesseract");
+        std::env::set_var(
+            "CODEX_SKYSIGHT_TESSERACT_PATH",
+            "/definitely/missing/tesseract",
+        );
+
+        let policy = OcrPolicy::from_env();
+        let result = recognize_frame(&policy, Path::new("/tmp/missing-frame.jpg"), 100, 50, &[]);
+
+        assert!(!result.runs_ocr);
+        assert_eq!(result.status, "required_backend_unavailable");
+        assert!(result.error.is_some());
+        assert!(result.dependency_hint.is_some());
+    }
+
+    #[test]
+    fn fake_rapidocr_backend_parses_json_observations() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        let temp = tempfile::tempdir().unwrap();
+        let fake_python = temp.path().join("fake-python");
+        fs::write(
+            &fake_python,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -eq 3 ]]; then
+  echo '__CODEX_RAPIDOCR_JSON__{"rapidocr":"3.9.1","onnxruntime":"1.22.0","lang_type":"en"}'
+  exit 0
+fi
+echo '__CODEX_RAPIDOCR_JSON__{"boxes":[[[10,20],[90,20],[90,40],[10,40]],[[10,60],[55,60],[55,74],[10,74]]],"txts":["Codex Rapid","OCR"],"scores":[0.97,0.91],"elapse":0.123,"lang_type":"en"}'
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&fake_python).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_python, permissions).unwrap();
+        let image = temp.path().join("frame.jpg");
+        fs::write(&image, b"not-a-real-image-but-fake-backend-does-not-care").unwrap();
+        std::env::set_var("CODEX_SKYSIGHT_OCR", "enabled");
+        std::env::set_var("CODEX_SKYSIGHT_OCR_BACKEND", "rapidocr");
+        std::env::set_var("CODEX_SKYSIGHT_RAPIDOCR_PYTHON", &fake_python);
+        std::env::set_var("CODEX_SKYSIGHT_RAPIDOCR_LANG", "en");
+
+        let policy = OcrPolicy::from_env();
+        let readiness = policy.readiness();
+        assert!(readiness.available);
+        assert_eq!(readiness.backend, "rapidocr-python");
+        assert_eq!(readiness.language, "en");
+        assert!(readiness
+            .version
+            .as_deref()
+            .is_some_and(|version| version.contains("rapidocr 3.9.1")));
+
+        let result = recognize_frame(&policy, &image, 200, 100, &[]);
+
+        assert_eq!(result.status, "completed");
+        assert!(result.runs_ocr);
+        assert_eq!(result.backend, "rapidocr-python");
+        assert_eq!(result.language, "en");
+        assert_eq!(result.normalized_text, "Codex Rapid\nOCR");
+        assert_eq!(result.observations.len(), 2);
+        assert_eq!(result.observations[0].pixel_bounding_box.x, 10);
+        assert_eq!(result.observations[0].pixel_bounding_box.y, 20);
+        assert_eq!(result.observations[0].pixel_bounding_box.width, 80);
+        assert_eq!(result.observations[0].pixel_bounding_box.height, 20);
+        assert!(result.observations[0].top_candidates[0].confidence > 0.9);
+    }
+
+    #[test]
+    fn auto_backend_prefers_rapidocr_when_available() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        let temp = tempfile::tempdir().unwrap();
+        let fake_python = temp.path().join("fake-python");
+        fs::write(
+            &fake_python,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+echo '__CODEX_RAPIDOCR_JSON__{"rapidocr":"3.9.1","onnxruntime":"1.22.0"}'
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&fake_python).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_python, permissions).unwrap();
+        std::env::set_var("CODEX_SKYSIGHT_OCR", "enabled");
+        std::env::set_var("CODEX_SKYSIGHT_RAPIDOCR_PYTHON", &fake_python);
+
+        let policy = OcrPolicy::from_env();
+        let readiness = policy.readiness();
+
+        assert_eq!(policy.backend_preference, OcrBackendPreference::Auto);
+        assert!(readiness.available);
+        assert_eq!(readiness.backend, "rapidocr-python");
+    }
+
+    #[test]
+    fn fake_tesseract_tsv_groups_words_into_observations() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        let temp = tempfile::tempdir().unwrap();
+        let fake_tesseract = temp.path().join("fake-tesseract");
+        fs::write(
+            &fake_tesseract,
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "tesseract 5.3.4"
+  exit 0
+fi
+out="${2}.tsv"
+cat > "$out" <<'TSV'
+level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
+5	1	1	1	1	1	10	20	40	12	95	Codex
+5	1	1	1	1	2	55	20	30	12	91	OCR
+5	1	1	1	2	1	10	50	35	12	80	Local
+TSV
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&fake_tesseract).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&fake_tesseract, permissions).unwrap();
+        let image = temp.path().join("frame.jpg");
+        fs::write(&image, b"not-a-real-image-but-fake-backend-does-not-care").unwrap();
+        std::env::set_var("CODEX_SKYSIGHT_OCR", "enabled");
+        std::env::set_var("CODEX_SKYSIGHT_OCR_BACKEND", "tesseract");
+        std::env::set_var("CODEX_SKYSIGHT_TESSERACT_PATH", &fake_tesseract);
+
+        let policy = OcrPolicy::from_env();
+        let result = recognize_frame(&policy, &image, 200, 100, &[]);
+
+        assert_eq!(result.status, "completed");
+        assert!(result.runs_ocr);
+        assert_eq!(result.normalized_text, "Codex OCR\nLocal");
+        assert_eq!(result.observations.len(), 2);
+        assert_eq!(result.observations[0].normalized_text, "Codex OCR");
+        assert_eq!(result.observations[0].pixel_bounding_box.x, 10);
+        assert_eq!(result.observations[0].pixel_bounding_box.width, 75);
+        assert!(result.observations[0].top_candidates[0].confidence > 0.9);
+    }
+
+    #[test]
+    fn text_matching_exclusion_suppresses_output() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        let mut result = OcrFrameResult::completed_for_test("bank.example account");
+
+        result.apply_text_exclusions(&["bank.example".to_string()]);
+
+        assert_eq!(result.status, "suppressed_by_exclusion_text");
+        assert_eq!(result.normalized_text, "");
+        assert!(result.observations.is_empty());
+        assert_eq!(result.suppressed_text_observation_count, 1);
+    }
+
+    #[test]
+    fn persistence_limits_bound_ocr_text_and_observations() {
+        let _guard = env_lock();
+        clear_ocr_env();
+        let mut result = OcrFrameResult {
+            runs_ocr: true,
+            status: "completed".to_string(),
+            backend: "tesseract-cli".to_string(),
+            language: "eng".to_string(),
+            backend_version: None,
+            normalized_text: String::new(),
+            dependency_hint: None,
+            error: None,
+            duration_ms: 1,
+            truncated: false,
+            suppressed_text_observation_count: 0,
+            observations: (0..(MAX_OCR_OBSERVATIONS + 5))
+                .map(|index| OcrObservation {
+                    bounding_box: NormalizedBoundingBox {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 1.0,
+                        height: 1.0,
+                        coordinate_space: "vision-normalized-bottom-left",
+                    },
+                    pixel_bounding_box: PixelBoundingBox {
+                        x: 0,
+                        y: 0,
+                        width: 1,
+                        height: 1,
+                        coordinate_space: "pixel-top-left",
+                    },
+                    top_candidates: vec![OcrCandidate {
+                        text: format!("{index}-{}", "x".repeat(MAX_OCR_CANDIDATE_TEXT_BYTES + 20)),
+                        confidence: 0.9,
+                    }],
+                    normalized_text: format!(
+                        "{index}-{}",
+                        "y".repeat(MAX_OCR_CANDIDATE_TEXT_BYTES + 20)
+                    ),
+                })
+                .collect(),
+        };
+
+        result.apply_persistence_limits();
+
+        assert!(result.truncated);
+        assert_eq!(result.observations.len(), MAX_OCR_OBSERVATIONS);
+        assert!(result.normalized_text.len() <= MAX_OCR_NORMALIZED_TEXT_BYTES);
+        assert!(result
+            .observations
+            .iter()
+            .all(|observation| observation.normalized_text.len() <= MAX_OCR_CANDIDATE_TEXT_BYTES));
+        assert!(result.observations.iter().all(|observation| observation
+            .top_candidates
+            .iter()
+            .all(|candidate| candidate.text.len() <= MAX_OCR_CANDIDATE_TEXT_BYTES)));
+    }
+
+    fn clear_ocr_env() {
+        for key in [
+            "CODEX_SKYSIGHT_OCR",
+            "CODEX_CHRONICLE_OCR",
+            "CODEX_SKYSIGHT_OCR_BACKEND",
+            "CODEX_CHRONICLE_OCR_BACKEND",
+            "CODEX_SKYSIGHT_TESSERACT_PATH",
+            "CODEX_CHRONICLE_TESSERACT_PATH",
+            "CODEX_SKYSIGHT_RAPIDOCR_PYTHON",
+            "CODEX_CHRONICLE_RAPIDOCR_PYTHON",
+            "CODEX_SKYSIGHT_RAPIDOCR_LANG",
+            "CODEX_CHRONICLE_RAPIDOCR_LANG",
+            "CODEX_SKYSIGHT_OCR_LANG",
+            "CODEX_SKYSIGHT_OCR_PSM",
+            "CODEX_SKYSIGHT_OCR_TIMEOUT_MS",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap()
+    }
+}

--- a/record-replay-linux/src/skysight.rs
+++ b/record-replay-linux/src/skysight.rs
@@ -98,6 +98,26 @@ pub struct SkysightStatus {
     pub summary_agent_last_run_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary_agent_last_error: Option<String>,
+    #[serde(default)]
+    pub ocr_enabled: bool,
+    #[serde(default)]
+    pub ocr_available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_backend: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_backend_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_dependency_hint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_last_run_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ocr_last_error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -221,6 +241,26 @@ struct SegmentPaths {
 struct DesktopEvidenceCapture {
     events: Vec<Value>,
     artifact_count: usize,
+    ocr_last_run_at: Option<String>,
+    ocr_last_error: Option<String>,
+}
+
+fn record_ocr_capture_status(
+    capture: &mut DesktopEvidenceCapture,
+    recorded_at: &str,
+    event: &Value,
+) {
+    if event
+        .get("ocr_runs")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        capture.ocr_last_run_at = Some(recorded_at.to_string());
+        capture.ocr_last_error = event
+            .get("ocr_error")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -368,6 +408,8 @@ pub fn start_skysight(
         started_at: Some(now_timestamp()),
         end_reason: None,
         message: Some("Skysight daemon started".to_string()),
+        ocr_policy: None,
+        ocr_readiness: None,
     })?;
     write_status(paths, &status)?;
     Ok(status)
@@ -397,6 +439,8 @@ pub fn run_skysight_daemon(
                 started_at: None,
                 end_reason: Some("stop-requested".to_string()),
                 message: Some("Skysight daemon stopped".to_string()),
+                ocr_policy: None,
+                ocr_readiness: None,
             })?;
             write_status(paths, &status)?;
             let _ = fs::remove_file(&paths.stop_request_path);
@@ -416,6 +460,8 @@ pub fn run_skysight_daemon(
                 started_at: None,
                 end_reason: None,
                 message: Some("Skysight daemon paused".to_string()),
+                ocr_policy: None,
+                ocr_readiness: None,
             })?;
             write_status(paths, &status)?;
             thread::sleep(interval);
@@ -433,6 +479,8 @@ pub fn run_skysight_daemon(
                 started_at: None,
                 end_reason: None,
                 message: Some(format!("Skysight snapshot failed: {error:#}")),
+                ocr_policy: None,
+                ocr_readiness: None,
             })?;
             write_status(paths, &status)?;
         }
@@ -464,6 +512,8 @@ pub fn pause_skysight<S: Into<String>>(
         started_at: None,
         end_reason: None,
         message: Some("Skysight paused".to_string()),
+        ocr_policy: None,
+        ocr_readiness: None,
     })?;
     write_status(paths, &status)?;
     Ok(status)
@@ -489,6 +539,8 @@ pub fn resume_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
         } else {
             "Skysight pause cleared; daemon is not running".to_string()
         }),
+        ocr_policy: None,
+        ocr_readiness: None,
     })?;
     write_status(paths, &status)?;
     Ok(status)
@@ -513,6 +565,8 @@ pub fn capture_skysight_snapshot(
             started_at: None,
             end_reason: None,
             message: Some("Skysight is paused; resume before capturing a snapshot".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
         })?;
         write_status(paths, &status)?;
         return Ok(status);
@@ -520,6 +574,8 @@ pub fn capture_skysight_snapshot(
 
     codex_computer_use_linux::diagnostics::hydrate_session_bus_env();
     let diagnostics = codex_computer_use_linux::diagnostics::doctor_report();
+    let ocr_policy = crate::ocr::OcrPolicy::from_env();
+    let ocr_readiness = ocr_policy.readiness();
     let recorded_at = now_timestamp();
     let window_ended_at = Utc::now();
     let source = source.unwrap_or("snapshot");
@@ -534,12 +590,25 @@ pub fn capture_skysight_snapshot(
         "diagnostics": &diagnostics,
         "exclusions": &exclusions,
     })];
-    events.push(provider_readiness_event(&recorded_at, source, &diagnostics));
+    events.push(provider_readiness_event(
+        &recorded_at,
+        source,
+        &diagnostics,
+        &ocr_policy,
+        &ocr_readiness,
+    ));
     let diagnostics_artifact =
         write_diagnostics_artifact(&segment, &recorded_at, source, &diagnostics, &exclusions)?;
     events.push(diagnostics_artifact);
-    let desktop_evidence =
-        collect_desktop_evidence(paths, &segment, &recorded_at, source, &exclusions);
+    let desktop_evidence = collect_desktop_evidence(
+        paths,
+        &segment,
+        &recorded_at,
+        source,
+        &exclusions,
+        ocr_policy.clone(),
+        ocr_readiness.clone(),
+    );
     events.extend(desktop_evidence.events);
     let event_count = events.len();
     let suppressed_event_count = suppressed_event_count(&events);
@@ -610,6 +679,8 @@ pub fn capture_skysight_snapshot(
         } else {
             "Skysight snapshot captured; daemon is not running".to_string()
         }),
+        ocr_policy: Some(ocr_policy),
+        ocr_readiness: Some(ocr_readiness),
     })?;
     let mut status = status;
     status.last_10min_resource = Some(ten_minute_path);
@@ -624,6 +695,10 @@ pub fn capture_skysight_snapshot(
     if let Some(ran_at) = summary_agent_report.ran_at {
         status.summary_agent_last_run_at = Some(ran_at);
         status.summary_agent_last_error = summary_agent_report.error;
+    }
+    if let Some(ran_at) = desktop_evidence.ocr_last_run_at {
+        status.ocr_last_run_at = Some(ran_at);
+        status.ocr_last_error = desktop_evidence.ocr_last_error;
     }
     status.next_summary_agent_run_at = summary_agent_report
         .next_run_at
@@ -679,6 +754,8 @@ pub fn skysight_status(paths: &SkysightPaths) -> Result<SkysightStatus> {
             started_at: None,
             end_reason: Some("not-started".to_string()),
             message: Some("Skysight has not been started".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
         }),
     }
 }
@@ -706,6 +783,8 @@ pub fn stop_skysight(paths: &SkysightPaths) -> Result<SkysightStatus> {
         started_at: None,
         end_reason: Some("recording_controls_stopped".to_string()),
         message: Some("Skysight stopped".to_string()),
+        ocr_policy: None,
+        ocr_readiness: None,
     })?;
     write_status(paths, &status)?;
     Ok(status)
@@ -768,6 +847,8 @@ fn provider_readiness_event(
     recorded_at: &str,
     source: &str,
     diagnostics: &codex_computer_use_linux::diagnostics::DoctorReport,
+    ocr_policy: &crate::ocr::OcrPolicy,
+    ocr_readiness: &crate::ocr::OcrReadiness,
 ) -> Value {
     json!({
         "schema_version": 1,
@@ -799,6 +880,18 @@ fn provider_readiness_event(
                 "status": "available_from_window_metadata",
                 "url_hints_supported": false,
                 "note": "Linux Skysight records browser window/title evidence after applying exclusions. URL evidence is ingested from explicit browser traces or observations.",
+            },
+            "ocr": {
+                "backend": ocr_readiness.backend,
+                "mode": ocr_policy.mode_name(),
+                "enabled": ocr_readiness.enabled,
+                "available": ocr_readiness.available,
+                "status": ocr_readiness.status,
+                "language": ocr_readiness.language,
+                "network": false,
+                "version": ocr_readiness.version,
+                "dependency_hint": ocr_readiness.dependency_hint,
+                "error": ocr_readiness.error,
             },
             "input_capture_libei": {
                 "portal": &diagnostics.portals.input_capture,
@@ -849,6 +942,8 @@ fn collect_desktop_evidence(
     recorded_at: &str,
     source: &str,
     exclusions: &[SkysightExclusion],
+    ocr_policy: crate::ocr::OcrPolicy,
+    ocr_readiness: crate::ocr::OcrReadiness,
 ) -> DesktopEvidenceCapture {
     let segment_dir = segment.segment_dir.clone();
     let screen_recording_dir = chronicle_screen_recording_dir();
@@ -870,6 +965,8 @@ fn collect_desktop_evidence(
             worker_recorded_at,
             worker_source,
             exclusions,
+            ocr_policy,
+            ocr_readiness,
         ))
     })
     .join()
@@ -883,6 +980,8 @@ fn collect_desktop_evidence(
                 error.to_string(),
             )],
             artifact_count: 0,
+            ocr_last_run_at: None,
+            ocr_last_error: None,
         },
         Err(_) => DesktopEvidenceCapture {
             events: vec![capture_error_event(
@@ -892,6 +991,8 @@ fn collect_desktop_evidence(
                 "desktop evidence capture thread panicked",
             )],
             artifact_count: 0,
+            ocr_last_run_at: None,
+            ocr_last_error: None,
         },
     }
 }
@@ -902,6 +1003,8 @@ async fn collect_desktop_evidence_async(
     recorded_at: String,
     source: String,
     exclusions: Vec<SkysightExclusion>,
+    ocr_policy: crate::ocr::OcrPolicy,
+    ocr_readiness: crate::ocr::OcrReadiness,
 ) -> Result<DesktopEvidenceCapture> {
     let artifacts_dir = segment_dir.join(ARTIFACTS_DIR_NAME);
     crate::secure_fs::create_private_dir_all(&artifacts_dir)?;
@@ -982,16 +1085,21 @@ async fn collect_desktop_evidence_async(
         .or(focused_browser_domain_exclusion);
 
     capture_screenshot_evidence(
-        &segment_dir,
-        &recorded_at,
-        &source,
+        ScreenshotEvidenceContext {
+            segment_dir: &segment_dir,
+            recorded_at: &recorded_at,
+            source: &source,
+            screen_recording_dir: Some(&screen_recording_dir),
+            ocr_policy: &ocr_policy,
+            ocr_readiness: &ocr_readiness,
+        },
         ScreenshotSuppression {
             visible_excluded_windows,
             visible_domain_excluded_browser_windows,
             visible_unverified_browser_domain_windows,
             unverified_exclusions: window_listing_unavailable && !exclusions.is_empty(),
         },
-        Some(&screen_recording_dir),
+        &exclusions,
         &mut capture,
     )
     .await?;
@@ -1157,19 +1265,27 @@ struct AccessibilitySuppression<'a> {
     focused_browser_domain_unverified: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ScreenshotEvidenceContext<'a> {
+    segment_dir: &'a Path,
+    recorded_at: &'a str,
+    source: &'a str,
+    screen_recording_dir: Option<&'a Path>,
+    ocr_policy: &'a crate::ocr::OcrPolicy,
+    ocr_readiness: &'a crate::ocr::OcrReadiness,
+}
+
 async fn capture_screenshot_evidence(
-    segment_dir: &Path,
-    recorded_at: &str,
-    source: &str,
+    context: ScreenshotEvidenceContext<'_>,
     suppression: ScreenshotSuppression,
-    screen_recording_dir: Option<&Path>,
+    exclusions: &[SkysightExclusion],
     capture: &mut DesktopEvidenceCapture,
 ) -> Result<()> {
     if suppression.unverified_exclusions {
         capture.events.push(json!({
             "schema_version": 1,
-            "recorded_at": recorded_at,
-            "source": source,
+            "recorded_at": context.recorded_at,
+            "source": context.source,
             "kind": "suppressed_evidence",
             "provider": "screenshot",
             "count": 1,
@@ -1181,8 +1297,8 @@ async fn capture_screenshot_evidence(
     if suppression.visible_unverified_browser_domain_windows > 0 {
         capture.events.push(json!({
             "schema_version": 1,
-            "recorded_at": recorded_at,
-            "source": source,
+            "recorded_at": context.recorded_at,
+            "source": context.source,
             "kind": "suppressed_evidence",
             "provider": "screenshot",
             "count": suppression.visible_unverified_browser_domain_windows,
@@ -1194,8 +1310,8 @@ async fn capture_screenshot_evidence(
     if suppression.visible_domain_excluded_browser_windows > 0 {
         capture.events.push(json!({
             "schema_version": 1,
-            "recorded_at": recorded_at,
-            "source": source,
+            "recorded_at": context.recorded_at,
+            "source": context.source,
             "kind": "suppressed_evidence",
             "provider": "screenshot",
             "count": suppression.visible_domain_excluded_browser_windows,
@@ -1207,8 +1323,8 @@ async fn capture_screenshot_evidence(
     if suppression.visible_excluded_windows > 0 {
         capture.events.push(json!({
             "schema_version": 1,
-            "recorded_at": recorded_at,
-            "source": source,
+            "recorded_at": context.recorded_at,
+            "source": context.source,
             "kind": "suppressed_evidence",
             "provider": "screenshot",
             "count": suppression.visible_excluded_windows,
@@ -1224,18 +1340,24 @@ async fn capture_screenshot_evidence(
             } else {
                 "png"
             };
-            let chronicle_event =
-                write_chronicle_screen_recording_artifacts(screen_recording_dir, recorded_at, &raw);
+            let chronicle_event = write_chronicle_screen_recording_artifacts(
+                context.screen_recording_dir,
+                context.recorded_at,
+                &raw,
+                exclusions,
+                context.ocr_policy,
+                context.ocr_readiness,
+            );
             let relative =
                 PathBuf::from(ARTIFACTS_DIR_NAME).join(format!("screenshot.{extension}"));
-            let absolute = segment_dir.join(&relative);
+            let absolute = context.segment_dir.join(&relative);
             let byte_count = raw.bytes.len();
             crate::secure_fs::write_private_file(&absolute, raw.bytes)?;
             capture.artifact_count += 1;
             capture.events.push(json!({
                 "schema_version": 1,
-                "recorded_at": recorded_at,
-                "source": source,
+                "recorded_at": context.recorded_at,
+                "source": context.source,
                 "kind": "screenshot",
                 "file": relative.to_string_lossy(),
                 "path": absolute,
@@ -1246,13 +1368,14 @@ async fn capture_screenshot_evidence(
                 "bytes": byte_count,
             }));
             if let Some(event) = chronicle_event {
+                record_ocr_capture_status(capture, context.recorded_at, &event);
                 capture.events.push(event);
             }
         }
         Err(error) => capture.events.push(capture_error_event(
             "screenshot",
-            recorded_at,
-            source,
+            context.recorded_at,
+            context.source,
             error.to_string(),
         )),
     }
@@ -1382,9 +1505,19 @@ fn write_chronicle_screen_recording_artifacts(
     screen_recording_dir: Option<&Path>,
     recorded_at: &str,
     raw: &screenshot::RawScreenshotCapture,
+    exclusions: &[SkysightExclusion],
+    ocr_policy: &crate::ocr::OcrPolicy,
+    ocr_readiness: &crate::ocr::OcrReadiness,
 ) -> Option<Value> {
     let screen_recording_dir = screen_recording_dir?;
-    match write_chronicle_screen_recording_artifacts_inner(screen_recording_dir, recorded_at, raw) {
+    match write_chronicle_screen_recording_artifacts_inner(
+        screen_recording_dir,
+        recorded_at,
+        raw,
+        exclusions,
+        ocr_policy,
+        ocr_readiness,
+    ) {
         Ok(event) => Some(event),
         Err(error) => Some(capture_error_event(
             "chronicle_screen_recording",
@@ -1399,6 +1532,9 @@ fn write_chronicle_screen_recording_artifacts_inner(
     screen_recording_dir: &Path,
     recorded_at: &str,
     raw: &screenshot::RawScreenshotCapture,
+    exclusions: &[SkysightExclusion],
+    ocr_policy: &crate::ocr::OcrPolicy,
+    ocr_readiness: &crate::ocr::OcrReadiness,
 ) -> Result<Value> {
     let captured_at = timestamp(recorded_at).unwrap_or_else(Utc::now);
     let display_id = "0";
@@ -1434,6 +1570,18 @@ fn write_chronicle_screen_recording_artifacts_inner(
     crate::secure_fs::write_private_file(&latest_frame_path, &jpeg_bytes)?;
     crate::secure_fs::write_private_file(&sparse_frame_path, &jpeg_bytes)?;
     crate::secure_fs::write_private_file(&capture_marker_path, "active\n")?;
+    let exclusion_values = exclusions
+        .iter()
+        .map(|rule| rule.value.clone())
+        .collect::<Vec<_>>();
+    let ocr_result = crate::ocr::recognize_frame_with_readiness(
+        ocr_policy,
+        ocr_readiness,
+        &sparse_frame_path,
+        jpeg_payload.width,
+        jpeg_payload.height,
+        &exclusion_values,
+    );
     write_json_artifact(
         &capture_metadata_path,
         &json!({
@@ -1451,21 +1599,25 @@ fn write_chronicle_screen_recording_artifacts_inner(
             "safe_to_persist": true,
             "privacy_filter": {
                 "source": "linux-skysight-exclusion-filter",
-                "ocr": "unavailable-linux"
+                "screenshot_gate": "passed-before-ocr",
+                "ocr": {
+                    "status": ocr_result.status,
+                    "backend": ocr_result.backend,
+                    "language": ocr_result.language,
+                    "text_exclusion_filter": "applied"
+                }
             }
         }),
     )?;
     crate::secure_fs::append_private_line(
         &ocr_path,
-        &serde_json::to_string(&json!({
-            "schema_version": 1,
-            "captured_at": recorded_at,
-            "frame_index": frame_index,
-            "persisted_frame_path": sparse_frame_path,
-            "normalized_text": "",
-            "runs_ocr": false,
-            "ocr_status": "unavailable-linux"
-        }))?,
+        &serde_json::to_string(&ocr_result.to_json_line(
+            recorded_at,
+            frame_index,
+            &sparse_frame_path,
+            &latest_frame_path,
+            display_id,
+        ))?,
     )?;
     let pruned_file_count = prune_expired_chronicle_screen_recordings(screen_recording_dir)?;
 
@@ -1479,6 +1631,14 @@ fn write_chronicle_screen_recording_artifacts_inner(
         "capture_metadata_path": capture_metadata_path,
         "ocr_path": ocr_path,
         "sparse_frame_path": sparse_frame_path,
+        "ocr_status": ocr_result.status,
+        "ocr_backend": ocr_result.backend,
+        "ocr_language": ocr_result.language,
+        "ocr_runs": ocr_result.runs_ocr,
+        "ocr_truncated": ocr_result.truncated,
+        "ocr_text_observation_count": ocr_result.observations.len(),
+        "ocr_normalized_text_bytes": ocr_result.normalized_text.len(),
+        "ocr_error": ocr_result.error,
         "display_id": display_id,
         "frame_index": frame_index,
         "pruned_file_count": pruned_file_count,
@@ -1944,6 +2104,8 @@ struct StatusValueInput<'a> {
     started_at: Option<String>,
     end_reason: Option<String>,
     message: Option<String>,
+    ocr_policy: Option<crate::ocr::OcrPolicy>,
+    ocr_readiness: Option<crate::ocr::OcrReadiness>,
 }
 
 fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
@@ -1951,6 +2113,12 @@ fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
     let latest = latest_segment(input.paths)?;
     let exclusions_count = list_skysight_exclusions(input.paths)?.len();
     let capture_capabilities = capture_capability_notes();
+    let ocr_policy = input
+        .ocr_policy
+        .unwrap_or_else(crate::ocr::OcrPolicy::from_env);
+    let ocr_readiness = input
+        .ocr_readiness
+        .unwrap_or_else(|| ocr_policy.readiness());
     let summarizer_capabilities = summarizer_capability_notes();
     let process_start_time_ticks = input
         .pid
@@ -1985,7 +2153,7 @@ fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
     };
     Ok(SkysightStatus {
         ok: true,
-        schema_version: 2,
+        schema_version: 3,
         state: input.state.to_string(),
         is_running: input.is_running,
         paused: input.paused,
@@ -2027,6 +2195,20 @@ fn status_value(input: StatusValueInput<'_>) -> Result<SkysightStatus> {
         summary_agent_last_error: existing
             .as_ref()
             .and_then(|status| status.summary_agent_last_error.clone()),
+        ocr_enabled: ocr_readiness.enabled,
+        ocr_available: ocr_readiness.available,
+        ocr_mode: Some(ocr_policy.mode_name().to_string()),
+        ocr_status: Some(ocr_readiness.status),
+        ocr_backend: Some(ocr_readiness.backend),
+        ocr_backend_version: ocr_readiness.version,
+        ocr_language: Some(ocr_readiness.language),
+        ocr_dependency_hint: ocr_readiness.dependency_hint,
+        ocr_last_run_at: existing
+            .as_ref()
+            .and_then(|status| status.ocr_last_run_at.clone()),
+        ocr_last_error: existing
+            .as_ref()
+            .and_then(|status| status.ocr_last_error.clone()),
         pid: input.pid,
         process_start_time_ticks,
         started_at: input.started_at.or_else(|| {
@@ -2624,6 +2806,7 @@ fn format_10min_resource(
         .cloned()
         .unwrap_or(Value::Null);
     let browser_summary = browser_observation_summary(events).unwrap_or(Value::Null);
+    let ocr_summary = ocr_event_summary(events);
     let event_kinds = event_kind_counts(events);
     let segment_count = recent_segments.len().max(1);
     let event_total: usize = recent_segments
@@ -2642,7 +2825,7 @@ fn format_10min_resource(
         .sum::<usize>()
         .max(metadata.suppressed_event_count);
     format!(
-        "# Skysight Activity Summary\n\n## Memory summary\n\nLinux Skysight captured local activity at `{recorded_at}` from `{source}` and folded it into the current 10-minute window. The segment contains Computer Use diagnostics, provider readiness, and bounded desktop evidence artifacts for future Codex context. [skysight memory]\n\n### Relevant prior context\n\nThis summary covers `{segment_count}` segment(s) in the recent 10-minute window.\n\n### Important non-obvious context about the user\n\n- Linux Record & Replay Skysight wrote this segment under `{segment_dir}`.\n- Exclusion rules active during capture: `{exclusion_count}`.\n- Suppressed evidence records in the window: `{suppressed_total}`.\n\n## Recording summary\n\n- Segment events: `{events_path}`.\n- Segment metadata: `{metadata_path}`.\n- Event records in window: `{event_total}`.\n- Evidence artifacts in window: `{artifact_total}`.\n- Event kinds captured in this segment:\n\n```json\n{event_kinds}\n```\n\n- Windowing readiness is captured in the diagnostics payload and window metadata artifact when available.\n- Browser observation evidence is captured from filtered browser windows when available.\n- Accessibility readiness is captured in the diagnostics payload and AT-SPI artifact when available.\n- Browser observations:\n\n```json\n{browser_summary}\n```\n\n- Diagnostics summary:\n\n```json\n{diagnostics_summary}\n```\n\n- Capture capabilities:\n\n```json\n{capabilities}\n```\n\n## Citations\n\n- {events_path}\n- {metadata_path}\n",
+        "# Skysight Activity Summary\n\n## Memory summary\n\nLinux Skysight captured local activity at `{recorded_at}` from `{source}` and folded it into the current 10-minute window. The segment contains Computer Use diagnostics, provider readiness, and bounded desktop evidence artifacts for future Codex context. [skysight memory]\n\n### Relevant prior context\n\nThis summary covers `{segment_count}` segment(s) in the recent 10-minute window.\n\n### Important non-obvious context about the user\n\n- Linux Record & Replay Skysight wrote this segment under `{segment_dir}`.\n- Exclusion rules active during capture: `{exclusion_count}`.\n- Suppressed evidence records in the window: `{suppressed_total}`.\n\n## Recording summary\n\n- Segment events: `{events_path}`.\n- Segment metadata: `{metadata_path}`.\n- Event records in window: `{event_total}`.\n- Evidence artifacts in window: `{artifact_total}`.\n- Event kinds captured in this segment:\n\n```json\n{event_kinds}\n```\n\n- Windowing readiness is captured in the diagnostics payload and window metadata artifact when available.\n- Browser observation evidence is captured from filtered browser windows when available.\n- Accessibility readiness is captured in the diagnostics payload and AT-SPI artifact when available.\n- Browser observations:\n\n```json\n{browser_summary}\n```\n\n- OCR evidence:\n\n```json\n{ocr_summary}\n```\n\n- Diagnostics summary:\n\n```json\n{diagnostics_summary}\n```\n\n- Capture capabilities:\n\n```json\n{capabilities}\n```\n\n## Citations\n\n- {events_path}\n- {metadata_path}\n",
         segment_dir = metadata
             .metadata_path
             .parent()
@@ -2660,9 +2843,49 @@ fn format_10min_resource(
             .unwrap_or_else(|_| "null".to_string()),
         browser_summary =
             serde_json::to_string_pretty(&browser_summary).unwrap_or_else(|_| "null".to_string()),
+        ocr_summary =
+            serde_json::to_string_pretty(&ocr_summary).unwrap_or_else(|_| "null".to_string()),
         capabilities =
             serde_json::to_string_pretty(&capabilities).unwrap_or_else(|_| "null".to_string()),
     )
+}
+
+fn ocr_event_summary(events: &[Value]) -> Value {
+    let mut status_counts = std::collections::BTreeMap::<String, usize>::new();
+    let mut paths = Vec::<String>::new();
+    let mut normalized_text_bytes = 0_u64;
+    let mut truncated_count = 0_usize;
+
+    for event in events.iter().filter(|event| {
+        event.get("kind").and_then(Value::as_str) == Some("chronicle_screen_recording")
+    }) {
+        let status = event
+            .get("ocr_status")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        *status_counts.entry(status.to_string()).or_default() += 1;
+        if let Some(path) = event.get("ocr_path").and_then(Value::as_str) {
+            paths.push(path.to_string());
+        }
+        normalized_text_bytes += event
+            .get("ocr_normalized_text_bytes")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        if event
+            .get("ocr_truncated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            truncated_count += 1;
+        }
+    }
+
+    json!({
+        "status_counts": status_counts,
+        "ocr_paths": paths,
+        "normalized_text_bytes": normalized_text_bytes,
+        "truncated_count": truncated_count,
+    })
 }
 
 fn format_6h_resource(
@@ -3105,6 +3328,89 @@ mod tests {
     }
 
     #[test]
+    fn ocr_capture_status_tracks_only_actual_ocr_runs() {
+        let mut capture = DesktopEvidenceCapture::default();
+
+        record_ocr_capture_status(
+            &mut capture,
+            "2026-06-30T00:00:00Z",
+            &json!({
+                "ocr_runs": false,
+                "ocr_error": "provider probe failed",
+            }),
+        );
+        assert_eq!(capture.ocr_last_run_at, None);
+        assert_eq!(capture.ocr_last_error, None);
+
+        record_ocr_capture_status(
+            &mut capture,
+            "2026-06-30T00:01:00Z",
+            &json!({
+                "ocr_runs": true,
+                "ocr_error": "recognition failed",
+            }),
+        );
+        assert_eq!(
+            capture.ocr_last_run_at.as_deref(),
+            Some("2026-06-30T00:01:00Z")
+        );
+        assert_eq!(
+            capture.ocr_last_error.as_deref(),
+            Some("recognition failed")
+        );
+
+        record_ocr_capture_status(
+            &mut capture,
+            "2026-06-30T00:02:00Z",
+            &json!({
+                "ocr_runs": true,
+            }),
+        );
+        assert_eq!(
+            capture.ocr_last_run_at.as_deref(),
+            Some("2026-06-30T00:02:00Z")
+        );
+        assert_eq!(capture.ocr_last_error, None);
+    }
+
+    #[test]
+    fn status_value_does_not_report_readiness_probe_error_as_ocr_last_error() {
+        let _guard = env_guard();
+        let temp = tempfile::tempdir().unwrap();
+        let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+        ensure_layout(&paths).unwrap();
+
+        let status = status_value(StatusValueInput {
+            paths: &paths,
+            state: "running",
+            is_running: true,
+            paused: false,
+            pause_reason: None,
+            interval_seconds: Some(60),
+            pid: Some(std::process::id()),
+            started_at: Some(now_timestamp()),
+            end_reason: None,
+            message: None,
+            ocr_policy: Some(crate::ocr::OcrPolicy::from_env()),
+            ocr_readiness: Some(crate::ocr::OcrReadiness {
+                enabled: true,
+                available: false,
+                backend: "rapidocr-python".to_string(),
+                status: "backend_unavailable".to_string(),
+                language: "en".to_string(),
+                version: None,
+                dependency_hint: Some("install rapidocr".to_string()),
+                error: Some("readiness probe failed".to_string()),
+            }),
+        })
+        .unwrap();
+
+        assert_eq!(status.ocr_status.as_deref(), Some("backend_unavailable"));
+        assert_eq!(status.ocr_last_run_at, None);
+        assert_eq!(status.ocr_last_error, None);
+    }
+
+    #[test]
     fn resource_timestamp_parses_chronicle_style_names() {
         let path = PathBuf::from("2026-06-30T15-04-05-abcd-6h-linux-activity.md");
         let parsed = resource_timestamp(&path).unwrap();
@@ -3204,6 +3510,8 @@ mod tests {
             started_at: Some(now_timestamp()),
             end_reason: None,
             message: Some("test daemon alive".to_string()),
+            ocr_policy: None,
+            ocr_readiness: None,
         })
         .unwrap();
         write_status(&paths, &status).unwrap();
@@ -3275,6 +3583,8 @@ mod tests {
             started_at: Some(now_timestamp()),
             end_reason: None,
             message: None,
+            ocr_policy: None,
+            ocr_readiness: None,
         })
         .unwrap();
         status.summary_agent_state = Some(first.state);
@@ -3394,6 +3704,17 @@ mod tests {
     fn screenshot_is_suppressed_when_exclusions_cannot_be_verified() {
         let temp = tempfile::tempdir().unwrap();
         let mut capture = DesktopEvidenceCapture::default();
+        let ocr_policy = crate::ocr::OcrPolicy::from_env();
+        let ocr_readiness = crate::ocr::OcrReadiness {
+            enabled: false,
+            available: false,
+            backend: "auto".to_string(),
+            status: "disabled".to_string(),
+            language: "eng".to_string(),
+            version: None,
+            dependency_hint: None,
+            error: None,
+        };
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -3401,14 +3722,19 @@ mod tests {
 
         runtime
             .block_on(capture_screenshot_evidence(
-                temp.path(),
-                "2026-06-30T00:00:00Z",
-                "test",
+                ScreenshotEvidenceContext {
+                    segment_dir: temp.path(),
+                    recorded_at: "2026-06-30T00:00:00Z",
+                    source: "test",
+                    screen_recording_dir: None,
+                    ocr_policy: &ocr_policy,
+                    ocr_readiness: &ocr_readiness,
+                },
                 ScreenshotSuppression {
                     unverified_exclusions: true,
                     ..Default::default()
                 },
-                None,
+                &[],
                 &mut capture,
             ))
             .unwrap();

--- a/record-replay-linux/tests/skysight_tests.rs
+++ b/record-replay-linux/tests/skysight_tests.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 use std::{
     collections::BTreeSet,
     env, fs,
+    os::unix::fs::PermissionsExt,
+    path::Path,
     sync::{Mutex, OnceLock},
 };
 
@@ -185,6 +187,15 @@ fn skysight_snapshot_creates_segment_directory_and_rollup_resources() {
         .is_some_and(|name| name.contains("-6h-")));
     assert_eq!(status.exclusions_count, 0);
     assert!(!status.capture_capability_notes.is_empty());
+    assert!(status
+        .ocr_backend
+        .as_deref()
+        .is_some_and(|backend| matches!(backend, "rapidocr-python" | "tesseract-cli" | "auto")));
+    assert_eq!(status.ocr_language.as_deref(), Some("eng"));
+    assert!(status
+        .ocr_status
+        .as_deref()
+        .is_some_and(|state| matches!(state, "available" | "backend_unavailable" | "disabled")));
     assert!(!status.summarizer_capability_notes.is_empty());
 
     let events = read_jsonl(&events_path);
@@ -222,6 +233,7 @@ fn skysight_snapshot_creates_segment_directory_and_rollup_resources() {
     assert!(resource.contains("Event kinds captured"));
     assert!(resource.contains("Evidence artifacts in window"));
     assert!(resource.contains("Browser observations"));
+    assert!(resource.contains("OCR evidence"));
     assert!(resource.contains("Diagnostics summary"));
     assert!(resource.contains("Capture capabilities"));
     assert!(status
@@ -258,6 +270,42 @@ fn skysight_snapshot_creates_segment_directory_and_rollup_resources() {
     let stopped = stop_skysight(&paths).unwrap();
     assert_eq!(stopped.state, "stopped");
     assert!(!stopped.is_running);
+}
+
+#[test]
+fn skysight_status_reports_fake_tesseract_ocr_readiness() {
+    let _guard = env_guard();
+    let old_ocr = env::var_os("CODEX_SKYSIGHT_OCR");
+    let old_backend = env::var_os("CODEX_SKYSIGHT_OCR_BACKEND");
+    let old_tesseract = env::var_os("CODEX_SKYSIGHT_TESSERACT_PATH");
+    let old_lang = env::var_os("CODEX_SKYSIGHT_OCR_LANG");
+
+    let temp = tempfile::tempdir().unwrap();
+    let fake_tesseract = temp.path().join("fake-tesseract");
+    write_fake_tesseract(&fake_tesseract, "version-only");
+    env::set_var("CODEX_SKYSIGHT_OCR", "enabled");
+    env::set_var("CODEX_SKYSIGHT_OCR_BACKEND", "tesseract");
+    env::set_var("CODEX_SKYSIGHT_TESSERACT_PATH", &fake_tesseract);
+    env::set_var("CODEX_SKYSIGHT_OCR_LANG", "eng");
+
+    let paths = SkysightPaths::new(temp.path().join("runtime"), temp.path().join("resources"));
+    let status = skysight_status(&paths).unwrap();
+    let value = serde_json::to_value(status).unwrap();
+
+    assert_eq!(value["ocr_enabled"], true);
+    assert_eq!(value["ocr_available"], true);
+    assert_eq!(value["ocr_mode"], "enabled");
+    assert_eq!(value["ocr_status"], "available");
+    assert_eq!(value["ocr_backend"], "tesseract-cli");
+    assert_eq!(value["ocr_language"], "eng");
+    assert!(value["ocr_backend_version"]
+        .as_str()
+        .is_some_and(|version| version.contains("tesseract")));
+
+    restore_env("CODEX_SKYSIGHT_OCR", old_ocr);
+    restore_env("CODEX_SKYSIGHT_OCR_BACKEND", old_backend);
+    restore_env("CODEX_SKYSIGHT_TESSERACT_PATH", old_tesseract);
+    restore_env("CODEX_SKYSIGHT_OCR_LANG", old_lang);
 }
 
 #[test]
@@ -377,4 +425,28 @@ fn read_jsonl(path: &std::path::Path) -> Vec<Value> {
         .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str(line).unwrap())
         .collect()
+}
+
+fn write_fake_tesseract(path: &Path, mode: &str) {
+    let body = match mode {
+        "version-only" => {
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  echo "tesseract 5.3.4"
+  exit 0
+fi
+out="${2}.tsv"
+cat > "$out" <<'TSV'
+level	page_num	block_num	par_num	line_num	word_num	left	top	width	height	conf	text
+5	1	1	1	1	1	10	20	40	12	95	Codex
+TSV
+"#
+        }
+        other => panic!("unknown fake tesseract mode {other}"),
+    };
+    fs::write(path, body).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
 }


### PR DESCRIPTION
Summary
- Adds local Skysight OCR evidence with a backend-neutral OCR result contract.
- Uses RapidOCR plus ONNXRuntime as the preferred optional backend when available.
- Preserves Tesseract CLI as fallback and keeps OCR non-fatal unless required.

Validation
- cargo fmt --check -p codex-record-replay-linux
- cargo test -p codex-record-replay-linux
- node --test linux-features/record-and-replay/test.js
- Real RapidOCR smoke in devcontainer with rapidocr, onnxruntime, pillow, and libgl1 recognized a generated Codex RapidOCR image.
