### PR TITLE
[codex] Keep reasoning effort labels in English

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -17,6 +17,7 @@ Enable it in the local, gitignored feature config:
 
 | Tweak | Patch module | What it does | Settings |
 | --- | --- | --- | --- |
+| `reasoning.keepEffortLabelsEnglish` | `patches/reasoning-effort-labels.js` | Keeps reasoning effort values in English in the Simplified Chinese UI while leaving the surrounding interface translated. | `tweaks.reasoning.keepEffortLabelsEnglish.enabled` |
 | `sidebar.projectName` | `patches/sidebar-project-name.js` | Styles project names in the left sidebar project list. It does not style `Projects` / `Chats` section headings and does not style chat rows. | `tweaks.sidebar.projectName.enabled`, `tweaks.sidebar.projectName.style` |
 
 ## Settings
@@ -45,6 +46,19 @@ Example local config:
 ```
 
 Each tweak documents its own config keys below.
+
+### `reasoning.keepEffortLabelsEnglish`
+
+Leaves the reasoning effort values as `None`, `Minimal`, `Low`, `Medium`,
+`High`, `XHigh`, `Max`, and `Ultra` in the Simplified Chinese locale. The
+surrounding picker title and usage warning remain translated. This avoids
+collapsing distinct upstream values such as `XHigh` and `Ultra` into the same
+Chinese label.
+
+Config keys:
+
+- `enabled`: `true` applies the tweak, `false` keeps the feature enabled but
+  uses the upstream translated effort labels.
 
 ### `sidebar.projectName`
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -7,6 +7,11 @@
     "patchDescriptors": "./patch.js"
   },
   "tweaks": {
+    "reasoning": {
+      "keepEffortLabelsEnglish": {
+        "enabled": true
+      }
+    },
     "sidebar": {
       "projectName": {
         "enabled": true,

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const sidebarProjectName = require("./patches/sidebar-project-name.js");
+const reasoningEffortLabels = require("./patches/reasoning-effort-labels.js");
 
 function patchesFrom(...modules) {
   return modules.flatMap((moduleExports) =>
@@ -9,5 +10,5 @@ function patchesFrom(...modules) {
 }
 
 module.exports = {
-  descriptors: patchesFrom(sidebarProjectName),
+  descriptors: patchesFrom(sidebarProjectName, reasoningEffortLabels),
 };

--- a/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
+++ b/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
@@ -1,0 +1,91 @@
+"use strict";
+
+const ZH_CN_LOCALE_ASSET_PATTERN = /^zh-CN-[^.]+\.js$/;
+const ENGLISH_REASONING_LABELS = Object.freeze({
+  "composer.mode.local.reasoning.none.label": "None",
+  "composer.mode.local.reasoning.minimal.label": "Minimal",
+  "composer.mode.local.reasoning.low.label": "Low",
+  "composer.mode.local.reasoning.medium.label": "Medium",
+  "composer.mode.local.reasoning.high.label": "High",
+  "composer.mode.local.reasoning.xhigh.label": "XHigh",
+  "composer.mode.local.reasoning.max.label": "Max",
+  "composer.mode.local.reasoning.ultra.label": "Ultra",
+});
+
+function warn(message) {
+  console.warn(`WARN: ${message} - skipping missing ui-tweaks reasoning label markers`);
+}
+
+function reasoningLabelConfig(context) {
+  const defaults = context?.feature?.manifest?.tweaks?.reasoning?.keepEffortLabelsEnglish;
+  const settings = context?.feature?.settings?.tweaks?.reasoning?.keepEffortLabelsEnglish;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
+}
+
+function enabled(context) {
+  return reasoningLabelConfig(context).enabled !== false;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function applyEnglishReasoningLabels(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context)) {
+      return source;
+    }
+
+    let patched = source;
+    const missingKeys = [];
+    for (const [key, label] of Object.entries(ENGLISH_REASONING_LABELS)) {
+      const replacement = `"${key}":\`${label}\``;
+      if (patched.includes(replacement)) {
+        continue;
+      }
+
+      const pattern = new RegExp(`"${escapeRegExp(key)}":\\\`[^\\\`]*\\\``);
+      if (!pattern.test(patched)) {
+        missingKeys.push(key);
+        continue;
+      }
+      patched = patched.replace(pattern, replacement);
+    }
+
+    if (missingKeys.length > 0 && context.warnOnMissingMarkers === true) {
+      warn(`Could not find ${missingKeys.join(", ")}`);
+    }
+    return patched;
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
+const descriptors = [
+  {
+    id: "reasoning-effort-labels-english",
+    phase: "webview-asset",
+    order: 20_797,
+    ciPolicy: "optional",
+    pattern: ZH_CN_LOCALE_ASSET_PATTERN,
+    missingDescription: "Simplified Chinese locale bundle",
+    skipDescription: "ui-tweaks English reasoning effort label patch",
+    apply: (source, context = {}) =>
+      applyEnglishReasoningLabels(source, { ...context, warnOnMissingMarkers: true }),
+  },
+];
+
+module.exports = {
+  ENGLISH_REASONING_LABELS,
+  ZH_CN_LOCALE_ASSET_PATTERN,
+  applyEnglishReasoningLabels,
+  descriptors,
+};

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -21,12 +21,33 @@ const {
   descriptors: patches,
   sidebarProjectNameCss,
 } = require("./patches/sidebar-project-name.js");
+const {
+  ENGLISH_REASONING_LABELS,
+  ZH_CN_LOCALE_ASSET_PATTERN,
+  applyEnglishReasoningLabels,
+} = require("./patches/reasoning-effort-labels.js");
 
 function projectBundleFixture() {
   return [
     "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
     "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pr-1`,children:p});return [j,V]}",
   ].join("");
+}
+
+function simplifiedChineseLocaleFixture() {
+  const labels = {
+    "composer.mode.local.reasoning.none.label": "无",
+    "composer.mode.local.reasoning.minimal.label": "极低",
+    "composer.mode.local.reasoning.low.label": "轻度",
+    "composer.mode.local.reasoning.medium.label": "中",
+    "composer.mode.local.reasoning.high.label": "高",
+    "composer.mode.local.reasoning.xhigh.label": "极高",
+    "composer.mode.local.reasoning.max.label": "最高",
+    "composer.mode.local.reasoning.ultra.label": "极高",
+  };
+  return Object.entries(labels)
+    .map(([key, value]) => `"${key}":\`${value}\``)
+    .join(",");
 }
 
 function applyPatchTwice(source, context) {
@@ -73,11 +94,45 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
     const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot });
     assert.deepEqual(
       descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
-      [["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"]],
+      [
+        ["feature:ui-tweaks:sidebar-project-name-style", "webview-asset", "optional"],
+        ["feature:ui-tweaks:reasoning-effort-labels-english", "webview-asset", "optional"],
+      ],
     );
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
+});
+
+test("reasoning effort labels stay in English in the Simplified Chinese locale", () => {
+  const source = simplifiedChineseLocaleFixture();
+  const patched = applyEnglishReasoningLabels(source);
+
+  for (const [key, label] of Object.entries(ENGLISH_REASONING_LABELS)) {
+    assert.match(patched, new RegExp(`"${key.replaceAll(".", "\\.")}":\\\`${label}\\\``));
+  }
+  assert.equal(applyEnglishReasoningLabels(patched), patched);
+  assert.match("zh-CN-BPHwMaw8.js", ZH_CN_LOCALE_ASSET_PATTERN);
+  assert.doesNotMatch("zh-TW-rBlCyjlT.js", ZH_CN_LOCALE_ASSET_PATTERN);
+});
+
+test("English reasoning effort labels can be disabled", () => {
+  const source = simplifiedChineseLocaleFixture();
+  const context = {
+    feature: {
+      settings: {
+        tweaks: {
+          reasoning: {
+            keepEffortLabelsEnglish: {
+              enabled: false,
+            },
+          },
+        },
+      },
+    },
+  };
+
+  assert.equal(applyEnglishReasoningLabels(source, context), source);
 });
 
 test("sidebar project descriptor targets only the current project sidebar asset", () => {


### PR DESCRIPTION
## Summary

- add an optional Simplified Chinese locale tweak for reasoning effort values
- keep `None`, `Minimal`, `Low`, `Medium`, `High`, `XHigh`, `Max`, and `Ultra`
  in English
- leave the surrounding picker title and usage warning translated

## Why

The current Simplified Chinese locale translates both `XHigh` and `Ultra` as
`极高`, even though they are separate upstream effort values. Keeping the enum
values in English avoids ambiguous duplicate labels and preserves the exact
terminology used by the CLI and configuration files.

The patch is fail-soft, idempotent, scoped only to the `zh-CN` locale bundle,
and lives inside the disabled-by-default `ui-tweaks` feature.

## User impact

Users who enable `ui-tweaks` and use Simplified Chinese retain a translated
interface while seeing unambiguous reasoning effort values. Baseline
installations and other locales are unchanged.

## Validation

- `node --test linux-features/ui-tweaks/test.js`
- `git diff --check`
- verified the installed `zh-CN` asset contains all eight English labels
