### PR TITLE
Fix current ui-tweaks sidebar bundle

### DIFF
--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -2,7 +2,7 @@
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN =
-  /^app-initial~app-main~page-[^.]+\.js$/;
+  /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/;
 const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pr-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -137,6 +137,10 @@ test("English reasoning effort labels can be disabled", () => {
 
 test("sidebar project descriptor targets only the current project sidebar asset", () => {
   assert.match(
+    "app-initial~app-main~projects-index-page~remote-conversation-page-CFT2LLOB.js",
+    PROJECTS_SIDEBAR_ASSET_PATTERN,
+  );
+  assert.doesNotMatch(
     "app-initial~app-main~page-BF1QkwFT.js",
     PROJECTS_SIDEBAR_ASSET_PATTERN,
   );


### PR DESCRIPTION
## Summary

- Retarget the opt-in sidebar project-name style to the current projects-index and remote-conversation bundle.
- Stop matching the retired generic app page chunk, which no longer contains the sidebar markers.
- Add exact positive and stale-target regression coverage without changing the existing style runtime or configuration behavior.

## Validation

- `node --test linux-features/ui-tweaks/test.js`
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `cargo check --workspace`
- `cargo test --workspace`
- ShellCheck and Semgrep on the changed JavaScript files
- Isolated build and packed-ASAR inspection against the `26.707.31428` DMG
- Local merge with #756, including the combined `ui-tweaks` suite and real-DMG feature application