### PR TITLE
Fix automation update eager patch matching for current app shell

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -979,6 +979,32 @@ test("app-server feature enablement descriptor matches current app-main chunks",
   assert.equal(descriptor.pattern.test("experimental-feature-visibility-Bvp90zWX.js"), false);
 });
 
+test("automation_update eager descriptor matches the current dynamic tools chunk", () => {
+  const descriptor = corePatchDescriptors().find(
+    (descriptor) => descriptor.id === "automation-update-eager-tool",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-old.js",
+    ),
+    false,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~editor-diff-page~thread-app-~g4rafana-current.js",
+    ),
+    true,
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-current.js",
+    ),
+    false,
+  );
+});
+
 test("patch descriptors reject unsupported ciPolicy values", () => {
   assert.throws(
     () =>

--- a/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
+++ b/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-.*\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~editor-diff-page~thread-app-~.*\.js$/,
     missingDescription: "dynamic Codex app tools bundle",
     skipDescription: "automation_update eager dynamic tool patch",
     apply: applyAutomationUpdateEagerToolPatch,


### PR DESCRIPTION
## Summary

- Update the `automation-update-eager-tool` descriptor to match the current upstream app shell chunk.
- Add a regression test that accepts the current dynamic tools bundle and rejects the older stale chunk.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `make check`
- `bash tests/scripts_smoke.sh`
- `make test`
- `make inspect-upstream` against the current upstream DMG
- `make inspect-upstream-intel` with the candidate patch report
- `make build-app-fresh` with the current upstream DMG

On `origin/main`, the current DMG skips `automation-update-eager-tool`. With this patch, that optional patch applies again. The remaining `linux-window-controls-safe-area` skip is handled separately in #735.
