### PR TITLE
fix(kwin): support Plasma 5 window API (clientList/activeClient fallback)

### DIFF
--- a/computer-use-linux/src/windowing/backends/kwin.rs
+++ b/computer-use-linux/src/windowing/backends/kwin.rs
@@ -225,7 +225,7 @@ fn write_kwin_window_script(
     write_kwin_script_file(plugin_name, &script)
 }
 
-fn kwin_window_script_source(
+pub(crate) fn kwin_window_script_source(
     service_name: &str,
     callback_object_path: &str,
     plugin_name: &str,
@@ -311,11 +311,30 @@ fn kwin_window_script_source(
         return null;
     }}
 
+    function listWindows() {{
+        try {{
+            if (typeof workspace.windowList === "function") {{
+                return workspace.windowList();
+            }}
+        }} catch (error) {{}}
+        try {{
+            if (typeof workspace.clientList === "function") {{
+                return workspace.clientList();
+            }}
+        }} catch (error) {{}}
+        try {{
+            if (workspace.stackingOrder && typeof workspace.stackingOrder.length === "number") {{
+                return workspace.stackingOrder;
+            }}
+        }} catch (error) {{}}
+        return [];
+    }}
+
     var activeWindow = null;
     try {{
-        activeWindow = workspace.activeWindow;
+        activeWindow = "activeWindow" in workspace ? workspace.activeWindow : workspace.activeClient;
     }} catch (error) {{}}
-    var windows = workspace.windowList().map(function(window) {{
+    var windows = listWindows().map(function(window) {{
         var geo = geometry(window);
         return {{
             uuid: read(window, "uuid"),
@@ -442,6 +461,11 @@ pub(crate) fn kwin_activate_script_source(
             }}
         }} catch (error) {{}}
         try {{
+            if (typeof workspace.clientList === "function") {{
+                return workspace.clientList();
+            }}
+        }} catch (error) {{}}
+        try {{
             if (workspace.stackingOrder && typeof workspace.stackingOrder.length === "number") {{
                 return workspace.stackingOrder;
             }}
@@ -482,13 +506,14 @@ pub(crate) fn kwin_activate_script_source(
 
         var activated = false;
         var activationError = null;
-        try {{
-            workspace.activeWindow = targetWindow;
-            activated = true;
-        }} catch (error) {{
-            activationError = error;
-        }}
-        if (!activated) {{
+        if ("activeWindow" in workspace) {{
+            try {{
+                workspace.activeWindow = targetWindow;
+                activated = true;
+            }} catch (error) {{
+                activationError = error;
+            }}
+        }} else {{
             try {{
                 workspace.activeClient = targetWindow;
                 activated = true;

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -22,7 +22,8 @@ mod tests {
     use super::backends::hyprland::{parse_hyprland_clients, HYPRLAND_BACKEND};
     use super::backends::i3::{parse_i3_tree, parse_xprop_pid, I3_BACKEND};
     use super::backends::kwin::{
-        kwin_activate_script_source, kwin_window_id_from_uuid, parse_kwin_windows, KWIN_BACKEND,
+        kwin_activate_script_source, kwin_window_id_from_uuid, kwin_window_script_source,
+        parse_kwin_windows, KWIN_BACKEND,
     };
     use super::registry::{
         descriptors, list_note, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND,
@@ -699,6 +700,23 @@ mod tests {
     }
 
     #[test]
+    fn kwin_window_script_supports_plasma5_and_plasma6_window_apis() {
+        let script = kwin_window_script_source(
+            ":1.234",
+            "/com/openai/Codex/KWinWindowQuery/test",
+            "codex_kwin_window_query_test",
+        )
+        .unwrap();
+
+        assert!(script.contains(r#"typeof workspace.windowList === "function""#));
+        assert!(script.contains("workspace.windowList()"));
+        assert!(script.contains(r#"typeof workspace.clientList === "function""#));
+        assert!(script.contains("workspace.clientList()"));
+        assert!(script
+            .contains(r#"activeWindow = "activeWindow" in workspace ? workspace.activeWindow : workspace.activeClient;"#));
+    }
+
+    #[test]
     fn kwin_activation_script_focuses_window_directly() {
         let script = kwin_activate_script_source(
             ":1.234",
@@ -711,6 +729,10 @@ mod tests {
         assert!(script.contains(r#"var targetUuid = "b4dfacf8-a559-43c9-8b1f-ecd5cfd78359";"#));
         assert!(script.contains("targetWindow.minimized = false;"));
         assert!(script.contains("workspace.activeWindow = targetWindow;"));
+        assert!(script.contains(r#"typeof workspace.clientList === "function""#));
+        assert!(script.contains("workspace.clientList()"));
+        assert!(script.contains(r#""activeWindow" in workspace"#));
+        assert!(script.contains("workspace.activeClient = targetWindow;"));
         assert!(script.contains(r#""ReceiveResult""#));
         assert!(!script.contains("WindowsRunner"));
     }


### PR DESCRIPTION
## Problem

On Plasma 5.27 (KDE X11), the KWin backend scripts use Plasma 6-only APIs:
- `workspace.windowList()` does not exist on Plasma 5
- `workspace.activeWindow` does not exist on Plasma 5

This causes Computer Use to return `backend: "unavailable"` even when `doctor` reports ready.

## Solution

Add runtime API detection to generated KWin scripts so they work on both Plasma 5 and Plasma 6:

- **Window listing**: new `listWindows()` helper tries `windowList()` → `clientList()` → `stackingOrder`
- **Active window read**: ternary fallback `activeWindow` → `activeClient`
- **Window activation**: check `"activeWindow" in workspace` before assigning, fall back to `activeClient`
- **Activation script**: add `clientList()` fallback to the existing `windowList()`/`stackingOrder` chain

## Testing

Tested on Plasma 5.27 X11:
- `codex-computer-use-linux doctor` → ready
- `codex-computer-use-linux windows` → `{"backend": "kwin", "windows": [...]}`
- `codex-computer-use-linux screenshot` → working

## References

Similar API difference documented by [wdotool](https://gitlab.com/univk/wdotool): Plasma 6 uses `workspace.windowList`/`workspace.activeWindow`, Plasma 5 uses `workspace.clientList`/`workspace.activeClient`.