### PR TITLE
fix(launcher): stabilize GNOME Wayland multi-monitor scaling

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -94,6 +94,13 @@ CODEX_OZONE_PLATFORM=x11 codex-desktop
 CODEX_OZONE_PLATFORM=wayland codex-desktop
 ```
 
+On GNOME Wayland with more than one monitor, the default `auto` rendering
+profile detects connected displays through `/sys/class/drm` and forces the
+X11/XWayland backend. This avoids Electron resizing or rescaling the maximized
+window when pointer focus crosses to another display. To opt back in to native
+Wayland, set `CODEX_OZONE_PLATFORM=wayland` or
+`CODEX_LINUX_RENDERING_MODE=default`.
+
 For a local self-build, replace `codex-desktop` with `./codex-app/start.sh`.
 Explicit launcher flags (`--x11`, `--wayland`, `--ozone-platform=*`,
 `--force-device-scale-factor=*`) always win over these environment variables.

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -2433,6 +2433,39 @@ is_wslg_session() {
     [ -n "${DISPLAY:-}" ] && [ -e /mnt/wslg ]
 }
 
+gnome_desktop_detected() {
+    case "${XDG_CURRENT_DESKTOP:-}:${XDG_SESSION_DESKTOP:-}:${DESKTOP_SESSION:-}" in
+        *GNOME*|*gnome*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+connected_drm_monitor_count() {
+    local drm_root="${CODEX_DRM_CLASS_ROOT:-/sys/class/drm}"
+    local status_file status count=0
+
+    [ -d "$drm_root" ] || return 1
+
+    for status_file in "$drm_root"/*/status; do
+        [ -f "$status_file" ] || continue
+        IFS= read -r status < "$status_file" || continue
+        [ "$status" = "connected" ] || continue
+        count=$((count + 1))
+    done
+
+    [ "$count" -gt 0 ] || return 1
+    printf '%s\n' "$count"
+}
+
+gnome_wayland_multi_monitor_detected() {
+    local count
+
+    [ "${XDG_SESSION_TYPE:-}" = "wayland" ] || return 1
+    gnome_desktop_detected || return 1
+    count="$(connected_drm_monitor_count)" || return 1
+    [ "$count" -gt 1 ]
+}
+
 normalize_linux_rendering_mode() {
     case "${CODEX_LINUX_RENDERING_MODE:-auto}" in
         auto|default|wslg|wayland-gpu)
@@ -2648,6 +2681,10 @@ apply_electron_rendering_profile() {
         auto)
             if [ "$ELECTRON_WSLG_DETECTED" -eq 1 ]; then
                 ELECTRON_RENDERING_MODE="wslg"
+            elif [ "$ELECTRON_PLATFORM_EXPLICIT" -eq 0 ] &&
+                [ "$ELECTRON_OZONE_SWITCH_IN_ARGS" -eq 0 ] &&
+                gnome_wayland_multi_monitor_detected; then
+                ELECTRON_RENDERING_MODE="gnome-wayland-multi-monitor"
             else
                 ELECTRON_RENDERING_MODE="default"
             fi
@@ -2663,6 +2700,13 @@ apply_electron_rendering_profile() {
             return 0
             ;;
     esac
+
+    if [ "$ELECTRON_RENDERING_MODE" = "gnome-wayland-multi-monitor" ]; then
+        ELECTRON_OZONE_PLATFORM="x11"
+        ELECTRON_OZONE_HINT=""
+        echo "Detected GNOME Wayland multi-monitor session; forcing --ozone-platform=x11 for stable window scale/maximize behavior. Set CODEX_OZONE_PLATFORM=wayland or CODEX_LINUX_RENDERING_MODE=default to opt out."
+        return 0
+    fi
 
     [ "$ELECTRON_RENDERING_MODE" = "wslg" ] || return 0
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4015,6 +4015,14 @@ EOF
     output="$(env -i PATH="$PATH" HOME="$HOME" XDG_SESSION_TYPE=wayland CODEX_LINUX_RENDERING_MODE=default "$launcher_probe" probe)"
     [[ "$output" == *"comp=1"* && "$output" == *"<--disable-gpu-compositing>"* ]] || fail "Wayland default profile must disable GPU compositing for side-panel stability: $output"
 
+    local drm_stub_dir="$TMP_DIR/drm-stubs/two"
+    mkdir -p "$drm_stub_dir/card0-DP-2" "$drm_stub_dir/card0-HDMI-3"
+    printf '%s\n' connected > "$drm_stub_dir/card0-DP-2/status"
+    printf '%s\n' connected > "$drm_stub_dir/card0-HDMI-3/status"
+    output="$(env -i PATH="$PATH" HOME="$HOME" CODEX_DRM_CLASS_ROOT="$drm_stub_dir" DISPLAY=:0 XDG_SESSION_TYPE=wayland XDG_CURRENT_DESKTOP=ubuntu:GNOME "$launcher_probe" probe)"
+    [[ "$output" == *"mode=gnome-wayland-multi-monitor"* && "$output" == *"<--ozone-platform=x11>"* ]] || fail "GNOME Wayland multi-monitor auto profile must force X11 for stable maximize/scale behavior: $output"
+    [[ "$output" != *"<--ozone-platform-hint=auto>"* ]] || fail "GNOME Wayland multi-monitor auto profile must not leave backend selection to Electron: $output"
+
     output="$(env -i PATH="$PATH" HOME="$HOME" XDG_SESSION_TYPE=wayland CODEX_LINUX_RENDERING_MODE=default CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 "$launcher_probe" probe)"
     [[ "$output" == *"comp=0"* && "$output" != *"<--disable-gpu-compositing>"* ]] || fail "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=0 must suppress the Wayland compositor workaround: $output"
 


### PR DESCRIPTION
## Summary

This PR stabilizes Codex Desktop startup on GNOME Wayland sessions with multiple monitors by selecting the X11/XWayland Ozone backend automatically when the launcher is in its default `auto` rendering mode.

## Root Cause

On GNOME Wayland multi-monitor setups, Electron 42 can pick the native Wayland backend through `--ozone-platform-hint=auto`. In that backend, moving pointer focus across displays can trigger display/scale related window state changes. On an installed package this showed up as a maximized Codex window suddenly shrinking/rescaling when the pointer moved to a side monitor, while other desktop apps remained stable.

The installed launcher already had manual escape hatches (`CODEX_OZONE_PLATFORM=x11`, `CODEX_FORCE_DEVICE_SCALE_FACTOR`, and explicit `--x11` / `--wayland` flags), but the default path still left backend selection to Electron on the affected GNOME Wayland multi-monitor layout.

## Fix

- Detect GNOME Wayland multi-monitor sessions in the launcher via connected DRM connector state under `/sys/class/drm`, avoiding any undeclared runtime tool dependency.
- In the default `auto` rendering mode, force `--ozone-platform=x11` for that layout instead of passing `--ozone-platform-hint=auto`.
- Preserve explicit user choices: `--wayland`, `--ozone-platform=*`, `CODEX_OZONE_PLATFORM=*`, and `CODEX_LINUX_RENDERING_MODE=default|wayland-gpu|wslg` still win.
- Document the fallback and the opt-out path in troubleshooting docs.
- Add a smoke test that reproduces the GNOME Wayland two-monitor launcher decision.

## Generality

This is intentionally broader than one machine but still scoped. The fallback applies to the class of GNOME Wayland sessions with more than one monitor, which is where Electron's native Wayland backend is most likely to encounter monitor-dependent scale/maximize drift. It does not change single-monitor sessions, WSLg, non-GNOME desktops, or any launch where the user explicitly requested a backend.

If future Electron/GNOME versions make native Wayland reliable for this layout, users can already opt back in with `CODEX_OZONE_PLATFORM=wayland` or `CODEX_LINUX_RENDERING_MODE=default`, and the condition can be relaxed later.

## Validation

- `bash -n install.sh && bash -n scripts/lib/*.sh && bash -n launcher/start.sh.template && bash -n scripts/build-deb.sh && bash -n scripts/build-rpm.sh && bash -n scripts/build-pacman.sh && bash -n scripts/build-appimage.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- Local package rebuild and runtime validation on a GNOME Wayland dual-monitor setup: the previous shrink/rescale behavior disappeared after the launcher selected X11/XWayland.

