### PR TITLE
docs: add GNOME/X11 titlebar lockup troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,7 @@
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log` |
 | GPU / Vulkan / Wayland errors | Try `CODEX_LINUX_RENDERING_MODE=wayland-gpu ./codex-app/start.sh` or persistent launch flags below |
 | Window flickering, resize ghosting, or stale frame trails | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh`, then `./codex-app/start.sh --disable-gpu` if needed |
+| Right-clicking the title bar leaves GNOME/X11 input stuck | Press `Esc` first, or use `Alt+Space` for the window menu. If the lockup is repeatable, test the optional `frameless-titlebar` feature below and include your distro, GNOME version, X11/Wayland session, package method, and `.codex-linux/linux-features-staged.json` when reporting it |
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
@@ -52,6 +53,49 @@ For native Wayland IME setups, try:
 
 Restart Codex Desktop after changing this file. Warm-start launches reuse the
 running Electron process and will not pick up new flags.
+
+## GNOME/X11 Title Bar Right-click Lockups
+
+On some GNOME/X11 setups, right-clicking the Codex title bar can leave the
+desktop input focused on the window-manager menu. Try `Esc` first. `Alt+Space`
+opens the same window menu through the keyboard path and can be a safer
+workaround while debugging.
+
+If the issue is repeatable, verify whether the installed app is using optional
+Linux features:
+
+```bash
+if [ -f /opt/codex-desktop/.codex-linux/linux-features-staged.json ]; then
+  cat /opt/codex-desktop/.codex-linux/linux-features-staged.json
+else
+  echo "No staged Linux feature manifest found for this install"
+fi
+```
+
+Then test the disabled-by-default `frameless-titlebar` feature in a local
+checkout:
+
+```bash
+cp linux-features/features.example.json linux-features/features.json
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("linux-features/features.json")
+data = json.loads(path.read_text())
+enabled = set(data.get("enabled", []))
+enabled.add("frameless-titlebar")
+data["enabled"] = sorted(enabled)
+path.write_text(json.dumps(data, indent=2) + "\n")
+PY
+make install-native
+```
+
+When opening an issue, include the distro/version, GNOME Shell version,
+`XDG_SESSION_TYPE`, package method, Codex Desktop build information, and whether
+the lockup happens with `frameless-titlebar` enabled. This path changes the
+window controls contract, so it is kept opt-in rather than enabled for all
+Linux users.
 
 ## Authenticated HTTP Proxies
 

--- a/linux-features/frameless-titlebar/README.md
+++ b/linux-features/frameless-titlebar/README.md
@@ -2,8 +2,10 @@
 
 This optional feature hides the Linux Electron titlebar overlay controls and
 removes the native menu chrome from the main Codex window. It is intended for
-Wayland compositors or window managers where compositor-managed decorations
-already provide the expected window controls, such as Hyprland setups.
+compositors or window managers where compositor-managed decorations already
+provide the expected window controls, such as Hyprland setups. It is also a
+useful diagnostic switch for GNOME/X11 titlebar right-click lockups, because it
+removes the Linux Window Controls Overlay path from the main window.
 
 The default build leaves the existing Linux titlebar overlay behavior in place.
 Enable this only when the built-in Codex titlebar/buttons visually conflict
@@ -41,6 +43,10 @@ For a manual check, enable the feature as above, rebuild, and launch the app:
 - Changing the system dark/light theme must not crash the app or repaint a
   titlebar strip; the patch removes all Linux `setTitleBarOverlay` calls,
   which would otherwise throw on a window created without `titleBarOverlay`.
+- On GNOME/X11, right-click the same titlebar area that previously locked input
+  and verify whether clicks outside the window recover normally. If the issue
+  still reproduces, disable the feature again and report the distro, GNOME
+  version, session type, and installed `.codex-linux/linux-features-staged.json`.
 
 ## Known risks
 


### PR DESCRIPTION
Hi,

This adds a troubleshooting path for the GNOME/X11 title-bar right-click lockup reports in #496 and #649.

The patch does not change the default window behavior. It documents the immediate recovery path with `Esc` / `Alt+Space`, points users at the existing opt-in `frameless-titlebar` feature for a targeted retest, and lists the environment and build details needed when reporting whether the issue still reproduces.

I kept this as documentation because my local Zorin GNOME/X11 repro setup could trigger the title-bar menu/input grab, but it did not reproduce the persistent desktop-wide lock reported on Ubuntu 22.04/X11. Physical clicks outside the menu recovered in one or two clicks locally, and `Esc` always recovered focus. So I do not think a default titlebar behavior change is justified from my side yet.

Validation:
- `git diff --check origin/main...HEAD`
- `node --test linux-features/frameless-titlebar/test.js` - 5 pass / 0 fail
- `node --test scripts/patch-linux-window-ui.test.js` - 339 pass / 0 fail
- `make check`
- `make test` - 192 pass / 0 fail
- GNOME/X11 local retest on Zorin 18.1 / GNOME Shell 46.0 / X11:
  - titlebar menu/input grab observed
  - persistent desktop-wide lock not reproduced
  - `Esc` recovered focus in every run
  - physical clicks outside the menu recovered in one or two clicks
  - no leftover nested GNOME/X11 test processes after cleanup