### PR TITLE
fix(nix): refresh Codex DMG source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,11 +80,11 @@
         '';
 
         codexDmg = pkgs.fetchurl {
-          url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
-          hash = "sha256-MKL+mR5Ibx7W1SUWeWOXM1aNIN7cDXHJieggC8cRxGw=";
+          url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
+          hash = "sha256-TukDFPYFaGI+WE63hQuBc3d307761tMCi9+oco6sImU=";
         };
 
-        codexVersion = "26.623.141536";
+        codexVersion = "26.707.30751";
         electronVersion = "42.1.0";
         electronPlatform =
           {


### PR DESCRIPTION
Reopens #717 with `main` as the base branch. The original PR was merged into #716's feature branch, so its Nix source refresh did not land on `main`.

Updates the Nix package to Codex `26.707.30751`:

- fetch `ChatGPT.dmg`
- use the matching fixed-output hash
- record the matching package version

Impact: Nix builds now download and package the current upstream DMG.

Validation:

- `nix build --no-link --print-build-logs .#packages.x86_64-linux.codex-desktop`

@ilysenko, could you please review this replacement PR targeting `main`?