### PR TITLE
Fix read-aloud warning for normalizer bundles

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -183,7 +183,9 @@ function applyAssistantRenderPatch(source) {
 
   const needle = "(0,$.jsx)(O6,{item:e,assistantCopyText:l,assistantRatingEventContext:f,after:u,conversationId:n,cwd:o,onFork:g})";
   if (!source.includes(needle)) {
-    if (source.includes("assistantCopyText") || source.includes("renderPlaceholderWhileStreaming")) {
+    // Turn normalizers can contain renderPlaceholderWhileStreaming without
+    // rendering assistant UI. assistantCopyText is the render-call signal here.
+    if (source.includes("assistantCopyText")) {
       warn("Could not find assistant message render call", "read aloud assistant render patch");
     }
     return source;

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -28,6 +28,17 @@ function twice(fn, source) {
   return patched;
 }
 
+function captureWarnings(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    return { result: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 test("main bundle patch adds a Linux read aloud handler", () => {
   const source = [
     "let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);",
@@ -854,6 +865,23 @@ test("assistant render patch adds an explicit read aloud button under the messag
   assert.doesNotMatch(patched, /children:"Read aloud"/);
   assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(n,p,o,e\.currentTarget\)/);
   assert.match(patched, /\$\.Fragment/);
+});
+
+test("assistant render patch ignores normalized assistant items without render props", () => {
+  const source = "case`agentMessage`:{let s=e.status===`inProgress`&&d>=0&&t===d,l=s&&Spt(i.content);a.push({type:`assistant-message`,content:m,completed:!s,renderPlaceholderWhileStreaming:l});break}";
+  const { result: patched, warnings } = captureWarnings(() => applyAssistantRenderPatch(source));
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("assistant render patch still warns when an assistant render candidate drifts", () => {
+  const source = "return renderMessage({item:n,assistantCopyText:p,conversationId:o,renderCodeBlocksAsWritingBlocks:V})";
+  const { result: patched, warnings } = captureWarnings(() => applyAssistantRenderPatch(source));
+
+  assert.equal(patched, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Could not find assistant message render call/);
 });
 
 test("assistant render patch preserves the current JSX runtime alias", () => {


### PR DESCRIPTION
## Summary

- avoid reporting read-aloud assistant render drift on turn-normalizer bundles that only build assistant-message items
- keep the warning for actual render candidates that still expose `assistantCopyText`
- add regression coverage for both the normalizer and render-drift cases

## Validation

- `node --test linux-features/read-aloud/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
