### PR TITLE
Prefer newest local CLI when launching Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ Use, Codex CLI install/update, or local auto-update rebuilds.
 
 The Codex CLI is still required at runtime. The first launch can install or
 update `@openai/codex` with the bundled `npm`, or you can manage the CLI
-yourself.
+yourself. When multiple `codex` binaries are installed, the launcher selects
+the newest version it can find in the GUI `PATH` and known user install
+locations, and records the selected path and version in
+`~/.cache/codex-desktop/launcher.log`. Set `CODEX_CLI_PATH` to pin a specific
+binary.
 
 X11 and Wayland sessions are supported. The launcher prefers XWayland on
 Wayland when available for better Electron popup positioning, then falls back
@@ -219,7 +223,7 @@ not download or extract the DMG themselves. See
 |---|---|
 | `/tmp` is mounted `noexec` | Set `TMPDIR` and `XDG_CACHE_HOME` to executable directories under `$HOME` |
 | Blank window or splash stuck | Check `~/.cache/codex-desktop/launcher.log` and whether port `5175` is already in use |
-| `CODEX_CLI_PATH` or CLI install error | Reopen the app or install `@openai/codex` manually |
+| `CODEX_CLI_PATH` or CLI install error | Check the selected CLI path/version in `~/.cache/codex-desktop/launcher.log`, reopen the app, or install `@openai/codex` manually |
 | Wayland / GPU / Vulkan hang | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` or persistent launch flags |
 | Resize ghosting or stale frame trails | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh` or `--disable-gpu-compositing` |
 | Computer Use UI is hidden | Enable the UI opt-in; account/server rollouts may still hide upstream-gated parts |

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -20,6 +20,12 @@ installs continue to update through npm, while official standalone installs
 under `~/.codex/packages/standalone` are updated with the official standalone
 installer instead of being replaced through npm.
 
+Before the preflight runs, the launcher resolves the newest local `codex`
+binary it can find across the GUI `PATH` and known user install locations. This
+prevents an older system-wide CLI from winning over a newer user install, and
+the selected path plus version are written to the launcher log. `CODEX_CLI_PATH`
+still pins an explicit binary when users need one.
+
 ## Inspect State
 
 ```bash

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1362,11 +1362,228 @@ resolve_notification_icon() {
     echo "$APP_NOTIFICATION_ICON_NAME"
 }
 
-find_codex_cli() {
-    if command -v codex >/dev/null 2>&1; then
-        command -v codex
+codex_cli_version_probe() {
+    local output_file="$1"
+    shift
+    local probe_pid attempt wait_status
+
+    "$@" >"$output_file" 2>/dev/null &
+    probe_pid=$!
+    for ((attempt = 0; attempt < 50; attempt++)); do
+        if ! kill -0 "$probe_pid" 2>/dev/null; then
+            break
+        fi
+        sleep 0.02
+    done
+    if kill -0 "$probe_pid" 2>/dev/null; then
+        kill "$probe_pid" 2>/dev/null || true
+        for ((attempt = 0; attempt < 10; attempt++)); do
+            if ! kill -0 "$probe_pid" 2>/dev/null; then
+                break
+            fi
+            sleep 0.02
+        done
+        if kill -0 "$probe_pid" 2>/dev/null; then
+            kill -9 "$probe_pid" 2>/dev/null || true
+        fi
+        wait "$probe_pid" 2>/dev/null || true
+        return 124
+    fi
+    wait_status=0
+    wait "$probe_pid" 2>/dev/null || wait_status=$?
+    return "$wait_status"
+}
+
+codex_cli_version() {
+    local cli_path="$1"
+    local output version probe_file probe_status
+
+    probe_file="$(mktemp "${TMPDIR:-/tmp}/codex-cli-version.XXXXXX")" || return 1
+    probe_status=0
+    codex_cli_version_probe "$probe_file" "$cli_path" --version || probe_status=$?
+    if [ "$probe_status" -ne 0 ]; then
+        [ "$probe_status" -ne 124 ] || {
+            rm -f "$probe_file"
+            return 1
+        }
+        probe_status=0
+        codex_cli_version_probe "$probe_file" "$cli_path" version || probe_status=$?
+        [ "$probe_status" -eq 0 ] || {
+            rm -f "$probe_file"
+            return 1
+        }
+    fi
+    output="$(cat "$probe_file" 2>/dev/null || true)"
+    rm -f "$probe_file"
+    version="$(printf '%s\n' "$output" | sed -nE 's/.*(^|[[:space:]])v?([0-9]+([.][0-9]+)+(-[0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?([+][0-9A-Za-z-]+([.][0-9A-Za-z-]+)*)?)($|[^0-9A-Za-z._+-]).*/\2/p' | head -n 1)"
+    [ -n "$version" ] || return 1
+    echo "$version"
+}
+
+codex_cli_version_core() {
+    local version="${1%%+*}"
+    echo "${version%%-*}"
+}
+
+codex_cli_version_prerelease() {
+    local version="${1%%+*}"
+
+    case "$version" in
+        *-*) echo "${version#*-}" ;;
+        *) echo "" ;;
+    esac
+}
+
+codex_cli_version_core_compare() {
+    local left="$1"
+    local right="$2"
+    local left_core right_core left_part right_part i max
+    local -a left_parts right_parts
+
+    left_core="$(codex_cli_version_core "$left")"
+    right_core="$(codex_cli_version_core "$right")"
+    IFS=. read -r -a left_parts <<< "$left_core"
+    IFS=. read -r -a right_parts <<< "$right_core"
+    max="${#left_parts[@]}"
+    [ "${#right_parts[@]}" -gt "$max" ] && max="${#right_parts[@]}"
+
+    for ((i = 0; i < max; i++)); do
+        left_part="${left_parts[$i]:-0}"
+        right_part="${right_parts[$i]:-0}"
+        [[ "$left_part" =~ ^[0-9]+$ ]] || return 1
+        [[ "$right_part" =~ ^[0-9]+$ ]] || return 1
+        if ((10#$left_part > 10#$right_part)); then
+            echo 1
+            return 0
+        fi
+        if ((10#$left_part < 10#$right_part)); then
+            echo -1
+            return 0
+        fi
+    done
+
+    echo 0
+}
+
+codex_cli_prerelease_compare() {
+    local left="$1"
+    local right="$2"
+    local left_id right_id left_is_num right_is_num ordered i max
+    local -a left_ids right_ids
+
+    if [ -z "$left" ] && [ -z "$right" ]; then
+        echo 0
         return 0
     fi
+    if [ -z "$left" ]; then
+        echo 1
+        return 0
+    fi
+    if [ -z "$right" ]; then
+        echo -1
+        return 0
+    fi
+
+    IFS=. read -r -a left_ids <<< "$left"
+    IFS=. read -r -a right_ids <<< "$right"
+    max="${#left_ids[@]}"
+    [ "${#right_ids[@]}" -gt "$max" ] && max="${#right_ids[@]}"
+
+    for ((i = 0; i < max; i++)); do
+        if [ "$i" -ge "${#left_ids[@]}" ]; then
+            echo -1
+            return 0
+        fi
+        if [ "$i" -ge "${#right_ids[@]}" ]; then
+            echo 1
+            return 0
+        fi
+        left_id="${left_ids[$i]}"
+        right_id="${right_ids[$i]}"
+        [ "$left_id" = "$right_id" ] && continue
+
+        left_is_num=0
+        right_is_num=0
+        [[ "$left_id" =~ ^[0-9]+$ ]] && left_is_num=1
+        [[ "$right_id" =~ ^[0-9]+$ ]] && right_is_num=1
+
+        if [ "$left_is_num" -eq 1 ] && [ "$right_is_num" -eq 1 ]; then
+            if ((10#$left_id > 10#$right_id)); then
+                echo 1
+            else
+                echo -1
+            fi
+            return 0
+        fi
+        if [ "$left_is_num" -eq 1 ]; then
+            echo -1
+            return 0
+        fi
+        if [ "$right_is_num" -eq 1 ]; then
+            echo 1
+            return 0
+        fi
+        ordered="$(printf '%s\n%s\n' "$left_id" "$right_id" | LC_ALL=C sort | tail -n 1)"
+        if [ "$ordered" = "$left_id" ]; then
+            echo 1
+        else
+            echo -1
+        fi
+        return 0
+    done
+
+    echo 0
+}
+
+codex_cli_version_compare() {
+    local left="$1"
+    local right="$2"
+    local core_compare left_prerelease right_prerelease
+
+    core_compare="$(codex_cli_version_core_compare "$left" "$right")" || return 1
+    case "$core_compare" in
+        1|-1)
+            echo "$core_compare"
+            return 0
+            ;;
+    esac
+
+    left_prerelease="$(codex_cli_version_prerelease "$left")"
+    right_prerelease="$(codex_cli_version_prerelease "$right")"
+    codex_cli_prerelease_compare "$left_prerelease" "$right_prerelease"
+}
+
+codex_cli_version_gte() {
+    local left="$1"
+    local right="$2"
+    local comparison
+
+    [ "$left" = "$right" ] && return 0
+    comparison="$(codex_cli_version_compare "$left" "$right")" || return 1
+    [ "$comparison" != "-1" ]
+}
+
+codex_cli_version_gt() {
+    local comparison
+
+    comparison="$(codex_cli_version_compare "$1" "$2")" || return 1
+    [ "$comparison" = "1" ]
+}
+
+path_contains_candidate() {
+    local path_list="$1"
+    local candidate="$2"
+
+    case ":$path_list:" in
+        *":$candidate:"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+find_codex_cli_entry() {
+    local candidate first_candidate="" best_candidate="" best_version="" candidate_version
+    local seen_candidates="" path_entry
+    local -a path_entries
 
     local nvm_dir="${NVM_DIR:-}"
     if [ -z "$nvm_dir" ]; then
@@ -1380,13 +1597,23 @@ find_codex_cli() {
         export NVM_DIR="$nvm_dir"
         # shellcheck disable=SC1090
         . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true
-        if command -v codex >/dev/null 2>&1; then
-            command -v codex
-            return 0
-        fi
     fi
 
-    local candidate
+    IFS=: read -r -a path_entries <<< "${PATH:-}"
+    for path_entry in "${path_entries[@]}"; do
+        [ -n "$path_entry" ] || path_entry="."
+        candidate="$path_entry/codex"
+        if [ -x "$candidate" ] && ! path_contains_candidate "$seen_candidates" "$candidate"; then
+            seen_candidates="${seen_candidates:+$seen_candidates:}$candidate"
+            first_candidate="${first_candidate:-$candidate}"
+            candidate_version="$(codex_cli_version "$candidate" || true)"
+            if [ -n "$candidate_version" ] && { [ -z "$best_candidate" ] || codex_cli_version_gt "$candidate_version" "$best_version"; }; then
+                best_candidate="$candidate"
+                best_version="$candidate_version"
+            fi
+        fi
+    done
+
     for candidate in \
         "$HOME/.bun/bin/codex" \
         "$HOME/.npm-global/bin/codex" \
@@ -1399,13 +1626,36 @@ find_codex_cli() {
         "/usr/local/bin/codex" \
         "/usr/bin/codex"
     do
-        if [ -x "$candidate" ]; then
-            echo "$candidate"
-            return 0
+        if [ -x "$candidate" ] && ! path_contains_candidate "$seen_candidates" "$candidate"; then
+            seen_candidates="${seen_candidates:+$seen_candidates:}$candidate"
+            first_candidate="${first_candidate:-$candidate}"
+            candidate_version="$(codex_cli_version "$candidate" || true)"
+            if [ -n "$candidate_version" ] && { [ -z "$best_candidate" ] || codex_cli_version_gt "$candidate_version" "$best_version"; }; then
+                best_candidate="$candidate"
+                best_version="$candidate_version"
+            fi
         fi
     done
 
+    if [ -n "$best_candidate" ]; then
+        printf '%s\t%s\n' "$best_candidate" "$best_version"
+        return 0
+    fi
+    if [ -n "$first_candidate" ]; then
+        printf '%s\t\n' "$first_candidate"
+        return 0
+    fi
+
     return 1
+}
+
+find_codex_cli() {
+    local resolved resolved_path
+
+    resolved="$(find_codex_cli_entry || true)"
+    [ -n "$resolved" ] || return 1
+    IFS=$'\t' read -r resolved_path _ <<< "$resolved"
+    echo "$resolved_path"
 }
 
 notify_error() {
@@ -3017,9 +3267,14 @@ else
     log_phase "warm_start_ready"
 fi
 
+CODEX_CLI_VERSION=""
 if [ -z "${CODEX_CLI_PATH:-}" ]; then
-    CODEX_CLI_PATH="$(find_codex_cli || true)"
-    export CODEX_CLI_PATH
+    CODEX_CLI_ENTRY="$(find_codex_cli_entry || true)"
+    if [ -n "$CODEX_CLI_ENTRY" ]; then
+        IFS=$'\t' read -r CODEX_CLI_PATH CODEX_CLI_VERSION <<< "$CODEX_CLI_ENTRY"
+        export CODEX_CLI_PATH
+        [ -z "$CODEX_CLI_VERSION" ] || export CODEX_CLI_VERSION
+    fi
     log_phase "cli_lookup"
 fi
 export CHROME_DESKTOP="${CHROME_DESKTOP:-$CODEX_LINUX_APP_ID.desktop}"
@@ -3097,7 +3352,15 @@ if needs_cold_start; then
     fi
 fi
 
-echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
+if [ -n "${CODEX_CLI_PATH:-}" ] && [ -z "${CODEX_CLI_VERSION:-}" ]; then
+    CODEX_CLI_VERSION="$(codex_cli_version "$CODEX_CLI_PATH" || true)"
+    export CODEX_CLI_VERSION
+fi
+if [ -n "${CODEX_CLI_VERSION:-}" ]; then
+    echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip} (version $CODEX_CLI_VERSION)"
+else
+    echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
+fi
 echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"
 
 launch_electron "${LAUNCHER_ARGS[@]}"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4094,6 +4094,11 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "prompt-install-cli"
     assert_contains "$REPO_DIR/launcher/start.sh.template" '.npm-global/bin/codex'
     assert_contains "$REPO_DIR/launcher/start.sh.template" '.config}/nvm/versions/node'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "codex_cli_version_probe"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "codex_cli_version"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "codex_cli_version_compare"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "find_codex_cli_entry"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_CLI_VERSION"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_UPDATE_MANAGER_PATH"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "resolve_update_manager_path"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "run_update_manager"
@@ -4184,6 +4189,169 @@ EOF
     assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh" "assets/codex-linux.png"
     assert_contains "$REPO_DIR/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh" "CODEX_USER_LOCAL_RECORD_DMG_FINGERPRINT"
     assert_contains "$REPO_DIR/contrib/user-local-install/README.md" "--force-x11"
+
+    local cli_resolver_probe old_cli_bin version_only_cli_bin blocked_cli_bin partial_blocked_cli_bin fallback_blocked_cli_bin same_core_prerelease_cli_bin newer_prerelease_cli_bin semver_home_dir home_dir selected_cli selected_entry expected_entry hanging_pids pid
+    cli_resolver_probe="$TMP_DIR/launcher-cli-resolver-probe.sh"
+    python3 - "$REPO_DIR/launcher/start.sh.template" "$cli_resolver_probe" <<'PY'
+import re
+import sys
+
+source_path, output_path = sys.argv[1:3]
+source = open(source_path, encoding="utf-8").read()
+functions = []
+for name in (
+    "codex_cli_version_probe",
+    "codex_cli_version",
+    "codex_cli_version_core",
+    "codex_cli_version_prerelease",
+    "codex_cli_version_core_compare",
+    "codex_cli_prerelease_compare",
+    "codex_cli_version_compare",
+    "codex_cli_version_gte",
+    "codex_cli_version_gt",
+    "path_contains_candidate",
+    "find_codex_cli_entry",
+    "find_codex_cli",
+):
+    match = re.search(rf"^{name}\(\) \{{[\s\S]*?^}}\n", source, re.M)
+    if match is None:
+        raise SystemExit(f"missing launcher function {name}")
+    functions.append(match.group(0))
+
+probe = "#!/usr/bin/env bash\nset -Eeuo pipefail\n" + "\n".join(functions) + "\nif [ \"${1:-path}\" = \"entry\" ]; then find_codex_cli_entry; else find_codex_cli; fi\n"
+open(output_path, "w", encoding="utf-8").write(probe)
+PY
+    chmod +x "$cli_resolver_probe"
+    old_cli_bin="$TMP_DIR/old-cli-bin"
+    home_dir="$TMP_DIR/cli-home"
+    mkdir -p "$old_cli_bin" "$home_dir/.npm-global/bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ] || [ "${1:-}" = "version" ]; then echo "codex-cli 0.120.0"; exit 0; fi' \
+        'exit 1' > "$old_cli_bin/codex"
+    chmod +x "$old_cli_bin/codex"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ] || [ "${1:-}" = "version" ]; then echo "codex-cli 0.142.5"; exit 0; fi' \
+        'exit 1' > "$home_dir/.npm-global/bin/codex"
+    chmod +x "$home_dir/.npm-global/bin/codex"
+    selected_cli="$(env -i PATH="$old_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$home_dir/.npm-global/bin/codex" ] \
+        || fail "launcher must prefer the newest discovered Codex CLI over the first PATH entry: $selected_cli"
+    selected_entry="$(env -i PATH="$old_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe" entry)"
+    expected_entry="$(printf '%s\t%s' "$home_dir/.npm-global/bin/codex" "0.142.5")"
+    [ "$selected_entry" = "$expected_entry" ] \
+        || fail "launcher must carry the selected Codex CLI version without probing again: $selected_entry"
+
+    same_core_prerelease_cli_bin="$TMP_DIR/same-core-prerelease-cli-bin"
+    semver_home_dir="$TMP_DIR/semver-cli-home"
+    mkdir -p "$same_core_prerelease_cli_bin" "$semver_home_dir/.npm-global/bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ] || [ "${1:-}" = "version" ]; then echo "codex-cli 0.142.0-alpha.1"; exit 0; fi' \
+        'exit 1' > "$same_core_prerelease_cli_bin/codex"
+    chmod +x "$same_core_prerelease_cli_bin/codex"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ] || [ "${1:-}" = "version" ]; then echo "codex-cli 0.142.0"; exit 0; fi' \
+        'exit 1' > "$semver_home_dir/.npm-global/bin/codex"
+    chmod +x "$semver_home_dir/.npm-global/bin/codex"
+    selected_cli="$(env -i PATH="$same_core_prerelease_cli_bin:/usr/bin:/bin" HOME="$semver_home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$semver_home_dir/.npm-global/bin/codex" ] \
+        || fail "launcher must prefer a stable Codex CLI over a prerelease with the same core version: $selected_cli"
+
+    newer_prerelease_cli_bin="$TMP_DIR/newer-prerelease-cli-bin"
+    mkdir -p "$newer_prerelease_cli_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ] || [ "${1:-}" = "version" ]; then echo "codex-cli 0.143.0-alpha.1"; exit 0; fi' \
+        'exit 1' > "$newer_prerelease_cli_bin/codex"
+    chmod +x "$newer_prerelease_cli_bin/codex"
+    selected_cli="$(env -i PATH="$newer_prerelease_cli_bin:/usr/bin:/bin" HOME="$semver_home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$newer_prerelease_cli_bin/codex" ] \
+        || fail "launcher must keep a prerelease Codex CLI when its core version is newer than the stable fallback: $selected_cli"
+
+    version_only_cli_bin="$TMP_DIR/version-only-cli-bin"
+    mkdir -p "$version_only_cli_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ]; then exit 2; fi' \
+        'if [ "${1:-}" = "version" ]; then echo "codex-cli 0.150.0"; exit 0; fi' \
+        'exit 1' > "$version_only_cli_bin/codex"
+    chmod +x "$version_only_cli_bin/codex"
+    selected_cli="$(env -i PATH="$version_only_cli_bin:$old_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$version_only_cli_bin/codex" ] \
+        || fail "launcher must accept Codex CLI versions from the fallback version command: $selected_cli"
+
+    blocked_cli_bin="$TMP_DIR/blocked-cli-bin"
+    mkdir -p "$blocked_cli_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "%s\n" "$$" >> "$HOME/hanging-cli-pids"' \
+        'sleep 30' \
+        'echo "codex-cli 9.999.0"' > "$blocked_cli_bin/codex"
+    chmod +x "$blocked_cli_bin/codex"
+    rm -f "$home_dir/hanging-cli-pids"
+    selected_cli="$(env -i PATH="$blocked_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$home_dir/.npm-global/bin/codex" ] \
+        || fail "launcher must skip a blocked Codex CLI probe and keep looking: $selected_cli"
+    hanging_pids="$home_dir/hanging-cli-pids"
+    if [ -f "$hanging_pids" ]; then
+        while read -r pid; do
+            [ -n "$pid" ] || continue
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+                fail "blocked Codex CLI probe left a process running: $pid"
+            fi
+        done < "$hanging_pids"
+    fi
+
+    partial_blocked_cli_bin="$TMP_DIR/partial-blocked-cli-bin"
+    mkdir -p "$partial_blocked_cli_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "%s\n" "$$" >> "$HOME/hanging-cli-pids"' \
+        'echo "codex-cli 9.999.0"' \
+        'sleep 30' > "$partial_blocked_cli_bin/codex"
+    chmod +x "$partial_blocked_cli_bin/codex"
+    rm -f "$home_dir/hanging-cli-pids"
+    selected_cli="$(env -i PATH="$partial_blocked_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$home_dir/.npm-global/bin/codex" ] \
+        || fail "launcher must ignore partial version output from a timed-out Codex CLI probe: $selected_cli"
+    hanging_pids="$home_dir/hanging-cli-pids"
+    if [ -f "$hanging_pids" ]; then
+        while read -r pid; do
+            [ -n "$pid" ] || continue
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+                fail "partial blocked Codex CLI probe left a process running: $pid"
+            fi
+        done < "$hanging_pids"
+    fi
+
+    fallback_blocked_cli_bin="$TMP_DIR/fallback-blocked-cli-bin"
+    mkdir -p "$fallback_blocked_cli_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'if [ "${1:-}" = "--version" ]; then exit 2; fi' \
+        'printf "%s\n" "$$" >> "$HOME/hanging-cli-pids"' \
+        'echo "codex-cli 9.999.0"' \
+        'sleep 30' > "$fallback_blocked_cli_bin/codex"
+    chmod +x "$fallback_blocked_cli_bin/codex"
+    rm -f "$home_dir/hanging-cli-pids"
+    selected_cli="$(env -i PATH="$fallback_blocked_cli_bin:/usr/bin:/bin" HOME="$home_dir" "$cli_resolver_probe")"
+    [ "$selected_cli" = "$home_dir/.npm-global/bin/codex" ] \
+        || fail "launcher must ignore partial version output from a timed-out fallback Codex CLI probe: $selected_cli"
+    hanging_pids="$home_dir/hanging-cli-pids"
+    if [ -f "$hanging_pids" ]; then
+        while read -r pid; do
+            [ -n "$pid" ] || continue
+            if kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+                fail "fallback blocked Codex CLI probe left a process running: $pid"
+            fi
+        done < "$hanging_pids"
+    fi
 
     node - "$REPO_DIR/launcher/start.sh.template" <<'NODE' || fail "Bundled backend plugin cache syncs must expose marketplace plugin links"
 const fs = require("node:fs");


### PR DESCRIPTION
## Summary
- Resolve executable `codex` candidates from the GUI `PATH` and known user install locations, then choose the newest readable version instead of the first `PATH` hit.
- Keep the resolver local-only and bound version probes so a broken candidate cannot stall launcher startup.
- Log the selected CLI path and version, document the behavior, and keep `CODEX_CLI_PATH` as the explicit override.

Fixes #672

## Tests
- Red check: `origin/main` selects the older `PATH` CLI in the reported fixture.
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js` (335 pass / 0 fail)
- `node --test linux-features/*/test.js` (385 pass / 0 fail)
- `make check`
- `make test` (192 pass / 0 fail)