### PR TITLE
Fix Copilot reasoning effort chunks for current app

### DIFF
--- a/linux-features/copilot-reasoning-effort/README.md
+++ b/linux-features/copilot-reasoning-effort/README.md
@@ -25,12 +25,12 @@ feature to the generated app.
 
 ## What It Patches
 
-- `use-model-settings-*.js` reads and writes
-  `copilot-default-reasoning-effort` next to `copilot-default-model`.
-- `font-settings-*.js` keeps the model's full `supportedReasoningEfforts` list
-  for Copilot auth instead of forcing only `medium`.
-- `index-*.js` keeps reasoning effort dropdown entries and the `/reasoning`
-  command enabled when the normal model and effort prerequisites are present.
+- The current `...quick-chat-window-page~chatg~k0ede4gb-*.js` bundle reads and
+  writes `copilot-default-reasoning-effort` next to `copilot-default-model` and
+  keeps the model's full `supportedReasoningEfforts` list for Copilot auth.
+- The current `...hotkey-window-thread-page~ho~iufn7mg3-*.js` bundle keeps the
+  reasoning effort controls and `/reasoning` command enabled when the normal
+  model and effort prerequisites are present.
 
 ## Validation
 

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -86,6 +86,15 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
 function applyCopilotReasoningEffortModelListPatch(currentSource) {
   const copilotReasoningFilterRegex =
     /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([^)]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
+  const currentCopilotReasoningFilterRegex =
+    /([A-Za-z_$][\w$]*)=\(([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.find\([^)]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\3\)\.filter\(/g;
+
+  if (currentCopilotReasoningFilterRegex.test(currentSource)) {
+    return currentSource.replace(
+      currentCopilotReasoningFilterRegex,
+      (_match, resultVar, _authMethodVar, effortsVar) => `${resultVar}=[...${effortsVar}].filter(`,
+    );
+  }
 
   if (!copilotReasoningFilterRegex.test(currentSource)) {
     if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
@@ -104,6 +113,43 @@ function applyCopilotReasoningEffortModelListPatch(currentSource) {
 
 function applyCopilotReasoningEffortUiPatch(currentSource) {
   let patchedSource = currentSource;
+
+  const currentComposerGateRegex =
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\?\.authMethod===`copilot`,([A-Za-z_$][\w$]*)=!([A-Za-z_$][\w$]*)(?:&&!\1)?(?=,)/;
+  const currentComposerGateMatch = currentComposerGateRegex.exec(patchedSource);
+  if (currentComposerGateMatch) {
+    const authMethodVar = currentComposerGateMatch[1];
+    patchedSource = patchedSource.replace(
+      currentComposerGateRegex,
+      "$1=$2?.authMethod===`copilot`,$3=!$4",
+    );
+
+    const currentDropdownNeedle = `reasoningEffortDisabled:${authMethodVar}`;
+    const currentDropdownIndex = patchedSource.indexOf(
+      currentDropdownNeedle,
+      currentComposerGateMatch.index,
+    );
+    if (
+      currentDropdownIndex >= currentComposerGateMatch.index &&
+      currentDropdownIndex < currentComposerGateMatch.index + 10_000
+    ) {
+      patchedSource =
+        patchedSource.slice(0, currentDropdownIndex) +
+        "reasoningEffortDisabled:!1" +
+        patchedSource.slice(currentDropdownIndex + currentDropdownNeedle.length);
+    } else if (!patchedSource.includes("reasoningEffortDisabled:!1")) {
+      console.warn(
+        "WARN: Could not find current Copilot reasoning effort dropdown gate - skipping current dropdown patch",
+      );
+    }
+  } else if (
+    patchedSource.includes("composer.increaseReasoningEffort") &&
+    patchedSource.includes("reasoningEffortDisabled:")
+  ) {
+    console.warn(
+      "WARN: Could not find current Copilot reasoning effort shortcut gate - skipping current UI patch",
+    );
+  }
 
   const reasoningDropdownPatch = "disabled:!1,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`";
   const reasoningDropdownRegex =
@@ -130,10 +176,22 @@ function applyCopilotReasoningEffortUiPatch(currentSource) {
 
   const slashCommandNeedle = "let w=s&&f&&!p,T;";
   const slashCommandPatch = "let w=s&&f,T;";
-  if (patchedSource.includes(slashCommandPatch)) {
+  const currentSlashCommandRegex =
+    /(composer\.reasoningSlashCommand\.title[\s\S]{0,1000}?let )([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)&&!0,([A-Za-z_$][\w$]*);/;
+  const currentSlashCommandPatchedRegex =
+    /(composer\.reasoningSlashCommand\.title[\s\S]{0,1000}?let )([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&!0,([A-Za-z_$][\w$]*);/;
+  if (
+    patchedSource.includes(slashCommandPatch) ||
+    currentSlashCommandPatchedRegex.test(patchedSource)
+  ) {
     // Already patched.
   } else if (patchedSource.includes(slashCommandNeedle)) {
     patchedSource = patchedSource.replace(slashCommandNeedle, slashCommandPatch);
+  } else if (currentSlashCommandRegex.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      currentSlashCommandRegex,
+      "$1$2=$3&&$4&&!0,$6;",
+    );
   } else if (patchedSource.includes("composer.reasoningSlashCommand.title")) {
     console.warn(
       "WARN: Could not find reasoning slash command enabled state - skipping Copilot reasoning slash command patch",
@@ -149,7 +207,7 @@ module.exports = {
       id: "settings",
       name: "copilot-reasoning-effort-settings",
       phase: "webview-asset",
-      pattern: /^(use-model-settings|use-collaboration-mode)-.*\.js$/,
+      pattern: /^(use-model-settings|use-collaboration-mode|app-initial~.*quick-chat-window-page~chatg~).*\.js$/,
       missingDescription: "model settings bundle",
       skipDescription: "Copilot reasoning effort settings patch",
       apply: applyCopilotReasoningEffortSettingsPatch,
@@ -158,7 +216,7 @@ module.exports = {
       id: "model-list",
       name: "copilot-reasoning-effort-model-list",
       phase: "webview-asset",
-      pattern: /^(font-settings|model-queries)-.*\.js$/,
+      pattern: /^(font-settings|model-queries|app-initial~.*quick-chat-window-page~chatg~).*\.js$/,
       missingDescription: "font settings bundle",
       skipDescription: "Copilot reasoning effort model list patch",
       apply: applyCopilotReasoningEffortModelListPatch,
@@ -167,7 +225,8 @@ module.exports = {
       id: "ui",
       name: "copilot-reasoning-effort-ui",
       phase: "webview-asset",
-      pattern: /^index-.*\.js$/,
+      pattern:
+        /^(index-.*|app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*)\.js$/,
       missingDescription: "webview index bundle",
       skipDescription: "Copilot reasoning effort UI patch",
       apply: applyCopilotReasoningEffortUiPatch,

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -35,8 +35,6 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
   const copilotSavePatchMarker = "copilot-default-reasoning-effort`,";
   const copilotAsyncSaveRegex =
     /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2,\{throwOnFailure:!0\}\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)(throw Error\(`Model settings host is unavailable`\);|return;)/;
-  const copilotSaveRegex =
-    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)return;/;
   if (patchedSource.includes(copilotSavePatchMarker)) {
     // Already patched.
   } else if (copilotAsyncSaveRegex.test(patchedSource)) {
@@ -57,23 +55,6 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
       ) =>
         `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){await ${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar},{throwOnFailure:!0});await ${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar},{throwOnFailure:!0});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})${unavailableTail}`,
     );
-  } else if (copilotSaveRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      copilotSaveRegex,
-      (
-        _match,
-        updateConversationVar,
-        modelArgVar,
-        effortArgVar,
-        isCopilotVar,
-        persistStateVar,
-        stateScopeVar,
-        loggerVar,
-        configVar,
-        hostReadyVar,
-      ) =>
-        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar}),${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})return;`,
-    );
   } else if (patchedSource.includes("copilot-default-model")) {
     console.warn(
       "WARN: Could not find Copilot default model writer - skipping Copilot reasoning effort persistence patch",
@@ -84,10 +65,10 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
 }
 
 function applyCopilotReasoningEffortModelListPatch(currentSource) {
-  const copilotReasoningFilterRegex =
-    /([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.supportedReasoningEfforts\.find\([^)]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\[\.\.\.\2\.supportedReasoningEfforts\]/g;
   const currentCopilotReasoningFilterRegex =
     /([A-Za-z_$][\w$]*)=\(([A-Za-z_$][\w$]*)===`copilot`\?\[([A-Za-z_$][\w$]*)\.find\([^)]*\)\?\?\{reasoningEffort:`medium`,description:`medium effort`\}\]:\3\)\.filter\(/g;
+  const patchedCurrentCopilotReasoningFilterRegex =
+    /[A-Za-z_$][\w$]*=\[\.\.\.[A-Za-z_$][\w$]*\]\.filter\(\(\{reasoningEffort:/;
 
   if (currentCopilotReasoningFilterRegex.test(currentSource)) {
     return currentSource.replace(
@@ -95,20 +76,16 @@ function applyCopilotReasoningEffortModelListPatch(currentSource) {
       (_match, resultVar, _authMethodVar, effortsVar) => `${resultVar}=[...${effortsVar}].filter(`,
     );
   }
-
-  if (!copilotReasoningFilterRegex.test(currentSource)) {
-    if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
-      console.warn(
-        "WARN: Could not find Copilot model reasoning effort filter - skipping Copilot reasoning effort model list patch",
-      );
-    }
+  if (patchedCurrentCopilotReasoningFilterRegex.test(currentSource)) {
     return currentSource;
   }
 
-  return currentSource.replace(
-    copilotReasoningFilterRegex,
-    (_, _authMethodVar, modelVar) => `[...${modelVar}.supportedReasoningEfforts]`,
-  );
+  if (currentSource.includes("reasoningEffort:`medium`") && currentSource.includes("supportedReasoningEfforts")) {
+    console.warn(
+      "WARN: Could not find current Copilot model reasoning effort filter - skipping Copilot reasoning effort model list patch",
+    );
+  }
+  return currentSource;
 }
 
 function applyCopilotReasoningEffortUiPatch(currentSource) {
@@ -151,42 +128,12 @@ function applyCopilotReasoningEffortUiPatch(currentSource) {
     );
   }
 
-  const reasoningDropdownPatch = "disabled:!1,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`";
-  const reasoningDropdownRegex =
-    /disabled:([A-Za-z_$][\w$]*),RightIcon:([A-Za-z_$][\w$]*)===([A-Za-z_$][\w$]*)\?rg:void 0,onSelect:\(\)=>\{([A-Za-z_$][\w$]*)\.get\(bh\)\.log\(\{eventName:`codex_composer_reasoning_effort_changed`/;
-  if (patchedSource.includes(reasoningDropdownPatch)) {
-    // Already patched.
-  } else if (reasoningDropdownRegex.test(patchedSource)) {
-    patchedSource = patchedSource.replace(
-      reasoningDropdownRegex,
-      (
-        _match,
-        _disabledVar,
-        effortVar,
-        selectedEffortVar,
-        scopeVar,
-      ) =>
-        `disabled:!1,RightIcon:${effortVar}===${selectedEffortVar}?rg:void 0,onSelect:()=>{${scopeVar}.get(bh).log({eventName:\`codex_composer_reasoning_effort_changed\``,
-    );
-  } else if (patchedSource.includes("codex_composer_reasoning_effort_changed")) {
-    console.warn(
-      "WARN: Could not find reasoning effort dropdown disabled state - skipping Copilot reasoning effort dropdown patch",
-    );
-  }
-
-  const slashCommandNeedle = "let w=s&&f&&!p,T;";
-  const slashCommandPatch = "let w=s&&f,T;";
   const currentSlashCommandRegex =
     /(composer\.reasoningSlashCommand\.title[\s\S]{0,1000}?let )([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&!([A-Za-z_$][\w$]*)&&!0,([A-Za-z_$][\w$]*);/;
   const currentSlashCommandPatchedRegex =
     /(composer\.reasoningSlashCommand\.title[\s\S]{0,1000}?let )([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)&&!0,([A-Za-z_$][\w$]*);/;
-  if (
-    patchedSource.includes(slashCommandPatch) ||
-    currentSlashCommandPatchedRegex.test(patchedSource)
-  ) {
+  if (currentSlashCommandPatchedRegex.test(patchedSource)) {
     // Already patched.
-  } else if (patchedSource.includes(slashCommandNeedle)) {
-    patchedSource = patchedSource.replace(slashCommandNeedle, slashCommandPatch);
   } else if (currentSlashCommandRegex.test(patchedSource)) {
     patchedSource = patchedSource.replace(
       currentSlashCommandRegex,
@@ -207,7 +154,7 @@ module.exports = {
       id: "settings",
       name: "copilot-reasoning-effort-settings",
       phase: "webview-asset",
-      pattern: /^(use-model-settings|use-collaboration-mode|app-initial~.*quick-chat-window-page~chatg~).*\.js$/,
+      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/,
       missingDescription: "model settings bundle",
       skipDescription: "Copilot reasoning effort settings patch",
       apply: applyCopilotReasoningEffortSettingsPatch,
@@ -216,7 +163,7 @@ module.exports = {
       id: "model-list",
       name: "copilot-reasoning-effort-model-list",
       phase: "webview-asset",
-      pattern: /^(font-settings|model-queries|app-initial~.*quick-chat-window-page~chatg~).*\.js$/,
+      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/,
       missingDescription: "font settings bundle",
       skipDescription: "Copilot reasoning effort model list patch",
       apply: applyCopilotReasoningEffortModelListPatch,
@@ -225,8 +172,7 @@ module.exports = {
       id: "ui",
       name: "copilot-reasoning-effort-ui",
       phase: "webview-asset",
-      pattern:
-        /^(index-.*|app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*)\.js$/,
+      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
       missingDescription: "webview index bundle",
       skipDescription: "Copilot reasoning effort UI patch",
       apply: applyCopilotReasoningEffortUiPatch,

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -25,6 +25,17 @@ function applyPatchTwice(patchFn, source) {
   return patched;
 }
 
+function withCapturedWarns(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 function copilotReasoningEffortSettingsFixture() {
   return [
     "function bwe(){let e=(0,Y.c)(3),t=wr(),{data:n,isLoading:r}=or(`copilot-default-model`),i=n??t.defaultModel,a;return e[0]!==r||e[1]!==i?(a={model:i,reasoningEffort:`medium`,profile:null,isLoading:r},e[0]=r,e[1]=i,e[2]=a):a=e[2],a}",
@@ -40,10 +51,23 @@ function currentCopilotReasoningEffortModelListFixture() {
   return "function Ge(){let t=`copilot`;return r.forEach(e=>{let n=t===`copilot`?[e.supportedReasoningEfforts.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];i.push({...e,supportedReasoningEfforts:n})})}";
 }
 
+function currentFilteredCopilotReasoningEffortModelListFixture() {
+  return "function Jv({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>vg(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c,hasModelSupportingMaxReasoningEffort:u,hasModelSupportingUltraReasoningEffort:d}}";
+}
+
 function copilotReasoningEffortUiFixture() {
   return [
     "function qU(){let E=o?.authMethod===`copilot`,D=ZH(T,f.model),O=QH(f.reasoningEffort,D),le=D.map(e=>{let{reasoningEffort:t}=e;return(0,$.jsx)(jm.Item,{\"data-reasoning-selected\":t===O?`true`:void 0,disabled:E,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`,metadata:{reasoning_effort:t}}),p(f.model,t),H()},children:(0,$.jsx)(nM,{effort:t})},t)})}",
     "function bY(e){let p=o?.authMethod===`copilot`;let w=s&&f&&!p,T;return{enabled:w,dependencies:T}}",
+  ].join("");
+}
+
+function currentCopilotReasoningEffortUiFixture() {
+  return [
+    "function dz(){let k=!Bm(u),A=a?.authMethod===`copilot`,j=!k&&!A,M=yh(d,m);return aO(`composer.increaseReasoningEffort`,()=>we(`increase`),{enabled:j}),(0,gz.jsx)(_m,{reasoningEffortDisabled:A})}",
+    "function unrelatedGate(){let q=a&&b&&!0,c;return q}",
+    "function uU(){let p=o?.authMethod===`copilot`;let E=i.formatMessage({id:`composer.reasoningSlashCommand.title`});let O=s&&f&&!p&&!0,k;return{enabled:O,dependencies:k}}",
+    "function permissionGate(){let A=O.length>0,j=!w&&!A;return{shouldAutoDenyPermissionRequest:j}}",
   ].join("");
 }
 
@@ -122,6 +146,18 @@ test("keeps all model reasoning efforts for current Copilot model query chunks",
   assert.doesNotMatch(patched, /description:`medium effort`/);
 });
 
+test("keeps filtered current app reasoning efforts for Copilot auth", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortModelListPatch,
+    currentFilteredCopilotReasoningEffortModelListFixture(),
+  );
+
+  assert.match(patched, /let t=i\?n\.supportedReasoningEfforts:n\.supportedReasoningEfforts\.filter/);
+  assert.match(patched, /a=\[\.\.\.t\]\.filter\(\(\{reasoningEffort:e\}\)=>vg\(e\)&&r\.has\(e\)\)/);
+  assert.doesNotMatch(patched, /e===`copilot`\?\[/);
+  assert.doesNotMatch(patched, /description:`medium effort`/);
+});
+
 test("allows Copilot auth to change reasoning effort from the UI", () => {
   const patched = applyPatchTwice(
     applyCopilotReasoningEffortUiPatch,
@@ -132,6 +168,39 @@ test("allows Copilot auth to change reasoning effort from the UI", () => {
   assert.match(patched, /let w=s&&f,T;/);
   assert.doesNotMatch(patched, /disabled:E,RightIcon:t===O\?rg:void 0/);
   assert.doesNotMatch(patched, /let w=s&&f&&!p,T;/);
+});
+
+test("allows Copilot auth to use the current app effort controls", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortUiPatch,
+    currentCopilotReasoningEffortUiFixture(),
+  );
+
+  assert.match(patched, /A=a\?\.authMethod===`copilot`,j=!k,M=/);
+  assert.match(patched, /reasoningEffortDisabled:!1/);
+  assert.match(patched, /let E=i\.formatMessage\(\{id:`composer\.reasoningSlashCommand\.title`\}\);let O=s&&f&&!0,k;/);
+  assert.doesNotMatch(patched, /j=!k&&!A/);
+  assert.doesNotMatch(patched, /reasoningEffortDisabled:A/);
+  assert.doesNotMatch(patched, /O=s&&f&&!p&&!0/);
+  assert.match(patched, /let q=a&&b&&!0,c/);
+  assert.match(patched, /A=O\.length>0,j=!w&&!A/);
+});
+
+test("current app UI drift warns without touching adjacent gates", () => {
+  const source = [
+    "function dz(){let k=!Bm(u),A=isCopilot(a),j=!k&&!A,M=yh(d,m);",
+    "return aO(`composer.increaseReasoningEffort`,()=>we(`increase`),{enabled:j}),",
+    "(0,gz.jsx)(_m,{reasoningEffortDisabled:A})}",
+    "function permissionGate(){let A=O.length>0,j=!w&&!A;return j}",
+  ].join("");
+  const { value, warnings } = withCapturedWarns(() =>
+    applyCopilotReasoningEffortUiPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /current Copilot reasoning effort shortcut gate/);
+  assert.match(value, /A=O\.length>0,j=!w&&!A/);
 });
 
 test("feature descriptor loader exposes the Copilot webview asset patches only when enabled", () => {
@@ -186,6 +255,38 @@ test("enabled feature descriptors patch matching webview assets", () => {
         readAsset(extractedDir, "index-fixture.js"),
         /disabled:!1,RightIcon:t===O\?rg:void 0/,
       );
+    });
+  });
+});
+
+test("enabled feature descriptors patch the current app settings chunk", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+  const currentSettingsChunk =
+    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js";
+  const currentUiChunk =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js";
+
+  withTempFeatureConfig(["copilot-reasoning-effort"], () => {
+    withTempDir((extractedDir) => {
+      writeAsset(
+        extractedDir,
+        currentSettingsChunk,
+        `${copilotReasoningEffortSettingsFixture()};${currentFilteredCopilotReasoningEffortModelListFixture()}`,
+      );
+      writeAsset(extractedDir, currentUiChunk, currentCopilotReasoningEffortUiFixture());
+      writeAsset(extractedDir, "index-fixture.js", copilotReasoningEffortUiFixture());
+
+      const descriptors = normalizePatchDescriptors(
+        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+      );
+      applyWebviewAssetPatchDescriptors(extractedDir, descriptors, {}, null);
+      const patched = readAsset(extractedDir, currentSettingsChunk);
+
+      assert.match(patched, /copilot-default-reasoning-effort/);
+      assert.match(patched, /a=\[\.\.\.t\]\.filter/);
+      assert.doesNotMatch(patched, /e===`copilot`\?\[/);
+      assert.match(readAsset(extractedDir, currentUiChunk), /reasoningEffortDisabled:!1/);
+      assert.match(readAsset(extractedDir, currentUiChunk), /O=s&&f&&!0,k/);
     });
   });
 });

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -39,27 +39,12 @@ function withCapturedWarns(fn) {
 function copilotReasoningEffortSettingsFixture() {
   return [
     "function bwe(){let e=(0,Y.c)(3),t=wr(),{data:n,isLoading:r}=or(`copilot-default-model`),i=n??t.defaultModel,a;return e[0]!==r||e[1]!==i?(a={model:i,reasoningEffort:`medium`,profile:null,isLoading:r},e[0]=r,e[1]=i,e[2]=a):a=e[2],a}",
-    "function $9(e=null){let t=j(fe),m=a?.authMethod===`copilot`,g=(0,q.useCallback)(async(t,n)=>!1,[]),c={profile:null},i=!0,r=`local`,s=`/tmp`,v=()=>{},y=()=>{};return{setModelAndReasoningEffort:(0,q.useCallback)(async(e,n)=>{try{if(await g(e,n))return;if(m){Jn(t,`copilot-default-model`,e);return}if(h.info(`Setting default model and reasoning effort`,{safe:{newModel:e,newEffort:n,profile:c.profile}}),!i)return;await Gt(`set-default-model-config-for-host`,{hostId:r,model:e,reasoningEffort:n,profile:c.profile}),await v(),await t.query.fetch(Ss,{hostId:r,cwd:s})}catch(e){y(e)}},[m,g,c.profile,v,i,r,t,y,s])}}",
+    "function $9(e=null){let t=j(fe),m=a?.authMethod===`copilot`,g=(0,q.useCallback)(async(t,n)=>!1,[]),c={profile:null},i=!0,r=`local`,s=`/tmp`,v=()=>{},y=()=>{};return{setModelAndReasoningEffort:(0,q.useCallback)(async(e,n)=>{try{if(await g(e,n))return;if(m){await Jn(t,`copilot-default-model`,e,{throwOnFailure:!0});return}if(h.info(`Setting default model and reasoning effort`,{safe:{newModel:e,newEffort:n,profile:c.profile}}),!i)throw Error(`Model settings host is unavailable`);await Gt(`set-default-model-config-for-host`,{hostId:r,model:e,reasoningEffort:n,profile:c.profile}),await v(),await t.query.fetch(Ss,{hostId:r,cwd:s})}catch(e){y(e)}},[m,g,c.profile,v,i,r,t,y,s])}}",
   ].join("");
-}
-
-function copilotReasoningEffortModelListFixture() {
-  return "function Ge(){let s=`copilot`,d={};return e.forEach(e=>{let t=s===`copilot`?[e.supportedReasoningEfforts.find(Ue)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];d.models.push({...e,supportedReasoningEfforts:t})})}";
-}
-
-function currentCopilotReasoningEffortModelListFixture() {
-  return "function Ge(){let t=`copilot`;return r.forEach(e=>{let n=t===`copilot`?[e.supportedReasoningEfforts.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:[...e.supportedReasoningEfforts];i.push({...e,supportedReasoningEfforts:n})})}";
 }
 
 function currentFilteredCopilotReasoningEffortModelListFixture() {
   return "function Jv({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>vg(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c,hasModelSupportingMaxReasoningEffort:u,hasModelSupportingUltraReasoningEffort:d}}";
-}
-
-function copilotReasoningEffortUiFixture() {
-  return [
-    "function qU(){let E=o?.authMethod===`copilot`,D=ZH(T,f.model),O=QH(f.reasoningEffort,D),le=D.map(e=>{let{reasoningEffort:t}=e;return(0,$.jsx)(jm.Item,{\"data-reasoning-selected\":t===O?`true`:void 0,disabled:E,RightIcon:t===O?rg:void 0,onSelect:()=>{i.get(bh).log({eventName:`codex_composer_reasoning_effort_changed`,metadata:{reasoning_effort:t}}),p(f.model,t),H()},children:(0,$.jsx)(nM,{effort:t})},t)})}",
-    "function bY(e){let p=o?.authMethod===`copilot`;let w=s&&f&&!p,T;return{enabled:w,dependencies:T}}",
-  ].join("");
 }
 
 function currentCopilotReasoningEffortUiFixture() {
@@ -118,32 +103,10 @@ test("persists Copilot reasoning effort with the default Copilot model", () => {
   assert.match(patched, /isLoading:r\|\|codexCopilotReasoningEffortLoading/);
   assert.match(
     patched,
-    /Jn\(t,`copilot-default-model`,e\),Jn\(t,`copilot-default-reasoning-effort`,n\);return/,
+    /await Jn\(t,`copilot-default-model`,e,\{throwOnFailure:!0\}\);await Jn\(t,`copilot-default-reasoning-effort`,n,\{throwOnFailure:!0\}\);return/,
   );
   assert.doesNotMatch(patched, /reasoningEffort:`medium`,profile:null,isLoading:r/);
-  assert.doesNotMatch(patched, /Jn\(t,`copilot-default-model`,e\);return/);
-});
-
-test("keeps all model reasoning efforts available for Copilot auth", () => {
-  const patched = applyPatchTwice(
-    applyCopilotReasoningEffortModelListPatch,
-    copilotReasoningEffortModelListFixture(),
-  );
-
-  assert.match(patched, /let t=\[\.\.\.e\.supportedReasoningEfforts\]/);
-  assert.doesNotMatch(patched, /s===`copilot`\?\[/);
-  assert.doesNotMatch(patched, /description:`medium effort`/);
-});
-
-test("keeps all model reasoning efforts for current Copilot model query chunks", () => {
-  const patched = applyPatchTwice(
-    applyCopilotReasoningEffortModelListPatch,
-    currentCopilotReasoningEffortModelListFixture(),
-  );
-
-  assert.match(patched, /let n=\[\.\.\.e\.supportedReasoningEfforts\]/);
-  assert.doesNotMatch(patched, /t===`copilot`\?\[/);
-  assert.doesNotMatch(patched, /description:`medium effort`/);
+  assert.doesNotMatch(patched, /await Jn\(t,`copilot-default-model`,e,\{throwOnFailure:!0\}\);return/);
 });
 
 test("keeps filtered current app reasoning efforts for Copilot auth", () => {
@@ -156,18 +119,11 @@ test("keeps filtered current app reasoning efforts for Copilot auth", () => {
   assert.match(patched, /a=\[\.\.\.t\]\.filter\(\(\{reasoningEffort:e\}\)=>vg\(e\)&&r\.has\(e\)\)/);
   assert.doesNotMatch(patched, /e===`copilot`\?\[/);
   assert.doesNotMatch(patched, /description:`medium effort`/);
-});
-
-test("allows Copilot auth to change reasoning effort from the UI", () => {
-  const patched = applyPatchTwice(
-    applyCopilotReasoningEffortUiPatch,
-    copilotReasoningEffortUiFixture(),
+  const { value, warnings } = withCapturedWarns(() =>
+    applyCopilotReasoningEffortModelListPatch(patched),
   );
-
-  assert.match(patched, /disabled:!1,RightIcon:t===O\?rg:void 0/);
-  assert.match(patched, /let w=s&&f,T;/);
-  assert.doesNotMatch(patched, /disabled:E,RightIcon:t===O\?rg:void 0/);
-  assert.doesNotMatch(patched, /let w=s&&f&&!p,T;/);
+  assert.equal(value, patched);
+  assert.deepEqual(warnings, []);
 });
 
 test("allows Copilot auth to use the current app effort controls", () => {
@@ -226,36 +182,14 @@ test("feature descriptor loader exposes the Copilot webview asset patches only w
       ["webview-asset", "webview-asset", "webview-asset"],
     );
     assert.ok(descriptors.every((descriptor) => descriptor.ciPolicy === "optional"));
-  });
-});
-
-test("enabled feature descriptors patch matching webview assets", () => {
-  const featuresRoot = path.resolve(__dirname, "..");
-
-  withTempFeatureConfig(["copilot-reasoning-effort"], () => {
-    withTempDir((extractedDir) => {
-      writeAsset(extractedDir, "use-collaboration-mode-fixture.js", copilotReasoningEffortSettingsFixture());
-      writeAsset(extractedDir, "model-queries-fixture.js", currentCopilotReasoningEffortModelListFixture());
-      writeAsset(extractedDir, "index-fixture.js", copilotReasoningEffortUiFixture());
-
-      const descriptors = normalizePatchDescriptors(
-        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
-      );
-      applyWebviewAssetPatchDescriptors(extractedDir, descriptors, {}, null);
-
-      assert.match(
-        readAsset(extractedDir, "use-collaboration-mode-fixture.js"),
-        /copilot-default-reasoning-effort/,
-      );
-      assert.match(
-        readAsset(extractedDir, "model-queries-fixture.js"),
-        /\[\.\.\.e\.supportedReasoningEfforts\]/,
-      );
-      assert.match(
-        readAsset(extractedDir, "index-fixture.js"),
-        /disabled:!1,RightIcon:t===O\?rg:void 0/,
-      );
-    });
+    const currentSettingsChunk =
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-current.js";
+    const currentUiChunk =
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js";
+    assert.match(currentSettingsChunk, descriptors[0].pattern);
+    assert.match(currentSettingsChunk, descriptors[1].pattern);
+    assert.match(currentUiChunk, descriptors[2].pattern);
+    assert.ok(descriptors.every((descriptor) => !descriptor.pattern.test("unrelated-bundle.js")));
   });
 });
 
@@ -274,7 +208,6 @@ test("enabled feature descriptors patch the current app settings chunk", () => {
         `${copilotReasoningEffortSettingsFixture()};${currentFilteredCopilotReasoningEffortModelListFixture()}`,
       );
       writeAsset(extractedDir, currentUiChunk, currentCopilotReasoningEffortUiFixture());
-      writeAsset(extractedDir, "index-fixture.js", copilotReasoningEffortUiFixture());
 
       const descriptors = normalizePatchDescriptors(
         loadLinuxFeaturePatchDescriptors({ featuresRoot }),


### PR DESCRIPTION
## Summary

- Match only the current quick-chat settings/model-list bundle and composer UI bundle used by the `26.707.31428` app.
- Enable the current Copilot effort dropdown, keyboard actions, and `/reasoning` command while preserving adjacent permission gates.
- Remove older-DMG regexes, descriptor targets, fixtures, and documentation so the feature follows the repository current-DMG-only policy.

## Validation

- `node --test linux-features/copilot-reasoning-effort/test.js`
- `node --test linux-features/*/test.js` — 414 tests passed
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- Exact `26.707.31428` settings/model/UI application with warning-free idempotence
- `node --check` on both patched current bundles
- Legacy target/fixture marker scan