### PR TITLE
fix: preserve Linux application menu accelerators

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2348,24 +2348,21 @@ test("recognizes the Linux removeMenu snippet as already applied", () => {
   assert.equal((patched.match(/process\.platform===`linux`&&k\.removeMenu\(\),/g) ?? []).length, 1);
 });
 
-test("suppresses the global application menu on Linux", () => {
+test("preserves the global application menu on Linux for accelerators", () => {
   const source =
     "let $e=[{role:`help`,submenu:[]}],et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(et);";
   const patched = applyPatchTwice(applyLinuxApplicationMenuPatch, source);
 
-  assert.equal(
-    patched,
-    "let $e=[{role:`help`,submenu:[]}],et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(process.platform===`linux`?null:et);",
-  );
+  assert.equal(patched, source);
 });
 
-test("recognizes an already Linux-suppressed application menu", () => {
+test("migrates a Linux-suppressed application menu back to the real menu", () => {
   const source =
     "let et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(process.platform===`linux`?null:et);";
 
   const patched = applyPatchTwice(applyLinuxApplicationMenuPatch, source);
 
-  assert.equal(patched, source);
+  assert.equal(patched, "let et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(et);");
 });
 
 test("recognizes already-applied Linux opaque background patch", () => {

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -372,27 +372,10 @@ function applyLinuxMenuPatch(currentSource) {
 }
 
 function applyLinuxApplicationMenuPatch(currentSource) {
-  const applicationMenuRegex =
-    /([A-Za-z_$][\w$]*)\.Menu\.setApplicationMenu\(([A-Za-z_$][\w$]*)\)/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(
-    applicationMenuRegex,
-    (_match, electronAlias, menuAlias) => {
-      patchedAny = true;
-      return `${electronAlias}.Menu.setApplicationMenu(process.platform===\`linux\`?null:${menuAlias})`;
-    },
+  return currentSource.replace(
+    /([A-Za-z_$][\w$]*)\.Menu\.setApplicationMenu\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\)/g,
+    (_match, electronAlias, menuAlias) => `${electronAlias}.Menu.setApplicationMenu(${menuAlias})`,
   );
-
-  const hasApplicationMenuCall = /[A-Za-z_$][\w$]*\.Menu\.setApplicationMenu\(/.test(currentSource);
-  const hasLinuxNullApplicationMenu =
-    /[A-Za-z_$][\w$]*\.Menu\.setApplicationMenu\(process\.platform===`linux`\?null:[A-Za-z_$][\w$]*\)/.test(
-      currentSource,
-    );
-  if (!patchedAny && hasApplicationMenuCall && !hasLinuxNullApplicationMenu) {
-    console.warn("WARN: Could not find application menu call shape — skipping Linux application menu patch");
-  }
-
-  return patchedSource;
 }
 
 function applyLinuxSetIconPatch(currentSource, iconAsset) {


### PR DESCRIPTION
## Summary
fixes Linux keyboard shortcuts such as `Ctrl+G` for search and `Ctrl++` / `Ctrl+-` for zoom.
the commit `fbee0d2` caused this bug since it sets the Electron application menu to `null`.
## Validation
```bash
node --test scripts/patch-linux-window-ui.test.js
```
all tests pass.
