### PR TITLE
Fix managed Node launcher PATH setup

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -564,13 +564,14 @@ export_packaged_runtime_env() {
 prepend_managed_node_runtime_to_path() {
     [ -x "$MANAGED_NODE_BIN_DIR/node" ] || return 0
 
+    local current_path="${PATH:-}"
     if [ -z "${CODEX_LINUX_USER_PATH+x}" ]; then
-        export CODEX_LINUX_USER_PATH="${PATH:-}"
+        export CODEX_LINUX_USER_PATH="$current_path"
     fi
 
-    case ":$PATH:" in
-        *":$MANAGED_NODE_BIN_DIR:"*) ;;
-        *) export PATH="$MANAGED_NODE_BIN_DIR:$PATH" ;;
+    case "$current_path" in
+        "$MANAGED_NODE_BIN_DIR"|"$MANAGED_NODE_BIN_DIR":*) ;;
+        *) export PATH="$MANAGED_NODE_BIN_DIR${current_path:+:$current_path}" ;;
     esac
     export CODEX_MANAGED_NODE_RUNTIME_DIR="$SCRIPT_DIR/resources/node-runtime"
 }

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3555,6 +3555,47 @@ test_bundled_plugin_builders_accept_prebuilt_binaries() {
     assert_contains "$output_log" "$host"
 }
 
+test_launcher_managed_node_handles_unset_path() {
+    info "Checking managed Node PATH setup without an inherited PATH"
+    local workspace="$TMP_DIR/launcher-unset-path"
+    local probe="$workspace/probe.sh"
+    local managed_node_bin_dir
+
+    managed_node_bin_dir="$(dirname "$(command -v node)")"
+    mkdir -p "$workspace"
+
+    cat > "$probe" <<EOF
+#!/usr/bin/env bash
+set -u
+SCRIPT_DIR=$(printf '%q' "$workspace")
+MANAGED_NODE_BIN_DIR=$(printf '%q' "$managed_node_bin_dir")
+EOF
+    awk '
+        /^prepend_managed_node_runtime_to_path\(\) \{/ { capture = 1 }
+        capture { print }
+        capture && /^}/ { exit }
+    ' "$REPO_DIR/launcher/start.sh.template" >> "$probe"
+    cat >> "$probe" <<'EOF'
+unset PATH
+prepend_managed_node_runtime_to_path
+[ "$PATH" = "$MANAGED_NODE_BIN_DIR" ] || exit 2
+[ "${CODEX_LINUX_USER_PATH+x}" = x ] || exit 3
+[ -z "$CODEX_LINUX_USER_PATH" ] || exit 4
+[ "$CODEX_MANAGED_NODE_RUNTIME_DIR" = "$SCRIPT_DIR/resources/node-runtime" ] || exit 5
+
+PATH="/tmp/untrusted:$MANAGED_NODE_BIN_DIR:/usr/bin"
+unset CODEX_LINUX_USER_PATH
+prepend_managed_node_runtime_to_path
+case "$PATH" in
+    "$MANAGED_NODE_BIN_DIR":*) ;;
+    *) exit 6 ;;
+esac
+[ "$CODEX_LINUX_USER_PATH" = "/tmp/untrusted:$MANAGED_NODE_BIN_DIR:/usr/bin" ] || exit 7
+EOF
+
+    /usr/bin/bash "$probe" || fail "Expected managed Node PATH setup to tolerate an unset PATH"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -3798,9 +3839,9 @@ if "if needs_cold_start;" not in runtime_body:
     raise SystemExit("second-instance handoff must skip CLI preflight")
 if 'run_cold_start_hooks' not in runtime_body:
     raise SystemExit("cold start must run feature-staged hooks before Electron launches")
-if 'export CODEX_LINUX_USER_PATH="${PATH:-}"' not in source:
+if 'local current_path="${PATH:-}"' not in source or 'export CODEX_LINUX_USER_PATH="$current_path"' not in source:
     raise SystemExit("launcher must capture the user PATH before prepending the managed Node runtime")
-if source.index('export CODEX_LINUX_USER_PATH="${PATH:-}"') > source.index('export PATH="$MANAGED_NODE_BIN_DIR:$PATH"'):
+if source.index('export CODEX_LINUX_USER_PATH="$current_path"') > source.index('export PATH="$MANAGED_NODE_BIN_DIR${current_path:+:$current_path}"'):
     raise SystemExit("launcher must capture CODEX_LINUX_USER_PATH before mutating PATH for Electron")
 for name, body in (("prelaunch", prelaunch_hooks_body), ("cold-start", cold_start_hooks_body), ("launcher", launcher_hooks_body)):
     if 'CODEX_HOME="$CODEX_HOME"' not in body:
@@ -7497,6 +7538,7 @@ main() {
     test_chrome_browser_client_profile_root_variants
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
+    test_launcher_managed_node_handles_unset_path
     test_launcher_template_sanity
     test_launcher_cli_resolution_policy
     test_webview_server_cache_policy

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3576,6 +3576,7 @@ EOF
         capture && /^}/ { exit }
     ' "$REPO_DIR/launcher/start.sh.template" >> "$probe"
     cat >> "$probe" <<'EOF'
+unset CODEX_LINUX_USER_PATH
 unset PATH
 prepend_managed_node_runtime_to_path
 [ "$PATH" = "$MANAGED_NODE_BIN_DIR" ] || exit 2


### PR DESCRIPTION
## Summary

- tolerate an unset or empty inherited `PATH` when prepending the managed Node runtime
- keep the managed Node directory first even if it already appears later in `PATH`
- add a launcher regression probe for both cases

## Root cause

The generated launcher enables `set -u`, but `prepend_managed_node_runtime_to_path` expanded bare `$PATH`. With no inherited `PATH`, startup aborted with `PATH: unbound variable`. The old containment check also skipped prepending when the managed directory appeared later, allowing an earlier executable to win.

## Validation

- focused launcher regression probe: pass
- manual unset, normal, and later-entry PATH probes: pass
- `bash -n install.sh launcher/start.sh.template tests/scripts_smoke.sh`: pass
- `git diff --check`: pass
- full `tests/scripts_smoke.sh`: blocked on this Windows host by pre-existing POSIX mode semantics (expected 755, observed 777)