### PR TITLE
Add opt-in API key model visibility feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ workarounds.
 |---|---|---|---|
 | Record and Replay (alpha) | Opt-in alpha | `record-and-replay` | [Docs](linux-features/record-and-replay/README.md) |
 | Agent Workspaces | Opt-in | `agent-workspace` | [Docs](linux-features/agent-workspace/README.md) |
+| API key model visibility | Opt-in | `api-key-model-visibility` | [Docs](linux-features/api-key-model-visibility/README.md) |
 | API key service tier | Opt-in | `api-key-service-tier` | [Docs](linux-features/api-key-service-tier/README.md) |
 | Linux AppShots | Opt-in | `appshots` | [Docs](linux-features/appshots/README.md) |
 | Authenticated proxy | Opt-in | `authenticated-proxy` | [Docs](linux-features/authenticated-proxy/README.md) |
@@ -223,8 +224,10 @@ workarounds.
 | UI tweaks | Opt-in | `ui-tweaks` | [Docs](linux-features/ui-tweaks/README.md) |
 | X11/EWMH Computer Use adapter | Opt-in | `x11-ewmh-computer-use` | [Docs](linux-features/x11-ewmh-computer-use/README.md) |
 
-Server-gated upstream features, such as model rollouts, are controlled by
-OpenAI per account. Rebuilding this wrapper does not unlock them.
+ChatGPT-account model rollouts remain controlled by OpenAI per account.
+Rebuilding this wrapper does not unlock them. API-key-authenticated custom
+providers can opt in to their own visible CLI model catalog with
+`api-key-model-visibility`.
 
 ## Optional Linux Features
 

--- a/linux-features/api-key-model-visibility/README.md
+++ b/linux-features/api-key-model-visibility/README.md
@@ -1,0 +1,50 @@
+# API Key Model Visibility
+
+This opt-in feature makes the desktop model picker trust the non-hidden model
+catalog returned by Codex CLI for API-key authenticated hosts.
+
+The upstream desktop UI can apply a separate Statsig `available_models`
+allowlist after `model/list` succeeds. That allowlist is useful for ChatGPT
+rollouts, but it can hide models exposed by an OpenAI-compatible provider even
+when the provider marks them as visible. This feature bypasses that extra
+allowlist only when the active host reports `authMethod = "apikey"`.
+
+## Enable
+
+Add the feature id to `linux-features/features.json`:
+
+```json
+{
+  "enabled": [
+    "api-key-model-visibility"
+  ]
+}
+```
+
+Then rebuild the app:
+
+```bash
+./install.sh
+```
+
+## Behavior
+
+- API-key hosts show every `model/list` entry whose `hidden` field is false.
+- ChatGPT, Copilot, and Amazon Bedrock hosts keep the upstream filtering rules.
+- Models that the CLI marks as hidden remain hidden.
+- The feature does not grant model access. The configured provider must accept
+  the selected model id.
+- Reasoning choices such as Max or Ultra appear only when the selected model
+  advertises those efforts and the desktop UI enables them.
+
+## Risks
+
+The CLI can list a model that the configured provider or current API key cannot
+actually use. In that case the model will appear in the picker but the provider
+may reject requests at runtime.
+
+## Test
+
+```bash
+node --test linux-features/api-key-model-visibility/test.js
+```

--- a/linux-features/api-key-model-visibility/feature.json
+++ b/linux-features/api-key-model-visibility/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "api-key-model-visibility",
+  "title": "API Key Model Visibility",
+  "description": "Opt-in desktop model picker support for non-hidden models reported by API-key authenticated OpenAI-compatible providers.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/api-key-model-visibility/patch.js
+++ b/linux-features/api-key-model-visibility/patch.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
+const PATCH_MARKER = "codexLinuxApiKeyModelVisibility";
+
+function warn(message, patchName) {
+  console.warn(`WARN: ${message} - skipping ${patchName}`);
+}
+
+function applyApiKeyModelVisibilityPatch(source) {
+  const modelVisibilityPattern = new RegExp(
+    `(function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
+      `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
+      `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},` +
+      `useHiddenModels:(${JS_IDENT})\\}\\)\\{let[\\s\\S]{0,600}?[,;]${JS_IDENT}=)` +
+      `\\3&&\\2!==\\\`amazonBedrock\\\`(?=[,;])`,
+    "g",
+  );
+  const patchedVisibilityPattern = new RegExp(
+    `function ${JS_IDENT}\\(\\{authMethod:(${JS_IDENT}),availableModels:${JS_IDENT},` +
+      `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
+      `includeUltraReasoningEffort:${JS_IDENT},models:${JS_IDENT},` +
+      `useHiddenModels:(${JS_IDENT})\\}\\)\\{let[\\s\\S]{0,600}?[,;]${JS_IDENT}=` +
+      `\\2&&\\1!==\\\`amazonBedrock\\\`&&\\1!==\\\`apikey\\\`/\\*${PATCH_MARKER}\\*/(?=[,;])`,
+  );
+
+  const patched = source.replace(
+    modelVisibilityPattern,
+    (_match, prefix, authMethodVar, useHiddenModelsVar) =>
+      `${prefix}${useHiddenModelsVar}&&${authMethodVar}!==\`amazonBedrock\`&&` +
+      `${authMethodVar}!==\`apikey\`/*${PATCH_MARKER}*/`,
+  );
+
+  if (patched !== source) {
+    return patched;
+  }
+
+  if (patchedVisibilityPattern.test(source)) {
+    return source;
+  }
+
+  if (
+    source.includes("list-models-for-host") &&
+    source.includes("useHiddenModels") &&
+    source.includes("amazonBedrock")
+  ) {
+    warn("Could not find desktop model allowlist gate", "API key model visibility patch");
+  }
+  return source;
+}
+
+const descriptors = [
+  {
+    id: "api-key-model-visibility-ui",
+    phase: "webview-asset",
+    order: 20550,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~.*\.js$/,
+    missingDescription: "app main webview bundle",
+    skipDescription: "API key model visibility patch",
+    apply: applyApiKeyModelVisibilityPatch,
+  },
+];
+
+module.exports = {
+  applyApiKeyModelVisibilityPatch,
+  descriptors,
+};

--- a/linux-features/api-key-model-visibility/test.js
+++ b/linux-features/api-key-model-visibility/test.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  applyWebviewAssetPatchDescriptors,
+  normalizePatchDescriptors,
+} = require("../../scripts/patches/engine.js");
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  applyApiKeyServiceTierPatch,
+} = require("../api-key-service-tier/patch.js");
+const {
+  applyApiKeyModelVisibilityPatch,
+  descriptors,
+} = require("./patch.js");
+
+function applyPatchTwice(patchFn, source) {
+  const once = patchFn(source);
+  assert.notEqual(once, source);
+  assert.equal(patchFn(once), once);
+  return once;
+}
+
+function modelCatalogFixture() {
+  return "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`;return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){s.push(n),n.isDefault&&(c=n)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+}
+
+function serviceTierCompatibleFixture() {
+  return "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+}
+
+function evaluateCatalog(source, authMethod, useHiddenModels = true) {
+  const catalog = Function(`${source};return vbe;`)();
+  return catalog({
+    authMethod,
+    availableModels: new Set(["gpt-5.5"]),
+    defaultModel: "gpt-5.5",
+    enabledReasoningEfforts: new Set(),
+    includeUltraReasoningEffort: true,
+    models: [
+      { model: "gpt-5.6-sol", hidden: false, isDefault: true },
+      { model: "gpt-5.6-terra", hidden: false, isDefault: false },
+      { model: "gpt-5.6-luna", hidden: false, isDefault: false },
+      { model: "gpt-5.5", hidden: false, isDefault: false },
+      { model: "codex-auto-review", hidden: true, isDefault: false },
+    ],
+    useHiddenModels,
+  });
+}
+
+function modelNames(catalog) {
+  return catalog.models.map((model) => model.model);
+}
+
+function withTempDir(callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-model-visibility-"));
+  try {
+    return callback(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function withFeatureConfig(enabled, callback) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  return withTempDir((tempDir) => {
+    const configPath = path.join(tempDir, "features.json");
+    fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+    process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+    try {
+      return callback(path.resolve(__dirname, ".."));
+    } finally {
+      if (originalConfig == null) {
+        delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+      } else {
+        process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+      }
+    }
+  });
+}
+
+test("api-key-model-visibility stays disabled until listed in features.json", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withFeatureConfig(["api-key-model-visibility"], (featuresRoot) => {
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      loaded.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+      [["feature:api-key-model-visibility:api-key-model-visibility-ui", "webview-asset", "optional"]],
+    );
+  });
+});
+
+test("descriptor is optional and targets app main webview chunks", () => {
+  assert.deepEqual(
+    descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+    [["api-key-model-visibility-ui", "webview-asset", "optional"]],
+  );
+  assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), true);
+  assert.equal(descriptors[0].pattern.test("settings-page-abc.js"), false);
+});
+
+test("API-key hosts use visible CLI models instead of the desktop allowlist", () => {
+  const patched = applyPatchTwice(applyApiKeyModelVisibilityPatch, modelCatalogFixture());
+  const catalog = evaluateCatalog(patched, "apikey");
+
+  assert.match(patched, /e!==`apikey`\/\*codexLinuxApiKeyModelVisibility\*\//);
+  assert.deepEqual(modelNames(catalog), [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+  ]);
+  assert.equal(catalog.defaultModel.model, "gpt-5.6-sol");
+});
+
+test("API-key hosts still exclude models marked hidden by the CLI", () => {
+  const patched = applyApiKeyModelVisibilityPatch(modelCatalogFixture());
+
+  assert.equal(modelNames(evaluateCatalog(patched, "apikey")).includes("codex-auto-review"), false);
+});
+
+test("ChatGPT and existing no-allowlist paths keep their upstream behavior", () => {
+  const patched = applyApiKeyModelVisibilityPatch(modelCatalogFixture());
+
+  assert.deepEqual(modelNames(evaluateCatalog(patched, "chatgpt")), ["gpt-5.5"]);
+  assert.deepEqual(modelNames(evaluateCatalog(patched, "chatgpt", false)), [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+  ]);
+  assert.deepEqual(modelNames(evaluateCatalog(patched, "amazonBedrock")), [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+  ]);
+});
+
+test("model visibility and API key service tier patches compose in either order", () => {
+  const source = serviceTierCompatibleFixture();
+  const visibilityFirst = applyApiKeyServiceTierPatch(
+    applyApiKeyModelVisibilityPatch(source),
+  );
+  const serviceTierFirst = applyApiKeyModelVisibilityPatch(
+    applyApiKeyServiceTierPatch(source),
+  );
+
+  assert.equal(visibilityFirst, serviceTierFirst);
+  for (const patched of [visibilityFirst, serviceTierFirst]) {
+    assert.match(patched, /codexLinuxApiKeyModelVisibility/);
+    assert.match(patched, /codexLinuxApiKeyServiceTierModel:e===`apikey`/);
+  }
+});
+
+test("extended upstream model gates fail soft instead of patching mid-expression", () => {
+  const source = modelCatalogFixture().replace(
+    "l=o&&e!==`amazonBedrock`;",
+    "l=o&&e!==`amazonBedrock`&&featureGate;",
+  );
+
+  assert.equal(applyApiKeyModelVisibilityPatch(source), source);
+});
+
+test("enabled descriptor patches a matching extracted webview asset", () => {
+  withFeatureConfig(["api-key-model-visibility"], (featuresRoot) => {
+    withTempDir((extractedDir) => {
+      const assetsDir = path.join(extractedDir, "webview", "assets");
+      const assetPath = path.join(assetsDir, "app-initial~app-main~fixture.js");
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(assetPath, modelCatalogFixture());
+
+      const normalized = normalizePatchDescriptors(
+        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+      );
+      applyWebviewAssetPatchDescriptors(extractedDir, normalized, {}, null);
+
+      assert.match(fs.readFileSync(assetPath, "utf8"), /codexLinuxApiKeyModelVisibility/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add a default-disabled `api-key-model-visibility` Linux feature
- let API-key-authenticated hosts use the non-hidden model catalog returned by Codex CLI instead of the desktop Statsig `available_models` allowlist
- preserve the existing ChatGPT, Copilot, Amazon Bedrock, and CLI-hidden model behavior
- document the feature and add focused drift, idempotency, composition, and behavior tests

## Motivation

An OpenAI-compatible API-key provider can return visible models from `model/list`, but Codex Desktop may hide them afterward when its dynamic `available_models` allowlist has not caught up. This makes the CLI and desktop model pickers disagree even though both use the same provider.

The patch does not hardcode model ids. Future models returned as non-hidden by the CLI are picked up automatically for API-key hosts. It does not grant provider access or force reasoning-effort UI gates such as Ultra.

## Scope

This remains opt-in under `linux-features/` and is disabled by default. The patch only changes the API-key authentication branch of the existing model-catalog filter and fails soft if the upstream minified expression changes.

## Validation

- `node --test linux-features/api-key-model-visibility/test.js linux-features/api-key-service-tier/test.js` (`14/14`)
- `node --test linux-features/*/test.js` (`410/410`)
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- rebuilt and inspected upstream app `26.707.31428` / Electron `42.1.0`; the feature descriptor applied exactly once to the expected webview asset
