### PR TITLE
Add optional Omarchy theme integration

### DIFF
--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -10,6 +10,10 @@ import sys
 import urllib.parse
 
 
+USER_STYLESHEET_ENDPOINT = "/__codex_user_stylesheet.css"
+MAX_USER_STYLESHEET_BYTES = 256 * 1024
+
+
 def _install_parent_death_signal():
     # Ensure the kernel terminates this process if the launcher (parent) exits
     # without invoking its cleanup trap (SIGKILL, OOM, crash). Without this,
@@ -56,6 +60,39 @@ class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
             if header in self.headers:
                 del self.headers[header]
         return super().send_head()
+
+    def user_stylesheet_path(self):
+        configured = os.environ.get("CODEX_LINUX_WEBVIEW_USER_STYLESHEET", "").strip()
+        if not configured:
+            configured = os.environ.get("CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT", "").strip()
+        if not configured:
+            return None
+        return os.path.expanduser(os.path.expandvars(configured))
+
+    def serve_user_stylesheet(self):
+        payload = b""
+        try:
+            css_path = self.user_stylesheet_path()
+            if css_path is None or not os.path.isfile(css_path):
+                raise OSError("user stylesheet is missing or is not a file")
+            with open(css_path, "rb") as handle:
+                payload = handle.read(MAX_USER_STYLESHEET_BYTES + 1)
+            if len(payload) > MAX_USER_STYLESHEET_BYTES:
+                payload = b""
+        except OSError:
+            payload = b""
+        self.send_response(200)
+        self.send_header("Content-Type", "text/css; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    def do_GET(self):
+        if self.normalized_request_path() == USER_STYLESHEET_ENDPOINT:
+            self.serve_user_stylesheet()
+            return
+        return super().do_GET()
 
     def end_headers(self):
         self.send_header("Cache-Control", "no-store, max-age=0")

--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -5,7 +5,6 @@ import functools
 import http.server
 import os
 import posixpath
-import re
 import signal
 import sys
 import urllib.parse
@@ -13,7 +12,6 @@ import urllib.parse
 
 USER_STYLESHEET_ENDPOINT = "/__codex_user_stylesheet.css"
 MAX_USER_STYLESHEET_BYTES = 256 * 1024
-SHELL_DEFAULT_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):-([^{}]*)\}")
 
 
 def _install_parent_death_signal():
@@ -69,10 +67,6 @@ class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
             configured = os.environ.get("CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT", "").strip()
         if not configured:
             return None
-        configured = SHELL_DEFAULT_VAR_PATTERN.sub(
-            lambda match: os.environ.get(match.group(1)) or match.group(2),
-            configured,
-        )
         return os.path.expanduser(os.path.expandvars(configured))
 
     def serve_user_stylesheet(self):

--- a/launcher/webview-server.py
+++ b/launcher/webview-server.py
@@ -5,6 +5,7 @@ import functools
 import http.server
 import os
 import posixpath
+import re
 import signal
 import sys
 import urllib.parse
@@ -12,6 +13,7 @@ import urllib.parse
 
 USER_STYLESHEET_ENDPOINT = "/__codex_user_stylesheet.css"
 MAX_USER_STYLESHEET_BYTES = 256 * 1024
+SHELL_DEFAULT_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):-([^{}]*)\}")
 
 
 def _install_parent_death_signal():
@@ -67,6 +69,10 @@ class CodexWebviewHandler(http.server.SimpleHTTPRequestHandler):
             configured = os.environ.get("CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT", "").strip()
         if not configured:
             return None
+        configured = SHELL_DEFAULT_VAR_PATTERN.sub(
+            lambda match: os.environ.get(match.group(1)) or match.group(2),
+            configured,
+        )
         return os.path.expanduser(os.path.expandvars(configured))
 
     def serve_user_stylesheet(self):

--- a/linux-features/omarchy-theme/README.md
+++ b/linux-features/omarchy-theme/README.md
@@ -1,0 +1,89 @@
+# Omarchy Theme
+
+Optional integration that makes Codex Desktop follow the active
+[Omarchy](https://omarchy.org/) color palette. It is disabled by default.
+
+The feature:
+
+- installs an Omarchy `themed/` template in the user's configuration on first
+  launch without overwriting an existing customized template;
+- asks `omarchy theme refresh` to generate
+  `~/.config/omarchy/current/theme/codex-desktop.css` when needed;
+- selects that generated file through the loopback-only Codex webview server's
+  generic user-stylesheet endpoint;
+- injects a guarded renderer stylesheet loader that refreshes the CSS every five
+  seconds and when the window regains focus.
+
+It never edits Omarchy source under `~/.local/share/omarchy/`.
+
+## Enable
+
+Add the feature to the gitignored `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["omarchy-theme"]
+}
+```
+
+Then rebuild Codex Desktop with `./install.sh`, `make install-native`, or the
+corresponding AppImage/Nix workflow. The generated app must be rebuilt after
+changing feature selection.
+
+On first launch the prelaunch hook installs:
+
+```text
+~/.config/omarchy/themed/codex-desktop.css.tpl
+```
+
+If Omarchy cannot be refreshed automatically, run:
+
+```bash
+omarchy theme refresh
+```
+
+Subsequent `omarchy theme set ...` and `omarchy theme refresh` operations update
+the generated stylesheet, and an open Codex window picks it up within five
+seconds.
+
+## Configuration
+
+- `CODEX_LINUX_WEBVIEW_USER_STYLESHEET=/absolute/or/~/path.css` overrides the
+  generated CSS file served to Codex.
+- `CODEX_OMARCHY_CONFIG_HOME=/path/to/omarchy` overrides the default
+  `~/.config/omarchy` directory.
+- `CODEX_OMARCHY_THEME_AUTO_REFRESH=0` prevents the first-launch hook from
+  invoking `omarchy theme refresh`.
+
+The generic stylesheet endpoint returns empty CSS when the configured file is
+missing, not a regular file, unreadable, or larger than 256 KiB.
+
+## Disable and cleanup
+
+Remove `omarchy-theme` from `features.json` and rebuild. Declarative feature
+resources and runtime hooks are removed automatically. The user-owned Omarchy
+template remains so local customizations are not deleted; remove it manually if
+desired, then run `omarchy theme refresh`.
+
+## Test
+
+```bash
+node --test linux-features/omarchy-theme/test.js
+```
+
+Manual acceptance checks:
+
+1. Launch Codex and confirm its palette matches `omarchy theme current`.
+2. Change themes or run `omarchy theme refresh`.
+3. Confirm the open Codex window updates within five seconds.
+4. Rebuild with the feature disabled and confirm Codex uses its normal theme.
+
+## Risks
+
+- Codex CSS variables and utility selectors can drift with upstream webview
+  releases; unsupported selectors simply stop affecting those elements.
+- User CSS can obscure controls or reduce contrast. Only load trusted,
+  user-owned CSS.
+- Polling performs one small loopback stylesheet request every five seconds.
+- Existing customized Omarchy templates are never overwritten automatically,
+  so they may need manual updates when this feature's template changes.

--- a/linux-features/omarchy-theme/README.md
+++ b/linux-features/omarchy-theme/README.md
@@ -50,10 +50,10 @@ seconds.
 
 - `CODEX_LINUX_WEBVIEW_USER_STYLESHEET=/absolute/or/~/path.css` overrides the
   generated CSS file served to Codex.
-- `CODEX_OMARCHY_CONFIG_HOME=/path/to/omarchy` overrides the default
-  `~/.config/omarchy` directory.
 - `CODEX_OMARCHY_THEME_AUTO_REFRESH=0` prevents the first-launch hook from
   invoking `omarchy theme refresh`.
+- `CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS=15` changes the bounded wait for
+  that refresh. Values must be whole seconds between 1 and 60.
 
 The generic stylesheet endpoint returns empty CSS when the configured file is
 missing, not a regular file, unreadable, or larger than 256 KiB.

--- a/linux-features/omarchy-theme/codex-desktop.css.tpl
+++ b/linux-features/omarchy-theme/codex-desktop.css.tpl
@@ -1,0 +1,84 @@
+/* Managed by the Codex Desktop Linux omarchy-theme feature. */
+:root {
+  color-scheme: dark;
+  --codex-omarchy-accent: {{ accent }};
+  --codex-omarchy-background: {{ background }};
+  --codex-omarchy-foreground: {{ foreground }};
+  --codex-omarchy-surface: {{ color0 }};
+  --codex-omarchy-surface-muted: {{ color8 }};
+  --codex-omarchy-selection-background: {{ selection_background }};
+  --codex-omarchy-selection-foreground: {{ selection_foreground }};
+
+  --text-primary: {{ foreground }};
+  --text-secondary: {{ color7 }};
+  --text-tertiary: {{ color8 }};
+  --text-quaternary: {{ color8 }};
+  --text-error: {{ color1 }};
+  --text-success: {{ color2 }};
+
+  --main-surface-primary: {{ background }};
+  --main-surface-secondary: {{ color0 }};
+  --main-surface-tertiary: {{ color0 }};
+  --sidebar-surface-primary: {{ background }};
+  --sidebar-surface-secondary: {{ color0 }};
+  --sidebar-surface-tertiary: {{ color0 }};
+  --composer-surface-primary: {{ background }};
+  --composer-surface-secondary: {{ color0 }};
+
+  --border-light: color-mix(in srgb, {{ foreground }} 14%, transparent);
+  --border-medium: color-mix(in srgb, {{ foreground }} 24%, transparent);
+  --border-heavy: color-mix(in srgb, {{ foreground }} 34%, transparent);
+  --accent-primary: {{ accent }};
+  --link: {{ accent }};
+}
+
+html,
+body,
+#root {
+  background: {{ background }} !important;
+  color: {{ foreground }} !important;
+}
+
+::selection {
+  background: {{ selection_background }} !important;
+  color: {{ selection_foreground }} !important;
+}
+
+.bg-token-main-surface-primary,
+.bg-token-sidebar-surface-primary,
+.bg-token-bg-primary {
+  background-color: {{ background }} !important;
+}
+
+.bg-token-main-surface-secondary,
+.bg-token-sidebar-surface-secondary,
+.bg-token-bg-secondary,
+.bg-token-bg-tertiary {
+  background-color: {{ color0 }} !important;
+}
+
+.text-token-text-primary {
+  color: {{ foreground }} !important;
+}
+
+.text-token-text-secondary,
+.text-token-text-tertiary {
+  color: {{ color7 }} !important;
+}
+
+.border-token-border-light,
+.border-token-border-medium {
+  border-color: color-mix(in srgb, {{ foreground }} 18%, transparent) !important;
+}
+
+a,
+.text-token-text-link,
+.text-token-link {
+  color: {{ accent }} !important;
+}
+
+.ProseMirror,
+textarea,
+input {
+  caret-color: {{ accent }} !important;
+}

--- a/linux-features/omarchy-theme/feature.json
+++ b/linux-features/omarchy-theme/feature.json
@@ -1,0 +1,28 @@
+{
+  "id": "omarchy-theme",
+  "title": "Omarchy Theme",
+  "description": "Loads user CSS generated from the active Omarchy theme into Codex Desktop.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "resources": [
+    {
+      "source": "codex-desktop.css.tpl",
+      "target": ".codex-linux/features/omarchy-theme/codex-desktop.css.tpl",
+      "mode": "0644"
+    }
+  ],
+  "runtimeHooks": {
+    "env": {
+      "source": "user-stylesheet.env",
+      "name": "user-stylesheet.env",
+      "mode": "0644"
+    },
+    "prelaunch": {
+      "source": "install-template.sh",
+      "name": "install-template.sh",
+      "mode": "0755"
+    }
+  }
+}

--- a/linux-features/omarchy-theme/install-template.sh
+++ b/linux-features/omarchy-theme/install-template.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+warn() {
+    echo "WARN: omarchy-theme: $*" >&2
+}
+
+truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+if [ -z "${HOME:-}" ] || [ -z "${CODEX_LINUX_FEATURES_DIR:-}" ]; then
+    warn "HOME or CODEX_LINUX_FEATURES_DIR is unavailable; skipping Omarchy template setup"
+    exit 0
+fi
+
+source_path="$CODEX_LINUX_FEATURES_DIR/omarchy-theme/codex-desktop.css.tpl"
+if [ ! -f "$source_path" ]; then
+    warn "template source not found at $source_path"
+    exit 0
+fi
+
+omarchy_home="${CODEX_OMARCHY_CONFIG_HOME:-$HOME/.config/omarchy}"
+target_dir="$omarchy_home/themed"
+target_path="$target_dir/codex-desktop.css.tpl"
+generated_path="$omarchy_home/current/theme/codex-desktop.css"
+
+if [ -f "$target_path" ] && ! cmp -s "$source_path" "$target_path"; then
+    warn "$target_path already exists with local changes; leaving it untouched"
+    exit 0
+fi
+
+if [ ! -f "$target_path" ]; then
+    if ! mkdir -p "$target_dir" || ! install -m 0644 "$source_path" "$target_path"; then
+        warn "could not install Omarchy template at $target_path"
+        exit 0
+    fi
+    echo "Installed Omarchy Codex Desktop theme template at $target_path" >&2
+fi
+
+if [ -s "$generated_path" ]; then
+    exit 0
+fi
+
+if ! truthy "${CODEX_OMARCHY_THEME_AUTO_REFRESH:-1}"; then
+    warn "theme CSS is not generated yet; run 'omarchy theme refresh'"
+    exit 0
+fi
+
+if ! command -v omarchy >/dev/null 2>&1; then
+    warn "Omarchy CLI not found; run 'omarchy theme refresh' after it is available"
+    exit 0
+fi
+
+if ! omarchy theme refresh; then
+    warn "'omarchy theme refresh' failed; run it manually to generate the Codex stylesheet"
+fi

--- a/linux-features/omarchy-theme/install-template.sh
+++ b/linux-features/omarchy-theme/install-template.sh
@@ -30,10 +30,7 @@ generated_path="$omarchy_home/current/theme/codex-desktop.css"
 
 if [ -f "$target_path" ] && ! cmp -s "$source_path" "$target_path"; then
     warn "$target_path already exists with local changes; leaving it untouched"
-    exit 0
-fi
-
-if [ ! -f "$target_path" ]; then
+elif [ ! -f "$target_path" ]; then
     if ! mkdir -p "$target_dir" || ! install -m 0644 "$source_path" "$target_path"; then
         warn "could not install Omarchy template at $target_path"
         exit 0

--- a/linux-features/omarchy-theme/install-template.sh
+++ b/linux-features/omarchy-theme/install-template.sh
@@ -23,7 +23,7 @@ if [ ! -f "$source_path" ]; then
     exit 0
 fi
 
-omarchy_home="${CODEX_OMARCHY_CONFIG_HOME:-$HOME/.config/omarchy}"
+omarchy_home="$HOME/.config/omarchy"
 target_dir="$omarchy_home/themed"
 target_path="$target_dir/codex-desktop.css.tpl"
 generated_path="$omarchy_home/current/theme/codex-desktop.css"
@@ -52,6 +52,20 @@ if ! command -v omarchy >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! omarchy theme refresh; then
-    warn "'omarchy theme refresh' failed; run it manually to generate the Codex stylesheet"
+refresh_timeout_seconds="${CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS:-15}"
+case "$refresh_timeout_seconds" in
+    [1-9]|[1-5][0-9]|60) ;;
+    *)
+        warn "refresh timeout must be a whole number between 1 and 60 seconds; using 15 seconds"
+        refresh_timeout_seconds=15
+        ;;
+esac
+
+if ! command -v timeout >/dev/null 2>&1; then
+    warn "timeout command not found; skipping automatic refresh to avoid blocking app launch"
+    exit 0
+fi
+
+if ! timeout --kill-after=2s "${refresh_timeout_seconds}s" omarchy theme refresh; then
+    warn "'omarchy theme refresh' timed out or failed; run it manually to generate the Codex stylesheet"
 fi

--- a/linux-features/omarchy-theme/patch.js
+++ b/linux-features/omarchy-theme/patch.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const RUNTIME_VERSION = "omarchy-theme-v1";
+const STYLE_LINK_ID = "codex-linux-omarchy-theme-link";
+const THEME_CSS_ENDPOINT = "/__codex_user_stylesheet.css";
+
+function omarchyThemeRuntimeSource() {
+  return [
+    ";(()=>{",
+    `const VERSION=${JSON.stringify(RUNTIME_VERSION)};`,
+    "if(globalThis.codexLinuxOmarchyThemeVersion===VERSION)return;",
+    "try{globalThis.codexLinuxOmarchyThemeCleanup?.()}catch{}",
+    "globalThis.codexLinuxOmarchyThemeVersion=VERSION;",
+    `const STYLE_LINK_ID=${JSON.stringify(STYLE_LINK_ID)};`,
+    `const THEME_CSS_ENDPOINT=${JSON.stringify(THEME_CSS_ENDPOINT)};`,
+    "let interval=null,installed=false;",
+    "function refresh(){if(typeof document===`undefined`)return;const target=document.head||document.documentElement;if(!target)return;let link=document.getElementById(STYLE_LINK_ID);if(!link){link=document.createElement(`link`);link.id=STYLE_LINK_ID;link.rel=`stylesheet`;link.type=`text/css`;target.appendChild(link)}link.href=THEME_CSS_ENDPOINT+`?t=`+Date.now()}",
+    "function onVisibilityChange(){document.hidden||refresh()}",
+    "function install(){if(installed)return;installed=true;refresh();interval=setInterval(refresh,5000);window.addEventListener(`focus`,refresh);document.addEventListener(`visibilitychange`,onVisibilityChange)}",
+    "function cleanup(){document.removeEventListener(`DOMContentLoaded`,install);document.removeEventListener(`visibilitychange`,onVisibilityChange);window.removeEventListener(`focus`,refresh);interval!=null&&clearInterval(interval);interval=null;installed=false}",
+    "globalThis.codexLinuxOmarchyThemeCleanup=cleanup;",
+    "document.readyState===`loading`?document.addEventListener(`DOMContentLoaded`,install,{once:true}):install();",
+    "})();",
+  ].join("");
+}
+
+function applyOmarchyThemeLoader(source) {
+  if (typeof source !== "string") {
+    return source;
+  }
+  if (source.includes("codexLinuxOmarchyThemeVersion=")) {
+    return source;
+  }
+  return `${source}\n${omarchyThemeRuntimeSource()}`;
+}
+
+module.exports = {
+  RUNTIME_VERSION,
+  STYLE_LINK_ID,
+  THEME_CSS_ENDPOINT,
+  descriptors: [
+    {
+      id: "omarchy-theme-css-loader",
+      phase: "webview-asset",
+      order: 20_780,
+      ciPolicy: "optional",
+      pattern: /^index-.*\.js$/,
+      missingDescription: "webview index bundle",
+      skipDescription: "Omarchy theme CSS loader",
+      apply: applyOmarchyThemeLoader,
+    },
+  ],
+  applyOmarchyThemeLoader,
+  omarchyThemeRuntimeSource,
+};

--- a/linux-features/omarchy-theme/test.js
+++ b/linux-features/omarchy-theme/test.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const http = require("node:http");
+const net = require("node:net");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  enabledLinuxFeatureIds,
+  enabledLinuxFeatureInstallPlan,
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  RUNTIME_VERSION,
+  STYLE_LINK_ID,
+  THEME_CSS_ENDPOINT,
+  applyOmarchyThemeLoader,
+  omarchyThemeRuntimeSource,
+} = require("./patch.js");
+
+const FEATURE_DIR = __dirname;
+const REPO_ROOT = path.resolve(FEATURE_DIR, "..", "..");
+
+function withFeatureConfig(enabled, fn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-omarchy-theme-config-"));
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const configPath = path.join(tempDir, "features.json");
+  fs.writeFileSync(configPath, `${JSON.stringify({ enabled }, null, 2)}\n`);
+  process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+  try {
+    return fn(path.resolve(FEATURE_DIR, ".."));
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(address.port);
+      });
+    });
+  });
+}
+
+function request(port, requestPath) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      { host: "127.0.0.1", port, path: requestPath, timeout: 1000 },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () =>
+          resolve({
+            status: response.statusCode,
+            headers: response.headers,
+            body: Buffer.concat(chunks),
+          }),
+        );
+      },
+    );
+    req.once("error", reject);
+    req.once("timeout", () => req.destroy(new Error("request timed out")));
+  });
+}
+
+async function waitForServer(proc, port) {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    if (proc.exitCode != null) {
+      throw new Error(`webview server exited early with ${proc.exitCode}`);
+    }
+    try {
+      await request(port, "/index.html");
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error("webview server did not start");
+}
+
+async function withWebviewServer(serverPath, cwd, env, fn) {
+  const port = await getFreePort();
+  const proc = spawn("python3", [serverPath, String(port), "--bind", "127.0.0.1"], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  proc.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  try {
+    await waitForServer(proc, port);
+    return await fn(port);
+  } finally {
+    proc.kill("SIGTERM");
+    await Promise.race([
+      new Promise((resolve) => proc.once("exit", resolve)),
+      new Promise((resolve) => setTimeout(resolve, 2000)),
+    ]);
+    if (proc.exitCode == null) {
+      proc.kill("SIGKILL");
+    }
+    assert.doesNotMatch(stderr, /Traceback|Exception/);
+  }
+}
+
+test("omarchy-theme stays disabled until selected", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot }), []);
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+});
+
+test("omarchy-theme exposes optional patches, resources, and hooks when enabled", () => {
+  withFeatureConfig(["omarchy-theme"], (featuresRoot) => {
+    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot }), ["omarchy-theme"]);
+
+    const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.equal(descriptors.length, 1);
+    assert.equal(descriptors[0].id, "feature:omarchy-theme:omarchy-theme-css-loader");
+    assert.equal(descriptors[0].ciPolicy, "optional");
+    assert.match("index-main.js", descriptors[0].pattern);
+
+    const plan = enabledLinuxFeatureInstallPlan({ featuresRoot });
+    assert.deepEqual(
+      plan.resources.map((resource) => [resource.id, resource.target, resource.mode]),
+      [[
+        "omarchy-theme",
+        ".codex-linux/features/omarchy-theme/codex-desktop.css.tpl",
+        0o644,
+      ]],
+    );
+    assert.deepEqual(
+      plan.runtimeHooks.map((hook) => [hook.id, hook.key, hook.target, hook.mode]),
+      [
+        [
+          "omarchy-theme",
+          "env",
+          ".codex-linux/env.d/omarchy-theme-user-stylesheet.env",
+          0o644,
+        ],
+        [
+          "omarchy-theme",
+          "prelaunch",
+          ".codex-linux/prelaunch.d/omarchy-theme-install-template.sh",
+          0o755,
+        ],
+      ],
+    );
+  });
+});
+
+test("renderer patch is idempotent and installs one guarded runtime", () => {
+  const source = "console.log('codex');";
+  const patched = applyOmarchyThemeLoader(source);
+  assert.notEqual(patched, source);
+  assert.equal(applyOmarchyThemeLoader(patched), patched);
+  assert.match(patched, new RegExp(RUNTIME_VERSION));
+  assert.match(patched, new RegExp(STYLE_LINK_ID));
+  assert.match(patched, new RegExp(THEME_CSS_ENDPOINT.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+
+  const links = new Map();
+  const windowListeners = new Map();
+  const documentListeners = new Map();
+  let intervalCount = 0;
+  let clearIntervalCount = 0;
+  let appendCount = 0;
+  const sandbox = {
+    Date: { now: () => 1234 },
+    document: {
+      readyState: "complete",
+      hidden: false,
+      head: {
+        appendChild(link) {
+          appendCount += 1;
+          links.set(link.id, link);
+        },
+      },
+      documentElement: null,
+      getElementById(id) {
+        return links.get(id) ?? null;
+      },
+      createElement(tag) {
+        return { tag };
+      },
+      addEventListener(name, listener) {
+        documentListeners.set(name, listener);
+      },
+      removeEventListener(name, listener) {
+        if (documentListeners.get(name) === listener) documentListeners.delete(name);
+      },
+    },
+    window: {
+      addEventListener(name, listener) {
+        windowListeners.set(name, listener);
+      },
+      removeEventListener(name, listener) {
+        if (windowListeners.get(name) === listener) windowListeners.delete(name);
+      },
+    },
+    setInterval() {
+      intervalCount += 1;
+      return 7;
+    },
+    clearInterval() {
+      clearIntervalCount += 1;
+    },
+  };
+
+  vm.createContext(sandbox);
+  vm.runInContext(omarchyThemeRuntimeSource(), sandbox);
+  vm.runInContext(omarchyThemeRuntimeSource(), sandbox);
+
+  assert.equal(appendCount, 1);
+  assert.equal(intervalCount, 1);
+  assert.equal(windowListeners.size, 1);
+  assert.equal(documentListeners.size, 1);
+  assert.equal(links.get(STYLE_LINK_ID).href, `${THEME_CSS_ENDPOINT}?t=1234`);
+
+  sandbox.codexLinuxOmarchyThemeCleanup();
+  assert.equal(clearIntervalCount, 1);
+  assert.equal(windowListeners.size, 0);
+  assert.equal(documentListeners.size, 0);
+});
+
+test("webview server safely serves default and overridden user stylesheets", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-omarchy-theme-server-"));
+  try {
+    const serverPath = path.join(REPO_ROOT, "launcher", "webview-server.py");
+    const webviewDir = path.join(tempDir, "webview");
+    const generatedCss = path.join(tempDir, "generated.css");
+    fs.mkdirSync(webviewDir, { recursive: true });
+    fs.writeFileSync(path.join(webviewDir, "index.html"), "<!doctype html>");
+
+    fs.writeFileSync(generatedCss, ":root{--accent:#fabd2f}");
+    await withWebviewServer(
+      serverPath,
+      webviewDir,
+      { CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: generatedCss },
+      async (port) => {
+        const existing = await request(port, `${THEME_CSS_ENDPOINT}?t=123`);
+        assert.equal(existing.status, 200);
+        assert.equal(existing.headers["content-type"], "text/css; charset=utf-8");
+        assert.equal(existing.body.toString(), ":root{--accent:#fabd2f}");
+
+        fs.rmSync(generatedCss);
+        const missing = await request(port, THEME_CSS_ENDPOINT);
+        assert.equal(missing.status, 200);
+        assert.equal(missing.body.length, 0);
+
+        fs.writeFileSync(generatedCss, Buffer.alloc(262145, 97));
+        const oversized = await request(port, THEME_CSS_ENDPOINT);
+        assert.equal(oversized.status, 200);
+        assert.equal(oversized.body.length, 0);
+      },
+    );
+
+    const overrideCss = path.join(tempDir, "override.css");
+    fs.writeFileSync(overrideCss, "body{color:papayawhip}");
+    await withWebviewServer(
+      serverPath,
+      webviewDir,
+      {
+        CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: generatedCss,
+        CODEX_LINUX_WEBVIEW_USER_STYLESHEET: overrideCss,
+      },
+      async (port) => {
+        const overridden = await request(port, THEME_CSS_ENDPOINT);
+        assert.equal(overridden.status, 200);
+        assert.equal(overridden.body.toString(), "body{color:papayawhip}");
+      },
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("prelaunch hook installs the template, refreshes once, and preserves local edits", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-omarchy-template-install-"));
+  try {
+    const home = path.join(tempDir, "home");
+    const featuresDir = path.join(tempDir, "features");
+    const stagedDir = path.join(featuresDir, "omarchy-theme");
+    const omarchyHome = path.join(home, ".config", "omarchy");
+    const target = path.join(omarchyHome, "themed", "codex-desktop.css.tpl");
+    const generated = path.join(omarchyHome, "current", "theme", "codex-desktop.css");
+    const binDir = path.join(tempDir, "bin");
+    const callLog = path.join(tempDir, "omarchy.log");
+    fs.mkdirSync(stagedDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.copyFileSync(path.join(FEATURE_DIR, "codex-desktop.css.tpl"), path.join(stagedDir, "codex-desktop.css.tpl"));
+    const fakeOmarchy = path.join(binDir, "omarchy");
+    fs.writeFileSync(
+      fakeOmarchy,
+      `#!/usr/bin/env bash\nset -e\nprintf '%s\\n' "$*" >> "$OMARCHY_TEST_LOG"\nmkdir -p "$CODEX_OMARCHY_CONFIG_HOME/current/theme"\nprintf 'generated' > "$CODEX_OMARCHY_CONFIG_HOME/current/theme/codex-desktop.css"\n`,
+    );
+    fs.chmodSync(fakeOmarchy, 0o755);
+
+    const env = {
+      ...process.env,
+      HOME: home,
+      PATH: `${binDir}:/usr/bin:/bin`,
+      CODEX_LINUX_FEATURES_DIR: featuresDir,
+      CODEX_OMARCHY_CONFIG_HOME: omarchyHome,
+      OMARCHY_TEST_LOG: callLog,
+    };
+    const first = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(first.status, 0, first.stderr);
+    assert.equal(fs.readFileSync(target, "utf8"), fs.readFileSync(path.join(FEATURE_DIR, "codex-desktop.css.tpl"), "utf8"));
+    assert.equal(fs.readFileSync(generated, "utf8"), "generated");
+    assert.equal(fs.readFileSync(callLog, "utf8"), "theme refresh\n");
+
+    fs.writeFileSync(target, "/* local customization */\n");
+    fs.rmSync(generated);
+    const second = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+      env,
+      encoding: "utf8",
+    });
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(target, "utf8"), "/* local customization */\n");
+    assert.equal(fs.readFileSync(callLog, "utf8"), "theme refresh\n");
+    assert.match(second.stderr, /leaving it untouched/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/linux-features/omarchy-theme/test.js
+++ b/linux-features/omarchy-theme/test.js
@@ -296,36 +296,12 @@ test("webview server safely serves default and overridden user stylesheets", asy
       webviewDir,
       {
         HOME: defaultHome,
-        CODEX_OMARCHY_CONFIG_HOME: "",
         CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: configuredDefault,
       },
       async (port) => {
         const defaultConfigured = await request(port, THEME_CSS_ENDPOINT);
         assert.equal(defaultConfigured.status, 200);
         assert.equal(defaultConfigured.body.toString(), "body{color:default-config}");
-      },
-    );
-
-    const customOmarchyHome = path.join(tempDir, "custom-omarchy");
-    const customGeneratedCss = path.join(
-      customOmarchyHome,
-      "current",
-      "theme",
-      "codex-desktop.css",
-    );
-    fs.mkdirSync(path.dirname(customGeneratedCss), { recursive: true });
-    fs.writeFileSync(customGeneratedCss, "body{color:custom-config}");
-    await withWebviewServer(
-      serverPath,
-      webviewDir,
-      {
-        CODEX_OMARCHY_CONFIG_HOME: customOmarchyHome,
-        CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: configuredDefault,
-      },
-      async (port) => {
-        const customized = await request(port, THEME_CSS_ENDPOINT);
-        assert.equal(customized.status, 200);
-        assert.equal(customized.body.toString(), "body{color:custom-config}");
       },
     );
 
@@ -366,7 +342,7 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
     const fakeOmarchy = path.join(binDir, "omarchy");
     fs.writeFileSync(
       fakeOmarchy,
-      `#!/usr/bin/env bash\nset -e\nprintf '%s\\n' "$*" >> "$OMARCHY_TEST_LOG"\nmkdir -p "$CODEX_OMARCHY_CONFIG_HOME/current/theme"\nprintf 'generated' > "$CODEX_OMARCHY_CONFIG_HOME/current/theme/codex-desktop.css"\n`,
+      `#!/usr/bin/env bash\nset -e\nprintf '%s\\n' "$*" >> "$OMARCHY_TEST_LOG"\nmkdir -p "$HOME/.config/omarchy/current/theme"\nprintf 'generated' > "$HOME/.config/omarchy/current/theme/codex-desktop.css"\n`,
     );
     fs.chmodSync(fakeOmarchy, 0o755);
 
@@ -375,7 +351,6 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
       HOME: home,
       PATH: `${binDir}:/usr/bin:/bin`,
       CODEX_LINUX_FEATURES_DIR: featuresDir,
-      CODEX_OMARCHY_CONFIG_HOME: omarchyHome,
       OMARCHY_TEST_LOG: callLog,
     };
     const first = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
@@ -398,6 +373,42 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
     assert.equal(fs.readFileSync(generated, "utf8"), "generated");
     assert.equal(fs.readFileSync(callLog, "utf8"), "theme refresh\ntheme refresh\n");
     assert.match(second.stderr, /leaving it untouched/);
+
+    fs.rmSync(generated);
+    fs.writeFileSync(
+      fakeOmarchy,
+      "#!/usr/bin/env bash\nsleep 30\n",
+    );
+    const startedAt = Date.now();
+    const hanging = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+      env: {
+        ...env,
+        CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS: "1",
+      },
+      encoding: "utf8",
+    });
+    assert.equal(hanging.status, 0, hanging.stderr);
+    assert.ok(Date.now() - startedAt < 5000, "prelaunch hook must not wait for a hung refresh");
+    assert.match(hanging.stderr, /timed out or failed/);
+    assert.equal(fs.existsSync(generated), false);
+
+    const timeoutLog = path.join(tempDir, "timeout.log");
+    fs.writeFileSync(
+      path.join(binDir, "timeout"),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "$OMARCHY_TEST_TIMEOUT_LOG"\nexit 124\n`,
+    );
+    fs.chmodSync(path.join(binDir, "timeout"), 0o755);
+    const oversizedTimeout = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+      env: {
+        ...env,
+        CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS: "999999999999999999999",
+        OMARCHY_TEST_TIMEOUT_LOG: timeoutLog,
+      },
+      encoding: "utf8",
+    });
+    assert.equal(oversizedTimeout.status, 0, oversizedTimeout.stderr);
+    assert.match(oversizedTimeout.stderr, /whole number between 1 and 60 seconds/);
+    assert.equal(fs.readFileSync(timeoutLog, "utf8"), "--kill-after=2s 15s omarchy theme refresh\n");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/linux-features/omarchy-theme/test.js
+++ b/linux-features/omarchy-theme/test.js
@@ -248,6 +248,12 @@ test("webview server safely serves default and overridden user stylesheets", asy
     const serverPath = path.join(REPO_ROOT, "launcher", "webview-server.py");
     const webviewDir = path.join(tempDir, "webview");
     const generatedCss = path.join(tempDir, "generated.css");
+    const configuredDefaultLine = fs
+      .readFileSync(path.join(FEATURE_DIR, "user-stylesheet.env"), "utf8")
+      .split("\n")
+      .find((line) => line.startsWith("CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT="));
+    assert.ok(configuredDefaultLine);
+    const configuredDefault = configuredDefaultLine.slice(configuredDefaultLine.indexOf("=") + 1);
     fs.mkdirSync(webviewDir, { recursive: true });
     fs.writeFileSync(path.join(webviewDir, "index.html"), "<!doctype html>");
 
@@ -274,6 +280,55 @@ test("webview server safely serves default and overridden user stylesheets", asy
       },
     );
 
+    const defaultHome = path.join(tempDir, "default-home");
+    const defaultGeneratedCss = path.join(
+      defaultHome,
+      ".config",
+      "omarchy",
+      "current",
+      "theme",
+      "codex-desktop.css",
+    );
+    fs.mkdirSync(path.dirname(defaultGeneratedCss), { recursive: true });
+    fs.writeFileSync(defaultGeneratedCss, "body{color:default-config}");
+    await withWebviewServer(
+      serverPath,
+      webviewDir,
+      {
+        HOME: defaultHome,
+        CODEX_OMARCHY_CONFIG_HOME: "",
+        CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: configuredDefault,
+      },
+      async (port) => {
+        const defaultConfigured = await request(port, THEME_CSS_ENDPOINT);
+        assert.equal(defaultConfigured.status, 200);
+        assert.equal(defaultConfigured.body.toString(), "body{color:default-config}");
+      },
+    );
+
+    const customOmarchyHome = path.join(tempDir, "custom-omarchy");
+    const customGeneratedCss = path.join(
+      customOmarchyHome,
+      "current",
+      "theme",
+      "codex-desktop.css",
+    );
+    fs.mkdirSync(path.dirname(customGeneratedCss), { recursive: true });
+    fs.writeFileSync(customGeneratedCss, "body{color:custom-config}");
+    await withWebviewServer(
+      serverPath,
+      webviewDir,
+      {
+        CODEX_OMARCHY_CONFIG_HOME: customOmarchyHome,
+        CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT: configuredDefault,
+      },
+      async (port) => {
+        const customized = await request(port, THEME_CSS_ENDPOINT);
+        assert.equal(customized.status, 200);
+        assert.equal(customized.body.toString(), "body{color:custom-config}");
+      },
+    );
+
     const overrideCss = path.join(tempDir, "override.css");
     fs.writeFileSync(overrideCss, "body{color:papayawhip}");
     await withWebviewServer(
@@ -294,7 +349,7 @@ test("webview server safely serves default and overridden user stylesheets", asy
   }
 });
 
-test("prelaunch hook installs the template, refreshes once, and preserves local edits", () => {
+test("prelaunch hook installs the template, refreshes missing CSS, and preserves local edits", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-omarchy-template-install-"));
   try {
     const home = path.join(tempDir, "home");
@@ -340,7 +395,8 @@ test("prelaunch hook installs the template, refreshes once, and preserves local 
     });
     assert.equal(second.status, 0, second.stderr);
     assert.equal(fs.readFileSync(target, "utf8"), "/* local customization */\n");
-    assert.equal(fs.readFileSync(callLog, "utf8"), "theme refresh\n");
+    assert.equal(fs.readFileSync(generated, "utf8"), "generated");
+    assert.equal(fs.readFileSync(callLog, "utf8"), "theme refresh\ntheme refresh\n");
     assert.match(second.stderr, /leaving it untouched/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/linux-features/omarchy-theme/user-stylesheet.env
+++ b/linux-features/omarchy-theme/user-stylesheet.env
@@ -1,0 +1,3 @@
+# The core loopback webview server expands '~' before reading this path.
+# CODEX_LINUX_WEBVIEW_USER_STYLESHEET can override this default at launch time.
+CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT=~/.config/omarchy/current/theme/codex-desktop.css

--- a/linux-features/omarchy-theme/user-stylesheet.env
+++ b/linux-features/omarchy-theme/user-stylesheet.env
@@ -1,3 +1,3 @@
-# The core loopback webview server expands '~' before reading this path.
+# The core loopback webview server expands shell-style defaults and '~' before reading this path.
 # CODEX_LINUX_WEBVIEW_USER_STYLESHEET can override this default at launch time.
-CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT=~/.config/omarchy/current/theme/codex-desktop.css
+CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT=${CODEX_OMARCHY_CONFIG_HOME:-~/.config/omarchy}/current/theme/codex-desktop.css

--- a/linux-features/omarchy-theme/user-stylesheet.env
+++ b/linux-features/omarchy-theme/user-stylesheet.env
@@ -1,3 +1,3 @@
-# The core loopback webview server expands shell-style defaults and '~' before reading this path.
+# The core loopback webview server expands '~' before reading this path.
 # CODEX_LINUX_WEBVIEW_USER_STYLESHEET can override this default at launch time.
-CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT=${CODEX_OMARCHY_CONFIG_HOME:-~/.config/omarchy}/current/theme/codex-desktop.css
+CODEX_LINUX_WEBVIEW_USER_STYLESHEET_DEFAULT=~/.config/omarchy/current/theme/codex-desktop.css


### PR DESCRIPTION
## Summary

- add an optional, default-disabled Omarchy theme integration
- install the Codex theme template under the current Omarchy config path
- serve the generated CSS through a bounded loopback stylesheet endpoint
- refresh the renderer stylesheet without restarting the app
- bound automatic `omarchy theme refresh` so a hung CLI cannot block app launch

## Validation

- `node --test linux-features/omarchy-theme/test.js` (5/5)
- `bash -n linux-features/omarchy-theme/install-template.sh`
- `python3 -m py_compile launcher/webview-server.py`
- `git diff --check`
- GitHub CI pending for the updated head

## Notes

The integration remains opt-in. It follows the current Omarchy path at `~/.config/omarchy`; the unsupported config-home override was removed. A direct `CODEX_LINUX_WEBVIEW_USER_STYLESHEET` override remains available for trusted CSS files.
