### PR TITLE
Fix automation heartbeat tool loading

### DIFF
--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -56,11 +56,12 @@ papers over.
 
 ### Webview server model
 
-The bundled Python server already uses `ThreadingHTTPServer` and serves the
-hashed `/assets/` bundle with `Cache-Control: public, max-age=31536000,
-immutable`, so parallel chunk fetches and cross-restart disk caching are
-covered. Replacing it with a Rust server was evaluated and rejected until
-evidence shows Python itself is the bottleneck — see
+The bundled Python server already uses `ThreadingHTTPServer` and serves
+webview files with explicit `no-store` headers. The Linux packaging flow
+patches upstream webview assets without renaming every hashed chunk, so the
+server must force revalidation to keep Electron from reusing stale renderer
+code after rebuilds or updates. Replacing it with a Rust server was evaluated
+and rejected until evidence shows Python itself is the bottleneck — see
 [Webview server evaluation](webview-server-evaluation.md).
 
 ### Startup ordering (partially overlapped)

--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -51,23 +51,16 @@ class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
             normalized_path = "/" + normalized_path
         return normalized_path
 
-    def is_immutable_asset_request(self):
-        return self.normalized_request_path().startswith("/assets/")
-
     def send_head(self):
-        if not self.is_immutable_asset_request():
-            for header in ("If-Modified-Since", "If-None-Match"):
-                if header in self.headers:
-                    del self.headers[header]
+        for header in ("If-Modified-Since", "If-None-Match"):
+            if header in self.headers:
+                del self.headers[header]
         return super().send_head()
 
     def end_headers(self):
-        if self.is_immutable_asset_request():
-            self.send_header("Cache-Control", "public, max-age=31536000, immutable")
-        else:
-            self.send_header("Cache-Control", "no-store, max-age=0")
-            self.send_header("Pragma", "no-cache")
-            self.send_header("Expires", "0")
+        self.send_header("Cache-Control", "no-store, max-age=0")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
         super().end_headers()
 
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -152,6 +152,7 @@ const {
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
+  applyAutomationUpdateEagerToolPatch,
   applyLinuxAppSunsetPatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,
@@ -877,6 +878,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-i18n-gate",
     "linux-profile-settings-menu",
     "automation-schedule-multi-time-rrule",
+    "automation-update-eager-tool",
     "linux-app-sunset-gate",
     "linux-app-server-feature-enablement",
     "linux-app-server-backfill-wait",
@@ -4818,6 +4820,17 @@ test("shows the profile dropdown settings route on Linux", () => {
   assert.match(patched, /let Ct=!0,Pt=Ct,Ft=f\(De,`settings`\)/);
   assert.match(patched, /\/settings\/general-settings/);
   assert.match(patched, /codex\.profileDropdown\.settingsPage/);
+});
+
+test("keeps automation_update eager in dynamic tools built during thread start", () => {
+  const source =
+    "async function pUt(){return[{type:`namespace`,name:cX,description:`Tools provided by the Codex app.`,tools:[...h?[_ee()]:[],...[],...i?.open_in_codex===!0?[TBt]:[],...h&&d?[SBt]:[],lu,...h&&y?[Ra]:[],...[],...g?AHt({availableHandoffHosts:e,availableModels:b,crossHostHandoffEnabled:n,forkThreadEnabled:!0}):[],...h&&_?[PBt,FBt]:[],...m===`conversational_onboarding`?[yoe]:[],...v&&m!==`conversational_onboarding`?[...vee,bu]:[]].map(e=>({type:`function`,...e,..._Ut.has(e.name)?{}:{deferLoading:!0}}))}]}async sendRequest(e,t,n){if(e===`config/read`)return this.sendConfigReadRequest(t,n);let{request:r,promise:i}=this.createRequest(e,t,n);return i}";
+
+  const patched = applyPatchTwice(applyAutomationUpdateEagerToolPatch, source);
+
+  assert.match(patched, /e\.name===`automation_update`&&delete t\.deferLoading/);
+  assert.match(patched, /\{deferLoading:!0\}/);
+  assert.doesNotMatch(patched, /codex-linux-automation-dynamic-tools-diagnostics/);
 });
 
 test("removes unsupported features from default app-server feature sync", () => {

--- a/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
+++ b/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyAutomationUpdateEagerToolPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "automation-update-eager-tool",
+    phase: "webview-asset",
+    order: 1045,
+    ciPolicy: "optional",
+    pattern: /\.js$/,
+    missingDescription: "webview JavaScript bundle",
+    skipDescription: "automation_update eager dynamic tool patch",
+    apply: applyAutomationUpdateEagerToolPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -720,6 +720,29 @@ function applyLinuxAppServerFeatureEnablementPatch(currentSource) {
   ].join("");
 }
 
+function applyAutomationUpdateEagerToolPatch(currentSource) {
+  const marker = "e.name===`automation_update`&&delete t.deferLoading";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const dynamicToolsNeedle =
+    "tools:[...h?[_ee()]:[],...[],...i?.open_in_codex===!0?[TBt]:[],...h&&d?[SBt]:[],lu,...h&&y?[Ra]:[],...[],...g?AHt({availableHandoffHosts:e,availableModels:b,crossHostHandoffEnabled:n,forkThreadEnabled:!0}):[],...h&&_?[PBt,FBt]:[],...m===`conversational_onboarding`?[yoe]:[],...v&&m!==`conversational_onboarding`?[...vee,bu]:[]].map(e=>({type:`function`,...e,..._Ut.has(e.name)?{}:{deferLoading:!0}}))";
+  const dynamicToolsPatch =
+    "tools:[...h?[_ee()]:[],...[],...i?.open_in_codex===!0?[TBt]:[],...h&&d?[SBt]:[],lu,...h&&y?[Ra]:[],...[],...g?AHt({availableHandoffHosts:e,availableModels:b,crossHostHandoffEnabled:n,forkThreadEnabled:!0}):[],...h&&_?[PBt,FBt]:[],...m===`conversational_onboarding`?[yoe]:[],...v&&m!==`conversational_onboarding`?[...vee,bu]:[]].map(e=>{let t={type:`function`,...e,..._Ut.has(e.name)?{}:{deferLoading:!0}};return e.name===`automation_update`&&delete t.deferLoading,t})";
+
+  if (!currentSource.includes(dynamicToolsNeedle)) {
+    if (currentSource.includes("automation_update") && currentSource.includes("deferLoading:!0")) {
+      console.warn(
+        "WARN: Could not find dynamic tools construction point — skipping automation_update eager tool patch",
+      );
+    }
+    return currentSource;
+  }
+
+  return currentSource.replace(dynamicToolsNeedle, dynamicToolsPatch);
+}
+
 function applyLinuxAppServerBackfillWaitPatch(currentSource) {
   const helperSource =
     "function codexLinuxIsStateDbBackfillMessage(e){return typeof e===`string`&&e.toLowerCase().includes(`state db backfill is running`)}" +
@@ -2011,6 +2034,7 @@ module.exports = {
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
+  applyAutomationUpdateEagerToolPatch,
   applyLinuxChatSearchHydrationPatch,
   applyLinuxBrowserUseAvailabilityPatch,
   applyLinuxBrowserUseExternalAvailabilityPatch,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4720,17 +4720,17 @@ try:
 
     asset_status, asset_headers, _ = request("HEAD", "/assets/app-test-abc123.js")
     assert asset_status == 200, asset_status
-    assert asset_headers.get("cache-control") == "public, max-age=31536000, immutable", asset_headers
-    assert "pragma" not in asset_headers, asset_headers
-    assert "expires" not in asset_headers, asset_headers
+    assert asset_headers.get("cache-control") == "no-store, max-age=0", asset_headers
+    assert asset_headers.get("pragma") == "no-cache", asset_headers
+    assert asset_headers.get("expires") == "0", asset_headers
 
     cached_status, cached_headers, _ = request(
         "GET",
         "/assets/app-test-abc123.js",
         {"If-Modified-Since": asset_headers["last-modified"]},
     )
-    assert cached_status == 304, (cached_status, cached_headers)
-    assert cached_headers.get("cache-control") == "public, max-age=31536000, immutable", cached_headers
+    assert cached_status == 200, (cached_status, cached_headers)
+    assert cached_headers.get("cache-control") == "no-store, max-age=0", cached_headers
 
     refreshed_index_status, _, _ = request(
         "GET",


### PR DESCRIPTION
## Summary
- keep `automation_update` eager in webview dynamic tools so heartbeat/reminder requests do not depend on deferred `tool_search` loading
- remove immutable caching for local webview assets so patched renderer bundles are not reused stale after rebuilds or updates
- update patcher and smoke tests for the new automation tool and cache policy

## Tests
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- `python3 -m py_compile launcher/webview-server.py`
- `bash tests/scripts_smoke.sh`