### PR TITLE
feat(updater): add runtime diagnostics command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.8.6"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -31,9 +31,16 @@ need to pin a particular binary from a GUI-launched session.
 ```bash
 systemctl --user status codex-update-manager.service
 codex-update-manager status --json
+codex-update-manager diagnose --json
 sed -n '1,160p' ~/.local/state/codex-update-manager/state.json
 sed -n '1,160p' ~/.local/state/codex-update-manager/service.log
 ```
+
+`diagnose` is read-only and intended for post-update support reports. It checks
+the persisted updater state, installed app executable, launcher `app.pid` and
+`webview.pid`, local webview HTTP endpoint, warm-start handoff socket, and
+Linux build metadata without starting, stopping, installing, or repairing
+anything.
 
 Runtime files:
 

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.8.6"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{Cli, Commands},
     codex_cli,
     config::{RuntimeConfig, RuntimePaths},
-    feature_picker, install, install_rollback, liveness, logging, notify, rollback,
+    diagnostics, feature_picker, install, install_rollback, liveness, logging, notify, rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
     upstream, wrapper, wrapper_apply,
 };
@@ -51,6 +51,10 @@ const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
 /// Runs the updater command-line entrypoint.
 pub async fn run(cli: Cli) -> Result<()> {
     let paths = RuntimePaths::detect()?;
+    if let Commands::Diagnose { json } = &cli.command {
+        return run_diagnose_command(&paths, *json).await;
+    }
+
     paths.ensure_dirs()?;
     logging::init(&paths.log_file)?;
 
@@ -90,6 +94,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             print_path,
         } => run_prompt_install_cli(&mut state, &paths, cli_path, print_path),
         Commands::Status { json } => run_status(&config, &mut state, &paths, json),
+        Commands::Diagnose { .. } => unreachable!("diagnose is handled before runtime writes"),
         Commands::InstallReady => run_install_ready(&config, &mut state, &paths).await,
         Commands::Rollback => rollback::run(&config, &mut state, &paths).await,
         Commands::InstallDeb { path } => install::install_deb(&path),
@@ -99,6 +104,17 @@ pub async fn run(cli: Cli) -> Result<()> {
         Commands::InstallRollbackRpm { path } => install_rollback::install_rpm(&path),
         Commands::InstallRollbackPacman { path } => install_rollback::install_pacman(&path),
     }
+}
+
+async fn run_diagnose_command(paths: &RuntimePaths, json: bool) -> Result<()> {
+    let mut config = RuntimeConfig::load_or_default(paths)?;
+    if let Some(enabled) = crate::config::settings_wrapper_updates_override() {
+        config.enable_wrapper_updates = enabled;
+    }
+    let mut state =
+        PersistedState::load_or_default(&paths.state_file, effective_auto_install(&config))?;
+    state.installed_version = install::installed_package_version();
+    diagnostics::run(&config, &state, paths, json).await
 }
 
 fn persist_state(paths: &RuntimePaths, state: &PersistedState) -> Result<()> {

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -52,6 +52,11 @@ pub enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Print read-only post-update/runtime diagnostics for support and smoke checks.
+    Diagnose {
+        #[arg(long)]
+        json: bool,
+    },
     /// Install the already rebuilt update package, if one is ready.
     InstallReady,
     /// Roll back to the last retained known-good package.

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -171,7 +171,7 @@ impl RuntimeConfig {
 }
 
 const APP_SETTINGS_FILE: &str = "settings.json";
-const DEFAULT_APP_ID: &str = "codex-desktop";
+pub(crate) const DEFAULT_APP_ID: &str = "codex-desktop";
 const AUTO_INSTALL_SETTING_KEY: &str = "codex-linux-auto-update-on-exit";
 const WRAPPER_UPDATES_SETTING_KEY: &str = "codex-linux-wrapper-updates-enabled";
 
@@ -179,22 +179,40 @@ const WRAPPER_UPDATES_SETTING_KEY: &str = "codex-linux-wrapper-updates-enabled";
 /// bundle do: `CODEX_LINUX_APP_ID`, then `CODEX_APP_ID`, then `codex-desktop`.
 /// Invalid ids fall back to the default so a malformed env value can never point
 /// the lookup at an attacker-controlled path.
-fn resolve_app_id() -> String {
-    fn valid(id: &str) -> bool {
-        !id.is_empty()
-            && id
-                .bytes()
-                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
-    }
-
+pub(crate) fn resolve_app_id() -> String {
     for var in ["CODEX_LINUX_APP_ID", "CODEX_APP_ID"] {
         if let Ok(value) = std::env::var(var) {
-            if valid(&value) {
+            if valid_app_id(&value) {
                 return value;
             }
         }
     }
     DEFAULT_APP_ID.to_string()
+}
+
+pub(crate) fn valid_app_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+pub(crate) fn resolve_launch_instance_id() -> Option<String> {
+    std::env::var("CODEX_LINUX_INSTANCE_ID")
+        .ok()
+        .filter(|value| valid_app_id(value))
+}
+
+pub(crate) fn resolve_app_state_dir() -> Result<PathBuf> {
+    let base_dirs = BaseDirs::new().context("Could not resolve XDG base directories")?;
+    let state_root = base_dirs
+        .state_dir()
+        .unwrap_or_else(|| base_dirs.data_local_dir());
+    let app_state_dir = state_root.join(resolve_app_id());
+    Ok(match resolve_launch_instance_id() {
+        Some(instance) => app_state_dir.join("instances").join(instance),
+        None => app_state_dir,
+    })
 }
 
 /// Resolves the app `settings.json` path mirroring the launcher

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -1,12 +1,11 @@
 //! Read-only diagnostics for installed Codex Desktop Linux runtimes.
 
 use crate::{
-    config::{RuntimeConfig, RuntimePaths},
+    config::{self, RuntimeConfig, RuntimePaths},
     liveness,
     state::PersistedState,
 };
-use anyhow::{Context, Result};
-use directories::BaseDirs;
+use anyhow::Result;
 use serde::Serialize;
 use std::{
     env, fs,
@@ -14,8 +13,8 @@ use std::{
     time::Duration,
 };
 
-const DEFAULT_APP_ID: &str = "codex-desktop";
 const DEFAULT_WEBVIEW_PORT: u16 = 5175;
+const SIDE_BY_SIDE_WEBVIEW_PORT: u16 = 5176;
 const WEBVIEW_TIMEOUT: Duration = Duration::from_secs(2);
 
 type WebviewProbe = (String, bool, Option<u16>, Option<String>);
@@ -126,8 +125,8 @@ fn collect_with_webview(
 ) -> Result<DiagnosticsReport> {
     let running = liveness::is_app_running(config);
     let app_running = running.as_ref().copied().unwrap_or(false);
-    let app_state_dir = codex_desktop_state_dir()?;
-    let app_pid_file = liveness::app_pid_file()?;
+    let app_state_dir = config::resolve_app_state_dir()?;
+    let app_pid_file = app_state_dir.join("app.pid");
     let webview_pid_file = app_state_dir.join("webview.pid");
     let metadata = metadata_diagnostics(config);
     let app = AppDiagnostics {
@@ -281,11 +280,37 @@ async fn check_webview(url: String) -> (String, bool, Option<u16>, Option<String
 }
 
 fn webview_url() -> String {
-    let port = env::var("CODEX_WEBVIEW_PORT")
-        .ok()
-        .and_then(|value| value.parse::<u16>().ok())
-        .unwrap_or(DEFAULT_WEBVIEW_PORT);
+    let port = webview_port();
     format!("http://127.0.0.1:{port}/")
+}
+
+fn webview_port() -> u16 {
+    env::var("CODEX_WEBVIEW_PORT")
+        .ok()
+        .and_then(|value| parse_tcp_port(&value))
+        .or_else(|| {
+            env::var("CODEX_LINUX_WEBVIEW_PORT")
+                .ok()
+                .and_then(|value| parse_tcp_port(&value))
+        })
+        .unwrap_or_else(default_webview_port)
+}
+
+fn default_webview_port() -> u16 {
+    if config::resolve_app_id() == config::DEFAULT_APP_ID {
+        DEFAULT_WEBVIEW_PORT
+    } else {
+        SIDE_BY_SIDE_WEBVIEW_PORT
+    }
+}
+
+fn parse_tcp_port(value: &str) -> Option<u16> {
+    let port = value.parse::<u32>().ok()?;
+    if (1..=u16::MAX as u32).contains(&port) {
+        Some(port as u16)
+    } else {
+        None
+    }
 }
 
 fn pid_file_diagnostics(path: &Path) -> PidFileDiagnostics {
@@ -351,57 +376,24 @@ fn first_existing_or_first(paths: Vec<PathBuf>) -> Option<PathBuf> {
         .or_else(|| paths.into_iter().next())
 }
 
-fn codex_desktop_state_dir() -> Result<PathBuf> {
-    let base_dirs = BaseDirs::new().context("Could not resolve XDG base directories")?;
-    let state_root = base_dirs
-        .state_dir()
-        .unwrap_or_else(|| base_dirs.data_local_dir());
-    Ok(state_root.join(app_id()))
-}
-
 fn launch_action_socket_path() -> Result<PathBuf> {
-    let app_id = app_id();
-    let instance_id = env::var("CODEX_LINUX_INSTANCE_ID")
-        .ok()
-        .filter(|value| valid_app_id(value));
-    let base = env::var_os("XDG_RUNTIME_DIR")
+    let app_id = config::resolve_app_id();
+    let instance_id = config::resolve_launch_instance_id();
+    if let Some(base) = env::var_os("XDG_RUNTIME_DIR")
         .map(PathBuf::from)
         .filter(|path| !path.as_os_str().is_empty())
-        .or_else(|| {
-            BaseDirs::new().map(|base_dirs| {
-                base_dirs
-                    .state_dir()
-                    .unwrap_or_else(|| base_dirs.data_local_dir())
-                    .to_path_buf()
-            })
-        })
-        .context("Could not resolve XDG runtime or state directory")?;
-    let root = base.join(app_id);
-    Ok(match instance_id {
-        Some(instance) => root
-            .join("instances")
-            .join(instance)
-            .join("launch-action.sock"),
-        None => root.join("launch-action.sock"),
-    })
-}
-
-fn app_id() -> String {
-    for var in ["CODEX_LINUX_APP_ID", "CODEX_APP_ID"] {
-        if let Ok(value) = env::var(var) {
-            if valid_app_id(&value) {
-                return value;
-            }
-        }
+    {
+        let root = base.join(app_id);
+        return Ok(match instance_id {
+            Some(instance) => root
+                .join("instances")
+                .join(instance)
+                .join("launch-action.sock"),
+            None => root.join("launch-action.sock"),
+        });
     }
-    DEFAULT_APP_ID.to_string()
-}
 
-fn valid_app_id(value: &str) -> bool {
-    !value.is_empty()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    Ok(config::resolve_app_state_dir()?.join("launch-action.sock"))
 }
 
 fn optional_path(path: Option<&PathBuf>) -> String {
@@ -450,6 +442,29 @@ mod tests {
     }
 
     #[test]
+    fn app_runtime_paths_follow_app_id_and_instance() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+            "XDG_RUNTIME_DIR",
+        ]);
+        env::set_var("CODEX_LINUX_APP_ID", "codex-test");
+        env::set_var("CODEX_LINUX_INSTANCE_ID", "port-6176");
+        env::set_var("XDG_RUNTIME_DIR", "/tmp/codex-runtime-test");
+
+        assert!(config::resolve_app_state_dir()?.ends_with("codex-test/instances/port-6176"));
+        assert_eq!(
+            launch_action_socket_path()?,
+            PathBuf::from(
+                "/tmp/codex-runtime-test/codex-test/instances/port-6176/launch-action.sock"
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
     fn launch_socket_uses_runtime_dir_and_instance() -> Result<()> {
         let _env_guard = env_lock();
         let _restore_env = EnvRestoreGuard::capture(&[
@@ -469,6 +484,27 @@ mod tests {
             )
         );
         Ok(())
+    }
+
+    #[test]
+    fn webview_port_matches_launcher_precedence() {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "CODEX_WEBVIEW_PORT",
+            "CODEX_LINUX_WEBVIEW_PORT",
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+        ]);
+        env::set_var("CODEX_LINUX_APP_ID", "codex-side");
+        env::remove_var("CODEX_WEBVIEW_PORT");
+        env::remove_var("CODEX_LINUX_WEBVIEW_PORT");
+        assert_eq!(webview_port(), SIDE_BY_SIDE_WEBVIEW_PORT);
+
+        env::set_var("CODEX_LINUX_WEBVIEW_PORT", "6176");
+        assert_eq!(webview_port(), 6176);
+
+        env::set_var("CODEX_WEBVIEW_PORT", "6177");
+        assert_eq!(webview_port(), 6177);
     }
 
     #[test]
@@ -572,6 +608,7 @@ mod tests {
         let _env_guard = env_lock();
         let _restore_env = EnvRestoreGuard::capture(&[
             "CODEX_WEBVIEW_PORT",
+            "CODEX_LINUX_WEBVIEW_PORT",
             "CODEX_LINUX_APP_ID",
             "CODEX_APP_ID",
             "CODEX_LINUX_INSTANCE_ID",

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -1,0 +1,608 @@
+//! Read-only diagnostics for installed Codex Desktop Linux runtimes.
+
+use crate::{
+    config::{RuntimeConfig, RuntimePaths},
+    liveness,
+    state::PersistedState,
+};
+use anyhow::{Context, Result};
+use directories::BaseDirs;
+use serde::Serialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+const DEFAULT_APP_ID: &str = "codex-desktop";
+const DEFAULT_WEBVIEW_PORT: u16 = 5175;
+const WEBVIEW_TIMEOUT: Duration = Duration::from_secs(2);
+
+type WebviewProbe = (String, bool, Option<u16>, Option<String>);
+
+#[derive(Debug, Serialize)]
+struct DiagnosticsReport {
+    schema: &'static str,
+    ok: bool,
+    warnings: Vec<String>,
+    update: UpdateDiagnostics,
+    app: AppDiagnostics,
+    webview: WebviewDiagnostics,
+    warm_start: WarmStartDiagnostics,
+    metadata: MetadataDiagnostics,
+    paths: PathDiagnostics,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateDiagnostics {
+    status: String,
+    installed_version: String,
+    candidate_version: Option<String>,
+    last_known_good_version: Option<String>,
+    update_error: Option<String>,
+    cli_status: String,
+}
+
+#[derive(Debug, Serialize)]
+struct AppDiagnostics {
+    executable_path: PathBuf,
+    executable_exists: bool,
+    running: bool,
+    running_error: Option<String>,
+    pid_file: PidFileDiagnostics,
+}
+
+#[derive(Debug, Serialize)]
+struct PidFileDiagnostics {
+    path: PathBuf,
+    exists: bool,
+    pid: Option<u32>,
+    process_alive: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+struct WebviewDiagnostics {
+    url: String,
+    ok: bool,
+    status: Option<u16>,
+    error: Option<String>,
+    pid_file: PidFileDiagnostics,
+}
+
+#[derive(Debug, Serialize)]
+struct WarmStartDiagnostics {
+    socket_path: PathBuf,
+    socket_exists: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct MetadataDiagnostics {
+    build_info_path: Option<PathBuf>,
+    build_info_exists: bool,
+    source_info_path: Option<PathBuf>,
+    source_info_exists: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct PathDiagnostics {
+    config_file: PathBuf,
+    state_file: PathBuf,
+    log_file: PathBuf,
+    cache_dir: PathBuf,
+    state_dir: PathBuf,
+    builder_bundle_root: PathBuf,
+}
+
+/// Runs the diagnostics command.
+pub async fn run(
+    config: &RuntimeConfig,
+    state: &PersistedState,
+    paths: &RuntimePaths,
+    json: bool,
+) -> Result<()> {
+    let report = collect(config, state, paths).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_text(&report);
+    }
+    Ok(())
+}
+
+async fn collect(
+    config: &RuntimeConfig,
+    state: &PersistedState,
+    paths: &RuntimePaths,
+) -> Result<DiagnosticsReport> {
+    let webview = check_webview(webview_url()).await;
+    collect_with_webview(config, state, paths, webview)
+}
+
+fn collect_with_webview(
+    config: &RuntimeConfig,
+    state: &PersistedState,
+    paths: &RuntimePaths,
+    webview: WebviewProbe,
+) -> Result<DiagnosticsReport> {
+    let running = liveness::is_app_running(config);
+    let app_running = running.as_ref().copied().unwrap_or(false);
+    let app_state_dir = codex_desktop_state_dir()?;
+    let app_pid_file = liveness::app_pid_file()?;
+    let webview_pid_file = app_state_dir.join("webview.pid");
+    let metadata = metadata_diagnostics(config);
+    let app = AppDiagnostics {
+        executable_path: config.app_executable_path.clone(),
+        executable_exists: config.app_executable_path.exists(),
+        running: app_running,
+        running_error: running.err().map(|error| error.to_string()),
+        pid_file: pid_file_diagnostics(&app_pid_file),
+    };
+    let report_without_warnings = DiagnosticsReport {
+        schema: "codex-update-manager/diagnostics/v1",
+        ok: false,
+        warnings: Vec::new(),
+        update: UpdateDiagnostics {
+            status: format!("{:?}", state.status),
+            installed_version: state.installed_version.clone(),
+            candidate_version: state.candidate_version.clone(),
+            last_known_good_version: state.last_known_good_version.clone(),
+            update_error: state.error_message.clone(),
+            cli_status: format!("{:?}", state.cli_status),
+        },
+        app,
+        webview: WebviewDiagnostics {
+            url: webview.0,
+            ok: webview.1,
+            status: webview.2,
+            error: webview.3,
+            pid_file: pid_file_diagnostics(&webview_pid_file),
+        },
+        warm_start: WarmStartDiagnostics {
+            socket_path: launch_action_socket_path()?,
+            socket_exists: false,
+        },
+        metadata,
+        paths: PathDiagnostics {
+            config_file: paths.config_file.clone(),
+            state_file: paths.state_file.clone(),
+            log_file: paths.log_file.clone(),
+            cache_dir: paths.cache_dir.clone(),
+            state_dir: paths.state_dir.clone(),
+            builder_bundle_root: config.builder_bundle_root.clone(),
+        },
+    };
+
+    let mut report = DiagnosticsReport {
+        warm_start: WarmStartDiagnostics {
+            socket_exists: report_without_warnings.warm_start.socket_path.exists(),
+            ..report_without_warnings.warm_start
+        },
+        ..report_without_warnings
+    };
+    report.warnings = diagnostics_warnings(&report);
+    report.ok = report.warnings.is_empty();
+    Ok(report)
+}
+
+fn print_text(report: &DiagnosticsReport) {
+    println!(
+        "diagnostics: {}",
+        if report.ok { "ok" } else { "attention" }
+    );
+    for warning in &report.warnings {
+        println!("warning: {warning}");
+    }
+    println!(
+        "update: status={} installed={} candidate={} error={}",
+        report.update.status,
+        report.update.installed_version,
+        report.update.candidate_version.as_deref().unwrap_or("none"),
+        report.update.update_error.as_deref().unwrap_or("none")
+    );
+    println!(
+        "app: executable={} exists={} running={}",
+        report.app.executable_path.display(),
+        report.app.executable_exists,
+        report.app.running
+    );
+    println!(
+        "app_pid: path={} pid={} alive={}",
+        report.app.pid_file.path.display(),
+        optional_pid(report.app.pid_file.pid),
+        optional_bool(report.app.pid_file.process_alive)
+    );
+    println!(
+        "webview: url={} ok={} status={} error={}",
+        report.webview.url,
+        report.webview.ok,
+        report
+            .webview
+            .status
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "none".to_string()),
+        report.webview.error.as_deref().unwrap_or("none")
+    );
+    println!(
+        "webview_pid: path={} pid={} alive={}",
+        report.webview.pid_file.path.display(),
+        optional_pid(report.webview.pid_file.pid),
+        optional_bool(report.webview.pid_file.process_alive)
+    );
+    println!(
+        "warm_start: socket={} exists={}",
+        report.warm_start.socket_path.display(),
+        report.warm_start.socket_exists
+    );
+    println!(
+        "metadata: build_info={} exists={} source_info={} exists={}",
+        optional_path(report.metadata.build_info_path.as_ref()),
+        report.metadata.build_info_exists,
+        optional_path(report.metadata.source_info_path.as_ref()),
+        report.metadata.source_info_exists
+    );
+}
+
+fn diagnostics_warnings(report: &DiagnosticsReport) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if !report.app.executable_exists {
+        warnings.push("app executable is missing".to_string());
+    }
+    if report.update.update_error.is_some() {
+        warnings.push("updater state has an update error".to_string());
+    }
+    if report.app.running && !report.webview.ok {
+        warnings.push("app is running but webview did not respond".to_string());
+    }
+    if report.app.running && report.app.pid_file.pid.is_none() {
+        warnings.push("app is running but app.pid is missing or invalid".to_string());
+    }
+    if report.app.running
+        && report.webview.pid_file.exists
+        && report.webview.pid_file.process_alive == Some(false)
+    {
+        warnings.push("webview.pid points to a dead process".to_string());
+    }
+    if !report.metadata.build_info_exists {
+        warnings.push("Linux build-info metadata is missing".to_string());
+    }
+    warnings
+}
+
+async fn check_webview(url: String) -> (String, bool, Option<u16>, Option<String>) {
+    let client = reqwest::Client::new();
+    let request = client.get(&url).timeout(WEBVIEW_TIMEOUT);
+    match request.send().await {
+        Ok(response) => {
+            let status = response.status().as_u16();
+            (url, response.status().is_success(), Some(status), None)
+        }
+        Err(error) => (url, false, None, Some(error.to_string())),
+    }
+}
+
+fn webview_url() -> String {
+    let port = env::var("CODEX_WEBVIEW_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_WEBVIEW_PORT);
+    format!("http://127.0.0.1:{port}/")
+}
+
+fn pid_file_diagnostics(path: &Path) -> PidFileDiagnostics {
+    let pid = read_pid(path);
+    PidFileDiagnostics {
+        path: path.to_path_buf(),
+        exists: path.exists(),
+        pid,
+        process_alive: pid.map(process_alive),
+    }
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    fs::read_to_string(path).ok()?.trim().parse::<u32>().ok()
+}
+
+fn process_alive(pid: u32) -> bool {
+    Path::new("/proc").join(pid.to_string()).exists()
+}
+
+fn metadata_diagnostics(config: &RuntimeConfig) -> MetadataDiagnostics {
+    let build_info_path = first_existing_or_first(build_info_paths(config));
+    let source_info_path = first_existing_or_first(source_info_paths(config));
+    MetadataDiagnostics {
+        build_info_exists: build_info_path.as_ref().is_some_and(|path| path.exists()),
+        source_info_exists: source_info_path.as_ref().is_some_and(|path| path.exists()),
+        build_info_path,
+        source_info_path,
+    }
+}
+
+fn build_info_paths(config: &RuntimeConfig) -> Vec<PathBuf> {
+    config
+        .app_executable_path
+        .parent()
+        .map(|app_root| {
+            vec![
+                app_root.join(".codex-linux/build-info.json"),
+                app_root.join("resources/codex-linux-build-info.json"),
+            ]
+        })
+        .unwrap_or_default()
+}
+
+fn source_info_paths(config: &RuntimeConfig) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(app_root) = config.app_executable_path.parent() {
+        paths.push(app_root.join(".codex-linux/source-info.json"));
+    }
+    paths.push(
+        config
+            .builder_bundle_root
+            .join(".codex-linux/source-info.json"),
+    );
+    paths
+}
+
+fn first_existing_or_first(paths: Vec<PathBuf>) -> Option<PathBuf> {
+    paths
+        .iter()
+        .find(|path| path.exists())
+        .cloned()
+        .or_else(|| paths.into_iter().next())
+}
+
+fn codex_desktop_state_dir() -> Result<PathBuf> {
+    let base_dirs = BaseDirs::new().context("Could not resolve XDG base directories")?;
+    let state_root = base_dirs
+        .state_dir()
+        .unwrap_or_else(|| base_dirs.data_local_dir());
+    Ok(state_root.join(app_id()))
+}
+
+fn launch_action_socket_path() -> Result<PathBuf> {
+    let app_id = app_id();
+    let instance_id = env::var("CODEX_LINUX_INSTANCE_ID")
+        .ok()
+        .filter(|value| valid_app_id(value));
+    let base = env::var_os("XDG_RUNTIME_DIR")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .or_else(|| {
+            BaseDirs::new().map(|base_dirs| {
+                base_dirs
+                    .state_dir()
+                    .unwrap_or_else(|| base_dirs.data_local_dir())
+                    .to_path_buf()
+            })
+        })
+        .context("Could not resolve XDG runtime or state directory")?;
+    let root = base.join(app_id);
+    Ok(match instance_id {
+        Some(instance) => root
+            .join("instances")
+            .join(instance)
+            .join("launch-action.sock"),
+        None => root.join("launch-action.sock"),
+    })
+}
+
+fn app_id() -> String {
+    for var in ["CODEX_LINUX_APP_ID", "CODEX_APP_ID"] {
+        if let Ok(value) = env::var(var) {
+            if valid_app_id(&value) {
+                return value;
+            }
+        }
+    }
+    DEFAULT_APP_ID.to_string()
+}
+
+fn valid_app_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn optional_path(path: Option<&PathBuf>) -> String {
+    path.map(|path| path.display().to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn optional_pid(pid: Option<u32>) -> String {
+    pid.map(|value| value.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+fn optional_bool(value: Option<bool>) -> String {
+    value
+        .map(|flag| flag.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{RuntimeConfig, RuntimePaths},
+        state::PersistedState,
+        test_util::{env_lock, EnvRestoreGuard},
+    };
+    use anyhow::Result;
+
+    fn test_paths(root: &Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config/config.toml"),
+            state_file: root.join("state/state.json"),
+            log_file: root.join("state/service.log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    fn test_config(root: &Path) -> RuntimeConfig {
+        let paths = test_paths(root);
+        let mut config = RuntimeConfig::default_with_paths(&paths);
+        config.app_executable_path = root.join("app/electron");
+        config.builder_bundle_root = root.join("builder");
+        config
+    }
+
+    #[test]
+    fn launch_socket_uses_runtime_dir_and_instance() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+            "XDG_RUNTIME_DIR",
+        ]);
+        env::set_var("CODEX_LINUX_APP_ID", "codex-test");
+        env::set_var("CODEX_LINUX_INSTANCE_ID", "sidecar");
+        env::set_var("XDG_RUNTIME_DIR", "/tmp/codex-runtime-test");
+
+        assert_eq!(
+            launch_action_socket_path()?,
+            PathBuf::from(
+                "/tmp/codex-runtime-test/codex-test/instances/sidecar/launch-action.sock"
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn metadata_prefers_existing_build_info_paths() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let config = test_config(temp.path());
+        fs::create_dir_all(temp.path().join("app/resources"))?;
+        fs::write(
+            temp.path()
+                .join("app/resources/codex-linux-build-info.json"),
+            "{}",
+        )?;
+
+        let metadata = metadata_diagnostics(&config);
+
+        assert_eq!(
+            metadata.build_info_path.as_deref(),
+            Some(
+                temp.path()
+                    .join("app/resources/codex-linux-build-info.json")
+                    .as_path()
+            )
+        );
+        assert!(metadata.build_info_exists);
+        Ok(())
+    }
+
+    #[test]
+    fn warnings_flag_running_app_with_dead_webview_pid() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = test_config(temp.path());
+        let paths = test_paths(temp.path());
+        let report = DiagnosticsReport {
+            schema: "codex-update-manager/diagnostics/v1",
+            ok: false,
+            warnings: Vec::new(),
+            update: UpdateDiagnostics {
+                status: "Idle".to_string(),
+                installed_version: "test".to_string(),
+                candidate_version: None,
+                last_known_good_version: None,
+                update_error: None,
+                cli_status: "Unknown".to_string(),
+            },
+            app: AppDiagnostics {
+                executable_path: config.app_executable_path,
+                executable_exists: true,
+                running: true,
+                running_error: None,
+                pid_file: PidFileDiagnostics {
+                    path: paths.state_dir.join("codex-desktop/app.pid"),
+                    exists: true,
+                    pid: Some(std::process::id()),
+                    process_alive: Some(true),
+                },
+            },
+            webview: WebviewDiagnostics {
+                url: "http://127.0.0.1:5175/".to_string(),
+                ok: false,
+                status: None,
+                error: Some("connection refused".to_string()),
+                pid_file: PidFileDiagnostics {
+                    path: paths.state_dir.join("codex-desktop/webview.pid"),
+                    exists: true,
+                    pid: Some(u32::MAX),
+                    process_alive: Some(false),
+                },
+            },
+            warm_start: WarmStartDiagnostics {
+                socket_path: paths.state_dir.join("codex-desktop/launch-action.sock"),
+                socket_exists: false,
+            },
+            metadata: MetadataDiagnostics {
+                build_info_path: Some(PathBuf::from("/missing/build-info.json")),
+                build_info_exists: true,
+                source_info_path: None,
+                source_info_exists: false,
+            },
+            paths: PathDiagnostics {
+                config_file: paths.config_file,
+                state_file: paths.state_file,
+                log_file: paths.log_file,
+                cache_dir: paths.cache_dir,
+                state_dir: paths.state_dir,
+                builder_bundle_root: config.builder_bundle_root,
+            },
+        };
+
+        let warnings = diagnostics_warnings(&report);
+
+        assert!(warnings
+            .iter()
+            .any(|item| item == "app is running but webview did not respond"));
+        assert!(warnings
+            .iter()
+            .any(|item| item == "webview.pid points to a dead process"));
+    }
+
+    #[test]
+    fn collect_marks_missing_metadata_without_failing() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "CODEX_WEBVIEW_PORT",
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+            "XDG_RUNTIME_DIR",
+        ]);
+        env::set_var("CODEX_WEBVIEW_PORT", "9");
+        env::set_var("CODEX_LINUX_APP_ID", "codex-test");
+        env::set_var("XDG_RUNTIME_DIR", "/tmp/codex-runtime-test");
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let state = PersistedState::new(true);
+        let webview = (
+            webview_url(),
+            false,
+            None,
+            Some("connection refused".to_string()),
+        );
+
+        let report = collect_with_webview(&config, &state, &paths, webview)?;
+
+        assert!(!report.ok);
+        assert!(report
+            .warnings
+            .iter()
+            .any(|item| item == "app executable is missing"));
+        assert!(report
+            .warnings
+            .iter()
+            .any(|item| item == "Linux build-info metadata is missing"));
+        Ok(())
+    }
+}

--- a/updater/src/liveness.rs
+++ b/updater/src/liveness.rs
@@ -1,8 +1,7 @@
 //! Process liveness checks for the Electron app managed by the updater.
 
-use crate::config::RuntimeConfig;
+use crate::config::{self, RuntimeConfig};
 use anyhow::{Context, Result};
-use directories::BaseDirs;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -10,11 +9,7 @@ use std::{
 
 /// Returns the PID file used by the Linux launcher to track the Electron app.
 pub fn app_pid_file() -> Result<PathBuf> {
-    let base_dirs = BaseDirs::new().context("Could not resolve XDG base directories")?;
-    let state_root = base_dirs
-        .state_dir()
-        .unwrap_or_else(|| base_dirs.data_local_dir());
-    Ok(state_root.join("codex-desktop").join("app.pid"))
+    Ok(config::resolve_app_state_dir()?.join("app.pid"))
 }
 
 /// Detects whether the managed Electron app is currently running.
@@ -80,12 +75,22 @@ fn read_exe_link(pid: u32) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::{env_lock, EnvRestoreGuard};
     use anyhow::Result;
 
     #[test]
-    fn pid_file_is_located_under_xdg_state() -> Result<()> {
+    fn pid_file_is_located_under_resolved_app_state() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "CODEX_LINUX_APP_ID",
+            "CODEX_APP_ID",
+            "CODEX_LINUX_INSTANCE_ID",
+        ]);
+        std::env::set_var("CODEX_LINUX_APP_ID", "codex-test");
+        std::env::set_var("CODEX_LINUX_INSTANCE_ID", "port-6175");
+
         let pid_file = app_pid_file()?;
-        assert!(pid_file.ends_with("codex-desktop/app.pid"));
+        assert!(pid_file.ends_with("codex-test/instances/port-6175/app.pid"));
         Ok(())
     }
 

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -7,6 +7,7 @@ mod changelog;
 mod cli;
 mod codex_cli;
 mod config;
+mod diagnostics;
 mod feature_picker;
 mod install;
 mod install_rollback;


### PR DESCRIPTION
## Summary
- add `codex-update-manager diagnose` with text and `--json` output for post-update support reports
- report updater state, installed app executable, launcher pid files, local webview health, warm-start socket, build metadata, and relevant runtime paths
- route `diagnose` before updater runtime writes so the command does not create/update state or logs

## Validation
- `cargo fmt -p codex-update-manager --check`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager`
- `cargo run -p codex-update-manager -- diagnose`
- `cargo run -p codex-update-manager -- diagnose --json`