### PR TITLE
Fix Linux patches for ChatGPT/Codex 26.707

### DIFF
--- a/scripts/patches/impl/avatar-overlay.js
+++ b/scripts/patches/impl/avatar-overlay.js
@@ -1,429 +1,525 @@
-"use strict";
-
-const {
-  findMatchingBrace,
-  requireName,
-} = require("../lib/minified-js.js");
+const { findMatchingBrace, requireName } = require("../lib/minified-js.js");
 const { recordStrategy } = require("../strategy-telemetry.js");
 
 function findAvatarMethod(source, signatureRegex) {
-  const match = source.match(signatureRegex);
-  if (match == null) {
-    return null;
-  }
-  const openIndex = match.index + match[0].length - 1;
-  const closeIndex = findMatchingBrace(source, openIndex);
-  if (closeIndex === -1) {
-    return null;
-  }
-  return {
-    match,
-    start: match.index,
-    end: closeIndex + 1,
-    text: source.slice(match.index, closeIndex + 1),
-  };
+	const match = source.match(signatureRegex);
+	if (match == null) {
+		return null;
+	}
+	const openIndex = match.index + match[0].length - 1;
+	const closeIndex = findMatchingBrace(source, openIndex);
+	if (closeIndex === -1) {
+		return null;
+	}
+	return {
+		match,
+		start: match.index,
+		end: closeIndex + 1,
+		text: source.slice(match.index, closeIndex + 1),
+	};
 }
 
-function findAvatarMethodAfter(source, signatureRegex, startIndex, endIndex = source.length) {
-  const match = source.slice(startIndex, endIndex).match(signatureRegex);
-  if (match == null) {
-    return null;
-  }
-  const absoluteIndex = startIndex + match.index;
-  const openIndex = absoluteIndex + match[0].length - 1;
-  const closeIndex = findMatchingBrace(source, openIndex);
-  if (closeIndex === -1 || closeIndex + 1 > endIndex) {
-    return null;
-  }
-  return {
-    match,
-    start: absoluteIndex,
-    end: closeIndex + 1,
-    text: source.slice(absoluteIndex, closeIndex + 1),
-  };
+function findAvatarMethodAfter(
+	source,
+	signatureRegex,
+	startIndex,
+	endIndex = source.length,
+) {
+	const match = source.slice(startIndex, endIndex).match(signatureRegex);
+	if (match == null) {
+		return null;
+	}
+	const absoluteIndex = startIndex + match.index;
+	const openIndex = absoluteIndex + match[0].length - 1;
+	const closeIndex = findMatchingBrace(source, openIndex);
+	if (closeIndex === -1 || closeIndex + 1 > endIndex) {
+		return null;
+	}
+	return {
+		match,
+		start: absoluteIndex,
+		end: closeIndex + 1,
+		text: source.slice(absoluteIndex, closeIndex + 1),
+	};
 }
 
 function avatarOverlayRegionStart(source) {
-  const routeIndex = source.indexOf("`/avatar-overlay`");
-  if (routeIndex !== -1) {
-    return routeIndex;
-  }
-  const stateMessageIndex = source.indexOf("avatar-overlay-open-state-changed");
-  return stateMessageIndex === -1 ? 0 : stateMessageIndex;
+	const routeIndex = source.indexOf("`/avatar-overlay`");
+	if (routeIndex !== -1) {
+		return routeIndex;
+	}
+	const stateMessageIndex = source.indexOf("avatar-overlay-open-state-changed");
+	return stateMessageIndex === -1 ? 0 : stateMessageIndex;
 }
 
 function findAvatarOverlayClass(source) {
-  const classRegex = /class(?:\s+[A-Za-z_$][\w$]*)?(?:\s+extends\s+[A-Za-z_$][\w$.]*)?\{/g;
-  classRegex.lastIndex = avatarOverlayRegionStart(source);
-  let match;
-  while ((match = classRegex.exec(source)) != null) {
-    const openIndex = match.index + match[0].length - 1;
-    const closeIndex = findMatchingBrace(source, openIndex);
-    if (closeIndex === -1) {
-      // findMatchingBrace cannot balance this class (e.g. it contains a regex
-      // literal with an unbalanced brace). Skip it and keep scanning instead of
-      // aborting — the avatar overlay class may appear later in the bundle.
-      classRegex.lastIndex = openIndex + 1;
-      continue;
-    }
-    const text = source.slice(match.index, closeIndex + 1);
-    if (
-      text.includes("appearance:`avatarOverlay`") ||
-      text.includes("avatar-overlay-open-state-changed")
-    ) {
-      return {
-        start: match.index,
-        end: closeIndex + 1,
-        text,
-      };
-    }
-    classRegex.lastIndex = closeIndex + 1;
-  }
-  return null;
+	const classRegex =
+		/class(?:\s+[A-Za-z_$][\w$]*)?(?:\s+extends\s+[A-Za-z_$][\w$.]*)?\{/g;
+	classRegex.lastIndex = avatarOverlayRegionStart(source);
+	let match;
+	while ((match = classRegex.exec(source)) != null) {
+		const openIndex = match.index + match[0].length - 1;
+		const closeIndex = findMatchingBrace(source, openIndex);
+		if (closeIndex === -1) {
+			// findMatchingBrace cannot balance this class (e.g. it contains a regex
+			// literal with an unbalanced brace). Skip it and keep scanning instead of
+			// aborting — the avatar overlay class may appear later in the bundle.
+			classRegex.lastIndex = openIndex + 1;
+			continue;
+		}
+		const text = source.slice(match.index, closeIndex + 1);
+		if (
+			text.includes("appearance:`avatarOverlay`") ||
+			text.includes("avatar-overlay-open-state-changed")
+		) {
+			return {
+				start: match.index,
+				end: closeIndex + 1,
+				text,
+			};
+		}
+		classRegex.lastIndex = closeIndex + 1;
+	}
+	return null;
 }
 
 function findAvatarOverlayMethod(source, signatureRegex) {
-  const overlayClass = findAvatarOverlayClass(source);
-  if (overlayClass == null) {
-    return null;
-  }
-  return findAvatarMethodAfter(source, signatureRegex, overlayClass.start, overlayClass.end);
+	const overlayClass = findAvatarOverlayClass(source);
+	if (overlayClass == null) {
+		return null;
+	}
+	return findAvatarMethodAfter(
+		source,
+		signatureRegex,
+		overlayClass.start,
+		overlayClass.end,
+	);
 }
 
 function replaceAvatarMethod(source, signatureRegex, replacement) {
-  const method = findAvatarMethod(source, signatureRegex);
-  if (method == null || method.text === replacement) {
-    return source;
-  }
-  return source.slice(0, method.start) + replacement + source.slice(method.end);
+	const method = findAvatarMethod(source, signatureRegex);
+	if (method == null || method.text === replacement) {
+		return source;
+	}
+	return source.slice(0, method.start) + replacement + source.slice(method.end);
 }
 
 function replaceAvatarMethodText(source, method, replacement) {
-  if (method == null || method.text === replacement) {
-    return source;
-  }
-  return source.slice(0, method.start) + replacement + source.slice(method.end);
+	if (method == null || method.text === replacement) {
+		return source;
+	}
+	return source.slice(0, method.start) + replacement + source.slice(method.end);
 }
 
 function avatarCursorRegionPatch(electronVar) {
-  return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)}`;
+	return `codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let __codexCursor=${electronVar}.screen.getCursorScreenPoint(),__codexBounds=e.getContentBounds(),__codexX=__codexCursor.x-__codexBounds.x,__codexY=__codexCursor.y-__codexBounds.y,__codexWindowHit=__codexX>=0&&__codexY>=0&&__codexX<=__codexBounds.width&&__codexY<=__codexBounds.height;if(!__codexWindowHit)return!1;let __codexHit=e=>e!=null&&__codexX>=e.left&&__codexX<=e.left+e.width&&__codexY>=e.top&&__codexY<=e.top+e.height;return __codexHit(t.mascot)||__codexHit(t.tray)}`;
 }
 
 function avatarInputShapePatch() {
-  return "codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null)return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
+	return "codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;let r;try{r=e.getContentBounds()}catch{return null}if(r==null||!Number.isFinite(r.width)||!Number.isFinite(r.height))return null;if(this.dragState!=null)return[{x:0,y:0,width:r.width,height:r.height}];let i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}";
 }
 
 function avatarApplyInputShapePatch() {
-  return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`||typeof this.codexLinuxIsAvatarShapeBackend==`function`&&!this.codexLinuxIsAvatarShapeBackend())return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
+	return "codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`||typeof this.codexLinuxIsAvatarShapeBackend==`function`&&!this.codexLinuxIsAvatarShapeBackend())return!1;try{let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}";
 }
 
 function patchAvatarOverlayWindowOptions(source) {
-  const windowOptionsPatch =
-    "appearance:`avatarOverlay`,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
-  if (source.includes(windowOptionsPatch)) {
-    return source;
-  }
-  return source
-    .replace(
-      "appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1",
-      windowOptionsPatch,
-    )
-    .replace(
-      "appearance:`avatarOverlay`,focusable:!1",
-      windowOptionsPatch,
-    );
+	const windowOptionsPatch =
+		"appearance:`avatarOverlay`,alwaysOnTop:process.platform===`linux`,skipTaskbar:process.platform===`linux`,focusable:process.platform===`linux`?!0:!1";
+	if (source.includes(windowOptionsPatch)) {
+		return source;
+	}
+	return source
+		.replace(
+			"appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1",
+			windowOptionsPatch,
+		)
+		.replace("appearance:`avatarOverlay`,focusable:!1", windowOptionsPatch);
 }
 
 function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
-  let patched = source;
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxBuildAvatarInputShape\(e\)\{/,
-    avatarInputShapePatch(),
-  );
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxApplyAvatarInputShape\(e\)\{/,
-    avatarApplyInputShapePatch(),
-  );
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxIsCursorInAvatarInteractiveRegion\(e\)\{/,
-    avatarCursorRegionPatch(electronVar),
-  );
-  return patched;
+	let patched = source;
+	patched = replaceAvatarMethod(
+		patched,
+		/codexLinuxBuildAvatarInputShape\(e\)\{/,
+		avatarInputShapePatch(),
+	);
+	patched = replaceAvatarMethod(
+		patched,
+		/codexLinuxApplyAvatarInputShape\(e\)\{/,
+		avatarApplyInputShapePatch(),
+	);
+	patched = replaceAvatarMethod(
+		patched,
+		/codexLinuxIsCursorInAvatarInteractiveRegion\(e\)\{/,
+		avatarCursorRegionPatch(electronVar),
+	);
+	return patched;
 }
 
 function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
-  let patchedSource = currentSource;
-  const electronVar = requireName(currentSource, "electron") ?? "n";
-  const childProcessVar = requireName(currentSource, "node:child_process");
-  const withElectronAlias = (source) =>
-    electronVar === "n" ? source : source.replaceAll("n.screen", `${electronVar}.screen`);
-  const i3SessionMethod =
-    "codexLinuxIsI3Session(){let e=[process.env.XDG_CURRENT_DESKTOP,process.env.DESKTOP_SESSION,process.env.I3SOCK].filter(Boolean).join(`:`).toLowerCase();return/(^|[:;/])i3([:;/.-]|$)/.test(e)}";
-  const compositorHintsMethod =
-    childProcessVar == null
-      ? "codexLinuxApplyAvatarCompositorHints(e){}"
-      : `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,l,h,d,f]=c;if(Number(l)!==t.x||Number(h)!==t.y||Number(d)!==t.width||Number(f)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
-  const shapeBackendMethod =
-    `codexLinuxIsAvatarShapeBackend(){if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY}`;
+	let patchedSource = currentSource;
+	const electronVar = requireName(currentSource, "electron") ?? "n";
+	const childProcessVar = requireName(currentSource, "node:child_process");
+	const withElectronAlias = (source) =>
+		electronVar === "n"
+			? source
+			: source.replaceAll("n.screen", `${electronVar}.screen`);
+	const i3SessionMethod =
+		"codexLinuxIsI3Session(){let e=[process.env.XDG_CURRENT_DESKTOP,process.env.DESKTOP_SESSION,process.env.I3SOCK].filter(Boolean).join(`:`).toLowerCase();return/(^|[:;/])i3([:;/.-]|$)/.test(e)}";
+	const compositorHintsMethod =
+		childProcessVar == null
+			? "codexLinuxApplyAvatarCompositorHints(e){}"
+			: `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,l,h,d,f]=c;if(Number(l)!==t.x||Number(h)!==t.y||Number(d)!==t.width||Number(f)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
+	const shapeBackendMethod = `codexLinuxIsAvatarShapeBackend(){if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY}`;
 
-  const interactivityNeedle =
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}refreshCursorAtCurrentMousePosition(e){";
-  const previousShapeInteractivityNeedle =
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;if(this.dragState!=null){let t=e.getContentBounds();return[{x:0,y:0,width:t.width,height:t.height}]}let r=e.getContentBounds(),i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;try{e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}codexLinuxStartAvatarPassthroughRecovery(){if(process.platform!==`linux`||this.codexLinuxAvatarPassthroughRecoveryTimer!=null)return;this.codexLinuxAvatarPassthroughRecoveryTimer=setInterval(()=>{let e=this.window;if(e==null||e.isDestroyed()||!e.isVisible()){this.codexLinuxStopAvatarPassthroughRecovery();return}this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy()},32),this.codexLinuxAvatarPassthroughRecoveryTimer.unref?.()}codexLinuxSyncAvatarPointerInteractivity(e){if(process.platform!==`linux`||e==null||e.isDestroyed())return!1;if(this.dragState!=null){if(this.pointerInteractive)return!1;return this.pointerInteractive=!0,!0}let t;try{t=this.codexLinuxIsCursorInAvatarInteractiveRegion(e)}catch{t=!0}return this.pointerInteractive===t?!1:(this.pointerInteractive=t,!0)}codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let r=n.screen.getCursorScreenPoint(),i=e.getContentBounds(),a=r.x-i.x,o=r.y-i.y;if(a<0||o<0||a>i.width||o>i.height)return!1;let s=e=>e!=null&&a>=e.left&&a<=e.left+e.width&&o>=e.top&&o<=e.top+e.height;return s(t.mascot)||s(t.tray)}refreshCursorAtCurrentMousePosition(e){";
-  const previousSetShapePolicyPatch =
-    "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
-  const setShapePolicyPatch =
-    "if(this.codexLinuxIsAvatarShapeBackend()&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
-  // previousShapeInteractivityNeedle embeds the older Stop-based policy block;
-  // finalize it at build time so the replaceAll below only fires for trees
-  // patched by an older wrapper, not on every fresh DMG.
-  const interactivityPatch = withElectronAlias(previousShapeInteractivityNeedle)
-    .replace(
-      "codexLinuxStopAvatarPassthroughRecovery(){",
-      `${i3SessionMethod}${compositorHintsMethod}${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
-    )
-    .replaceAll(previousSetShapePolicyPatch, setShapePolicyPatch);
+	const interactivityNeedle =
+		"applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}refreshCursorAtCurrentMousePosition(e){";
+	const previousShapeInteractivityNeedle =
+		"applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;if(this.dragState!=null){let t=e.getContentBounds();return[{x:0,y:0,width:t.width,height:t.height}]}let r=e.getContentBounds(),i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;try{e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}codexLinuxStartAvatarPassthroughRecovery(){if(process.platform!==`linux`||this.codexLinuxAvatarPassthroughRecoveryTimer!=null)return;this.codexLinuxAvatarPassthroughRecoveryTimer=setInterval(()=>{let e=this.window;if(e==null||e.isDestroyed()||!e.isVisible()){this.codexLinuxStopAvatarPassthroughRecovery();return}this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy()},32),this.codexLinuxAvatarPassthroughRecoveryTimer.unref?.()}codexLinuxSyncAvatarPointerInteractivity(e){if(process.platform!==`linux`||e==null||e.isDestroyed())return!1;if(this.dragState!=null){if(this.pointerInteractive)return!1;return this.pointerInteractive=!0,!0}let t;try{t=this.codexLinuxIsCursorInAvatarInteractiveRegion(e)}catch{t=!0}return this.pointerInteractive===t?!1:(this.pointerInteractive=t,!0)}codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let r=n.screen.getCursorScreenPoint(),i=e.getContentBounds(),a=r.x-i.x,o=r.y-i.y;if(a<0||o<0||a>i.width||o>i.height)return!1;let s=e=>e!=null&&a>=e.left&&a<=e.left+e.width&&o>=e.top&&o<=e.top+e.height;return s(t.mascot)||s(t.tray)}refreshCursorAtCurrentMousePosition(e){";
+	const previousSetShapePolicyPatch =
+		"if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
+	const setShapePolicyPatch =
+		"if(this.codexLinuxIsAvatarShapeBackend()&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
+	// previousShapeInteractivityNeedle embeds the older Stop-based policy block;
+	// finalize it at build time so the replaceAll below only fires for trees
+	// patched by an older wrapper, not on every fresh DMG.
+	const interactivityPatch = withElectronAlias(previousShapeInteractivityNeedle)
+		.replace(
+			"codexLinuxStopAvatarPassthroughRecovery(){",
+			`${i3SessionMethod}${compositorHintsMethod}${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
+		)
+		.replaceAll(previousSetShapePolicyPatch, setShapePolicyPatch);
+	const currentComputerUseInteractivityNeedle =
+		"applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}setComputerUseCursorLocation";
+	// ELI5: the July avatar overlay added computer-use cursor methods between
+	// pointer policy and cursor refresh. We inject the Linux passthrough helpers
+	// before that new method so the rest of the class keeps its original order.
+	const currentComputerUseInteractivityPatch = withElectronAlias(
+		`applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}${setShapePolicyPatch}process.platform===\`linux\`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}${i3SessionMethod}${compositorHintsMethod}${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}${avatarInputShapePatch()}${avatarApplyInputShapePatch()}codexLinuxStartAvatarPassthroughRecovery(){if(process.platform!==\`linux\`||this.codexLinuxAvatarPassthroughRecoveryTimer!=null)return;this.codexLinuxAvatarPassthroughRecoveryTimer=setInterval(()=>{let e=this.window;if(e==null||e.isDestroyed()||!e.isVisible()){this.codexLinuxStopAvatarPassthroughRecovery();return}this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy()},32),this.codexLinuxAvatarPassthroughRecoveryTimer.unref?.()}codexLinuxSyncAvatarPointerInteractivity(e){if(process.platform!==\`linux\`||e==null||e.isDestroyed())return!1;if(this.dragState!=null){if(this.pointerInteractive)return!1;return this.pointerInteractive=!0,!0}let t;try{t=this.codexLinuxIsCursorInAvatarInteractiveRegion(e)}catch{t=!0}return this.pointerInteractive===t?!1:(this.pointerInteractive=t,!0)}${avatarCursorRegionPatch(electronVar)}setComputerUseCursorLocation`,
+	);
 
-  if (!patchedSource.includes("codexLinuxIsI3Session")) {
-    if (patchedSource.includes(interactivityNeedle)) {
-      recordStrategy("avatar-interactivity", "upstream");
-      patchedSource = patchedSource.replace(interactivityNeedle, interactivityPatch);
-    } else if (
-      patchedSource.includes("avatar-overlay") &&
-      patchedSource.includes("applyPointerInteractivityPolicy(){let e=this.window")
-    ) {
-      recordStrategy("avatar-interactivity", "none");
-      console.warn(
-        "WARN: Could not find avatar overlay mouse passthrough policy — skipping Linux avatar overlay passthrough recovery patch",
-      );
-      return currentSource;
-    }
-  } else {
-    recordStrategy("avatar-interactivity", "already-applied");
-  }
-  if (
-    patchedSource.includes("codexLinuxIsI3Session") &&
-    !patchedSource.includes("codexLinuxApplyAvatarCompositorHints")
-  ) {
-    patchedSource = patchedSource.replace(
-      `${i3SessionMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
-      `${i3SessionMethod}${compositorHintsMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
-    );
-  }
-  if (
-    patchedSource.includes("codexLinuxIsI3Session") &&
-    !patchedSource.includes("codexLinuxIsAvatarShapeBackend")
-  ) {
-    patchedSource = patchedSource.replace(
-      "codexLinuxStopAvatarPassthroughRecovery(){",
-      `${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
-    );
-  }
-  patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
-  const beforeFocusablePatch = patchedSource;
-  patchedSource = patchAvatarOverlayWindowOptions(patchedSource);
-  recordStrategy(
-    "avatar-window-options",
-    patchedSource === beforeFocusablePatch
-      ? patchedSource.includes("appearance:`avatarOverlay`") ? "already-applied" : "none"
-      : "upstream",
-  );
+	if (!patchedSource.includes("codexLinuxIsI3Session")) {
+		if (patchedSource.includes(interactivityNeedle)) {
+			recordStrategy("avatar-interactivity", "upstream");
+			patchedSource = patchedSource.replace(
+				interactivityNeedle,
+				interactivityPatch,
+			);
+		} else if (patchedSource.includes(currentComputerUseInteractivityNeedle)) {
+			recordStrategy("avatar-interactivity", "upstream-computer-use");
+			patchedSource = patchedSource.replace(
+				currentComputerUseInteractivityNeedle,
+				currentComputerUseInteractivityPatch,
+			);
+		} else if (
+			patchedSource.includes("avatar-overlay") &&
+			patchedSource.includes(
+				"applyPointerInteractivityPolicy(){let e=this.window",
+			)
+		) {
+			recordStrategy("avatar-interactivity", "none");
+			console.warn(
+				"WARN: Could not find avatar overlay mouse passthrough policy — skipping Linux avatar overlay passthrough recovery patch",
+			);
+			return currentSource;
+		}
+	} else {
+		recordStrategy("avatar-interactivity", "already-applied");
+	}
+	if (
+		patchedSource.includes("codexLinuxIsI3Session") &&
+		!patchedSource.includes("codexLinuxApplyAvatarCompositorHints")
+	) {
+		patchedSource = patchedSource.replace(
+			`${i3SessionMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
+			`${i3SessionMethod}${compositorHintsMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
+		);
+	}
+	if (
+		patchedSource.includes("codexLinuxIsI3Session") &&
+		!patchedSource.includes("codexLinuxIsAvatarShapeBackend")
+	) {
+		patchedSource = patchedSource.replace(
+			"codexLinuxStopAvatarPassthroughRecovery(){",
+			`${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
+		);
+	}
+	patchedSource = upgradeAvatarOverlayInjectedMethods(
+		patchedSource,
+		electronVar,
+	);
+	const beforeFocusablePatch = patchedSource;
+	patchedSource = patchAvatarOverlayWindowOptions(patchedSource);
+	recordStrategy(
+		"avatar-window-options",
+		patchedSource === beforeFocusablePatch
+			? patchedSource.includes("appearance:`avatarOverlay`")
+				? "already-applied"
+				: "none"
+			: "upstream",
+	);
 
-  const startDragMethod = findAvatarOverlayMethod(
-    patchedSource,
-    /startDrag\([^)]*\)\{/,
-  );
-  if (startDragMethod?.text.includes(
-    "process.platform===`linux`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())",
-  )) {
-    recordStrategy("avatar-start-drag", "already-applied");
-  } else if (startDragMethod?.text.includes("this.dragState=")) {
-    recordStrategy("avatar-start-drag", "upstream-method");
-    patchedSource = replaceAvatarMethodText(
-      patchedSource,
-      startDragMethod,
-      `${startDragMethod.text.slice(0, -1)},process.platform===\`linux\`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())}`,
-    );
-  } else if (
-    patchedSource.includes("avatar-overlay") &&
-    !patchedSource.includes("process.platform===`linux`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())")
-  ) {
-    recordStrategy("avatar-start-drag", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay drag start — skipping Linux avatar overlay drag interactivity patch",
-    );
-  }
+	const startDragMethod = findAvatarOverlayMethod(
+		patchedSource,
+		/startDrag\([^)]*\)\{/,
+	);
+	if (
+		startDragMethod?.text.includes(
+			"process.platform===`linux`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())",
+		)
+	) {
+		recordStrategy("avatar-start-drag", "already-applied");
+	} else if (startDragMethod?.text.includes("this.dragState=")) {
+		recordStrategy("avatar-start-drag", "upstream-method");
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			startDragMethod,
+			`${startDragMethod.text.slice(0, -1)},process.platform===\`linux\`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())}`,
+		);
+	} else if (
+		patchedSource.includes("avatar-overlay") &&
+		!patchedSource.includes(
+			"process.platform===`linux`&&(this.pointerInteractive=!0,this.applyPointerInteractivityPolicy())",
+		)
+	) {
+		recordStrategy("avatar-start-drag", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay drag start — skipping Linux avatar overlay drag interactivity patch",
+		);
+	}
 
-  const endDragMethod = findAvatarOverlayMethod(
-    patchedSource,
-    /endDrag\([A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*)?\)\{/,
-  );
-  if (endDragMethod?.text.includes(
-    "this.reclampWindowToVisibleDisplay({shouldPersist:!0}),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
-  )) {
-    recordStrategy("avatar-end-drag", "already-applied");
-  } else if (endDragMethod?.text.includes("this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0})")) {
-    recordStrategy("avatar-end-drag", "upstream-method");
-    patchedSource = replaceAvatarMethodText(
-      patchedSource,
-      endDragMethod,
-      endDragMethod.text.replace(
-        /this\.dragState=null,this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\)/,
-        "this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0}),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
-      ),
-    );
-  } else if (patchedSource.includes("avatar-overlay")) {
-    recordStrategy("avatar-end-drag", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay drag end — skipping Linux avatar overlay drag cleanup patch",
-    );
-  }
+	const endDragMethod = findAvatarOverlayMethod(
+		patchedSource,
+		/endDrag\([A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*)?\)\{/,
+	);
+	if (
+		endDragMethod?.text.includes(
+			"this.reclampWindowToVisibleDisplay({shouldPersist:!0}),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+		)
+	) {
+		recordStrategy("avatar-end-drag", "already-applied");
+	} else if (
+		endDragMethod?.text.includes(
+			"this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0})",
+		)
+	) {
+		recordStrategy("avatar-end-drag", "upstream-method");
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			endDragMethod,
+			endDragMethod.text.replace(
+				/this\.dragState=null,this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\)/,
+				"this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0}),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+			),
+		);
+	} else if (
+		endDragMethod?.text.includes(
+			":this.reclampWindowToVisibleDisplay({shouldPersist:!0});",
+		)
+	) {
+		recordStrategy("avatar-end-drag", "upstream-conditional-method");
+		// ELI5: the July bundle puts the reclamp inside a conditional branch. We
+		// sync Linux hitboxes right after that branch finishes moving the window.
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			endDragMethod,
+			endDragMethod.text.replace(
+				/:this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\);/,
+				":this.reclampWindowToVisibleDisplay({shouldPersist:!0});process.platform===`linux`&&this.applyPointerInteractivityPolicy();",
+			),
+		);
+	} else if (patchedSource.includes("avatar-overlay")) {
+		recordStrategy("avatar-end-drag", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay drag end — skipping Linux avatar overlay drag cleanup patch",
+		);
+	}
 
-  const setElementSizeMethod = findAvatarOverlayMethod(
-    patchedSource,
-    /setElementSize\([A-Za-z_$][\w$]*,\{(?:[^{}]*,)?mascot:[A-Za-z_$][\w$]*,tray:[A-Za-z_$][\w$]*(?:,[^{}]*)?\}\)\{/,
-  );
-  if (setElementSizeMethod != null) {
-    if (
-      !/this\.(?:applyLayout|applyLatestElementSizes)\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(setElementSizeMethod.text)
-    ) {
-      recordStrategy("avatar-element-size", "upstream");
-      const patchedMethod = setElementSizeMethod.text.replace(
-        /this\.(applyLayout|applyLatestElementSizes)\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
-        "this.$1($2),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
-      );
-      if (patchedMethod !== setElementSizeMethod.text) {
-        patchedSource =
-          patchedSource.slice(0, setElementSizeMethod.start) +
-          patchedMethod +
-          patchedSource.slice(setElementSizeMethod.end);
-      }
-    } else {
-      recordStrategy("avatar-element-size", "already-applied");
-    }
-  } else if (
-    patchedSource.includes("avatar-overlay") &&
-    !/setElementSize\([^{}]+\)\{[^]*?this\.applyLayout\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(patchedSource)
-  ) {
-    recordStrategy("avatar-element-size", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay element size update — skipping Linux avatar overlay layout interactivity patch",
-    );
-  }
+	const setElementSizeMethod = findAvatarOverlayMethod(
+		patchedSource,
+		/setElementSize\([A-Za-z_$][\w$]*,\{[^{}]*mascot:[A-Za-z_$][\w$]*,[^{}]*tray:[A-Za-z_$][\w$]*[^{}]*\}\)\{/,
+	);
+	if (setElementSizeMethod != null) {
+		if (
+			!/this\.(?:applyLayout|applyLatestElementSizes)\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(
+				setElementSizeMethod.text,
+			)
+		) {
+			recordStrategy("avatar-element-size", "upstream");
+			const patchedMethod = setElementSizeMethod.text.replace(
+				/this\.(applyLayout|applyLatestElementSizes)\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
+				"this.$1($2),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+			);
+			if (patchedMethod !== setElementSizeMethod.text) {
+				patchedSource =
+					patchedSource.slice(0, setElementSizeMethod.start) +
+					patchedMethod +
+					patchedSource.slice(setElementSizeMethod.end);
+			}
+		} else {
+			recordStrategy("avatar-element-size", "already-applied");
+		}
+	} else if (
+		patchedSource.includes("avatar-overlay") &&
+		!/setElementSize\([^{}]+\)\{[^]*?this\.applyLayout\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(
+			patchedSource,
+		)
+	) {
+		recordStrategy("avatar-element-size", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay element size update — skipping Linux avatar overlay layout interactivity patch",
+		);
+	}
 
-  if (!patchedSource.includes("this.codexLinuxAvatarCompositorHintsApplied=!1")) {
-    patchedSource = patchedSource.replace(
-      /return this\.window=([A-Za-z_$][\w$]*),/,
-      "return this.window=$1,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,",
-    );
-  }
+	if (
+		!patchedSource.includes("this.codexLinuxAvatarCompositorHintsApplied=!1")
+	) {
+		patchedSource = patchedSource.replace(
+			/return this\.window=([A-Za-z_$][\w$]*),/,
+			"return this.window=$1,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,",
+		);
+	}
 
-  const i3TrayFallbackRegex =
-    /traySize:this\.traySize\?\?([A-Za-z_$][\w$]*|\([^{};]*?\))\}\);this\.anchor=/;
-  const i3TrayFallbackPatch =
-    "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1});this.anchor=";
-  if (
-    !patchedSource.includes(
-      "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()",
-    )
-  ) {
-    if (i3TrayFallbackRegex.test(patchedSource)) {
-      recordStrategy("avatar-i3-tray-fallback", "upstream");
-      patchedSource = patchedSource.replace(i3TrayFallbackRegex, i3TrayFallbackPatch);
-    } else if (patchedSource.includes("avatar-overlay")) {
-      recordStrategy("avatar-i3-tray-fallback", "none");
-      console.warn(
-        "WARN: Could not find avatar overlay default tray layout — skipping Linux i3 hidden tray layout patch",
-      );
-    }
-  } else {
-    recordStrategy("avatar-i3-tray-fallback", "already-applied");
-  }
+	const i3TrayFallbackRegex =
+		/traySize:this\.traySize\?\?([A-Za-z_$][\w$]*|\([^{};]*?\))\}\);this\.anchor=/;
+	const i3TrayFallbackPatch =
+		"traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1});this.anchor=";
+	const currentI3TrayFallbackRegex =
+		/traySize:this\.traySize\?\?(\(this\.layoutMode===`native`\?[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*\))\}\)/;
+	const currentI3TrayFallbackPatch =
+		"traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1})";
+	if (
+		!patchedSource.includes(
+			"traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()",
+		)
+	) {
+		if (i3TrayFallbackRegex.test(patchedSource)) {
+			recordStrategy("avatar-i3-tray-fallback", "upstream");
+			patchedSource = patchedSource.replace(
+				i3TrayFallbackRegex,
+				i3TrayFallbackPatch,
+			);
+		} else if (currentI3TrayFallbackRegex.test(patchedSource)) {
+			recordStrategy("avatar-i3-tray-fallback", "upstream-current-layout");
+			patchedSource = patchedSource.replace(
+				currentI3TrayFallbackRegex,
+				currentI3TrayFallbackPatch,
+			);
+		} else if (patchedSource.includes("avatar-overlay")) {
+			recordStrategy("avatar-i3-tray-fallback", "none");
+			console.warn(
+				"WARN: Could not find avatar overlay default tray layout — skipping Linux i3 hidden tray layout patch",
+			);
+		}
+	} else {
+		recordStrategy("avatar-i3-tray-fallback", "already-applied");
+	}
 
-  const applyLayoutMethod = findAvatarOverlayMethod(
-    patchedSource,
-    /(?<![\w$.])applyLayout\([^{}]*\)\{/,
-  );
-  if (applyLayoutMethod?.text.includes(
-    "this.applyPointerInteractivityPolicy()",
-  )) {
-    recordStrategy("avatar-apply-layout", "already-applied");
-  } else if (
-    applyLayoutMethod != null &&
-    /this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/.test(applyLayoutMethod.text)
-  ) {
-    recordStrategy("avatar-apply-layout", "upstream");
-    patchedSource = replaceAvatarMethodText(
-      patchedSource,
-      applyLayoutMethod,
-      applyLayoutMethod.text.replace(
-        /this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/,
-        "this.setWindowBounds($1,$2.windowBounds$3),this.sendLayoutToRenderer($1$4),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
-      ),
-    );
-  } else if (
-    patchedSource.includes("avatar-overlay")
-  ) {
-    recordStrategy("avatar-apply-layout", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay layout application — skipping Linux avatar overlay layout sync patch",
-    );
-  }
+	const applyLayoutMethod = findAvatarOverlayMethod(
+		patchedSource,
+		/(?<![\w$.])applyLayout\([^{}]*\)\{/,
+	);
+	if (
+		applyLayoutMethod?.text.includes("this.applyPointerInteractivityPolicy()")
+	) {
+		recordStrategy("avatar-apply-layout", "already-applied");
+	} else if (
+		applyLayoutMethod != null &&
+		/this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/.test(
+			applyLayoutMethod.text,
+		)
+	) {
+		recordStrategy("avatar-apply-layout", "upstream");
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			applyLayoutMethod,
+			applyLayoutMethod.text.replace(
+				/this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/,
+				"this.setWindowBounds($1,$2.windowBounds$3),this.sendLayoutToRenderer($1$4),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+			),
+		);
+	} else if (
+		applyLayoutMethod != null &&
+		/this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.compositionHost\.updateMascotRect\(\2\.mascot\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/.test(
+			applyLayoutMethod.text,
+		)
+	) {
+		recordStrategy("avatar-apply-layout", "upstream-with-composition-host");
+		// ELI5: upstream now updates the native mascot layer between moving the
+		// window and notifying the renderer. Keep that, then refresh Linux hitboxes.
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			applyLayoutMethod,
+			applyLayoutMethod.text.replace(
+				/this\.setWindowBounds\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\.windowBounds((?:,[A-Za-z_$][\w$]*)*)\),this\.compositionHost\.updateMascotRect\(\2\.mascot\),this\.sendLayoutToRenderer\(\1((?:,[A-Za-z_$][\w$]*)*)\)/,
+				"this.setWindowBounds($1,$2.windowBounds$3),this.compositionHost.updateMascotRect($2.mascot),this.sendLayoutToRenderer($1$4),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+			),
+		);
+	} else if (patchedSource.includes("avatar-overlay")) {
+		recordStrategy("avatar-apply-layout", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay layout application — skipping Linux avatar overlay layout sync patch",
+		);
+	}
 
-  const showWindowMethod = findAvatarOverlayMethod(
-    patchedSource,
-    /showWindow\(([A-Za-z_$][\w$]*)\)\{/,
-  );
-  const showWindowArg = showWindowMethod?.match[1] ?? null;
-  if (showWindowMethod?.text.includes("codexLinuxApplyAvatarCompositorHints")) {
-    recordStrategy("avatar-show-window", "already-applied");
-  } else if (
-    showWindowMethod != null &&
-    showWindowArg != null &&
-    showWindowMethod.text.includes(`${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),`)
-  ) {
-    recordStrategy("avatar-show-window", "upstream-regex");
-    patchedSource = replaceAvatarMethodText(
-      patchedSource,
-      showWindowMethod,
-      showWindowMethod.text.replace(
-        `${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),`,
-        `${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),process.platform===\`linux\`&&this.codexLinuxApplyAvatarCompositorHints(${showWindowArg}),process.platform===\`linux\`&&this.applyPointerInteractivityPolicy(),`,
-      ),
-    );
-  } else if (patchedSource.includes("avatar-overlay")) {
-    recordStrategy("avatar-show-window", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay show window — skipping Linux avatar overlay show sync patch",
-    );
-  }
+	const showWindowMethod = findAvatarOverlayMethod(
+		patchedSource,
+		/showWindow\(([A-Za-z_$][\w$]*)\)\{/,
+	);
+	const showWindowArg = showWindowMethod?.match[1] ?? null;
+	if (showWindowMethod?.text.includes("codexLinuxApplyAvatarCompositorHints")) {
+		recordStrategy("avatar-show-window", "already-applied");
+	} else if (
+		showWindowMethod != null &&
+		showWindowArg != null &&
+		showWindowMethod.text.includes(
+			`${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),`,
+		)
+	) {
+		recordStrategy("avatar-show-window", "upstream-regex");
+		patchedSource = replaceAvatarMethodText(
+			patchedSource,
+			showWindowMethod,
+			showWindowMethod.text.replace(
+				`${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),`,
+				`${showWindowArg}.moveTop(),${showWindowArg}.showInactive(),process.platform===\`linux\`&&this.codexLinuxApplyAvatarCompositorHints(${showWindowArg}),process.platform===\`linux\`&&this.applyPointerInteractivityPolicy(),`,
+			),
+		);
+	} else if (patchedSource.includes("avatar-overlay")) {
+		recordStrategy("avatar-show-window", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay show window — skipping Linux avatar overlay show sync patch",
+		);
+	}
 
-  const closedPatchRegex =
-    /this\.window===[A-Za-z_$][\w$]*&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\),[\s\S]*?this\.window=null,/;
-  if (closedPatchRegex.test(patchedSource)) {
-    recordStrategy("avatar-close-cleanup", "already-applied");
-  } else if (/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/.test(patchedSource)) {
-    recordStrategy("avatar-close-cleanup", "upstream");
-    patchedSource = patchedSource.replace(
-      /this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/,
-      "this.window===$1&&(this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.cancelMomentum(),$2this.window=null,",
-    );
-  } else if (
-    patchedSource.includes("avatar-overlay") &&
-    patchedSource.includes("codexLinuxStartAvatarPassthroughRecovery")
-  ) {
-    recordStrategy("avatar-close-cleanup", "none");
-    console.warn(
-      "WARN: Could not find avatar overlay close cleanup — skipping Linux avatar overlay passthrough cleanup patch",
-    );
-  }
+	const closedPatchRegex =
+		/this\.window===[A-Za-z_$][\w$]*&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\),[\s\S]*?this\.window=null,/;
+	if (closedPatchRegex.test(patchedSource)) {
+		recordStrategy("avatar-close-cleanup", "already-applied");
+	} else if (
+		/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/.test(
+			patchedSource,
+		)
+	) {
+		recordStrategy("avatar-close-cleanup", "upstream");
+		patchedSource = patchedSource.replace(
+			/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/,
+			"this.window===$1&&(this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.cancelMomentum(),$2this.window=null,",
+		);
+	} else if (
+		patchedSource.includes("avatar-overlay") &&
+		patchedSource.includes("codexLinuxStartAvatarPassthroughRecovery")
+	) {
+		recordStrategy("avatar-close-cleanup", "none");
+		console.warn(
+			"WARN: Could not find avatar overlay close cleanup — skipping Linux avatar overlay passthrough cleanup patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 module.exports = {
-  applyLinuxAvatarOverlayMousePassthroughPatch,
+	applyLinuxAvatarOverlayMousePassthroughPatch,
 };

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -1,218 +1,287 @@
-"use strict";
-
 function applyLinuxQuitGuardPatch(currentSource) {
-  let patchedSource = currentSource;
+	const patchedSource = currentSource;
 
-  const quitGuardNeedle = "let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
-  const quitGuardSuffix =
-    "let codexLinuxQuitInProgress=!1,codexLinuxExplicitQuitApproved=!1,codexLinuxExplicitQuitDrainTimeoutMs=3e3,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxPrepareForExplicitQuit=()=>{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress()},codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0,codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;";
-  const quitGuardPatch = `${quitGuardNeedle}${quitGuardSuffix}`;
+	const quitGuardNeedle =
+		"let n=require(`electron`),i=require(`node:path`),o=require(`node:fs`);";
+	const quitGuardSuffix =
+		"let codexLinuxQuitInProgress=!1,codexLinuxExplicitQuitApproved=!1,codexLinuxExplicitQuitDrainTimeoutMs=3e3,codexLinuxMarkQuitInProgress=()=>{codexLinuxQuitInProgress=!0},codexLinuxPrepareForExplicitQuit=()=>{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress()},codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0,codexLinuxIsQuitInProgress=()=>codexLinuxQuitInProgress===!0;";
+	const quitGuardPatch = `${quitGuardNeedle}${quitGuardSuffix}`;
 
-  if (patchedSource.includes("codexLinuxExplicitQuitApproved=!1")) {
-    return patchedSource;
-  }
+	if (patchedSource.includes("codexLinuxExplicitQuitApproved=!1")) {
+		return patchedSource;
+	}
 
-  if (patchedSource.includes(quitGuardNeedle)) {
-    return patchedSource.replace(quitGuardNeedle, quitGuardPatch);
-  }
+	if (patchedSource.includes(quitGuardNeedle)) {
+		return patchedSource.replace(quitGuardNeedle, quitGuardPatch);
+	}
 
-  const currentCommaQuitGuardNeedle =
-    /let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?,([A-Za-z_$][\w$]*)=require\(`node:path`\),([A-Za-z_$][\w$]*)=require\(`node:fs`\);/;
-  const currentCommaQuitGuardMatch = patchedSource.match(currentCommaQuitGuardNeedle);
-  if (currentCommaQuitGuardMatch != null) {
-    const matchedPrefix = currentCommaQuitGuardMatch[0];
-    return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
-  }
+	const currentCommaQuitGuardNeedle =
+		/let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?,([A-Za-z_$][\w$]*)=require\(`node:path`\),([A-Za-z_$][\w$]*)=require\(`node:fs`\);/;
+	const currentCommaQuitGuardMatch = patchedSource.match(
+		currentCommaQuitGuardNeedle,
+	);
+	if (currentCommaQuitGuardMatch != null) {
+		const matchedPrefix = currentCommaQuitGuardMatch[0];
+		return patchedSource.replace(
+			matchedPrefix,
+			`${matchedPrefix}${quitGuardSuffix}`,
+		);
+	}
 
-  const currentBundlerQuitGuardNeedle =
-    /let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?;(?:\1=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:path`\);(?:\2=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:fs`\);(?:\3=[^;]+;)?/;
-  const currentBundlerQuitGuardMatch = patchedSource.match(currentBundlerQuitGuardNeedle);
-  if (currentBundlerQuitGuardMatch != null) {
-    const matchedPrefix = currentBundlerQuitGuardMatch[0];
-    return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
-  }
+	const currentBundlerQuitGuardNeedle =
+		/let ([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?;(?:\1=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:path`\);(?:\2=[^;]+;)?[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:fs`\);(?:\3=[^;]+;)?/;
+	const currentBundlerQuitGuardMatch = patchedSource.match(
+		currentBundlerQuitGuardNeedle,
+	);
+	if (currentBundlerQuitGuardMatch != null) {
+		const matchedPrefix = currentBundlerQuitGuardMatch[0];
+		return patchedSource.replace(
+			matchedPrefix,
+			`${matchedPrefix}${quitGuardSuffix}`,
+		);
+	}
 
-  const splitQuitGuardNeedle =
-    /let ([A-Za-z_$][\w$]*)=require\(`electron`\);(?:\1=[^;]+;)?let ([A-Za-z_$][\w$]*)=require\(`node:path`\);(?:\2=[^;]+;)?let ([A-Za-z_$][\w$]*)=require\(`node:fs`\);(?:\3=[^;]+;)?/;
-  const splitQuitGuardMatch = patchedSource.match(splitQuitGuardNeedle);
-  if (splitQuitGuardMatch != null) {
-    const matchedPrefix = splitQuitGuardMatch[0];
-    return patchedSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
-  }
+	const splitQuitGuardNeedle =
+		/let ([A-Za-z_$][\w$]*)=require\(`electron`\);(?:\1=[^;]+;)?let ([A-Za-z_$][\w$]*)=require\(`node:path`\);(?:\2=[^;]+;)?let ([A-Za-z_$][\w$]*)=require\(`node:fs`\);(?:\3=[^;]+;)?/;
+	const splitQuitGuardMatch = patchedSource.match(splitQuitGuardNeedle);
+	if (splitQuitGuardMatch != null) {
+		const matchedPrefix = splitQuitGuardMatch[0];
+		return patchedSource.replace(
+			matchedPrefix,
+			`${matchedPrefix}${quitGuardSuffix}`,
+		);
+	}
 
-  if (patchedSource.includes("require(`electron`)") && patchedSource.includes("require(`node:path`)")) {
-    console.warn("WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch");
-  }
+	// ELI5: the July upstream bundle wraps CommonJS imports with `e.o(...)` after
+	// loading them. We anchor after fs is imported so the quit-state helpers are
+	// still top-level globals that every later quit/tray patch can see.
+	const wrappedImportQuitGuardNeedle =
+		/(?:let|,)\s*([A-Za-z_$][\w$]*)=(?:codexLinuxPatchExternalOpen\()?require\(`electron`\)(?:\))?;\1=[A-Za-z_$][\w$]*\.o\(\1\);[\s\S]{0,800}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:path`\);\2=[A-Za-z_$][\w$]*\.o\(\2\);[\s\S]{0,800}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:fs`\);\3=[A-Za-z_$][\w$]*\.o\(\3\);/;
+	const wrappedImportQuitGuardMatch = patchedSource.match(
+		wrappedImportQuitGuardNeedle,
+	);
+	if (wrappedImportQuitGuardMatch != null) {
+		const matchedPrefix = wrappedImportQuitGuardMatch[0];
+		return patchedSource.replace(
+			matchedPrefix,
+			`${matchedPrefix}${quitGuardSuffix}`,
+		);
+	}
 
-  return patchedSource;
+	if (
+		patchedSource.includes("require(`electron`)") &&
+		patchedSource.includes("require(`node:path`)")
+	) {
+		console.warn(
+			"WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch",
+		);
+	}
+
+	return patchedSource;
 }
 
 function linuxExplicitQuitExpression() {
-  return "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
+	return "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
 }
 
 function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  const explicitQuitDrainGuard =
-    "process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())";
-  let patchedAny = false;
+	const explicitQuitDrainGuard =
+		"process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())";
+	let patchedAny = false;
 
-  const drainRegex =
-    /Promise\.all\(\[([A-Za-z_$][\w$]*)\.flush\(\),([A-Za-z_$][\w$]*)\.flush\(\)\]\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
-  patchedSource = patchedSource.replace(
-    drainRegex,
-    (_match, firstDrainVar, secondDrainVar, flushDisposeVar, disposablesVar, electronVar) => {
-      patchedAny = true;
-      return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([${firstDrainVar}.flush(),${secondDrainVar}.flush()]);if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
-    },
-  );
+	const drainRegex =
+		/Promise\.all\(\[([A-Za-z_$][\w$]*)\.flush\(\),([A-Za-z_$][\w$]*)\.flush\(\)\]\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
+	patchedSource = patchedSource.replace(
+		drainRegex,
+		(
+			_match,
+			firstDrainVar,
+			secondDrainVar,
+			flushDisposeVar,
+			disposablesVar,
+			electronVar,
+		) => {
+			patchedAny = true;
+			return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([${firstDrainVar}.flush(),${secondDrainVar}.flush()]);if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
+		},
+	);
 
-  if (
-    !patchedAny &&
-    !patchedSource.includes("codexLinuxDrainPromise=Promise.all(") &&
-    patchedSource.includes("n.app.on(`will-quit`,") &&
-    patchedSource.includes(".flush()")
-  ) {
-    console.warn("WARN: Could not find will-quit drain sequence — skipping Linux explicit quit drain timeout patch");
-  }
+	if (
+		!patchedAny &&
+		!patchedSource.includes("codexLinuxDrainPromise=Promise.all(") &&
+		patchedSource.includes("n.app.on(`will-quit`,") &&
+		patchedSource.includes(".flush()")
+	) {
+		console.warn(
+			"WARN: Could not find will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  const promptBypassExpression =
-    "(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||";
-  const promptBypassGuard = `if(${promptBypassExpression}`;
-  const quitMarkerExpression =
-    "process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
-  const beforeQuitNeedle =
-    "if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
-  const beforeQuitPatch =
-    `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
-  const beforeQuitRegex =
-    /if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
-  const acceptedPromptRegex =
-    /([A-Za-z_$][\w$]*)\.markQuitApproved\(\),([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\)/g;
-  let patchedAny = false;
+	const promptBypassExpression =
+		"(typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||";
+	const promptBypassGuard = `if(${promptBypassExpression}`;
+	const quitMarkerExpression =
+		"process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
+	const beforeQuitNeedle =
+		"if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}";
+	const beforeQuitPatch = `if(${promptBypassExpression}e||i.canQuitWithoutPrompt()||r||!s&&!c){${quitMarkerExpression}g=!0,a.markAppQuitting();return}`;
+	const beforeQuitRegex =
+		/if\(([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)\.canQuitWithoutPrompt\(\)\|\|([A-Za-z_$][\w$]*)\|\|!([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\);return\}/g;
+	const acceptedPromptRegex =
+		/([A-Za-z_$][\w$]*)\.markQuitApproved\(\),([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)\.markAppQuitting\(\)/g;
+	let patchedAny = false;
 
-  if (patchedSource.includes(beforeQuitNeedle)) {
-    patchedAny = true;
-    patchedSource = patchedSource.split(beforeQuitNeedle).join(beforeQuitPatch);
-  }
+	if (patchedSource.includes(beforeQuitNeedle)) {
+		patchedAny = true;
+		patchedSource = patchedSource.split(beforeQuitNeedle).join(beforeQuitPatch);
+	}
 
-  patchedSource = patchedSource.replace(
-    beforeQuitRegex,
-    (_match, updateInstallVar, quitControllerVar, appQuittingVar, activeConversationVar, automationVar, quittingStateVar, appQuittingControllerVar) => {
-      patchedAny = true;
-      return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
-    },
-  );
-  patchedSource = patchedSource.replace(
-    acceptedPromptRegex,
-    (match, quitControllerVar, quittingStateVar, appQuittingControllerVar, offset, source) => {
-      const prefix = source.slice(Math.max(0, offset - 120), offset);
-      if (prefix.includes("codexLinuxMarkQuitInProgress()")) {
-        return match;
-      }
-      patchedAny = true;
-      return `${quitMarkerExpression}${quitControllerVar}.markQuitApproved(),${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting()`;
-    },
-  );
+	patchedSource = patchedSource.replace(
+		beforeQuitRegex,
+		(
+			_match,
+			updateInstallVar,
+			quitControllerVar,
+			appQuittingVar,
+			activeConversationVar,
+			automationVar,
+			quittingStateVar,
+			appQuittingControllerVar,
+		) => {
+			patchedAny = true;
+			return `if(${promptBypassExpression}${updateInstallVar}||${quitControllerVar}.canQuitWithoutPrompt()||${appQuittingVar}||!${activeConversationVar}&&!${automationVar}){${quitMarkerExpression}${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting();return}`;
+		},
+	);
+	patchedSource = patchedSource.replace(
+		acceptedPromptRegex,
+		(
+			match,
+			quitControllerVar,
+			quittingStateVar,
+			appQuittingControllerVar,
+			offset,
+			source,
+		) => {
+			const prefix = source.slice(Math.max(0, offset - 120), offset);
+			if (prefix.includes("codexLinuxMarkQuitInProgress()")) {
+				return match;
+			}
+			patchedAny = true;
+			return `${quitMarkerExpression}${quitControllerVar}.markQuitApproved(),${quittingStateVar}=!0,${appQuittingControllerVar}.markAppQuitting()`;
+		},
+	);
 
-  if (
-    !patchedAny &&
-    !patchedSource.includes(promptBypassGuard) &&
-    patchedSource.includes("showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`]") &&
-    patchedSource.includes(".canQuitWithoutPrompt()")
-  ) {
-    console.warn("WARN: Could not find before-quit confirmation guard — skipping Linux explicit quit prompt bypass patch");
-  }
+	if (
+		!patchedAny &&
+		!patchedSource.includes(promptBypassGuard) &&
+		patchedSource.includes(
+			"showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`]",
+		) &&
+		patchedSource.includes(".canQuitWithoutPrompt()")
+	) {
+		console.warn(
+			"WARN: Could not find before-quit confirmation guard — skipping Linux explicit quit prompt bypass patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 function applyLinuxExplicitTrayQuitPatch(currentSource) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  const quitMarkerExpression = linuxExplicitQuitExpression();
+	const quitMarkerExpression = linuxExplicitQuitExpression();
 
-  const trayQuitNeedle = "{label:rB(this.appName),click:()=>{n.app.quit()}}";
-  const trayQuitPatch =
-    `{label:rB(this.appName),click:()=>{${quitMarkerExpression}n.app.quit()}}`;
-  const patchedTrayQuitRegex =
-    /\{label:[^{}]+,click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\)\}\}/;
-  const trayQuitRegex =
-    /\{label:rB\(([^)]+)\),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
-  const genericTrayQuitRegex =
-    /\{label:([A-Za-z_$][\w$]*\(this\.appName\)),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
-  let patchedAny = false;
-  if (patchedSource.includes(trayQuitNeedle)) {
-    patchedAny = true;
-    patchedSource = patchedSource.split(trayQuitNeedle).join(trayQuitPatch);
-  }
-  patchedSource = patchedSource.replace(
-    trayQuitRegex,
-    (_match, appNameExpr, electronVar) => {
-      patchedAny = true;
-      return `{label:rB(${appNameExpr}),click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
-    },
-  );
-  patchedSource = patchedSource.replace(
-    genericTrayQuitRegex,
-    (_match, labelExpression, electronVar) => {
-      patchedAny = true;
-      return `{label:${labelExpression},click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
-    },
-  );
-  if (
-    !patchedAny &&
-    !patchedTrayQuitRegex.test(patchedSource) &&
-    patchedSource.includes("getNativeTrayMenuItems(){") &&
-    (patchedSource.includes("label:rB(") || patchedSource.includes("role:`quit`"))
-  ) {
-    console.warn("WARN: Could not find tray quit menu handler — skipping Linux explicit tray quit patch");
-  }
+	const trayQuitNeedle = "{label:rB(this.appName),click:()=>{n.app.quit()}}";
+	const trayQuitPatch = `{label:rB(this.appName),click:()=>{${quitMarkerExpression}n.app.quit()}}`;
+	const patchedTrayQuitRegex =
+		/\{label:[^{}]+,click:\(\)=>\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\)\}\}/;
+	const trayQuitRegex =
+		/\{label:rB\(([^)]+)\),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
+	const genericTrayQuitRegex =
+		/\{label:([A-Za-z_$][\w$]*\(this\.appName\)),click:\(\)=>\{([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\}/g;
+	let patchedAny = false;
+	if (patchedSource.includes(trayQuitNeedle)) {
+		patchedAny = true;
+		patchedSource = patchedSource.split(trayQuitNeedle).join(trayQuitPatch);
+	}
+	patchedSource = patchedSource.replace(
+		trayQuitRegex,
+		(_match, appNameExpr, electronVar) => {
+			patchedAny = true;
+			return `{label:rB(${appNameExpr}),click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
+		},
+	);
+	patchedSource = patchedSource.replace(
+		genericTrayQuitRegex,
+		(_match, labelExpression, electronVar) => {
+			patchedAny = true;
+			return `{label:${labelExpression},click:()=>{${quitMarkerExpression}${electronVar}.app.quit()}}`;
+		},
+	);
+	if (
+		!patchedAny &&
+		!patchedTrayQuitRegex.test(patchedSource) &&
+		patchedSource.includes("getNativeTrayMenuItems(){") &&
+		(patchedSource.includes("label:rB(") ||
+			patchedSource.includes("role:`quit`"))
+	) {
+		console.warn(
+			"WARN: Could not find tray quit menu handler — skipping Linux explicit tray quit patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 function applyLinuxExplicitIpcQuitPatch(currentSource) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  const quitMarkerExpression = linuxExplicitQuitExpression();
+	const quitMarkerExpression = linuxExplicitQuitExpression();
 
-  const quitAppNeedle = "if(o.type===`quit-app`){n.app.quit();return}";
-  const quitAppPatch = `if(o.type===\`quit-app\`){${quitMarkerExpression}n.app.quit();return}`;
-  const quitAppRegex =
-    /if\(([A-Za-z_$][\w$]*)\.type===`quit-app`\)\{([A-Za-z_$][\w$]*)\.app\.quit\(\);return\}/g;
-  const patchedQuitAppRegex =
-    /if\([A-Za-z_$][\w$]*\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\);return\}/;
-  let patchedAny = false;
-  if (patchedSource.includes(quitAppNeedle)) {
-    patchedAny = true;
-    patchedSource = patchedSource.split(quitAppNeedle).join(quitAppPatch);
-  }
-  patchedSource = patchedSource.replace(
-    quitAppRegex,
-    (_match, messageVar, electronVar) => {
-      patchedAny = true;
-      return `if(${messageVar}.type===\`quit-app\`){${quitMarkerExpression}${electronVar}.app.quit();return}`;
-    },
-  );
-  if (!patchedAny && !patchedQuitAppRegex.test(patchedSource) && patchedSource.includes("type===`quit-app`")) {
-    console.warn("WARN: Could not find quit-app IPC handler — skipping Linux explicit quit-app patch");
-  }
+	const quitAppNeedle = "if(o.type===`quit-app`){n.app.quit();return}";
+	const quitAppPatch = `if(o.type===\`quit-app\`){${quitMarkerExpression}n.app.quit();return}`;
+	const quitAppRegex =
+		/if\(([A-Za-z_$][\w$]*)\.type===`quit-app`\)\{([A-Za-z_$][\w$]*)\.app\.quit\(\);return\}/g;
+	const patchedQuitAppRegex =
+		/if\([A-Za-z_$][\w$]*\.type===`quit-app`\)\{typeof codexLinuxPrepareForExplicitQuit===`function`\?codexLinuxPrepareForExplicitQuit\(\):typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress\(\),[A-Za-z_$][\w$]*\.app\.quit\(\);return\}/;
+	let patchedAny = false;
+	if (patchedSource.includes(quitAppNeedle)) {
+		patchedAny = true;
+		patchedSource = patchedSource.split(quitAppNeedle).join(quitAppPatch);
+	}
+	patchedSource = patchedSource.replace(
+		quitAppRegex,
+		(_match, messageVar, electronVar) => {
+			patchedAny = true;
+			return `if(${messageVar}.type===\`quit-app\`){${quitMarkerExpression}${electronVar}.app.quit();return}`;
+		},
+	);
+	if (
+		!patchedAny &&
+		!patchedQuitAppRegex.test(patchedSource) &&
+		patchedSource.includes("type===`quit-app`")
+	) {
+		console.warn(
+			"WARN: Could not find quit-app IPC handler — skipping Linux explicit quit-app patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 module.exports = {
-  applyLinuxExplicitIpcQuitPatch,
-  applyLinuxExplicitQuitPromptBypassPatch,
-  applyLinuxExplicitTrayQuitPatch,
-  applyLinuxQuitGuardPatch,
-  applyLinuxWillQuitDrainTimeoutPatch,
+	applyLinuxExplicitIpcQuitPatch,
+	applyLinuxExplicitQuitPromptBypassPatch,
+	applyLinuxExplicitTrayQuitPatch,
+	applyLinuxQuitGuardPatch,
+	applyLinuxWillQuitDrainTimeoutPatch,
 };

--- a/scripts/patches/impl/main-process/tray.js
+++ b/scripts/patches/impl/main-process/tray.js
@@ -1,487 +1,665 @@
-"use strict";
-
 const {
-  TRAY_GUARD_LOOKAHEAD,
-  escapeRegExp,
-  findMatchingBrace,
-  requireName,
+	TRAY_GUARD_LOOKAHEAD,
+	escapeRegExp,
+	findMatchingBrace,
+	requireName,
 } = require("../../lib/minified-js.js");
 
 function findNamedFunctionBody(source, functionName) {
-  const functionMatch = source.match(
-    new RegExp(`(?:async\\s+)?function\\s+${escapeRegExp(functionName)}\\([^)]*\\)\\{`),
-  );
-  if (functionMatch == null) {
-    return null;
-  }
+	const functionMatch = source.match(
+		new RegExp(
+			`(?:async\\s+)?function\\s+${escapeRegExp(functionName)}\\([^)]*\\)\\{`,
+		),
+	);
+	if (functionMatch == null) {
+		return null;
+	}
 
-  const openIndex = functionMatch.index + functionMatch[0].length - 1;
-  const closeIndex = findMatchingBrace(source, openIndex);
-  return closeIndex === -1 ? null : source.slice(openIndex, closeIndex + 1);
+	const openIndex = functionMatch.index + functionMatch[0].length - 1;
+	const closeIndex = findMatchingBrace(source, openIndex);
+	return closeIndex === -1 ? null : source.slice(openIndex, closeIndex + 1);
 }
 
 function isTrayFactoryFunction(source, functionName) {
-  const body = findNamedFunctionBody(source, functionName);
-  return body != null && /new [A-Za-z_$][\w$]*\.Tray\(/.test(body);
+	const body = findNamedFunctionBody(source, functionName);
+	return body != null && /new [A-Za-z_$][\w$]*\.Tray\(/.test(body);
 }
 
 function findDynamicTraySetup(source) {
-  const setupRegex =
-    /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await ([A-Za-z_$][\w$]*)\(\{(?:buildFlavor|appBrand):/g;
-  let match;
-  while ((match = setupRegex.exec(source)) != null) {
-    const [, setupFn, factoryFn] = match;
-    if (isTrayFactoryFunction(source, factoryFn)) {
-      return { setupFn, factoryFn, index: match.index };
-    }
-  }
-  return null;
+	const setupRegex =
+		/let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await ([A-Za-z_$][\w$]*)\(\{(?:buildFlavor|appBrand):/g;
+	let match;
+	while ((match = setupRegex.exec(source)) != null) {
+		const [, setupFn, factoryFn] = match;
+		if (isTrayFactoryFunction(source, factoryFn)) {
+			return { setupFn, factoryFn, index: match.index };
+		}
+	}
+	return null;
 }
 
 function findDynamicTrayStartupCall(source, setupFn, startIndex) {
-  const startupRegex = new RegExp(`([A-Za-z_$][\\w$]*)&&${escapeRegExp(setupFn)}\\(\\);`, "g");
-  startupRegex.lastIndex = startIndex;
-  return startupRegex.exec(source);
+	const startupRegex = new RegExp(
+		`([A-Za-z_$][\\w$]*)&&${escapeRegExp(setupFn)}\\(\\);`,
+		"g",
+	);
+	startupRegex.lastIndex = startIndex;
+	return startupRegex.exec(source);
 }
 
 function addDynamicTraySetupFailureLogging(source, traySetup) {
-  const logMessage = "[codex-linux] Failed to set up system tray";
-  if (traySetup == null || source.includes(logMessage)) {
-    return source;
-  }
+	const logMessage = "[codex-linux] Failed to set up system tray";
+	if (traySetup == null || source.includes(logMessage)) {
+		return source;
+	}
 
-  const openIndex = source.indexOf("{", traySetup.index);
-  if (openIndex === -1) {
-    return source;
-  }
-  const closeIndex = findMatchingBrace(source, openIndex);
-  if (closeIndex === -1) {
-    return source;
-  }
+	const openIndex = source.indexOf("{", traySetup.index);
+	if (openIndex === -1) {
+		return source;
+	}
+	const closeIndex = findMatchingBrace(source, openIndex);
+	if (closeIndex === -1) {
+		return source;
+	}
 
-  const body = source.slice(openIndex, closeIndex + 1);
-  if (!body.includes(`await ${traySetup.factoryFn}(`)) {
-    return source;
-  }
+	const body = source.slice(openIndex, closeIndex + 1);
+	if (!body.includes(`await ${traySetup.factoryFn}(`)) {
+		return source;
+	}
 
-  const catchRegex = /catch\(([A-Za-z_$][\w$]*)\)\{/;
-  const catchMatch = body.match(catchRegex);
-  if (catchMatch == null) {
-    return source;
-  }
+	const catchRegex = /catch\(([A-Za-z_$][\w$]*)\)\{/;
+	const catchMatch = body.match(catchRegex);
+	if (catchMatch == null) {
+		return source;
+	}
 
-  const [, errorVar] = catchMatch;
-  const catchOpenIndex = catchMatch.index + catchMatch[0].length - 1;
-  const catchCloseIndex = findMatchingBrace(body, catchOpenIndex);
-  if (catchCloseIndex === -1) {
-    return source;
-  }
+	const [, errorVar] = catchMatch;
+	const catchOpenIndex = catchMatch.index + catchMatch[0].length - 1;
+	const catchCloseIndex = findMatchingBrace(body, catchOpenIndex);
+	if (catchCloseIndex === -1) {
+		return source;
+	}
 
-  const catchBody = body.slice(catchOpenIndex + 1, catchCloseIndex);
-  const separator = catchBody.trim().length === 0 || /[;,]$/.test(catchBody.trim()) ? "" : ";";
-  const linuxWarning = `${separator}process.platform===\`linux\`&&console.warn(\`${logMessage}\`,${errorVar})`;
-  const patchedBody =
-    `${body.slice(0, catchCloseIndex)}${linuxWarning}${body.slice(catchCloseIndex)}`;
-  return `${source.slice(0, openIndex)}${patchedBody}${source.slice(closeIndex + 1)}`;
+	const catchBody = body.slice(catchOpenIndex + 1, catchCloseIndex);
+	const separator =
+		catchBody.trim().length === 0 || /[;,]$/.test(catchBody.trim()) ? "" : ";";
+	const linuxWarning = `${separator}process.platform===\`linux\`&&console.warn(\`${logMessage}\`,${errorVar})`;
+	const patchedBody = `${body.slice(0, catchCloseIndex)}${linuxWarning}${body.slice(catchCloseIndex)}`;
+	return `${source.slice(0, openIndex)}${patchedBody}${source.slice(closeIndex + 1)}`;
 }
 
 function applyLinuxTrayPatch(currentSource, iconPathExpression) {
-  let patchedSource = currentSource;
-  const electronVar = requireName(currentSource, "electron") ?? "n";
-  const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
-  const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
+	let patchedSource = currentSource;
+	const electronVar = requireName(currentSource, "electron") ?? "n";
+	const packagedTrayIconPathExpression =
+		"process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
+	const packagedAppIconPathExpression =
+		"process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
 
-  const trayGuardNeedle =
-    "process.platform!==`win32`&&process.platform!==`darwin`?null:";
-  const trayGuardPatch =
-    "process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`?null:";
-  const trayGuardIndex = patchedSource.indexOf(trayGuardNeedle);
-  if (patchedSource.includes(trayGuardPatch)) {
-    // Already patched.
-  } else if (
-    trayGuardIndex !== -1 &&
-    /new [A-Za-z_$][\w$]*\.Tray\(/.test(
-      patchedSource.slice(trayGuardIndex, trayGuardIndex + TRAY_GUARD_LOOKAHEAD),
-    )
-  ) {
-    patchedSource = patchedSource.replace(trayGuardNeedle, trayGuardPatch);
-  } else {
-    console.warn("WARN: Could not find tray platform guard — skipping Linux tray guard patch");
-  }
+	const trayGuardNeedle =
+		"process.platform!==`win32`&&process.platform!==`darwin`?null:";
+	const trayGuardPatch =
+		"process.platform!==`win32`&&process.platform!==`darwin`&&process.platform!==`linux`?null:";
+	const trayGuardIndex = patchedSource.indexOf(trayGuardNeedle);
+	if (patchedSource.includes(trayGuardPatch)) {
+		// Already patched.
+	} else if (
+		trayGuardIndex !== -1 &&
+		/new [A-Za-z_$][\w$]*\.Tray\(/.test(
+			patchedSource.slice(
+				trayGuardIndex,
+				trayGuardIndex + TRAY_GUARD_LOOKAHEAD,
+			),
+		)
+	) {
+		patchedSource = patchedSource.replace(trayGuardNeedle, trayGuardPatch);
+	} else {
+		console.warn(
+			"WARN: Could not find tray platform guard — skipping Linux tray guard patch",
+		);
+	}
 
-  if (iconPathExpression != null) {
-    const linuxIconFallback =
-      `if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}`;
-    const legacyGetFileIconSize = `process.platform===\`win32\`?\`small\`:\`normal\``;
-    const trayIconNeedle =
-      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:${legacyGetFileIconSize}}),chronicleRunningIcon:null}}`;
-    const trayIconPatch =
-      `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}${linuxIconFallback}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:${legacyGetFileIconSize}}),chronicleRunningIcon:null}}`;
-    const trayIconFallbackRegex =
-      /for\(let ([A-Za-z_$][\w$]*) of ([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(\1\);if\(!\3\.isEmpty\(\)\)return\{defaultIcon:\3,chronicleRunningIcon:null\}\}return\{defaultIcon:await \4\.app\.getFileIcon\(process\.execPath,\{size:((?:process\.platform===`win32`\?`small`:`normal`)|`small`|`normal`)\}\),chronicleRunningIcon:null\}\}/;
-    if (
-      patchedSource.includes(`nativeImage.createFromPath(${packagedTrayIconPathExpression})`) ||
-      patchedSource.includes(`nativeImage.createFromPath(${packagedAppIconPathExpression})`)
-    ) {
-      // Already patched.
-    } else if (patchedSource.includes(trayIconNeedle)) {
-      patchedSource = patchedSource.replace(trayIconNeedle, trayIconPatch);
-    } else if (trayIconFallbackRegex.test(patchedSource)) {
-      patchedSource = patchedSource.replace(
-        trayIconFallbackRegex,
-        (_match, iconPathVar, candidatesVar, imageVar, electronAlias, sizeExpression) =>
-          `for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:${sizeExpression}}),chronicleRunningIcon:null}}`,
-      );
-    } else {
-      console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");
-    }
-  }
+	if (iconPathExpression != null) {
+		const linuxIconFallback = `if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}`;
+		const legacyGetFileIconSize = `process.platform===\`win32\`?\`small\`:\`normal\``;
+		const trayIconNeedle = `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:${legacyGetFileIconSize}}),chronicleRunningIcon:null}}`;
+		const trayIconPatch = `for(let e of o){let t=${electronVar}.nativeImage.createFromPath(e);if(!t.isEmpty())return{defaultIcon:t,chronicleRunningIcon:null}}${linuxIconFallback}return{defaultIcon:await ${electronVar}.app.getFileIcon(process.execPath,{size:${legacyGetFileIconSize}}),chronicleRunningIcon:null}}`;
+		const trayIconFallbackRegex =
+			/for\(let ([A-Za-z_$][\w$]*) of ([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(\1\);if\(!\3\.isEmpty\(\)\)return\{defaultIcon:\3,chronicleRunningIcon:null\}\}return\{defaultIcon:await \4\.app\.getFileIcon\(process\.execPath,\{size:((?:process\.platform===`win32`\?`small`:`normal`)|`small`|`normal`)\}\),chronicleRunningIcon:null\}\}/;
+		if (
+			patchedSource.includes(
+				`nativeImage.createFromPath(${packagedTrayIconPathExpression})`,
+			) ||
+			patchedSource.includes(
+				`nativeImage.createFromPath(${packagedAppIconPathExpression})`,
+			)
+		) {
+			// Already patched.
+		} else if (patchedSource.includes(trayIconNeedle)) {
+			patchedSource = patchedSource.replace(trayIconNeedle, trayIconPatch);
+		} else if (trayIconFallbackRegex.test(patchedSource)) {
+			patchedSource = patchedSource.replace(
+				trayIconFallbackRegex,
+				(
+					_match,
+					iconPathVar,
+					candidatesVar,
+					imageVar,
+					electronAlias,
+					sizeExpression,
+				) =>
+					`for(let ${iconPathVar} of ${candidatesVar}){let ${imageVar}=${electronAlias}.nativeImage.createFromPath(${iconPathVar});if(!${imageVar}.isEmpty())return{defaultIcon:${imageVar},chronicleRunningIcon:null}}if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:${sizeExpression}}),chronicleRunningIcon:null}}`,
+			);
+		} else {
+			// ELI5: the July bundle moved tray icon lookup into a helper that first
+			// calls `K9(...)`, then falls back to Electron's app icon. Add our Linux
+			// package icons between those two steps so the tray has a real PNG.
+			const currentTrayIconHelperRegex =
+				/let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\);return \1==null\?\{defaultIcon:await ([A-Za-z_$][\w$]*)\.app\.getFileIcon\(process\.execPath,\{size:`small`\}\),chronicleRunningIcon:null\}:\{defaultIcon:\1,chronicleRunningIcon:null\}/;
+			if (currentTrayIconHelperRegex.test(patchedSource)) {
+				patchedSource = patchedSource.replace(
+					currentTrayIconHelperRegex,
+					(
+						_match,
+						foundIconVar,
+						helperFn,
+						buildFlavorVar,
+						appBrandVar,
+						repoRootVar,
+						electronAlias,
+					) =>
+						`let ${foundIconVar}=${helperFn}(${buildFlavorVar},${appBrandVar},${repoRootVar});if(${foundIconVar}==null&&process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronAlias}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronAlias}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronAlias}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}return ${foundIconVar}==null?{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:\`small\`}),chronicleRunningIcon:null}:{defaultIcon:${foundIconVar},chronicleRunningIcon:null}`,
+				);
+			} else {
+				console.warn(
+					"WARN: Could not find tray icon fallback — skipping Linux tray icon patch",
+				);
+			}
+		}
+	}
 
-  const patchedCloseToTrayRegex =
-    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLast(?:Local)?WindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
-  if (patchedCloseToTrayRegex.test(patchedSource)) {
-    // Already patched with a newer minifier's window variable.
-  } else {
-    const closeToTrayRegex =
-      /if\(process\.platform===`win32`&&!this\.isAppQuitting&&this\.options\.(canHideLast(?:Local)?WindowToTray)\?\.\(\)===!0&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\.preventDefault\(\),([A-Za-z_$][\w$]*)\.hide\(\);return\}/;
-    const closeToTrayMatch = patchedSource.match(closeToTrayRegex);
-    if (closeToTrayMatch != null) {
-      const [, gateMethodName, hasOtherWindowVar, eventVar, windowVar] = closeToTrayMatch;
-      patchedSource = patchedSource.replace(
-        closeToTrayRegex,
-        `if((process.platform===\`win32\`||process.platform===\`linux\`)&&!this.isAppQuitting&&!(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress())&&this.options.${gateMethodName}?.()===!0&&!${hasOtherWindowVar}){${eventVar}.preventDefault(),${windowVar}.hide();return}`,
-      );
-    } else {
-      console.warn("WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch");
-    }
-  }
+	const patchedCloseToTrayRegex =
+		/if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLast(?:Local)?WindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
+	if (patchedCloseToTrayRegex.test(patchedSource)) {
+		// Already patched with a newer minifier's window variable.
+	} else {
+		const closeToTrayRegex =
+			/if\(process\.platform===`win32`&&!this\.isAppQuitting&&this\.options\.(canHideLast(?:Local)?WindowToTray)\?\.\(\)===!0&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\.preventDefault\(\),([A-Za-z_$][\w$]*)\.hide\(\);return\}/;
+		const closeToTrayMatch = patchedSource.match(closeToTrayRegex);
+		if (closeToTrayMatch != null) {
+			const [, gateMethodName, hasOtherWindowVar, eventVar, windowVar] =
+				closeToTrayMatch;
+			patchedSource = patchedSource.replace(
+				closeToTrayRegex,
+				`if((process.platform===\`win32\`||process.platform===\`linux\`)&&!this.isAppQuitting&&!(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress())&&this.options.${gateMethodName}?.()===!0&&!${hasOtherWindowVar}){${eventVar}.preventDefault(),${windowVar}.hide();return}`,
+			);
+		} else {
+			console.warn(
+				"WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch",
+			);
+		}
+	}
 
-  const trayContextMethodNeedle =
-    "trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(";
-  const trayContextMethodPatch =
-    `trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};setLinuxTrayContextMenu(){let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());this.tray.setContextMenu?.(e);return e}constructor(`;
-  if (patchedSource.includes("setLinuxTrayContextMenu(){")) {
-    patchedSource = patchedSource.replace(
-      /setLinuxTrayContextMenu\(\)\{let e=[A-Za-z_$][\w$]*\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/,
-      `setLinuxTrayContextMenu(){let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`,
-    );
-  } else if (patchedSource.includes(trayContextMethodNeedle)) {
-    patchedSource = patchedSource.replace(trayContextMethodNeedle, trayContextMethodPatch);
-  } else {
-    console.warn("WARN: Could not find tray controller fields — skipping Linux tray context menu method patch");
-  }
+	const trayContextMethodNeedle =
+		"trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(";
+	const trayContextMethodPatch = `trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};setLinuxTrayContextMenu(){let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());this.tray.setContextMenu?.(e);return e}constructor(`;
+	if (patchedSource.includes("setLinuxTrayContextMenu(){")) {
+		patchedSource = patchedSource.replace(
+			/setLinuxTrayContextMenu\(\)\{let e=[A-Za-z_$][\w$]*\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/,
+			`setLinuxTrayContextMenu(){let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`,
+		);
+	} else if (patchedSource.includes(trayContextMethodNeedle)) {
+		patchedSource = patchedSource.replace(
+			trayContextMethodNeedle,
+			trayContextMethodPatch,
+		);
+	} else {
+		console.warn(
+			"WARN: Could not find tray controller fields — skipping Linux tray context menu method patch",
+		);
+	}
 
-  const trayClickNeedle =
-    "this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
-  const trayClickPatchWithoutContextSetup =
-    "this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
-  const trayClickPatch =
-    "process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
-  const canSetLinuxTrayContextMenu = patchedSource.includes("setLinuxTrayContextMenu(){");
-  if (patchedSource.includes("process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`")) {
-    // Already patched.
-  } else if (patchedSource.includes(trayClickNeedle)) {
-    patchedSource = patchedSource.replace(
-      trayClickNeedle,
-      canSetLinuxTrayContextMenu ? trayClickPatch : trayClickPatchWithoutContextSetup,
-    );
-  } else if (canSetLinuxTrayContextMenu && patchedSource.includes(trayClickPatchWithoutContextSetup)) {
-    patchedSource = patchedSource.replace(trayClickPatchWithoutContextSetup, trayClickPatch);
-  } else {
-    console.warn("WARN: Could not find tray click handler — skipping Linux tray menu click patch");
-  }
+	const trayClickNeedle =
+		"this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+	const trayClickPatchWithoutContextSetup =
+		"this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+	const trayClickPatch =
+		"process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`,()=>{process.platform===`linux`?this.openNativeTrayMenu():this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}";
+	const canSetLinuxTrayContextMenu = patchedSource.includes(
+		"setLinuxTrayContextMenu(){",
+	);
+	if (
+		patchedSource.includes(
+			"process.platform===`linux`&&this.setLinuxTrayContextMenu(),this.tray.on(`click`",
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes(trayClickNeedle)) {
+		patchedSource = patchedSource.replace(
+			trayClickNeedle,
+			canSetLinuxTrayContextMenu
+				? trayClickPatch
+				: trayClickPatchWithoutContextSetup,
+		);
+	} else if (
+		canSetLinuxTrayContextMenu &&
+		patchedSource.includes(trayClickPatchWithoutContextSetup)
+	) {
+		patchedSource = patchedSource.replace(
+			trayClickPatchWithoutContextSetup,
+			trayClickPatch,
+		);
+	} else {
+		console.warn(
+			"WARN: Could not find tray click handler — skipping Linux tray menu click patch",
+		);
+	}
 
-  const trayMenuBuildNeedle =
-    `openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
-  const trayMenuBuildExistingPatch =
-    `openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=process.platform===\`linux\`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
-  const trayMenuBuildPatch =
-    `openNativeTrayMenu(){if(process.platform===\`linux\`&&(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress()))return;this.updateChronicleTrayIcon();let e=process.platform===\`linux\`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
-  const trayMenuBuildAnyAliasRegex =
-    /openNativeTrayMenu\(\)\{this\.updateChronicleTrayIcon\(\);let e=([A-Za-z_$][\w$]*)\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/;
-  const trayMenuBuildExistingAnyAliasRegex =
-    /openNativeTrayMenu\(\)\{this\.updateChronicleTrayIcon\(\);let e=process\.platform===`linux`&&this\.setLinuxTrayContextMenu\?this\.setLinuxTrayContextMenu\(\):([A-Za-z_$][\w$]*)\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/;
-  if (patchedSource.includes("openNativeTrayMenu(){if(process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress()))return;")) {
-    // Already patched.
-  } else if (patchedSource.includes(trayMenuBuildExistingPatch)) {
-    patchedSource = patchedSource.replace(trayMenuBuildExistingPatch, trayMenuBuildPatch);
-  } else if (trayMenuBuildExistingAnyAliasRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(trayMenuBuildExistingAnyAliasRegex, trayMenuBuildPatch);
-  } else if (patchedSource.includes(trayMenuBuildNeedle)) {
-    patchedSource = patchedSource.replace(trayMenuBuildNeedle, trayMenuBuildPatch);
-  } else if (trayMenuBuildAnyAliasRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(trayMenuBuildAnyAliasRegex, trayMenuBuildPatch);
-  } else {
-    console.warn("WARN: Could not find tray native menu builder — skipping Linux tray context menu builder patch");
-  }
+	const trayMenuBuildNeedle = `openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
+	const trayMenuBuildExistingPatch = `openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=process.platform===\`linux\`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
+	const trayMenuBuildPatch = `openNativeTrayMenu(){if(process.platform===\`linux\`&&(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress()))return;this.updateChronicleTrayIcon();let e=process.platform===\`linux\`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():${electronVar}.Menu.buildFromTemplate(this.getNativeTrayMenuItems());`;
+	const trayMenuBuildAnyAliasRegex =
+		/openNativeTrayMenu\(\)\{this\.updateChronicleTrayIcon\(\);let e=([A-Za-z_$][\w$]*)\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/;
+	const trayMenuBuildExistingAnyAliasRegex =
+		/openNativeTrayMenu\(\)\{this\.updateChronicleTrayIcon\(\);let e=process\.platform===`linux`&&this\.setLinuxTrayContextMenu\?this\.setLinuxTrayContextMenu\(\):([A-Za-z_$][\w$]*)\.Menu\.buildFromTemplate\(this\.getNativeTrayMenuItems\(\)\);/;
+	if (
+		patchedSource.includes(
+			"openNativeTrayMenu(){if(process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress()))return;",
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes(trayMenuBuildExistingPatch)) {
+		patchedSource = patchedSource.replace(
+			trayMenuBuildExistingPatch,
+			trayMenuBuildPatch,
+		);
+	} else if (trayMenuBuildExistingAnyAliasRegex.test(patchedSource)) {
+		patchedSource = patchedSource.replace(
+			trayMenuBuildExistingAnyAliasRegex,
+			trayMenuBuildPatch,
+		);
+	} else if (patchedSource.includes(trayMenuBuildNeedle)) {
+		patchedSource = patchedSource.replace(
+			trayMenuBuildNeedle,
+			trayMenuBuildPatch,
+		);
+	} else if (trayMenuBuildAnyAliasRegex.test(patchedSource)) {
+		patchedSource = patchedSource.replace(
+			trayMenuBuildAnyAliasRegex,
+			trayMenuBuildPatch,
+		);
+	} else {
+		console.warn(
+			"WARN: Could not find tray native menu builder — skipping Linux tray context menu builder patch",
+		);
+	}
 
-  const trayContextMenuNeedle =
-    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
-  const trayContextMenuPatch =
-    "if(process.platform===`linux`)return;e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
-  const oldLinuxPopupPatch =
-    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)}";
-  const badLinuxPopupPatch =
-    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),if(process.platform===`linux`)return;e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
-  if (patchedSource.includes("if(process.platform===`linux`)return;e.once(`menu-will-show`")) {
-    // Already patched.
-  } else if (patchedSource.includes(badLinuxPopupPatch)) {
-    patchedSource = patchedSource.replace(badLinuxPopupPatch, trayContextMenuPatch);
-  } else if (patchedSource.includes(oldLinuxPopupPatch)) {
-    patchedSource = patchedSource.replace(oldLinuxPopupPatch, trayContextMenuPatch);
-  } else if (patchedSource.includes(trayContextMenuNeedle)) {
-    patchedSource = patchedSource.replace(trayContextMenuNeedle, trayContextMenuPatch);
-  } else {
-    console.warn("WARN: Could not find tray native menu popup — skipping Linux tray popup guard patch");
-  }
+	const trayContextMenuNeedle =
+		"e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+	const trayContextMenuPatch =
+		"if(process.platform===`linux`)return;e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+	const oldLinuxPopupPatch =
+		"e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)}";
+	const badLinuxPopupPatch =
+		"e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),if(process.platform===`linux`)return;e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
+	if (
+		patchedSource.includes(
+			"if(process.platform===`linux`)return;e.once(`menu-will-show`",
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes(badLinuxPopupPatch)) {
+		patchedSource = patchedSource.replace(
+			badLinuxPopupPatch,
+			trayContextMenuPatch,
+		);
+	} else if (patchedSource.includes(oldLinuxPopupPatch)) {
+		patchedSource = patchedSource.replace(
+			oldLinuxPopupPatch,
+			trayContextMenuPatch,
+		);
+	} else if (patchedSource.includes(trayContextMenuNeedle)) {
+		patchedSource = patchedSource.replace(
+			trayContextMenuNeedle,
+			trayContextMenuPatch,
+		);
+	} else {
+		console.warn(
+			"WARN: Could not find tray native menu popup — skipping Linux tray popup guard patch",
+		);
+	}
 
-  const trayMenuThreadsNeedle =
-    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return";
-  const trayMenuThreadsExistingPatch =
-    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.();return";
-  const trayMenuThreadsPatch =
-    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.();return";
-  if (patchedSource.includes("this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()")) {
-    // Already patched.
-  } else if (patchedSource.includes(trayMenuThreadsExistingPatch)) {
-    patchedSource = patchedSource.replace(trayMenuThreadsExistingPatch, trayMenuThreadsPatch);
-  } else if (patchedSource.includes(trayMenuThreadsNeedle)) {
-    patchedSource = patchedSource.replace(trayMenuThreadsNeedle, trayMenuThreadsPatch);
-  } else {
-    console.warn("WARN: Could not find tray menu thread update handler — skipping Linux tray context refresh patch");
-  }
+	const trayMenuThreadsNeedle =
+		"case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return";
+	const trayMenuThreadsExistingPatch =
+		"case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.();return";
+	const trayMenuThreadsPatch =
+		"case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.();return";
+	if (
+		patchedSource.includes(
+			"this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()",
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes(trayMenuThreadsExistingPatch)) {
+		patchedSource = patchedSource.replace(
+			trayMenuThreadsExistingPatch,
+			trayMenuThreadsPatch,
+		);
+	} else if (patchedSource.includes(trayMenuThreadsNeedle)) {
+		patchedSource = patchedSource.replace(
+			trayMenuThreadsNeedle,
+			trayMenuThreadsPatch,
+		);
+	} else {
+		console.warn(
+			"WARN: Could not find tray menu thread update handler — skipping Linux tray context refresh patch",
+		);
+	}
 
-  const trayStartupNeedle = "E&&oe();";
-  const previousTrayStartupPatch = "(E||process.platform===`linux`)&&oe();";
-  const trayEnabledExpression = "process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
-  const trayStartupPatch = `(E||${trayEnabledExpression})&&oe();`;
-  patchedSource = patchedSource.replaceAll(
-    "process.platform===`linux`&&codexLinuxIsTrayEnabled())&&",
-    `${trayEnabledExpression})&&`,
-  );
-  if (patchedSource.includes(trayStartupPatch)) {
-    // Already patched.
-  } else if (patchedSource.includes(previousTrayStartupPatch)) {
-    patchedSource = patchedSource.replace(previousTrayStartupPatch, trayStartupPatch);
-  } else if (patchedSource.includes(trayStartupNeedle)) {
-    patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
-  } else {
-    const traySetup = findDynamicTraySetup(patchedSource);
-    const dynamicTrayStartupMatch = traySetup == null
-      ? null
-      : findDynamicTrayStartupCall(patchedSource, traySetup.setupFn, traySetup.index);
-    if (
-      traySetup != null &&
-      patchedSource.includes(`${trayEnabledExpression})&&${traySetup.setupFn}();`)
-    ) {
-      // Already patched with a newer minifier's tray setup identifier.
-    } else if (dynamicTrayStartupMatch != null) {
-      const isWindowsVar = dynamicTrayStartupMatch[1];
-      patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||${trayEnabledExpression})&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
-    } else {
-      console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
-    }
-  }
+	const trayStartupNeedle = "E&&oe();";
+	const previousTrayStartupPatch = "(E||process.platform===`linux`)&&oe();";
+	const trayEnabledExpression =
+		"process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
+	const trayStartupPatch = `(E||${trayEnabledExpression})&&oe();`;
+	patchedSource = patchedSource.replaceAll(
+		"process.platform===`linux`&&codexLinuxIsTrayEnabled())&&",
+		`${trayEnabledExpression})&&`,
+	);
+	if (patchedSource.includes(trayStartupPatch)) {
+		// Already patched.
+	} else if (patchedSource.includes(previousTrayStartupPatch)) {
+		patchedSource = patchedSource.replace(
+			previousTrayStartupPatch,
+			trayStartupPatch,
+		);
+	} else if (patchedSource.includes(trayStartupNeedle)) {
+		patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
+	} else {
+		const traySetup = findDynamicTraySetup(patchedSource);
+		const dynamicTrayStartupMatch =
+			traySetup == null
+				? null
+				: findDynamicTrayStartupCall(
+						patchedSource,
+						traySetup.setupFn,
+						traySetup.index,
+					);
+		if (
+			traySetup != null &&
+			patchedSource.includes(
+				`${trayEnabledExpression})&&${traySetup.setupFn}();`,
+			)
+		) {
+			// Already patched with a newer minifier's tray setup identifier.
+		} else if (dynamicTrayStartupMatch != null) {
+			const isWindowsVar = dynamicTrayStartupMatch[1];
+			patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||${trayEnabledExpression})&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
+		} else {
+			console.warn(
+				"WARN: Could not find tray startup call — skipping Linux tray startup patch",
+			);
+		}
+	}
 
-  const traySetupForDiagnostics = findDynamicTraySetup(patchedSource);
-  const sourceWithTrayDiagnostics = addDynamicTraySetupFailureLogging(
-    patchedSource,
-    traySetupForDiagnostics,
-  );
-  if (
-    traySetupForDiagnostics != null &&
-    sourceWithTrayDiagnostics === patchedSource &&
-    !patchedSource.includes("[codex-linux] Failed to set up system tray")
-  ) {
-    console.warn("WARN: Could not find tray setup catch handler — skipping Linux tray diagnostics patch");
-  }
-  patchedSource = sourceWithTrayDiagnostics;
+	const traySetupForDiagnostics = findDynamicTraySetup(patchedSource);
+	const sourceWithTrayDiagnostics = addDynamicTraySetupFailureLogging(
+		patchedSource,
+		traySetupForDiagnostics,
+	);
+	if (
+		traySetupForDiagnostics != null &&
+		sourceWithTrayDiagnostics === patchedSource &&
+		!patchedSource.includes("[codex-linux] Failed to set up system tray")
+	) {
+		console.warn(
+			"WARN: Could not find tray setup catch handler — skipping Linux tray diagnostics patch",
+		);
+	}
+	patchedSource = sourceWithTrayDiagnostics;
 
-  return patchedSource;
+	return patchedSource;
 }
 
 function buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar) {
-  return `function codexLinuxBuildInfoPaths(){let __codexBuildInfoPaths=[];try{__codexBuildInfoPaths.push((0,${pathVar}.join)(process.resourcesPath,\`codex-linux-build-info.json\`)),__codexBuildInfoPaths.push((0,${pathVar}.join)(process.resourcesPath,\`..\`,\`.codex-linux\`,\`build-info.json\`))}catch{}return __codexBuildInfoPaths}function codexLinuxReadBuildInfo(){for(let __codexBuildInfoPath of codexLinuxBuildInfoPaths())try{if(${fsVar}.existsSync(__codexBuildInfoPath)){let __codexBuildInfo=JSON.parse(${fsVar}.readFileSync(__codexBuildInfoPath,\`utf8\`));if(__codexBuildInfo&&typeof __codexBuildInfo===\`object\`&&!Array.isArray(__codexBuildInfo))return{info:__codexBuildInfo,path:__codexBuildInfoPath}}}catch{}return{info:null,path:null}}function codexLinuxBuildInfoValue(__codexBuildInfoValue,__codexBuildInfoFallback=\`unknown\`){return typeof __codexBuildInfoValue===\`string\`&&__codexBuildInfoValue.trim().length>0?__codexBuildInfoValue:Array.isArray(__codexBuildInfoValue)&&__codexBuildInfoValue.length>0?__codexBuildInfoValue.join(\`, \`):__codexBuildInfoValue==null?__codexBuildInfoFallback:String(__codexBuildInfoValue)}function codexLinuxBuildInfoCommitUrl(__codexBuildInfo){let __codexBuildInfoCommitUrl=__codexBuildInfo?.source?.commitUrl;return typeof __codexBuildInfoCommitUrl===\`string\`&&/^https:\\/\\/github\\.com\\/[^/\\s]+\\/[^/\\s]+\\/commit\\/[0-9a-f]{7,40}$/i.test(__codexBuildInfoCommitUrl)?__codexBuildInfoCommitUrl:null}function codexLinuxGetBuildInfo(){let __codexBuildInfoResult=codexLinuxReadBuildInfo();return{...__codexBuildInfoResult,commitUrl:codexLinuxBuildInfoCommitUrl(__codexBuildInfoResult.info)}}function codexLinuxBuildInfoDetail(__codexBuildInfo,__codexBuildInfoPath){if(!__codexBuildInfo)return\`No Linux build metadata file was found in this app install.\`;let __codexBuildInfoTarget=__codexBuildInfo.linuxTarget??{},__codexBuildInfoDistro=__codexBuildInfoTarget.distro??{},__codexBuildInfoDmg=__codexBuildInfo.upstreamDmg??{},__codexBuildInfoSource=__codexBuildInfo.source??{},__codexBuildInfoFeatures=__codexBuildInfo.linuxFeatures?.enabled??[],__codexBuildInfoProfile=__codexBuildInfo.packageProfile??{},__codexBuildInfoCommit=__codexBuildInfoSource.commit||__codexBuildInfoSource.shortCommit,__codexBuildInfoCommitValue=__codexBuildInfoCommit?__codexBuildInfoSource.dirty?\`\${__codexBuildInfoCommit} (dirty)\`:__codexBuildInfoCommit:\`unknown\`,__codexBuildInfoDistroValue=__codexBuildInfoDistro.prettyName||[__codexBuildInfoDistro.id,__codexBuildInfoDistro.versionId].filter(Boolean).join(\` \`)||\`unknown\`,__codexBuildInfoCommitLink=codexLinuxBuildInfoCommitUrl(__codexBuildInfo);return[\`Metadata file: \${codexLinuxBuildInfoValue(__codexBuildInfoPath)}\`,\`Linux package profile: \${codexLinuxBuildInfoValue(__codexBuildInfoProfile.label)}\`,\`Distro: \${__codexBuildInfoDistroValue}\`,\`Package manager: \${codexLinuxBuildInfoValue(__codexBuildInfoTarget.packageManager??__codexBuildInfoProfile.packageManager)}\`,\`Package format: \${codexLinuxBuildInfoValue(__codexBuildInfoTarget.packageFormat??__codexBuildInfoProfile.format)}\`,\`Enabled features: \${__codexBuildInfoFeatures.length>0?__codexBuildInfoFeatures.join(\`, \`):\`none\`}\`,\`Upstream app version: \${codexLinuxBuildInfoValue(__codexBuildInfoDmg.appVersion)}\`,\`Upstream DMG SHA256: \${codexLinuxBuildInfoValue(__codexBuildInfoDmg.sha256)}\`,\`Electron: \${codexLinuxBuildInfoValue(__codexBuildInfo.electronVersion)}\`,\`Linux source commit: \${__codexBuildInfoCommitValue}\`,...(__codexBuildInfoCommitLink?[\`Source commit URL: \${__codexBuildInfoCommitLink}\`]:[]),\`Source branch: \${codexLinuxBuildInfoValue(__codexBuildInfoSource.branch)}\`,\`Generated: \${codexLinuxBuildInfoValue(__codexBuildInfo.generatedAt)}\`].join(\`\\n\`)}async function codexLinuxOpenBuildInfoCommit(){let __codexBuildInfoResult=codexLinuxGetBuildInfo();return __codexBuildInfoResult.commitUrl?(await ${electronVar}.shell?.openExternal(__codexBuildInfoResult.commitUrl),{success:!0}):{success:!1}}async function codexLinuxShowBuildInfo(){try{let __codexBuildInfoResult=codexLinuxGetBuildInfo(),__codexBuildInfoCommitUrl=__codexBuildInfoResult.commitUrl,__codexBuildInfoPath=__codexBuildInfoResult.path,__codexBuildInfoButtons=[],__codexBuildInfoButtonIndex=0;__codexBuildInfoCommitUrl&&__codexBuildInfoButtons.push(\`Open Source Commit\`),__codexBuildInfoPath&&__codexBuildInfoButtons.push(\`Open Metadata File\`),__codexBuildInfoButtons.push(\`OK\`);let __codexBuildInfoBoxResponse=await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:__codexBuildInfoButtons,defaultId:__codexBuildInfoButtons.length-1,cancelId:__codexBuildInfoButtons.length-1,message:\`Codex Desktop Linux build information\`,detail:codexLinuxBuildInfoDetail(__codexBuildInfoResult.info,__codexBuildInfoPath)});if(__codexBuildInfoCommitUrl&&__codexBuildInfoBoxResponse?.response===__codexBuildInfoButtonIndex++){await ${electronVar}.shell?.openExternal(__codexBuildInfoCommitUrl);return}if(__codexBuildInfoPath&&__codexBuildInfoBoxResponse?.response===__codexBuildInfoButtonIndex++)await ${electronVar}.shell?.openPath?.(__codexBuildInfoPath)}catch{}}`;
+	return `function codexLinuxBuildInfoPaths(){let __codexBuildInfoPaths=[];try{__codexBuildInfoPaths.push((0,${pathVar}.join)(process.resourcesPath,\`codex-linux-build-info.json\`)),__codexBuildInfoPaths.push((0,${pathVar}.join)(process.resourcesPath,\`..\`,\`.codex-linux\`,\`build-info.json\`))}catch{}return __codexBuildInfoPaths}function codexLinuxReadBuildInfo(){for(let __codexBuildInfoPath of codexLinuxBuildInfoPaths())try{if(${fsVar}.existsSync(__codexBuildInfoPath)){let __codexBuildInfo=JSON.parse(${fsVar}.readFileSync(__codexBuildInfoPath,\`utf8\`));if(__codexBuildInfo&&typeof __codexBuildInfo===\`object\`&&!Array.isArray(__codexBuildInfo))return{info:__codexBuildInfo,path:__codexBuildInfoPath}}}catch{}return{info:null,path:null}}function codexLinuxBuildInfoValue(__codexBuildInfoValue,__codexBuildInfoFallback=\`unknown\`){return typeof __codexBuildInfoValue===\`string\`&&__codexBuildInfoValue.trim().length>0?__codexBuildInfoValue:Array.isArray(__codexBuildInfoValue)&&__codexBuildInfoValue.length>0?__codexBuildInfoValue.join(\`, \`):__codexBuildInfoValue==null?__codexBuildInfoFallback:String(__codexBuildInfoValue)}function codexLinuxBuildInfoCommitUrl(__codexBuildInfo){let __codexBuildInfoCommitUrl=__codexBuildInfo?.source?.commitUrl;return typeof __codexBuildInfoCommitUrl===\`string\`&&/^https:\\/\\/github\\.com\\/[^/\\s]+\\/[^/\\s]+\\/commit\\/[0-9a-f]{7,40}$/i.test(__codexBuildInfoCommitUrl)?__codexBuildInfoCommitUrl:null}function codexLinuxGetBuildInfo(){let __codexBuildInfoResult=codexLinuxReadBuildInfo();return{...__codexBuildInfoResult,commitUrl:codexLinuxBuildInfoCommitUrl(__codexBuildInfoResult.info)}}function codexLinuxBuildInfoDetail(__codexBuildInfo,__codexBuildInfoPath){if(!__codexBuildInfo)return\`No Linux build metadata file was found in this app install.\`;let __codexBuildInfoTarget=__codexBuildInfo.linuxTarget??{},__codexBuildInfoDistro=__codexBuildInfoTarget.distro??{},__codexBuildInfoDmg=__codexBuildInfo.upstreamDmg??{},__codexBuildInfoSource=__codexBuildInfo.source??{},__codexBuildInfoFeatures=__codexBuildInfo.linuxFeatures?.enabled??[],__codexBuildInfoProfile=__codexBuildInfo.packageProfile??{},__codexBuildInfoCommit=__codexBuildInfoSource.commit||__codexBuildInfoSource.shortCommit,__codexBuildInfoCommitValue=__codexBuildInfoCommit?__codexBuildInfoSource.dirty?\`\${__codexBuildInfoCommit} (dirty)\`:__codexBuildInfoCommit:\`unknown\`,__codexBuildInfoDistroValue=__codexBuildInfoDistro.prettyName||[__codexBuildInfoDistro.id,__codexBuildInfoDistro.versionId].filter(Boolean).join(\` \`)||\`unknown\`,__codexBuildInfoCommitLink=codexLinuxBuildInfoCommitUrl(__codexBuildInfo);return[\`Metadata file: \${codexLinuxBuildInfoValue(__codexBuildInfoPath)}\`,\`Linux package profile: \${codexLinuxBuildInfoValue(__codexBuildInfoProfile.label)}\`,\`Distro: \${__codexBuildInfoDistroValue}\`,\`Package manager: \${codexLinuxBuildInfoValue(__codexBuildInfoTarget.packageManager??__codexBuildInfoProfile.packageManager)}\`,\`Package format: \${codexLinuxBuildInfoValue(__codexBuildInfoTarget.packageFormat??__codexBuildInfoProfile.format)}\`,\`Enabled features: \${__codexBuildInfoFeatures.length>0?__codexBuildInfoFeatures.join(\`, \`):\`none\`}\`,\`Upstream app version: \${codexLinuxBuildInfoValue(__codexBuildInfoDmg.appVersion)}\`,\`Upstream DMG SHA256: \${codexLinuxBuildInfoValue(__codexBuildInfoDmg.sha256)}\`,\`Electron: \${codexLinuxBuildInfoValue(__codexBuildInfo.electronVersion)}\`,\`Linux source commit: \${__codexBuildInfoCommitValue}\`,...(__codexBuildInfoCommitLink?[\`Source commit URL: \${__codexBuildInfoCommitLink}\`]:[]),\`Source branch: \${codexLinuxBuildInfoValue(__codexBuildInfoSource.branch)}\`,\`Generated: \${codexLinuxBuildInfoValue(__codexBuildInfo.generatedAt)}\`].join(\`\\n\`)}async function codexLinuxOpenBuildInfoCommit(){let __codexBuildInfoResult=codexLinuxGetBuildInfo();return __codexBuildInfoResult.commitUrl?(await ${electronVar}.shell?.openExternal(__codexBuildInfoResult.commitUrl),{success:!0}):{success:!1}}async function codexLinuxShowBuildInfo(){try{let __codexBuildInfoResult=codexLinuxGetBuildInfo(),__codexBuildInfoCommitUrl=__codexBuildInfoResult.commitUrl,__codexBuildInfoPath=__codexBuildInfoResult.path,__codexBuildInfoButtons=[],__codexBuildInfoButtonIndex=0;__codexBuildInfoCommitUrl&&__codexBuildInfoButtons.push(\`Open Source Commit\`),__codexBuildInfoPath&&__codexBuildInfoButtons.push(\`Open Metadata File\`),__codexBuildInfoButtons.push(\`OK\`);let __codexBuildInfoBoxResponse=await ${electronVar}.dialog?.showMessageBox({type:\`info\`,buttons:__codexBuildInfoButtons,defaultId:__codexBuildInfoButtons.length-1,cancelId:__codexBuildInfoButtons.length-1,message:\`Codex Desktop Linux build information\`,detail:codexLinuxBuildInfoDetail(__codexBuildInfoResult.info,__codexBuildInfoPath)});if(__codexBuildInfoCommitUrl&&__codexBuildInfoBoxResponse?.response===__codexBuildInfoButtonIndex++){await ${electronVar}.shell?.openExternal(__codexBuildInfoCommitUrl);return}if(__codexBuildInfoPath&&__codexBuildInfoBoxResponse?.response===__codexBuildInfoButtonIndex++)await ${electronVar}.shell?.openPath?.(__codexBuildInfoPath)}catch{}}`;
 }
 
 function addLinuxBuildInfoRequestHandler(currentSource) {
-  const handler = "\"codex-linux-get-build-info\":async()=>codexLinuxGetBuildInfo(),\"codex-linux-open-build-info-commit\":async()=>codexLinuxOpenBuildInfoCommit(),\"codex-linux-show-build-info\":async()=>{await codexLinuxShowBuildInfo();return{success:!0}},";
-  const nestedHandler = `({${handler}`;
-  let patchedSource = currentSource;
-  let changed = false;
-  if (patchedSource.includes(nestedHandler)) {
-    patchedSource = patchedSource.replace(nestedHandler, "({");
-    changed = true;
-  } else if (patchedSource.includes(handler)) {
-    return { source: patchedSource, changed: false };
-  }
+	const handler =
+		'"codex-linux-get-build-info":async()=>codexLinuxGetBuildInfo(),"codex-linux-open-build-info-commit":async()=>codexLinuxOpenBuildInfoCommit(),"codex-linux-show-build-info":async()=>{await codexLinuxShowBuildInfo();return{success:!0}},';
+	const nestedHandler = `({${handler}`;
+	let patchedSource = currentSource;
+	let changed = false;
+	if (patchedSource.includes(nestedHandler)) {
+		patchedSource = patchedSource.replace(nestedHandler, "({");
+		changed = true;
+	} else if (patchedSource.includes(handler)) {
+		return { source: patchedSource, changed: false };
+	}
 
-  const handlerKeyIndexes = [
-    patchedSource.indexOf("\"set-global-state\":async"),
-    patchedSource.indexOf("\"get-global-state\":async"),
-  ].filter((index) => index !== -1);
-  if (handlerKeyIndexes.length === 0) {
-    return { source: patchedSource, changed };
-  }
+	const handlerKeyIndexes = [
+		patchedSource.indexOf('"set-global-state":async'),
+		patchedSource.indexOf('"get-global-state":async'),
+	].filter((index) => index !== -1);
+	if (handlerKeyIndexes.length === 0) {
+		return { source: patchedSource, changed };
+	}
 
-  const keyIndex = Math.min(...handlerKeyIndexes);
-  return {
-    source: `${patchedSource.slice(0, keyIndex)}${handler}${patchedSource.slice(keyIndex)}`,
-    changed: true,
-  };
+	const keyIndex = Math.min(...handlerKeyIndexes);
+	return {
+		source: `${patchedSource.slice(0, keyIndex)}${handler}${patchedSource.slice(keyIndex)}`,
+		changed: true,
+	};
 }
 
-function findLinuxBuildInfoHelperInsertionIndex(source, classMatch, helpMenuMatch) {
-  if (classMatch?.index != null) {
-    return classMatch.index;
-  }
-  if (helpMenuMatch?.index == null) {
-    return null;
-  }
+function findLinuxBuildInfoHelperInsertionIndex(
+	source,
+	classMatch,
+	helpMenuMatch,
+) {
+	if (classMatch?.index != null) {
+		return classMatch.index;
+	}
+	if (helpMenuMatch?.index == null) {
+		return null;
+	}
 
-  const statementStart = source.lastIndexOf(";", helpMenuMatch.index) + 1;
-  const insertionIndex = statementStart === 0 ? 0 : statementStart;
-  return insertionIndex <= helpMenuMatch.index ? insertionIndex : null;
+	const statementStart = source.lastIndexOf(";", helpMenuMatch.index) + 1;
+	const insertionIndex = statementStart === 0 ? 0 : statementStart;
+	return insertionIndex <= helpMenuMatch.index ? insertionIndex : null;
 }
 
 function applyLinuxBuildInfoTrayPatch(currentSource) {
-  const electronVar = requireName(currentSource, "electron");
-  const fsVar = requireName(currentSource, "node:fs");
-  const pathVar = requireName(currentSource, "node:path");
-  const hasHelper = currentSource.includes("function codexLinuxShowBuildInfo()");
-  if (!hasHelper && (electronVar == null || fsVar == null || pathVar == null)) {
-    console.warn("WARN: Could not find build info module bindings — skipping Linux build info tray patch");
-    return currentSource;
-  }
+	const electronVar = requireName(currentSource, "electron");
+	const fsVar = requireName(currentSource, "node:fs");
+	const pathVar = requireName(currentSource, "node:path");
+	const hasHelper = currentSource.includes(
+		"function codexLinuxShowBuildInfo()",
+	);
+	if (!hasHelper && (electronVar == null || fsVar == null || pathVar == null)) {
+		console.warn(
+			"WARN: Could not find build info module bindings — skipping Linux build info tray patch",
+		);
+		return currentSource;
+	}
 
-  let patchedSource = currentSource;
-  let changed = false;
-  if (
-    electronVar != null &&
-    patchedSource.includes(`let ${electronVar}=await ${electronVar}.dialog?.showMessageBox`)
-  ) {
-    patchedSource = patchedSource
-      .replace(
-        `let ${electronVar}=await ${electronVar}.dialog?.showMessageBox`,
-        `let __codexBuildInfoBoxResponse=await ${electronVar}.dialog?.showMessageBox`,
-      )
-      .replaceAll(
-        `&&${electronVar}?.response===`,
-        "&&__codexBuildInfoBoxResponse?.response===",
-      );
-    changed = true;
-  }
-  const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
-  const classRegex = /var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
-  const helpMenuPattern = /\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/;
-  const currentHelpMenuPattern = /\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[/;
-  const helperInsertionIndex = findLinuxBuildInfoHelperInsertionIndex(
-    currentSource,
-    currentSource.match(classRegex),
-    currentSource.match(helpMenuPattern) ?? currentSource.match(currentHelpMenuPattern),
-  );
-  const canInstallHelper = hasHelper || helperInsertionIndex != null;
-  const trayMenuMatch = patchedSource.match(trayMenuRegex);
-  if (trayMenuMatch == null && !patchedSource.includes("role:`help`")) {
-    console.warn("WARN: Could not find tray menu items method — skipping Linux build info tray patch");
-  } else if (
-    trayMenuMatch != null &&
-    !/getNativeTrayMenuItems\(\)\{[^]*?label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}/.test(patchedSource)
-  ) {
-    const menuPrefix =
-      "...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
-    patchedSource = patchedSource.replace(trayMenuRegex, (match) => `${match}${menuPrefix}`);
-    changed = true;
-  }
+	let patchedSource = currentSource;
+	let changed = false;
+	if (
+		electronVar != null &&
+		patchedSource.includes(
+			`let ${electronVar}=await ${electronVar}.dialog?.showMessageBox`,
+		)
+	) {
+		patchedSource = patchedSource
+			.replace(
+				`let ${electronVar}=await ${electronVar}.dialog?.showMessageBox`,
+				`let __codexBuildInfoBoxResponse=await ${electronVar}.dialog?.showMessageBox`,
+			)
+			.replaceAll(
+				`&&${electronVar}?.response===`,
+				"&&__codexBuildInfoBoxResponse?.response===",
+			);
+		changed = true;
+	}
+	const trayMenuRegex = /getNativeTrayMenuItems\(\)\{[^]*?return\[/g;
+	const classRegex =
+		/var [A-Za-z_$][\w$]*=class\{[^]*?getNativeTrayMenuItems\(\)\{[^]*?return\[/;
+	const helpMenuPattern =
+		/\{role:`help`,id:[A-Za-z_$][\w$]*\.bn\.help,submenu:\[/;
+	const currentHelpMenuPattern =
+		/\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[/;
+	const helperInsertionIndex = findLinuxBuildInfoHelperInsertionIndex(
+		currentSource,
+		currentSource.match(classRegex),
+		currentSource.match(helpMenuPattern) ??
+			currentSource.match(currentHelpMenuPattern),
+	);
+	const canInstallHelper = hasHelper || helperInsertionIndex != null;
+	const trayMenuMatch = patchedSource.match(trayMenuRegex);
+	if (trayMenuMatch == null && !patchedSource.includes("role:`help`")) {
+		console.warn(
+			"WARN: Could not find tray menu items method — skipping Linux build info tray patch",
+		);
+	} else if (
+		trayMenuMatch != null &&
+		!/getNativeTrayMenuItems\(\)\{[^]*?label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}/.test(
+			patchedSource,
+		)
+	) {
+		const menuPrefix =
+			"...process.platform===`linux`?[{label:`Build Information`,click:()=>{codexLinuxShowBuildInfo()}},{type:`separator`}]:[],";
+		patchedSource = patchedSource.replace(
+			trayMenuRegex,
+			(match) => `${match}${menuPrefix}`,
+		);
+		changed = true;
+	}
 
-  const helpMenuRegex = /\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[/g;
-  if (
-    !/\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],/.test(patchedSource)
-  ) {
-    if (canInstallHelper) {
-      let patchedHelpMenu = false;
-      patchedSource = patchedSource.replace(helpMenuRegex, (match) => {
-        patchedHelpMenu = true;
-        return `${match}...process.platform===\`linux\`?[{label:\`Build Information\`,click:()=>{codexLinuxShowBuildInfo()}},{type:\`separator\`}]:[],`;
-      });
-      changed = changed || patchedHelpMenu;
-      if (!patchedHelpMenu && patchedSource.includes("role:`help`")) {
-        console.warn("WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch");
-      }
-    } else if (patchedSource.includes("role:`help`")) {
-      console.warn("WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch");
-    }
-  }
+	const helpMenuRegex =
+		/\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[/g;
+	if (
+		!/\{role:`help`,id:[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\.help,submenu:\[\.\.\.process\.platform===`linux`\?\[\{label:`Build Information`,click:\(\)=>\{codexLinuxShowBuildInfo\(\)\}\},\{type:`separator`\}\]:\[\],/.test(
+			patchedSource,
+		)
+	) {
+		if (canInstallHelper) {
+			let patchedHelpMenu = false;
+			patchedSource = patchedSource.replace(helpMenuRegex, (match) => {
+				patchedHelpMenu = true;
+				return `${match}...process.platform===\`linux\`?[{label:\`Build Information\`,click:()=>{codexLinuxShowBuildInfo()}},{type:\`separator\`}]:[],`;
+			});
+			changed = changed || patchedHelpMenu;
+			if (!patchedHelpMenu && patchedSource.includes("role:`help`")) {
+				console.warn(
+					"WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch",
+				);
+			}
+		} else if (patchedSource.includes("role:`help`")) {
+			console.warn(
+				"WARN: Could not find Help menu insertion point — skipping Linux build info app menu patch",
+			);
+		}
+	}
 
-  const handlerPatch = addLinuxBuildInfoRequestHandler(patchedSource);
-  patchedSource = handlerPatch.source;
-  changed = changed || handlerPatch.changed;
+	const handlerPatch = addLinuxBuildInfoRequestHandler(patchedSource);
+	patchedSource = handlerPatch.source;
+	changed = changed || handlerPatch.changed;
 
-  if (!changed || hasHelper) {
-    return patchedSource;
-  }
+	if (!changed || hasHelper) {
+		return patchedSource;
+	}
 
-  const classMatch = patchedSource.match(classRegex);
-  const helpMenuMatch = patchedSource.match(helpMenuPattern) ?? patchedSource.match(currentHelpMenuPattern);
-  const helperIndex = findLinuxBuildInfoHelperInsertionIndex(patchedSource, classMatch, helpMenuMatch);
-  if (helperIndex == null) {
-    console.warn("WARN: Could not find build info helper insertion point — skipping Linux build info patch");
-    return currentSource;
-  }
+	const classMatch = patchedSource.match(classRegex);
+	const helpMenuMatch =
+		patchedSource.match(helpMenuPattern) ??
+		patchedSource.match(currentHelpMenuPattern);
+	const helperIndex = findLinuxBuildInfoHelperInsertionIndex(
+		patchedSource,
+		classMatch,
+		helpMenuMatch,
+	);
+	if (helperIndex == null) {
+		console.warn(
+			"WARN: Could not find build info helper insertion point — skipping Linux build info patch",
+		);
+		return currentSource;
+	}
 
-  const helpers = buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar);
-  return `${patchedSource.slice(0, helperIndex)}${helpers};${patchedSource.slice(helperIndex)}`;
+	const helpers = buildLinuxBuildInfoHelpers(electronVar, fsVar, pathVar);
+	return `${patchedSource.slice(0, helperIndex)}${helpers};${patchedSource.slice(helperIndex)}`;
 }
 
 function applyLinuxSingleInstancePatch(currentSource) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  const singleInstanceLockNeedle =
-    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady()";
-  const singleInstanceLockPatch =
-    "agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});if(process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()){n.app.quit();return}let A=Date.now();await n.app.whenReady()";
-  const unguardedSingleInstanceLock =
-    "process.platform===`linux`&&!n.app.requestSingleInstanceLock()";
-  const guardedSingleInstanceLock =
-    "process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()";
-  if (patchedSource.includes(guardedSingleInstanceLock)) {
-    // Already patched.
-  } else if (patchedSource.includes(unguardedSingleInstanceLock)) {
-    patchedSource = patchedSource.replaceAll(unguardedSingleInstanceLock, guardedSingleInstanceLock);
-  } else if (patchedSource.includes(singleInstanceLockNeedle)) {
-    patchedSource = patchedSource.replace(singleInstanceLockNeedle, singleInstanceLockPatch);
-  } else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
-    // Newer bundles take the single-instance lock in bootstrap.js and hand args into main here.
-  } else {
-    console.warn("WARN: Could not find startup handoff point — skipping Linux single-instance lock patch");
-  }
+	const singleInstanceLockNeedle =
+		"agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady()";
+	const singleInstanceLockPatch =
+		"agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});if(process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()){n.app.quit();return}let A=Date.now();await n.app.whenReady()";
+	const unguardedSingleInstanceLock =
+		"process.platform===`linux`&&!n.app.requestSingleInstanceLock()";
+	const guardedSingleInstanceLock =
+		"process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&!n.app.requestSingleInstanceLock()";
+	if (patchedSource.includes(guardedSingleInstanceLock)) {
+		// Already patched.
+	} else if (patchedSource.includes(unguardedSingleInstanceLock)) {
+		patchedSource = patchedSource.replaceAll(
+			unguardedSingleInstanceLock,
+			guardedSingleInstanceLock,
+		);
+	} else if (patchedSource.includes(singleInstanceLockNeedle)) {
+		patchedSource = patchedSource.replace(
+			singleInstanceLockNeedle,
+			singleInstanceLockPatch,
+		);
+	} else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
+		// Newer bundles take the single-instance lock in bootstrap.js and hand args into main here.
+	} else {
+		console.warn(
+			"WARN: Could not find startup handoff point — skipping Linux single-instance lock patch",
+		);
+	}
 
-  const secondInstanceHandlerNeedle =
-    "l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
-  const secondInstanceHandlerExistingPatch =
-    "let codexLinuxSecondInstanceHandler=(e,t)=>{R.deepLinks.queueProcessArgs(t)||ie()};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
-  const secondInstanceHandlerPatch =
-    "let codexLinuxSecondInstanceHandler=(e,t)=>{(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())?void 0:R.deepLinks.queueProcessArgs(t)||ie()},codexLinuxBeforeQuitHandler=()=>{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()};process.platform===`linux`&&(n.app.on(`before-quit`,codexLinuxBeforeQuitHandler),k.add(()=>{n.app.off(`before-quit`,codexLinuxBeforeQuitHandler)}),n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
-  if (
-    patchedSource.includes("codexLinuxBeforeQuitHandler=()=>{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()}") &&
-    patchedSource.includes("(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())?void 0:R.deepLinks.queueProcessArgs(t)||ie()")
-  ) {
-    // Already patched.
-  } else if (patchedSource.includes(secondInstanceHandlerExistingPatch)) {
-    patchedSource = patchedSource.replace(secondInstanceHandlerExistingPatch, secondInstanceHandlerPatch);
-  } else if (patchedSource.includes(secondInstanceHandlerNeedle)) {
-    patchedSource = patchedSource.replace(secondInstanceHandlerNeedle, secondInstanceHandlerPatch);
-  } else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
-    // bootstrap.js owns the Electron second-instance event and calls this bundle's handler.
-  } else {
-    console.warn("WARN: Could not find second-instance handler — skipping Linux second-instance focus patch");
-  }
+	const secondInstanceHandlerNeedle =
+		"l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
+	const secondInstanceHandlerExistingPatch =
+		"let codexLinuxSecondInstanceHandler=(e,t)=>{R.deepLinks.queueProcessArgs(t)||ie()};process.platform===`linux`&&(n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
+	const secondInstanceHandlerPatch =
+		"let codexLinuxSecondInstanceHandler=(e,t)=>{(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())?void 0:R.deepLinks.queueProcessArgs(t)||ie()},codexLinuxBeforeQuitHandler=()=>{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()};process.platform===`linux`&&(n.app.on(`before-quit`,codexLinuxBeforeQuitHandler),k.add(()=>{n.app.off(`before-quit`,codexLinuxBeforeQuitHandler)}),n.app.on(`second-instance`,codexLinuxSecondInstanceHandler),k.add(()=>{n.app.off(`second-instance`,codexLinuxSecondInstanceHandler)})),l(e=>{R.deepLinks.queueProcessArgs(e)||ie()});let ae=";
+	if (
+		patchedSource.includes(
+			"codexLinuxBeforeQuitHandler=()=>{typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()}",
+		) &&
+		patchedSource.includes(
+			"(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())?void 0:R.deepLinks.queueProcessArgs(t)||ie()",
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes(secondInstanceHandlerExistingPatch)) {
+		patchedSource = patchedSource.replace(
+			secondInstanceHandlerExistingPatch,
+			secondInstanceHandlerPatch,
+		);
+	} else if (patchedSource.includes(secondInstanceHandlerNeedle)) {
+		patchedSource = patchedSource.replace(
+			secondInstanceHandlerNeedle,
+			secondInstanceHandlerPatch,
+		);
+	} else if (patchedSource.includes("setSecondInstanceArgsHandler")) {
+		// bootstrap.js owns the Electron second-instance event and calls this bundle's handler.
+	} else {
+		console.warn(
+			"WARN: Could not find second-instance handler — skipping Linux second-instance focus patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 module.exports = {
-  applyLinuxBuildInfoTrayPatch,
-  applyLinuxSingleInstancePatch,
-  applyLinuxTrayPatch,
+	applyLinuxBuildInfoTrayPatch,
+	applyLinuxSingleInstancePatch,
+	applyLinuxTrayPatch,
 };

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -1,705 +1,889 @@
-"use strict";
-
-const {
-  escapeRegExp,
-} = require("../../lib/minified-js.js");
+const { escapeRegExp } = require("../../lib/minified-js.js");
 
 const LINUX_TITLEBAR_OVERLAY_HEIGHT = 30;
 const LINUX_TITLEBAR_OVERLAY_HELPER = "codexLinuxTitleBarOverlay";
 
 function linuxTitlebarOverlayHelperSource(
-  electronAlias,
-  lightBackgroundAlias,
-  lightSymbolAlias,
-  darkSymbolAlias,
+	electronAlias,
+	lightBackgroundAlias,
+	lightSymbolAlias,
+	darkSymbolAlias,
 ) {
-  return `function ${LINUX_TITLEBAR_OVERLAY_HELPER}(e=1){return{color:${electronAlias}.nativeTheme.shouldUseDarkColors?\`#111111\`:${lightBackgroundAlias},symbolColor:${electronAlias}.nativeTheme.shouldUseDarkColors?${lightSymbolAlias}:${darkSymbolAlias},height:Math.round(${LINUX_TITLEBAR_OVERLAY_HEIGHT}*e)}}`;
+	return `function ${LINUX_TITLEBAR_OVERLAY_HELPER}(e=1){return{color:${electronAlias}.nativeTheme.shouldUseDarkColors?\`#111111\`:${lightBackgroundAlias},symbolColor:${electronAlias}.nativeTheme.shouldUseDarkColors?${lightSymbolAlias}:${darkSymbolAlias},height:Math.round(${LINUX_TITLEBAR_OVERLAY_HEIGHT}*e)}}`;
 }
 
 function ensureLinuxTitlebarOverlayHelper(source, anchorText, helperSource) {
-  if (source.includes(`function ${LINUX_TITLEBAR_OVERLAY_HELPER}(`)) {
-    return source;
-  }
+	if (source.includes(`function ${LINUX_TITLEBAR_OVERLAY_HELPER}(`)) {
+		return source;
+	}
 
-  const anchorIndex = source.indexOf(anchorText);
-  if (anchorIndex === -1) {
-    return null;
-  }
+	const anchorIndex = source.indexOf(anchorText);
+	if (anchorIndex === -1) {
+		return null;
+	}
 
-  return (
-    source.slice(0, anchorIndex + anchorText.length) +
-    helperSource +
-    source.slice(anchorIndex + anchorText.length)
-  );
+	return (
+		source.slice(0, anchorIndex + anchorText.length) +
+		helperSource +
+		source.slice(anchorIndex + anchorText.length)
+	);
 }
 
 // Main-process patches adapt Electron shell behavior: windows, tray, menu,
 // single-instance handling, file manager integration, and packaged runtime glue.
 function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
-  let patchedSource = currentSource;
+	let patchedSource = currentSource;
 
-  if (iconAsset != null) {
-    const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
-    const iconPathNeedle = `icon:${iconPathExpression}`;
-    const setIconNeedle = `setIcon(${iconPathExpression})`;
-    const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
+	if (iconAsset != null) {
+		const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
+		const iconPathNeedle = `icon:${iconPathExpression}`;
+		const setIconNeedle = `setIcon(${iconPathExpression})`;
+		const readyToShowSetIconInsertionPattern =
+			/[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
 
-    const windowOptionsNeedle = "...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
-    const currentLinuxAutoHideMenuBarNeedle =
-      "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
-    const legacyLinuxSystemTitlebarNeedle =
-      `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
-    const windowOptionsReplacement =
-      `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
+		const windowOptionsNeedle =
+			"...process.platform===`win32`?{autoHideMenuBar:!0}:{},";
+		const currentLinuxAutoHideMenuBarNeedle =
+			"...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
+		const legacyLinuxSystemTitlebarNeedle = `...process.platform===\`win32\`||process.platform===\`linux\`?{autoHideMenuBar:!0,...process.platform===\`linux\`?{${iconPathNeedle}}:{}}:{},`;
+		const windowOptionsReplacement = `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
 
-    if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
-      patchedSource = patchedSource.split(legacyLinuxSystemTitlebarNeedle).join(windowOptionsReplacement);
-    }
+		if (patchedSource.includes(legacyLinuxSystemTitlebarNeedle)) {
+			patchedSource = patchedSource
+				.split(legacyLinuxSystemTitlebarNeedle)
+				.join(windowOptionsReplacement);
+		}
 
-    if (patchedSource.includes(windowOptionsNeedle)) {
-      patchedSource = patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
-    } else if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
-      patchedSource = patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
-    } else if (
-      patchedSource === currentSource &&
-      !patchedSource.includes(iconPathNeedle) &&
-      !patchedSource.includes(setIconNeedle) &&
-      !readyToShowSetIconInsertionPattern.test(patchedSource)
-    ) {
-      console.warn("WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch");
-    }
-  }
+		if (patchedSource.includes(windowOptionsNeedle)) {
+			patchedSource = patchedSource
+				.split(windowOptionsNeedle)
+				.join(windowOptionsReplacement);
+		} else if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
+			patchedSource = patchedSource
+				.split(currentLinuxAutoHideMenuBarNeedle)
+				.join(windowOptionsReplacement);
+		} else if (
+			patchedSource === currentSource &&
+			!patchedSource.includes(iconPathNeedle) &&
+			!patchedSource.includes(setIconNeedle) &&
+			!readyToShowSetIconInsertionPattern.test(patchedSource)
+		) {
+			console.warn(
+				"WARN: Could not find BrowserWindow autoHideMenuBar snippet — skipping window options patch",
+			);
+		}
+	}
 
-  patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
-  patchedSource = applyLinuxPrimaryFocusablePatch(patchedSource);
-  return patchedSource;
+	patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
+	patchedSource = applyLinuxPrimaryFocusablePatch(patchedSource);
+	return patchedSource;
 }
 
 function applyDefinedBrowserWindowOptionsPatch(currentSource) {
-  const browserWindowOptionsRegex =
-    /show:([A-Za-z_$][\w$]*),parent:([A-Za-z_$][\w$]*),focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?\{autoHideMenuBar:!0\}:process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/[^`]+`\}:\{\},)backgroundMaterial:([A-Za-z_$][\w$]*)\?\?void 0,\.\.\.([A-Za-z_$][\w$]*),minWidth:([A-Za-z_$][\w$]*)\?\.width,minHeight:\7\?\.height,webPreferences:([A-Za-z_$][\w$]*)/g;
+	const browserWindowOptionsRegex =
+		/show:([A-Za-z_$][\w$]*),parent:([A-Za-z_$][\w$]*),focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?\{autoHideMenuBar:!0\}:process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/[^`]+`\}:\{\},)backgroundMaterial:([A-Za-z_$][\w$]*)\?\?void 0,\.\.\.([A-Za-z_$][\w$]*),minWidth:([A-Za-z_$][\w$]*)\?\.width,minHeight:\7\?\.height,webPreferences:([A-Za-z_$][\w$]*)/g;
 
-  return currentSource.replace(
-    browserWindowOptionsRegex,
-    (
-      _match,
-      showAlias,
-      parentAlias,
-      focusableAlias,
-      platformOptions,
-      backgroundMaterialAlias,
-      appearanceOptionsAlias,
-      minimumSizeAlias,
-      webPreferencesAlias,
-    ) =>
-      `show:${showAlias},...${parentAlias}==null?{}:{parent:${parentAlias}},...${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
-  );
+	return currentSource.replace(
+		browserWindowOptionsRegex,
+		(
+			_match,
+			showAlias,
+			parentAlias,
+			focusableAlias,
+			platformOptions,
+			backgroundMaterialAlias,
+			appearanceOptionsAlias,
+			minimumSizeAlias,
+			webPreferencesAlias,
+		) =>
+			`show:${showAlias},...${parentAlias}==null?{}:{parent:${parentAlias}},...${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
+	);
 }
 
 function findCreateWindowAppearanceAlias(currentSource, matchIndex) {
-  const prefix = currentSource.slice(Math.max(0, matchIndex - 3000), matchIndex);
-  const createWindowRegex =
-    /createWindow\([^)]*\)\{let\{[^}]*appearance:([A-Za-z_$][\w$]*)(?:=[^,}]+)?/g;
-  let match;
-  let appearanceAlias = null;
-  while ((match = createWindowRegex.exec(prefix)) != null) {
-    appearanceAlias = match[1];
-  }
-  return appearanceAlias;
+	const prefix = currentSource.slice(
+		Math.max(0, matchIndex - 3000),
+		matchIndex,
+	);
+	const createWindowRegex =
+		/createWindow\([^)]*\)\{let\{[^}]*appearance:([A-Za-z_$][\w$]*)(?:=[^,}]+)?/g;
+	let match;
+	let appearanceAlias = null;
+	while ((match = createWindowRegex.exec(prefix)) != null) {
+		appearanceAlias = match[1];
+	}
+	return appearanceAlias;
 }
 
 function hasPrimaryBrowserWindowFocusableCandidate(currentSource) {
-  return /createWindow\([^)]*\)\{let\{[^}]*appearance:[A-Za-z_$][\w$]*(?:=`primary`)?[^}]*\}=[\s\S]{0,3500}?new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{[\s\S]{0,2000}?focusable:/.test(
-    currentSource,
-  );
+	return /createWindow\([^)]*\)\{let\{[^}]*appearance:[A-Za-z_$][\w$]*(?:=`primary`)?[^}]*\}=[\s\S]{0,3500}?new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{[\s\S]{0,2000}?focusable:/.test(
+		currentSource,
+	);
 }
 
 function applyLinuxPrimaryFocusablePatch(currentSource) {
-  if (
-    currentSource.includes("===`primary`?{focusable:!0}") ||
-    currentSource.includes("===`primary`?!0:")
-  ) {
-    return currentSource;
-  }
+	if (
+		currentSource.includes("===`primary`?{focusable:!0}") ||
+		currentSource.includes("===`primary`?!0:")
+	) {
+		return currentSource;
+	}
 
-  let patchedAny = false;
-  let skippedAny = false;
-  const focusableSpreadRegex =
-    /\.\.\.([A-Za-z_$][\w$]*)==null\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`\?)/g;
-  let patchedSource = currentSource.replace(
-    focusableSpreadRegex,
-    (match, focusableAlias, platformOptions, offset) => {
-      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
-      if (appearanceAlias == null) {
-        skippedAny = true;
-        return match;
-      }
-      patchedAny = true;
-      return (
-        `...process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?{focusable:!0}:` +
-        `${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}`
-      );
-    },
-  );
+	let patchedAny = false;
+	let skippedAny = false;
+	const focusableSpreadRegex =
+		/\.\.\.([A-Za-z_$][\w$]*)==null\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`\?)/g;
+	let patchedSource = currentSource.replace(
+		focusableSpreadRegex,
+		(match, focusableAlias, platformOptions, offset) => {
+			const appearanceAlias = findCreateWindowAppearanceAlias(
+				currentSource,
+				offset,
+			);
+			if (appearanceAlias == null) {
+				skippedAny = true;
+				return match;
+			}
+			patchedAny = true;
+			return (
+				`...process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?{focusable:!0}:` +
+				`${focusableAlias}==null?{}:{focusable:${focusableAlias}},${platformOptions}`
+			);
+		},
+	);
 
-  const focusableDirectRegex =
-    /focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?)/g;
-  patchedSource = patchedSource.replace(
-    focusableDirectRegex,
-    (match, focusableAlias, platformOptions, offset) => {
-      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
-      if (appearanceAlias == null) {
-        skippedAny = true;
-        return match;
-      }
-      patchedAny = true;
-      return (
-        `focusable:process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
-        `${focusableAlias},${platformOptions}`
-      );
-    },
-  );
+	const focusableDirectRegex =
+		/focusable:([A-Za-z_$][\w$]*),(\.\.\.process\.platform===`win32`\?)/g;
+	patchedSource = patchedSource.replace(
+		focusableDirectRegex,
+		(match, focusableAlias, platformOptions, offset) => {
+			const appearanceAlias = findCreateWindowAppearanceAlias(
+				currentSource,
+				offset,
+			);
+			if (appearanceAlias == null) {
+				skippedAny = true;
+				return match;
+			}
+			patchedAny = true;
+			return (
+				`focusable:process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
+				`${focusableAlias},${platformOptions}`
+			);
+		},
+	);
 
-  const focusableCurrentShapeRegex =
-    /(new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{(?:(?!\}\);)[\s\S]){0,2000}?focusable:)(!?[A-Za-z_$][\w$]*|![01]|null),/g;
-  patchedSource = patchedSource.replace(
-    focusableCurrentShapeRegex,
-    (match, browserWindowPrefix, focusableExpression, offset) => {
-      const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
-      if (appearanceAlias == null) {
-        skippedAny = true;
-        return match;
-      }
-      patchedAny = true;
-      return (
-        `${browserWindowPrefix}process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
-        `${focusableExpression},`
-      );
-    },
-  );
+	// ELI5: the July bundle writes optional object fields as `x===void 0` and
+	// already includes Linux in the menu-bar spread. This keeps the main window
+	// focusable on Linux without changing secondary/avatar windows.
+	const focusableVoidSpreadRegex =
+		/\.\.\.([A-Za-z_$][\w$]*)===void 0\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`(?:\|\|process\.platform===`linux`)?\?)/g;
+	patchedSource = patchedSource.replace(
+		focusableVoidSpreadRegex,
+		(match, focusableAlias, platformOptions, offset) => {
+			const appearanceAlias = findCreateWindowAppearanceAlias(
+				currentSource,
+				offset,
+			);
+			if (appearanceAlias == null) {
+				skippedAny = true;
+				return match;
+			}
+			patchedAny = true;
+			return (
+				`...process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?{focusable:!0}:` +
+				`${focusableAlias}===void 0?{}:{focusable:${focusableAlias}},${platformOptions}`
+			);
+		},
+	);
 
-  if (!patchedAny && skippedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
-    throw new Error("Could not derive primary BrowserWindow appearance alias for Linux focusable patch");
-  }
+	const focusableCurrentShapeRegex =
+		/(new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{(?:(?!\}\);)[\s\S]){0,2000}?focusable:)(!?[A-Za-z_$][\w$]*|![01]|null),/g;
+	patchedSource = patchedSource.replace(
+		focusableCurrentShapeRegex,
+		(match, browserWindowPrefix, focusableExpression, offset) => {
+			const appearanceAlias = findCreateWindowAppearanceAlias(
+				currentSource,
+				offset,
+			);
+			if (appearanceAlias == null) {
+				skippedAny = true;
+				return match;
+			}
+			patchedAny = true;
+			return (
+				`${browserWindowPrefix}process.platform===\`linux\`&&${appearanceAlias}===\`primary\`?!0:` +
+				`${focusableExpression},`
+			);
+		},
+	);
 
-  if (!patchedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
-    throw new Error("Could not patch primary BrowserWindow focusable option for Linux");
-  }
+	if (
+		!patchedAny &&
+		skippedAny &&
+		hasPrimaryBrowserWindowFocusableCandidate(currentSource)
+	) {
+		throw new Error(
+			"Could not derive primary BrowserWindow appearance alias for Linux focusable patch",
+		);
+	}
 
-  return patchedSource;
+	if (!patchedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
+		throw new Error(
+			"Could not patch primary BrowserWindow focusable option for Linux",
+		);
+	}
+
+	return patchedSource;
 }
 
 function applyLinuxNativeTitlebarPatch(currentSource) {
-  const patchedPrimaryTitlebarRegex = new RegExp(
-    `===\`linux\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}\\(([A-Za-z_$][\\w$]*)\\)\\}`,
-  );
-  const alreadyPatchedTitlebarMatch = currentSource.match(patchedPrimaryTitlebarRegex);
-  const helperFunctionRegex = new RegExp(
-    'function ' +
-      escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
-      '\\([^)]*\\)\\{return\\{color:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?`#111111`:([A-Za-z_$][\\w$]*),symbolColor:\\1\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(' +
-      LINUX_TITLEBAR_OVERLAY_HEIGHT +
-      '\\*[A-Za-z_$][\\w$]*\\)\\}\\}',
-  );
-  const helperFunctionMatch = currentSource.match(helperFunctionRegex);
+	const patchedPrimaryTitlebarRegex = new RegExp(
+		`===\`linux\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}\\(([A-Za-z_$][\\w$]*)\\)\\}`,
+	);
+	const alreadyPatchedTitlebarMatch = currentSource.match(
+		patchedPrimaryTitlebarRegex,
+	);
+	const helperFunctionRegex = new RegExp(
+		"function " +
+			escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
+			"\\([^)]*\\)\\{return\\{color:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?`#111111`:([A-Za-z_$][\\w$]*),symbolColor:\\1\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(" +
+			LINUX_TITLEBAR_OVERLAY_HEIGHT +
+			"\\*[A-Za-z_$][\\w$]*\\)\\}\\}",
+	);
+	const helperFunctionMatch = currentSource.match(helperFunctionRegex);
 
-  const primaryTitlebarRegex =
-    /case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\?\{titleBarStyle:`hiddenInset`,trafficLightPosition:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\}:\{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:\3\(\4\)\}:\1===`win32`(\|\|\1===`linux`)?\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(\4\)\}:\{titleBarStyle:`default`\};/g;
-  const primaryTitlebarMatch = primaryTitlebarRegex.exec(currentSource);
-  if (primaryTitlebarMatch == null && alreadyPatchedTitlebarMatch == null) {
-    console.warn("WARN: Could not find primary BrowserWindow titlebar snippet — skipping Linux native titlebar patch");
-    return currentSource;
-  }
+	const primaryTitlebarRegex =
+		/case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\?\{titleBarStyle:`hiddenInset`,trafficLightPosition:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\}:\{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:\3\(\4\)\}:\1===`win32`(\|\|\1===`linux`)?\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(\4\)\}:\{titleBarStyle:`default`\};/g;
+	const primaryTitlebarMatch = primaryTitlebarRegex.exec(currentSource);
+	let patchedSource = currentSource;
 
-  let patchedSource = currentSource;
-  let electronAlias;
-  let lightSymbolAlias;
-  let darkSymbolAlias;
-  let lightBackgroundAlias;
+	// ELI5: upstream merged quickChat and primary into one titlebar branch and
+	// already added Linux beside Windows. We split Linux back into its own branch
+	// so future Linux-only titlebar behavior has a safe landing spot.
+	const combinedQuickChatPrimaryTitlebarRegex =
+		/case`quickChat`:case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?\{titleBarStyle:`hiddenInset`,trafficLightPosition:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),\.\.\.([A-Za-z_$][\w$]*)===`quickChat`\?\{hasShadow:!0,resizable:!0,transparent:!0\}:\{\},\.\.\.([A-Za-z_$][\w$]*)\?\{\}:\{vibrancy:`menu`\}\}:\1===`win32`\|\|\1===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(\3\),\.\.\.\4===`quickChat`\?\{resizable:!0\}:\{\}\}:\{titleBarStyle:`default`,\.\.\.\4===`quickChat`\?\{resizable:!0\}:\{\}\};/g;
+	if (primaryTitlebarMatch == null && alreadyPatchedTitlebarMatch == null) {
+		const combinedTitlebarMatch =
+			combinedQuickChatPrimaryTitlebarRegex.exec(currentSource);
+		if (combinedTitlebarMatch == null) {
+			console.warn(
+				"WARN: Could not find primary BrowserWindow titlebar snippet — skipping Linux native titlebar patch",
+			);
+			return currentSource;
+		}
+		const [
+			,
+			platformAlias,
+			trafficLightAlias,
+			zoomAlias,
+			appearanceAlias,
+			opaqueAlias,
+			overlayHelperAlias,
+		] = combinedTitlebarMatch;
+		combinedQuickChatPrimaryTitlebarRegex.lastIndex = 0;
+		return patchedSource.replace(
+			combinedQuickChatPrimaryTitlebarRegex,
+			`case\`quickChat\`:case\`primary\`:return ${platformAlias}===\`darwin\`?{titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias}),...${appearanceAlias}===\`quickChat\`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...${opaqueAlias}?{}:{vibrancy:\`menu\`}}:${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias}),...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}}:${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias}),...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}}:{titleBarStyle:\`default\`,...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}};`,
+		);
+	}
 
-  if (primaryTitlebarMatch != null) {
-    const [, platformAlias, opaqueWindowsAlias, trafficLightAlias, zoomAlias, , overlayHelperAlias] = primaryTitlebarMatch;
-    const overlayHelperRegex = new RegExp(
-      `function ${escapeRegExp(overlayHelperAlias)}\\([^)]*\\)\\{return\\{color:[A-Za-z_$][\\w$]*,symbolColor:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(([A-Za-z_$][\\w$]*)\\*[^)]*\\)\\}\\}`,
-    );
-    const overlayHelperMatch = currentSource.match(overlayHelperRegex);
-    const linuxBackgroundMatch = currentSource.match(
-      /===`linux`&&!([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\)\?\{backgroundColor:([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:null\}/,
-    );
+	let electronAlias;
+	let lightSymbolAlias;
+	let darkSymbolAlias;
+	let lightBackgroundAlias;
 
-    if (overlayHelperMatch == null || linuxBackgroundMatch == null) {
-      console.warn("WARN: Could not derive titleBarOverlay aliases — skipping Linux native titlebar patch");
-      return currentSource;
-    }
+	if (primaryTitlebarMatch != null) {
+		const [
+			,
+			platformAlias,
+			opaqueWindowsAlias,
+			trafficLightAlias,
+			zoomAlias,
+			,
+			overlayHelperAlias,
+		] = primaryTitlebarMatch;
+		const overlayHelperRegex = new RegExp(
+			`function ${escapeRegExp(overlayHelperAlias)}\\([^)]*\\)\\{return\\{color:[A-Za-z_$][\\w$]*,symbolColor:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(([A-Za-z_$][\\w$]*)\\*[^)]*\\)\\}\\}`,
+		);
+		const overlayHelperMatch = currentSource.match(overlayHelperRegex);
+		const linuxBackgroundMatch = currentSource.match(
+			/===`linux`&&!([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\)\?\{backgroundColor:([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:null\}/,
+		);
 
-    [, electronAlias, lightSymbolAlias, darkSymbolAlias] = overlayHelperMatch;
-    [, , , , lightBackgroundAlias] = linuxBackgroundMatch;
-    const replacement =
-      `case\`primary\`:return ${platformAlias}===\`darwin\`?${opaqueWindowsAlias}?{titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:{vibrancy:\`menu\`,titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias})}:${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias})}:{titleBarStyle:\`default\`};`;
+		if (overlayHelperMatch == null || linuxBackgroundMatch == null) {
+			console.warn(
+				"WARN: Could not derive titleBarOverlay aliases — skipping Linux native titlebar patch",
+			);
+			return currentSource;
+		}
 
-    primaryTitlebarRegex.lastIndex = 0;
-    patchedSource = patchedSource.replace(primaryTitlebarRegex, replacement);
-    patchedSource = ensureLinuxTitlebarOverlayHelper(
-      patchedSource,
-      overlayHelperMatch[0],
-      linuxTitlebarOverlayHelperSource(
-        electronAlias,
-        lightBackgroundAlias,
-        lightSymbolAlias,
-        darkSymbolAlias,
-      ),
-    );
-    if (patchedSource == null) {
-      console.warn("WARN: Could not insert Linux titleBarOverlay helper — skipping Linux native titlebar patch");
-      return currentSource;
-    }
-  } else if (helperFunctionMatch != null) {
-    [, electronAlias, lightBackgroundAlias, lightSymbolAlias, darkSymbolAlias] = helperFunctionMatch;
-  } else {
-    console.warn("WARN: Could not derive Linux titleBarOverlay helper aliases — skipping Linux native titlebar patch");
-    return currentSource;
-  }
+		[, electronAlias, lightSymbolAlias, darkSymbolAlias] = overlayHelperMatch;
+		[, , , , lightBackgroundAlias] = linuxBackgroundMatch;
+		const replacement = `case\`primary\`:return ${platformAlias}===\`darwin\`?${opaqueWindowsAlias}?{titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:{vibrancy:\`menu\`,titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias})}:${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias})}:{titleBarStyle:\`default\`};`;
 
-  // Zoom-change overlay call site: newer upstream includes Linux in the
-  // win32 branch and reuses the transparent win32 overlay helper there.
-  const zoomOverlayRegex =
-    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g;
-  patchedSource = patchedSource.replace(
-    zoomOverlayRegex,
-    (zoomMatchText, zoomWindowAlias, zoomValueAlias, zoomHelperAlias) => {
-      if (zoomHelperAlias === LINUX_TITLEBAR_OVERLAY_HELPER) {
-        return zoomMatchText;
-      }
-      return `(process.platform===\`win32\`||process.platform===\`linux\`)&&(this.windowZooms.set(${zoomWindowAlias}.id,${zoomValueAlias}),${zoomWindowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomValueAlias}):${zoomHelperAlias}(${zoomValueAlias})))`;
-    },
-  );
+		primaryTitlebarRegex.lastIndex = 0;
+		patchedSource = patchedSource.replace(primaryTitlebarRegex, replacement);
+		patchedSource = ensureLinuxTitlebarOverlayHelper(
+			patchedSource,
+			overlayHelperMatch[0],
+			linuxTitlebarOverlayHelperSource(
+				electronAlias,
+				lightBackgroundAlias,
+				lightSymbolAlias,
+				darkSymbolAlias,
+			),
+		);
+		if (patchedSource == null) {
+			console.warn(
+				"WARN: Could not insert Linux titleBarOverlay helper — skipping Linux native titlebar patch",
+			);
+			return currentSource;
+		}
+	} else if (helperFunctionMatch != null) {
+		[, electronAlias, lightBackgroundAlias, lightSymbolAlias, darkSymbolAlias] =
+			helperFunctionMatch;
+	} else {
+		console.warn(
+			"WARN: Could not derive Linux titleBarOverlay helper aliases — skipping Linux native titlebar patch",
+		);
+		return currentSource;
+	}
 
-  if (
-    new RegExp(
-      `setTitleBarOverlay\\(process\\.platform===\`linux\`\\?${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\(this\\.windowZooms\\.get\\(`,
-    ).test(patchedSource)
-  ) {
-    return patchedSource;
-  }
+	// Zoom-change overlay call site: newer upstream includes Linux in the
+	// win32 branch and reuses the transparent win32 overlay helper there.
+	const zoomOverlayRegex =
+		/\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g;
+	patchedSource = patchedSource.replace(
+		zoomOverlayRegex,
+		(zoomMatchText, zoomWindowAlias, zoomValueAlias, zoomHelperAlias) => {
+			if (zoomHelperAlias === LINUX_TITLEBAR_OVERLAY_HELPER) {
+				return zoomMatchText;
+			}
+			return `(process.platform===\`win32\`||process.platform===\`linux\`)&&(this.windowZooms.set(${zoomWindowAlias}.id,${zoomValueAlias}),${zoomWindowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomValueAlias}):${zoomHelperAlias}(${zoomValueAlias})))`;
+		},
+	);
 
-  const escapedElectronAlias = escapeRegExp(electronAlias);
-  // Upstream has renamed installWindowsTitleBarOverlaySync (e.g. to
-  // installApplicationMenuTitleBarOverlaySync) and made its guard
-  // Linux-aware while still calling the transparent win32 helper, so match
-  // any install*TitleBarOverlaySync name and both guard shapes.
-  const overlaySyncRegex = new RegExp(
-    "(install[A-Za-z_$][\\w$]*TitleBarOverlaySync)\\(([A-Za-z_$][\\w$]*),([A-Za-z_$][\\w$]*)\\)\\{if\\(process\\.platform!==`win32`(?:&&process\\.platform!==`linux`)?\\|\\|\\3!==`primary`\\)return;let ([A-Za-z_$][\\w$]*)=\\(\\)=>\\{\\2\\.isDestroyed\\(\\)\\|\\|\\2\\.setTitleBarOverlay\\(([A-Za-z_$][\\w$]*)\\(this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\)\\};return " +
-      escapedElectronAlias +
-      "\\.nativeTheme\\.on\\(`updated`,\\4\\),\\4\\(\\),\\(\\)=>\\{" +
-      escapedElectronAlias +
-      "\\.nativeTheme\\.off\\(`updated`,\\4\\)\\}\\}",
-  );
-  let overlaySyncMatch = patchedSource.match(overlaySyncRegex);
-  let overlaySyncReplacementRegex = overlaySyncRegex;
-  if (overlaySyncMatch == null) {
-    const existingLinuxOverlaySyncRegex = new RegExp(
-      "(install[A-Za-z_$][\\w$]*TitleBarOverlaySync)\\(([A-Za-z_$][\\w$]*),([A-Za-z_$][\\w$]*)\\)\\{if\\(\\(process\\.platform!==`win32`&&process\\.platform!==`linux`\\)\\|\\|\\3!==`primary`\\)return;let ([A-Za-z_$][\\w$]*)=\\(\\)=>\\{\\2\\.isDestroyed\\(\\)\\|\\|\\2\\.setTitleBarOverlay\\(process\\.platform===`linux`\\?\\{color:" +
-        escapedElectronAlias +
-        "\\.nativeTheme\\.shouldUseDarkColors\\?[A-Za-z_$][\\w$]*:[A-Za-z_$][\\w$]*,symbolColor:" +
-        escapedElectronAlias +
-        "\\.nativeTheme\\.shouldUseDarkColors\\?[A-Za-z_$][\\w$]*:[A-Za-z_$][\\w$]*,height:Math\\.round\\((?:[A-Za-z_$][\\w$]*|\\d+(?:\\.\\d+)?)\\*this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\}:([A-Za-z_$][\\w$]*)\\(this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\)\\};return " +
-        escapedElectronAlias +
-        "\\.nativeTheme\\.on\\(`updated`,\\4\\),\\4\\(\\),\\(\\)=>\\{" +
-        escapedElectronAlias +
-        "\\.nativeTheme\\.off\\(`updated`,\\4\\)\\}\\}",
-    );
-    overlaySyncMatch = patchedSource.match(existingLinuxOverlaySyncRegex);
-    overlaySyncReplacementRegex = existingLinuxOverlaySyncRegex;
-  }
-  if (overlaySyncMatch == null) {
-    if (/install[A-Za-z_$][\w$]*TitleBarOverlaySync\(/.test(patchedSource)) {
-      console.warn("WARN: Could not patch titleBarOverlay nativeTheme sync for Linux");
-    }
-    return patchedSource;
-  }
+	if (
+		new RegExp(
+			`setTitleBarOverlay\\(process\\.platform===\`linux\`\\?${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\(this\\.windowZooms\\.get\\(`,
+		).test(patchedSource)
+	) {
+		return patchedSource;
+	}
 
-  const [, overlaySyncMethodName, windowAlias, windowTypeAlias, updateAlias, windowsOverlayHelperAlias] =
-    overlaySyncMatch;
-  const overlaySyncReplacement =
-    `${overlaySyncMethodName}(${windowAlias},${windowTypeAlias}){if((process.platform!==\`win32\`&&process.platform!==\`linux\`)||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(this.windowZooms.get(${windowAlias}.id)):${windowsOverlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`;
-  const replacedSource = patchedSource.replace(overlaySyncReplacementRegex, overlaySyncReplacement);
-  if (replacedSource !== patchedSource) {
-    return replacedSource;
-  }
+	const escapedElectronAlias = escapeRegExp(electronAlias);
+	// Upstream has renamed installWindowsTitleBarOverlaySync (e.g. to
+	// installApplicationMenuTitleBarOverlaySync) and made its guard
+	// Linux-aware while still calling the transparent win32 helper, so match
+	// any install*TitleBarOverlaySync name and both guard shapes.
+	const overlaySyncRegex = new RegExp(
+		"(install[A-Za-z_$][\\w$]*TitleBarOverlaySync)\\(([A-Za-z_$][\\w$]*),([A-Za-z_$][\\w$]*)\\)\\{if\\(process\\.platform!==`win32`(?:&&process\\.platform!==`linux`)?\\|\\|\\3!==`primary`\\)return;let ([A-Za-z_$][\\w$]*)=\\(\\)=>\\{\\2\\.isDestroyed\\(\\)\\|\\|\\2\\.setTitleBarOverlay\\(([A-Za-z_$][\\w$]*)\\(this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\)\\};return " +
+			escapedElectronAlias +
+			"\\.nativeTheme\\.on\\(`updated`,\\4\\),\\4\\(\\),\\(\\)=>\\{" +
+			escapedElectronAlias +
+			"\\.nativeTheme\\.off\\(`updated`,\\4\\)\\}\\}",
+	);
+	let overlaySyncMatch = patchedSource.match(overlaySyncRegex);
+	let overlaySyncReplacementRegex = overlaySyncRegex;
+	if (overlaySyncMatch == null) {
+		const existingLinuxOverlaySyncRegex = new RegExp(
+			"(install[A-Za-z_$][\\w$]*TitleBarOverlaySync)\\(([A-Za-z_$][\\w$]*),([A-Za-z_$][\\w$]*)\\)\\{if\\(\\(process\\.platform!==`win32`&&process\\.platform!==`linux`\\)\\|\\|\\3!==`primary`\\)return;let ([A-Za-z_$][\\w$]*)=\\(\\)=>\\{\\2\\.isDestroyed\\(\\)\\|\\|\\2\\.setTitleBarOverlay\\(process\\.platform===`linux`\\?\\{color:" +
+				escapedElectronAlias +
+				"\\.nativeTheme\\.shouldUseDarkColors\\?[A-Za-z_$][\\w$]*:[A-Za-z_$][\\w$]*,symbolColor:" +
+				escapedElectronAlias +
+				"\\.nativeTheme\\.shouldUseDarkColors\\?[A-Za-z_$][\\w$]*:[A-Za-z_$][\\w$]*,height:Math\\.round\\((?:[A-Za-z_$][\\w$]*|\\d+(?:\\.\\d+)?)\\*this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\}:([A-Za-z_$][\\w$]*)\\(this\\.windowZooms\\.get\\(\\2\\.id\\)\\)\\)\\};return " +
+				escapedElectronAlias +
+				"\\.nativeTheme\\.on\\(`updated`,\\4\\),\\4\\(\\),\\(\\)=>\\{" +
+				escapedElectronAlias +
+				"\\.nativeTheme\\.off\\(`updated`,\\4\\)\\}\\}",
+		);
+		overlaySyncMatch = patchedSource.match(existingLinuxOverlaySyncRegex);
+		overlaySyncReplacementRegex = existingLinuxOverlaySyncRegex;
+	}
+	if (overlaySyncMatch == null) {
+		if (/install[A-Za-z_$][\w$]*TitleBarOverlaySync\(/.test(patchedSource)) {
+			console.warn(
+				"WARN: Could not patch titleBarOverlay nativeTheme sync for Linux",
+			);
+		}
+		return patchedSource;
+	}
 
-  const methodDefinitionRegex = /install[A-Za-z_$][\w$]*TitleBarOverlaySync\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)\{if\(/g;
-  let methodStart = -1;
-  for (const match of patchedSource.matchAll(methodDefinitionRegex)) {
-    methodStart = match.index;
-  }
-  const methodEndMarker = "}isOpaqueWindowsEnabled(){";
-  const methodEnd = methodStart === -1 ? -1 : patchedSource.indexOf(methodEndMarker, methodStart);
-  if (methodEnd !== -1) {
-    return patchedSource.slice(0, methodStart) + overlaySyncReplacement + patchedSource.slice(methodEnd + 1);
-  }
+	const [
+		,
+		overlaySyncMethodName,
+		windowAlias,
+		windowTypeAlias,
+		updateAlias,
+		windowsOverlayHelperAlias,
+	] = overlaySyncMatch;
+	const overlaySyncReplacement = `${overlaySyncMethodName}(${windowAlias},${windowTypeAlias}){if((process.platform!==\`win32\`&&process.platform!==\`linux\`)||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(this.windowZooms.get(${windowAlias}.id)):${windowsOverlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`;
+	const replacedSource = patchedSource.replace(
+		overlaySyncReplacementRegex,
+		overlaySyncReplacement,
+	);
+	if (replacedSource !== patchedSource) {
+		return replacedSource;
+	}
 
-  return patchedSource;
+	const methodDefinitionRegex =
+		/install[A-Za-z_$][\w$]*TitleBarOverlaySync\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)\{if\(/g;
+	let methodStart = -1;
+	for (const match of patchedSource.matchAll(methodDefinitionRegex)) {
+		methodStart = match.index;
+	}
+	const methodEndMarker = "}isOpaqueWindowsEnabled(){";
+	const methodEnd =
+		methodStart === -1
+			? -1
+			: patchedSource.indexOf(methodEndMarker, methodStart);
+	if (methodEnd !== -1) {
+		return (
+			patchedSource.slice(0, methodStart) +
+			overlaySyncReplacement +
+			patchedSource.slice(methodEnd + 1)
+		);
+	}
+
+	return patchedSource;
 }
 
 function applyLinuxMenuPatch(currentSource) {
-  const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
-  let patchedSource = currentSource
-    .replace(
-      /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    )
-    .replace(
-      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    );
-  let patchedAny = patchedSource !== currentSource;
-  patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
-    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.removeMenu(),`;
-    if (source.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
-      return match;
-    }
-    patchedAny = true;
-    return `${linuxPatch}${match}`;
-  });
+	const menuRegex =
+		/process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
+	let patchedSource = currentSource
+		.replace(
+			/process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+			(_match, windowVar) =>
+				`process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+		)
+		.replace(
+			/process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
+			(_match, windowVar) =>
+				`process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
+		);
+	let patchedAny = patchedSource !== currentSource;
+	patchedSource = patchedSource.replace(
+		menuRegex,
+		(match, windowVar, offset, source) => {
+			const linuxPatch = `process.platform===\`linux\`&&${windowVar}.removeMenu(),`;
+			if (
+				source.slice(Math.max(0, offset - linuxPatch.length), offset) ===
+				linuxPatch
+			) {
+				return match;
+			}
+			patchedAny = true;
+			return `${linuxPatch}${match}`;
+		},
+	);
 
-  const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
-  const hasLinuxRemoveMenu = /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
-  if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
-    console.warn("WARN: Could not find window menu visibility snippet — skipping menu patch");
-  }
+	const hasWindowsRemoveMenu =
+		/process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(
+			patchedSource,
+		);
+	const hasLinuxRemoveMenu =
+		/process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(
+			patchedSource,
+		);
+	if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
+		console.warn(
+			"WARN: Could not find window menu visibility snippet — skipping menu patch",
+		);
+	}
 
-  return patchedSource;
+	return patchedSource;
 }
 
 function applyLinuxApplicationMenuPatch(currentSource) {
-  return currentSource.replace(
-    /([A-Za-z_$][\w$]*)\.Menu\.setApplicationMenu\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\)/g,
-    (_match, electronAlias, menuAlias) => `${electronAlias}.Menu.setApplicationMenu(${menuAlias})`,
-  );
+	return currentSource.replace(
+		/([A-Za-z_$][\w$]*)\.Menu\.setApplicationMenu\(process\.platform===`linux`\?null:([A-Za-z_$][\w$]*)\)/g,
+		(_match, electronAlias, menuAlias) =>
+			`${electronAlias}.Menu.setApplicationMenu(${menuAlias})`,
+	);
 }
 
 function applyLinuxSetIconPatch(currentSource, iconAsset) {
-  if (iconAsset == null) {
-    return currentSource;
-  }
+	if (iconAsset == null) {
+		return currentSource;
+	}
 
-  const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
-  const readyRegex = /([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(readyRegex, (match, windowVar, offset) => {
-    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setIcon(${iconPathExpression}),`;
-    const prefix = currentSource.slice(Math.max(0, offset - Math.max(400, linuxPatch.length * 2)), offset);
-    if (prefix.includes(linuxPatch)) {
-      return match;
-    }
-    patchedAny = true;
-    return `${linuxPatch}${match}`;
-  });
+	const iconPathExpression = `process.resourcesPath+\`/../content/webview/assets/${iconAsset}\``;
+	const readyRegex = /([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/g;
+	let patchedAny = false;
+	const patchedSource = currentSource.replace(
+		readyRegex,
+		(match, windowVar, offset) => {
+			const linuxPatch = `process.platform===\`linux\`&&${windowVar}.setIcon(${iconPathExpression}),`;
+			const prefix = currentSource.slice(
+				Math.max(0, offset - Math.max(400, linuxPatch.length * 2)),
+				offset,
+			);
+			if (prefix.includes(linuxPatch)) {
+				return match;
+			}
+			patchedAny = true;
+			return `${linuxPatch}${match}`;
+		},
+	);
 
-  if (patchedAny) {
-    return patchedSource;
-  }
+	if (patchedAny) {
+		return patchedSource;
+	}
 
-  if (currentSource.includes(`setIcon(${iconPathExpression})`)) {
-    return currentSource;
-  }
+	if (currentSource.includes(`setIcon(${iconPathExpression})`)) {
+		return currentSource;
+	}
 
-  console.warn("WARN: Could not find window setIcon insertion point — skipping setIcon patch");
-  return currentSource;
+	console.warn(
+		"WARN: Could not find window setIcon insertion point — skipping setIcon patch",
+	);
+	return currentSource;
 }
 
 function applyLinuxReadyToShowWindowStatePatch(currentSource) {
-  const alreadyPatchedRegex =
-    /[A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{[A-Za-z_$][\w$]*\.isDestroyed\(\)\|\|[A-Za-z_$][\w$]*\.maximize\(\)\}\)/;
-  if (alreadyPatchedRegex.test(currentSource)) {
-    return currentSource;
-  }
+	const alreadyPatchedRegex =
+		/[A-Za-z_$][\w$]*&&[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{[A-Za-z_$][\w$]*\.isDestroyed\(\)\|\|[A-Za-z_$][\w$]*\.maximize\(\)\}\)/;
+	if (alreadyPatchedRegex.test(currentSource)) {
+		return currentSource;
+	}
 
-  const readyToShowMaximizeRegex =
-    /([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.maximize\(\)\}\)/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(readyToShowMaximizeRegex, (_match, windowVar, offset, source) => {
-    const prefix = source.slice(Math.max(0, offset - 120), offset);
-    const maximizedStateMatch = prefix.match(/([A-Za-z_$][\w$]*)&&process\.platform===`linux`&&[A-Za-z_$][\w$]*\.setIcon\(/);
-    const maximizedStateVar = maximizedStateMatch?.[1] ?? "false";
-    patchedAny = true;
-    return `${maximizedStateVar}&&${windowVar}.once(\`ready-to-show\`,()=>{${windowVar}.isDestroyed()||${windowVar}.maximize()})`;
-  });
+	const readyToShowMaximizeRegex =
+		/([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.maximize\(\)\}\)/g;
+	let patchedAny = false;
+	const patchedSource = currentSource.replace(
+		readyToShowMaximizeRegex,
+		(_match, windowVar, offset, source) => {
+			const prefix = source.slice(Math.max(0, offset - 120), offset);
+			const maximizedStateMatch = prefix.match(
+				/([A-Za-z_$][\w$]*)&&process\.platform===`linux`&&[A-Za-z_$][\w$]*\.setIcon\(/,
+			);
+			const maximizedStateVar = maximizedStateMatch?.[1] ?? "false";
+			patchedAny = true;
+			return `${maximizedStateVar}&&${windowVar}.once(\`ready-to-show\`,()=>{${windowVar}.isDestroyed()||${windowVar}.maximize()})`;
+		},
+	);
 
-  if (patchedAny) {
-    return patchedSource;
-  }
+	if (patchedAny) {
+		return patchedSource;
+	}
 
-  if (currentSource.includes("ready-to-show") && currentSource.includes(".maximize()")) {
-    console.warn("WARN: Could not find ready-to-show maximize hook — skipping Linux window-state patch");
-  }
+	if (
+		currentSource.includes("ready-to-show") &&
+		currentSource.includes(".maximize()")
+	) {
+		console.warn(
+			"WARN: Could not find ready-to-show maximize hook — skipping Linux window-state patch",
+		);
+	}
 
-  return currentSource;
+	return currentSource;
 }
 
 function applyLinuxResizeRepaintPatch(currentSource) {
-  const helperName = "codexLinuxInstallResizeRepaintHook";
-  const helper =
-    "function codexLinuxInstallResizeRepaintHook(e){if(!(process.platform===`linux`)||e.__codexLinuxResizeRepaintHookInstalled)return;e.__codexLinuxResizeRepaintHookInstalled=!0;let __codexResizeRepaintScheduled=!1,__codexResizeRepaint=()=>{__codexResizeRepaintScheduled||(__codexResizeRepaintScheduled=!0,setTimeout(()=>{if(__codexResizeRepaintScheduled=!1,e.isDestroyed())return;let __codexWebContents=e.webContents;__codexWebContents==null||__codexWebContents.isDestroyed?.()||typeof __codexWebContents.invalidate==`function`&&__codexWebContents.invalidate()},16))};e.on(`resize`,__codexResizeRepaint),e.on(`resized`,__codexResizeRepaint)}";
-  const readyToShowRegex =
-    /(^|[^A-Za-z0-9_$])((?:[A-Za-z_$][\w$]*&&)?)([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/g;
-  let patchedAny = false;
-  const patchedSource = currentSource.replace(
-    readyToShowRegex,
-    (match, leading, guardPrefix, windowVar, offset, source) => {
-      const linuxPatch = `process.platform===\`linux\`&&${helperName}(${windowVar}),`;
-      const insertionPoint = offset + leading.length;
-      const prefix = source.slice(Math.max(0, insertionPoint - Math.max(400, linuxPatch.length * 2)), insertionPoint);
-      if (prefix.includes(linuxPatch)) {
-        return match;
-      }
-      patchedAny = true;
-      return `${leading}${linuxPatch}${guardPrefix}${windowVar}.once(\`ready-to-show\`,()=>{`;
-    },
-  );
+	const helperName = "codexLinuxInstallResizeRepaintHook";
+	const helper =
+		"function codexLinuxInstallResizeRepaintHook(e){if(!(process.platform===`linux`)||e.__codexLinuxResizeRepaintHookInstalled)return;e.__codexLinuxResizeRepaintHookInstalled=!0;let __codexResizeRepaintScheduled=!1,__codexResizeRepaint=()=>{__codexResizeRepaintScheduled||(__codexResizeRepaintScheduled=!0,setTimeout(()=>{if(__codexResizeRepaintScheduled=!1,e.isDestroyed())return;let __codexWebContents=e.webContents;__codexWebContents==null||__codexWebContents.isDestroyed?.()||typeof __codexWebContents.invalidate==`function`&&__codexWebContents.invalidate()},16))};e.on(`resize`,__codexResizeRepaint),e.on(`resized`,__codexResizeRepaint)}";
+	const readyToShowRegex =
+		/(^|[^A-Za-z0-9_$])((?:[A-Za-z_$][\w$]*&&)?)([A-Za-z_$][\w$]*)\.once\(`ready-to-show`,\(\)=>\{/g;
+	let patchedAny = false;
+	const patchedSource = currentSource.replace(
+		readyToShowRegex,
+		(match, leading, guardPrefix, windowVar, offset, source) => {
+			const linuxPatch = `process.platform===\`linux\`&&${helperName}(${windowVar}),`;
+			const insertionPoint = offset + leading.length;
+			const prefix = source.slice(
+				Math.max(0, insertionPoint - Math.max(400, linuxPatch.length * 2)),
+				insertionPoint,
+			);
+			if (prefix.includes(linuxPatch)) {
+				return match;
+			}
+			patchedAny = true;
+			return `${leading}${linuxPatch}${guardPrefix}${windowVar}.once(\`ready-to-show\`,()=>{`;
+		},
+	);
 
-  if (!patchedAny) {
-    if (currentSource.includes(`${helperName}(`)) {
-      return currentSource;
-    }
-    if (currentSource.includes("ready-to-show")) {
-      console.warn("WARN: Could not find ready-to-show hook — skipping Linux resize repaint patch");
-    }
-    return currentSource;
-  }
+	if (!patchedAny) {
+		if (currentSource.includes(`${helperName}(`)) {
+			return currentSource;
+		}
+		if (currentSource.includes("ready-to-show")) {
+			console.warn(
+				"WARN: Could not find ready-to-show hook — skipping Linux resize repaint patch",
+			);
+		}
+		return currentSource;
+	}
 
-  if (patchedSource.includes(`function ${helperName}(`)) {
-    return patchedSource;
-  }
+	if (patchedSource.includes(`function ${helperName}(`)) {
+		return patchedSource;
+	}
 
-  for (const prefix of ['"use strict";', "'use strict';"]) {
-    if (patchedSource.startsWith(prefix)) {
-      return `${prefix}${helper}${patchedSource.slice(prefix.length)}`;
-    }
-  }
+	for (const prefix of ['"use strict";', "'use strict';"]) {
+		if (patchedSource.startsWith(prefix)) {
+			return `${prefix}${helper}${patchedSource.slice(prefix.length)}`;
+		}
+	}
 
-  return `${helper}${patchedSource}`;
+	return `${helper}${patchedSource}`;
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  let patchedSource = currentSource;
-  const shouldAlwaysOpaqueSurfaceRegex =
-    /shouldAlwaysUseOpaqueWindowSurface\(([A-Za-z_$][\w$]*)\)\{return\s*([A-Za-z_$][\w$]*)\(\{appearance:\1,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!([A-Za-z_$][\w$]*)\(\)&&!([A-Za-z_$][\w$]*)\(\1\)\}/u;
-  const shouldAlwaysOpaqueSurfaceMatch = patchedSource.match(shouldAlwaysOpaqueSurfaceRegex);
-  if (shouldAlwaysOpaqueSurfaceMatch != null) {
-    const [
-      match,
-      appearanceParam,
-      opaqueSurfaceHelper,
-      nativeSurfaceCapabilityHelper,
-      transparentAppearancePredicate,
-    ] = shouldAlwaysOpaqueSurfaceMatch;
-    const replacement =
-      `shouldAlwaysUseOpaqueWindowSurface(${appearanceParam}){return process.platform===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})||${opaqueSurfaceHelper}({appearance:${appearanceParam},opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!${nativeSurfaceCapabilityHelper}()&&!${transparentAppearancePredicate}(${appearanceParam})}`;
-    patchedSource = patchedSource.replace(match, replacement);
-  } else if (
-    /shouldAlwaysUseOpaqueWindowSurface\([A-Za-z_$][\w$]*\)\{return\s*process\.platform===`linux`&&!/.test(patchedSource)
-  ) {
-    // Already patched.
-  } else if (patchedSource.includes("shouldAlwaysUseOpaqueWindowSurface(")) {
-    console.warn("WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch");
-  }
+	let patchedSource = currentSource;
+	const shouldAlwaysOpaqueSurfaceRegex =
+		/shouldAlwaysUseOpaqueWindowSurface\(([A-Za-z_$][\w$]*)\)\{return\s*([A-Za-z_$][\w$]*)\(\{appearance:\1,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!([A-Za-z_$][\w$]*)\(\)&&!([A-Za-z_$][\w$]*)\(\1\)\}/u;
+	const shouldAlwaysOpaqueSurfaceMatch = patchedSource.match(
+		shouldAlwaysOpaqueSurfaceRegex,
+	);
+	if (shouldAlwaysOpaqueSurfaceMatch != null) {
+		const [
+			match,
+			appearanceParam,
+			opaqueSurfaceHelper,
+			nativeSurfaceCapabilityHelper,
+			transparentAppearancePredicate,
+		] = shouldAlwaysOpaqueSurfaceMatch;
+		const replacement = `shouldAlwaysUseOpaqueWindowSurface(${appearanceParam}){return process.platform===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})||${opaqueSurfaceHelper}({appearance:${appearanceParam},opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!${nativeSurfaceCapabilityHelper}()&&!${transparentAppearancePredicate}(${appearanceParam})}`;
+		patchedSource = patchedSource.replace(match, replacement);
+	} else if (
+		/shouldAlwaysUseOpaqueWindowSurface\([A-Za-z_$][\w$]*\)\{return\s*process\.platform===`linux`&&!/.test(
+			patchedSource,
+		)
+	) {
+		// Already patched.
+	} else if (patchedSource.includes("shouldAlwaysUseOpaqueWindowSurface(")) {
+		console.warn(
+			"WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch",
+		);
+	}
 
-  if (
-    patchedSource.includes("===`linux`&&!OM(") ||
-    /===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(patchedSource)
-  ) {
-    return patchedSource;
-  }
+	if (
+		patchedSource.includes("===`linux`&&!OM(") ||
+		/===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(
+			patchedSource,
+		)
+	) {
+		return patchedSource;
+	}
 
-  const colorConstRegex =
-    /([A-Za-z_$][\w$]*)=`#00000000`,([A-Za-z_$][\w$]*)=`#000000`,([A-Za-z_$][\w$]*)=`#f9f9f9`/;
-  const colorMatch = patchedSource.match(colorConstRegex);
+	const colorConstRegex =
+		/([A-Za-z_$][\w$]*)=`#00000000`,([A-Za-z_$][\w$]*)=`#000000`,([A-Za-z_$][\w$]*)=`#f9f9f9`/;
+	const colorMatch = patchedSource.match(colorConstRegex);
 
-  if (!colorMatch) {
-    console.warn(
-      "WARN: Could not find color constants (#00000000, #000000, #f9f9f9) — skipping background patch",
-    );
-    return patchedSource;
-  }
+	if (!colorMatch) {
+		console.warn(
+			"WARN: Could not find color constants (#00000000, #000000, #f9f9f9) — skipping background patch",
+		);
+		return patchedSource;
+	}
 
-  const [, transparentVar, darkVar, lightVar] = colorMatch;
+	const [, transparentVar, darkVar, lightVar] = colorMatch;
 
-  const currentFuncParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3&&!([A-Za-z_$][\w$]*)\(\2\)&&\(\1===`darwin`\|\|\1===`win32`\)\?/;
-  const currentFuncMatch = patchedSource.match(currentFuncParamRegex);
-  if (currentFuncMatch != null) {
-    const [, platformParam, appearanceParam, , darkColorsParam, transparentAppearancePredicate] =
-      currentFuncMatch;
-    const win32Needle =
-      `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
-    const linuxBgPrefix =
-      `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:`;
+	const currentFuncParamRegex =
+		/function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3&&!([A-Za-z_$][\w$]*)\(\2\)&&\(\1===`darwin`\|\|\1===`win32`\)\?/;
+	const currentFuncMatch = patchedSource.match(currentFuncParamRegex);
+	if (currentFuncMatch != null) {
+		const [
+			,
+			platformParam,
+			appearanceParam,
+			,
+			darkColorsParam,
+			transparentAppearancePredicate,
+		] = currentFuncMatch;
+		const win32Needle = `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
+		const linuxBgPrefix = `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:`;
 
-    if (patchedSource.includes(linuxBgPrefix)) {
-      return patchedSource;
-    }
-    if (patchedSource.includes(win32Needle)) {
-      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
-    }
+		if (patchedSource.includes(linuxBgPrefix)) {
+			return patchedSource;
+		}
+		if (patchedSource.includes(win32Needle)) {
+			return patchedSource.replace(
+				win32Needle,
+				`${linuxBgPrefix}${win32Needle.slice(1)}`,
+			);
+		}
 
-    console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-    return patchedSource;
-  }
+		console.warn(
+			"WARN: Could not find BrowserWindow background color needle — skipping background patch",
+		);
+		return patchedSource;
+	}
 
-  const currentSurfaceFuncParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
-  const currentSurfaceFuncMatch = patchedSource.match(currentSurfaceFuncParamRegex);
-  if (currentSurfaceFuncMatch != null) {
-    const [, platformParam, appearanceParam, , darkColorsParam, darkVarFromReturn, lightVarFromReturn, transparentAppearancePredicate] =
-      currentSurfaceFuncMatch;
-    const win32Needle =
-      `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
-    const linuxBgPrefix =
-      `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVarFromReturn}:${lightVarFromReturn},backgroundMaterial:null}:`;
+	const currentSurfaceFuncParamRegex =
+		/function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
+	const currentSurfaceFuncMatch = patchedSource.match(
+		currentSurfaceFuncParamRegex,
+	);
+	if (currentSurfaceFuncMatch != null) {
+		const [
+			,
+			platformParam,
+			appearanceParam,
+			,
+			darkColorsParam,
+			darkVarFromReturn,
+			lightVarFromReturn,
+			transparentAppearancePredicate,
+		] = currentSurfaceFuncMatch;
+		const win32Needle = `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
+		const linuxBgPrefix = `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVarFromReturn}:${lightVarFromReturn},backgroundMaterial:null}:`;
 
-    if (patchedSource.includes(linuxBgPrefix)) {
-      return patchedSource;
-    }
-    if (patchedSource.includes(win32Needle)) {
-      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
-    }
+		if (patchedSource.includes(linuxBgPrefix)) {
+			return patchedSource;
+		}
+		if (patchedSource.includes(win32Needle)) {
+			return patchedSource.replace(
+				win32Needle,
+				`${linuxBgPrefix}${win32Needle.slice(1)}`,
+			);
+		}
 
-    console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-    return patchedSource;
-  }
+		console.warn(
+			"WARN: Could not find BrowserWindow background color needle — skipping background patch",
+		);
+		return patchedSource;
+	}
 
-  const funcParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
-  const funcMatch = patchedSource.match(funcParamRegex);
+	const funcParamRegex =
+		/function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
+	const funcMatch = patchedSource.match(funcParamRegex);
 
-  if (funcMatch == null) {
-    console.warn("WARN: Could not find BrowserWindow background function signature — skipping background patch");
-    return patchedSource;
-  }
+	if (funcMatch == null) {
+		console.warn(
+			"WARN: Could not find BrowserWindow background function signature — skipping background patch",
+		);
+		return patchedSource;
+	}
 
-  const [, platformParam, appearanceParam, darkColorsParam, transparentAppearancePredicate] =
-    funcMatch;
-  const bgNeedle =
-    `backgroundMaterial:\`mica\`}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-  const oldLinuxBgPatch =
-    `backgroundMaterial:\`mica\`}:process.platform===\`linux\`?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-  const bgReplacement =
-    `backgroundMaterial:\`mica\`}:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
+	const [
+		,
+		platformParam,
+		appearanceParam,
+		darkColorsParam,
+		transparentAppearancePredicate,
+	] = funcMatch;
+	const bgNeedle = `backgroundMaterial:\`mica\`}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
+	const oldLinuxBgPatch = `backgroundMaterial:\`mica\`}:process.platform===\`linux\`?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
+	const bgReplacement = `backgroundMaterial:\`mica\`}:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
 
-  if (patchedSource.includes(bgNeedle)) {
-    return patchedSource.replace(bgNeedle, bgReplacement);
-  }
-  if (patchedSource.includes(oldLinuxBgPatch)) {
-    return patchedSource.replace(oldLinuxBgPatch, bgReplacement);
-  }
+	if (patchedSource.includes(bgNeedle)) {
+		return patchedSource.replace(bgNeedle, bgReplacement);
+	}
+	if (patchedSource.includes(oldLinuxBgPatch)) {
+		return patchedSource.replace(oldLinuxBgPatch, bgReplacement);
+	}
 
-  console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-  return patchedSource;
+	console.warn(
+		"WARN: Could not find BrowserWindow background color needle — skipping background patch",
+	);
+	return patchedSource;
 }
 
 function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {
-  if (!currentSource.includes("codex.aboutDialog.title")) {
-    return currentSource;
-  }
+	if (!currentSource.includes("codex.aboutDialog.title")) {
+		return currentSource;
+	}
 
-  const alreadyUsesBundledIcon =
-    iconPathExpression != null &&
-    currentSource.includes(`nativeImage.createFromPath(${iconPathExpression})`);
-  const aboutHtmlIconNullSafeRegex =
-    /[A-Za-z_$][\w$]*==null\|\|([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/;
-  const aboutWindowIconNullSafeRegex =
-    /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon==null\|\|\1\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/;
-  const alreadyNullSafe =
-    aboutWindowIconNullSafeRegex.test(currentSource) &&
-    aboutHtmlIconNullSafeRegex.test(currentSource) &&
-    /windowIcon:[A-Za-z_$][\w$]*\?\?null\}/.test(currentSource);
-  if (alreadyUsesBundledIcon && alreadyNullSafe) {
-    return currentSource;
-  }
+	const alreadyUsesBundledIcon =
+		iconPathExpression != null &&
+		currentSource.includes(`nativeImage.createFromPath(${iconPathExpression})`);
+	const aboutHtmlIconNullSafeRegex =
+		/[A-Za-z_$][\w$]*==null\|\|([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/;
+	const aboutWindowIconNullSafeRegex =
+		/\.\.\.([A-Za-z_$][\w$]*)\.windowIcon==null\|\|\1\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/;
+	const alreadyNullSafe =
+		aboutWindowIconNullSafeRegex.test(currentSource) &&
+		aboutHtmlIconNullSafeRegex.test(currentSource) &&
+		/windowIcon:[A-Za-z_$][\w$]*\?\?null\}/.test(currentSource);
+	if (alreadyUsesBundledIcon && alreadyNullSafe) {
+		return currentSource;
+	}
 
-  let patchedSource = currentSource;
-  if (iconPathExpression != null) {
-    const aboutIconPromiseRegex =
-      /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\]/;
-    patchedSource = patchedSource.replace(
-      aboutIconPromiseRegex,
-      `[
+	let patchedSource = currentSource;
+	if (iconPathExpression != null) {
+		const aboutIconPromiseRegex =
+			/\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\]/;
+		patchedSource = patchedSource.replace(
+			aboutIconPromiseRegex,
+			`[
 process.platform===\`linux\`?null:$1?$2($3):null,
 process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4.app.getFileIcon($5,{size:process.platform===\`win32\`?\`large\`:\`normal\`}).catch(()=>null)
 ]`,
-    );
-    if (patchedSource === currentSource) {
-      // 26.623 reshaped the about icon promise array: the non-win32 size
-      // ternary collapsed to {size:`normal`} and a win32 nativeImage branch was
-      // added — [t?k_(i):null,n?a.nativeImage.createFromPath(i):a.app.getFileIcon(i,{size:`normal`})].
-      // Without this branch the Linux-safe icon (and the .catch on getFileIcon)
-      // never apply, so a getFileIcon rejection on Linux makes the About window
-      // builder throw before its try/catch and the dialog never opens.
-      const aboutIconPromiseRegex26623 =
-        /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(([^()]+)\):([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\]/;
-      patchedSource = patchedSource.replace(
-        aboutIconPromiseRegex26623,
-        `[
+		);
+		if (patchedSource === currentSource) {
+			// 26.623 reshaped the about icon promise array: the non-win32 size
+			// ternary collapsed to {size:`normal`} and a win32 nativeImage branch was
+			// added — [t?k_(i):null,n?a.nativeImage.createFromPath(i):a.app.getFileIcon(i,{size:`normal`})].
+			// Without this branch the Linux-safe icon (and the .catch on getFileIcon)
+			// never apply, so a getFileIcon rejection on Linux makes the About window
+			// builder throw before its try/catch and the dialog never opens.
+			const aboutIconPromiseRegex26623 =
+				/\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(([^()]+)\):([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\]/;
+			patchedSource = patchedSource.replace(
+				aboutIconPromiseRegex26623,
+				`[
 process.platform===\`linux\`?null:$1?$2($3):null,
 process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$5.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4?$5.nativeImage.createFromPath($6):$7.app.getFileIcon($8,{size:\`normal\`}).catch(()=>null)
 ]`,
-      );
-    }
-  } else {
-    const patchedGetFileIconRegex =
-      /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\.catch\(\(\)=>null\)/;
-    if (!patchedGetFileIconRegex.test(patchedSource)) {
-      const getFileIconRegex =
-        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)/;
-      patchedSource = patchedSource.replace(
-        getFileIconRegex,
-        "$1.app.getFileIcon($2,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
-      );
-    }
-    if (patchedSource === currentSource) {
-      // 26.623 fallback (no bundled icon): just make the reshaped getFileIcon
-      // call rejection-proof so the About window builder cannot throw on Linux.
-      const patchedGetFileIconRegex26623 =
-        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\.catch\(\(\)=>null\)/;
-      if (!patchedGetFileIconRegex26623.test(patchedSource)) {
-        const getFileIconRegex26623 =
-          /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)/;
-        patchedSource = patchedSource.replace(
-          getFileIconRegex26623,
-          "$1.app.getFileIcon($2,{size:`normal`}).catch(()=>null)",
-        );
-      }
-    }
-  }
+			);
+		}
+	} else {
+		const patchedGetFileIconRegex =
+			/([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\.catch\(\(\)=>null\)/;
+		if (!patchedGetFileIconRegex.test(patchedSource)) {
+			const getFileIconRegex =
+				/([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)/;
+			patchedSource = patchedSource.replace(
+				getFileIconRegex,
+				"$1.app.getFileIcon($2,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
+			);
+		}
+		if (patchedSource === currentSource) {
+			// 26.623 fallback (no bundled icon): just make the reshaped getFileIcon
+			// call rejection-proof so the About window builder cannot throw on Linux.
+			const patchedGetFileIconRegex26623 =
+				/([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\.catch\(\(\)=>null\)/;
+			if (!patchedGetFileIconRegex26623.test(patchedSource)) {
+				const getFileIconRegex26623 =
+					/([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)/;
+				patchedSource = patchedSource.replace(
+					getFileIconRegex26623,
+					"$1.app.getFileIcon($2,{size:`normal`}).catch(()=>null)",
+				);
+			}
+		}
+	}
 
-  patchedSource = patchedSource
-    .replace(
-      /([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/g,
-      "$1==null||$1.isEmpty()?null:$1.resize(",
-    )
-    .replace(/windowIcon:([A-Za-z_$][\w$]*)\}/g, "windowIcon:$1??null}")
-    .replace(
-      /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/g,
-      "...$1.windowIcon==null||$1.windowIcon.isEmpty()?{}:{icon:$1.windowIcon}",
-    );
+	patchedSource = patchedSource
+		.replace(
+			/([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/g,
+			"$1==null||$1.isEmpty()?null:$1.resize(",
+		)
+		.replace(/windowIcon:([A-Za-z_$][\w$]*)\}/g, "windowIcon:$1??null}")
+		.replace(
+			/\.\.\.([A-Za-z_$][\w$]*)\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/g,
+			"...$1.windowIcon==null||$1.windowIcon.isEmpty()?{}:{icon:$1.windowIcon}",
+		);
 
-  if (patchedSource !== currentSource) {
-    return patchedSource;
-  }
+	if (patchedSource !== currentSource) {
+		return patchedSource;
+	}
 
-  console.warn("WARN: Could not patch About dialog icon fallback for Linux");
-  return currentSource;
+	console.warn("WARN: Could not patch About dialog icon fallback for Linux");
+	return currentSource;
 }
 
 module.exports = {
-  applyLinuxAboutDialogPatch,
-  applyLinuxApplicationMenuPatch,
-  applyLinuxMenuPatch,
-  applyLinuxNativeTitlebarPatch,
-  applyLinuxOpaqueBackgroundPatch,
-  applyLinuxReadyToShowWindowStatePatch,
-  applyLinuxResizeRepaintPatch,
-  applyLinuxSetIconPatch,
-  applyLinuxWindowOptionsPatch,
+	applyLinuxAboutDialogPatch,
+	applyLinuxApplicationMenuPatch,
+	applyLinuxMenuPatch,
+	applyLinuxNativeTitlebarPatch,
+	applyLinuxOpaqueBackgroundPatch,
+	applyLinuxReadyToShowWindowStatePatch,
+	applyLinuxResizeRepaintPatch,
+	applyLinuxSetIconPatch,
+	applyLinuxWindowOptionsPatch,
 };


### PR DESCRIPTION
## Summary

Fix the required Linux patch matchers for the July 9 upstream `Codex.dmg`
/ `ChatGPT.app` bundle update.

The new upstream app build (`26.707.30751`) reshaped several minified main
process surfaces enough that the Linux updater correctly refused to build with
critical patch enforcement enabled.

This updates the required patchers for the new bundle shape instead of using
`CODEX_ENFORCE_CRITICAL_PATCHES=0`.

## Upstream build verified

- Upstream DMG app version: `26.707.30751`
- Upstream DMG size: `560955080`
- Upstream DMG sha256: `4ee90314f60568623e584eb7850b81737777d3befad6d3028bdfa8728eac2265`

## What changed

- Support the new wrapped CommonJS import shape for the Linux quit guard.
- Support the new `createWindow` optional-field / focusable shape.
- Support the merged `quickChat` / `primary` titlebar branch.
- Support the new tray icon fallback helper shape.
- Support the avatar overlay's new computer-use cursor and layout flow.

## Validation

Built locally on Arch with critical patch enforcement enabled:

```txt
required core: applied=13, already-applied=4
required failures: 0
```

Commands run:

```bash
DMG=~/.cache/codex-update-manager/downloads/Codex.dmg ./install.sh
make package
```

Installed package smoke check:

```txt
codex-desktop 2026.07.09.191649-1
required patch failures: 0
required patch count: 17
```

Optional drift still exists in unrelated optional patches, but all
`required-upstream` patches pass without bypassing the critical gate.
