### PR TITLE
Restore Linux desktop settings route scan

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1404,7 +1404,9 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
 // `settings-page-*.js` bundle then carries only the icon map, nav order, slug
 // groups, and visibility/loading switches. This is the layout that rendered the
 // Linux desktop nav entry with the page component injected as its icon.
-function createSplitRouteNativeKeyboardShortcutsSettingsFixture() {
+function createSplitRouteNativeKeyboardShortcutsSettingsFixture({
+  routeChunkName = "app-initial~app-main~automations-page-A.js",
+} = {}) {
   const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-split-route-shortcuts-"));
   const assetsDir = path.join(extractedDir, "webview", "assets");
   fs.mkdirSync(assetsDir, { recursive: true });
@@ -1454,7 +1456,7 @@ function createSplitRouteNativeKeyboardShortcutsSettingsFixture() {
   );
   // The hoisted lazy route map, assigned as a bare `FW={...}` inside an IIFE body.
   writeAsset(
-    "app-initial~app-main~automations-page-A.js",
+    routeChunkName,
     [
       "var Bn,Ya,Pr,FW,Xn=e((()=>{Bn=s(),Ya=t(f(),1),Pr=o(),",
       'FW={"general-settings":(0,Ya.lazy)(()=>Pr(()=>import(`./general-settings-A.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([1,2]))),',
@@ -4553,6 +4555,32 @@ test("adds Linux desktop settings when the lazy route map is hoisted into a sepa
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
     assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("finds Linux desktop settings route map in hashed settings-page chunks", () => {
+  const routeChunkName = "app-initial~settings-page-A.js";
+  const { extractedDir, assetsDir } = createSplitRouteNativeKeyboardShortcutsSettingsFixture({
+    routeChunkName,
+  });
+  try {
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.deepEqual(warnings, []);
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), true);
+
+    const routeChunkSource = fs.readFileSync(path.join(assetsDir, routeChunkName), "utf8");
+    assert.match(
+      routeChunkSource,
+      /"linux-desktop":\(0,Ya\.lazy\)\(\(\)=>Pr\(\(\)=>import\(`\.\/linux-desktop-settings-linux\.js`\),\[\],import\.meta\.url\)\),"general-settings":/,
+    );
+
+    const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
+    assert.match(settingsPageSource, /"linux-desktop":wt,"general-settings":wt/);
+    assert.doesNotMatch(settingsPageSource, /codexLinuxDesktopSettings/);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -626,12 +626,13 @@ function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
   }
 
   // Newer builds split the lazy settings route map out of `app-main-*.js`/`index-*.js`
-  // into hashed concatenation chunks named `app-initial~app-main~*.js` (e.g. the
-  // automations-page chunk), while the icon/navigation metadata stays in
-  // `settings-page-*.js`. Scan all three so the route map is always discoverable.
+  // into hashed concatenation chunks. Some keep the `app-initial~app-main~*`
+  // prefix; others are settings-page chunks without that prefix. The
+  // icon/navigation metadata still lives in a settings-page chunk, so scan any
+  // hashed settings-page JS file plus the legacy app-main/index candidates.
   const candidates = fs
     .readdirSync(webviewAssetsDir)
-    .filter((name) => /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/.test(name) || /settings-page.*\.js$/.test(name))
+    .filter((name) => /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/.test(name) || /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name))
     .sort();
 
   let routeMatched = false;


### PR DESCRIPTION
## Summary
- broaden the Linux Desktop settings route scan to include hashed settings-page chunks such as `app-initial~settings-page-*.js`
- add regression coverage for that route-map location while preserving the separate navigation/icon patch behavior

## Root cause
The Linux Desktop settings page patch only scanned legacy app-main/index chunks, `app-initial~app-main~*` chunks, and direct `settings-page*` bundles. If upstream hoists the lazy route map into a hashed settings-page concatenation chunk without the app-main prefix, the optional patch can miss the route map and skip restoring the Linux Desktop settings entry.

## Validation
- `node --test scripts/patch-linux-window-ui.test.js`
- `nix build .#codex-desktop --no-link --print-out-paths`
- inspected the Nix output for `linux-desktop-settings-linux.js` and `keybinds-settings` patch report status `applied`