### PR TITLE
Fix Browser Use trusted hash patch drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -6857,6 +6857,29 @@ test("auto-approves the latest Browser Use node_repl runtime config builder", ()
   );
 });
 
+test("auto-approves the current vo Browser Use node_repl runtime config builder", () => {
+  const source =
+    "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`],w=!1,t={vo:e=>e,Gr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},p=null,b=null,f=[],g=null,v=!1;function build(){return t.vo({codexCliPath:c.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:w?t.Gr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,traceMeta:v,trustedBrowserClientSha256s:d,shouldUseWslPaths:w})}";
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(
+    patched,
+    /t\.vo\(\{codexCliPath:c\.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:w\?t\.Gr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
+  );
+  assert.match(
+    patched,
+    /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:w/,
+  );
+  assert.equal(
+    (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
+    1,
+  );
+});
+
 test("auto-approves and trusts the current Browser Use node_repl runtime config builder", () => {
   const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-current-browser-client-hash-"));
   try {

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -11,7 +11,7 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   const approvalPatch =
     "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
   const needle = "startup_timeout_sec:120,env:{";
-  const runtimeFactoryMethods = String.raw`Dn|Pn|Fa|La|Ha|\$a`;
+  const runtimeFactoryMethods = String.raw`Dn|Pn|Fa|La|Ha|vo|\$a`;
   let patchedSource = currentSource;
   let patchedTrustedHashes = false;
   if (patchedSource.includes(needle)) {


### PR DESCRIPTION
## Summary

- add the current `vo` Browser Use runtime factory name to the node_repl approval/trusted-hash patch allowlist
- add a regression fixture for the `t.vo({ ... trustedBrowserClientSha256s: d ... })` runtime config shape

## Why

The 26.623 bundle can emit Browser Use node_repl runtime config through `t.vo(...)`. The Linux patch already handles earlier minified factory names, but this drift means it can miss both the JS auto-approval insertion and the Linux trusted browser-client hash wrapper. When that happens, rebuilt Linux bundles can keep stale trusted client hashes and reject the bundled Browser/Chrome client transport.

## Validation

- `node - <<'NODE' ... NODE` focused assertion against `applyBrowserUseNodeReplApprovalPatch` for the `vo` fixture: passed
- `node --test scripts/patch-linux-window-ui.test.js`: Browser Use node_repl fixtures passed, including the new `vo` fixture; the full file still exits non-zero on this Bluefin host because the unrelated existing package-profile test `package profile distinguishes Fedora package managers by major version` sees `rpm-ostree` where it expects `dnf`

## Scope

This branch is based on `upstream/main` and contains only the two Browser Use patch/test changes.
