### PR TITLE
Simplify launcher CLI resolution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ Use, Codex CLI install/update, or local auto-update rebuilds.
 
 The Codex CLI is still required at runtime. The first launch can install or
 update `@openai/codex` with the bundled `npm`, or you can manage the CLI
-yourself.
+yourself. The launcher does not rank installed CLIs by version; it uses an
+explicit `CODEX_CLI_PATH` first, then the normal lookup order, and logs the
+resolved CLI path plus best-effort version so GUI PATH issues are visible.
+Set `CODEX_CLI_PATH=/path/to/codex` when you want to pin a specific binary.
 
 X11 and Wayland sessions are supported. The launcher prefers XWayland on
 Wayland when available for better Electron popup positioning, then falls back
@@ -219,7 +222,7 @@ not download or extract the DMG themselves. See
 |---|---|
 | `/tmp` is mounted `noexec` | Set `TMPDIR` and `XDG_CACHE_HOME` to executable directories under `$HOME` |
 | Blank window or splash stuck | Check `~/.cache/codex-desktop/launcher.log` and whether port `5175` is already in use |
-| `CODEX_CLI_PATH` or CLI install error | Reopen the app or install `@openai/codex` manually |
+| `CODEX_CLI_PATH` or CLI install error | Check `~/.cache/codex-desktop/launcher.log`, set `CODEX_CLI_PATH=/path/to/codex` to pin a binary, or install `@openai/codex` manually |
 | Wayland / GPU / Vulkan hang | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` or persistent launch flags |
 | Resize ghosting or stale frame trails | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh` or `--disable-gpu-compositing` |
 | Computer Use UI is hidden | Enable the UI opt-in; account/server rollouts may still hide upstream-gated parts |

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -20,6 +20,12 @@ installs continue to update through npm, while official standalone installs
 under `~/.codex/packages/standalone` are updated with the official standalone
 installer instead of being replaced through npm.
 
+The launcher does not choose the newest installed CLI. It resolves an explicit
+`CODEX_CLI_PATH` first, then falls back to the usual `PATH`, nvm, and known
+user/system locations. Startup logs include the resolved path plus a
+best-effort CLI version probe; set `CODEX_CLI_PATH=/path/to/codex` when you
+need to pin a particular binary from a GUI-launched session.
+
 ## Inspect State
 
 ```bash

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1408,24 +1408,45 @@ find_codex_cli() {
     return 1
 }
 
+pid_parent_matches() {
+    local pid="$1"
+    local expected_parent="$2"
+    local stat_line
+    local rest
+
+    [ -r "/proc/$pid/stat" ] || return 1
+    stat_line=$(< "/proc/$pid/stat") || return 1
+    rest=${stat_line##*) }
+    set -- $rest
+    # $1 = state, $2 = ppid
+    [ "${2:-}" = "$expected_parent" ]
+}
+
 codex_cli_version_probe() {
     local output_file="$1"
     shift
     local marker="${output_file}.timed-out"
     local probe_pid
     local watchdog_pid
+    local self_pid=$$
     local status=0
 
     rm -f "$marker"
-    "$@" >"$output_file" 2>/dev/null &
+    ( trap - EXIT
+      { exec 9>&-; } 2>/dev/null || true
+      exec "$@" >"$output_file" 2>/dev/null
+    ) &
     probe_pid="$!"
     ( trap - EXIT
+      { exec 9>&-; } 2>/dev/null || true
       sleep 1
-      if kill -0 "$probe_pid" 2>/dev/null; then
+      if pid_parent_matches "$probe_pid" "$self_pid"; then
           : > "$marker"
           kill "$probe_pid" 2>/dev/null || true
           sleep 0.05
-          kill -9 "$probe_pid" 2>/dev/null || true
+          if pid_parent_matches "$probe_pid" "$self_pid"; then
+              kill -9 "$probe_pid" 2>/dev/null || true
+          fi
       fi
     ) &
     watchdog_pid="$!"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1408,6 +1408,98 @@ find_codex_cli() {
     return 1
 }
 
+codex_cli_version_probe() {
+    local output_file="$1"
+    shift
+    local marker="${output_file}.timed-out"
+    local probe_pid
+    local watchdog_pid
+    local status=0
+
+    rm -f "$marker"
+    "$@" >"$output_file" 2>/dev/null &
+    probe_pid="$!"
+    ( trap - EXIT
+      sleep 1
+      if kill -0 "$probe_pid" 2>/dev/null; then
+          : > "$marker"
+          kill "$probe_pid" 2>/dev/null || true
+          sleep 0.05
+          kill -9 "$probe_pid" 2>/dev/null || true
+      fi
+    ) &
+    watchdog_pid="$!"
+
+    if wait "$probe_pid"; then
+        status=0
+    else
+        status=$?
+    fi
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+
+    if [ -e "$marker" ]; then
+        rm -f "$marker"
+        return 124
+    fi
+    rm -f "$marker"
+    return "$status"
+}
+
+codex_cli_version() {
+    local cli_path="$1"
+    local probe_file
+    local output
+    local version
+    local version_arg
+    local probe_status=0
+
+    [ -n "$cli_path" ] || return 1
+    [ -x "$cli_path" ] || return 1
+    probe_file="$(mktemp "${TMPDIR:-/tmp}/codex-cli-version.XXXXXX" 2>/dev/null)" || return 1
+
+    for version_arg in --version version; do
+        : > "$probe_file"
+        if codex_cli_version_probe "$probe_file" "$cli_path" "$version_arg"; then
+            output="$(sed -n '1,3p' "$probe_file" 2>/dev/null || true)"
+            version="$(printf '%s\n' "$output" | sed -nE '
+s/^v?([0-9]+([.][0-9]+)+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?)([^0-9A-Za-z._+-].*)?$/\1/p
+s/.*[^0-9A-Za-z._+-]v?([0-9]+([.][0-9]+)+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?)([^0-9A-Za-z._+-].*)?$/\1/p
+' | head -n 1)"
+            if [ -n "$version" ]; then
+                rm -f "$probe_file" "${probe_file}.timed-out"
+                echo "$version"
+                return 0
+            fi
+        else
+            probe_status=$?
+            if [ "$probe_status" -eq 124 ]; then
+                rm -f "$probe_file" "${probe_file}.timed-out"
+                return 1
+            fi
+        fi
+    done
+
+    rm -f "$probe_file" "${probe_file}.timed-out"
+    return 1
+}
+
+log_codex_cli_path() {
+    local version
+
+    if [ -z "${CODEX_CLI_PATH:-}" ]; then
+        echo "Using CODEX_CLI_PATH=warm-start-skip"
+        return 0
+    fi
+
+    version="$(codex_cli_version "$CODEX_CLI_PATH" || true)"
+    if [ -n "$version" ]; then
+        echo "Using CODEX_CLI_PATH=$CODEX_CLI_PATH (version $version)"
+    else
+        echo "Using CODEX_CLI_PATH=$CODEX_CLI_PATH (version unknown; set CODEX_CLI_PATH=/path/to/codex to pin a known CLI)"
+    fi
+}
+
 notify_error() {
     local message="$1"
     local icon
@@ -3097,7 +3189,7 @@ if needs_cold_start; then
     fi
 fi
 
-echo "Using CODEX_CLI_PATH=${CODEX_CLI_PATH:-warm-start-skip}"
+log_codex_cli_path
 echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"
 
 launch_electron "${LAUNCHER_ARGS[@]}"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1428,7 +1428,8 @@ codex_cli_version_probe() {
     local marker="${output_file}.timed-out"
     local probe_pid
     local watchdog_pid
-    local self_pid=$$
+    # Under command substitution, $$ stays the top-level launcher PID.
+    local self_pid="${BASHPID:-$$}"
     local status=0
 
     rm -f "$marker"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3751,6 +3751,13 @@ if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip missing-CLI failure")
 if '"$HOME/.bun/bin/codex"' not in source:
     raise SystemExit("CLI lookup must include bun global install path")
+if "codex_cli_version_probe()" not in source or "codex_cli_version()" not in source:
+    raise SystemExit("CLI lookup must log a bounded best-effort resolved CLI version probe")
+if "version unknown; set CODEX_CLI_PATH=/path/to/codex" not in source:
+    raise SystemExit("CLI lookup diagnostics must explain explicit CODEX_CLI_PATH pinning")
+for unexpected in ("find_codex_cli_entry", "codex_cli_version_compare", "codex_cli_version_gt", "sort -V"):
+    if unexpected in source:
+        raise SystemExit(f"launcher must not rank discovered CLI candidates with {unexpected}")
 if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
 if 'run_cold_start_hooks' not in runtime_body:
@@ -4225,6 +4232,111 @@ if (!launcher.includes('ln -sfnT "$target" "$link_path"')) {
   throw new Error("replace_symlink must replace plugin links as paths, not as directory children");
 }
 NODE
+}
+
+test_launcher_cli_resolution_policy() {
+    info "Checking launcher CLI resolution policy"
+    local launcher_probe="$TMP_DIR/launcher-cli-policy-probe.sh"
+    python3 - "$REPO_DIR/launcher/start.sh.template" "$launcher_probe" <<'PY'
+import pathlib
+import re
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+functions = []
+for name in ("find_codex_cli", "codex_cli_version_probe", "codex_cli_version", "log_codex_cli_path"):
+    match = re.search(r"^" + re.escape(name) + r"\(\) \{[\s\S]*?^\}\n", source, re.M)
+    if match is None:
+        raise SystemExit(f"missing {name}")
+    functions.append(match.group(0))
+
+pathlib.Path(sys.argv[2]).write_text(
+    "#!/usr/bin/env bash\n"
+    "set -Eeuo pipefail\n\n"
+    + "\n".join(functions)
+    + r'''
+case "${1:?}" in
+    find)
+        find_codex_cli
+        ;;
+    version)
+        codex_cli_version "$2"
+        ;;
+    log)
+        CODEX_CLI_PATH="${2:-}"
+        export CODEX_CLI_PATH
+        log_codex_cli_path
+        ;;
+    *)
+        exit 64
+        ;;
+esac
+''',
+    encoding="utf-8",
+)
+PY
+    chmod +x "$launcher_probe"
+
+    local workspace="$TMP_DIR/launcher-cli-policy"
+    local fake_home="$workspace/home"
+    local path_cli_bin="$workspace/path-cli-bin"
+    local selected_cli
+    mkdir -p "$path_cli_bin" "$fake_home/.npm-global/bin"
+
+    printf '#!/usr/bin/env bash\nprintf "codex-cli 0.120.0\\n"\n' > "$path_cli_bin/codex"
+    printf '#!/usr/bin/env bash\nprintf "codex-cli 9.999.0\\n"\n' > "$fake_home/.npm-global/bin/codex"
+    chmod +x "$path_cli_bin/codex" "$fake_home/.npm-global/bin/codex"
+
+    selected_cli="$(env -i PATH="$path_cli_bin:/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" find)"
+    [ "$selected_cli" = "$path_cli_bin/codex" ] || fail "CLI lookup must keep the first PATH hit, got $selected_cli"
+
+    local override_cli="$workspace/override-codex"
+    local log_output
+    printf '#!/usr/bin/env bash\nprintf "codex-cli 0.42.0\\n"\n' > "$override_cli"
+    chmod +x "$override_cli"
+    log_output="$(env -i PATH="$path_cli_bin:/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" log "$override_cli")"
+    [[ "$log_output" == "Using CODEX_CLI_PATH=$override_cli (version 0.42.0)" ]] || fail "CODEX_CLI_PATH must remain an explicit override with version logging: $log_output"
+
+    local dash_version_cli="$workspace/dash-version-codex"
+    local fallback_version_cli="$workspace/fallback-version-codex"
+    local version_output
+    printf '#!/usr/bin/env bash\n[ "${1:-}" = "--version" ] || exit 2\nprintf "codex-cli 0.150.0\\n"\n' > "$dash_version_cli"
+    printf '#!/usr/bin/env bash\nif [ "${1:-}" = "--version" ]; then exit 2; fi\n[ "${1:-}" = "version" ] || exit 2\nprintf "codex-cli v0.151.0\\n"\n' > "$fallback_version_cli"
+    chmod +x "$dash_version_cli" "$fallback_version_cli"
+
+    version_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" version "$dash_version_cli")"
+    [ "$version_output" = "0.150.0" ] || fail "CLI version probe must read --version output, got $version_output"
+    version_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" version "$fallback_version_cli")"
+    [ "$version_output" = "0.151.0" ] || fail "CLI version probe must fall back to version output, got $version_output"
+
+    local unknown_cli="$workspace/unknown-version-codex"
+    printf '#!/usr/bin/env bash\nprintf "codex-cli dev build\\n"\n' > "$unknown_cli"
+    chmod +x "$unknown_cli"
+    log_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" log "$unknown_cli")"
+    [[ "$log_output" == "Using CODEX_CLI_PATH=$unknown_cli (version unknown; set CODEX_CLI_PATH=/path/to/codex to pin a known CLI)" ]] || fail "CLI diagnostics must explain unknown versions and explicit pinning: $log_output"
+
+    local hanging_cli="$workspace/hanging-codex"
+    local hanging_pid_file="$workspace/hanging.pid"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'printf "%%s\\n" "$$" > %q\n' "$hanging_pid_file"
+        printf 'printf "codex-cli 9.999.0\\n"\n'
+        printf 'exec sleep 30\n'
+    } > "$hanging_cli"
+    chmod +x "$hanging_cli"
+
+    version_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" version "$hanging_cli" || true)"
+    [ -z "$version_output" ] || fail "hanging CLI probe must ignore partial version output, got $version_output"
+    assert_file_exists "$hanging_pid_file"
+    local hanging_pid
+    hanging_pid="$(cat "$hanging_pid_file")"
+    if kill -0 "$hanging_pid" 2>/dev/null; then
+        sleep 0.1
+    fi
+    if kill -0 "$hanging_pid" 2>/dev/null; then
+        kill -9 "$hanging_pid" 2>/dev/null || true
+        fail "hanging CLI probe left process $hanging_pid alive"
+    fi
 }
 
 test_webview_server_cache_policy() {
@@ -7045,6 +7157,7 @@ main() {
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_template_sanity
+    test_launcher_cli_resolution_policy
     test_webview_server_cache_policy
     test_process_detection_helper_cmdline_shapes
     test_webview_probe_equivalence

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3755,6 +3755,10 @@ if "codex_cli_version_probe()" not in source or "codex_cli_version()" not in sou
     raise SystemExit("CLI lookup must log a bounded best-effort resolved CLI version probe")
 if "version unknown; set CODEX_CLI_PATH=/path/to/codex" not in source:
     raise SystemExit("CLI lookup diagnostics must explain explicit CODEX_CLI_PATH pinning")
+if 'pid_parent_matches "$probe_pid" "$self_pid"' not in source:
+    raise SystemExit("CLI version probe watchdog must guard kills against PID reuse")
+if source.count('{ exec 9>&-; } 2>/dev/null || true') < 3:
+    raise SystemExit("CLI version probe children and Electron child must close launcher lock fd 9")
 for unexpected in ("find_codex_cli_entry", "codex_cli_version_compare", "codex_cli_version_gt", "sort -V"):
     if unexpected in source:
         raise SystemExit(f"launcher must not rank discovered CLI candidates with {unexpected}")
@@ -4244,7 +4248,7 @@ import sys
 
 source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
 functions = []
-for name in ("find_codex_cli", "codex_cli_version_probe", "codex_cli_version", "log_codex_cli_path"):
+for name in ("find_codex_cli", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "log_codex_cli_path"):
     match = re.search(r"^" + re.escape(name) + r"\(\) \{[\s\S]*?^\}\n", source, re.M)
     if match is None:
         raise SystemExit(f"missing {name}")
@@ -4314,6 +4318,21 @@ PY
     chmod +x "$unknown_cli"
     log_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" log "$unknown_cli")"
     [[ "$log_output" == "Using CODEX_CLI_PATH=$unknown_cli (version unknown; set CODEX_CLI_PATH=/path/to/codex to pin a known CLI)" ]] || fail "CLI diagnostics must explain unknown versions and explicit pinning: $log_output"
+
+    local fd_probe_cli="$workspace/fd-probe-codex"
+    local fd_state="$workspace/fd9.state"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'if { true >&9; } 2>/dev/null; then printf "open\\n" > %q; else printf "closed\\n" > %q; fi\n' "$fd_state" "$fd_state"
+        printf 'printf "codex-cli 0.200.0\\n"\n'
+    } > "$fd_probe_cli"
+    chmod +x "$fd_probe_cli"
+    version_output="$(
+        exec 9>"$workspace/launcher.lock"
+        env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" version "$fd_probe_cli"
+    )"
+    [ "$version_output" = "0.200.0" ] || fail "fd-guarded CLI probe must still read versions, got $version_output"
+    [ "$(cat "$fd_state")" = "closed" ] || fail "CLI version probe child must not inherit launcher lock fd 9"
 
     local hanging_cli="$workspace/hanging-codex"
     local hanging_pid_file="$workspace/hanging.pid"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3755,7 +3755,7 @@ if "codex_cli_version_probe()" not in source or "codex_cli_version()" not in sou
     raise SystemExit("CLI lookup must log a bounded best-effort resolved CLI version probe")
 if "version unknown; set CODEX_CLI_PATH=/path/to/codex" not in source:
     raise SystemExit("CLI lookup diagnostics must explain explicit CODEX_CLI_PATH pinning")
-if 'pid_parent_matches "$probe_pid" "$self_pid"' not in source:
+if 'local self_pid="${BASHPID:-$$}"' not in source or 'pid_parent_matches "$probe_pid" "$self_pid"' not in source:
     raise SystemExit("CLI version probe watchdog must guard kills against PID reuse")
 if source.count('{ exec 9>&-; } 2>/dev/null || true') < 3:
     raise SystemExit("CLI version probe children and Electron child must close launcher lock fd 9")
@@ -4355,6 +4355,29 @@ PY
     if kill -0 "$hanging_pid" 2>/dev/null; then
         kill -9 "$hanging_pid" 2>/dev/null || true
         fail "hanging CLI probe left process $hanging_pid alive"
+    fi
+
+    local hanging_log_cli="$workspace/hanging-log-codex"
+    local hanging_log_pid_file="$workspace/hanging-log.pid"
+    {
+        printf '#!/usr/bin/env bash\n'
+        printf 'printf "%%s\\n" "$$" > %q\n' "$hanging_log_pid_file"
+        printf 'printf "codex-cli 9.999.0\\n"\n'
+        printf 'exec sleep 2\n'
+    } > "$hanging_log_cli"
+    chmod +x "$hanging_log_cli"
+
+    log_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" log "$hanging_log_cli")"
+    [[ "$log_output" == "Using CODEX_CLI_PATH=$hanging_log_cli (version unknown; set CODEX_CLI_PATH=/path/to/codex to pin a known CLI)" ]] || fail "log path must time out hung CLI version probes under command substitution: $log_output"
+    assert_file_exists "$hanging_log_pid_file"
+    local hanging_log_pid
+    hanging_log_pid="$(cat "$hanging_log_pid_file")"
+    if kill -0 "$hanging_log_pid" 2>/dev/null; then
+        sleep 0.1
+    fi
+    if kill -0 "$hanging_log_pid" 2>/dev/null; then
+        kill -9 "$hanging_log_pid" 2>/dev/null || true
+        fail "hanging CLI log probe left process $hanging_log_pid alive"
     fi
 }
 


### PR DESCRIPTION
## Summary
- Keep launcher CLI resolution simple: no newest-CLI ranking.
- Keep `CODEX_CLI_PATH` as the explicit override, then use the existing PATH/nvm/known-location fallback order.
- Log the resolved CLI path plus a bounded best-effort version probe, including a pinning hint when the version is unknown.
- Document the policy in README/updater docs.

## Tests/checks run
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- `make check`

## Notes
Supersedes the broader newest-CLI ranking approach in #673 with the narrower policy requested during review.
