### PR TITLE
Fix Linux feature symlink staging

### DIFF
--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -616,7 +616,52 @@ function chmodRecursive(target, mode) {
   }
 }
 
-function copyInstallFile(source, target, mode) {
+function pathStaysInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+function assertNoSymbolicLinks(target, label) {
+  const stat = fs.lstatSync(target);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`${label} must not contain symbolic links`);
+  }
+  if (!stat.isDirectory()) {
+    return;
+  }
+  for (const name of fs.readdirSync(target)) {
+    assertNoSymbolicLinks(path.join(target, name), label);
+  }
+}
+
+function assertNoSymbolicLinksIfPresent(target, label) {
+  try {
+    assertNoSymbolicLinks(target, label);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function assertInstallParentInside(installDir, target, label) {
+  fs.mkdirSync(installDir, { recursive: true });
+  const installRoot = fs.realpathSync(installDir);
+  const parent = path.dirname(target);
+  fs.mkdirSync(parent, { recursive: true });
+  const realParent = fs.realpathSync(parent);
+  if (!pathStaysInside(installRoot, realParent)) {
+    throw new Error(`${label} must stay inside the install directory`);
+  }
+}
+
+function copyInstallFile(installDir, source, target, mode) {
+  assertNoSymbolicLinks(source, "Linux feature source");
+  assertInstallParentInside(installDir, target, "Linux feature target");
+  assertNoSymbolicLinksIfPresent(target, "Linux feature target");
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.cpSync(source, target, { recursive: true, force: true });
   if (mode != null) {
@@ -735,12 +780,12 @@ function stageEnabledLinuxFeatureInstall(appDir, options = {}) {
     removePreviouslyStagedArtifacts(installDir, previousManifest);
   }
   for (const resource of plan.resources) {
-    copyInstallFile(resource.source, path.join(installDir, resource.target), resource.mode);
+    copyInstallFile(installDir, resource.source, path.join(installDir, resource.target), resource.mode);
     console.error(`Staged Linux feature resource: ${resource.id} -> ${resource.target}`);
   }
   for (const hook of plan.runtimeHooks) {
     const target = path.join(installDir, hook.target);
-    copyInstallFile(hook.source, target, hook.mode);
+    copyInstallFile(installDir, hook.source, target, hook.mode);
     console.error(`Staged Linux feature ${hook.key} hook: ${hook.id} -> ${path.relative(installDir, target)}`);
   }
   writeStagedFeatureManifest(installDir, plan);

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -647,14 +647,72 @@ function assertNoSymbolicLinksIfPresent(target, label) {
   }
 }
 
+function assertNoInstallPathSymbolicLinks(installDir, relativePath, label) {
+  let current = installDir;
+  for (const part of relativePathParts(relativePath)) {
+    current = path.join(current, part);
+    try {
+      const stat = fs.lstatSync(current);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`${label} must not contain symbolic links`);
+      }
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+  }
+}
+
 function assertInstallParentInside(installDir, target, label) {
-  fs.mkdirSync(installDir, { recursive: true });
-  const installRoot = fs.realpathSync(installDir);
   const parent = path.dirname(target);
+  const relativeParent = path.relative(installDir, parent);
+  assertInstallPathInsideIfPresent(installDir, relativeParent, label);
   fs.mkdirSync(parent, { recursive: true });
+  const installRoot = fs.realpathSync(installDir);
   const realParent = fs.realpathSync(parent);
   if (!pathStaysInside(installRoot, realParent)) {
     throw new Error(`${label} must stay inside the install directory`);
+  }
+  if (relativeParent !== "" && !relativeParent.startsWith("..") && !path.isAbsolute(relativeParent)) {
+    assertNoInstallPathSymbolicLinks(installDir, relativeParent, label);
+  }
+}
+
+function assertInstallPathInsideIfPresent(installDir, relativePath, label) {
+  fs.mkdirSync(installDir, { recursive: true });
+  const installRoot = fs.realpathSync(installDir);
+  const parts = relativePathParts(relativePath);
+  for (let index = parts.length; index >= 0; index -= 1) {
+    const candidate = index === 0
+      ? installDir
+      : path.join(installDir, ...parts.slice(0, index));
+    try {
+      const realCandidate = fs.realpathSync(candidate);
+      if (!pathStaysInside(installRoot, realCandidate)) {
+        throw new Error(`${label} must stay inside the install directory`);
+      }
+      break;
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  assertNoInstallPathSymbolicLinks(installDir, relativePath, label);
+}
+
+function installRelativeDirectoryExists(installDir, relativePath, label) {
+  const { normalized, resolved } = resolveInstallRelativePath(installDir, relativePath, label);
+  assertInstallPathInsideIfPresent(installDir, normalized, label);
+  try {
+    return fs.lstatSync(resolved).isDirectory();
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
   }
 }
 
@@ -727,6 +785,11 @@ function removeInstallRelativePath(installDir, relativePath) {
   if (normalized === STAGED_FEATURE_MANIFEST_RELATIVE_PATH) {
     return;
   }
+  assertInstallPathInsideIfPresent(
+    installDir,
+    normalized,
+    "Linux feature staged artifact target",
+  );
   fs.rmSync(resolved, { recursive: true, force: true });
 }
 
@@ -745,13 +808,14 @@ function removeLegacyDeclarativeRuntimeHooks(installDir, options = {}) {
     return;
   }
   for (const runtimeHook of Object.values(RUNTIME_HOOK_DIRS)) {
-    const hookDir = path.join(installDir, ".codex-linux", runtimeHook.dir);
-    if (!isDirectory(hookDir)) {
+    const hookDirRelative = [".codex-linux", runtimeHook.dir].join("/");
+    const hookDir = path.join(installDir, hookDirRelative);
+    if (!installRelativeDirectoryExists(installDir, hookDirRelative, "Linux feature runtime hook directory")) {
       continue;
     }
     for (const name of fs.readdirSync(hookDir)) {
       if (featureIds.some((id) => name.startsWith(`${id}-`))) {
-        fs.rmSync(path.join(hookDir, name), { recursive: true, force: true });
+        removeInstallRelativePath(installDir, path.join(hookDirRelative, name));
       }
     }
   }

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -29,6 +29,12 @@ function stageFeature(root, featuresRoot) {
   });
 }
 
+function writeStagedManifest(appDir, manifest) {
+  const manifestPath = path.join(appDir, ".codex-linux", "linux-features-staged.json");
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
 test("Linux feature staging rejects symlinked resource sources", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-source-"));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -86,4 +92,97 @@ test("Linux feature staging rejects symlinked install target parents", (t) => {
     /must stay inside the install directory/,
   );
   assert.equal(fs.existsSync(path.join(outside, "payload.txt")), false);
+});
+
+test("Linux feature staging rejects symlinked install target ancestors before creating parents", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-target-ancestor-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const appDir = path.join(root, "app");
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    resources: [
+      {
+        source: "payload.txt",
+        target: ".codex-linux/features/unsafe-link/nested/payload.txt",
+        mode: "0644",
+      },
+    ],
+  });
+  fs.mkdirSync(path.join(appDir, ".codex-linux", "features"), { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(featureDir, "payload.txt"), "payload\n");
+  fs.symlinkSync(outside, path.join(appDir, ".codex-linux", "features", "unsafe-link"), "junction");
+
+  assert.throws(
+    () => stageFeature(root, featuresRoot),
+    /must (stay inside the install directory|not contain symbolic links)/,
+  );
+  assert.equal(fs.existsSync(path.join(outside, "nested")), false);
+});
+
+test("Linux feature staging does not clean stale manifest targets through symlinked parents", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-manifest-cleanup-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const appDir = path.join(root, "app");
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    resources: [
+      {
+        source: "payload.txt",
+        target: ".codex-linux/features/unsafe-link/payload.txt",
+        mode: "0644",
+      },
+    ],
+  });
+  fs.mkdirSync(path.join(appDir, ".codex-linux", "features"), { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(featureDir, "payload.txt"), "payload\n");
+  fs.writeFileSync(path.join(outside, "payload.txt"), "outside\n");
+  fs.symlinkSync(outside, path.join(appDir, ".codex-linux", "features", "unsafe-link"), "junction");
+  writeStagedManifest(appDir, {
+    version: 1,
+    resources: [
+      {
+        id: "unsafe-link",
+        type: "resource",
+        target: ".codex-linux/features/unsafe-link/payload.txt",
+        mode: "0644",
+      },
+    ],
+    runtimeHooks: [],
+  });
+
+  assert.throws(
+    () => stageFeature(root, featuresRoot),
+    /must (stay inside the install directory|not contain symbolic links)/,
+  );
+  assert.equal(fs.readFileSync(path.join(outside, "payload.txt"), "utf8"), "outside\n");
+});
+
+test("Linux feature staging does not clean legacy hooks through symlinked hook dirs", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-hook-cleanup-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside-hooks");
+  const appDir = path.join(root, "app");
+  const { featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+  });
+  fs.mkdirSync(path.join(appDir, ".codex-linux"), { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(outside, "unsafe-link-old-hook.sh"), "outside\n");
+  fs.symlinkSync(outside, path.join(appDir, ".codex-linux", "prelaunch.d"), "junction");
+
+  assert.throws(
+    () => stageFeature(root, featuresRoot),
+    /must (stay inside the install directory|not contain symbolic links)/,
+  );
+  assert.equal(fs.readFileSync(path.join(outside, "unsafe-link-old-hook.sh"), "utf8"), "outside\n");
 });

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  stageEnabledLinuxFeatureInstall,
+} = require("./linux-features.js");
+
+function makeFeatureRoot(root, featureManifest) {
+  const featuresRoot = path.join(root, "linux-features");
+  const featureDir = path.join(featuresRoot, "unsafe-link");
+  fs.mkdirSync(featureDir, { recursive: true });
+  fs.writeFileSync(path.join(featuresRoot, "features.example.json"), '{"enabled":[]}\n');
+  fs.writeFileSync(path.join(featuresRoot, "features.json"), '{"enabled":["unsafe-link"]}\n');
+  fs.writeFileSync(path.join(featureDir, "README.md"), "# Unsafe Link\n");
+  fs.writeFileSync(path.join(featureDir, "feature.json"), `${JSON.stringify(featureManifest, null, 2)}\n`);
+  return { featureDir, featuresRoot };
+}
+
+function stageFeature(root, featuresRoot) {
+  stageEnabledLinuxFeatureInstall(path.join(root, "app"), {
+    featuresConfigPath: path.join(featuresRoot, "features.json"),
+    featuresRoot,
+  });
+}
+
+test("Linux feature staging rejects symlinked resource sources", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-source-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    resources: [
+      {
+        source: "payload-link",
+        target: ".codex-linux/features/unsafe-link/payload.txt",
+        mode: "0644",
+      },
+    ],
+  });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(outside, "payload.txt"), "outside\n");
+  fs.symlinkSync(outside, path.join(featureDir, "payload-link"), "junction");
+
+  assert.throws(
+    () => stageFeature(root, featuresRoot),
+    /must not contain symbolic links/,
+  );
+  assert.equal(
+    fs.existsSync(path.join(root, "app", ".codex-linux", "features", "unsafe-link", "payload.txt")),
+    false,
+  );
+});
+
+test("Linux feature staging rejects symlinked install target parents", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-symlink-target-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const appDir = path.join(root, "app");
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    resources: [
+      {
+        source: "payload.txt",
+        target: ".codex-linux/features/unsafe-link/payload.txt",
+        mode: "0644",
+      },
+    ],
+  });
+  fs.mkdirSync(path.join(appDir, ".codex-linux", "features"), { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  fs.writeFileSync(path.join(featureDir, "payload.txt"), "payload\n");
+  fs.symlinkSync(outside, path.join(appDir, ".codex-linux", "features", "unsafe-link"), "junction");
+
+  assert.throws(
+    () => stageFeature(root, featuresRoot),
+    /must stay inside the install directory/,
+  );
+  assert.equal(fs.existsSync(path.join(outside, "payload.txt")), false);
+});


### PR DESCRIPTION
## Summary
- reject symbolic links inside Linux feature resource sources before staging
- verify the real install target parent remains inside the app install directory
- add focused regression tests for source-link and target-parent-link staging attempts

## Root cause
Declarative Linux feature staging validated lexical relative paths, but it copied resources with fs.cpSync and then recursively chmodded the staged target. A symlinked feature source or preexisting symlinked target parent could redirect copy/chmod behavior outside the install tree.

## Validation
- node --test scripts/lib/linux-features.test.js
- node --check scripts/lib/linux-features.js && node --check scripts/lib/linux-features.test.js
- bash scripts/ci/run-node-checks.sh syntax
- git diff --check -- scripts/lib/linux-features.js scripts/lib/linux-features.test.js

Note: the broader Node suite was not green on Windows because existing tests depend on Linux chmod/symlink semantics and Linux platform probes.