### PR TITLE
fix(remote-mobile): clear stale waiting input state

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5398,14 +5398,19 @@ test("recovers completed stream items that arrive after local state lost their s
 
 test("treats empty active runtime status as stale once response rendering has completed", () => {
   const source =
-    "function LQt({hasInProgressSideChat:e,isResponseInProgress:t,latestTurnHasSystemError:n,resumeState:r,threadRuntimeStatus:i}){return e?`loading`:i?.type===`systemError`?`error`:i?.type===`active`?`loading`:r===`needs_resume`?`idle`:n?`error`:t===!0?`loading`:`idle`}";
+    "function LQt({hasInProgressSideChat:e,isResponseInProgress:t,latestTurnHasSystemError:n,resumeState:r,threadRuntimeStatus:i}){return e?`loading`:i?.type===`systemError`?`error`:i?.type===`active`?`loading`:r===`needs_resume`?`idle`:n?`error`:t===!0?`loading`:`idle`}function RQt({pendingRequestType:e,requests:t,resumeState:n,threadRuntimeStatus:r}){return t==null||n==null?null:n===`needs_resume`?r?.type===`active`&&r.activeFlags.includes(`waitingOnApproval`)&&yi(t)?`approval`:r?.type===`active`&&r.activeFlags.includes(`waitingOnUserInput`)?`response`:null:Zr(e)?`approval`:e===`userInput`?`response`:null}var IQt,AQt,OQt=e((()=>{G(),Lr(),Tt(),Ni(),kt(),IQt=s(V,(e,{get:t})=>{let n=t(rr,e);return LQt({hasInProgressSideChat:t(Qw,e),isResponseInProgress:t(ki,e),resumeState:t(si,e)??(n==null?null:`needs_resume`),threadRuntimeStatus:t(Or,e)??n?.threadRuntimeStatus??null,latestTurnHasSystemError:t(Ui,e)===!0})}),AQt=s(V,(e,{get:t})=>RQt({pendingRequestType:t(wr,e)?.type??null,requests:t(fi,e),resumeState:t(si,e),threadRuntimeStatus:t(Or,e)}))}))";
 
   const patched = applyPatchTwice(applyLinuxRemoteTerminalStatusRecoveryPatch, source);
 
   assert.match(patched, /codexLinuxRemoteTerminalStatusActive=i\?\.type===`active`/);
   assert.match(
     patched,
-    /codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&\(t===!0\|\|!Array\.isArray\(i\.activeFlags\)\|\|i\.activeFlags\.length>0\)/,
+    /codexLinuxRemoteTerminalStatusWaitingOnUserInput/,
+  );
+  assert.match(patched, /function codexLinuxRemoteHasUserInputRequest/);
+  assert.match(
+    patched,
+    /hasUserInputRequest:codexLinuxRemoteHasUserInputRequest\(t\(fi,e\)\)/,
   );
   assert.doesNotMatch(
     patched,
@@ -5413,29 +5418,84 @@ test("treats empty active runtime status as stale once response rendering has co
   );
 
   const context = {};
+  const runtimeSource = patched.slice(0, patched.indexOf("var IQt"));
   vm.runInNewContext(
-    `${patched};result={
+    `function yi(e){return Array.isArray(e)&&e.some(e=>e.method===\`item/commandExecution/requestApproval\`||e.method===\`item/fileChange/requestApproval\`||e.method===\`item/permissions/requestApproval\`)}
+     function Zr(e){return e===\`approval\`}
+     ${runtimeSource};result={
       stale:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
+      nullStatus:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:null}),
       streaming:LQt({hasInProgressSideChat:false,isResponseInProgress:true,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
-      waiting:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      waitingStale:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]},hasUserInputRequest:false}),
+      waitingWithRequest:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]},hasUserInputRequest:true}),
+      waitingWithoutWiredRequest:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
       unknownShape:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`}}),
       sideChat:LQt({hasInProgressSideChat:true,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[]}}),
       systemError:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`systemError\`}}),
       turnError:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:true,resumeState:null,threadRuntimeStatus:{type:\`idle\`}}),
-      needsResume:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`idle\`}})
+      needsResume:LQt({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`idle\`}}),
+      pendingStale:RQt({pendingRequestType:null,requests:[],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      pendingWithRequest:RQt({pendingRequestType:null,requests:[{method:\`item/tool/requestUserInput\`}],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      pendingMalformedActive:RQt({pendingRequestType:null,requests:[{method:\`item/tool/requestUserInput\`}],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`}}),
+      pendingApproval:RQt({pendingRequestType:null,requests:[{method:\`item/commandExecution/requestApproval\`}],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnApproval\`]}})
     };`,
     context,
   );
 
   assert.deepEqual(JSON.parse(JSON.stringify(context.result)), {
     stale: "idle",
+    nullStatus: "idle",
     streaming: "loading",
-    waiting: "loading",
+    waitingStale: "idle",
+    waitingWithRequest: "loading",
+    waitingWithoutWiredRequest: "loading",
     unknownShape: "loading",
     sideChat: "loading",
     systemError: "error",
     turnError: "error",
     needsResume: "idle",
+    pendingStale: null,
+    pendingWithRequest: "response",
+    pendingMalformedActive: null,
+    pendingApproval: "approval",
+  });
+});
+
+test("upgrades already-patched remote status recovery for stale waiting user input", () => {
+  const source =
+    "function nT({hasInProgressSideChat:e,isResponseInProgress:t,latestTurnHasSystemError:n,resumeState:r,threadRuntimeStatus:i}){let codexLinuxRemoteTerminalStatusActive=i?.type===`active`,codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&(t===!0||!Array.isArray(i.activeFlags)||i.activeFlags.length>0);return e?`loading`:i?.type===`systemError`?`error`:codexLinuxRemoteTerminalStatusLoading?`loading`:r===`needs_resume`?`idle`:n?`error`:t===!0?`loading`:`idle`}function rT({pendingRequestType:e,requests:t,resumeState:n,threadRuntimeStatus:r}){return t==null||n==null?null:n===`needs_resume`?r?.type===`active`&&r.activeFlags.includes(`waitingOnApproval`)&&yi(t)?`approval`:r?.type===`active`&&r.activeFlags.includes(`waitingOnUserInput`)?`response`:null:Zr(e)?`approval`:e===`userInput`?`response`:null}var iT,aT,oT=e((()=>{G(),Lr(),tT(),Ni(),kt(),iT=s(V,(e,{get:t})=>{let n=t(rr,e);return nT({hasInProgressSideChat:t(Qw,e),isResponseInProgress:t(ki,e),resumeState:t(si,e)??(n==null?null:`needs_resume`),threadRuntimeStatus:t(Or,e)??n?.threadRuntimeStatus??null,latestTurnHasSystemError:t(Ui,e)===!0})}),aT=s(V,(e,{get:t})=>rT({pendingRequestType:t(wr,e)?.type??null,requests:t(fi,e),resumeState:t(si,e),threadRuntimeStatus:t(Or,e)}))}))";
+
+  const patched = applyPatchTwice(applyLinuxRemoteTerminalStatusRecoveryPatch, source);
+  assert.match(
+    patched,
+    /hasUserInputRequest:codexLinuxRemoteHasUserInputRequest\(t\(fi,e\)\)/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&\(t===!0\|\|!Array\.isArray\(i\.activeFlags\)\|\|i\.activeFlags\.length>0\)/,
+  );
+
+  const context = {};
+  const runtimeSource = patched.slice(0, patched.indexOf("var iT"));
+  vm.runInNewContext(
+    `function yi(e){return Array.isArray(e)&&e.some(e=>e.method===\`item/commandExecution/requestApproval\`)}
+     function Zr(e){return e===\`approval\`}
+     ${runtimeSource};result={
+      staleStatus:nT({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]},hasUserInputRequest:false}),
+      realStatus:nT({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]},hasUserInputRequest:true}),
+      missingWiringStatus:nT({hasInProgressSideChat:false,isResponseInProgress:false,latestTurnHasSystemError:false,resumeState:null,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      stalePending:rT({pendingRequestType:null,requests:[],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}}),
+      realPending:rT({pendingRequestType:null,requests:[{method:\`item/tool/requestOptionPicker\`}],resumeState:\`needs_resume\`,threadRuntimeStatus:{type:\`active\`,activeFlags:[\`waitingOnUserInput\`]}})
+     };`,
+    context,
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.result)), {
+    staleStatus: "idle",
+    realStatus: "loading",
+    missingWiringStatus: "loading",
+    stalePending: null,
+    realPending: "response",
   });
 });
 

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -1000,32 +1000,133 @@ function applyLinuxCompletedItemRecoveryPatch(currentSource) {
 }
 
 function applyLinuxRemoteTerminalStatusRecoveryPatch(currentSource) {
-  if (currentSource.includes("codexLinuxRemoteTerminalStatusActive=")) {
+  if (
+    currentSource.includes("codexLinuxRemoteTerminalStatusWaitingOnUserInput") &&
+    currentSource.includes("hasUserInputRequest:codexLinuxRemoteHasUserInputRequest") &&
+    currentSource.includes("&&codexLinuxRemoteHasUserInputRequest")
+  ) {
     return currentSource;
   }
 
+  let patchedSource = currentSource;
+  const userInputRequestHelper =
+    "function codexLinuxRemoteHasUserInputRequest(e){try{return Array.isArray(e)&&e.some(e=>e?.method===`item/tool/requestUserInput`||e?.method===`item/tool/requestOptionPicker`||e?.method===`item/tool/requestSetupCodexContextPicker`||e?.method===`item/tool/call`&&(e?.params?.tool===`request_onboarding_input`||e?.params?.tool===`request_option_picker`||e?.params?.tool===`setup_codex_context_picker`||e?.params?.tool===`setup_codex_step`))}catch{return!1}}";
+  const withUserInputHelper = (replacement) =>
+    patchedSource.includes("function codexLinuxRemoteHasUserInputRequest(")
+      ? replacement
+      : `${userInputRequestHelper}${replacement}`;
+  const buildTerminalStatusReplacement = (
+    fnName,
+    sideChatVar,
+    responseProgressVar,
+    systemErrorVar,
+    resumeStateVar,
+    runtimeStatusVar,
+  ) =>
+    `function ${fnName}({hasInProgressSideChat:${sideChatVar},isResponseInProgress:${responseProgressVar},latestTurnHasSystemError:${systemErrorVar},resumeState:${resumeStateVar},threadRuntimeStatus:${runtimeStatusVar},hasUserInputRequest:codexLinuxRemoteHasUserInputRequestPending=!0}){let codexLinuxRemoteTerminalStatusActive=${runtimeStatusVar}?.type===\`active\`,codexLinuxRemoteTerminalStatusActiveFlags=Array.isArray(${runtimeStatusVar}?.activeFlags)?${runtimeStatusVar}.activeFlags:null,codexLinuxRemoteTerminalStatusWaitingOnUserInput=codexLinuxRemoteTerminalStatusActiveFlags?.includes(\`waitingOnUserInput\`)===!0,codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&(${responseProgressVar}===!0||codexLinuxRemoteTerminalStatusActiveFlags==null||codexLinuxRemoteTerminalStatusActiveFlags.length>0&&(!codexLinuxRemoteTerminalStatusWaitingOnUserInput||codexLinuxRemoteHasUserInputRequestPending===!0));return ${sideChatVar}?\`loading\`:${runtimeStatusVar}?.type===\`systemError\`?\`error\`:codexLinuxRemoteTerminalStatusLoading?\`loading\`:${resumeStateVar}===\`needs_resume\`?\`idle\`:${systemErrorVar}?\`error\`:${responseProgressVar}===!0?\`loading\`:\`idle\`}`;
+
   const terminalStatusPattern =
     /function ([A-Za-z_$][\w$]*)\(\{hasInProgressSideChat:([A-Za-z_$][\w$]*),isResponseInProgress:([A-Za-z_$][\w$]*),latestTurnHasSystemError:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{return \2\?`loading`:\6\?\.type===`systemError`\?`error`:\6\?\.type===`active`\?`loading`:\5===`needs_resume`\?`idle`:\4\?`error`:\3===!0\?`loading`:`idle`\}/u;
+  const oldPatchedTerminalStatusPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{hasInProgressSideChat:([A-Za-z_$][\w$]*),isResponseInProgress:([A-Za-z_$][\w$]*),latestTurnHasSystemError:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{let codexLinuxRemoteTerminalStatusActive=\6\?\.type===`active`,codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&\(\3===!0\|\|!Array\.isArray\(\6\.activeFlags\)\|\|\6\.activeFlags\.length>0\);return \2\?`loading`:\6\?\.type===`systemError`\?`error`:codexLinuxRemoteTerminalStatusLoading\?`loading`:\5===`needs_resume`\?`idle`:\4\?`error`:\3===!0\?`loading`:`idle`\}/u;
 
-  if (terminalStatusPattern.test(currentSource)) {
-    return currentSource.replace(
+  let terminalStatusFnName = null;
+
+  if (terminalStatusPattern.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
       terminalStatusPattern,
-      (_match, fnName, sideChatVar, responseProgressVar, systemErrorVar, resumeStateVar, runtimeStatusVar) =>
-        `function ${fnName}({hasInProgressSideChat:${sideChatVar},isResponseInProgress:${responseProgressVar},latestTurnHasSystemError:${systemErrorVar},resumeState:${resumeStateVar},threadRuntimeStatus:${runtimeStatusVar}}){let codexLinuxRemoteTerminalStatusActive=${runtimeStatusVar}?.type===\`active\`,codexLinuxRemoteTerminalStatusLoading=codexLinuxRemoteTerminalStatusActive&&(${responseProgressVar}===!0||!Array.isArray(${runtimeStatusVar}.activeFlags)||${runtimeStatusVar}.activeFlags.length>0);return ${sideChatVar}?\`loading\`:${runtimeStatusVar}?.type===\`systemError\`?\`error\`:codexLinuxRemoteTerminalStatusLoading?\`loading\`:${resumeStateVar}===\`needs_resume\`?\`idle\`:${systemErrorVar}?\`error\`:${responseProgressVar}===!0?\`loading\`:\`idle\`}`,
+      (_match, fnName, sideChatVar, responseProgressVar, systemErrorVar, resumeStateVar, runtimeStatusVar) => {
+        terminalStatusFnName = fnName;
+        return withUserInputHelper(
+          buildTerminalStatusReplacement(
+            fnName,
+            sideChatVar,
+            responseProgressVar,
+            systemErrorVar,
+            resumeStateVar,
+            runtimeStatusVar,
+          ),
+        );
+      },
     );
+  } else if (oldPatchedTerminalStatusPattern.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      oldPatchedTerminalStatusPattern,
+      (_match, fnName, sideChatVar, responseProgressVar, systemErrorVar, resumeStateVar, runtimeStatusVar) => {
+        terminalStatusFnName = fnName;
+        return withUserInputHelper(
+          buildTerminalStatusReplacement(
+            fnName,
+            sideChatVar,
+            responseProgressVar,
+            systemErrorVar,
+            resumeStateVar,
+            runtimeStatusVar,
+          ),
+        );
+      },
+    );
+  }
+
+  const pendingRequestPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{pendingRequestType:([A-Za-z_$][\w$]*),requests:([A-Za-z_$][\w$]*),resumeState:([A-Za-z_$][\w$]*),threadRuntimeStatus:([A-Za-z_$][\w$]*)\}\)\{return \3==null\|\|\4==null\?null:\4===`needs_resume`\?\5\?\.type===`active`&&\5\.activeFlags\.includes\(`waitingOnApproval`\)&&([A-Za-z_$][\w$]*)\(\3\)\?`approval`:\5\?\.type===`active`&&\5\.activeFlags\.includes\(`waitingOnUserInput`\)\?`response`:null:([A-Za-z_$][\w$]*)\(\2\)\?`approval`:\2===`userInput`\?`response`:null\}/u;
+  let pendingRequestFnName = null;
+  if (pendingRequestPattern.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      pendingRequestPattern,
+      (_match, fnName, pendingTypeVar, requestsVar, resumeStateVar, runtimeStatusVar, approvalRequestFn, approvalTypeFn) => {
+        pendingRequestFnName = fnName;
+        return withUserInputHelper(
+          `function ${fnName}({pendingRequestType:${pendingTypeVar},requests:${requestsVar},resumeState:${resumeStateVar},threadRuntimeStatus:${runtimeStatusVar}}){return ${requestsVar}==null||${resumeStateVar}==null?null:${resumeStateVar}===\`needs_resume\`?${runtimeStatusVar}?.type===\`active\`&&Array.isArray(${runtimeStatusVar}?.activeFlags)&&${runtimeStatusVar}.activeFlags.includes(\`waitingOnApproval\`)&&${approvalRequestFn}(${requestsVar})?\`approval\`:${runtimeStatusVar}?.type===\`active\`&&Array.isArray(${runtimeStatusVar}?.activeFlags)&&${runtimeStatusVar}.activeFlags.includes(\`waitingOnUserInput\`)&&codexLinuxRemoteHasUserInputRequest(${requestsVar})?\`response\`:null:${approvalTypeFn}(${pendingTypeVar})?\`approval\`:${pendingTypeVar}===\`userInput\`?\`response\`:null}`,
+        );
+      },
+    );
+  } else {
+    const existingPendingRequestPattern =
+      /function ([A-Za-z_$][\w$]*)\(\{pendingRequestType:[A-Za-z_$][\w$]*,requests:[A-Za-z_$][\w$]*,resumeState:[A-Za-z_$][\w$]*,threadRuntimeStatus:[A-Za-z_$][\w$]*\}\)\{[^}]*codexLinuxRemoteHasUserInputRequest/u;
+    const match = patchedSource.match(existingPendingRequestPattern);
+    pendingRequestFnName = match?.[1] ?? null;
+  }
+
+  if (terminalStatusFnName != null && pendingRequestFnName != null) {
+    const pendingCallPattern = new RegExp(
+      `${pendingRequestFnName}\\(\\{pendingRequestType:[^{}]+?,requests:([^{}]*\\([^{}]*\\)[^{}]*?),resumeState:[^{}]+?,threadRuntimeStatus:[^{}]+?\\}\\)`,
+      "u",
+    );
+    const pendingCallMatch = patchedSource.match(pendingCallPattern);
+    const requestExpression = pendingCallMatch?.[1] ?? null;
+    const terminalCallPattern = new RegExp(
+      `${terminalStatusFnName}\\(\\{hasInProgressSideChat:([^{}]+?),isResponseInProgress:([^{}]+?),resumeState:([^{}]+?),threadRuntimeStatus:([^{}]+?),latestTurnHasSystemError:([^{}]+?)\\}\\)`,
+      "u",
+    );
+    if (requestExpression != null && terminalCallPattern.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        terminalCallPattern,
+        `${terminalStatusFnName}({hasInProgressSideChat:$1,isResponseInProgress:$2,resumeState:$3,threadRuntimeStatus:$4,latestTurnHasSystemError:$5,hasUserInputRequest:codexLinuxRemoteHasUserInputRequest(${requestExpression})})`,
+      );
+    } else if (
+      patchedSource.includes("pendingRequestType") &&
+      patchedSource.includes("hasInProgressSideChat") &&
+      !patchedSource.includes("hasUserInputRequest:codexLinuxRemoteHasUserInputRequest")
+    ) {
+      console.warn(
+        "WARN: Could not wire remote terminal status to pending user-input requests — stale waiting-user-input recovery may be incomplete",
+      );
+    }
   }
 
   if (
     currentSource.includes("hasInProgressSideChat") &&
     currentSource.includes("isResponseInProgress") &&
-    currentSource.includes("threadRuntimeStatus")
+    currentSource.includes("threadRuntimeStatus") &&
+    patchedSource === currentSource
   ) {
     console.warn(
       "WARN: Could not find remote terminal status insertion point — skipping Linux remote terminal status recovery patch",
     );
   }
 
-  return currentSource;
+  return patchedSource;
 }
 
 function applyLinuxI18nGatePatch(currentSource) {


### PR DESCRIPTION
## Summary

- tighten the Linux webview recovery around restored `waitingOnUserInput` runtime state
- keep that state active only when a real pending user-input request is still present
- keep permission waits, real user-input waits, malformed active states, and already-patched bundles behaving as before

## Why

While testing #639, I could reproduce one stale shape in the Linux webview patch path: a restored thread can still report `waitingOnUserInput` after the request list no longer contains a matching input request. In that state, remote mobile can keep looking busy even though the conversation is ready for the next message.

The permission wait path already checks the request list before surfacing that state. This adds the same kind of guard for user-input waits, while keeping unknown active shapes on the safe loading side.

Refs #639.

## Tests

- `node --check scripts/patches/impl/webview/index.js && node --check scripts/patch-linux-window-ui.test.js`
- `git diff --check`
- `node --test --test-name-pattern "remote status|empty active runtime status|upgrades already-patched" scripts/patch-linux-window-ui.test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `make check && make test`
- patcher dry-run twice against a copied installed content tree; the webview bundle contains the new helper, call-site wiring, stale pending guard, and safe optional flag handling after patching
