### PR TITLE
Fix current AppShots chunk matching

### DIFF
--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -81,7 +81,7 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
   const alreadyPatched = [
     /this\.configuredHotkey=[A-Za-z_$][\w$]*===void 0\?\(process\.platform===`linux`\?null:[A-Za-z_$][\w$]*\):[A-Za-z_$][\w$]*/,
     /supported:this\.enabled&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:this\.configuredHotkey,isActive:this\.registration!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
-    /!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`/,
+    /if\(!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\)return\{success:!1,error:`Not supported\.`,state:this\.getState\(\)\}/,
     /!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|this\.configuredHotkey==null/,
     /return [A-Za-z_$][\w$]*\.length===1\?\([A-Za-z_$][\w$]*===`darwin`\|\|[A-Za-z_$][\w$]*===`linux`\)\?/,
     /return \([A-Za-z_$][\w$]*===`darwin`\|\|[A-Za-z_$][\w$]*===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&/,
@@ -95,12 +95,13 @@ function applyLinuxAppshotHotkeyPatch(currentSource) {
   let patchedSource = currentSource;
   const counts = [];
   function replaceRequired(pattern, replacement) {
-    let count = 0;
-    patchedSource = patchedSource.replace(pattern, (...args) => {
-      count += 1;
-      return typeof replacement === "function" ? replacement(...args) : replacement;
-    });
+    const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+    const count = [...patchedSource.matchAll(new RegExp(pattern.source, flags))].length;
     counts.push(count);
+    if (count !== 1) {
+      return;
+    }
+    patchedSource = patchedSource.replace(pattern, replacement);
   }
 
   replaceRequired(
@@ -272,17 +273,18 @@ async function codexLinuxAppshotScreenshot(e,t){
 let n=codexLinuxAppshotRequire(\`node:fs\`),r=codexLinuxAppshotRequire(\`node:os\`),i=codexLinuxAppshotRequire(\`node:path\`),a=codexLinuxAppshotRequire(\`node:child_process\`),o=codexLinuxAppshotRequire(\`electron\`).nativeImage,s=codexLinuxAppshotCropRects(e,t);
 if(s.length===0)return codexLinuxAppshotWarn(\`screenshot-crop-missing\`,{hasBounds:e?.bounds!=null}),null;
 for(let c of codexLinuxAppshotScreenshotCommands(e))for(let l of c.programs){
-let u=i.join(r.tmpdir(),\`codex-appshot-\${process.pid}-\${Date.now()}-\${Math.random().toString(16).slice(2)}.png\`),d=i.join(r.tmpdir(),\`codex-appshot-crop-\${process.pid}-\${Date.now()}-\${Math.random().toString(16).slice(2)}.png\`),f=c.output===\`append\`?[...c.args,u]:[...c.args,...c.output,u];
+let u=null;
 try{
-await codexLinuxAppshotExecFile(a,l,f,{timeout:15000,maxBuffer:8388608});
-if(!n.existsSync(u)){codexLinuxAppshotWarn(\`screenshot-output-missing\`,{source:c.source,program:l});continue}
-let e=n.statSync(u);if(e.size<=0){codexLinuxAppshotWarn(\`screenshot-output-empty\`,{source:c.source,program:l});continue}
-let t=await codexLinuxAppshotCropWithImageMagick({childProcess:a,fs:n,sourcePath:u,tmpPath:d,cropRects:s});
+u=n.mkdtempSync(i.join(r.tmpdir(),\`codex-appshot-\`)),n.chmodSync(u,448);let d=i.join(u,\`source.png\`),f=i.join(u,\`crop.png\`),p=c.output===\`append\`?[...c.args,d]:[...c.args,...c.output,d];
+await codexLinuxAppshotExecFile(a,l,p,{timeout:15000,maxBuffer:8388608});
+if(!n.existsSync(d)){codexLinuxAppshotWarn(\`screenshot-output-missing\`,{source:c.source,program:l});continue}
+let e=n.statSync(d);if(e.size<=0){codexLinuxAppshotWarn(\`screenshot-output-empty\`,{source:c.source,program:l});continue}
+let t=await codexLinuxAppshotCropWithImageMagick({childProcess:a,fs:n,sourcePath:d,tmpPath:f,cropRects:s});
 if(t!=null)return{dataURL:t.dataURL,width:t.width,height:t.height,source:\`\${c.source}:imagemagick-window-crop\`};
-let r=codexLinuxAppshotCropNativeImage(o,u,s);
+let r=codexLinuxAppshotCropNativeImage(o,d,s);
 if(r!=null)return{dataURL:r.image.toDataURL(),width:r.width,height:r.height,source:\`\${c.source}:feature-window-crop\`}
 }catch(e){codexLinuxAppshotWarn(\`screenshot-command-failed\`,{source:c.source,program:l,message:e instanceof Error?e.message:String(e),stderr:typeof e?.codexStderr===\`string\`?e.codexStderr.slice(0,200):\`\`})}
-finally{try{n.rmSync(u,{force:true})}catch{}try{n.rmSync(d,{force:true})}catch{}}
+finally{if(u!=null)try{n.rmSync(u,{recursive:true,force:true})}catch{}}
 }
 return codexLinuxAppshotWarn(\`screenshot-all-commands-failed\`,{commandCount:codexLinuxAppshotScreenshotCommands(e).length}),null
 }
@@ -315,7 +317,7 @@ function replaceIdentifierCall(source, identifier, method, replacement) {
       break;
     }
     const previous = matchIndex > 0 ? source[matchIndex - 1] : "";
-    if (/[A-Za-z0-9_$]/.test(previous)) {
+    if (previous === "." || /[A-Za-z0-9_$]/.test(previous)) {
       const nextCursor = matchIndex + needle.length;
       output += source.slice(cursor, nextCursor);
       cursor = nextCursor;

--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -78,100 +78,75 @@ function applyLinuxAppshotMainProcessPatch(currentSource) {
 }
 
 function applyLinuxAppshotHotkeyPatch(currentSource) {
-  let changed = false;
-
-  currentSource = currentSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\),([A-Za-z_$][\w$]*)=\1===void 0\?([A-Za-z_$][\w$]*):\1,([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\4,isActive:\6!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\6\?\.unregister\(\),\6=null,!\8\|\|process\.platform!==`darwin`\|\|\4==null\)\{/g,
-    (
-      match,
-      storedVar,
-      globalStateVar,
-      getterName,
-      configuredVar,
-      defaultHotkeyVar,
-      registrationVar,
-      stateFnVar,
-      enabledVar,
-      reconcileFnVar,
-    ) => {
-      changed = true;
-      return `let ${storedVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`),${configuredVar}=${storedVar}===void 0?(process.platform===\`linux\`?null:${defaultHotkeyVar}):${storedVar},${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null,linuxWayland:codexLinuxAppshotIsWayland()}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
-    },
-  );
-  currentSource = currentSource.replace(
-    /return ([A-Za-z_$][\w$]*)\.length===1\?([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\2\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/g,
-    (match, partsVar, platformVar, supportedBareModifierFn, hotkeyVar) => {
-      changed = true;
-      return `return ${partsVar}.length===1?(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)?${supportedBareModifierFn}(${hotkeyVar},${platformVar})?null:\`This shortcut key is not supported.\`:\`Choose a shortcut with Ctrl or Alt plus another key.\`:\`Use Ctrl, Alt, or Command when combining with another key.\``;
-    },
-  );
-  currentSource = currentSource.replace(
-    /new Set\(\[\.\.\.([A-Za-z_$][\w$]*),`shift`\]\)/g,
-    (match, baseModifiersVar) => {
-      changed = true;
-      return `new Set([...${baseModifiersVar},\`shift\`,\`super\`,\`meta\`,\`win\`])`;
-    },
-  );
-
-  if (
-    currentSource.includes("process.platform===`linux`?null") &&
-    currentSource.includes("process.platform!==`darwin`&&process.platform!==`linux`") &&
-    currentSource.includes("!codexLinuxAppshotIsWayland()") &&
-    currentSource.includes("if(process.platform!==`darwin`&&process.platform!==`linux`)return null") &&
-    currentSource.includes("codexLinuxAppshotIsWayland") &&
-    currentSource.includes("`super`,`meta`,`win`")
-  ) {
+  const alreadyPatched = [
+    /this\.configuredHotkey=[A-Za-z_$][\w$]*===void 0\?\(process\.platform===`linux`\?null:[A-Za-z_$][\w$]*\):[A-Za-z_$][\w$]*/,
+    /supported:this\.enabled&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:this\.configuredHotkey,isActive:this\.registration!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
+    /!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`/,
+    /!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|this\.configuredHotkey==null/,
+    /return [A-Za-z_$][\w$]*\.length===1\?\([A-Za-z_$][\w$]*===`darwin`\|\|[A-Za-z_$][\w$]*===`linux`\)\?/,
+    /return \([A-Za-z_$][\w$]*===`darwin`\|\|[A-Za-z_$][\w$]*===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&/,
+    /if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null/,
+    /new Set\(\[\.\.\.[A-Za-z_$][\w$]*,`shift`,`super`,`meta`,`win`\]\)/,
+  ].every((pattern) => pattern.test(currentSource));
+  if (alreadyPatched && currentSource.includes("function codexLinuxAppshotIsWayland")) {
     return currentSource;
   }
 
-  let patchedSource = currentSource.replace(
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=process\.platform\)\{return \3===`darwin`&&([A-Za-z_$][\w$]*)\(\2\)!=null\}/g,
-    (match, fnName, hotkeyVar, platformVar, modifierFn) => {
-      changed = true;
-      return `function ${fnName}(${hotkeyVar},${platformVar}=process.platform){return (${platformVar}===\`darwin\`||${platformVar}===\`linux\`&&!codexLinuxAppshotIsWayland())&&${modifierFn}(${hotkeyVar})!=null}`;
-    },
+  let patchedSource = currentSource;
+  const counts = [];
+  function replaceRequired(pattern, replacement) {
+    let count = 0;
+    patchedSource = patchedSource.replace(pattern, (...args) => {
+      count += 1;
+      return typeof replacement === "function" ? replacement(...args) : replacement;
+    });
+    counts.push(count);
+  }
+
+  replaceRequired(
+    /this\.configuredHotkey=([A-Za-z_$][\w$]*)===void 0\?([A-Za-z_$][\w$]*):\1/,
+    (match, storedVar, defaultHotkeyVar) =>
+      `this.configuredHotkey=${storedVar}===void 0?(process.platform===\`linux\`?null:${defaultHotkeyVar}):${storedVar}`,
+  );
+  replaceRequired(
+    /getState\(\)\{return\{supported:this\.enabled&&process\.platform===`darwin`,configuredHotkey:this\.configuredHotkey,isActive:this\.registration!=null\}\}/,
+    "getState(){return{supported:this.enabled&&(process.platform===`darwin`||process.platform===`linux`),configuredHotkey:this.configuredHotkey,isActive:this.registration!=null,linuxWayland:codexLinuxAppshotIsWayland()}}",
+  );
+  replaceRequired(
+    /if\(!this\.enabled\|\|process\.platform!==`darwin`\)return\{success:!1,error:`Not supported\.`,state:this\.getState\(\)\}/,
+    "if(!this.enabled||process.platform!==`darwin`&&process.platform!==`linux`)return{success:!1,error:`Not supported.`,state:this.getState()}",
+  );
+  replaceRequired(
+    /!this\.enabled\|\|process\.platform!==`darwin`\|\|this\.configuredHotkey==null/,
+    "!this.enabled||process.platform!==`darwin`&&process.platform!==`linux`||this.configuredHotkey==null",
+  );
+  replaceRequired(
+    /return ([A-Za-z_$][\w$]*)\.length===1\?([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\2\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/,
+    (match, partsVar, platformVar, supportedBareModifierFn, hotkeyVar) =>
+      `return ${partsVar}.length===1?(${platformVar}===\`darwin\`||${platformVar}===\`linux\`)?${supportedBareModifierFn}(${hotkeyVar},${platformVar})?null:\`This shortcut key is not supported.\`:\`Choose a shortcut with Ctrl or Alt plus another key.\`:\`Use Ctrl, Alt, or Command when combining with another key.\``,
+  );
+  replaceRequired(
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=process\.platform\)\{return \3===`darwin`&&([A-Za-z_$][\w$]*)\(\2\)!=null\}/,
+    (match, fnName, hotkeyVar, platformVar, modifierFn) =>
+      `function ${fnName}(${hotkeyVar},${platformVar}=process.platform){return (${platformVar}===\`darwin\`||${platformVar}===\`linux\`&&!codexLinuxAppshotIsWayland())&&${modifierFn}(${hotkeyVar})!=null}`,
+  );
+  replaceRequired(
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=`press`\)\{if\(process\.platform!==`darwin`\)return null;/,
+    (match, fnName, hotkeyVar, handlerVar, triggerVar) =>
+      `function ${fnName}(${hotkeyVar},${handlerVar},${triggerVar}=\`press\`){if(process.platform!==\`darwin\`&&process.platform!==\`linux\`)return null;`,
+  );
+  replaceRequired(
+    /new Set\(\[\.\.\.([A-Za-z_$][\w$]*),`shift`\]\)/,
+    (match, baseModifiersVar) =>
+      `new Set([...${baseModifiersVar},\`shift\`,\`super\`,\`meta\`,\`win\`])`,
   );
 
-  patchedSource = patchedSource.replace(
-    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=`press`\)\{if\(process\.platform!==`darwin`\)return null;/g,
-    (match, fnName, hotkeyVar, handlerVar, triggerVar) => {
-      changed = true;
-      return `function ${fnName}(${hotkeyVar},${handlerVar},${triggerVar}=\`press\`){if(process.platform!==\`darwin\`&&process.platform!==\`linux\`)return null;`;
-    },
-  );
-
-  patchedSource = patchedSource.replace(
-    /let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.(getStored|get)\(`appshotHotkey`\)\?\?([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)=null,([A-Za-z_$][\w$]*)=\(\)=>\(\{supported:([A-Za-z_$][\w$]*)&&process\.platform===`darwin`,configuredHotkey:\1,isActive:\5!=null\}\),([A-Za-z_$][\w$]*)=\(\)=>\{if\(\5\?\.unregister\(\),\5=null,!\7\|\|process\.platform!==`darwin`\|\|\1==null\)\{/,
-    (
-      match,
-      configuredVar,
-      globalStateVar,
-      getterName,
-      defaultHotkeyVar,
-      registrationVar,
-      stateFnVar,
-      enabledVar,
-      reconcileFnVar,
-    ) => {
-      changed = true;
-      return `let ${configuredVar}=${globalStateVar}.${getterName}(\`appshotHotkey\`)??(process.platform===\`linux\`?null:${defaultHotkeyVar});let ${registrationVar}=null,${stateFnVar}=()=>({supported:${enabledVar}&&(process.platform===\`darwin\`||process.platform===\`linux\`),configuredHotkey:${configuredVar},isActive:${registrationVar}!=null,linuxWayland:codexLinuxAppshotIsWayland()}),${reconcileFnVar}=()=>{if(${registrationVar}?.unregister(),${registrationVar}=null,!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`||${configuredVar}==null){`;
-    },
-  );
-
-  patchedSource = patchedSource.replace(
-    /if\(!([A-Za-z_$][\w$]*)\|\|process\.platform!==`darwin`\)return\{success:!1,error:`Not supported\.`,state:([A-Za-z_$][\w$]*)\(\)\};if\(([A-Za-z_$][\w$]*)!=null\)\{/,
-    (match, enabledVar, stateFnVar, nextHotkeyVar) => {
-      changed = true;
-      return `if(!${enabledVar}||process.platform!==\`darwin\`&&process.platform!==\`linux\`)return{success:!1,error:\`Not supported.\`,state:${stateFnVar}()};if(${nextHotkeyVar}!=null){`;
-    },
-  );
-
-  if (changed) {
+  if (counts.every((count) => count === 1)) {
     return withLinuxAppshotWaylandHelper(patchedSource);
   }
 
   if (currentSource.includes("appshotHotkey") || currentSource.includes("appshot-hotkey-state")) {
-    warn("Could not find AppShots hotkey controller", "Linux AppShots hotkey patch");
+    warn("Could not find current AppShots hotkey class", "Linux AppShots hotkey patch");
   }
   return currentSource;
 }
@@ -187,7 +162,8 @@ function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
     return currentSource;
   }
 
-  const stateDataVar = currentSource.match(/\{data:([A-Za-z_$][\w$]*)\}=/)?.[1] ?? null;
+  const stateDataVar =
+    currentSource.match(/\b([A-Za-z_$][\w$]*)\?\.configuredHotkey\?\?null/)?.[1] ?? null;
   if (stateDataVar == null) {
     if (currentSource.includes("appshot-hotkey-state") || currentSource.includes("DoubleCommand")) {
       warn("Could not find AppShots settings state binding", "Linux AppShots settings hotkey patch");
@@ -195,28 +171,51 @@ function applyLinuxAppshotSettingsHotkeyPatch(currentSource) {
     return currentSource;
   }
 
-  let changed = false;
+  let optionsMatched = false;
   let optionsVarName = null;
   let patchedSource = currentSource.replace(
-    /((?:var\s+|,)([A-Za-z_$][\w$]*)=)(\[\{hotkey:`DoubleCommand`,label:`[^`]+`\},\{hotkey:`DoubleOption`,label:`[^`]+`\},\{hotkey:`DoubleShift`,label:`[^`]+`\}\])(?=;)/,
+    /((?:var\s+|,)([A-Za-z_$][\w$]*)=)(\[\{hotkey:`DoubleCommand`,label:`[^`]+`\},\{hotkey:`DoubleOption`,label:`[^`]+`\},\{hotkey:`DoubleShift`,label:`[^`]+`\}\])(?=[,;)}])/,
     (match, declarationPrefix, optionsVar, macOptions) => {
-      changed = true;
+      optionsMatched = true;
       optionsVarName = optionsVar;
-      const helper =
-        `codexLinuxAppshotHotkeyOptions=e=>typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)?e?.linuxWayland?${linuxWaylandOptions}:${linuxX11Options}:${optionsVar}`;
-      return `${declarationPrefix}${macOptions},${helper}`;
+      return `${declarationPrefix}${macOptions}`;
     },
   );
 
-  if (changed && optionsVarName != null) {
-    const escapedOptionsVarName = escapeRegExp(optionsVarName);
-    patchedSource = patchedSource
-      .replace(new RegExp(`\\b${escapedOptionsVarName}\\.find\\(`, "g"), `codexLinuxAppshotHotkeyOptions(${stateDataVar}).find(`)
-      .replace(new RegExp(`\\b${escapedOptionsVarName}\\.map\\(`, "g"), `codexLinuxAppshotHotkeyOptions(${stateDataVar}).map(`);
+  let patchedFind = false;
+  let patchedMap = false;
+  if (optionsMatched && optionsVarName != null) {
+    const findResult = replaceIdentifierCall(
+      patchedSource,
+      optionsVarName,
+      "find",
+      `codexLinuxAppshotHotkeyOptions(${stateDataVar}).find(`,
+    );
+    patchedSource = findResult.source;
+    patchedFind = findResult.count > 0;
+    const mapResult = replaceIdentifierCall(
+      patchedSource,
+      optionsVarName,
+      "map",
+      `codexLinuxAppshotHotkeyOptions(${stateDataVar}).map(`,
+    );
+    patchedSource = mapResult.source;
+    patchedMap = mapResult.count > 0;
   }
 
-  if (changed) {
-    return patchedSource;
+  if (optionsMatched && patchedFind && patchedMap) {
+    const helper =
+      `function codexLinuxAppshotHotkeyOptions(e){return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)?e?.linuxWayland?${linuxWaylandOptions}:${linuxX11Options}:${optionsVarName}}`;
+    const sourceMapIndex = patchedSource.lastIndexOf("\n//# sourceMappingURL=");
+    if (sourceMapIndex >= 0) {
+      return `${patchedSource.slice(0, sourceMapIndex)};${helper}${patchedSource.slice(sourceMapIndex)}`;
+    }
+    return `${patchedSource}\n;${helper}`;
+  }
+
+  if (optionsMatched) {
+    warn("Could not find both AppShots settings hotkey option call sites", "Linux AppShots settings patch");
+    return currentSource;
   }
 
   if (currentSource.includes("appshot-hotkey-state") || currentSource.includes("DoubleCommand")) {
@@ -303,6 +302,33 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function replaceIdentifierCall(source, identifier, method, replacement) {
+  const needle = `${identifier}.${method}(`;
+  let count = 0;
+  let cursor = 0;
+  let output = "";
+
+  while (cursor < source.length) {
+    const matchIndex = source.indexOf(needle, cursor);
+    if (matchIndex < 0) {
+      output += source.slice(cursor);
+      break;
+    }
+    const previous = matchIndex > 0 ? source[matchIndex - 1] : "";
+    if (/[A-Za-z0-9_$]/.test(previous)) {
+      const nextCursor = matchIndex + needle.length;
+      output += source.slice(cursor, nextCursor);
+      cursor = nextCursor;
+      continue;
+    }
+    output += source.slice(cursor, matchIndex) + replacement;
+    cursor = matchIndex + needle.length;
+    count += 1;
+  }
+
+  return { source: output, count };
+}
+
 const descriptors = [
   {
     id: "linux-appshots-main-process",
@@ -314,7 +340,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^appshot-availability-.*\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -87,6 +87,7 @@ function currentAppshotSettingsRuntimeFixture() {
     "let o={configuredHotkey:`DoubleOption`,linuxWayland:!1};",
     "function render(){let f=o?.configuredHotkey??null;return{selected:X.find(e=>e.hotkey===f)??null,labels:X.map(e=>e.label)}}",
     "function unrelated(){return AX.find(e=>e)+AX.map(e=>e)}",
+    "function propertyAccess(){return obj.X.find(e=>e)+obj.X.map(e=>e)}",
     "globalThis.result=render();",
     "\n//# sourceMappingURL=fixture.js.map",
   ].join("");
@@ -246,6 +247,12 @@ test("routes AppShots capture through the self-contained Linux feature", () => {
   assert.match(patched, /\[linux-appshots\]/);
   assert.match(patched, /codexLinuxAppshotCropRects/);
   assert.match(patched, /codexLinuxAppshotFirstValidCrop/);
+  assert.match(patched, /mkdtempSync\(i\.join\(r\.tmpdir\(\),`codex-appshot-`\)\)/);
+  assert.match(patched, /chmodSync\(u,448\)/);
+  assert.match(patched, /i\.join\(u,`source\.png`\)/);
+  assert.match(patched, /i\.join\(u,`crop\.png`\)/);
+  assert.match(patched, /rmSync\(u,\{recursive:true,force:true\}\)/);
+  assert.doesNotMatch(patched, /i\.join\(r\.tmpdir\(\),`codex-appshot-\$\{/);
   assert.doesNotMatch(patched, /\[`appshot`/);
   assert.doesNotMatch(patched, /bare-modifier-monitor/);
   assert.match(
@@ -327,6 +334,31 @@ test("AppShots hotkey patch fails closed when one current class shape drifts", (
   ]);
 });
 
+test("AppShots hotkey patch rejects a partially patched setter", () => {
+  const fullyPatched = applyLinuxAppshotHotkeyPatch(currentAppshotHotkeyMainBundleFixture());
+  const partial = fullyPatched.replace(
+    "if(!this.enabled||process.platform!==`darwin`&&process.platform!==`linux`)return{success:!1,error:`Not supported.`,state:this.getState()}",
+    "if(!this.enabled||process.platform!==`darwin`)return{success:!1,error:`Not supported.`,state:this.getState()}",
+  );
+
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyLinuxAppshotHotkeyPatch(partial), partial);
+  }), [
+    "WARN: Could not find current AppShots hotkey class - skipping Linux AppShots hotkey patch",
+  ]);
+});
+
+test("AppShots hotkey patch rejects duplicate current class contracts", () => {
+  const source = currentAppshotHotkeyMainBundleFixture();
+  const duplicate = `${source}${source}`;
+
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyLinuxAppshotHotkeyPatch(duplicate), duplicate);
+  }), [
+    "WARN: Could not find current AppShots hotkey class - skipping Linux AppShots hotkey patch",
+  ]);
+});
+
 test("shows Linux AppShots accelerator choices in current settings chunk", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotSettingsHotkeyPatch,
@@ -364,6 +396,7 @@ test("current AppShots settings helper is declared in strict module scope", () =
   );
   assert.doesNotMatch(patched, /,codexLinuxAppshotHotkeyOptions=/);
   assert.match(patched, /AX\.find\(e=>e\)\+AX\.map\(e=>e\)/);
+  assert.match(patched, /obj\.X\.find\(e=>e\)\+obj\.X\.map\(e=>e\)/);
   assert.ok(
     patched.indexOf("function codexLinuxAppshotHotkeyOptions") <
       patched.indexOf("//# sourceMappingURL=fixture.js.map"),

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -7,6 +7,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 
 const {
   loadLinuxFeaturePatchDescriptors,
@@ -25,6 +26,18 @@ function applyPatchTwice(patchFn, source) {
   assert.notEqual(once, source);
   assert.equal(patchFn(once), once);
   return once;
+}
+
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    callback();
+  } finally {
+    console.warn = originalWarn;
+  }
+  return warnings;
 }
 
 function appshotAvailabilityAtomBundleFixture() {
@@ -49,32 +62,33 @@ function appshotMainProcessBundleFixture() {
   ].join("");
 }
 
-function appshotHotkeyMainBundleFixture() {
+function currentAppshotHotkeyMainBundleFixture() {
   return [
-    "var uG=`DoubleCommand`,dG=6e4;",
-    "var SO=new Set([`cmdorctrl`,`command`,`cmd`,`control`,`ctrl`,`alt`,`option`]),CO=new Set([...SO,`shift`]);",
-    "function rw(e,t=process.platform){return t===`darwin`&&aw(e)!=null}",
-    "function QC(e,t,r=`press`){if(process.platform!==`darwin`)return null;let i=aw(e);return i==null?null:KC(e,t,r)}",
-    "function bw(e,t,r){if(iw(e))return rw(e)?QC(e,t,r?.bareModifierTrigger):null;let i=Ew(e),a=()=>{t.onPressed()},o=n.globalShortcut.register(i,a);return o?{handlesRelease:!1,unregister:()=>{n.globalShortcut.unregister(i)}}:null}",
-    "function fG({globalState:e,windowManager:n,enabled:r}){let i=e.get(`appshotHotkey`)??uG,a=null,o=()=>({supported:r&&process.platform===`darwin`,configuredHotkey:i,isActive:a!=null}),s=()=>{if(a?.unregister(),a=null,!r||process.platform!==`darwin`||i==null){t.$r().info(`Appshot hotkey inactive`,{safe:{enabled:r,platform:process.platform,configured:i!=null},sensitive:{}});return}if(t.$r().info(`Registering appshot hotkey`,{safe:{hotkey:i},sensitive:{}}),Cw(i,{bareModifierTrigger:`immediatePress`}),a=bw(i,{onPressed:()=>{t.$r().info(`Appshot hotkey pressed`,{safe:{hotkey:i},sensitive:{}});let e=n.getPrimaryWindow();if(e==null||e.isDestroyed()){return}let r=n.wasPrimaryWindowFocusedWithin(e,dG);r||n.sendMessageToWindow(e,{type:`navigate-to-route`,path:`/`,state:{focusComposerNonce:Date.now()}}),n.sendMessageToWindow(e,{type:`appshot-shortcut`})}},{bareModifierTrigger:`immediatePress`}),a==null)throw Error(`Unable to register shortcut: ${i}`);t.$r().info(`Registered appshot hotkey`,{safe:{hotkey:i},sensitive:{}})},c=n=>{if(!r||process.platform!==`darwin`)return{success:!1,error:`Not supported.`,state:o()};if(n!=null){let e=Sw(n);if(e!=null)return{success:!1,error:e,state:o()}}let a=i;i=n;try{s()}catch(e){i=a;return{success:!1,error:e instanceof Error?e.message:String(e),state:o()}}return e.set(`appshotHotkey`,i??void 0),{success:!0,state:o()}};try{s()}catch(e){}return{getState:o,setHotkey:c,dispose:()=>{a?.unregister(),a=null}}}",
+    "var R8=`DoubleCommand`;",
+    "var Yk=new Set([`cmdorctrl`,`command`,`cmd`,`control`,`ctrl`,`alt`,`option`]),Jk=new Set([...Yk,`shift`]);",
+    "function Lk(e,t=process.platform){return t===`darwin`&&zk(e)!=null}",
+    "function Mk(e,t,n=`press`){if(process.platform!==`darwin`)return null;let r=zk(e);return r==null?null:Nk(r,t,n)}",
+    "function nA(e,t=process.platform){let n=Gk(e);if(Lk(e,t))return null;if(n.some(wE))return n.length===1?t===`darwin`?Lk(e,t)?null:`This shortcut key is not supported.`:`Choose a shortcut with Ctrl or Alt plus another key.`:`Use Ctrl, Alt, or Command when combining with another key.`;return null}",
+    "var B8=class{configuredHotkey;registration=null;constructor(e){this.enabled=!0;let a=e.getStored(`appshotHotkey`);this.configuredHotkey=a===void 0?R8:a}getState(){return{supported:this.enabled&&process.platform===`darwin`,configuredHotkey:this.configuredHotkey,isActive:this.registration!=null}}setHotkey(e){if(!this.enabled||process.platform!==`darwin`)return{success:!1,error:`Not supported.`,state:this.getState()};return{success:!0,state:this.getState()}}reconcile(){if(this.registration?.unregister(),this.registration=null,!this.enabled||process.platform!==`darwin`||this.configuredHotkey==null)return null;return Mk(this.configuredHotkey,()=>{})}};",
+    "globalThis.AppshotHotkeys=B8;",
   ].join("");
 }
 
-function appshotHotkeyStoredMainBundleFixture() {
+function currentAppshotSettingsBundleFixture() {
   return [
-    "var bX=`DoubleCommand`,xX=6e4;",
-    "var JE=new Set([`cmdorctrl`,`command`,`cmd`,`control`,`ctrl`,`alt`,`option`]),LE=new Set([...JE,`shift`]);",
-    "function CE(e,t=process.platform){return t===`darwin`&&TE(e)!=null}",
-    "function vE(e,t,n=`press`){if(process.platform!==`darwin`)return null;let r=TE(e);return r==null?null:DE(r,t,n)}",
-    "function HE(e,t=process.platform){let n=GE(e);if(CE(e,t))return null;if(n.some(wE))return n.length===1?t===`darwin`?CE(e,t)?null:`This shortcut key is not supported.`:`Choose a shortcut with Ctrl or Alt plus another key.`:`Use Ctrl, Alt, or Command when combining with another key.`;return null}",
-    "function SX({globalState:e,windowManager:n,enabled:r}){let i=e.getStored(`appshotHotkey`),a=i===void 0?bX:i,o=null,s=()=>({supported:r&&process.platform===`darwin`,configuredHotkey:a,isActive:o!=null}),c=()=>{if(o?.unregister(),o=null,!r||process.platform!==`darwin`||a==null){t.Nr().info(`Appshot hotkey inactive`,{safe:{enabled:r,platform:process.platform,configured:a!=null},sensitive:{}});return}if(t.Nr().info(`Registering appshot hotkey`,{safe:{hotkey:a},sensitive:{}}),UE(a,{bareModifierTrigger:`immediatePress`}),o=BE(a,{onPressed:()=>{t.Nr().info(`Appshot hotkey pressed`,{safe:{hotkey:a},sensitive:{}});let e=n.getPrimaryWindow();if(e==null||e.isDestroyed()){return}let r=n.wasPrimaryWindowFocusedWithin(e,xX);r||n.sendMessageToWindow(e,{type:`navigate-to-route`,path:`/`,state:{focusComposerNonce:Date.now()}}),n.sendMessageToWindow(e,{type:`appshot-shortcut`})}},{bareModifierTrigger:`immediatePress`}),o==null)throw Error(`Unable to register shortcut: ${a}`);t.Nr().info(`Registered appshot hotkey`,{safe:{hotkey:a},sensitive:{}})},l=n=>{if(!r||process.platform!==`darwin`&&process.platform!==`linux`)return{success:!1,error:`Not supported.`,state:s()};if(n!=null){let e=HE(n);if(e!=null)return{success:!1,error:e,state:s()}}let i=a;a=n;try{c()}catch(e){a=i;return{success:!1,error:e instanceof Error?e.message:String(e),state:s()}}return e.set(`appshotHotkey`,a),{success:!0,state:s()}};try{c()}catch(e){}return{rpc:{getState:s,setHotkey:l},dispose:()=>{o?.unregister(),o=null}}}",
+    "var J,Y,X,Se=e((()=>{J=[`appshot-hotkey-state`],Y=o(M,()=>({queryKey:J,queryFn:async()=>{let e=C.appshotHotkeys;return e==null?{supported:!1,configuredHotkey:null,isActive:!1}:e.getState()},staleTime:k.ONE_MINUTE})),X=[{hotkey:`DoubleCommand`,label:`⌘ + ⌘`},{hotkey:`DoubleOption`,label:`⌥ + ⌥`},{hotkey:`DoubleShift`,label:`⇧ + ⇧`}]}));",
+    "function Te(){let e=(0,Q.c)(41),o=A(Y),i=null,a=()=>{},d=async()=>{},f=o?.configuredHotkey??null,p;e[6]===f?p=e[7]:(p=X.find(e=>e.hotkey===f)??null,e[6]=f,e[7]=p);let m=p,O;e[20]!==d||e[21]!==f||e[22]!==m?.hotkey?(O=X.map(e=>item({selected:e.hotkey===m?.hotkey,onSelect:()=>d(e.hotkey),children:e.label})),e[20]=d,e[21]=f,e[22]=m?.hotkey,e[23]=O):O=e[23];return O}",
   ].join("");
 }
 
-function appshotSettingsBundleFixture() {
+function currentAppshotSettingsRuntimeFixture() {
   return [
-    "var O=d(),A=e(t(),1),j=n(),M=[{hotkey:`DoubleCommand`,label:`\\u2318 + \\u2318`},{hotkey:`DoubleOption`,label:`\\u2325 + \\u2325`},{hotkey:`DoubleShift`,label:`\\u21e7 + \\u21e7`}];",
-    "function N(){let{data:h}=l(`appshot-hotkey-state`,{queryConfig:{enabled:t}}),x=c(`appshot-set-hotkey`);let w=h?.configuredHotkey??null,y=M.map(e=>e.label).join(`,`),E=M.find(e=>e.hotkey===w)??null;return E??y}",
+    "var J,Y,X,Se=(()=>{J=[],Y={},X=[{hotkey:`DoubleCommand`,label:`Command`},{hotkey:`DoubleOption`,label:`Option`},{hotkey:`DoubleShift`,label:`Shift`}]})();",
+    "let o={configuredHotkey:`DoubleOption`,linuxWayland:!1};",
+    "function render(){let f=o?.configuredHotkey??null;return{selected:X.find(e=>e.hotkey===f)??null,labels:X.map(e=>e.label)}}",
+    "function unrelated(){return AX.find(e=>e)+AX.map(e=>e)}",
+    "globalThis.result=render();",
+    "\n//# sourceMappingURL=fixture.js.map",
   ].join("");
 }
 
@@ -123,7 +137,18 @@ test("appshots availability descriptor matches the current bundle", () => {
     (descriptor) => descriptor.id === "linux-appshots-availability",
   );
 
-  assert.ok(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"));
+  assert.equal(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"), false);
+  assert.ok(
+    descriptor.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    ),
+  );
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-Bty5T9_s.js",
+    ),
+    false,
+  );
 });
 
 test("stages the Linux bare modifier monitor helper and Wayland portal hook", () => {
@@ -238,10 +263,10 @@ test("routes AppShots capture through the self-contained Linux feature", () => {
   assert.match(patched, /type:`completed`,transitionSnapshotDataURL:s\.dataURL/);
 });
 
-test("enables AppShots hotkeys and bare modifiers on Linux", () => {
+test("enables the current AppShots hotkey class and bare modifiers on Linux", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotHotkeyPatch,
-    appshotHotkeyMainBundleFixture(),
+    currentAppshotHotkeyMainBundleFixture(),
   );
 
   assert.match(
@@ -250,92 +275,108 @@ test("enables AppShots hotkeys and bare modifiers on Linux", () => {
   );
   assert.match(
     patched,
-    /function rw\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&aw\(e\)!=null\}/,
+    /function Lk\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&zk\(e\)!=null\}/,
   );
   assert.match(
     patched,
-    /function QC\(e,t,r=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
+    /function Mk\(e,t,n=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
   );
-  assert.match(patched, /new Set\(\[\.\.\.SO,`shift`,`super`,`meta`,`win`\]\)/);
-  assert.match(patched, /appshotHotkey`\)\?\?\(process\.platform===`linux`\?null:uG\)/);
-  assert.doesNotMatch(patched, /process\.platform===`linux`\?`DoubleShift`/);
-  assert.doesNotMatch(patched, /process\.platform===`linux`&&i!=null&&iw\(i\)&&\(i=null\)/);
+  assert.match(patched, /new Set\(\[\.\.\.Yk,`shift`,`super`,`meta`,`win`\]\)/);
   assert.match(
     patched,
-    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:i,isActive:a!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
+    /this\.configuredHotkey=a===void 0\?\(process\.platform===`linux`\?null:R8\):a/,
   );
   assert.match(
     patched,
-    /!r\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|i==null/,
+    /supported:this\.enabled&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:this\.configuredHotkey,isActive:this\.registration!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
   );
   assert.match(
     patched,
-    /if\(!r\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\)return\{success:!1,error:`Not supported\.`,state:o\(\)\}/,
+    /if\(!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\)return\{success:!1,error:`Not supported\.`,state:this\.getState\(\)\}/,
   );
-  assert.match(patched, /type:`appshot-shortcut`/);
-  assert.doesNotMatch(patched, /bare-modifier-monitor/);
-  assert.doesNotMatch(patched, /codexLinuxAppshotBareModifierHotkey/);
-  assert.doesNotMatch(patched, /codexLinuxAppshotRegisterBareModifierHotkey/);
+  assert.match(
+    patched,
+    /!this\.enabled\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|this\.configuredHotkey==null/,
+  );
+  assert.match(
+    patched,
+    /return n\.length===1\?\(t===`darwin`\|\|t===`linux`\)\?Lk\(e,t\)\?null:`This shortcut key is not supported\.`/,
+  );
+
+  const context = {
+    globalThis: {},
+    process: { env: { XDG_SESSION_TYPE: "x11" }, platform: "linux" },
+  };
+  vm.runInNewContext(patched, context);
+  const state = new context.globalThis.AppshotHotkeys({ getStored() {} }).getState();
+  assert.equal(state.supported, true);
+  assert.equal(state.configuredHotkey, null);
+  assert.equal(state.linuxWayland, false);
 });
 
-test("enables Linux AppShots hotkeys for stored upstream controller shape", () => {
-  const patched = applyPatchTwice(
-    applyLinuxAppshotHotkeyPatch,
-    appshotHotkeyStoredMainBundleFixture(),
+test("AppShots hotkey patch fails closed when one current class shape drifts", () => {
+  const source = currentAppshotHotkeyMainBundleFixture().replace(
+    "new Set([...Yk,`shift`])",
+    "new Set([...Yk,`shift`,`alt`])",
   );
 
-  assert.match(
-    patched,
-    /function codexLinuxAppshotIsWayland\(\)\{return process\.platform===`linux`&&\(\(process\.env\.XDG_SESSION_TYPE\|\|``\)\.toLowerCase\(\)===`wayland`\|\|!!process\.env\.WAYLAND_DISPLAY\)\}/,
-  );
-  assert.match(
-    patched,
-    /function CE\(e,t=process\.platform\)\{return \(t===`darwin`\|\|t===`linux`&&!codexLinuxAppshotIsWayland\(\)\)&&TE\(e\)!=null\}/,
-  );
-  assert.match(
-    patched,
-    /function vE\(e,t,n=`press`\)\{if\(process\.platform!==`darwin`&&process\.platform!==`linux`\)return null;/,
-  );
-  assert.match(patched, /new Set\(\[\.\.\.JE,`shift`,`super`,`meta`,`win`\]\)/);
-  assert.match(
-    patched,
-    /return n\.length===1\?\(t===`darwin`\|\|t===`linux`\)\?CE\(e,t\)\?null:`This shortcut key is not supported\.`:`Choose a shortcut with Ctrl or Alt plus another key\.`:`Use Ctrl, Alt, or Command when combining with another key\.`/,
-  );
-  assert.match(
-    patched,
-    /let i=e\.getStored\(`appshotHotkey`\),a=i===void 0\?\(process\.platform===`linux`\?null:bX\):i,o=null/,
-  );
-  assert.match(
-    patched,
-    /supported:r&&\(process\.platform===`darwin`\|\|process\.platform===`linux`\),configuredHotkey:a,isActive:o!=null,linuxWayland:codexLinuxAppshotIsWayland\(\)/,
-  );
-  assert.match(
-    patched,
-    /!r\|\|process\.platform!==`darwin`&&process\.platform!==`linux`\|\|a==null/,
-  );
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyLinuxAppshotHotkeyPatch(source), source);
+  }), [
+    "WARN: Could not find current AppShots hotkey class - skipping Linux AppShots hotkey patch",
+  ]);
 });
 
-test("shows Linux AppShots accelerator choices in settings", () => {
+test("shows Linux AppShots accelerator choices in current settings chunk", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotSettingsHotkeyPatch,
-    appshotSettingsBundleFixture(),
+    currentAppshotSettingsBundleFixture(),
   );
 
-  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
-  assert.match(patched, /codexLinuxAppshotHotkeyOptions=e=>/);
+  assert.match(patched, /function codexLinuxAppshotHotkeyOptions\(e\)/);
   assert.match(
     patched,
-    /e\?\.linuxWayland\?\[\{hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`\}\]:\[\{hotkey:`DoubleOption`,label:`Alt \+ Alt`\}/,
+    /codexLinuxAppshotHotkeyOptions\(o\)\.find\(e=>e\.hotkey===f\)/,
   );
-  assert.match(patched, /codexLinuxAppshotHotkeyOptions\(h\)\.find/);
-  assert.match(patched, /codexLinuxAppshotHotkeyOptions\(h\)\.map/);
-  assert.doesNotMatch(patched, /\bM\.find\(/);
-  assert.doesNotMatch(patched, /\bM\.map\(/);
+  assert.match(patched, /codexLinuxAppshotHotkeyOptions\(o\)\.map/);
+  assert.doesNotMatch(patched, /\bX\.find\(/);
+  assert.doesNotMatch(patched, /\bX\.map\(/);
   assert.match(patched, /hotkey:`DoubleOption`,label:`Alt \+ Alt`/);
-  assert.match(patched, /hotkey:`DoubleShift`,label:`Shift \+ Shift`/);
   assert.match(patched, /hotkey:`Ctrl\+Super\+A`,label:`Ctrl \+ Super \+ A`/);
-  assert.doesNotMatch(patched, /hotkey:`Alt\+Super\+A`/);
-  assert.doesNotMatch(patched, /hotkey:`Ctrl\+Alt\+A`/);
-  assert.match(patched, /hotkey:`DoubleCommand`,label:`\\u2318 \+ \\u2318`/);
-  assert.match(patched, /hotkey:`DoubleShift`,label:`\\u21e7 \+ \\u21e7`/);
+});
+
+test("current AppShots settings helper is declared in strict module scope", () => {
+  const patched = applyPatchTwice(
+    applyLinuxAppshotSettingsHotkeyPatch,
+    currentAppshotSettingsRuntimeFixture(),
+  );
+  const context = {
+    globalThis: {},
+    navigator: { userAgent: "Linux" },
+  };
+
+  vm.runInNewContext(`"use strict";${patched}`, context);
+
+  assert.equal(context.globalThis.result.selected.hotkey, "DoubleOption");
+  assert.deepEqual(
+    Array.from(context.globalThis.result.labels),
+    ["Alt + Alt", "Shift + Shift", "Ctrl + Super + A"],
+  );
+  assert.doesNotMatch(patched, /,codexLinuxAppshotHotkeyOptions=/);
+  assert.match(patched, /AX\.find\(e=>e\)\+AX\.map\(e=>e\)/);
+  assert.ok(
+    patched.indexOf("function codexLinuxAppshotHotkeyOptions") <
+      patched.indexOf("//# sourceMappingURL=fixture.js.map"),
+  );
+  assert.ok(patched.endsWith("//# sourceMappingURL=fixture.js.map"));
+});
+
+test("AppShots settings patch fails closed when one option call site drifts", () => {
+  const source = currentAppshotSettingsRuntimeFixture().replace("X.map(", "Array.from(X).map(");
+
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyLinuxAppshotSettingsHotkeyPatch(source), source);
+  }), [
+    "WARN: Could not find both AppShots settings hotkey option call sites - skipping Linux AppShots settings patch",
+  ]);
 });

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -242,7 +242,7 @@ test("routes AppShots capture through the self-contained Linux feature", () => {
   assert.match(patched, /codexLinuxAppshotCropWithImageMagick/);
   assert.ok(
     patched.indexOf("await codexLinuxAppshotCropWithImageMagick") <
-      patched.indexOf("codexLinuxAppshotCropNativeImage(o,u,s)"),
+      patched.indexOf("codexLinuxAppshotCropNativeImage(o,d,s)"),
   );
   assert.match(patched, /\[linux-appshots\]/);
   assert.match(patched, /codexLinuxAppshotCropRects/);


### PR DESCRIPTION
## Summary

- Match only the latest shared app-shell chunk for AppShots availability and the current settings chunk.
- Patch the current AppShots hotkey class atomically for Linux, including its default, support state, setter, reconcile guard, Wayland state, and bare-modifier helpers.
- Declare the Linux settings helper at module scope before the final source-map trailer.
- Require every current hotkey and settings call site so partial drift leaves the original bundle unchanged with a warning.
- Remove the superseded availability, controller, and settings bundle shapes while keeping capture and IPC behavior unchanged.

## Validation

- `node --test linux-features/appshots/test.js`
- `bash scripts/ci/run-node-checks.sh`
- `bash tests/scripts_smoke.sh`
- Semgrep against `origin/main`
- Direct two-pass application of all four descriptors to the raw `26.707.31428` DMG
- Current hotkey-class marker, strict ESM, source-map placement, and syntax checks
- Isolated build and packed-ASAR inspection with `appshots` enabled
