### PR TITLE
Detach CLI version probe watchdog from the caller pipe (1s cold-start stall)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Cold launches no longer stall for a full second between acquiring the
+  launcher lock and spawning Electron. The CLI version log line reads the
+  probe result through command substitution, and the probe's watchdog
+  subshell inherited that pipe: its `sleep 1` child survived the watchdog
+  kill and held the pipe open until the sleep expired, so even a CLI that
+  answers `--version` in ~50 ms blocked the launch path for ~1 s. The
+  watchdog now runs detached from the caller's stdout/stderr, cutting that
+  launch phase from ~1010 ms to ~74 ms and making the window (and GNOME's
+  startup feedback) appear about a second sooner on every cold start.
+
 ### Changed
 
 - The launcher now passes `--disable-dev-shm-usage` to Electron only when

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -83,4 +83,13 @@ repository beyond faithfully reporting it.
 ### CLI preflight
 
 Launcher CLI preflight is best-effort, recently hardened, and not part of the
-rendering path. No performance changes were made there.
+rendering path. One launch-path cost hid there, though: the CLI version log
+line reads `codex_cli_version` through command substitution, and the probe's
+watchdog subshell inherited that pipe. Its `sleep 1` child survived the
+watchdog kill and held the pipe open, so every cold launch stalled for the
+full watchdog second even when the CLI answered in ~50 ms. The watchdog now
+runs with stdout/stderr detached (`>/dev/null 2>&1`), which cut the
+`launch_state_refreshed_under_lock` → `electron_launch` gap from ~1010 ms to
+~74 ms. When adding bounded probes, keep watchdog subshells detached from any
+caller pipe — an orphaned `sleep` holding an inherited fd blocks command
+substitution until it exits.

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1459,6 +1459,10 @@ codex_cli_version_probe() {
       exec "$@" >"$output_file" 2>/dev/null
     ) &
     probe_pid="$!"
+    # The watchdog (and its sleep child, which outlives the kill below) must
+    # not inherit the caller's stdout: codex_cli_version runs under command
+    # substitution, and an inherited pipe fd would block the caller for the
+    # full watchdog second even when the probe answers immediately.
     ( trap - EXIT
       { exec 9>&-; } 2>/dev/null || true
       sleep 1
@@ -1470,7 +1474,7 @@ codex_cli_version_probe() {
               kill -9 "$probe_pid" 2>/dev/null || true
           fi
       fi
-    ) &
+    ) >/dev/null 2>&1 &
     watchdog_pid="$!"
 
     if wait "$probe_pid"; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4536,6 +4536,18 @@ PY
     version_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" version "$fallback_version_cli")"
     [ "$version_output" = "0.151.0" ] || fail "CLI version probe must fall back to version output, got $version_output"
 
+    # The version probe result is read through command substitution on the
+    # launch path. The watchdog subshell (and its sleep child) must not
+    # inherit that pipe, or a fast CLI still blocks the caller for the full
+    # watchdog second waiting for pipe EOF.
+    local fast_probe_start_ns fast_probe_end_ns fast_probe_elapsed_ms
+    fast_probe_start_ns="$(date +%s%N)"
+    version_output="$(env -i PATH="/usr/bin:/bin" HOME="$fake_home" "$launcher_probe" version "$dash_version_cli")"
+    fast_probe_end_ns="$(date +%s%N)"
+    fast_probe_elapsed_ms=$(( (10#$fast_probe_end_ns - 10#$fast_probe_start_ns) / 1000000 ))
+    [ "$version_output" = "0.150.0" ] || fail "fast CLI version probe must still parse --version output, got $version_output"
+    [ "$fast_probe_elapsed_ms" -lt 700 ] || fail "CLI version probe must not hold the command-substitution pipe until the watchdog sleep expires, took ${fast_probe_elapsed_ms}ms"
+
     local unknown_cli="$workspace/unknown-version-codex"
     printf '#!/usr/bin/env bash\nprintf "codex-cli dev build\\n"\n' > "$unknown_cli"
     chmod +x "$unknown_cli"


### PR DESCRIPTION
## What changed

- The CLI version probe's watchdog subshell in `launcher/start.sh.template` now runs
  with stdout/stderr detached (`>/dev/null 2>&1`), so its `sleep 1` child can no longer
  hold the caller's command-substitution pipe after the watchdog is killed.

## Why

`log_codex_cli_path` reads `codex_cli_version` via command substitution on the launch
path, immediately before Electron is spawned. The watchdog subshell inherited the
substitution pipe; its sleep child survives the watchdog kill and holds the pipe open,
and command substitution waits for pipe EOF. Result: every cold launch stalled ~1 s
even with a CLI that answers `--version` in ~50 ms. Measured on a live cold start, the
`launch_state_refreshed_under_lock` → `electron_launch` phase gap drops from ~1010 ms
to ~74 ms, so the window and GNOME's startup feedback (dock icon / launch spinner) show
up about a second sooner. Same bug class as the session-bus probe cleanup fixed in
1a63ae5; the decision record now documents the pattern for future bounded probes.

## Source-of-truth files edited

- `launcher/start.sh.template`, `tests/scripts_smoke.sh`
- `CHANGELOG.md`, `docs/launcher-performance.md`

## How it was tested

- TDD: a new timing regression test in `test_launcher_cli_resolution_policy` reads a
  fast stub CLI through command substitution and asserts completion well under the
  watchdog second — it fails at ~1010 ms before the fix and passes at ~60 ms after.
- Full `bash tests/scripts_smoke.sh` passes; `bash -n` on the template.
- Regenerated launcher measured on a real cold start (phase log confirms the gap).

## Known risks / follow-ups

- None functional: the watchdog's output was never meaningful, and probe/timeout
  semantics are unchanged. `webview_port_is_open`'s watchdog shares the shape but is
  only used in status contexts (never captured), so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)