### PR TITLE
Cache immutable webview assets

### DIFF
--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -4,8 +4,10 @@ import ctypes.util
 import functools
 import http.server
 import os
+import posixpath
 import signal
 import sys
+import urllib.parse
 
 
 def _install_parent_death_signal():
@@ -39,16 +41,33 @@ if len(sys.argv) >= 4 and sys.argv[2] == "--bind":
 
 
 class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
+    def normalized_request_path(self):
+        request_path = urllib.parse.urlsplit(self.path).path
+        decoded_path = urllib.parse.unquote(request_path)
+        normalized_path = posixpath.normpath(decoded_path)
+        if decoded_path.endswith("/") and not normalized_path.endswith("/"):
+            normalized_path += "/"
+        if not normalized_path.startswith("/"):
+            normalized_path = "/" + normalized_path
+        return normalized_path
+
+    def is_immutable_asset_request(self):
+        return self.normalized_request_path().startswith("/assets/")
+
     def send_head(self):
-        for header in ("If-Modified-Since", "If-None-Match"):
-            if header in self.headers:
-                del self.headers[header]
+        if not self.is_immutable_asset_request():
+            for header in ("If-Modified-Since", "If-None-Match"):
+                if header in self.headers:
+                    del self.headers[header]
         return super().send_head()
 
     def end_headers(self):
-        self.send_header("Cache-Control", "no-store, max-age=0")
-        self.send_header("Pragma", "no-cache")
-        self.send_header("Expires", "0")
+        if self.is_immutable_asset_request():
+            self.send_header("Cache-Control", "public, max-age=31536000, immutable")
+        else:
+            self.send_header("Cache-Control", "no-store, max-age=0")
+            self.send_header("Pragma", "no-cache")
+            self.send_header("Expires", "0")
         super().end_headers()
 
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4076,6 +4076,113 @@ if (!launcher.includes('ln -sfnT "$target" "$link_path"')) {
 NODE
 }
 
+test_webview_server_cache_policy() {
+    info "Checking webview server cache policy"
+    python3 - "$REPO_DIR/launcher/webview-server.py" <<'PY'
+import http.client
+import os
+import pathlib
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+server_path = pathlib.Path(sys.argv[1])
+workspace = pathlib.Path(tempfile.mkdtemp(prefix="codex-webview-cache-policy-"))
+proc = None
+
+try:
+    (workspace / "assets").mkdir()
+    (workspace / "apps").mkdir()
+    (workspace / "index.html").write_text("<!doctype html><title>Codex</title>", encoding="utf8")
+    (workspace / "assets" / "app-test-abc123.js").write_text("export default 1;\n", encoding="utf8")
+    (workspace / "apps" / "icon.png").write_bytes(b"png")
+    fixed_mtime = 1_700_000_000
+    for path in workspace.rglob("*"):
+        if path.is_file():
+            os.utime(path, (fixed_mtime, fixed_mtime))
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    proc = subprocess.Popen(
+        [sys.executable, str(server_path), str(port), "--bind", "127.0.0.1"],
+        cwd=workspace,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+    deadline = time.time() + 5
+    while True:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            if proc.poll() is not None:
+                raise AssertionError(f"webview server exited early with {proc.returncode}")
+            if time.time() > deadline:
+                raise AssertionError("webview server did not start")
+            time.sleep(0.05)
+
+    def request(method, path, headers=None):
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request(method, path, headers=headers or {})
+        response = conn.getresponse()
+        body = response.read()
+        result = (response.status, {k.lower(): v for k, v in response.getheaders()}, body)
+        conn.close()
+        return result
+
+    index_status, index_headers, _ = request("HEAD", "/index.html")
+    assert index_status == 200, index_status
+    assert index_headers.get("cache-control") == "no-store, max-age=0", index_headers
+    assert index_headers.get("pragma") == "no-cache", index_headers
+    assert index_headers.get("expires") == "0", index_headers
+
+    asset_status, asset_headers, _ = request("HEAD", "/assets/app-test-abc123.js")
+    assert asset_status == 200, asset_status
+    assert asset_headers.get("cache-control") == "public, max-age=31536000, immutable", asset_headers
+    assert "pragma" not in asset_headers, asset_headers
+    assert "expires" not in asset_headers, asset_headers
+
+    cached_status, cached_headers, _ = request(
+        "GET",
+        "/assets/app-test-abc123.js",
+        {"If-Modified-Since": asset_headers["last-modified"]},
+    )
+    assert cached_status == 304, (cached_status, cached_headers)
+    assert cached_headers.get("cache-control") == "public, max-age=31536000, immutable", cached_headers
+
+    refreshed_index_status, _, _ = request(
+        "GET",
+        "/index.html",
+        {"If-Modified-Since": index_headers["last-modified"]},
+    )
+    assert refreshed_index_status == 200, refreshed_index_status
+
+    icon_status, icon_headers, _ = request("HEAD", "/apps/icon.png")
+    assert icon_status == 200, icon_status
+    assert icon_headers.get("cache-control") == "no-store, max-age=0", icon_headers
+
+    escaped_index_status, escaped_index_headers, _ = request("HEAD", "/assets/../index.html")
+    assert escaped_index_status == 200, escaped_index_status
+    assert escaped_index_headers.get("cache-control") == "no-store, max-age=0", escaped_index_headers
+finally:
+    if proc is not None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+    shutil.rmtree(workspace, ignore_errors=True)
+PY
+}
+
 test_process_detection_helper_cmdline_shapes() {
     info "Checking Electron helper process detection cmdline shapes"
     local nul_cmdline="$TMP_DIR/electron-helper-nul.cmdline"
@@ -6786,6 +6893,7 @@ main() {
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_template_sanity
+    test_webview_server_cache_policy
     test_process_detection_helper_cmdline_shapes
     test_webview_probe_equivalence
     test_side_by_side_launcher_identity


### PR DESCRIPTION
Hi,

This keeps the local webview server from forcing `no-store` on hashed assets.
HTML and other non-asset paths still stay uncached, but `/assets/*` is now served with `Cache-Control: public, max-age=31536000, immutable` and normal conditional requests are preserved.

In a Chrome benchmark against the packaged webview content, four repeated loads went from:

- `index.html`: 293 requests / 43.32 MiB to 77 requests / 10.87 MiB
- `avatar-overlay-composition-surface.html`: 313 requests / 43.72 MiB to 82 requests / 10.97 MiB

I also added a smoke test covering immutable asset caching, HTML no-store behavior, non-asset no-store behavior, conditional `304` responses, and a normalized `/assets/../index.html` path.

Tests:

- `python3 -m py_compile launcher/webview-server.py`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- `node --test scripts/patch-linux-window-ui.test.js`
