### PR TITLE
Add DMG integrity guard for Linux settings patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ build-dev-app:
 	CODEX_INSTALL_DIR="$(DEV_APP_DIR)" \
 		./install.sh "$(DMG)"
 	@mkdir -p "$(CURDIR)/bin"
-	@ln -sfn "$(DEV_APP_DIR)/start.sh" "$(DEV_APP_BIN)"
+	@ln -sfn "$$(realpath --relative-to="$$(dirname "$(DEV_APP_BIN)")" "$(DEV_APP_DIR)/start.sh")" "$(DEV_APP_BIN)"
 	@echo "[make] Side-by-side launcher: $(DEV_APP_BIN)"
 
 run-dev-app:

--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -1892,43 +1892,6 @@ function resolveAgentWorkspaceSettingsAsset(extractedDir) {
   };
 }
 
-function collectOptionalMatchingAssetPatches(extractedDir, predicate, patchFn) {
-  const assetsDir = webviewAssetsDir(extractedDir);
-  if (!fs.existsSync(assetsDir)) {
-    return [];
-  }
-
-  const candidates = fs
-    .readdirSync(assetsDir)
-    .filter((name) => name.endsWith(".js"))
-    .sort();
-  const patches = [];
-
-  for (const candidate of candidates) {
-    const filePath = path.join(assetsDir, candidate);
-    const currentSource = fs.readFileSync(filePath, "utf8");
-    if (!predicate(currentSource)) {
-      continue;
-    }
-    try {
-      patches.push({
-        filePath,
-        currentSource,
-        patchedSource: patchFn(currentSource),
-      });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.warn(`WARN: Optional Agent Workspaces settings patch skipped for ${candidate}: ${message}`);
-    }
-  }
-
-  return patches;
-}
-
-function isAgentWorkspaceSettingsSectionsMetadataBundleSource(currentSource) {
-  return currentSource.includes("slug:`local-environments`") && currentSource.includes("slug:`worktrees`");
-}
-
 function isAgentWorkspaceSettingsSharedMetadataBundleSource(currentSource) {
   return (
     currentSource.includes('"local-environments":{id:`settings.nav.local-environments`') &&
@@ -1952,30 +1915,6 @@ function isAgentWorkspaceSettingsNavigationBundleSource(currentSource) {
   );
 }
 
-function applyAgentWorkspaceSettingsSectionsPatch(currentSource) {
-  if (currentSource.includes(`slug:\`${SETTINGS_SLUG}\``)) {
-    return currentSource;
-  }
-
-  const preferredNeedle = "{slug:`local-environments`},{slug:`worktrees`}";
-  if (currentSource.includes(preferredNeedle)) {
-    return currentSource.replace(
-      preferredNeedle,
-      `{slug:\`local-environments\`},{slug:\`${SETTINGS_SLUG}\`},{slug:\`worktrees\`}`,
-    );
-  }
-
-  const fallbackNeedle = "n=[{slug:`general-settings`},";
-  if (currentSource.includes(fallbackNeedle)) {
-    return currentSource.replace(
-      fallbackNeedle,
-      `n=[{slug:\`general-settings\`},{slug:\`${SETTINGS_SLUG}\`},`,
-    );
-  }
-
-  throw new Error("could not add agent workspace settings section");
-}
-
 function addAgentWorkspaceToSettingsSlugLists(currentSource) {
   return currentSource
     .replaceAll(
@@ -1990,20 +1929,10 @@ function addAgentWorkspaceToSettingsSlugLists(currentSource) {
 
 function addAgentWorkspaceVisibilityCases(currentSource) {
   let patchedSource = currentSource;
-  const replacements = [
-    [
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return",
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:case`data-controls`:case`environments`:return",
-    ],
-    [
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return",
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
-    ],
-    [
-      "case`worktrees`:case`local-environments`:case`environments`:return",
-      "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
-    ],
-  ];
+  const replacements = [[
+    "case`worktrees`:case`local-environments`:case`environments`:return",
+    "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
+  ]];
 
   for (const [needle, replacement] of replacements) {
     if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
@@ -2016,16 +1945,10 @@ function addAgentWorkspaceVisibilityCases(currentSource) {
 
 function addAgentWorkspaceLoadingCases(currentSource) {
   let patchedSource = currentSource;
-  const replacements = [
-    [
-      "case`local-environments`:case`worktrees`:case`environments`:",
-      "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
-    ],
-    [
-      "case`worktrees`:case`local-environments`:case`environments`:",
-      "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:",
-    ],
-  ];
+  const replacements = [[
+    "case`local-environments`:case`worktrees`:case`environments`:",
+    "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
+  ]];
 
   for (const [needle, replacement] of replacements) {
     if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
@@ -2034,13 +1957,6 @@ function addAgentWorkspaceLoadingCases(currentSource) {
   }
 
   return patchedSource;
-}
-
-function removeAgentWorkspaceSettingsIconDeclaration(currentSource) {
-  return currentSource.replace(
-    /var codexLinuxAgentWorkspaceSettingsIcon=[\s\S]*?\]\}\);(?=[A-Za-z_$][\w$]*=\{)/,
-    "",
-  );
 }
 
 function applyAgentWorkspaceSettingsSharedPatch(currentSource) {
@@ -2090,29 +2006,6 @@ function applyAgentWorkspaceSettingsIndexPatch(currentSource) {
     );
   }
 
-  const iconPattern = /([,{])"general-settings":([A-Za-z_$][\w$]*),/;
-  if (
-    !new RegExp(`[,{]"${SETTINGS_SLUG}":[A-Za-z_$][\\w$]*,"general-settings":`).test(patchedSource) &&
-    iconPattern.test(patchedSource)
-  ) {
-    patchedSource = patchedSource.replace(
-      iconPattern,
-      (_match, prefix, icon) => `${prefix}"${SETTINGS_SLUG}":${icon},"general-settings":${icon},`,
-    );
-  }
-
-  const hasLegacyVisibilityGate =
-    patchedSource.includes("case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:") ||
-    patchedSource.includes("case`local-environments`:case`worktrees`:case`environments`:") ||
-    patchedSource.includes("case`worktrees`:case`local-environments`:case`environments`:");
-  patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
-  patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
-  patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
-
-  if (hasLegacyVisibilityGate && !patchedSource.includes(`case\`${SETTINGS_SLUG}\``)) {
-    throw new Error("could not add agent workspace settings visibility");
-  }
-
   return patchedSource;
 }
 
@@ -2144,7 +2037,6 @@ function applyAgentWorkspaceSettingsPagePatch(currentSource) {
   patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
   patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
   patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
-  patchedSource = removeAgentWorkspaceSettingsIconDeclaration(patchedSource);
 
   if (!patchedSource.includes(`\`${SETTINGS_SLUG}\``)) {
     throw new Error("could not add agent workspace settings navigation");
@@ -2162,10 +2054,11 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   const candidates = fs
     .readdirSync(assetsDir)
     .filter((name) =>
-      /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/.test(name) ||
+      /^app-initial~app-main~.*\.js$/.test(name) ||
       /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name)
     )
     .sort();
+  let metadataMatched = false;
   let routeMatched = false;
   let navigationMatched = false;
   const patches = [];
@@ -2174,6 +2067,10 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
     const filePath = path.join(assetsDir, candidate);
     const currentSource = fs.readFileSync(filePath, "utf8");
     let patchedSource = currentSource;
+    if (isAgentWorkspaceSettingsSharedMetadataBundleSource(currentSource)) {
+      metadataMatched = true;
+      patchedSource = applyAgentWorkspaceSettingsSharedPatch(patchedSource);
+    }
     if (isAgentWorkspaceSettingsRouteBundleSource(currentSource)) {
       routeMatched = true;
       patchedSource = applyAgentWorkspaceSettingsIndexPatch(patchedSource);
@@ -2187,6 +2084,9 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
     }
   }
 
+  if (!metadataMatched) {
+    throw new Error("could not find webview settings metadata bundle");
+  }
   if (!routeMatched) {
     throw new Error("could not find webview settings route bundle");
   }
@@ -2203,19 +2103,7 @@ function patchAgentWorkspaceSettingsAssets(extractedDir) {
     const previousSettingsSource = fs.existsSync(settingsAsset.filePath)
       ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
-    const patches = [
-      ...collectOptionalMatchingAssetPatches(
-        extractedDir,
-        isAgentWorkspaceSettingsSectionsMetadataBundleSource,
-        applyAgentWorkspaceSettingsSectionsPatch,
-      ),
-      ...collectOptionalMatchingAssetPatches(
-        extractedDir,
-        isAgentWorkspaceSettingsSharedMetadataBundleSource,
-        applyAgentWorkspaceSettingsSharedPatch,
-      ),
-      ...collectAgentWorkspaceRouteAndNavigationPatches(extractedDir),
-    ];
+    const patches = collectAgentWorkspaceRouteAndNavigationPatches(extractedDir);
 
     fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");
     let changed = previousSettingsSource !== settingsAsset.source ? 1 : 0;
@@ -2266,7 +2154,6 @@ module.exports = {
   applyAgentWorkspaceMainBridgePatch,
   applyAgentWorkspaceSettingsIndexPatch,
   applyAgentWorkspaceSettingsPagePatch,
-  applyAgentWorkspaceSettingsSectionsPatch,
   applyAgentWorkspaceSettingsSharedPatch,
   buildAgentWorkspaceSettingsSource,
   patchAgentWorkspaceSettingsAssets,

--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -2036,6 +2036,13 @@ function addAgentWorkspaceLoadingCases(currentSource) {
   return patchedSource;
 }
 
+function removeAgentWorkspaceSettingsIconDeclaration(currentSource) {
+  return currentSource.replace(
+    /var codexLinuxAgentWorkspaceSettingsIcon=[\s\S]*?\]\}\);(?=[A-Za-z_$][\w$]*=\{)/,
+    "",
+  );
+}
+
 function applyAgentWorkspaceSettingsSharedPatch(currentSource) {
   let patchedSource = currentSource;
   if (!patchedSource.includes(`settings.nav.${SETTINGS_SLUG}`)) {
@@ -2137,6 +2144,7 @@ function applyAgentWorkspaceSettingsPagePatch(currentSource) {
   patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
   patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
   patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
+  patchedSource = removeAgentWorkspaceSettingsIconDeclaration(patchedSource);
 
   if (!patchedSource.includes(`\`${SETTINGS_SLUG}\``)) {
     throw new Error("could not add agent workspace settings navigation");

--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -180,8 +180,6 @@ function buildAgentWorkspaceSettingsSource({
   chunkAsset,
   reactAsset,
   reactExportName = "t",
-  settingsPageAsset,
-  settingsPageExportName = "t",
   codexRequestAsset,
   codexRequestExportName = "n",
   vscodeApiAsset,
@@ -190,10 +188,20 @@ function buildAgentWorkspaceSettingsSource({
   return `import{s as __toESM}from"./${chunkAsset}";
 import{${reactExportName} as __reactFactory}from"./${reactAsset}";
 import{${codexRequestExportName} as __post}from"./${requestAsset}";
-import{${settingsPageExportName} as SettingsPage}from"./${settingsPageAsset}";
 
 var React=__toESM(__reactFactory(),1);
 var h=React.createElement;
+function SettingsPage({title,subtitle,children}){
+  return h("div",{className:"h-full min-h-0 w-full overflow-y-auto"},
+    h("div",{className:"mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-6"},
+      h("div",{className:"flex flex-col gap-1"},
+        h("h2",{className:"text-xl font-semibold text-token-text-primary"},title),
+        subtitle?h("p",{className:"text-sm text-token-text-secondary"},subtitle):null
+      ),
+      children
+    )
+  );
+}
 var COMMAND_KEY=${JSON.stringify(SETTINGS_COMMAND_KEY)};
 var PERMISSIONS_KEY=${JSON.stringify(SETTINGS_PERMISSIONS_KEY)};
 var DEFAULT_COMMAND_LABEL="Auto-discovered agent-workspace-linux";
@@ -1773,32 +1781,104 @@ function webviewAssetsDir(extractedDir) {
   return path.join(extractedDir, "webview", "assets");
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function importBindings(source) {
+  const bindings = new Map();
+  const importPattern = /import\{([^}]+)\}from"\.\/([^"]+)"/g;
+  let match;
+  while ((match = importPattern.exec(source)) != null) {
+    const [, specifiers, assetName] = match;
+    for (const rawSpecifier of specifiers.split(",")) {
+      const specifier = rawSpecifier.trim();
+      if (specifier.length === 0) {
+        continue;
+      }
+      const aliased = specifier.match(/^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/);
+      if (aliased != null) {
+        bindings.set(aliased[2], { assetName, exportName: aliased[1] });
+      } else {
+        bindings.set(specifier, { assetName, exportName: specifier });
+      }
+    }
+  }
+  return bindings;
+}
+
+function inferRuntimeDependenciesFromSettingsSource(source) {
+  const jsxLocal = source.match(/\(0,([A-Za-z_$][\w$]*)\.jsx\)/)?.[1] ?? null;
+  const reactLocal = source.match(/\(0,([A-Za-z_$][\w$]*)\.useState\)/)?.[1] ?? null;
+  if (jsxLocal == null || reactLocal == null) {
+    return null;
+  }
+
+  const jsxFactoryLocal = source.match(
+    new RegExp(`${escapeRegExp(jsxLocal)}=([A-Za-z_$][\\w$]*)\\(\\)`),
+  )?.[1] ?? null;
+  const reactFactoryLocal = source.match(
+    new RegExp(`${escapeRegExp(reactLocal)}=[A-Za-z_$][\\w$]*\\(([A-Za-z_$][\\w$]*)\\(\\),1\\)`),
+  )?.[1] ?? null;
+  if (jsxFactoryLocal == null || reactFactoryLocal == null) {
+    return null;
+  }
+
+  const bindings = importBindings(source);
+  const reactBinding = bindings.get(reactFactoryLocal);
+  if (bindings.get(jsxFactoryLocal) == null || reactBinding == null) {
+    return null;
+  }
+
+  return {
+    reactAsset: reactBinding.assetName,
+    reactExportName: reactBinding.exportName,
+  };
+}
+
+function inferRuntimeDependenciesFromSettingsAssets(assetsDir) {
+  const candidates = fs
+    .readdirSync(assetsDir)
+    .filter((name) => /^settings-page-.*\.js$/.test(name) || /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name))
+    .sort();
+  for (const candidate of candidates) {
+    const dependencies = inferRuntimeDependenciesFromSettingsSource(
+      fs.readFileSync(path.join(assetsDir, candidate), "utf8"),
+    );
+    if (dependencies != null) {
+      return dependencies;
+    }
+  }
+  return null;
+}
+
 function resolveAgentWorkspaceSettingsAsset(extractedDir) {
   const assetsDir = webviewAssetsDir(extractedDir);
   if (!fs.existsSync(assetsDir)) {
     throw new Error(`missing webview assets directory ${assetsDir}`);
   }
 
-  const jsxRuntimeAsset = findRequiredWebviewAsset(
-    assetsDir,
-    /^jsx-runtime-.*\.js$/,
-    "react.transitional.element",
-    "JSX runtime asset",
-  );
-  const jsxRuntimeSource = fs.readFileSync(path.join(assetsDir, jsxRuntimeAsset), "utf8");
-  const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
-  const reactAsset = jsxExportsReactFactory
-    ? jsxRuntimeAsset
-    : findRequiredWebviewAsset(assetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
-  const reactExportName = jsxExportsReactFactory ? "n" : "t";
+  const runtimeDependencies = inferRuntimeDependenciesFromSettingsAssets(assetsDir);
+  let reactAsset;
+  let reactExportName;
+  if (runtimeDependencies != null) {
+    ({ reactAsset, reactExportName } = runtimeDependencies);
+  } else {
+    const jsxRuntimeAsset = findRequiredWebviewAsset(
+      assetsDir,
+      /^jsx-runtime-.*\.js$/,
+      "react.transitional.element",
+      "JSX runtime asset",
+    );
+    const jsxRuntimeSource = fs.readFileSync(path.join(assetsDir, jsxRuntimeAsset), "utf8");
+    const jsxExportsReactFactory = /export\{[^}]*\bn\b/.test(jsxRuntimeSource);
+    reactAsset = jsxExportsReactFactory
+      ? jsxRuntimeAsset
+      : findRequiredWebviewAsset(assetsDir, /^react-.*\.js$/, "react.transitional.element", "React asset");
+    reactExportName = jsxExportsReactFactory ? "n" : "t";
+  }
   const chunkAsset = findImportedAsset(assetsDir, reactAsset, "React shared chunk asset");
   const codexRequestAsset = findCodexRequestWebviewAsset(assetsDir);
-  const settingsPageAsset = findRequiredWebviewAsset(
-    assetsDir,
-    /^settings-content-layout-.*\.js$/,
-    null,
-    "settings content layout asset",
-  );
 
   return {
     filePath: path.join(assetsDir, SETTINGS_ASSET),
@@ -1806,33 +1886,70 @@ function resolveAgentWorkspaceSettingsAsset(extractedDir) {
       chunkAsset,
       reactAsset,
       reactExportName,
-      settingsPageAsset,
-      settingsPageExportName: "t",
       codexRequestAsset: codexRequestAsset.assetName,
       codexRequestExportName: codexRequestAsset.exportName,
     }),
   };
 }
 
-function patchRequiredAssets(extractedDir, filenamePattern, patchFn, description) {
+function collectOptionalMatchingAssetPatches(extractedDir, predicate, patchFn) {
   const assetsDir = webviewAssetsDir(extractedDir);
-  const candidates = fs
-    .readdirSync(assetsDir)
-    .filter((name) => filenamePattern.test(name))
-    .sort();
-  if (candidates.length === 0) {
-    throw new Error(`could not find ${description}`);
+  if (!fs.existsSync(assetsDir)) {
+    return [];
   }
 
-  return candidates.map((candidate) => {
+  const candidates = fs
+    .readdirSync(assetsDir)
+    .filter((name) => name.endsWith(".js"))
+    .sort();
+  const patches = [];
+
+  for (const candidate of candidates) {
     const filePath = path.join(assetsDir, candidate);
     const currentSource = fs.readFileSync(filePath, "utf8");
-    return {
-      filePath,
-      currentSource,
-      patchedSource: patchFn(currentSource),
-    };
-  });
+    if (!predicate(currentSource)) {
+      continue;
+    }
+    try {
+      patches.push({
+        filePath,
+        currentSource,
+        patchedSource: patchFn(currentSource),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`WARN: Optional Agent Workspaces settings patch skipped for ${candidate}: ${message}`);
+    }
+  }
+
+  return patches;
+}
+
+function isAgentWorkspaceSettingsSectionsMetadataBundleSource(currentSource) {
+  return currentSource.includes("slug:`local-environments`") && currentSource.includes("slug:`worktrees`");
+}
+
+function isAgentWorkspaceSettingsSharedMetadataBundleSource(currentSource) {
+  return (
+    currentSource.includes('"local-environments":{id:`settings.nav.local-environments`') &&
+    currentSource.includes("settings.section.worktrees")
+  );
+}
+
+function isAgentWorkspaceSettingsRouteBundleSource(currentSource) {
+  return (
+    currentSource.includes(SETTINGS_ASSET) ||
+    /"general-settings":\(0,[A-Za-z_$][\w$]*\.lazy\)\(\(\)=>[A-Za-z_$][\w$]*\(/.test(currentSource)
+  );
+}
+
+function isAgentWorkspaceSettingsNavigationBundleSource(currentSource) {
+  return (
+    /[A-Za-z_$][\w$]*=\{[^;]*"local-environments":[A-Za-z_$][\w$]*,[^;]*worktrees:/.test(currentSource) &&
+    currentSource.includes("slugs:[`") &&
+    currentSource.includes("`local-environments`") &&
+    currentSource.includes("`worktrees`")
+  );
 }
 
 function applyAgentWorkspaceSettingsSectionsPatch(currentSource) {
@@ -1857,6 +1974,66 @@ function applyAgentWorkspaceSettingsSectionsPatch(currentSource) {
   }
 
   throw new Error("could not add agent workspace settings section");
+}
+
+function addAgentWorkspaceToSettingsSlugLists(currentSource) {
+  return currentSource
+    .replaceAll(
+      "`local-environments`,`worktrees`",
+      "`local-environments`,`agent-workspaces`,`worktrees`",
+    )
+    .replaceAll(
+      "`local-environments`,`environments`,`worktrees`",
+      "`local-environments`,`agent-workspaces`,`environments`,`worktrees`",
+    );
+}
+
+function addAgentWorkspaceVisibilityCases(currentSource) {
+  let patchedSource = currentSource;
+  const replacements = [
+    [
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return",
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:case`data-controls`:case`environments`:return",
+    ],
+    [
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return",
+      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
+    ],
+    [
+      "case`worktrees`:case`local-environments`:case`environments`:return",
+      "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
+    ],
+  ];
+
+  for (const [needle, replacement] of replacements) {
+    if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
+      patchedSource = patchedSource.replace(needle, replacement);
+    }
+  }
+
+  return patchedSource;
+}
+
+function addAgentWorkspaceLoadingCases(currentSource) {
+  let patchedSource = currentSource;
+  const replacements = [
+    [
+      "case`local-environments`:case`worktrees`:case`environments`:",
+      "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
+    ],
+    [
+      "case`worktrees`:case`local-environments`:case`environments`:",
+      "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:",
+    ],
+  ];
+
+  for (const [needle, replacement] of replacements) {
+    if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
+      patchedSource = patchedSource.replace(needle, replacement);
+    }
+  }
+
+  return patchedSource;
 }
 
 function applyAgentWorkspaceSettingsSharedPatch(currentSource) {
@@ -1919,23 +2096,11 @@ function applyAgentWorkspaceSettingsIndexPatch(currentSource) {
 
   const hasLegacyVisibilityGate =
     patchedSource.includes("case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:") ||
-    patchedSource.includes("case`local-environments`:case`worktrees`:case`environments`:");
-  patchedSource = patchedSource.replaceAll(
-    "`local-environments`,`worktrees`",
-    "`local-environments`,`agent-workspaces`,`worktrees`",
-  );
-  if (!patchedSource.includes("case`local-environments`:case`agent-workspaces`:case`data-controls`:case`environments`:return")) {
-    patchedSource = patchedSource.replace(
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:",
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:",
-    );
-  }
-  if (!patchedSource.includes("case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:")) {
-    patchedSource = patchedSource.replace(
-      "case`local-environments`:case`worktrees`:case`environments`:",
-      "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
-    );
-  }
+    patchedSource.includes("case`local-environments`:case`worktrees`:case`environments`:") ||
+    patchedSource.includes("case`worktrees`:case`local-environments`:case`environments`:");
+  patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
+  patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
+  patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
 
   if (hasLegacyVisibilityGate && !patchedSource.includes(`case\`${SETTINGS_SLUG}\``)) {
     throw new Error("could not add agent workspace settings visibility");
@@ -1944,43 +2109,13 @@ function applyAgentWorkspaceSettingsIndexPatch(currentSource) {
   return patchedSource;
 }
 
-function inferSettingsPageJsxAlias(source) {
-  return source.match(/\(0,([A-Za-z_$][\w$]*)\.jsxs\)\(\`svg\`,/)?.[1] ?? "Z";
-}
-
-function agentWorkspaceSettingsNavIconSource(jsxAlias = "Z") {
-  return `codexLinuxAgentWorkspaceSettingsIcon=e=>(0,${jsxAlias}.jsxs)(\`svg\`,{width:16,height:16,viewBox:\`0 0 16 16\`,fill:\`none\`,xmlns:\`http://www.w3.org/2000/svg\`,...e,children:[(0,${jsxAlias}.jsx)(\`rect\`,{x:2.25,y:2.25,width:11.5,height:11.5,rx:2.1,stroke:\`currentColor\`,strokeWidth:1.2,strokeDasharray:\`1.8 1.4\`}),(0,${jsxAlias}.jsx)(\`path\`,{d:\`M6.15 5.55 7.4 9.55M9.85 5.55 8.6 9.55M6.4 5h3.2\`,stroke:\`currentColor\`,strokeWidth:1.1,strokeLinecap:\`round\`,strokeLinejoin:\`round\`}),(0,${jsxAlias}.jsx)(\`circle\`,{cx:5.1,cy:5, r:1.15,stroke:\`currentColor\`,strokeWidth:1.1}),(0,${jsxAlias}.jsx)(\`circle\`,{cx:10.9,cy:5,r:1.15,stroke:\`currentColor\`,strokeWidth:1.1}),(0,${jsxAlias}.jsx)(\`circle\`,{cx:8,cy:11,r:1.15,stroke:\`currentColor\`,strokeWidth:1.1})]})`;
-}
-
-function applyAgentWorkspaceSettingsIconPatch(currentSource) {
-  if (currentSource.includes("codexLinuxAgentWorkspaceSettingsIcon=e=>")) {
-    return currentSource;
-  }
-
-  const iconMapMatch = currentSource.match(
-    /(?:var |let |const |,)[A-Za-z_$][\w$]*=\{[^;\n]*"local-environments":[^;\n]*worktrees:/,
-  );
-  if (iconMapMatch == null) {
-    return currentSource;
-  }
-
-  const iconSource = agentWorkspaceSettingsNavIconSource(inferSettingsPageJsxAlias(currentSource));
-  const index = iconMapMatch.index ?? 0;
-  if (iconMapMatch[0].startsWith(",")) {
-    return `${currentSource.slice(0, index)},${iconSource}${currentSource.slice(index)}`;
-  }
-
-  const keyword = iconMapMatch[0].match(/^(var |let |const )/)?.[1] ?? "var ";
-  return `${currentSource.slice(0, index)}${keyword}${iconSource};${currentSource.slice(index)}`;
-}
-
 function applyAgentWorkspaceSettingsPagePatch(currentSource) {
   let patchedSource = currentSource;
 
-  patchedSource = applyAgentWorkspaceSettingsIconPatch(patchedSource);
-  const agentWorkspaceIcon = patchedSource.includes("codexLinuxAgentWorkspaceSettingsIcon=e=>")
-    ? "codexLinuxAgentWorkspaceSettingsIcon"
-    : patchedSource.match(/"local-environments":([A-Za-z_$][\w$]*)/)?.[1] ?? null;
+  // Reuse an existing icon alias instead of injecting a new minified-scope
+  // symbol. Upstream can wrap the icon map in initializer closures, and a
+  // dangling injected symbol breaks the whole Settings route.
+  const agentWorkspaceIcon = patchedSource.match(/"local-environments":([A-Za-z_$][\w$]*)/)?.[1] ?? null;
 
   if (agentWorkspaceIcon != null) {
     patchedSource = patchedSource.replace(
@@ -1999,24 +2134,9 @@ function applyAgentWorkspaceSettingsPagePatch(currentSource) {
     );
   }
 
-  patchedSource = patchedSource.replaceAll(
-    "`local-environments`,`worktrees`",
-    "`local-environments`,`agent-workspaces`,`worktrees`",
-  );
-
-  if (!patchedSource.includes("case`local-environments`:case`agent-workspaces`:case`environments`:return")) {
-    patchedSource = patchedSource.replace(
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return",
-      "case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
-    );
-  }
-
-  if (!patchedSource.includes("case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:")) {
-    patchedSource = patchedSource.replace(
-      "case`local-environments`:case`worktrees`:case`environments`:",
-      "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
-    );
-  }
+  patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
+  patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
+  patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
 
   if (!patchedSource.includes(`\`${SETTINGS_SLUG}\``)) {
     throw new Error("could not add agent workspace settings navigation");
@@ -2025,35 +2145,45 @@ function applyAgentWorkspaceSettingsPagePatch(currentSource) {
   return patchedSource;
 }
 
-function patchAgentWorkspaceRouteAssets(extractedDir) {
+function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   const assetsDir = webviewAssetsDir(extractedDir);
+  if (!fs.existsSync(assetsDir)) {
+    throw new Error(`missing webview assets directory ${assetsDir}`);
+  }
+
   const candidates = fs
     .readdirSync(assetsDir)
-    .filter((name) => /^(app-main|index)-.*\.js$/.test(name))
+    .filter((name) =>
+      /^(?:(?:app-main|index)-|app-initial~app-main~).*\.js$/.test(name) ||
+      /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name)
+    )
     .sort();
-  let lastError = null;
+  let routeMatched = false;
+  let navigationMatched = false;
   const patches = [];
 
   for (const candidate of candidates) {
     const filePath = path.join(assetsDir, candidate);
     const currentSource = fs.readFileSync(filePath, "utf8");
-    if (!currentSource.includes(SETTINGS_ASSET) && !currentSource.includes('"general-settings":(0,')) {
-      continue;
+    let patchedSource = currentSource;
+    if (isAgentWorkspaceSettingsRouteBundleSource(currentSource)) {
+      routeMatched = true;
+      patchedSource = applyAgentWorkspaceSettingsIndexPatch(patchedSource);
     }
-
-    try {
-      patches.push({
-        filePath,
-        currentSource,
-        patchedSource: applyAgentWorkspaceSettingsIndexPatch(currentSource),
-      });
-    } catch (error) {
-      lastError = error;
+    if (isAgentWorkspaceSettingsNavigationBundleSource(currentSource)) {
+      navigationMatched = true;
+      patchedSource = applyAgentWorkspaceSettingsPagePatch(patchedSource);
+    }
+    if (patchedSource !== currentSource) {
+      patches.push({ filePath, currentSource, patchedSource });
     }
   }
 
-  if (patches.length === 0) {
-    throw lastError ?? new Error("could not find webview settings route bundle");
+  if (!routeMatched) {
+    throw new Error("could not find webview settings route bundle");
+  }
+  if (!navigationMatched) {
+    throw new Error("could not find webview settings navigation bundle");
   }
 
   return patches;
@@ -2066,25 +2196,17 @@ function patchAgentWorkspaceSettingsAssets(extractedDir) {
       ? fs.readFileSync(settingsAsset.filePath, "utf8")
       : null;
     const patches = [
-      ...patchRequiredAssets(
+      ...collectOptionalMatchingAssetPatches(
         extractedDir,
-        /^settings-sections-.*\.js$/,
+        isAgentWorkspaceSettingsSectionsMetadataBundleSource,
         applyAgentWorkspaceSettingsSectionsPatch,
-        "settings sections bundle",
       ),
-      ...patchRequiredAssets(
+      ...collectOptionalMatchingAssetPatches(
         extractedDir,
-        /^settings-shared-.*\.js$/,
+        isAgentWorkspaceSettingsSharedMetadataBundleSource,
         applyAgentWorkspaceSettingsSharedPatch,
-        "settings shared bundle",
       ),
-      ...patchRequiredAssets(
-        extractedDir,
-        /^settings-page-.*\.js$/,
-        applyAgentWorkspaceSettingsPagePatch,
-        "settings page bundle",
-      ),
-      ...patchAgentWorkspaceRouteAssets(extractedDir),
+      ...collectAgentWorkspaceRouteAndNavigationPatches(extractedDir),
     ];
 
     fs.writeFileSync(settingsAsset.filePath, settingsAsset.source, "utf8");

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -29,7 +29,6 @@ const {
   applyAgentWorkspaceMainBridgePatch,
   applyAgentWorkspaceSettingsIndexPatch,
   applyAgentWorkspaceSettingsPagePatch,
-  applyAgentWorkspaceSettingsSectionsPatch,
   applyAgentWorkspaceSettingsSharedPatch,
   buildAgentWorkspaceSettingsSource,
   patchAgentWorkspaceSettingsAssets,
@@ -139,10 +138,6 @@ function buildBridgeHarness({ env = {}, globalState = new Map(), execFile, spawn
   return { handlers: host.handlers(), execCalls, spawnCalls };
 }
 
-function syntheticSettingsSections() {
-  return "var e=`general-settings`,t={},n=[{slug:`general-settings`},{slug:`appearance`},{slug:`local-environments`},{slug:`worktrees`}];export{n,t as r,e as t};";
-}
-
 function syntheticSettingsShared() {
   return [
     "var c=r({",
@@ -155,70 +150,6 @@ function syntheticSettingsShared() {
     "case`local-environments`:{return (0,d.jsx)(n,{id:`settings.section.local-environments`,defaultMessage:`Environments`})}",
     "case`worktrees`:{return (0,d.jsx)(n,{id:`settings.section.worktrees`,defaultMessage:`Worktrees`})}",
     "}}",
-  ].join("");
-}
-
-function syntheticSettingsSharedWithSlugAliasCollision() {
-  return [
-    "var c=r({",
-    '"local-environments":{id:`settings.nav.local-environments`,defaultMessage:`Environments`,description:`Title for environments settings section`},',
-    "worktrees:{id:`settings.nav.worktrees`,defaultMessage:`Worktrees`,description:`Title for worktrees settings section`}",
-    "});",
-    "function m(e){let t=(0,u.c)(3),{slug:n}=e;switch(n){",
-    "case`local-environments`:{return (0,d.jsx)(r,{id:`settings.section.local-environments`,defaultMessage:`Environments`})}",
-    "case`worktrees`:{return (0,d.jsx)(r,{id:`settings.section.worktrees`,defaultMessage:`Worktrees`})}",
-    "}}",
-  ].join("");
-}
-
-function syntheticIndex() {
-  return [
-    "var i_e={\"general-settings\":(0,Z.lazy)(()=>s(()=>import(`./general-settings.js`),[],import.meta.url)),appearance:(0,Z.lazy)(()=>s(()=>import(`./appearance.js`),[],import.meta.url))};",
-    "let Kge={\"general-settings\":Icon,appearance:Icon};",
-    "let qge=[`general-settings`,`appearance`,`local-environments`,`worktrees`],Jge=[{key:`connection`,heading:null,slugs:[`agent`,`local-environments`,`worktrees`]}];",
-    "function Qge(){let l=`electron`,e=e=>{switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`data-controls`:case`environments`:return l===`electron`;case`account`:case`general-settings`:case`agent`:case`personalization`:case`mcp-settings`:return!0}};if(O)bb0:switch(D.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`account`:case`data-controls`:case`personalization`:k=!1;break bb0;case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:case`connections`:case`plugins-settings`:case`skills-settings`:k=!1}}",
-  ].join("");
-}
-
-function syntheticSettingsPage() {
-  return [
-    "var Z={jsx(){},jsxs(){}};",
-    'var pe={"general-settings":G,"browser-use":de,"computer-use":oe,"read-aloud-settings":codexLinuxReadAloudSettingsIcon,"local-environments":q,worktrees:W,"data-controls":U};',
-    "var me=[`general-settings`,`appearance`,`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`connections`,`git-settings`,`local-environments`,`worktrees`,`browser-use`,`computer-use`,`read-aloud-settings`,`data-controls`];",
-    "var he=[{key:`app`,heading:Q.appHeading,slugs:[`general-settings`,`appearance`,`connections`,`git-settings`,`usage`]},{key:`connection`,heading:Q.hostHeading,slugs:[`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`browser-use`,`computer-use`,`read-aloud-settings`,`local-environments`,`worktrees`,`data-controls`]}];",
-    "function visible(e){switch(e.slug){case`read-aloud-settings`:return a;case`computer-use`:return A;case`browser-use`:return j;case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
-    "if(R)bb0:switch(L.slug){case`computer-use`:z=k.isLoading||m.isLoading;break bb0;case`browser-use`:z=f.isLoading||m.isLoading||_;break bb0;case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:case`connections`:z=!1}",
-  ].join("");
-}
-
-function syntheticSettingsPageWithRenamedIconMap() {
-  return [
-    "var Q=i(),me=e=>(0,Q.jsxs)(`svg`,{children:[(0,Q.jsx)(`path`,{})]}),he={\"general-settings\":W,\"local-environments\":Y,worktrees:U,environments:Y};",
-    "var ge=[`general-settings`,`local-environments`,`worktrees`,`data-controls`];",
-    "function visible(e){switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
-    "if(V)bb0:switch(B.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:H=!1}",
-  ].join("");
-}
-
-function syntheticSettingsPageWithInitializerIconMap() {
-  return [
-    "var Bn,Vn,Q,Hn,Un=e(()=>{",
-    "Bn=o(),Vn=t(n(),1),Q=f(),Hn={\"general-settings\":W,\"local-environments\":Y,worktrees:U,environments:Y};",
-    "});",
-    "var ge=[`general-settings`,`local-environments`,`worktrees`,`data-controls`];",
-    "function visible(e){switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
-    "if(V)bb0:switch(B.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:H=!1}",
-  ].join("");
-}
-
-function syntheticSettingsPageWithOrphanedInjectedIcon() {
-  return [
-    "var Bn,Vn,Q,Hn,Un=e(()=>{",
-    "Bn=o(),Vn=t(n(),1),Q=f();var codexLinuxAgentWorkspaceSettingsIcon=e=>(0,Q.jsxs)(`svg`,{children:[(0,Q.jsx)(`path`,{d:`M6 6.25 7.45 8 6 9.75`})]});Hn={\"general-settings\":W,\"local-environments\":Y,\"agent-workspaces\":codexLinuxAgentWorkspaceSettingsIcon,worktrees:U,environments:Y};",
-    "});",
-    "var ge=[`general-settings`,`local-environments`,`worktrees`,`data-controls`];",
-    "function visible(e){switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
-    "if(V)bb0:switch(B.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:H=!1}",
   ].join("");
 }
 
@@ -257,55 +188,21 @@ function writeSyntheticExtractedApp(root) {
   fs.mkdirSync(assetsDir, { recursive: true });
   fs.writeFileSync(path.join(buildDir, "main.js"), syntheticMainBundle());
   fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "codex" }));
-  fs.writeFileSync(path.join(assetsDir, "settings-sections-test.js"), syntheticSettingsSections());
-  fs.writeFileSync(path.join(assetsDir, "settings-shared-test.js"), syntheticSettingsShared());
-  fs.writeFileSync(path.join(assetsDir, "settings-page-test.js"), syntheticSettingsPage());
-  fs.writeFileSync(path.join(assetsDir, "index-test.js"), syntheticIndex());
   fs.writeFileSync(path.join(assetsDir, "local-conversation-thread-test.js"), staleConversationMonitorBundle());
   fs.writeFileSync(path.join(assetsDir, "composer-test.js"), syntheticComposerBundle());
   fs.writeFileSync(path.join(assetsDir, "mcp-settings-test.js"), syntheticMcpSettingsBundle());
   fs.writeFileSync(path.join(assetsDir, "general-settings-test.js"), syntheticGeneralSettingsBundle());
   fs.writeFileSync(path.join(assetsDir, "chunk-test.js"), "export function s(e){return e}");
-  fs.writeFileSync(path.join(assetsDir, "react-test.js"), 'import{s}from"./chunk-test.js";/* react.transitional.element */export{ReactFactory as t};function ReactFactory(){return{createElement(){return{}},useState(){return[null,()=>{}]},useCallback(e){return e},useEffect(){}}}');
-  fs.writeFileSync(path.join(assetsDir, "jsx-runtime-test.js"), "/* react.transitional.element */export{j as t};function j(){return{jsx(){},jsxs(){}}}");
   fs.writeFileSync(
     path.join(assetsDir, "setting-storage-test.js"),
     "async function send(e,t,n,r,i){return fetch(`vscode://codex/${e}`)}async function request(...e){let[t,n]=e,{params:r,select:i,signal:a,source:o}=n??{};return send(t,r,i,a,o)}export{request as l};",
   );
-  fs.writeFileSync(path.join(assetsDir, "settings-content-layout-test.js"), "export function t(){}");
   fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
+  rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir);
   return { buildDir, assetsDir };
 }
 
-function rewriteSettingsPageWithBundledRuntime(assetsDir) {
-  fs.rmSync(path.join(assetsDir, "jsx-runtime-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "react-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "settings-content-layout-test.js"), { force: true });
-  fs.writeFileSync(
-    path.join(assetsDir, "runtime-test.js"),
-    'import{s}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
-  );
-  const settingsPagePath = path.join(assetsDir, "settings-page-test.js");
-  const settingsPageSource = fs.readFileSync(settingsPagePath, "utf8");
-  fs.writeFileSync(
-    settingsPagePath,
-    [
-      'import{s as __toESM}from"./chunk-test.js";',
-      'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
-      'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
-      'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
-      settingsPageSource,
-    ].join(""),
-  );
-}
-
 function rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir) {
-  fs.rmSync(path.join(assetsDir, "jsx-runtime-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "react-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "settings-content-layout-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "settings-sections-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "settings-shared-test.js"), { force: true });
-  fs.rmSync(path.join(assetsDir, "index-test.js"), { force: true });
   fs.writeFileSync(
     path.join(assetsDir, "runtime-test.js"),
     'import{s}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
@@ -356,17 +253,17 @@ function flushPromises() {
 function buildSettingsVmSource() {
   return buildAgentWorkspaceSettingsSource({
     chunkAsset: "chunk-test.js",
-    reactAsset: "react-test.js",
-    reactExportName: "t",
-    settingsPageAsset: "settings-content-layout-test.js",
+    reactAsset: "runtime-test.js",
+    reactExportName: "r",
+    settingsPageAsset: "settings-page-test.js",
     settingsPageExportName: "t",
     codexRequestAsset: "setting-storage-test.js",
     codexRequestExportName: "l",
   })
     .replace('import{s as __toESM}from"./chunk-test.js";\n', "")
-    .replace('import{t as __reactFactory}from"./react-test.js";\n', "")
+    .replace('import{r as __reactFactory}from"./runtime-test.js";\n', "")
     .replace('import{l as __post}from"./setting-storage-test.js";\n', "")
-    .replace('import{t as SettingsPage}from"./settings-content-layout-test.js";\n', "")
+    .replace('import{t as SettingsPage}from"./settings-page-test.js";\n', "")
     .replace(
       "export{AgentWorkspacesSettings,AgentWorkspacesSettings as default};",
       "globalThis.__commandArgv=commandArgv;globalThis.__startupAppFromManual=startupAppFromManual;globalThis.AgentWorkspacesSettings=AgentWorkspacesSettings;",
@@ -1108,9 +1005,9 @@ test("manual startup argv parser preserves explicit argv tokens", () => {
 test("generated agent workspace settings module is valid ESM syntax", () => {
   const source = buildAgentWorkspaceSettingsSource({
     chunkAsset: "chunk-test.js",
-    reactAsset: "react-test.js",
-    reactExportName: "t",
-    settingsPageAsset: "settings-content-layout-test.js",
+    reactAsset: "runtime-test.js",
+    reactExportName: "r",
+    settingsPageAsset: "settings-page-test.js",
     settingsPageExportName: "t",
     codexRequestAsset: "setting-storage-test.js",
     codexRequestExportName: "l",
@@ -1697,66 +1594,29 @@ test("generated settings UI auto-opens the GPUI viewer after approved workspace 
 });
 
 test("settings asset patches add navigation, route, visibility, and title", () => {
-  const sections = applyAgentWorkspaceSettingsSectionsPatch(syntheticSettingsSections());
-  assert.match(sections, new RegExp(`slug:\`${SETTINGS_SLUG}\``));
-  assert.equal(applyAgentWorkspaceSettingsSectionsPatch(sections), sections);
-
   const shared = applyAgentWorkspaceSettingsSharedPatch(syntheticSettingsShared());
   assert.match(shared, new RegExp(`settings\\.nav\\.${SETTINGS_SLUG}`));
   assert.match(shared, new RegExp(`settings\\.section\\.${SETTINGS_SLUG}`));
   assert.equal(applyAgentWorkspaceSettingsSharedPatch(shared), shared);
-
-  const sharedWithCollision = applyAgentWorkspaceSettingsSharedPatch(syntheticSettingsSharedWithSlugAliasCollision());
-  assert.match(sharedWithCollision, /case`agent-workspaces`:\{return \(0,d\.jsx\)\(r,\{id:`settings\.section\.agent-workspaces`/);
-  assert.doesNotMatch(sharedWithCollision, /case`agent-workspaces`:\{return \(0,d\.jsx\)\(n,\{id:`settings\.section\.agent-workspaces`/);
-
-  const index = applyAgentWorkspaceSettingsIndexPatch(syntheticIndex());
-  assert.match(index, new RegExp(SETTINGS_ASSET));
-  assert.match(index, new RegExp(`"${SETTINGS_SLUG}":Icon`));
-  assert.match(index, /case`local-environments`:case`agent-workspaces`:case`data-controls`:case`environments`:return l===`electron`/);
-  assert.match(index, /case`local-environments`:case`agent-workspaces`:case`worktrees`/);
-  assert.equal(applyAgentWorkspaceSettingsIndexPatch(index), index);
 
   const appMain = applyAgentWorkspaceSettingsIndexPatch(syntheticAppMainRouteRegistry());
   assert.match(appMain, new RegExp(SETTINGS_ASSET));
   assert.doesNotMatch(appMain, new RegExp(`"${SETTINGS_SLUG}":Icon`));
   assert.equal(applyAgentWorkspaceSettingsIndexPatch(appMain), appMain);
 
-  const settingsPage = applyAgentWorkspaceSettingsPagePatch(syntheticSettingsPage());
-  assert.doesNotMatch(settingsPage, /codexLinuxAgentWorkspaceSettingsIcon/);
-  assert.doesNotMatch(settingsPage, /M6 6\.25 7\.45 8 6 9\.75/);
-  assert.match(settingsPage, new RegExp(`"local-environments":q,"${SETTINGS_SLUG}":q,worktrees`));
+  const settingsPage = applyAgentWorkspaceSettingsPagePatch(
+    [
+      'var Hn={"linux-desktop":S,"general-settings":S,"local-environments":ln,worktrees:F,environments:ln,"mcp-settings":S,connections:S};',
+      "var Wn=[`general-settings`,`linux-desktop`,`local-environments`,`worktrees`,`data-controls`],Gn=[{key:`coding`,slugs:[`local-environments`,`environments`,`worktrees`]}];",
+      "function visible(S){switch(S.slug){case`pets`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
+      "function load(S){switch(S.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:return!1}}",
+    ].join(""),
+  );
+  assert.match(settingsPage, new RegExp(`"local-environments":ln,"${SETTINGS_SLUG}":ln,worktrees`));
   assert.match(settingsPage, /`local-environments`,`agent-workspaces`,`worktrees`/);
-  assert.match(settingsPage, /case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
+  assert.match(settingsPage, /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
   assert.match(settingsPage, /case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`/);
   assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPage), settingsPage);
-
-  const settingsPageWithRenamedIconMap = applyAgentWorkspaceSettingsPagePatch(
-    syntheticSettingsPageWithRenamedIconMap(),
-  );
-  assert.doesNotMatch(settingsPageWithRenamedIconMap, /codexLinuxAgentWorkspaceSettingsIcon/);
-  assert.match(settingsPageWithRenamedIconMap, new RegExp(`"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees`));
-
-  const settingsPageWithInitializerIconMap = applyAgentWorkspaceSettingsPagePatch(
-    syntheticSettingsPageWithInitializerIconMap(),
-  );
-  assert.doesNotMatch(settingsPageWithInitializerIconMap, /codexLinuxAgentWorkspaceSettingsIcon/);
-  assert.match(
-    settingsPageWithInitializerIconMap,
-    new RegExp(`Hn=\\{"general-settings":W,"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees:U`),
-  );
-  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPageWithInitializerIconMap), settingsPageWithInitializerIconMap);
-
-  const settingsPageWithOrphanedInjectedIcon = applyAgentWorkspaceSettingsPagePatch(
-    syntheticSettingsPageWithOrphanedInjectedIcon(),
-  );
-  assert.doesNotMatch(settingsPageWithOrphanedInjectedIcon, /codexLinuxAgentWorkspaceSettingsIcon/);
-  assert.doesNotMatch(settingsPageWithOrphanedInjectedIcon, /M6 6\.25 7\.45 8 6 9\.75/);
-  assert.match(
-    settingsPageWithOrphanedInjectedIcon,
-    new RegExp(`Hn=\\{"general-settings":W,"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees:U`),
-  );
-  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPageWithOrphanedInjectedIcon), settingsPageWithOrphanedInjectedIcon);
 });
 
 test("agent-workspace feature participates in ASAR patching and reports", () => {
@@ -1775,10 +1635,9 @@ test("agent-workspace feature participates in ASAR patching and reports", () => 
         assert.match(fs.readFileSync(path.join(buildDir, "main.js"), "utf8"), /"linux-agent-workspace":async/);
         assert.ok(fs.existsSync(path.join(assetsDir, SETTINGS_ASSET)));
         assert.match(fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8"), /AgentWorkspacesSettings/);
-        assert.match(fs.readFileSync(path.join(assetsDir, "settings-sections-test.js"), "utf8"), /agent-workspaces/);
-        assert.match(fs.readFileSync(path.join(assetsDir, "settings-shared-test.js"), "utf8"), /Agent Workspaces/);
         assert.match(fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8"), /agent-workspaces/);
-        assert.match(fs.readFileSync(path.join(assetsDir, "index-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~messages-test.js"), "utf8"), /Agent Workspaces/);
+        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
         assert.equal(
           fs.readFileSync(path.join(assetsDir, "local-conversation-thread-test.js"), "utf8"),
           staleConversationMonitorBundle(),
@@ -1817,7 +1676,7 @@ test("agent-workspace settings resolve latest upstream request API asset", () =>
     const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
     assert.match(settingsSource, /import\{l as __post\}from"\.\/setting-storage-test\.js"/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "index-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }
@@ -1827,11 +1686,9 @@ test("agent-workspace settings infer runtime dependencies from bundled settings 
   const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-agent-workspace-bundled-runtime-"));
   try {
     const { assetsDir } = writeSyntheticExtractedApp(tempApp);
-    rewriteSettingsPageWithBundledRuntime(assetsDir);
 
-    assert.equal(fs.existsSync(path.join(assetsDir, "jsx-runtime-test.js")), false);
-    assert.equal(fs.existsSync(path.join(assetsDir, "react-test.js")), false);
-    assert.equal(fs.existsSync(path.join(assetsDir, "settings-content-layout-test.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "runtime-test.js")), true);
+    assert.equal(fs.existsSync(path.join(assetsDir, "settings-page-test.js")), true);
 
     const { value: result, warnings } = captureWarns(() => patchAgentWorkspaceSettingsAssets(tempApp));
 
@@ -1842,11 +1699,10 @@ test("agent-workspace settings infer runtime dependencies from bundled settings 
     );
     const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
     assert.match(settingsSource, /import\{r as __reactFactory\}from"\.\/runtime-test\.js"/);
-    assert.doesNotMatch(settingsSource, /settings-content-layout-test/);
     assert.match(settingsSource, /function SettingsPage/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);
     assert.match(fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8"), /agent-workspaces/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "index-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }
@@ -1856,11 +1712,6 @@ test("agent-workspace settings patch supports consolidated current settings bund
   const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-agent-workspace-current-settings-"));
   try {
     const { assetsDir } = writeSyntheticExtractedApp(tempApp);
-    rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir);
-
-    assert.equal(fs.existsSync(path.join(assetsDir, "settings-sections-test.js")), false);
-    assert.equal(fs.existsSync(path.join(assetsDir, "settings-shared-test.js")), false);
-    assert.equal(fs.existsSync(path.join(assetsDir, "index-test.js")), false);
 
     const { value: result, warnings } = captureWarns(() => patchAgentWorkspaceSettingsAssets(tempApp));
 
@@ -1875,7 +1726,6 @@ test("agent-workspace settings patch supports consolidated current settings bund
 
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8");
     assert.match(settingsPageSource, /"local-environments":ln,"agent-workspaces":ln,worktrees:F/);
-    assert.doesNotMatch(settingsPageSource, /codexLinuxAgentWorkspaceSettingsIcon/);
     assert.match(settingsPageSource, /`local-environments`,`agent-workspaces`,`worktrees`/);
     assert.match(settingsPageSource, /slugs:\[`local-environments`,`agent-workspaces`,`environments`,`worktrees`\]/);
     assert.match(settingsPageSource, /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -211,6 +211,17 @@ function syntheticSettingsPageWithInitializerIconMap() {
   ].join("");
 }
 
+function syntheticSettingsPageWithOrphanedInjectedIcon() {
+  return [
+    "var Bn,Vn,Q,Hn,Un=e(()=>{",
+    "Bn=o(),Vn=t(n(),1),Q=f();var codexLinuxAgentWorkspaceSettingsIcon=e=>(0,Q.jsxs)(`svg`,{children:[(0,Q.jsx)(`path`,{d:`M6 6.25 7.45 8 6 9.75`})]});Hn={\"general-settings\":W,\"local-environments\":Y,\"agent-workspaces\":codexLinuxAgentWorkspaceSettingsIcon,worktrees:U,environments:Y};",
+    "});",
+    "var ge=[`general-settings`,`local-environments`,`worktrees`,`data-controls`];",
+    "function visible(e){switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
+    "if(V)bb0:switch(B.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:H=!1}",
+  ].join("");
+}
+
 function syntheticAppMainRouteRegistry() {
   return [
     "function render(e){return routeMap[e.slug]}",
@@ -1735,6 +1746,17 @@ test("settings asset patches add navigation, route, visibility, and title", () =
     new RegExp(`Hn=\\{"general-settings":W,"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees:U`),
   );
   assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPageWithInitializerIconMap), settingsPageWithInitializerIconMap);
+
+  const settingsPageWithOrphanedInjectedIcon = applyAgentWorkspaceSettingsPagePatch(
+    syntheticSettingsPageWithOrphanedInjectedIcon(),
+  );
+  assert.doesNotMatch(settingsPageWithOrphanedInjectedIcon, /codexLinuxAgentWorkspaceSettingsIcon/);
+  assert.doesNotMatch(settingsPageWithOrphanedInjectedIcon, /M6 6\.25 7\.45 8 6 9\.75/);
+  assert.match(
+    settingsPageWithOrphanedInjectedIcon,
+    new RegExp(`Hn=\\{"general-settings":W,"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees:U`),
+  );
+  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPageWithOrphanedInjectedIcon), settingsPageWithOrphanedInjectedIcon);
 });
 
 test("agent-workspace feature participates in ASAR patching and reports", () => {

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -200,6 +200,17 @@ function syntheticSettingsPageWithRenamedIconMap() {
   ].join("");
 }
 
+function syntheticSettingsPageWithInitializerIconMap() {
+  return [
+    "var Bn,Vn,Q,Hn,Un=e(()=>{",
+    "Bn=o(),Vn=t(n(),1),Q=f(),Hn={\"general-settings\":W,\"local-environments\":Y,worktrees:U,environments:Y};",
+    "});",
+    "var ge=[`general-settings`,`local-environments`,`worktrees`,`data-controls`];",
+    "function visible(e){switch(e.slug){case`appearance`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
+    "if(V)bb0:switch(B.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:H=!1}",
+  ].join("");
+}
+
 function syntheticAppMainRouteRegistry() {
   return [
     "function render(e){return routeMap[e.slug]}",
@@ -253,6 +264,71 @@ function writeSyntheticExtractedApp(root) {
   fs.writeFileSync(path.join(assetsDir, "settings-content-layout-test.js"), "export function t(){}");
   fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
   return { buildDir, assetsDir };
+}
+
+function rewriteSettingsPageWithBundledRuntime(assetsDir) {
+  fs.rmSync(path.join(assetsDir, "jsx-runtime-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "react-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "settings-content-layout-test.js"), { force: true });
+  fs.writeFileSync(
+    path.join(assetsDir, "runtime-test.js"),
+    'import{s}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
+  );
+  const settingsPagePath = path.join(assetsDir, "settings-page-test.js");
+  const settingsPageSource = fs.readFileSync(settingsPagePath, "utf8");
+  fs.writeFileSync(
+    settingsPagePath,
+    [
+      'import{s as __toESM}from"./chunk-test.js";',
+      'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
+      'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
+      'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
+      settingsPageSource,
+    ].join(""),
+  );
+}
+
+function rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir) {
+  fs.rmSync(path.join(assetsDir, "jsx-runtime-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "react-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "settings-content-layout-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "settings-sections-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "settings-shared-test.js"), { force: true });
+  fs.rmSync(path.join(assetsDir, "index-test.js"), { force: true });
+  fs.writeFileSync(
+    path.join(assetsDir, "runtime-test.js"),
+    'import{s}from"./chunk-test.js";export{ReactFactory as r,jsxFactory as j};function ReactFactory(){return{createElement(){return{}},useState(value){return[value,()=>{}]},useCallback(fn){return fn},useEffect(){}}}function jsxFactory(){return{jsx(){},jsxs(){}}}',
+  );
+  fs.writeFileSync(
+    path.join(assetsDir, "settings-page-test.js"),
+    [
+      'import{s as __toESM}from"./chunk-test.js";',
+      'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
+      'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
+      'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
+      "var Z=$,S=e=>(0,Z.jsxs)(`svg`,{children:[]}),ln=S,F=S;",
+      'var Hn={"linux-desktop":S,"general-settings":S,"local-environments":ln,worktrees:F,environments:ln,"mcp-settings":S,connections:S};',
+      "var Wn=[`general-settings`,`linux-desktop`,`local-environments`,`worktrees`,`data-controls`],Gn=[{key:`personal`,slugs:[`general-settings`,`linux-desktop`]},{key:`coding`,slugs:[`local-environments`,`environments`,`worktrees`]}];",
+      "function visible(S){switch(S.slug){case`computer-use`:return!0;case`browser-use`:return!0;case`appearance`:return!0;case`pets`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;case`linux-desktop`:case`general-settings`:case`agent`:case`personalization`:return!0;}}",
+      "function load(S){let T=!1;switch(S.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:case`connections`:T=!1;break}return T}",
+      "var lr=[`profile`,`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`local-environments`,`worktrees`,`data-controls`];",
+    ].join(""),
+  );
+  fs.writeFileSync(
+    path.join(assetsDir, "app-initial~app-main~messages-test.js"),
+    syntheticSettingsShared(),
+  );
+  fs.writeFileSync(
+    path.join(assetsDir, "app-initial~app-main~automations-page-test.js"),
+    [
+      "function EH(e){let t=(0,DH.c)(2),{slug:n}=e,r=AH[n],i;return t[0]===r?i=t[1]:(i=(0,kH.jsx)(r,{}),t[0]=r,t[1]=i),i}",
+      "var DH,OH,kH,AH,jH=e((()=>{DH=q(),OH=t(J(),1),kH=Y(),AH={",
+      '"linux-desktop":(0,OH.lazy)(()=>Cs(()=>import(`./linux-desktop-settings-linux.js`),[],import.meta.url)),',
+      '"general-settings":(0,OH.lazy)(()=>Cs(()=>import(`./general-settings-nSa2QlZR.js`).then(e=>({default:e.GeneralSettings})),__vite__mapDeps([1]),import.meta.url)),',
+      '"keyboard-shortcuts":(0,OH.lazy)(()=>Cs(()=>import(`./keyboard-shortcuts-settings-B1AsiCWy.js`).then(e=>({default:e.KeyboardShortcutsSettings})),__vite__mapDeps([2]),import.meta.url))',
+      "}}));",
+    ].join(""),
+  );
 }
 
 function writeModernCodexRequestAsset(assetsDir) {
@@ -1636,12 +1712,9 @@ test("settings asset patches add navigation, route, visibility, and title", () =
   assert.equal(applyAgentWorkspaceSettingsIndexPatch(appMain), appMain);
 
   const settingsPage = applyAgentWorkspaceSettingsPagePatch(syntheticSettingsPage());
-  assert.match(settingsPage, /codexLinuxAgentWorkspaceSettingsIcon=e=>/);
-  assert.match(settingsPage, /strokeDasharray/);
-  assert.match(settingsPage, /`circle`/);
+  assert.doesNotMatch(settingsPage, /codexLinuxAgentWorkspaceSettingsIcon/);
   assert.doesNotMatch(settingsPage, /M6 6\.25 7\.45 8 6 9\.75/);
-  assert.match(settingsPage, new RegExp(`"${SETTINGS_SLUG}":codexLinuxAgentWorkspaceSettingsIcon`));
-  assert.doesNotMatch(settingsPage, new RegExp(`"${SETTINGS_SLUG}":q`));
+  assert.match(settingsPage, new RegExp(`"local-environments":q,"${SETTINGS_SLUG}":q,worktrees`));
   assert.match(settingsPage, /`local-environments`,`agent-workspaces`,`worktrees`/);
   assert.match(settingsPage, /case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
   assert.match(settingsPage, /case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`/);
@@ -1650,19 +1723,18 @@ test("settings asset patches add navigation, route, visibility, and title", () =
   const settingsPageWithRenamedIconMap = applyAgentWorkspaceSettingsPagePatch(
     syntheticSettingsPageWithRenamedIconMap(),
   );
-  assert.match(settingsPageWithRenamedIconMap, /codexLinuxAgentWorkspaceSettingsIcon=e=>\(0,Q\.jsxs\)/);
+  assert.doesNotMatch(settingsPageWithRenamedIconMap, /codexLinuxAgentWorkspaceSettingsIcon/);
+  assert.match(settingsPageWithRenamedIconMap, new RegExp(`"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees`));
+
+  const settingsPageWithInitializerIconMap = applyAgentWorkspaceSettingsPagePatch(
+    syntheticSettingsPageWithInitializerIconMap(),
+  );
+  assert.doesNotMatch(settingsPageWithInitializerIconMap, /codexLinuxAgentWorkspaceSettingsIcon/);
   assert.match(
-    settingsPageWithRenamedIconMap,
-    new RegExp(`"${SETTINGS_SLUG}":codexLinuxAgentWorkspaceSettingsIcon`),
+    settingsPageWithInitializerIconMap,
+    new RegExp(`Hn=\\{"general-settings":W,"local-environments":Y,"${SETTINGS_SLUG}":Y,worktrees:U`),
   );
-  assert.ok(
-    settingsPageWithRenamedIconMap.indexOf("codexLinuxAgentWorkspaceSettingsIcon=e=>") <
-      settingsPageWithRenamedIconMap.indexOf(`"${SETTINGS_SLUG}":codexLinuxAgentWorkspaceSettingsIcon`),
-  );
-  assert.equal(
-    (settingsPageWithRenamedIconMap.match(/codexLinuxAgentWorkspaceSettingsIcon=e=>/g) ?? []).length,
-    1,
-  );
+  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPageWithInitializerIconMap), settingsPageWithInitializerIconMap);
 });
 
 test("agent-workspace feature participates in ASAR patching and reports", () => {
@@ -1724,6 +1796,78 @@ test("agent-workspace settings resolve latest upstream request API asset", () =>
     assert.match(settingsSource, /import\{l as __post\}from"\.\/setting-storage-test\.js"/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);
     assert.match(fs.readFileSync(path.join(assetsDir, "index-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+  } finally {
+    fs.rmSync(tempApp, { recursive: true, force: true });
+  }
+});
+
+test("agent-workspace settings infer runtime dependencies from bundled settings page", () => {
+  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-agent-workspace-bundled-runtime-"));
+  try {
+    const { assetsDir } = writeSyntheticExtractedApp(tempApp);
+    rewriteSettingsPageWithBundledRuntime(assetsDir);
+
+    assert.equal(fs.existsSync(path.join(assetsDir, "jsx-runtime-test.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "react-test.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "settings-content-layout-test.js")), false);
+
+    const { value: result, warnings } = captureWarns(() => patchAgentWorkspaceSettingsAssets(tempApp));
+
+    assert.equal(result.matched, true);
+    assert.ok(
+      warnings.every((warning) => !warning.includes("Agent Workspaces")),
+      warnings.join("\n"),
+    );
+    const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
+    assert.match(settingsSource, /import\{r as __reactFactory\}from"\.\/runtime-test\.js"/);
+    assert.doesNotMatch(settingsSource, /settings-content-layout-test/);
+    assert.match(settingsSource, /function SettingsPage/);
+    assert.match(settingsSource, /AgentWorkspacesSettings/);
+    assert.match(fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8"), /agent-workspaces/);
+    assert.match(fs.readFileSync(path.join(assetsDir, "index-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+  } finally {
+    fs.rmSync(tempApp, { recursive: true, force: true });
+  }
+});
+
+test("agent-workspace settings patch supports consolidated current settings bundles", () => {
+  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-agent-workspace-current-settings-"));
+  try {
+    const { assetsDir } = writeSyntheticExtractedApp(tempApp);
+    rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir);
+
+    assert.equal(fs.existsSync(path.join(assetsDir, "settings-sections-test.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "settings-shared-test.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "index-test.js")), false);
+
+    const { value: result, warnings } = captureWarns(() => patchAgentWorkspaceSettingsAssets(tempApp));
+
+    assert.equal(result.matched, true);
+    assert.ok(
+      warnings.every((warning) => !warning.includes("Agent Workspaces")),
+      warnings.join("\n"),
+    );
+    const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
+    assert.match(settingsSource, /import\{r as __reactFactory\}from"\.\/runtime-test\.js"/);
+    assert.match(settingsSource, /function SettingsPage/);
+
+    const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8");
+    assert.match(settingsPageSource, /"local-environments":ln,"agent-workspaces":ln,worktrees:F/);
+    assert.doesNotMatch(settingsPageSource, /codexLinuxAgentWorkspaceSettingsIcon/);
+    assert.match(settingsPageSource, /`local-environments`,`agent-workspaces`,`worktrees`/);
+    assert.match(settingsPageSource, /slugs:\[`local-environments`,`agent-workspaces`,`environments`,`worktrees`\]/);
+    assert.match(settingsPageSource, /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
+    assert.match(settingsPageSource, /case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`/);
+    assert.match(settingsPageSource, /lr=\[`profile`,`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`local-environments`,`agent-workspaces`,`worktrees`,`data-controls`\]/);
+
+    const sharedSource = fs.readFileSync(path.join(assetsDir, "app-initial~app-main~messages-test.js"), "utf8");
+    assert.match(sharedSource, /settings\.nav\.agent-workspaces/);
+    assert.match(sharedSource, /settings\.section\.agent-workspaces/);
+
+    const routeSource = fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8");
+    assert.match(routeSource, new RegExp(SETTINGS_ASSET));
+    assert.match(routeSource, /"agent-workspaces":\(0,OH\.lazy\)\(\(\)=>Cs\(\(\)=>import\(`\.\/agent-workspaces-linux\.js`\),\[\],import\.meta\.url\)\),"general-settings":/);
+    assert.equal(patchAgentWorkspaceSettingsAssets(tempApp).changed, 0);
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }

--- a/scripts/dev/upstream-dmg-intel.js
+++ b/scripts/dev/upstream-dmg-intel.js
@@ -11,6 +11,7 @@ const defaultRegistryPath = path.join(__dirname, "upstream-dmg-protected-surface
 const BLOCKING_CLASSIFICATIONS = new Set([
   "REMOVED",
   "PATCH_BROKEN",
+  "PATCH_INTEGRITY_BROKEN",
   "LINUX_SUBSTRATE_GAP",
   "PROTECTED_SURFACE_PARTIAL",
   "PROTECTED_SURFACE_MISSING",

--- a/scripts/dev/upstream-dmg-intel.test.js
+++ b/scripts/dev/upstream-dmg-intel.test.js
@@ -561,6 +561,31 @@ test("classifies required patch-report failures as acceptance blockers", () =>
     assert.ok(!findClassification(driftReport, "record_and_replay_event_stream", "PATCH_REVIEW"));
   }));
 
+test("classifies unresolved Linux settings patch symbols as acceptance blockers", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    writeFile(
+      path.join(
+        candidateApp,
+        "Contents/Resources/webview/assets/settings-page-bad-linux-patch.js",
+      ),
+      'var icons={"agent-workspaces":codexLinuxAgentWorkspaceSettingsIcon,worktrees:WorktreesIcon};',
+    );
+
+    const candidate = extractProtectedSurfaces({
+      inventory: createInventory({ registry, sourcePath: candidateApp }),
+      registry,
+      repoRoot: process.cwd(),
+    });
+    const driftReport = compareProtectedSurfaces({ candidate });
+
+    const finding = findClassification(driftReport, "linux_patch_integrity", "PATCH_INTEGRITY_BROKEN");
+    assert.ok(finding);
+    assert.equal(finding.category, "patch-integrity");
+    assert.match(finding.findings[0].symbol, /codexLinuxAgentWorkspaceSettingsIcon/);
+    assert.match(finding.findings[0].path, /settings-page-bad-linux-patch\.js$/);
+  }));
+
 test("keeps drift report evidence compact and marks hashed asset churn", () => {
   const baseline = {
     source: { path: "baseline.app" },

--- a/scripts/dev/upstream-dmg-intel.test.js
+++ b/scripts/dev/upstream-dmg-intel.test.js
@@ -564,12 +564,30 @@ test("classifies required patch-report failures as acceptance blockers", () =>
 test("classifies unresolved Linux settings patch symbols as acceptance blockers", () =>
   withTempDir((workspace) => {
     const candidateApp = createFixtureApp(workspace, "candidate");
+    const assetsDir = path.join(candidateApp, "Contents/Resources/webview/assets");
     writeFile(
-      path.join(
-        candidateApp,
-        "Contents/Resources/webview/assets/settings-page-bad-linux-patch.js",
-      ),
+      path.join(assetsDir, "settings-page-bad-linux-patch.js"),
       'var icons={"agent-workspaces":codexLinuxAgentWorkspaceSettingsIcon,worktrees:WorktreesIcon};',
+    );
+    writeFile(
+      path.join(assetsDir, "settings-page-bare-assignment.js"),
+      "codexLinuxReadAloudSettingsIcon=e=>null;var icons={read:codexLinuxReadAloudSettingsIcon};",
+    );
+    writeFile(
+      path.join(assetsDir, "settings-page-comma-assignment.js"),
+      "foo(),codexLinuxHooksSettingsIcon=e=>null;var icons={hooks:codexLinuxHooksSettingsIcon};",
+    );
+    writeFile(
+      path.join(assetsDir, "settings-page-nested-assignment.js"),
+      "var init=()=>{codexLinuxMcpSettingsIcon=e=>null};var icons={mcp:codexLinuxMcpSettingsIcon};",
+    );
+    writeFile(
+      path.join(assetsDir, "settings-page-good-direct-declaration.js"),
+      "var codexLinuxDeclaredSettingsIcon=e=>null;var icons={declared:codexLinuxDeclaredSettingsIcon};",
+    );
+    writeFile(
+      path.join(assetsDir, "settings-page-good-comma-declaration.js"),
+      "var existing=1,codexLinuxCommaDeclaredSettingsIcon=e=>null;var icons={declared:codexLinuxCommaDeclaredSettingsIcon};",
     );
 
     const candidate = extractProtectedSurfaces({
@@ -582,8 +600,49 @@ test("classifies unresolved Linux settings patch symbols as acceptance blockers"
     const finding = findClassification(driftReport, "linux_patch_integrity", "PATCH_INTEGRITY_BROKEN");
     assert.ok(finding);
     assert.equal(finding.category, "patch-integrity");
-    assert.match(finding.findings[0].symbol, /codexLinuxAgentWorkspaceSettingsIcon/);
-    assert.match(finding.findings[0].path, /settings-page-bad-linux-patch\.js$/);
+    const findingPaths = new Set(finding.findings.map((entry) => path.basename(entry.path)));
+    assert.ok(findingPaths.has("settings-page-bad-linux-patch.js"));
+    assert.ok(findingPaths.has("settings-page-bare-assignment.js"));
+    assert.ok(findingPaths.has("settings-page-comma-assignment.js"));
+    assert.ok(findingPaths.has("settings-page-nested-assignment.js"));
+    assert.equal(findingPaths.has("settings-page-good-direct-declaration.js"), false);
+    assert.equal(findingPaths.has("settings-page-good-comma-declaration.js"), false);
+  }));
+
+test("folds patch-report post-patch integrity findings into candidate-only reports", () =>
+  withTempDir((workspace) => {
+    const candidateApp = createFixtureApp(workspace, "candidate");
+    const outputDir = path.join(workspace, "post-patch-integrity-report");
+    const patchReportPath = path.join(workspace, "patch-report.json");
+    writeJson(patchReportPath, {
+      patches: [],
+      postPatchIntegrity: {
+        sourcePath: path.join(workspace, "app-extracted"),
+        findingCount: 1,
+        findings: [
+          {
+            path: "webview/assets/settings-page-patched.js",
+            reason: "Linux settings patch symbol is referenced without a local declaration",
+            snippet: '"agent-workspaces":codexLinuxAgentWorkspaceSettingsIcon',
+            symbol: "codexLinuxAgentWorkspaceSettingsIcon",
+          },
+        ],
+      },
+    });
+
+    const reports = buildIntelReports({
+      autoBaseline: false,
+      candidatePath: candidateApp,
+      outputDir,
+      patchReportPath,
+      registry,
+      repoRoot: process.cwd(),
+    });
+
+    const finding = findClassification(reports.driftReport, "linux_patch_integrity", "PATCH_INTEGRITY_BROKEN");
+    assert.ok(finding);
+    assert.equal(finding.findingCount, 1);
+    assert.equal(finding.findings[0].path, "webview/assets/settings-page-patched.js");
   }));
 
 test("keeps drift report evidence compact and marks hashed asset churn", () => {

--- a/scripts/lib/upstream-dmg-intel.js
+++ b/scripts/lib/upstream-dmg-intel.js
@@ -941,12 +941,67 @@ function createNativeBinaryMap(inventory, registry = null) {
 
 const LINUX_SETTINGS_PATCH_SYMBOL_PATTERN = /\bcodexLinux[A-Za-z0-9_$]*SettingsIcon\b/g;
 
+function segmentDeclaresSymbol(segment, symbol) {
+  const escaped = escapeRegExp(symbol);
+  return new RegExp(`^\\s*${escaped}(?![A-Za-z0-9_$])`).test(segment);
+}
+
+function hasVariableDeclarator(source, symbol) {
+  const keywordPattern = /\b(?:var|let|const)\b/g;
+  let match;
+  while ((match = keywordPattern.exec(source)) != null) {
+    let segmentStart = keywordPattern.lastIndex;
+    let depth = 0;
+    let quote = null;
+    let escaped = false;
+    let terminated = false;
+    for (let index = segmentStart; index < source.length; index += 1) {
+      const char = source[index];
+      if (quote != null) {
+        if (escaped) {
+          escaped = false;
+        } else if (char === "\\") {
+          escaped = true;
+        } else if (char === quote) {
+          quote = null;
+        }
+        continue;
+      }
+      if (char === '"' || char === "'" || char === "`") {
+        quote = char;
+        continue;
+      }
+      if (char === "(" || char === "[" || char === "{") {
+        depth += 1;
+        continue;
+      }
+      if (char === ")" || char === "]" || char === "}") {
+        depth = Math.max(0, depth - 1);
+        continue;
+      }
+      if (depth === 0 && (char === "," || char === ";")) {
+        if (segmentDeclaresSymbol(source.slice(segmentStart, index), symbol)) {
+          return true;
+        }
+        if (char === ";") {
+          terminated = true;
+          break;
+        }
+        segmentStart = index + 1;
+      }
+    }
+    if (!terminated && segmentDeclaresSymbol(source.slice(segmentStart), symbol)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function hasLocalPatchSymbolDeclaration(source, symbol) {
   const escaped = escapeRegExp(symbol);
   return (
     new RegExp(`\\bfunction\\s+${escaped}\\s*\\(`).test(source) ||
-    new RegExp(`\\b(?:var|let|const)\\s+[^;]*\\b${escaped}\\s*=`).test(source) ||
-    new RegExp(`[;,]\\s*${escaped}\\s*=`).test(source)
+    hasVariableDeclarator(source, symbol)
   );
 }
 
@@ -1035,6 +1090,31 @@ function patchFindingsBySurface(patchReport, surfacesById = {}) {
   return map;
 }
 
+function postPatchIntegrityFindingsFromReport(patchReport) {
+  const findings = patchReport?.postPatchIntegrity?.findings ?? patchReport?.postPatchIntegrity ?? [];
+  return Array.isArray(findings) ? findings : [];
+}
+
+function mergedPostPatchIntegrityFindings(...findingGroups) {
+  const merged = new Map();
+  for (const finding of findingGroups.flat()) {
+    if (finding == null || typeof finding !== "object") {
+      continue;
+    }
+    const symbol = finding.symbol ?? "unknown-symbol";
+    const pathKey = finding.path ?? "unknown-path";
+    const reason = finding.reason ?? "Linux settings patch symbol is referenced without a local declaration";
+    const key = `${symbol}\0${pathKey}\0${finding.snippet ?? ""}`;
+    merged.set(key, {
+      path: pathKey,
+      reason,
+      snippet: finding.snippet ?? null,
+      symbol,
+    });
+  }
+  return [...merged.values()].sort((a, b) => `${a.symbol}:${a.path}`.localeCompare(`${b.symbol}:${b.path}`));
+}
+
 function compareProtectedSurfaces({ baseline, candidate, patchReport = null } = {}) {
   const hasBaseline = baseline != null;
   const patchFindings = patchFindingsBySurface(patchReport, {
@@ -1099,7 +1179,10 @@ function compareProtectedSurfaces({ baseline, candidate, patchReport = null } = 
       }
     }
   }
-  const postPatchIntegrity = candidate?.postPatchIntegrity ?? [];
+  const postPatchIntegrity = mergedPostPatchIntegrityFindings(
+    candidate?.postPatchIntegrity ?? [],
+    postPatchIntegrityFindingsFromReport(patchReport),
+  );
   if (postPatchIntegrity.length > 0) {
     surfaceDrift.push({
       surfaceId: "linux_patch_integrity",

--- a/scripts/lib/upstream-dmg-intel.js
+++ b/scripts/lib/upstream-dmg-intel.js
@@ -23,6 +23,7 @@ const ACTIONABLE_CLASSIFICATIONS = new Set([
   "REMOVED",
   "NEW_UPSTREAM_CAPABILITY",
   "PATCH_BROKEN",
+  "PATCH_INTEGRITY_BROKEN",
   "PATCH_REVIEW",
   "LINUX_SUBSTRATE_GAP",
   "PROTECTED_SURFACE_PARTIAL",
@@ -55,6 +56,10 @@ function normalizePath(value) {
 
 function toRegex(pattern) {
   return pattern instanceof RegExp ? pattern : new RegExp(pattern, "i");
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function matchAny(patterns, value) {
@@ -682,6 +687,7 @@ function extractProtectedSurfaces({ inventory, registry, repoRoot = process.cwd(
   const bridgeMap = createBridgeMap(inventory);
   const pluginMap = createPluginMap(inventory);
   const nativeBinaryMap = createNativeBinaryMap(inventory, registry);
+  const postPatchIntegrity = findPostPatchIntegrityFindings(inventory);
   const surfaces = (registry.surfaces ?? []).map((surface) => {
     const evidence = fileEvidenceForSurface(inventory, surface).sort((a, b) => a.path.localeCompare(b.path));
     const anchors = evaluateRequiredAnchors(inventory, surface, { bridgeMap, pluginMap, nativeBinaryMap });
@@ -721,6 +727,7 @@ function extractProtectedSurfaces({ inventory, registry, repoRoot = process.cwd(
     bridgeMap,
     pluginMap,
     nativeBinaryMap,
+    postPatchIntegrity,
   };
 }
 
@@ -932,6 +939,39 @@ function createNativeBinaryMap(inventory, registry = null) {
   return { binaries };
 }
 
+const LINUX_SETTINGS_PATCH_SYMBOL_PATTERN = /\bcodexLinux[A-Za-z0-9_$]*SettingsIcon\b/g;
+
+function hasLocalPatchSymbolDeclaration(source, symbol) {
+  const escaped = escapeRegExp(symbol);
+  return (
+    new RegExp(`\\bfunction\\s+${escaped}\\s*\\(`).test(source) ||
+    new RegExp(`\\b(?:var|let|const)\\s+[^;]*\\b${escaped}\\s*=`).test(source) ||
+    new RegExp(`[;,]\\s*${escaped}\\s*=`).test(source)
+  );
+}
+
+function findPostPatchIntegrityFindings(inventory) {
+  const findings = [];
+  for (const file of inventory.files) {
+    if (file.text == null) {
+      continue;
+    }
+    const symbols = [...new Set(file.text.match(LINUX_SETTINGS_PATCH_SYMBOL_PATTERN) ?? [])];
+    for (const symbol of symbols) {
+      if (hasLocalPatchSymbolDeclaration(file.text, symbol)) {
+        continue;
+      }
+      findings.push({
+        path: file.relativePath,
+        reason: "Linux settings patch symbol is referenced without a local declaration",
+        snippet: textSnippet(file.text, symbol),
+        symbol,
+      });
+    }
+  }
+  return findings.sort((a, b) => `${a.symbol}:${a.path}`.localeCompare(`${b.symbol}:${b.path}`));
+}
+
 function classifySurfaceDrift({ baselineSurface, candidateSurface }) {
   const baselinePresent = baselineSurface?.status === "PRESENT";
   const candidatePresent = candidateSurface?.status === "PRESENT";
@@ -1058,6 +1098,18 @@ function compareProtectedSurfaces({ baseline, candidate, patchReport = null } = 
         });
       }
     }
+  }
+  const postPatchIntegrity = candidate?.postPatchIntegrity ?? [];
+  if (postPatchIntegrity.length > 0) {
+    surfaceDrift.push({
+      surfaceId: "linux_patch_integrity",
+      title: "Linux post-patch JavaScript integrity",
+      category: "patch-integrity",
+      classification: "PATCH_INTEGRITY_BROKEN",
+      findingCount: postPatchIntegrity.length,
+      findings: postPatchIntegrity.slice(0, 20),
+      omittedFindingCount: Math.max(0, postPatchIntegrity.length - 20),
+    });
   }
 
   const classificationCounts = {};
@@ -1653,6 +1705,7 @@ module.exports = {
   createPluginMap,
   compareMaps,
   extractProtectedSurfaces,
+  findPostPatchIntegrityFindings,
   renderActionPlanMarkdown,
   renderDriftMarkdown,
   resolveBaselinePath,

--- a/scripts/patch-linux-window-ui.js
+++ b/scripts/patch-linux-window-ui.js
@@ -9,6 +9,10 @@ const {
 const {
   patchExtractedApp,
 } = require("./patches/runner.js");
+const {
+  createInventory,
+  findPostPatchIntegrityFindings,
+} = require("./lib/upstream-dmg-intel.js");
 
 const USAGE = "Usage: patch-linux-window-ui.js [--report-json path] [--enforce-critical] <extracted-app-asar-dir>";
 
@@ -47,6 +51,15 @@ function main() {
   // Enforcement needs the report data even when no --report-json was requested.
   const report = reportJson == null && !enforceCritical ? null : createPatchReport();
   patchExtractedApp(extractedDir, { report });
+  if (report != null) {
+    const inventory = createInventory({ sourcePath: extractedDir });
+    const findings = findPostPatchIntegrityFindings(inventory);
+    report.postPatchIntegrity = {
+      sourcePath: extractedDir,
+      findingCount: findings.length,
+      findings,
+    };
+  }
   // Write the report before gating so CI artifact upload sees it even on failure.
   writePatchReport(reportJson, report);
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -46,6 +46,7 @@ const {
 } = require("./patches/impl/avatar-overlay.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
+  applyBrowserUseNodeReplApprovalAssets,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExternalOpenEnvPatch,
@@ -7026,6 +7027,40 @@ test("auto-approves the current vo Browser Use node_repl runtime config builder"
     (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
     1,
   );
+});
+
+test("patches re-chunked Browser Use trust hash and approval assets", () => {
+  const extractedDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-browser-rechunked-"));
+  try {
+    const buildDir = path.join(extractedDir, ".vite", "build");
+    fs.mkdirSync(buildDir, { recursive: true });
+    const mainChunk = path.join(buildDir, "main-current.js");
+    const srcChunk = path.join(buildDir, "src-current.js");
+    fs.writeFileSync(
+      mainChunk,
+      "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`],w=!1,t={vo:e=>e,Gr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},p=null,b=null,f=[],g=null,v=!1;function build(){return t.vo({codexCliPath:c.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:w?t.Gr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,traceMeta:v,trustedBrowserClientSha256s:d,shouldUseWslPaths:w})}",
+      "utf8",
+    );
+    fs.writeFileSync(
+      srcChunk,
+      "return{[`mcp_servers.${pt}`]:{args:[],command:i,env:n,startup_timeout_sec:120}}",
+      "utf8",
+    );
+
+    const result = applyBrowserUseNodeReplApprovalAssets(extractedDir);
+
+    assert.deepEqual(result, { matched: 2, changed: 2 });
+    const patchedMain = fs.readFileSync(mainChunk, "utf8");
+    const patchedSrc = fs.readFileSync(srcChunk, "utf8");
+    assert.match(patchedMain, /function codexLinuxTrustedBrowserClientSha256s/);
+    assert.match(
+      patchedMain,
+      /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:w/,
+    );
+    assert.match(patchedSrc, /tools:\{js:\{approval_mode:`approve`\}\}/);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
 });
 
 test("auto-approves and trusts the current Browser Use node_repl runtime config builder", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -8436,6 +8436,10 @@ test("patcher CLI writes --report-json output", () => {
       ].join(""),
     );
     fs.writeFileSync(path.join(tempRoot, "package.json"), JSON.stringify({ name: "codex" }));
+    fs.writeFileSync(
+      path.join(assetsDir, "settings-page-bad-linux-patch.js"),
+      'var icons={"agent-workspaces":codexLinuxAgentWorkspaceSettingsIcon,worktrees:WorktreesIcon};',
+    );
 
     const result = spawnSync(
       process.execPath,
@@ -8447,6 +8451,9 @@ test("patcher CLI writes --report-json output", () => {
     const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
     assert.equal(report.mainBundle, "main.js");
     assert.ok(report.patches.some((patch) => patch.name === "main-process-ui"));
+    assert.equal(report.postPatchIntegrity.findingCount, 1);
+    assert.match(report.postPatchIntegrity.findings[0].symbol, /codexLinuxAgentWorkspaceSettingsIcon/);
+    assert.match(report.postPatchIntegrity.findings[0].path, /settings-page-bad-linux-patch\.js$/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1957,7 +1957,7 @@ test("bypasses the upstream before-quit confirmation after a Linux explicit quit
 
   assert.match(
     patched,
-    /if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/,
+    /if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/,
   );
   assert.match(
     patched,
@@ -1993,7 +1993,7 @@ test("patches remaining before-quit and drain guards when another copy is alread
   assert.equal((patchedPromptSource.match(/codexLinuxShouldBypassQuitPrompt\(\)/g) ?? []).length, 2);
   assert.match(
     patchedPromptSource,
-    /function secondPrompt\(\)\{if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}\}/,
+    /function secondPrompt\(\)\{if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}\}/,
   );
 
   const unpatchedDrain =

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1078,7 +1078,7 @@ function beforeQuitConfirmationBundleFixture() {
 
 function willQuitDrainBundleFixture() {
   return [
-    "n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([...u.values()].map(e=>e.flush())).finally(()=>{d(),f.dispose(),n.app.quit()})}});",
+    "n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([u.flush(),p.flush()]).finally(()=>{d(),f.dispose(),n.app.quit()})}});",
   ].join("");
 }
 
@@ -1923,30 +1923,29 @@ test("adds the Linux quit guard when electron/path/fs requires are split across 
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
 });
 
-test("adds the Linux quit guard when only the Electron require is recognizable", () => {
+test("adds the Linux quit guard for the current wrapped electron/path/fs prelude", () => {
   const source =
-    "const e=require(`./app-session.js`);let t=require(`electron`);class WindowManager{}";
+    "function codexLinuxPatchExternalOpen(e){return e}let n=codexLinuxPatchExternalOpen(require(`electron`)),i=require(`node:path`),a=require(`node:fs`);";
 
   const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
 
-  assert.match(patched, /^let codexLinuxQuitInProgress=!1/);
+  assert.match(patched, /let n=codexLinuxPatchExternalOpen\(require\(`electron`\)\),i=require\(`node:path`\),a=require\(`node:fs`\);let codexLinuxQuitInProgress=!1/);
   assert.match(patched, /codexLinuxExplicitQuitApproved=!1/);
-  assert.match(patched, /codexLinuxMarkQuitInProgress=\(\)=>\{codexLinuxQuitInProgress=!0\}/);
   assert.match(patched, /codexLinuxPrepareForExplicitQuit=\(\)=>\{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress\(\)\}/);
-  assert.match(patched, /codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0/);
-  assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
   assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
 });
 
-test("upgrades the legacy Linux quit guard helper when re-patching older bundles", () => {
+test("adds the Linux quit guard for the current interleaved bundler prelude", () => {
   const source =
-    "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);let codexLinuxQuitInProgress=!1,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;var x=1;";
+    "let a=codexLinuxPatchExternalOpen(require(`electron`));a=e.o(a);let o=require(`node:os`);o=e.o(o);let s=require(`node:path`);s=e.o(s);let c=require(`node:util`),l=require(`node:crypto`),u=require(`node:fs`);u=e.o(u);let d=require(`node:fs/promises`);";
 
   const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
 
-  assert.doesNotMatch(patched, /let codexLinuxQuitInProgress=!1,codexLinuxMarkQuitInProgress=\(\)=>\{codexLinuxQuitInProgress=!0\},codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0;/);
+  assert.match(patched, /let d=require\(`node:fs\/promises`\);/);
+  assert.match(patched, /u=e\.o\(u\);let codexLinuxQuitInProgress=!1/);
+  assert.match(patched, /codexLinuxExplicitQuitApproved=!1/);
   assert.match(patched, /codexLinuxPrepareForExplicitQuit=\(\)=>\{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress\(\)\}/);
-  assert.match(patched, /codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0/);
+  assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
 });
 
 test("bypasses the upstream before-quit confirmation after a Linux explicit quit", () => {
@@ -1958,7 +1957,7 @@ test("bypasses the upstream before-quit confirmation after a Linux explicit quit
 
   assert.match(
     patched,
-    /if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/,
+    /if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/,
   );
   assert.match(
     patched,
@@ -1974,42 +1973,11 @@ test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
   );
 
   assert.match(patched, /codexLinuxExplicitQuitDrainTimeoutMs=3e3/);
-  assert.match(patched, /\(\(\)=>\{let codexLinuxFinalizeQuit=\(\)=>\{d\(\),f\.dispose\(\),n\.app\.quit\(\)\},codexLinuxDrainPromise=Promise\.all\(\[\.\.\.u\.values\(\)\]\.map\(e=>e\.flush\(\)\)\);/);
+  assert.match(patched, /\(\(\)=>\{let codexLinuxFinalizeQuit=\(\)=>\{d\(\),f\.dispose\(\),n\.app\.quit\(\)\},codexLinuxDrainPromise=Promise\.all\(\[u\.flush\(\),p\.flush\(\)\]\);/);
   assert.match(patched, /if\(process\.platform===`linux`&&\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)\)\{Promise\.race\(\[codexLinuxDrainPromise,new Promise\(e=>setTimeout\(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`\?codexLinuxExplicitQuitDrainTimeoutMs:3e3\)\)\]\)\.finally\(codexLinuxFinalizeQuit\);return\}/);
   assert.doesNotMatch(patched, /\\`number\\`/);
   assert.match(patched, /codexLinuxDrainPromise\.finally\(codexLinuxFinalizeQuit\)\}\)\(\)/);
   assert.doesNotThrow(() => new Function(patched));
-});
-
-test("patches remaining before-quit and drain guards when another copy is already patched", () => {
-  const promptBypassExpression =
-    "(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||";
-  const patchedPrompt = `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}`;
-  const unpatchedPrompt =
-    "if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
-  const patchedPromptSource = applyPatchTwice(
-    applyLinuxExplicitQuitPromptBypassPatch,
-    `${patchedPrompt}function secondPrompt(){${unpatchedPrompt}}`,
-  );
-  assert.equal((patchedPromptSource.match(/codexLinuxShouldBypassQuitPrompt\(\)/g) ?? []).length, 2);
-  assert.match(
-    patchedPromptSource,
-    /function secondPrompt\(\)\{if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}\}/,
-  );
-
-  const unpatchedDrain =
-    "Promise.all([...u.values()].map(e=>e.flush())).finally(()=>{d(),f.dispose(),n.app.quit()})";
-  const patchedDrain =
-    "(()=>{let codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all([...u.values()].map(e=>e.flush()));if(process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()";
-  const patchedDrainSource = applyPatchTwice(
-    applyLinuxWillQuitDrainTimeoutPatch,
-    `${patchedDrain}function secondDrain(){${unpatchedDrain}}`,
-  );
-  assert.equal((patchedDrainSource.match(/codexLinuxDrainPromise=Promise\.all/g) ?? []).length, 2);
-  assert.match(
-    patchedDrainSource,
-    /function secondDrain\(\)\{\(\(\)=>\{let codexLinuxFinalizeQuit=\(\)=>\{d\(\),f\.dispose\(\),n\.app\.quit\(\)\},codexLinuxDrainPromise=Promise\.all\(\[\.\.\.u\.values\(\)\]\.map\(e=>e\.flush\(\)\)\);/,
-  );
 });
 
 test("marks Linux quit-in-progress for the tray quit path", () => {
@@ -6913,100 +6881,7 @@ test("uses xdg-open path when CODEX_LINUX_DISABLE_EXTERNAL_OPEN_PATCH is not 1",
   assert.equal(spawnCalls[0].command, "xdg-open");
 });
 
-test("auto-approves the app-provided Browser Use node_repl bridge", () => {
-  const source =
-    "return{[`mcp_servers.${pt}`]:{command:i.nodeReplPath,args:[],startup_timeout_sec:120,env:{[dt]:l,[ft]:i.nodePath}}}";
-
-  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-  assert.match(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
-  assert.match(patched, /env:\{\[dt\]:l,\[ft\]:i\.nodePath/);
-});
-
-test("patches all Browser Use node_repl approval configs in one pass", () => {
-  const source = [
-    "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{[dt]:l}",
-    "startup_timeout_sec:120,env:{[ft]:i.nodePath}",
-  ].join("");
-
-  const patched = applyBrowserUseNodeReplApprovalPatch(source);
-
-  assert.equal((patched.match(/approval_mode:`approve`/g) || []).length, 2);
-  assert.doesNotMatch(patched, /startup_timeout_sec:120,env:\{/);
-});
-
-test("auto-approves the older Browser Use node_repl runtime config builder", () => {
-  const source =
-    "return e.Dn({codexCliPath:o.codexCliPath,nodePath:o.nodePath,nodeReplPath:o.nodeReplPath,platform:o.platform})";
-
-  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-  assert.match(
-    patched,
-    /e\.Dn\(\{codexCliPath:o\.codexCliPath,nodePath:o\.nodePath,nodeReplPath:o\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:o\.platform\}\)/,
-  );
-});
-
-test("auto-approves the current Browser Use node_repl runtime config builder", () => {
-  const source =
-    "return e.Pn({codexCliPath:c.codexCliPath,codexHome:f,extraEnv:y,nodeModuleDirs:d,nodePath:c.nodePath,nodeReplPath:l?t.Cr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:h,traceMeta:_,trustAllCode:g,trustedBrowserClientSha256s:u,shouldUseWslPaths:l})";
-
-  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-  assert.match(
-    patched,
-    /e\.Pn\(\{codexCliPath:c\.codexCliPath,codexHome:f,extraEnv:y,nodeModuleDirs:d,nodePath:c\.nodePath,nodeReplPath:l\?t\.Cr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-  );
-});
-
-test("auto-approves the Electron 42 Browser Use node_repl runtime config builder", () => {
-  const source =
-    "return t.Fa({codexCliPath:c.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:u?t.kr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,sentryUserId:l,traceMeta:v,trustAllCode:_,trustedBrowserClientSha256s:d,shouldUseWslPaths:u})";
-
-  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-  assert.match(
-    patched,
-    /t\.Fa\(\{codexCliPath:c\.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:u\?t\.kr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-  );
-});
-
-test("auto-approves the current $a Browser Use node_repl runtime config builder", () => {
-  const source =
-    "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`],t={$a:e=>e,Fr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},p=null,b=null,f=[],g=null,v=null,_=!1,w=!1;function build(){return t.$a({codexCliPath:c.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:w?t.Fr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,sentryUserId:v,traceMeta:_,trustAllCode:null,trustedBrowserClientSha256s:d,shouldUseWslPaths:w})}";
-
-  const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-  assert.match(
-    patched,
-    /t\.\$a\(\{codexCliPath:c\.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:w\?t\.Fr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-  );
-  assert.match(
-    patched,
-    /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:w/,
-  );
-});
-
-test("auto-approves the latest Browser Use node_repl runtime config builder", () => {
-  const source =
-    "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`],w=!1,t={Ha:e=>e,Nr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},p=null,b=null,f=[],g=null,v=!1;function build(){return t.Ha({codexCliPath:c.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:w?t.Nr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,traceMeta:v,trustedBrowserClientSha256s:d,shouldUseWslPaths:w})}";
-
-  const { value: patched, warnings } = captureWarns(() =>
-    applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source),
-  );
-
-  assert.deepEqual(warnings, []);
-  assert.match(
-    patched,
-    /t\.Ha\(\{codexCliPath:c\.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:w\?t\.Nr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-  );
-  assert.match(
-    patched,
-    /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:w/,
-  );
-});
-
-test("auto-approves the current vo Browser Use node_repl runtime config builder", () => {
+test("trusts the current vo Browser Use node_repl runtime config builder", () => {
   const source =
     "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`],w=!1,t={vo:e=>e,Gr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},p=null,b=null,f=[],g=null,v=!1;function build(){return t.vo({codexCliPath:c.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:w?t.Gr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,traceMeta:v,trustedBrowserClientSha256s:d,shouldUseWslPaths:w})}";
 
@@ -7015,10 +6890,7 @@ test("auto-approves the current vo Browser Use node_repl runtime config builder"
   );
 
   assert.deepEqual(warnings, []);
-  assert.match(
-    patched,
-    /t\.vo\(\{codexCliPath:c\.codexCliPath,codexHome:p,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:w\?t\.Gr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-  );
+  assert.doesNotMatch(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
   assert.match(
     patched,
     /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:w/,
@@ -7063,7 +6935,7 @@ test("patches re-chunked Browser Use trust hash and approval assets", () => {
   }
 });
 
-test("auto-approves and trusts the current Browser Use node_repl runtime config builder", () => {
+test("trusts Linux patched bundled Browser Use clients through the current vo config builder", () => {
   const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-current-browser-client-hash-"));
   try {
     const browserClient = path.join(
@@ -7091,15 +6963,12 @@ test("auto-approves and trusts the current Browser Use node_repl runtime config 
     const browserHash = cryptoHash("patched current browser client\n");
     const chromeHash = cryptoHash("patched current chrome client\n");
     const source =
-      "\"use strict\";let o=require(`node:fs`),a=require(`node:path`),s=require(`node:crypto`),d=[`upstream-hash`],u=!1,t={La:e=>e,jr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},m=null,b=null,f=[],g=null,l=null,v=null,_=!1;function build(){return t.La({codexCliPath:c.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:u?t.jr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,sentryUserId:l,traceMeta:v,trustAllCode:_,trustedBrowserClientSha256s:d,shouldUseWslPaths:u}).trustedBrowserClientSha256s}";
+      "\"use strict\";let o=require(`node:fs`),a=require(`node:path`),s=require(`node:crypto`),d=[`upstream-hash`],u=!1,t={vo:e=>e,jr:e=>e},c={codexCliPath:null,nodePath:null,nodeReplPath:null,platform:`linux`},m=null,b=null,f=[],g=null,v=null;function build(){return t.vo({codexCliPath:c.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:u?t.jr(c.nodeReplPath):c.nodeReplPath,platform:c.platform,requestMeta:g,traceMeta:v,trustedBrowserClientSha256s:d,shouldUseWslPaths:u}).trustedBrowserClientSha256s}";
 
     const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
 
     assert.match(patched, /^"use strict";function codexLinuxTrustedBrowserClientSha256s/);
-    assert.match(
-      patched,
-      /t\.La\(\{codexCliPath:c\.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c\.nodePath,nodeReplPath:u\?t\.jr\(c\.nodeReplPath\):c\.nodeReplPath,tools:\{js:\{approval_mode:`approve`\}\},platform:c\.platform/,
-    );
+    assert.doesNotMatch(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
     assert.match(
       patched,
       /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(d\),shouldUseWslPaths:u/,
@@ -7114,71 +6983,6 @@ test("auto-approves and trusts the current Browser Use node_repl runtime config 
       process: { platform: "linux", resourcesPath: resourcesRoot },
     });
     assert.deepEqual(Array.from(linuxHashes), ["upstream-hash", browserHash, chromeHash]);
-  } finally {
-    fs.rmSync(resourcesRoot, { recursive: true, force: true });
-  }
-});
-
-test("recognizes already-approved Electron 42 Browser Use node_repl runtime config builder", () => {
-  const source =
-    "return t.Fa({codexCliPath:c.codexCliPath,codexHome:m,extraEnv:b,nodeModuleDirs:f,nodePath:c.nodePath,nodeReplPath:u?t.kr(c.nodeReplPath):c.nodeReplPath,tools:{js:{approval_mode:`approve`}},platform:c.platform,requestMeta:g,sentryUserId:l,traceMeta:v,trustAllCode:_,trustedBrowserClientSha256s:d,shouldUseWslPaths:u})";
-
-  const { value: patched, warnings } = captureWarns(() =>
-    applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source),
-  );
-
-  assert.equal(patched, source);
-  assert.deepEqual(warnings, []);
-});
-
-test("trusts Linux patched bundled Browser Use clients by hashing staged files", () => {
-  const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-browser-client-hash-"));
-  try {
-    const browserClient = path.join(
-      resourcesRoot,
-      "plugins",
-      "openai-bundled",
-      "plugins",
-      "browser",
-      "scripts",
-      "browser-client.mjs",
-    );
-    const chromeClient = path.join(
-      resourcesRoot,
-      "plugins",
-      "openai-bundled",
-      "plugins",
-      "chrome",
-      "scripts",
-      "browser-client.mjs",
-    );
-    fs.mkdirSync(path.dirname(browserClient), { recursive: true });
-    fs.mkdirSync(path.dirname(chromeClient), { recursive: true });
-    fs.writeFileSync(browserClient, "patched browser client\n", "utf8");
-    fs.writeFileSync(chromeClient, "patched chrome client\n", "utf8");
-    const browserHash = cryptoHash("patched browser client\n");
-    const chromeHash = cryptoHash("patched chrome client\n");
-    const source =
-      "\"use strict\";let o=require(`node:fs`),i=require(`node:path`),s=require(`node:crypto`),nt=[`upstream-hash`];function nn({trustedBrowserClientSha256s:e}){return e}function build(){let p=!0,v=!1,f=nt;return nn({trustedBrowserClientSha256s:p||v?f:[]})}";
-
-    const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
-
-    assert.match(patched, /^"use strict";function codexLinuxTrustedBrowserClientSha256s/);
-    assert.equal(
-      (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
-      1,
-    );
-    assert.match(patched, /codexLinuxTrustedBrowserClientSha256s\(f\)/);
-    const linuxHashes = vm.runInNewContext(`${patched};build();`, {
-      require,
-      process: { platform: "linux", resourcesPath: resourcesRoot },
-    });
-    assert.deepEqual(Array.from(linuxHashes), ["upstream-hash", browserHash, chromeHash]);
-    const darwinHashes = vm.runInNewContext(`${patched};build();`, {
-      require,
-      process: { platform: "darwin", resourcesPath: resourcesRoot },
-    });
-    assert.deepEqual(Array.from(darwinHashes), ["upstream-hash"]);
   } finally {
     fs.rmSync(resourcesRoot, { recursive: true, force: true });
   }

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -8,15 +8,9 @@ const {
 } = require("../../lib/minified-js.js");
 
 function applyBrowserUseNodeReplApprovalPatch(currentSource) {
-  const approvalPatch =
-    "startup_timeout_sec:120,tools:{js:{approval_mode:`approve`}},env:{";
-  const needle = "startup_timeout_sec:120,env:{";
-  const runtimeFactoryMethods = String.raw`Dn|Pn|Fa|La|Ha|vo|\$a`;
+  const runtimeFactoryMethods = "vo";
   let patchedSource = currentSource;
   let patchedTrustedHashes = false;
-  if (patchedSource.includes(needle)) {
-    patchedSource = patchedSource.split(needle).join(approvalPatch);
-  }
 
   const runtimeFactoryTrustedHashesRegex =
     new RegExp(String.raw`([A-Za-z_$][\w$]*)\.(${runtimeFactoryMethods})\(\{([^{}]*?trustedBrowserClientSha256s:)(?!codexLinuxTrustedBrowserClientSha256s\()([A-Za-z_$][\w$]*)(,[^{}]*?\})\)`, "g");
@@ -33,19 +27,6 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
       },
     );
   }
-
-  const currentRuntimeConfigRegex =
-    new RegExp(String.raw`([A-Za-z_$][\w$]*)\.(${runtimeFactoryMethods})\(\{([^{}]*?)nodeReplPath:([^,{}]+)(,)(?!tools:\{js:\{approval_mode:\`approve\`\}\})`, "g");
-  const currentRuntimeConfigAlreadyApprovedRegex =
-    new RegExp(String.raw`[A-Za-z_$][\w$]*\.(?:${runtimeFactoryMethods})\(\{[^{}]*?nodeReplPath:[^,{}]+,tools:\{js:\{approval_mode:\`approve\`\}\},`);
-  let patchedAnyCurrentRuntimeConfig = false;
-  patchedSource = patchedSource.replace(
-    currentRuntimeConfigRegex,
-    (_match, runtimeFactoryVar, runtimeFactoryMethod, configPrefix, nodeReplPathVar, comma) => {
-      patchedAnyCurrentRuntimeConfig = true;
-      return `${runtimeFactoryVar}.${runtimeFactoryMethod}({${configPrefix}nodeReplPath:${nodeReplPathVar}${comma}tools:{js:{approval_mode:\`approve\`}},`;
-    },
-  );
 
   // 26.623+: the browser-use node_repl mcp server config is emitted as a
   // standalone object literal `{args:[],command:VAR,env:VAR,startup_timeout_sec:120}`
@@ -64,19 +45,6 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     },
   );
 
-  const trustedHashesRegex =
-    /trustedBrowserClientSha256s:([^,{}]+)\|\|([^,{}]+)\?([A-Za-z_$][\w$]*):\[\]/g;
-  patchedSource = patchedSource.replace(
-    trustedHashesRegex,
-    (match, browserUseEnabledVar, nativePipeEnabledVar, trustedHashesVar) => {
-      if (match.includes("codexLinuxTrustedBrowserClientSha256s(")) {
-        return match;
-      }
-      patchedTrustedHashes = true;
-      return `trustedBrowserClientSha256s:${browserUseEnabledVar}||${nativePipeEnabledVar}?codexLinuxTrustedBrowserClientSha256s(${trustedHashesVar}):[]`;
-    },
-  );
-
   if (
     patchedTrustedHashes &&
     !patchedSource.includes("function codexLinuxTrustedBrowserClientSha256s(")
@@ -87,10 +55,6 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     if (fsVar == null || pathVar == null || cryptoVar == null) {
       console.warn(
         "WARN: Could not find fs/path/crypto aliases — skipping Linux Browser Use trusted hash patch",
-      );
-      patchedSource = patchedSource.replace(
-        /trustedBrowserClientSha256s:([^,{}]+)\|\|([^,{}]+)\?codexLinuxTrustedBrowserClientSha256s\(([A-Za-z_$][\w$]*)\):\[\]/g,
-        "trustedBrowserClientSha256s:$1||$2?$3:[]",
       );
       patchedSource = patchedSource.replace(
         /trustedBrowserClientSha256s:codexLinuxTrustedBrowserClientSha256s\(([A-Za-z_$][\w$]*)\)/g,
@@ -115,7 +79,7 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
     !patchedTrustedHashes &&
     !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(") &&
     patchedSource.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S") &&
-    /trustedBrowserClientSha256s:[^,{}]+\|\|/.test(patchedSource)
+    patchedSource.includes("trustedBrowserClientSha256s:")
   ) {
     console.warn(
       "WARN: Could not find Browser Use trusted hash insertion point — skipping Linux Browser Use trusted hash patch",
@@ -125,9 +89,6 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   if (
     patchedSource === currentSource &&
     patchedSource.includes("startup_timeout_sec:120") &&
-    !patchedSource.includes(approvalPatch) &&
-    !patchedAnyCurrentRuntimeConfig &&
-    !currentRuntimeConfigAlreadyApprovedRegex.test(patchedSource) &&
     !patchedAnyMcpServerConfig &&
     !mcpServerConfigAlreadyApprovedRegex.test(patchedSource) &&
     !patchedTrustedHashes &&

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -161,7 +161,8 @@ function applyBrowserUseNodeReplApprovalAssets(extractedDir) {
         const source = fs.readFileSync(candidate, "utf8");
         return (
           source.includes("startup_timeout_sec:120") ||
-          source.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S")
+          source.includes("NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S") ||
+          source.includes("trustedBrowserClientSha256s")
         );
       } catch {
         return false;

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -45,6 +45,10 @@ function linuxExplicitQuitExpression() {
   return "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
 }
 
+function linuxCanQuitWithoutPromptExpression(quitControllerVar) {
+  return `(typeof ${quitControllerVar}.canQuitWithoutPrompt===\`function\`&&${quitControllerVar}.canQuitWithoutPrompt())`;
+}
+
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
   let patchedSource = currentSource;
 
@@ -96,7 +100,7 @@ function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
   const beforeQuitNeedle =
     "if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
   const beforeQuitPatch =
-    `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
+    `if(${promptBypassExpression}e||${linuxCanQuitWithoutPromptExpression("i")}||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
   const beforeQuitRegex =
     /if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
   const patchedBeforeQuitWithoutMarkerRegex =
@@ -114,14 +118,14 @@ function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
     beforeQuitRegex,
     (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
       patchedAny = true;
-      return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
+      return `if(${promptBypassExpression}${updateInstallVar}||${linuxCanQuitWithoutPromptExpression(quitControllerVar)}||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
     },
   );
   patchedSource = patchedSource.replace(
     patchedBeforeQuitWithoutMarkerRegex,
     (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
       patchedAny = true;
-      return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
+      return `if(${promptBypassExpression}${updateInstallVar}||${linuxCanQuitWithoutPromptExpression(quitControllerVar)}||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
     },
   );
   patchedSource = patchedSource.replace(

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -4,8 +4,6 @@ function applyLinuxQuitGuardPatch(currentSource) {
   let patchedSource = currentSource;
 
   const quitGuardNeedle = "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
-  const legacyQuitGuardSuffix =
-    "let codexLinuxQuitInProgress=!1,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;";
   const quitGuardSuffix =
     "let codexLinuxQuitInProgress=!1,codexLinuxExplicitQuitApproved=!1,codexLinuxExplicitQuitDrainTimeoutMs=3e3,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxPrepareForExplicitQuit=()=>{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress()},codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0,codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;";
   const quitGuardPatch = `${quitGuardNeedle}${quitGuardSuffix}`;
@@ -14,12 +12,24 @@ function applyLinuxQuitGuardPatch(currentSource) {
     return patchedSource;
   }
 
-  if (patchedSource.includes(legacyQuitGuardSuffix)) {
-    return patchedSource.replace(legacyQuitGuardSuffix, quitGuardSuffix);
-  }
-
   if (patchedSource.includes(quitGuardNeedle)) {
     return patchedSource.replace(quitGuardNeedle, quitGuardPatch);
+  }
+
+  const currentCommaQuitGuardNeedle =
+    /let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?,([A-Za-z_$][\w$]*)=require\(`node:path`\),([A-Za-z_$][\w$]*)=require\(`node:fs`\);/;
+  const currentCommaQuitGuardMatch = patchedSource.match(currentCommaQuitGuardNeedle);
+  if (currentCommaQuitGuardMatch != null) {
+    const matchedPrefix = currentCommaQuitGuardMatch[0];
+    return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
+  }
+
+  const currentBundlerQuitGuardNeedle =
+    /let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?;(?:\1=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:path`\);(?:\2=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:fs`\);(?:\3=[^;]+;)?/;
+  const currentBundlerQuitGuardMatch = patchedSource.match(currentBundlerQuitGuardNeedle);
+  if (currentBundlerQuitGuardMatch != null) {
+    const matchedPrefix = currentBundlerQuitGuardMatch[0];
+    return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
   }
 
   const splitQuitGuardNeedle =
@@ -28,10 +38,6 @@ function applyLinuxQuitGuardPatch(currentSource) {
   if (splitQuitGuardMatch != null) {
     const matchedPrefix = splitQuitGuardMatch[0];
     return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
-  }
-
-  if (patchedSource.includes("require(`electron`)")) {
-    return `${quitGuardSuffix}${patchedSource}`;
   }
 
   if (patchedSource.includes("require(`electron`)") && patchedSource.includes("require(`node:path`)")) {
@@ -45,35 +51,20 @@ function linuxExplicitQuitExpression() {
   return "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
 }
 
-function linuxCanQuitWithoutPromptExpression(quitControllerVar) {
-  return `(typeof ${quitControllerVar}.canQuitWithoutPrompt===\`function\`&&${quitControllerVar}.canQuitWithoutPrompt())`;
-}
-
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
   let patchedSource = currentSource;
 
   const explicitQuitDrainGuard =
     "process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())";
-  const originalDrainSnippet =
-    "Promise.all([...u.values()].map(e=>e.flush())).finally(()=>{d(),f.dispose(),n.app.quit()})";
-  const patchedDrainSnippet =
-    "(()=>{let codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all([...u.values()].map(e=>e.flush()));" +
-    `if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}` +
-    "codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()";
   let patchedAny = false;
 
-  if (patchedSource.includes(originalDrainSnippet)) {
-    patchedAny = true;
-    patchedSource = patchedSource.split(originalDrainSnippet).join(patchedDrainSnippet);
-  }
-
   const drainRegex =
-    /Promise\.all\(\[\.\.\.([A-Za-z_$][\w$]*)\.values\(\)\]\.map\(e=>e\.flush\(\)\)\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
+    /Promise\.all\(\[([A-Za-z_$][\w$]*)\.flush\(\),([A-Za-z_$][\w$]*)\.flush\(\)\]\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
   patchedSource = patchedSource.replace(
     drainRegex,
-    (_match, globalStatesVar, flushDisposeVar, disposablesVar, electronVar) => {
+    (_match, firstDrainVar, secondDrainVar, flushDisposeVar, disposablesVar, electronVar) => {
       patchedAny = true;
-      return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([...${globalStatesVar}.values()].map(e=>e.flush()));if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
+      return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([${firstDrainVar}.flush(),${secondDrainVar}.flush()]);if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
     },
   );
 
@@ -81,7 +72,7 @@ function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
     !patchedAny &&
     !patchedSource.includes("codexLinuxDrainPromise=Promise.all(") &&
     patchedSource.includes("n.app.on(`will-quit`,") &&
-    patchedSource.includes(".map(e=>e.flush())")
+    patchedSource.includes(".flush()")
   ) {
     console.warn("WARN: Could not find will-quit drain sequence — skipping Linux explicit quit drain timeout patch");
   }
@@ -100,11 +91,9 @@ function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
   const beforeQuitNeedle =
     "if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
   const beforeQuitPatch =
-    `if(${promptBypassExpression}e||${linuxCanQuitWithoutPromptExpression("i")}||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
+    `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
   const beforeQuitRegex =
     /if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
-  const patchedBeforeQuitWithoutMarkerRegex =
-    /if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
   const acceptedPromptRegex =
     /([A-Za-z_$][\w$]*)\.markQuitApproved\(\),([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\)/g;
   let patchedAny = false;
@@ -118,14 +107,7 @@ function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
     beforeQuitRegex,
     (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
       patchedAny = true;
-      return `if(${promptBypassExpression}${updateInstallVar}||${linuxCanQuitWithoutPromptExpression(quitControllerVar)}||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
-    },
-  );
-  patchedSource = patchedSource.replace(
-    patchedBeforeQuitWithoutMarkerRegex,
-    (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
-      patchedAny = true;
-      return `if(${promptBypassExpression}${updateInstallVar}||${linuxCanQuitWithoutPromptExpression(quitControllerVar)}||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
+      return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
     },
   );
   patchedSource = patchedSource.replace(

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1316,6 +1316,39 @@ SCRIPT
     [ -z "$third_line" ] || fail "Expected make build-app-fresh default DMG argument to be empty, got: $(cat "$install_log")"
 }
 
+test_make_build_dev_app_writes_host_portable_launcher_symlink() {
+    info "Checking make build-dev-app writes a host-portable launcher symlink"
+    local workspace="$TMP_DIR/make-build-dev-app"
+    local install_log="$workspace/install-env.log"
+    local launcher="$workspace/bin/codex-cua-lab"
+    local target
+
+    mkdir -p "$workspace"
+
+    cat > "$workspace/install.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+printf '%s\n' "$CODEX_APP_ID" > "$TEST_INSTALL_LOG"
+printf '%s\n' "$CODEX_APP_DISPLAY_NAME" >> "$TEST_INSTALL_LOG"
+printf '%s\n' "$CODEX_INSTALL_DIR" >> "$TEST_INSTALL_LOG"
+mkdir -p "$CODEX_INSTALL_DIR"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$CODEX_INSTALL_DIR/start.sh"
+chmod +x "$CODEX_INSTALL_DIR/start.sh"
+SCRIPT
+    chmod +x "$workspace/install.sh"
+
+    TEST_INSTALL_LOG="$install_log" make -f "$REPO_DIR/Makefile" -C "$workspace" build-dev-app >/dev/null
+
+    assert_file_exists "$launcher"
+    target="$(readlink "$launcher")"
+    [ "$target" = "../codex-cua-lab-app/start.sh" ] \
+        || fail "Expected dev app launcher to use a relative symlink, got: $target"
+    [ -x "$launcher" ] || fail "Expected dev app launcher symlink to resolve on the host"
+    assert_contains "$install_log" "codex-cua-lab"
+    assert_contains "$install_log" "Codex CUA Lab"
+    assert_contains "$install_log" "$workspace/codex-cua-lab-app"
+}
+
 test_installer_refreshes_stale_cached_dmg_metadata() {
     info "Checking installer DMG cache freshness metadata branches"
     local workspace="$TMP_DIR/dmg-cache-refresh"
@@ -2038,10 +2071,10 @@ SCRIPT
     assert_contains "$wizard_log" "Atomic host: yes"
 
     CODEX_LINUX_TARGET_ATOMIC=maybe \
-    PATH="$fake_bin:/usr/bin:/bin" \
+    PATH="$fake_bin" \
     OS_RELEASE_FILE="$os_release" \
     OSTREE_BOOTED_FILE="$ostree_booted" \
-    bash -c '
+    /bin/bash -c '
         # shellcheck disable=SC1091
         source "$1"
         OS_RELEASE_ID="$(os_release_field ID)"
@@ -2055,10 +2088,10 @@ SCRIPT
     assert_contains "$helper_output" "atomic=yes"
 
     CODEX_LINUX_TARGET_ATOMIC=0 \
-    PATH="$fake_bin:/usr/bin:/bin" \
+    PATH="$fake_bin" \
     OS_RELEASE_FILE="$os_release" \
     OSTREE_BOOTED_FILE="$ostree_booted" \
-    bash -c '
+    /bin/bash -c '
         # shellcheck disable=SC1091
         source "$1"
         OS_RELEASE_ID="$(os_release_field ID)"
@@ -2072,10 +2105,10 @@ SCRIPT
     assert_contains "$helper_output" "atomic=no"
 
     rm -f "$ostree_booted"
-    PATH="$fake_bin:/usr/bin:/bin" \
+    PATH="$fake_bin" \
     OS_RELEASE_FILE="$os_release" \
     OSTREE_BOOTED_FILE="$ostree_booted" \
-    bash -c '
+    /bin/bash -c '
         # shellcheck disable=SC1091
         source "$1"
         OS_RELEASE_ID="$(os_release_field ID)"
@@ -2780,24 +2813,6 @@ test_setup_native_wizard_cleanup_deletes_only_confirmed_paths() {
     assert_contains "$output_log" "Deleted $key_file"
     assert_contains "$output_log" "Deleted $read_aloud_data"
     assert_contains "$output_log" "Skipped $plugin_cache"
-}
-
-test_upstream_build_app_workflow_tracks_dmg_metadata() {
-    info "Checking upstream build-app workflow metadata and cache behavior"
-    local workflow="$REPO_DIR/.github/workflows/upstream-build-app.yml"
-
-    assert_file_exists "$workflow"
-    assert_contains "$workflow" 'name: Upstream Build App'
-    assert_contains "$workflow" 'UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg'
-    assert_contains "$workflow" 'actions/cache@v4'
-    assert_contains "$workflow" 'path: /tmp/codex-upstream-ci/Codex.dmg'
-    assert_contains "$workflow" 'Last-Modified'
-    assert_contains "$workflow" 'sha256sum'
-    assert_contains "$workflow" 'CODEX_PATCH_REPORT_JSON="$GITHUB_WORKSPACE/patch-report.json"'
-    assert_contains "$workflow" 'node scripts/ci/validate-patch-report.js patch-report.json --profile upstream-build'
-    assert_contains "$workflow" 'make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg'
-    assert_contains "$workflow" 'DMG Last-Modified'
-    assert_contains "$workflow" 'DMG SHA-256'
 }
 
 make_update_nix_hash_fixture() {
@@ -5707,7 +5722,7 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0'
     assert_contains "$extracted/.vite/build/main-test.js" '{label:rB(this.appName),click:()=>{typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit()}}'
     assert_contains "$extracted/.vite/build/main-test.js" 'if(o.type===`quit-app`){typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit();return}'
-    assert_contains "$extracted/.vite/build/main-test.js" 'if((typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||e||i.canQuitWithoutPrompt()||r||!s&&!c){process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),g=!0,a.markAppQuitting();return}'
+    assert_contains "$extracted/.vite/build/main-test.js" 'if((typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||e||(typeof i.canQuitWithoutPrompt===`function`&&i.canQuitWithoutPrompt())||r||!s&&!c){process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),g=!0,a.markAppQuitting();return}'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),i.markQuitApproved(),g=!0,a.markAppQuitting()'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all('
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxExplicitQuitDrainTimeoutMs'
@@ -5725,7 +5740,7 @@ const source = fs.readFileSync(process.argv[2], "utf8");
 const helperSnippet = source.match(/let codexLinuxQuitInProgress=!1,[^;]*codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0,[^;]*codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0;/)?.[0];
 const traySnippet = source.match(/\{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\)\}\}/)?.[0];
 const quitAppSnippet = source.match(/if\(o\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\);return\}/)?.[0];
-const beforeQuitSnippet = source.match(/if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/)?.[0];
+const beforeQuitSnippet = source.match(/if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/)?.[0];
 if (!helperSnippet || !traySnippet || !quitAppSnippet || !beforeQuitSnippet) {
   throw new Error("Could not extract explicit quit snippets");
 }
@@ -7413,6 +7428,7 @@ main() {
     test_make_run_app_reports_missing_launcher
     test_make_build_app_uses_installer_download_flow_by_default
     test_make_build_app_fresh_uses_installer_fresh_flow
+    test_make_build_dev_app_writes_host_portable_launcher_symlink
     test_installer_refreshes_stale_cached_dmg_metadata
     test_extract_dmg_repairs_safe_7z_link_warnings
     test_fresh_install_removes_cached_dmg_metadata
@@ -7444,7 +7460,6 @@ main() {
     test_setup_native_wizard_blank_interactive_cleanup_ids_skip_cleanup
     test_setup_native_wizard_dry_run_cleanup_does_not_delete_confirmed_paths
     test_setup_native_wizard_cleanup_deletes_only_confirmed_paths
-    test_upstream_build_app_workflow_tracks_dmg_metadata
     test_update_nix_hashes_skips_unchanged_package_verification
     test_update_nix_hashes_verifies_changed_pins
     test_update_nix_hashes_verifies_changed_dmg_hash

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5712,7 +5712,7 @@ let n=require(`electron`),i=require(`node:path`),a=require(`node:fs`);
 var pb=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{n.app.quit()}}]}};
 function qB(r,o){if(o.type===`quit-app`){n.app.quit();return}return o}
 n.app.on(`before-quit`,o=>{let s=BI(),c=t.sr().some(e=>e.status===`ACTIVE`);if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}let l=n.app.getName();if(n.dialog.showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`],defaultId:0,cancelId:1,noLink:!0,title:`Quit ${l}?`,message:`Quit ${l}?`,detail:vB({hasInProgressLocalConversation:s,hasEnabledAutomations:c})})!==0){o.preventDefault();return}i.markQuitApproved(),g=!0,a.markAppQuitting()});
-n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([...u.values()].map(e=>e.flush())).finally(()=>{d(),f.dispose(),n.app.quit()})}});
+n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([u.flush(),p.flush()]).finally(()=>{d(),f.dispose(),n.app.quit()})}});
 JS
 )"
     make_fake_extracted_asar "$extracted" "$bundle_body"
@@ -5722,7 +5722,7 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0'
     assert_contains "$extracted/.vite/build/main-test.js" '{label:rB(this.appName),click:()=>{typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit()}}'
     assert_contains "$extracted/.vite/build/main-test.js" 'if(o.type===`quit-app`){typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit();return}'
-    assert_contains "$extracted/.vite/build/main-test.js" 'if((typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||e||(typeof i.canQuitWithoutPrompt===`function`&&i.canQuitWithoutPrompt())||r||!s&&!c){process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),g=!0,a.markAppQuitting();return}'
+    assert_contains "$extracted/.vite/build/main-test.js" 'if((typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||e||i.canQuitWithoutPrompt()||r||!s&&!c){process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),g=!0,a.markAppQuitting();return}'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),i.markQuitApproved(),g=!0,a.markAppQuitting()'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all('
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxExplicitQuitDrainTimeoutMs'
@@ -5740,7 +5740,7 @@ const source = fs.readFileSync(process.argv[2], "utf8");
 const helperSnippet = source.match(/let codexLinuxQuitInProgress=!1,[^;]*codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0,[^;]*codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0;/)?.[0];
 const traySnippet = source.match(/\{label:rB\(this\.appName\),click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\)\}\}/)?.[0];
 const quitAppSnippet = source.match(/if\(o\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),n\.app\.quit\(\);return\}/)?.[0];
-const beforeQuitSnippet = source.match(/if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|\(typeof i\.canQuitWithoutPrompt===`function`&&i\.canQuitWithoutPrompt\(\)\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/)?.[0];
+const beforeQuitSnippet = source.match(/if\(\(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt\(\)\)\|\|e\|\|i\.canQuitWithoutPrompt\(\)\|\|r\|\|!s&&!c\)\{process\.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),g=!0,a\.markAppQuitting\(\);return\}/)?.[0];
 if (!helperSnippet || !traySnippet || !quitAppSnippet || !beforeQuitSnippet) {
   throw new Error("Could not extract explicit quit snippets");
 }


### PR DESCRIPTION
## Summary

- add a DMG-intel acceptance blocker for unresolved Linux settings patch symbols
- run that integrity scan inside the patcher and carry findings through `patch-report.json`, so `Codex.dmg + patch-report` flows see post-patch webview failures
- distinguish real `var` / `let` / `const` declarators from bare assignment expressions in Linux settings icon detection
- update Agent Workspaces settings icon patching and Browser Use node_repl trust detection for current upstream chunk shapes

## Verification

- `docker run --rm -v "$PWD":/workspaces/codex-desktop-linux -w /workspaces/codex-desktop-linux codex-desktop-linux-devcontainer:local node --test scripts/dev/upstream-dmg-intel.test.js scripts/patch-linux-window-ui.test.js` (362/362)
- `docker run --rm -v "$PWD":/workspaces/codex-desktop-linux -w /workspaces/codex-desktop-linux codex-desktop-linux-devcontainer:local node --test scripts/patch-linux-window-ui.test.js linux-features/agent-workspace/test.js` (378/378, run before the review-fix follow-up; the follow-up did not touch `linux-features/agent-workspace`)
