### PR TITLE
fix(remote-mobile): hydrate late app-server events

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -42,6 +42,7 @@ const REMOTE_MOBILE_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntime
 const REMOTE_MOBILE_UNKNOWN_TURN_MARKER = "codexLinuxRemoteMobileHydrateUnknownTurn";
 const REMOTE_MOBILE_NOTIFICATION_QUEUE_MARKER = "codexLinuxRemoteMobileNotificationQueue";
 const REMOTE_MOBILE_IN_FLIGHT_HYDRATION_MARKER = "codexLinuxRemoteMobileHydrationInFlight";
+const REMOTE_MOBILE_LATE_EVENT_HYDRATION_MARKER = "codexLinuxRemoteMobileHydrateLateEvent";
 const REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER = "codexLinuxRemoteControlEnablementBridge";
 const REMOTE_CONTROL_ENABLE_FOR_HOST_PARAMS_MARKER = "codexLinuxRemoteControlEnableForHostParams";
 const REMOTE_CONTROL_AUTO_CONNECT_CLEANUP_MARKER = "codexLinuxRemoteControlAutoConnectCleanup";
@@ -1240,6 +1241,28 @@ function browserClientHasNativeChromeBackendPreferenceRouting(source) {
   );
 }
 
+function buildLateUnknownConversationHydrationReplacement(eventName, conversationIdVar, loggerVar) {
+  const pendingMapVar = "codexLinuxRemoteMobilePendingMap";
+  const queueVar = "codexLinuxRemoteMobileQueue";
+  const inFlightVar = "codexLinuxRemoteMobileInFlight";
+  const readVar = "codexLinuxRemoteMobileRead";
+  return (
+    `if(!this.conversations.get(${conversationIdVar})){/*${REMOTE_MOBILE_LATE_EVENT_HYDRATION_MARKER}*/` +
+    `let ${pendingMapVar}=this.codexLinuxRemoteMobilePendingNotifications??=new Map,${queueVar}=${pendingMapVar}.get(${conversationIdVar});` +
+    `${queueVar}||(${queueVar}=[],${pendingMapVar}.set(${conversationIdVar},${queueVar})),${queueVar}.push(n);` +
+    `let ${inFlightVar}=this.codexLinuxRemoteMobileInFlightHydrations??=new Set;` +
+    `if(${inFlightVar}.has(${conversationIdVar})){${loggerVar}.warning(\`Queueing ${eventName} for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:${queueVar}.length},sensitive:{}});break}` +
+    `${loggerVar}.warning(\`Hydrating conversation for ${eventName}\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:${queueVar}.length},sensitive:{}});` +
+    `let ${readVar}=(s=0)=>this.readThread(${conversationIdVar},{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar})??[];` +
+    `if(!t){if(s<12){${loggerVar}.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>${readVar}(s+1),250);return}` +
+    `this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar}),${loggerVar}.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length},sensitive:{}});return}` +
+    `this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar});for(let e of c)this.onNotification(e.method,e.params)})` +
+    `.catch(e=>{if(s<12){${loggerVar}.warning(\`Retrying hydration for ${eventName}\`,{safe:{conversationId:${conversationIdVar},attempt:s+1},sensitive:{error:e}}),setTimeout(()=>${readVar}(s+1),250);return}` +
+    `this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar}),${loggerVar}.error(\`Failed to hydrate conversation for ${eventName}\`,{safe:{conversationId:${conversationIdVar}},sensitive:{error:e}})});` +
+    `${inFlightVar}.add(${conversationIdVar}),${readVar}();break}`
+  );
+}
+
 function applyLinuxRemoteMobileConversationHydrationPatch(source) {
   let patched = source;
 
@@ -1283,7 +1306,7 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       patched = patched.replace(
         itemStartedNeedle,
         (_needle, conversationIdVar, loggerVar) =>
-          `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing item/started for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received item/started for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`,
+          buildLateUnknownConversationHydrationReplacement("item/started", conversationIdVar, loggerVar),
       );
     } else if (patched.includes("Received item/started for unknown conversation")) {
       console.warn("WARN: Could not find unknown item/started needle - skipping remote mobile item queue patch");
@@ -1295,7 +1318,7 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       patched = patched.replace(
         itemCompletedNeedle,
         (_needle, conversationIdVar, loggerVar) =>
-          `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing item/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received item/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`,
+          buildLateUnknownConversationHydrationReplacement("item/completed", conversationIdVar, loggerVar),
       );
     } else if (patched.includes("Received item/completed for unknown conversation")) {
       console.warn("WARN: Could not find unknown item/completed needle - skipping remote mobile item queue patch");
@@ -1305,7 +1328,7 @@ function applyLinuxRemoteMobileConversationHydrationPatch(source) {
       /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received turn\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u;
     const turnCompletedReplacement =
       (_needle, conversationIdVar, loggerVar) =>
-        `if(!this.conversations.get(${conversationIdVar})){let o=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar});if(o){o.push(n),${loggerVar}.warning(\`Queueing turn/completed for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:o.length},sensitive:{}});break}${loggerVar}.error(\`Received turn/completed for unknown conversation\`,{safe:{conversationId:${conversationIdVar}},sensitive:{}});break}`;
+        buildLateUnknownConversationHydrationReplacement("turn/completed", conversationIdVar, loggerVar);
     if (turnCompletedNeedle.test(patched)) {
       patched = patched.replace(turnCompletedNeedle, turnCompletedReplacement);
     } else if (patched.includes("Received turn/completed for unknown conversation")) {
@@ -1676,7 +1699,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-conversation-hydration",
     phase: "webview-asset",
-    pattern: /^(?:app-server-manager-signals|thread-context-inputs|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~).*\.js$/,
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~).*\.js$/,
     order: 20_150,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -752,6 +752,19 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       ),
       true,
     );
+
+    const hydrationDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration"
+    );
+    assert.ok(hydrationDescriptor);
+    assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), true);
+    assert.equal(
+      hydrationDescriptor.pattern.test(
+        "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~onboarding-page~hotkey-~ke3yc5wu-BLQiF1Gs.js",
+      ),
+      true,
+    );
+    assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
   });
 });
 
@@ -1590,6 +1603,142 @@ test("Linux remote mobile hydration uses nested real thread ids", async () => {
   assert.deepEqual(streamed, ["thread-a"]);
 });
 
+test("Linux remote mobile hydration recovers when a completed turn is the first observed event", async () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const manager = new context.module.exports();
+  const readThreadIds = [];
+
+  manager.conversations = new Map();
+  manager.frameTextDeltaQueue = { drainBefore: () => false };
+  manager.readThread = async (threadId) => {
+    readThreadIds.push(threadId);
+    return { thread: { id: threadId } };
+  };
+  manager.upsertConversationFromThread = (thread) => {
+    manager.conversations.set(thread.id, thread);
+  };
+
+  manager.onNotification("turn/completed", {
+    threadId: "thread-a",
+    turn: { id: "turn-a", threadId: "thread-a", status: "completed" },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(readThreadIds, ["thread-a"]);
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+});
+
+test("Linux remote mobile hydration recovers when a completed item is the first observed event", async () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const manager = new context.module.exports();
+  const readThreadIds = [];
+  const updatedConversations = [];
+
+  manager.conversations = new Map();
+  manager.frameTextDeltaQueue = { drainBefore: () => false };
+  manager.readThread = async (threadId) => {
+    readThreadIds.push(threadId);
+    return { thread: { id: threadId } };
+  };
+  manager.upsertConversationFromThread = (thread) => {
+    manager.conversations.set(thread.id, thread);
+  };
+  manager.updateConversationState = (threadId) => {
+    updatedConversations.push(threadId);
+  };
+
+  manager.onNotification("item/completed", {
+    item: { id: "item-a", type: "agentMessage" },
+    threadId: "thread-a",
+    turnId: "turn-a",
+    completedAtMs: 1,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(readThreadIds, ["thread-a"]);
+  assert.deepEqual(updatedConversations, ["thread-a"]);
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+});
+
+test("Linux remote mobile hydration restarts when a pending queue exists without an in-flight read", async () => {
+  const source = syntheticAppServerManagerSignalsBundle();
+  const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const manager = new context.module.exports();
+  const readThreadIds = [];
+  const updatedConversations = [];
+  let resolveRead;
+
+  manager.conversations = new Map();
+  manager.frameTextDeltaQueue = { drainBefore: () => false };
+  manager.codexLinuxRemoteMobilePendingNotifications = new Map([
+    [
+      "thread-a",
+      [
+        {
+          method: "turn/completed",
+          params: { threadId: "thread-a", turn: { id: "turn-a", threadId: "thread-a" } },
+        },
+      ],
+    ],
+  ]);
+  manager.readThread = (threadId) => {
+    readThreadIds.push(threadId);
+    return new Promise((resolve) => {
+      resolveRead = () => resolve({ thread: { id: threadId } });
+    });
+  };
+  manager.upsertConversationFromThread = (thread) => {
+    manager.conversations.set(thread.id, thread);
+  };
+  manager.updateConversationState = (threadId) => {
+    updatedConversations.push(threadId);
+  };
+
+  manager.onNotification("item/completed", {
+    item: { id: "item-a", type: "agentMessage" },
+    threadId: "thread-a",
+    turnId: "turn-a",
+    completedAtMs: 1,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(readThreadIds, ["thread-a"]);
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications.get("thread-a").length, 2);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations.has("thread-a"), true);
+
+  resolveRead();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+  assert.deepEqual(updatedConversations, ["thread-a"]);
+});
+
 test("Linux remote mobile hydration dedupes concurrent unknown turn reads", async () => {
   const source = syntheticAppServerManagerSignalsBundle();
   const patched = applyLinuxRemoteMobileConversationHydrationPatch(source);
@@ -1924,11 +2073,17 @@ test("remote mobile feature patch report records feature metadata and partial wa
       assert.ok(settingsPatch.warnings.some((warning) => warning.includes("SSH install release needles")));
 
       const hydrationPatch = report.patches.find(
-        (patch) => patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
+        (patch) => patch.name === "linux-app-server-conversation-hydration",
       );
-      assert.equal(hydrationPatch.sourceKind, "feature");
+      assert.equal(hydrationPatch.sourceKind, "core");
       assert.equal(hydrationPatch.status, "applied-with-warnings");
       assert.ok(hydrationPatch.warnings.some((warning) => warning.includes("unknown turn/completed needle")));
+
+      const featureHydrationPatch = report.patches.find(
+        (patch) => patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration",
+      );
+      assert.equal(featureHydrationPatch.sourceKind, "feature");
+      assert.equal(featureHydrationPatch.status, "already-applied");
     } finally {
       fs.rmSync(tempApp, { recursive: true, force: true });
     }
@@ -2373,8 +2528,14 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         assert.ok(
           report.patches.some((patch) =>
-            patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration" &&
+            patch.name === "linux-app-server-conversation-hydration" &&
             patch.status === "applied",
+          ),
+        );
+        assert.ok(
+          report.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration" &&
+            patch.status === "already-applied",
           ),
         );
         assert.ok(

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -148,6 +148,7 @@ const {
   applyLocalEnvironmentActionModalDraftPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxAppServerConversationHydrationPatch,
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
@@ -879,6 +880,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-app-sunset-gate",
     "linux-app-server-feature-enablement",
     "linux-app-server-backfill-wait",
+    "linux-app-server-conversation-hydration",
     "linux-completed-item-recovery",
     "linux-remote-terminal-status-recovery",
     "linux-skills-list-dedupe",
@@ -5000,6 +5002,226 @@ test("keeps current app-server backfill helpers visible outside the Sentry handl
   );
   assert.equal(context.startupTimeout, 3e5);
   assert.equal(context.turnTimeout, 3e4);
+});
+
+test("hydrates missing conversations when final app-server events arrive before turn start replay", async () => {
+  const source = [
+    "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let h=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)});return}}",
+    "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`turn/started`:{let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),this.updateConversationState(r,e=>{});break}case`turn/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`turn/completed`,n.params)}))break;let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}break}case`item/started`:{let{item:e,threadId:t,turnId:r,startedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/started for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.markConversationStreaming(a),this.updateConversationState(a,t=>{});break}case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;let{item:e,threadId:t,turnId:r,completedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.updateConversationState(a,t=>{});break}}}}",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxAppServerConversationHydrationPatch, source);
+
+  assert.match(patched, /codexLinuxRemoteMobileHydrateUnknownTurn/);
+  assert.match(patched, /codexLinuxRemoteMobileHydrateLateEvent/);
+  assert.match(patched, /codexLinuxRemoteMobilePendingNotifications\?\?=new Map/);
+  assert.match(patched, /codexLinuxRemoteMobileInFlightHydrations\?\?=new Set/);
+  assert.match(patched, /Hydrating conversation for turn\/completed/);
+  assert.match(patched, /Hydrating conversation for item\/completed/);
+  assert.match(patched, /Skipping hydration for ambiguous turn\/started/);
+
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const completedTurnManager = new context.module.exports();
+  const completedTurnReads = [];
+  completedTurnManager.conversations = new Map();
+  completedTurnManager.frameTextDeltaQueue = { drainBefore: () => false };
+  completedTurnManager.readThread = async (threadId) => {
+    completedTurnReads.push(threadId);
+    return { thread: { id: threadId } };
+  };
+  completedTurnManager.upsertConversationFromThread = (thread) => {
+    completedTurnManager.conversations.set(thread.id, thread);
+  };
+
+  completedTurnManager.onNotification("turn/completed", {
+    threadId: "thread-a",
+    turn: { id: "turn-a", threadId: "thread-a", status: "completed" },
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(completedTurnReads, ["thread-a"]);
+  assert.equal(completedTurnManager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(completedTurnManager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+
+  const completedItemManager = new context.module.exports();
+  const completedItemReads = [];
+  const updatedConversations = [];
+  completedItemManager.conversations = new Map();
+  completedItemManager.frameTextDeltaQueue = { drainBefore: () => false };
+  completedItemManager.readThread = async (threadId) => {
+    completedItemReads.push(threadId);
+    return { thread: { id: threadId } };
+  };
+  completedItemManager.upsertConversationFromThread = (thread) => {
+    completedItemManager.conversations.set(thread.id, thread);
+  };
+  completedItemManager.updateConversationState = (threadId) => {
+    updatedConversations.push(threadId);
+  };
+
+  completedItemManager.onNotification("item/completed", {
+    item: { id: "item-a", type: "agentMessage" },
+    threadId: "thread-b",
+    turnId: "turn-b",
+    completedAtMs: 1,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(completedItemReads, ["thread-b"]);
+  assert.deepEqual(updatedConversations, ["thread-b"]);
+  assert.equal(completedItemManager.codexLinuxRemoteMobilePendingNotifications?.has("thread-b"), false);
+  assert.equal(completedItemManager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-b"), false);
+});
+
+test("coalesces final app-server events while hydrating a missing conversation", async () => {
+  const source = [
+    "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let h=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)});return}}",
+    "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`turn/started`:{let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),this.updateConversationState(r,e=>{});break}case`turn/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`turn/completed`,n.params)}))break;let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}break}case`item/started`:{let{item:e,threadId:t,turnId:r,startedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/started for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.markConversationStreaming(a),this.updateConversationState(a,t=>{});break}case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;let{item:e,threadId:t,turnId:r,completedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.updateConversationState(a,t=>{});break}}}}",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxAppServerConversationHydrationPatch, source);
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const manager = new context.module.exports();
+  const readThreadIds = [];
+  const updatedConversations = [];
+  let resolveRead;
+
+  manager.conversations = new Map();
+  manager.frameTextDeltaQueue = { drainBefore: () => false };
+  manager.readThread = (threadId) => {
+    readThreadIds.push(threadId);
+    return new Promise((resolve) => {
+      resolveRead = () => resolve({ thread: { id: threadId } });
+    });
+  };
+  manager.upsertConversationFromThread = (thread) => {
+    manager.conversations.set(thread.id, thread);
+  };
+  manager.updateConversationState = (threadId) => {
+    updatedConversations.push(threadId);
+  };
+
+  manager.onNotification("turn/completed", {
+    threadId: "thread-a",
+    turn: { id: "turn-a", threadId: "thread-a", status: "completed" },
+  });
+  manager.onNotification("item/completed", {
+    item: { id: "item-a", type: "agentMessage" },
+    threadId: "thread-a",
+    turnId: "turn-a",
+    completedAtMs: 1,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(readThreadIds, ["thread-a"]);
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications.get("thread-a").length, 2);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations.has("thread-a"), true);
+
+  resolveRead();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+  assert.deepEqual(updatedConversations, ["thread-a"]);
+});
+
+test("restarts late-event hydration when a pending queue exists without an in-flight read", async () => {
+  const source = [
+    "function Of({conversationId:e,conversations:t,getWorkspaceBrowserRoot:n,getWorkspaceKind:r,hostId:i,setConversation:a,thread:o,threadsById:s,updateConversationState:c}){let h=o.status??null;if(t.has(e)){c(e,e=>{e.resumeState===`needs_resume`&&(e.threadRuntimeStatus=h)});return}}",
+    "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`turn/started`:{let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/started for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}this.markConversationStreaming(r),this.updateConversationState(r,e=>{});break}case`turn/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`turn/completed`,n.params)}))break;let{threadId:e,turn:t}=n.params,r=I(e);if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{conversationId:r},sensitive:{}});break}break}case`item/started`:{let{item:e,threadId:t,turnId:r,startedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/started for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.markConversationStreaming(a),this.updateConversationState(a,t=>{});break}case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;let{item:e,threadId:t,turnId:r,completedAtMs:i}=n.params,a=I(t);if(!this.conversations.get(a)){z.error(`Received item/completed for unknown conversation`,{safe:{conversationId:a},sensitive:{}});break}this.updateConversationState(a,t=>{});break}}}}",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxAppServerConversationHydrationPatch, source);
+  const context = {
+    module: { exports: {} },
+    I: (value) => value,
+    setTimeout,
+    z: { error() {}, warning() {} },
+  };
+  vm.runInNewContext(`${patched};module.exports=T;`, context);
+  const manager = new context.module.exports();
+  const readThreadIds = [];
+  const updatedConversations = [];
+  let resolveRead;
+
+  manager.conversations = new Map();
+  manager.frameTextDeltaQueue = { drainBefore: () => false };
+  manager.codexLinuxRemoteMobilePendingNotifications = new Map([
+    [
+      "thread-a",
+      [
+        {
+          method: "turn/completed",
+          params: { threadId: "thread-a", turn: { id: "turn-a", threadId: "thread-a" } },
+        },
+      ],
+    ],
+  ]);
+  manager.readThread = (threadId) => {
+    readThreadIds.push(threadId);
+    return new Promise((resolve) => {
+      resolveRead = () => resolve({ thread: { id: threadId } });
+    });
+  };
+  manager.upsertConversationFromThread = (thread) => {
+    manager.conversations.set(thread.id, thread);
+  };
+  manager.updateConversationState = (threadId) => {
+    updatedConversations.push(threadId);
+  };
+
+  manager.onNotification("item/completed", {
+    item: { id: "item-a", type: "agentMessage" },
+    threadId: "thread-a",
+    turnId: "turn-a",
+    completedAtMs: 1,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(readThreadIds, ["thread-a"]);
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications.get("thread-a").length, 2);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations.has("thread-a"), true);
+
+  resolveRead();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(manager.codexLinuxRemoteMobilePendingNotifications?.has("thread-a"), false);
+  assert.equal(manager.codexLinuxRemoteMobileInFlightHydrations?.has("thread-a"), false);
+  assert.deepEqual(updatedConversations, ["thread-a"]);
+});
+
+test("discovers app-server conversation hydration as a core Linux webview patch", () => {
+  const descriptor = corePatchDescriptors().find(
+    (patch) => patch.id === "linux-app-server-conversation-hydration",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.phase, "webview-asset");
+  assert.equal(descriptor.ciPolicy, "optional");
+  assert.match(String(descriptor.pattern), /app-server-manager-signals/);
+  assert.equal(descriptor.pattern.test("app-server-manager-signals-test.js"), true);
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~bj5tp28r-DtNK7ujn.js",
+    ),
+    true,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~onboarding-page~hotkey-~ke3yc5wu-BLQiF1Gs.js",
+    ),
+    true,
+  );
+  assert.equal(descriptor.pattern.test("remote-connections-settings-fixture.js"), false);
 });
 
 test("recovers completed stream items that arrive after local state lost their started item", () => {

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxAppServerConversationHydrationPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-app-server-conversation-hydration",
+    phase: "webview-asset",
+    order: 1043,
+    ciPolicy: "optional",
+    pattern: /^(?:app-server-manager-signals|thread-context-inputs|app-initial~app-main~worktree-init-v2-page~remote-conversation-page~).*\.js$/,
+    missingDescription: "app-server manager signals bundle",
+    skipDescription: "Linux app-server conversation hydration patch",
+    apply: applyLinuxAppServerConversationHydrationPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -16,6 +16,11 @@ const LINUX_SAFE_MONOSPACE_FONT_STACK =
   "\"Noto Sans Mono\", \"DejaVu Sans Mono\", \"Liberation Mono\", \"Ubuntu Mono\", ui-monospace, \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace";
 const LINUX_TOOLTIP_COLLISION_PADDING_TOP = 44;
 const LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT = 138;
+const LINUX_APP_SERVER_CONVERSATION_HYDRATION_THREAD_RUNTIME_MARKER = "codexLinuxRemoteMobileThreadRuntimeStatus";
+const LINUX_APP_SERVER_CONVERSATION_HYDRATION_UNKNOWN_TURN_MARKER = "codexLinuxRemoteMobileHydrateUnknownTurn";
+const LINUX_APP_SERVER_CONVERSATION_HYDRATION_QUEUE_MARKER = "codexLinuxRemoteMobileNotificationQueue";
+const LINUX_APP_SERVER_CONVERSATION_HYDRATION_IN_FLIGHT_MARKER = "codexLinuxRemoteMobileHydrationInFlight";
+const LINUX_APP_SERVER_CONVERSATION_HYDRATION_LATE_EVENT_MARKER = "codexLinuxRemoteMobileHydrateLateEvent";
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -863,6 +868,103 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
     console.warn(
       "WARN: App-server backfill wait patch applied only partially — startup backfill may still time out early",
     );
+  }
+
+  return patchedSource;
+}
+
+function buildLateUnknownConversationHydrationReplacement(eventName, conversationIdVar, loggerVar) {
+  const pendingMapVar = "codexLinuxRemoteMobilePendingMap";
+  const queueVar = "codexLinuxRemoteMobileQueue";
+  const inFlightVar = "codexLinuxRemoteMobileInFlight";
+  const readVar = "codexLinuxRemoteMobileRead";
+  return (
+    `if(!this.conversations.get(${conversationIdVar})){/*${LINUX_APP_SERVER_CONVERSATION_HYDRATION_LATE_EVENT_MARKER}*/` +
+    `let ${pendingMapVar}=this.codexLinuxRemoteMobilePendingNotifications??=new Map,${queueVar}=${pendingMapVar}.get(${conversationIdVar});` +
+    `${queueVar}||(${queueVar}=[],${pendingMapVar}.set(${conversationIdVar},${queueVar})),${queueVar}.push(n);` +
+    `let ${inFlightVar}=this.codexLinuxRemoteMobileInFlightHydrations??=new Set;` +
+    `if(${inFlightVar}.has(${conversationIdVar})){${loggerVar}.warning(\`Queueing ${eventName} for hydrating conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:${queueVar}.length},sensitive:{}});break}` +
+    `${loggerVar}.warning(\`Hydrating conversation for ${eventName}\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:${queueVar}.length},sensitive:{}});` +
+    `let ${readVar}=(s=0)=>this.readThread(${conversationIdVar},{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(${conversationIdVar})??[];` +
+    `if(!t){if(s<12){${loggerVar}.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>${readVar}(s+1),250);return}` +
+    `this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar}),${loggerVar}.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:${conversationIdVar},queuedNotificationCount:c.length},sensitive:{}});return}` +
+    `this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar});for(let e of c)this.onNotification(e.method,e.params)})` +
+    `.catch(e=>{if(s<12){${loggerVar}.warning(\`Retrying hydration for ${eventName}\`,{safe:{conversationId:${conversationIdVar},attempt:s+1},sensitive:{error:e}}),setTimeout(()=>${readVar}(s+1),250);return}` +
+    `this.codexLinuxRemoteMobilePendingNotifications?.delete(${conversationIdVar}),this.codexLinuxRemoteMobileInFlightHydrations?.delete(${conversationIdVar}),${loggerVar}.error(\`Failed to hydrate conversation for ${eventName}\`,{safe:{conversationId:${conversationIdVar}},sensitive:{error:e}})});` +
+    `${inFlightVar}.add(${conversationIdVar}),${readVar}();break}`
+  );
+}
+
+function applyLinuxAppServerConversationHydrationPatch(currentSource) {
+  let patchedSource = currentSource;
+
+  if (!patchedSource.includes(LINUX_APP_SERVER_CONVERSATION_HYDRATION_THREAD_RUNTIME_MARKER)) {
+    const runtimeNeedle =
+      /([A-Za-z_$][\w$]*)\.resumeState===`needs_resume`&&\(\1\.threadRuntimeStatus=([A-Za-z_$][\w$]*)\)/u;
+    if (runtimeNeedle.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        runtimeNeedle,
+        (_needle, conversationVar, runtimeVar) =>
+          `/*${LINUX_APP_SERVER_CONVERSATION_HYDRATION_THREAD_RUNTIME_MARKER}*/(${conversationVar}.resumeState===\`needs_resume\`||${runtimeVar}?.type===\`active\`||${runtimeVar}?.type===\`idle\`)&&(${conversationVar}.threadRuntimeStatus=${runtimeVar})`,
+      );
+    } else if (
+      patchedSource.includes("threadRuntimeStatus:e.threadRuntimeStatus") &&
+      patchedSource.includes("t===`needs_resume`?n?.type===`active`")
+    ) {
+      // Current upstream already preserves threadRuntimeStatus on summaries.
+    } else if (patchedSource.includes("threadRuntimeStatus") && patchedSource.includes("resumeState")) {
+      console.warn(
+        "WARN: Could not find app-server conversation runtime-status needle — skipping Linux app-server hydration runtime-status patch",
+      );
+    }
+  }
+
+  if (!patchedSource.includes(LINUX_APP_SERVER_CONVERSATION_HYDRATION_QUEUE_MARKER)) {
+    const unknownTurnNeedle =
+      /(let\{threadId:([A-Za-z_$][\w$]*),turn:[A-Za-z_$][\w$]*\}=([A-Za-z_$][\w$]*)\.params,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2\);)if\(!this\.conversations\.get\(\4\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received turn\/started for unknown conversation`,\{safe:\{conversationId:\4\},sensitive:\{\}\}\);break\}/u;
+    const unknownTurnReplacement =
+      (_needle, prefix, _threadIdParamVar, notificationVar, conversationIdVar, normalizerFn, loggerVar) =>
+        `${prefix}if(!this.conversations.get(${conversationIdVar})){/*${LINUX_APP_SERVER_CONVERSATION_HYDRATION_UNKNOWN_TURN_MARKER}*//*${LINUX_APP_SERVER_CONVERSATION_HYDRATION_QUEUE_MARKER}*//*${LINUX_APP_SERVER_CONVERSATION_HYDRATION_IN_FLIGHT_MARKER}*/let l=${notificationVar}.params?.turn?.threadId??${notificationVar}.params?.thread?.id,d=l!=null?${normalizerFn}(l):null,u=${notificationVar}.params?.turn?.id??${notificationVar}.params?.turnId;if(d==null||u!=null&&d===${normalizerFn}(u)){${loggerVar}.warning(\`Skipping hydration for ambiguous turn/started\`,{safe:{conversationId:${conversationIdVar},resolvedConversationId:d,turnId:u??null},sensitive:{}});break}${notificationVar}={...${notificationVar},params:{...${notificationVar}.params,threadId:l}};if(this.conversations.get(d)){this.onNotification(${notificationVar}.method,${notificationVar}.params);break}let i=this.codexLinuxRemoteMobilePendingNotifications??=new Map,a=i.get(d);a||(a=[],i.set(d,a));let p=u!=null?a.findIndex(e=>{let t=e.params?.turn?.id??e.params?.turnId;return e.method===${notificationVar}.method&&t!=null&&${normalizerFn}(t)===${normalizerFn}(u)}):-1;p>=0?a[p]=${notificationVar}:a.push(${notificationVar});let h=this.codexLinuxRemoteMobileInFlightHydrations??=new Set;if(h.has(d)){${loggerVar}.warning(\`Queueing turn/started for hydrating conversation\`,{safe:{conversationId:d,queuedNotificationCount:a.length,dedupedNotification:p>=0},sensitive:{}});break}${loggerVar}.warning(\`Hydrating conversation for turn/started\`,{safe:{conversationId:d,queuedNotificationCount:a.length},sensitive:{}});let o=(s=0)=>this.readThread(d,{includeTurns:!1}).then(e=>{let t=e?.thread??e,c=this.codexLinuxRemoteMobilePendingNotifications?.get(d)??[];if(!t){if(s<12){${loggerVar}.warning(\`Retrying hydration for missing conversation\`,{safe:{conversationId:d,queuedNotificationCount:c.length,attempt:s+1},sensitive:{}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(d),this.codexLinuxRemoteMobileInFlightHydrations?.delete(d),${loggerVar}.warning(\`Skipping hydration for missing conversation\`,{safe:{conversationId:d,queuedNotificationCount:c.length},sensitive:{}});return}this.upsertConversationFromThread(t),this.codexLinuxRemoteMobilePendingNotifications?.delete(d),this.codexLinuxRemoteMobileInFlightHydrations?.delete(d);for(let e of c)this.onNotification(e.method,e.params)}).catch(e=>{if(s<12){${loggerVar}.warning(\`Retrying hydration for turn/started\`,{safe:{conversationId:d,attempt:s+1},sensitive:{error:e}}),setTimeout(()=>o(s+1),250);return}this.codexLinuxRemoteMobilePendingNotifications?.delete(d),this.codexLinuxRemoteMobileInFlightHydrations?.delete(d),${loggerVar}.error(\`Failed to hydrate conversation for turn/started\`,{safe:{conversationId:d},sensitive:{error:e}})});h.add(d),o();break}`;
+
+    if (unknownTurnNeedle.test(patchedSource)) {
+      patchedSource = patchedSource.replace(unknownTurnNeedle, unknownTurnReplacement);
+    } else if (patchedSource.includes("Received turn/started for unknown conversation")) {
+      console.warn(
+        "WARN: Could not find unknown turn/started needle — skipping Linux app-server conversation hydration patch",
+      );
+    }
+
+    const unknownEventGuards = [
+      {
+        eventName: "item/started",
+        needle:
+          /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received item\/started for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u,
+      },
+      {
+        eventName: "item/completed",
+        needle:
+          /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received item\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u,
+      },
+      {
+        eventName: "turn/completed",
+        needle:
+          /if\(!this\.conversations\.get\(([A-Za-z_$][\w$]*)\)\)\{([A-Za-z_$][\w$]*)\.error\(`Received turn\/completed for unknown conversation`,\{safe:\{conversationId:\1\},sensitive:\{\}\}\);break\}/u,
+      },
+    ];
+
+    for (const { eventName, needle } of unknownEventGuards) {
+      if (needle.test(patchedSource)) {
+        patchedSource = patchedSource.replace(
+          needle,
+          (_match, conversationIdVar, loggerVar) =>
+            buildLateUnknownConversationHydrationReplacement(eventName, conversationIdVar, loggerVar),
+        );
+      } else if (patchedSource.includes(`Received ${eventName} for unknown conversation`)) {
+        console.warn(
+          `WARN: Could not find unknown ${eventName} needle — skipping Linux app-server conversation ${eventName} hydration patch`,
+        );
+      }
+    }
   }
 
   return patchedSource;
@@ -1905,6 +2007,7 @@ function patchCommentPreloadBundle(extractedDir) {
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxAppServerConversationHydrationPatch,
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,


### PR DESCRIPTION
Refs #639.

This fixes another stale remote mobile state case on Linux.

When the mobile view has lost the local conversation entry for a thread, the app-server can still send late final events such as `turn/completed` or `item/completed`. The current Linux bundle treats those as unknown conversations and drops them. On Android this can leave the thread looking like it is still working until the user leaves and reopens the conversation, because that forces a fresh thread read.

The patch keeps this recovery in the core Linux webview path, so it applies to standard installs as well as opt-in remote-mobile-control builds. For missing conversations it hydrates the thread, queues late notifications while the read is in flight, then replays them once the thread is available.

I also covered a partial queue state during review: if a late-event queue already exists but no hydration read is in flight, the next late event restarts the thread read instead of leaving the queue stuck.

Validation:

- `node --test --test-name-pattern "pending queue exists without an in-flight|restarts when a pending queue" scripts/patch-linux-window-ui.test.js linux-features/remote-mobile-control/test.js`: 2 pass / 0 fail
- `node --test scripts/patch-linux-window-ui.test.js`: 339 pass / 0 fail
- `node --test linux-features/remote-mobile-control/test.js`: 76 pass / 0 fail
- `node --test linux-features/*/test.js`: 390 pass / 0 fail
- `bash tests/scripts_smoke.sh`: OK
- `make check`: OK
- `make test`: 192 pass / 0 fail
- descriptor dry-run against a copy of the current installed remote conversation bundle: matched and applied
