### PR TITLE
Fix safe-area patch matching for the current app shell

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -979,6 +979,32 @@ test("app-server feature enablement descriptor matches current app-main chunks",
   assert.equal(descriptor.pattern.test("experimental-feature-visibility-Bvp90zWX.js"), false);
 });
 
+test("window controls safe-area descriptor matches current app shell chunks", () => {
+  const descriptor = corePatchDescriptors().find(
+    (descriptor) => descriptor.id === "linux-window-controls-safe-area",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~appgen-settings-page~settings-page~skills-settings~plugins-settings~re~old.js",
+    ),
+    false,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js",
+    ),
+    true,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~current.js",
+    ),
+    false,
+  );
+});
+
 test("patch descriptors reject unsupported ciPolicy values", () => {
   assert.throws(
     () =>

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -47,7 +47,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1040,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~appgen-settings-page~settings-page~skills-settings~plugins-settings~re~.*\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~.*\.js$/,
     missingDescription: "window controls safe-area bundle",
     skipDescription: "Linux window controls safe-area patch",
     apply: applyLinuxWindowControlsSafeAreaPatch,


### PR DESCRIPTION
## Summary

- Update the Linux window-controls safe-area patch descriptor so it matches the current upstream app shell chunk.
- Add a regression test that covers the current bundle shape and rejects the older stale shape.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `make check`
- `bash tests/scripts_smoke.sh`
- `make test`
- `make inspect-upstream` against the current upstream DMG
- `make inspect-upstream-intel` against the current upstream DMG
- `make build-app-fresh` against the current upstream DMG
- `codex-app/start.sh --diagnose-scaling`

The baseline build skips `linux-window-controls-safe-area` on the current DMG because the shell chunk name moved. With this patch, that optional patch is applied again while the other skipped optional patch state stays unchanged.
