### PR TITLE
Harden latest DMG main-process patches

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -184,14 +184,10 @@ const fileManagerBundle =
   "var lu=jl({id:`fileManager`,label:`Finder`,icon:`apps/finder.png`,kind:`fileManager`,darwin:{detect:()=>`open`,args:e=>il(e)},win32:{label:`File Explorer`,icon:`apps/file-explorer.png`,detect:uu,args:e=>il(e),open:async({path:e})=>du(e)}});function uu(){}";
 const terminalEnvBundle =
   "var Q0=`xterm-256color`;var t={t(e){return e}};var Backend=class{isLocalTerminalSession(e){return e?.type===`local`}async getWorktreeShellEnvironmentForCwd(e){return null}async buildTerminalEnv(e,n,r){let i={...process.env};if(n!=null&&(i.CODEX_APP_TITLE=n),this.isLocalTerminalSession(r)){let t=await this.getWorktreeShellEnvironmentForCwd(e);if(t!=null){for(let e of t.exclude)delete i[e];Object.assign(i,t.set)}}return process.platform!==`win32`&&(i.TERM=Q0,delete i.TERMINFO,delete i.TERMINFO_DIRS),t.t(i)}};";
-const alreadyOpaqueBackgroundBundle =
-  "process.platform===`linux`?{backgroundColor:e?t:n,backgroundMaterial:null}:{backgroundColor:r,backgroundMaterial:null}";
-const opaqueBackgroundBundleWithDriftingGw =
-  "var cM=`#00000000`,lM=`#000000`,uM=`#f9f9f9`;function OM(e){return e===`avatarOverlay`||e===`browserCommentPopup`}function jM({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return e===`win32`&&!OM(t)?n?{backgroundColor:r?lM:uM,backgroundMaterial:`none`}:{backgroundColor:cM,backgroundMaterial:`mica`}:{backgroundColor:cM,backgroundMaterial:null}}function gw(e){return e.page==null?e.snapshot.url:mw(e.page)}";
-const currentOpaqueBackgroundBundle =
-  "var QK=`#00000000`,$K=`#000000`,eq=`#f9f9f9`;function vq(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`}function xq({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!vq(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?$K:eq,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!vq(t)?{backgroundColor:QK,backgroundMaterial:`mica`}:{backgroundColor:QK,backgroundMaterial:null}}";
+const currentOpaqueWindowSurfaceBackgroundHelper =
+  "var W4=`#00000000`,G4=`#000000`,K4=`#f9f9f9`;function g3(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`||e===`hud`}function v3({appearance:e,opaqueWindowsEnabled:t,platform:n}){return t&&!g3(e)&&(n===`darwin`||n===`win32`)}function S3({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?G4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!g3(t)?{backgroundColor:W4,backgroundMaterial:`mica`}:{backgroundColor:W4,backgroundMaterial:null}}";
 const currentOpaqueWindowSurfaceBackgroundBundle =
-  "var W4=`#00000000`,G4=`#000000`,K4=`#f9f9f9`;function g3(e){return e===`avatarOverlay`||e===`browserCommentPopup`||e===`globalDictation`||e===`hotkeyWindowHome`||e===`hotkeyWindowThread`||e===`hud`}function v3({appearance:e,opaqueWindowsEnabled:t,platform:n}){return t&&!g3(e)&&(n===`darwin`||n===`win32`)}function S3({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?G4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`&&!g3(t)?{backgroundColor:W4,backgroundMaterial:`mica`}:{backgroundColor:W4,backgroundMaterial:null}}class k3{isOpaqueWindowsEnabled(){return theme?.opaqueWindows===!0}shouldUseOpaqueWindowSurface(e,t,n){return this.shouldAlwaysUseOpaqueWindowSurface(e)}shouldAlwaysUseOpaqueWindowSurface(e){return v3({appearance:e,opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!BA()&&!g3(e)}}";
+  `${currentOpaqueWindowSurfaceBackgroundHelper}class k3{isOpaqueWindowsEnabled(){return theme?.opaqueWindows===!0}shouldUseOpaqueWindowSurface(e,t,n){return this.shouldAlwaysUseOpaqueWindowSurface(e)}shouldAlwaysUseOpaqueWindowSurface(e){return v3({appearance:e,opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!BA()&&!g3(e)}}`;
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -1652,7 +1648,7 @@ test("patchExtractedApp patches worker file manager support", () => {
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),
@@ -1691,7 +1687,7 @@ test("patchExtractedApp reports worker file manager patch drift", () => {
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),
@@ -2320,31 +2316,6 @@ test("migrates a Linux-suppressed application menu back to the real menu", () =>
   assert.equal(patched, "let et=n.Menu.buildFromTemplate($e);n.Menu.setApplicationMenu(et);");
 });
 
-test("recognizes already-applied Linux opaque background patch", () => {
-  const patched = applyPatchTwice(applyLinuxOpaqueBackgroundPatch, alreadyOpaqueBackgroundBundle);
-  assert.equal(patched, alreadyOpaqueBackgroundBundle);
-});
-
-test("uses the local transparent appearance predicate for Linux opaque backgrounds", () => {
-  const patched = applyPatchTwice(
-    applyLinuxOpaqueBackgroundPatch,
-    opaqueBackgroundBundleWithDriftingGw,
-  );
-
-  assert.match(patched, /e===`linux`&&!OM\(t\)\?\{backgroundColor:r\?lM:uM/);
-  assert.doesNotMatch(patched, /process\.platform===`linux`&&!gw\(t\)/);
-});
-
-test("patches current BrowserWindow background helper shape for Linux opaque backgrounds", () => {
-  const patched = applyPatchTwice(applyLinuxOpaqueBackgroundPatch, currentOpaqueBackgroundBundle);
-
-  assert.match(
-    patched,
-    /:e===`linux`&&!vq\(t\)\?\{backgroundColor:r\?\$K:eq,backgroundMaterial:null\}:e===`win32`&&!vq\(t\)\?/,
-  );
-  assert.match(patched, /vq\(e\).*hotkeyWindowThread/);
-});
-
 test("patches current opaque window surface background helper shape for Linux", () => {
   const patched = applyPatchTwice(applyLinuxOpaqueBackgroundPatch, currentOpaqueWindowSurfaceBackgroundBundle);
 
@@ -2357,6 +2328,32 @@ test("patches current opaque window surface background helper shape for Linux", 
     /shouldAlwaysUseOpaqueWindowSurface\(e\)\{return process\.platform===`linux`&&!g3\(e\)\|\|v3\(\{appearance:e,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!BA\(\)&&!g3\(e\)\}/,
   );
   assert.match(patched, /opaqueWindowSurfaceEnabled:n/);
+});
+
+test("does not mistake an unrelated Linux background branch for the current patched helper", () => {
+  const unrelatedLinuxBackground =
+    "function legacy({platform:e,appearance:t,prefersDarkColors:r}){return e===`linux`&&!x(t)?{backgroundColor:r?D:L,backgroundMaterial:null}:null}";
+  const patched = applyPatchTwice(
+    applyLinuxOpaqueBackgroundPatch,
+    `${unrelatedLinuxBackground}${currentOpaqueWindowSurfaceBackgroundBundle}`,
+  );
+
+  assert.match(
+    patched,
+    /function S3\([^}]+\}\)\{return n\?[^;]+:e===`linux`&&!g3\(t\)\?\{backgroundColor:r\?G4:K4,backgroundMaterial:null\}:e===`win32`&&!g3\(t\)\?/,
+  );
+  assert.match(patched, new RegExp(escapeRegExp(unrelatedLinuxBackground)));
+});
+
+test("reports drift when the current opaque background helper has no surface predicate", () => {
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxOpaqueBackgroundPatch(currentOpaqueWindowSurfaceBackgroundHelper),
+  );
+
+  assert.equal(patched, currentOpaqueWindowSurfaceBackgroundHelper);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch",
+  ]);
 });
 
 test("patches current webview opaque window default bundle shapes", () => {
@@ -2817,7 +2814,7 @@ test("adds Linux window icon handling when an icon asset is available", () => {
       windowOptionsSource,
       "process.platform===`win32`&&k.removeMenu(),",
       readyToShowSource,
-      alreadyOpaqueBackgroundBundle,
+      currentOpaqueWindowSurfaceBackgroundBundle,
       fileManagerBundle,
       trayBundleFixture(),
       singleInstanceBundleFixture(),
@@ -3223,47 +3220,88 @@ test("adds Linux build information to the app Help menu", () => {
   );
 });
 
-test("makes About dialog prefer the bundled Linux icon asset", () => {
-  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
-  const source = [
-    "let a=require(`electron`),r={T:()=>null,V:()=>({formatMessage:({defaultMessage:e})=>e})},t={dt:()=>null,Kr:()=>null};",
-    "var $X=`codex.aboutDialog.title`,eZ=`About {appName}`,tZ=`codex.aboutDialog.ok`,nZ=`codex.aboutDialog.versionLine`,rZ=`Version {version}`,iZ=`codex.aboutDialog.versionLineWithDate`,aZ=`Version {version} • Released {releaseDate}`,oZ=`codex.aboutDialog.buildInfoLabel`,sZ=`Build information`,cZ=380,lZ=360,uZ=72,pZ=null;",
-    "async function bZ(){let e=process.platform===`darwin`,t=e?r.T():process.execPath,[n,i]=await Promise.all([e?Fw(t):null,a.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`})]);return{htmlIconDataUrl:n??(i.isEmpty()?null:i.resize({width:uZ,height:uZ,quality:`best`}).toDataURL()),windowIcon:i}}",
-    "let d={windowIcon:null},q={...d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}};",
+function currentAboutDialogBundleFixture() {
+  return [
+    "let c=require(`electron`),a={s:()=>null};",
+    "var q6=`codex.aboutDialog.title`,i8=72;",
+    "async function h8(e){let t=process.platform===`darwin`,n=process.platform===`win32`,r=process.execPath;t?r=a.s():n&&(r=`icon`);let[i,o]=await Promise.all([t?GD(r):null,n?c.nativeImage.createFromPath(r):c.app.getFileIcon(r,{size:`normal`})]);return{htmlIconDataUrl:i??(o.isEmpty()?null:o.resize({width:i8,height:i8,quality:`best`}).toDataURL()),windowIcon:o}}",
+    "let p={windowIcon:null},S={...p.windowIcon.isEmpty()?{}:{icon:p.windowIcon}};",
   ].join("");
+}
 
-  const patched = applyPatchTwice(applyLinuxAboutDialogPatch, source, iconPathExpression);
+test("makes the current About dialog prefer the bundled Linux icon asset", () => {
+  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
+  const patched = applyPatchTwice(
+    applyLinuxAboutDialogPatch,
+    currentAboutDialogBundleFixture(),
+    iconPathExpression,
+  );
 
   assert.match(
     patched,
     new RegExp(`nativeImage\\.createFromPath\\(${escapeRegExp(iconPathExpression)}\\)`),
   );
-  assert.match(patched, /process\.platform===`linux`\?null:e\?Fw\(t\):null/);
-  assert.match(patched, /windowIcon==null\|\|d\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:d\.windowIcon\}/);
-  assert.match(patched, /i==null\|\|i\.isEmpty\(\)\?null:i\.resize\(/);
-  assert.match(patched, /windowIcon:i\?\?null/);
+  assert.match(patched, /process\.platform===`linux`\?null:t\?GD\(r\):null/);
+  assert.match(patched, /:n\?c\.nativeImage\.createFromPath\(r\):c\.app\.getFileIcon/);
+  assert.match(patched, /p\.windowIcon==null\|\|p\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:p\.windowIcon\}/);
+  assert.match(patched, /o==null\|\|o\.isEmpty\(\)\?null:o\.resize\(/);
+  assert.match(patched, /windowIcon:o\?\?null/);
+  assert.match(patched, /let p=\{windowIcon:null\}/);
+  assert.doesNotMatch(patched, /null\?\?null/);
   assert.doesNotThrow(() => new Function(patched));
 });
 
-test("upgrades partially patched About dialog icon fallbacks after alias drift", () => {
-  const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
-  const source = [
-    "let r=require(`electron`),n={T:()=>null};",
-    "var UZ=`codex.aboutDialog.title`,eQ=72;",
-    "async function dQ(){let e=process.platform===`darwin`,t=e?n.T():process.execPath,[i,a]=await Promise.all([",
-    "process.platform===`linux`?null:e?tT(t):null,",
-    "process.platform===`linux`?Promise.resolve((()=>{let __codexLinuxAboutIcon=r.nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`);return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):r.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
-    "]);return{htmlIconDataUrl:i??(a.isEmpty()?null:a.resize({width:eQ,height:eQ,quality:`best`}).toDataURL()),windowIcon:a}}",
-    "let f={windowIcon:null},x={...f.windowIcon.isEmpty()?{}:{icon:f.windowIcon}};",
-  ].join("");
+test("keeps the current no-icon About dialog patch idempotent", () => {
   const { value: patched, warnings } = captureWarns(() =>
-    applyPatchTwice(applyLinuxAboutDialogPatch, source, iconPathExpression),
+    applyPatchTwice(
+      applyLinuxAboutDialogPatch,
+      currentAboutDialogBundleFixture(),
+      null,
+    ),
   );
 
   assert.deepEqual(warnings, []);
-  assert.match(patched, /a==null\|\|a\.isEmpty\(\)\?null:a\.resize\(/);
-  assert.match(patched, /windowIcon:a\?\?null/);
-  assert.match(patched, /f\.windowIcon==null\|\|f\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:f\.windowIcon\}/);
+  assert.match(
+    patched,
+    /:c\.app\.getFileIcon\(r,\{size:`normal`\}\)\.catch\(\(\)=>null\)\]/,
+  );
+  assert.match(patched, /o==null\|\|o\.isEmpty\(\)\?null:o\.resize\(/);
+  assert.equal((patched.match(/o==null\|\|/g) ?? []).length, 1);
+  assert.match(patched, /windowIcon:o\?\?null/);
+  assert.match(patched, /p\.windowIcon==null\|\|p\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:p\.windowIcon\}/);
+  assert.match(patched, /let p=\{windowIcon:null\}/);
+  assert.doesNotMatch(patched, /null\?\?null/);
+  assert.doesNotThrow(() => new Function(patched));
+});
+
+test("rejects the obsolete pre-26.623 About dialog shape", () => {
+  const source = [
+    "let a=require(`electron`);",
+    "var $X=`codex.aboutDialog.title`,uZ=72;",
+    "async function bZ(){let e=process.platform===`darwin`,t=e?`icon`:process.execPath,[n,i]=await Promise.all([e?Fw(t):null,a.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`})]);return{htmlIconDataUrl:n??(i.isEmpty()?null:i.resize({width:uZ,height:uZ,quality:`best`}).toDataURL()),windowIcon:i}}",
+    "let d={windowIcon:null},q={...d.windowIcon.isEmpty()?{}:{icon:d.windowIcon}};",
+  ].join("");
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxAboutDialogPatch(source, null),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, ["WARN: Could not patch About dialog icon fallback for Linux"]);
+});
+
+test("does not partially patch current About shapes with mismatched result aliases", () => {
+  const malformedSources = [
+    currentAboutDialogBundleFixture().replace("windowIcon:o}", "windowIcon:z}"),
+    currentAboutDialogBundleFixture().replace("{icon:p.windowIcon}", "{icon:q.windowIcon}"),
+  ];
+
+  for (const source of malformedSources) {
+    const { value: patched, warnings } = captureWarns(() =>
+      applyLinuxAboutDialogPatch(source, null),
+    );
+    assert.equal(patched, source);
+    assert.deepEqual(warnings, ["WARN: Could not patch About dialog icon fallback for Linux"]);
+  }
 });
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {
@@ -7343,7 +7381,7 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
     mainBundlePrefix,
     currentMainBundlePrefix,
     "process.platform===`win32`&&k.removeMenu(),",
-    alreadyOpaqueBackgroundBundle,
+    currentOpaqueWindowSurfaceBackgroundBundle,
     fileManagerBundle,
     trayBundleFixture(),
     singleInstanceBundleFixture(),
@@ -7494,7 +7532,7 @@ test("missing icon asset skips only icon patches", () => {
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),
@@ -7543,7 +7581,7 @@ test("patchExtractedApp scans current Computer Use settings bundles when UI is e
         [
           mainBundlePrefix,
           "process.platform===`win32`&&k.removeMenu(),",
-          alreadyOpaqueBackgroundBundle,
+          currentOpaqueWindowSurfaceBackgroundBundle,
           fileManagerBundle,
           trayBundleFixture(),
           singleInstanceBundleFixture(),
@@ -7625,7 +7663,7 @@ test("patchExtractedApp records a structured patch report", () => {
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),
@@ -8250,7 +8288,7 @@ test("patcher CLI writes --report-json output", () => {
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),
@@ -8529,7 +8567,7 @@ test("patcher CLI --enforce-critical exits non-zero with an aggregated message",
       [
         mainBundlePrefix,
         "process.platform===`win32`&&k.removeMenu(),",
-        alreadyOpaqueBackgroundBundle,
+        currentOpaqueWindowSurfaceBackgroundBundle,
         fileManagerBundle,
         trayBundleFixture(),
         singleInstanceBundleFixture(),

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -93,7 +93,6 @@ const {
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxSettingsPersistencePatch,
-  applyLinuxTrayCloseSettingPatch,
 } = require("./patches/impl/launch-actions.js");
 const {
   applyLinuxMultiInstanceBootstrapPatch,
@@ -177,6 +176,8 @@ const {
 
 const mainBundlePrefix =
   "let s=require(`node:url`),n=require(`electron`);n=e.o(n);let i=require(`node:path`);i=e.o(i);let o=require(`node:fs`);o=e.o(o);";
+const currentMainBundlePrefix =
+  "const e={o:e=>e};let s=require(`node:url`),c=require(`electron`);c=e.o(c);let l=require(`node:os`);l=e.o(l);let u=require(`node:path`);u=e.o(u);let d=require(`node:util`),f=require(`node:crypto`),p=require(`node:fs`);p=e.o(p);";
 const workerBundlePrefix =
   "let i=require(`node:path`),o=require(`node:fs`);";
 const fileManagerBundle =
@@ -868,7 +869,6 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-local-app-server-feature-enablement-handler",
     "linux-remote-control-config-preservation",
     "linux-app-updater-menu",
-    "linux-tray-close-setting",
     "linux-settings-persistence",
     "linux-launch-actions",
     "linux-hotkey-window-prewarm",
@@ -1044,10 +1044,11 @@ test("subagent nickname metadata descriptor follows upstream metadata bundle nam
 function trayBundleFixture() {
   return [
     "async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let r=await Ww(e.buildFlavor,e.appBrand,e.repoRoot),i=new n.Tray(r.defaultIcon);return i})()))}",
-    "async function Ww(e,t,r){if(process.platform===`darwin`){let e=n.nativeImage.createFromPath(r);return e.isEmpty()?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`normal`}),chronicleRunningIcon:null}:{defaultIcon:e,chronicleRunningIcon:null}}let a=Nw(e,t,r);return a==null?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:a,chronicleRunningIcon:null}}",
+    "async function Ww(e,t,i){if(process.platform===`darwin`){return null}let r=K9(e,t,i);return r==null?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:r,chronicleRunningIcon:null}}",
+    "function K9(e,t,r){let a=[(0,i.join)(r,`electron`,`src`,`icons`,`tray.png`)];for(let e of a){let t=n.nativeImage.createFromPath(e);if(!t.isEmpty())return t}return null}",
     "var pb=class{trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(){this.tray={on(){},setContextMenu(){},popUpContextMenu(){}};this.onTrayButtonClick=()=>{};this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}async handleMessage(e){switch(e.type){case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return}}openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}updateChronicleTrayIcon(){}getNativeTrayMenuItems(){return[]}}",
-    "v&&k.on(`close`,e=>{this.persistPrimaryWindowBounds(k,f);let t=this.getPrimaryWindows(f).some(e=>e!==k);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}if(process.platform===`darwin`&&!this.isAppQuitting&&!t){e.preventDefault(),k.hide()}});",
-    "let E=process.platform===`win32`;E&&oe();",
+    "v&&k.on(`close`,e=>{this.persistPrimaryWindowBounds(k);let t=this.getPrimaryWindows().some(e=>e!==k);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}if(process.platform===`darwin`&&!this.isAppQuitting&&!t){e.preventDefault(),k.hide()}});",
+    "let oe=async()=>{O=!0;try{await Hw({appBrand:a.U(),buildFlavor:b,repoRoot:j.repoRoot})}catch(e){O=!1,v.reportNonFatal(e instanceof Error?e:`Failed to set up tray`,{kind:`tray-setup-failed`,tags:{errorType:`tray-setup-failed`}}),N.ensureWindow()}};E&&oe();",
   ].join("");
 }
 
@@ -1548,29 +1549,23 @@ function currentBootstrapUpdaterBundleWithAppUpdateStateBroadcastFixture() {
   ].join("");
 }
 
-function avatarOverlayBundleFixture() {
-  return currentAvatarOverlayBundleFixture();
-}
-
-function currentAvatarOverlayBundleFixture() {
+function latestAvatarOverlayBundleFixture() {
   return [
-    "let a=require(`electron`),f=require(`node:child_process`);",
-    "var rV=`/avatar-overlay`,zB={width:356,height:320},oV={width:112,height:121},k2={width:0,height:0},O2={width:276,height:131};",
-    "var h2=class{constructor(e,t,n,r){this.cursorSource=e;this.pointerAnchorX=t;this.pointerAnchorY=n;this.displayBounds=r}recordMovementIntent(){this.hasMovementIntent=!0}getCursorPointForSource(){return null}shouldSuppressRendererThrow(){return!1}updateDisplayBounds(e){this.displayBounds=e}};",
-    "var fV=class{window=null;rendererReady=!1;layout=null;mascotSize=oV;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;windowStagedForNativePresentation=!1;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1},getCursorPosition(){return null}};nativePositionController={clear(){}};",
-    "constructor(e,t){this.windowManager=e,this.globalState=t}",
-    "isOpen(){let e=this.window;return e!=null&&!e.isDestroyed()&&e.isVisible()&&!this.windowStagedForNativePresentation}",
-    "setPointerInteraction(e,t){let n=this.window;n==null||n.isDestroyed()||n.webContents.id!==e||(this.pointerInteractive=t,this.movedWindowPersistTimer??this.applyPointerInteractivityPolicy())}",
-    "startDrag(e,t){let n=this.window;if(n==null||n.isDestroyed()||n.webContents.id!==e)return;this.cancelMomentum(),this.suppressNextRendererThrow=!1,this.clearDetachedDisplayRestore();let r=this.getLayout(n);this.nativePositionController.clear();let i=V2(this.compositionHost.getCursorPosition()),o=t.pointerScreenX!=null&&t.pointerScreenY!=null?{x:t.pointerScreenX,y:t.pointerScreenY}:a.screen.getCursorScreenPoint(),s=i??o,c=t.pointerWindowX-r.mascot.left,l=t.pointerWindowY-r.mascot.top;this.dragState=new h2(i==null?`renderer`:`native`,c,l,a.screen.getDisplayNearestPoint(s).bounds)}",
-    "moveDrag(e){return e}",
-    "endDrag(e,t){let n=this.window;if(n==null||n.isDestroyed()||n.webContents.id!==e)return;let r=this.dragState,i=this.windowServerDragActive,a=null;this.suppressNextRendererThrow=r?.shouldSuppressRendererThrow()??!1,this.dragState=null,this.windowServerDragActive=!1,i?this.persistWindowBounds(n,a??this.getCurrentDisplay()):this.reclampWindowToVisibleDisplay({shouldPersist:!0});let o=this.dockTarget}",
-    "setElementSize(e,{elementSizeRevision:t,isTrayVisible:n,mascot:r,nativeCompositionEnabled:a,tray:o}){let i=this.window;i==null||i.isDestroyed()||i.webContents.id!==e||(this.cancelMomentum(),this.layoutMode=n==null?`native`:`legacy`,this.mascotSize=r,this.traySize=o,this.applyLatestElementSizes(i),this.stageWindowForNativePresentation(i),this.showWindowIfReady(i))}",
-    "applyLatestElementSizes(e){this.anchor={...this.anchor,width:this.mascotSize.width,height:this.mascotSize.height},this.applyLayout(e)}",
-    "async createWindow(e){let t=await this.windowManager.createWindow({title:a.app.getName(),width:zB.width,height:zB.height,appearance:`avatarOverlay`,focusable:!1,show:!1,initialRoute:rV});return this.window=t,this.compositionHost.setOverlayWindow(t),this.rendererReady=this.windowManager.isWebContentsReady(t.webContents.id),this.clearDetachedDisplayRestore(),this.displayBounds=null,this.displayId=null,this.dragState=null,this.layout=null,this.mascotSize=oV,this.mousePassthroughEnabled=!1,this.traySize=null,t.on(`closed`,()=>{this.window===t&&(this.cancelMomentum(),this.clearMovedWindowPersist(),this.window=null,this.dragState=null,this.layout=null,this.rendererReady=!1,this.pointerInteractive=!1,this.mousePassthroughEnabled=!1,this.compositionHost.setOverlayWindow(null),this.broadcastOpenState())}),t}",
-    "applyLayout(e,t=this.getCurrentDisplay(),n=!1,r=!0,i=null){if(e.isDestroyed())return;let o=this.getLayoutForDisplay(t);this.displayId=t.id,this.layout=o,this.setWindowBounds(e,o.windowBounds,n,r),this.compositionHost.updateMascotRect(o.mascot),this.sendLayoutToRenderer(e,i)}getLayoutForDisplay(e){return UB({anchor:this.anchor,displayBounds:this.layoutMode===`native`?e.workArea:e.bounds,mode:this.layoutMode,mascotSize:this.mascotSize,nativeMaterialAttached:this.compositionHost.isNativeMaterialAttached(),previousPlacement:this.placement,traySize:this.traySize??(this.layoutMode===`native`?k2:O2)})}getLayout(e){if(this.layout??this.applyLayout(e),this.layout==null)throw Error(`Expected avatar overlay layout`);return this.layout}",
-    "showWindow(e){if(e.isDestroyed())return;let t=this.isOpen();this.windowStagedForNativePresentation&&=(e.setOpacity(1),!1),e.moveTop(),e.showInactive(),!t&&this.isOpen()&&(this.finishPendingPresentation(),this.broadcastOpenState())}showWindowIfReady(e){!this.rendererReady||this.initialPresentationState!==`ready`||(this.showWindow(e),this.applyPointerInteractivityPolicy())}stageWindowForNativePresentation(e){e.isDestroyed()||this.applyPointerInteractivityPolicy()}broadcastOpenState(){this.windowManager.sendMessageToAllRegisteredWindows({type:`avatar-overlay-open-state-changed`,isOpen:this.isOpen()})}",
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}setComputerUseCursorLocation(e){this.computerUseCursorLocation=e}refreshCursorAtCurrentMousePosition(e){let t=a.screen.getCursorScreenPoint()}};",
-    "function V2(e){return e==null?null:{x:e.pointerScreenX,y:e.pointerScreenY}}function H2(e){return`${e.width}x${e.height}`}",
+    "let c=require(`electron`),h=require(`node:child_process`);",
+    "var d5=`/avatar-overlay`,of={width:356,height:320},m5={width:112,height:121},y5={width:0,height:0},v5={width:276,height:131};",
+    "var fV=class{window=null;layout=null;mascotSize=m5;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1},getCursorPosition(){return null},performWindowDrag(){return!1},updateMascotRect(){},publishRemoteHostedPIPContentHost(){}};nativePositionController={clear(){}};",
+    "startDrag(e,t,n=!1){let r=this.window;if(r==null||r.isDestroyed()||r.webContents.id!==e)return;this.cancelMomentum();let i=this.getLayout(r),a=this.compositionHost.getCursorPosition(),o=t.pointerScreenX!=null?{x:t.pointerScreenX,y:t.pointerScreenY}:c.screen.getCursorScreenPoint();this.dragState=new a5(a==null?`renderer`:`native`,t.pointerWindowX-i.mascot.left,t.pointerWindowY-i.mascot.top,c.screen.getDisplayNearestPoint(o).bounds,n),this.windowServerDragActive=this.layoutMode===`native`&&!n&&this.compositionHost.performWindowDrag(),this.windowServerDragActive||(this.windowServerDragWindowX=null)}",
+    "endDrag(e,t){let n=this.window;if(n==null||n.isDestroyed()||n.webContents.id!==e)return;let r=this.dragState,i=this.windowServerDragActive,a=null;this.dragState=null,this.windowServerDragActive=!1,this.windowServerDragWindowX=null,i?this.persistWindowBounds(n,a??this.getCurrentDisplay()):this.reclampWindowToVisibleDisplay({shouldPersist:!0});let o=this.dockTarget;o!=null&&this.dockPresentation(o.anchor,o.onDock)}",
+    "setElementSize(e,{elementSizeRevision:t,isTrayVisible:n,mascot:r,nativeCompositionEnabled:i,tray:a}){let o=this.window;if(o==null||o.isDestroyed()||o.webContents.id!==e)return;this.mascotSize=r,this.traySize=a,this.applyLatestElementSizes(o),this.stageWindowForNativePresentation(o),this.showWindowIfReady(o)}",
+    "async createWindow(){let e=await this.windowManager.createWindow({title:c.app.getName(),width:of.width,height:of.height,appearance:`avatarOverlay`,focusable:!1,show:!1,initialRoute:d5});return this.window=e,this.compositionHost.setOverlayWindow(e),this.dragState=null,this.layout=null,this.mousePassthroughEnabled=!1,this.traySize=null,e.on(`closed`,()=>{if(this.window!==e)return;let t=this.presentationVisibility!=null;this.cancelMomentum(),this.clearMovedWindowPersist(),this.window=null,this.dragState=null,this.pointerInteractive=!1,this.mousePassthroughEnabled=!1,this.compositionHost.setOverlayWindow(null),this.broadcastOpenState()}),e}",
+    "getLayoutForDisplay(e){return pf({anchor:this.anchor,displayBounds:this.layoutMode===`native`?e.workArea:e.bounds,mode:this.layoutMode,mascotSize:this.mascotSize,nativeMaterialAttached:this.compositionHost.isNativeMaterialAttached(),previousPlacement:this.placement,traySize:this.traySize??(this.layoutMode===`native`?y5:v5)})}",
+    "applyLayout(e,t=this.getCurrentDisplay(),n=!1,r=!0,i=null){if(e.isDestroyed())return;let a=this.getLayoutForDisplay(t);this.layout=a,this.setWindowBounds(e,a.windowBounds,n,r),this.compositionHost.updateMascotRect(a.mascot),this.sendLayoutToRenderer(e,i),this.computerUseCursorLocation!=null&&this.dragState==null&&this.sendComputerUseCursorLocationToRenderer(e)}",
+    "showWindow(e){if(e.isDestroyed())return;let t=this.isOpen();e.moveTop(),e.showInactive(),this.compositionHost.publishRemoteHostedPIPContentHost(),!t&&this.isOpen()&&this.broadcastOpenState()}",
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}",
+    "setComputerUseCursorLocation(e){this.computerUseCursorLocation=e,this.computerUseCursorPoint=e.isActive?{x:e.x,y:e.y}:null}",
+    "sendComputerUseCursorLocationToRenderer(e){this.windowManager.sendMessageToWebContents(e.webContents,{type:`avatar-overlay-computer-use-cursor-changed`})}",
+    "refreshCursorAtCurrentMousePosition(e){let t=c.screen.getCursorScreenPoint();return this.sendCursorPointToAvatarOverlay(e,t,!1)}",
+    "};",
   ].join("");
 }
 
@@ -1895,8 +1890,8 @@ test("registers local app-server feature enablement in internal and Electron han
   );
 });
 
-test("adds the Linux quit guard to the current module prelude", () => {
-  const source = mainBundlePrefix;
+test("adds the Linux quit guard to the current comma-declared Electron prelude", () => {
+  const source = currentMainBundlePrefix;
 
   const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
 
@@ -1906,11 +1901,33 @@ test("adds the Linux quit guard to the current module prelude", () => {
   assert.match(patched, /codexLinuxPrepareForExplicitQuit=\(\)=>\{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress\(\)\}/);
   assert.match(patched, /codexLinuxShouldBypassQuitPrompt=\(\)=>codexLinuxExplicitQuitApproved===!0/);
   assert.match(patched, /codexLinuxIsQuitInProgress=\(\)=>codexLinuxQuitInProgress===!0/);
+});
+
+test("keeps the current Linux quit guard module-scoped after helper declarations", () => {
+  const source = `function upstreamHelper(){return!0}${currentMainBundlePrefix}`;
+
+  const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
+
+  assert.match(patched, /p=e\.o\(p\);let codexLinuxQuitInProgress=!1/);
+  assert.match(patched, /codexLinuxExplicitQuitApproved=!1/);
+  assert.match(patched, /codexLinuxPrepareForExplicitQuit=\(\)=>\{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress\(\)\}/);
+  assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
+});
+
+test("adds the Linux quit guard for the current interleaved bundler prelude", () => {
+  const source = `${currentMainBundlePrefix}let m=require(\`node:fs/promises\`);`;
+
+  const patched = applyPatchTwice(applyLinuxQuitGuardPatch, source);
+
+  assert.match(patched, /let m=require\(`node:fs\/promises`\);/);
+  assert.match(patched, /p=e\.o\(p\);let codexLinuxQuitInProgress=!1/);
+  assert.match(patched, /codexLinuxExplicitQuitApproved=!1/);
+  assert.match(patched, /codexLinuxPrepareForExplicitQuit=\(\)=>\{codexLinuxExplicitQuitApproved=!0,codexLinuxMarkQuitInProgress\(\)\}/);
   assert.equal((patched.match(/codexLinuxQuitInProgress=!1/g) ?? []).length, 1);
 });
 
 test("bypasses the upstream before-quit confirmation after a Linux explicit quit", () => {
-  const source = `${mainBundlePrefix}${beforeQuitConfirmationBundleFixture()}`;
+  const source = `${currentMainBundlePrefix}${beforeQuitConfirmationBundleFixture()}`;
   const patched = applyPatchTwice(
     applyLinuxExplicitQuitPromptBypassPatch,
     applyLinuxQuitGuardPatch(source),
@@ -1927,7 +1944,7 @@ test("bypasses the upstream before-quit confirmation after a Linux explicit quit
 });
 
 test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
-  const source = `${mainBundlePrefix}${willQuitDrainBundleFixture()}`;
+  const source = `${currentMainBundlePrefix}${willQuitDrainBundleFixture()}`;
   const patched = applyPatchTwice(
     applyLinuxWillQuitDrainTimeoutPatch,
     applyLinuxQuitGuardPatch(source),
@@ -1942,7 +1959,7 @@ test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
 });
 
 test("marks Linux quit-in-progress for the tray quit path", () => {
-  const source = `${mainBundlePrefix}${explicitQuitBundleFixture()}`;
+  const source = `${currentMainBundlePrefix}${explicitQuitBundleFixture()}`;
   const patched = applyPatchTwice(
     applyLinuxExplicitTrayQuitPatch,
     applyLinuxQuitGuardPatch(source),
@@ -1955,7 +1972,7 @@ test("marks Linux quit-in-progress for the tray quit path", () => {
 });
 
 test("marks Linux quit-in-progress for the quit-app IPC path", () => {
-  const source = `${mainBundlePrefix}${explicitQuitBundleFixture()}`;
+  const source = `${currentMainBundlePrefix}${explicitQuitBundleFixture()}`;
   const patched = applyPatchTwice(
     applyLinuxExplicitIpcQuitPatch,
     applyLinuxQuitGuardPatch(source),
@@ -2029,14 +2046,80 @@ test("patches remaining explicit quit handlers when another copy is already patc
   );
 });
 
-test("uses the current combined quick-chat and primary Linux titlebar overlay", () => {
+test("uses the frameless native Codex titlebar for primary Linux windows", () => {
   const source = [
-    "function L9({platform:e,appearance:t,opaqueWindowSurfaceEnabled:n,prefersDarkColors:r}){return n?{backgroundColor:r?_ne:vne,backgroundMaterial:e===`win32`?`none`:null}:e===`win32`?{backgroundColor:k9,backgroundMaterial:`mica`}:{backgroundColor:k9,backgroundMaterial:null}}",
-    "function j9(e=1){return{color:k9,symbolColor:c.nativeTheme.shouldUseDarkColors?Ane:kne,height:Math.round(One*e)}}",
-    "function z9({appearance:e,opaqueWindowSurfaceEnabled:t,platform:n,windowZoom:r=1}){switch(e){case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:j9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};case`secondary`:return{titleBarStyle:`default`}}}",
-    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
-    "process.platform===`darwin`?n.setWindowButtonPosition(A9(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(j9(t)))",
-    "process.platform===`darwin`?o.setWindowButtonPosition(A9(i)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(o.id,i),o.setTitleBarOverlay(j9(i)))",
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxNativeTitlebarPatch, source);
+
+  assert.match(
+    patched,
+    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:a\.nativeTheme\.shouldUseDarkColors\?`#111111`:o2,symbolColor:a\.nativeTheme\.shouldUseDarkColors\?v2:_2,height:Math\.round\(30\*e\)\}\}/,
+  );
+  assert.match(
+    patched,
+    /titleBarOverlay:n===`linux`\?codexLinuxTitleBarOverlay\(r\):b2\(r\),\.\.\.e===`quickChat`/,
+  );
+  assert.match(patched, /\.\.\.t\?\{\}:\{vibrancy:`menu`\}/);
+  assert.doesNotMatch(patched, /titleBarOverlay:b2\(r\),\.\.\.e===`quickChat`/);
+});
+
+test("uses a module-scoped Linux native titlebar helper when aliases shadow Electron", () => {
+  const source = [
+    "function A3(e){return e===`avatarOverlay`}",
+    "function I3({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A3(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?L4:K4,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A3(t)?{backgroundColor:r?L4:K4,backgroundMaterial:null}:{backgroundColor:W4,backgroundMaterial:null}}",
+    "function o3(e=1){return{color:W4,symbolColor:r.nativeTheme.shouldUseDarkColors?i3:r3,height:Math.round(g3*e)}}",
+    "function T3({appearance:e,opaqueWindowSurfaceEnabled:t,platform:n,windowZoom:r=1}){switch(e){case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:a3(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:o3(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};}}",
+  ].join("");
+  const { value, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxNativeTitlebarPatch, source),
+  );
+
+  assert.match(
+    value,
+    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:r\.nativeTheme\.shouldUseDarkColors\?`#111111`:K4,symbolColor:r\.nativeTheme\.shouldUseDarkColors\?i3:r3,height:Math\.round\(30\*e\)\}\}/,
+  );
+  assert.match(
+    value,
+    /titleBarOverlay:n===`linux`\?codexLinuxTitleBarOverlay\(r\):o3\(r\),\.\.\.e===`quickChat`/,
+  );
+  assert.doesNotMatch(value, /titleBarOverlay:\{color:r\.nativeTheme\.shouldUseDarkColors/);
+  assert.deepEqual(warnings, []);
+});
+
+test("updates the Linux native titlebar overlay when nativeTheme changes", () => {
+  const source = [
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(b2(this.windowZooms.get(e.id)))};return a.nativeTheme.on(`updated`,n),n(),()=>{a.nativeTheme.off(`updated`,n)}}",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxNativeTitlebarPatch, source);
+
+  assert.match(
+    patched,
+    /if\(process\.platform!==`win32`&&process\.platform!==`linux`\|\|t!==`primary`&&t!==`quickChat`\)return/,
+  );
+  assert.match(
+    patched,
+    /e\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(e\.id\)\):b2\(this\.windowZooms\.get\(e\.id\)\)\)/,
+  );
+  assert.doesNotMatch(patched, /webContents\.executeJavaScript\(/);
+  assert.doesNotMatch(patched, /data-codex-window-type/);
+});
+
+test("redirects the renamed Linux-aware titlebar overlay sync away from the transparent win32 helper", () => {
+  const source = [
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(b2(this.windowZooms.get(e.id)))};return a.nativeTheme.on(`updated`,n),n(),()=>{a.nativeTheme.off(`updated`,n)}}",
+    "process.platform===`darwin`?n.setWindowButtonPosition(y2(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(b2(t)))",
   ].join("");
   const { value: patched, warnings } = captureWarns(() =>
     applyPatchTwice(applyLinuxNativeTitlebarPatch, source),
@@ -2044,26 +2127,45 @@ test("uses the current combined quick-chat and primary Linux titlebar overlay", 
 
   assert.match(
     patched,
-    /function codexLinuxTitleBarOverlay\(e=1\)\{return\{color:c\.nativeTheme\.shouldUseDarkColors\?`#111111`:vne,symbolColor:c\.nativeTheme\.shouldUseDarkColors\?Ane:kne,height:Math\.round\(30\*e\)\}\}/,
+    /titleBarOverlay:n===`linux`\?codexLinuxTitleBarOverlay\(r\):b2\(r\),\.\.\.e===`quickChat`/,
   );
   assert.match(
     patched,
-    /n===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay\(r\),\.\.\.e===`quickChat`/,
+    /installApplicationMenuTitleBarOverlaySync\(e,t\)\{if\(process\.platform!==`win32`&&process\.platform!==`linux`\|\|t!==`primary`&&t!==`quickChat`\)return/,
   );
   assert.match(
     patched,
-    /e\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(e\.id\)\):j9\(this\.windowZooms\.get\(e\.id\)\)\)/,
+    /e\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(e\.id\)\):b2\(this\.windowZooms\.get\(e\.id\)\)\)/,
   );
   assert.match(
     patched,
-    /n\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(t\):j9\(t\)\)/,
+    /n\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(t\):b2\(t\)\)/,
   );
+  assert.doesNotMatch(patched, /setTitleBarOverlay\(b2\(/);
+  assert.deepEqual(warnings, []);
+});
+
+
+test("updates every Linux zoom titlebar overlay refresh call site", () => {
+  const source = [
+    "function A2(e){return e===`avatarOverlay`}",
+    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
+    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(b2(this.windowZooms.get(e.id)))};return a.nativeTheme.on(`updated`,n),n(),()=>{a.nativeTheme.off(`updated`,n)}}",
+    "process.platform===`darwin`?n.setWindowButtonPosition(y2(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(b2(t)))",
+    "process.platform===`darwin`?o.setWindowButtonPosition(y2(i)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(o.id,i),o.setTitleBarOverlay(b2(i)))",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxNativeTitlebarPatch, source);
+
   assert.equal(
     (patched.match(/setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay/g) ?? []).length,
     3,
   );
-  assert.doesNotMatch(patched, /setTitleBarOverlay\(j9\(/);
-  assert.deepEqual(warnings, []);
+  assert.doesNotMatch(
+    patched,
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\([^)]+\),[A-Za-z_$][\w$]*\.setTitleBarOverlay\(b2\([^)]+\)\)\)/,
+  );
 });
 
 test("adds a right-side safe area for Linux window controls in application menu chrome", () => {
@@ -2421,7 +2523,7 @@ test("warns when the skills hook is recognizable but the flatten shape drifted",
 test("adds Linux avatar overlay mouse passthrough recovery", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,
-    avatarOverlayBundleFixture(),
+    latestAvatarOverlayBundleFixture(),
   );
 
   assert.match(patched, /codexLinuxAvatarPassthroughRecoveryTimer/);
@@ -2434,16 +2536,17 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /process\.env\.I3SOCK/);
   assert.match(patched, /codexLinuxApplyAvatarCompositorHints\(e\)/);
   assert.match(patched, /getNativeWindowHandle\?\.\(\)/);
-  assert.match(patched, /f\.execFile\(`xdotool`,\[`search`,`--pid`,String\(process\.pid\)\]/);
-  assert.match(patched, /f\.execFile\(`xwininfo`,\[`-id`,e\]/);
-  assert.match(patched, /f\.execFile\(`xprop`/);
+  assert.match(patched, /h\.execFile\(`xdotool`,\[`search`,`--pid`,String\(process\.pid\)\]/);
+  assert.match(patched, /h\.execFile\(`xwininfo`,\[`-id`,e\]/);
+  assert.match(patched, /h\.execFile\(`xprop`/);
   assert.match(patched, /_GTK_FRAME_EXTENTS/);
   assert.match(patched, /Override Redirect State/);
   assert.match(patched, /Absolute upper-left X/);
-  assert.match(patched, /Number\(l\)!==t\.x/);
-  assert.match(patched, /Number\(h\)!==t\.y/);
-  assert.match(patched, /Number\(d\)!==t\.width/);
-  assert.doesNotMatch(patched, /let\[,l,u,d,f\]=c/);
+  assert.match(patched, /Number\(__codexAvatarX\)!==t\.x/);
+  assert.match(patched, /Number\(__codexAvatarY\)!==t\.y/);
+  assert.match(patched, /Number\(__codexAvatarWidth\)!==t\.width/);
+  assert.match(patched, /Number\(__codexAvatarHeight\)!==t\.height/);
+  assert.doesNotMatch(patched, /let\[,l,h,d,f\]=c/);
   assert.doesNotMatch(patched, /this\.codexLinuxIsI3Session\(\)\)\{this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.pointerInteractive=!0,this\.mousePassthroughEnabled&&\(this\.mousePassthroughEnabled=!1\),e\.setIgnoreMouseEvents\(!1\);return\}/);
   assert.match(patched, /if\(this\.codexLinuxIsAvatarShapeBackend\(\)&&typeof e\.setShape==`function`\)\{/);
   assert.match(patched, /if\(this\.codexLinuxIsAvatarShapeBackend\(\)&&typeof e\.setShape==`function`\)\{this\.codexLinuxStartAvatarPassthroughRecovery\(\),/);
@@ -2469,21 +2572,21 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.doesNotMatch(patched, /let r=r\.screen\.getCursorScreenPoint\(\)/);
   assert.match(patched, /catch\{t=!0\}/);
   assert.match(patched, /this\.pointerInteractive=t/);
-  assert.match(patched, /this\.dragState=new h2\(i==null\?`renderer`:`native`,c,l,a\.screen\.getDisplayNearestPoint\(s\)\.bounds\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/);
-  assert.match(patched, /:this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\);process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\);let o=/);
-  assert.match(patched, /this\.applyLatestElementSizes\(i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
-  assert.match(patched, /this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.compositionHost\.setOverlayWindow\(t\)/);
-  assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`&&this\.codexLinuxIsI3Session\(\)\?this\.traySize:this\.traySize\?\?\(this\.layoutMode===`native`\?k2:O2\)/);
-  assert.match(patched, /this\.sendLayoutToRenderer\(e,i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
+  assert.match(patched, /this\.windowServerDragActive\|\|\(this\.windowServerDragWindowX=null\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)\}endDrag\(e,t\)/);
+  assert.match(patched, /this\.dockPresentation\(o\.anchor,o\.onDock\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}setElementSize/);
+  assert.match(patched, /this\.applyLatestElementSizes\(o\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
+  assert.match(patched, /this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.compositionHost\.setOverlayWindow\(e\)/);
+  assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`&&this\.codexLinuxIsI3Session\(\)\?this\.traySize:this\.traySize\?\?\(this\.layoutMode===`native`\?y5:v5\)/);
+  assert.match(patched, /this\.sendComputerUseCursorLocationToRenderer\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}showWindow/);
   assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.doesNotMatch(patched, /codexLinuxRecoverAvatarPointerInteractivity/);
-  assert.match(patched, /this\.window===t&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
+  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
 });
 
 test("keeps Linux avatar overlay above the app while reply inputs are focusable", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,
-    avatarOverlayBundleFixture(),
+    latestAvatarOverlayBundleFixture(),
   );
 
   assert.match(
@@ -2502,7 +2605,7 @@ test("keeps Linux avatar overlay above the app while reply inputs are focusable"
 test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
   const patched = applyPatchTwice(
     applyLinuxAvatarOverlayMousePassthroughPatch,
-    avatarOverlayBundleFixture(),
+    latestAvatarOverlayBundleFixture(),
   );
   const cursor = { x: 5843, y: 1036 };
   let ozonePlatform = "";
@@ -2517,15 +2620,8 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
       if (moduleName === "node:child_process") {
         return { execFile() {} };
       }
-      if (moduleName === "electron") {
-        return context.a;
-      }
-      throw new Error(`Unexpected module: ${moduleName}`);
-    },
-    pV(bounds) {
-      return bounds;
-    },
-    a: {
+      assert.equal(moduleName, "electron");
+      return {
       app: {
         getName: () => "Codex",
         commandLine: { getSwitchValue: () => ozonePlatform },
@@ -2534,6 +2630,7 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
         getCursorScreenPoint: () => cursor,
         getDisplayNearestPoint: () => ({ bounds: { x: 0, y: 0, width: 800, height: 600 } }),
       },
+      };
     },
   };
   vm.runInNewContext(`${patched};globalThis.AvatarOverlayController=fV;`, context);
@@ -2606,45 +2703,53 @@ test("Linux avatar overlay interactivity is bounded to avatar regions", () => {
   assert.equal(setShapeCalls, 1);
   ozonePlatform = "wayland";
   assert.equal(controller.codexLinuxIsAvatarShapeBackend(), false);
+  ozonePlatform = "x11";
+  let failingBoundsCalls = 0;
   assert.equal(
     controller.codexLinuxApplyAvatarInputShape({
       isDestroyed: () => false,
       getContentBounds: () => {
+        failingBoundsCalls += 1;
         throw new Error("drift");
       },
       setShape() {},
     }),
     false,
   );
+  assert.equal(failingBoundsCalls, 1);
+  controller.codexLinuxAvatarInputShapeKey = null;
+  let failingSetShapeCalls = 0;
   assert.equal(
     controller.codexLinuxApplyAvatarInputShape({
       isDestroyed: () => false,
       getContentBounds: () => ({ x: 5743, y: 936, width: 356, height: 320 }),
       setShape() {
+        failingSetShapeCalls += 1;
         throw new Error("unsupported");
       },
     }),
     false,
   );
+  assert.equal(failingSetShapeCalls, 1);
 });
 
-test("keeps avatar overlay interactivity working after native presentation drift", () => {
+test("patches the latest avatar overlay class without depending on adjacent methods", () => {
   const { value: patched, warnings } = captureWarns(() =>
     applyPatchTwice(
       applyLinuxAvatarOverlayMousePassthroughPatch,
-      currentAvatarOverlayBundleFixture(),
+      latestAvatarOverlayBundleFixture(),
     ),
   );
 
   assert.deepEqual(warnings, []);
-  assert.match(patched, /this\.applyLatestElementSizes\(i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
-  assert.match(patched, /this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.compositionHost\.setOverlayWindow\(t\)/);
-  assert.match(patched, /this\.dragState=new h2\(i==null\?`renderer`:`native`,c,l,a\.screen\.getDisplayNearestPoint\(s\)\.bounds\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/);
-  assert.match(patched, /:this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\);process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\);let o=/);
-  assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`&&this\.codexLinuxIsI3Session\(\)\?this\.traySize:this\.traySize\?\?\(this\.layoutMode===`native`\?k2:O2\)/);
-  assert.match(patched, /this\.sendLayoutToRenderer\(e,i\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
-  assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\),!t&&this\.isOpen\(\)&&\(this\.finishPendingPresentation\(\),this\.broadcastOpenState\(\)\)\}showWindowIfReady/);
-  assert.match(patched, /this\.cancelMomentum\(\),this\.clearMovedWindowPersist\(\),this\.window=null/);
+  assert.match(patched, /codexLinuxIsI3Session\(\)/);
+  assert.match(patched, /setComputerUseCursorLocation\(e\)\{this\.computerUseCursorLocation=e/);
+  assert.match(patched, /sendComputerUseCursorLocationToRenderer\(e\)\{this\.windowManager\.sendMessageToWebContents/);
+  assert.match(patched, /this\.windowServerDragActive=!1[\s\S]*?process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}setElementSize/);
+  assert.match(patched, /this\.applyLatestElementSizes\(o\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
+  assert.match(patched, /this\.compositionHost\.updateMascotRect\(a\.mascot\)[\s\S]*?process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}showWindow/);
+  assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\)/);
+  assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`/);
 });
 
 test("scopes avatar overlay method matching away from unrelated earlier classes", () => {
@@ -2654,7 +2759,7 @@ test("scopes avatar overlay method matching away from unrelated earlier classes"
   const { value: patched, warnings } = captureWarns(() =>
     applyPatchTwice(
       applyLinuxAvatarOverlayMousePassthroughPatch,
-      `${unrelatedClass}${currentAvatarOverlayBundleFixture()}`,
+      `${unrelatedClass}${latestAvatarOverlayBundleFixture()}`,
     ),
   );
 
@@ -2665,16 +2770,16 @@ test("scopes avatar overlay method matching away from unrelated earlier classes"
   );
   assert.match(
     patched,
-    /this\.dragState=new h2\(i==null\?`renderer`:`native`,c,l,a\.screen\.getDisplayNearestPoint\(s\)\.bounds\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/,
+    /this\.windowServerDragActive\|\|\(this\.windowServerDragWindowX=null\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/,
   );
 });
 
 test("bounds avatar overlay method matching to the overlay class body", () => {
   const unrelatedClass =
     "var Other=class{startDrag(e,t){this.dragState={fake:!0}}endDrag(e,t){this.dragState=null,this.reclampWindowToVisibleDisplay({shouldPersist:!0})}setElementSize(e,{mascot:t,tray:n}){this.applyLayout(e)}applyLayout(e){this.setWindowBounds(e,o.windowBounds),this.sendLayoutToRenderer(e)}showWindow(e){e.moveTop(),e.showInactive(),this.broadcastOpenState()}};";
-  const source = currentAvatarOverlayBundleFixture().replace(
-    "var h2=class",
-    `${unrelatedClass}var h2=class`,
+  const source = latestAvatarOverlayBundleFixture().replace(
+    "var fV=class",
+    `${unrelatedClass}var fV=class`,
   );
 
   const { value: patched, warnings } = captureWarns(() =>
@@ -2688,7 +2793,7 @@ test("bounds avatar overlay method matching to the overlay class body", () => {
   assert.equal(patched.includes(unrelatedClass), true);
   assert.match(
     patched,
-    /this\.dragState=new h2\(i==null\?`renderer`:`native`,c,l,a\.screen\.getDisplayNearestPoint\(s\)\.bounds\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/,
+    /this\.windowServerDragActive\|\|\(this\.windowServerDragWindowX=null\),process\.platform===`linux`&&\(this\.pointerInteractive=!0,this\.applyPointerInteractivityPolicy\(\)\)/,
   );
 });
 
@@ -2745,7 +2850,49 @@ test("adds Linux window icon handling to current Linux autoHideMenuBar options",
   assert.match(patched, new RegExp(`icon:${escapeRegExp(iconPathExpression)}`));
 });
 
-test("forces the current primary BrowserWindow to be focusable on Linux", () => {
+test("omits undefined BrowserWindow options in the current window manager bundle", () => {
+  const iconAsset = "app-test.png";
+  const source = [
+    "let M=new a.BrowserWindow({width:b,height:x,...S===void 0||C===void 0?{}:{x:S,y:C},",
+    "title:n??a.app.getName(),backgroundColor:A,show:l,parent:p,...m===void 0?{}:{focusable:m},",
+    "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k});",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, iconAsset);
+
+  assert.match(patched, /show:l,\.\.\.p===void 0\?\{\}:\{parent:p\},\.\.\.m===void 0\?\{\}:\{focusable:m\}/);
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\},\.\.\.D,\.\.\.T==null\?\{\}:\{minWidth:T\.width,minHeight:T\.height\},webPreferences:k/);
+  assert.doesNotMatch(patched, /show:l,parent:p,\.\.\.m===void 0/);
+  assert.doesNotMatch(patched, /backgroundMaterial:j\?\?void 0/);
+  assert.doesNotMatch(patched, /minWidth:T\?\.width/);
+});
+
+test("keeps the latest primary BrowserWindow focusable without an icon asset", () => {
+  const source = [
+    "async createWindow(e={}){let{appearance:c=`primary`,show:l=!0,parent:p,focusable:m}=e,",
+    "M=new a.BrowserWindow({width:b,height:x,title:n??a.app.getName(),backgroundColor:A,",
+    "show:l,parent:p,...m===void 0?{}:{focusable:m},",
+    "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, null);
+
+  assert.match(
+    patched,
+    /\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m===void 0\?\{\}:\{focusable:m\}/,
+  );
+  assert.match(
+    patched,
+    /\.\.\.process\.platform===`win32`\|\|process\.platform===`linux`\?\{autoHideMenuBar:!0\}:\{\}/,
+  );
+  assert.match(patched, /\.\.\.p===void 0\?\{\}:\{parent:p\}/);
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\}/);
+  assert.match(patched, /\.\.\.T==null\?\{\}:\{minWidth:T\.width,minHeight:T\.height\}/);
+});
+
+test("forces Linux primary BrowserWindow to be focusable", () => {
   const iconAsset = "app-test.png";
   const source = [
     "async createWindow(e={}){let{title:n,width:i=1280,height:o=820,appearance:c=`primary`,",
@@ -2760,9 +2907,80 @@ test("forces the current primary BrowserWindow to be focusable on Linux", () => 
 
   assert.match(
     patched,
-    /show:l,parent:p,\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m===void 0\?\{\}:\{focusable:m\}/,
+    /show:l,\.\.\.p===void 0\?\{\}:\{parent:p\},\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m===void 0\?\{\}:\{focusable:m\}/,
   );
-  assert.match(patched, /process\.platform===`linux`\?\{icon:process\.resourcesPath/);
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\},\.\.\.D/);
+  assert.doesNotMatch(patched, /show:l,parent:p,\.\.\.m===void 0/);
+});
+
+test("preserves nullish BrowserWindow option semantics", () => {
+  const source = [
+    "function makeOptions(j,T){let l=!0,p,m,D={},k={};return{show:l,parent:p,...m===void 0?{}:{focusable:m},",
+    "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},",
+    "backgroundMaterial:j??void 0,...D,minWidth:T?.width,minHeight:T?.height,webPreferences:k}}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, "app-test.png");
+  const makeOptions = new Function(
+    "process",
+    `${patched};return makeOptions`,
+  )({ platform: "linux", resourcesPath: "/tmp/resources" });
+  const options = makeOptions(null, null);
+
+  assert.match(patched, /\.\.\.j==null\?\{\}:\{backgroundMaterial:j\}/);
+  assert.match(
+    patched,
+    /\.\.\.T==null\?\{\}:\{minWidth:T\.width,minHeight:T\.height\}/,
+  );
+  assert.doesNotMatch(patched, /\.\.\.T===void 0/);
+  assert.equal("backgroundMaterial" in options, false);
+  assert.equal("minWidth" in options, false);
+  assert.equal("minHeight" in options, false);
+});
+
+test("ignores unrelated BrowserWindow focusable candidates while patching the primary window", () => {
+  const source = [
+    "new a.BrowserWindow({acceptFirstMouse:!0,focusable:!1,webPreferences:u});",
+    "async createWindow(e={}){let{title:n,appearance:c=`primary`,focusable:m}=e,",
+    "M=new a.BrowserWindow({width:b,height:x,title:n??a.app.getName(),...m===void 0?{}:{focusable:m},",
+    "...process.platform===`win32`?{autoHideMenuBar:!0}:process.platform===`linux`?{icon:process.resourcesPath+`/../content/webview/assets/app-test.png`}:{},webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, "app-test.png");
+
+  assert.match(patched, /acceptFirstMouse:!0,focusable:!1,webPreferences:u/);
+  assert.match(
+    patched,
+    /\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m===void 0\?\{\}:\{focusable:m\}/,
+  );
+});
+
+test("keeps current focusable destructuring valid while patching the BrowserWindow spread", () => {
+  const source = [
+    "async createWindow(e={}){let{title:n,width:i=1280,height:o=820,appearance:c=`primary`,",
+    "focusable:m}=e,M=new a.BrowserWindow({width:b,height:x,...m===void 0?{}:{focusable:m},",
+    "...process.platform===`win32`?{autoHideMenuBar:!0}:process.platform===`linux`?{icon:process.resourcesPath+`/../content/webview/assets/app-test.png`}:{},webPreferences:k});}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxWindowOptionsPatch, source, "app-test.png");
+
+  assert.match(patched, /appearance:c=`primary`,focusable:m\}=e/);
+  assert.match(
+    patched,
+    /new a\.BrowserWindow\(\{width:b,height:x,\.\.\.process\.platform===`linux`&&c===`primary`\?\{focusable:!0\}:m===void 0\?\{\}:\{focusable:m\},/,
+  );
+});
+
+test("fails loudly when primary BrowserWindow focusable shape cannot be patched", () => {
+  const source = [
+    "async createWindow(e={}){let{appearance:c=`primary`}=e,",
+    "M=new a.BrowserWindow({width:b,height:x,focusable:getFocusable(),webPreferences:k});}",
+  ].join("");
+
+  assert.throws(
+    () => applyLinuxWindowOptionsPatch(source, null),
+    /Could not patch primary BrowserWindow focusable option for Linux/,
+  );
 });
 
 test("patches remaining Linux window icon snippets when another window is already patched", () => {
@@ -2829,7 +3047,11 @@ test("adds Linux tray support including the platform guard", () => {
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
   const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
   const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
-  const patched = applyPatchTwice(applyLinuxTrayPatch, trayBundleFixture(), iconPathExpression);
+  const patched = applyPatchTwice(
+    applyLinuxTrayPatch,
+    `${mainBundlePrefix}${trayBundleFixture()}`,
+    iconPathExpression,
+  );
 
   assert.match(
     patched,
@@ -2876,8 +3098,9 @@ test("uses collision-proof Linux tray icon variables when Electron alias is r", 
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
   const source = [
     "let r=require(`electron`),i=require(`node:path`);",
-    "async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let t=await Ww(e.buildFlavor,e.appBrand,e.repoRoot),i=new r.Tray(t.defaultIcon);return i})()))}",
-    "async function Ww(e,t,n){if(process.platform===`darwin`){let e=r.nativeImage.createFromPath(n);return e.isEmpty()?{defaultIcon:await r.app.getFileIcon(process.execPath,{size:`normal`}),chronicleRunningIcon:null}:{defaultIcon:e,chronicleRunningIcon:null}}let a=Nw(e,t,n);return a==null?{defaultIcon:await r.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:a,chronicleRunningIcon:null}}",
+    "async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let t=await Ww(e.appBrand,e.buildFlavor,e.repoRoot),i=new r.Tray(t.defaultIcon);return i})()))}",
+    "async function Ww(e,t,n){if(process.platform===`darwin`){return null}let o=K9(e,t,n);return o==null?{defaultIcon:await r.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:o,chronicleRunningIcon:null}}",
+    "function K9(e,t,n){let a=[(0,i.join)(n,`electron`,`src`,`icons`,`tray.png`)];for(let e of a){let t=r.nativeImage.createFromPath(e);if(!t.isEmpty())return t}return null}",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, iconPathExpression);
@@ -2891,10 +3114,7 @@ test("uses collision-proof Linux tray icon variables when Electron alias is r", 
 
 test("adds Linux tray icon fallback when current upstream uses small file icon fallback", () => {
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
-  const source = trayBundleFixture().replace(
-    "n.app.getFileIcon(process.execPath,{size:process.platform===`win32`?`small`:`normal`})",
-    "n.app.getFileIcon(process.execPath,{size:`small`})",
-  );
+  const source = `${mainBundlePrefix}${trayBundleFixture()}`;
 
   const { value: patched, warnings } = captureWarns(() =>
     applyPatchTwice(applyLinuxTrayPatch, source, iconPathExpression),
@@ -2902,6 +3122,7 @@ test("adds Linux tray icon fallback when current upstream uses small file icon f
 
   assert.deepEqual(warnings, []);
   assert.match(patched, /__codexLinuxTrayIcon=n\.nativeImage\.createFromPath/);
+  assert.match(patched, /let r=K9\(e,t,i\);if\(r!=null\)return\{defaultIcon:r,chronicleRunningIcon:null\};if\(process\.platform===`linux`\)/);
   assert.match(patched, /n\.app\.getFileIcon\(process\.execPath,\{size:`small`\}\)/);
 });
 
@@ -2909,6 +3130,7 @@ test("adds Linux tray support even when About dialog already uses the bundled ic
   const iconPathExpression = "process.resourcesPath+`/../content/webview/assets/app-test.png`";
   const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
   const source = [
+    mainBundlePrefix,
     trayBundleFixture(),
     "async function bZ(){let t=process.execPath;return process.platform===`linux`?Promise.resolve((()=>{let __codexLinuxAboutIcon=n.nativeImage.createFromPath(process.resourcesPath+`/../content/webview/assets/app-test.png`);return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):n.app.getFileIcon(t,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)}",
   ].join("");
@@ -3046,9 +3268,10 @@ test("upgrades partially patched About dialog icon fallbacks after alias drift",
 
 test("adds Linux tray support for current minified window and startup identifiers", () => {
   const source = [
-    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
-    "async function eN(e){let t=await Ww(e.buildFlavor,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
-    "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
+    mainBundlePrefix,
+    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j);let t=this.getPrimaryWindows().some(e=>e!==j);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
+    "async function eN(e){let t=await Ww(e.buildFlavor,e.appBrand,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
+    "let ce$=async()=>{O=!0;try{await eN({appBrand:a.U(),buildFlavor:b,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
@@ -3071,6 +3294,7 @@ test("adds Linux tray support for current minified window and startup identifier
 
 test("adds Linux tray startup support for current appBrand initializer", () => {
   const source = [
+    "let a=require(`electron`);",
     "async function H5(e){let t=await W5(e.appBrand,e.repoRoot),n=new a.Tray(t.defaultIcon);return n}",
     "let ye=async()=>{O=!0;try{await H5({appBrand:r.et(),repoRoot:j.repoRoot})}catch(e){O=!1,_.reportNonFatal(e instanceof Error?e:`Failed to set up tray`,{kind:`tray-setup-failed`,tags:{errorType:`tray-setup-failed`}}),ee()}};E&&ye();",
   ].join("");
@@ -3092,10 +3316,11 @@ test("adds Linux tray startup support for current appBrand initializer", () => {
 
 test("scopes dynamic tray startup matching to the tray initializer", () => {
   const source = [
+    mainBundlePrefix,
     "async function aa(e){return e.buildFlavor}",
     "let startOther=async()=>{A=!0;try{await aa({buildFlavor:a})}catch(e){A=!1}};U&&startOther();",
-    "async function eN(e){let t=await Ww(e.buildFlavor,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
-    "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
+    "async function eN(e){let t=await Ww(e.buildFlavor,e.appBrand,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
+    "let ce$=async()=>{O=!0;try{await eN({appBrand:a.U(),buildFlavor:b,repoRoot:j.repoRoot})}catch(e){O=!1}};E&&ce$();",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
@@ -3116,28 +3341,11 @@ test("scopes dynamic tray startup matching to the tray initializer", () => {
   );
 });
 
-test("migrates Linux tray startup patch to tolerate missing settings helper", () => {
-  const source = [
-    "async function eN(e){let t=await Ww(e.buildFlavor,e.repoRoot),r=new n.Tray(t.defaultIcon);return r}",
-    "let ce$=async()=>{O=!0;try{await eN({buildFlavor:a,repoRoot:j.repoRoot})}catch(e){O=!1}};(E||process.platform===`linux`&&codexLinuxIsTrayEnabled())&&ce$();",
-  ].join("");
-
-  const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
-
-  assert.match(
-    patched,
-    /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
-  );
-  assert.match(
-    patched,
-    /catch\(e\)\{O=!1;process\.platform===`linux`&&console\.warn\(`\[codex-linux\] Failed to set up system tray`,e\)\}/,
-  );
-});
-
 test("logs Linux tray setup failures when the catch body contains nested objects", () => {
   const source = [
-    "async function s4(e){let t=await l4(e.buildFlavor,e.repoRoot),n=new a.Tray(t.defaultIcon);return n}",
-    "let _e=async()=>{k=!0;try{await s4({buildFlavor:o,repoRoot:M.repoRoot})}catch(e){k=!1,v.reportNonFatal(e instanceof Error?e:`Failed to set up tray`,{kind:`tray-setup-failed`,tags:{errorType:`tray-setup-failed`}}),N.ensureWindow()}};D&&_e();",
+    "let a=require(`electron`);",
+    "async function s4(e){let t=await l4(e.buildFlavor,e.appBrand,e.repoRoot),n=new a.Tray(t.defaultIcon);return n}",
+    "let _e=async()=>{k=!0;try{await s4({appBrand:r.U(),buildFlavor:o,repoRoot:M.repoRoot})}catch(e){k=!1,v.reportNonFatal(e instanceof Error?e:`Failed to set up tray`,{kind:`tray-setup-failed`,tags:{errorType:`tray-setup-failed`}}),N.ensureWindow()}};D&&_e();",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
@@ -3154,15 +3362,16 @@ test("logs Linux tray setup failures when the catch body contains nested objects
 
 test("scopes close-to-tray already-patched detection to the handler", () => {
   const source = [
+    mainBundlePrefix,
     "let unrelated=(process.platform===`win32`||process.platform===`linux`)&&x===`local`;",
-    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j,f);let t=this.getPrimaryWindows(f).some(e=>e!==j);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
+    "v&&j.on(`close`,e=>{this.persistPrimaryWindowBounds(j);let t=this.getPrimaryWindows().some(e=>e!==j);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastWindowToTray?.()===!0&&!t){e.preventDefault(),j.hide();return}});",
   ].join("");
 
   const patched = applyPatchTwice(applyLinuxTrayPatch, source, null);
 
   assert.match(
     patched,
-    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLastLocalWindowToTray\?\.\(\)===!0&&!t\)\{e\.preventDefault\(\),j\.hide\(\);return\}/,
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&!t\)\{e\.preventDefault\(\),j\.hide\(\);return\}/,
   );
 });
 
@@ -3634,50 +3843,6 @@ test("skips the launch-action patch without throwing when upstream startup archi
   ].join("");
 
   assert.doesNotThrow(() => applyLinuxLaunchActionArgsPatch(source));
-});
-
-test("gates current close-to-tray setting through the captured global state", () => {
-  const source = "let j=KD({moduleDir:__dirname});let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});t.Mr().info(`Launching app`);";
-  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
-
-  assert.match(
-    patched,
-    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
-  );
-  assert.doesNotMatch(patched, /M\.globalState\.get/);
-});
-
-test("does not treat unrelated Linux setting references as close-to-tray patched", () => {
-  const source = [
-    "let j=KD({moduleDir:__dirname});",
-    "let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});",
-    "let codexLinuxGetSetting=e=>process.platform!==`linux`||j.globalState.get(`codex-linux-system-tray-enabled`)!==!1;",
-    "t.Mr().info(`Launching app`);",
-  ].join("");
-
-  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
-
-  assert.match(
-    patched,
-    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
-  );
-});
-
-test("chooses the nearest globalState alias for close-to-tray settings", () => {
-  const source = [
-    "let stale={globalState:{get(){return false}}};",
-    "let j=KD({moduleDir:__dirname});",
-    "let M=FM({buildFlavor:a,globalState:j.globalState,canHideLastLocalWindowToTray:()=>O,disposables:k});",
-    "t.Mr().info(`Launching app`);",
-  ].join("");
-
-  const patched = applyPatchTwice(applyLinuxTrayCloseSettingPatch, source);
-
-  assert.match(
-    patched,
-    /canHideLastLocalWindowToTray:\(\)=>O&&\(process\.platform!==`linux`\|\|j\.globalState\.get\(`codex-linux-system-tray-enabled`\)!==!1\),disposables:k/,
-  );
-  assert.doesNotMatch(patched, /stale\.globalState\.get\(`codex-linux-system-tray-enabled`\)/);
 });
 
 test("allows bundled Computer Use on Linux as well as macOS", () => {
@@ -7176,6 +7341,7 @@ test("uses CODEX_APP_ID for Electron desktopName", () => {
 test("patchMainBundleSource keeps non-icon patches active without an icon asset", () => {
   const source = [
     mainBundlePrefix,
+    currentMainBundlePrefix,
     "process.platform===`win32`&&k.removeMenu(),",
     alreadyOpaqueBackgroundBundle,
     fileManagerBundle,
@@ -7206,6 +7372,25 @@ test("patchMainBundleSource keeps non-icon patches active without an icon asset"
   assert.doesNotMatch(
     patched,
     /nativeImage\.createFromPath\(process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\//,
+  );
+});
+
+test("patchMainBundleSource stays idempotent after wrapping the Electron require", () => {
+  const source = [
+    currentMainBundlePrefix,
+    trayBundleFixture().replaceAll("n.", "c."),
+  ].join("");
+
+  const patched = patchMainBundleSource(source, "app-test.png");
+
+  assert.equal(patchMainBundleSource(patched, "app-test.png"), patched);
+  assert.match(
+    patched,
+    /setLinuxTrayContextMenu\(\)\{let e=c\.Menu\.buildFromTemplate/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /setLinuxTrayContextMenu\(\)\{let e=n\.Menu\.buildFromTemplate/,
   );
 });
 
@@ -8240,32 +8425,6 @@ test("a throwing webview-asset patch leaves no partially patched assets", () => 
     assert.equal(fs.readFileSync(path.join(assetsDir, "demo-b.js"), "utf8"), "second asset");
   } finally {
     fs.rmSync(coreRoot, { recursive: true, force: true });
-    fs.rmSync(tempApp, { recursive: true, force: true });
-  }
-});
-
-test("tray close-to-tray patch failure is engine-caught and does not abort patching", () => {
-  // Recognizable-but-unpatchable shape: both markers present, gate shape absent —
-  // applyLinuxTrayCloseSettingPatch throws, the engine must absorb it.
-  const source = "canHideLastLocalWindowToTray /* drifted */ console.log(`Launching app`)";
-  assert.throws(() => applyLinuxTrayCloseSettingPatch(source), /tray settings patch failed/);
-
-  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-tray-close-throw-app-"));
-  try {
-    const buildDir = path.join(tempApp, ".vite", "build");
-    fs.mkdirSync(buildDir, { recursive: true });
-    fs.writeFileSync(path.join(buildDir, "main.js"), source);
-
-    const report = createPatchReport();
-    captureWarns(() => patchExtractedApp(tempApp, { report }));
-
-    const entry = report.patches.find((patch) => patch.name === "linux-tray-close-setting");
-    assert.equal(entry?.status, "skipped-optional");
-    assert.equal(entry?.error, true);
-    assert.ok(
-      !criticalFailuresFromReport(report).some((failure) => failure.name === "linux-tray-close-setting"),
-    );
-  } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }
 });

--- a/scripts/patches/core/all-linux/main-process/launch-actions/patch.js
+++ b/scripts/patches/core/all-linux/main-process/launch-actions/patch.js
@@ -4,20 +4,12 @@ const {
   mainBundlePatch,
 } = require("../../../../descriptor.js");
 const {
-  applyLinuxTrayCloseSettingPatch,
   applyLinuxSettingsPersistencePatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxHotkeyWindowPrewarmPatch,
 } = require("../../../../impl/launch-actions.js");
 
 module.exports = [
-  mainBundlePatch({
-    id: "linux-tray-close-setting",
-    phase: "main-bundle",
-    order: 200,
-    ciPolicy: "optional",
-    apply: applyLinuxTrayCloseSettingPatch,
-  }),
   mainBundlePatch({
     id: "linux-settings-persistence",
     phase: "main-bundle",

--- a/scripts/patches/impl/avatar-overlay.js
+++ b/scripts/patches/impl/avatar-overlay.js
@@ -6,24 +6,6 @@ const {
 } = require("../lib/minified-js.js");
 const { recordStrategy } = require("../strategy-telemetry.js");
 
-function findAvatarMethod(source, signatureRegex) {
-  const match = source.match(signatureRegex);
-  if (match == null) {
-    return null;
-  }
-  const openIndex = match.index + match[0].length - 1;
-  const closeIndex = findMatchingBrace(source, openIndex);
-  if (closeIndex === -1) {
-    return null;
-  }
-  return {
-    match,
-    start: match.index,
-    end: closeIndex + 1,
-    text: source.slice(match.index, closeIndex + 1),
-  };
-}
-
 function findAvatarMethodAfter(source, signatureRegex, startIndex, endIndex = source.length) {
   const match = source.slice(startIndex, endIndex).match(signatureRegex);
   if (match == null) {
@@ -45,16 +27,16 @@ function findAvatarMethodAfter(source, signatureRegex, startIndex, endIndex = so
 
 function avatarOverlayRegionStart(source) {
   const routeIndex = source.indexOf("`/avatar-overlay`");
-  if (routeIndex !== -1) {
-    return routeIndex;
-  }
-  const stateMessageIndex = source.indexOf("avatar-overlay-open-state-changed");
-  return stateMessageIndex === -1 ? 0 : stateMessageIndex;
+  return routeIndex === -1 ? null : routeIndex;
 }
 
 function findAvatarOverlayClass(source) {
+  const regionStart = avatarOverlayRegionStart(source);
+  if (regionStart == null) {
+    return null;
+  }
   const classRegex = /class(?:\s+[A-Za-z_$][\w$]*)?(?:\s+extends\s+[A-Za-z_$][\w$.]*)?\{/g;
-  classRegex.lastIndex = avatarOverlayRegionStart(source);
+  classRegex.lastIndex = regionStart;
   let match;
   while ((match = classRegex.exec(source)) != null) {
     const openIndex = match.index + match[0].length - 1;
@@ -67,10 +49,7 @@ function findAvatarOverlayClass(source) {
       continue;
     }
     const text = source.slice(match.index, closeIndex + 1);
-    if (
-      text.includes("appearance:`avatarOverlay`") ||
-      text.includes("avatar-overlay-open-state-changed")
-    ) {
+    if (text.includes("appearance:`avatarOverlay`")) {
       return {
         start: match.index,
         end: closeIndex + 1,
@@ -88,14 +67,6 @@ function findAvatarOverlayMethod(source, signatureRegex) {
     return null;
   }
   return findAvatarMethodAfter(source, signatureRegex, overlayClass.start, overlayClass.end);
-}
-
-function replaceAvatarMethod(source, signatureRegex, replacement) {
-  const method = findAvatarMethod(source, signatureRegex);
-  if (method == null || method.text === replacement) {
-    return source;
-  }
-  return source.slice(0, method.start) + replacement + source.slice(method.end);
 }
 
 function replaceAvatarMethodText(source, method, replacement) {
@@ -123,72 +94,67 @@ function patchAvatarOverlayWindowOptions(source) {
   if (source.includes(windowOptionsPatch)) {
     return source;
   }
-  return source
-    .replace(
-      "appearance:`avatarOverlay`,focusable:process.platform===`linux`?!0:!1",
-      windowOptionsPatch,
-    )
-    .replace(
-      "appearance:`avatarOverlay`,focusable:!1",
-      windowOptionsPatch,
-    );
-}
-
-function upgradeAvatarOverlayInjectedMethods(source, electronVar) {
-  let patched = source;
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxBuildAvatarInputShape\(e\)\{/,
-    avatarInputShapePatch(),
+  return source.replace(
+    "appearance:`avatarOverlay`,focusable:!1",
+    windowOptionsPatch,
   );
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxApplyAvatarInputShape\(e\)\{/,
-    avatarApplyInputShapePatch(),
-  );
-  patched = replaceAvatarMethod(
-    patched,
-    /codexLinuxIsCursorInAvatarInteractiveRegion\(e\)\{/,
-    avatarCursorRegionPatch(electronVar),
-  );
-  return patched;
 }
 
 function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
+  if (!currentSource.includes("`/avatar-overlay`")) {
+    return currentSource;
+  }
+
   let patchedSource = currentSource;
-  const electronVar = requireName(currentSource, "electron") ?? "n";
+  const electronVar = requireName(currentSource, "electron");
   const childProcessVar = requireName(currentSource, "node:child_process");
-  const withElectronAlias = (source) =>
-    electronVar === "n" ? source : source.replaceAll("n.screen", `${electronVar}.screen`);
+  if (electronVar == null || childProcessVar == null) {
+    console.warn(
+      "WARN: Could not find avatar overlay module bindings — skipping Linux avatar overlay passthrough recovery patch",
+    );
+    return currentSource;
+  }
   const i3SessionMethod =
     "codexLinuxIsI3Session(){let e=[process.env.XDG_CURRENT_DESKTOP,process.env.DESKTOP_SESSION,process.env.I3SOCK].filter(Boolean).join(`:`).toLowerCase();return/(^|[:;/])i3([:;/.-]|$)/.test(e)}";
   const compositorHintsMethod =
-    childProcessVar == null
-      ? "codexLinuxApplyAvatarCompositorHints(e){}"
-      : `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,l,h,d,f]=c;if(Number(l)!==t.x||Number(h)!==t.y||Number(d)!==t.width||Number(f)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
+    `codexLinuxApplyAvatarCompositorHints(e){if(process.platform!==\`linux\`||!this.codexLinuxIsI3Session()||this.codexLinuxAvatarCompositorHintsApplied||this.codexLinuxAvatarCompositorHintsApplying||e==null||e.isDestroyed()||!process.env.DISPLAY)return;let t;try{t=e.getBounds?.()??e.getContentBounds?.()}catch{}if(t==null||!Number.isFinite(t.x)||!Number.isFinite(t.y)||!Number.isFinite(t.width)||!Number.isFinite(t.height))return;let n=[];try{let r=e.getNativeWindowHandle?.();r!=null&&r.length>=4&&n.push(String(r.readUInt32LE(0)))}catch{}this.codexLinuxAvatarCompositorHintsApplying=!0;let r=e=>{let r=[...new Set(e)].filter(e=>/^[0-9]+$/.test(e)&&e!==\`0\`);if(r.length===0){this.codexLinuxAvatarCompositorHintsApplying=!1;return}let i=r.length,a=!1,o=()=>{i--,i===0&&(this.codexLinuxAvatarCompositorHintsApplying=!1,a&&(this.codexLinuxAvatarCompositorHintsApplied=!0))},s=e=>{try{${childProcessVar}.execFile(\`xwininfo\`,[\`-id\`,e],{timeout:1e3},(r,i)=>{if(r){o();return}let s=String(i??\`\`),c=s.match(/Absolute upper-left X:\\s+(-?\\d+)[\\s\\S]*Absolute upper-left Y:\\s+(-?\\d+)[\\s\\S]*Width:\\s+(\\d+)[\\s\\S]*Height:\\s+(\\d+)/);if(c==null||!/Override Redirect State:\\s+yes/.test(s)){o();return}let[,__codexAvatarX,__codexAvatarY,__codexAvatarWidth,__codexAvatarHeight]=c;if(Number(__codexAvatarX)!==t.x||Number(__codexAvatarY)!==t.y||Number(__codexAvatarWidth)!==t.width||Number(__codexAvatarHeight)!==t.height){o();return}try{${childProcessVar}.execFile(\`xprop\`,[\`-id\`,e,\`-f\`,\`_GTK_FRAME_EXTENTS\`,\`32c\`,\`-set\`,\`_GTK_FRAME_EXTENTS\`,\`0, 0, 0, 0\`],{timeout:1e3},e=>{e||(a=!0),o()})}catch{o()}})}catch{o()}};for(let t of r)s(t)};try{${childProcessVar}.execFile(\`xdotool\`,[\`search\`,\`--pid\`,String(process.pid)],{timeout:1e3},(e,t)=>{r([...n,...String(t??\`\`).trim().split(/\\s+/).filter(Boolean)])})}catch{r(n)}}`;
   const shapeBackendMethod =
     `codexLinuxIsAvatarShapeBackend(){if(process.platform!==\`linux\`)return!1;let e=\`\`;try{e=${electronVar}.app.commandLine.getSwitchValue(\`ozone-platform\`)}catch{}return e===\`x11\`||e===\`\`&&!process.env.WAYLAND_DISPLAY}`;
 
   const interactivityNeedle =
     "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1;return}let t=!this.pointerInteractive;if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
-  const interactivityTemplate =
-    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}codexLinuxBuildAvatarInputShape(e){let t=this.layout;if(t==null)return null;if(this.dragState!=null){let t=e.getContentBounds();return[{x:0,y:0,width:t.width,height:t.height}]}let r=e.getContentBounds(),i=e=>{if(e==null)return null;let t=Math.max(0,e.left),n=Math.max(0,e.top),i=Math.min(r.width,e.left+e.width)-t,a=Math.min(r.height,e.top+e.height)-n;return i<=0||a<=0?null:{x:t,y:n,width:i,height:a}};return[i(t.mascot),i(t.tray)].filter(Boolean)}codexLinuxApplyAvatarInputShape(e){if(process.platform!==`linux`||e==null||e.isDestroyed()||typeof e.setShape!=`function`)return!1;let t=this.codexLinuxBuildAvatarInputShape(e);if(t==null)return!1;let n=JSON.stringify(t);if(this.codexLinuxAvatarInputShapeKey===n)return!0;try{e.setShape(t),this.codexLinuxAvatarInputShapeKey=n;return!0}catch{this.codexLinuxAvatarInputShapeKey=null;return!1}}codexLinuxStartAvatarPassthroughRecovery(){if(process.platform!==`linux`||this.codexLinuxAvatarPassthroughRecoveryTimer!=null)return;this.codexLinuxAvatarPassthroughRecoveryTimer=setInterval(()=>{let e=this.window;if(e==null||e.isDestroyed()||!e.isVisible()){this.codexLinuxStopAvatarPassthroughRecovery();return}this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy()},32),this.codexLinuxAvatarPassthroughRecoveryTimer.unref?.()}codexLinuxSyncAvatarPointerInteractivity(e){if(process.platform!==`linux`||e==null||e.isDestroyed())return!1;if(this.dragState!=null){if(this.pointerInteractive)return!1;return this.pointerInteractive=!0,!0}let t;try{t=this.codexLinuxIsCursorInAvatarInteractiveRegion(e)}catch{t=!0}return this.pointerInteractive===t?!1:(this.pointerInteractive=t,!0)}codexLinuxIsCursorInAvatarInteractiveRegion(e){let t=this.layout;if(t==null)return!1;let r=n.screen.getCursorScreenPoint(),i=e.getContentBounds(),a=r.x-i.x,o=r.y-i.y;if(a<0||o<0||a>i.width||o>i.height)return!1;let s=e=>e!=null&&a>=e.left&&a<=e.left+e.width&&o>=e.top&&o<=e.top+e.height;return s(t.mascot)||s(t.tray)}refreshCursorAtCurrentMousePosition(e){";
-  const templateSetShapePolicy =
-    "if(process.platform===`linux`&&typeof e.setShape==`function`){this.codexLinuxStopAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
-  const setShapePolicyPatch =
-    "if(this.codexLinuxIsAvatarShapeBackend()&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}";
-  const interactivityPatch = withElectronAlias(interactivityTemplate)
-    .replace(
-      "codexLinuxStopAvatarPassthroughRecovery(){",
-      `${i3SessionMethod}${compositorHintsMethod}${shapeBackendMethod}codexLinuxStopAvatarPassthroughRecovery(){`,
-    )
-    .replaceAll(templateSetShapePolicy, setShapePolicyPatch)
-    .replace(/refreshCursorAtCurrentMousePosition\(e\)\{$/, "");
+  const interactivityMethodPatch =
+    "applyPointerInteractivityPolicy(){let e=this.window;if(e==null||e.isDestroyed()){this.mousePassthroughEnabled=!1,this.codexLinuxStopAvatarPassthroughRecovery();return}if(this.codexLinuxIsAvatarShapeBackend()&&typeof e.setShape==`function`){this.codexLinuxStartAvatarPassthroughRecovery(),this.mousePassthroughEnabled&&(this.mousePassthroughEnabled=!1,e.setIgnoreMouseEvents(!1));if(this.codexLinuxApplyAvatarInputShape(e))return}process.platform===`linux`&&(this.codexLinuxStartAvatarPassthroughRecovery(),this.codexLinuxSyncAvatarPointerInteractivity(e));let t=!this.pointerInteractive;this.dragState!=null&&(t=!1);if(this.mousePassthroughEnabled!==t){if(this.mousePassthroughEnabled=t,t){e.setIgnoreMouseEvents(!0,{forward:!0});return}e.setIgnoreMouseEvents(!1),this.refreshCursorAtCurrentMousePosition(e)}}";
+  const stopRecoveryMethod =
+    "codexLinuxStopAvatarPassthroughRecovery(){this.codexLinuxAvatarPassthroughRecoveryTimer!=null&&(clearInterval(this.codexLinuxAvatarPassthroughRecoveryTimer),this.codexLinuxAvatarPassthroughRecoveryTimer=null)}";
+  const startRecoveryMethod =
+    "codexLinuxStartAvatarPassthroughRecovery(){if(process.platform!==`linux`||this.codexLinuxAvatarPassthroughRecoveryTimer!=null)return;this.codexLinuxAvatarPassthroughRecoveryTimer=setInterval(()=>{let e=this.window;if(e==null||e.isDestroyed()||!e.isVisible()){this.codexLinuxStopAvatarPassthroughRecovery();return}this.codexLinuxSyncAvatarPointerInteractivity(e)&&this.applyPointerInteractivityPolicy()},32),this.codexLinuxAvatarPassthroughRecoveryTimer.unref?.()}";
+  const syncInteractivityMethod =
+    "codexLinuxSyncAvatarPointerInteractivity(e){if(process.platform!==`linux`||e==null||e.isDestroyed())return!1;if(this.dragState!=null){if(this.pointerInteractive)return!1;return this.pointerInteractive=!0,!0}let t;try{t=this.codexLinuxIsCursorInAvatarInteractiveRegion(e)}catch{t=!0}return this.pointerInteractive===t?!1:(this.pointerInteractive=t,!0)}";
+  const interactivityPatch =
+    interactivityMethodPatch +
+    i3SessionMethod +
+    compositorHintsMethod +
+    shapeBackendMethod +
+    stopRecoveryMethod +
+    avatarInputShapePatch() +
+    avatarApplyInputShapePatch() +
+    startRecoveryMethod +
+    syncInteractivityMethod +
+    avatarCursorRegionPatch(electronVar);
 
   if (!patchedSource.includes("codexLinuxIsI3Session")) {
-    if (patchedSource.includes(interactivityNeedle)) {
+    const interactivityMethod = findAvatarOverlayMethod(
+      patchedSource,
+      /applyPointerInteractivityPolicy\(\)\{/,
+    );
+    if (interactivityMethod?.text === interactivityNeedle) {
       recordStrategy("avatar-interactivity", "upstream");
-      patchedSource = patchedSource.replace(interactivityNeedle, interactivityPatch);
+      patchedSource = replaceAvatarMethodText(
+        patchedSource,
+        interactivityMethod,
+        interactivityPatch,
+      );
     } else if (
       patchedSource.includes("avatar-overlay") &&
       patchedSource.includes("applyPointerInteractivityPolicy(){let e=this.window")
@@ -202,7 +168,6 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   } else {
     recordStrategy("avatar-interactivity", "already-applied");
   }
-  patchedSource = upgradeAvatarOverlayInjectedMethods(patchedSource, electronVar);
   const beforeFocusablePatch = patchedSource;
   patchedSource = patchAvatarOverlayWindowOptions(patchedSource);
   recordStrategy(
@@ -239,21 +204,18 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
 
   const endDragMethod = findAvatarOverlayMethod(
     patchedSource,
-    /endDrag\([A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*)?\)\{/,
+    /endDrag\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)\{/,
   );
   if (endDragMethod?.text.includes(
-    "this.reclampWindowToVisibleDisplay({shouldPersist:!0});process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+    "process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
   )) {
     recordStrategy("avatar-end-drag", "already-applied");
-  } else if (endDragMethod?.text.includes(":this.reclampWindowToVisibleDisplay({shouldPersist:!0});")) {
+  } else if (endDragMethod?.text.includes("this.dragState=null")) {
     recordStrategy("avatar-end-drag", "upstream-method");
     patchedSource = replaceAvatarMethodText(
       patchedSource,
       endDragMethod,
-      endDragMethod.text.replace(
-        /:this\.reclampWindowToVisibleDisplay\(\{shouldPersist:!0\}\);/,
-        ":this.reclampWindowToVisibleDisplay({shouldPersist:!0});process.platform===`linux`&&this.applyPointerInteractivityPolicy();",
-      ),
+      `${endDragMethod.text.slice(0, -1)},process.platform===\`linux\`&&this.applyPointerInteractivityPolicy()}`,
     );
   } else if (patchedSource.includes("avatar-overlay")) {
     recordStrategy("avatar-end-drag", "none");
@@ -264,16 +226,16 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
 
   const setElementSizeMethod = findAvatarOverlayMethod(
     patchedSource,
-    /setElementSize\([A-Za-z_$][\w$]*,\{[^{}]*mascot:[A-Za-z_$][\w$]*[^{}]*tray:[A-Za-z_$][\w$]*[^{}]*\}\)\{/,
+    /setElementSize\([^)]*\)\{/,
   );
   if (setElementSizeMethod != null) {
     if (
-      !/this\.(?:applyLayout|applyLatestElementSizes)\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(setElementSizeMethod.text)
+      !/this\.applyLatestElementSizes\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(setElementSizeMethod.text)
     ) {
       recordStrategy("avatar-element-size", "upstream");
       const patchedMethod = setElementSizeMethod.text.replace(
-        /this\.(applyLayout|applyLatestElementSizes)\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
-        "this.$1($2),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
+        /this\.applyLatestElementSizes\(([A-Za-z_$][\w$]*)\)(?!,process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\))/g,
+        "this.applyLatestElementSizes($1),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
       );
       if (patchedMethod !== setElementSizeMethod.text) {
         patchedSource =
@@ -286,7 +248,7 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     }
   } else if (
     patchedSource.includes("avatar-overlay") &&
-    !/setElementSize\([^{}]+\)\{[^]*?this\.applyLayout\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(patchedSource)
+    !/setElementSize\([^{}]+\)\{[^]*?this\.applyLatestElementSizes\([A-Za-z_$][\w$]*\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/.test(patchedSource)
   ) {
     recordStrategy("avatar-element-size", "none");
     console.warn(
@@ -302,9 +264,9 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   }
 
   const i3TrayFallbackRegex =
-    /traySize:this\.traySize\?\?(\(this\.layoutMode===`native`\?[A-Za-z_$][\w$]*:[A-Za-z_$][\w$]*\))\}\)\}getLayout\(/;
+    /traySize:this\.traySize\?\?(\([^{};]*?\))(?=\}\))/;
   const i3TrayFallbackPatch =
-    "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1})}getLayout(";
+    "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()?this.traySize:this.traySize??$1";
   if (
     !patchedSource.includes(
       "traySize:process.platform===`linux`&&typeof this.codexLinuxIsI3Session==`function`&&this.codexLinuxIsI3Session()",
@@ -333,16 +295,14 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     recordStrategy("avatar-apply-layout", "already-applied");
   } else if (
     applyLayoutMethod != null &&
-    /this\.sendLayoutToRenderer\([A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*)?\)/.test(applyLayoutMethod.text)
+    applyLayoutMethod.text.includes("this.setWindowBounds(") &&
+    applyLayoutMethod.text.includes("this.sendLayoutToRenderer(")
   ) {
     recordStrategy("avatar-apply-layout", "upstream");
     patchedSource = replaceAvatarMethodText(
       patchedSource,
       applyLayoutMethod,
-      applyLayoutMethod.text.replace(
-        /this\.sendLayoutToRenderer\(([A-Za-z_$][\w$]*)(,[A-Za-z_$][\w$]*)?\)/,
-        "this.sendLayoutToRenderer($1$2),process.platform===`linux`&&this.applyPointerInteractivityPolicy()",
-      ),
+      `${applyLayoutMethod.text.slice(0, -1)},process.platform===\`linux\`&&this.applyPointerInteractivityPolicy()}`,
     );
   } else if (
     patchedSource.includes("avatar-overlay")
@@ -381,20 +341,44 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
     );
   }
 
-  const closedPatchRegex =
-    /this\.window===[A-Za-z_$][\w$]*&&\(this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\),[\s\S]*?this\.window=null,/;
-  if (closedPatchRegex.test(patchedSource)) {
+  const createWindowMethod = findAvatarOverlayMethod(
+    patchedSource,
+    /async createWindow\([^)]*\)\{/,
+  );
+  const closedHandlerMarker = ".on(`closed`,()=>{";
+  const closedHandlerIndex = createWindowMethod?.text.indexOf(closedHandlerMarker) ?? -1;
+  const closedHandlerOpenIndex = closedHandlerIndex + closedHandlerMarker.length - 1;
+  const closedHandlerCloseIndex = closedHandlerIndex === -1
+    ? -1
+    : findMatchingBrace(createWindowMethod.text, closedHandlerOpenIndex);
+  const closedHandler = closedHandlerCloseIndex === -1
+    ? null
+    : createWindowMethod.text.slice(closedHandlerOpenIndex, closedHandlerCloseIndex + 1);
+  const closeCleanup =
+    "this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,";
+  if (closedHandler?.includes(closeCleanup)) {
     recordStrategy("avatar-close-cleanup", "already-applied");
-  } else if (/this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/.test(patchedSource)) {
-    recordStrategy("avatar-close-cleanup", "upstream");
-    patchedSource = patchedSource.replace(
-      /this\.window===([A-Za-z_$][\w$]*)&&\(this\.cancelMomentum\(\),((?:(?!this\.window=null,).)*?)this\.window=null,/,
-      "this.window===$1&&(this.codexLinuxStopAvatarPassthroughRecovery(),this.codexLinuxAvatarInputShapeKey=null,this.codexLinuxAvatarCompositorHintsApplied=!1,this.codexLinuxAvatarCompositorHintsApplying=!1,this.cancelMomentum(),$2this.window=null,",
-    );
   } else if (
-    patchedSource.includes("avatar-overlay") &&
-    patchedSource.includes("codexLinuxStartAvatarPassthroughRecovery")
+    createWindowMethod != null &&
+    closedHandler != null &&
+    closedHandler.includes("this.cancelMomentum(),") &&
+    closedHandler.includes("this.window=null,")
   ) {
+    recordStrategy("avatar-close-cleanup", "upstream");
+    const patchedClosedHandler = closedHandler.replace(
+      "this.cancelMomentum(),",
+      `${closeCleanup}this.cancelMomentum(),`,
+    );
+    const patchedCreateWindowMethod =
+      createWindowMethod.text.slice(0, closedHandlerOpenIndex) +
+      patchedClosedHandler +
+      createWindowMethod.text.slice(closedHandlerCloseIndex + 1);
+    patchedSource = replaceAvatarMethodText(
+      patchedSource,
+      createWindowMethod,
+      patchedCreateWindowMethod,
+    );
+  } else if (patchedSource.includes("avatar-overlay")) {
     recordStrategy("avatar-close-cleanup", "none");
     console.warn(
       "WARN: Could not find avatar overlay close cleanup — skipping Linux avatar overlay passthrough cleanup patch",

--- a/scripts/patches/impl/launch-actions.js
+++ b/scripts/patches/impl/launch-actions.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const {
-  CLOSE_GATE_PREFIX_LOOKBACK,
   HANDLER_PREFIX_LOOKBACK,
   escapeRegExp,
   findDisposableVar,
@@ -99,41 +98,6 @@ function applyLinuxSettingsPersistencePatch(currentSource) {
     (_match, keyVar, valueVar, originVar, setterCall) =>
       `"set-global-state":async({key:${keyVar},value:${valueVar},origin:${originVar}})=>(${setterCall},codexLinuxPersistSettingsState(${keyVar},${valueVar}),`,
   );
-}
-
-function applyLinuxTrayCloseSettingPatch(currentSource) {
-  let patchedSource = currentSource;
-
-  const patchedCloseGateRegex = new RegExp(
-    `canHideLastLocalWindowToTray:\\(\\)=>[A-Za-z_$][\\w$]*&&\\(process\\.platform!==\`linux\`\\|\\|[^,{}]+\\.get\\(\`${escapeRegExp(linuxSettingsKeys.systemTray)}\`\\)!==!1\\),disposables:[A-Za-z_$][\\w$]*`,
-  );
-  if (patchedCloseGateRegex.test(patchedSource)) {
-    return patchedSource;
-  }
-
-  const closeGateRegex =
-    /canHideLastLocalWindowToTray:\(\)=>([A-Za-z_$][\w$]*),disposables:([A-Za-z_$][\w$]*)/;
-  const closeGateMatch = patchedSource.match(closeGateRegex);
-  if (closeGateMatch != null) {
-    const [, trayReadyVar, disposableVar] = closeGateMatch;
-    const prefix = patchedSource.slice(
-      Math.max(0, closeGateMatch.index - CLOSE_GATE_PREFIX_LOOKBACK),
-      closeGateMatch.index,
-    );
-    const globalStateExpr = findLinuxGlobalStateExpression(prefix);
-    if (globalStateExpr != null) {
-      return patchedSource.replace(
-        closeGateRegex,
-        `canHideLastLocalWindowToTray:()=>${trayReadyVar}&&(process.platform!==\`linux\`||${globalStateExpr}.get(\`${linuxSettingsKeys.systemTray}\`)!==!1),disposables:${disposableVar}`,
-      );
-    }
-  }
-
-  if (patchedSource.includes("canHideLastLocalWindowToTray") && patchedSource.includes("Launching app")) {
-    throw new Error("Required Linux tray settings patch failed: could not gate close-to-tray behavior");
-  }
-
-  return patchedSource;
 }
 
 function buildSemanticLinuxLaunchActionPatch({
@@ -349,5 +313,4 @@ module.exports = {
   applyLinuxHotkeyWindowPrewarmPatch,
   applyLinuxLaunchActionArgsPatch,
   applyLinuxSettingsPersistencePatch,
-  applyLinuxTrayCloseSettingPatch,
 };

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -8,14 +8,15 @@ function applyLinuxQuitGuardPatch(currentSource) {
     return currentSource;
   }
 
-  const modulePreludeRegex =
-    /let ([A-Za-z_$][\w$]*)=require\(`node:url`\),([A-Za-z_$][\w$]*)=require\(`electron`\);\2=[A-Za-z_$][\w$]*\.[A-Za-z_$][\w$]*\(\2\);/;
-  const modulePreludeMatch = currentSource.match(modulePreludeRegex);
-  if (modulePreludeMatch != null) {
-    return currentSource.replace(modulePreludeRegex, `${modulePreludeMatch[0]}${quitGuardSuffix}`);
+  const currentBundlerQuitGuardNeedle =
+    /(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`electron`\);\1=[^;]+;[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:path`\);\2=[^;]+;[\s\S]{0,500}?(?:let|,)\s*([A-Za-z_$][\w$]*)=require\(`node:fs`\);\3=[^;]+;/;
+  const currentBundlerQuitGuardMatch = currentSource.match(currentBundlerQuitGuardNeedle);
+  if (currentBundlerQuitGuardMatch != null) {
+    const matchedPrefix = currentBundlerQuitGuardMatch[0];
+    return currentSource.replace(matchedPrefix, `${matchedPrefix}${quitGuardSuffix}`);
   }
 
-  if (currentSource.includes("require(`electron`)")) {
+  if (currentSource.includes("require(`electron`)") && currentSource.includes("require(`node:path`)")) {
     console.warn("WARN: Could not find Linux quit guard insertion point — skipping explicit quit-state patch");
   }
 

--- a/scripts/patches/impl/main-process/tray.js
+++ b/scripts/patches/impl/main-process/tray.js
@@ -27,7 +27,7 @@ function isTrayFactoryFunction(source, functionName) {
 
 function findDynamicTraySetup(source) {
   const setupRegex =
-    /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await ([A-Za-z_$][\w$]*)\(\{(?:buildFlavor|appBrand):/g;
+    /let ([A-Za-z_$][\w$]*)=async\(\)=>\{[A-Za-z_$][\w$]*=!0;try\{await ([A-Za-z_$][\w$]*)\(\{appBrand:/g;
   let match;
   while ((match = setupRegex.exec(source)) != null) {
     const [, setupFn, factoryFn] = match;
@@ -87,7 +87,19 @@ function addDynamicTraySetupFailureLogging(source, traySetup) {
 
 function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   let patchedSource = currentSource;
-  const electronVar = requireName(currentSource, "electron") ?? "n";
+  const electronVar = requireName(currentSource, "electron");
+  if (electronVar == null) {
+    if (
+      currentSource.includes("new ") && currentSource.includes(".Tray(") ||
+      currentSource.includes("canHideLastWindowToTray") ||
+      currentSource.includes("trayMenuThreads=")
+    ) {
+      console.warn(
+        "WARN: Could not find tray Electron binding — skipping Linux tray patch",
+      );
+    }
+    return currentSource;
+  }
   const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
   const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
 
@@ -112,44 +124,31 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   if (iconPathExpression != null) {
     const linuxIconFallback =
       `if(process.platform===\`linux\`){let __codexLinuxTrayIcon=${electronVar}.nativeImage.createFromPath(${packagedTrayIconPathExpression});if(!__codexLinuxTrayIcon.isEmpty())return{defaultIcon:__codexLinuxTrayIcon,chronicleRunningIcon:null};let __codexLinuxAppIcon=${electronVar}.nativeImage.createFromPath(${packagedAppIconPathExpression});if(!__codexLinuxAppIcon.isEmpty())return{defaultIcon:__codexLinuxAppIcon,chronicleRunningIcon:null};let __codexLinuxUpstreamTrayIcon=${electronVar}.nativeImage.createFromPath(${iconPathExpression});if(!__codexLinuxUpstreamTrayIcon.isEmpty())return{defaultIcon:__codexLinuxUpstreamTrayIcon,chronicleRunningIcon:null}}`;
+    const trayIconFallbackRegex =
+      /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*(?:,[A-Za-z_$][\w$]*)*)\);return \1==null\?\{defaultIcon:await ([A-Za-z_$][\w$]*)\.app\.getFileIcon\(process\.execPath,\{size:`small`\}\),chronicleRunningIcon:null\}:\{defaultIcon:\1,chronicleRunningIcon:null\}/;
     if (
       patchedSource.includes(`nativeImage.createFromPath(${packagedTrayIconPathExpression})`) ||
       patchedSource.includes(`nativeImage.createFromPath(${packagedAppIconPathExpression})`)
     ) {
       // Already patched.
+    } else if (trayIconFallbackRegex.test(patchedSource)) {
+      patchedSource = patchedSource.replace(
+        trayIconFallbackRegex,
+        (_match, resultAlias, resolverAlias, resolverArgs, electronAlias) =>
+          `let ${resultAlias}=${resolverAlias}(${resolverArgs});if(${resultAlias}!=null)return{defaultIcon:${resultAlias},chronicleRunningIcon:null};${linuxIconFallback}return{defaultIcon:await ${electronAlias}.app.getFileIcon(process.execPath,{size:\`small\`}),chronicleRunningIcon:null}`,
+      );
     } else {
-      const iconLoaderRegex =
-        /async function ([A-Za-z_$][\w$]*)\([^)]*\)\{if\(process\.platform===`darwin`\)\{/g;
-      let iconLoaderMatch = null;
-      for (const match of patchedSource.matchAll(iconLoaderRegex)) {
-        const body = findNamedFunctionBody(patchedSource, match[1]);
-        if (
-          body?.includes(`${electronVar}.app.getFileIcon(process.execPath,{size:\`small\`})`) &&
-          body.includes(`${electronVar}.nativeImage.createFromPath(`)
-        ) {
-          iconLoaderMatch = match;
-          break;
-        }
-      }
-      if (iconLoaderMatch == null) {
-        console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");
-      } else {
-        const insertionIndex = iconLoaderMatch.index + iconLoaderMatch[0].indexOf("{") + 1;
-        patchedSource =
-          patchedSource.slice(0, insertionIndex) +
-          linuxIconFallback +
-          patchedSource.slice(insertionIndex);
-      }
+      console.warn("WARN: Could not find tray icon fallback — skipping Linux tray icon patch");
     }
   }
 
   const patchedCloseToTrayRegex =
-    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLast(?:Local)?WindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
   if (patchedCloseToTrayRegex.test(patchedSource)) {
     // Already patched with a newer minifier's window variable.
   } else {
     const closeToTrayRegex =
-      /if\(process\.platform===`win32`&&!this\.isAppQuitting&&this\.options\.(canHideLast(?:Local)?WindowToTray)\?\.\(\)===!0&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\.preventDefault\(\),([A-Za-z_$][\w$]*)\.hide\(\);return\}/;
+      /if\(process\.platform===`win32`&&!this\.isAppQuitting&&this\.options\.(canHideLastWindowToTray)\?\.\(\)===!0&&!([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\.preventDefault\(\),([A-Za-z_$][\w$]*)\.hide\(\);return\}/;
     const closeToTrayMatch = patchedSource.match(closeToTrayRegex);
     if (closeToTrayMatch != null) {
       const [, gateMethodName, hasOtherWindowVar, eventVar, windowVar] = closeToTrayMatch;
@@ -225,16 +224,8 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
   const trayContextMenuPatch =
     "if(process.platform===`linux`)return;e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
-  const oldLinuxPopupPatch =
-    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)}";
-  const badLinuxPopupPatch =
-    "e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),if(process.platform===`linux`)return;e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}";
   if (patchedSource.includes("if(process.platform===`linux`)return;e.once(`menu-will-show`")) {
     // Already patched.
-  } else if (patchedSource.includes(badLinuxPopupPatch)) {
-    patchedSource = patchedSource.replace(badLinuxPopupPatch, trayContextMenuPatch);
-  } else if (patchedSource.includes(oldLinuxPopupPatch)) {
-    patchedSource = patchedSource.replace(oldLinuxPopupPatch, trayContextMenuPatch);
   } else if (patchedSource.includes(trayContextMenuNeedle)) {
     patchedSource = patchedSource.replace(trayContextMenuNeedle, trayContextMenuPatch);
   } else {
@@ -243,50 +234,31 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
 
   const trayMenuThreadsNeedle =
     "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return";
-  const trayMenuThreadsExistingPatch =
-    "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&this.setLinuxTrayContextMenu?.();return";
   const trayMenuThreadsPatch =
     "case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.();return";
   if (patchedSource.includes("this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()")) {
     // Already patched.
-  } else if (patchedSource.includes(trayMenuThreadsExistingPatch)) {
-    patchedSource = patchedSource.replace(trayMenuThreadsExistingPatch, trayMenuThreadsPatch);
   } else if (patchedSource.includes(trayMenuThreadsNeedle)) {
     patchedSource = patchedSource.replace(trayMenuThreadsNeedle, trayMenuThreadsPatch);
   } else {
     console.warn("WARN: Could not find tray menu thread update handler — skipping Linux tray context refresh patch");
   }
 
-  const trayStartupNeedle = "E&&oe();";
-  const previousTrayStartupPatch = "(E||process.platform===`linux`)&&oe();";
   const trayEnabledExpression = "process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
-  const trayStartupPatch = `(E||${trayEnabledExpression})&&oe();`;
-  patchedSource = patchedSource.replaceAll(
-    "process.platform===`linux`&&codexLinuxIsTrayEnabled())&&",
-    `${trayEnabledExpression})&&`,
-  );
-  if (patchedSource.includes(trayStartupPatch)) {
+  const traySetup = findDynamicTraySetup(patchedSource);
+  const dynamicTrayStartupMatch = traySetup == null
+    ? null
+    : findDynamicTrayStartupCall(patchedSource, traySetup.setupFn, traySetup.index);
+  if (
+    traySetup != null &&
+    patchedSource.includes(`${trayEnabledExpression})&&${traySetup.setupFn}();`)
+  ) {
     // Already patched.
-  } else if (patchedSource.includes(previousTrayStartupPatch)) {
-    patchedSource = patchedSource.replace(previousTrayStartupPatch, trayStartupPatch);
-  } else if (patchedSource.includes(trayStartupNeedle)) {
-    patchedSource = patchedSource.replace(trayStartupNeedle, trayStartupPatch);
+  } else if (dynamicTrayStartupMatch != null) {
+    const isWindowsVar = dynamicTrayStartupMatch[1];
+    patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||${trayEnabledExpression})&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
   } else {
-    const traySetup = findDynamicTraySetup(patchedSource);
-    const dynamicTrayStartupMatch = traySetup == null
-      ? null
-      : findDynamicTrayStartupCall(patchedSource, traySetup.setupFn, traySetup.index);
-    if (
-      traySetup != null &&
-      patchedSource.includes(`${trayEnabledExpression})&&${traySetup.setupFn}();`)
-    ) {
-      // Already patched with a newer minifier's tray setup identifier.
-    } else if (dynamicTrayStartupMatch != null) {
-      const isWindowsVar = dynamicTrayStartupMatch[1];
-      patchedSource = `${patchedSource.slice(0, dynamicTrayStartupMatch.index)}(${isWindowsVar}||${trayEnabledExpression})&&${traySetup.setupFn}();${patchedSource.slice(dynamicTrayStartupMatch.index + dynamicTrayStartupMatch[0].length)}`;
-    } else {
-      console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
-    }
+    console.warn("WARN: Could not find tray startup call — skipping Linux tray startup patch");
   }
 
   const traySetupForDiagnostics = findDynamicTraySetup(patchedSource);

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -409,10 +409,39 @@ function applyLinuxResizeRepaintPatch(currentSource) {
 }
 
 function applyLinuxOpaqueBackgroundPatch(currentSource) {
-  let patchedSource = currentSource;
   const shouldAlwaysOpaqueSurfaceRegex =
     /shouldAlwaysUseOpaqueWindowSurface\(([A-Za-z_$][\w$]*)\)\{return\s*([A-Za-z_$][\w$]*)\(\{appearance:\1,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!([A-Za-z_$][\w$]*)\(\)&&!([A-Za-z_$][\w$]*)\(\1\)\}/u;
-  const shouldAlwaysOpaqueSurfaceMatch = patchedSource.match(shouldAlwaysOpaqueSurfaceRegex);
+  const patchedShouldAlwaysOpaqueSurfaceRegex =
+    /shouldAlwaysUseOpaqueWindowSurface\(([A-Za-z_$][\w$]*)\)\{return\s*process\.platform===`linux`&&!([A-Za-z_$][\w$]*)\(\1\)\|\|([A-Za-z_$][\w$]*)\(\{appearance:\1,opaqueWindowsEnabled:this\.isOpaqueWindowsEnabled\(\),platform:process\.platform\}\)\|\|!([A-Za-z_$][\w$]*)\(\)&&!\2\(\1\)\}/u;
+  const shouldAlwaysOpaqueSurfaceMatch = currentSource.match(shouldAlwaysOpaqueSurfaceRegex);
+  const shouldAlwaysOpaqueSurfaceReady =
+    shouldAlwaysOpaqueSurfaceMatch != null ||
+    patchedShouldAlwaysOpaqueSurfaceRegex.test(currentSource);
+
+  if (!shouldAlwaysOpaqueSurfaceReady) {
+    console.warn("WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch");
+  }
+
+  const opaqueWindowSurfaceFunctionRegex =
+    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
+  const patchedOpaqueWindowSurfaceFunctionRegex =
+    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`linux`&&!([A-Za-z_$][\w$]*)\(\2\)\?\{backgroundColor:\4\?\5:\6,backgroundMaterial:null\}:\1===`win32`&&!\7\(\2\)\?/;
+  const opaqueWindowSurfaceFunctionMatch = currentSource.match(
+    opaqueWindowSurfaceFunctionRegex,
+  );
+  const opaqueWindowSurfaceFunctionReady =
+    opaqueWindowSurfaceFunctionMatch != null ||
+    patchedOpaqueWindowSurfaceFunctionRegex.test(currentSource);
+
+  if (!opaqueWindowSurfaceFunctionReady) {
+    console.warn("WARN: Could not find BrowserWindow background function signature — skipping background patch");
+  }
+
+  if (!shouldAlwaysOpaqueSurfaceReady || !opaqueWindowSurfaceFunctionReady) {
+    return currentSource;
+  }
+
+  let patchedSource = currentSource;
   if (shouldAlwaysOpaqueSurfaceMatch != null) {
     const [
       match,
@@ -424,105 +453,35 @@ function applyLinuxOpaqueBackgroundPatch(currentSource) {
     const replacement =
       `shouldAlwaysUseOpaqueWindowSurface(${appearanceParam}){return process.platform===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})||${opaqueSurfaceHelper}({appearance:${appearanceParam},opaqueWindowsEnabled:this.isOpaqueWindowsEnabled(),platform:process.platform})||!${nativeSurfaceCapabilityHelper}()&&!${transparentAppearancePredicate}(${appearanceParam})}`;
     patchedSource = patchedSource.replace(match, replacement);
-  } else if (
-    /shouldAlwaysUseOpaqueWindowSurface\([A-Za-z_$][\w$]*\)\{return\s*process\.platform===`linux`&&!/.test(patchedSource)
-  ) {
-    // Already patched.
-  } else if (patchedSource.includes("shouldAlwaysUseOpaqueWindowSurface(")) {
-    console.warn("WARN: Could not find opaque surface mode predicate — skipping Linux opaque surface patch");
   }
 
-  if (
-    patchedSource.includes("===`linux`&&!OM(") ||
-    /===`linux`&&![A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\?\{backgroundColor:[^{}]+,backgroundMaterial:null\}/.test(patchedSource)
-  ) {
+  if (opaqueWindowSurfaceFunctionMatch == null) {
     return patchedSource;
   }
 
-  const colorConstRegex =
-    /([A-Za-z_$][\w$]*)=`#00000000`,([A-Za-z_$][\w$]*)=`#000000`,([A-Za-z_$][\w$]*)=`#f9f9f9`/;
-  const colorMatch = patchedSource.match(colorConstRegex);
+  const [
+    ,
+    platformParam,
+    appearanceParam,
+    ,
+    darkColorsParam,
+    darkBackground,
+    lightBackground,
+    transparentAppearancePredicate,
+  ] = opaqueWindowSurfaceFunctionMatch;
+  const win32Needle =
+    `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
+  const linuxBackground =
+    `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkBackground}:${lightBackground},backgroundMaterial:null}:`;
 
-  if (!colorMatch) {
-    console.warn(
-      "WARN: Could not find color constants (#00000000, #000000, #f9f9f9) — skipping background patch",
-    );
-    return patchedSource;
-  }
-
-  const [, transparentVar, darkVar, lightVar] = colorMatch;
-
-  const currentFuncParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3&&!([A-Za-z_$][\w$]*)\(\2\)&&\(\1===`darwin`\|\|\1===`win32`\)\?/;
-  const currentFuncMatch = patchedSource.match(currentFuncParamRegex);
-  if (currentFuncMatch != null) {
-    const [, platformParam, appearanceParam, , darkColorsParam, transparentAppearancePredicate] =
-      currentFuncMatch;
-    const win32Needle =
-      `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
-    const linuxBgPrefix =
-      `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:`;
-
-    if (patchedSource.includes(linuxBgPrefix)) {
-      return patchedSource;
-    }
-    if (patchedSource.includes(win32Needle)) {
-      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
-    }
-
+  if (!patchedSource.includes(win32Needle)) {
     console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
     return patchedSource;
   }
-
-  const currentSurfaceFuncParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\3\?\{backgroundColor:\4\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:\1===`win32`\?`none`:null\}:\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)\?/;
-  const currentSurfaceFuncMatch = patchedSource.match(currentSurfaceFuncParamRegex);
-  if (currentSurfaceFuncMatch != null) {
-    const [, platformParam, appearanceParam, , darkColorsParam, darkVarFromReturn, lightVarFromReturn, transparentAppearancePredicate] =
-      currentSurfaceFuncMatch;
-    const win32Needle =
-      `:${platformParam}===\`win32\`&&!${transparentAppearancePredicate}(${appearanceParam})?`;
-    const linuxBgPrefix =
-      `:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVarFromReturn}:${lightVarFromReturn},backgroundMaterial:null}:`;
-
-    if (patchedSource.includes(linuxBgPrefix)) {
-      return patchedSource;
-    }
-    if (patchedSource.includes(win32Needle)) {
-      return patchedSource.replace(win32Needle, `${linuxBgPrefix}${win32Needle.slice(1)}`);
-    }
-
-    console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-    return patchedSource;
-  }
-
-  const funcParamRegex =
-    /function\s+[A-Za-z_$][\w$]*\(\{platform:([A-Za-z_$][\w$]*),appearance:([A-Za-z_$][\w$]*),opaqueWindowsEnabled:[A-Za-z_$][\w$]*,prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return\s*\1===`win32`&&!([A-Za-z_$][\w$]*)\(\2\)/;
-  const funcMatch = patchedSource.match(funcParamRegex);
-
-  if (funcMatch == null) {
-    console.warn("WARN: Could not find BrowserWindow background function signature — skipping background patch");
-    return patchedSource;
-  }
-
-  const [, platformParam, appearanceParam, darkColorsParam, transparentAppearancePredicate] =
-    funcMatch;
-  const bgNeedle =
-    `backgroundMaterial:\`mica\`}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-  const oldLinuxBgPatch =
-    `backgroundMaterial:\`mica\`}:process.platform===\`linux\`?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-  const bgReplacement =
-    `backgroundMaterial:\`mica\`}:${platformParam}===\`linux\`&&!${transparentAppearancePredicate}(${appearanceParam})?{backgroundColor:${darkColorsParam}?${darkVar}:${lightVar},backgroundMaterial:null}:{backgroundColor:${transparentVar},backgroundMaterial:null}}`;
-
-  if (patchedSource.includes(bgNeedle)) {
-    return patchedSource.replace(bgNeedle, bgReplacement);
-  }
-  if (patchedSource.includes(oldLinuxBgPatch)) {
-    return patchedSource.replace(oldLinuxBgPatch, bgReplacement);
-  }
-
-  console.warn("WARN: Could not find BrowserWindow background color needle — skipping background patch");
-  return patchedSource;
+  return patchedSource.replace(
+    win32Needle,
+    `${linuxBackground}${win32Needle.slice(1)}`,
+  );
 }
 
 function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {
@@ -530,84 +489,68 @@ function applyLinuxAboutDialogPatch(currentSource, iconPathExpression) {
     return currentSource;
   }
 
-  const alreadyUsesBundledIcon =
-    iconPathExpression != null &&
-    currentSource.includes(`nativeImage.createFromPath(${iconPathExpression})`);
   const aboutHtmlIconNullSafeRegex =
-    /[A-Za-z_$][\w$]*==null\|\|([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/;
+    /htmlIconDataUrl:[A-Za-z_$][\w$]*\?\?\(([A-Za-z_$][\w$]*)==null\|\|\1\.isEmpty\(\)\?null:\1\.resize\([^)]*\)\.toDataURL\(\)\),windowIcon:\1\?\?null\}/;
   const aboutWindowIconNullSafeRegex =
     /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon==null\|\|\1\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/;
-  const alreadyNullSafe =
-    aboutWindowIconNullSafeRegex.test(currentSource) &&
+  const aboutHtmlIconUnsafeRegex =
+    /htmlIconDataUrl:([A-Za-z_$][\w$]*)\?\?\(([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\2\.resize\(([^)]*)\)\.toDataURL\(\)\),windowIcon:\2\}/;
+  const aboutWindowIconUnsafeRegex =
+    /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/;
+  const safeCurrentFileIconRegex =
+    /\[[A-Za-z_$][\w$]*\?[A-Za-z_$][\w$]*\([^()]+\):null,[A-Za-z_$][\w$]*\?[A-Za-z_$][\w$]*\.nativeImage\.createFromPath\([^()]+\):[A-Za-z_$][\w$]*\.app\.getFileIcon\([^()]+,\{size:`normal`\}\)\.catch\(\(\)=>null\)\]/;
+  const safeBundledIconRegex =
+    iconPathExpression == null
+      ? null
+      : new RegExp(
+          `\\[\\s*process\\.platform===\`linux\`\\?null:[A-Za-z_$][\\w$]*\\?[A-Za-z_$][\\w$]*\\([^()]+\\):null,\\s*process\\.platform===\`linux\`\\?Promise\\.resolve\\(\\(\\(\\)=>\\{let __codexLinuxAboutIcon=[A-Za-z_$][\\w$]*\\.nativeImage\\.createFromPath\\(${escapeRegExp(iconPathExpression)}\\);return __codexLinuxAboutIcon\\.isEmpty\\(\\)\\?null:__codexLinuxAboutIcon\\}\\)\\(\\)\\):[A-Za-z_$][\\w$]*\\?[A-Za-z_$][\\w$]*\\.nativeImage\\.createFromPath\\([^()]+\\):[A-Za-z_$][\\w$]*\\.app\\.getFileIcon\\([^()]+,\\{size:\`normal\`\\}\\)\\.catch\\(\\(\\)=>null\\)\\s*\\]`,
+        );
+  const iconSourceReady =
+    iconPathExpression == null
+      ? safeCurrentFileIconRegex.test(currentSource)
+      : safeBundledIconRegex.test(currentSource);
+  if (
+    iconSourceReady &&
     aboutHtmlIconNullSafeRegex.test(currentSource) &&
-    /windowIcon:[A-Za-z_$][\w$]*\?\?null\}/.test(currentSource);
-  if (alreadyUsesBundledIcon && alreadyNullSafe) {
+    aboutWindowIconNullSafeRegex.test(currentSource)
+  ) {
+    return currentSource;
+  }
+
+  const currentAboutIconPromiseRegex =
+    /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(([^()]+)\):([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\]/;
+  if (
+    !currentAboutIconPromiseRegex.test(currentSource) ||
+    !aboutHtmlIconUnsafeRegex.test(currentSource) ||
+    !aboutWindowIconUnsafeRegex.test(currentSource)
+  ) {
+    console.warn("WARN: Could not patch About dialog icon fallback for Linux");
     return currentSource;
   }
 
   let patchedSource = currentSource;
   if (iconPathExpression != null) {
-    const aboutIconPromiseRegex =
-      /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\]/;
     patchedSource = patchedSource.replace(
-      aboutIconPromiseRegex,
+      currentAboutIconPromiseRegex,
       `[
-process.platform===\`linux\`?null:$1?$2($3):null,
-process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$4.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4.app.getFileIcon($5,{size:process.platform===\`win32\`?\`large\`:\`normal\`}).catch(()=>null)
-]`,
-    );
-    if (patchedSource === currentSource) {
-      // 26.623 reshaped the about icon promise array: the non-win32 size
-      // ternary collapsed to {size:`normal`} and a win32 nativeImage branch was
-      // added — [t?k_(i):null,n?a.nativeImage.createFromPath(i):a.app.getFileIcon(i,{size:`normal`})].
-      // Without this branch the Linux-safe icon (and the .catch on getFileIcon)
-      // never apply, so a getFileIcon rejection on Linux makes the About window
-      // builder throw before its try/catch and the dialog never opens.
-      const aboutIconPromiseRegex26623 =
-        /\[([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\(([^()]+)\):null,([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*)\.nativeImage\.createFromPath\(([^()]+)\):([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\]/;
-      patchedSource = patchedSource.replace(
-        aboutIconPromiseRegex26623,
-        `[
 process.platform===\`linux\`?null:$1?$2($3):null,
 process.platform===\`linux\`?Promise.resolve((()=>{let __codexLinuxAboutIcon=$5.nativeImage.createFromPath(${iconPathExpression});return __codexLinuxAboutIcon.isEmpty()?null:__codexLinuxAboutIcon})()):$4?$5.nativeImage.createFromPath($6):$7.app.getFileIcon($8,{size:\`normal\`}).catch(()=>null)
 ]`,
-      );
-    }
+    );
   } else {
-    const patchedGetFileIconRegex =
-      /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)\.catch\(\(\)=>null\)/;
-    if (!patchedGetFileIconRegex.test(patchedSource)) {
-      const getFileIconRegex =
-        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:process\.platform===`win32`\?`large`:`normal`\}\)/;
-      patchedSource = patchedSource.replace(
-        getFileIconRegex,
-        "$1.app.getFileIcon($2,{size:process.platform===`win32`?`large`:`normal`}).catch(()=>null)",
-      );
-    }
-    if (patchedSource === currentSource) {
-      // 26.623 fallback (no bundled icon): just make the reshaped getFileIcon
-      // call rejection-proof so the About window builder cannot throw on Linux.
-      const patchedGetFileIconRegex26623 =
-        /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)\.catch\(\(\)=>null\)/;
-      if (!patchedGetFileIconRegex26623.test(patchedSource)) {
-        const getFileIconRegex26623 =
-          /([A-Za-z_$][\w$]*)\.app\.getFileIcon\(([^()]+),\{size:`normal`\}\)/;
-        patchedSource = patchedSource.replace(
-          getFileIconRegex26623,
-          "$1.app.getFileIcon($2,{size:`normal`}).catch(()=>null)",
-        );
-      }
-    }
+    patchedSource = patchedSource.replace(
+      currentAboutIconPromiseRegex,
+      "[$1?$2($3):null,$4?$5.nativeImage.createFromPath($6):$7.app.getFileIcon($8,{size:`normal`}).catch(()=>null)]",
+    );
   }
 
   patchedSource = patchedSource
     .replace(
-      /([A-Za-z_$][\w$]*)\.isEmpty\(\)\?null:\1\.resize\(/g,
-      "$1==null||$1.isEmpty()?null:$1.resize(",
+      aboutHtmlIconUnsafeRegex,
+      "htmlIconDataUrl:$1??($2==null||$2.isEmpty()?null:$2.resize($3).toDataURL()),windowIcon:$2??null}",
     )
-    .replace(/windowIcon:([A-Za-z_$][\w$]*)\}/g, "windowIcon:$1??null}")
     .replace(
-      /\.\.\.([A-Za-z_$][\w$]*)\.windowIcon\.isEmpty\(\)\?\{\}:\{icon:\1\.windowIcon\}/g,
+      aboutWindowIconUnsafeRegex,
       "...$1.windowIcon==null||$1.windowIcon.isEmpty()?{}:{icon:$1.windowIcon}",
     );
 

--- a/scripts/patches/impl/main-process/window.js
+++ b/scripts/patches/impl/main-process/window.js
@@ -2,6 +2,7 @@
 
 const {
   escapeRegExp,
+  findMatchingBrace,
 } = require("../../lib/minified-js.js");
 
 const LINUX_TITLEBAR_OVERLAY_HEIGHT = 30;
@@ -44,15 +45,14 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
     const setIconNeedle = `setIcon(${iconPathExpression})`;
     const readyToShowSetIconInsertionPattern = /[A-Za-z_$][\w$]*\.once\(`ready-to-show`,\(\)=>\{/;
 
-    const windowOptionsNeedle =
+    const currentLinuxAutoHideMenuBarNeedle =
       "...process.platform===`win32`||process.platform===`linux`?{autoHideMenuBar:!0}:{},";
     const windowOptionsReplacement =
       `...process.platform===\`win32\`?{autoHideMenuBar:!0}:process.platform===\`linux\`?{${iconPathNeedle}}:{},`;
 
-    if (patchedSource.includes(windowOptionsNeedle)) {
-      patchedSource = patchedSource.split(windowOptionsNeedle).join(windowOptionsReplacement);
+    if (patchedSource.includes(currentLinuxAutoHideMenuBarNeedle)) {
+      patchedSource = patchedSource.split(currentLinuxAutoHideMenuBarNeedle).join(windowOptionsReplacement);
     } else if (
-      patchedSource === currentSource &&
       !patchedSource.includes(iconPathNeedle) &&
       !patchedSource.includes(setIconNeedle) &&
       !readyToShowSetIconInsertionPattern.test(patchedSource)
@@ -61,8 +61,30 @@ function applyLinuxWindowOptionsPatch(currentSource, iconAsset) {
     }
   }
 
+  patchedSource = applyDefinedBrowserWindowOptionsPatch(patchedSource);
   patchedSource = applyLinuxPrimaryFocusablePatch(patchedSource);
   return patchedSource;
+}
+
+function applyDefinedBrowserWindowOptionsPatch(currentSource) {
+  const browserWindowOptionsRegex =
+    /show:([A-Za-z_$][\w$]*),parent:([A-Za-z_$][\w$]*),\.\.\.([A-Za-z_$][\w$]*)===void 0\?\{\}:\{focusable:\3\},(\.\.\.process\.platform===`win32`(?:\|\|process\.platform===`linux`)?\?\{autoHideMenuBar:!0\}(?::process\.platform===`linux`\?\{icon:process\.resourcesPath\+`\/\.\.\/content\/webview\/assets\/[^`]+`\})?:\{\},)backgroundMaterial:([A-Za-z_$][\w$]*)\?\?void 0,\.\.\.([A-Za-z_$][\w$]*),minWidth:([A-Za-z_$][\w$]*)\?\.width,minHeight:\7\?\.height,webPreferences:([A-Za-z_$][\w$]*)/g;
+
+  return currentSource.replace(
+    browserWindowOptionsRegex,
+    (
+      _match,
+      showAlias,
+      parentAlias,
+      focusableAlias,
+      platformOptions,
+      backgroundMaterialAlias,
+      appearanceOptionsAlias,
+      minimumSizeAlias,
+      webPreferencesAlias,
+    ) =>
+      `show:${showAlias},...${parentAlias}===void 0?{}:{parent:${parentAlias}},...${focusableAlias}===void 0?{}:{focusable:${focusableAlias}},${platformOptions}...${backgroundMaterialAlias}==null?{}:{backgroundMaterial:${backgroundMaterialAlias}},...${appearanceOptionsAlias},...${minimumSizeAlias}==null?{}:{minWidth:${minimumSizeAlias}.width,minHeight:${minimumSizeAlias}.height},webPreferences:${webPreferencesAlias}`,
+  );
 }
 
 function findCreateWindowAppearanceAlias(currentSource, matchIndex) {
@@ -78,29 +100,28 @@ function findCreateWindowAppearanceAlias(currentSource, matchIndex) {
 }
 
 function hasPrimaryBrowserWindowFocusableCandidate(currentSource) {
-  return /createWindow\([^)]*\)\{let\{[^}]*appearance:[A-Za-z_$][\w$]*=`primary`[^}]*\}=[\s\S]{0,3500}?new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{[\s\S]{0,2000}?\.\.\.[A-Za-z_$][\w$]*===void 0\?\{\}:\{focusable:[A-Za-z_$][\w$]*\}/.test(
+  return /createWindow\([^)]*\)\{let\{[^}]*appearance:[A-Za-z_$][\w$]*(?:=`primary`)?[^}]*\}=[\s\S]{0,3500}?new\s+[A-Za-z_$][\w$]*\.BrowserWindow\(\{[\s\S]{0,2000}?focusable:/.test(
     currentSource,
   );
 }
 
 function applyLinuxPrimaryFocusablePatch(currentSource) {
   if (
-    currentSource.includes("===`primary`?{focusable:!0}") ||
-    currentSource.includes("===`primary`?!0:")
+    currentSource.includes("===`primary`?{focusable:!0}")
   ) {
     return currentSource;
   }
 
   let patchedAny = false;
-  let skippedAny = false;
+  let matchedAny = false;
   const focusableSpreadRegex =
-    /\.\.\.([A-Za-z_$][\w$]*)===void 0\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`\?)/g;
-  let patchedSource = currentSource.replace(
+    /\.\.\.([A-Za-z_$][\w$]*)===void 0\?\{\}:\{focusable:\1\},(\.\.\.process\.platform===`win32`(?:\|\|process\.platform===`linux`)?\?)/g;
+  const patchedSource = currentSource.replace(
     focusableSpreadRegex,
     (match, focusableAlias, platformOptions, offset) => {
+      matchedAny = true;
       const appearanceAlias = findCreateWindowAppearanceAlias(currentSource, offset);
       if (appearanceAlias == null) {
-        skippedAny = true;
         return match;
       }
       patchedAny = true;
@@ -111,7 +132,7 @@ function applyLinuxPrimaryFocusablePatch(currentSource) {
     },
   );
 
-  if (!patchedAny && skippedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
+  if (!patchedAny && matchedAny && hasPrimaryBrowserWindowFocusableCandidate(currentSource)) {
     throw new Error("Could not derive primary BrowserWindow appearance alias for Linux focusable patch");
   }
 
@@ -122,47 +143,66 @@ function applyLinuxPrimaryFocusablePatch(currentSource) {
   return patchedSource;
 }
 
+function findMinifiedMethod(source, signatureRegex) {
+  const match = source.match(signatureRegex);
+  if (match == null) {
+    return null;
+  }
+  const openIndex = match.index + match[0].length - 1;
+  const closeIndex = findMatchingBrace(source, openIndex);
+  if (closeIndex === -1) {
+    return null;
+  }
+  return {
+    match,
+    start: match.index,
+    end: closeIndex + 1,
+    text: source.slice(match.index, closeIndex + 1),
+  };
+}
+
 function applyLinuxNativeTitlebarPatch(currentSource) {
-  const upstreamTitlebarRegex =
-    /(case`quickChat`:case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?[\s\S]{0,1000}?):\2===`win32`\|\|\2===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\),\.\.\.([A-Za-z_$][\w$]*)===`quickChat`\?\{resizable:!0\}:\{\}\}:\{titleBarStyle:`default`,\.\.\.\5===`quickChat`\?\{resizable:!0\}:\{\}\};/;
-  const patchedTitlebarRegex = new RegExp(
-    `case\`quickChat\`:case\`primary\`:return [\\s\\S]{0,1000}?===\`win32\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:([A-Za-z_$][\\w$]*)\\(([A-Za-z_$][\\w$]*)\\)[\\s\\S]{0,300}?===\`linux\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}\\(\\2\\)`,
+  const helperFunctionRegex = new RegExp(
+    'function ' +
+      escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
+      '\\([^)]*\\)\\{return\\{color:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?`#111111`:([A-Za-z_$][\\w$]*),symbolColor:\\1\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(' +
+      LINUX_TITLEBAR_OVERLAY_HEIGHT +
+      '\\*[A-Za-z_$][\\w$]*\\)\\}\\}',
   );
-  const upstreamTitlebarMatch = currentSource.match(upstreamTitlebarRegex);
-  const patchedTitlebarMatch = currentSource.match(patchedTitlebarRegex);
-  if (upstreamTitlebarMatch == null && patchedTitlebarMatch == null) {
+  const primaryTitlebarRegex =
+    /(case`quickChat`:case`primary`:return [^;]{0,2000}?([A-Za-z_$][\w$]*)===`win32`\|\|\2===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:)([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)/;
+  const patchedPrimaryTitlebarRegex = new RegExp(
+    `(case\`quickChat\`:case\`primary\`:return [^;]{0,2000}?titleBarOverlay:)([A-Za-z_$][\\w$]*)===\`linux\`\\?${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\(([A-Za-z_$][\\w$]*)\\):([A-Za-z_$][\\w$]*)\\(\\3\\)`,
+  );
+  const primaryTitlebarMatch = currentSource.match(primaryTitlebarRegex);
+  const patchedPrimaryTitlebarMatch = currentSource.match(patchedPrimaryTitlebarRegex);
+  if (primaryTitlebarMatch == null && patchedPrimaryTitlebarMatch == null) {
     console.warn("WARN: Could not find primary BrowserWindow titlebar snippet — skipping Linux native titlebar patch");
     return currentSource;
   }
 
-  const overlayHelperAlias = upstreamTitlebarMatch?.[3] ?? patchedTitlebarMatch[1];
-  const overlayHelperRegex = new RegExp(
-    `function ${escapeRegExp(overlayHelperAlias)}\\([^)]*\\)\\{return\\{color:[A-Za-z_$][\\w$]*,symbolColor:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\([^)]*\\)\\}\\}`,
-  );
-  const overlayHelperMatch = currentSource.match(overlayHelperRegex);
-  const backgroundHelperMatch = currentSource.match(
-    /function [A-Za-z_$][\w$]*\(\{platform:[A-Za-z_$][\w$]*,appearance:[A-Za-z_$][\w$]*,opaqueWindowSurfaceEnabled:([A-Za-z_$][\w$]*),prefersDarkColors:([A-Za-z_$][\w$]*)\}\)\{return \1\?\{backgroundColor:\2\?[A-Za-z_$][\w$]*:([A-Za-z_$][\w$]*),backgroundMaterial:/,
-  );
-  if (overlayHelperMatch == null || backgroundHelperMatch == null) {
-    console.warn("WARN: Could not derive titleBarOverlay aliases — skipping Linux native titlebar patch");
-    return currentSource;
-  }
-
-  const [, electronAlias, lightSymbolAlias, darkSymbolAlias] = overlayHelperMatch;
-  const lightBackgroundAlias = backgroundHelperMatch[3];
   let patchedSource = currentSource;
+  let electronAlias;
+  if (primaryTitlebarMatch != null) {
+    const [, titlebarPrefix, platformAlias, overlayHelperAlias, zoomAlias] = primaryTitlebarMatch;
+    const overlayHelperRegex = new RegExp(
+      `function ${escapeRegExp(overlayHelperAlias)}\\([^)]*\\)\\{return\\{color:[A-Za-z_$][\\w$]*,symbolColor:([A-Za-z_$][\\w$]*)\\.nativeTheme\\.shouldUseDarkColors\\?([A-Za-z_$][\\w$]*):([A-Za-z_$][\\w$]*),height:Math\\.round\\(([A-Za-z_$][\\w$]*)\\*[^)]*\\)\\}\\}`,
+    );
+    const overlayHelperMatch = currentSource.match(overlayHelperRegex);
+    const linuxBackgroundMatch = currentSource.match(
+      /===`linux`&&!([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*\)\?\{backgroundColor:([A-Za-z_$][\w$]*)\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*),backgroundMaterial:null\}/,
+    );
+    if (overlayHelperMatch == null || linuxBackgroundMatch == null) {
+      console.warn("WARN: Could not derive titleBarOverlay aliases — skipping Linux native titlebar patch");
+      return currentSource;
+    }
 
-  if (upstreamTitlebarMatch != null) {
-    const [, darwinBranch, platformAlias, , zoomAlias, appearanceAlias] = upstreamTitlebarMatch;
-    const windowsBranch =
-      `${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias}),...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}}`;
-    const linuxBranch =
-      `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias}),...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}}`;
-    const defaultBranch =
-      `{titleBarStyle:\`default\`,...${appearanceAlias}===\`quickChat\`?{resizable:!0}:{}};`;
+    const [, currentElectronAlias, lightSymbolAlias, darkSymbolAlias] = overlayHelperMatch;
+    const lightBackgroundAlias = linuxBackgroundMatch[4];
+    electronAlias = currentElectronAlias;
     patchedSource = patchedSource.replace(
-      upstreamTitlebarRegex,
-      `${darwinBranch}:${windowsBranch}:${linuxBranch}:${defaultBranch}`,
+      primaryTitlebarRegex,
+      `${titlebarPrefix}${platformAlias}===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias}):${overlayHelperAlias}(${zoomAlias})`,
     );
     patchedSource = ensureLinuxTitlebarOverlayHelper(
       patchedSource,
@@ -174,30 +214,58 @@ function applyLinuxNativeTitlebarPatch(currentSource) {
         darkSymbolAlias,
       ),
     );
+    if (patchedSource == null) {
+      console.warn("WARN: Could not insert Linux titleBarOverlay helper — skipping Linux native titlebar patch");
+      return currentSource;
+    }
+  } else {
+    const helperFunctionMatch = currentSource.match(helperFunctionRegex);
+    if (helperFunctionMatch == null) {
+      console.warn("WARN: Could not derive Linux titleBarOverlay helper aliases — skipping Linux native titlebar patch");
+      return currentSource;
+    }
+    electronAlias = helperFunctionMatch[1];
   }
 
-  const escapedOverlayHelper = escapeRegExp(overlayHelperAlias);
-  const syncOverlayRegex = new RegExp(
-    `([A-Za-z_$][\\w$]*)\\.setTitleBarOverlay\\(${escapedOverlayHelper}\\(this\\.windowZooms\\.get\\(\\1\\.id\\)\\)\\)`,
-    "g",
-  );
-  patchedSource = patchedSource.replace(
-    syncOverlayRegex,
-    (_match, windowAlias) =>
-      `${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(this.windowZooms.get(${windowAlias}.id)):${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))`,
-  );
-
-  const zoomOverlayRegex = new RegExp(
-    `([A-Za-z_$][\\w$]*)\\.setTitleBarOverlay\\(${escapedOverlayHelper}\\(([A-Za-z_$][\\w$]*)\\)\\)`,
-    "g",
-  );
+  const zoomOverlayRegex =
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g;
   patchedSource = patchedSource.replace(
     zoomOverlayRegex,
-    (_match, windowAlias, zoomAlias) =>
-      `${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias}):${overlayHelperAlias}(${zoomAlias}))`,
+    (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
+      `(process.platform===\`win32\`||process.platform===\`linux\`)&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(${zoomAlias}):${overlayHelperAlias}(${zoomAlias})))`,
   );
 
-  return patchedSource;
+  const overlaySyncMethod = findMinifiedMethod(
+    patchedSource,
+    /install[A-Za-z_$][\w$]*TitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{/,
+  );
+  if (overlaySyncMethod == null) {
+    return patchedSource;
+  }
+  if (overlaySyncMethod.text.includes(`setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(`)) {
+    return patchedSource;
+  }
+
+  const windowAlias = overlaySyncMethod.match[1];
+  const overlayCallRegex = new RegExp(
+    `${escapeRegExp(windowAlias)}\\.setTitleBarOverlay\\(([A-Za-z_$][\\w$]*)\\(this\\.windowZooms\\.get\\(${escapeRegExp(windowAlias)}\\.id\\)\\)\\)`,
+  );
+  const overlayCallMatch = overlaySyncMethod.text.match(overlayCallRegex);
+  if (overlayCallMatch == null) {
+    console.warn("WARN: Could not patch titleBarOverlay nativeTheme sync for Linux");
+    return patchedSource;
+  }
+
+  const windowsOverlayHelperAlias = overlayCallMatch[1];
+  const patchedMethod = overlaySyncMethod.text.replace(
+    overlayCallRegex,
+    `${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?${LINUX_TITLEBAR_OVERLAY_HELPER}(this.windowZooms.get(${windowAlias}.id)):${windowsOverlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))`,
+  );
+  return (
+    patchedSource.slice(0, overlaySyncMethod.start) +
+    patchedMethod +
+    patchedSource.slice(overlaySyncMethod.end)
+  );
 }
 
 function applyLinuxMenuPatch(currentSource) {

--- a/scripts/patches/lib/minified-js.js
+++ b/scripts/patches/lib/minified-js.js
@@ -1,13 +1,27 @@
 "use strict";
 
 const TRAY_GUARD_LOOKAHEAD = 1200;
-const CLOSE_GATE_PREFIX_LOOKBACK = 8000;
 const HANDLER_PREFIX_LOOKBACK = 12000;
 
 function requireName(source, moduleName) {
   const escaped = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = source.match(new RegExp(`([A-Za-z_$][\\w$]*)=require\\(([\\\`"'])${escaped}\\2\\)`));
-  return match?.[1] ?? null;
+  const directMatch = source.match(
+    new RegExp(`([A-Za-z_$][\\w$]*)=require\\(([\\\`"'])${escaped}\\2\\)`),
+  );
+  if (directMatch != null) {
+    return directMatch[1];
+  }
+
+  if (moduleName === "electron") {
+    const wrappedMatch = source.match(
+      new RegExp(
+        `([A-Za-z_$][\\w$]*)=codexLinuxPatchExternalOpen\\(require\\(([\\\`"'])${escaped}\\2\\)\\)`,
+      ),
+    );
+    return wrappedMatch?.[1] ?? null;
+  }
+
+  return null;
 }
 
 function inferModuleAlias(source, moduleName) {
@@ -165,7 +179,6 @@ function findExportedAlias(source, localName) {
 }
 
 module.exports = {
-  CLOSE_GATE_PREFIX_LOOKBACK,
   HANDLER_PREFIX_LOOKBACK,
   TRAY_GUARD_LOOKAHEAD,
   escapeRegExp,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5551,7 +5551,7 @@ test_linux_tray_patch_smoke() {
     mkdir -p "$workspace"
     bundle_body="$(cat <<'JS'
 let D={removeMenu(){},setMenuBarVisibility(){},setIcon(){},once(){}};
-let n=require(`electron`),i=require(`node:path`),a=require(`node:fs`);
+const x={o:e=>e};let s=require(`node:url`),n=require(`electron`);n=x.o(n);let l=require(`node:os`);l=x.o(l);let i=require(`node:path`);i=x.o(i);let d=require(`node:util`),q=require(`node:crypto`),a=require(`node:fs`);a=x.o(a);
 let t={join(){},C:{Prod:`prod`},A(){}};
 let k={hide(){},isDestroyed(){return false}};
 let f=`local`;
@@ -5562,13 +5562,13 @@ async function la(e){let t=ua(e);if(t&&(0,a.statSync)(t).isFile()){n.shell.showI
 function ua(e){return e}
 var Ua=Mi({id:`systemDefault`,label:`System Default App`,icon:`apps/file-explorer.png`,kind:`systemDefault`,hidden:!0,darwin:{icon:`apps/finder.png`,detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},win32:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)},linux:{detect:()=>`system-default`,iconPath:()=>null,args:e=>[e],open:async({path:e})=>Wa(e)}});
 async function Wa(e){return e}
-function Nw(e,n){return `icon`}
 async function Hw(e){return process.platform!==`win32`&&process.platform!==`darwin`?null:(zw=!0,Lw??Rw??(Rw=(async()=>{let r=await Ww(e.buildFlavor,e.appBrand,e.repoRoot),i=new n.Tray(r.defaultIcon);return i})()))}
-async function Ww(e,t,r){if(process.platform===`darwin`){let e=n.nativeImage.createFromPath(r);return e.isEmpty()?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`normal`}),chronicleRunningIcon:null}:{defaultIcon:e,chronicleRunningIcon:null}}let a=Nw(e,t,r);return a==null?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:a,chronicleRunningIcon:null}}
+async function Ww(e,t,i){if(process.platform===`darwin`){return null}let r=K9(e,t,i);return r==null?{defaultIcon:await n.app.getFileIcon(process.execPath,{size:`small`}),chronicleRunningIcon:null}:{defaultIcon:r,chronicleRunningIcon:null}}
+function K9(e,t,r){let a=[(0,i.join)(r,`electron`,`src`,`icons`,`tray.png`)];for(let e of a){let t=n.nativeImage.createFromPath(e);if(!t.isEmpty())return t}return null}
 var pb=class{trayMenuThreads={runningThreads:[],unreadThreads:[],pinnedThreads:[],recentThreads:[],usageLimits:[]};constructor(){this.tray={on(){},setContextMenu(){},popUpContextMenu(){}};this.onTrayButtonClick=()=>{};this.tray.on(`click`,()=>{this.onTrayButtonClick()}),this.tray.on(`right-click`,()=>{this.openNativeTrayMenu()})}async handleMessage(e){switch(e.type){case`tray-menu-threads-changed`:this.trayMenuThreads=e.trayMenuThreads;return}}openNativeTrayMenu(){this.updateChronicleTrayIcon();let e=n.Menu.buildFromTemplate(this.getNativeTrayMenuItems());e.once(`menu-will-show`,()=>{this.isNativeTrayMenuOpen=!0}),e.once(`menu-will-close`,()=>{this.isNativeTrayMenuOpen=!1,this.handleNativeTrayMenuClosed()}),this.tray.popUpContextMenu(e)}updateChronicleTrayIcon(){}getNativeTrayMenuItems(){return[]}}
-v&&k.on(`close`,e=>{this.persistPrimaryWindowBounds(k,f);let t=this.getPrimaryWindows(f).some(e=>e!==k);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastLocalWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}if(process.platform===`darwin`&&!this.isAppQuitting&&!t){e.preventDefault(),k.hide()}});
+v&&k.on(`close`,e=>{this.persistPrimaryWindowBounds(k);let t=this.getPrimaryWindows().some(e=>e!==k);if(process.platform===`win32`&&!this.isAppQuitting&&this.options.canHideLastWindowToTray?.()===!0&&!t){e.preventDefault(),k.hide();return}if(process.platform===`darwin`&&!this.isAppQuitting&&!t){e.preventDefault(),k.hide()}});
 let E=process.platform===`win32`;
-let oe=async()=>{};
+let oe=async()=>{O=!0;try{await Hw({appBrand:a.U(),buildFlavor:b,repoRoot:j.repoRoot})}catch(e){O=!1}};
 let se=async e=>{};
 E&&oe();let ce=Hr({});
 JS
@@ -5604,7 +5604,7 @@ function registerCloseHandler({ quitInProgress = false, isAppQuitting = false, t
   const state = { hideCalls: 0 };
   const controller = {
     isAppQuitting,
-    options: { canHideLastLocalWindowToTray: () => trayEnabled },
+    options: { canHideLastWindowToTray: () => trayEnabled },
     persistPrimaryWindowBounds() {},
     getPrimaryWindows() {
       return [];
@@ -5631,7 +5631,7 @@ function runCloseWithoutHelper({ trayEnabled = true, isAppQuitting = false } = {
   const state = { hideCalls: 0 };
   const controller = {
     isAppQuitting,
-    options: { canHideLastLocalWindowToTray: () => trayEnabled },
+    options: { canHideLastWindowToTray: () => trayEnabled },
     persistPrimaryWindowBounds() {},
     getPrimaryWindows() {
       return [];
@@ -5707,7 +5707,7 @@ test_linux_explicit_quit_patch_smoke() {
 
     mkdir -p "$workspace"
     bundle_body="$(cat <<'JS'
-let s=require(`node:url`),c=require(`electron`);c=e.o(c);let n=c,i=require(`node:path`),a=require(`node:fs`);
+const x={o:e=>e};let s=require(`node:url`),n=require(`electron`);n=x.o(n);let l=require(`node:os`);l=x.o(l);let i=require(`node:path`);i=x.o(i);let d=require(`node:util`),q=require(`node:crypto`),a=require(`node:fs`);a=x.o(a);
 var pb=class{getNativeTrayMenuItems(){return[{label:rB(this.appName),click:()=>{n.app.quit()}}]}};
 function qB(r,o){if(o.type===`quit-app`){n.app.quit();return}return o}
 n.app.on(`before-quit`,o=>{let s=BI(),c=t.sr().some(e=>e.status===`ACTIVE`);if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}let l=n.app.getName();if(n.dialog.showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`],defaultId:0,cancelId:1,noLink:!0,title:`Quit ${l}?`,message:`Quit ${l}?`,detail:vB({hasInProgressLocalConversation:s,hasEnabledAutomations:c})})!==0){o.preventDefault();return}i.markQuitApproved(),g=!0,a.markAppQuitting()});
@@ -5951,10 +5951,10 @@ test_linux_single_instance_patch_smoke() {
     mkdir -p "$workspace"
     bundle_body="$(cat <<'JS'
 let S=globalThis.__codexSmoke;
-let n={app:{whenReady(){return Promise.resolve()},quit(){S.quitCount++},requestSingleInstanceLock(){S.lockCount++;return true},on(e,t){S.appHandlers[e]=t},off(e,t){S.offHandlers[e]=t}}};
+let n=require(`electron`);
 let t={Er(){return {info(){}}},jn:class{add(e){S.disposables.push(e)}},y(){return{setSecondInstanceArgsHandler:e=>{S.initialHandler=e}}},g(e){return e},t(e){return Array.isArray(e)&&e.includes(`--open-project`)}};
 let i={default:{dirname(e){S.dirnameCalls.push(e);return `/tmp`}}},o={mkdirSync(...e){S.mkdirSyncCalls.push(e)},rmSync(...e){S.rmSyncCalls.push(e)}},u={default:{createServer(e){S.createServerCalls++;S.socketConnectionHandler=e;return S.socketServer}}};
-async function uT(){let{setSecondInstanceArgsHandler:l}=t.y(),k=new t.jn;k.add(()=>{}),t.Er().info(`Launching app`,{safe:{agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();let w=(...e)=>{S.traceCalls.push(e)},M={globalState:S.globalState,repoRoot:`/tmp/codex-smoke`},z=`local`,R={deepLinks:{queueProcessArgs(e){S.queueArgs.push(e);return Array.isArray(e)&&e.some(e=>{let t=String(e);return t.startsWith(`codex://`)||t.startsWith(`codex-browser-sidebar://`)})},flushPendingDeepLinks(){S.flushPendingDeepLinksCalls++;return Promise.resolve()}},navigateToRoute(e,t){S.navigateCalls.push({windowId:e.id,path:t})}},P={windowManager:{sendMessageToWindow(e,t){S.messages.push({windowId:e.id,message:t})}},hotkeyWindowLifecycleManager:{hide(){S.hideCalls++},show(){S.showCalls++;return S.hotkeyWindowShowResult},ensureHotkeyWindowController(){S.ensureHotkeyWindowControllerCalls++;return S.hotkeyWindowController}},getPrimaryWindow(){return S.primaryWindow},createFreshLocalWindow(e){S.createFreshLocalWindowCalls.push(e);return S.createdWindow},ensureHostWindow(e){S.ensureHostWindowCalls.push(e);return S.primaryWindow??S.createdWindow}},g={reportNonFatal(e,t){S.errors.push({error:String(e),meta:t})}},re=e=>{S.focusCalls.push(e.id);e.isMinimized()&&e.restore(),e.show(),e.focus()},ie=async()=>{S.ieCalls++;try{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow()??await P.createFreshLocalWindow(`/`);if(e==null)return;re(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{let n=t.t(t.g(e));if(R.deepLinks.queueProcessArgs(e)){n&&ie();return}if(n){ie();return}ie()});let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))},oe=async()=>{S.trayStartupCalls++};let E=process.platform===`win32`;E&&oe();let me=await P.ensureHostWindow(z);me&&re(me),w(`local window ensured`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()}
+async function uT(){let{setSecondInstanceArgsHandler:l}=t.y(),k=new t.jn;k.add(()=>{}),t.Er().info(`Launching app`,{safe:{agentRunId:process.env.CODEX_ELECTRON_AGENT_RUN_ID?.trim()||null}});let A=Date.now();await n.app.whenReady();let w=(...e)=>{S.traceCalls.push(e)},M={globalState:S.globalState,repoRoot:`/tmp/codex-smoke`},z=`local`,R={deepLinks:{queueProcessArgs(e){S.queueArgs.push(e);return Array.isArray(e)&&e.some(e=>{let t=String(e);return t.startsWith(`codex://`)||t.startsWith(`codex-browser-sidebar://`)})},flushPendingDeepLinks(){S.flushPendingDeepLinksCalls++;return Promise.resolve()}},navigateToRoute(e,t){S.navigateCalls.push({windowId:e.id,path:t})}},P={windowManager:{sendMessageToWindow(e,t){S.messages.push({windowId:e.id,message:t})}},hotkeyWindowLifecycleManager:{hide(){S.hideCalls++},show(){S.showCalls++;return S.hotkeyWindowShowResult},ensureHotkeyWindowController(){S.ensureHotkeyWindowControllerCalls++;return S.hotkeyWindowController}},getPrimaryWindow(){return S.primaryWindow},createFreshLocalWindow(e){S.createFreshLocalWindowCalls.push(e);return S.createdWindow},ensureHostWindow(e){S.ensureHostWindowCalls.push(e);return S.primaryWindow??S.createdWindow}},g={reportNonFatal(e,t){S.errors.push({error:String(e),meta:t})}},re=e=>{S.focusCalls.push(e.id);e.isMinimized()&&e.restore(),e.show(),e.focus()},ie=async()=>{S.ieCalls++;try{P.hotkeyWindowLifecycleManager.hide();let e=P.getPrimaryWindow()??await P.createFreshLocalWindow(`/`);if(e==null)return;re(e)}catch(e){g.reportNonFatal(e instanceof Error?e:`Failed to open window on second instance`,{kind:`second-instance-open-window-failed`})}};l(e=>{let n=t.t(t.g(e));if(R.deepLinks.queueProcessArgs(e)){n&&ie();return}if(n){ie();return}ie()});let ae=async(e,t)=>{P.hotkeyWindowLifecycleManager.hide();let n=P.getPrimaryWindow(),r=n??await P.createFreshLocalWindow(e);r!=null&&(n!=null&&t.navigateExistingWindow&&R.navigateToRoute(r,e),re(r))};async function ore(e){return new n.Tray(e)}let oe=async()=>{N=!0;try{await ore({appBrand:`codex`,buildFlavor:`prod`,repoRoot:M.repoRoot}),S.trayStartupCalls++}catch(e){N=!1}};let E=process.platform===`win32`;E&&oe();let me=await P.ensureHostWindow(z);me&&re(me),w(`local window ensured`,A,{hostId:z,localWindowVisible:me?.isVisible()??!1}),A=Date.now(),await R.deepLinks.flushPendingDeepLinks()}
 JS
 )"
     make_fake_extracted_asar "$extracted" "$bundle_body"
@@ -6169,6 +6169,29 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
     console,
     process: { platform: "linux", env },
     require(moduleName) {
+      if (moduleName === "electron") {
+        return {
+          app: {
+            whenReady() {
+              return Promise.resolve();
+            },
+            quit() {
+              state.quitCount++;
+            },
+            requestSingleInstanceLock() {
+              state.lockCount++;
+              return true;
+            },
+            on(event, handler) {
+              state.appHandlers[event] = handler;
+            },
+            off(event, handler) {
+              state.offHandlers[event] = handler;
+            },
+          },
+          Tray: class {},
+        };
+      }
       if (moduleName === "node:path") {
         return {
           dirname(path) {


### PR DESCRIPTION
## Summary

- follow up on #716 with current-only main-process matching for Codex 26.707.30751 and Electron 42.1.0
- preserve nullish BrowserWindow option semantics, current tray/icon resolution, avatar overlay input handling, and explicit quit lifecycle behavior
- keep repeated full-bundle patching idempotent after the Electron require wrapper is installed
- remove the obsolete `linux-tray-close-setting` descriptor and its legacy `canHideLastLocalWindowToTray` compatibility path

## User-visible behavior

- primary and overlay windows retain valid Linux options when upstream values are null or no icon asset is available
- the native titlebar, avatar overlay, tray, close-to-tray, and explicit quit patches match the current upstream bundle without guessed aliases
- rebuilding an already patched bundle no longer changes tray bindings on the second pass

## Source of truth

- current bundle matching lives in `scripts/patches/impl/main-process/`, `scripts/patches/impl/avatar-overlay.js`, and `scripts/patches/lib/minified-js.js`
- the obsolete descriptor removal is in `scripts/patches/core/all-linux/main-process/launch-actions/patch.js` and `scripts/patches/impl/launch-actions.js`
- regressions are covered in `scripts/patch-linux-window-ui.test.js` and `tests/scripts_smoke.sh`

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (335 passed)
- `node --test linux-features/*/test.js` (402 passed)
- `bash tests/scripts_smoke.sh`
- `MAX_BUILD_THREADS=4 ./install.sh ./Codex.dmg` against app 26.707.30751 / Electron 42.1.0
- second enforced real-DMG patch pass: all 17 required patches `already-applied`; main bundle SHA-256 remained byte-identical
- `git diff --check`, changed JavaScript syntax checks, and `bash -n tests/scripts_smoke.sh`

## Environment and limits

- validated on Arch Linux x86_64
- the full production package artifacts were not rebuilt after the final review fix; the smoke suite exercised Debian, RPM, pacman, and AppImage packaging paths
- the real-DMG report has no required failures; the existing optional Computer Use install-flow bundle patch remains skipped because the current bundle is absent

## Risk

The change is limited to latest-DMG main-process patch matching and its fixtures. No optional feature is enabled or added.
