### PR TITLE
[codex] Add optional GPT-5.6 model picker tweak

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -17,6 +17,7 @@ Enable it in the local, gitignored feature config:
 
 | Tweak | Patch module | What it does | Settings |
 | --- | --- | --- | --- |
+| `modelPicker.showModelsByDefault` | `patches/model-picker-model-list.js` | Opens the advanced picker by default and shows model choices inline instead of hiding them behind the compact Power slider and a nested Model submenu. | `tweaks.modelPicker.showModelsByDefault.enabled` |
 | `sidebar.projectName` | `patches/sidebar-project-name.js` | Styles project names in the left sidebar project list. It does not style `Projects` / `Chats` section headings and does not style chat rows. | `tweaks.sidebar.projectName.enabled`, `tweaks.sidebar.projectName.style` |
 
 ## Settings
@@ -45,6 +46,18 @@ Example local config:
 ```
 
 Each tweak documents its own config keys below.
+
+### `modelPicker.showModelsByDefault`
+
+Makes the detailed model list the default Codex composer picker view. The model
+rows are rendered inline, so newly available families such as GPT-5.6 Luna,
+Terra, and Sol remain visible without first switching away from the compact
+Power slider or opening a nested Model submenu.
+
+Config keys:
+
+- `enabled`: `true` applies the tweak, `false` keeps the feature enabled but
+  leaves the upstream model picker unchanged.
 
 ### `sidebar.projectName`
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -7,6 +7,11 @@
     "patchDescriptors": "./patch.js"
   },
   "tweaks": {
+    "modelPicker": {
+      "showModelsByDefault": {
+        "enabled": true
+      }
+    },
     "sidebar": {
       "projectName": {
         "enabled": true,

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const sidebarProjectName = require("./patches/sidebar-project-name.js");
+const modelPickerModelList = require("./patches/model-picker-model-list.js");
 
 function patchesFrom(...modules) {
   return modules.flatMap((moduleExports) =>
@@ -9,5 +10,5 @@ function patchesFrom(...modules) {
 }
 
 module.exports = {
-  descriptors: patchesFrom(sidebarProjectName),
+  descriptors: patchesFrom(sidebarProjectName, modelPickerModelList),
 };

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -1,0 +1,200 @@
+"use strict";
+
+const MODEL_PICKER_STATE_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
+const MODEL_PICKER_MENU_ASSET_PATTERN =
+  /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/;
+const SIMPLE_MENU_VIEW_PATTERN =
+  /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
+const ADVANCED_MENU_VIEW_PATTERN =
+  /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v2`,`advanced`\)/;
+const MODEL_TITLE_MARKER = "composer.intelligenceDropdown.model.title";
+const MODEL_ROW_MARKER = "composer.intelligenceDropdown.model.rowLabel";
+const EFFORT_TITLE_MARKER = "composer.intelligenceDropdown.effort.title";
+const INLINE_MODEL_LIST_RUNTIME_MARKER = "codex-linux-inline-model-list";
+const MODEL_ALLOWLIST_MARKER = "l?t.has(n.model):!n.hidden";
+const GPT_56_ALLOWLIST_MARKER =
+  "l?t.has(n.model)||n.model.startsWith(`gpt-5.6-`)&&!n.hidden:!n.hidden";
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping ui-tweaks model picker patch`);
+}
+
+function modelPickerConfig(context) {
+  const defaults = context?.feature?.manifest?.tweaks?.modelPicker?.showModelsByDefault;
+  const settings = context?.feature?.settings?.tweaks?.modelPicker?.showModelsByDefault;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
+}
+
+function enabled(context) {
+  return modelPickerConfig(context).enabled !== false;
+}
+
+function applyDefaultAdvancedViewPatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context) || ADVANCED_MENU_VIEW_PATTERN.test(source)) {
+      return source;
+    }
+    if (!SIMPLE_MENU_VIEW_PATTERN.test(source)) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the persisted model picker view marker");
+      }
+      return source;
+    }
+
+    return source.replace(
+      SIMPLE_MENU_VIEW_PATTERN,
+      '$1=$2(`composer-model-picker-menu-view-v2`,`advanced`)',
+    );
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+function findInlineModelListVariable(source) {
+  const titleIndex = source.indexOf(MODEL_TITLE_MARKER);
+  const rowIndex = source.indexOf(MODEL_ROW_MARKER, titleIndex);
+  if (titleIndex < 0 || rowIndex < 0) {
+    return null;
+  }
+
+  const section = source.slice(titleIndex, rowIndex);
+  const assignments = [
+    ...section.matchAll(/let\s+([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*),[A-Za-z_$][\w$]*;/g),
+  ];
+  return assignments.at(-1)?.[1] ?? null;
+}
+
+function applyInlineModelListPatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context) || source.includes(INLINE_MODEL_LIST_RUNTIME_MARKER)) {
+      return source;
+    }
+
+    const inlineModelListVariable = findInlineModelListVariable(source);
+    const effortIndex = source.indexOf(EFFORT_TITLE_MARKER);
+    if (inlineModelListVariable == null || effortIndex < 0) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the model list and advanced picker markers");
+      }
+      return source;
+    }
+
+    const tail = source.slice(effortIndex);
+    const advancedChildrenPattern =
+      /(let\s+[A-Za-z_$][\w$]*=\(0,([A-Za-z_$][\w$]*)\.jsxs\)\(\2\.Fragment,\{children:\[)([A-Za-z_$][\w$]*),/;
+    const match = tail.match(advancedChildrenPattern);
+    if (match == null) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the advanced picker child list");
+      }
+      return source;
+    }
+
+    const patchedTail = tail.replace(
+      advancedChildrenPattern,
+      `$1${inlineModelListVariable},/*${INLINE_MODEL_LIST_RUNTIME_MARKER}*/`,
+    );
+    return source.slice(0, effortIndex) + patchedTail;
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+function applyGpt56AllowlistPatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context) || source.includes(GPT_56_ALLOWLIST_MARKER)) {
+      return source;
+    }
+    if (!source.includes(MODEL_ALLOWLIST_MARKER)) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the model availability allowlist marker");
+      }
+      return source;
+    }
+
+    return source.replace(MODEL_ALLOWLIST_MARKER, GPT_56_ALLOWLIST_MARKER);
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+function applyModelPickerModelListPatch(source, context = {}) {
+  return applyInlineModelListPatch(
+    applyGpt56AllowlistPatch(applyDefaultAdvancedViewPatch(source, context), context),
+    context,
+  );
+}
+
+const descriptors = [
+  {
+    id: "model-picker-default-advanced-view",
+    phase: "webview-asset",
+    order: 20_794,
+    ciPolicy: "optional",
+    pattern: MODEL_PICKER_STATE_ASSET_PATTERN,
+    missingDescription: "composer model picker state bundle",
+    skipDescription: "ui-tweaks model picker default advanced view patch",
+    apply: (source, context = {}) =>
+      applyDefaultAdvancedViewPatch(source, { ...context, warnOnMissingMarkers: true }),
+  },
+  {
+    id: "model-picker-include-gpt-5-6",
+    phase: "webview-asset",
+    order: 20_795,
+    ciPolicy: "optional",
+    pattern: MODEL_PICKER_MENU_ASSET_PATTERN,
+    missingDescription: "composer model picker menu bundle",
+    skipDescription: "ui-tweaks GPT-5.6 model allowlist patch",
+    apply: (source, context = {}) =>
+      applyGpt56AllowlistPatch(source, { ...context, warnOnMissingMarkers: true }),
+  },
+  {
+    id: "model-picker-inline-model-list",
+    phase: "webview-asset",
+    order: 20_796,
+    ciPolicy: "optional",
+    pattern: MODEL_PICKER_MENU_ASSET_PATTERN,
+    missingDescription: "composer model picker menu bundle",
+    skipDescription: "ui-tweaks model picker inline model list patch",
+    apply: (source, context = {}) =>
+      applyInlineModelListPatch(source, { ...context, warnOnMissingMarkers: true }),
+  },
+];
+
+module.exports = {
+  ADVANCED_MENU_VIEW_PATTERN,
+  EFFORT_TITLE_MARKER,
+  GPT_56_ALLOWLIST_MARKER,
+  INLINE_MODEL_LIST_RUNTIME_MARKER,
+  MODEL_ALLOWLIST_MARKER,
+  MODEL_PICKER_MENU_ASSET_PATTERN,
+  MODEL_PICKER_STATE_ASSET_PATTERN,
+  MODEL_ROW_MARKER,
+  MODEL_TITLE_MARKER,
+  SIMPLE_MENU_VIEW_PATTERN,
+  applyDefaultAdvancedViewPatch,
+  applyGpt56AllowlistPatch,
+  applyInlineModelListPatch,
+  applyModelPickerModelListPatch,
+  descriptors,
+  findInlineModelListVariable,
+};

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -12,6 +12,18 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  ADVANCED_MENU_VIEW_PATTERN,
+  GPT_56_ALLOWLIST_MARKER,
+  INLINE_MODEL_LIST_RUNTIME_MARKER,
+  MODEL_ALLOWLIST_MARKER,
+  MODEL_PICKER_MENU_ASSET_PATTERN,
+  MODEL_PICKER_STATE_ASSET_PATTERN,
+  SIMPLE_MENU_VIEW_PATTERN,
+  applyDefaultAdvancedViewPatch,
+  applyGpt56AllowlistPatch,
+  applyInlineModelListPatch,
+} = require("./patches/model-picker-model-list.js");
+const {
   DEFAULT_PROJECT_NAME_STYLE,
   PROJECTS_SIDEBAR_ASSET_PATTERN,
   PROJECT_NAME_SELECTOR,
@@ -26,6 +38,27 @@ function projectBundleFixture() {
   return [
     "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
     "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pr-1`,children:p});return [j,V]}",
+  ].join("");
+}
+
+function modelPickerStateBundleFixture() {
+  return [
+    "function picker(){",
+    "vz=wu(`composer-model-picker-menu-view-v1`,`simple`);",
+    "}",
+  ].join("");
+}
+
+function modelPickerMenuBundleFixture() {
+  return [
+    "function menu(){",
+    "id:`composer.intelligenceDropdown.model.title`;",
+    `const allowed=${MODEL_ALLOWLIST_MARKER};`,
+    "let ue=fragment;let de=ue,fe;",
+    "id:`composer.intelligenceDropdown.model.rowLabel`;",
+    "id:`composer.intelligenceDropdown.effort.title`;",
+    "let we=(0,c6.jsxs)(c6.Fragment,{children:[ye,effort]});",
+    "}",
   ].join("");
 }
 
@@ -73,11 +106,86 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
     const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
     assert.deepEqual(
       descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
-      [["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"]],
+      [
+        ["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"],
+        ["feature:ui-tweaks:model-picker-default-advanced-view", "webview-asset", "optional"],
+        ["feature:ui-tweaks:model-picker-include-gpt-5-6", "webview-asset", "optional"],
+        ["feature:ui-tweaks:model-picker-inline-model-list", "webview-asset", "optional"],
+      ],
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+test("model picker descriptors target the current state and menu bundles", () => {
+  assert.match(
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    MODEL_PICKER_STATE_ASSET_PATTERN,
+  );
+  assert.match(
+    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
+    MODEL_PICKER_MENU_ASSET_PATTERN,
+  );
+  assert.doesNotMatch(
+    "app-initial~app-main~page-BF1QkwFT.js",
+    MODEL_PICKER_STATE_ASSET_PATTERN,
+  );
+  assert.doesNotMatch(
+    "app-initial~app-main~page-BF1QkwFT.js",
+    MODEL_PICKER_MENU_ASSET_PATTERN,
+  );
+});
+
+test("model picker opens advanced view and renders model choices inline", () => {
+  const stateSource = modelPickerStateBundleFixture();
+  const menuSource = modelPickerMenuBundleFixture();
+  const patchedState = applyDefaultAdvancedViewPatch(stateSource);
+  const allowlistedMenu = applyGpt56AllowlistPatch(menuSource);
+  const patchedMenu = applyInlineModelListPatch(allowlistedMenu);
+
+  assert.match(patchedState, ADVANCED_MENU_VIEW_PATTERN);
+  assert.doesNotMatch(patchedState, SIMPLE_MENU_VIEW_PATTERN);
+  assert.match(patchedMenu, new RegExp(GPT_56_ALLOWLIST_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.doesNotMatch(patchedMenu, new RegExp(MODEL_ALLOWLIST_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(patchedMenu, new RegExp(INLINE_MODEL_LIST_RUNTIME_MARKER));
+  assert.match(patchedMenu, /children:\[de,\/\*codex-linux-inline-model-list\*\//);
+  assert.equal(applyDefaultAdvancedViewPatch(patchedState), patchedState);
+  assert.equal(applyGpt56AllowlistPatch(patchedMenu), patchedMenu);
+  assert.equal(applyInlineModelListPatch(patchedMenu), patchedMenu);
+});
+
+test("model picker tweak can be disabled through feature settings", () => {
+  const stateSource = modelPickerStateBundleFixture();
+  const menuSource = modelPickerMenuBundleFixture();
+  const context = {
+    feature: {
+      settings: {
+        tweaks: {
+          modelPicker: {
+            showModelsByDefault: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  assert.equal(applyDefaultAdvancedViewPatch(stateSource, context), stateSource);
+  assert.equal(applyGpt56AllowlistPatch(menuSource, context), menuSource);
+  assert.equal(applyInlineModelListPatch(menuSource, context), menuSource);
+});
+
+test("model picker drift warns and leaves the asset unchanged", () => {
+  const source = "console.log('model picker drifted');";
+  const { value, warnings } = withCapturedWarns(() =>
+    applyDefaultAdvancedViewPatch(source, { warnOnMissingMarkers: true }),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^WARN: Could not find the persisted model picker view marker/);
 });
 
 test("sidebar project descriptor targets only the current project sidebar asset", () => {


### PR DESCRIPTION
## Summary

- add an optional `ui-tweaks` model picker setting
- open the advanced picker by default and render model choices inline
- include non-hidden `gpt-5.6-*` models when the upstream `available_models` whitelist is stale

## Why

The local app-server already returns GPT-5.6 Sol, Terra, and Luna with
`hidden: false`, but the Desktop frontend can still remove them through its
feature-config model whitelist. This leaves the CLI able to select the models
while the Desktop model picker does not show them.

The patch preserves the existing whitelist behavior for other model families
and only admits visible GPT-5.6 models. It is fail-soft, idempotent, and lives
inside the disabled-by-default `ui-tweaks` feature.

## User impact

Users who enable `ui-tweaks` can see and select GPT-5.6 Sol, Terra, and Luna
directly from the composer model picker. Baseline installations are unchanged.

## Validation

- `node --test linux-features/ui-tweaks/test.js`
- `git diff --check`
- verified in the real Electron window on Fedora 44 with the RPM build; the
  picker displayed Sol, Terra, and Luna alongside the existing model families
