### PR TITLE
[codex] Handle pacman-managed CLI separately from npm updates

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,6 +7,8 @@
 | `ERR_CONNECTION_REFUSED` on the webview port | Ensure `python3` works and the configured port is free |
 | Stuck on Codex logo splash | Check `~/.cache/codex-desktop/launcher.log`; another process may be serving the webview port |
 | `CODEX_CLI_PATH` error | Reopen the app to retry automatic CLI install, or install manually with `npm i -g @openai/codex` / `npm i -g --prefix ~/.local @openai/codex` |
+| `codex-update-manager status --json` shows `cli_status: "update_required"` for `/usr/bin/codex` on Arch | Pacman itself has a newer package for the installed CLI. Update through pacman instead of npm, for example `sudo pacman -Syu`; pacman-managed CLI installs are intentionally not auto-updated through npm |
+| `codex-update-manager status --json` shows `/usr/bin/codex` with `cli_status: "up_to_date"` but `cli_official_latest_version` is newer than `cli_package_manager_latest_version` | The distro package is behind the official npm release, but pacman does not currently offer a newer package. Codex Desktop will not auto-switch channels; read `cli_error_message` and decide whether to stay on the distro-managed CLI or replace it with another install method |
 | `nix run` exits with no window or terminal output | Check `~/.cache/codex-desktop/launcher.log`; the Nix package still requires a user-provided `codex` CLI |
 | `gh auth status` works in terminal but fails inside Codex Desktop | See [GitHub CLI auth in app-launched shells](github-cli-auth.md) |
 | Electron hangs while CLI is outdated | Re-run the launcher and check `~/.cache/codex-desktop/launcher.log` plus `~/.local/state/codex-update-manager/service.log` |

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -20,11 +20,36 @@ installs continue to update through npm, while official standalone installs
 under `~/.codex/packages/standalone` are updated with the official standalone
 installer instead of being replaced through npm.
 
+System-package-managed CLI installs are reused but not mutated through npm or
+the standalone installer flow. On Arch-like hosts, when the resolved CLI lives
+under a system bin directory and `pacman -Qo` confirms package ownership, the
+updater tracks two separate version signals in state:
+`cli_official_latest_version` for the latest published `@openai/codex` npm
+release and `cli_package_manager_latest_version` for the latest package version
+currently known to pacman.
+
+For pacman-managed installs, `cli_status` follows the package-manager-actionable
+result, not the npm result:
+
+- if pacman currently offers a newer package, `cli_status` becomes
+  `UpdateRequired` and the stored status message tells the user to update
+  through pacman instead (for example: `sudo pacman -Syu`)
+- if pacman does not currently offer a newer package but npm upstream is newer,
+  `cli_status` stays `UpToDate` and the stored status message explains that the
+  distro package and official upstream have diverged so the user can decide
+  whether to stay on the distro-managed CLI or switch installation channels
+
+If the CLI resolves to a system-path binary but `pacman -Qo` cannot determine
+ownership, the updater still skips npm auto-updates and reports that ownership
+verification failed so the user can inspect the CLI source manually.
+
 The launcher does not choose the newest installed CLI. It resolves an explicit
 `CODEX_CLI_PATH` first, then falls back to the usual `PATH`, nvm, and known
 user/system locations. Startup logs include the resolved path plus a
 best-effort CLI version probe; set `CODEX_CLI_PATH=/path/to/codex` when you
-need to pin a particular binary from a GUI-launched session.
+need to pin a particular binary from a GUI-launched session. `CODEX_CLI_PATH`
+does not bypass install-type detection; if it points at a pacman-managed CLI,
+the same non-npm guidance applies.
 
 ## Inspect State
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -617,7 +617,10 @@ fn run_status(
     }
 
     if json {
-        println!("{}", serde_json::to_string_pretty(state)?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&status_json_value(state)?)?
+        );
     } else {
         println!("status: {:?}", state.status);
         println!("installed_version: {}", state.installed_version);
@@ -663,6 +666,17 @@ fn run_status(
     }
 
     Ok(())
+}
+
+fn status_json_value(state: &PersistedState) -> Result<serde_json::Value> {
+    let mut value = serde_json::to_value(state)?;
+    if let Some(object) = value.as_object_mut() {
+        object.insert(
+            "cli_latest_version".to_string(),
+            serde_json::to_value(&state.cli_official_latest_version)?,
+        );
+    }
+    Ok(value)
 }
 
 fn update_error_status_line(state: &PersistedState) -> String {
@@ -3588,6 +3602,20 @@ mod tests {
 
         assert!(result.is_err());
         assert_eq!(state.cli_status, CliStatus::Updating);
+        Ok(())
+    }
+
+    #[test]
+    fn status_json_keeps_legacy_cli_latest_version_alias() -> Result<()> {
+        let mut state = PersistedState::new(true);
+        state.cli_official_latest_version = Some("0.42.1".to_string());
+        state.cli_package_manager_latest_version = Some("0.42.0-1".to_string());
+
+        let value = status_json_value(&state)?;
+
+        assert_eq!(value["cli_latest_version"], "0.42.1");
+        assert_eq!(value["cli_official_latest_version"], "0.42.1");
+        assert_eq!(value["cli_package_manager_latest_version"], "0.42.0-1");
         Ok(())
     }
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -643,8 +643,18 @@ fn run_status(
             state.cli_installed_version.as_deref().unwrap_or("unknown")
         );
         println!(
-            "cli_latest_version: {}",
-            state.cli_latest_version.as_deref().unwrap_or("unknown")
+            "cli_official_latest_version: {}",
+            state
+                .cli_official_latest_version
+                .as_deref()
+                .unwrap_or("unknown")
+        );
+        println!(
+            "cli_package_manager_latest_version: {}",
+            state
+                .cli_package_manager_latest_version
+                .as_deref()
+                .unwrap_or("unknown")
         );
         println!(
             "cli_error: {}",

--- a/updater/src/cli_management.rs
+++ b/updater/src/cli_management.rs
@@ -1,0 +1,429 @@
+//! Detects when the resolved Codex CLI is owned by a system package manager.
+
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const PACMAN_CANDIDATES: &[&str] = &["/usr/bin/pacman", "/bin/pacman"];
+// Prefer the os-release family signal over enumerating Arch derivatives one by one.
+// If a derivative does not advertise `ID_LIKE=arch`, we conservatively skip this path
+// until we have distro-specific evidence that the pacman ownership workflow should apply.
+const ARCH_LIKE_IDS: &[&str] = &["arch", "archlinux"];
+const SYSTEM_CLI_ROOTS: &[&str] = &["/usr/bin", "/bin"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SystemPackageManagedCli {
+    ManagedByPacman {
+        package_name: String,
+        query_path: PathBuf,
+    },
+    PacmanOwnershipUnknown {
+        query_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PacmanPackageVersionStatus {
+    pub latest_version: String,
+    pub update_available: bool,
+}
+
+pub fn query_package_manager_version_status(
+    managed_cli: &SystemPackageManagedCli,
+    path_env: &OsString,
+) -> Option<PacmanPackageVersionStatus> {
+    let SystemPackageManagedCli::ManagedByPacman { package_name, .. } = managed_cli else {
+        return None;
+    };
+    let pacman = query_pacman_program(path_env)?;
+    let latest_version = query_pacman_sync_package_version(&pacman, path_env, package_name)?;
+    let upgrade_version = query_pacman_upgrade_version(&pacman, path_env, package_name);
+    let update_available = upgrade_version.is_some_and(|version| version == latest_version);
+    Some(PacmanPackageVersionStatus {
+        latest_version,
+        update_available,
+    })
+}
+
+pub fn detect_system_package_managed_cli(
+    cli_path: &Path,
+    path_env: &OsString,
+) -> Option<SystemPackageManagedCli> {
+    #[cfg(test)]
+    if let Some(config) = test_detection_config(path_env) {
+        return detect_with(cli_path, path_env, &config);
+    }
+
+    let config = DetectionConfig::runtime(path_env);
+    detect_with(cli_path, path_env, &config)
+}
+
+#[derive(Debug, Clone)]
+struct DetectionConfig {
+    arch_like_host: bool,
+    pacman_program: Option<PathBuf>,
+    system_roots: Vec<PathBuf>,
+}
+
+impl DetectionConfig {
+    fn runtime(path_env: &OsString) -> Self {
+        Self {
+            arch_like_host: arch_like_host(),
+            pacman_program: pacman_program(path_env),
+            system_roots: SYSTEM_CLI_ROOTS.iter().map(PathBuf::from).collect(),
+        }
+    }
+}
+
+fn detect_with(
+    cli_path: &Path,
+    path_env: &OsString,
+    config: &DetectionConfig,
+) -> Option<SystemPackageManagedCli> {
+    if !config.arch_like_host {
+        return None;
+    }
+
+    let query_path = system_cli_query_path(cli_path, &config.system_roots)?;
+    let pacman = config.pacman_program.as_deref()?;
+
+    match query_pacman_owner(pacman, path_env, &query_path) {
+        Some(package_name) => Some(SystemPackageManagedCli::ManagedByPacman {
+            package_name,
+            query_path,
+        }),
+        None => Some(SystemPackageManagedCli::PacmanOwnershipUnknown { query_path }),
+    }
+}
+
+fn system_cli_query_path(cli_path: &Path, system_roots: &[PathBuf]) -> Option<PathBuf> {
+    let mut candidates = vec![cli_path.to_path_buf()];
+    if let Ok(canonical_path) = fs::canonicalize(cli_path) {
+        if !candidates
+            .iter()
+            .any(|existing| existing == &canonical_path)
+        {
+            candidates.push(canonical_path);
+        }
+    }
+
+    candidates
+        .into_iter()
+        .find(|candidate| system_roots.iter().any(|root| candidate.starts_with(root)))
+}
+
+fn pacman_program(path_env: &OsString) -> Option<PathBuf> {
+    PACMAN_CANDIDATES
+        .iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+        .or_else(|| find_in_path("pacman", path_env))
+}
+
+fn query_pacman_program(path_env: &OsString) -> Option<PathBuf> {
+    #[cfg(test)]
+    if let Some(path) = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH") {
+        return Some(PathBuf::from(path));
+    }
+
+    pacman_program(path_env)
+}
+
+fn query_pacman_owner(pacman: &Path, path_env: &OsString, query_path: &Path) -> Option<String> {
+    let output = Command::new(pacman)
+        .env("PATH", path_env)
+        .args(["-Qo", "--"])
+        .arg(query_path)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_pacman_owner(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_pacman_owner(raw: &str) -> Option<String> {
+    let owned_by = raw.split_once(" is owned by ")?;
+    owned_by.1.split_whitespace().next().map(ToOwned::to_owned)
+}
+
+fn query_pacman_sync_package_version(
+    pacman: &Path,
+    path_env: &OsString,
+    package_name: &str,
+) -> Option<String> {
+    let output = Command::new(pacman)
+        .env("PATH", path_env)
+        .args(["-Si", "--", package_name])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_pacman_info_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_pacman_info_version(raw: &str) -> Option<String> {
+    raw.lines().find_map(|line| {
+        let (field, value) = line.split_once(':')?;
+        if field.trim() == "Version" {
+            let version = value.trim();
+            if version.is_empty() {
+                None
+            } else {
+                Some(version.to_string())
+            }
+        } else {
+            None
+        }
+    })
+}
+
+fn query_pacman_upgrade_version(
+    pacman: &Path,
+    path_env: &OsString,
+    package_name: &str,
+) -> Option<String> {
+    let output = Command::new(pacman)
+        .env("PATH", path_env)
+        .args(["-Qu", "--", package_name])
+        .output()
+        .ok()?;
+
+    if !output.status.success() || output.stdout.is_empty() {
+        return None;
+    }
+
+    parse_pacman_upgrade_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+fn parse_pacman_upgrade_version(raw: &str) -> Option<String> {
+    raw.lines()
+        .find_map(|line| line.split(" -> ").nth(1).map(str::trim))
+        .filter(|version| !version.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn find_in_path(name: &str, path_env: &OsString) -> Option<PathBuf> {
+    std::env::split_paths(path_env)
+        .map(|entry| entry.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+fn arch_like_host() -> bool {
+    os_release_fields()
+        .map(|(id, id_like)| os_release_matches(&[id.as_str(), id_like.as_str()], ARCH_LIKE_IDS))
+        .unwrap_or(false)
+}
+
+fn os_release_fields() -> Option<(String, String)> {
+    let contents = ["/etc/os-release", "/usr/lib/os-release"]
+        .into_iter()
+        .find_map(|path| fs::read_to_string(path).ok())?;
+    let mut id = String::new();
+    let mut id_like = String::new();
+
+    for line in contents.lines() {
+        if let Some(value) = line.strip_prefix("ID=") {
+            id = trim_os_release_value(value).to_ascii_lowercase();
+        } else if let Some(value) = line.strip_prefix("ID_LIKE=") {
+            id_like = trim_os_release_value(value).to_ascii_lowercase();
+        }
+    }
+
+    Some((id, id_like))
+}
+
+fn trim_os_release_value(value: &str) -> &str {
+    value.trim().trim_matches('"').trim_matches('\'')
+}
+
+fn os_release_matches(fields: &[&str], expected: &[&str]) -> bool {
+    fields.iter().any(|field| {
+        field
+            .split_whitespace()
+            .any(|token| expected.contains(&token))
+    })
+}
+
+#[cfg(test)]
+fn test_detection_config(path_env: &OsString) -> Option<DetectionConfig> {
+    let root = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT")?;
+    let pacman_program = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH")
+        .map(PathBuf::from)
+        .or_else(|| pacman_program(path_env));
+    let arch_like_host = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST")
+        .is_some_and(|value| !value.is_empty());
+    Some(DetectionConfig {
+        arch_like_host,
+        pacman_program,
+        system_roots: vec![PathBuf::from(root)],
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs as unix_fs;
+    use tempfile::tempdir;
+
+    fn write_executable_script(path: &Path, contents: &str) {
+        fs::write(path, contents).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o755);
+        }
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[test]
+    fn detects_pacman_managed_cli_through_canonical_path() {
+        let temp = tempdir().unwrap();
+        let tool_bin = temp.path().join("tool-bin");
+        let system_root = temp.path().join("system-root/usr/bin");
+        let home_bin = temp.path().join("home-bin");
+        fs::create_dir_all(&tool_bin).unwrap();
+        fs::create_dir_all(&system_root).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+
+        let pacman_path = tool_bin.join("pacman");
+        write_executable_script(
+            &pacman_path,
+            "#!/bin/sh\nif [ \"$1\" = \"-Qo\" ] && [ \"$2\" = \"--\" ]; then\n  printf '%s is owned by openai-codex 0.143.0-1\\n' \"$3\"\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let system_codex = system_root.join("codex");
+        write_executable_script(
+            &system_codex,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo codex-cli v0.143.0\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let visible_codex = home_bin.join("codex");
+        unix_fs::symlink(&system_codex, &visible_codex).unwrap();
+
+        let detection = detect_with(
+            &visible_codex,
+            &std::env::join_paths([tool_bin, PathBuf::from("/usr/bin"), PathBuf::from("/bin")])
+                .unwrap(),
+            &DetectionConfig {
+                arch_like_host: true,
+                pacman_program: Some(pacman_path),
+                system_roots: vec![system_root],
+            },
+        );
+
+        assert_eq!(
+            detection,
+            Some(SystemPackageManagedCli::ManagedByPacman {
+                package_name: "openai-codex".to_string(),
+                query_path: system_codex,
+            })
+        );
+    }
+
+    #[test]
+    fn reports_unknown_pacman_ownership_for_system_path_cli() {
+        let temp = tempdir().unwrap();
+        let tool_bin = temp.path().join("tool-bin");
+        let system_root = temp.path().join("system-root/usr/bin");
+        fs::create_dir_all(&tool_bin).unwrap();
+        fs::create_dir_all(&system_root).unwrap();
+
+        let pacman_path = tool_bin.join("pacman");
+        write_executable_script(
+            &pacman_path,
+            "#!/bin/sh\nif [ \"$1\" = \"-Qo\" ] && [ \"$2\" = \"--\" ]; then\n  echo 'error: no package owns path' >&2\n  exit 1\nfi\nexit 1\n",
+        );
+
+        let system_codex = system_root.join("codex");
+        write_executable_script(
+            &system_codex,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo codex-cli v0.143.0\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let detection = detect_with(
+            &system_codex,
+            &std::env::join_paths([tool_bin, PathBuf::from("/usr/bin"), PathBuf::from("/bin")])
+                .unwrap(),
+            &DetectionConfig {
+                arch_like_host: true,
+                pacman_program: Some(pacman_path),
+                system_roots: vec![system_root],
+            },
+        );
+
+        assert_eq!(
+            detection,
+            Some(SystemPackageManagedCli::PacmanOwnershipUnknown {
+                query_path: system_codex,
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_non_system_paths_even_on_arch_like_hosts() {
+        let temp = tempdir().unwrap();
+        let tool_bin = temp.path().join("tool-bin");
+        let pacman_path = tool_bin.join("pacman");
+        fs::create_dir_all(&tool_bin).unwrap();
+        write_executable_script(&pacman_path, "#!/bin/sh\nexit 1\n");
+
+        let local_codex = temp.path().join("local-bin/codex");
+        fs::create_dir_all(local_codex.parent().unwrap()).unwrap();
+        write_executable_script(
+            &local_codex,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  echo codex-cli v0.143.0\n  exit 0\nfi\nexit 1\n",
+        );
+
+        let detection = detect_with(
+            &local_codex,
+            &std::env::join_paths([tool_bin, PathBuf::from("/usr/bin"), PathBuf::from("/bin")])
+                .unwrap(),
+            &DetectionConfig {
+                arch_like_host: true,
+                pacman_program: Some(pacman_path),
+                system_roots: vec![temp.path().join("system-root/usr/bin")],
+            },
+        );
+
+        assert_eq!(detection, None);
+    }
+
+    #[test]
+    fn os_release_matching_prefers_arch_family_tokens_over_derivative_names() {
+        assert!(os_release_matches(&["arch", ""], ARCH_LIKE_IDS));
+        assert!(os_release_matches(&["artix", "arch"], ARCH_LIKE_IDS));
+        assert!(os_release_matches(
+            &["manjaro", "arch linux"],
+            ARCH_LIKE_IDS
+        ));
+        assert!(!os_release_matches(&["artix", ""], ARCH_LIKE_IDS));
+        assert!(!os_release_matches(&["manjaro", ""], ARCH_LIKE_IDS));
+    }
+
+    #[test]
+    fn parses_pacman_sync_version_output() {
+        assert_eq!(
+            parse_pacman_info_version("Repository      : extra\nName            : openai-codex\nVersion         : 0.143.0-2\n"),
+            Some("0.143.0-2".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_pacman_upgrade_output() {
+        assert_eq!(
+            parse_pacman_upgrade_version("openai-codex 0.143.0-1 -> 0.143.0-2\n"),
+            Some("0.143.0-2".to_string())
+        );
+        assert_eq!(parse_pacman_upgrade_version(""), None);
+    }
+}

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -1,6 +1,7 @@
 //! CLI discovery and prelaunch update checks for the user-installed Codex CLI.
 
 use crate::{
+    cli_management,
     config::RuntimePaths,
     state::{CliStatus, PersistedState},
 };
@@ -29,7 +30,8 @@ const CLI_INSTALLED_VERSION_TTL: Duration = Duration::hours(1);
 pub struct PreflightOutcome {
     pub cli_path: PathBuf,
     pub installed_version: String,
-    pub latest_version: Option<String>,
+    pub official_latest_version: Option<String>,
+    pub package_manager_latest_version: Option<String>,
     pub updated: bool,
 }
 
@@ -45,10 +47,17 @@ pub fn preflight(
         None if allow_install_missing => install_missing_cli(state, paths, requested_path)?,
         None => anyhow::bail!("Codex CLI not found in PATH or known install locations"),
     };
+    let path_env = command_path_env();
+    let managed_cli = cli_management::detect_system_package_managed_cli(&cli_path, &path_env);
+    let package_manager_version_status =
+        current_package_manager_version_status(managed_cli.as_ref(), &path_env);
     let cached_installed_version = state.cli_installed_version.clone();
     let installed_version = read_installed_version(&cli_path)?;
     state.cli_path = Some(cli_path.clone());
     state.cli_installed_version = Some(installed_version.clone());
+    state.cli_package_manager_latest_version = package_manager_version_status
+        .as_ref()
+        .map(|status| status.latest_version.clone());
     state.cli_last_verified_at = Some(Utc::now());
     persist_state(paths, state)?;
 
@@ -61,15 +70,20 @@ pub fn preflight(
             installed_version,
             "skipping Codex CLI registry lookup because the cached result is still fresh"
         );
-        refresh_cli_status_from_latest(state, &installed_version);
-        state.cli_error_message = None;
+        refresh_cli_status_from_latest(
+            state,
+            &cli_path,
+            &installed_version,
+            managed_cli.as_ref(),
+            package_manager_version_status.as_ref(),
+        );
         persist_state(paths, state)?;
-        return Ok(PreflightOutcome {
+        return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
-            latest_version: state.cli_latest_version.clone(),
-            updated: false,
-        });
+            state,
+            false,
+        ));
     }
 
     state.cli_last_check_at = Some(Utc::now());
@@ -77,39 +91,76 @@ pub fn preflight(
     state.cli_status = CliStatus::Checking;
     persist_state(paths, state)?;
 
-    let latest_version = match read_latest_version() {
-        Ok(version) => version,
+    let official_latest_version = match read_latest_version() {
+        Ok(version) => Some(version),
         Err(error) => {
-            state.cli_status = CliStatus::Unknown;
-            state.cli_latest_version = None;
-            state.cli_error_message = Some(format!(
-                "Could not check the latest {CLI_PACKAGE_NAME} version: {error}"
-            ));
-            persist_state(paths, state)?;
-            warn!(?error, "unable to check latest Codex CLI version");
-            return Ok(PreflightOutcome {
-                cli_path,
-                installed_version,
-                latest_version: None,
-                updated: false,
-            });
+            state.cli_official_latest_version = None;
+            if managed_cli.is_none() {
+                state.cli_status = CliStatus::Unknown;
+                state.cli_error_message = Some(format!(
+                    "Could not check the latest {CLI_PACKAGE_NAME} version: {error}"
+                ));
+                persist_state(paths, state)?;
+                warn!(?error, "unable to check latest Codex CLI version");
+                return Ok(preflight_outcome_from_state(
+                    cli_path,
+                    installed_version,
+                    state,
+                    false,
+                ));
+            }
+            warn!(?error, "unable to check latest official Codex CLI version");
+            None
         }
     };
 
-    state.cli_latest_version = Some(latest_version.clone());
-    if installed_cli_version_satisfies_latest(&installed_version, &latest_version) {
-        state.cli_status = CliStatus::UpToDate;
-        state.cli_error_message = None;
+    state.cli_official_latest_version = official_latest_version.clone();
+
+    refresh_cli_status_from_latest(
+        state,
+        &cli_path,
+        &installed_version,
+        managed_cli.as_ref(),
+        package_manager_version_status.as_ref(),
+    );
+
+    if managed_cli.is_some() {
         persist_state(paths, state)?;
-        return Ok(PreflightOutcome {
+        return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
-            latest_version: Some(latest_version),
-            updated: false,
-        });
+            state,
+            false,
+        ));
     }
 
-    state.cli_status = CliStatus::UpdateRequired;
+    let latest_version = match official_latest_version {
+        Some(version) => version,
+        None => {
+            state.cli_status = CliStatus::Unknown;
+            state.cli_official_latest_version = None;
+            state.cli_error_message = Some(format!(
+                "Could not check the latest {CLI_PACKAGE_NAME} version"
+            ));
+            persist_state(paths, state)?;
+            return Ok(preflight_outcome_from_state(
+                cli_path,
+                installed_version,
+                state,
+                false,
+            ));
+        }
+    };
+    if state.cli_status == CliStatus::UpToDate {
+        persist_state(paths, state)?;
+        return Ok(preflight_outcome_from_state(
+            cli_path,
+            installed_version,
+            state,
+            false,
+        ));
+    }
+
     persist_state(paths, state)?;
     info!(
         installed_version,
@@ -147,12 +198,12 @@ pub fn preflight(
     state.cli_status = CliStatus::UpToDate;
     state.cli_error_message = None;
     persist_state(paths, state)?;
-    Ok(PreflightOutcome {
-        cli_path: refreshed_path,
-        installed_version: refreshed_version,
-        latest_version: Some(latest_version),
-        updated: true,
-    })
+    Ok(preflight_outcome_from_state(
+        refreshed_path,
+        refreshed_version,
+        state,
+        true,
+    ))
 }
 
 #[cfg(test)]
@@ -170,11 +221,23 @@ pub fn refresh_cached_status(state: &mut PersistedState, paths: &RuntimePaths) -
     let Some(installed_version) = cached_installed_version_if_fresh(state, &cli_path) else {
         return refresh_status(state, paths);
     };
+    let path_env = command_path_env();
+    let managed_cli = cli_management::detect_system_package_managed_cli(&cli_path, &path_env);
+    let package_manager_version_status =
+        current_package_manager_version_status(managed_cli.as_ref(), &path_env);
 
-    state.cli_path = Some(cli_path);
+    state.cli_path = Some(cli_path.clone());
     state.cli_installed_version = Some(installed_version.clone());
-    refresh_cli_status_from_latest(state, &installed_version);
-    state.cli_error_message = None;
+    state.cli_package_manager_latest_version = package_manager_version_status
+        .as_ref()
+        .map(|status| status.latest_version.clone());
+    refresh_cli_status_from_latest(
+        state,
+        &cli_path,
+        &installed_version,
+        managed_cli.as_ref(),
+        package_manager_version_status.as_ref(),
+    );
 
     persist_if_changed(paths, state, &original_state)
 }
@@ -189,6 +252,10 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
             return Ok(());
         }
     };
+    let path_env = command_path_env();
+    let managed_cli = cli_management::detect_system_package_managed_cli(&cli_path, &path_env);
+    let package_manager_version_status =
+        current_package_manager_version_status(managed_cli.as_ref(), &path_env);
 
     let cached_installed_version = state.cli_installed_version.clone();
     let installed_version = match read_installed_version(&cli_path) {
@@ -207,8 +274,11 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
         }
     };
 
-    state.cli_path = Some(cli_path);
+    state.cli_path = Some(cli_path.clone());
     state.cli_installed_version = Some(installed_version.clone());
+    state.cli_package_manager_latest_version = package_manager_version_status
+        .as_ref()
+        .map(|status| status.latest_version.clone());
     state.cli_last_verified_at = Some(Utc::now());
 
     if should_skip_latest_version_check(
@@ -220,8 +290,13 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
             installed_version,
             "skipping Codex CLI registry lookup because the cached result is still fresh"
         );
-        refresh_cli_status_from_latest(state, &installed_version);
-        state.cli_error_message = None;
+        refresh_cli_status_from_latest(
+            state,
+            &cli_path,
+            &installed_version,
+            managed_cli.as_ref(),
+            package_manager_version_status.as_ref(),
+        );
         persist_state(paths, state)?;
         return Ok(());
     }
@@ -233,25 +308,48 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
 
     match read_latest_version() {
         Ok(latest_version) => {
-            state.cli_latest_version = Some(latest_version);
-            refresh_cli_status_from_latest(state, &installed_version);
-            state.cli_error_message = None;
+            state.cli_official_latest_version = Some(latest_version);
+            refresh_cli_status_from_latest(
+                state,
+                &cli_path,
+                &installed_version,
+                managed_cli.as_ref(),
+                package_manager_version_status.as_ref(),
+            );
         }
         Err(error) => {
-            let cached_latest_matches_install = cached_latest_version_matches_install(
-                state,
-                cached_installed_version.as_deref(),
-                &installed_version,
-            );
-            if cached_latest_matches_install {
-                refresh_cli_status_from_latest(state, &installed_version);
+            if managed_cli.is_some() {
+                state.cli_official_latest_version = None;
+                refresh_cli_status_from_latest(
+                    state,
+                    &cli_path,
+                    &installed_version,
+                    managed_cli.as_ref(),
+                    package_manager_version_status.as_ref(),
+                );
+                warn!(?error, "unable to check latest official Codex CLI version");
             } else {
-                state.cli_status = CliStatus::Unknown;
+                let cached_latest_matches_install = cached_latest_version_matches_install(
+                    state,
+                    cached_installed_version.as_deref(),
+                    &installed_version,
+                );
+                if cached_latest_matches_install {
+                    refresh_cli_status_from_latest(
+                        state,
+                        &cli_path,
+                        &installed_version,
+                        managed_cli.as_ref(),
+                        package_manager_version_status.as_ref(),
+                    );
+                } else {
+                    state.cli_status = CliStatus::Unknown;
+                }
+                state.cli_error_message = Some(format!(
+                    "Could not check the latest {CLI_PACKAGE_NAME} version: {error}"
+                ));
+                warn!(?error, "unable to check latest Codex CLI version");
             }
-            state.cli_error_message = Some(format!(
-                "Could not check the latest {CLI_PACKAGE_NAME} version: {error}"
-            ));
-            warn!(?error, "unable to check latest Codex CLI version");
         }
     }
 
@@ -424,19 +522,120 @@ fn cached_latest_version_matches_install(
     cached_installed_version: Option<&str>,
     installed_version: &str,
 ) -> bool {
-    state.cli_latest_version.is_some() && cached_installed_version == Some(installed_version)
+    state.cli_official_latest_version.is_some()
+        && cached_installed_version == Some(installed_version)
 }
 
-fn refresh_cli_status_from_latest(state: &mut PersistedState, installed_version: &str) {
-    state.cli_status = match state.cli_latest_version.as_deref() {
-        Some(latest_version)
-            if installed_cli_version_satisfies_latest(installed_version, latest_version) =>
-        {
-            CliStatus::UpToDate
+fn refresh_cli_status_from_latest(
+    state: &mut PersistedState,
+    cli_path: &Path,
+    installed_version: &str,
+    managed_cli: Option<&cli_management::SystemPackageManagedCli>,
+    package_manager_version_status: Option<&cli_management::PacmanPackageVersionStatus>,
+) {
+    match managed_cli {
+        Some(cli_management::SystemPackageManagedCli::ManagedByPacman { package_name, .. }) => {
+            match package_manager_version_status {
+                Some(status) if status.update_available => {
+                    state.cli_status = CliStatus::UpdateRequired;
+                    state.cli_error_message = Some(format!(
+                        "This Codex CLI is managed by pacman package '{package_name}'. Pacman currently offers {}. Update it through pacman instead of npm (for example: sudo pacman -Syu).",
+                        status.latest_version
+                    ));
+                }
+                Some(status) => {
+                    state.cli_status = CliStatus::UpToDate;
+                    state.cli_error_message = state
+                        .cli_official_latest_version
+                        .as_deref()
+                        .filter(|official_latest| {
+                            !installed_cli_version_satisfies_latest(installed_version, official_latest)
+                        })
+                        .map(|official_latest| {
+                            format!(
+                                "This Codex CLI is managed by pacman package '{package_name}'. Pacman does not currently offer a newer package (latest known package: {}), but the official {CLI_PACKAGE_NAME} upstream is {official_latest}. Decide for yourself whether to keep the distro-managed package or switch CLI installation channels.",
+                                status.latest_version
+                            )
+                        });
+                }
+                None => {
+                    state.cli_status = CliStatus::Unknown;
+                    state.cli_error_message = Some(format!(
+                        "This Codex CLI is managed by pacman package '{package_name}', but Codex Desktop could not determine the latest version currently available through pacman. This install will not be auto-updated through npm; check pacman directly."
+                    ));
+                }
+            }
         }
-        Some(_) => CliStatus::UpdateRequired,
-        None => CliStatus::Unknown,
-    };
+        Some(cli_management::SystemPackageManagedCli::PacmanOwnershipUnknown { query_path }) => {
+            match state.cli_official_latest_version.as_deref() {
+                Some(official_latest)
+                    if installed_cli_version_satisfies_latest(
+                        installed_version,
+                        official_latest,
+                    ) =>
+                {
+                    state.cli_status = CliStatus::UpToDate;
+                    state.cli_error_message = None;
+                }
+                Some(official_latest) => {
+                    state.cli_status = CliStatus::Unknown;
+                    state.cli_error_message = Some(format!(
+                        "Codex Desktop resolved Codex CLI to {}, but pacman -Qo {} could not determine which package owns it. The official {CLI_PACKAGE_NAME} upstream is {official_latest}; this install will not be auto-updated through npm, so inspect the CLI source and decide how to update it.",
+                        cli_path.display(),
+                        query_path.display()
+                    ));
+                }
+                None => {
+                    state.cli_status = CliStatus::Unknown;
+                    state.cli_error_message = Some(format!(
+                        "Codex Desktop resolved Codex CLI to {}, but pacman -Qo {} could not determine which package owns it, and the official {CLI_PACKAGE_NAME} version could not be checked. This install will not be auto-updated through npm; inspect the CLI source and decide how to update it.",
+                        cli_path.display(),
+                        query_path.display()
+                    ));
+                }
+            }
+        }
+        None => match state.cli_official_latest_version.as_deref() {
+            Some(latest_version)
+                if installed_cli_version_satisfies_latest(installed_version, latest_version) =>
+            {
+                state.cli_status = CliStatus::UpToDate;
+                state.cli_error_message = None;
+            }
+            Some(_) => {
+                state.cli_status = CliStatus::UpdateRequired;
+                state.cli_error_message = None;
+            }
+            None => {
+                state.cli_status = CliStatus::Unknown;
+                state.cli_error_message = None;
+            }
+        },
+    }
+}
+
+fn current_package_manager_version_status(
+    managed_cli: Option<&cli_management::SystemPackageManagedCli>,
+    path_env: &OsString,
+) -> Option<cli_management::PacmanPackageVersionStatus> {
+    managed_cli.and_then(|managed_cli| {
+        cli_management::query_package_manager_version_status(managed_cli, path_env)
+    })
+}
+
+fn preflight_outcome_from_state(
+    cli_path: PathBuf,
+    installed_version: String,
+    state: &PersistedState,
+    updated: bool,
+) -> PreflightOutcome {
+    PreflightOutcome {
+        cli_path,
+        installed_version,
+        official_latest_version: state.cli_official_latest_version.clone(),
+        package_manager_latest_version: state.cli_package_manager_latest_version.clone(),
+        updated,
+    }
 }
 
 fn installed_cli_version_satisfies_latest(installed_version: &str, latest_version: &str) -> bool {
@@ -741,7 +940,8 @@ fn install_missing_cli(
     persist_state(paths, state)?;
 
     let latest_version = read_latest_version()?;
-    state.cli_latest_version = Some(latest_version.clone());
+    state.cli_official_latest_version = Some(latest_version.clone());
+    state.cli_package_manager_latest_version = None;
     persist_state(paths, state)?;
 
     info!(
@@ -1022,13 +1222,31 @@ mod tests {
         Ok(visible_codex)
     }
 
+    fn link_test_system_tool(tool_bin: &Path, name: &str) -> Result<()> {
+        let target = [
+            PathBuf::from("/bin").join(name),
+            PathBuf::from("/usr/bin").join(name),
+        ]
+        .into_iter()
+        .find(|candidate| candidate.is_file())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("system tool {name} not found"),
+            )
+        })?;
+        let link_path = tool_bin.join(name);
+        if !link_path.exists() {
+            std::os::unix::fs::symlink(target, link_path)?;
+        }
+        Ok(())
+    }
+
     fn set_test_path_with_tool_bin(tool_bin: &Path) -> Result<()> {
-        let path_entries = [
-            tool_bin.to_path_buf(),
-            PathBuf::from("/usr/bin"),
-            PathBuf::from("/bin"),
-        ];
-        std::env::set_var("PATH", std::env::join_paths(path_entries)?);
+        for tool in ["sh", "cat", "mkdir", "ln", "chmod"] {
+            link_test_system_tool(tool_bin, tool)?;
+        }
+        std::env::set_var("PATH", std::env::join_paths([tool_bin.to_path_buf()])?);
         Ok(())
     }
 
@@ -1045,6 +1263,45 @@ mod tests {
                 install_log.display()
             ),
         )
+    }
+
+    fn write_fake_pacman_managed_package(
+        tool_bin: &Path,
+        package_name: &str,
+        sync_version: &str,
+        upgrade_version: Option<&str>,
+        query_log: &Path,
+    ) -> Result<PathBuf> {
+        let pacman_path = tool_bin.join("pacman");
+        write_executable_script(
+            &pacman_path,
+            &format!(
+                "#!/bin/sh\necho \"$1|$2|$3\" >> \"{}\"\nif [ \"$1\" = \"-Qo\" ] && [ \"$2\" = \"--\" ]; then\n  printf '%s is owned by {} 0.143.0-1\\n' \"$3\"\n  exit 0\nfi\nif [ \"$1\" = \"-Si\" ] && [ \"$2\" = \"--\" ] && [ \"$3\" = \"{}\" ]; then\n  printf 'Repository      : extra\\nName            : {}\\nVersion         : {}\\n'\n  exit 0\nfi\nif [ \"$1\" = \"-Qu\" ] && [ \"$2\" = \"--\" ] && [ \"$3\" = \"{}\" ]; then\n{}\n  exit 0\nfi\nexit 1\n",
+                query_log.display(),
+                package_name,
+                package_name,
+                package_name,
+                sync_version,
+                package_name,
+                upgrade_version.map_or_else(
+                    String::new,
+                    |version| format!("  printf '{} 0.42.0-1 -> {}\\n'\n", package_name, version),
+                )
+            ),
+        )?;
+        Ok(pacman_path)
+    }
+
+    fn write_fake_pacman_unknown_owner(tool_bin: &Path, query_log: &Path) -> Result<PathBuf> {
+        let pacman_path = tool_bin.join("pacman");
+        write_executable_script(
+            &pacman_path,
+            &format!(
+                "#!/bin/sh\necho \"$1|$2|$3\" >> \"{}\"\nif [ \"$1\" = \"-Qo\" ] && [ \"$2\" = \"--\" ]; then\n  echo 'error: No package owns path' >&2\n  exit 1\nfi\nexit 1\n",
+                query_log.display()
+            ),
+        )?;
+        Ok(pacman_path)
     }
 
     fn write_fake_standalone_installer_curl(tool_bin: &Path) -> Result<()> {
@@ -1167,7 +1424,7 @@ exit 1
     fn skips_registry_lookup_when_previous_check_is_fresh_for_same_cli_version() {
         let mut state = PersistedState::new(true);
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.42.1".to_string());
+        state.cli_official_latest_version = Some("0.42.1".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::minutes(30));
 
         assert!(should_skip_latest_version_check(
@@ -1181,7 +1438,7 @@ exit 1
     fn does_not_skip_registry_lookup_when_cli_version_changed() {
         let mut state = PersistedState::new(true);
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.42.1".to_string());
+        state.cli_official_latest_version = Some("0.42.1".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::minutes(30));
 
         assert!(!should_skip_latest_version_check(
@@ -1195,7 +1452,7 @@ exit 1
     fn does_not_skip_registry_lookup_when_cached_check_is_stale() {
         let mut state = PersistedState::new(true);
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.42.0".to_string());
+        state.cli_official_latest_version = Some("0.42.0".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::hours(2));
 
         assert!(!should_skip_latest_version_check(
@@ -1233,13 +1490,14 @@ exit 1
         let mut state = PersistedState::new(true);
         state.cli_path = Some(codex_path.clone());
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.43.0".to_string());
+        state.cli_official_latest_version = Some("0.43.0".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::minutes(30));
         refresh_status(&mut state, &paths)?;
 
         assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.43.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.43.0"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpdateRequired);
         assert_eq!(state.cli_error_message, None);
         Ok(())
@@ -1259,7 +1517,7 @@ exit 1
 
         let mut state = PersistedState::new(true);
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.42.0".to_string());
+        state.cli_official_latest_version = Some("0.42.0".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::minutes(5));
         state.cli_status = CliStatus::Unknown;
         state.cli_error_message = Some("previous error".to_string());
@@ -1268,9 +1526,11 @@ exit 1
 
         assert_eq!(outcome.cli_path, codex_path);
         assert_eq!(outcome.installed_version, "0.42.0");
-        assert_eq!(outcome.latest_version.as_deref(), Some("0.42.0"));
+        assert_eq!(outcome.official_latest_version.as_deref(), Some("0.42.0"));
+        assert_eq!(outcome.package_manager_latest_version, None);
         assert!(!outcome.updated);
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(state.cli_error_message, None);
         Ok(())
@@ -1291,7 +1551,7 @@ exit 1
         let mut state = PersistedState::new(true);
         state.cli_path = Some(codex_path.clone());
         state.cli_installed_version = Some("0.42.0".to_string());
-        state.cli_latest_version = Some("0.42.1".to_string());
+        state.cli_official_latest_version = Some("0.42.1".to_string());
         state.cli_last_check_at = Some(Utc::now() - Duration::minutes(30));
         state.cli_last_verified_at = Some(Utc::now() - Duration::minutes(30));
 
@@ -1299,8 +1559,251 @@ exit 1
 
         assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpdateRequired);
         assert_eq!(state.cli_error_message, None);
+        Ok(())
+    }
+
+    #[test]
+    fn preflight_reports_actionable_pacman_update_without_running_npm_install() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let tool_bin = temp.path().join("tool-bin");
+        let system_root = temp.path().join("system-root/usr/bin");
+        fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&system_root)?;
+
+        let codex_path = system_root.join("codex");
+        write_executable_script(
+            &codex_path,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+
+        let npm_install_log = temp.path().join("npm-install.log");
+        let pacman_query_log = temp.path().join("pacman-query.log");
+        write_fake_latest_npm(&tool_bin, "0.42.2", &npm_install_log)?;
+        let pacman_path = write_fake_pacman_managed_package(
+            &tool_bin,
+            "openai-codex",
+            "0.42.1-1",
+            Some("0.42.1-1"),
+            &pacman_query_log,
+        )?;
+
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            "CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT",
+            "CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        set_test_path_with_tool_bin(&tool_bin)?;
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT", &system_root);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH", &pacman_path);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST", "1");
+
+        let mut state = PersistedState::new(true);
+        let outcome = preflight(&mut state, &paths, Some(codex_path.clone()), false)?;
+
+        assert!(!outcome.updated);
+        assert_eq!(outcome.cli_path, codex_path);
+        assert_eq!(outcome.installed_version, "0.42.0");
+        assert_eq!(outcome.official_latest_version.as_deref(), Some("0.42.2"));
+        assert_eq!(
+            outcome.package_manager_latest_version.as_deref(),
+            Some("0.42.1-1")
+        );
+        assert_eq!(state.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.2"));
+        assert_eq!(
+            state.cli_package_manager_latest_version.as_deref(),
+            Some("0.42.1-1")
+        );
+        assert_eq!(
+            state.cli_error_message.as_deref(),
+            Some(
+                "This Codex CLI is managed by pacman package 'openai-codex'. Pacman currently offers 0.42.1-1. Update it through pacman instead of npm (for example: sudo pacman -Syu)."
+            )
+        );
+        assert!(!npm_install_log.exists());
+        assert_eq!(
+            fs::read_to_string(&pacman_query_log)?,
+            format!(
+                "-Qo|--|{}\n-Si|--|openai-codex\n-Qu|--|openai-codex\n",
+                codex_path.display()
+            )
+        );
+        assert_eq!(read_installed_version(&codex_path)?, "0.42.0");
+        Ok(())
+    }
+
+    #[test]
+    fn preflight_reports_channel_mismatch_for_pacman_managed_cli_without_actionable_update(
+    ) -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let tool_bin = temp.path().join("tool-bin");
+        let system_root = temp.path().join("system-root/usr/bin");
+        fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&system_root)?;
+
+        let codex_path = system_root.join("codex");
+        write_executable_script(
+            &codex_path,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+
+        let npm_install_log = temp.path().join("npm-install.log");
+        let pacman_query_log = temp.path().join("pacman-query.log");
+        write_fake_latest_npm(&tool_bin, "0.42.2", &npm_install_log)?;
+        let pacman_path = write_fake_pacman_managed_package(
+            &tool_bin,
+            "openai-codex",
+            "0.42.0-1",
+            None,
+            &pacman_query_log,
+        )?;
+
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            "CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT",
+            "CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        set_test_path_with_tool_bin(&tool_bin)?;
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT", &system_root);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH", &pacman_path);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST", "1");
+
+        let mut state = PersistedState::new(true);
+        let outcome = preflight(&mut state, &paths, Some(codex_path.clone()), false)?;
+
+        assert!(!outcome.updated);
+        assert_eq!(outcome.cli_path, codex_path);
+        assert_eq!(outcome.installed_version, "0.42.0");
+        assert_eq!(outcome.official_latest_version.as_deref(), Some("0.42.2"));
+        assert_eq!(
+            outcome.package_manager_latest_version.as_deref(),
+            Some("0.42.0-1")
+        );
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.2"));
+        assert_eq!(
+            state.cli_package_manager_latest_version.as_deref(),
+            Some("0.42.0-1")
+        );
+        let message = state
+            .cli_error_message
+            .as_deref()
+            .expect("channel mismatch should set a guidance message");
+        assert!(message.contains("Pacman does not currently offer a newer package"));
+        assert!(message.contains("latest known package: 0.42.0-1"));
+        assert!(message.contains("official @openai/codex upstream is 0.42.2"));
+        assert!(message.contains("switch CLI installation channels"));
+        assert!(!npm_install_log.exists());
+        assert_eq!(
+            fs::read_to_string(&pacman_query_log)?,
+            format!(
+                "-Qo|--|{}\n-Si|--|openai-codex\n-Qu|--|openai-codex\n",
+                codex_path.display()
+            )
+        );
+        assert_eq!(read_installed_version(&codex_path)?, "0.42.0");
+        Ok(())
+    }
+
+    #[test]
+    fn preflight_skips_npm_upgrade_when_pacman_cannot_confirm_owner() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let tool_bin = temp.path().join("tool-bin");
+        let system_root = temp.path().join("system-root/usr/bin");
+        fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&system_root)?;
+
+        let codex_path = system_root.join("codex");
+        write_executable_script(
+            &codex_path,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+
+        let npm_install_log = temp.path().join("npm-install.log");
+        let pacman_query_log = temp.path().join("pacman-query.log");
+        write_fake_latest_npm(&tool_bin, "0.42.1", &npm_install_log)?;
+        let pacman_path = write_fake_pacman_unknown_owner(&tool_bin, &pacman_query_log)?;
+
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            "CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT",
+            "CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        set_test_path_with_tool_bin(&tool_bin)?;
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::remove_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP");
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_SYSTEM_CLI_ROOT", &system_root);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PACMAN_PATH", &pacman_path);
+        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_FORCE_ARCH_HOST", "1");
+
+        let mut state = PersistedState::new(true);
+        let outcome = preflight(&mut state, &paths, Some(codex_path.clone()), false)?;
+
+        assert!(!outcome.updated);
+        assert_eq!(outcome.cli_path, codex_path);
+        assert_eq!(outcome.installed_version, "0.42.0");
+        assert_eq!(outcome.official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(outcome.package_manager_latest_version, None);
+        assert_eq!(state.cli_status, CliStatus::Unknown);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
+        let message = state
+            .cli_error_message
+            .as_deref()
+            .expect("ownership failure should set a guidance message");
+        assert!(message.contains("pacman -Qo"));
+        assert!(message.contains("could not determine which package owns it"));
+        assert!(message.contains(&codex_path.display().to_string()));
+        assert!(!npm_install_log.exists());
+        assert_eq!(
+            fs::read_to_string(&pacman_query_log)?,
+            format!("-Qo|--|{}\n", codex_path.display())
+        );
+        assert_eq!(read_installed_version(&codex_path)?, "0.42.0");
         Ok(())
     }
 
@@ -1476,7 +1979,8 @@ exit 1
         assert_eq!(outcome.cli_path, visible_codex);
         assert_eq!(outcome.installed_version, "0.42.1");
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&outcome.cli_path)?, "0.42.1");
         assert!(!npm_install_log.exists());
@@ -1525,7 +2029,8 @@ exit 1
         assert!(!updated);
         assert_eq!(state.cli_path.as_deref(), Some(visible_codex.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.43.0"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert!(!npm_install_log.exists());
         assert!(!curl_call_log.exists());
@@ -1638,7 +2143,8 @@ exit 1
         assert!(updated);
         assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&codex_path)?, "0.42.1");
         Ok(())
@@ -1706,7 +2212,8 @@ exit 1
         assert_eq!(outcome.installed_version, "0.42.1");
         assert_eq!(state.cli_path.as_deref(), Some(user_codex.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&system_codex)?, "0.42.0");
         Ok(())
@@ -1749,7 +2256,8 @@ exit 1
         assert!(!updated);
         assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.43.0"));
-        assert_eq!(state.cli_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&codex_path)?, "0.43.0");
         Ok(())

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -263,6 +263,7 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
         Err(error) => {
             state.cli_path = Some(cli_path);
             state.cli_installed_version = None;
+            state.cli_package_manager_latest_version = None;
             state.cli_last_verified_at = None;
             state.cli_status = CliStatus::Failed;
             state.cli_error_message = Some(format!(
@@ -477,6 +478,7 @@ fn requested_cli_path(state: &PersistedState) -> Option<PathBuf> {
 fn mark_cli_missing(state: &mut PersistedState) {
     state.cli_path = None;
     state.cli_installed_version = None;
+    state.cli_package_manager_latest_version = None;
     state.cli_last_verified_at = None;
     state.cli_status = CliStatus::NotInstalled;
     state.cli_error_message = Some(CLI_NOT_INSTALLED_MESSAGE.to_string());
@@ -1574,8 +1576,10 @@ exit 1
         paths.ensure_dirs()?;
 
         let tool_bin = temp.path().join("tool-bin");
+        let pacman_bin = temp.path().join("pacman-bin");
         let system_root = temp.path().join("system-root/usr/bin");
         fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&pacman_bin)?;
         fs::create_dir_all(&system_root)?;
 
         let codex_path = system_root.join("codex");
@@ -1588,7 +1592,7 @@ exit 1
         let pacman_query_log = temp.path().join("pacman-query.log");
         write_fake_latest_npm(&tool_bin, "0.42.2", &npm_install_log)?;
         let pacman_path = write_fake_pacman_managed_package(
-            &tool_bin,
+            &pacman_bin,
             "openai-codex",
             "0.42.1-1",
             Some("0.42.1-1"),
@@ -1659,8 +1663,10 @@ exit 1
         paths.ensure_dirs()?;
 
         let tool_bin = temp.path().join("tool-bin");
+        let pacman_bin = temp.path().join("pacman-bin");
         let system_root = temp.path().join("system-root/usr/bin");
         fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&pacman_bin)?;
         fs::create_dir_all(&system_root)?;
 
         let codex_path = system_root.join("codex");
@@ -1673,7 +1679,7 @@ exit 1
         let pacman_query_log = temp.path().join("pacman-query.log");
         write_fake_latest_npm(&tool_bin, "0.42.2", &npm_install_log)?;
         let pacman_path = write_fake_pacman_managed_package(
-            &tool_bin,
+            &pacman_bin,
             "openai-codex",
             "0.42.0-1",
             None,
@@ -1745,8 +1751,10 @@ exit 1
         paths.ensure_dirs()?;
 
         let tool_bin = temp.path().join("tool-bin");
+        let pacman_bin = temp.path().join("pacman-bin");
         let system_root = temp.path().join("system-root/usr/bin");
         fs::create_dir_all(&tool_bin)?;
+        fs::create_dir_all(&pacman_bin)?;
         fs::create_dir_all(&system_root)?;
 
         let codex_path = system_root.join("codex");
@@ -1758,7 +1766,7 @@ exit 1
         let npm_install_log = temp.path().join("npm-install.log");
         let pacman_query_log = temp.path().join("pacman-query.log");
         write_fake_latest_npm(&tool_bin, "0.42.1", &npm_install_log)?;
-        let pacman_path = write_fake_pacman_unknown_owner(&tool_bin, &pacman_query_log)?;
+        let pacman_path = write_fake_pacman_unknown_owner(&pacman_bin, &pacman_query_log)?;
 
         let _restore_env = EnvRestoreGuard::capture(&[
             "HOME",
@@ -1830,6 +1838,7 @@ exit 1
         let mut state = PersistedState::new(true);
         state.cli_path = Some(missing_path);
         state.cli_installed_version = Some("0.42.0".to_string());
+        state.cli_package_manager_latest_version = Some("0.42.1-1".to_string());
         state.cli_last_verified_at = Some(Utc::now() - Duration::minutes(30));
 
         refresh_cached_status(&mut state, &paths)?;
@@ -1862,6 +1871,7 @@ exit 1
 
         assert_eq!(state.cli_path, None);
         assert_eq!(state.cli_installed_version, None);
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::NotInstalled);
         assert_eq!(
             state.cli_error_message.as_deref(),
@@ -1890,6 +1900,7 @@ exit 1
         std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
 
         let mut state = PersistedState::new(true);
+        state.cli_package_manager_latest_version = Some("0.42.1-1".to_string());
         refresh_status(&mut state, &paths)?;
 
         if let Some(home) = original_home {
@@ -1920,11 +1931,54 @@ exit 1
 
         assert_eq!(state.cli_path, None);
         assert_eq!(state.cli_installed_version, None);
+        assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::NotInstalled);
         assert_eq!(
             state.cli_error_message.as_deref(),
             Some(CLI_NOT_INSTALLED_MESSAGE)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn refresh_status_clears_package_manager_latest_when_cli_version_is_unreadable() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        let codex_path = bin_dir.join("codex");
+        write_executable_script(&codex_path, "#!/bin/sh\nexit 1\n")?;
+
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(codex_path.clone());
+        state.cli_package_manager_latest_version = Some("0.42.1-1".to_string());
+        refresh_status(&mut state, &paths)?;
+
+        assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
+        assert_eq!(state.cli_installed_version, None);
+        assert_eq!(state.cli_package_manager_latest_version, None);
+        assert_eq!(state.cli_status, CliStatus::Failed);
+        assert!(state
+            .cli_error_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Could not read the installed"));
         Ok(())
     }
 

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -5,6 +5,7 @@ mod builder;
 mod cache_cleanup;
 mod changelog;
 mod cli;
+mod cli_management;
 mod codex_cli;
 mod config;
 mod feature_picker;

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -86,8 +86,10 @@ pub struct PersistedState {
     pub cli_path: Option<PathBuf>,
     #[serde(default)]
     pub cli_installed_version: Option<String>,
+    #[serde(default, alias = "cli_latest_version")]
+    pub cli_official_latest_version: Option<String>,
     #[serde(default)]
-    pub cli_latest_version: Option<String>,
+    pub cli_package_manager_latest_version: Option<String>,
     #[serde(default)]
     pub cli_status: CliStatus,
     #[serde(default)]
@@ -140,7 +142,8 @@ impl PersistedState {
             rollback_blocked_candidate_version: None,
             cli_path: None,
             cli_installed_version: None,
-            cli_latest_version: None,
+            cli_official_latest_version: None,
+            cli_package_manager_latest_version: None,
             cli_status: CliStatus::Unknown,
             cli_last_check_at: None,
             cli_last_verified_at: None,
@@ -305,9 +308,41 @@ mod tests {
         let loaded = PersistedState::load_or_default(&path, true)?;
         assert_eq!(loaded.cli_status, CliStatus::Unknown);
         assert_eq!(loaded.cli_installed_version, None);
-        assert_eq!(loaded.cli_latest_version, None);
+        assert_eq!(loaded.cli_official_latest_version, None);
+        assert_eq!(loaded.cli_package_manager_latest_version, None);
         assert_eq!(loaded.cli_error_message, None);
         assert!(!loaded.waiting_for_app_exit_auto_install);
+        Ok(())
+    }
+
+    #[test]
+    fn loads_legacy_cli_latest_version_into_official_latest() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("state.json");
+        fs::write(
+            &path,
+            r#"{
+  "installed_version": "2026.03.24+deadbeef",
+  "candidate_version": null,
+  "status": "idle",
+  "last_check_at": null,
+  "last_successful_check_at": null,
+  "remote_headers_fingerprint": null,
+  "dmg_sha256": null,
+  "artifact_paths": {"dmg_path": null, "workspace_dir": null, "deb_path": null},
+  "error_message": null,
+  "notified_events": [],
+  "auto_install_on_app_exit": true,
+  "cli_latest_version": "0.42.1"
+}"#,
+        )?;
+
+        let loaded = PersistedState::load_or_default(&path, true)?;
+        assert_eq!(
+            loaded.cli_official_latest_version.as_deref(),
+            Some("0.42.1")
+        );
+        assert_eq!(loaded.cli_package_manager_latest_version, None);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- detect Arch pacman-managed Codex CLI installs and query pacman for ownership and latest package status
- keep npm-managed and standalone CLI behavior unchanged while skipping npm auto-upgrades for pacman-managed system binaries
- separate `cli_official_latest_version` from `cli_package_manager_latest_version` in updater state, status output, and docs

## Context

- Fixes #705
- Related to #283 and #284, which fixed npm path recovery after user-prefix installs; this PR addresses the separate ownership/update-model problem for pacman-managed `/usr/bin/codex`

## Scope

This change is intentionally scoped to pacman-managed CLI installs on Arch-like systems. Other distro package manager ownership/update models are left unchanged in this PR.

## Behavior

- if pacman has a newer package, `cli_status` becomes `UpdateRequired` with pacman guidance
- if pacman does not have a newer package but npm upstream is newer, `cli_status` stays `UpToDate` with informational channel-mismatch guidance
- if `pacman -Qo` cannot determine ownership, the updater skips npm auto-update and reports `Unknown`

## Validation

- `cargo fmt --all`
- `cargo test -p codex-update-manager`

## Not run

- Manual Arch smoke test not run; covered by updater unit tests that simulate `pacman -Qo`, `pacman -Si`, and `pacman -Qu`
- Native package builds not run because this change is confined to updater logic and documentation