### PR TITLE
Fix current remote-control UI chunk matching

### DIFF
--- a/linux-features/remote-control-ui/README.md
+++ b/linux-features/remote-control-ui/README.md
@@ -1,6 +1,6 @@
 # Remote Control UI
 
-Opt-in Linux UI patches for upstream `remote_control` and Codex mobile surfaces.
+Opt-in Linux UI patches for upstream `remote_control` and related settings surfaces.
 
 This feature only opens the Linux UI gates. It does not fake backend state such
 as connected clients, MFA completion, or remote control environments.
@@ -20,4 +20,3 @@ Run the feature tests with:
 ```bash
 node --test linux-features/remote-control-ui/test.js
 ```
-

--- a/linux-features/remote-control-ui/feature.json
+++ b/linux-features/remote-control-ui/feature.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-control-ui",
   "title": "Remote Control UI",
-  "description": "Adds opt-in Linux visibility patches for remote control, Codex mobile onboarding, and related settings surfaces.",
+  "description": "Adds opt-in Linux visibility patches for remote control and related settings surfaces.",
   "defaultEnabled": false,
   "entrypoints": {
     "patchDescriptors": "./patch.js"

--- a/linux-features/remote-control-ui/patch.js
+++ b/linux-features/remote-control-ui/patch.js
@@ -18,11 +18,15 @@ function replaceOnce(source, needle, replacement, patchName) {
 }
 
 function applyRemoteConnectionsVisibilityPatch(source) {
-  const patched = source.replace(
+  let patched = source.replace(
     /([A-Za-z_$][\w$]*)\(`4114442250`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
     `($1(\`4114442250\`)||${LINUX_GATE})`,
   );
-  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
+  patched = patched.replace(
+    /([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`4114442250`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
+    `($1($2,\`4114442250\`)||${LINUX_GATE})`,
+  );
+  if (patched !== source || source.includes(`\`4114442250\`)||${LINUX_GATE}`)) {
     return patched;
   }
   warn("Could not find remote connections Statsig gate", "remote control UI remote connections visibility patch");
@@ -32,13 +36,16 @@ function applyRemoteConnectionsVisibilityPatch(source) {
 function applyRemoteControlConnectionsVisibilityPatch(source) {
   let patched = source.replace(
     /return!!([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)\?\.available===!0(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
-    `return!!$1&&$2?.available===!0||${LINUX_GATE}`,
+    `return(!!$1||${LINUX_GATE})&&$2?.available===!0`,
   );
   patched = patched.replace(
     /return\s+([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.available\?\?!0\)&&\2\?\.accessRequired!==!0(?!&&navigator\.userAgent\.includes\(`Linux`\))/g,
     `return ($1||${LINUX_GATE})&&($2?.available??!0)&&$2?.accessRequired!==!0`,
   );
-  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
+  const alreadyPatched =
+    /return\(!![A-Za-z_$][\w$]*\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&[A-Za-z_$][\w$]*\?\.available===!0/.test(source) ||
+    /return \([A-Za-z_$][\w$]*\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&\([A-Za-z_$][\w$]*\?\.available\?\?!0\)&&[A-Za-z_$][\w$]*\?\.accessRequired!==!0/.test(source);
+  if (patched !== source || alreadyPatched) {
     return patched;
   }
   if (
@@ -60,7 +67,10 @@ function applyExperimentalFeaturesPatch(source) {
   if (source.includes(needle)) {
     return source.replace(needle, "");
   }
-  if (source.includes("e.name!==`realtime_conversation`&&e.name!==`chronicle`")) {
+  if (
+    source.includes("e.name!==`realtime_conversation`&&e.name!==`chronicle`") ||
+    source.includes("!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`")
+  ) {
     return source;
   }
   if (source.includes("remote_control")) {
@@ -72,24 +82,6 @@ function applyExperimentalFeaturesPatch(source) {
   return source;
 }
 
-function applyMobileStatsigLinuxPatch(source, patchName) {
-  const patched = source.replace(
-    /([A-Za-z_$][\w$]*)\(`2798711298`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
-    `($1(\`2798711298\`)||${LINUX_GATE})`,
-  );
-  if (patched !== source || source.includes(`||${LINUX_GATE}`)) {
-    return patched;
-  }
-  if (!source.includes("2798711298") && !source.includes("CODEX_MOBILE_SETUP_COMPLETED")) {
-    return source;
-  }
-  if (source.includes("remote-connection-visibility-")) {
-    return source;
-  }
-  warn("Could not find mobile Statsig gate", patchName);
-  return source;
-}
-
 module.exports = {
   descriptors: [
     {
@@ -97,7 +89,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20500,
       ciPolicy: "optional",
-      pattern: /^remote-connection-visibility-.*\.js$/,
+      pattern: /^app-initial~app-main~(?:hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar|pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu)-.*\.js$/,
       missingDescription: "remote connection visibility bundle",
       skipDescription: "remote control UI remote connections visibility patch",
       apply: applyRemoteConnectionsVisibilityPatch,
@@ -107,7 +99,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20510,
       ciPolicy: "optional",
-      pattern: /^(?:remote-control-connections-visibility|remote-connection-visibility)-.*\.js$/,
+      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*\.js$/,
       missingDescription: "remote control connections visibility bundle",
       skipDescription: "remote control UI remote control connections visibility patch",
       apply: applyRemoteControlConnectionsVisibilityPatch,
@@ -117,30 +109,10 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^experimental-features-queries-.*\.js$/,
+      pattern: /^settings-route-state-.*\.js$/,
       missingDescription: "experimental features query bundle",
       skipDescription: "remote control UI experimental features patch",
       apply: applyExperimentalFeaturesPatch,
-    },
-    {
-      id: "nux-gate",
-      phase: "webview-asset",
-      order: 20530,
-      ciPolicy: "optional",
-      pattern: /^nux-gate-.*\.js$/,
-      missingDescription: "Codex mobile NUX gate bundle",
-      skipDescription: "remote control UI mobile NUX gate patch",
-      apply: (source) => applyMobileStatsigLinuxPatch(source, "remote control UI mobile NUX gate patch"),
-    },
-    {
-      id: "app-main",
-      phase: "webview-asset",
-      order: 20540,
-      ciPolicy: "optional",
-      pattern: /^app-main-.*\.js$/,
-      missingDescription: "Codex mobile app main bundle",
-      skipDescription: "remote control UI mobile app main patch",
-      apply: (source) => applyMobileStatsigLinuxPatch(source, "remote control UI mobile app main patch"),
     },
   ],
 };

--- a/linux-features/remote-control-ui/patch.js
+++ b/linux-features/remote-control-ui/patch.js
@@ -6,17 +6,6 @@ function warn(message, patchName) {
   console.warn(`WARN: ${message} — skipping ${patchName}`);
 }
 
-function replaceOnce(source, needle, replacement, patchName) {
-  if (source.includes(replacement)) {
-    return source;
-  }
-  if (!source.includes(needle)) {
-    warn("Could not find expected needle", patchName);
-    return source;
-  }
-  return source.replace(needle, replacement);
-}
-
 function applyRemoteConnectionsVisibilityPatch(source) {
   let patched = source.replace(
     /([A-Za-z_$][\w$]*)\(`4114442250`\)(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
@@ -34,26 +23,14 @@ function applyRemoteConnectionsVisibilityPatch(source) {
 }
 
 function applyRemoteControlConnectionsVisibilityPatch(source) {
-  let patched = source.replace(
-    /return!!([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)\?\.available===!0(?!\|\|navigator\.userAgent\.includes\(`Linux`\))/g,
-    `return(!!$1||${LINUX_GATE})&&$2?.available===!0`,
-  );
-  patched = patched.replace(
+  const patched = source.replace(
     /return\s+([A-Za-z_$][\w$]*)&&\(([A-Za-z_$][\w$]*)\?\.available\?\?!0\)&&\2\?\.accessRequired!==!0(?!&&navigator\.userAgent\.includes\(`Linux`\))/g,
     `return ($1||${LINUX_GATE})&&($2?.available??!0)&&$2?.accessRequired!==!0`,
   );
   const alreadyPatched =
-    /return\(!![A-Za-z_$][\w$]*\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&[A-Za-z_$][\w$]*\?\.available===!0/.test(source) ||
     /return \([A-Za-z_$][\w$]*\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&\([A-Za-z_$][\w$]*\?\.available\?\?!0\)&&[A-Za-z_$][\w$]*\?\.accessRequired!==!0/.test(source);
   if (patched !== source || alreadyPatched) {
     return patched;
-  }
-  if (
-    source.includes("function p(){let") &&
-    source.includes("remote_control_connections") &&
-    source.includes("addedRemoteControlEnvIds")
-  ) {
-    return source;
   }
   warn(
     "Could not find remote control connections visibility gate",
@@ -67,10 +44,7 @@ function applyExperimentalFeaturesPatch(source) {
   if (source.includes(needle)) {
     return source.replace(needle, "");
   }
-  if (
-    source.includes("e.name!==`realtime_conversation`&&e.name!==`chronicle`") ||
-    source.includes("!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`")
-  ) {
+  if (source.includes("!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`")) {
     return source;
   }
   if (source.includes("remote_control")) {

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -77,15 +77,13 @@ test("remote-control UI feature exposes optional webview asset descriptors when 
     assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["remote-control-ui"]);
 
     const patches = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
-    assert.equal(patches.length, 5);
+    assert.equal(patches.length, 3);
     assert.deepEqual(
       patches.map((patch) => [patch.name, patch.phase, patch.ciPolicy]),
       [
         ["feature:remote-control-ui:remote-connections-visibility", "webview-asset", "optional"],
         ["feature:remote-control-ui:remote-control-connections-visibility", "webview-asset", "optional"],
         ["feature:remote-control-ui:experimental-features", "webview-asset", "optional"],
-        ["feature:remote-control-ui:nux-gate", "webview-asset", "optional"],
-        ["feature:remote-control-ui:app-main", "webview-asset", "optional"],
       ],
     );
   });
@@ -95,20 +93,18 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
   const remoteConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-connections-visibility");
   const remoteControlConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-control-connections-visibility");
   const experimentalFeaturesPatch = featurePatches.find((patch) => patch.id === "experimental-features");
-  const appMainPatch = featurePatches.find((patch) => patch.id === "app-main");
-  const nuxGatePatch = featurePatches.find((patch) => patch.id === "nux-gate");
   const remoteConnectionsSource =
     "function c(){let e=(0,s.c)(3),{data:n}=t(a,r(i)),c=o(`4114442250`);if(n?.config[`features.remote_connections`]===!0)return!0;let l=n?.config.features;if(typeof l!=`object`||!l||Array.isArray(l))return c;let u;return e[0]!==l||e[1]!==c?(u=Object.getOwnPropertyDescriptor(l,`remote_connections`)?.value===!0||c,e[0]=l,e[1]=c,e[2]=u):u=e[2],u}";
+  const atomRemoteConnectionsSource =
+    "function s(e){if(e(c,`4114442250`))return`enabled`;return`disabled`}";
   const currentRemoteConnectionsSource =
     "function d(){let e=(0,u.c)(3),{data:i}=n(s,r(t)),a=c(`4114442250`);if(i?.config[`features.remote_connections`]===!0)return!0;let o=i?.config.features;if(typeof o!=`object`||!o||Array.isArray(o))return a;let l;return e[0]!==o||e[1]!==a?(l=Object.getOwnPropertyDescriptor(o,`remote_connections`)?.value===!0||a,e[0]=o,e[1]=a,e[2]=l):l=e[2],l}";
   const currentRemoteControlConnectionsSource =
     "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
-  const currentAppMainSource =
-    "function m_(){let e=(0,Z.c)(14),t=Pg(),{data:n,isLoading:r}=Ps(d.CODEX_MOBILE_SETUP_COMPLETED),i=Ql(),a=ec(`2798711298`),[o]=ts(`local_app_server_feature_enablement`),[s,c]=gt(Vg),l=o?.remote_control??!1,u=t&&i&&a&&!l&&!r&&!n&&!s;return u}";
-  const currentNuxGateSource =
-    "import{r as ee}from\"./remote-connection-visibility-6MV6akfy.js\";function wt(){let i=ee(),a=z(),[o]=E(`remote_connections`),s=o?.some(Tt)??!1;return i&&!a&&o!=null&&s}";
+  const legacyRemoteControlConnectionsSource =
+    "function p(flag,state){return!!flag&&state?.available===!0}";
   const experimentalFeaturesSource =
-    "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`realtime_conversation`&&e.name!==`remote_control`&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}";
+    "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`remote_control`&&!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}";
 
   const firstPatched = remoteConnectionsPatch.apply(remoteConnectionsSource, {});
   assert.match(firstPatched, /navigator\.userAgent\.includes\(`Linux`\)/);
@@ -118,27 +114,114 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
   assert.match(currentRemoteConnectionsPatched, /c\(`4114442250`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/);
   assert.equal(remoteConnectionsPatch.apply(currentRemoteConnectionsPatched, {}), currentRemoteConnectionsPatched);
 
+  const atomRemoteConnectionsPatched = remoteConnectionsPatch.apply(atomRemoteConnectionsSource, {});
+  assert.match(atomRemoteConnectionsPatched, /e\(c,`4114442250`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/);
+  assert.equal(remoteConnectionsPatch.apply(atomRemoteConnectionsPatched, {}), atomRemoteConnectionsPatched);
+
   const currentRemoteControlConnectionsPatched = remoteControlConnectionsPatch.apply(currentRemoteControlConnectionsSource, {});
   assert.match(currentRemoteControlConnectionsPatched, /\(t\|\|navigator\.userAgent\.includes\(`Linux`\)\)&&\(e\?\.available\?\?!0\)/);
-  assert.equal(remoteControlConnectionsPatch.apply(currentRemoteControlConnectionsPatched, {}), currentRemoteControlConnectionsPatched);
-
-  const currentAppMainPatched = appMainPatch.apply(currentAppMainSource, {});
-  assert.match(currentAppMainPatched, /ec\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/);
-  assert.equal(appMainPatch.apply(currentAppMainPatched, {}), currentAppMainPatched);
-
-  const { value: currentNuxGatePatched, warnings: currentNuxGateWarnings } = captureWarns(() =>
-    nuxGatePatch.apply(currentNuxGateSource, {}),
+  const { value: remoteControlPatchedAgain, warnings: remoteControlPatchedAgainWarnings } = captureWarns(() =>
+    remoteControlConnectionsPatch.apply(currentRemoteControlConnectionsPatched, {}),
   );
-  assert.equal(currentNuxGatePatched, currentNuxGateSource);
-  assert.deepEqual(currentNuxGateWarnings, []);
+  assert.equal(remoteControlPatchedAgain, currentRemoteControlConnectionsPatched);
+  assert.deepEqual(remoteControlPatchedAgainWarnings, []);
+
+  const legacyRemoteControlConnectionsPatched = remoteControlConnectionsPatch.apply(
+    legacyRemoteControlConnectionsSource,
+    {},
+  );
+  const legacyGate = new Function(
+    "flag",
+    "state",
+    "navigator",
+    `${legacyRemoteControlConnectionsPatched};return p(flag,state)`,
+  );
+  const currentGate = new Function(
+    "remoteControlConnectionsState",
+    "slingshotEnabled",
+    "navigator",
+    `${currentRemoteControlConnectionsPatched};return a({remoteControlConnectionsState,slingshotEnabled})`,
+  );
+  const linuxNavigator = { userAgent: "Linux" };
+  const macNavigator = { userAgent: "Macintosh" };
+
+  assert.equal(legacyGate(false, { available: false }, linuxNavigator), false);
+  assert.equal(legacyGate(false, { available: true }, linuxNavigator), true);
+  assert.equal(legacyGate(false, { available: true }, macNavigator), false);
+  assert.equal(currentGate({ available: false, accessRequired: false }, false, linuxNavigator), false);
+  assert.equal(currentGate({ available: true, accessRequired: true }, false, linuxNavigator), false);
+  assert.equal(currentGate({ available: true, accessRequired: false }, false, linuxNavigator), true);
 
   const filtered = experimentalFeaturesPatch.apply(experimentalFeaturesSource, {});
   assert.doesNotMatch(filtered, /e\.name!==`remote_control`/);
-  assert.equal(experimentalFeaturesPatch.apply(filtered, {}), filtered);
+  const { value: filteredAgain, warnings: filteredAgainWarnings } = captureWarns(() =>
+    experimentalFeaturesPatch.apply(filtered, {}),
+  );
+  assert.equal(filteredAgain, filtered);
+  assert.deepEqual(filteredAgainWarnings, []);
 
   const { value, warnings } = captureWarns(() => remoteConnectionsPatch.apply("real codex bundle", {}));
   assert.equal(value, "real codex bundle");
   assert.match(warnings.join("\n"), /Could not find remote connections Statsig gate/);
+
+  const unrelatedLinuxGate = "const unrelated=flag||navigator.userAgent.includes(`Linux`);const gate=get(\"4114442250\")";
+  const { value: driftedValue, warnings: driftedWarnings } = captureWarns(() =>
+    remoteConnectionsPatch.apply(unrelatedLinuxGate, {}),
+  );
+  assert.equal(driftedValue, unrelatedLinuxGate);
+  assert.match(driftedWarnings.join("\n"), /Could not find remote connections Statsig gate/);
+
+  const unrelatedRemoteControlLinuxGate =
+    "const unrelated=(flag||navigator.userAgent.includes(`Linux`))&&other;function RD(){return enabled&&state?.available}";
+  const { value: remoteControlDriftedValue, warnings: remoteControlDriftedWarnings } = captureWarns(() =>
+    remoteControlConnectionsPatch.apply(unrelatedRemoteControlLinuxGate, {}),
+  );
+  assert.equal(remoteControlDriftedValue, unrelatedRemoteControlLinuxGate);
+  assert.match(
+    remoteControlDriftedWarnings.join("\n"),
+    /Could not find remote control connections visibility gate/,
+  );
+});
+
+test("remote-control UI descriptors match the current 26.707 app chunks", () => {
+  const remoteConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-connections-visibility");
+  const remoteControlConnectionsPatch = featurePatches.find((patch) => patch.id === "remote-control-connections-visibility");
+  const experimentalFeaturesPatch = featurePatches.find((patch) => patch.id === "experimental-features");
+
+  assert.ok(
+    remoteConnectionsPatch.pattern.test(
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-DseH-M7x.js",
+    ),
+  );
+  assert.ok(
+    remoteConnectionsPatch.pattern.test(
+      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+    ),
+  );
+  assert.equal(
+    remoteConnectionsPatch.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    ),
+    false,
+  );
+
+  assert.ok(
+    remoteControlConnectionsPatch.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js",
+    ),
+  );
+  assert.equal(
+    remoteControlConnectionsPatch.pattern.test(
+      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+    ),
+    false,
+  );
+
+  assert.ok(experimentalFeaturesPatch.pattern.test("settings-route-state-BwIfDYxh.js"));
+  assert.equal(
+    experimentalFeaturesPatch.pattern.test("experimental-features-queries-old.js"),
+    false,
+  );
 });
 
 test("remote-control UI feature patches matching webview assets and records patch report entries", () => {
@@ -154,24 +237,29 @@ test("remote-control UI feature patches matching webview assets and records patc
         fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
 
         fs.writeFileSync(
-          path.join(assetsDir, "remote-connection-visibility-test.js"),
-          "function c(){let e=(0,s.c)(3),{data:n}=t(a,r(i)),c=o(`4114442250`);if(n?.config[`features.remote_connections`]===!0)return!0;let l=n?.config.features;if(typeof l!=`object`||!l||Array.isArray(l))return c;let u;return e[0]!==l||e[1]!==c?(u=Object.getOwnPropertyDescriptor(l,`remote_connections`)?.value===!0||c,e[0]=l,e[1]=c,e[2]=u):u=e[2],u}",
+          path.join(
+            assetsDir,
+            "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-DseH-M7x.js",
+          ),
+          "function s(e){if(e(c,`4114442250`))return`enabled`;return`disabled`}",
         );
         fs.writeFileSync(
-          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          path.join(
+            assetsDir,
+            "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+          ),
+          "function d(){let e=(0,u.c)(3),{data:i}=n(s,r(t)),a=c(`4114442250`);if(i?.config[`features.remote_connections`]===!0)return!0;let o=i?.config.features;if(typeof o!=`object`||!o||Array.isArray(o))return a;let l;return e[0]!==o||e[1]!==a?(l=Object.getOwnPropertyDescriptor(o,`remote_connections`)?.value===!0||a,e[0]=o,e[1]=a,e[2]=l):l=e[2],l}",
+        );
+        fs.writeFileSync(
+          path.join(
+            assetsDir,
+            "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js",
+          ),
           "function p(){let e=t(`1042620455`),n=r(`remote_control_connections_state`);return!!e&&n?.available===!0}",
         );
         fs.writeFileSync(
-          path.join(assetsDir, "experimental-features-queries-test.js"),
-          "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`realtime_conversation`&&e.name!==`remote_control`&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}",
-        );
-        fs.writeFileSync(
-          path.join(assetsDir, "nux-gate-test.js"),
-          "function g(){let e=o(`2798711298`),t=n?.remote_control??!1;return e&&!t}",
-        );
-        fs.writeFileSync(
-          path.join(assetsDir, "app-main-test.js"),
-          "function h(){let e=o(`2798711298`),t=n?.remote_control??!1;return e&&!t&&r!==`CODEX_MOBILE_SETUP_COMPLETED`}",
+          path.join(assetsDir, "settings-route-state-BwIfDYxh.js"),
+          "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`remote_control`&&!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}",
         );
 
         const report = createPatchReport();
@@ -182,29 +270,48 @@ test("remote-control UI feature patches matching webview assets and records patc
         );
 
         assert.match(
-          fs.readFileSync(path.join(assetsDir, "remote-connection-visibility-test.js"), "utf8"),
+          fs.readFileSync(
+            path.join(
+              assetsDir,
+              "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-DseH-M7x.js",
+            ),
+            "utf8",
+          ),
           /navigator\.userAgent\.includes\(`Linux`\)/,
         );
         assert.match(
-          fs.readFileSync(path.join(assetsDir, "remote-control-connections-visibility-test.js"), "utf8"),
+          fs.readFileSync(
+            path.join(
+              assetsDir,
+              "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+            ),
+            "utf8",
+          ),
+          /navigator\.userAgent\.includes\(`Linux`\)/,
+        );
+        assert.match(
+          fs.readFileSync(
+            path.join(
+              assetsDir,
+              "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js",
+            ),
+            "utf8",
+          ),
           /navigator\.userAgent\.includes\(`Linux`\)/,
         );
         assert.doesNotMatch(
-          fs.readFileSync(path.join(assetsDir, "experimental-features-queries-test.js"), "utf8"),
+          fs.readFileSync(path.join(assetsDir, "settings-route-state-BwIfDYxh.js"), "utf8"),
           /e\.name!==`remote_control`/,
         );
-        assert.match(
-          fs.readFileSync(path.join(assetsDir, "nux-gate-test.js"), "utf8"),
-          /o\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/,
-        );
-        assert.match(
-          fs.readFileSync(path.join(assetsDir, "app-main-test.js"), "utf8"),
-          /o\(`2798711298`\)\|\|navigator\.userAgent\.includes\(`Linux`\)/,
-        );
-        assert.ok(
-          report.patches.some((patch) =>
-            patch.name === "feature:remote-control-ui:remote-connections-visibility" && patch.status === "applied"
-          ),
+        assert.deepEqual(
+          report.patches
+            .filter((patch) => patch.featureId === "remote-control-ui")
+            .map((patch) => [patch.name, patch.status]),
+          [
+            ["feature:remote-control-ui:remote-connections-visibility", "applied"],
+            ["feature:remote-control-ui:remote-control-connections-visibility", "applied"],
+            ["feature:remote-control-ui:experimental-features", "applied"],
+          ],
         );
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -238,7 +238,7 @@ test("remote-control UI feature patches matching webview assets and records patc
             assetsDir,
             "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js",
           ),
-          "function p(){let e=t(`1042620455`),n=r(`remote_control_connections_state`);return!!e&&n?.available===!0}",
+          "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}",
         );
         fs.writeFileSync(
           path.join(assetsDir, "settings-route-state-BwIfDYxh.js"),

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -101,8 +101,6 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
     "function d(){let e=(0,u.c)(3),{data:i}=n(s,r(t)),a=c(`4114442250`);if(i?.config[`features.remote_connections`]===!0)return!0;let o=i?.config.features;if(typeof o!=`object`||!o||Array.isArray(o))return a;let l;return e[0]!==o||e[1]!==a?(l=Object.getOwnPropertyDescriptor(o,`remote_connections`)?.value===!0||a,e[0]=o,e[1]=a,e[2]=l):l=e[2],l}";
   const currentRemoteControlConnectionsSource =
     "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
-  const legacyRemoteControlConnectionsSource =
-    "function p(flag,state){return!!flag&&state?.available===!0}";
   const experimentalFeaturesSource =
     "var Z=`remote_control`;function Ie(e){return e.stage===`beta`?e.name!==`memories`&&e.name!==`multi_agent`&&e.name!==`plugins`&&e.name!==`plugin`&&e.name!==`remote_control`&&!e.name.startsWith(`realtime_`)&&e.name!==`chronicle`&&e.name!==`workspace_dependencies`:!1}";
 
@@ -126,16 +124,6 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
   assert.equal(remoteControlPatchedAgain, currentRemoteControlConnectionsPatched);
   assert.deepEqual(remoteControlPatchedAgainWarnings, []);
 
-  const legacyRemoteControlConnectionsPatched = remoteControlConnectionsPatch.apply(
-    legacyRemoteControlConnectionsSource,
-    {},
-  );
-  const legacyGate = new Function(
-    "flag",
-    "state",
-    "navigator",
-    `${legacyRemoteControlConnectionsPatched};return p(flag,state)`,
-  );
   const currentGate = new Function(
     "remoteControlConnectionsState",
     "slingshotEnabled",
@@ -143,11 +131,6 @@ test("remote-control UI feature patches are idempotent and fail soft", () => {
     `${currentRemoteControlConnectionsPatched};return a({remoteControlConnectionsState,slingshotEnabled})`,
   );
   const linuxNavigator = { userAgent: "Linux" };
-  const macNavigator = { userAgent: "Macintosh" };
-
-  assert.equal(legacyGate(false, { available: false }, linuxNavigator), false);
-  assert.equal(legacyGate(false, { available: true }, linuxNavigator), true);
-  assert.equal(legacyGate(false, { available: true }, macNavigator), false);
   assert.equal(currentGate({ available: false, accessRequired: false }, false, linuxNavigator), false);
   assert.equal(currentGate({ available: true, accessRequired: true }, false, linuxNavigator), false);
   assert.equal(currentGate({ available: true, accessRequired: false }, false, linuxNavigator), true);


### PR DESCRIPTION
## Summary

- Retarget the remote-control UI descriptors to the current `26.707.31428` webview chunks.
- Handle both current forms of the remote-connections Statsig gate while keeping drift detection narrow.
- Restore the current experimental settings surface and remove obsolete mobile onboarding descriptors whose gates no longer exist upstream.
- Update the feature description and add coverage for current chunks, idempotence, negative matches, and unrelated Linux markers.

## Validation

- `node --test linux-features/remote-control-ui/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- Full build and feature-only inspection against the `26.707.31428` DMG
- All-features inspection with the current remote-mobile changes included
