### PR TITLE
fix(nix): refresh upstream Nix pins for 26.707.31428

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
-          hash = "sha256-TukDFPYFaGI+WE63hQuBc3d307761tMCi9+oco6sImU=";
+          hash = "sha256-b2evfi+TQJOriv687BE3TUDI24+RAPtmIPJBVUAdgxk=";
         };
 
-        codexVersion = "26.707.30751";
+        codexVersion = "26.707.31428";
         electronVersion = "42.1.0";
         electronPlatform =
           {


### PR DESCRIPTION
## Summary
- Refresh `codexDmg` SRI hash and `codexVersion` to the current upstream DMG payload (`ChatGPT.dmg`), which has advanced to **26.707.31428**.
- Supersedes #730 (which pinned `26.707.31123`): the live DMG has since been rebuilt and its internal version is now **aligned with the Sparkle appcast** (`26.707.31428`).
- Electron pin unchanged (`42.1.0`), so no electron/native-module hash changes — diff is `flake.nix` only (2 lines).

## Validation
- Verified with `scripts/ci/update-nix-hashes.sh` against the exact upstream DMG (`sha256-b2evfi+TQJOriv687BE3TUDI24+RAPtmIPJBVUAdgxk=`).
- `validate-nix-pins.sh` confirms `Codex app version pin = 26.707.31428` matches the DMG payload.
- All Codex Desktop Nix package outputs build successfully:
  `codex-desktop`, `codex-desktop-computer-use-ui`, `codex-desktop-remote-mobile-control`, `codex-desktop-computer-use-ui-remote-mobile-control`, `installer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)