### PR TITLE
Detect Fedora Atomic rpm-ostree targets

### DIFF
--- a/scripts/bootstrap-wizard.sh
+++ b/scripts/bootstrap-wizard.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FEATURES_ROOT="${CODEX_LINUX_FEATURES_ROOT:-$REPO_DIR/linux-features}"
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/linux-target-detect.sh"
 SETUP_ERROR_REPORTED=0
 COLOR_RESET=""
 COLOR_BOLD=""
@@ -187,94 +189,6 @@ feature_config_path() {
     fi
 }
 
-os_release_field() {
-    local field="$1"
-    local file line value
-
-    for file in ${OS_RELEASE_FILE:-} /etc/os-release /usr/lib/os-release; do
-        [ -n "$file" ] || continue
-        [ -r "$file" ] || continue
-        while IFS= read -r line; do
-            case "$line" in
-                "$field="*)
-                    value="${line#*=}"
-                    value="${value#\"}"
-                    value="${value%\"}"
-                    value="${value#\'}"
-                    value="${value%\'}"
-                    printf '%s\n' "${value,,}"
-                    return 0
-                    ;;
-            esac
-        done < "$file"
-    done
-
-    return 1
-}
-
-os_release_matches() {
-    local expected token
-    for expected in "$@"; do
-        [ "${OS_RELEASE_ID:-}" = "$expected" ] && return 0
-        for token in ${OS_RELEASE_ID_LIKE:-}; do
-            [ "$token" = "$expected" ] && return 0
-        done
-    done
-    return 1
-}
-
-detect_package_manager() {
-    if os_release_matches debian ubuntu linuxmint pop elementary zorin && command -v apt-get >/dev/null 2>&1; then
-        echo "apt"
-    elif os_release_matches arch archlinux manjaro endeavouros artix && command -v pacman >/dev/null 2>&1; then
-        echo "pacman"
-    elif os_release_matches opensuse suse sles && command -v zypper >/dev/null 2>&1; then
-        echo "zypper"
-    elif os_release_matches fedora rhel centos rocky almalinux ol; then
-        if command -v dnf5 >/dev/null 2>&1; then
-            echo "dnf5"
-        elif command -v dnf >/dev/null 2>&1; then
-            echo "dnf"
-        else
-            echo "unknown"
-        fi
-    elif command -v apt-get >/dev/null 2>&1; then
-        echo "apt"
-    elif command -v dnf5 >/dev/null 2>&1; then
-        echo "dnf5"
-    elif command -v dnf >/dev/null 2>&1; then
-        echo "dnf"
-    elif command -v pacman >/dev/null 2>&1; then
-        echo "pacman"
-    elif command -v zypper >/dev/null 2>&1; then
-        echo "zypper"
-    else
-        echo "unknown"
-    fi
-}
-
-detect_package_format() {
-    if os_release_matches arch archlinux manjaro endeavouros artix; then
-        echo "pacman"
-    elif os_release_matches fedora rhel centos rocky almalinux ol sles suse opensuse; then
-        echo "rpm"
-    elif os_release_matches debian ubuntu linuxmint pop elementary zorin; then
-        echo "deb"
-    elif command -v pacman >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
-        echo "pacman"
-    elif command -v rpmbuild >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
-        echo "rpm"
-    elif command -v dpkg-deb >/dev/null 2>&1; then
-        echo "deb"
-    elif command -v rpmbuild >/dev/null 2>&1; then
-        echo "rpm"
-    elif command -v pacman >/dev/null 2>&1; then
-        echo "pacman"
-    else
-        echo "unknown"
-    fi
-}
-
 command_status() {
     local name="$1"
     if command -v "$name" >/dev/null 2>&1; then
@@ -353,6 +267,9 @@ install_command_for_packages() {
             ;;
         dnf)
             printf 'sudo dnf install %s' "$packages"
+            ;;
+        rpm-ostree)
+            printf 'sudo rpm-ostree install %s' "$packages"
             ;;
         pacman)
             printf 'sudo pacman -S %s' "$packages"
@@ -630,12 +547,17 @@ print_system_summary() {
     OS_RELEASE_ID="$(os_release_field ID 2>/dev/null || true)"
     OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
     OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID 2>/dev/null || true)"
+    local atomic_host="no"
+    if linux_target_is_atomic; then
+        atomic_host="yes"
+    fi
 
     info "Codex Desktop Linux guided setup"
     info "Repository: $REPO_DIR"
     info "Distro: ID=${OS_RELEASE_ID:-unknown} ID_LIKE=${OS_RELEASE_ID_LIKE:-unknown} VERSION_ID=${OS_RELEASE_VERSION_ID:-unknown}"
     info "Package manager: $(detect_package_manager)"
     info "Native package format: $(detect_package_format)"
+    info "Atomic host: $atomic_host"
     info "Session: XDG_CURRENT_DESKTOP=${XDG_CURRENT_DESKTOP:-unknown} DESKTOP_SESSION=${DESKTOP_SESSION:-unknown} XDG_SESSION_TYPE=${XDG_SESSION_TYPE:-unknown} WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-none} DISPLAY=${DISPLAY:-none}"
     info "Helpers: pkexec=$(command_status pkexec) kdialog=$(command_status kdialog) zenity=$(command_status zenity)"
     info "Computer Use readiness: ydotool=$(command_status ydotool) ydotoold=$(command_status ydotoold) ydotoold.service(system)=[$(service_state ydotoold.service system)] ydotoold.service(user)=[$(service_state ydotoold.service user)] ydotool.service(system)=[$(service_state ydotool.service system)] ydotool.service(user)=[$(service_state ydotool.service user)] socket=$(ydotool_socket_summary) portal=$(portal_summary)"

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 # install-deps.sh — Install system dependencies for Codex Desktop Linux
-# Supports: Debian/Ubuntu (apt), Fedora 41+ (dnf5), Fedora <41 (dnf), Arch (pacman), openSUSE (zypper)
+# Supports: Debian/Ubuntu (apt), Fedora 41+ (dnf5), Fedora <41 (dnf), Fedora Atomic detection (rpm-ostree), Arch (pacman), openSUSE (zypper)
 # Also installs the Rust toolchain (cargo) via rustup when not already present.
 set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/linux-target-detect.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -158,7 +162,7 @@ ensure_nodejs_compatible() {
         return
     fi
 
-    if [ "$distro" = "dnf5" ]; then
+    if [ "$distro" = "dnf5" ] || [ "$distro" = "rpm-ostree" ]; then
         info "Skipping system Node.js check; install.sh provides the managed Node.js runtime"
         return
     fi
@@ -187,86 +191,8 @@ Install a supported Node.js version for this distro, or use install.sh to downlo
 Check apt output above or install Node.js ${MIN_NODE_MAJOR}+ manually."
 }
 
-# ---------------------------------------------------------------------------
-# Distro detection
-# ---------------------------------------------------------------------------
-os_release_field() {
-    local field="$1"
-    local file line value
-
-    for file in ${OS_RELEASE_FILE:-} /etc/os-release /usr/lib/os-release; do
-        [ -n "$file" ] || continue
-        [ -r "$file" ] || continue
-        while IFS= read -r line; do
-            case "$line" in
-                "$field="*)
-                    value="${line#*=}"
-                    value="${value#\"}"
-                    value="${value%\"}"
-                    value="${value#\'}"
-                    value="${value%\'}"
-                    printf '%s\n' "${value,,}"
-                    return 0
-                    ;;
-            esac
-        done < "$file"
-    done
-
-    return 1
-}
-
-os_release_matches() {
-    local expected token
-    for expected in "$@"; do
-        [ "${OS_RELEASE_ID:-}" = "$expected" ] && return 0
-        for token in ${OS_RELEASE_ID_LIKE:-}; do
-            [ "$token" = "$expected" ] && return 0
-        done
-    done
-    return 1
-}
-
-os_release_version_major() {
-    local version="${OS_RELEASE_VERSION_ID:-}"
-    version="${version%%.*}"
-    case "$version" in
-        ''|*[!0-9]*) return 1 ;;
-        *) printf '%s\n' "$version" ;;
-    esac
-}
-
 detect_distro() {
-    if os_release_matches debian ubuntu linuxmint pop elementary zorin && command -v apt-get &>/dev/null; then
-        echo "apt"
-    elif os_release_matches arch archlinux manjaro endeavouros artix && command -v pacman &>/dev/null; then
-        echo "pacman"
-    elif os_release_matches opensuse suse sles && command -v zypper &>/dev/null; then
-        echo "zypper"
-    elif os_release_matches fedora rhel centos rocky almalinux ol; then
-        local major
-        major="$(os_release_version_major 2>/dev/null || true)"
-        if [ "${OS_RELEASE_ID:-}" = "fedora" ] && [ -n "$major" ] && [ "$major" -lt 41 ] && command -v dnf &>/dev/null; then
-            echo "dnf"
-        elif command -v dnf5 &>/dev/null; then
-            echo "dnf5"
-        elif command -v dnf &>/dev/null; then
-            echo "dnf"
-        else
-            echo "unknown"
-        fi
-    elif command -v apt-get &>/dev/null; then
-        echo "apt"
-    elif command -v dnf5 &>/dev/null; then
-        echo "dnf5"
-    elif command -v dnf &>/dev/null; then
-        echo "dnf"
-    elif command -v pacman &>/dev/null; then
-        echo "pacman"
-    elif command -v zypper &>/dev/null; then
-        echo "zypper"
-    else
-        echo "unknown"
-    fi
+    detect_package_manager
 }
 
 preferred_gui_prompt_package() {
@@ -311,6 +237,33 @@ install_dnf() {
         nodejs npm python3 \
         p7zip p7zip-plugins curl unzip rpm-build make gcc-c++
     sudo dnf groupinstall -y 'Development Tools'
+}
+
+install_rpm_ostree() {
+    info "Detected Fedora Atomic / rpm-ostree host"
+
+    local -a missing=()
+    command -v python3 >/dev/null 2>&1 || missing+=("python3")
+    if ! command -v 7zz >/dev/null 2>&1 && ! command -v 7z >/dev/null 2>&1; then
+        missing+=("7zip")
+    fi
+    command -v curl >/dev/null 2>&1 || missing+=("curl")
+    command -v unzip >/dev/null 2>&1 || missing+=("unzip")
+    command -v rpmbuild >/dev/null 2>&1 || missing+=("rpm-build")
+    command -v make >/dev/null 2>&1 || missing+=("make")
+    command -v g++ >/dev/null 2>&1 || missing+=("gcc-c++")
+
+    if [ "${#missing[@]}" -eq 0 ]; then
+        info "rpm-ostree layered build dependencies are already available"
+        return
+    fi
+
+    error "Fedora Atomic hosts layer packages with rpm-ostree and usually need a reboot before new tools are available.
+Review and run manually if this is the host you want to layer:
+  sudo rpm-ostree install python3 7zip curl unzip rpm-build make gcc-c++
+  systemctl reboot
+Then rerun this script after the reboot.
+Still missing: ${missing[*]}"
 }
 
 install_pacman() {
@@ -489,6 +442,7 @@ case "$DISTRO" in
     apt)     install_apt    ;;
     dnf5)    install_dnf5   ;;
     dnf)     install_dnf    ;;
+    rpm-ostree) install_rpm_ostree ;;
     pacman)  install_pacman ;;
     zypper)  install_zypper ;;
     *)

--- a/scripts/lib/build-info.js
+++ b/scripts/lib/build-info.js
@@ -200,6 +200,15 @@ function packageProfile(target) {
       notes: "Managed Node.js runtime is bundled; no distro Node.js package is required",
     };
   }
+  if (target.atomic && ids.has("fedora")) {
+    return {
+      id: "fedora-atomic",
+      label: "Fedora Atomic Desktop",
+      packageManager: "rpm-ostree",
+      format: ".rpm",
+      notes: "Native packages are layered with rpm-ostree instead of installed with dnf",
+    };
+  }
   if (id === "fedora") {
     return {
       id: versionMajor != null && versionMajor < 41 ? "fedora-pre-41" : "fedora-41-plus",
@@ -271,6 +280,7 @@ function linuxTargetInfo(target) {
     sessionType: target.sessionType,
     wayland: target.wayland,
     x11: target.x11,
+    atomic: target.atomic,
   };
 }
 

--- a/scripts/lib/linux-target-context.js
+++ b/scripts/lib/linux-target-context.js
@@ -23,6 +23,20 @@ function splitTokens(value) {
     .filter(Boolean);
 }
 
+function booleanOverride(value) {
+  const normalized = normalizeToken(value);
+  if (!normalized) {
+    return null;
+  }
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return null;
+}
+
 function flattenValues(values) {
   const flattened = [];
   for (const value of values) {
@@ -154,7 +168,7 @@ function detectPackageFormat(tokens, env) {
   return "unknown";
 }
 
-function detectPackageManager(tokens, env, versionMajorValue) {
+function detectPackageManager(tokens, env, versionMajorValue, atomic) {
   const override = normalizeToken(env.CODEX_LINUX_TARGET_PACKAGE_MANAGER);
   if (override) {
     return override;
@@ -169,6 +183,9 @@ function detectPackageManager(tokens, env, versionMajorValue) {
     return "zypper";
   }
   if (tokenMatches(tokens, ["fedora", "rhel", "centos", "rocky", "almalinux", "ol"])) {
+    if (atomic && executableExists("rpm-ostree", env)) {
+      return "rpm-ostree";
+    }
     if (tokens[0] === "fedora" && versionMajorValue != null && versionMajorValue < 41) {
       return executableExists("dnf", env) ? "dnf" : "unknown";
     }
@@ -194,6 +211,18 @@ function buildDesktopTokens(env) {
     env.DESKTOP_SESSION ||
     "";
   return splitTokens(desktop.replace(/[:;]/gu, " "));
+}
+
+function detectAtomicDesktop(env, options = {}) {
+  if (typeof options.atomic === "boolean") {
+    return options.atomic;
+  }
+  const override = booleanOverride(env.CODEX_LINUX_TARGET_ATOMIC);
+  if (override != null) {
+    return override;
+  }
+  const ostreeBootedPath = options.ostreeBootedPath ?? env.OSTREE_BOOTED_FILE ?? "/run/ostree-booted";
+  return Boolean(ostreeBootedPath) && fs.existsSync(ostreeBootedPath);
 }
 
 function createHelpers(target) {
@@ -230,6 +259,7 @@ function detectLinuxTargetContext(options = {}) {
   const distroTokens = [id, ...idLike].filter(Boolean);
   const sessionType = normalizeToken(env.CODEX_LINUX_TARGET_SESSION_TYPE || env.XDG_SESSION_TYPE || "");
   const desktopTokens = buildDesktopTokens(env);
+  const atomic = detectAtomicDesktop(env, options);
   const target = {
     osReleasePath: osRelease.path,
     arch: env.CODEX_LINUX_TARGET_ARCH || process.arch,
@@ -242,7 +272,7 @@ function detectLinuxTargetContext(options = {}) {
       prettyName: env.CODEX_LINUX_TARGET_PRETTY_NAME || osRelease.fields.PRETTY_NAME || "",
     },
     packageFormat: detectPackageFormat(distroTokens, env),
-    packageManager: detectPackageManager(distroTokens, env, versionMajorValue),
+    packageManager: detectPackageManager(distroTokens, env, versionMajorValue, atomic),
     desktop: {
       raw: env.CODEX_LINUX_TARGET_DESKTOP || env.XDG_CURRENT_DESKTOP || env.DESKTOP_SESSION || "",
       tokens: desktopTokens,
@@ -250,6 +280,7 @@ function detectLinuxTargetContext(options = {}) {
     sessionType,
     wayland: sessionType === "wayland" || Boolean(env.WAYLAND_DISPLAY),
     x11: sessionType === "x11" || Boolean(env.DISPLAY),
+    atomic,
   };
   target.helpers = createHelpers(target);
   Object.assign(target, target.helpers);
@@ -269,6 +300,7 @@ module.exports = {
   PACMAN_IDS,
   RPM_IDS,
   detectLinuxTargetContext,
+  detectAtomicDesktop,
   executableExists,
   flattenValues,
   linuxTargetSummary,

--- a/scripts/lib/linux-target-detect.sh
+++ b/scripts/lib/linux-target-detect.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+os_release_field() {
+    local field="$1"
+    local file line value
+    local -a files
+
+    if [ -n "${OS_RELEASE_FILE:-}" ]; then
+        files=("$OS_RELEASE_FILE")
+    else
+        files=(/etc/os-release /usr/lib/os-release)
+    fi
+
+    for file in "${files[@]}"; do
+        [ -n "$file" ] || continue
+        [ -r "$file" ] || continue
+        while IFS= read -r line; do
+            case "$line" in
+                "$field="*)
+                    value="${line#*=}"
+                    value="${value#\"}"
+                    value="${value%\"}"
+                    value="${value#\'}"
+                    value="${value%\'}"
+                    printf '%s\n' "${value,,}"
+                    return 0
+                    ;;
+            esac
+        done < "$file"
+    done
+
+    return 1
+}
+
+os_release_matches() {
+    local expected token
+    for expected in "$@"; do
+        [ "${OS_RELEASE_ID:-}" = "$expected" ] && return 0
+        for token in ${OS_RELEASE_ID_LIKE:-}; do
+            [ "$token" = "$expected" ] && return 0
+        done
+    done
+    return 1
+}
+
+os_release_version_major() {
+    local version="${OS_RELEASE_VERSION_ID:-}"
+    version="${version%%.*}"
+    case "$version" in
+        ''|*[!0-9]*) return 1 ;;
+        *) printf '%s\n' "$version" ;;
+    esac
+}
+
+linux_target_is_atomic() {
+    local override="${CODEX_LINUX_TARGET_ATOMIC:-}"
+    override="${override,,}"
+    case "$override" in
+        1|true|yes|on)
+            return 0
+            ;;
+        0|false|no|off)
+            return 1
+            ;;
+        "")
+            ;;
+        *)
+            ;;
+    esac
+
+    local ostree_booted="${OSTREE_BOOTED_FILE:-/run/ostree-booted}"
+    [ -n "$ostree_booted" ] && [ -e "$ostree_booted" ]
+}
+
+detect_package_manager() {
+    if os_release_matches debian ubuntu linuxmint pop elementary zorin && command -v apt-get >/dev/null 2>&1; then
+        echo "apt"
+    elif os_release_matches arch archlinux manjaro endeavouros artix && command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    elif os_release_matches opensuse suse sles && command -v zypper >/dev/null 2>&1; then
+        echo "zypper"
+    elif os_release_matches fedora rhel centos rocky almalinux ol; then
+        local major
+        major="$(os_release_version_major 2>/dev/null || true)"
+        if linux_target_is_atomic && command -v rpm-ostree >/dev/null 2>&1; then
+            echo "rpm-ostree"
+        elif [ "${OS_RELEASE_ID:-}" = "fedora" ] && [ -n "$major" ] && [ "$major" -lt 41 ] && command -v dnf >/dev/null 2>&1; then
+            echo "dnf"
+        elif command -v dnf5 >/dev/null 2>&1; then
+            echo "dnf5"
+        elif command -v dnf >/dev/null 2>&1; then
+            echo "dnf"
+        else
+            echo "unknown"
+        fi
+    elif command -v apt-get >/dev/null 2>&1; then
+        echo "apt"
+    elif command -v dnf5 >/dev/null 2>&1; then
+        echo "dnf5"
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "dnf"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    elif command -v zypper >/dev/null 2>&1; then
+        echo "zypper"
+    else
+        echo "unknown"
+    fi
+}
+
+detect_package_format() {
+    if os_release_matches arch archlinux manjaro endeavouros artix; then
+        echo "pacman"
+    elif os_release_matches fedora rhel centos rocky almalinux ol sles suse opensuse; then
+        echo "rpm"
+    elif os_release_matches debian ubuntu linuxmint pop elementary zorin; then
+        echo "deb"
+    elif command -v pacman >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
+        echo "pacman"
+    elif command -v rpmbuild >/dev/null 2>&1 && ! command -v dpkg-deb >/dev/null 2>&1; then
+        echo "rpm"
+    elif command -v dpkg-deb >/dev/null 2>&1; then
+        echo "deb"
+    elif command -v rpmbuild >/dev/null 2>&1; then
+        echo "rpm"
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "pacman"
+    else
+        echo "unknown"
+    fi
+}

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -606,6 +606,93 @@ test("package profile distinguishes Fedora package managers by major version", (
   assert.equal(packageProfile(fedora41).packageManager, "dnf5");
 });
 
+test("package profile identifies Fedora Atomic hosts that use rpm-ostree", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-fedora-atomic-target-"));
+  try {
+    const binDir = path.join(tempRoot, "bin");
+    const ostreeBootedPath = path.join(tempRoot, "ostree-booted");
+    fs.mkdirSync(binDir, { recursive: true });
+    for (const command of ["rpm-ostree", "rpmbuild"]) {
+      const commandPath = path.join(binDir, command);
+      fs.writeFileSync(commandPath, "#!/bin/sh\nexit 0\n", "utf8");
+      fs.chmodSync(commandPath, 0o755);
+    }
+    fs.writeFileSync(ostreeBootedPath, "", "utf8");
+
+    const fedoraAtomic = detectLinuxTargetContext({
+      osReleaseFields: {
+        ID: "fedora",
+        ID_LIKE: "",
+        VERSION_ID: "44",
+        PRETTY_NAME: "Fedora Linux 44 (KDE Plasma Desktop Edition)",
+      },
+      env: {
+        PATH: binDir,
+        OSTREE_BOOTED_FILE: ostreeBootedPath,
+      },
+    });
+
+    assert.equal(fedoraAtomic.atomic, true);
+    assert.equal(fedoraAtomic.packageFormat, "rpm");
+    assert.equal(fedoraAtomic.packageManager, "rpm-ostree");
+    assert.equal(fedoraAtomic.packageManagerIs("rpm-ostree"), true);
+    assert.equal(packageProfile(fedoraAtomic).id, "fedora-atomic");
+    assert.equal(packageProfile(fedoraAtomic).packageManager, "rpm-ostree");
+
+    const fedoraInvalidAtomicOverride = detectLinuxTargetContext({
+      osReleaseFields: {
+        ID: "fedora",
+        ID_LIKE: "",
+        VERSION_ID: "44",
+      },
+      env: {
+        PATH: binDir,
+        CODEX_LINUX_TARGET_ATOMIC: "maybe",
+        OSTREE_BOOTED_FILE: ostreeBootedPath,
+      },
+    });
+
+    assert.equal(fedoraInvalidAtomicOverride.atomic, true);
+    assert.equal(fedoraInvalidAtomicOverride.packageManager, "rpm-ostree");
+
+    const fedoraAtomicOverrideOff = detectLinuxTargetContext({
+      osReleaseFields: {
+        ID: "fedora",
+        ID_LIKE: "",
+        VERSION_ID: "44",
+      },
+      env: {
+        PATH: binDir,
+        CODEX_LINUX_TARGET_ATOMIC: "0",
+        OSTREE_BOOTED_FILE: ostreeBootedPath,
+      },
+    });
+
+    assert.equal(fedoraAtomicOverrideOff.atomic, false);
+    assert.equal(fedoraAtomicOverrideOff.packageManager, "unknown");
+    assert.equal(packageProfile(fedoraAtomicOverrideOff).id, "fedora-41-plus");
+
+    const fedoraRegular = detectLinuxTargetContext({
+      osReleaseFields: {
+        ID: "fedora",
+        ID_LIKE: "",
+        VERSION_ID: "44",
+        PRETTY_NAME: "Fedora Linux 44",
+      },
+      env: {
+        PATH: binDir,
+        OSTREE_BOOTED_FILE: path.join(tempRoot, "missing-ostree-booted"),
+      },
+    });
+
+    assert.equal(fedoraRegular.atomic, false);
+    assert.equal(fedoraRegular.packageManager, "unknown");
+    assert.equal(packageProfile(fedoraRegular).id, "fedora-41-plus");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("auto-discovered core patches can target a specific Linux distro", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-core-patch-root-"));
   try {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1940,6 +1940,153 @@ test_fedora_dependency_bootstrap_installs_rpmbuild() {
     assert_contains "$readme" "sudo dnf install python3 p7zip p7zip-plugins curl unzip rpm-build make gcc-c++"
 }
 
+test_fedora_atomic_rpm_ostree_target_detection() {
+    info "Checking Fedora Atomic rpm-ostree target detection"
+    local workspace="$TMP_DIR/fedora-atomic-target"
+    local fake_bin="$workspace/bin"
+    local os_release="$workspace/os-release"
+    local ostree_booted="$workspace/ostree-booted"
+    local install_log="$workspace/install-deps.log"
+    local wizard_log="$workspace/bootstrap-wizard.log"
+    local helper_output="$workspace/helper-output.log"
+
+    mkdir -p "$fake_bin"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$fake_bin/rpm-ostree"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$fake_bin/rpmbuild"
+    chmod +x "$fake_bin/rpm-ostree" "$fake_bin/rpmbuild"
+    cat > "$os_release" <<'EOF'
+ID=fedora
+ID_LIKE=
+VERSION_ID="44"
+PRETTY_NAME="Fedora Linux 44 (KDE Plasma Desktop Edition)"
+VARIANT_ID=kde
+EOF
+    : > "$ostree_booted"
+
+    PATH="$fake_bin:/usr/bin:/bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    DETECT_ONLY=1 \
+        bash "$REPO_DIR/scripts/install-deps.sh" >"$install_log"
+    assert_contains "$install_log" "Detected dependency profile: rpm-ostree"
+    assert_contains "$install_log" "ID=fedora"
+    assert_not_contains "$install_log" "ID_LIKE=ubuntu"
+
+    local missing_bin="$workspace/missing-bin"
+    local missing_log="$workspace/install-deps-missing.log"
+    mkdir -p "$missing_bin"
+    for command in dirname pwd uname; do
+        ln -s "$(command -v "$command")" "$missing_bin/$command"
+    done
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$missing_bin/rpm-ostree"
+    chmod +x "$missing_bin/rpm-ostree"
+
+    local status=0
+    PATH="$missing_bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    HOME="$workspace/home-missing" \
+        /bin/bash "$REPO_DIR/scripts/install-deps.sh" >"$missing_log" 2>&1 || status=$?
+    [ "$status" -ne 0 ] || fail "Expected rpm-ostree install-deps to stop before packages are layered"
+    assert_contains "$missing_log" "sudo rpm-ostree install python3 7zip curl unzip rpm-build make gcc-c++"
+    assert_contains "$missing_log" "Still missing:"
+    assert_not_contains "$missing_log" "nodejs npm"
+
+    local layered_bin="$workspace/layered-bin"
+    local layered_log="$workspace/install-deps-layered.log"
+    mkdir -p "$layered_bin"
+    for command in dirname pwd uname grep; do
+        ln -s "$(command -v "$command")" "$layered_bin/$command"
+    done
+    for command in rpm-ostree python3 7zz curl unzip rpmbuild make g++ cargo; do
+        cat > "$layered_bin/$command" <<'SCRIPT'
+#!/bin/sh
+command_name="${0##*/}"
+case "$command_name" in
+    7zz) echo "7-Zip 26.00" ;;
+    cargo) echo "cargo 1.96.0" ;;
+    *) exit 0 ;;
+esac
+SCRIPT
+        chmod +x "$layered_bin/$command"
+    done
+
+    PATH="$layered_bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    HOME="$workspace/home-layered" \
+        /bin/bash "$REPO_DIR/scripts/install-deps.sh" >"$layered_log" 2>&1
+    assert_contains "$layered_log" "rpm-ostree layered build dependencies are already available"
+    assert_contains "$layered_log" "Skipping system Node.js check; install.sh provides the managed Node.js runtime"
+    assert_contains "$layered_log" "All dependencies installed"
+    assert_not_contains "$layered_log" "Node.js 20+ with npm and npx is required"
+
+    PATH="$fake_bin:/usr/bin:/bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    CODEX_BOOTSTRAP_DRY_RUN=1 \
+    CODEX_BOOTSTRAP_NONINTERACTIVE=1 \
+    CODEX_LINUX_FEATURES_ROOT="$REPO_DIR/linux-features" \
+    CODEX_LINUX_FEATURES_CONFIG="$workspace/features.json" \
+        bash "$REPO_DIR/scripts/bootstrap-wizard.sh" >"$wizard_log"
+    assert_contains "$wizard_log" "Package manager: rpm-ostree"
+    assert_contains "$wizard_log" "Native package format: rpm"
+    assert_contains "$wizard_log" "Atomic host: yes"
+
+    CODEX_LINUX_TARGET_ATOMIC=maybe \
+    PATH="$fake_bin:/usr/bin:/bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    bash -c '
+        # shellcheck disable=SC1091
+        source "$1"
+        OS_RELEASE_ID="$(os_release_field ID)"
+        OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
+        OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID)"
+        printf "manager=%s\natomic=%s\n" \
+            "$(detect_package_manager)" \
+            "$(linux_target_is_atomic && echo yes || echo no)"
+    ' _ "$REPO_DIR/scripts/lib/linux-target-detect.sh" >"$helper_output"
+    assert_contains "$helper_output" "manager=rpm-ostree"
+    assert_contains "$helper_output" "atomic=yes"
+
+    CODEX_LINUX_TARGET_ATOMIC=0 \
+    PATH="$fake_bin:/usr/bin:/bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    bash -c '
+        # shellcheck disable=SC1091
+        source "$1"
+        OS_RELEASE_ID="$(os_release_field ID)"
+        OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
+        OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID)"
+        printf "manager=%s\natomic=%s\n" \
+            "$(detect_package_manager)" \
+            "$(linux_target_is_atomic && echo yes || echo no)"
+    ' _ "$REPO_DIR/scripts/lib/linux-target-detect.sh" >"$helper_output"
+    assert_contains "$helper_output" "manager=unknown"
+    assert_contains "$helper_output" "atomic=no"
+
+    rm -f "$ostree_booted"
+    PATH="$fake_bin:/usr/bin:/bin" \
+    OS_RELEASE_FILE="$os_release" \
+    OSTREE_BOOTED_FILE="$ostree_booted" \
+    bash -c '
+        # shellcheck disable=SC1091
+        source "$1"
+        OS_RELEASE_ID="$(os_release_field ID)"
+        OS_RELEASE_ID_LIKE="$(os_release_field ID_LIKE 2>/dev/null || true)"
+        OS_RELEASE_VERSION_ID="$(os_release_field VERSION_ID)"
+        printf "manager=%s\nformat=%s\natomic=%s\n" \
+            "$(detect_package_manager)" \
+            "$(detect_package_format)" \
+            "$(linux_target_is_atomic && echo yes || echo no)"
+    ' _ "$REPO_DIR/scripts/lib/linux-target-detect.sh" >"$helper_output"
+    assert_contains "$helper_output" "manager=unknown"
+    assert_contains "$helper_output" "format=rpm"
+    assert_contains "$helper_output" "atomic=no"
+}
+
 test_setup_native_wizard_noninteractive_feature_writer() {
     info "Checking setup-native wizard non-interactive feature writer"
     local workspace="$TMP_DIR/setup-native-writer"
@@ -6846,6 +6993,7 @@ main() {
     test_rebuild_candidate_uses_validated_default_dmg
     test_native_shortcut_targets_compose_existing_flows
     test_fedora_dependency_bootstrap_installs_rpmbuild
+    test_fedora_atomic_rpm_ostree_target_detection
     test_setup_native_wizard_noninteractive_feature_writer
     test_setup_native_wizard_rejects_invalid_feature_ids
     test_setup_native_wizard_rejects_features_without_readme


### PR DESCRIPTION
Hi,

This follows up on the useful target-detection part from #659 after that PR was closed, without carrying over the localization, Read Aloud, or build-info UI changes.

The installer stays conservative on rpm-ostree systems: it detects the profile and prints the manual layering command, but it does not run rpm-ostree automatically. The shell setup paths now share the same target detector, so setup-native and install-deps report the same host shape. The JS build metadata path also reports Fedora Atomic as an rpm-ostree target.

What changed:
- detect ostree-booted Fedora hosts and report rpm-ostree in the JS target context and build metadata
- share shell distro and package detection through scripts/lib/linux-target-detect.sh
- add direct JS and shell smoke coverage for Fedora Atomic with rpm-ostree present and no dnf or dnf5
- cover invalid atomic override fallback and explicit atomic opt-out

Tested:
- bash -n scripts/lib/linux-target-detect.sh scripts/install-deps.sh scripts/bootstrap-wizard.sh
- node --check scripts/lib/linux-target-context.js && node --check scripts/lib/build-info.js && node --check scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js --test-name-pattern 'Fedora Atomic|package profile|Linux target context'
- bash scripts/ci/run-node-checks.sh
- bash tests/scripts_smoke.sh
- make check
- make test
- cargo clippy --workspace --all-targets -- -D warnings

Thanks.