### PR TITLE
Overlap webview startup and run plugin cache syncs concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
+- Cold starts overlap the webview server boot with the rest of launcher
+  startup and run the five bundled plugin cache syncs concurrently. The
+  launcher now spawns the Python webview server, does CLI lookup and cache
+  syncs while it boots, and only then waits for readiness and verifies the
+  origin — still strictly before Electron launches. The shared bundled
+  marketplace metadata is staged exactly once before the concurrent syncs
+  instead of being rewritten inside each sync. Measured on a warm-cache cold
+  start, the sync block drops from ~285 ms to ~110 ms and the webview wait
+  from ~150 ms to ~35 ms, putting Electron spawn ~330 ms earlier.
 - The launcher now passes `--disable-dev-shm-usage` to Electron only when
   `/dev/shm` is missing, not writable, or smaller than 1 GiB (the container
   case the flag exists for). On regular desktops Chromium's renderer/GPU

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -63,13 +63,29 @@ covered. Replacing it with a Rust server was evaluated and rejected until
 evidence shows Python itself is the bottleneck — see
 [Webview server evaluation](webview-server-evaluation.md).
 
-### Serialized startup ordering
+### Startup ordering (partially overlapped)
 
-The launcher intentionally starts the webview server, verifies the origin,
-and only then launches Electron so Chromium never races a server that has
-not bound yet. The server binds in milliseconds; parallelizing the spawn
-would buy little and risk the documented startup markers and warm-start
-handoff behavior.
+The invariant is unchanged: Electron never launches before the webview
+origin is verified, so Chromium cannot race a server that has not bound
+yet. Within that constraint the cold-start path now overlaps independent
+work instead of serializing it:
+
+- The Python webview server is spawned first
+  (`start_webview_server`), and its readiness wait plus origin
+  verification run later (`await_webview_server_ready`), after the CLI
+  lookup and plugin cache syncs — the server finishes booting while the
+  launcher does unrelated work, leaving ~35 ms of residual wait instead
+  of ~150 ms.
+- The five bundled plugin cache syncs run concurrently and are all
+  awaited before cold-start hooks dispatch (~110 ms instead of ~285 ms).
+  They only touch disjoint per-plugin cache directories; the shared
+  bundled marketplace metadata they previously each rewrote is staged
+  exactly once beforehand (`stage_bundled_marketplace_metadata`), which
+  is also what makes the concurrency safe.
+
+Launching Electron itself in parallel with any of this remains rejected:
+the renderer needs a verified local origin, and the warm-start handoff
+markers depend on the current ordering.
 
 ### In-app startup latency
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -673,9 +673,25 @@ print(name.strip())
 PY
 }
 
+# The bundled marketplace metadata is shared by every plugin sync below and
+# the syncs run concurrently on cold start, so the marketplace.json copy is
+# staged exactly once here instead of racing rm+cp inside each sync.
+stage_bundled_marketplace_metadata() {
+    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
+    local marketplace_plugins_dir="$marketplace_root/.agents/plugins"
+
+    [ -f "$source_marketplace" ] || return 0
+    mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
+    rm -f "$marketplace_plugins_dir/marketplace.json"
+    cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
+        chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
+        echo "Bundled marketplace metadata sync failed; continuing with existing marketplace cache."
+}
+
 sync_browser_use_bundled_plugin_cache() {
     local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/browser"
-    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local plugin_json=""
     local source_client=""
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
@@ -706,13 +722,7 @@ sync_browser_use_bundled_plugin_cache() {
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
     marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"
-    if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-        rm -f "$marketplace_plugins_dir/marketplace.json"
-        cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
-            chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
-            echo "Browser Use bundled marketplace sync failed; continuing with existing marketplace cache."
-    fi
+    mkdir -p "$marketplace_root/plugins"
 
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
@@ -846,7 +856,6 @@ PY
 
 sync_chrome_bundled_plugin_cache() {
     local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/chrome"
-    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local plugin_json="$source_plugin/.codex-plugin/plugin.json"
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
     local extension_arch
@@ -943,12 +952,6 @@ sync_chrome_bundled_plugin_cache() {
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
     marketplace_plugin_link="$marketplace_root/plugins/chrome"
     mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-    if [ -f "$source_marketplace" ]; then
-        rm -f "$marketplace_plugins_dir/marketplace.json"
-        cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
-            chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
-            echo "Chrome bundled marketplace sync failed; continuing with existing marketplace cache."
-    fi
     replace_symlink "$cache_root/latest" "$marketplace_plugin_link"
 
     host_path="$cache_root/latest/extension-host/linux/$extension_arch/extension-host"
@@ -959,7 +962,6 @@ sync_chrome_bundled_plugin_cache() {
 
 sync_computer_use_bundled_plugin_cache() {
     local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/computer-use"
-    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local plugin_json="$source_plugin/.codex-plugin/plugin.json"
     local source_backend="$source_plugin/bin/codex-computer-use-linux"
     local source_cosmic_helper="$source_plugin/bin/codex-computer-use-cosmic"
@@ -983,13 +985,7 @@ sync_computer_use_bundled_plugin_cache() {
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
     marketplace_plugin_link="$marketplace_root/plugins/computer-use"
-    if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-        rm -f "$marketplace_plugins_dir/marketplace.json"
-        cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
-            chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
-            echo "Computer Use bundled marketplace sync failed; continuing with existing marketplace cache."
-    fi
+    mkdir -p "$marketplace_root/plugins"
 
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
@@ -1032,7 +1028,6 @@ sync_computer_use_bundled_plugin_cache() {
 
 sync_read_aloud_bundled_plugin_cache() {
     local source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/read-aloud"
-    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local plugin_json="$source_plugin/.codex-plugin/plugin.json"
     local source_backend="$source_plugin/bin/codex-read-aloud-linux"
     local source_runner="$source_plugin/bin/kokoro-stdin"
@@ -1059,13 +1054,7 @@ sync_read_aloud_bundled_plugin_cache() {
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
     marketplace_plugins_dir="$marketplace_root/.agents/plugins"
     marketplace_plugin_link="$marketplace_root/plugins/read-aloud"
-    if [ -f "$source_marketplace" ]; then
-        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-        rm -f "$marketplace_plugins_dir/marketplace.json"
-        cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
-            chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
-            echo "Read Aloud bundled marketplace sync failed; continuing with existing marketplace cache."
-    fi
+    mkdir -p "$marketplace_root/plugins"
 
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
@@ -1110,7 +1099,6 @@ sync_read_aloud_bundled_plugin_cache() {
 
 sync_extra_bundled_plugin_cache() {
     local plugins_root="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins"
-    local source_marketplace="$SCRIPT_DIR/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
     local source_plugin
     local plugin_json
@@ -1167,12 +1155,6 @@ sync_extra_bundled_plugin_cache() {
         marketplace_plugins_dir="$marketplace_root/.agents/plugins"
         marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"
         mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-        if [ -f "$source_marketplace" ]; then
-            rm -f "$marketplace_plugins_dir/marketplace.json"
-            cp "$source_marketplace" "$marketplace_plugins_dir/marketplace.json" && \
-                chmod u+w "$marketplace_plugins_dir/marketplace.json" || \
-                echo "Extra bundled marketplace sync failed; continuing with existing marketplace cache."
-        fi
         replace_symlink "$cache_root/latest" "$marketplace_plugin_link"
     done
 }
@@ -2236,7 +2218,9 @@ adopt_discovered_webview_server() {
     return 1
 }
 
-ensure_webview_server() {
+start_webview_server() {
+    WEBVIEW_STARTUP_PENDING=0
+
     if [ ! -d "$WEBVIEW_DIR" ] || [ ! "$(ls -A "$WEBVIEW_DIR" 2>/dev/null)" ]; then
         return 0
     fi
@@ -2293,8 +2277,20 @@ ensure_webview_server() {
     python3 "$SCRIPT_DIR/.codex-linux/webview-server.py" "$CODEX_LINUX_WEBVIEW_PORT" --bind 127.0.0.1 &
     STARTED_WEBVIEW_PID=$!
     echo "$STARTED_WEBVIEW_PID" > "$WEBVIEW_PID_FILE"
+    WEBVIEW_STARTUP_PENDING=1
 
     echo "Started webview server pid=$STARTED_WEBVIEW_PID dir=$WEBVIEW_DIR"
+    log_phase "webview_spawned"
+}
+
+# Readiness runs separately from the spawn so the Python server finishes
+# booting while the launcher does unrelated cold-start work (CLI lookup,
+# plugin cache syncs). Electron never launches before this verifies the
+# origin; the server is tied to the launcher lifetime via PR_SET_PDEATHSIG,
+# so early-exit paths cannot leak it.
+await_webview_server_ready() {
+    [ "${WEBVIEW_STARTUP_PENDING:-0}" -eq 1 ] || return 0
+    WEBVIEW_STARTUP_PENDING=0
 
     if ! wait_for_webview_server; then
         notify_error "$CODEX_LINUX_APP_DISPLAY_NAME webview server did not become ready on port $CODEX_LINUX_WEBVIEW_PORT. Check the launcher log for the embedded http.server output."
@@ -3516,7 +3512,7 @@ elif needs_cold_start; then
     log_phase "packaged_prelaunch_start"
     run_packaged_runtime_prelaunch
     log_phase "packaged_prelaunch"
-    ensure_webview_server
+    start_webview_server
 else
     echo "Skipping packaged prelaunch and webview setup for warm start"
     log_phase "warm_start_ready"
@@ -3575,18 +3571,31 @@ if needs_cold_start; then
     # recreate read-only plugin cache trees before the sync below replaces them.
     monitor_bundled_marketplace_tmp_permissions
     log_phase "bundled_marketplace_tmp_monitor_started"
-    sync_browser_use_bundled_plugin_cache
+    stage_bundled_marketplace_metadata
+    log_phase "bundled_marketplace_metadata_staged"
+    sync_browser_use_bundled_plugin_cache &
+    SYNC_BROWSER_USE_PID=$!
+    sync_chrome_bundled_plugin_cache &
+    SYNC_CHROME_PID=$!
+    sync_computer_use_bundled_plugin_cache &
+    SYNC_COMPUTER_USE_PID=$!
+    sync_read_aloud_bundled_plugin_cache &
+    SYNC_READ_ALOUD_PID=$!
+    sync_extra_bundled_plugin_cache &
+    SYNC_EXTRA_PID=$!
+    wait "$SYNC_BROWSER_USE_PID"
     log_phase "browser_use_plugin_cache_synced"
-    sync_chrome_bundled_plugin_cache
+    wait "$SYNC_CHROME_PID"
     log_phase "chrome_plugin_cache_synced"
-    sync_computer_use_bundled_plugin_cache
+    wait "$SYNC_COMPUTER_USE_PID"
     log_phase "computer_use_plugin_cache_synced"
-    sync_read_aloud_bundled_plugin_cache
+    wait "$SYNC_READ_ALOUD_PID"
     log_phase "read_aloud_plugin_cache_synced"
-    sync_extra_bundled_plugin_cache
+    wait "$SYNC_EXTRA_PID"
     log_phase "extra_bundled_plugin_cache_synced"
     run_cold_start_hooks
     log_phase "cold_start_hooks_dispatched"
+    await_webview_server_ready
 fi
 resolve_browser_use_runtime_env
 log_phase "browser_use_runtime_env_resolved"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3618,8 +3618,8 @@ cold_start_hooks_body = source.split("run_cold_start_hooks() {", 1)[1].split("ru
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
 stale_body = source.split("pid_is_stale_webview_server() {", 1)[1].split("stop_owned_webview_server() {", 1)[0]
 multi_body = source.split("configure_multi_launch_instance() {", 1)[1].split('WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"', 1)[0]
-adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("ensure_webview_server() {", 1)[0]
-ensure_body = source.split("ensure_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
+adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("start_webview_server() {", 1)[0]
+ensure_body = source.split("start_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
 reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
 orphan_body = source.split("pid_is_orphaned_runtime_process() {", 1)[1].split("detect_cross_install_conflict() {", 1)[0]
 reap_body = source.split("reap_orphaned_runtime_processes() {", 1)[1].split("reconcile_runtime_state() {", 1)[0]
@@ -3729,13 +3729,24 @@ if "second_instance_handoff_ready" not in runtime_body:
     raise SystemExit("second-instance handoff must skip cold-start setup")
 if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permissions\nreconcile_runtime_state" in runtime_body:
     raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
-if not re.search(r'if needs_cold_start; then\s+log_phase "cold_start_cache_sync_start"\s+clear_bundled_marketplace_tmp_cache.*?monitor_bundled_marketplace_tmp_permissions.*?sync_browser_use_bundled_plugin_cache.*?sync_chrome_bundled_plugin_cache.*?sync_computer_use_bundled_plugin_cache.*?sync_read_aloud_bundled_plugin_cache.*?run_cold_start_hooks.*?log_phase "cold_start_hooks_dispatched"\s+fi', runtime_body, re.S):
-    raise SystemExit("bundled marketplace cleanup, plugin sync, and cold-start hooks must run only on cold start")
+if not re.search(r'if needs_cold_start; then\s+log_phase "cold_start_cache_sync_start"\s+clear_bundled_marketplace_tmp_cache.*?monitor_bundled_marketplace_tmp_permissions.*?stage_bundled_marketplace_metadata.*?sync_browser_use_bundled_plugin_cache &.*?sync_chrome_bundled_plugin_cache &.*?sync_computer_use_bundled_plugin_cache &.*?sync_read_aloud_bundled_plugin_cache &.*?sync_extra_bundled_plugin_cache &.*?run_cold_start_hooks.*?log_phase "cold_start_hooks_dispatched"\s+await_webview_server_ready\s+fi', runtime_body, re.S):
+    raise SystemExit("bundled marketplace cleanup, staged metadata, concurrent plugin syncs, cold-start hooks, and the webview readiness wait must run only on cold start")
+# The plugin syncs run concurrently, so the shared marketplace.json is staged
+# exactly once beforehand instead of racing rm+cp per sync, and every sync is
+# awaited before cold-start hooks so the app never sees a partial cache.
+if source.count('rm -f "$marketplace_plugins_dir/marketplace.json"') != 1:
+    raise SystemExit("bundled marketplace metadata must be staged exactly once, not per plugin sync")
+for sync_pid_var in ("SYNC_BROWSER_USE_PID", "SYNC_CHROME_PID", "SYNC_COMPUTER_USE_PID", "SYNC_READ_ALOUD_PID", "SYNC_EXTRA_PID"):
+    if 'wait "$' + sync_pid_var + '"' not in runtime_body:
+        raise SystemExit(f"cold start must await concurrent plugin sync {sync_pid_var}")
+    if runtime_body.index('wait "$' + sync_pid_var + '"') > runtime_body.index("run_cold_start_hooks"):
+        raise SystemExit(f"plugin sync {sync_pid_var} must be awaited before cold-start hooks run")
 for marker in (
     "initial_launch_state_refresh_start",
     "initial_launch_state_refreshed",
     "feature_prelaunch_start",
     "packaged_prelaunch_start",
+    "bundled_marketplace_metadata_staged",
     "browser_use_plugin_cache_synced",
     "chrome_plugin_cache_synced",
     "computer_use_plugin_cache_synced",
@@ -3802,13 +3813,37 @@ if 'STARTED_WEBVIEW_PID="$pid"' not in adopt_body:
 if "running_app_is_active" not in adopt_body:
     raise SystemExit("adopt_existing_webview_server must detect live-app reuse before cleanup")
 if "if adopt_existing_webview_server; then" not in ensure_body:
-    raise SystemExit("ensure_webview_server must split adoption from origin verification")
+    raise SystemExit("start_webview_server must split adoption from origin verification")
 if "stop_stale_webview_server" not in ensure_body:
-    raise SystemExit("ensure_webview_server must clear stale deleted webview servers before treating the port as foreign")
+    raise SystemExit("start_webview_server must clear stale deleted webview servers before treating the port as foreign")
 if ensure_body.find("stop_stale_webview_server") > ensure_body.find("is already serving Codex content"):
-    raise SystemExit("ensure_webview_server must try stale-server cleanup before foreign reachable-port failure")
+    raise SystemExit("start_webview_server must try stale-server cleanup before foreign reachable-port failure")
 if "Keeping the live app untouched" not in ensure_body:
-    raise SystemExit("ensure_webview_server must not stop a live app server when validation fails")
+    raise SystemExit("start_webview_server must not stop a live app server when validation fails")
+
+# Cold-start overlap: the webview server is spawned before the plugin cache
+# syncs and only awaited (readiness + origin verification) after them, so the
+# Python server boots while the launcher does unrelated work. Electron must
+# still never launch before the origin is verified.
+if "ensure_webview_server" in source:
+    raise SystemExit("ensure_webview_server was split into start_webview_server + await_webview_server_ready")
+if "WEBVIEW_STARTUP_PENDING" not in source:
+    raise SystemExit("start_webview_server must track pending startup for await_webview_server_ready")
+cold_flow = source.split("elif needs_cold_start; then", 1)[1]
+if "\n    start_webview_server\n" not in cold_flow:
+    raise SystemExit("cold start must spawn the webview server before the cache syncs")
+overlap_start = cold_flow.index("\n    start_webview_server\n")
+overlap_sync = cold_flow.index('log_phase "cold_start_cache_sync_start"')
+overlap_last_sync = cold_flow.index("sync_extra_bundled_plugin_cache")
+overlap_await = cold_flow.index("\n    await_webview_server_ready\n")
+overlap_lock = cold_flow.index("acquire_launcher_lock")
+if not (overlap_start < overlap_sync < overlap_last_sync < overlap_await < overlap_lock):
+    raise SystemExit("webview readiness wait must overlap the plugin cache syncs and finish before the launcher lock")
+await_body = source.split("await_webview_server_ready() {", 1)[1].split("clear_stale_pid_file() {", 1)[0]
+if "wait_for_webview_server" not in await_body or "verify_webview_origin" not in await_body:
+    raise SystemExit("await_webview_server_ready must keep readiness and origin verification before Electron")
+if 'log_phase "webview_ready"' not in await_body:
+    raise SystemExit("await_webview_server_ready must keep the webview_ready phase marker")
 if 'if [ -n "${RUNNING_APP_PID:-}" ] && running_app_is_active; then' not in reconcile_body:
     raise SystemExit("reconcile_runtime_state must preserve runtime markers when a live app still exists")
 if 'discover_running_app_pid' in reconcile_body:


### PR DESCRIPTION
## What changed

- `ensure_webview_server` is split into `start_webview_server` (spawn) and
  `await_webview_server_ready` (readiness + origin verification). The Python webview
  server now boots while the launcher does CLI lookup and plugin cache syncs; the wait
  runs after them — still strictly before Electron, so the verified-origin invariant is
  unchanged, and PR_SET_PDEATHSIG ties the server to the launcher on early-exit paths.
- The five bundled plugin cache syncs run concurrently and are each awaited before
  cold-start hooks dispatch, keeping every existing phase marker. The shared bundled
  marketplace metadata they previously each rewrote (identical rm+cp of the same
  marketplace.json, five times) is staged exactly once beforehand
  (`stage_bundled_marketplace_metadata`) — a DRY cleanup that is also what makes the
  concurrency safe; the syncs otherwise touch only disjoint per-plugin cache dirs.

## Why

Cold starts serialized independent work before Electron could spawn. Measured on a
warm-cache cold start: sync block ~285 ms → ~110 ms, webview wait ~150 ms → ~35 ms,
Electron spawn ~330 ms earlier, window mapped at ~2.6 s instead of ~3.1 s.

## Source-of-truth files edited

- `launcher/start.sh.template`, `tests/scripts_smoke.sh`
- `CHANGELOG.md`, `docs/launcher-performance.md` (startup-ordering decision record updated)

## How it was tested

- TDD: structural checks written first and confirmed failing — spawn-before-syncs /
  await-after-syncs ordering, single marketplace staging site, per-sync waits before
  cold-start hooks, preserved phase markers, cold-start-only scoping.
- Full `bash tests/scripts_smoke.sh` and `bash tests/webview_probe_equivalence.sh` pass;
  `bash -n` on the template.
- Live cold start against the regenerated launcher verified the phase timeline,
  `marketplace.json` staging, and all plugin cache symlinks.
- `cargo check`/`cargo test` and the package builds were not run: no Rust or
  package-payload changes (launcher template ships identically to all formats).

## Known risks / follow-ups

- Sync log lines can now interleave in the launcher log (single-line O_APPEND writes,
  so no corruption). Per-sync phase timestamps reflect completion order under
  concurrency. Launching Electron in parallel remains rejected — the renderer needs a
  verified origin (documented in `docs/launcher-performance.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)