### PR TITLE
Launcher performance: gate --disable-dev-shm-usage and renderer accessibility on actual need

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,6 +394,9 @@ package. The daily-driver flow remains `install.sh` plus a native package plus
   Historical Wayland/X11 input-focus investigation for issue #569.
 - `docs/webview-server-evaluation.md`
   Decision record for the future local webview server model.
+- `docs/launcher-performance.md`
+  Decision record for launcher Electron performance defaults and the
+  alternatives that were reviewed and deliberately left unchanged.
 
 ## Generated Artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   shared-memory buffers stay in RAM-backed `/dev/shm` instead of disk-backed
   temp storage, which improves rendering performance. Override with
   `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`.
+- The launcher now adds `--force-renderer-accessibility` only when an
+  assistive technology is detected (Orca or brltty running, the GNOME
+  screen-reader setting, or the `GNOME_ACCESSIBILITY` /
+  `QT_LINUX_ACCESSIBILITY_ALWAYS_ON` / `ACCESSIBILITY_ENABLED` env markers).
+  Keeping the Chromium accessibility engine on in every renderer measurably
+  slows the webview UI, and the WSLg and wayland-gpu profiles already
+  skipped it for that reason. `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`
+  still overrides the detection in both directions.
 - Refactored ASAR patching internals so `scripts/patch-linux-window-ui.js` is a
   CLI-only entrypoint and patch descriptors/implementations live under
   `scripts/patches/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`.
 - The launcher now adds `--force-renderer-accessibility` only when an
   assistive technology is detected (Orca or brltty running, the GNOME
-  screen-reader setting, or the `GNOME_ACCESSIBILITY` /
+  screen-reader setting, the AT-SPI accessibility state that
+  `codex-computer-use-linux setup` enables — `org.a11y.Status IsEnabled` or
+  `toolkit-accessibility` — or the `GNOME_ACCESSIBILITY` /
   `QT_LINUX_ACCESSIBILITY_ALWAYS_ON` / `ACCESSIBILITY_ENABLED` env markers).
   Keeping the Chromium accessibility engine on in every renderer measurably
   slows the webview UI, and the WSLg and wayland-gpu profiles already
-  skipped it for that reason. `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`
-  still overrides the detection in both directions.
+  skipped it for that reason. Session-bus probes are watchdog-capped at
+  0.5 s so a broken bus cannot delay launch.
+  `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0` still overrides the detection in
+  both directions.
 - Refactored ASAR patching internals so `scripts/patch-linux-window-ui.js` is a
   CLI-only entrypoint and patch descriptors/implementations live under
   `scripts/patches/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- The launcher now passes `--disable-dev-shm-usage` to Electron only when
+  `/dev/shm` is missing, not writable, or smaller than 1 GiB (the container
+  case the flag exists for). On regular desktops Chromium's renderer/GPU
+  shared-memory buffers stay in RAM-backed `/dev/shm` instead of disk-backed
+  temp storage, which improves rendering performance. Override with
+  `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`.
 - Refactored ASAR patching internals so `scripts/patch-linux-window-ui.js` is a
   CLI-only entrypoint and patch descriptors/implementations live under
   `scripts/patches/`.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Full list: [Troubleshooting](docs/troubleshooting.md).
 - [Linux Features architecture](docs/linux-features-architecture.md)
 - [Wayland input focus investigation](docs/wayland-input-focus-investigation.md)
 - [Webview server evaluation](docs/webview-server-evaluation.md)
+- [Launcher performance notes](docs/launcher-performance.md)
 
 ## Disclaimer
 

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -20,11 +20,17 @@ launcher log, and repository history rather than synthetic benchmarks.
   (observable as `/tmp/.org.chromium.Chromium.*` mappings in every process).
   Override: `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`.
 - `--force-renderer-accessibility` is now added only when an assistive
-  technology is detected (Orca or brltty running, the GNOME screen-reader
-  setting, or accessibility env markers). Keeping the accessibility engine on
-  in every renderer makes each DOM update also rebuild and serialize the
-  accessibility tree; the WSLg and wayland-gpu profiles already skipped the
-  flag for that reason. Override: `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`.
+  technology is detected: Orca or brltty running, the GNOME screen-reader
+  setting, the AT-SPI state that `codex-computer-use-linux setup` enables
+  (`org.a11y.Status IsEnabled` via busctl, or its
+  `org.gnome.desktop.interface toolkit-accessibility` gsettings fallback), or
+  accessibility env markers. Keeping the accessibility engine on in every
+  renderer makes each DOM update also rebuild and serialize the accessibility
+  tree; the WSLg and wayland-gpu profiles already skipped the flag for that
+  reason. Session-bus probes (gsettings/busctl) run under the launcher's
+  ppid-guarded watchdog pattern capped at 0.5 s, so a broken session bus
+  counts as "not detected" instead of delaying launch.
+  Override: `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`.
 
 Both decisions are visible at runtime in the `Electron launch mode:` line of
 `~/.cache/codex-desktop/launcher.log` (`dev_shm_usage_disabled=`,

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -1,0 +1,80 @@
+# Launcher Performance Notes
+
+## Context
+
+This decision record captures a performance comparison between Codex Desktop
+and another Electron 42 app (Claude Desktop) running side by side on the same
+X11 GNOME 4K host, what the launcher changed as a result, and — just as
+importantly — what was reviewed and deliberately left alone so future work
+does not re-litigate it without new evidence.
+
+Evidence came from live process command lines, `/proc/<pid>/maps`, the
+launcher log, and repository history rather than synthetic benchmarks.
+
+## What Changed
+
+- `--disable-dev-shm-usage` is now passed only when `/dev/shm` is missing,
+  not writable, or smaller than 1 GiB. The flag exists for containers with a
+  tiny `/dev/shm` (Docker defaults to 64 MiB); everywhere else it pushed
+  Chromium's renderer/GPU shared-memory buffers into disk-backed temp storage
+  (observable as `/tmp/.org.chromium.Chromium.*` mappings in every process).
+  Override: `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`.
+- `--force-renderer-accessibility` is now added only when an assistive
+  technology is detected (Orca or brltty running, the GNOME screen-reader
+  setting, or accessibility env markers). Keeping the accessibility engine on
+  in every renderer makes each DOM update also rebuild and serialize the
+  accessibility tree; the WSLg and wayland-gpu profiles already skipped the
+  flag for that reason. Override: `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0`.
+
+Both decisions are visible at runtime in the `Electron launch mode:` line of
+`~/.cache/codex-desktop/launcher.log` (`dev_shm_usage_disabled=`,
+`renderer_accessibility_forced=`).
+
+## Reviewed And Deliberately Not Changed
+
+### `--no-sandbox` and `--disable-gpu-sandbox`
+
+These are security-posture flags, not measurable rendering-performance
+factors. Removing them is a separate compatibility project: the Electron
+SUID/user-namespace sandbox behaves differently across distributions and
+container/AppImage environments, and the troubleshooting docs currently
+promise `--no-sandbox` behavior. Out of scope for performance work.
+
+### Wayland `--disable-gpu-compositing` workaround
+
+On Wayland sessions the launcher intentionally trades compositing performance
+for side-panel rendering stability. That is a documented workaround with an
+explicit opt-out (`CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0`); do not remove
+it for performance reasons without re-testing the side-panel flicker it
+papers over.
+
+### Webview server model
+
+The bundled Python server already uses `ThreadingHTTPServer` and serves the
+hashed `/assets/` bundle with `Cache-Control: public, max-age=31536000,
+immutable`, so parallel chunk fetches and cross-restart disk caching are
+covered. Replacing it with a Rust server was evaluated and rejected until
+evidence shows Python itself is the bottleneck — see
+[Webview server evaluation](webview-server-evaluation.md).
+
+### Serialized startup ordering
+
+The launcher intentionally starts the webview server, verifies the origin,
+and only then launches Electron so Chromium never races a server that has
+not bound yet. The server binds in milliseconds; parallelizing the spawn
+would buy little and risk the documented startup markers and warm-start
+handoff behavior.
+
+### In-app startup latency
+
+Most of the visible loading-screen time is spent inside the upstream app:
+the renderer blocks on `codex app-server` RPCs after the static assets load
+(the launcher log shows individual calls such as `app/list` taking multiple
+seconds on cold start). That is upstream application behavior inside
+`app.asar`, not Linux adaptation glue, and is out of scope for this
+repository beyond faithfully reporting it.
+
+### CLI preflight
+
+Launcher CLI preflight is best-effort, recently hardened, and not part of the
+rendering path. No performance changes were made there.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,7 @@
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Renderer crashes in containers with a tiny `/dev/shm` | The launcher keeps `--disable-dev-shm-usage` automatically when `/dev/shm` is missing or below 1 GiB; force it with `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1` |
+| Screen reader does not read the app UI | Renderer accessibility is forced automatically when Orca, brltty, the GNOME screen-reader setting, or accessibility env markers are detected; force it with `CODEX_FORCE_RENDERER_ACCESSIBILITY=1` |
 | Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
 | Computer Use plugin invisible in UI | Enable the Computer Use UI opt-in; upstream server/account rollout can still hide some controls |
 | Computer Use `doctor` reports no input backend | Grant `/dev/uinput`, enable XDG RemoteDesktop portal, or start `ydotoold` / `ydotool.service` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,7 +15,7 @@
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
 | Renderer crashes in containers with a tiny `/dev/shm` | The launcher keeps `--disable-dev-shm-usage` automatically when `/dev/shm` is missing or below 1 GiB; force it with `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1` |
-| Screen reader does not read the app UI | Renderer accessibility is forced automatically when Orca, brltty, the GNOME screen-reader setting, or accessibility env markers are detected; force it with `CODEX_FORCE_RENDERER_ACCESSIBILITY=1` |
+| Screen reader does not read the app UI | Renderer accessibility is forced automatically when Orca, brltty, the GNOME screen-reader setting, AT-SPI accessibility state (`org.a11y.Status IsEnabled` or `toolkit-accessibility`, e.g. after `codex-computer-use-linux setup`), or accessibility env markers are detected; force it with `CODEX_FORCE_RENDERER_ACCESSIBILITY=1` |
 | Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
 | Computer Use plugin invisible in UI | Enable the Computer Use UI opt-in; upstream server/account rollout can still hide some controls |
 | Computer Use `doctor` reports no input backend | Grant `/dev/uinput`, enable XDG RemoteDesktop portal, or start `ydotoold` / `ydotool.service` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,6 +14,7 @@
 | Window flickering, resize ghosting, or stale frame trails | Try `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1 ./codex-app/start.sh`, then `./codex-app/start.sh --disable-gpu` if needed |
 | Transparent or dark left sidebar | Check whether the Linux opaque-window patch was applied, then rebuild with a current checkout |
 | Sandbox errors | The launcher already sets `--no-sandbox` |
+| Renderer crashes in containers with a tiny `/dev/shm` | The launcher keeps `--disable-dev-shm-usage` automatically when `/dev/shm` is missing or below 1 GiB; force it with `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1` |
 | Stale install / cached DMG | `make build-app-fresh` removes the generated app and cached DMG, then downloads current upstream |
 | Computer Use plugin invisible in UI | Enable the Computer Use UI opt-in; upstream server/account rollout can still hide some controls |
 | Computer Use `doctor` reports no input backend | Grant `/dev/uinput`, enable XDG RemoteDesktop portal, or start `ydotoold` / `ydotool.service` |

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2791,29 +2791,27 @@ assistive_technology_detected() {
 # AT-SPI state that `codex-computer-use-linux setup` enables (org.a11y.Status
 # IsEnabled via busctl, with org.gnome.desktop.interface toolkit-accessibility
 # as its gsettings fallback). gsettings/busctl can hang on a broken session
-# bus, so the probes run in a subshell killed by the same ppid-guarded
-# watchdog webview_port_is_open uses (/usr/bin/timeout intentionally avoided;
-# see that function), capped at 0.5 s. A killed or failing probe counts as
-# "not detected" and never blocks launch.
-session_bus_assistive_technology_detected() {
-    local probe_pid kill_pid rc=1 self_pid=$$
+# bus, so each external helper runs under a watchdog capped at 0.5 s. When
+# setsid is available the watchdog kills the helper process group, which keeps
+# shell stubs and helper descendants from surviving launch. A killed or failing
+# probe counts as "not detected" and never blocks launch.
+SESSION_BUS_PROBE_OUTPUT=""
 
-    ( trap - EXIT
-      if command -v gsettings >/dev/null 2>&1; then
-          case "$(gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled 2>/dev/null || true)" in
-              true) exit 0 ;;
-          esac
-          case "$(gsettings get org.gnome.desktop.interface toolkit-accessibility 2>/dev/null || true)" in
-              true) exit 0 ;;
-          esac
-      fi
-      if command -v busctl >/dev/null 2>&1; then
-          case "$(busctl --user get-property org.a11y.Bus /org/a11y/bus org.a11y.Status IsEnabled 2>/dev/null || true)" in
-              "b true") exit 0 ;;
-          esac
-      fi
-      exit 1 ) 2>/dev/null &
+session_bus_probe_command() {
+    local output_file probe_pid kill_pid rc=1 self_pid use_process_group=0
+
+    SESSION_BUS_PROBE_OUTPUT=""
+    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-session-bus-probe.XXXXXX")" || return 1
+    self_pid=${BASHPID:-$$}
+
+    if command -v setsid >/dev/null 2>&1; then
+        setsid "$@" >"$output_file" 2>/dev/null &
+        use_process_group=1
+    else
+        "$@" >"$output_file" 2>/dev/null &
+    fi
     probe_pid=$!
+
     ( trap - EXIT
       sleep 0.5
       [ -r "/proc/$probe_pid/stat" ] || exit 0
@@ -2824,13 +2822,57 @@ session_bus_assistive_technology_detected() {
       rest=${stat_line##*) }
       set -- $rest
       # $1 = state, $2 = ppid
-      [ "${2:-}" = "$self_pid" ] && kill -9 "$probe_pid" 2>/dev/null
+      [ "${2:-}" = "$self_pid" ] || exit 0
+      if [ "$use_process_group" -eq 1 ]; then
+          kill -TERM "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true
+          sleep 0.1
+          kill -KILL "-$probe_pid" 2>/dev/null || kill -KILL "$probe_pid" 2>/dev/null || true
+      else
+          kill -TERM "$probe_pid" 2>/dev/null || true
+          sleep 0.1
+          kill -KILL "$probe_pid" 2>/dev/null || true
+      fi
     ) 2>/dev/null &
     kill_pid=$!
-    if wait "$probe_pid" 2>/dev/null; then rc=0; fi
-    kill "$kill_pid" 2>/dev/null
-    wait "$kill_pid" 2>/dev/null
-    return $rc
+
+    if wait "$probe_pid" 2>/dev/null; then
+        rc=0
+    else
+        rc=$?
+    fi
+    kill "$kill_pid" 2>/dev/null || true
+    wait "$kill_pid" 2>/dev/null || true
+
+    if [ "$rc" -eq 0 ] && [ -r "$output_file" ]; then
+        SESSION_BUS_PROBE_OUTPUT="$(< "$output_file")"
+    fi
+    rm -f "$output_file"
+    return "$rc"
+}
+
+session_bus_assistive_technology_detected() {
+    if command -v gsettings >/dev/null 2>&1; then
+        if session_bus_probe_command gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled; then
+            case "$SESSION_BUS_PROBE_OUTPUT" in
+                true) return 0 ;;
+            esac
+        fi
+        if session_bus_probe_command gsettings get org.gnome.desktop.interface toolkit-accessibility; then
+            case "$SESSION_BUS_PROBE_OUTPUT" in
+                true) return 0 ;;
+            esac
+        fi
+    fi
+
+    if command -v busctl >/dev/null 2>&1; then
+        if session_bus_probe_command busctl --user get-property org.a11y.Bus /org/a11y/bus org.a11y.Status IsEnabled; then
+            case "$SESSION_BUS_PROBE_OUTPUT" in
+                "b true") return 0 ;;
+            esac
+        fi
+    fi
+
+    return 1
 }
 
 should_force_renderer_accessibility() {

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -245,7 +245,8 @@ Environment:
   CODEX_LAUNCHER_LOCK_WAIT_SECONDS=N
                               Seconds to wait for another launcher to leave the startup lock (default: 5)
   CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1
-                              Override --force-renderer-accessibility; auto skips it under WSLg and wayland-gpu
+                              Override --force-renderer-accessibility; auto forces it only when assistive
+                              technology is detected and never under WSLg or native wayland-gpu
   CODEX_MULTI_LAUNCH=1        Treat normal launches like --new-instance
   CODEX_MULTI_LAUNCH_PORT_RANGE=START-END
                               Port allocation range for --new-instance (default: CODEX_WEBVIEW_PORT through +4)
@@ -2700,6 +2701,37 @@ effective_electron_ozone_platform() {
     fi
 }
 
+# --force-renderer-accessibility keeps Chromium's accessibility engine active
+# in every renderer, so each DOM update also rebuilds and serializes the
+# accessibility tree — a measurable slowdown for the complex webview UI. Only
+# pay that cost when an assistive technology is plausibly in use; anything
+# missed by this detection can set CODEX_FORCE_RENDERER_ACCESSIBILITY=1.
+assistive_technology_detected() {
+    local env_marker
+
+    for env_marker in "${GNOME_ACCESSIBILITY:-}" "${QT_LINUX_ACCESSIBILITY_ALWAYS_ON:-}" "${ACCESSIBILITY_ENABLED:-}"; do
+        if truthy_env_value "$env_marker"; then
+            return 0
+        fi
+    done
+
+    if command -v gsettings >/dev/null 2>&1; then
+        case "$(gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled 2>/dev/null)" in
+            true)
+                return 0
+                ;;
+        esac
+    fi
+
+    if command -v pgrep >/dev/null 2>&1; then
+        if pgrep -x orca >/dev/null 2>&1 || pgrep -x brltty >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 should_force_renderer_accessibility() {
     local effective_platform
 
@@ -2725,11 +2757,10 @@ should_force_renderer_accessibility() {
         wayland-gpu)
             effective_platform="$(effective_electron_ozone_platform)"
             [ "$effective_platform" = "wayland" ] && return 1
-            return 0
             ;;
     esac
 
-    return 0
+    assistive_technology_detected
 }
 
 set_electron_defaults() {

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2715,21 +2715,59 @@ assistive_technology_detected() {
         fi
     done
 
-    if command -v gsettings >/dev/null 2>&1; then
-        case "$(gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled 2>/dev/null)" in
-            true)
-                return 0
-                ;;
-        esac
-    fi
-
     if command -v pgrep >/dev/null 2>&1; then
         if pgrep -x orca >/dev/null 2>&1 || pgrep -x brltty >/dev/null 2>&1; then
             return 0
         fi
     fi
 
-    return 1
+    session_bus_assistive_technology_detected
+}
+
+# Session-bus accessibility signals: the GNOME screen-reader setting plus the
+# AT-SPI state that `codex-computer-use-linux setup` enables (org.a11y.Status
+# IsEnabled via busctl, with org.gnome.desktop.interface toolkit-accessibility
+# as its gsettings fallback). gsettings/busctl can hang on a broken session
+# bus, so the probes run in a subshell killed by the same ppid-guarded
+# watchdog webview_port_is_open uses (/usr/bin/timeout intentionally avoided;
+# see that function), capped at 0.5 s. A killed or failing probe counts as
+# "not detected" and never blocks launch.
+session_bus_assistive_technology_detected() {
+    local probe_pid kill_pid rc=1 self_pid=$$
+
+    ( trap - EXIT
+      if command -v gsettings >/dev/null 2>&1; then
+          case "$(gsettings get org.gnome.desktop.a11y.applications screen-reader-enabled 2>/dev/null || true)" in
+              true) exit 0 ;;
+          esac
+          case "$(gsettings get org.gnome.desktop.interface toolkit-accessibility 2>/dev/null || true)" in
+              true) exit 0 ;;
+          esac
+      fi
+      if command -v busctl >/dev/null 2>&1; then
+          case "$(busctl --user get-property org.a11y.Bus /org/a11y/bus org.a11y.Status IsEnabled 2>/dev/null || true)" in
+              "b true") exit 0 ;;
+          esac
+      fi
+      exit 1 ) 2>/dev/null &
+    probe_pid=$!
+    ( trap - EXIT
+      sleep 0.5
+      [ -r "/proc/$probe_pid/stat" ] || exit 0
+      # /proc/<pid>/stat: "<pid> (comm) <state> <ppid> ..." — comm can contain
+      # spaces/parens, so strip up to the last ") " before splitting fields.
+      local stat_line rest
+      stat_line=$(< "/proc/$probe_pid/stat") || exit 0
+      rest=${stat_line##*) }
+      set -- $rest
+      # $1 = state, $2 = ppid
+      [ "${2:-}" = "$self_pid" ] && kill -9 "$probe_pid" 2>/dev/null
+    ) 2>/dev/null &
+    kill_pid=$!
+    if wait "$probe_pid" 2>/dev/null; then rc=0; fi
+    kill "$kill_pid" 2>/dev/null
+    wait "$kill_pid" 2>/dev/null
+    return $rc
 }
 
 should_force_renderer_accessibility() {

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -240,6 +240,8 @@ Environment:
                               or force native Wayland with GPU compositing enabled
   CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0|1
                               Override Wayland side-panel compositing workaround; 1 forces and 0 disables
+  CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1
+                              Override --disable-dev-shm-usage; auto keeps it only when /dev/shm is missing or small
   CODEX_LAUNCHER_LOCK_WAIT_SECONDS=N
                               Seconds to wait for another launcher to leave the startup lock (default: 5)
   CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1
@@ -2612,6 +2614,56 @@ apply_electron_rendering_profile() {
     fi
 }
 
+# --disable-dev-shm-usage exists for containers whose /dev/shm is too small
+# for Chromium's renderer/GPU shared-memory transport (Docker defaults to
+# 64 MiB). Everywhere else the flag pushes those buffers onto disk-backed
+# temp storage and hurts rendering performance, so it is only kept when
+# /dev/shm is missing, not writable, or below 1 GiB.
+dev_shm_size_kb() {
+    local size_kb
+    size_kb="$(df -Pk /dev/shm 2>/dev/null | awk 'NR == 2 { print $2 }')"
+    case "$size_kb" in
+        ""|*[!0-9]*)
+            return 1
+            ;;
+    esac
+    printf '%s\n' "$size_kb"
+}
+
+should_disable_dev_shm_usage() {
+    local min_size_kb=1048576 size_kb
+
+    if [ -n "${CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE:-}" ]; then
+        if truthy_env_value "$CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE"; then
+            return 0
+        fi
+        if falsey_env_value "$CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE"; then
+            return 1
+        fi
+        case "$CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE" in
+            auto|AUTO|Auto) ;;
+            *)
+                echo "Invalid CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE='${CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE:-}'; using automatic /dev/shm detection" >&2
+                ;;
+        esac
+    fi
+
+    if [ ! -d /dev/shm ] || [ ! -w /dev/shm ]; then
+        return 0
+    fi
+
+    if ! size_kb="$(dev_shm_size_kb)"; then
+        return 0
+    fi
+
+    if [ "$size_kb" -lt "$min_size_kb" ]; then
+        echo "Detected small /dev/shm (${size_kb} KiB); keeping --disable-dev-shm-usage. Set CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=0 to opt out."
+        return 0
+    fi
+
+    return 1
+}
+
 should_disable_gpu_compositing() {
     if [ "$ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED" -eq 1 ]; then
         return 0
@@ -2694,6 +2746,7 @@ set_electron_defaults() {
     ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS=0
     ELECTRON_GPU_COMPOSITING_DISABLED=0
     ELECTRON_GPU_COMPOSITING_SWITCH_PROVIDED=0
+    ELECTRON_DEV_SHM_USAGE_DISABLED=0
     ELECTRON_RENDERER_ACCESSIBILITY_FORCED=0
     ELECTRON_ARGS=()
     ELECTRON_ENABLE_FEATURES=()
@@ -2898,9 +2951,15 @@ build_electron_launch_args() {
         --no-sandbox
         --class="$CODEX_LINUX_APP_ID"
         --app-id="$CODEX_LINUX_APP_ID"
-        --disable-dev-shm-usage
         --disable-gpu-sandbox
     )
+
+    if should_disable_dev_shm_usage; then
+        ELECTRON_LAUNCH_ARGS+=(--disable-dev-shm-usage)
+        ELECTRON_DEV_SHM_USAGE_DISABLED=1
+    else
+        ELECTRON_DEV_SHM_USAGE_DISABLED=0
+    fi
 
     if should_disable_gpu_compositing; then
         ELECTRON_LAUNCH_ARGS+=(--disable-gpu-compositing)
@@ -3057,7 +3116,7 @@ launch_electron() {
 
     if [ "$WARM_START" -eq 1 ]; then
         release_launcher_lock
-        echo "Electron warm-start handoff: pid=$RUNNING_APP_PID rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED renderer_accessibility_forced=$ELECTRON_RENDERER_ACCESSIBILITY_FORCED"
+        echo "Electron warm-start handoff: pid=$RUNNING_APP_PID rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED dev_shm_usage_disabled=$ELECTRON_DEV_SHM_USAGE_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED renderer_accessibility_forced=$ELECTRON_RENDERER_ACCESSIBILITY_FORCED"
         if [ "$ELECTRON_GPU_COMPOSITING_DISABLED" = "0" ] && [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
             echo "Rendering hint: if the side panel flickers or appears transparent on Wayland, retry with CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1"
         fi
@@ -3066,7 +3125,7 @@ launch_electron() {
         return $?
     fi
 
-    echo "Electron launch mode: rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED renderer_accessibility_forced=$ELECTRON_RENDERER_ACCESSIBILITY_FORCED"
+    echo "Electron launch mode: rendering_mode=$ELECTRON_RENDERING_MODE wslg_detected=$ELECTRON_WSLG_DETECTED ozone_platform=${ELECTRON_OZONE_PLATFORM:-default} ozone_hint=${ELECTRON_OZONE_HINT:-none} gpu_enabled=$ELECTRON_GPU_ENABLED gpu_disable_arg=$ELECTRON_GPU_DISABLE_SWITCH_IN_ARGS gpu_compositing_disabled=$ELECTRON_GPU_COMPOSITING_DISABLED dev_shm_usage_disabled=$ELECTRON_DEV_SHM_USAGE_DISABLED gl_switch_added=$ELECTRON_GL_SWITCH_ADDED renderer_accessibility_forced=$ELECTRON_RENDERER_ACCESSIBILITY_FORCED"
     if [ "$ELECTRON_GPU_COMPOSITING_DISABLED" = "0" ] && [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
         echo "Rendering hint: if the side panel flickers or appears transparent on Wayland, retry with CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1"
     fi

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3931,12 +3931,22 @@ open(output_path, "w", encoding="utf-8").write(probe)
 PY
     chmod +x "$launcher_probe"
 
-    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe --x11 -- --use-gl=angle)"
+    local at_stub_dir="$TMP_DIR/assistive-tech-stubs"
+    mkdir -p "$at_stub_dir/none" "$at_stub_dir/orca" "$at_stub_dir/screenreader"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/none/pgrep"
+    printf '%s\n' '#!/usr/bin/env bash' "printf 'false\\n'" > "$at_stub_dir/none/gsettings"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$at_stub_dir/orca/pgrep"
+    printf '%s\n' '#!/usr/bin/env bash' "printf 'false\\n'" > "$at_stub_dir/orca/gsettings"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/screenreader/pgrep"
+    printf '%s\n' '#!/usr/bin/env bash' "printf 'true\\n'" > "$at_stub_dir/screenreader/gsettings"
+    chmod +x "$at_stub_dir"/*/pgrep "$at_stub_dir"/*/gsettings
+
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe --x11 -- --use-gl=angle)"
     [[ "$output" == *"electron=<--use-gl=angle>"* ]] || fail "launcher must pass Electron args after -- without the separator: $output"
     [[ "$output" != *"electron=<--><--use-gl=angle>"* ]] || fail "launcher must not pass the -- separator to Electron: $output"
     [[ "$output" == *"<--ozone-platform=x11>"* ]] || fail "launcher --x11 must still set the Electron ozone platform: $output"
     [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "default Linux profile must keep GPU compositing enabled: $output"
-    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "default Linux profile must still force renderer accessibility: $output"
+    [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "default Linux profile must not force renderer accessibility without assistive technology: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" XDG_SESSION_TYPE=wayland CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
     [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "Wayland default profile must disable GPU compositing for side-panel stability: $output"
@@ -4020,17 +4030,20 @@ EOF
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu CODEX_FORCE_RENDERER_ACCESSIBILITY=1 "$launcher_probe" probe)"
     [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "CODEX_FORCE_RENDERER_ACCESSIBILITY=1 must force renderer accessibility under wayland-gpu: $output"
 
-    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe --x11)"
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe --x11)"
     [[ "$output" == *"mode=wayland-gpu"* && "$output" == *"ozone_platform=x11"* ]] || fail "explicit --x11 must override the wayland-gpu platform: $output"
-    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with explicit --x11 must keep X11 renderer accessibility default: $output"
+    [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with explicit --x11 must fall back to assistive-technology detection: $output"
 
-    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe --safe-mode)"
+    output="$(env -i PATH="$at_stub_dir/orca:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe --x11)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with explicit --x11 must force renderer accessibility when a screen reader runs: $output"
+
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe --safe-mode)"
     [[ "$output" == *"mode=wayland-gpu"* && "$output" == *"ozone_platform=x11"* && "$output" == *"gpu=0"* ]] || fail "safe-mode must override wayland-gpu to X11 software rendering: $output"
-    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with safe-mode must keep X11 renderer accessibility default: $output"
+    [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with safe-mode must fall back to assistive-technology detection: $output"
 
-    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe -- --ozone-platform=x11)"
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wayland-gpu "$launcher_probe" probe -- --ozone-platform=x11)"
     [[ "$output" == *"electron=<--ozone-platform=x11>"* && "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "pass-through X11 platform must override wayland-gpu hinting: $output"
-    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with pass-through X11 platform must keep X11 renderer accessibility default: $output"
+    [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "wayland-gpu with pass-through X11 platform must fall back to assistive-technology detection: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe)"
     [[ "$output" == *"mode=wslg"* && "$output" == *"comp=0"* && "$output" == *"gl_added=1"* ]] || fail "forced WSLg profile must keep GPU compositing enabled and add ANGLE: $output"
@@ -4043,6 +4056,21 @@ EOF
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_FORCE_RENDERER_ACCESSIBILITY=0 "$launcher_probe" probe)"
     [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "CODEX_FORCE_RENDERER_ACCESSIBILITY=0 must disable renderer accessibility under default Linux: $output"
+
+    output="$(env -i PATH="$at_stub_dir/orca:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "a running screen reader must force renderer accessibility under default Linux: $output"
+
+    output="$(env -i PATH="$at_stub_dir/screenreader:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "the GNOME screen-reader setting must force renderer accessibility under default Linux: $output"
+
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" GNOME_ACCESSIBILITY=1 CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "GNOME_ACCESSIBILITY=1 must force renderer accessibility under default Linux: $output"
+
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1 CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "QT_LINUX_ACCESSIBILITY_ALWAYS_ON=1 must force renderer accessibility under default Linux: $output"
+
+    output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_FORCE_RENDERER_ACCESSIBILITY=1 "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "CODEX_FORCE_RENDERER_ACCESSIBILITY=1 must force renderer accessibility without detected assistive technology: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe --wayland --use-gl=desktop)"
     [[ "$output" == *"<--ozone-platform=wayland>"* && "$output" == *"electron=<--use-gl=desktop>"* ]] || fail "explicit rendering args must override WSLg defaults: $output"
@@ -4133,6 +4161,7 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "dev_shm_usage_disabled="
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--force-renderer-accessibility"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "assistive_technology_detected"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "PACKAGED_RUNTIME_HELPER"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--allow-install-missing"
     assert_contains "$REPO_DIR/scripts/lib/process-detection.sh" "CODEX_INSTALL_ALLOW_RUNNING"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3956,6 +3956,10 @@ EOF
     # Hung session bus: gsettings blocks far past the launch-path budget.
     cat > "$at_stub_dir/slowbus/gsettings" <<'EOF'
 #!/usr/bin/env bash
+: "${CODEX_TEST_SLOWBUS_PID_FILE:=}"
+if [ -n "$CODEX_TEST_SLOWBUS_PID_FILE" ]; then
+    printf '%s\n' "$$" > "$CODEX_TEST_SLOWBUS_PID_FILE"
+fi
 sleep 5
 printf 'true\n'
 EOF
@@ -4103,13 +4107,21 @@ EOF
     output="$(env -i PATH="$at_stub_dir/atspibus:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
     [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "org.a11y.Status IsEnabled (Computer Use setup) must force renderer accessibility: $output"
 
-    local at_probe_start_ns at_probe_end_ns at_probe_elapsed_ms
+    local at_probe_start_ns at_probe_end_ns at_probe_elapsed_ms slowbus_pid slowbus_pid_file
+    slowbus_pid_file="$TMP_DIR/slowbus-gsettings.pid"
+    rm -f "$slowbus_pid_file"
     at_probe_start_ns="$(date +%s%N)"
-    output="$(env -i PATH="$at_stub_dir/slowbus:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    output="$(env -i PATH="$at_stub_dir/slowbus:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_TEST_SLOWBUS_PID_FILE="$slowbus_pid_file" "$launcher_probe" probe)"
     at_probe_end_ns="$(date +%s%N)"
     at_probe_elapsed_ms=$(( (10#$at_probe_end_ns - 10#$at_probe_start_ns) / 1000000 ))
     [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "a hung session bus must not force renderer accessibility: $output"
     [ "$at_probe_elapsed_ms" -lt 3000 ] || fail "session-bus assistive-tech probe must be watchdog-capped, took ${at_probe_elapsed_ms}ms: $output"
+    [ -s "$slowbus_pid_file" ] || fail "hung session-bus probe did not start the gsettings helper"
+    slowbus_pid="$(< "$slowbus_pid_file")"
+    if kill -0 "$slowbus_pid" 2>/dev/null; then
+        kill -KILL "$slowbus_pid" 2>/dev/null || true
+        fail "session-bus assistive-tech watchdog leaked hung gsettings pid $slowbus_pid"
+    fi
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe --wayland --use-gl=desktop)"
     [[ "$output" == *"<--ozone-platform=wayland>"* && "$output" == *"electron=<--use-gl=desktop>"* ]] || fail "explicit rendering args must override WSLg defaults: $output"
@@ -4301,6 +4313,7 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--force-renderer-accessibility"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "assistive_technology_detected"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "session_bus_probe_command"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_OZONE_PLATFORM=x11|wayland|auto"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_FORCE_DEVICE_SCALE_FACTOR=N"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "print_scaling_diagnostics"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4064,6 +4064,42 @@ EOF
     output="$(env -i PATH="$PATH" HOME="$HOME" WSL_INTEROP=/tmp/codex-wsl WAYLAND_DISPLAY=wayland-0 "$launcher_probe" probe)"
     [[ "$output" == *"mode=wslg"* && "$output" == *"wslg=1"* ]] || fail "auto rendering mode must detect WSLg from WSL and GUI markers: $output"
 
+    local dev_shm_stub_dir="$TMP_DIR/dev-shm-stubs"
+    mkdir -p "$dev_shm_stub_dir/large" "$dev_shm_stub_dir/small" "$dev_shm_stub_dir/broken"
+    cat > "$dev_shm_stub_dir/large/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'tmpfs 16000000 0 16000000 0%% /dev/shm\n'
+EOF
+    cat > "$dev_shm_stub_dir/small/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'tmpfs 65536 0 65536 0%% /dev/shm\n'
+EOF
+    cat > "$dev_shm_stub_dir/broken/df" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$dev_shm_stub_dir/large/df" "$dev_shm_stub_dir/small/df" "$dev_shm_stub_dir/broken/df"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/large:$PATH" HOME="$HOME" "$launcher_probe" probe)"
+    [[ "$output" != *"<--disable-dev-shm-usage>"* ]] || fail "adequate /dev/shm must not disable Chromium /dev/shm usage: $output"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/small:$PATH" HOME="$HOME" "$launcher_probe" probe)"
+    [[ "$output" == *"<--disable-dev-shm-usage>"* ]] || fail "small /dev/shm must keep --disable-dev-shm-usage: $output"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/broken:$PATH" HOME="$HOME" "$launcher_probe" probe)"
+    [[ "$output" == *"<--disable-dev-shm-usage>"* ]] || fail "unreadable /dev/shm capacity must keep --disable-dev-shm-usage: $output"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/large:$PATH" HOME="$HOME" CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1 "$launcher_probe" probe)"
+    [[ "$output" == *"<--disable-dev-shm-usage>"* ]] || fail "CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=1 must force --disable-dev-shm-usage: $output"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/small:$PATH" HOME="$HOME" CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=0 "$launcher_probe" probe)"
+    [[ "$output" != *"<--disable-dev-shm-usage>"* ]] || fail "CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=0 must suppress --disable-dev-shm-usage: $output"
+
+    output="$(env -i PATH="$dev_shm_stub_dir/small:$PATH" HOME="$HOME" CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=bogus "$launcher_probe" probe 2>/dev/null)"
+    [[ "$output" == *"<--disable-dev-shm-usage>"* ]] || fail "invalid CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE must fall back to /dev/shm detection: $output"
+
     assert_contains "$REPO_DIR/launcher/start.sh.template" "warm_start_ipc_sent"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "launcher_phase"
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'date +%s%N'
@@ -4093,6 +4129,8 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_LINUX_RENDERING_MODE=auto|default|wslg|wayland-gpu"
     assert_contains "$REPO_DIR/launcher/start.sh.template" '--ozone-platform-hint="$ELECTRON_OZONE_HINT"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--disable-gpu-sandbox"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "dev_shm_usage_disabled="
     assert_contains "$REPO_DIR/launcher/start.sh.template" "--force-renderer-accessibility"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "PACKAGED_RUNTIME_HELPER"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3932,14 +3932,39 @@ PY
     chmod +x "$launcher_probe"
 
     local at_stub_dir="$TMP_DIR/assistive-tech-stubs"
-    mkdir -p "$at_stub_dir/none" "$at_stub_dir/orca" "$at_stub_dir/screenreader"
+    mkdir -p "$at_stub_dir/none" "$at_stub_dir/orca" "$at_stub_dir/screenreader" \
+        "$at_stub_dir/toolkit" "$at_stub_dir/atspibus" "$at_stub_dir/slowbus"
     printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/none/pgrep"
     printf '%s\n' '#!/usr/bin/env bash' "printf 'false\\n'" > "$at_stub_dir/none/gsettings"
     printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$at_stub_dir/orca/pgrep"
     printf '%s\n' '#!/usr/bin/env bash' "printf 'false\\n'" > "$at_stub_dir/orca/gsettings"
     printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/screenreader/pgrep"
     printf '%s\n' '#!/usr/bin/env bash' "printf 'true\\n'" > "$at_stub_dir/screenreader/gsettings"
-    chmod +x "$at_stub_dir"/*/pgrep "$at_stub_dir"/*/gsettings
+    # Computer Use gsettings fallback: toolkit-accessibility on, screen reader off.
+    cat > "$at_stub_dir/toolkit/gsettings" <<'EOF'
+#!/usr/bin/env bash
+case "${3:-}" in
+    toolkit-accessibility) printf 'true\n' ;;
+    *) printf 'false\n' ;;
+esac
+EOF
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/toolkit/pgrep"
+    # Computer Use primary path: org.a11y.Status IsEnabled=true via busctl.
+    printf '%s\n' '#!/usr/bin/env bash' "printf 'false\\n'" > "$at_stub_dir/atspibus/gsettings"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/atspibus/pgrep"
+    printf '%s\n' '#!/usr/bin/env bash' "printf 'b true\\n'" > "$at_stub_dir/atspibus/busctl"
+    # Hung session bus: gsettings blocks far past the launch-path budget.
+    cat > "$at_stub_dir/slowbus/gsettings" <<'EOF'
+#!/usr/bin/env bash
+sleep 5
+printf 'true\n'
+EOF
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/slowbus/pgrep"
+    local at_stub_variant
+    for at_stub_variant in none orca screenreader toolkit slowbus; do
+        printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$at_stub_dir/$at_stub_variant/busctl"
+    done
+    chmod +x "$at_stub_dir"/*/pgrep "$at_stub_dir"/*/gsettings "$at_stub_dir"/*/busctl
 
     output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe --x11 -- --use-gl=angle)"
     [[ "$output" == *"electron=<--use-gl=angle>"* ]] || fail "launcher must pass Electron args after -- without the separator: $output"
@@ -4071,6 +4096,20 @@ EOF
 
     output="$(env -i PATH="$at_stub_dir/none:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default CODEX_FORCE_RENDERER_ACCESSIBILITY=1 "$launcher_probe" probe)"
     [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "CODEX_FORCE_RENDERER_ACCESSIBILITY=1 must force renderer accessibility without detected assistive technology: $output"
+
+    output="$(env -i PATH="$at_stub_dir/toolkit:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "toolkit-accessibility=true (Computer Use gsettings fallback) must force renderer accessibility: $output"
+
+    output="$(env -i PATH="$at_stub_dir/atspibus:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    [[ "$output" == *"renderer_accessibility=1"* && "$output" == *"<--force-renderer-accessibility>"* ]] || fail "org.a11y.Status IsEnabled (Computer Use setup) must force renderer accessibility: $output"
+
+    local at_probe_start_ns at_probe_end_ns at_probe_elapsed_ms
+    at_probe_start_ns="$(date +%s%N)"
+    output="$(env -i PATH="$at_stub_dir/slowbus:$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
+    at_probe_end_ns="$(date +%s%N)"
+    at_probe_elapsed_ms=$(( (10#$at_probe_end_ns - 10#$at_probe_start_ns) / 1000000 ))
+    [[ "$output" == *"renderer_accessibility=0"* && "$output" != *"<--force-renderer-accessibility>"* ]] || fail "a hung session bus must not force renderer accessibility: $output"
+    [ "$at_probe_elapsed_ms" -lt 3000 ] || fail "session-bus assistive-tech probe must be watchdog-capped, took ${at_probe_elapsed_ms}ms: $output"
 
     output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_LINUX_RENDERING_MODE=wslg "$launcher_probe" probe --wayland --use-gl=desktop)"
     [[ "$output" == *"<--ozone-platform=wayland>"* && "$output" == *"electron=<--use-gl=desktop>"* ]] || fail "explicit rendering args must override WSLg defaults: $output"


### PR DESCRIPTION
## What changed

- `--disable-dev-shm-usage` is now passed only when `/dev/shm` is missing, not writable,
  or below 1 GiB (the container case the flag exists for — Docker defaults to 64 MiB).
  New override: `CODEX_ELECTRON_DISABLE_DEV_SHM_USAGE=auto|0|1`, mirroring
  `CODEX_ELECTRON_DISABLE_GPU_COMPOSITING`.
- `--force-renderer-accessibility` is now added only when an assistive technology is
  detected (Orca/brltty running, the GNOME screen-reader setting, or the
  `GNOME_ACCESSIBILITY` / `QT_LINUX_ACCESSIBILITY_ALWAYS_ON` / `ACCESSIBILITY_ENABLED`
  env markers). `CODEX_FORCE_RENDERER_ACCESSIBILITY=1|0` still wins in both directions.
- Launch-mode diagnostics now log `dev_shm_usage_disabled=`, and a new decision record
  `docs/launcher-performance.md` documents these defaults plus the alternatives that were
  reviewed and deliberately left unchanged.

## Why

A side-by-side comparison with another Electron 42 app on the same X11 GNOME 4K host
showed every Codex process mapping Chromium shared memory from disk-backed
`/tmp/.org.chromium.*` (the other app maps RAM-backed `/dev/shm`), and the Chromium
accessibility engine forced on with no assistive technology present, which serializes the
accessibility tree on every DOM update. The WSLg and wayland-gpu profiles already skip
forced accessibility for performance; this extends the same policy behind detection.

## Source-of-truth files edited

- `launcher/start.sh.template`
- `tests/scripts_smoke.sh`
- `docs/troubleshooting.md`, `docs/launcher-performance.md` (new)
- `README.md`, `AGENTS.md`, `CHANGELOG.md`

## How it was tested

- TDD via the launcher rendering probe in `tests/scripts_smoke.sh`; new tests were
  written first and confirmed failing:
  - `df` stubs for large / small / unreadable `/dev/shm`
  - PATH stubs for Orca and `gsettings` screen-reader detection
  - env-marker detection cases
  - `1` / `0` / invalid override values across the default, wayland-gpu, and WSLg profiles
- Full `bash tests/scripts_smoke.sh` passes.
- `bash -n` on `install.sh`, `scripts/lib/*.sh`, the package builders, and the template.
- `codex-app/start.sh` regenerated from the template and probed on a real 4K X11 host:
  both flags are correctly omitted there, and all overrides are honored.

## Limitations

- No Rust or package-payload changes, so `cargo check`/`cargo test` and the package
  builds were not run.

## Known risks / follow-ups

- An assistive technology the detection misses (or one started after the app launches)
  needs `CODEX_FORCE_RENDERER_ACCESSIBILITY=1`; this is documented in troubleshooting
  and worth a reviewer's eye.
- Hosts with `/dev/shm` between 64 MiB and 1 GiB keep the old conservative behavior.
- Intentionally out-of-scope items (sandbox flags, Wayland compositing workaround,
  webview server model, startup ordering, upstream RPC latency) are recorded in
  `docs/launcher-performance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)