### PR TITLE
Fix remote mobile patch targets for current chunks

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -10,6 +10,7 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - linux-features/remote-mobile-control/**
       - scripts/ci/validate-patch-report.js
       - .github/workflows/upstream-build-app.yml
   push:
@@ -21,6 +22,7 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - linux-features/remote-mobile-control/**
       - scripts/ci/validate-patch-report.js
       - .github/workflows/upstream-build-app.yml
   workflow_dispatch:
@@ -140,6 +142,30 @@ jobs:
       - name: Validate required upstream patches
         run: node scripts/ci/validate-patch-report.js patch-report.json --profile upstream-build
 
+      - name: Inspect upstream DMG with remote mobile control enabled
+        run: |
+          set -euo pipefail
+
+          features_config="$(mktemp)"
+          report_dir="$GITHUB_WORKSPACE/remote-mobile-upstream-inspect"
+          trap 'rm -f "$features_config"' EXIT
+
+          printf '%s\n' '{"enabled":["remote-mobile-control"]}' > "$features_config"
+
+          CODEX_LINUX_FEATURES_CONFIG="$features_config" \
+            make inspect-upstream DMG="$UPSTREAM_DMG_PATH" REBUILD_REPORT_DIR="$report_dir"
+
+          node scripts/ci/validate-patch-report.js "$report_dir/patch-report.json" \
+            --profile upstream-build \
+            --require-enabled-feature remote-mobile-control \
+            --require-success linux-app-server-conversation-hydration \
+            --require-success linux-completed-item-recovery \
+            --require-success feature:remote-mobile-control:linux-remote-control-load-gate \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-conversation-hydration \
+            --require-success feature:remote-mobile-control:linux-remote-control-status-read-guard \
+            --require-success feature:remote-mobile-control:linux-remote-control-status-wait \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task
+
       - name: Upload upstream DMG metadata artifact
         # The build step now aborts on critical patch failures; keep uploading
         # the patch report so the failure is diagnosable from the artifact.
@@ -150,6 +176,7 @@ jobs:
           path: |
             upstream-dmg-metadata.json
             patch-report.json
+            remote-mobile-upstream-inspect/*.json
           if-no-files-found: ignore
 
       - name: Write build summary
@@ -167,4 +194,6 @@ jobs:
             echo "- Cache Hit: \`${{ steps.dmg-cache.outputs.cache-hit || 'false' }}\`"
             echo "- Build command: \`make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg\`"
             echo "- Patch report: \`patch-report.json\`"
+            echo "- Remote mobile inspect: \`make inspect-upstream DMG=$UPSTREAM_DMG_PATH\` with \`remote-mobile-control\` enabled"
+            echo "- Remote mobile patch report: \`remote-mobile-upstream-inspect/patch-report.json\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -158,13 +158,12 @@ jobs:
           node scripts/ci/validate-patch-report.js "$report_dir/patch-report.json" \
             --profile upstream-build \
             --require-enabled-feature remote-mobile-control \
-            --require-success linux-app-server-conversation-hydration \
-            --require-success linux-completed-item-recovery \
-            --require-success feature:remote-mobile-control:linux-remote-control-load-gate \
+            --require-applied linux-app-server-conversation-hydration \
+            --require-applied linux-completed-item-recovery \
+            --require-applied feature:remote-mobile-control:linux-remote-control-load-gate \
             --require-success feature:remote-mobile-control:linux-remote-mobile-conversation-hydration \
-            --require-success feature:remote-mobile-control:linux-remote-control-status-read-guard \
-            --require-success feature:remote-mobile-control:linux-remote-control-status-wait \
-            --require-success feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task
+            --require-applied feature:remote-mobile-control:linux-remote-control-status-read-guard \
+            --require-applied feature:remote-mobile-control:linux-remote-control-status-wait
 
       - name: Upload upstream DMG metadata artifact
         # The build step now aborts on critical patch failures; keep uploading

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -56,9 +56,9 @@ const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProjectlessRemoteTaskId";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/u;
+  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/u;
 const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN =
-  /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~.*\.js$/u;
+  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*)\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -56,7 +56,7 @@ const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProjectlessRemoteTaskId";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/u;
+  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/u;
 const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN =
   /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*)\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -54,11 +54,8 @@ const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMo
 const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAppServerArgs";
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
-const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProjectlessRemoteTaskId";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/u;
-const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN =
-  /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*)\.js$/u;
+  /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -1540,49 +1537,6 @@ function applyLinuxRemoteMobileActiveStatusPatch(source) {
   );
 }
 
-function applyLinuxRemoteMobileProjectlessRemoteTaskPatch(source) {
-  if (source.includes(REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER)) {
-    return source;
-  }
-  if (!source.includes("No owner repo found for remote task")) {
-    return source;
-  }
-
-  const currentPattern =
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\2,\3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\5\);if\(!\7\)\{([A-Za-z_$][\w$]*)\.has\(\2\.task\.id\)\|\|\(\9\.add\(\2\.task\.id\),([A-Za-z_$][\w$]*)\.warning\(`No owner repo found for remote task`,\{safe:\{taskId:\2\.task\.id\},sensitive:\{\}\}\)\);return\}/u;
-  const match = source.match(currentPattern);
-  if (match == null) {
-    console.warn("WARN: Could not find remote task owner-repo grouping needle - skipping projectless remote task patch");
-    return source;
-  }
-
-  const [
-    needle,
-    functionName,
-    remoteTaskVar,
-    remoteProjectsByLabelVar,
-    projectGroupsVar,
-    remoteProjectVar,
-    remoteProjectForTaskFn,
-    ownerRepoVar,
-    ownerRepoForProjectFn,
-  ] = match;
-
-  return source.replace(
-    needle,
-    [
-      `function ${functionName}(${remoteTaskVar},${remoteProjectsByLabelVar},${projectGroupsVar}){`,
-      `let ${remoteProjectVar}=${remoteProjectForTaskFn}(${remoteTaskVar},${remoteProjectsByLabelVar}),`,
-      `${ownerRepoVar}=${ownerRepoForProjectFn}(${remoteProjectVar});`,
-      `if(!${ownerRepoVar}){`,
-      `let ${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}=${remoteTaskVar}.task?.id??${remoteTaskVar}.conversationId??${remoteTaskVar}.key??\`unknown\`,`,
-      `codexLinuxRemoteMobileProjectlessRemoteTaskLabel=${remoteTaskVar}.task?.task_status_display?.environment_label??${remoteTaskVar}.task?.title??\`Remote task\`,`,
-      `codexLinuxRemoteMobileProjectlessRemoteTaskGroup={projectId:\`remote-task:\${${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}}\`,projectKind:\`remote\`,label:codexLinuxRemoteMobileProjectlessRemoteTaskLabel,path:\`\${${REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER}}\`,repositoryData:null,isCodexWorktree:!1,threadKeys:[]};`,
-      `${projectGroupsVar}.push(codexLinuxRemoteMobileProjectlessRemoteTaskGroup),codexLinuxRemoteMobileProjectlessRemoteTaskGroup.threadKeys.push(${remoteTaskVar}.key);return}`,
-    ].join(""),
-  );
-}
-
 module.exports = [
   {
     id: "linux-remote-control-device-key",
@@ -1759,16 +1713,6 @@ module.exports = [
     skipDescription: "Linux remote-mobile active status patch",
     apply: applyLinuxRemoteMobileActiveStatusPatch,
   },
-  {
-    id: "linux-remote-mobile-projectless-remote-task",
-    phase: "webview-asset",
-    pattern: REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN,
-    order: 20_170,
-    ciPolicy: "optional",
-    missingDescription: "sidebar project groups bundle",
-    skipDescription: "Linux remote-mobile projectless remote task patch",
-    apply: applyLinuxRemoteMobileProjectlessRemoteTaskPatch,
-  },
 ];
 
 module.exports.applyLinuxRemoteControlDeviceKeyPatch = applyLinuxRemoteControlDeviceKeyPatch;
@@ -1798,5 +1742,3 @@ module.exports.applyLinuxRemoteControlSshInstallActionPatch = applyLinuxRemoteCo
 module.exports.applyLinuxRemoteControlSshInstallReleasePatch = applyLinuxRemoteControlSshInstallReleasePatch;
 module.exports.applyLinuxRemoteControlSettingsUxPatch = applyLinuxRemoteControlSettingsUxPatch;
 module.exports.applyLinuxRemoteControlSelectedTabPatch = applyLinuxRemoteControlSelectedTabPatch;
-module.exports.applyLinuxRemoteMobileProjectlessRemoteTaskPatch =
-  applyLinuxRemoteMobileProjectlessRemoteTaskPatch;

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -55,6 +55,10 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_MARKER = "codexLinuxRemoteMobileProjectlessRemoteTaskId";
+const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
+  /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/u;
+const REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN =
+  /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~.*\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -1618,7 +1622,7 @@ module.exports = [
   {
     id: "linux-remote-control-load-gate",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-.*\.js$/,
+    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
     order: 20_118,
     ciPolicy: "optional",
     missingDescription: "remote-control loader gate bundle",
@@ -1698,7 +1702,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-conversation-hydration",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*\.js$/,
+    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
     order: 20_150,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1708,7 +1712,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-read-guard",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*\.js$/,
+    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
     order: 20_151,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1758,7 +1762,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-projectless-remote-task",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-.*\.js$/,
+    pattern: REMOTE_MOBILE_PROJECTLESS_REMOTE_TASK_ASSET_PATTERN,
     order: 20_170,
     ciPolicy: "optional",
     missingDescription: "sidebar project groups bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -54,6 +54,10 @@ const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~test.js";
 const REMOTE_CONTROL_STATUS_ASSET =
   "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
+const LATEST_REMOTE_CONVERSATION_ASSET =
+  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
+const LATEST_PROJECTLESS_REMOTE_TASK_ASSET =
+  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 
 function syntheticMainBundle() {
   return [
@@ -766,8 +770,10 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(statusGuardDescriptor);
     assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
+    assert.equal(statusGuardDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
     const statusWaitDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-wait"
@@ -781,25 +787,31 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(hydrationDescriptor);
     assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(hydrationDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
+    assert.equal(hydrationDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
     const loadGateDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-load-gate"
     );
     assert.ok(loadGateDescriptor);
     assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
+    assert.equal(loadGateDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
     const projectlessRemoteTaskDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task"
     );
     assert.ok(projectlessRemoteTaskDescriptor);
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), true);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), true);
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
   });
 });
 

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -52,12 +52,12 @@ const CURRENT_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~test.js";
 const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~test.js";
-const REMOTE_CONTROL_STATUS_ASSET =
-  "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
 const LATEST_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
+const UNIFIED_REMOTE_CONVERSATION_ASSET =
+  "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
 
 function syntheticMainBundle() {
   return [
@@ -771,6 +771,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(statusGuardDescriptor);
     assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(statusGuardDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(statusGuardDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
@@ -779,7 +780,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-wait"
     );
     assert.ok(statusWaitDescriptor);
-    assert.equal(statusWaitDescriptor.pattern.test(REMOTE_CONTROL_STATUS_ASSET), true);
+    assert.equal(statusWaitDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(statusWaitDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
 
     const hydrationDescriptor = descriptors.find((descriptor) =>
@@ -788,6 +789,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(hydrationDescriptor);
     assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(hydrationDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(hydrationDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
@@ -799,6 +801,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(loadGateDescriptor);
     assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
     assert.equal(loadGateDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
@@ -812,6 +815,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(projectlessRemoteTaskDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
   });
 });
 
@@ -2147,7 +2151,7 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
-        path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+        path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
         syntheticRemoteConnectionVisibilityBundle() +
           syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle(),
@@ -2480,10 +2484,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
         fs.writeFileSync(path.join(buildDir, "workspace-root-drop-handler-test.js"), syntheticAppServerLaunchBundle());
         fs.writeFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
           syntheticRemoteConnectionVisibilityBundle() +
             syntheticAppServerManagerSignalsBundle() +
-            syntheticAppServerManagerStatusBundle(),
+            syntheticAppServerManagerStatusBundle() +
+            syntheticCurrentStatusWaitBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
@@ -2513,10 +2518,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticAppServerManagerSignalsBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, REMOTE_CONTROL_STATUS_ASSET),
-          syntheticAppServerManagerStatusBundle() + syntheticCurrentStatusWaitBundle(),
-        );
-        fs.writeFileSync(
           path.join(assetsDir, "app-server-manager-signals-test.js"),
           syntheticAppServerManagerSignalsBundle(),
         );
@@ -2539,7 +2540,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
         const patchedAppMainFile = fs.readFileSync(
@@ -2559,11 +2560,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedSignalsFile = fs.readFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
         const patchedStatusFile = fs.readFileSync(
-          path.join(assetsDir, REMOTE_CONTROL_STATUS_ASSET),
+          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
         const patchedSidebarProjectGroupsFile = fs.readFileSync(

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -36,7 +36,6 @@ const {
   applyLinuxRemoteMobileConversationHydrationPatch,
   applyLinuxRemoteControlStatusReadGuardPatch,
   applyLinuxRemoteControlStatusWaitPatch,
-  applyLinuxRemoteMobileProjectlessRemoteTaskPatch,
   applyLinuxRemoteConnectionsRefreshPatch,
   applyLinuxRemoteControlSettingsUxPatch,
   applyLinuxRemoteControlSelectedTabPatch,
@@ -50,11 +49,9 @@ const OLD_APP_SERVER_MANAGER_ASSET =
   "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~test.js";
 const CURRENT_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~test.js";
-const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
-  "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~test.js";
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
-const LATEST_PROJECTLESS_REMOTE_TASK_ASSET =
+const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
@@ -312,12 +309,6 @@ function syntheticCurrentStatusWaitBundle() {
 function syntheticAppMainActiveStatusBundle() {
   return [
     "function pS({latestTurnStatus:e,resumeState:t,streamRole:n,threadRuntimeStatus:r}){return n==null?t===`needs_resume`?`needs-resume`:`read-only`:n.role===`follower`?`follower`:r?.type===`active`||e===`inProgress`?`active`:`inactive`}",
-  ].join("");
-}
-
-function syntheticSidebarProjectGroupsBundle() {
-  return [
-    "function AD(e,t,n){let r=MD(e,t),i=ND(r);if(!i){RD.has(e.task.id)||(RD.add(e.task.id),y.warning(`No owner repo found for remote task`,{safe:{taskId:e.task.id},sensitive:{}}));return}let a=i.repoName.toLowerCase();(n.find(e=>hD(e.repositoryData?.ownerRepo,i)&&e.repositoryData?.repoPath===``&&e.repositoryData?.rootFolder?.toLowerCase()===a)??null??n.find(e=>hD(e.repositoryData?.ownerRepo,i))??jD(i,r,n)).threadKeys.push(e.key)}",
   ].join("");
 }
 
@@ -732,7 +723,6 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-control-enable-for-host-params",
       "feature:remote-mobile-control:linux-remote-control-enablement-bridge",
       "feature:remote-mobile-control:linux-remote-mobile-active-status",
-      "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
       "main-bundle",
@@ -740,7 +730,6 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "main-bundle",
       "main-bundle",
       "extracted-app:post-webview",
-      "webview-asset",
       "webview-asset",
       "webview-asset",
       "webview-asset",
@@ -769,12 +758,12 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-read-guard"
     );
     assert.ok(statusGuardDescriptor);
-    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
-    assert.equal(statusGuardDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(statusGuardDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
-    assert.equal(statusGuardDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
     const statusWaitDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-wait"
@@ -787,35 +776,25 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration"
     );
     assert.ok(hydrationDescriptor);
-    assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
-    assert.equal(hydrationDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(hydrationDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(hydrationDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
-    assert.equal(hydrationDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(hydrationDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
     const loadGateDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-load-gate"
     );
     assert.ok(loadGateDescriptor);
-    assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
-    assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
     assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
-    assert.equal(loadGateDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(loadGateDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
 
-    const projectlessRemoteTaskDescriptor = descriptors.find((descriptor) =>
-      descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task"
-    );
-    assert.ok(projectlessRemoteTaskDescriptor);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), true);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(LATEST_PROJECTLESS_REMOTE_TASK_ASSET), true);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
-    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
   });
 });
 
@@ -2156,10 +2135,6 @@ test("remote mobile feature patch report records feature metadata and partial wa
           syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle(),
       );
-      fs.writeFileSync(
-        path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
-        syntheticSidebarProjectGroupsBundle(),
-      );
       fs.writeFileSync(path.join(assetsDir, "app-main-test.js"), syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle() + syntheticAppMainActiveStatusBundle());
       fs.writeFileSync(
         path.join(assetsDir, "remote-connections-settings-test.js"),
@@ -2210,19 +2185,6 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.rmSync(tempApp, { recursive: true, force: true });
     }
   });
-});
-
-test("Linux remote mobile projectless remote task patch groups tasks without owner repo metadata", () => {
-  const source = syntheticSidebarProjectGroupsBundle();
-  const patched = applyLinuxRemoteMobileProjectlessRemoteTaskPatch(source);
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /codexLinuxRemoteMobileProjectlessRemoteTaskId/);
-  assert.match(patched, /projectId:`remote-task:\$\{codexLinuxRemoteMobileProjectlessRemoteTaskId\}`/);
-  assert.match(patched, /repositoryData:null/);
-  assert.match(patched, /threadKeys:\[\]/);
-  assert.doesNotMatch(patched, /No owner repo found for remote task/);
-  assert.equal(applyLinuxRemoteMobileProjectlessRemoteTaskPatch(patched), patched);
 });
 
 test("Linux remote mobile active-status patch treats active thread status as active without stream role", () => {
@@ -2491,10 +2453,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             syntheticCurrentStatusWaitBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
-          syntheticSidebarProjectGroupsBundle(),
-        );
-        fs.writeFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
           syntheticVisibilityBundle(),
         );
@@ -2567,10 +2525,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
-        const patchedSidebarProjectGroupsFile = fs.readFileSync(
-          path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
-          "utf8",
-        );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
@@ -2590,7 +2544,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileThreadRuntimeStatus/);
         assert.match(patchedStatusFile, /codexLinuxRemoteControlShouldReadStatus/);
         assert.match(patchedStatusFile, /codexLinuxRemoteControlStatusWaitMs/);
-        assert.match(patchedSidebarProjectGroupsFile, /codexLinuxRemoteMobileProjectlessRemoteTaskId/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteControlEnablementBridge/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteMobileActiveStatus/);
         assert.ok(
@@ -2692,12 +2645,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-mobile-active-status" &&
-            patch.status === "applied",
-          ),
-        );
-        assert.ok(
-          report.patches.some((patch) =>
-            patch.name === "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task" &&
             patch.status === "applied",
           ),
         );

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -44,14 +44,16 @@ const {
 } = require("./patch.js");
 
 const REPO_ROOT = path.resolve(__dirname, "../..");
-const REMOTE_CONTROL_GATE_ASSET =
+const OLD_REMOTE_CONTROL_GATE_ASSET =
   "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-test.js";
-const APP_SERVER_MANAGER_ASSET =
+const OLD_APP_SERVER_MANAGER_ASSET =
   "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~test.js";
+const CURRENT_REMOTE_CONVERSATION_ASSET =
+  "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~test.js";
+const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
+  "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~test.js";
 const REMOTE_CONTROL_STATUS_ASSET =
   "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
-const PROJECTLESS_REMOTE_TASK_ASSET =
-  REMOTE_CONTROL_GATE_ASSET;
 
 function syntheticMainBundle() {
   return [
@@ -763,8 +765,8 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-read-guard"
     );
     assert.ok(statusGuardDescriptor);
-    assert.equal(statusGuardDescriptor.pattern.test(REMOTE_CONTROL_STATUS_ASSET), true);
-    assert.equal(statusGuardDescriptor.pattern.test(APP_SERVER_MANAGER_ASSET), false);
+    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
 
     const statusWaitDescriptor = descriptors.find((descriptor) =>
@@ -772,13 +774,14 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(statusWaitDescriptor);
     assert.equal(statusWaitDescriptor.pattern.test(REMOTE_CONTROL_STATUS_ASSET), true);
-    assert.equal(statusWaitDescriptor.pattern.test(APP_SERVER_MANAGER_ASSET), false);
+    assert.equal(statusWaitDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
 
     const hydrationDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-conversation-hydration"
     );
     assert.ok(hydrationDescriptor);
-    assert.equal(hydrationDescriptor.pattern.test(APP_SERVER_MANAGER_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
 
@@ -786,8 +789,17 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-load-gate"
     );
     assert.ok(loadGateDescriptor);
-    assert.equal(loadGateDescriptor.pattern.test(REMOTE_CONTROL_GATE_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
+
+    const projectlessRemoteTaskDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task"
+    );
+    assert.ok(projectlessRemoteTaskDescriptor);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), true);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
+    assert.equal(projectlessRemoteTaskDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
   });
 });
 
@@ -2123,8 +2135,14 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
-        path.join(assetsDir, REMOTE_CONTROL_GATE_ASSET),
-        syntheticRemoteConnectionVisibilityBundle() + syntheticSidebarProjectGroupsBundle(),
+        path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+        syntheticRemoteConnectionVisibilityBundle() +
+          syntheticAppServerManagerSignalsBundle() +
+          syntheticAppServerManagerStatusBundle(),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
+        syntheticSidebarProjectGroupsBundle(),
       );
       fs.writeFileSync(path.join(assetsDir, "app-main-test.js"), syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle() + syntheticAppMainActiveStatusBundle());
       fs.writeFileSync(
@@ -2135,8 +2153,8 @@ test("remote mobile feature patch report records feature metadata and partial wa
         ),
       );
       fs.writeFileSync(
-        path.join(assetsDir, APP_SERVER_MANAGER_ASSET),
-        syntheticAppServerManagerSignalsBundle() + syntheticAppServerManagerStatusBundle(),
+        path.join(assetsDir, OLD_APP_SERVER_MANAGER_ASSET),
+        syntheticAppServerManagerSignalsBundle(),
       );
       fs.writeFileSync(
         path.join(assetsDir, "app-server-manager-signals-test.js"),
@@ -2450,8 +2468,14 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
         fs.writeFileSync(path.join(buildDir, "workspace-root-drop-handler-test.js"), syntheticAppServerLaunchBundle());
         fs.writeFileSync(
-          path.join(assetsDir, REMOTE_CONTROL_GATE_ASSET),
-          syntheticRemoteConnectionVisibilityBundle() + syntheticSidebarProjectGroupsBundle(),
+          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
+          syntheticRemoteConnectionVisibilityBundle() +
+            syntheticAppServerManagerSignalsBundle() +
+            syntheticAppServerManagerStatusBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
+          syntheticSidebarProjectGroupsBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-control-connections-visibility-test.js"),
@@ -2473,7 +2497,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticMobileConnectedSettingsBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, APP_SERVER_MANAGER_ASSET),
+          path.join(assetsDir, OLD_APP_SERVER_MANAGER_ASSET),
           syntheticAppServerManagerSignalsBundle(),
         );
         fs.writeFileSync(
@@ -2503,7 +2527,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, REMOTE_CONTROL_GATE_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
         const patchedAppMainFile = fs.readFileSync(
@@ -2523,7 +2547,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedSignalsFile = fs.readFileSync(
-          path.join(assetsDir, APP_SERVER_MANAGER_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_ASSET),
           "utf8",
         );
         const patchedStatusFile = fs.readFileSync(
@@ -2531,7 +2555,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedSidebarProjectGroupsFile = fs.readFileSync(
-          path.join(assetsDir, PROJECTLESS_REMOTE_TASK_ASSET),
+          path.join(assetsDir, CURRENT_PROJECTLESS_REMOTE_TASK_ASSET),
           "utf8",
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);

--- a/scripts/ci/validate-patch-report.js
+++ b/scripts/ci/validate-patch-report.js
@@ -12,11 +12,21 @@ const {
 } = require("../lib/patch-report.js");
 
 function usage() {
-  return "Usage: validate-patch-report.js <patch-report.json> [--profile upstream-build]";
+  return [
+    "Usage: validate-patch-report.js <patch-report.json> [--profile upstream-build]",
+    "       [--require-enabled-feature FEATURE_ID] [--require-success PATCH_NAME]",
+  ].join("\n");
+}
+
+function uniqueStrings(values) {
+  const list = Array.isArray(values) ? values : [values];
+  return [...new Set(list.filter((value) => typeof value === "string" && value.length > 0))];
 }
 
 function parseArgs(argv) {
   let profile = "upstream-build";
+  const requiredEnabledFeatures = [];
+  const requiredSuccessfulPatches = [];
   const positional = [];
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -27,9 +37,25 @@ function parseArgs(argv) {
         throw new Error(usage());
       }
       index += 1;
+    } else if (arg === "--require-enabled-feature") {
+      const featureId = argv[index + 1];
+      if (!featureId) {
+        throw new Error(usage());
+      }
+      requiredEnabledFeatures.push(featureId);
+      index += 1;
+    } else if (arg === "--require-success") {
+      const patchName = argv[index + 1];
+      if (!patchName) {
+        throw new Error(usage());
+      }
+      requiredSuccessfulPatches.push(patchName);
+      index += 1;
     } else if (arg === "--help" || arg === "-h") {
       console.log(usage());
       process.exit(0);
+    } else if (arg.startsWith("--")) {
+      throw new Error(`Unknown option: ${arg}\n${usage()}`);
     } else {
       positional.push(arg);
     }
@@ -39,7 +65,14 @@ function parseArgs(argv) {
     throw new Error(usage());
   }
 
-  return { profile, reportPath: positional[0] };
+  return {
+    profile,
+    reportPath: positional[0],
+    requirements: {
+      requiredEnabledFeatures: uniqueStrings(requiredEnabledFeatures),
+      requiredSuccessfulPatches: uniqueStrings(requiredSuccessfulPatches),
+    },
+  };
 }
 
 function readReport(reportPath) {
@@ -51,9 +84,13 @@ function readReport(reportPath) {
   return report;
 }
 
-function validateReport(report, profile) {
+function validateReport(report, profile, requirements = {}) {
   const requiredNames = requiredPatchNamesForProfile(profile);
-  const patchesByName = new Map(report.patches.map((patch) => [patch.name, patch]));
+  const patches = Array.isArray(report?.patches) ? report.patches : [];
+  const patchesByName = new Map(patches.map((patch) => [patch.name, patch]));
+  const enabledFeatures = new Set(Array.isArray(report.enabledFeatures) ? report.enabledFeatures : []);
+  const requiredEnabledFeatures = uniqueStrings(requirements.requiredEnabledFeatures ?? []);
+  const requiredSuccessfulPatches = uniqueStrings(requirements.requiredSuccessfulPatches ?? []);
   const failures = [];
 
   // A required patch that never ran leaves no report entry, so the
@@ -69,6 +106,23 @@ function validateReport(report, profile) {
   // applicable status fails validation.
   for (const failure of criticalFailuresFromReport(report)) {
     failures.push(`${failure.name}: ${failure.status}${failure.reason ? ` (${failure.reason})` : ""}`);
+  }
+
+  for (const featureId of requiredEnabledFeatures) {
+    if (!enabledFeatures.has(featureId)) {
+      failures.push(`feature ${featureId}: not enabled in patch report`);
+    }
+  }
+
+  for (const name of requiredSuccessfulPatches) {
+    const patch = patchesByName.get(name);
+    if (patch == null) {
+      failures.push(`${name}: missing from patch report`);
+      continue;
+    }
+    if (!SUCCESS_STATUSES.has(patch.status)) {
+      failures.push(`${name}: ${patch.status}${patch.reason ? ` (${patch.reason})` : ""}`);
+    }
   }
 
   return failures;
@@ -87,10 +141,10 @@ function printOptionalDrift(report) {
 
 function main() {
   try {
-    const { profile, reportPath } = parseArgs(process.argv.slice(2));
+    const { profile, reportPath, requirements } = parseArgs(process.argv.slice(2));
     const report = readReport(reportPath);
     printOptionalDrift(report);
-    const failures = validateReport(report, profile);
+    const failures = validateReport(report, profile, requirements);
     if (failures.length > 0) {
       console.error(`Required patch validation failed for profile ${profile}:`);
       for (const failure of failures) {

--- a/scripts/ci/validate-patch-report.js
+++ b/scripts/ci/validate-patch-report.js
@@ -6,6 +6,7 @@ const {
   requiredPatchNamesForProfile,
 } = require("../patches/runner.js");
 const {
+  PATCH_STATUS_APPLIED,
   SUCCESS_STATUSES,
   criticalFailuresFromReport,
   optionalDriftFromReport,
@@ -15,6 +16,7 @@ function usage() {
   return [
     "Usage: validate-patch-report.js <patch-report.json> [--profile upstream-build]",
     "       [--require-enabled-feature FEATURE_ID] [--require-success PATCH_NAME]",
+    "       [--require-applied PATCH_NAME]",
   ].join("\n");
 }
 
@@ -26,6 +28,7 @@ function uniqueStrings(values) {
 function parseArgs(argv) {
   let profile = "upstream-build";
   const requiredEnabledFeatures = [];
+  const requiredAppliedPatches = [];
   const requiredSuccessfulPatches = [];
   const positional = [];
 
@@ -51,6 +54,13 @@ function parseArgs(argv) {
       }
       requiredSuccessfulPatches.push(patchName);
       index += 1;
+    } else if (arg === "--require-applied") {
+      const patchName = argv[index + 1];
+      if (!patchName) {
+        throw new Error(usage());
+      }
+      requiredAppliedPatches.push(patchName);
+      index += 1;
     } else if (arg === "--help" || arg === "-h") {
       console.log(usage());
       process.exit(0);
@@ -69,6 +79,7 @@ function parseArgs(argv) {
     profile,
     reportPath: positional[0],
     requirements: {
+      requiredAppliedPatches: uniqueStrings(requiredAppliedPatches),
       requiredEnabledFeatures: uniqueStrings(requiredEnabledFeatures),
       requiredSuccessfulPatches: uniqueStrings(requiredSuccessfulPatches),
     },
@@ -89,6 +100,7 @@ function validateReport(report, profile, requirements = {}) {
   const patches = Array.isArray(report?.patches) ? report.patches : [];
   const patchesByName = new Map(patches.map((patch) => [patch.name, patch]));
   const enabledFeatures = new Set(Array.isArray(report.enabledFeatures) ? report.enabledFeatures : []);
+  const requiredAppliedPatches = uniqueStrings(requirements.requiredAppliedPatches ?? []);
   const requiredEnabledFeatures = uniqueStrings(requirements.requiredEnabledFeatures ?? []);
   const requiredSuccessfulPatches = uniqueStrings(requirements.requiredSuccessfulPatches ?? []);
   const failures = [];
@@ -122,6 +134,17 @@ function validateReport(report, profile, requirements = {}) {
     }
     if (!SUCCESS_STATUSES.has(patch.status)) {
       failures.push(`${name}: ${patch.status}${patch.reason ? ` (${patch.reason})` : ""}`);
+    }
+  }
+
+  for (const name of requiredAppliedPatches) {
+    const patch = patchesByName.get(name);
+    if (patch == null) {
+      failures.push(`${name}: missing from patch report`);
+      continue;
+    }
+    if (patch.status !== PATCH_STATUS_APPLIED) {
+      failures.push(`${name}: expected applied, got ${patch.status}${patch.reason ? ` (${patch.reason})` : ""}`);
     }
   }
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5360,6 +5360,8 @@ test("discovers current app-server conversation core Linux webview patches", () 
     "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~bj5tp28r-Dcs9S3fj.js";
   const latestConversationAsset =
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-Bty5T9_s.js";
+  const unifiedConversationAsset =
+    "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js";
   const oldConversationAsset =
     "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~h59fr3q5-Cm3GYhJA.js";
   const projectlessRemoteTaskAsset =
@@ -5375,8 +5377,10 @@ test("discovers current app-server conversation core Linux webview patches", () 
     assert.equal(descriptor.ciPolicy, "optional");
     assert.match(String(descriptor.pattern), /worktree-init-v2-page/);
     assert.match(String(descriptor.pattern), /glxlkd48/);
+    assert.match(String(descriptor.pattern), /b76hmflu/);
     assert.equal(descriptor.pattern.test(currentConversationAsset), true);
     assert.equal(descriptor.pattern.test(latestConversationAsset), true);
+    assert.equal(descriptor.pattern.test(unifiedConversationAsset), true);
     assert.equal(descriptor.pattern.test(oldConversationAsset), false);
     assert.equal(descriptor.pattern.test(projectlessRemoteTaskAsset), false);
     assert.equal(descriptor.pattern.test(latestProjectlessRemoteTaskAsset), false);

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5356,11 +5356,11 @@ test("restarts late-event hydration when a pending queue exists without an in-fl
 });
 
 test("discovers current app-server conversation core Linux webview patches", () => {
-  const currentConversationAsset =
+  const legacyConversationAsset =
     "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~bj5tp28r-Dcs9S3fj.js";
-  const latestConversationAsset =
+  const legacyLatestConversationAsset =
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-Bty5T9_s.js";
-  const unifiedConversationAsset =
+  const currentConversationAsset =
     "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js";
   const oldConversationAsset =
     "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~h59fr3q5-Cm3GYhJA.js";
@@ -5375,12 +5375,10 @@ test("discovers current app-server conversation core Linux webview patches", () 
     assert.ok(descriptor);
     assert.equal(descriptor.phase, "webview-asset");
     assert.equal(descriptor.ciPolicy, "optional");
-    assert.match(String(descriptor.pattern), /worktree-init-v2-page/);
-    assert.match(String(descriptor.pattern), /glxlkd48/);
     assert.match(String(descriptor.pattern), /b76hmflu/);
     assert.equal(descriptor.pattern.test(currentConversationAsset), true);
-    assert.equal(descriptor.pattern.test(latestConversationAsset), true);
-    assert.equal(descriptor.pattern.test(unifiedConversationAsset), true);
+    assert.equal(descriptor.pattern.test(legacyConversationAsset), false);
+    assert.equal(descriptor.pattern.test(legacyLatestConversationAsset), false);
     assert.equal(descriptor.pattern.test(oldConversationAsset), false);
     assert.equal(descriptor.pattern.test(projectlessRemoteTaskAsset), false);
     assert.equal(descriptor.pattern.test(latestProjectlessRemoteTaskAsset), false);
@@ -8664,6 +8662,10 @@ test("validateReport can require enabled features and successful patch entries",
   };
 
   const failures = validateReport(report, "feature-probe", {
+    requiredAppliedPatches: [
+      "feature:remote-mobile-control:linux-remote-control-load-gate",
+      "linux-app-server-conversation-hydration",
+    ],
     requiredEnabledFeatures: ["remote-mobile-control", "missing-feature"],
     requiredSuccessfulPatches: [
       "feature:remote-mobile-control:linux-remote-control-load-gate",
@@ -8679,7 +8681,9 @@ test("validateReport can require enabled features and successful patch entries",
     ),
   );
   assert.ok(
-    !failures.some((failure) => failure.startsWith("linux-app-server-conversation-hydration:")),
+    failures.includes(
+      "linux-app-server-conversation-hydration: expected applied, got already-applied",
+    ),
   );
   assert.ok(failures.includes("feature missing-feature: not enabled in patch report"));
   assert.ok(

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5358,10 +5358,14 @@ test("restarts late-event hydration when a pending queue exists without an in-fl
 test("discovers current app-server conversation core Linux webview patches", () => {
   const currentConversationAsset =
     "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~bj5tp28r-Dcs9S3fj.js";
+  const latestConversationAsset =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-Bty5T9_s.js";
   const oldConversationAsset =
     "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~h59fr3q5-Cm3GYhJA.js";
   const projectlessRemoteTaskAsset =
     "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~kmtatxxf-DEE2TwPG.js";
+  const latestProjectlessRemoteTaskAsset =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js";
 
   for (const id of ["linux-app-server-conversation-hydration", "linux-completed-item-recovery"]) {
     const descriptor = corePatchDescriptors().find((patch) => patch.id === id);
@@ -5370,9 +5374,12 @@ test("discovers current app-server conversation core Linux webview patches", () 
     assert.equal(descriptor.phase, "webview-asset");
     assert.equal(descriptor.ciPolicy, "optional");
     assert.match(String(descriptor.pattern), /worktree-init-v2-page/);
+    assert.match(String(descriptor.pattern), /glxlkd48/);
     assert.equal(descriptor.pattern.test(currentConversationAsset), true);
+    assert.equal(descriptor.pattern.test(latestConversationAsset), true);
     assert.equal(descriptor.pattern.test(oldConversationAsset), false);
     assert.equal(descriptor.pattern.test(projectlessRemoteTaskAsset), false);
+    assert.equal(descriptor.pattern.test(latestProjectlessRemoteTaskAsset), false);
     assert.equal(descriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(descriptor.pattern.test("remote-connections-settings-fixture.js"), false);
   }
@@ -8627,6 +8634,58 @@ test("criticalFailuresFromReport agrees with validateReport and skips non-applic
   assert.ok(failures.some((failure) => failure.startsWith("req-bad:")));
   assert.ok(!failures.some((failure) => failure.startsWith("req-not-applicable:")));
   assert.ok(!failures.some((failure) => failure.startsWith("opt-bad:")));
+});
+
+test("validateReport can require enabled features and successful patch entries", () => {
+  const report = {
+    enabledFeatures: ["remote-mobile-control"],
+    patches: [
+      {
+        name: "feature:remote-mobile-control:linux-remote-control-load-gate",
+        status: "applied",
+        ciPolicy: "optional",
+      },
+      {
+        name: "linux-app-server-conversation-hydration",
+        status: "already-applied",
+        ciPolicy: "optional",
+      },
+      {
+        name: "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task",
+        status: "skipped-optional",
+        ciPolicy: "optional",
+        reason: "missing sidebar project groups bundle",
+      },
+    ],
+  };
+
+  const failures = validateReport(report, "feature-probe", {
+    requiredEnabledFeatures: ["remote-mobile-control", "missing-feature"],
+    requiredSuccessfulPatches: [
+      "feature:remote-mobile-control:linux-remote-control-load-gate",
+      "linux-app-server-conversation-hydration",
+      "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task",
+      "feature:remote-mobile-control:missing-entry",
+    ],
+  });
+
+  assert.ok(
+    !failures.some((failure) =>
+      failure.startsWith("feature:remote-mobile-control:linux-remote-control-load-gate:"),
+    ),
+  );
+  assert.ok(
+    !failures.some((failure) => failure.startsWith("linux-app-server-conversation-hydration:")),
+  );
+  assert.ok(failures.includes("feature missing-feature: not enabled in patch report"));
+  assert.ok(
+    failures.some((failure) =>
+      failure.startsWith(
+        "feature:remote-mobile-control:linux-remote-mobile-projectless-remote-task: skipped-optional",
+      ),
+    ),
+  );
+  assert.ok(failures.includes("feature:remote-mobile-control:missing-entry: missing from patch report"));
 });
 
 test("terminal user PATH patch drift is reported as optional", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5355,23 +5355,27 @@ test("restarts late-event hydration when a pending queue exists without an in-fl
   assert.deepEqual(updatedConversations, ["thread-a"]);
 });
 
-test("discovers app-server conversation hydration as a core Linux webview patch", () => {
-  const descriptor = corePatchDescriptors().find(
-    (patch) => patch.id === "linux-app-server-conversation-hydration",
-  );
+test("discovers current app-server conversation core Linux webview patches", () => {
+  const currentConversationAsset =
+    "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~bj5tp28r-Dcs9S3fj.js";
+  const oldConversationAsset =
+    "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~h59fr3q5-Cm3GYhJA.js";
+  const projectlessRemoteTaskAsset =
+    "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~pull-requests-page~plug~kmtatxxf-DEE2TwPG.js";
 
-  assert.ok(descriptor);
-  assert.equal(descriptor.phase, "webview-asset");
-  assert.equal(descriptor.ciPolicy, "optional");
-  assert.match(String(descriptor.pattern), /thread-app-shell-chrome/);
-  assert.equal(
-    descriptor.pattern.test(
-      "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~h59fr3q5-Cm3GYhJA.js",
-    ),
-    true,
-  );
-  assert.equal(descriptor.pattern.test("app-server-manager-signals-test.js"), false);
-  assert.equal(descriptor.pattern.test("remote-connections-settings-fixture.js"), false);
+  for (const id of ["linux-app-server-conversation-hydration", "linux-completed-item-recovery"]) {
+    const descriptor = corePatchDescriptors().find((patch) => patch.id === id);
+
+    assert.ok(descriptor);
+    assert.equal(descriptor.phase, "webview-asset");
+    assert.equal(descriptor.ciPolicy, "optional");
+    assert.match(String(descriptor.pattern), /worktree-init-v2-page/);
+    assert.equal(descriptor.pattern.test(currentConversationAsset), true);
+    assert.equal(descriptor.pattern.test(oldConversationAsset), false);
+    assert.equal(descriptor.pattern.test(projectlessRemoteTaskAsset), false);
+    assert.equal(descriptor.pattern.test("app-server-manager-signals-test.js"), false);
+    assert.equal(descriptor.pattern.test("remote-connections-settings-fixture.js"), false);
+  }
 });
 
 test("recovers completed stream items that arrive after local state lost their started item", () => {

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/,
+    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/,
+    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/,
+    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*\.js$/,
+    pattern: /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/,
+    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/,
+    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*)\.js$/,
+    pattern: /^app-initial~app-main~(?:worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*|new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-.*|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*\.js$/,
+    pattern: /^app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~.*\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,


### PR DESCRIPTION
## Summary

The `26.707.31428` unified app moved the conversation manager signals, completed-item path, remote-control load gate, and status handling into the `b76hmflu` chunk. This updates the affected core and opt-in `remote-mobile-control` selectors while keeping the previous `worktree-init-v2` and `glxlkd48` forms supported. The older `thread-app-shell` fixture remains intentionally unsupported.

The PR also adds a feature-enabled upstream-DMG check. It now fails unless the relevant core patches and remote-mobile descriptors, including the current status-wait patch, are present and successful. That workflow runs only when the remote-mobile feature or its shared patch/report infrastructure changes.

`remote-mobile-control` remains disabled by default. This is still a partial repair for #726; the standalone runtime handoff and ChatGPT-auth path are outside this change.

## Validation

- 814 Node tests
- script smoke suite
- `cargo check`
- 217 Rust tests
- feature-enabled inspect against the `26.707.31428` DMG with exact patch-report validation
- isolated full app build with the same feature config
- syntax check of the patched `b76hmflu` bundle
- raw-DMG selector check: one matching asset per affected descriptor, with no conversation/projectless overlap
- second patch pass: unchanged tree hash, with every affected descriptor reporting `already-applied` without warnings
