### PR TITLE
Fix frameless titlebar for current app bundles

### DIFF
--- a/linux-features/frameless-titlebar/README.md
+++ b/linux-features/frameless-titlebar/README.md
@@ -41,8 +41,8 @@ For a manual check, enable the feature as above, rebuild, and launch the app:
   compositor's bindings (for example Hyprland's `bindm` mouse binds and
   `killactive`/`fullscreen` dispatchers).
 - Changing the system dark/light theme must not crash the app or repaint a
-  titlebar strip; the patch removes all Linux `setTitleBarOverlay` calls,
-  which would otherwise throw on a window created without `titleBarOverlay`.
+  titlebar strip in the primary window; the patch removes its Linux
+  `setTitleBarOverlay` calls while preserving the Quick Chat overlay.
 - On GNOME/X11, right-click the same titlebar area that previously locked input
   and verify whether clicks outside the window recover normally. If the issue
   still reproduces, disable the feature again and report the distro, GNOME

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -1,32 +1,22 @@
 "use strict";
 
 function applyFramelessTitlebarBranchPatch(currentSource) {
-  const splitLinuxTitlebarRegex =
-    /([A-Za-z_$][\w$]*)===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay\(([A-Za-z_$][\w$]*)\),(\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\})\}:/g;
   let patchedTitlebar = false;
-  let patchedSource = currentSource.replace(
-    splitLinuxTitlebarRegex,
-    (_match, platformAlias, _zoomAlias, quickChatOptions) => {
-      patchedTitlebar = true;
-      return `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,${quickChatOptions}}:`;
-    },
-  );
-
   const combinedLinuxTitlebarRegex =
-    /([A-Za-z_$][\w$]*)===`win32`\|\|\1===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\1===`linux`\?codexLinuxTitleBarOverlay\(([A-Za-z_$][\w$]*)\):([A-Za-z_$][\w$]*)\(\2\),(\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\})\}:/g;
-  patchedSource = patchedSource.replace(
+    /([A-Za-z_$][\w$]*)===`win32`\|\|\1===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\1===`linux`\?codexLinuxTitleBarOverlay\(([A-Za-z_$][\w$]*)\):([A-Za-z_$][\w$]*)\(\2\),(\.\.\.([A-Za-z_$][\w$]*)===`quickChat`\?\{resizable:!0\}:\{\})\}:/g;
+  const patchedSource = currentSource.replace(
     combinedLinuxTitlebarRegex,
-    (_match, platformAlias, zoomAlias, overlayHelperAlias, quickChatOptions) => {
+    (_match, platformAlias, zoomAlias, overlayHelperAlias, quickChatOptions, windowTypeAlias) => {
       patchedTitlebar = true;
       return (
         `${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias}),${quickChatOptions}}:` +
-        `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,${quickChatOptions}}:`
+        `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,...${windowTypeAlias}===\`quickChat\`?{titleBarOverlay:codexLinuxTitleBarOverlay(${zoomAlias}),resizable:!0}:{}}:`
       );
     },
   );
 
   const patchedLinuxTitlebarRegex =
-    /[A-Za-z_$][\w$]*===`linux`\?\{titleBarStyle:`hidden`,\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\}\}:/;
+    /[A-Za-z_$][\w$]*===`linux`\?\{titleBarStyle:`hidden`,\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{titleBarOverlay:codexLinuxTitleBarOverlay\([A-Za-z_$][\w$]*\),resizable:!0\}:\{\}\}:/;
   if (!patchedTitlebar && !patchedLinuxTitlebarRegex.test(patchedSource)) {
     console.warn("WARN: Could not find primary BrowserWindow titlebar snippet - skipping frameless titlebar branch patch");
   }
@@ -37,30 +27,30 @@ function applyFramelessTitlebarBranchPatch(currentSource) {
 function applyFramelessTitlebarOverlaySyncPatch(currentSource) {
   let patchedZoom = false;
   let patchedSource = currentSource.replace(
-    /(setWindowZoom\([^)]*\)\{[\s\S]{0,600}?)\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(\3\):([A-Za-z_$][\w$]*)\(\3\)\)\)/g,
-    (_match, functionPrefix, windowAlias, zoomAlias, overlayHelperAlias) => {
+    /(setWindowZoom\([^)]*\)\{(?=[\s\S]{0,600}?,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*&&this\.windowAppearances\.get\()[\s\S]{0,600}?)\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\3\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(\4\):([A-Za-z_$][\w$]*)\(\4\)\)\)/g,
+    (_match, functionPrefix, appearanceAlias, windowAlias, zoomAlias, overlayHelperAlias) => {
       patchedZoom = true;
-      return `${functionPrefix}process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`;
+      return `${functionPrefix}(process.platform===\`win32\`||process.platform===\`linux\`&&${appearanceAlias}===\`quickChat\`)&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?codexLinuxTitleBarOverlay(${zoomAlias}):${overlayHelperAlias}(${zoomAlias})))`;
     },
   );
 
   const patchedZoomRegex =
-    /setWindowZoom\([^)]*\)\{[\s\S]{0,600}?process\.platform===`win32`&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\([A-Za-z_$][\w$]*\(\2\)\)\)/;
+    /setWindowZoom\([^)]*\)\{(?=[\s\S]{0,600}?,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*&&this\.windowAppearances\.get\()[\s\S]{0,600}?\(process\.platform===`win32`\|\|process\.platform===`linux`&&\1===`quickChat`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(\3\):[A-Za-z_$][\w$]*\(\3\)\)\)/;
   if (currentSource.includes("setWindowZoom(") && !patchedZoom && !patchedZoomRegex.test(patchedSource)) {
     console.warn("WARN: Could not find setWindowZoom titlebar overlay snippet - skipping frameless zoom patch");
   }
 
   let patchedSync = false;
   patchedSource = patchedSource.replace(
-    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`&&process\.platform!==`linux`\|\|\3!==`primary`&&\3!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\2\.id\)\):([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
-    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, overlayHelperAlias, electronAlias) => {
+    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`&&process\.platform!==`linux`\|\|\2!==`primary`&&\2!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\1\.id\)\):([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\1\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\3\),\3\(\),\(\)=>\{\5\.nativeTheme\.off\(`updated`,\3\)\}\}/g,
+    (_match, windowAlias, windowTypeAlias, updateAlias, overlayHelperAlias, electronAlias) => {
       patchedSync = true;
-      return `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`&&${windowTypeAlias}!==\`quickChat\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`;
+      return `installApplicationMenuTitleBarOverlaySync(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`&&(process.platform!==\`linux\`||${windowTypeAlias}!==\`quickChat\`)||${windowTypeAlias}!==\`primary\`&&${windowTypeAlias}!==\`quickChat\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(process.platform===\`linux\`?codexLinuxTitleBarOverlay(this.windowZooms.get(${windowAlias}.id)):${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`;
     },
   );
 
   const patchedSyncRegex =
-    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`\|\|\2!==`primary`&&\2!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.setTitleBarOverlay\([A-Za-z_$][\w$]*\(this\.windowZooms\.get\(\1\.id\)\)\)\}/;
+    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`&&\(process\.platform!==`linux`\|\|\2!==`quickChat`\)\|\|\2!==`primary`&&\2!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\1\.id\)\):[A-Za-z_$][\w$]*\(this\.windowZooms\.get\(\1\.id\)\)\)\}/;
   if (
     currentSource.includes("installApplicationMenuTitleBarOverlaySync(") &&
     !patchedSync &&

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -1,124 +1,95 @@
 "use strict";
 
-const LINUX_TITLEBAR_OVERLAY_HELPER = "codexLinuxTitleBarOverlay";
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function applyFramelessTitlebarBranchPatch(currentSource) {
-  const primaryTitlebarRegex =
-    /case`primary`:return ([A-Za-z_$][\w$]*)===`darwin`\?([A-Za-z_$][\w$]*)\?\{titleBarStyle:`hiddenInset`,trafficLightPosition:([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\}:\{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:\3\(\4\)\}:\1===`win32`(\|\|\1===`linux`)?\?\{titleBarStyle:`hidden`,titleBarOverlay:([A-Za-z_$][\w$]*)\(\4\)\}:\{titleBarStyle:`default`\};/g;
-  let patchedSource = currentSource;
+  const splitLinuxTitlebarRegex =
+    /([A-Za-z_$][\w$]*)===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay\(([A-Za-z_$][\w$]*)\),(\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\})\}:/g;
   let patchedTitlebar = false;
-
-  primaryTitlebarRegex.lastIndex = 0;
-  patchedSource = patchedSource.replace(
-    primaryTitlebarRegex,
-    (_match, platformAlias, opaqueWindowsAlias, trafficLightAlias, zoomAlias, _linuxInWin32Branch, overlayHelperAlias) => {
+  let patchedSource = currentSource.replace(
+    splitLinuxTitlebarRegex,
+    (_match, platformAlias, _zoomAlias, quickChatOptions) => {
       patchedTitlebar = true;
-      return `case\`primary\`:return ${platformAlias}===\`darwin\`?${opaqueWindowsAlias}?{titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:{vibrancy:\`menu\`,titleBarStyle:\`hiddenInset\`,trafficLightPosition:${trafficLightAlias}(${zoomAlias})}:${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias})}:${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`}:{titleBarStyle:\`default\`};`;
+      return `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,${quickChatOptions}}:`;
     },
   );
 
-  const linuxOverlayRegex = new RegExp(
-    `([A-Za-z_$][\\w$]*)===\`linux\`\\?\\{titleBarStyle:\`hidden\`,titleBarOverlay:${escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER)}\\([^)]*\\)\\}:`,
-    "g",
+  const combinedLinuxTitlebarRegex =
+    /([A-Za-z_$][\w$]*)===`win32`\|\|\1===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:\1===`linux`\?codexLinuxTitleBarOverlay\(([A-Za-z_$][\w$]*)\):([A-Za-z_$][\w$]*)\(\2\),(\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\})\}:/g;
+  patchedSource = patchedSource.replace(
+    combinedLinuxTitlebarRegex,
+    (_match, platformAlias, zoomAlias, overlayHelperAlias, quickChatOptions) => {
+      patchedTitlebar = true;
+      return (
+        `${platformAlias}===\`win32\`?{titleBarStyle:\`hidden\`,titleBarOverlay:${overlayHelperAlias}(${zoomAlias}),${quickChatOptions}}:` +
+        `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`,${quickChatOptions}}:`
+      );
+    },
   );
-  patchedSource = patchedSource.replace(linuxOverlayRegex, (_match, platformAlias) => {
-    patchedTitlebar = true;
-    return `${platformAlias}===\`linux\`?{titleBarStyle:\`hidden\`}:`;
-  });
 
-  if (!patchedTitlebar && !/===`linux`\?\{titleBarStyle:`hidden`\}/.test(patchedSource)) {
+  const patchedLinuxTitlebarRegex =
+    /[A-Za-z_$][\w$]*===`linux`\?\{titleBarStyle:`hidden`,\.\.\.[A-Za-z_$][\w$]*===`quickChat`\?\{resizable:!0\}:\{\}\}:/;
+  if (!patchedTitlebar && !patchedLinuxTitlebarRegex.test(patchedSource)) {
     console.warn("WARN: Could not find primary BrowserWindow titlebar snippet - skipping frameless titlebar branch patch");
   }
 
   return patchedSource;
 }
 
-// The zoom path and the overlay sync method each appear in multiple shapes
-// depending on upstream and core-patch vintage. setWindowZoom: a plain
-// overlay helper body, or a codexLinuxTitleBarOverlay ternary body after the
-// core linux-native-titlebar patch. Overlay sync: the un-widened upstream
-// form, the current upstream form with a win32/linux gate but a plain
-// overlay helper body, and the core-patched form with a
-// codexLinuxTitleBarOverlay ternary body. All must collapse to win32-only.
 function applyFramelessTitlebarOverlaySyncPatch(currentSource) {
+  let patchedZoom = false;
   let patchedSource = currentSource.replace(
-    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(\2\)\)\)/g,
-    (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
-      `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`,
+    /(setWindowZoom\([^)]*\)\{[\s\S]{0,600}?)\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(\3\):([A-Za-z_$][\w$]*)\(\3\)\)\)/g,
+    (_match, functionPrefix, windowAlias, zoomAlias, overlayHelperAlias) => {
+      patchedZoom = true;
+      return `${functionPrefix}process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`;
+    },
   );
 
-  const linuxZoomOverlayTernaryRegex = new RegExp(
-    "\\(process\\.platform===`win32`\\|\\|process\\.platform===`linux`\\)&&\\(this\\.windowZooms\\.set\\(([A-Za-z_$][\\w$]*)\\.id,([A-Za-z_$][\\w$]*)\\),\\1\\.setTitleBarOverlay\\(process\\.platform===`linux`\\?" +
-      escapeRegExp(LINUX_TITLEBAR_OVERLAY_HELPER) +
-      "\\([^)]*\\):([A-Za-z_$][\\w$]*)\\(\\2\\)\\)\\)",
-    "g",
-  );
+  const patchedZoomRegex =
+    /setWindowZoom\([^)]*\)\{[\s\S]{0,600}?process\.platform===`win32`&&\(this\.windowZooms\.set\(([A-Za-z_$][\w$]*)\.id,([A-Za-z_$][\w$]*)\),\1\.setTitleBarOverlay\([A-Za-z_$][\w$]*\(\2\)\)\)/;
+  if (currentSource.includes("setWindowZoom(") && !patchedZoom && !patchedZoomRegex.test(patchedSource)) {
+    console.warn("WARN: Could not find setWindowZoom titlebar overlay snippet - skipping frameless zoom patch");
+  }
+
+  let patchedSync = false;
   patchedSource = patchedSource.replace(
-    linuxZoomOverlayTernaryRegex,
-    (_match, windowAlias, zoomAlias, overlayHelperAlias) =>
-      `process.platform===\`win32\`&&(this.windowZooms.set(${windowAlias}.id,${zoomAlias}),${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(${zoomAlias})))`,
+    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`&&process\.platform!==`linux`\|\|\3!==`primary`&&\3!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\2\.id\)\):([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
+    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, overlayHelperAlias, electronAlias) => {
+      patchedSync = true;
+      return `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`&&${windowTypeAlias}!==\`quickChat\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`;
+    },
   );
 
-  patchedSource = patchedSource.replace(
-    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\((?:\(process\.platform!==`win32`&&process\.platform!==`linux`\)|process\.platform!==`win32`&&process\.platform!==`linux`)\|\|\3!==`primary`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
-    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, overlayHelperAlias, electronAlias) =>
-      `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${overlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`,
-  );
-
-  return patchedSource.replace(
-    /(install(?:Windows|ApplicationMenu)TitleBarOverlaySync)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(\(process\.platform!==`win32`&&process\.platform!==`linux`\)\|\|\3!==`primary`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\2\.isDestroyed\(\)\|\|\2\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(\2\.id\)\):([A-Za-z_$][\w$]*)\(this\.windowZooms\.get\(\2\.id\)\)\)\};return ([A-Za-z_$][\w$]*)\.nativeTheme\.on\(`updated`,\4\),\4\(\),\(\)=>\{\6\.nativeTheme\.off\(`updated`,\4\)\}\}/g,
-    (_match, methodName, windowAlias, windowTypeAlias, updateAlias, windowsOverlayHelperAlias, electronAlias) =>
-      `${methodName}(${windowAlias},${windowTypeAlias}){if(process.platform!==\`win32\`||${windowTypeAlias}!==\`primary\`)return;let ${updateAlias}=()=>{${windowAlias}.isDestroyed()||${windowAlias}.setTitleBarOverlay(${windowsOverlayHelperAlias}(this.windowZooms.get(${windowAlias}.id)))};return ${electronAlias}.nativeTheme.on(\`updated\`,${updateAlias}),${updateAlias}(),()=>{${electronAlias}.nativeTheme.off(\`updated\`,${updateAlias})}}`,
-  );
-}
-
-function applyFramelessTitlebarMenuPatch(currentSource) {
-  const menuRegex = /process\.platform===`win32`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),/g;
-  let patchedSource = currentSource
-    .replace(
-      /process\.platform===`linux`&&\(([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),\1\.removeMenu\?\.\(\)\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    )
-    .replace(
-      /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.setMenuBarVisibility\(!1\),process\.platform===`win32`&&\1\.removeMenu\(\),/g,
-      (_match, windowVar) => `process.platform===\`linux\`&&${windowVar}.removeMenu(),process.platform===\`win32\`&&${windowVar}.removeMenu(),`,
-    );
-  let patchedAny = patchedSource !== currentSource;
-  patchedSource = patchedSource.replace(menuRegex, (match, windowVar, offset, source) => {
-    const linuxPatch = `process.platform===\`linux\`&&${windowVar}.removeMenu(),`;
-    if (source.slice(Math.max(0, offset - linuxPatch.length), offset) === linuxPatch) {
-      return match;
-    }
-    patchedAny = true;
-    return `${linuxPatch}${match}`;
-  });
-
-  const hasWindowsRemoveMenu = /process\.platform===`win32`&&[A-Za-z_$][\w$]*\.removeMenu\(\),/.test(patchedSource);
-  const hasLinuxRemoveMenu = /process\.platform===`linux`&&([A-Za-z_$][\w$]*)\.removeMenu\(\),process\.platform===`win32`&&\1\.removeMenu\(\),/.test(patchedSource);
-  if (!patchedAny && hasWindowsRemoveMenu && !hasLinuxRemoveMenu) {
-    console.warn("WARN: Could not find window menu visibility snippet - skipping frameless titlebar menu patch");
+  const patchedSyncRegex =
+    /installApplicationMenuTitleBarOverlaySync\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(process\.platform!==`win32`\|\|\2!==`primary`&&\2!==`quickChat`\)return;let ([A-Za-z_$][\w$]*)=\(\)=>\{\1\.isDestroyed\(\)\|\|\1\.setTitleBarOverlay\([A-Za-z_$][\w$]*\(this\.windowZooms\.get\(\1\.id\)\)\)\}/;
+  if (
+    currentSource.includes("installApplicationMenuTitleBarOverlaySync(") &&
+    !patchedSync &&
+    !patchedSyncRegex.test(patchedSource)
+  ) {
+    console.warn("WARN: Could not find application menu titlebar overlay sync snippet - skipping frameless sync patch");
   }
 
   return patchedSource;
 }
 
 function applyFramelessTitlebarMainPatch(currentSource) {
-  return applyFramelessTitlebarMenuPatch(
-    applyFramelessTitlebarOverlaySyncPatch(
-      applyFramelessTitlebarBranchPatch(currentSource),
-    ),
+  return applyFramelessTitlebarOverlaySyncPatch(
+    applyFramelessTitlebarBranchPatch(currentSource),
   );
 }
 
 function applyFramelessTitlebarWebviewPatch(currentSource) {
+  let foundApplicationMenuLayout = false;
   let patchedSource = currentSource.replace(
     /applicationMenu:Object\.freeze\(\{left:0,right:\d+\}\)/g,
-    "applicationMenu:Object.freeze({left:0,right:0})",
+    () => {
+      foundApplicationMenuLayout = true;
+      return "applicationMenu:Object.freeze({left:0,right:0})";
+    },
   );
+  const hasApplicationMenuLayout = currentSource.includes("applicationMenu:Object.freeze(");
+  const recognizedApplicationMenuLayout =
+    foundApplicationMenuLayout || patchedSource.includes("applicationMenu:Object.freeze({left:0,right:0})");
 
   const linuxApplicationMenuChrome = "case`win32`:case`linux`:return`application-menu`";
   const linuxNativeChrome = "case`win32`:return`application-menu`;case`linux`:return`native`";
@@ -149,16 +120,34 @@ function applyFramelessTitlebarWebviewPatch(currentSource) {
     foundApplicationMenuBridge = true;
     return `function ${functionName}(){return!1}`;
   });
+  const disabledApplicationMenuBridgeRegex =
+    /function ([A-Za-z_$][\w$]*)\(\)\{return!1\}[\s\S]{0,1600}?if\(!\1\(\)\)return null;[\s\S]{0,1600}?showApplicationMenu/;
 
   const recognizedChromeMapping = foundApplicationMenuChrome || hasNativeChrome;
   const recognizedBrowserGate = foundApplicationMenuBrowserGate || hasNativeBrowserGate;
-  if (
-    !recognizedChromeMapping &&
-    !recognizedBrowserGate &&
-    !foundApplicationMenuBridge &&
-    currentSource.includes("applicationMenu:Object.freeze({left:0,right:")
-  ) {
+  const recognizedApplicationMenuBridge =
+    foundApplicationMenuBridge || disabledApplicationMenuBridgeRegex.test(patchedSource);
+  const hasApplicationMenuChromeConsumer =
+    currentSource.includes("dataset.codexWindowChrome===`application-menu`");
+
+  if (hasApplicationMenuLayout && !recognizedApplicationMenuLayout) {
+    console.warn("WARN: Could not find application menu layout - skipping frameless webview layout patch");
+  }
+  if (hasApplicationMenuLayout && !recognizedBrowserGate) {
+    console.warn("WARN: Could not find application menu browser gate - skipping frameless webview platform patch");
+  }
+  if (hasApplicationMenuLayout && !recognizedApplicationMenuBridge) {
+    console.warn("WARN: Could not find application menu bridge guard - skipping frameless webview bridge patch");
+  }
+  if (hasApplicationMenuChromeConsumer && !recognizedChromeMapping) {
     console.warn("WARN: Could not find Linux window controls chrome mapping - skipping frameless webview chrome patch");
+  }
+  if (
+    !hasApplicationMenuLayout &&
+    !hasApplicationMenuChromeConsumer &&
+    !recognizedChromeMapping
+  ) {
+    console.warn("WARN: Could not identify frameless titlebar webview target - skipping frameless webview patch");
   }
 
   return patchedSource;
@@ -177,7 +166,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_730,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page-.*\.js$/,
+    pattern: /^(?:app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb|app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu)-.*\.js$/,
     missingDescription: "main app chrome bundle",
     skipDescription: "frameless titlebar webview layout patch",
     apply: applyFramelessTitlebarWebviewPatch,
@@ -188,7 +177,6 @@ module.exports = {
   descriptors: patches,
   applyFramelessTitlebarBranchPatch,
   applyFramelessTitlebarMainPatch,
-  applyFramelessTitlebarMenuPatch,
   applyFramelessTitlebarOverlaySyncPatch,
   applyFramelessTitlebarWebviewPatch,
 };

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -88,7 +88,7 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
 
 test("frameless-titlebar removes current Linux overlay controls without changing quick chat", () => {
   const source = [
-    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:j9(r),...e===`quickChat`?{resizable:!0}:{}}:n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:n===`linux`?codexLinuxTitleBarOverlay(r):j9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
     "setWindowZoom(e,t){let n=c.BrowserWindow.fromWebContents(e),r=n&&this.windowAppearances.get(n.id);n==null||r!==`primary`&&r!==`quickChat`||(process.platform===`darwin`?n.setWindowButtonPosition(A9(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(t):j9(t))))}",
     "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(this.windowZooms.get(e.id)):j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
     "(process.platform===`win32`||process.platform===`linux`)&&k.removeMenu(),",
@@ -105,19 +105,28 @@ test("frameless-titlebar removes current Linux overlay controls without changing
   );
   assert.match(
     patched,
-    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
+    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{titleBarOverlay:codexLinuxTitleBarOverlay\(r\),resizable:!0\}:\{\}\}/,
   );
   assert.match(
     patched,
-    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(j9\(t\)\)\)/,
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`&&r===`quickChat`\)&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(t\):j9\(t\)\)\)/,
   );
-  assert.match(patched, /if\(process\.platform!==`win32`\|\|t!==`primary`&&t!==`quickChat`\)return/);
+  assert.match(
+    patched,
+    /if\(process\.platform!==`win32`&&\(process\.platform!==`linux`\|\|t!==`quickChat`\)\|\|t!==`primary`&&t!==`quickChat`\)return/,
+  );
+  assert.match(
+    patched,
+    /e\.setTitleBarOverlay\(process\.platform===`linux`\?codexLinuxTitleBarOverlay\(this\.windowZooms\.get\(e\.id\)\):j9\(this\.windowZooms\.get\(e\.id\)\)\)/,
+  );
   assert.match(
     patched,
     /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&k\.removeMenu\(\),/,
   );
-  assert.doesNotMatch(patched, /titleBarOverlay:codexLinuxTitleBarOverlay/);
-  assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
+  assert.doesNotMatch(
+    patched,
+    /n===`linux`\?\{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay/,
+  );
 });
 
 test("frameless-titlebar composes with the current native-titlebar patch shape", () => {
@@ -135,7 +144,7 @@ test("frameless-titlebar composes with the current native-titlebar patch shape",
   );
   assert.match(
     patched,
-    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
+    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{titleBarOverlay:codexLinuxTitleBarOverlay\(r\),resizable:!0\}:\{\}\}/,
   );
   assert.doesNotMatch(patched, /titleBarOverlay:n===`linux`/);
 });

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -11,8 +11,9 @@ const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
 const {
+  applyFramelessTitlebarBranchPatch,
   applyFramelessTitlebarMainPatch,
-  applyFramelessTitlebarMenuPatch,
+  applyFramelessTitlebarOverlaySyncPatch,
   applyFramelessTitlebarWebviewPatch,
 } = require("./patch.js");
 
@@ -64,7 +65,19 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
     const webviewPatch = descriptors.find(
       (descriptor) => descriptor.id === "feature:frameless-titlebar:webview-window-controls-layout",
     );
-    assert.match("app-initial~app-main~onboarding-page-abc.js", webviewPatch.pattern);
+    assert.match(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-abc.js",
+      webviewPatch.pattern,
+    );
+    assert.match(
+      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-abc.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~duyd76c5-abc.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch("app-initial~app-main~onboarding-page-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("use-window-controls-safe-area-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("app-initial~app-main~onboarding-page~debug-window-page-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("app-main-abc.js", webviewPatch.pattern);
@@ -73,88 +86,106 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
   }
 });
 
-test("frameless-titlebar removes Linux overlay controls and menu chrome", () => {
+test("frameless-titlebar removes current Linux overlay controls without changing quick chat", () => {
   const source = [
-    "function A2(e){return e===`avatarOverlay`}",
-    "function I2({platform:e,appearance:t,opaqueWindowsEnabled:n,prefersDarkColors:r}){return n&&!A2(t)&&(e===`darwin`||e===`win32`)?{backgroundColor:r?a2:o2,backgroundMaterial:e===`win32`?`none`:null}:e===`linux`&&!A2(t)?{backgroundColor:r?a2:o2,backgroundMaterial:null}:{backgroundColor:i2,backgroundMaterial:null}}",
-    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
-    "function codexLinuxTitleBarOverlay(e=1){return{color:a.nativeTheme.shouldUseDarkColors?`#111111`:o2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(30*e)}}",
-    "case`primary`:return n===`darwin`?t?{titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r)}:{vibrancy:`menu`,titleBarStyle:`hiddenInset`,trafficLightPosition:y2(r)}:n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:b2(r)}:n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay(r)}:{titleBarStyle:`default`};",
-    "setWindowZoom(e,t){let n=r.BrowserWindow.fromWebContents(e);n==null||this.windowAppearances.get(n.id)!==`primary`||(process.platform===`darwin`?n.setWindowButtonPosition(f6(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(b2(t))))}",
-    "installWindowsTitleBarOverlaySync(e,t){if((process.platform!==`win32`&&process.platform!==`linux`)||t!==`primary`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(this.windowZooms.get(e.id)):b2(this.windowZooms.get(e.id)))};return a.nativeTheme.on(`updated`,n),n(),()=>{a.nativeTheme.off(`updated`,n)}}",
-    "process.platform===`linux`&&k.setMenuBarVisibility(!1),process.platform===`win32`&&k.removeMenu(),",
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`,trafficLightPosition:A9(r),...e===`quickChat`?{hasShadow:!0,resizable:!0,transparent:!0}:{},...t?{}:{vibrancy:`menu`}}:n===`win32`?{titleBarStyle:`hidden`,titleBarOverlay:j9(r),...e===`quickChat`?{resizable:!0}:{}}:n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};",
+    "setWindowZoom(e,t){let n=c.BrowserWindow.fromWebContents(e),r=n&&this.windowAppearances.get(n.id);n==null||r!==`primary`&&r!==`quickChat`||(process.platform===`darwin`?n.setWindowButtonPosition(A9(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(t):j9(t))))}",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(this.windowZooms.get(e.id)):j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
+    "(process.platform===`win32`||process.platform===`linux`)&&k.removeMenu(),",
   ].join("");
+  let patched;
+  const warnings = captureWarnings(() => {
+    patched = applyPatchTwice(applyFramelessTitlebarMainPatch, source);
+  });
 
-  const patched = applyPatchTwice(applyFramelessTitlebarMainPatch, source);
-
-  assert.match(patched, /n===`linux`\?\{titleBarStyle:`hidden`\}/);
+  assert.deepEqual(warnings, []);
   assert.match(
     patched,
-    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(b2\(t\)\)\)/,
+    /n===`win32`\?\{titleBarStyle:`hidden`,titleBarOverlay:j9\(r\),\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
   );
-  assert.match(patched, /if\(process\.platform!==`win32`\|\|t!==`primary`\)return/);
   assert.match(
     patched,
-    /process\.platform===`linux`&&k\.removeMenu\(\),process\.platform===`win32`&&k\.removeMenu\(\),/,
+    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
   );
-  assert.doesNotMatch(patched, /setMenuBarVisibility/);
+  assert.match(
+    patched,
+    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(j9\(t\)\)\)/,
+  );
+  assert.match(patched, /if\(process\.platform!==`win32`\|\|t!==`primary`&&t!==`quickChat`\)return/);
+  assert.match(
+    patched,
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&k\.removeMenu\(\),/,
+  );
   assert.doesNotMatch(patched, /titleBarOverlay:codexLinuxTitleBarOverlay/);
   assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
-  assert.doesNotMatch(patched, /process\.platform!==`linux`[^;]*setTitleBarOverlay/);
 });
 
-test("frameless-titlebar leaves core Linux removeMenu patch idempotent", () => {
+test("frameless-titlebar composes with the current native-titlebar patch shape", () => {
   const source =
-    "process.platform===`linux`&&k.removeMenu(),process.platform===`win32`&&k.removeMenu(),";
+    "case`quickChat`:case`primary`:return n===`darwin`?{titleBarStyle:`hiddenInset`}:n===`win32`||n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:n===`linux`?codexLinuxTitleBarOverlay(r):j9(r),...e===`quickChat`?{resizable:!0}:{}}:{titleBarStyle:`default`,...e===`quickChat`?{resizable:!0}:{}};";
+  let patched;
+  const warnings = captureWarnings(() => {
+    patched = applyPatchTwice(applyFramelessTitlebarBranchPatch, source);
+  });
 
-  const patched = applyPatchTwice(applyFramelessTitlebarMenuPatch, source);
-
-  assert.equal(patched, source);
-  assert.equal((patched.match(/process\.platform===`linux`&&k\.removeMenu\(\),/g) ?? []).length, 1);
-  assert.doesNotMatch(patched, /setMenuBarVisibility/);
-});
-
-test("frameless-titlebar collapses the core-patched zoom overlay ternary", () => {
-  const source = [
-    "function b2(e=1){return{color:i2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(g2*e)}}",
-    "function codexLinuxTitleBarOverlay(e=1){return{color:a.nativeTheme.shouldUseDarkColors?`#111111`:o2,symbolColor:a.nativeTheme.shouldUseDarkColors?v2:_2,height:Math.round(30*e)}}",
-    "setWindowZoom(e,t){let n=r.BrowserWindow.fromWebContents(e);n==null||this.windowAppearances.get(n.id)!==`primary`||(process.platform===`darwin`?n.setWindowButtonPosition(f6(t)):(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(process.platform===`linux`?codexLinuxTitleBarOverlay(t):b2(t))))}",
-  ].join("");
-
-  const patched = applyPatchTwice(applyFramelessTitlebarMainPatch, source);
-
+  assert.deepEqual(warnings, []);
   assert.match(
     patched,
-    /process\.platform===`win32`&&\(this\.windowZooms\.set\(n\.id,t\),n\.setTitleBarOverlay\(b2\(t\)\)\)/,
+    /n===`win32`\?\{titleBarStyle:`hidden`,titleBarOverlay:j9\(r\),\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
   );
-  assert.doesNotMatch(patched, /setTitleBarOverlay\(process\.platform===`linux`/);
-  assert.doesNotMatch(patched, /process\.platform===`linux`[^;]*setTitleBarOverlay/);
+  assert.match(
+    patched,
+    /n===`linux`\?\{titleBarStyle:`hidden`,\.\.\.e===`quickChat`\?\{resizable:!0\}:\{\}\}/,
+  );
+  assert.doesNotMatch(patched, /titleBarOverlay:n===`linux`/);
+});
+
+test("frameless-titlebar reports current main-process drift", () => {
+  const titlebarSource =
+    "n===`linux`?{titleBarStyle:`hidden`,titleBarOverlay:codexLinuxTitleBarOverlay(r),...e===`quickChat`?{resizable:!1}:{}}:";
+  const overlaySource = [
+    "setWindowZoom(e,t){(process.platform===`win32`||process.platform===`linux`)&&(this.windowZooms.set(n.id,t),n.setTitleBarOverlay(process.platform===`linux`?linuxOverlayV2(t):j9(t)))}",
+    "installApplicationMenuTitleBarOverlaySync(e,t){if(process.platform!==`win32`&&process.platform!==`linux`||t!==`primary`&&t!==`quickChat`)return;let n=()=>{e.isDestroyed()||e.setTitleBarOverlay(process.platform===`linux`?linuxOverlayV2(this.windowZooms.get(e.id)):j9(this.windowZooms.get(e.id)))};return c.nativeTheme.on(`updated`,n),n(),()=>{c.nativeTheme.off(`updated`,n)}}",
+  ].join("");
+
+  assert.deepEqual(captureWarnings(() => applyFramelessTitlebarBranchPatch(titlebarSource)), [
+    "WARN: Could not find primary BrowserWindow titlebar snippet - skipping frameless titlebar branch patch",
+  ]);
+  assert.deepEqual(captureWarnings(() => applyFramelessTitlebarOverlaySyncPatch(overlaySource)), [
+    "WARN: Could not find setWindowZoom titlebar overlay snippet - skipping frameless zoom patch",
+    "WARN: Could not find application menu titlebar overlay sync snippet - skipping frameless sync patch",
+  ]);
 });
 
 test("frameless-titlebar maps Linux window controls chrome to native webview layout", () => {
-  const source = [
+  const layoutSource = [
     "var eV=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+hyt,right:0}),modern:Object.freeze({left:76+hyt,right:0})}),applicationMenu:Object.freeze({left:0,right:138})});",
     "function Nvt(){return vKe()&&window.electronBridge?.showApplicationMenu!=null}",
-    "function chrome(e){switch(e){case`win32`:case`linux`:return`application-menu`;default:return`native`}}",
+    "function menu(){if(!Nvt())return null;let i=window.electronBridge?.showApplicationMenu;return i}",
     "let newer=i.includes(`win`)||r.includes(`windows`)||i.includes(`linux`)?t??eV.applicationMenu:eV.default;",
   ].join("");
+  const chromeSource = [
+    "function chrome(e){switch(e){case`win32`:case`linux`:return`application-menu`;case`darwin`:case`unknown`:return`native`}}",
+    "function usesChrome(){return document.documentElement.dataset.codexWindowChrome===`application-menu`}",
+  ].join("");
 
-  const patched = applyPatchTwice(applyFramelessTitlebarWebviewPatch, source);
+  const patchedLayout = applyPatchTwice(applyFramelessTitlebarWebviewPatch, layoutSource);
+  const patchedChrome = applyPatchTwice(applyFramelessTitlebarWebviewPatch, chromeSource);
 
   assert.equal(
-    (patched.match(/applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/g) ?? []).length,
+    (patchedLayout.match(/applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/g) ?? []).length,
     1,
   );
-  assert.match(patched, /case`win32`:return`application-menu`;case`linux`:return`native`/);
-  assert.match(patched, /function Nvt\(\)\{return!1\}/);
-  assert.match(patched, /i\.includes\(`win`\)\|\|r\.includes\(`windows`\)\?t\?\?eV\.applicationMenu:eV\.default/);
-  assert.doesNotMatch(patched, /case`win32`:case`linux`:return`application-menu`/);
-  assert.doesNotMatch(patched, /showApplicationMenu/);
-  assert.doesNotMatch(patched, /includes\(`linux`\)\?t\?\?eV\.applicationMenu/);
-  assert.doesNotMatch(patched, /right:138/);
+  assert.match(patchedChrome, /case`win32`:return`application-menu`;case`linux`:return`native`/);
+  assert.match(patchedLayout, /function Nvt\(\)\{return!1\}/);
+  assert.match(patchedLayout, /i\.includes\(`win`\)\|\|r\.includes\(`windows`\)\?t\?\?eV\.applicationMenu:eV\.default/);
+  assert.doesNotMatch(patchedChrome, /case`win32`:case`linux`:return`application-menu`/);
+  assert.doesNotMatch(patchedLayout, /function Nvt\(\)\{return [^}]*showApplicationMenu/);
+  assert.doesNotMatch(patchedLayout, /includes\(`linux`\)\?t\?\?eV\.applicationMenu/);
+  assert.doesNotMatch(patchedLayout, /right:138/);
 });
 
-test("frameless-titlebar warns when only an unrelated disabled function matches bridge output", () => {
+test("frameless-titlebar reports each current webview sub-contract drift", () => {
   const source = [
     "var eV=Object.freeze({default:Object.freeze({left:0,right:0}),applicationMenu:Object.freeze({left:0,right:138})});",
     "function unrelated(){return!1}",
@@ -166,6 +197,15 @@ test("frameless-titlebar warns when only an unrelated disabled function matches 
   const warnings = captureWarnings(() => applyFramelessTitlebarWebviewPatch(source));
 
   assert.deepEqual(warnings, [
+    "WARN: Could not find application menu browser gate - skipping frameless webview platform patch",
+    "WARN: Could not find application menu bridge guard - skipping frameless webview bridge patch",
+  ]);
+
+  const chromeDrift = [
+    "function chrome(e){switch(e){case`win32`:return`application-menu`;case`linux`:return`overlay-v2`;default:return`native`}}",
+    "function usesChrome(){return document.documentElement.dataset.codexWindowChrome===`application-menu`}",
+  ].join("");
+  assert.deepEqual(captureWarnings(() => applyFramelessTitlebarWebviewPatch(chromeDrift)), [
     "WARN: Could not find Linux window controls chrome mapping - skipping frameless webview chrome patch",
   ]);
 });


### PR DESCRIPTION
## Summary

- follow the current primary and Quick Chat BrowserWindow titlebar shape
- keep the Windows overlay and Quick Chat options unchanged while removing Linux overlay updates
- patch the current `k0ede4gb` and `b76hmflu` webview chunks
- report partial titlebar, overlay, bridge, platform, and chrome drift instead of treating an incomplete patch as applied

The feature remains opt-in and no tracked feature configuration changes.

## Validation

- `node --test linux-features/frameless-titlebar/test.js`
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js`
- `cargo check --workspace`
- `cargo test --workspace`
- `bash tests/scripts_smoke.sh`
- full rebuild from the current `26.707.31428` DMG
- packed ASAR syntax, marker, and Linux overlay absence checks
- fresh five-job GitHub Actions matrix on the published head