### PR TITLE
Restore Linux desktop settings section metadata

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4562,6 +4562,44 @@ test("adds Linux desktop settings when the lazy route map is hoisted into a sepa
   }
 });
 
+test("composes Linux desktop section metadata and route patches in the same asset", () => {
+  const routeChunkName = "app-initial~app-main~automations-page-A.js";
+  const { extractedDir, assetsDir } = createSplitRouteNativeKeyboardShortcutsSettingsFixture({
+    routeChunkName,
+  });
+  const routeChunkPath = path.join(assetsDir, routeChunkName);
+  try {
+    fs.writeFileSync(
+      routeChunkPath,
+      [
+        fs.readFileSync(routeChunkPath, "utf8"),
+        "var Bj=`general-settings.import.profile.keyboard-shortcuts.codex-micro.appshots.appearance.pets.agent.git-settings.data-controls.cloud-settings.cloud-environments.code-review.personalization.usage.browser-use.computer-use.local-environments.worktrees.environments.mcp-settings.hooks-settings.connections.plugins-settings.skills-settings`.split(`.`);",
+        "var Uj=[{slug:`general-settings`},{slug:`import`},{slug:`profile`},{slug:`appearance`},{slug:`pets`},{slug:`appshots`},{slug:`git-settings`},{slug:`connections`},{slug:`cloud-settings`},{slug:`cloud-environments`},{slug:`code-review`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`keyboard-shortcuts`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`},{slug:`hooks-settings`},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}];",
+      ].join(""),
+      "utf8",
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.deepEqual(warnings, []);
+
+    const routeChunkSource = fs.readFileSync(routeChunkPath, "utf8");
+    assert.match(
+      routeChunkSource,
+      /"linux-desktop":\(0,Ya\.lazy\)\(\(\)=>Pr\(\(\)=>import\(`\.\/linux-desktop-settings-linux\.js`\),\[\],import\.meta\.url\)\),"general-settings":/,
+    );
+    assert.match(routeChunkSource, /Bj=`general-settings\.linux-desktop\.import\.profile\.keyboard-shortcuts/);
+    assert.match(routeChunkSource, /Uj=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`import`\}/);
+
+    const secondResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(secondResult.matched, true);
+    assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
 test("finds Linux desktop settings route map in hashed settings-page chunks", () => {
   const routeChunkName = "app-initial~settings-page-A.js";
   const { extractedDir, assetsDir } = createSplitRouteNativeKeyboardShortcutsSettingsFixture({
@@ -4596,6 +4634,18 @@ test("adds Linux desktop section to current native Keyboard Shortcuts sections b
 
   assert.match(patched, /e=\[`general-settings`,`linux-desktop`,`profile`,`keyboard-shortcuts`/);
   assert.match(patched, /r=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`profile`\}/);
+});
+
+test("adds Linux desktop section to split current section metadata bundle", () => {
+  const source = [
+    "var Bj=`general-settings.import.profile.keyboard-shortcuts.codex-micro.appshots.appearance.pets.agent.git-settings.data-controls.cloud-settings.cloud-environments.code-review.personalization.usage.browser-use.computer-use.local-environments.worktrees.environments.mcp-settings.hooks-settings.connections.plugins-settings.skills-settings`.split(`.`);",
+    "var Uj=[{slug:`general-settings`},{slug:`import`},{slug:`profile`},{slug:`appearance`},{slug:`pets`},{slug:`appshots`},{slug:`git-settings`},{slug:`connections`},{slug:`cloud-settings`},{slug:`cloud-environments`},{slug:`code-review`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`personalization`},{slug:`keyboard-shortcuts`},{slug:`usage`},{slug:`browser-use`},{slug:`computer-use`},{slug:`mcp-settings`},{slug:`hooks-settings`},{slug:`plugins-settings`},{slug:`skills-settings`},{slug:`data-controls`}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxDesktopSettingsSectionsPatch, source);
+
+  assert.match(patched, /Bj=`general-settings\.linux-desktop\.import\.profile\.keyboard-shortcuts/);
+  assert.match(patched, /Uj=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`import`\}/);
 });
 
 test("adds the Linux desktop section title when the JSX message component identifier drifts", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4648,6 +4648,20 @@ test("adds Linux desktop section to split current section metadata bundle", () =
   assert.match(patched, /Uj=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`import`\}/);
 });
 
+test("adds Linux desktop section to duplicate section metadata shapes in one asset", () => {
+  const source = [
+    "var e=[`general-settings`,`profile`,`keyboard-shortcuts`,`account`],r=[`general-settings`,`import`,`keyboard-shortcuts`,`usage`];",
+    "var Bj=`general-settings.profile.keyboard-shortcuts`.split(`.`),Cj=`general-settings.import.keyboard-shortcuts`.split(`.`);",
+    "var Uj=[{slug:`general-settings`},{slug:`profile`},{slug:`keyboard-shortcuts`}],Vj=[{slug:`general-settings`},{slug:`appearance`},{slug:`keyboard-shortcuts`}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxDesktopSettingsSectionsPatch, source);
+
+  assert.equal([...patched.matchAll(/=\[`general-settings`,`linux-desktop`,/g)].length, 2);
+  assert.equal([...patched.matchAll(/`general-settings\.linux-desktop\.[^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\)/g)].length, 2);
+  assert.equal([...patched.matchAll(/=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},/g)].length, 2);
+});
+
 test("adds the Linux desktop section title when the JSX message component identifier drifts", () => {
   const patched = applyLinuxDesktopSettingsSharedPatch(
     settingsSharedBundleWithDriftingJsxAliasFixture(),

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -577,6 +577,7 @@ function collectOptionalAssetPatches(extractedDir, filenamePattern, patchFn) {
         filePath,
         currentSource,
         patchedSource: patchFn(currentSource),
+        patchFn,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -610,6 +611,7 @@ function collectOptionalMatchingAssetPatches(extractedDir, predicate, patchFn) {
         filePath,
         currentSource,
         patchedSource: patchFn(currentSource),
+        patchFn,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -651,7 +653,21 @@ function collectLinuxDesktopRouteAndNavigationPatches(extractedDir) {
       patchedSource = applyLinuxDesktopSettingsNavigationPatch(patchedSource);
     }
     if (patchedSource !== currentSource) {
-      patches.push({ filePath, currentSource, patchedSource });
+      patches.push({
+        filePath,
+        currentSource,
+        patchedSource,
+        patchFn(source) {
+          let nextSource = source;
+          if (isSettingsRouteBundleSource(nextSource)) {
+            nextSource = applyLinuxDesktopSettingsRoutePatch(nextSource);
+          }
+          if (isSettingsNavigationBundleSource(nextSource)) {
+            nextSource = applyLinuxDesktopSettingsNavigationPatch(nextSource);
+          }
+          return nextSource;
+        },
+      });
     }
   }
 
@@ -697,6 +713,34 @@ function hasNativeKeyboardShortcutsSettings(extractedDir) {
   return true;
 }
 
+function applyCollectedAssetPatchWrites(patches) {
+  const firstSourcesByPath = new Map();
+  const latestSourcesByPath = new Map();
+  let changed = 0;
+
+  for (const patch of patches) {
+    if (!firstSourcesByPath.has(patch.filePath)) {
+      firstSourcesByPath.set(patch.filePath, patch.currentSource);
+    }
+    const currentSource = latestSourcesByPath.get(patch.filePath) ?? patch.currentSource;
+    const patchedSource = currentSource === patch.currentSource || typeof patch.patchFn !== "function"
+      ? patch.patchedSource
+      : patch.patchFn(currentSource);
+    if (patchedSource !== currentSource) {
+      changed += 1;
+    }
+    latestSourcesByPath.set(patch.filePath, patchedSource);
+  }
+
+  for (const [filePath, patchedSource] of latestSourcesByPath) {
+    if (patchedSource !== firstSourcesByPath.get(filePath)) {
+      fs.writeFileSync(filePath, patchedSource, "utf8");
+    }
+  }
+
+  return changed;
+}
+
 function patchKeybindsSettingsAssets(extractedDir) {
   try {
     if (!hasNativeKeyboardShortcutsSettings(extractedDir)) {
@@ -731,12 +775,7 @@ function patchKeybindsSettingsAssets(extractedDir) {
     }
     fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
     let changed = generatedWrites.length + (previousSettingsSource !== settingsAsset.source ? 1 : 0);
-    for (const patch of patches) {
-      if (patch.patchedSource !== patch.currentSource) {
-        fs.writeFileSync(patch.filePath, patch.patchedSource, "utf8");
-        changed += 1;
-      }
-    }
+    changed += applyCollectedAssetPatchWrites(patches);
     return {
       matched: true,
       changed,
@@ -777,30 +816,36 @@ function applyKeybindsSettingsSectionsPatch(currentSource) {
 
 function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   let patchedSource = currentSource;
+  const arrayOrderPattern = /[A-Za-z_$][\w$]*=\[`general-settings`,/;
+  const patchedArrayOrderPattern = /=\[`general-settings`,`linux-desktop`/;
+  const splitOrderPattern = /`general-settings\.[^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\)/;
+  const patchedSplitOrderPattern = /`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/;
+  const objectSlugListPattern = /[A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},/;
+  const patchedObjectSlugListPattern = /[A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},\{slug:`linux-desktop`\},/;
 
   if (
-    patchedSource.includes("slug:`linux-desktop`") &&
-    (/=\[`general-settings`,`linux-desktop`/.test(patchedSource)
-      || /`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/.test(patchedSource))
+    (!arrayOrderPattern.test(currentSource) || patchedArrayOrderPattern.test(patchedSource)) &&
+    (!splitOrderPattern.test(currentSource) || patchedSplitOrderPattern.test(patchedSource)) &&
+    (!objectSlugListPattern.test(currentSource) || patchedObjectSlugListPattern.test(patchedSource))
   ) {
     return patchedSource;
   }
 
-  if (!/=\[`general-settings`,`linux-desktop`/.test(patchedSource)) {
-    const orderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
-    if (orderPattern.test(patchedSource)) {
-      patchedSource = patchedSource.replace(orderPattern, "$1`linux-desktop`,");
+  if (!patchedArrayOrderPattern.test(patchedSource)) {
+    const arrayInsertPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
+    if (arrayInsertPattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(arrayInsertPattern, "$1`linux-desktop`,");
     }
   }
 
-  if (!/`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/.test(patchedSource)) {
-    const splitOrderPattern = /(`general-settings\.)(?!linux-desktop\.)([^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\))/;
-    if (splitOrderPattern.test(patchedSource)) {
-      patchedSource = patchedSource.replace(splitOrderPattern, "$1linux-desktop.$2");
+  if (!patchedSplitOrderPattern.test(patchedSource)) {
+    const splitInsertPattern = /(`general-settings\.)(?!linux-desktop\.)([^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\))/;
+    if (splitInsertPattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(splitInsertPattern, "$1linux-desktop.$2");
     }
   }
 
-  if (!patchedSource.includes("slug:`linux-desktop`")) {
+  if (!patchedObjectSlugListPattern.test(patchedSource)) {
     const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
     const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`linux-desktop`},";
     if (patchedSource.includes(sectionsNeedle)) {
@@ -824,8 +869,9 @@ function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   }
 
   if (
-    patchedSource.includes("slug:`linux-desktop`") &&
-    (/=\[`general-settings`,`linux-desktop`/.test(patchedSource) || !/[A-Za-z_$][\w$]*=\[`general-settings`,/.test(currentSource))
+    (!arrayOrderPattern.test(currentSource) || patchedArrayOrderPattern.test(patchedSource)) &&
+    (!splitOrderPattern.test(currentSource) || patchedSplitOrderPattern.test(patchedSource)) &&
+    (!objectSlugListPattern.test(currentSource) || patchedObjectSlugListPattern.test(patchedSource))
   ) {
     return patchedSource;
   }

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -816,63 +816,32 @@ function applyKeybindsSettingsSectionsPatch(currentSource) {
 
 function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   let patchedSource = currentSource;
-  const arrayOrderPattern = /[A-Za-z_$][\w$]*=\[`general-settings`,/;
-  const patchedArrayOrderPattern = /=\[`general-settings`,`linux-desktop`/;
-  const splitOrderPattern = /`general-settings\.[^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\)/;
-  const patchedSplitOrderPattern = /`general-settings\.linux-desktop\.[^`]*`\.split\(`\.`\)/;
-  const objectSlugListPattern = /[A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},/;
-  const patchedObjectSlugListPattern = /[A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},\{slug:`linux-desktop`\},/;
+  const unpatchedArrayOrderPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`,)/g;
+  const unpatchedSplitOrderPattern = /(`general-settings\.)(?!linux-desktop\.)([^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\))/g;
+  const unpatchedObjectSlugListPattern = /([A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},)(?!\{slug:`linux-desktop`\},)/g;
+  const hasUnpatchedEligibleSectionShape = (source) =>
+    /[A-Za-z_$][\w$]*=\[`general-settings`,(?!`linux-desktop`,)/.test(source) ||
+    /`general-settings\.(?!linux-desktop\.)[^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\)/.test(source) ||
+    /[A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},(?!\{slug:`linux-desktop`\},)/.test(source);
 
-  if (
-    (!arrayOrderPattern.test(currentSource) || patchedArrayOrderPattern.test(patchedSource)) &&
-    (!splitOrderPattern.test(currentSource) || patchedSplitOrderPattern.test(patchedSource)) &&
-    (!objectSlugListPattern.test(currentSource) || patchedObjectSlugListPattern.test(patchedSource))
-  ) {
+  if (!hasUnpatchedEligibleSectionShape(patchedSource)) {
     return patchedSource;
   }
 
-  if (!patchedArrayOrderPattern.test(patchedSource)) {
-    const arrayInsertPattern = /([A-Za-z_$][\w$]*=\[`general-settings`,)(?!`linux-desktop`)/;
-    if (arrayInsertPattern.test(patchedSource)) {
-      patchedSource = patchedSource.replace(arrayInsertPattern, "$1`linux-desktop`,");
-    }
-  }
+  patchedSource = patchedSource.replace(
+    unpatchedArrayOrderPattern,
+    "$1`linux-desktop`,",
+  );
+  patchedSource = patchedSource.replace(
+    unpatchedSplitOrderPattern,
+    "$1linux-desktop.$2",
+  );
+  patchedSource = patchedSource.replace(
+    unpatchedObjectSlugListPattern,
+    "$1{slug:`linux-desktop`},",
+  );
 
-  if (!patchedSplitOrderPattern.test(patchedSource)) {
-    const splitInsertPattern = /(`general-settings\.)(?!linux-desktop\.)([^`]*keyboard-shortcuts[^`]*`\.split\(`\.`\))/;
-    if (splitInsertPattern.test(patchedSource)) {
-      patchedSource = patchedSource.replace(splitInsertPattern, "$1linux-desktop.$2");
-    }
-  }
-
-  if (!patchedObjectSlugListPattern.test(patchedSource)) {
-    const sectionsNeedle = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},";
-    const sectionsPatch = "var e=`general-settings`,t=`mcp-settings`,n=[{slug:e},{slug:`linux-desktop`},";
-    if (patchedSource.includes(sectionsNeedle)) {
-      patchedSource = patchedSource.replace(sectionsNeedle, sectionsPatch);
-    } else {
-      const currentNeedle = "n=[{slug:e},{slug:`appearance`}";
-      if (patchedSource.includes(currentNeedle)) {
-        patchedSource = patchedSource.replace(currentNeedle, "n=[{slug:e},{slug:`linux-desktop`},{slug:`appearance`}");
-      } else {
-        const literalNeedle = "n=[{slug:`general-settings`},{slug:`appearance`}";
-        if (patchedSource.includes(literalNeedle)) {
-          patchedSource = patchedSource.replace(literalNeedle, "n=[{slug:`general-settings`},{slug:`linux-desktop`},{slug:`appearance`}");
-        } else {
-          const generalFirstPattern = /([A-Za-z_$][\w$]*=\[\{slug:(?:`general-settings`|[A-Za-z_$][\w$]*)\},)/;
-          if (generalFirstPattern.test(patchedSource)) {
-            patchedSource = patchedSource.replace(generalFirstPattern, "$1{slug:`linux-desktop`},");
-          }
-        }
-      }
-    }
-  }
-
-  if (
-    (!arrayOrderPattern.test(currentSource) || patchedArrayOrderPattern.test(patchedSource)) &&
-    (!splitOrderPattern.test(currentSource) || patchedSplitOrderPattern.test(patchedSource)) &&
-    (!objectSlugListPattern.test(currentSource) || patchedObjectSlugListPattern.test(patchedSource))
-  ) {
+  if (!hasUnpatchedEligibleSectionShape(patchedSource)) {
     return patchedSource;
   }
 


### PR DESCRIPTION
## Summary
- compose keybinds/Linux desktop webview asset patches per file so route/navigation writes do not overwrite section metadata writes
- tighten Linux desktop section metadata idempotence so split section-order and slug-list shapes are both verified
- add regression coverage for the current `app-initial~app-main~automations-page` bundle carrying both route and section metadata

## Validation
- `PATH=/run/current-system/sw/bin:$PATH node --test scripts/patch-linux-window-ui.test.js --test-name-pattern 'Linux desktop|Keyboard Shortcuts|settings route|section'`
- `PATH=/run/current-system/sw/bin:$PATH node --test scripts/patch-linux-window-ui.test.js`
- `PATH=/run/current-system/sw/bin:$PATH nix build .#codex-desktop-computer-use-ui-remote-mobile-control --no-link --print-out-paths`
- inspected generated package `/nix/store/97xy72qqhz4xjhiyljwzxlkx2c387s10-codex-desktop-computer-use-ui-remote-mobile-control-26.623.101652`: webview assets include `slug:\`linux-desktop\`` in `app-initial~app-main~automations-page-Bl6HoLGr.js` and still reference `linux-desktop-settings-linux.js`
