### PR TITLE
Fix Ubuntu 26.04 native install using the current ChatGPT.dmg URL

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -30,7 +30,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+  UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg
   UPSTREAM_DMG_PATH: /tmp/codex-upstream-ci/Codex.dmg
   DMG_CACHE_SCHEMA_VERSION: v1
 

--- a/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
+++ b/contrib/user-local-install/files/.local/lib/codex-desktop-linux/common.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 OPT_ROOT="${HOME}/.local/opt/codex-desktop-linux"
 APP_DIR="${OPT_ROOT}/codex-app"
-DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+DMG_URL="https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
 XDG_STATE_HOME="${XDG_STATE_HOME:-${HOME}/.local/state}"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -143,7 +143,7 @@ run_container_job() {
         -e "CI_PACKAGE_VERSION=$CI_PACKAGE_VERSION"
         -e "PACKAGE_VERSION=$CI_PACKAGE_VERSION"
         -e "CARGO_TERM_COLOR=${CARGO_TERM_COLOR:-always}"
-        -e "UPSTREAM_DMG_URL=${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+        -e "UPSTREAM_DMG_URL=${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg}"
         -e "UPSTREAM_DMG_PATH=${UPSTREAM_DMG_PATH:-/tmp/codex-upstream-ci/Codex.dmg}"
         -v "$REPO_DIR:/work"
         -v "$CI_CACHE_DIR:/ci-cache"

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -151,7 +151,7 @@ run_as_ci_user() {
         "CI_PACKAGE_VERSION=$CI_PACKAGE_VERSION"
         "PACKAGE_VERSION=$CI_PACKAGE_VERSION"
         "CI_DMG_PATH=${CI_DMG_PATH:-}"
-        "UPSTREAM_DMG_URL=${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+        "UPSTREAM_DMG_URL=${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg}"
         "UPSTREAM_DMG_PATH=${UPSTREAM_DMG_PATH:-/tmp/codex-upstream-ci/Codex.dmg}"
         "UPSTREAM_DMG_CACHE_HIT=${UPSTREAM_DMG_CACHE_HIT:-}"
         "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY:-}"

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
-UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg}"
 UPSTREAM_DMG_PATH="${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}"
 VERIFY_LOG="${VERIFY_LOG:-/tmp/codex-nix-build-verify.log}"
 # Upstream Codex Sparkle appcast (x64 runners). Used only for reporting when it

--- a/scripts/ci/validate-nix-pins.sh
+++ b/scripts/ci/validate-nix-pins.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 REPO_DIR="${REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FLAKE_FILE="${FLAKE_FILE:-$REPO_DIR/flake.nix}"
-UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}"
+UPSTREAM_DMG_URL="${UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg}"
 UPSTREAM_DMG_PATH="${1:-${UPSTREAM_DMG_PATH:-/tmp/Codex.dmg}}"
 NATIVE_MODULES_PKG="${NATIVE_MODULES_PKG:-$REPO_DIR/nix/native-modules/package.json}"
 

--- a/scripts/dev/upstream-dmg-intel-devcontainer
+++ b/scripts/dev/upstream-dmg-intel-devcontainer
@@ -14,7 +14,7 @@ Options:
   --candidate latest     Download current upstream DMG into reports/upstream-dmg/downloads/
                          Default when no candidate is passed
   --candidate-url URL    Upstream DMG URL for --candidate latest
-                         Default: https://persistent.oaistatic.com/codex-app-prod/Codex.dmg
+                         Default: https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg
   --baseline PATH        Optional known-good baseline DMG or extracted .app;
                          defaults to repo ./Codex.dmg when different
   --no-baseline          Do a candidate-only scan even when ./Codex.dmg exists
@@ -35,7 +35,7 @@ EOF
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 image="${CODEX_DMG_INTEL_IMAGE:-codex-desktop-linux-devcontainer:local}"
-candidate_url="${CODEX_DMG_INTEL_CANDIDATE_URL:-${CODEX_UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/Codex.dmg}}"
+candidate_url="${CODEX_DMG_INTEL_CANDIDATE_URL:-${CODEX_UPSTREAM_DMG_URL:-https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg}}"
 build_image=auto
 candidate_path=""
 baseline_path=""

--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -5,7 +5,7 @@
 # shellcheck shell=bash
 
 # ---- Download or find Codex DMG ----
-DEFAULT_DMG_URL="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+DEFAULT_DMG_URL="https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
 DMG_URL="${CODEX_UPSTREAM_DMG_URL:-$DEFAULT_DMG_URL}"
 DMG_REMOTE_FINGERPRINT=""
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1353,7 +1353,7 @@ test_installer_refreshes_stale_cached_dmg_metadata() {
     info "Checking installer DMG cache freshness metadata branches"
     local workspace="$TMP_DIR/dmg-cache-refresh"
     local bin_dir="$workspace/bin"
-    local url="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    local url="https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
     local url_sha256
 
     url_sha256="$(printf '%s' "$url" | sha256sum | awk '{print $1}')"
@@ -1798,7 +1798,7 @@ test_fresh_reuse_dmg_uses_cache_when_metadata_matches() {
     local bin_dir="$workspace/bin"
     local source_dir="$workspace/source"
     local output_log="$workspace/output.log"
-    local url="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
+    local url="https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
     local url_sha256
 
     url_sha256="$(printf '%s' "$url" | sha256sum | awk '{print $1}')"
@@ -2829,7 +2829,7 @@ make_update_nix_hash_fixture() {
   electronVersion = "42.1.0";
 
   codexDmg = pkgs.fetchurl {
-    url = "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg";
+    url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
     hash = "$hash_a";
   };
 

--- a/updater/src/config.rs
+++ b/updater/src/config.rs
@@ -141,7 +141,7 @@ impl RuntimeConfig {
         };
 
         Self {
-            dmg_url: "https://persistent.oaistatic.com/codex-app-prod/Codex.dmg".to_string(),
+            dmg_url: "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg".to_string(),
             initial_check_delay_seconds: 30,
             check_interval_hours: 6,
             auto_install_on_app_exit: true,


### PR DESCRIPTION
## Summary

The upstream macOS application download has moved from `Codex.dmg` to `ChatGPT.dmg`. This PR updates every production default that downloads or validates the upstream DMG:

- Native installer used by `make install-native`
- Local update manager defaults
- CI and Nix pin-validation helpers
- Upstream DMG development tooling
- Smoke-test fixtures

The local cache and staging filename remain `Codex.dmg` by design; only the remote download URL changes.

## Root cause

`scripts/lib/dmg.sh` still defaulted to:

`https://persistent.oaistatic.com/codex-app-prod/Codex.dmg`

As a result, Ubuntu 26.04 native installs using `make install-native` could request the obsolete endpoint instead of the current `ChatGPT.dmg` URL.

## User impact

Fresh installs and stale-cache refreshes now use:

`https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg`

This also keeps future updater rebuilds and CI/Nix checks aligned with the current upstream artifact.

## Validation

- Shell syntax checks for all changed shell scripts
- `make -n install-native`
- Full `tests/scripts_smoke.sh` suite
- `cargo check -p codex-update-manager`
- `git diff --check`\n\nFixes #722