### PR TITLE
Fix Linux settings page component resolution

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1324,7 +1324,10 @@ function createNativeKeyboardShortcutsSettingsFixture() {
     'function requestCodex(...args){let[method,request]=args,{params:params,select:select,signal:signal,source:source}=request??{};return rawCodex(method,params,select,signal,source)}async function rawCodex(method,params,select,signal,source){let result=(await transport.post(`vscode://codex/${method}`,JSON.stringify(params),headers(source),signal)).body;return select?select(result):result}export{requestCodex as z};',
   );
   writeAsset("general-settings-A.js", "hotkey-window-hotkey-state");
-  writeAsset("toggle-A.js", "export{t};");
+  writeAsset(
+    "toggle-A.js",
+    'function t({checked,disabled,onChange,ariaLabel}){return {role:"switch","aria-checked":checked,"aria-label":ariaLabel,disabled,onClick:()=>onChange(!checked)}}export{t};',
+  );
   writeAsset(
     "settings-row-A.js",
     "function a(e){let{label:t,description:n,control:r}=e;return null}function s(e){let{label:t,children:n}=e;return null}export{s as n,a as r};",
@@ -1362,7 +1365,10 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
     "setting-storage-A.js",
     'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
   );
-  writeAsset("toggle-A.js", "export{t};");
+  writeAsset(
+    "toggle-A.js",
+    'function t({checked,disabled,onChange,ariaLabel}){return {role:"switch","aria-checked":checked,"aria-label":ariaLabel,disabled,onClick:()=>onChange(!checked)}}export{t};',
+  );
   writeAsset(
     "settings-row-A.js",
     "function a(e){let{label:t,description:n,control:r}=e;return null}export{a as r};",
@@ -1430,7 +1436,10 @@ function createSplitRouteNativeKeyboardShortcutsSettingsFixture({
     "setting-storage-A.js",
     'async function requestCodex(...args){let[request]=args,{params:params,source:source}=request;return send("vscode://codex/",params)}export{requestCodex as z};',
   );
-  writeAsset("toggle-A.js", "export{t};");
+  writeAsset(
+    "toggle-A.js",
+    'function t({checked,disabled,onChange,ariaLabel}){return {role:"switch","aria-checked":checked,"aria-label":ariaLabel,disabled,onClick:()=>onChange(!checked)}}export{t};',
+  );
   writeAsset(
     "settings-row-A.js",
     "function a(e){let{label:t,description:n,control:r}=e;return null}export{a as r};",
@@ -4135,6 +4144,48 @@ test("uses a themed fallback toggle when upstream settings toggle is unavailable
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
     assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
+test("ignores settings row and toggle icon decoys from the current DMG", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  try {
+    fs.rmSync(path.join(assetsDir, "settings-row-A.js"));
+    fs.rmSync(path.join(assetsDir, "toggle-A.js"));
+    fs.writeFileSync(
+      path.join(assetsDir, "settings-row-disclosure-A.js"),
+      "function a(e){let{children:n,content:r,contentId:i,expanded:o}=e;return null}function c(){}export{c as n,a as t};",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(assetsDir, "toggle-left-A.js"),
+      "function createIcon(e,t){return{e,t}}var r=createIcon(`ToggleLeft`,[[`rect`,{width:`20`,height:`12`}]]);function i(){}export{i as n,r as t};",
+      "utf8",
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.deepEqual(warnings, []);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-row-linux.js")), true);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-toggle-linux.js")), true);
+
+    const linuxDesktopSource = fs.readFileSync(
+      path.join(assetsDir, linuxDesktopSettingsAsset),
+      "utf8",
+    );
+    assert.match(
+      linuxDesktopSource,
+      /import\{n as SettingsRow\}from"\.\/linux-settings-row-linux\.js"/,
+    );
+    assert.match(
+      linuxDesktopSource,
+      /import\{t as Toggle\}from"\.\/linux-settings-toggle-linux\.js"/,
+    );
+    assert.doesNotMatch(linuxDesktopSource, /settings-row-disclosure-A\.js/);
+    assert.doesNotMatch(linuxDesktopSource, /toggle-left-A\.js/);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -199,12 +199,12 @@ function inferSettingsRowExportName(source) {
   }
 
   if (localName == null) {
-    return "n";
+    return null;
   }
 
   const exportMatch = source.match(/export\{([^}]*)\}/);
   if (exportMatch == null) {
-    return "n";
+    return null;
   }
 
   for (const rawExport of exportMatch[1].split(",")) {
@@ -218,7 +218,7 @@ function inferSettingsRowExportName(source) {
     }
   }
 
-  return "n";
+  return null;
 }
 
 function importBindings(source) {
@@ -322,19 +322,47 @@ function linuxSettingsFallbackComponents({ jsxRuntimeAsset, jsxRuntimeExportName
   };
 }
 
-function inferFirstExportName(source, fallback = "t") {
-  const exportMatch = source.match(/export\{([^}]*)\}/);
-  if (exportMatch == null) {
-    return fallback;
+function inferToggleExportName(source) {
+  const functionPattern = /function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/g;
+  let match;
+  while ((match = functionPattern.exec(source)) != null) {
+    const nextFunctionIndex = source.indexOf("function ", functionPattern.lastIndex);
+    const functionSource = source.slice(
+      match.index,
+      nextFunctionIndex === -1 ? source.length : nextFunctionIndex,
+    );
+    if (
+      !functionSource.includes("checked") ||
+      !functionSource.includes("onChange") ||
+      !(
+        functionSource.includes("ariaLabel") ||
+        functionSource.includes("aria-label") ||
+        functionSource.includes("aria-checked") ||
+        functionSource.includes('role:"switch"') ||
+        functionSource.includes("role:`switch`")
+      )
+    ) {
+      continue;
+    }
+
+    const exportMatch = source.match(/export\{([^}]*)\}/);
+    if (exportMatch == null) {
+      return null;
+    }
+    for (const rawExport of exportMatch[1].split(",")) {
+      const exportPart = rawExport.trim();
+      const aliasedMatch = exportPart.match(
+        new RegExp(`^${escapeRegExp(match[1])}\\s+as\\s+([A-Za-z_$][\\w$]*)$`),
+      );
+      if (aliasedMatch != null) {
+        return aliasedMatch[1];
+      }
+      if (exportPart === match[1]) {
+        return match[1];
+      }
+    }
   }
-
-  const exportedNames = exportMatch[1].split(",").map((rawExport) => {
-    const exportPart = rawExport.trim();
-    const aliasedMatch = exportPart.match(/^[A-Za-z_$][\w$]*\s+as\s+([A-Za-z_$][\w$]*)$/);
-    return aliasedMatch?.[1] ?? exportPart;
-  }).filter((name) => /^[A-Za-z_$][\w$]*$/.test(name));
-
-  return exportedNames.includes(fallback) ? fallback : exportedNames[0] ?? fallback;
+  return null;
 }
 
 function inferToggleDependencyFromSettingsSource(source) {
@@ -359,16 +387,19 @@ function inferToggleDependencyFromSettingsSource(source) {
 }
 
 function resolveSettingsToggleDependency(webviewAssetsDir, fallbackComponents, generatedAssets) {
-  const directToggleAsset = fs
+  const directToggleAssets = fs
     .readdirSync(webviewAssetsDir)
     .filter((name) => /^toggle-.*\.js$/.test(name))
-    .sort()[0] ?? null;
-  if (directToggleAsset != null) {
+    .sort();
+  for (const directToggleAsset of directToggleAssets) {
     const source = fs.readFileSync(path.join(webviewAssetsDir, directToggleAsset), "utf8");
-    return {
-      assetName: directToggleAsset,
-      exportName: inferFirstExportName(source),
-    };
+    const exportName = inferToggleExportName(source);
+    if (exportName != null) {
+      return {
+        assetName: directToggleAsset,
+        exportName,
+      };
+    }
   }
 
   const settingsAssets = fs
@@ -459,12 +490,19 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     return component;
   };
 
-  const settingsRowCandidate = tryFindRequiredWebviewAsset(webviewAssetsDir, /^settings-row-.*\.js$/, null, "settings row asset");
+  let settingsRowCandidate = null;
+  let settingsRowExportName = null;
+  for (const candidate of fs.readdirSync(webviewAssetsDir).filter((name) => /^settings-row-.*\.js$/.test(name)).sort()) {
+    const source = fs.readFileSync(path.join(webviewAssetsDir, candidate), "utf8");
+    const exportName = inferSettingsRowExportName(source);
+    if (exportName != null) {
+      settingsRowCandidate = candidate;
+      settingsRowExportName = exportName;
+      break;
+    }
+  }
   const settingsRowFallback = settingsRowCandidate == null ? useFallbackComponent("settingsRow") : null;
   const settingsRowAsset = settingsRowCandidate ?? settingsRowFallback.assetName;
-  const settingsRowSource = settingsRowCandidate == null
-    ? settingsRowFallback.source
-    : fs.readFileSync(path.join(webviewAssetsDir, settingsRowAsset), "utf8");
   const settingsLayoutCandidate = tryFindRequiredWebviewAsset(
     webviewAssetsDir,
     /^settings-content-layout-.*\.js$/,
@@ -495,7 +533,7 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     vscodeApiExportName,
     hotkeySettingsAsset,
     settingsRowAsset,
-    settingsRowExportName: inferSettingsRowExportName(settingsRowSource),
+    settingsRowExportName: settingsRowExportName ?? settingsRowFallback.exportName,
     settingsPageAsset: settingsLayoutAsset,
     settingsPageExportName: settingsLayoutFallback == null ? "t" : settingsLayoutFallback.exportName,
     settingsSectionAsset: settingsGroupCandidate ?? settingsSectionFallback.assetName,


### PR DESCRIPTION
## Summary

- validate settings-row candidates by component behavior before importing them
- reject icon-only toggle assets and infer the real toggle from settings call sites
- fall back to generated Linux components when upstream candidates are incompatible
- add a regression fixture for the current DMG decoy asset names

## Root cause

The current DMG includes `settings-row-disclosure-*` and `toggle-left-*` assets. Filename-only discovery selected the disclosure initializer as `SettingsRow` and a Lucide icon as `Toggle`, causing the Linux settings route to fail when rendered.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (328/328 passing)
- focused current-DMG decoy regression test
- `node --check scripts/patches/impl/keybinds-settings.js`
- `git diff --check`
- verified dependency resolution against the installed current-DMG assets