### PR TITLE
Fix Linux native app usage query drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -6524,6 +6524,22 @@ test("enables native app usage queries on Linux when Computer Use labels move ou
   assert.doesNotMatch(patched, /a=n&&\(r===`macOS`\|\|r===`windows`\)/);
 });
 
+test("scopes unlabeled native app usage gate patch away from adjacent platform gates", () => {
+  const source =
+    "function unrelated(e){let{enabled:n}=e,{platform:r}=yt(),a=n&&(r===`macOS`||r===`windows`);return a}" +
+    "function Iz(e){let t=(0,Lz.c)(9),{enabled:o}=e,{platform:c,isLoading:l}=yt(),u=o&&(c===`macOS`||c===`windows`),p;t[0]===Symbol.for(`react.memo_cache_sentinel`)?(p={order:`usage`},t[0]=p):p=t[0];let s;t[1]===u?s=t[2]:(s={params:p,queryConfig:{enabled:u,staleTime:fe.FIVE_MINUTES,refetchOnWindowFocus:!1}},t[1]=u,t[2]=s);let h=Ce(`native-desktop-apps`,s),g;t[3]!==h||t[4]!==u?(g=u?h.data?.apps??[]:[],t[3]=h,t[4]=u,t[5]=g):g=t[5];let m=l||u&&h.isLoading,d;return t[6]!==g||t[7]!==m?(d={nativeApps:g,isLoading:m},t[6]=g,t[7]=m,t[8]=d):d=t[8],d}";
+
+  const patched = applyPatchTwice(applyLinuxComputerUseRendererAvailabilityPatch, source);
+  const unrelatedFunction = patched.slice(
+    patched.indexOf("function unrelated"),
+    patched.indexOf("function Iz"),
+  );
+
+  assert.match(unrelatedFunction, /a=n&&\(r===`macOS`\|\|r===`windows`\)/);
+  assert.doesNotMatch(unrelatedFunction, /`linux`/);
+  assert.match(patched, /u=o&&\(c===`macOS`\|\|c===`windows`\|\|c===`linux`\)/);
+});
+
 test("does not enable unrelated native desktop app queries on Linux", () => {
   const source =
     "function useNativeApps(e){let{enabled:n}=e,{platform:r,isLoading:i}=yt(),a=n&&(r===`macOS`||r===`windows`),o={params:{order:`usage`},queryConfig:{enabled:a}};return Ce(`native-desktop-apps`,o)}";

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -6514,6 +6514,16 @@ test("enables native app mentions on Linux in the current Computer Use picker", 
   assert.doesNotMatch(patched, /a=n&&\(r===`macOS`\|\|r===`windows`\)/);
 });
 
+test("enables native app usage queries on Linux when Computer Use labels move out of the chunk", () => {
+  const source =
+    "function Iz(e){let t=(0,Lz.c)(9),{enabled:n}=e,{platform:r,isLoading:i}=yt(),a=n&&(r===`macOS`||r===`windows`),o;t[0]===Symbol.for(`react.memo_cache_sentinel`)?(o={order:`usage`},t[0]=o):o=t[0];let s;t[1]===a?s=t[2]:(s={params:o,queryConfig:{enabled:a,staleTime:fe.FIVE_MINUTES,refetchOnWindowFocus:!1}},t[1]=a,t[2]=s);let c=Ce(`native-desktop-apps`,s),l;t[3]!==c||t[4]!==a?(l=a?c.data?.apps??[]:[],t[3]=c,t[4]=a,t[5]=l):l=t[5];let u=i||a&&c.isLoading,d;return t[6]!==l||t[7]!==u?(d={nativeApps:l,isLoading:u},t[6]=l,t[7]=u,t[8]=d):d=t[8],d}";
+
+  const patched = applyPatchTwice(applyLinuxComputerUseRendererAvailabilityPatch, source);
+
+  assert.match(patched, /a=n&&\(r===`macOS`\|\|r===`windows`\|\|r===`linux`\)/);
+  assert.doesNotMatch(patched, /a=n&&\(r===`macOS`\|\|r===`windows`\)/);
+});
+
 test("does not enable unrelated native desktop app queries on Linux", () => {
   const source =
     "function useNativeApps(e){let{enabled:n}=e,{platform:r,isLoading:i}=yt(),a=n&&(r===`macOS`||r===`windows`),o={params:{order:`usage`},queryConfig:{enabled:a}};return Ce(`native-desktop-apps`,o)}";

--- a/scripts/patches/impl/computer-use.js
+++ b/scripts/patches/impl/computer-use.js
@@ -72,6 +72,7 @@ const TRAY_GUARD_LOOKAHEAD = 1200;
 const CLOSE_GATE_PREFIX_LOOKBACK = 8000;
 const HANDLER_PREFIX_LOOKBACK = 12000;
 const DIRECT_HANDLER_PROXIMITY = 1200;
+const NATIVE_APPS_PLATFORM_GATE_LOOKAHEAD = 2400;
 
 const linuxSettingsKeys = {
   promptWindow: "codex-linux-prompt-window-enabled",
@@ -156,6 +157,15 @@ function hasComputerUseNativeAppsResultShape(source) {
   return /nativeApps:[A-Za-z_$][\w$]*/.test(source) &&
     /isLoading:[A-Za-z_$][\w$]*/.test(source) &&
     /[A-Za-z_$][\w$]*\.data\?\.apps/.test(source);
+}
+
+function isNativeAppsPlatformGateContext(source, matchEnd, nextPlatformGatePattern) {
+  const rest = source.slice(matchEnd);
+  const nextGateIndex = rest.search(nextPlatformGatePattern);
+  const contextLength = nextGateIndex === -1
+    ? NATIVE_APPS_PLATFORM_GATE_LOOKAHEAD
+    : Math.min(nextGateIndex, NATIVE_APPS_PLATFORM_GATE_LOOKAHEAD);
+  return rest.slice(0, contextLength).includes("native-desktop-apps");
 }
 
 function isComputerUseNameExpr(nameExpr, computerUseNameVar) {
@@ -557,9 +567,14 @@ function applyLinuxComputerUseRendererAvailabilityPatch(currentSource) {
   if (hasComputerUseNativeAppsMention(patchedSource)) {
     const nativeAppsPlatformPattern =
       /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)===`macOS`\|\|\3===`windows`\)/g;
+    const nativeAppsPlatformBoundaryPattern =
+      /[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*&&\(([A-Za-z_$][\w$]*)===`macOS`\|\|\1===`windows`(?:\|\|\1===`linux`)?\)/;
     patchedSource = patchedSource.replace(
       nativeAppsPlatformPattern,
-      (match, availableVar, enabledVar, platformVar) => {
+      (match, availableVar, enabledVar, platformVar, offset) => {
+        if (!isNativeAppsPlatformGateContext(patchedSource, offset + match.length, nativeAppsPlatformBoundaryPattern)) {
+          return match;
+        }
         nativeAppsGateChanged = true;
         return `${availableVar}=${enabledVar}&&(${platformVar}===\`macOS\`||${platformVar}===\`windows\`||${platformVar}===\`linux\`)`;
       },

--- a/scripts/patches/impl/computer-use.js
+++ b/scripts/patches/impl/computer-use.js
@@ -147,8 +147,15 @@ function hasComputerUseNativeAppsMention(source) {
       hasComputerUseLiteral(source) ||
       source.includes("computer-use-native-desktop-app-icon") ||
       source.includes("computerUse.nativeApps") ||
-      source.includes("computerUse.label")
+      source.includes("computerUse.label") ||
+      hasComputerUseNativeAppsResultShape(source)
     );
+}
+
+function hasComputerUseNativeAppsResultShape(source) {
+  return /nativeApps:[A-Za-z_$][\w$]*/.test(source) &&
+    /isLoading:[A-Za-z_$][\w$]*/.test(source) &&
+    /[A-Za-z_$][\w$]*\.data\?\.apps/.test(source);
 }
 
 function isComputerUseNameExpr(nameExpr, computerUseNameVar) {


### PR DESCRIPTION
## Summary

- related to #713
- keep Linux native desktop app usage queries enabled when the Computer Use labels are split out of the webview chunk
- detect the native-apps hook by its returned `{ nativeApps, isLoading }` shape instead of relying only on localized label strings
- scope the platform-gate rewrite so adjacent macOS/windows gates in the same chunk stay untouched
- add regression tests for the unlabeled chunk shape and adjacent-gate case while keeping the unrelated-query guard in place

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `timeout 300 bash tests/scripts_smoke.sh`
- `node --test linux-features/*/test.js`
- `git diff --check`

## Notes

This is intentionally scoped to the existing Computer Use native-apps hook. It does not change the Linux native apps backend, tray behavior, rate-limit footer, packaging, or feature opt-in rules.
