### PR TITLE
Adapt Browser Use trusted hash patch to direct builder

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1129,6 +1129,13 @@ function currentChromeNativeHostRuntimeBundleFixture() {
   ].join("");
 }
 
+function currentBrowserUseTrustedHashesRuntimeBuilderFixture() {
+  return "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`);function build({codexHome:t,nodePath:i,nodeReplPath:a,trustedBrowserClientSha256s:h=[],shouldUseWslPaths:f}){return h}";
+}
+
+const currentBrowserUseTrustedHashesInsertionRegex =
+  /trustedBrowserClientSha256s:h=\[\],shouldUseWslPaths:f\}\)\{h=codexLinuxTrustedBrowserClientSha256s\(h\);return h/;
+
 function electron42BrowserUseRuntimeResolverBundleFixture() {
   return [
     "let s=require(`node:path`),l=require(`node:fs`);",
@@ -6709,9 +6716,8 @@ test("uses xdg-open path when CODEX_LINUX_DISABLE_EXTERNAL_OPEN_PATCH is not 1",
   assert.equal(spawnCalls[0].command, "xdg-open");
 });
 
-test("trusts the current Browser Use setup function", () => {
-  const source =
-    "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`];async function build({resourcesPath:p,trustedBrowserClientSha256s:h=d}){return h}";
+test("trusts the current direct Browser Use node_repl runtime config builder", () => {
+  const source = currentBrowserUseTrustedHashesRuntimeBuilderFixture();
 
   const { value: patched, warnings } = captureWarns(() =>
     applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source),
@@ -6719,14 +6725,22 @@ test("trusts the current Browser Use setup function", () => {
 
   assert.deepEqual(warnings, []);
   assert.doesNotMatch(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
-  assert.match(
-    patched,
-    /trustedBrowserClientSha256s:h=codexLinuxTrustedBrowserClientSha256s\(d,p\)/,
-  );
+  assert.match(patched, currentBrowserUseTrustedHashesInsertionRegex);
   assert.equal(
     (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
     1,
   );
+});
+
+test("ignores the removed Browser Use async trusted-hash setup shape", () => {
+  const source =
+    "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`];async function build({resourcesPath:p,trustedBrowserClientSha256s:h=d}){return h}";
+  const { value, warnings } = captureWarns(() =>
+    applyBrowserUseNodeReplApprovalPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
 });
 
 test("ignores Browser Use schema-only trusted hash fields", () => {
@@ -6749,7 +6763,7 @@ test("patches re-chunked Browser Use trust hash and approval assets", () => {
     const srcChunk = path.join(buildDir, "src-current.js");
     fs.writeFileSync(
       mainChunk,
-      "\"use strict\";let l=require(`node:fs`),s=require(`node:path`),u=require(`node:crypto`),d=[`upstream-hash`];async function build({resourcesPath:p,trustedBrowserClientSha256s:h=d}){return h}",
+      currentBrowserUseTrustedHashesRuntimeBuilderFixture(),
       "utf8",
     );
     fs.writeFileSync(
@@ -6764,17 +6778,14 @@ test("patches re-chunked Browser Use trust hash and approval assets", () => {
     const patchedMain = fs.readFileSync(mainChunk, "utf8");
     const patchedSrc = fs.readFileSync(srcChunk, "utf8");
     assert.match(patchedMain, /function codexLinuxTrustedBrowserClientSha256s/);
-    assert.match(
-      patchedMain,
-      /trustedBrowserClientSha256s:h=codexLinuxTrustedBrowserClientSha256s\(d,p\)/,
-    );
+    assert.match(patchedMain, currentBrowserUseTrustedHashesInsertionRegex);
     assert.match(patchedSrc, /tools:\{js:\{approval_mode:`approve`\}\}/);
   } finally {
     fs.rmSync(extractedDir, { recursive: true, force: true });
   }
 });
 
-test("trusts Linux patched bundled Browser Use clients through the current setup function", async () => {
+test("trusts Linux patched bundled Browser Use clients through the current direct builder", async () => {
   const resourcesRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-current-browser-client-hash-"));
   try {
     const browserClient = path.join(
@@ -6801,26 +6812,24 @@ test("trusts Linux patched bundled Browser Use clients through the current setup
     fs.writeFileSync(chromeClient, "patched current chrome client\n", "utf8");
     const browserHash = cryptoHash("patched current browser client\n");
     const chromeHash = cryptoHash("patched current chrome client\n");
-    const source =
-      "\"use strict\";let o=require(`node:fs`),a=require(`node:path`),s=require(`node:crypto`),d=[`upstream-hash`];async function build({resourcesPath:p,trustedBrowserClientSha256s:h=d}){return h}";
+    const source = currentBrowserUseTrustedHashesRuntimeBuilderFixture();
 
     const patched = applyPatchTwice(applyBrowserUseNodeReplApprovalPatch, source);
 
     assert.match(patched, /^"use strict";function codexLinuxTrustedBrowserClientSha256s/);
     assert.doesNotMatch(patched, /tools:\{js:\{approval_mode:`approve`\}\}/);
-    assert.match(
-      patched,
-      /trustedBrowserClientSha256s:h=codexLinuxTrustedBrowserClientSha256s\(d,p\)/,
-    );
+    assert.match(patched, currentBrowserUseTrustedHashesInsertionRegex);
     assert.equal(
       (patched.match(/function codexLinuxTrustedBrowserClientSha256s/g) || []).length,
       1,
     );
-    assert.doesNotMatch(patched, /for\(let a of/);
-    const linuxHashes = await vm.runInNewContext(`${patched};build({resourcesPath:process.resourcesPath});`, {
-      require,
-      process: { platform: "linux", resourcesPath: resourcesRoot },
-    });
+    const linuxHashes = await vm.runInNewContext(
+      `${patched};build({trustedBrowserClientSha256s:[\`upstream-hash\`]});`,
+      {
+        require,
+        process: { platform: "linux", resourcesPath: resourcesRoot },
+      },
+    );
     assert.deepEqual(Array.from(linuxHashes), ["upstream-hash", browserHash, chromeHash]);
   } finally {
     fs.rmSync(resourcesRoot, { recursive: true, force: true });

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -10,21 +10,27 @@ const {
 function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   let patchedSource = currentSource;
   let patchedTrustedHashes = false;
-  const hasTrustedHashesSetup =
-    /async function [A-Za-z_$][\w$]*\(\{[^{}]*resourcesPath:[^{}]*trustedBrowserClientSha256s:/.test(currentSource);
+  const hasTrustedHashesRuntimeBuilder =
+    /(?<!async )function [A-Za-z_$][\w$]*\(\{(?=[^{}]*nodePath:)(?=[^{}]*nodeReplPath:)(?=[^{}]*shouldUseWslPaths:)[^{}]*trustedBrowserClientSha256s:[A-Za-z_$][\w$]*(?:=\[\])?[^{}]*\}\)\{/.test(currentSource);
 
-  const setupTrustedHashesRegex =
-    /(async function [A-Za-z_$][\w$]*\(\{[^{}]*?resourcesPath:([A-Za-z_$][\w$]*)[^{}]*?trustedBrowserClientSha256s:[A-Za-z_$][\w$]*=)(?!codexLinuxTrustedBrowserClientSha256s\()([A-Za-z_$][\w$]*)(\}\))/g;
+  const runtimeBuilderTrustedHashesRegex =
+    /(?<!async )function ([A-Za-z_$][\w$]*)\(\{(?=[^{}]*nodePath:)(?=[^{}]*nodeReplPath:)(?=[^{}]*shouldUseWslPaths:)([^{}]*?trustedBrowserClientSha256s:)([A-Za-z_$][\w$]*)([^{}]*?\})\)\{(?![A-Za-z_$][\w$]*=codexLinuxTrustedBrowserClientSha256s\()/g;
   if (
     requireName(patchedSource, "node:fs") != null &&
     requireName(patchedSource, "node:path") != null &&
     requireName(patchedSource, "node:crypto") != null
   ) {
     patchedSource = patchedSource.replace(
-      setupTrustedHashesRegex,
-      (match, configPrefix, resourcesPathVar, trustedHashesVar, configSuffix) => {
+      runtimeBuilderTrustedHashesRegex,
+      (
+        _match,
+        functionName,
+        configPrefix,
+        trustedHashesVar,
+        configSuffix,
+      ) => {
         patchedTrustedHashes = true;
-        return `${configPrefix}codexLinuxTrustedBrowserClientSha256s(${trustedHashesVar},${resourcesPathVar})${configSuffix}`;
+        return `function ${functionName}({${configPrefix}${trustedHashesVar}${configSuffix}){${trustedHashesVar}=codexLinuxTrustedBrowserClientSha256s(${trustedHashesVar});`;
       },
     );
   }
@@ -73,7 +79,7 @@ function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   if (
     !patchedTrustedHashes &&
     !patchedSource.includes("codexLinuxTrustedBrowserClientSha256s(") &&
-    hasTrustedHashesSetup
+    hasTrustedHashesRuntimeBuilder
   ) {
     console.warn(
       "WARN: Could not find Browser Use trusted hash insertion point — skipping Linux Browser Use trusted hash patch",


### PR DESCRIPTION
## Summary

- Adapt Browser Use trusted-hash injection to the current DMG’s direct `node_repl` runtime builder.
- Remove recognition of the retired async `resourcesPath` shape and add regression coverage for the current builder.

## Why

DMG `26.707.31428` no longer uses the runtime-factory shape covered by #692. The existing patch therefore misses the trusted-hash insertion point, preventing hashes for the Linux-patched bundled Browser and Chrome clients from being added to the trusted set.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- DMG SHA-256: `6f67af7e2f934093ab8afebcec11374d40c8db8f9100fb6620f24155401d8319`
- Confirmed `browser-use-node-repl-approval` was applied
- Confirmed the patched JavaScript chunk passes `node --check`

## Scope

Targets the latest DMG shape only. The change is limited to the Browser Use patch implementation.