### PR TITLE
fix(remote-mobile): recover stale stream state

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -148,6 +148,8 @@ const {
   applyLocalEnvironmentActionModalDraftPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxCompletedItemRecoveryPatch,
+  applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxBrowserUseAvailabilityPatch,
@@ -877,6 +879,8 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-app-sunset-gate",
     "linux-app-server-feature-enablement",
     "linux-app-server-backfill-wait",
+    "linux-completed-item-recovery",
+    "linux-remote-terminal-status-recovery",
     "linux-skills-list-dedupe",
     "linux-config-write-version-conflict",
     "linux-application-menu",
@@ -4971,6 +4975,111 @@ test("keeps current app-server backfill helpers visible outside the Sentry handl
   );
   assert.equal(context.startupTimeout, 3e5);
   assert.equal(context.turnTimeout, 3e4);
+});
+
+test("recovers completed stream items that arrive after local state lost their started item", () => {
+  const source = [
+    "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;",
+    "let{item:e,threadId:t,turnId:r,completedAtMs:i}=n.params,a=qf(t);if(!this.conversations.get(a)){$.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}",
+    "this.updateConversationState(a,t=>{let n=e.type===`userMessage`?gI(t,r):r==null?uI(t):fI(t,e=>e.turnId===r);if(!n)return;aR(n);",
+    "let a=Jtt({item:e,threadsById:this.threadStore.threadsById,onCollabAgentToolCall:e=>{this.hydrateCollabThreads(e.receiverThreadIds)}}),o=a.type===`contextCompaction`?n.items.find(e=>e.type===`contextCompaction`&&e.id===a.id):null;",
+    "if(a.type===`commandExecution`){let e=a.durationMs==null?null:i-a.durationMs;e!=null&&(n.commandExecutionStartedAtMsById??={},n.commandExecutionStartedAtMsById[a.id]??=e)}",
+    "let s=FF(a.type===`contextCompaction`?{...a,completed:!0,source:o?.type===`contextCompaction`&&`source`in o?o.source:`automatic`}:a);",
+    "if(e.type===`userMessage`){let t=Put(n.items,e.content,n.turnId,n.turnStartedAtMs,!1);if(t!=null){t.status=`accepted`,HI(n,FF({type:`steered`,id:e.id}));return}HI(n,s);return}",
+    "if(e.type===`hookPrompt`){HI(n,s);return}",
+    "Mut(e)&&(n.firstTurnWorkItemStartedAtMs=n.firstTurnWorkItemStartedAtMs??Date.now()),!(e.type!==`subAgentActivity`&&!TR(n,e.id,e.type))&&(e.type,HI(n,s))});break}}}}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxCompletedItemRecoveryPatch, source);
+
+  assert.match(patched, /codexLinuxCompletedItemExists=n\.items\.some\(e=>e\.id===s\.id\)/);
+  assert.match(
+    patched,
+    /if\(e\.type!==`subAgentActivity`&&codexLinuxCompletedItemExists&&!TR\(n,e\.id,e\.type\)\)return;HI\(n,s\)/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /!\(e\.type!==`subAgentActivity`&&!TR\(n,e\.id,e\.type\)\)&&\(e\.type,HI\(n,s\)\)/,
+  );
+
+  const context = {};
+  vm.runInNewContext(
+    [
+      "let errors=[];",
+      "var $={error:(message,details)=>errors.push({message,details})};",
+      "function qf(e){return e}",
+      "function fI(e,t){return e.turns.find(t)}",
+      "function gI(){throw Error(`unexpected userMessage path`)}",
+      "function uI(){throw Error(`unexpected null turn path`)}",
+      "function aR(){}",
+      "function Mut(){return true}",
+      "function Jtt({item:e}){return {type:e.type,id:e.id,text:e.text??null}}",
+      "function FF(e){return e}",
+      "function HI(e,t){let n=e.items.findIndex(e=>e.id===t.id);n>=0?e.items[n]=t:e.items.push(t)}",
+      "function TR(e,t,n){let r=e.items.find(e=>e.id===t&&e.type===n);if(r)return r;$.error(`Item not found in turn state`,{safe:{itemId:t},sensitive:{}});return null}",
+      "function Put(){return null}",
+      patched,
+      "function run(items){errors=[];let turn={turnId:`turn-1`,items:items.map(e=>({...e}))},conversation={turns:[turn]},manager=new T;manager.frameTextDeltaQueue={drainBefore:()=>false};manager.conversations=new Map([[`thread-1`,{}]]);manager.threadStore={threadsById:new Map};manager.hydrateCollabThreads=()=>{};manager.updateConversationState=(id,fn)=>fn(conversation);manager.onNotification(`item/completed`,{item:{type:`agentMessage`,id:`assistant-1`,text:`done`},threadId:`thread-1`,turnId:`turn-1`,completedAtMs:100});return {items:turn.items,errors}}",
+      "result={missing:run([]),existing:run([{type:`agentMessage`,id:`assistant-1`,text:`old`}]),wrongType:run([{type:`plan`,id:`assistant-1`,text:`old`}])};",
+    ].join(";"),
+    context,
+  );
+  const behavior = JSON.parse(JSON.stringify(context.result));
+  assert.deepEqual(behavior.missing.items, [
+    { type: "agentMessage", id: "assistant-1", text: "done" },
+  ]);
+  assert.deepEqual(behavior.existing.items, [
+    { type: "agentMessage", id: "assistant-1", text: "done" },
+  ]);
+  assert.deepEqual(behavior.wrongType.items, [
+    { type: "plan", id: "assistant-1", text: "old" },
+  ]);
+  assert.equal(behavior.missing.errors.length, 0);
+  assert.equal(behavior.existing.errors.length, 0);
+  assert.equal(behavior.wrongType.errors.length, 1);
+});
+
+test("treats empty active runtime status as stale once response rendering has completed", () => {
+  const source =
+    "function LQt({hasInProgressSideChat:e,isResponseInProgress:t,latestTurnHasSystemError:n,resumeState:r,threadRuntimeStatus:i}){return e?`loading`:i?.type===`systemError`?`error`:i?.type===`active`?`loading`:r===`needs_resume`?`idle`:n?`error`:t===!0?`loading`:`idle`}";
+
+  const patched = applyPatchTwice(applyLinuxRemoteTerminalStatusRecoveryPatch, source);
+
+  assert.match(patched, /codexLinuxRemoteTerminalStatusActive=i\?\.type===`active`/);
+  assert.match(
+    patched,
+    /codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&\(t===!0\|\|!Array\.isArray\(i\.activeFlags\)\|\|i\.activeFlags\.length>0\)/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /i\?\.type===`active`\?`loading`:r===`needs_resume`/,
+  );
+
+  const context = {};
+  vm.runInNewContext(
+    `${patched};result={
+      stale:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
+      streaming:LQt({hasInProgressSideChat:false,isResponseInProgress:true,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
+      waiting:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      unknownShape:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`}}),
+      sideChat:LQt({hasInProgressSideChat:true,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
+      systemError:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`systemError\`}}),
+      turnError:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:true,resumeState:null,threadRuntimeStatus:{type:\`idle\`}}),
+      needsResume:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`idle\`}})
+    };`,
+    context,
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.result)), {
+    stale: "idle",
+    streaming: "loading",
+    waiting: "loading",
+    unknownShape: "loading",
+    sideChat: "loading",
+    systemError: "error",
+    turnError: "error",
+    needsResume: "idle",
+  });
 });
 
 test("skips app-server timeout rewrite when the helper insertion anchor drifts", () => {

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxCompletedItemRecoveryPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-completed-item-recovery",
+    phase: "webview-asset",
+    order: 1043,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~.*\.js$/,
+    missingDescription: "app main webview bundle",
+    skipDescription: "Linux completed item recovery patch",
+    apply: applyLinuxCompletedItemRecoveryPatch,
+  }),
+];

--- a/scripts/patches/core/all-linux/webview/remote-terminal-status-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/remote-terminal-status-recovery/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxRemoteTerminalStatusRecoveryPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-remote-terminal-status-recovery",
+    phase: "webview-asset",
+    order: 1044,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~.*\.js$/,
+    missingDescription: "app main webview bundle",
+    skipDescription: "Linux remote terminal status recovery patch",
+    apply: applyLinuxRemoteTerminalStatusRecoveryPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -868,6 +868,64 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxCompletedItemRecoveryPatch(currentSource) {
+  if (currentSource.includes("codexLinuxCompletedItemExists=")) {
+    return currentSource;
+  }
+
+  const completedItemDropPattern =
+    /Mut\(([A-Za-z_$][\w$]*)\)&&\(([A-Za-z_$][\w$]*)\.firstTurnWorkItemStartedAtMs=\2\.firstTurnWorkItemStartedAtMs\?\?Date\.now\(\)\),!\(\1\.type!==`subAgentActivity`&&!TR\(\2,\1\.id,\1\.type\)\)&&\(\1\.type,HI\(\2,([A-Za-z_$][\w$]*)\)\)/u;
+
+  if (completedItemDropPattern.test(currentSource)) {
+    return currentSource.replace(
+      completedItemDropPattern,
+      (_match, completedItemVar, turnVar, viewItemVar) =>
+        `Mut(${completedItemVar})&&(${turnVar}.firstTurnWorkItemStartedAtMs=${turnVar}.firstTurnWorkItemStartedAtMs??Date.now());let codexLinuxCompletedItemExists=${turnVar}.items.some(e=>e.id===${viewItemVar}.id);if(${completedItemVar}.type!==\`subAgentActivity\`&&codexLinuxCompletedItemExists&&!TR(${turnVar},${completedItemVar}.id,${completedItemVar}.type))return;HI(${turnVar},${viewItemVar})`,
+    );
+  }
+
+  if (
+    currentSource.includes("Item not found in turn state") &&
+    currentSource.includes("case`item/completed`") &&
+    currentSource.includes("item/agentMessage/delta")
+  ) {
+    console.warn(
+      "WARN: Could not find completed item recovery insertion point — skipping Linux completed item recovery patch",
+    );
+  }
+
+  return currentSource;
+}
+
+function applyLinuxRemoteTerminalStatusRecoveryPatch(currentSource) {
+  if (currentSource.includes("codexLinuxRemoteTerminalStatusActive=")) {
+    return currentSource;
+  }
+
+  const terminalStatusPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{hasInProgressSideChat:([A-Za-z_$][\w$]*),isResponseInProgress:([A-Za-z_$][\w$]*),latestTurnHasSystemError:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{return \2\?`loading`:\6\?\.type===`systemError`\?`error`:\6\?\.type===`active`\?`loading`:\5===`needs_resume`\?`idle`:\4\?`error`:\3===!0\?`loading`:`idle`\}/u;
+
+  if (terminalStatusPattern.test(currentSource)) {
+    return currentSource.replace(
+      terminalStatusPattern,
+      (_match, fnName, sideChatVar, responseProgressVar, systemErrorVar, resumeStateVar, runtimeStatusVar) =>
+        `function ${fnName}({hasInProgressSideChat:${sideChatVar},isResponseInProgress:${responseProgressVar},latestTurnHasSystemError:${systemErrorVar},resumeState:${resumeStateVar},threadRuntimeStatus:${runtimeStatusVar}}){let codexLinuxRemoteTerminalStatusActive=${runtimeStatusVar}?.type===\`active\`,codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&(${responseProgressVar}===!0||!Array.isArray(${runtimeStatusVar}.activeFlags)||${runtimeStatusVar}.activeFlags.length>0);return ${sideChatVar}?\`loading\`:${runtimeStatusVar}?.type===\`systemError\`?\`error\`:codexLinuxRemoteTerminalStatusLoading?\`loading\`:${resumeStateVar}===\`needs_resume\`?\`idle\`:${systemErrorVar}?\`error\`:${responseProgressVar}===!0?\`loading\`:\`idle\`}`,
+    );
+  }
+
+  if (
+    currentSource.includes("hasInProgressSideChat") &&
+    currentSource.includes("isResponseInProgress") &&
+    currentSource.includes("threadRuntimeStatus")
+  ) {
+    console.warn(
+      "WARN: Could not find remote terminal status insertion point — skipping Linux remote terminal status recovery patch",
+    );
+  }
+
+  return currentSource;
+}
+
 function applyLinuxI18nGatePatch(currentSource) {
   const alreadyPatchedI18nGateRegexes = [
     /([A-Za-z_$][\w$]*)=[^;]*?\.get\(`enable_i18n`,!1\)[^;]*;let [^;]*,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.localeOverride\),[A-Za-z_$][\w$]*=\1\|\|\2!=null/u,
@@ -1847,6 +1905,8 @@ function patchCommentPreloadBundle(extractedDir) {
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxCompletedItemRecoveryPatch,
+  applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
   applyLinuxChatSearchHydrationPatch,
   applyLinuxBrowserUseAvailabilityPatch,


### PR DESCRIPTION
Hi,

This is a small follow-up to #663 and the remote mobile feedback tracked in #639.

While testing long remote mobile sessions, I found two stale stream states that can leave the Android view behind the finished conversation state:

- a completed stream item can be dropped if the local turn state lost the matching started item
- the remote composer can keep showing a running state when the thread runtime status is still active, but the response is no longer rendering and there are no active runtime flags

The patch keeps the existing remote hydration flow, but adds two fail-soft webview patches:

- recover the completed item payload when it is safe to do so
- treat an empty active runtime status as stale only when no response is in progress, while preserving real waits, approvals, and unknown status shapes

Tests:

- `node --test --test-name-pattern 'completed stream|empty active runtime|remote terminal status' scripts/patch-linux-window-ui.test.js`
- `node --test scripts/patch-linux-window-ui.test.js` - 334 pass / 0 fail
- `node --test linux-features/*/test.js` - 385 pass / 0 fail
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test` - 189 pass / 0 fail
- patcher dry-run against a copy of the currently installed extracted bundle: first run `applied`, second run `already-applied` for both new descriptors

Related to #639.
