### PR TITLE
Add upstream DMG intelligence tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/codex-*
 target/
 dist/
 dist-next/
+reports/upstream-dmg/
 linux-features/features.json
 linux-features/local/
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ SHELL := bash
 APP_DIR := $(CURDIR)/codex-app
 NEXT_APP_DIR := $(CURDIR)/codex-app-next
 REBUILD_REPORT_DIR := $(CURDIR)/dist-next/rebuild
+UPSTREAM_INTEL_CANDIDATE ?= $(strip $(DMG))
+UPSTREAM_INTEL_HOST_CANDIDATE := $(if $(strip $(UPSTREAM_INTEL_CANDIDATE)),$(UPSTREAM_INTEL_CANDIDATE),$(CURDIR)/Codex.dmg)
+UPSTREAM_INTEL_BASELINE ?=
+UPSTREAM_INTEL_PATCH_REPORT ?= $(REBUILD_REPORT_DIR)/patch-report.json
+UPSTREAM_INTEL_IMAGE ?= codex-desktop-linux-devcontainer:local
 PACKAGE_NAME := codex-desktop
 PACKAGE_WITH_UPDATER ?= 1
 MAX_BUILD_THREADS ?= 0
@@ -60,7 +65,7 @@ if [ -z "$$format" ]; then \
 fi; \
 printf '%s\n' "$$format"
 
-.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
+.PHONY: help check test build-updater maybe-build-updater update rebuild rebuild-install inspect-upstream inspect-upstream-intel inspect-upstream-intel-devcontainer build-app build-app-fresh setup-native bootstrap-native install-native update-native rebuild-next run-app build-dev-app run-dev-app deb rpm pacman appimage package install service-enable service-status clean-dist clean-state
 
 help:
 	@printf '\nCodex Desktop Linux Make Targets\n\n'
@@ -71,6 +76,8 @@ help:
 	@printf '  %-18s %s\n' "make rebuild" "Inspect a DMG and build a side-by-side candidate"
 	@printf '  %-18s %s\n' "make rebuild-install" "Find a DMG, rebuild, and install into codex-app/"
 	@printf '  %-18s %s\n' "make inspect-upstream" "Inspect a DMG and write rebuild reports without changing codex-app/"
+	@printf '  %-18s %s\n' "make inspect-upstream-intel" "Inventory protected upstream DMG surfaces and write drift reports"
+	@printf '  %-18s %s\n' "make inspect-upstream-intel-devcontainer" "Run upstream DMG intelligence inside the devcontainer image"
 	@printf '  %-18s %s\n' "make build-app" "Run install.sh and regenerate codex-app/ (reuses cached Codex.dmg)"
 	@printf '  %-18s %s\n' "make build-app-fresh" "Remove generated app and refresh cached Codex.dmg by default"
 	@printf '  %-18s %s\n' "make setup-native" "Guided setup summary and Linux feature config helper"
@@ -92,7 +99,10 @@ help:
 	@printf '  %-18s %s\n' "make clean-dist" "Remove generated dist/ artifacts"
 	@printf '  %-18s %s\n' "make clean-state" "Remove updater runtime state from XDG directories"
 	@printf '\nVariables:\n\n'
-	@printf '  %-18s %s\n' "DMG=/path/file.dmg" "Override the DMG; rebuild commands auto-find ./Codex.dmg"
+	@printf '  %-18s %s\n' "DMG=/path/file.dmg" "Override the DMG; devcontainer intel downloads latest when omitted"
+	@printf '  %-18s %s\n' "UPSTREAM_INTEL_BASELINE=..." "Optional known-good DMG/.app; defaults to ./Codex.dmg when different"
+	@printf '  %-18s %s\n' "UPSTREAM_INTEL_PATCH_REPORT=..." "Optional patch-report.json folded into upstream intelligence drift"
+	@printf '  %-18s %s\n' "UPSTREAM_INTEL_IMAGE=..." "Docker image for make inspect-upstream-intel-devcontainer"
 	@printf '  %-18s %s\n' "NEXT_APP_DIR=..." "Override side-by-side rebuild candidate directory"
 	@printf '  %-18s %s\n' "APP_DIR=..." "Override final app directory for make rebuild-install"
 	@printf '  %-18s %s\n' "REBUILD_REPORT_DIR=..." "Override inspect/rebuild report output directory"
@@ -117,6 +127,9 @@ help:
 	@printf '  %s\n' "make install-native"
 	@printf '  %s\n' "PACKAGE_WITH_UPDATER=0 make update-native"
 	@printf '  %s\n' "make inspect-upstream DMG=/tmp/Codex.dmg"
+	@printf '  %s\n' "make inspect-upstream-intel DMG=/tmp/Codex-new.dmg"
+	@printf '  %s\n' "make inspect-upstream-intel-devcontainer"
+	@printf '  %s\n' "make inspect-upstream-intel-devcontainer DMG=/tmp/Codex-new.dmg"
 	@printf '  %s\n' "make rebuild-next DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make run-app"
 	@printf '  %s\n' "make build-dev-app"
@@ -170,6 +183,31 @@ rebuild-install:
 inspect-upstream:
 	@echo "[make] Inspecting upstream DMG"
 	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" ./install.sh --inspect --report-dir "$(REBUILD_REPORT_DIR)" "$(DMG)"
+
+inspect-upstream-intel:
+	@echo "[make] Building upstream DMG intelligence report"
+	@args=(--candidate "$(UPSTREAM_INTEL_HOST_CANDIDATE)"); \
+	if [ -n "$(UPSTREAM_INTEL_BASELINE)" ]; then \
+		args+=("--baseline" "$(UPSTREAM_INTEL_BASELINE)"); \
+	fi; \
+	if [ -f "$(UPSTREAM_INTEL_PATCH_REPORT)" ]; then \
+		args+=("--patch-report" "$(UPSTREAM_INTEL_PATCH_REPORT)"); \
+	fi; \
+	node scripts/dev/upstream-dmg-intel.js "$${args[@]}"
+
+inspect-upstream-intel-devcontainer:
+	@echo "[make] Building upstream DMG intelligence report in devcontainer"
+	@args=(--image "$(UPSTREAM_INTEL_IMAGE)"); \
+	if [ -n "$(UPSTREAM_INTEL_CANDIDATE)" ]; then \
+		args+=("--candidate" "$(UPSTREAM_INTEL_CANDIDATE)"); \
+	fi; \
+	if [ -n "$(UPSTREAM_INTEL_BASELINE)" ]; then \
+		args+=("--baseline" "$(UPSTREAM_INTEL_BASELINE)"); \
+	fi; \
+	if [ -f "$(UPSTREAM_INTEL_PATCH_REPORT)" ]; then \
+		args+=("--patch-report" "$(UPSTREAM_INTEL_PATCH_REPORT)"); \
+	fi; \
+	scripts/dev/upstream-dmg-intel-devcontainer "$${args[@]}"
 
 build-app:
 	@echo "[make] Regenerating codex-app from DMG"

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -85,6 +85,27 @@ reuses the existing cached `Codex.dmg` verbatim, skips upstream metadata checks,
 and fails instead of downloading when no cached DMG or explicit `DMG=...` path is
 available. This also keeps `--fresh` from deleting the cached DMG.
 
+Before accepting a fast-moving upstream DMG, run the report-only intelligence
+lane to inventory protected Sky/Chronicle/Skysight/Computer Use/Record & Replay
+surfaces:
+
+```bash
+make inspect-upstream DMG=/path/to/Codex.dmg
+make inspect-upstream-intel-devcontainer
+```
+
+The devcontainer intelligence target downloads the current upstream DMG into
+`reports/upstream-dmg/downloads/` when `DMG=...` is omitted and automatically
+compares it against repo `./Codex.dmg` when that cached baseline exists.
+For an already downloaded candidate, pass only that one path:
+
+```bash
+make inspect-upstream-intel-devcontainer DMG=/path/to/new/Codex.dmg
+```
+
+See `docs/upstream-dmg-intelligence.md` for the protected-surface registry,
+JSON/Markdown report outputs, and fixture-based test strategy.
+
 Run the generated app:
 
 ```bash

--- a/docs/upstream-dmg-intelligence.md
+++ b/docs/upstream-dmg-intelligence.md
@@ -1,0 +1,194 @@
+# Upstream DMG Intelligence
+
+Use this lane when OpenAI ships a new macOS `Codex.dmg` and Linux parity work
+needs to know what moved before accepting the build.
+
+The intelligence command is report-only. It extracts a candidate DMG or scans an
+already extracted `.app`, inventories protected surfaces, and writes a JSON plus
+Markdown battle report under `reports/upstream-dmg/<timestamp>/`. That directory
+is gitignored; check in only deliberate fixtures or registry changes.
+
+## Commands
+
+Current upstream-vs-cached baseline check, using the repo devcontainer image:
+
+```bash
+make inspect-upstream-intel-devcontainer
+```
+
+The devcontainer wrapper is the preferred path for real DMG checks because it
+keeps `7zz`, Node, `jq`, and report-generation dependencies inside the project
+container. With no `DMG=...`, it downloads the current upstream DMG into the
+gitignored `reports/upstream-dmg/downloads/` directory and automatically uses
+repo `./Codex.dmg` as the baseline when that cached file exists and differs
+from the candidate. It builds `codex-desktop-linux-devcontainer:local` from
+`.devcontainer/Dockerfile` if that image is missing, mounts outside candidate
+or baseline paths into the container, and writes only the ignored report bundle
+under `reports/upstream-dmg/` by default.
+
+Inspect a specific candidate DMG without spelling out the baseline:
+
+```bash
+make inspect-upstream-intel-devcontainer DMG=/tmp/Codex-new.dmg
+```
+
+Host-side candidate-only inventory is still available when the host already has
+the same toolchain:
+
+```bash
+make inspect-upstream-intel DMG=./Codex.dmg
+```
+
+For CI or release acceptance, keep report generation unchanged but fail the
+command when protected-surface blockers are present:
+
+```bash
+scripts/dev/upstream-dmg-intel.js \
+  --candidate /path/to/new/Codex.dmg \
+  --fail-on-blockers
+```
+
+Explicit baseline comparison remains available for older known-good builds:
+
+```bash
+scripts/dev/upstream-dmg-intel.js \
+  --baseline /path/to/known-good/Codex.app \
+  --candidate /path/to/new/Codex.dmg
+```
+
+Pair it with the existing patch report path:
+
+```bash
+make inspect-upstream DMG=/path/to/new/Codex.dmg
+make inspect-upstream-intel-devcontainer DMG=/path/to/new/Codex.dmg
+```
+
+When `dist-next/rebuild/patch-report.json` exists, `make inspect-upstream-intel`
+folds it into the drift report. Required patch failures are classified as
+blocking `PATCH_BROKEN`; optional skipped or warning statuses are classified as
+review-only `PATCH_REVIEW`.
+
+## Outputs
+
+Each run writes:
+
+- `inventory.json`: normalized file inventory from resources, `app.asar`, and
+  extracted `app.asar.extracted` fixtures when present.
+- `protected-surfaces.json`: checked registry surfaces with evidence paths,
+  string hits, fingerprints, and Linux substrate status.
+- `bridge-map.json`: Electron IPC/context bridge handler names plus minified
+  string-literal channel candidates found in scanned text bundles.
+- `plugin-map.json`: bundled plugin manifests, MCP configs, and skill files.
+- `native-binary-map.json`: native candidate paths, file type output when
+  available, hashes, and protected string evidence.
+- `map-drift.json`: baseline/candidate structural deltas for bridge handlers,
+  plugin ids/files, MCP tools, native binaries, and Linux substrate gaps.
+- `drift-report.json` and `drift-report.md`: machine and human drift summaries.
+- `substrate-action-plan.md`: Linux follow-up paths for moved, changed, missing,
+  newly discovered, patch-broken, or substrate-gap surfaces.
+
+The CLI stdout summary includes `decision.acceptance`, `blockersCount`,
+`reviewItemsCount`, protected-surface status counts, and whether every protected
+surface is fully present. `--fail-on-blockers` exits with status `2` after
+writing the report bundle when `decision.blockersCount` is nonzero.
+
+When a baseline is provided, the command also writes `baseline/` and
+`candidate/` subdirectories with their own inventory, protected-surface,
+bridge, plugin, and native-binary maps so root-cause drift can be inspected
+without reverse-engineering the summary report.
+
+## Protected Surfaces
+
+The checked-in registry lives at:
+
+```bash
+scripts/dev/upstream-dmg-protected-surfaces.json
+```
+
+It currently protects the surfaces Linux mirrors or patches most aggressively:
+
+- `codex_chronicle`
+- `chronicle_settings_toggles`
+- `sky_computer_use_client`
+- `skysight_bridge`
+- `event_stream_mcp`
+- `record_and_replay_plugin`
+- `computer_use_plugin`
+- `chrome_native_messaging`
+- `dictation_transcript_finalization`
+- `browser_window_metadata`
+- `electron_ipc_bridge_handlers`
+- `plugin_manifests_marketplace`
+- `native_bridge_sidecars`
+- `browser_use_plugin`
+- `browser_use_node_repl_runtime`
+- `browser_use_native_pipe_bridge`
+- `browser_use_policy_shims`
+
+Do not treat registry names as proof that upstream still uses those names. The
+scanner records actual path, content, plugin, bridge, native string, and hash
+evidence from the candidate build.
+
+Registry entries can declare `requiredEvidence` anchors. A surface is `PRESENT`
+only when those anchors are satisfied; loose matches are reported as `PARTIAL`
+with `satisfiedAnchors`, `missingAnchors`, and `confidence` fields.
+
+The `chronicle_settings_toggles` surface intentionally protects both Settings
+routes that can change Chronicle state:
+
+- the dedicated Chronicle research preview row, including enable and disable
+  handlers;
+- the broad Memory master toggle path that calls `chronicleDisable` while
+  changing memory feature/config state.
+
+If either route moves or disappears, treat it as a Chronicle/Skysight parity
+review item before accepting the upstream DMG.
+
+## Drift Classifications
+
+- `UNCHANGED`: the protected surface is present with the same evidence paths and
+  fingerprint.
+- `MOVED`: the surface is still present, but evidence paths changed.
+- `RENAMED`: reserved for future structured rename hints.
+- `PAYLOAD_CHANGED`: paths remained stable, but content or native string
+  evidence changed.
+- `REMOVED`: a baseline-present surface disappeared from the candidate.
+- `NEW_UPSTREAM_CAPABILITY`: a candidate-present surface was missing in the
+  baseline.
+- `PATCH_BROKEN`: a required patch-report failure matched this protected
+  surface.
+- `PATCH_REVIEW`: an optional patch-report warning or skip matched this
+  protected surface.
+- `LINUX_SUBSTRATE_GAP`: upstream evidence exists, but the registry's required
+  Linux substrate path is missing.
+
+## Acceptance Gate
+
+The automated tests use synthetic `.app` fixtures and `app.asar.extracted`
+directories so normal verification does not rebuild Electron or require the real
+DMG. Manual real-DMG verification is still required before accepting a new
+upstream build. The normal path downloads current upstream and compares it to
+the cached repo baseline:
+
+```bash
+node --test scripts/dev/upstream-dmg-intel.test.js
+scripts/dev/upstream-dmg-intel-devcontainer \
+  --output-dir reports/upstream-dmg/<run-id>
+```
+
+Review `protected-surfaces.json` first. A candidate should not be accepted while
+required protected surfaces are `PARTIAL` or `MISSING` unless the Linux substrate
+owner has explicitly retired or replaced that contract. Then review
+`drift-report.json`, `drift-report.md`, and `substrate-action-plan.md` as the
+navigation layer:
+
+- `MOVED` with no structural bridge/plugin/MCP/native additions or removals is
+  usually hashed asset churn; update Linux code only when a patch, staging rule,
+  or mirror references one of the old paths.
+- `PAYLOAD_CHANGED` means a stable protected file changed hash or size. Review
+  the listed file samples and run the owning Linux feature or backend tests.
+- `REMOVED`, `PROTECTED_SURFACE_MISSING`, `PROTECTED_SURFACE_PARTIAL`,
+  `PATCH_BROKEN`, and `LINUX_SUBSTRATE_GAP` are acceptance blockers until the
+  registry, patch, or Linux substrate action is resolved. `PATCH_REVIEW` remains
+  review-only unless the protected surface is also missing, partial, removed, or
+  has a required patch failure.

--- a/scripts/dev/upstream-dmg-intel-devcontainer
+++ b/scripts/dev/upstream-dmg-intel-devcontainer
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/dev/upstream-dmg-intel-devcontainer [--candidate PATH|latest] [options]
+
+Run upstream DMG intelligence inside the repo devcontainer image. This keeps
+7zz/Node/tooling requirements out of the host while writing reports under the
+gitignored reports/upstream-dmg/ tree by default.
+
+Options:
+  --candidate PATH       Candidate Codex.dmg, extracted .app, or resources dir
+  --candidate latest     Download current upstream DMG into reports/upstream-dmg/downloads/
+                         Default when no candidate is passed
+  --candidate-url URL    Upstream DMG URL for --candidate latest
+                         Default: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+  --baseline PATH        Optional known-good baseline DMG or extracted .app;
+                         defaults to repo ./Codex.dmg when different
+  --no-baseline          Do a candidate-only scan even when ./Codex.dmg exists
+  --patch-report PATH    Optional patch-report.json
+  --registry PATH        Optional protected-surface registry path
+  --output-dir DIR       Output dir inside this repo; default is tool default
+  --timestamp VALUE      Timestamp slug used when --output-dir is omitted
+  --image IMAGE          Devcontainer image (default: codex-desktop-linux-devcontainer:local)
+  --build-image          Build the devcontainer image if missing
+  --no-build-image       Fail if the devcontainer image is missing
+  -h, --help             Show this help
+
+Examples:
+  scripts/dev/upstream-dmg-intel-devcontainer
+  scripts/dev/upstream-dmg-intel-devcontainer --candidate /tmp/Codex-new.dmg
+EOF
+}
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+image="${CODEX_DMG_INTEL_IMAGE:-codex-desktop-linux-devcontainer:local}"
+candidate_url="${CODEX_DMG_INTEL_CANDIDATE_URL:-${CODEX_UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}}"
+build_image=auto
+candidate_path=""
+baseline_path=""
+auto_baseline=1
+patch_report_path=""
+registry_path=""
+output_dir=""
+timestamp=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --candidate)
+      candidate_path="${2:-}"
+      shift 2
+      ;;
+    --candidate-url)
+      candidate_url="${2:-}"
+      shift 2
+      ;;
+    --baseline)
+      baseline_path="${2:-}"
+      auto_baseline=0
+      shift 2
+      ;;
+    --no-baseline)
+      auto_baseline=0
+      baseline_path=""
+      shift
+      ;;
+    --patch-report)
+      patch_report_path="${2:-}"
+      shift 2
+      ;;
+    --registry)
+      registry_path="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --timestamp)
+      timestamp="${2:-}"
+      shift 2
+      ;;
+    --image)
+      image="${2:-}"
+      shift 2
+      ;;
+    --build-image)
+      build_image=yes
+      shift
+      ;;
+    --no-build-image)
+      build_image=no
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$candidate_path" && "${1:0:1}" != "-" ]]; then
+        candidate_path="$1"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        echo >&2
+        usage >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+if [[ -z "$candidate_path" ]]; then
+  candidate_path="latest"
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required for upstream-dmg-intel-devcontainer" >&2
+  exit 127
+fi
+
+if ! docker image inspect "$image" >/dev/null 2>&1; then
+  case "$build_image" in
+    no)
+      echo "Docker image not found: $image" >&2
+      echo "Run with --build-image or build the devcontainer image first." >&2
+      exit 2
+      ;;
+    auto|yes)
+      docker build -t "$image" -f "$repo_root/.devcontainer/Dockerfile" "$repo_root"
+      ;;
+  esac
+fi
+
+resolve_existing() {
+  local label="$1"
+  local value="$2"
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  if [[ ! -e "$value" ]]; then
+    echo "$label not found: $value" >&2
+    exit 2
+  fi
+  python3 - "$value" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+}
+
+repo_real="$(python3 - "$repo_root" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).resolve())
+PY
+)"
+
+mounts=(-v "$repo_real:/workspaces/codex-desktop-linux")
+container_args=()
+mount_index=0
+mapped_path=""
+
+map_input_path() {
+  local label="$1"
+  local value="$2"
+  local abs rel base target
+  abs="$(resolve_existing "$label" "$value")"
+  case "$abs" in
+    "$repo_real"/*)
+      rel="${abs#"$repo_real"/}"
+      mapped_path="/workspaces/codex-desktop-linux/$rel"
+      ;;
+    "$repo_real")
+      mapped_path="/workspaces/codex-desktop-linux"
+      ;;
+    *)
+      base="$(basename "$abs")"
+      target="/mnt/upstream-dmg-intel/${mount_index}-${base}"
+      mount_index=$((mount_index + 1))
+      mounts+=(-v "$abs:$target:ro")
+      mapped_path="$target"
+      ;;
+  esac
+}
+
+map_output_dir() {
+  local value="$1"
+  local abs rel
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  abs="$(python3 - "$value" <<'PY'
+import sys
+from pathlib import Path
+
+print(Path(sys.argv[1]).expanduser().resolve())
+PY
+)"
+  case "$abs" in
+    "$repo_real"/*)
+      rel="${abs#"$repo_real"/}"
+      mapped_path="/workspaces/codex-desktop-linux/$rel"
+      ;;
+    *)
+      echo "--output-dir must be inside the repository so report output stays scoped and gitignored: $value" >&2
+      exit 2
+      ;;
+  esac
+}
+
+if [[ -z "$candidate_path" || "$candidate_path" == "latest" ]]; then
+  case "$candidate_url" in
+    https://*)
+      ;;
+    *)
+      echo "--candidate-url must be an HTTPS URL: $candidate_url" >&2
+      exit 2
+      ;;
+  esac
+  mapped_path="/workspaces/codex-desktop-linux/reports/upstream-dmg/downloads/Codex.dmg"
+  container_args+=(--candidate "$mapped_path")
+else
+  map_input_path "Candidate" "$candidate_path"
+  container_args+=(--candidate "$mapped_path")
+fi
+
+if [[ -n "$baseline_path" ]]; then
+  map_input_path "Baseline" "$baseline_path"
+  container_args+=(--baseline "$mapped_path")
+elif [[ "$auto_baseline" != "1" ]]; then
+  container_args+=(--no-baseline)
+fi
+
+if [[ -z "$patch_report_path" && -f "$repo_real/dist-next/rebuild/patch-report.json" ]]; then
+  patch_report_path="$repo_real/dist-next/rebuild/patch-report.json"
+fi
+if [[ -n "$patch_report_path" ]]; then
+  map_input_path "Patch report" "$patch_report_path"
+  container_args+=(--patch-report "$mapped_path")
+fi
+
+if [[ -n "$registry_path" ]]; then
+  map_input_path "Registry" "$registry_path"
+  container_args+=(--registry "$mapped_path")
+fi
+
+if [[ -n "$output_dir" ]]; then
+  map_output_dir "$output_dir"
+  container_args+=(--output-dir "$mapped_path")
+fi
+
+if [[ -n "$timestamp" ]]; then
+  container_args+=(--timestamp "$timestamp")
+fi
+
+docker_args=(--rm "${mounts[@]}" -w /workspaces/codex-desktop-linux)
+
+if [[ -z "$candidate_path" || "$candidate_path" == "latest" ]]; then
+  exec docker run \
+    "${docker_args[@]}" \
+    -e CODEX_DMG_INTEL_CANDIDATE_URL="$candidate_url" \
+    "$image" \
+    bash -lc '
+      set -euo pipefail
+      candidate_path="/workspaces/codex-desktop-linux/reports/upstream-dmg/downloads/Codex.dmg"
+      mkdir -p "$(dirname "$candidate_path")"
+      tmp_path="${candidate_path}.part"
+      curl -fL --retry 3 --connect-timeout 30 --max-time 600 \
+        -o "$tmp_path" "$CODEX_DMG_INTEL_CANDIDATE_URL"
+      mv "$tmp_path" "$candidate_path"
+      node scripts/dev/upstream-dmg-intel.js "$@"
+    ' bash "${container_args[@]}"
+fi
+
+exec docker run \
+  "${docker_args[@]}" \
+  "$image" \
+  node scripts/dev/upstream-dmg-intel.js "${container_args[@]}"

--- a/scripts/dev/upstream-dmg-intel.js
+++ b/scripts/dev/upstream-dmg-intel.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { buildIntelReports } = require("../lib/upstream-dmg-intel.js");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const defaultRegistryPath = path.join(__dirname, "upstream-dmg-protected-surfaces.json");
+const BLOCKING_CLASSIFICATIONS = new Set([
+  "REMOVED",
+  "PATCH_BROKEN",
+  "LINUX_SUBSTRATE_GAP",
+  "PROTECTED_SURFACE_PARTIAL",
+  "PROTECTED_SURFACE_MISSING",
+]);
+
+function usage() {
+  return `Usage: scripts/dev/upstream-dmg-intel.js --candidate PATH [options]
+
+Build an upstream DMG intelligence report without mutating codex-app/.
+
+Options:
+  --candidate PATH       Candidate Codex.dmg, extracted .app, or extracted app resources directory
+  --baseline PATH        Optional known-good baseline DMG or extracted .app; defaults to ./Codex.dmg when different
+  --no-baseline          Do a candidate-only scan even when ./Codex.dmg exists
+  --patch-report PATH    Optional patch-report.json to fold patch blockers/review items into drift-report.json
+  --registry PATH        Protected surface registry (default: scripts/dev/upstream-dmg-protected-surfaces.json)
+  --output-dir DIR       Exact output directory (default: reports/upstream-dmg/<timestamp>)
+  --timestamp VALUE      Timestamp slug used when --output-dir is omitted
+  --fail-on-blockers     Exit nonzero when protected-surface acceptance blockers are present
+  -h, --help             Show this help
+`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    autoBaseline: true,
+    baselinePath: null,
+    candidatePath: null,
+    outputDir: null,
+    failOnBlockers: false,
+    patchReportPath: null,
+    registryPath: defaultRegistryPath,
+    timestamp: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--candidate") {
+      args.candidatePath = argv[++index];
+    } else if (arg === "--baseline") {
+      args.baselinePath = argv[++index];
+    } else if (arg === "--no-baseline") {
+      args.autoBaseline = false;
+      args.baselinePath = null;
+    } else if (arg === "--patch-report") {
+      args.patchReportPath = argv[++index];
+    } else if (arg === "--registry") {
+      args.registryPath = argv[++index];
+    } else if (arg === "--output-dir") {
+      args.outputDir = argv[++index];
+    } else if (arg === "--timestamp") {
+      args.timestamp = argv[++index];
+    } else if (arg === "--fail-on-blockers") {
+      args.failOnBlockers = true;
+    } else if (arg === "-h" || arg === "--help") {
+      args.help = true;
+    } else if (!arg.startsWith("-") && args.candidatePath == null) {
+      args.candidatePath = arg;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function requireReadable(label, filePath) {
+  if (filePath == null) {
+    throw new Error(`${label} is required`);
+  }
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`${label} not found: ${filePath}`);
+  }
+}
+
+function statusCounts(surfaces = []) {
+  const counts = {};
+  for (const surface of surfaces) {
+    counts[surface.status] = (counts[surface.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function buildDecision({ driftReport, protectedSurfaces }) {
+  const surfaceDrift = driftReport.surfaceDrift ?? [];
+  const blockers = surfaceDrift.filter((item) => BLOCKING_CLASSIFICATIONS.has(item.classification));
+  const reviewItems = surfaceDrift.filter((item) => !BLOCKING_CLASSIFICATIONS.has(item.classification));
+  const protectedSurfaceStatusCounts = statusCounts(protectedSurfaces.surfaces ?? []);
+  const allProtectedSurfacesPresent =
+    (protectedSurfaces.surfaces ?? []).length > 0 &&
+    (protectedSurfaces.surfaces ?? []).every((surface) => surface.status === "PRESENT");
+  const acceptance = blockers.length > 0 ? "blocked" : (reviewItems.length > 0 ? "review" : "accepted");
+
+  return {
+    acceptance,
+    blockersCount: blockers.length,
+    reviewItemsCount: reviewItems.length,
+    allProtectedSurfacesPresent,
+    protectedSurfaceStatusCounts,
+    blockerClassifications: [...new Set(blockers.map((item) => item.classification))].sort(),
+  };
+}
+
+function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    process.stdout.write(usage());
+    return 0;
+  }
+
+  requireReadable("Candidate", args.candidatePath);
+  requireReadable("Registry", args.registryPath);
+  if (args.baselinePath != null) {
+    requireReadable("Baseline", args.baselinePath);
+  }
+  if (args.patchReportPath != null) {
+    requireReadable("Patch report", args.patchReportPath);
+  }
+
+  const registry = JSON.parse(fs.readFileSync(args.registryPath, "utf8"));
+  const reports = buildIntelReports({
+    autoBaseline: args.autoBaseline,
+    baselinePath: args.baselinePath,
+    candidatePath: args.candidatePath,
+    outputDir: args.outputDir,
+    patchReportPath: args.patchReportPath,
+    registry,
+    repoRoot,
+    timestamp: args.timestamp,
+  });
+  const decision = buildDecision({
+    driftReport: reports.driftReport,
+    protectedSurfaces: reports.protectedSurfaces,
+  });
+
+  const summary = {
+    outputDir: reports.outputDir,
+    inventory: path.join(reports.outputDir, "inventory.json"),
+    protectedSurfaces: path.join(reports.outputDir, "protected-surfaces.json"),
+    driftReport: path.join(reports.outputDir, "drift-report.json"),
+    driftMarkdown: path.join(reports.outputDir, "drift-report.md"),
+    substrateActionPlan: path.join(reports.outputDir, "substrate-action-plan.md"),
+    baselineSource: reports.driftReport.baselineSource,
+    classificationCounts: reports.driftReport.classificationCounts,
+    decision,
+  };
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+  if (args.failOnBlockers && decision.blockersCount > 0) {
+    console.error(
+      `Upstream DMG intelligence found ${decision.blockersCount} protected-surface acceptance blocker(s).`,
+    );
+    return 2;
+  }
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error.message);
+    console.error("");
+    console.error(usage());
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { buildDecision, main, parseArgs };

--- a/scripts/dev/upstream-dmg-intel.test.js
+++ b/scripts/dev/upstream-dmg-intel.test.js
@@ -1,0 +1,801 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  buildIntelReports,
+  compareProtectedSurfaces,
+  createInventory,
+  extractProtectedSurfaces,
+  renderActionPlanMarkdown,
+  resolveBaselinePath,
+} = require("../lib/upstream-dmg-intel.js");
+
+const registry = {
+  version: 1,
+  surfaces: [
+    {
+      id: "sky_computer_use_client",
+      title: "Sky Computer Use client",
+      category: "native",
+      pathPatterns: ["SkyComputerUseClient", "native/sky\\.node"],
+      contentNeedles: ["SkyComputerUseClient", "event_stream", "recording_controls"],
+      nativeStringNeedles: ["SkyComputerUseClient", "recording_controls"],
+      linuxSubstrate: {
+        requiredPaths: ["computer-use-linux/src/server.rs"],
+      },
+    },
+    {
+      id: "record_and_replay_event_stream",
+      title: "Record & Replay event stream MCP",
+      category: "plugin",
+      pathPatterns: ["record-and-replay"],
+      contentNeedles: ["event_stream_start", "browser_trace", "speech_context"],
+      pluginIds: ["record-and-replay"],
+      linuxSubstrate: {
+        requiredPaths: ["record-replay-linux/src/main.rs"],
+      },
+    },
+    {
+      id: "chrome_native_messaging",
+      title: "Chrome native messaging plugin",
+      category: "plugin",
+      pathPatterns: ["plugins/openai-bundled/plugins/chrome"],
+      contentNeedles: ["nativeMessaging", "codex-chrome-extension-host"],
+      pluginIds: ["chrome"],
+      linuxSubstrate: {
+        requiredPaths: ["computer-use-linux/src/bin/codex-chrome-extension-host.rs"],
+      },
+    },
+    {
+      id: "dictation_transcript_finalization",
+      title: "Dictation transcript finalization",
+      category: "webview",
+      pathPatterns: ["composer"],
+      contentNeedles: ["finalizeTranscript", "dictation", "transcript"],
+      linuxSubstrate: {
+        requiredPaths: ["linux-features/conversation-mode/patches.js"],
+      },
+    },
+    {
+      id: "chronicle_sidecar",
+      title: "Chronicle sidecar",
+      category: "native",
+      pathPatterns: ["codex_chronicle"],
+      contentNeedles: ["codex_chronicle", "session.json", "events.jsonl"],
+      nativeStringNeedles: ["codex_chronicle", "events.jsonl"],
+      linuxSubstrate: {
+        requiredPaths: ["record-replay-linux/src/chronicle.rs"],
+      },
+    },
+    {
+      id: "chronicle_settings_toggles",
+      title: "Chronicle settings toggle paths",
+      category: "webview",
+      pathPatterns: ["personalization-settings"],
+      contentNeedles: [
+        "chronicleSidecarPresent",
+        "chronicleSidecarProcessState",
+        "rememberConsentAccepted",
+        "mutateAsync({enabled:!0})",
+        "mutateAsync({enabled:!1})",
+        "chronicleDisable",
+        "memoryFeatureEnabled",
+        "generateMemoriesEnabled",
+        "useMemoriesEnabled",
+      ],
+      requiredEvidence: [
+        {
+          id: "dedicated-chronicle-preview-row",
+          pathPatterns: ["personalization-settings"],
+          contentNeedles: [
+            "settings.general.experimentalFeatures.chronicle.name",
+            "chronicleSidecarPresent",
+            "chronicleSidecarProcessState",
+            "rememberConsentAccepted",
+            "mutateAsync({enabled:!0})",
+            "mutateAsync({enabled:!1})",
+          ],
+        },
+        {
+          id: "memory-master-toggle-chronicle-disable",
+          pathPatterns: ["personalization-settings"],
+          contentNeedles: [
+            "function un",
+            "chronicleDisable",
+            "Promise.allSettled",
+            "memoryFeatureEnabled",
+            "generateMemoriesEnabled",
+            "useMemoriesEnabled",
+          ],
+        },
+      ],
+      linuxSubstrate: {
+        requiredPaths: ["linux-features/record-and-replay"],
+      },
+    },
+    {
+      id: "future_skysight_bridge",
+      title: "Future Skysight bridge",
+      category: "bridge",
+      pathPatterns: ["future-skysight"],
+      contentNeedles: ["futureSkysightBridge", "sky_snapshot_v2"],
+      linuxSubstrate: {
+        requiredPaths: ["linux-features/future-skysight/patch.js"],
+      },
+    },
+  ],
+};
+
+function withTempDir(fn) {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-upstream-intel-test-"));
+  try {
+    return fn(workspace);
+  } finally {
+    fs.rmSync(workspace, { force: true, recursive: true });
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function writeFile(filePath, content, mode) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, mode == null ? undefined : { mode });
+}
+
+function createFixtureApp(root, variant = "baseline") {
+  const appDir = path.join(root, `${variant}.app`);
+  const resources = path.join(appDir, "Contents/Resources");
+  const asarExtracted = path.join(resources, "app.asar.extracted");
+  const recordPlugin = path.join(resources, "plugins/openai-bundled/plugins/record-and-replay");
+  const chromePlugin = path.join(resources, "plugins/openai-bundled/plugins/chrome");
+
+  writeJson(path.join(resources, "package.json"), {
+    name: "codex-desktop",
+    version: variant === "candidate" ? "2026.7.3" : "2026.7.2",
+  });
+
+  const skyPayload =
+    "Mach-O SkyComputerUseClient event_stream recording_controls metadataPath eventsPath";
+  const skyPath =
+    variant === "candidate"
+      ? path.join(resources, "native/sky/sky.node")
+      : path.join(resources, "native/sky.node");
+  writeFile(skyPath, skyPayload, 0o755);
+
+  if (variant === "candidate") {
+    writeFile(
+      path.join(resources, "codex_chronicle"),
+      "Mach-O codex_chronicle session.json events.jsonl skysight_trace",
+      0o755,
+    );
+    writeFile(
+      path.join(asarExtracted, "future-skysight-bridge.js"),
+      "ipcMain.handle('futureSkysightBridge', () => sky_snapshot_v2())",
+    );
+  }
+
+  if (variant !== "candidate") {
+    writeFile(
+      path.join(asarExtracted, "composer/transcript.js"),
+      "function finalizeTranscript(dictation, transcript) { return transcript.final; }",
+    );
+  }
+
+  writeFile(
+    path.join(asarExtracted, "main/bridge.js"),
+    "ipcMain.handle('event_stream_start', start); ipcMain.handle('browser_trace', trace);",
+  );
+  writeFile(
+    path.join(asarExtracted, "main/minified-bridge.js"),
+    "const a='linux-record-replay-skysight-start',b=`speech_context`,c=\"focused_window\",d='computer-use-plugin-icon.png';ipcMain.handle(x,y);",
+  );
+
+  const broadMemoryToggle =
+    variant === "missing-memory-chronicle-disable"
+      ? ""
+      : "async function un({chronicleDisable,previousState,selectedEnabled,featureWrite,configWrite}){await Promise.allSettled([featureWrite(),configWrite(),chronicleDisable?.()??Promise.resolve()]);return {memoryFeatureEnabled:selectedEnabled,generateMemoriesEnabled:selectedEnabled,useMemoriesEnabled:selectedEnabled};}";
+  writeFile(
+    path.join(resources, "webview/assets/personalization-settings-fixture.js"),
+    [
+      "function fn(){",
+      "const name='settings.general.experimentalFeatures.chronicle.name';",
+      "const state={chronicleSidecarPresent:true,chronicleSidecarProcessState:'running'};",
+      "const enable=async({rememberConsentAccepted})=>o.mutateAsync({enabled:!0});",
+      "const disable=async()=>o.mutateAsync({enabled:!1});",
+      "return {name,state,enable,disable};",
+      "}",
+      broadMemoryToggle,
+    ].join(""),
+  );
+
+  writeJson(path.join(recordPlugin, ".codex-plugin/plugin.json"), {
+    id: "record-and-replay",
+    name: "record-and-replay",
+    version: "1.0.0",
+    mcpServers: {
+      "event-stream": {
+        command: "SkyComputerUseClient",
+      },
+    },
+    skills: [{ name: "record-and-replay", path: "skills/record-and-replay/SKILL.md" }],
+  });
+  writeJson(path.join(recordPlugin, ".mcp.json"), {
+    mcpServers: {
+      "event-stream": {
+        command: "SkyComputerUseClient",
+        tools:
+          variant === "candidate"
+            ? ["event_stream_start", "browser_trace", "speech_context", "skysight_snapshot"]
+            : ["event_stream_start", "browser_trace", "speech_context"],
+      },
+    },
+  });
+  writeFile(
+    path.join(recordPlugin, "skills/record-and-replay/SKILL.md"),
+    "Use event_stream_start, browser_trace, and speech_context to compile reusable skills.",
+  );
+
+  writeJson(path.join(chromePlugin, ".codex-plugin/plugin.json"), {
+    id: "chrome",
+    name: "chrome",
+    version: "1.0.0",
+  });
+  writeFile(
+    path.join(chromePlugin, "browser-client.mjs"),
+    "const nativeMessaging = 'codex-chrome-extension-host';",
+  );
+
+  return appDir;
+}
+
+function findClassification(driftReport, surfaceId, classification) {
+  return driftReport.surfaceDrift.find(
+    (entry) => entry.surfaceId === surfaceId && entry.classification === classification,
+  );
+}
+
+test("extracts protected surfaces, plugins, native binaries, and bridge calls from a fixture app", () =>
+  withTempDir((workspace) => {
+    const appDir = createFixtureApp(workspace, "baseline");
+
+    const inventory = createInventory({ registry, sourcePath: appDir });
+    const protectedSurfaces = extractProtectedSurfaces({
+      inventory,
+      registry,
+      repoRoot: process.cwd(),
+    });
+
+    assert.equal(inventory.source.kind, "app");
+    assert.ok(
+      inventory.files.some((file) => file.relativePath.endsWith("plugins/openai-bundled/plugins/chrome/browser-client.mjs")),
+    );
+    assert.equal(protectedSurfaces.surfacesById.sky_computer_use_client.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.record_and_replay_event_stream.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.chrome_native_messaging.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.chronicle_settings_toggles.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.chronicle_sidecar.status, "MISSING");
+    assert.ok(
+      protectedSurfaces.surfacesById.chronicle_settings_toggles.satisfiedAnchors.some(
+        (anchor) => anchor.id === "memory-master-toggle-chronicle-disable",
+      ),
+    );
+    assert.ok(
+      protectedSurfaces.surfacesById.chronicle_settings_toggles.requiredAnchors
+        .flatMap((anchor) => anchor.matchedNeedles)
+        .some((hit) => hit.needle === "chronicleDisable"),
+    );
+    assert.ok(
+      protectedSurfaces.pluginMap.plugins.some((plugin) => plugin.id === "record-and-replay"),
+    );
+    assert.ok(
+      protectedSurfaces.bridgeMap.handlers.some((handler) => handler.name === "event_stream_start"),
+    );
+    assert.ok(
+      protectedSurfaces.bridgeMap.channelCandidates.some(
+        (candidate) => candidate.name === "linux-record-replay-skysight-start",
+      ),
+    );
+    assert.ok(
+      protectedSurfaces.bridgeMap.channelCandidates.some(
+        (candidate) => candidate.name === "speech_context",
+      ),
+    );
+    assert.ok(
+      protectedSurfaces.bridgeMap.channelCandidates.every(
+        (candidate) => candidate.name !== "computer-use-plugin-icon.png",
+      ),
+    );
+    assert.ok(
+      protectedSurfaces.nativeBinaryMap.binaries.some((binary) =>
+        binary.relativePath.endsWith("native/sky.node"),
+      ),
+    );
+  }));
+
+test("marks Chronicle settings toggle surface partial when the Memory master toggle path disappears", () =>
+  withTempDir((workspace) => {
+    const appDir = createFixtureApp(workspace, "missing-memory-chronicle-disable");
+    const protectedSurfaces = extractProtectedSurfaces({
+      inventory: createInventory({ registry, sourcePath: appDir }),
+      registry,
+      repoRoot: process.cwd(),
+    });
+    const surface = protectedSurfaces.surfacesById.chronicle_settings_toggles;
+    assert.equal(surface.status, "PARTIAL");
+    assert.ok(
+      surface.satisfiedAnchors.some((anchor) => anchor.id === "dedicated-chronicle-preview-row"),
+    );
+    assert.ok(
+      surface.missingAnchors.some((anchor) => anchor.id === "memory-master-toggle-chronicle-disable"),
+    );
+    assert.ok(
+      surface.missingAnchors
+        .find((anchor) => anchor.id === "memory-master-toggle-chronicle-disable")
+        .missingNeedles.includes("chronicleDisable"),
+    );
+  }));
+
+test("classifies protected-surface drift from baseline to candidate", () =>
+  withTempDir((workspace) => {
+    const baselineApp = createFixtureApp(workspace, "baseline");
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const baseline = extractProtectedSurfaces({
+      inventory: createInventory({ registry, sourcePath: baselineApp }),
+      registry,
+      repoRoot: process.cwd(),
+    });
+    const candidate = extractProtectedSurfaces({
+      inventory: createInventory({ registry, sourcePath: candidateApp }),
+      registry,
+      repoRoot: process.cwd(),
+    });
+
+    const driftReport = compareProtectedSurfaces({
+      baseline,
+      candidate,
+      patchReport: {
+        patches: [
+          {
+            name: "record-and-replay bridge patch",
+            status: "skipped-optional",
+            reason: "upstream bridge marker moved",
+            surfaceId: "record_and_replay_event_stream",
+          },
+        ],
+      },
+    });
+
+    assert.ok(findClassification(driftReport, "sky_computer_use_client", "MOVED"));
+    assert.ok(findClassification(driftReport, "record_and_replay_event_stream", "PAYLOAD_CHANGED"));
+    assert.ok(findClassification(driftReport, "chrome_native_messaging", "UNCHANGED"));
+    assert.ok(findClassification(driftReport, "dictation_transcript_finalization", "REMOVED"));
+    assert.ok(findClassification(driftReport, "chronicle_sidecar", "NEW_UPSTREAM_CAPABILITY"));
+    assert.ok(findClassification(driftReport, "future_skysight_bridge", "LINUX_SUBSTRATE_GAP"));
+    assert.ok(findClassification(driftReport, "record_and_replay_event_stream", "PATCH_REVIEW"));
+    assert.ok(!findClassification(driftReport, "record_and_replay_event_stream", "PATCH_BROKEN"));
+  }));
+
+test("classifies required patch-report failures as acceptance blockers", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const candidate = extractProtectedSurfaces({
+      inventory: createInventory({ registry, sourcePath: candidateApp }),
+      registry,
+      repoRoot: process.cwd(),
+    });
+
+    const driftReport = compareProtectedSurfaces({
+      candidate,
+      patchReport: {
+        patches: [
+          {
+            name: "record-and-replay bridge patch",
+            status: "failed-required",
+            reason: "upstream bridge marker moved",
+            surfaceId: "record_and_replay_event_stream",
+          },
+        ],
+      },
+    });
+
+    assert.ok(findClassification(driftReport, "record_and_replay_event_stream", "PATCH_BROKEN"));
+    assert.ok(!findClassification(driftReport, "record_and_replay_event_stream", "PATCH_REVIEW"));
+  }));
+
+test("keeps drift report evidence compact and marks hashed asset churn", () => {
+  const baseline = {
+    source: { path: "baseline.app" },
+    surfacesById: {
+      vite_chunk_bridge: {
+        id: "vite_chunk_bridge",
+        title: "Vite chunk bridge",
+        category: "bridge",
+        status: "PRESENT",
+        evidence: [
+          {
+            path: ".vite/build/main-CNod9zFW.js",
+            sha256: "baseline-hash",
+            size: 100,
+            source: "asar",
+            type: "text",
+          },
+        ],
+      },
+    },
+  };
+  const candidate = {
+    source: { path: "candidate.app" },
+    surfacesById: {
+      vite_chunk_bridge: {
+        id: "vite_chunk_bridge",
+        title: "Vite chunk bridge",
+        category: "bridge",
+        status: "PRESENT",
+        evidence: [
+          {
+            path: ".vite/build/main-z6HVz-xR.js",
+            sha256: "candidate-hash",
+            size: 100,
+            source: "asar",
+            type: "text",
+          },
+        ],
+      },
+    },
+  };
+
+  const driftReport = compareProtectedSurfaces({ baseline, candidate });
+  const drift = findClassification(driftReport, "vite_chunk_bridge", "MOVED");
+  assert.ok(drift);
+  assert.equal(drift.baselineEvidence, undefined);
+  assert.equal(drift.candidateEvidence, undefined);
+  assert.equal(drift.evidenceSummary.baseline.evidenceCount, 1);
+  assert.equal(drift.evidenceSummary.candidate.evidenceCount, 1);
+  assert.equal(drift.evidenceDrift.pathMovementKind, "hashed_asset_churn");
+  assert.equal(drift.evidenceDrift.addedEvidence, undefined);
+  assert.equal(drift.evidenceDrift.removedEvidence, undefined);
+
+  const actionPlan = renderActionPlanMarkdown(
+    {
+      ...driftReport,
+      structuralDriftSummary: {
+        bridgeHandlers: { addedCount: 0, removedCount: 0 },
+        plugins: { addedCount: 0, removedCount: 0 },
+        mcpTools: { addedCount: 0, removedCount: 0 },
+        nativeBinaries: { addedCount: 0, removedCount: 0, changedCount: 0 },
+        hasStructuralAddRemove: false,
+      },
+    },
+    { source: { path: "candidate.app" } },
+  );
+  assert.match(actionPlan, /review candidate evidence paths before changing Linux substrate/);
+  assert.match(actionPlan, /Treat this as a navigation signal/);
+  assert.doesNotMatch(
+    actionPlan,
+    /update patch descriptors, staging paths, and Linux mirror code to the candidate evidence paths/,
+  );
+});
+
+test("does not collapse multi-hyphen hashed asset stems", () => {
+  const baseline = {
+    source: { path: "baseline.app" },
+    surfacesById: {
+      record_asset_bridge: {
+        id: "record_asset_bridge",
+        title: "Record asset bridge",
+        category: "bridge",
+        status: "PRESENT",
+        evidence: [
+          {
+            path: ".vite/build/record-and-replay-CNod9zFW.js",
+            sha256: "baseline-hash",
+            size: 100,
+            source: "asar",
+            type: "text",
+          },
+        ],
+      },
+    },
+  };
+  const candidate = {
+    source: { path: "candidate.app" },
+    surfacesById: {
+      record_asset_bridge: {
+        id: "record_asset_bridge",
+        title: "Record asset bridge",
+        category: "bridge",
+        status: "PRESENT",
+        evidence: [
+          {
+            path: ".vite/build/record-settings-NsW8qoL2.js",
+            sha256: "candidate-hash",
+            size: 100,
+            source: "asar",
+            type: "text",
+          },
+        ],
+      },
+    },
+  };
+
+  const driftReport = compareProtectedSurfaces({ baseline, candidate });
+  const drift = findClassification(driftReport, "record_asset_bridge", "MOVED");
+  assert.ok(drift);
+  assert.equal(drift.evidenceDrift.pathMovementKind, "mixed_hashed_asset_churn");
+});
+
+test("writes the expected report bundle for candidate-only and comparison runs", () =>
+  withTempDir((workspace) => {
+    const baselineApp = createFixtureApp(workspace, "baseline");
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const outputDir = path.join(workspace, "reports");
+    const fakeBin = path.join(workspace, "bin");
+    fs.mkdirSync(fakeBin, { recursive: true });
+    for (const tool of ["llvm-nm", "nm"]) {
+      writeFile(
+        path.join(fakeBin, tool),
+        `#!/usr/bin/env bash
+set -euo pipefail
+test -f "$2"
+printf '00000000 T _SkyComputerUseClient\\n'
+`,
+        0o755,
+      );
+    }
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${fakeBin}${path.delimiter}${oldPath ?? ""}`;
+
+    let reports;
+    try {
+      reports = buildIntelReports({
+        baselinePath: baselineApp,
+        candidatePath: candidateApp,
+        outputDir,
+        registry,
+        repoRoot: process.cwd(),
+        timestamp: "2026-07-03T12-00-00Z",
+      });
+    } finally {
+      if (oldPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = oldPath;
+      }
+    }
+
+    for (const reportName of [
+      "inventory.json",
+      "protected-surfaces.json",
+      "bridge-map.json",
+      "plugin-map.json",
+      "native-binary-map.json",
+      "map-drift.json",
+      "drift-report.json",
+      "drift-report.md",
+      "substrate-action-plan.md",
+      "baseline/inventory.json",
+      "baseline/plugin-map.json",
+      "candidate/inventory.json",
+      "candidate/plugin-map.json",
+    ]) {
+      assert.ok(fs.existsSync(path.join(reports.outputDir, reportName)), reportName);
+    }
+
+    const driftReport = JSON.parse(
+      fs.readFileSync(path.join(reports.outputDir, "drift-report.json"), "utf8"),
+    );
+    const inventory = JSON.parse(
+      fs.readFileSync(path.join(reports.outputDir, "inventory.json"), "utf8"),
+    );
+    const nativeBinaryMap = JSON.parse(
+      fs.readFileSync(path.join(reports.outputDir, "native-binary-map.json"), "utf8"),
+    );
+    const mapDrift = JSON.parse(
+      fs.readFileSync(path.join(reports.outputDir, "map-drift.json"), "utf8"),
+    );
+    const actionPlan = fs.readFileSync(path.join(reports.outputDir, "substrate-action-plan.md"), "utf8");
+    const skyDrift = findClassification(driftReport, "sky_computer_use_client", "MOVED");
+    assert.ok(findClassification(driftReport, "chronicle_sidecar", "NEW_UPSTREAM_CAPABILITY"));
+    assert.equal(skyDrift.baselineEvidence, undefined);
+    assert.equal(skyDrift.candidateEvidence, undefined);
+    assert.ok(skyDrift.evidenceSummary.baseline.evidenceCount > 0);
+    assert.ok(skyDrift.evidenceDrift.addedPathSamples.length > 0);
+    assert.equal(skyDrift.evidenceDrift.addedEvidence, undefined);
+    assert.ok(inventory.files.every((file) => file.text == null && file.nativeStrings == null));
+    assert.ok(
+      nativeBinaryMap.binaries.some((binary) =>
+        binary.protectedStringHits.some((hit) => hit.needle === "recording_controls"),
+      ),
+    );
+    assert.ok(
+      nativeBinaryMap.binaries.some(
+        (binary) =>
+          binary.symbols?.tool === "llvm-nm -g" &&
+          binary.symbols.symbols.includes("00000000 T _SkyComputerUseClient"),
+      ),
+    );
+    assert.equal(mapDrift.mode, "baselineComparison");
+    assert.ok(mapDrift.mcpDrift.added.includes("record-and-replay:event-stream:skysight_snapshot"));
+    assert.match(actionPlan, /review candidate evidence paths/);
+    assert.doesNotMatch(
+      actionPlan,
+      /update patch descriptors, staging paths, and Linux mirror code to the candidate evidence paths/,
+    );
+  }));
+
+test("auto-baseline uses repo Codex.dmg when candidate is different", () =>
+  withTempDir((workspace) => {
+    const repoRoot = path.join(workspace, "repo");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    const baselineApp = createFixtureApp(workspace, "baseline");
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const baselineCache = path.join(repoRoot, "Codex.dmg");
+    fs.cpSync(baselineApp, baselineCache, { recursive: true });
+
+    assert.equal(
+      resolveBaselinePath({
+        autoBaseline: true,
+        candidatePath: candidateApp,
+        repoRoot,
+      }),
+      baselineCache,
+    );
+    assert.equal(
+      resolveBaselinePath({
+        autoBaseline: true,
+        candidatePath: baselineCache,
+        repoRoot,
+      }),
+      null,
+    );
+
+    const outputDir = path.join(workspace, "auto-baseline-report");
+    const reports = buildIntelReports({
+      autoBaseline: true,
+      candidatePath: candidateApp,
+      outputDir,
+      registry,
+      repoRoot,
+    });
+
+    assert.equal(reports.mapDrift.mode, "baselineComparison");
+    assert.ok(fs.existsSync(path.join(outputDir, "baseline/inventory.json")));
+    assert.ok(fs.existsSync(path.join(outputDir, "candidate/inventory.json")));
+    assert.ok(findClassification(reports.driftReport, "chronicle_sidecar", "NEW_UPSTREAM_CAPABILITY"));
+  }));
+
+test("CLI loads the checked-in registry and writes the report bundle", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const outputDir = path.join(workspace, "cli-report");
+    const cliPath = path.join(process.cwd(), "scripts/dev/upstream-dmg-intel.js");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        cliPath,
+        "--candidate",
+        candidateApp,
+        "--output-dir",
+        outputDir,
+        "--timestamp",
+        "2026-07-03T12-00-00Z",
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.outputDir, outputDir);
+    assert.equal(summary.decision.acceptance, "blocked");
+    assert.ok(summary.decision.blockersCount > 0);
+    assert.equal(summary.decision.allProtectedSurfacesPresent, false);
+    assert.ok(fs.existsSync(path.join(outputDir, "inventory.json")));
+    assert.ok(fs.existsSync(path.join(outputDir, "protected-surfaces.json")));
+    assert.ok(fs.existsSync(path.join(outputDir, "substrate-action-plan.md")));
+    const protectedSurfaces = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "protected-surfaces.json"), "utf8"),
+    );
+    assert.equal(protectedSurfaces.surfacesById.record_and_replay_plugin.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.codex_chronicle.status, "PRESENT");
+    assert.equal(protectedSurfaces.surfacesById.chronicle_settings_toggles.status, "PRESENT");
+  }));
+
+test("CLI exits nonzero with --fail-on-blockers when acceptance blockers are present", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const outputDir = path.join(workspace, "cli-fail-report");
+    const cliPath = path.join(process.cwd(), "scripts/dev/upstream-dmg-intel.js");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        cliPath,
+        "--candidate",
+        candidateApp,
+        "--output-dir",
+        outputDir,
+        "--fail-on-blockers",
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 2, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.decision.acceptance, "blocked");
+    assert.ok(summary.decision.blockersCount > 0);
+    assert.match(result.stderr, /protected-surface acceptance blocker/);
+    assert.ok(fs.existsSync(path.join(outputDir, "drift-report.json")));
+  }));
+
+test("CLI keeps optional patch-report skips review-only under --fail-on-blockers", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const outputDir = path.join(workspace, "cli-optional-patch-report");
+    const cliPath = path.join(process.cwd(), "scripts/dev/upstream-dmg-intel.js");
+    const registryPath = path.join(workspace, "registry.json");
+    const patchReportPath = path.join(workspace, "patch-report.json");
+
+    writeJson(registryPath, {
+      version: 1,
+      surfaces: [
+        {
+          id: "record_and_replay_event_stream",
+          title: "Record & Replay event stream MCP",
+          category: "plugin",
+          pathPatterns: ["record-and-replay"],
+          contentNeedles: ["event_stream_start", "browser_trace", "speech_context"],
+          pluginIds: ["record-and-replay"],
+          linuxSubstrate: {
+            requiredPaths: ["record-replay-linux/src/main.rs"],
+          },
+        },
+      ],
+    });
+    writeJson(patchReportPath, {
+      patches: [
+        {
+          name: "record-and-replay bridge patch",
+          status: "skipped-optional",
+          reason: "upstream bridge marker moved",
+          surfaceId: "record_and_replay_event_stream",
+        },
+      ],
+    });
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        cliPath,
+        "--candidate",
+        candidateApp,
+        "--no-baseline",
+        "--registry",
+        registryPath,
+        "--patch-report",
+        patchReportPath,
+        "--output-dir",
+        outputDir,
+        "--fail-on-blockers",
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.decision.acceptance, "review");
+    assert.equal(summary.decision.blockersCount, 0);
+    assert.equal(summary.decision.reviewItemsCount, 1);
+    const driftReport = JSON.parse(fs.readFileSync(path.join(outputDir, "drift-report.json"), "utf8"));
+    assert.ok(findClassification(driftReport, "record_and_replay_event_stream", "PATCH_REVIEW"));
+    assert.ok(!findClassification(driftReport, "record_and_replay_event_stream", "PATCH_BROKEN"));
+  }));

--- a/scripts/dev/upstream-dmg-protected-surfaces.json
+++ b/scripts/dev/upstream-dmg-protected-surfaces.json
@@ -1,0 +1,791 @@
+{
+  "version": 1,
+  "description": "Protected upstream Codex Desktop macOS DMG surfaces that Linux packaging mirrors, patches, stages, or must explicitly classify before accepting a new upstream build.",
+  "surfaces": [
+    {
+      "id": "codex_chronicle",
+      "title": "Chronicle sidecar binary and event bundle schema",
+      "category": "native",
+      "pathPatterns": [
+        "(^|/)codex_chronicle$",
+        "chronicle"
+      ],
+      "contentNeedles": [
+        "codex_chronicle",
+        "Chronicle",
+        "session.json",
+        "events.jsonl",
+        "metadataPath",
+        "eventsPath"
+      ],
+      "nativeStringNeedles": [
+        "codex_chronicle",
+        "Chronicle",
+        "session.json",
+        "events.jsonl",
+        "metadataPath",
+        "eventsPath"
+      ],
+      "pluginIds": [
+        "record-and-replay"
+      ],
+      "patchNamePatterns": [
+        "chronicle",
+        "record.*replay"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "chronicle-binary",
+          "pathPatterns": [
+            "(^|/)codex_chronicle$"
+          ],
+          "nativeStringNeedles": [
+            "codex_chronicle"
+          ]
+        },
+        {
+          "id": "chronicle-event-bundle",
+          "nativeStringNeedles": [
+            "session.json",
+            "events.jsonl"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "record-replay-linux/src",
+          "linux-features/record-and-replay"
+        ]
+      }
+    },
+    {
+      "id": "chronicle_settings_toggles",
+      "title": "Chronicle Settings enable/disable toggle paths",
+      "category": "webview",
+      "pathPatterns": [
+        "personalization-settings.*\\.js$"
+      ],
+      "contentNeedles": [
+        "chronicleSidecarPresent",
+        "chronicleSidecarProcessState",
+        "rememberConsentAccepted",
+        "mutateAsync({enabled:!0})",
+        "mutateAsync({enabled:!1})",
+        "chronicleDisable",
+        "memoryFeatureEnabled",
+        "generateMemoriesEnabled",
+        "useMemoriesEnabled"
+      ],
+      "patchNamePatterns": [
+        "chronicle",
+        "memory",
+        "record.*replay",
+        "skysight"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "dedicated-chronicle-preview-row",
+          "pathPatterns": [
+            "personalization-settings.*\\.js$"
+          ],
+          "contentNeedles": [
+            "settings.general.experimentalFeatures.chronicle.name",
+            "chronicleSidecarPresent",
+            "chronicleSidecarProcessState",
+            "rememberConsentAccepted",
+            "mutateAsync({enabled:!0})",
+            "mutateAsync({enabled:!1})"
+          ]
+        },
+        {
+          "id": "memory-master-toggle-chronicle-disable",
+          "pathPatterns": [
+            "personalization-settings.*\\.js$"
+          ],
+          "contentNeedles": [
+            "function un",
+            "chronicleDisable",
+            "Promise.allSettled",
+            "memoryFeatureEnabled",
+            "generateMemoriesEnabled",
+            "useMemoriesEnabled"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "linux-features/record-and-replay",
+          "record-replay-linux/src"
+        ]
+      }
+    },
+    {
+      "id": "sky_computer_use_client",
+      "title": "Sky Computer Use client and Sky native module",
+      "category": "native",
+      "pathPatterns": [
+        "SkyComputerUseClient",
+        "Codex Computer Use\\.app",
+        "(^|/)native/sky(\\.node|/)",
+        "(^|/)sky\\.node$"
+      ],
+      "contentNeedles": [
+        "SkyComputerUseClient",
+        "SkyLinuxComputerUseClient",
+        "sky.node",
+        "recording_controls",
+        "event_stream",
+        "skysight"
+      ],
+      "nativeStringNeedles": [
+        "SkyComputerUseClient",
+        "recording_controls",
+        "event_stream",
+        "skysight",
+        "accessibility_snapshot"
+      ],
+      "pluginIds": [
+        "computer-use",
+        "record-and-replay"
+      ],
+      "patchNamePatterns": [
+        "computer.*use",
+        "sky",
+        "record.*replay"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "sky-native-runtime",
+          "nativeBinaryPatterns": [
+            "SkyComputerUseClient",
+            "(^|/)native/sky(\\.node|/)",
+            "(^|/)sky\\.node$"
+          ]
+        },
+        {
+          "id": "sky-control-strings",
+          "nativeStringNeedles": [
+            "metadataPath",
+            "eventsPath",
+            "skysight"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "computer-use-linux/src",
+          "linux-features/record-and-replay"
+        ]
+      }
+    },
+    {
+      "id": "skysight_bridge",
+      "title": "Skysight bridge and screenshot/status metadata",
+      "category": "bridge",
+      "pathPatterns": [
+        "skysight",
+        "sky"
+      ],
+      "contentNeedles": [
+        "skysight",
+        "accessibility_snapshot",
+        "desktop_snapshot",
+        "screenshot",
+        "window_id",
+        "app_id",
+        "wm_class",
+        "browser_trace"
+      ],
+      "nativeStringNeedles": [
+        "skysight",
+        "accessibility_snapshot",
+        "desktop_snapshot",
+        "screenshot"
+      ],
+      "patchNamePatterns": [
+        "skysight",
+        "desktop",
+        "computer.*use",
+        "record.*replay"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "skysight-status",
+          "contentNeedles": [
+            "skysight",
+            "screenshot"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "record-replay-linux/src/skysight.rs",
+          "record-replay-linux/src"
+        ]
+      }
+    },
+    {
+      "id": "event_stream_mcp",
+      "title": "event-stream MCP tools and browser/speech evidence paths",
+      "category": "mcp",
+      "pathPatterns": [
+        "event[-_]stream",
+        "\\.mcp\\.json$",
+        "record-and-replay"
+      ],
+      "contentNeedles": [
+        "event_stream_start",
+        "event_stream_stop",
+        "event_stream_cancel",
+        "browser_trace",
+        "speech_context",
+        "desktop_snapshot",
+        "skysight_start",
+        "skysight_snapshot"
+      ],
+      "pluginIds": [
+        "record-and-replay"
+      ],
+      "patchNamePatterns": [
+        "event.*stream",
+        "record.*replay"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "event-stream-tool-set",
+          "pluginIds": [
+            "record-and-replay"
+          ],
+          "mcpServerNames": [
+            "event-stream"
+          ],
+          "mcpCommandPatterns": [
+            "SkyComputerUseClient"
+          ],
+          "mcpArgs": [
+            "event-stream",
+            "mcp"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "record-replay-linux/src",
+          "linux-features/record-and-replay/plugin-template/.mcp.json"
+        ]
+      }
+    },
+    {
+      "id": "record_and_replay_plugin",
+      "title": "Record & Replay plugin, skill, MCP config, and bridge shell",
+      "category": "plugin",
+      "pathPatterns": [
+        "plugins/openai-bundled/plugins/record-and-replay",
+        "record-and-replay",
+        "Record & Replay"
+      ],
+      "contentNeedles": [
+        "record-and-replay",
+        "Record & Replay",
+        "Record a skill",
+        "event_stream_start",
+        "browser_trace",
+        "speech_context",
+        "SKILL.md"
+      ],
+      "pluginIds": [
+        "record-and-replay"
+      ],
+      "patchNamePatterns": [
+        "record.*replay"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "record-replay-plugin-manifest",
+          "pluginIds": [
+            "record-and-replay"
+          ]
+        },
+        {
+          "id": "record-replay-mcp-skill",
+          "pluginIds": [
+            "record-and-replay"
+          ],
+          "mcpServerNames": [
+            "event-stream"
+          ],
+          "pluginSkillPatterns": [
+            "record-and-replay/skills/record-and-replay/SKILL\\.md$"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "linux-features/record-and-replay",
+          "record-replay-linux"
+        ]
+      }
+    },
+    {
+      "id": "computer_use_plugin",
+      "title": "Computer Use plugin, gates, native helpers, and frontend enablement",
+      "category": "plugin",
+      "pathPatterns": [
+        "plugins/openai-bundled/plugins/computer-use",
+        "computer-use",
+        "Computer Use"
+      ],
+      "contentNeedles": [
+        "computer-use",
+        "Computer Use",
+        "codex-computer-use",
+        "SkyComputerUseClient",
+        "enableComputerUse",
+        "accessibility_snapshot"
+      ],
+      "pluginIds": [
+        "computer-use"
+      ],
+      "patchNamePatterns": [
+        "computer.*use",
+        "linux desktop settings"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "computer-use-plugin-manifest",
+          "pluginIds": [
+            "computer-use"
+          ]
+        },
+        {
+          "id": "computer-use-sky-client",
+          "nativeBinaryPatterns": [
+            "plugins/openai-bundled/plugins/computer-use/.*SkyComputerUseClient"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "computer-use-linux",
+          "plugins/openai-bundled/plugins/computer-use"
+        ]
+      }
+    },
+    {
+      "id": "browser_use_plugin",
+      "title": "Browser Use plugin manifest, client script, and skill shell",
+      "category": "plugin",
+      "pathPatterns": [
+        "plugins/openai-bundled/plugins/browser",
+        "browser-client\\.mjs",
+        "Browser"
+      ],
+      "contentNeedles": [
+        "browser",
+        "browser-client.mjs",
+        ".codex-plugin",
+        "skills"
+      ],
+      "pluginIds": [
+        "browser"
+      ],
+      "patchNamePatterns": [
+        "browser"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "browser-plugin-manifest",
+          "pluginIds": [
+            "browser"
+          ]
+        },
+        {
+          "id": "browser-client-script",
+          "pluginScriptPatterns": [
+            "plugins/openai-bundled/plugins/browser/.*browser-client\\.mjs"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/bundled-plugins.sh",
+          "scripts/lib/patch-chrome-plugin.js"
+        ]
+      }
+    },
+    {
+      "id": "browser_use_node_repl_runtime",
+      "title": "Browser Use node_repl runtime staging contract",
+      "category": "native",
+      "pathPatterns": [
+        "cua_node/bin/node_repl",
+        "(^|/)node_repl$",
+        "resources/node_repl"
+      ],
+      "contentNeedles": [
+        "node_repl",
+        "globalThis.nodeRepl"
+      ],
+      "nativeStringNeedles": [
+        "node_repl"
+      ],
+      "patchNamePatterns": [
+        "node_repl",
+        "browser"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "node-repl-runtime",
+          "nativeBinaryPatterns": [
+            "cua_node/bin/node_repl",
+            "(^|/)node_repl$"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/bundled-plugins.sh"
+        ]
+      }
+    },
+    {
+      "id": "browser_use_native_pipe_bridge",
+      "title": "Browser Use native pipe and nodeRepl bridge",
+      "category": "bridge",
+      "pathPatterns": [
+        "browser-client\\.mjs",
+        "nativePipe",
+        "nodeRepl"
+      ],
+      "contentNeedles": [
+        "nativePipe",
+        "import.meta.__codexNativePipe",
+        "globalThis.nodeRepl"
+      ],
+      "patchNamePatterns": [
+        "native.*pipe",
+        "nodeRepl",
+        "browser"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "native-pipe-bridge",
+          "contentNeedles": [
+            "nativePipe",
+            "globalThis.nodeRepl"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/patch-chrome-plugin.js",
+          "scripts/lib/bundled-plugins.sh"
+        ]
+      }
+    },
+    {
+      "id": "browser_use_policy_shims",
+      "title": "Browser Use policy shims and site-status allowlist",
+      "category": "webview",
+      "pathPatterns": [
+        "browser-client\\.mjs",
+        "config\\.toml",
+        "site_status",
+        "codexLinuxFileUrlPolicy"
+      ],
+      "contentNeedles": [
+        "config.toml",
+        "/aura/site_status",
+        "codexLinuxFileUrlPolicy"
+      ],
+      "patchNamePatterns": [
+        "file.*url",
+        "site_status",
+        "browser"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "browser-policy-shim",
+          "pathPatterns": [
+            "browser-client\\.mjs"
+          ],
+          "contentNeedles": [
+            "config.toml",
+            "/aura/site_status"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/patch-chrome-plugin.js"
+        ]
+      }
+    },
+    {
+      "id": "chrome_native_messaging",
+      "title": "Chrome plugin, native messaging host, and marketplace metadata",
+      "category": "plugin",
+      "pathPatterns": [
+        "plugins/openai-bundled/plugins/chrome",
+        "native[-_]messaging",
+        "codex-chrome-extension-host",
+        "chrome"
+      ],
+      "contentNeedles": [
+        "nativeMessaging",
+        "native-messaging",
+        "codex-chrome-extension-host",
+        "chrome-extension",
+        "browser-client.mjs",
+        "marketplace"
+      ],
+      "pluginIds": [
+        "chrome"
+      ],
+      "patchNamePatterns": [
+        "chrome",
+        "native.*messaging",
+        "browser"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "chrome-plugin-manifest",
+          "pluginIds": [
+            "chrome"
+          ]
+        },
+        {
+          "id": "chrome-browser-client",
+          "pluginScriptPatterns": [
+            "plugins/openai-bundled/plugins/chrome/.*browser-client\\.mjs",
+            "plugins/openai-bundled/plugins/chrome/.*installManifest\\.mjs"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "computer-use-linux/src/bin/codex-chrome-extension-host.rs",
+          "scripts/lib/patch-chrome-plugin.js"
+        ]
+      }
+    },
+    {
+      "id": "dictation_transcript_finalization",
+      "title": "Dictation and composer transcript finalization hooks",
+      "category": "webview",
+      "pathPatterns": [
+        "dictation",
+        "composer",
+        "transcript"
+      ],
+      "contentNeedles": [
+        "dictation",
+        "transcript",
+        "finalizeTranscript",
+        "speech_context",
+        "conversation_mode",
+        "composer"
+      ],
+      "patchNamePatterns": [
+        "dictation",
+        "conversation",
+        "composer"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "dictation-transcript-lifecycle",
+          "contentNeedles": [
+            "dictation",
+            "transcript"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "linux-features/conversation-mode"
+        ]
+      }
+    },
+    {
+      "id": "browser_window_metadata",
+      "title": "Browser and desktop window metadata APIs",
+      "category": "bridge",
+      "pathPatterns": [
+        "browser",
+        "window",
+        "metadata"
+      ],
+      "contentNeedles": [
+        "browser_trace",
+        "window_id",
+        "terminal_pid",
+        "terminal_cwd",
+        "app_id",
+        "wm_class",
+        "focused_window",
+        "list_windows"
+      ],
+      "patchNamePatterns": [
+        "browser",
+        "window",
+        "metadata",
+        "subagent"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "browser-window-contract",
+          "contentNeedles": [
+            "window_id"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "computer-use-linux/src/windowing",
+          "scripts/patches/core/all-linux/webview/subagent-metadata"
+        ]
+      }
+    },
+    {
+      "id": "electron_ipc_bridge_handlers",
+      "title": "Electron main-process IPC handlers for mirrored Linux systems",
+      "category": "bridge",
+      "pathPatterns": [
+        "main",
+        "bridge",
+        "ipc"
+      ],
+      "contentNeedles": [
+        "ipcMain.handle",
+        "ipcMain.on",
+        "contextBridge.exposeInMainWorld",
+        "recording_controls",
+        "event_stream",
+        "browser_trace",
+        "computerUse",
+        "dictation"
+      ],
+      "patchNamePatterns": [
+        "ipc",
+        "bridge",
+        "lifecycle",
+        "window"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "electron-ipc-entrypoint",
+          "contentNeedles": [
+            "ipcMain.handle"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/patches/core/all-linux/main-process",
+          "linux-features/record-and-replay/patch.js"
+        ]
+      }
+    },
+    {
+      "id": "plugin_manifests_marketplace",
+      "title": "Bundled plugin manifests and marketplace metadata",
+      "category": "plugin",
+      "pathPatterns": [
+        "plugins/openai-bundled",
+        "marketplace",
+        "\\.codex-plugin/plugin\\.json$",
+        "\\.mcp\\.json$"
+      ],
+      "contentNeedles": [
+        ".codex-plugin",
+        "mcpServers",
+        "marketplace",
+        "skills",
+        "record-and-replay",
+        "computer-use",
+        "chrome"
+      ],
+      "pluginIds": [
+        "record-and-replay",
+        "computer-use",
+        "chrome",
+        "browser"
+      ],
+      "patchNamePatterns": [
+        "plugin",
+        "marketplace",
+        "browser",
+        "chrome"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "bundled-plugin-manifests",
+          "pluginIds": [
+            "record-and-replay",
+            "computer-use",
+            "chrome",
+            "browser"
+          ]
+        },
+        {
+          "id": "bundled-mcp-manifests",
+          "mcpServerNames": [
+            "event-stream"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/bundled-plugins.sh",
+          "plugins/openai-bundled"
+        ]
+      }
+    },
+    {
+      "id": "native_bridge_sidecars",
+      "title": "Native bridge sidecars and mirrored plugin substrate",
+      "category": "native",
+      "pathPatterns": [
+        "Contents/MacOS",
+        "Contents/SharedSupport",
+        "\\.node$",
+        "\\.dylib$"
+      ],
+      "contentNeedles": [
+        "SkyComputerUseClient",
+        "codex_chronicle",
+        "node_repl",
+        "mcp"
+      ],
+      "nativeStringNeedles": [
+        "SkyComputerUseClient",
+        "codex_chronicle",
+        "node_repl",
+        "mcp"
+      ],
+      "patchNamePatterns": [
+        "native",
+        "bridge",
+        "node_repl"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "native-bridge-binaries",
+          "nativeBinaryPatterns": [
+            "Contents/MacOS",
+            "Contents/SharedSupport",
+            "\\.node$",
+            "\\.dylib$"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/bundled-plugins.sh",
+          "computer-use-linux",
+          "record-replay-linux"
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/lib/upstream-dmg-intel.js
+++ b/scripts/lib/upstream-dmg-intel.js
@@ -1,0 +1,1659 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const TEXT_FILE_PATTERN = /\.(cjs|css|html|js|json|mjs|md|text|ts|tsx|txt|xml|yml|yaml)$/i;
+const NATIVE_FILE_PATTERN = /(^|\/)(codex_chronicle|SkyComputerUseClient|sky\.node|node_repl|node|[^/]+\.(node|dylib))$/i;
+const DEFAULT_MAX_TEXT_BYTES = 2_500_000;
+const DEFAULT_MAX_INVENTORY_HASH_BYTES = 10_000_000;
+const DRIFT_PATH_SAMPLE_LIMIT = 8;
+const DRIFT_CHANGED_SAMPLE_LIMIT = 12;
+const MARKDOWN_PATH_SAMPLE_LIMIT = 3;
+const ACTION_PLAN_PATH_SAMPLE_LIMIT = 3;
+const SUCCESSFUL_PATCH_STATUSES = new Set(["applied", "already-applied", "skipped-target", "skipped-disabled"]);
+const BLOCKING_PATCH_STATUSES = new Set(["failed-required"]);
+const ACTIONABLE_CLASSIFICATIONS = new Set([
+  "MOVED",
+  "RENAMED",
+  "PAYLOAD_CHANGED",
+  "REMOVED",
+  "NEW_UPSTREAM_CAPABILITY",
+  "PATCH_BROKEN",
+  "PATCH_REVIEW",
+  "LINUX_SUBSTRATE_GAP",
+  "PROTECTED_SURFACE_PARTIAL",
+  "PROTECTED_SURFACE_MISSING",
+]);
+const STRING_LITERAL_PATTERN = /`([^`\\]*(?:\\.[^`\\]*)*)`|"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'/g;
+const BRIDGE_CHANNEL_TERM_PATTERN =
+  /browser[-_]trace|chrome|chronicle|computer[-_]use|desktop[-_]snapshot|dictation|event[-_]stream|focused[-_]window|global[-_]dictation|nativeMessaging|record[-_ ]?(?:and[-_ ]?)?replay|skysight|speech[-_]context|window[-_]metadata/i;
+const LOWER_BRIDGE_CHANNEL_PATTERN = /^[a-z][a-z0-9_.:-]{2,119}$/;
+const CAMEL_BRIDGE_CHANNEL_PATTERN = /^(?:browserTrace|computerUse|eventStream|focusedWindow|nativeMessaging|recordAndReplay|speechContext|windowMetadata)$/;
+const ASSET_EXTENSION_PATTERN = /\.(?:css|dylib|exe|gif|ico|jpeg|jpg|js|json|md|node|png|svg|ts|tsx|txt|wasm|yml|yaml)$/i;
+const commandPathCache = new Map();
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function normalizePath(value) {
+  return String(value).replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function toRegex(pattern) {
+  return pattern instanceof RegExp ? pattern : new RegExp(pattern, "i");
+}
+
+function matchAny(patterns, value) {
+  return (patterns ?? []).some((pattern) => toRegex(pattern).test(value));
+}
+
+function textSnippet(text, needle) {
+  const index = text.toLowerCase().indexOf(String(needle).toLowerCase());
+  if (index < 0) {
+    return null;
+  }
+  const start = Math.max(0, index - 80);
+  const end = Math.min(text.length, index + String(needle).length + 80);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+function includesNeedle(value, needle) {
+  const valueText = String(value);
+  const needleText = String(needle);
+  if (/^[A-Za-z0-9_]+$/.test(needleText) && needleText.length <= 4) {
+    const escaped = needleText.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(^|[^A-Za-z0-9_])${escaped}([^A-Za-z0-9_]|$)`, "i").test(valueText);
+  }
+  return valueText.toLowerCase().includes(needleText.toLowerCase());
+}
+
+function printableStrings(buffer, minLength = 4) {
+  const strings = new Set();
+  let current = "";
+  for (const byte of buffer) {
+    if (byte >= 32 && byte <= 126) {
+      current += String.fromCharCode(byte);
+    } else {
+      if (current.length >= minLength) {
+        strings.add(current);
+      }
+      current = "";
+    }
+  }
+  if (current.length >= minLength) {
+    strings.add(current);
+  }
+  return [...strings].sort();
+}
+
+function asarEntries(asarPath, prefix = "app.asar") {
+  const archive = fs.readFileSync(asarPath);
+  if (archive.length < 16) {
+    throw new Error(`Invalid ASAR archive: ${asarPath}`);
+  }
+
+  const headerSize = archive.readUInt32LE(4);
+  const jsonSize = archive.readUInt32LE(12);
+  const header = JSON.parse(archive.subarray(16, 16 + jsonSize).toString("utf8"));
+  const dataStart = 8 + headerSize;
+  const entries = [];
+
+  function walk(prefix, files) {
+    for (const [name, entry] of Object.entries(files ?? {})) {
+      const fullPath = prefix ? `${prefix}/${name}` : name;
+      if (entry.files) {
+        walk(fullPath, entry.files);
+      } else {
+        const size = Number(entry.size ?? 0);
+        const offset = Number(entry.offset ?? 0);
+        const unpacked = Boolean(entry.unpacked);
+        const buffer = unpacked ? null : archive.subarray(dataStart + offset, dataStart + offset + size);
+        entries.push({
+          buffer,
+          relativePath: `${prefix}/${fullPath}`,
+          size,
+          source: "asar",
+          unpacked,
+        });
+      }
+    }
+  }
+
+  walk("", header.files);
+  return entries;
+}
+
+function walkFiles(rootDir, source = "filesystem", prefix = "") {
+  const files = [];
+  const stack = [rootDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const dirent of entries) {
+      const fullPath = path.join(current, dirent.name);
+      if (dirent.isDirectory()) {
+        stack.push(fullPath);
+      } else if (dirent.isFile()) {
+        const stat = fs.statSync(fullPath);
+        const relativePath = normalizePath(path.join(prefix, path.relative(rootDir, fullPath)));
+        files.push({
+          absolutePath: fullPath,
+          mode: stat.mode,
+          relativePath,
+          size: stat.size,
+          source,
+        });
+      }
+    }
+  }
+  return files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+}
+
+function sourceKind(sourcePath) {
+  const stat = fs.statSync(sourcePath);
+  if (stat.isDirectory() && /\.app$/i.test(path.basename(sourcePath))) {
+    return "app";
+  }
+  if (stat.isDirectory()) {
+    return "directory";
+  }
+  if (/\.dmg$/i.test(sourcePath)) {
+    return "dmg";
+  }
+  throw new Error(`Unsupported upstream source: ${sourcePath}`);
+}
+
+function findAppDir(extractDir) {
+  const stack = [extractDir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const dirent of entries) {
+      if (!dirent.isDirectory()) {
+        continue;
+      }
+      const fullPath = path.join(current, dirent.name);
+      if (/\.app$/i.test(dirent.name)) {
+        return fullPath;
+      }
+      stack.push(fullPath);
+    }
+  }
+  return null;
+}
+
+function extractDmgToApp({ dmgPath, workDir }) {
+  const extractDir = path.join(workDir, "dmg-extract");
+  fs.mkdirSync(extractDir, { recursive: true });
+  const sevenZipCommand = commandOnPath("7zz") ?? commandOnPath("7z");
+  if (sevenZipCommand == null) {
+    throw new Error("7zz or 7z is required to inspect DMG files");
+  }
+  const seven = spawnSync(sevenZipCommand, ["x", "-y", "-snl", dmgPath, `-o${extractDir}`], {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const appDir = findAppDir(extractDir);
+  if (seven.status !== 0 && appDir == null) {
+    throw new Error(`7z failed to extract DMG: ${(seven.stderr || seven.stdout || "").trim()}`);
+  }
+  if (appDir == null) {
+    throw new Error(`Could not find .app bundle in extracted DMG: ${dmgPath}`);
+  }
+  return appDir;
+}
+
+function commandOnPath(command) {
+  const cacheKey = `${process.env.PATH ?? ""}\0${command}`;
+  if (commandPathCache.has(cacheKey)) {
+    return commandPathCache.get(cacheKey);
+  }
+  const resolved = resolveCommandOnPath(command);
+  commandPathCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+function resolveCommandOnPath(command) {
+  if (command.includes(path.sep)) {
+    return executablePathOrNull(command);
+  }
+  for (const entry of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!entry) {
+      continue;
+    }
+    const candidate = path.join(entry, command);
+    const resolved = executablePathOrNull(candidate);
+    if (resolved != null) {
+      return resolved;
+    }
+  }
+  return null;
+}
+
+function executablePathOrNull(candidate) {
+  try {
+    fs.accessSync(candidate, fs.constants.X_OK);
+    const stat = fs.statSync(candidate);
+    if (stat.isFile()) {
+      return candidate;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function collectInventoryFiles(appDir, options = {}) {
+  const resourcesDir = path.join(appDir, "Contents/Resources");
+  const hasAppBundleResources = fs.existsSync(resourcesDir);
+  const root = hasAppBundleResources ? appDir : appDir;
+  const resourcesPrefix = hasAppBundleResources ? "Contents/Resources" : "";
+  const files = walkFiles(root).filter((file) => !file.relativePath.includes("app.asar.extracted/"));
+  const asarPath = path.join(resourcesDir, "app.asar");
+  const asarExtractedDir = path.join(resourcesDir, "app.asar.extracted");
+
+  if (fs.existsSync(asarPath)) {
+    try {
+      files.push(...asarEntries(asarPath, normalizePath(path.join(resourcesPrefix, "app.asar"))));
+    } catch (error) {
+      files.push({
+        relativePath: "app.asar",
+        scanError: error.message,
+        size: fs.statSync(asarPath).size,
+        source: "asar",
+      });
+    }
+  }
+
+  if (fs.existsSync(asarExtractedDir)) {
+    files.push(...walkFiles(asarExtractedDir, "asar-extracted", normalizePath(path.join(resourcesPrefix, "app.asar"))));
+  }
+
+  return files.map((file) => enrichInventoryFile(file, options));
+}
+
+function fileType(file) {
+  if (file.relativePath.endsWith(".json")) {
+    return "json";
+  }
+  if (TEXT_FILE_PATTERN.test(file.relativePath)) {
+    return "text";
+  }
+  const executable = typeof file.mode === "number" && (file.mode & 0o111) !== 0;
+  const extension = path.posix.extname(file.relativePath);
+  if (NATIVE_FILE_PATTERN.test(file.relativePath) || (executable && extension === "")) {
+    return "native";
+  }
+  return "binary";
+}
+
+function readFileBuffer(file) {
+  if (file.buffer != null) {
+    return file.buffer;
+  }
+  if (file.absolutePath != null) {
+    return fs.readFileSync(file.absolutePath);
+  }
+  return null;
+}
+
+function runFileCommand(absolutePath) {
+  if (absolutePath == null) {
+    return null;
+  }
+  const result = spawnSync("file", ["-b", absolutePath], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  return result.stdout.trim() || null;
+}
+
+function enrichInventoryFile(file, options = {}) {
+  const maxTextBytes = options.maxTextBytes ?? DEFAULT_MAX_TEXT_BYTES;
+  const maxHashBytes = options.maxHashBytes ?? DEFAULT_MAX_INVENTORY_HASH_BYTES;
+  const type = fileType(file);
+  const buffer = file.unpacked ? null : readFileBuffer(file);
+  const enriched = {
+    absolutePath: file.absolutePath,
+    mode: file.mode == null ? null : `0${(file.mode & 0o777).toString(8)}`,
+    relativePath: normalizePath(file.relativePath),
+    size: file.size ?? buffer?.length ?? 0,
+    source: file.source,
+    type,
+  };
+
+  if (file.scanError != null) {
+    enriched.scanError = file.scanError;
+  }
+  if (buffer != null && enriched.size <= maxHashBytes) {
+    enriched.sha256 = sha256(buffer);
+  }
+  if (buffer != null && (type === "text" || type === "json") && enriched.size <= maxTextBytes) {
+    enriched.text = buffer.toString("utf8");
+  }
+  if (buffer != null && type === "native") {
+    enriched.nativeStrings = printableStrings(buffer).slice(0, 5000);
+    enriched.fileCommand = runFileCommand(file.absolutePath);
+  }
+
+  return enriched;
+}
+
+function createInventory({ registry = null, sourcePath, workDir = null } = {}) {
+  if (sourcePath == null) {
+    throw new Error("sourcePath is required");
+  }
+  const resolvedSourcePath = path.resolve(sourcePath);
+  const kind = sourceKind(resolvedSourcePath);
+  let scratchDir = workDir;
+  let cleanupScratch = false;
+  if (kind === "dmg" && scratchDir == null) {
+    scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-upstream-intel-"));
+    cleanupScratch = true;
+  }
+
+  try {
+    const appDir = kind === "dmg" ? extractDmgToApp({ dmgPath: resolvedSourcePath, workDir: scratchDir }) : resolvedSourcePath;
+    const files = collectInventoryFiles(appDir).sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+    return {
+      generatedAt: new Date().toISOString(),
+      registryVersion: registry?.version ?? null,
+      source: {
+        kind,
+        path: resolvedSourcePath,
+        appDir,
+      },
+      counts: {
+        files: files.length,
+        nativeFiles: files.filter((file) => file.type === "native").length,
+        textFiles: files.filter((file) => file.type === "text" || file.type === "json").length,
+      },
+      files,
+    };
+  } finally {
+    if (cleanupScratch && scratchDir != null) {
+      fs.rmSync(scratchDir, { force: true, recursive: true });
+    }
+  }
+}
+
+function fileEvidenceForSurface(inventory, surface) {
+  const evidence = [];
+  for (const file of inventory.files) {
+    const pathHit = matchAny(surface.pathPatterns, file.relativePath);
+    const contentHits = [];
+    const nativeHits = [];
+    if (file.text != null) {
+      for (const needle of surface.contentNeedles ?? []) {
+        if (includesNeedle(file.text, needle)) {
+          contentHits.push({ needle, snippet: textSnippet(file.text, needle) });
+        }
+      }
+    }
+    if (Array.isArray(file.nativeStrings)) {
+      for (const needle of surface.nativeStringNeedles ?? surface.contentNeedles ?? []) {
+        const matched = file.nativeStrings.find((value) => includesNeedle(value, needle));
+        if (matched != null) {
+          nativeHits.push({ needle, value: matched });
+        }
+      }
+    }
+    if (pathHit || contentHits.length > 0 || nativeHits.length > 0) {
+      evidence.push({
+        path: file.relativePath,
+        sha256: file.sha256 ?? null,
+        size: file.size,
+        source: file.source,
+        type: file.type,
+        pathHit,
+        contentHits,
+        nativeHits,
+      });
+    }
+  }
+  return evidence;
+}
+
+function anchorFileMatches(inventory, anchor) {
+  return inventory.files.filter((file) => {
+    const pathOk = (anchor.pathPatterns ?? []).length === 0 || matchAny(anchor.pathPatterns, file.relativePath);
+    if (!pathOk) {
+      return false;
+    }
+    if (anchor.type != null && file.type !== anchor.type) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function matchPatternList(patterns, value) {
+  return (patterns ?? []).every((pattern) => toRegex(pattern).test(value));
+}
+
+function pluginAnchorState(anchor, pluginMap) {
+  const plugins = pluginMap?.plugins ?? [];
+  const pluginIds = anchor.pluginIds ?? [];
+  const scriptPatterns = anchor.pluginScriptPatterns ?? [];
+  const skillPatterns = anchor.pluginSkillPatterns ?? [];
+  if (pluginIds.length === 0 && scriptPatterns.length === 0 && skillPatterns.length === 0) {
+    return { missing: [], matchedPaths: [] };
+  }
+  const missingPlugins = pluginIds.filter((pluginId) => !plugins.some((plugin) => plugin.id === pluginId));
+  const missingScripts = scriptPatterns.filter((pattern) =>
+    !plugins.some((plugin) => plugin.scripts.some((script) => toRegex(pattern).test(script))),
+  );
+  const missingSkills = skillPatterns.filter((pattern) =>
+    !plugins.some((plugin) => plugin.skills.some((skill) => toRegex(pattern).test(skill))),
+  );
+  const matchedPaths = [];
+  for (const plugin of plugins) {
+    if (pluginIds.length === 0 || pluginIds.includes(plugin.id)) {
+      matchedPaths.push(...plugin.manifests.map((manifest) => manifest.path));
+      matchedPaths.push(...plugin.scripts.filter((script) => matchAny(scriptPatterns, script)));
+      matchedPaths.push(...plugin.skills.filter((skill) => matchAny(skillPatterns, skill)));
+    }
+  }
+  return {
+    missing: [
+      ...missingPlugins.map((pluginId) => `plugin:${pluginId}`),
+      ...missingScripts.map((pattern) => `script:${pattern}`),
+      ...missingSkills.map((pattern) => `skill:${pattern}`),
+    ],
+    matchedPaths,
+  };
+}
+
+function mcpAnchorState(anchor, pluginMap) {
+  const matchedPaths = [];
+  const missing = [];
+  const pluginIds = anchor.pluginIds ?? [];
+  const serverNames = anchor.mcpServerNames ?? [];
+  const commandPatterns = anchor.mcpCommandPatterns ?? [];
+  const requiredArgs = anchor.mcpArgs ?? [];
+  if (
+    pluginIds.length === 0 &&
+    serverNames.length === 0 &&
+    commandPatterns.length === 0 &&
+    requiredArgs.length === 0
+  ) {
+    return { missing: [], matchedPaths: [] };
+  }
+  const servers = [];
+  for (const plugin of pluginMap?.plugins ?? []) {
+    if (pluginIds.length > 0 && !pluginIds.includes(plugin.id)) {
+      continue;
+    }
+    for (const manifest of plugin.mcpServers ?? []) {
+      for (const server of manifest.servers ?? []) {
+        servers.push({ pluginId: plugin.id, manifestPath: manifest.path, server });
+      }
+    }
+  }
+  if (serverNames.length > 0) {
+    for (const serverName of serverNames) {
+      const found = servers.some((entry) => entry.server.name === serverName);
+      if (!found) {
+        missing.push(`mcpServer:${serverName}`);
+      }
+    }
+  }
+  for (const pattern of commandPatterns) {
+    const found = servers.some((entry) => toRegex(pattern).test(entry.server.command ?? ""));
+    if (!found) {
+      missing.push(`mcpCommand:${pattern}`);
+    }
+  }
+  for (const arg of requiredArgs) {
+    const found = servers.some((entry) => entry.server.args.includes(arg));
+    if (!found) {
+      missing.push(`mcpArg:${arg}`);
+    }
+  }
+  for (const entry of servers) {
+    if (
+      (serverNames.length === 0 || serverNames.includes(entry.server.name)) &&
+      matchPatternList(commandPatterns, entry.server.command ?? "") &&
+      requiredArgs.every((arg) => entry.server.args.includes(arg))
+    ) {
+      matchedPaths.push(entry.manifestPath);
+    }
+  }
+  return { missing, matchedPaths };
+}
+
+function bridgeAnchorState(anchor, bridgeMap) {
+  const handlerNames = anchor.bridgeHandlers ?? [];
+  if (handlerNames.length === 0) {
+    return { missing: [], matchedPaths: [] };
+  }
+  const missing = handlerNames.filter((handlerName) => !bridgeMap?.handlers?.some((handler) => handler.name === handlerName));
+  const matchedPaths = (bridgeMap?.handlers ?? [])
+    .filter((handler) => handlerNames.length === 0 || handlerNames.includes(handler.name))
+    .map((handler) => handler.path);
+  return { missing: missing.map((handler) => `bridgeHandler:${handler}`), matchedPaths };
+}
+
+function nativeAnchorState(anchor, nativeBinaryMap) {
+  const patterns = anchor.nativeBinaryPatterns ?? [];
+  const binaries = nativeBinaryMap?.binaries ?? [];
+  const missing = patterns.filter((pattern) => !binaries.some((binary) => toRegex(pattern).test(binary.relativePath)));
+  return {
+    missing: missing.map((pattern) => `nativeBinary:${pattern}`),
+    matchedPaths: binaries.filter((binary) => matchAny(patterns, binary.relativePath)).map((binary) => binary.relativePath),
+  };
+}
+
+function evaluateRequiredAnchor(inventory, anchor, context = {}) {
+  const files = anchorFileMatches(inventory, anchor);
+  const missingNeedles = [];
+  const matchedNeedles = [];
+  const matchedPathSet = new Set();
+  for (const needle of anchor.contentNeedles ?? []) {
+    const matchedFiles = files.filter((file) => file.text != null && includesNeedle(file.text, needle));
+    if (matchedFiles.length === 0) {
+      missingNeedles.push(needle);
+    } else {
+      matchedNeedles.push({
+        needle,
+        type: "content",
+        paths: matchedFiles.map((file) => file.relativePath).sort().slice(0, 20),
+      });
+      for (const file of matchedFiles) matchedPathSet.add(file.relativePath);
+    }
+  }
+  for (const needle of anchor.nativeStringNeedles ?? []) {
+    const matchedFiles = files.filter(
+      (file) => Array.isArray(file.nativeStrings) && file.nativeStrings.some((value) => includesNeedle(value, needle)),
+    );
+    if (matchedFiles.length === 0) {
+      missingNeedles.push(needle);
+    } else {
+      matchedNeedles.push({
+        needle,
+        type: "nativeString",
+        paths: matchedFiles.map((file) => file.relativePath).sort().slice(0, 20),
+      });
+      for (const file of matchedFiles) matchedPathSet.add(file.relativePath);
+    }
+  }
+  const pluginState = pluginAnchorState(anchor, context.pluginMap);
+  const mcpState = mcpAnchorState(anchor, context.pluginMap);
+  const bridgeState = bridgeAnchorState(anchor, context.bridgeMap);
+  const nativeState = nativeAnchorState(anchor, context.nativeBinaryMap);
+  for (const matchedPath of [
+    ...pluginState.matchedPaths,
+    ...mcpState.matchedPaths,
+    ...bridgeState.matchedPaths,
+    ...nativeState.matchedPaths,
+  ]) {
+    matchedPathSet.add(matchedPath);
+  }
+  const requiredPathMatched = (anchor.pathPatterns ?? []).length === 0 || files.length > 0;
+  if (requiredPathMatched && (anchor.pathPatterns ?? []).length > 0 && missingNeedles.length === 0) {
+    for (const file of files) matchedPathSet.add(file.relativePath);
+  }
+  const structuralMissing = [
+    ...pluginState.missing,
+    ...mcpState.missing,
+    ...bridgeState.missing,
+    ...nativeState.missing,
+  ];
+  const satisfied = requiredPathMatched && missingNeedles.length === 0 && structuralMissing.length === 0;
+  return {
+    id: anchor.id,
+    title: anchor.title ?? anchor.id,
+    satisfied,
+    matchedPaths: [...matchedPathSet].sort().slice(0, 50),
+    matchedNeedles,
+    missingNeedles: [...missingNeedles, ...structuralMissing],
+    requiredPathMatched,
+  };
+}
+
+function evaluateRequiredAnchors(inventory, surface, context = {}) {
+  const anchors = surface.requiredEvidence ?? [];
+  const evaluated = anchors.map((anchor) => evaluateRequiredAnchor(inventory, anchor, context));
+  return {
+    anchors: evaluated,
+    satisfiedAnchors: evaluated.filter((anchor) => anchor.satisfied),
+    missingAnchors: evaluated.filter((anchor) => !anchor.satisfied),
+  };
+}
+
+function surfaceFingerprint(surfaceEvidence) {
+  const hash = crypto.createHash("sha256");
+  for (const item of surfaceEvidence) {
+    hash.update(item.path);
+    hash.update("\0");
+    hash.update(item.sha256 ?? String(item.size));
+    hash.update("\0");
+    for (const hit of item.contentHits ?? []) {
+      hash.update(String(hit.needle));
+      hash.update("\0");
+    }
+    for (const hit of item.nativeHits ?? []) {
+      hash.update(String(hit.needle));
+      hash.update("\0");
+      hash.update(String(hit.value));
+      hash.update("\0");
+    }
+  }
+  return hash.digest("hex");
+}
+
+function substrateStatus(surface, repoRoot) {
+  const requiredPaths = surface.linuxSubstrate?.requiredPaths ?? [];
+  if (requiredPaths.length === 0) {
+    return {
+      status: "UNKNOWN",
+      missingPaths: [],
+      requiredPaths,
+    };
+  }
+  const missingPaths = requiredPaths.filter((candidatePath) => !fs.existsSync(path.join(repoRoot, candidatePath)));
+  return {
+    status: missingPaths.length === 0 ? "PRESENT" : "MISSING",
+    missingPaths,
+    requiredPaths,
+  };
+}
+
+function extractProtectedSurfaces({ inventory, registry, repoRoot = process.cwd() } = {}) {
+  const bridgeMap = createBridgeMap(inventory);
+  const pluginMap = createPluginMap(inventory);
+  const nativeBinaryMap = createNativeBinaryMap(inventory, registry);
+  const surfaces = (registry.surfaces ?? []).map((surface) => {
+    const evidence = fileEvidenceForSurface(inventory, surface).sort((a, b) => a.path.localeCompare(b.path));
+    const anchors = evaluateRequiredAnchors(inventory, surface, { bridgeMap, pluginMap, nativeBinaryMap });
+    const hasAnchorContract = (surface.requiredEvidence ?? []).length > 0;
+    const status = hasAnchorContract
+      ? anchors.missingAnchors.length === 0
+        ? "PRESENT"
+        : evidence.length > 0
+          ? "PARTIAL"
+          : "MISSING"
+      : evidence.length > 0
+        ? "PRESENT"
+        : "MISSING";
+    const confidence = status === "PRESENT" ? (hasAnchorContract ? "high" : "medium") : status === "PARTIAL" ? "low" : "none";
+    return {
+      id: surface.id,
+      title: surface.title,
+      category: surface.category,
+      patchNamePatterns: surface.patchNamePatterns ?? [],
+      status,
+      confidence,
+      evidence,
+      evidenceCount: evidence.length,
+      requiredAnchors: anchors.anchors,
+      satisfiedAnchors: anchors.satisfiedAnchors,
+      missingAnchors: anchors.missingAnchors,
+      fingerprint: status === "PRESENT" ? surfaceFingerprint(evidence) : null,
+      linuxSubstrate: substrateStatus(surface, repoRoot),
+    };
+  });
+  return {
+    generatedAt: new Date().toISOString(),
+    source: inventory.source,
+    registryVersion: registry.version ?? null,
+    surfaces,
+    surfacesById: Object.fromEntries(surfaces.map((surface) => [surface.id, surface])),
+    bridgeMap,
+    pluginMap,
+    nativeBinaryMap,
+  };
+}
+
+function createBridgeMap(inventory) {
+  const handlerPattern = /\b(?:ipcMain|ipcRenderer|contextBridge)\.(?:handle|on|invoke|exposeInMainWorld)\(\s*(['"`])([^'"`]+)\1/g;
+  const handlers = [];
+  const channelCandidates = [];
+  const seenCandidates = new Set();
+  for (const file of inventory.files) {
+    if (file.text == null) {
+      continue;
+    }
+    for (const match of file.text.matchAll(handlerPattern)) {
+      handlers.push({
+        name: match[2],
+        path: file.relativePath,
+        kind: match[0].split("(")[0],
+      });
+    }
+    for (const match of file.text.matchAll(STRING_LITERAL_PATTERN)) {
+      const name = match[1] ?? match[2] ?? match[3] ?? "";
+      if (!isBridgeChannelCandidate(name)) {
+        continue;
+      }
+      const key = `${name}\0${file.relativePath}`;
+      if (seenCandidates.has(key)) {
+        continue;
+      }
+      seenCandidates.add(key);
+      channelCandidates.push({
+        name,
+        path: file.relativePath,
+        kind: "string-literal",
+      });
+    }
+  }
+  return {
+    handlers: handlers.sort((a, b) => `${a.name}:${a.path}`.localeCompare(`${b.name}:${b.path}`)),
+    channelCandidates: channelCandidates.sort((a, b) =>
+      `${a.name}:${a.path}`.localeCompare(`${b.name}:${b.path}`),
+    ),
+  };
+}
+
+function isBridgeChannelCandidate(name) {
+  return (
+    (LOWER_BRIDGE_CHANNEL_PATTERN.test(name) || CAMEL_BRIDGE_CHANNEL_PATTERN.test(name)) &&
+    BRIDGE_CHANNEL_TERM_PATTERN.test(name) &&
+    !ASSET_EXTENSION_PATTERN.test(name) &&
+    !/[-_.:]$/u.test(name)
+  );
+}
+
+function pluginIdFromPath(relativePath) {
+  const match = relativePath.match(/plugins\/openai-bundled\/plugins\/([^/]+)\//);
+  return match?.[1] ?? null;
+}
+
+function createPluginMap(inventory) {
+  const pluginsById = new Map();
+  for (const file of inventory.files) {
+    const pluginId = pluginIdFromPath(file.relativePath);
+    if (pluginId == null) {
+      continue;
+    }
+    const plugin = pluginsById.get(pluginId) ?? {
+      id: pluginId,
+      files: [],
+      fileFingerprints: [],
+      manifests: [],
+      mcpServers: [],
+      scripts: [],
+      skills: [],
+    };
+    plugin.files.push(file.relativePath);
+    plugin.fileFingerprints.push({
+      path: file.relativePath,
+      sha256: file.sha256 ?? null,
+      size: file.size,
+      mode: file.mode ?? null,
+    });
+    if (file.relativePath.endsWith(".codex-plugin/plugin.json") && file.text != null) {
+      try {
+        const manifest = JSON.parse(file.text);
+        plugin.manifests.push({
+          path: file.relativePath,
+          id: manifest.id ?? manifest.name ?? pluginId,
+          name: manifest.name ?? null,
+          version: manifest.version ?? null,
+          displayName: manifest.interface?.displayName ?? null,
+          shortDescription: manifest.interface?.shortDescription ?? null,
+          defaultPrompt: manifest.interface?.defaultPrompt ?? null,
+          mcpServerKeys: Array.isArray(manifest.mcpServers)
+            ? manifest.mcpServers.map((server) => server.name ?? server.id ?? null).filter(Boolean)
+            : Object.keys(manifest.mcpServers ?? {}),
+          skillCount: Array.isArray(manifest.skills) ? manifest.skills.length : 0,
+        });
+      } catch (error) {
+        plugin.manifests.push({ path: file.relativePath, parseError: error.message });
+      }
+    }
+    if (file.relativePath.endsWith(".mcp.json") && file.text != null) {
+      try {
+        const manifest = JSON.parse(file.text);
+        plugin.mcpServers.push({
+          path: file.relativePath,
+          servers: Object.entries(manifest.mcpServers ?? {}).map(([name, server]) => ({
+            name,
+            command: server.command ?? null,
+            args: Array.isArray(server.args) ? server.args : [],
+            envKeys: Object.keys(server.env ?? {}),
+            tools: Array.isArray(server.tools)
+              ? server.tools.map((tool) => (typeof tool === "string" ? tool : tool.name)).filter(Boolean)
+              : [],
+          })),
+        });
+      } catch (error) {
+        plugin.mcpServers.push({ path: file.relativePath, parseError: error.message });
+      }
+    }
+    if (/\/scripts\/[^/]+\.(mjs|js|cjs)$/i.test(file.relativePath) || /\/browser-client\.mjs$/i.test(file.relativePath)) {
+      plugin.scripts.push(file.relativePath);
+    }
+    if (/\/skills\/[^/]+\/SKILL\.md$/i.test(file.relativePath)) {
+      plugin.skills.push(file.relativePath);
+    }
+    pluginsById.set(pluginId, plugin);
+  }
+  return {
+    plugins: [...pluginsById.values()].sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+function nativeProtectedStringHits(file, registry) {
+  const strings = Array.isArray(file.nativeStrings) ? file.nativeStrings : [];
+  const needles = [
+    ...new Set(
+      (registry?.surfaces ?? []).flatMap((surface) => [
+        ...(surface.nativeStringNeedles ?? []),
+        ...(surface.contentNeedles ?? []),
+      ]),
+    ),
+  ];
+  return needles
+    .flatMap((needle) => {
+      const value = strings.find((candidate) => includesNeedle(candidate, needle));
+      return value == null ? [] : [{ needle, value }];
+    })
+    .slice(0, 200);
+}
+
+function runBoundedToolLines(command, args, maxLines = 200) {
+  const commandPath = commandOnPath(command);
+  if (commandPath == null) {
+    return null;
+  }
+  const result = spawnSync(commandPath, args, {
+    encoding: "utf8",
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  const lines = result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.slice(0, maxLines);
+}
+
+function nativeSymbolInventory(file) {
+  if (file.absolutePath == null) {
+    return null;
+  }
+  const llvmSymbols = runBoundedToolLines("llvm-nm", ["-g", file.absolutePath]);
+  if (llvmSymbols != null) {
+    return { tool: "llvm-nm -g", symbols: llvmSymbols };
+  }
+  const nmSymbols = runBoundedToolLines("nm", ["-g", file.absolutePath]);
+  if (nmSymbols != null) {
+    return { tool: "nm -g", symbols: nmSymbols };
+  }
+  return null;
+}
+
+function nativeLinkedLibraries(file) {
+  if (file.absolutePath == null) {
+    return null;
+  }
+  const otoolLibraries = runBoundedToolLines("otool", ["-L", file.absolutePath]);
+  if (otoolLibraries != null) {
+    return { tool: "otool -L", libraries: otoolLibraries };
+  }
+  return null;
+}
+
+function createNativeBinaryMap(inventory, registry = null) {
+  const binaries = inventory.files
+    .filter((file) => file.type === "native")
+    .map((file) => ({
+      relativePath: file.relativePath,
+      sha256: file.sha256 ?? null,
+      size: file.size,
+      fileCommand: file.fileCommand ?? null,
+      protectedStringHits: nativeProtectedStringHits(file, registry),
+      symbols: nativeSymbolInventory(file),
+      linkedLibraries: nativeLinkedLibraries(file),
+    }));
+  return { binaries };
+}
+
+function classifySurfaceDrift({ baselineSurface, candidateSurface }) {
+  const baselinePresent = baselineSurface?.status === "PRESENT";
+  const candidatePresent = candidateSurface?.status === "PRESENT";
+  if (baselinePresent && candidatePresent) {
+    const baselinePaths = new Set(baselineSurface.evidence.map((entry) => entry.path));
+    const candidatePaths = new Set(candidateSurface.evidence.map((entry) => entry.path));
+    const samePaths =
+      baselinePaths.size === candidatePaths.size &&
+      [...baselinePaths].every((entryPath) => candidatePaths.has(entryPath));
+    if (samePaths && baselineSurface.fingerprint === candidateSurface.fingerprint) {
+      return ["UNCHANGED"];
+    }
+    if (!samePaths) {
+      return ["MOVED"];
+    }
+    return ["PAYLOAD_CHANGED"];
+  }
+  if (baselinePresent && !candidatePresent) {
+    return ["REMOVED"];
+  }
+  if (!baselinePresent && candidatePresent) {
+    return ["NEW_UPSTREAM_CAPABILITY"];
+  }
+  return ["UNCHANGED"];
+}
+
+function patchFindingsBySurface(patchReport, surfacesById = {}) {
+  const map = new Map();
+  const surfaces = Object.values(surfacesById);
+  for (const patch of patchReport?.patches ?? []) {
+    if (SUCCESSFUL_PATCH_STATUSES.has(patch.status)) {
+      continue;
+    }
+    const classification = BLOCKING_PATCH_STATUSES.has(patch.status) ? "PATCH_BROKEN" : "PATCH_REVIEW";
+    const explicitSurfaceId = patch.surfaceId ?? patch.protectedSurfaceId ?? null;
+    const matchedSurfaceIds = new Set();
+    if (explicitSurfaceId != null) {
+      matchedSurfaceIds.add(explicitSurfaceId);
+    }
+    const patchText = [patch.name, patch.reason, patch.featureId].filter(Boolean).join(" ");
+    for (const surface of surfaces) {
+      if (matchAny(surface.patchNamePatterns, patchText)) {
+        matchedSurfaceIds.add(surface.id);
+      }
+    }
+    if (matchedSurfaceIds.size === 0) {
+      continue;
+    }
+    for (const surfaceId of matchedSurfaceIds) {
+      const list = map.get(surfaceId) ?? [];
+      list.push({
+        classification,
+        name: patch.name,
+        reviewOnly: classification === "PATCH_REVIEW",
+        status: patch.status,
+        reason: patch.reason ?? null,
+      });
+      map.set(surfaceId, list);
+    }
+  }
+  return map;
+}
+
+function compareProtectedSurfaces({ baseline, candidate, patchReport = null } = {}) {
+  const hasBaseline = baseline != null;
+  const patchFindings = patchFindingsBySurface(patchReport, {
+    ...(baseline?.surfacesById ?? {}),
+    ...(candidate?.surfacesById ?? {}),
+  });
+  const surfaceIds = new Set([
+    ...Object.keys(baseline?.surfacesById ?? {}),
+    ...Object.keys(candidate?.surfacesById ?? {}),
+  ]);
+  const surfaceDrift = [];
+  for (const surfaceId of [...surfaceIds].sort()) {
+    const baselineSurface = baseline?.surfacesById?.[surfaceId];
+    const candidateSurface = candidate?.surfacesById?.[surfaceId];
+    const classifications = hasBaseline ? classifySurfaceDrift({ baselineSurface, candidateSurface }) : [];
+    if (candidateSurface?.status === "PARTIAL") {
+      classifications.push("PROTECTED_SURFACE_PARTIAL");
+    } else if (candidateSurface?.status === "MISSING") {
+      classifications.push("PROTECTED_SURFACE_MISSING");
+    }
+    const evidenceDrift = compareEvidence(baselineSurface?.evidence ?? [], candidateSurface?.evidence ?? []);
+    for (const classification of classifications) {
+      surfaceDrift.push({
+        surfaceId,
+        title: candidateSurface?.title ?? baselineSurface?.title ?? surfaceId,
+        category: candidateSurface?.category ?? baselineSurface?.category ?? "unknown",
+        classification,
+        baselineStatus: baselineSurface?.status ?? "MISSING",
+        candidateStatus: candidateSurface?.status ?? "MISSING",
+        evidenceSummary: {
+          baseline: summarizeEvidenceState(baselineSurface?.evidence ?? []),
+          candidate: summarizeEvidenceState(candidateSurface?.evidence ?? []),
+        },
+        evidenceDrift: summarizeEvidenceDrift(evidenceDrift),
+        missingAnchors: summarizeAnchors(candidateSurface?.missingAnchors ?? []),
+      });
+    }
+    if ((candidateSurface?.status === "PRESENT") && candidateSurface.linuxSubstrate?.status === "MISSING") {
+      surfaceDrift.push({
+        surfaceId,
+        title: candidateSurface.title,
+        category: candidateSurface.category,
+        classification: "LINUX_SUBSTRATE_GAP",
+        missingPaths: candidateSurface.linuxSubstrate.missingPaths,
+      });
+    }
+    if (patchFindings.has(surfaceId)) {
+      const findingsByClassification = new Map();
+      for (const finding of patchFindings.get(surfaceId)) {
+        const list = findingsByClassification.get(finding.classification) ?? [];
+        list.push(finding);
+        findingsByClassification.set(finding.classification, list);
+      }
+      for (const [classification, patches] of findingsByClassification) {
+        surfaceDrift.push({
+          surfaceId,
+          title: candidateSurface?.title ?? baselineSurface?.title ?? surfaceId,
+          category: candidateSurface?.category ?? baselineSurface?.category ?? "unknown",
+          classification,
+          patches,
+        });
+      }
+    }
+  }
+
+  const classificationCounts = {};
+  for (const item of surfaceDrift) {
+    classificationCounts[item.classification] = (classificationCounts[item.classification] ?? 0) + 1;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    baselineSource: baseline?.source ?? null,
+    candidateSource: candidate?.source ?? null,
+    classificationCounts,
+    surfaceDrift,
+  };
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entryValue]) => {
+    if (entryValue == null) {
+      return false;
+    }
+    if (Array.isArray(entryValue) && entryValue.length === 0) {
+      return false;
+    }
+    return true;
+  }));
+}
+
+function summarizeEvidenceEntry(entry, { includeNeedles = true } = {}) {
+  return compactObject({
+    path: entry.path,
+    sha256: entry.sha256 ?? null,
+    size: entry.size,
+    source: entry.source,
+    type: entry.type,
+    contentNeedles: includeNeedles ? (entry.contentHits ?? []).map((hit) => hit.needle) : [],
+    nativeNeedles: includeNeedles ? (entry.nativeHits ?? []).map((hit) => hit.needle) : [],
+  });
+}
+
+function summarizeEvidenceList(evidence, maxItems = DRIFT_PATH_SAMPLE_LIMIT, options = {}) {
+  return evidence.slice(0, maxItems).map((entry) => summarizeEvidenceEntry(entry, options));
+}
+
+function summarizeEvidenceState(evidence, maxItems = DRIFT_PATH_SAMPLE_LIMIT) {
+  return {
+    evidenceCount: evidence.length,
+    pathSamples: summarizeEvidenceList(evidence, maxItems, { includeNeedles: false }),
+    omittedPathCount: Math.max(0, evidence.length - maxItems),
+  };
+}
+
+function summarizeChangedEvidence(entry) {
+  return compactObject({
+    path: entry.candidate.path === entry.baseline.path ? entry.candidate.path : undefined,
+    baselinePath: entry.candidate.path === entry.baseline.path ? undefined : entry.baseline.path,
+    candidatePath: entry.candidate.path === entry.baseline.path ? undefined : entry.candidate.path,
+    baselineSha256: entry.baseline.sha256 ?? null,
+    candidateSha256: entry.candidate.sha256 ?? null,
+    baselineSize: entry.baseline.size,
+    candidateSize: entry.candidate.size,
+    source: entry.candidate.source ?? entry.baseline.source,
+    type: entry.candidate.type ?? entry.baseline.type,
+  });
+}
+
+function normalizedHashedAssetPath(entryPath) {
+  const normalized = normalizePath(entryPath);
+  const directory = path.posix.dirname(normalized);
+  const basename = path.posix.basename(normalized);
+  const match = basename.match(/^(.+)-[A-Za-z0-9_-]{6,}(\.[A-Za-z0-9.]+)$/);
+  if (match == null) {
+    return null;
+  }
+  const normalizedBasename = `${match[1]}-<hash>${match[2]}`;
+  return directory === "." ? normalizedBasename : `${directory}/${normalizedBasename}`;
+}
+
+function classifyPathMovement(evidenceDrift) {
+  if (evidenceDrift.addedEvidence.length === 0 && evidenceDrift.removedEvidence.length === 0) {
+    return "none";
+  }
+  const addedKeys = evidenceDrift.addedEvidence.map((entry) => normalizedHashedAssetPath(entry.path));
+  const removedKeys = evidenceDrift.removedEvidence.map((entry) => normalizedHashedAssetPath(entry.path));
+  const allMovedPathsAreHashedAssets =
+    addedKeys.length > 0 &&
+    removedKeys.length > 0 &&
+    addedKeys.every(Boolean) &&
+    removedKeys.every(Boolean);
+  if (!allMovedPathsAreHashedAssets) {
+    return "protected_path_changed";
+  }
+  const addedSet = keyedSet(addedKeys);
+  const removedSet = keyedSet(removedKeys);
+  const sameNormalizedAssets =
+    addedSet.size === removedSet.size && [...addedSet].every((entryPath) => removedSet.has(entryPath));
+  return sameNormalizedAssets ? "hashed_asset_churn" : "mixed_hashed_asset_churn";
+}
+
+function summarizeEvidenceDrift(evidenceDrift) {
+  return {
+    pathMovementKind: classifyPathMovement(evidenceDrift),
+    addedPathSamples: summarizeEvidenceList(evidenceDrift.addedEvidence, DRIFT_PATH_SAMPLE_LIMIT, { includeNeedles: false }),
+    removedPathSamples: summarizeEvidenceList(evidenceDrift.removedEvidence, DRIFT_PATH_SAMPLE_LIMIT, { includeNeedles: false }),
+    changedPathSamples: evidenceDrift.changedEvidence.slice(0, DRIFT_CHANGED_SAMPLE_LIMIT).map(summarizeChangedEvidence),
+    unchangedEvidenceCount: evidenceDrift.unchangedEvidence.length,
+    addedEvidenceCount: evidenceDrift.addedEvidence.length,
+    removedEvidenceCount: evidenceDrift.removedEvidence.length,
+    changedEvidenceCount: evidenceDrift.changedEvidence.length,
+    omittedAddedPathCount: Math.max(0, evidenceDrift.addedEvidence.length - DRIFT_PATH_SAMPLE_LIMIT),
+    omittedRemovedPathCount: Math.max(0, evidenceDrift.removedEvidence.length - DRIFT_PATH_SAMPLE_LIMIT),
+    omittedChangedPathCount: Math.max(0, evidenceDrift.changedEvidence.length - DRIFT_CHANGED_SAMPLE_LIMIT),
+  };
+}
+
+function summarizeAnchors(anchors) {
+  return anchors.map((anchor) => ({
+    id: anchor.id,
+    title: anchor.title,
+    missingNeedles: anchor.missingNeedles ?? [],
+    matchedPaths: (anchor.matchedPaths ?? []).slice(0, 20),
+    matchedPathCount: (anchor.matchedPaths ?? []).length,
+  }));
+}
+
+function keyedSet(values) {
+  return new Set(values.filter(Boolean).sort());
+}
+
+function diffSets(baselineValues, candidateValues) {
+  const baselineSet = keyedSet(baselineValues);
+  const candidateSet = keyedSet(candidateValues);
+  return {
+    added: [...candidateSet].filter((value) => !baselineSet.has(value)),
+    removed: [...baselineSet].filter((value) => !candidateSet.has(value)),
+    unchanged: [...candidateSet].filter((value) => baselineSet.has(value)),
+  };
+}
+
+function compareEvidence(baselineEvidence, candidateEvidence) {
+  const baselineByPath = new Map(baselineEvidence.map((entry) => [entry.path, entry]));
+  const candidateByPath = new Map(candidateEvidence.map((entry) => [entry.path, entry]));
+  const addedEvidence = [];
+  const removedEvidence = [];
+  const changedEvidence = [];
+  const unchangedEvidence = [];
+  for (const [entryPath, candidateEntry] of candidateByPath) {
+    const baselineEntry = baselineByPath.get(entryPath);
+    if (baselineEntry == null) {
+      addedEvidence.push(candidateEntry);
+    } else if ((baselineEntry.sha256 ?? baselineEntry.size) !== (candidateEntry.sha256 ?? candidateEntry.size)) {
+      changedEvidence.push({ baseline: baselineEntry, candidate: candidateEntry });
+    } else {
+      unchangedEvidence.push(candidateEntry);
+    }
+  }
+  for (const [entryPath, baselineEntry] of baselineByPath) {
+    if (!candidateByPath.has(entryPath)) {
+      removedEvidence.push(baselineEntry);
+    }
+  }
+  return { addedEvidence, removedEvidence, changedEvidence, unchangedEvidence };
+}
+
+function bridgeHandlerKeys(map) {
+  return (map?.handlers ?? []).map((handler) => `${handler.kind}:${handler.name}:${handler.path}`);
+}
+
+function pluginIds(map) {
+  return (map?.plugins ?? []).map((plugin) => plugin.id);
+}
+
+function pluginById(map) {
+  return new Map((map?.plugins ?? []).map((plugin) => [plugin.id, plugin]));
+}
+
+function mcpToolKeys(pluginMap) {
+  const keys = [];
+  for (const plugin of pluginMap?.plugins ?? []) {
+    for (const mcpManifest of plugin.mcpServers ?? []) {
+      for (const server of mcpManifest.servers ?? []) {
+        for (const tool of server.tools ?? []) {
+          keys.push(`${plugin.id}:${server.name}:${tool}`);
+        }
+      }
+    }
+  }
+  return keys;
+}
+
+function nativeBinaryByPath(map) {
+  return new Map((map?.binaries ?? []).map((binary) => [binary.relativePath, binary]));
+}
+
+function compareMaps({ baselineProtected, candidateProtected }) {
+  if (baselineProtected == null) {
+    return {
+      mode: "inventoryOnly",
+      bridgeHandlerDrift: diffSets([], bridgeHandlerKeys(candidateProtected.bridgeMap)),
+      pluginDrift: diffSets([], pluginIds(candidateProtected.pluginMap)),
+      mcpDrift: diffSets([], mcpToolKeys(candidateProtected.pluginMap)),
+      nativeBinaryDrift: diffSets([], (candidateProtected.nativeBinaryMap?.binaries ?? []).map((binary) => binary.relativePath)),
+    };
+  }
+
+  const baselinePlugins = pluginById(baselineProtected.pluginMap);
+  const candidatePlugins = pluginById(candidateProtected.pluginMap);
+  const pluginFileDrift = {};
+  for (const pluginId of new Set([...baselinePlugins.keys(), ...candidatePlugins.keys()])) {
+    pluginFileDrift[pluginId] = diffSets(
+      baselinePlugins.get(pluginId)?.files ?? [],
+      candidatePlugins.get(pluginId)?.files ?? [],
+    );
+  }
+
+  const baselineNative = nativeBinaryByPath(baselineProtected.nativeBinaryMap);
+  const candidateNative = nativeBinaryByPath(candidateProtected.nativeBinaryMap);
+  const changedNative = [];
+  for (const [binaryPath, candidateBinary] of candidateNative) {
+    const baselineBinary = baselineNative.get(binaryPath);
+    if (baselineBinary != null && baselineBinary.sha256 !== candidateBinary.sha256) {
+      changedNative.push({ path: binaryPath, baselineSha256: baselineBinary.sha256, candidateSha256: candidateBinary.sha256 });
+    }
+  }
+
+  return {
+    mode: "baselineComparison",
+    bridgeHandlerDrift: diffSets(
+      bridgeHandlerKeys(baselineProtected.bridgeMap),
+      bridgeHandlerKeys(candidateProtected.bridgeMap),
+    ),
+    pluginDrift: diffSets(pluginIds(baselineProtected.pluginMap), pluginIds(candidateProtected.pluginMap)),
+    pluginFileDrift,
+    mcpDrift: diffSets(mcpToolKeys(baselineProtected.pluginMap), mcpToolKeys(candidateProtected.pluginMap)),
+    nativeBinaryDrift: {
+      ...diffSets([...baselineNative.keys()], [...candidateNative.keys()]),
+      changed: changedNative,
+    },
+    linuxSubstrateDrift: diffSets(
+      baselineProtected.surfaces.filter((surface) => surface.linuxSubstrate.status === "MISSING").map((surface) => surface.id),
+      candidateProtected.surfaces.filter((surface) => surface.linuxSubstrate.status === "MISSING").map((surface) => surface.id),
+    ),
+  };
+}
+
+function countDiffValues(diff) {
+  return {
+    addedCount: diff?.added?.length ?? 0,
+    removedCount: diff?.removed?.length ?? 0,
+    unchangedCount: diff?.unchanged?.length ?? 0,
+  };
+}
+
+function summarizeMapDrift(mapDrift) {
+  const pluginFileChanged = Object.entries(mapDrift?.pluginFileDrift ?? {}).filter(([, drift]) =>
+    (drift.added?.length ?? 0) > 0 || (drift.removed?.length ?? 0) > 0,
+  );
+  const summary = {
+    mode: mapDrift?.mode ?? "unknown",
+    bridgeHandlers: countDiffValues(mapDrift?.bridgeHandlerDrift),
+    plugins: countDiffValues(mapDrift?.pluginDrift),
+    mcpTools: countDiffValues(mapDrift?.mcpDrift),
+    nativeBinaries: {
+      ...countDiffValues(mapDrift?.nativeBinaryDrift),
+      changedCount: mapDrift?.nativeBinaryDrift?.changed?.length ?? 0,
+    },
+    linuxSubstrate: countDiffValues(mapDrift?.linuxSubstrateDrift),
+    pluginFileSetsChangedCount: pluginFileChanged.length,
+  };
+  summary.hasStructuralAddRemove =
+    summary.bridgeHandlers.addedCount > 0 ||
+    summary.bridgeHandlers.removedCount > 0 ||
+    summary.plugins.addedCount > 0 ||
+    summary.plugins.removedCount > 0 ||
+    summary.mcpTools.addedCount > 0 ||
+    summary.mcpTools.removedCount > 0 ||
+    summary.nativeBinaries.addedCount > 0 ||
+    summary.nativeBinaries.removedCount > 0 ||
+    summary.linuxSubstrate.addedCount > 0 ||
+    summary.linuxSubstrate.removedCount > 0;
+  return summary;
+}
+
+function markdownList(items) {
+  if (items.length === 0) {
+    return "- None\n";
+  }
+  return items.map((item) => `- ${item}`).join("\n") + "\n";
+}
+
+function renderDriftMarkdown(report) {
+  const lines = ["# Upstream DMG Drift Report", ""];
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push(`Candidate: ${report.candidateSource?.path ?? "unknown"}`);
+  if (report.baselineSource != null) {
+    lines.push(`Baseline: ${report.baselineSource.path}`);
+  }
+  lines.push("");
+  lines.push("## Classification Counts");
+  lines.push("");
+  lines.push(
+    markdownList(
+      Object.entries(report.classificationCounts).map(([classification, count]) => `${classification}: ${count}`),
+    ).trimEnd(),
+  );
+  lines.push("");
+  lines.push("## Protected Surface Drift");
+  lines.push("");
+  for (const item of report.surfaceDrift) {
+    lines.push(`### ${item.surfaceId} - ${item.classification}`);
+    if (item.title) {
+      lines.push(`Surface: ${item.title}`);
+    }
+    if (item.baselineStatus || item.candidateStatus) {
+      lines.push(`Status: ${item.baselineStatus ?? "n/a"} -> ${item.candidateStatus ?? "n/a"}`);
+    }
+    if (item.evidenceDrift != null) {
+      lines.push(
+        `Evidence drift: +${item.evidenceDrift.addedEvidenceCount ?? 0} / -${item.evidenceDrift.removedEvidenceCount ?? 0} / changed ${item.evidenceDrift.changedEvidenceCount ?? 0} / unchanged ${item.evidenceDrift.unchangedEvidenceCount ?? 0}`,
+      );
+      if (item.evidenceDrift.pathMovementKind && item.evidenceDrift.pathMovementKind !== "none") {
+        lines.push(`Path movement: ${item.evidenceDrift.pathMovementKind}`);
+      }
+    }
+    const candidatePaths = [...new Set((item.evidenceSummary?.candidate?.pathSamples ?? []).map((entry) => entry.path))]
+      .slice(0, MARKDOWN_PATH_SAMPLE_LIMIT);
+    const baselinePaths = [...new Set((item.evidenceSummary?.baseline?.pathSamples ?? []).map((entry) => entry.path))]
+      .slice(0, MARKDOWN_PATH_SAMPLE_LIMIT);
+    if (baselinePaths.length > 0) {
+      lines.push(`Baseline paths: ${baselinePaths.join(", ")}`);
+    }
+    if (candidatePaths.length > 0) {
+      lines.push(`Candidate paths: ${candidatePaths.join(", ")}`);
+    }
+    if (item.missingPaths?.length > 0) {
+      lines.push(`Missing Linux substrate paths: ${item.missingPaths.join(", ")}`);
+    }
+    if (item.missingAnchors?.length > 0) {
+      lines.push(`Missing required anchors: ${item.missingAnchors.map((anchor) => anchor.id).join(", ")}`);
+    }
+    if (item.patches?.length > 0) {
+      lines.push(`Patch failures: ${item.patches.map((patch) => `${patch.name} (${patch.status})`).join(", ")}`);
+    }
+    if (item.evidenceDrift?.changedPathSamples?.length > 0) {
+      const changedPaths = item.evidenceDrift.changedPathSamples
+        .slice(0, MARKDOWN_PATH_SAMPLE_LIMIT)
+        .map((entry) => `${entry.path ?? `${entry.baselinePath} -> ${entry.candidatePath}`}: ${formatHash(entry.baselineSha256)} -> ${formatHash(entry.candidateSha256)}`);
+      lines.push(`Changed payload samples: ${changedPaths.join("; ")}`);
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n").replace(/\n{3,}/g, "\n\n")}\n`;
+}
+
+function structuralSummaryLine(summary) {
+  if (summary == null) {
+    return null;
+  }
+  return [
+    `bridge +/- ${summary.bridgeHandlers.addedCount}/${summary.bridgeHandlers.removedCount}`,
+    `plugin +/- ${summary.plugins.addedCount}/${summary.plugins.removedCount}`,
+    `MCP +/- ${summary.mcpTools.addedCount}/${summary.mcpTools.removedCount}`,
+    `native +/- ${summary.nativeBinaries.addedCount}/${summary.nativeBinaries.removedCount}`,
+    `native changed ${summary.nativeBinaries.changedCount}`,
+  ].join("; ");
+}
+
+function formatHash(value) {
+  if (value == null) {
+    return "nohash";
+  }
+  return `${String(value).slice(0, 12)}...`;
+}
+
+function evidencePathList(entries, maxItems = ACTION_PLAN_PATH_SAMPLE_LIMIT) {
+  return entries
+    .slice(0, maxItems)
+    .map((entry) => `${entry.path} (${formatHash(entry.sha256)})`)
+    .join(", ");
+}
+
+function changedPayloadList(entries, maxItems = ACTION_PLAN_PATH_SAMPLE_LIMIT) {
+  return entries
+    .slice(0, maxItems)
+    .map((entry) => `- ${entry.path ?? `${entry.baselinePath} -> ${entry.candidatePath}`}: ${formatHash(entry.baselineSha256)} -> ${formatHash(entry.candidateSha256)}`)
+    .join("\n");
+}
+
+function renderActionPlanMarkdown(driftReport, candidateProtected, mapDrift = null) {
+  const actionable = driftReport.surfaceDrift.filter((item) => ACTIONABLE_CLASSIFICATIONS.has(item.classification));
+  const structuralSummary = driftReport.structuralDriftSummary ?? summarizeMapDrift(mapDrift);
+  const lines = ["# Linux Substrate Action Plan", ""];
+  lines.push(`Candidate: ${candidateProtected.source?.path ?? "unknown"}`);
+  const summaryLine = structuralSummaryLine(structuralSummary);
+  if (summaryLine != null) {
+    lines.push(`Structural maps: ${summaryLine}`);
+  }
+  lines.push("");
+  if (actionable.length === 0) {
+    lines.push("No protected-surface action required by this report.");
+    return `${lines.join("\n")}\n`;
+  }
+  for (const item of actionable) {
+    lines.push(`## ${item.surfaceId}`);
+    lines.push(`Classification: ${item.classification}`);
+    if (item.evidenceDrift != null) {
+      lines.push(
+        `Evidence: +${item.evidenceDrift.addedEvidenceCount ?? 0} / -${item.evidenceDrift.removedEvidenceCount ?? 0} / changed ${item.evidenceDrift.changedEvidenceCount ?? 0}; movement ${item.evidenceDrift.pathMovementKind ?? "unknown"}`,
+      );
+    }
+    if (item.classification === "MOVED") {
+      const structuralHint =
+        structuralSummary?.hasStructuralAddRemove === false
+          ? " Structural bridge/plugin/MCP/native paths did not add or disappear."
+          : "";
+      lines.push(`Action: review candidate evidence paths before changing Linux substrate.${structuralHint} Treat this as a navigation signal unless a Linux patch, staging rule, or mirror references one of the old paths.`);
+      if (item.evidenceDrift?.removedPathSamples?.length > 0) {
+        lines.push(`Removed path samples: ${evidencePathList(item.evidenceDrift.removedPathSamples)}`);
+      }
+      if (item.evidenceDrift?.addedPathSamples?.length > 0) {
+        lines.push(`Added path samples: ${evidencePathList(item.evidenceDrift.addedPathSamples)}`);
+      }
+    } else if (item.classification === "PAYLOAD_CHANGED") {
+      lines.push("Action: review payload diffs, refresh protected needles, and run the owning Linux feature/backend tests.");
+      if (item.evidenceDrift?.changedPathSamples?.length > 0) {
+        lines.push("Changed payload files:");
+        lines.push(changedPayloadList(item.evidenceDrift.changedPathSamples, 8));
+      }
+    } else if (item.classification === "REMOVED") {
+      lines.push("Action: verify whether upstream intentionally removed this surface before deleting Linux compatibility code.");
+    } else if (item.classification === "NEW_UPSTREAM_CAPABILITY") {
+      lines.push("Action: decide whether Linux needs a port, shim, explicit unsupported gate, or new optional feature.");
+    } else if (item.classification === "PATCH_BROKEN") {
+      lines.push("Action: repair the patch descriptor or feature patch before accepting the DMG.");
+    } else if (item.classification === "PATCH_REVIEW") {
+      lines.push("Action: review optional patch warning/skip details; do not block DMG acceptance unless a protected surface is also missing or broken.");
+    } else if (item.classification === "LINUX_SUBSTRATE_GAP") {
+      lines.push("Action: add or map the missing Linux substrate path before claiming parity.");
+      lines.push(`Missing paths: ${(item.missingPaths ?? []).join(", ")}`);
+    } else if (item.classification === "PROTECTED_SURFACE_PARTIAL") {
+      lines.push("Action: inspect the missing required anchors and decide whether the registry, upstream map, or Linux substrate needs updating.");
+      lines.push(`Missing anchors: ${(item.missingAnchors ?? []).map((anchor) => anchor.id).join(", ")}`);
+    } else if (item.classification === "PROTECTED_SURFACE_MISSING") {
+      lines.push("Action: locate the upstream replacement surface or explicitly retire the Linux mirror before accepting the DMG.");
+    }
+    lines.push("");
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function publicInventory(inventory) {
+  return {
+    ...inventory,
+    files: inventory.files.map((file) => {
+      const publicFile = { ...file };
+      delete publicFile.absolutePath;
+      delete publicFile.buffer;
+      delete publicFile.text;
+      delete publicFile.nativeStrings;
+      return publicFile;
+    }),
+  };
+}
+
+function sameResolvedPath(left, right) {
+  try {
+    return fs.realpathSync(left) === fs.realpathSync(right);
+  } catch {
+    return path.resolve(left) === path.resolve(right);
+  }
+}
+
+function resolveBaselinePath({ autoBaseline = false, baselinePath = null, candidatePath, repoRoot = process.cwd() } = {}) {
+  if (baselinePath != null || !autoBaseline) {
+    return baselinePath;
+  }
+  const defaultBaselinePath = path.join(repoRoot, "Codex.dmg");
+  if (!fs.existsSync(defaultBaselinePath)) {
+    return null;
+  }
+  if (candidatePath != null && sameResolvedPath(defaultBaselinePath, candidatePath)) {
+    return null;
+  }
+  return defaultBaselinePath;
+}
+
+function buildIntelReports({
+  autoBaseline = false,
+  baselinePath = null,
+  candidatePath,
+  outputDir,
+  patchReportPath = null,
+  registry,
+  repoRoot = process.cwd(),
+  timestamp = null,
+} = {}) {
+  if (candidatePath == null) {
+    throw new Error("candidatePath is required");
+  }
+  const scratchRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-upstream-intel-report-"));
+  try {
+    const resolvedBaselinePath = resolveBaselinePath({
+      autoBaseline,
+      baselinePath,
+      candidatePath,
+      repoRoot,
+    });
+    const reportDir =
+      outputDir ??
+      path.join(
+        repoRoot,
+        "reports/upstream-dmg",
+        timestamp ?? new Date().toISOString().replace(/[:.]/g, "-"),
+      );
+    const candidateInventory = createInventory({
+      registry,
+      sourcePath: candidatePath,
+      workDir: path.join(scratchRoot, "candidate"),
+    });
+    const candidateProtected = extractProtectedSurfaces({ inventory: candidateInventory, registry, repoRoot });
+    const baselineInventory =
+      resolvedBaselinePath == null
+        ? null
+        : createInventory({
+            registry,
+            sourcePath: resolvedBaselinePath,
+            workDir: path.join(scratchRoot, "baseline"),
+          });
+    const baselineProtected =
+      resolvedBaselinePath == null
+        ? null
+        : extractProtectedSurfaces({
+            inventory: baselineInventory,
+            registry,
+            repoRoot,
+          });
+    const patchReport =
+      patchReportPath != null && fs.existsSync(patchReportPath) ? readJson(patchReportPath) : null;
+    const driftReport = compareProtectedSurfaces({
+      baseline: baselineProtected,
+      candidate: candidateProtected,
+      patchReport,
+    });
+    const mapDrift = compareMaps({ baselineProtected, candidateProtected });
+    driftReport.structuralDriftSummary = summarizeMapDrift(mapDrift);
+
+    fs.mkdirSync(reportDir, { recursive: true });
+    writeJson(path.join(reportDir, "inventory.json"), publicInventory(candidateInventory));
+    writeJson(path.join(reportDir, "protected-surfaces.json"), candidateProtected);
+    writeJson(path.join(reportDir, "bridge-map.json"), candidateProtected.bridgeMap);
+    writeJson(path.join(reportDir, "plugin-map.json"), candidateProtected.pluginMap);
+    writeJson(path.join(reportDir, "native-binary-map.json"), candidateProtected.nativeBinaryMap);
+    writeJson(path.join(reportDir, "map-drift.json"), mapDrift);
+    writeJson(path.join(reportDir, "drift-report.json"), driftReport);
+    fs.writeFileSync(path.join(reportDir, "drift-report.md"), renderDriftMarkdown(driftReport), "utf8");
+    fs.writeFileSync(
+      path.join(reportDir, "substrate-action-plan.md"),
+      renderActionPlanMarkdown(driftReport, candidateProtected, mapDrift),
+      "utf8",
+    );
+
+    if (baselineProtected != null) {
+      writeJson(path.join(reportDir, "baseline/inventory.json"), publicInventory(baselineInventory));
+      writeJson(path.join(reportDir, "baseline/protected-surfaces.json"), baselineProtected);
+      writeJson(path.join(reportDir, "baseline/bridge-map.json"), baselineProtected.bridgeMap);
+      writeJson(path.join(reportDir, "baseline/plugin-map.json"), baselineProtected.pluginMap);
+      writeJson(path.join(reportDir, "baseline/native-binary-map.json"), baselineProtected.nativeBinaryMap);
+      writeJson(path.join(reportDir, "candidate/inventory.json"), publicInventory(candidateInventory));
+      writeJson(path.join(reportDir, "candidate/protected-surfaces.json"), candidateProtected);
+      writeJson(path.join(reportDir, "candidate/bridge-map.json"), candidateProtected.bridgeMap);
+      writeJson(path.join(reportDir, "candidate/plugin-map.json"), candidateProtected.pluginMap);
+      writeJson(path.join(reportDir, "candidate/native-binary-map.json"), candidateProtected.nativeBinaryMap);
+    }
+
+    return {
+      outputDir: reportDir,
+      inventory: candidateInventory,
+      protectedSurfaces: candidateProtected,
+      driftReport,
+      mapDrift,
+    };
+  } finally {
+    fs.rmSync(scratchRoot, { force: true, recursive: true });
+  }
+}
+
+module.exports = {
+  buildIntelReports,
+  compareProtectedSurfaces,
+  createBridgeMap,
+  createInventory,
+  createNativeBinaryMap,
+  createPluginMap,
+  compareMaps,
+  extractProtectedSurfaces,
+  renderActionPlanMarkdown,
+  renderDriftMarkdown,
+  resolveBaselinePath,
+};


### PR DESCRIPTION
Summary
- Adds upstream DMG intelligence tooling for protected-surface drift checks.
- Adds a one-command devcontainer wrapper for repeatable candidate-vs-baseline inspection.
- Keeps reports compact while surfacing blockers, structural drift, review-only drift, and protected surface coverage.

Validation
- node --test scripts/dev/upstream-dmg-intel.test.js
- bash -n scripts/dev/upstream-dmg-intel-devcontainer
