### PR TITLE
Fix open target discovery for current app flow

### DIFF
--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -124,18 +124,22 @@ function findPropertyBlock(source, propertyName) {
   };
 }
 
-function findAsyncFunctionBlockContaining(source, marker) {
+function findAsyncFunctionBlockContaining(source, marker, predicate = null) {
   let markerIndex = source.indexOf(marker);
   while (markerIndex !== -1) {
     const functionStart = source.lastIndexOf("async function ", markerIndex);
-    const blockStart = functionStart === -1 ? -1 : source.indexOf("{", functionStart);
+    const signatureEnd = functionStart === -1 ? -1 : source.indexOf("){", functionStart);
+    const blockStart = signatureEnd === -1 ? -1 : signatureEnd + 1;
     const block = findBalancedBlock(source, blockStart);
     if (block != null && block.end > markerIndex) {
-      return {
+      const candidate = {
         functionStart,
         header: source.slice(functionStart, blockStart),
         ...block,
       };
+      if (predicate == null || predicate(candidate)) {
+        return candidate;
+      }
     }
     markerIndex = source.indexOf(marker, markerIndex + marker.length);
   }
@@ -143,29 +147,57 @@ function findAsyncFunctionBlockContaining(source, marker) {
 }
 
 function findOpenTargetRegistryBindings(source) {
-  const registryMatch = source.match(
-    /function [A-Za-z_$][\w$]*\(e,t\)\{let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\(e\)\.find\(e=>e\.id===t\);/u,
+  const paramsMatches = [
+    ...source.matchAll(
+      /function [A-Za-z_$][\w$]*\(e,t\)\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(e\)\.find\(e=>e\.id===t\);return \1\?\.configuredCommand==null\|\|\1\.configuredIcon==null\?/gu,
+    ),
+  ];
+  const summaryMatches = [
+    ...source.matchAll(
+      /function [A-Za-z_$][\w$]*\(e\)\{return [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\(e\)\)\}/gu,
+    ),
+  ];
+  const paramsMatch = paramsMatches.find((match) =>
+    summaryMatches.some((summaryMatch) => summaryMatch[1] === match[2]),
   );
-  const summaryMatch = source.match(
-    /function [A-Za-z_$][\w$]*\(e\)\{return [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\(e\)\)\}/u,
+  const registryName = paramsMatch?.[2] ?? null;
+  const registryStart = registryName == null ? -1 : source.indexOf(`function ${registryName}(e){`);
+  const registryBlock = findBalancedBlock(
+    source,
+    registryStart === -1 ? -1 : source.indexOf("{", registryStart),
   );
-  const directMatch = source.match(
-    /function ([A-Za-z_$][\w$]*)\(e\)\{return e\.targets\}/u,
+  const defaultTargetsMatch = registryBlock?.text.match(
+    /if\([A-Za-z_$][\w$]*==null\)return ([A-Za-z_$][\w$]*);/u,
   );
-  const registryName = registryMatch?.[1] ?? summaryMatch?.[1] ?? directMatch?.[1] ?? null;
-  if (registryName == null || !source.includes(`function ${registryName}(`)) {
+  if (registryName == null || defaultTargetsMatch == null) {
     return null;
   }
 
-  const anchor = registryMatch?.index ?? summaryMatch?.index ?? directMatch?.index ?? 0;
-  const nearbySource = source.slice(Math.max(0, anchor - 5000), Math.min(source.length, anchor + 5000));
-  const detectContextMatches = [
-    ...nearbySource.matchAll(/await [A-Za-z_$][\w$]*\.detect\(([A-Za-z_$][\w$]*)\)/gu),
-  ];
+  let detectContextMatch = null;
+  const launchBlock = findAsyncFunctionBlockContaining(
+    source,
+    "Unknown open target",
+    (candidate) => {
+      const targetsMatch = candidate.header.match(
+        /targets:[A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)/u,
+      );
+      detectContextMatch = candidate.text.match(
+        /let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\.find\([A-Za-z_$][\w$]*=>[A-Za-z_$][\w$]*\.id===[A-Za-z_$][\w$]*\);if\(!\1\)throw Error\(`Unknown open target "\$\{[A-Za-z_$][\w$]*\}"`\);let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\?\?await \1\.detect\(([A-Za-z_$][\w$]*)\);if\(!\2\)throw Error\(`Open target "\$\{[A-Za-z_$][\w$]*\}" is not available`\)/u,
+      );
+      return targetsMatch?.[1] === defaultTargetsMatch[1] && detectContextMatch != null;
+    },
+  );
+  if (
+    launchBlock == null ||
+    detectContextMatch == null ||
+    !source.includes(`${detectContextMatch[3]}=async `)
+  ) {
+    return null;
+  }
 
   return {
     registryExpression: `${registryName}(e)`,
-    detectContext: detectContextMatches.at(-1)?.[1] ?? "void 0",
+    detectContext: detectContextMatch[3],
   };
 }
 
@@ -589,19 +621,6 @@ function applyOpenInTargetCommandPatch(currentSource) {
     return currentSource;
   }
 
-  const needles = [
-    "async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}",
-    "async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});return t}",
-  ];
-  const replacement =
-    "async getOpenInTargetCommand(e){let t=await codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e);if(process.platform===`linux`){if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}if(this.requestOpenInWorker==null)return;let{command:n}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(n==null)throw Error(`Open target \"${e}\" is not available`);return n}";
-
-  for (const needle of needles) {
-    if (currentSource.includes(needle)) {
-      return currentSource.replace(needle, replacement);
-    }
-  }
-
   const currentShapeMatch = currentSource.match(
     /async getOpenInTargetCommand\(e\)\{let\{command:t\}=await this\.getOpenInWorker\(\)\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.getSettingsStore\(\),e\)\}\);if\(t==null\)throw Error\(`Open target "\$\{e\}" is not available`\);return t\}/u,
   );
@@ -659,10 +678,7 @@ function applyOpenInTargetsAvailabilityPatch(currentSource) {
 
 function applyOpenInTargetsBridgeDetectionPatch(currentSource) {
   currentSource = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
-  if (
-    currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e)") ||
-    currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.settingsStore,e)")
-  ) {
+  if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.settingsStore,e)")) {
     return currentSource;
   }
   if (!currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
@@ -679,42 +695,10 @@ function applyOpenInTargetsBridgeDetectionPatch(currentSource) {
     return currentSource.replace(needle, replacement);
   }
 
-  const match = currentSource.match(
-    /openInTargets:\{detectTarget:async\(\{target:e\}\)=>\{if\(this\.options\.requestOpenInWorker==null\)throw Error\(`Open in worker unavailable`\);let\{command:t\}=await this\.options\.requestOpenInWorker\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.options\.settingsStore,e\)\}\);return\{available:t!=null\}\},loadTargetIcon:/u,
-  );
-
-  if (match == null) {
-    if (
-      currentSource.includes("openInTargets:{detectTarget") ||
-      (currentSource.includes("async detectTarget({target:") && currentSource.includes("get-target-command"))
-    ) {
-      warn("Could not find open-in bridge target detection");
-    }
-    return currentSource;
+  if (currentSource.includes("async detectTarget({target:") && currentSource.includes("get-target-command")) {
+    warn("Could not find open-in bridge target detection");
   }
-  const [needle, paramsFn] = match;
-  const replacement =
-    `openInTargets:{detectTarget:async({target:e})=>{let t=await codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e);if(process.platform===\`linux\`)return{available:t!=null};if(this.options.requestOpenInWorker==null)throw Error(\`Open in worker unavailable\`);let{command:n}=await this.options.requestOpenInWorker({method:\`get-target-command\`,params:${paramsFn}(this.options.settingsStore,e)});return{available:n!=null}},loadTargetIcon:`;
-  return currentSource.replace(needle, replacement);
-}
-
-function applyOpenInTargetExecutePatch(currentSource) {
-  if (currentSource.includes("targets:iP(e)")) {
-    return currentSource;
-  }
-
-  const needle =
-    "async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c})}";
-  const replacement =
-    "async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c,targets:iP(e)})}";
-
-  if (!currentSource.includes(needle)) {
-    if (currentSource.includes("async function ZN(")) {
-      warn("Could not find open-in target execution helper");
-    }
-    return currentSource;
-  }
-  return currentSource.replace(needle, replacement);
+  return currentSource;
 }
 
 function applyOpenInTargetsDirectoryModePatch(currentSource) {
@@ -814,7 +798,6 @@ function applyMainBundlePatch(currentSource) {
   patchedSource = applyOpenInTargetsAvailabilityPatch(patchedSource);
   patchedSource = applyOpenInTargetCommandPatch(patchedSource);
   patchedSource = applyOpenInTargetsBridgeDetectionPatch(patchedSource);
-  patchedSource = applyOpenInTargetExecutePatch(patchedSource);
   patchedSource = applyOpenInTargetsDirectoryModePatch(patchedSource);
   return patchedSource;
 }
@@ -823,7 +806,6 @@ module.exports = {
   applyNativeOpenTargetSelectionPatch,
   applyMainBundlePatch,
   applyOpenInTargetRegistryCommandPatch,
-  applyOpenInTargetExecutePatch,
   applyOpenInTargetCommandPatch,
   applyOpenInTargetsAvailabilityPatch,
   applyOpenInTargetsBridgeDetectionPatch,

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -823,7 +823,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^(?:open-target-selection-.*|app-initial~app-main~.*)\.js$/,
+      pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -124,6 +124,51 @@ function findPropertyBlock(source, propertyName) {
   };
 }
 
+function findAsyncFunctionBlockContaining(source, marker) {
+  let markerIndex = source.indexOf(marker);
+  while (markerIndex !== -1) {
+    const functionStart = source.lastIndexOf("async function ", markerIndex);
+    const blockStart = functionStart === -1 ? -1 : source.indexOf("{", functionStart);
+    const block = findBalancedBlock(source, blockStart);
+    if (block != null && block.end > markerIndex) {
+      return {
+        functionStart,
+        header: source.slice(functionStart, blockStart),
+        ...block,
+      };
+    }
+    markerIndex = source.indexOf(marker, markerIndex + marker.length);
+  }
+  return null;
+}
+
+function findOpenTargetRegistryBindings(source) {
+  const registryMatch = source.match(
+    /function [A-Za-z_$][\w$]*\(e,t\)\{let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\(e\)\.find\(e=>e\.id===t\);/u,
+  );
+  const summaryMatch = source.match(
+    /function [A-Za-z_$][\w$]*\(e\)\{return [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\(e\)\)\}/u,
+  );
+  const directMatch = source.match(
+    /function ([A-Za-z_$][\w$]*)\(e\)\{return e\.targets\}/u,
+  );
+  const registryName = registryMatch?.[1] ?? summaryMatch?.[1] ?? directMatch?.[1] ?? null;
+  if (registryName == null || !source.includes(`function ${registryName}(`)) {
+    return null;
+  }
+
+  const anchor = registryMatch?.index ?? summaryMatch?.index ?? directMatch?.index ?? 0;
+  const nearbySource = source.slice(Math.max(0, anchor - 5000), Math.min(source.length, anchor + 5000));
+  const detectContextMatches = [
+    ...nearbySource.matchAll(/await [A-Za-z_$][\w$]*\.detect\(([A-Za-z_$][\w$]*)\)/gu),
+  ];
+
+  return {
+    registryExpression: `${registryName}(e)`,
+    detectContext: detectContextMatches.at(-1)?.[1] ?? "void 0",
+  };
+}
+
 function insertOpenTargetHelpers(currentSource, insertionIndex, { fsVar, pathVar }) {
   if (currentSource.includes("function codexLinuxFindExecutable(")) {
     return currentSource;
@@ -506,26 +551,28 @@ function applyLinuxIconSummaryResolutionPatch(currentSource) {
   return currentSource.replace(needle, replacement);
 }
 
-function applyOpenInTargetRegistryCommandPatch(currentSource) {
-  const helper =
-    "function codexLinuxOpenTargetRegistryTargets(e){let t=null;try{t=typeof pP===`function`?pP(e):iP(e)}catch{}return Array.isArray(t)?t:Array.isArray(e?.targets)?e.targets:[]}" +
-    "async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==`linux`)return;let n=codexLinuxOpenTargetRegistryTargets(e).find(e=>e.id===t),r=typeof ZN!==`undefined`?ZN:typeof IN!==`undefined`?IN:void 0;return typeof n?.detect===`function`?await n.detect(r):null}";
-  const legacyHelpers = [
-    "async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==`linux`)return;let n=(typeof pP===`function`?pP(e):iP(e)).find(e=>e.id===t),r=typeof ZN!==`undefined`?ZN:typeof IN!==`undefined`?IN:void 0;return typeof n?.detect===`function`?await n.detect(r):null}",
-    "async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==`linux`)return;let n=iP(e).find(e=>e.id===t);return typeof n?.detect===`function`?await n.detect(IN):null}",
-  ];
-
-  if (currentSource.includes(helper)) {
-    return currentSource;
-  }
-  for (const legacyHelper of legacyHelpers) {
-    if (currentSource.includes(legacyHelper)) {
-      return currentSource.replace(legacyHelper, helper);
-    }
-  }
+function applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing = true } = {}) {
   if (currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
     return currentSource;
   }
+
+  const bindings = findOpenTargetRegistryBindings(currentSource);
+  if (bindings == null) {
+    if (
+      warnOnMissing &&
+      (
+        currentSource.includes("get-target-command") ||
+        currentSource.includes("getOpenInTargetCommand") ||
+        currentSource.includes("allAvailableTargets")
+      )
+    ) {
+      warn("Could not find open target registry");
+    }
+    return currentSource;
+  }
+
+  const helper =
+    `async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==\`linux\`)return;try{let n=${bindings.registryExpression}.find(e=>e.id===t);return typeof n?.detect===\`function\`?await n.detect(${bindings.detectContext}):null}catch{return null}}`;
 
   const insertionIndex = currentSource.indexOf("async function");
   const helperInsertionIndex = insertionIndex === -1 ? 0 : insertionIndex;
@@ -534,8 +581,11 @@ function applyOpenInTargetRegistryCommandPatch(currentSource) {
 }
 
 function applyOpenInTargetCommandPatch(currentSource) {
-  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource);
+  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
   if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e)")) {
+    return currentSource;
+  }
+  if (!currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
     return currentSource;
   }
 
@@ -559,7 +609,7 @@ function applyOpenInTargetCommandPatch(currentSource) {
     const [needle, paramsFn] = currentShapeMatch;
     return currentSource.replace(
       needle,
-      `async getOpenInTargetCommand(e){let t=await codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e);if(process.platform===\`linux\`){if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}let{command:n}=await this.getOpenInWorker()({method:\`get-target-command\`,params:${paramsFn}(this.getSettingsStore(),e)});if(n==null)throw Error(\`Open target "\${e}" is not available\`);return n}`,
+      `async getOpenInTargetCommand(e){if(process.platform===\`linux\`){let t=await codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e);if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}let{command:n}=await this.getOpenInWorker()({method:\`get-target-command\`,params:${paramsFn}(this.getSettingsStore(),e)});if(n==null)throw Error(\`Open target "\${e}" is not available\`);return n}`,
     );
   }
 
@@ -570,31 +620,63 @@ function applyOpenInTargetCommandPatch(currentSource) {
 }
 
 function applyOpenInTargetsAvailabilityPatch(currentSource) {
-  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource);
-  if (currentSource.includes("process.platform===`linux`?codexLinuxOpenTargetRegistryCommand(e,n.id)")) {
+  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
+  if (currentSource.includes("process.platform===`linux`?codexLinuxOpenTargetRegistryCommand(")) {
+    return currentSource;
+  }
+  if (!currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
     return currentSource;
   }
 
-  const match = currentSource.match(
-    /async function ([A-Za-z_$][\w$]*)\(e,t\)\{let n=await Promise\.all\(rP\(e\)\.map\(async n=>\{let r=iP\(e,n\.id\),\[i,a\]=await Promise\.all\(\[t\(\{method:`get-target-command`,params:r\}\)\.then\(e=>e\.command\)\.catch\(e=>\(tP\(\)\.error\(`Failed to detect open target`,\{safe:\{\},sensitive:\{id:n\.id,error:e\}\}\),null\)\),process\.platform===`win32`\?t\(\{method:`load-target-icon`,params:r\}\)\.then\(e=>e\.icon\)\.catch\(e=>\(tP\(\)\.warning\(`Failed to resolve open target icon`,\{safe:\{\},sensitive:\{id:n\.id,error:e\}\}\),n\.icon\)\):n\.icon\]\);return\{command:i,metadata:\{\.\.\.n,icon:a\}\}\}\)\);return\{allAvailableTargets:n\.flatMap\(\(\{command:e,metadata:t\}\)=>e==null\?\[\]:\[t\.id\]\),targetMetadata:n\.map\(\(\{metadata:e\}\)=>e\)\}\}/u,
+  const block = findAsyncFunctionBlockContaining(currentSource, "allAvailableTargets");
+  const signature = block?.header.match(
+    /^async function [A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)$/u,
   );
-  if (match == null) {
+  const mapping = block?.text.match(
+    /[A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\)\.map\(async ([A-Za-z_$][\w$]*)=>\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\(\1,\2\.id\),/u,
+  );
+  if (block == null || signature == null || mapping == null || signature[1] !== mapping[1]) {
     if (currentSource.includes("async function") && currentSource.includes("get-target-command") && currentSource.includes("allAvailableTargets")) {
       warn("Could not find open-in-targets availability detector");
     }
     return currentSource;
   }
 
-  const [needle, fnName] = match;
-  const replacement =
-    `async function ${fnName}(e,t){let n=await Promise.all(rP(e).map(async n=>{let r=iP(e,n.id),[i,a]=await Promise.all([process.platform===\`linux\`?codexLinuxOpenTargetRegistryCommand(e,n.id):t({method:\`get-target-command\`,params:r}).then(e=>e.command).catch(e=>(tP().error(\`Failed to detect open target\`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===\`win32\`?t({method:\`load-target-icon\`,params:r}).then(e=>e.icon).catch(e=>(tP().warning(\`Failed to resolve open target icon\`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}`;
-  return currentSource.replace(needle, replacement);
+  const [storeVar, workerVar] = signature.slice(1);
+  const [, , targetVar, paramsVar] = mapping;
+  const workerCall = `${workerVar}({method:\`get-target-command\`,params:${paramsVar}})`;
+  if (!block.text.includes(workerCall)) {
+    warn("Could not find open-in-targets availability worker call");
+    return currentSource;
+  }
+
+  const patchedBlock = block.text.replace(
+    workerCall,
+    `process.platform===\`linux\`?codexLinuxOpenTargetRegistryCommand(${storeVar},${targetVar}.id):${workerCall}`,
+  );
+  return currentSource.slice(0, block.start) + patchedBlock + currentSource.slice(block.end);
 }
 
 function applyOpenInTargetsBridgeDetectionPatch(currentSource) {
-  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource);
-  if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e)")) {
+  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
+  if (
+    currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.options.settingsStore,e)") ||
+    currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.settingsStore,e)")
+  ) {
     return currentSource;
+  }
+  if (!currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
+    return currentSource;
+  }
+
+  const currentClassMatch = currentSource.match(
+    /async detectTarget\(\{target:([A-Za-z_$][\w$]*)\}\)\{if\(this\.requestOpenInWorker==null\)throw Error\(`Open in worker unavailable`\);let\{command:([A-Za-z_$][\w$]*)\}=await this\.requestOpenInWorker\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.settingsStore,\1\)\}\);return\{available:\2!=null\}\}/u,
+  );
+  if (currentClassMatch != null) {
+    const [needle, targetVar, commandVar, paramsFn] = currentClassMatch;
+    const replacement =
+      `async detectTarget({target:${targetVar}}){if(process.platform===\`linux\`){let ${commandVar}=await codexLinuxOpenTargetRegistryCommand(this.settingsStore,${targetVar});return{available:${commandVar}!=null}}if(this.requestOpenInWorker==null)throw Error(\`Open in worker unavailable\`);let{command:_codexWorkerCommand}=await this.requestOpenInWorker({method:\`get-target-command\`,params:${paramsFn}(this.settingsStore,${targetVar})});return{available:_codexWorkerCommand!=null}}`;
+    return currentSource.replace(needle, replacement);
   }
 
   const match = currentSource.match(
@@ -602,7 +684,10 @@ function applyOpenInTargetsBridgeDetectionPatch(currentSource) {
   );
 
   if (match == null) {
-    if (currentSource.includes("openInTargets:{detectTarget")) {
+    if (
+      currentSource.includes("openInTargets:{detectTarget") ||
+      (currentSource.includes("async detectTarget({target:") && currentSource.includes("get-target-command"))
+    ) {
       warn("Could not find open-in bridge target detection");
     }
     return currentSource;
@@ -634,33 +719,48 @@ function applyOpenInTargetExecutePatch(currentSource) {
 
 function applyOpenInTargetsDirectoryModePatch(currentSource) {
   const helper = "function codexLinuxOpenTargetIsDirectory(";
-  const directoryNeedles = [
-    {
-      needle: "g=d||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[]",
-      replacement: "w=f!=null&&codexLinuxOpenTargetIsDirectory(f),g=d||w||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[]",
-    },
-    {
-      needle: "g=d||f!=null&&t.rs(f),_=f!=null&&cj(f),v=f!=null&&uj(f),y=g?await MF(i):_?await jF({filePath:f}):[]",
-      replacement: "w=f!=null&&codexLinuxOpenTargetIsDirectory(f),g=d||w||f!=null&&t.rs(f),_=f!=null&&cj(f),v=f!=null&&uj(f),y=g?await MF(i):_?await jF({filePath:f}):[]",
-    },
-  ];
-
   if (currentSource.includes(helper)) {
     return currentSource;
   }
-  if (!currentSource.includes('"open-in-targets":async')) {
+  const propertyIndex = currentSource.indexOf('"open-in-targets":async');
+  if (propertyIndex === -1) {
     return currentSource;
   }
-  const directoryPatch = directoryNeedles.find(({ needle }) => currentSource.includes(needle));
-  if (directoryPatch == null) {
+
+  const arrowIndex = currentSource.indexOf("=>{", propertyIndex);
+  const block = findBalancedBlock(currentSource, arrowIndex === -1 ? -1 : arrowIndex + 2);
+  if (block == null) {
     warn("Could not find open-in-targets path mode expression");
     return currentSource;
   }
 
+  const modeExpressions = [
+    ...block.text.matchAll(
+      /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\|\|([A-Za-z_$][\w$]*)!=null&&([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(\3\),/gu,
+    ),
+  ];
+  const modeExpression = modeExpressions.find((match) =>
+    block.text.includes(`mode:${match[1]}||`),
+  );
+  if (modeExpression == null) {
+    warn("Could not find open-in-targets path mode expression");
+    return currentSource;
+  }
+
+  const [needle, modeVar, remoteVar, pathVar, pathModule, pathMethod] = modeExpression;
+  const directoryVar = "_codexLinuxDirectory";
+  if (block.text.includes(directoryVar)) {
+    warn("Could not reserve open-in-targets directory variable");
+    return currentSource;
+  }
+  const replacement =
+    `${directoryVar}=${pathVar}!=null&&codexLinuxOpenTargetIsDirectory(${pathVar}),` +
+    `${modeVar}=${remoteVar}||${directoryVar}||${pathVar}!=null&&${pathModule}.${pathMethod}(${pathVar}),`;
+
   const helperSource =
     `function codexLinuxOpenTargetIsDirectory(e){if(process.platform!==\`linux\`||typeof e!==\`string\`)return!1;try{return(0,codexLinuxNodeFs().existsSync)(e)&&(0,codexLinuxNodeFs().statSync)(e).isDirectory()}catch{return!1}}`;
   const patchedSource = helperSource + currentSource;
-  return patchedSource.replace(directoryPatch.needle, directoryPatch.replacement);
+  return patchedSource.replace(needle, replacement);
 }
 
 function applyNativeOpenTargetSelectionPatch(currentSource) {

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -12,7 +12,6 @@ const {
   applyMainBundlePatch,
   applyNativeOpenTargetSelectionPatch,
   applyOpenInTargetCommandPatch,
-  applyOpenInTargetExecutePatch,
   applyOpenInTargetRegistryCommandPatch,
   applyOpenInTargetsBridgeDetectionPatch,
   applyOpenInTargetsAvailabilityPatch,
@@ -44,42 +43,22 @@ const collidingPathAliasBundle =
   fileManagerBundle +
   terminalOpenTargetBundle +
   ideOpenTargetsBundle;
-const iconResolverBundle =
-  "async function c_(e,t,a){return e===`win32`?Promise.all(t.map(async e=>{let t=a?.get(e.id)??null,r=e.iconPath?e.iconPath(t):t;return{id:e.id,label:e.label,icon:await d_(r,e.icon),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}})):l_(t)}function l_(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}async function d_(e,t){if(!e)return t;try{let r=e.toLowerCase().endsWith(`.lnk`)?await f_(e):await n.app.getFileIcon(e,{size:`normal`});return!r||r.isEmpty()?t:r.toDataURL()}catch(e){return t}}async function f_(e){return n.nativeImage.createFromPath(e)}";
 const currentIconResolverBundle =
   "async function VN(e,t,n){return e===`win32`?Promise.all(t.map(async e=>{let t=n?.get(e.id)??null,r=e.iconPath?e.iconPath(t):t;return{id:e.id,label:e.label,icon:await WN(r,e.icon),kind:e.kind,hidden:e.hidden,supportsSsh:e.supportsSsh}})):HN(t)}function HN(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}async function WN(e,t){if(!e)return t;try{let r=e.toLowerCase().endsWith(`.lnk`)?await UN(e):await n.app.getFileIcon(e,{size:`normal`});return!r||r.isEmpty()?t:r.toDataURL()}catch(e){return t}}async function UN(e){return n.nativeImage.createFromPath(e)}";
-const openInCommandBundle =
-  "async function JN(){}function iP(e){return e.targets}var IN={};class App{constructor(){this.requestOpenInWorker=async()=>({command:`worker-command`});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});return t}}";
-const currentOpenInCommandBundle =
-  "async function JN(){}function iP(e){return e.targets}var IN={};class App{constructor(){this.requestOpenInWorker=async()=>({command:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
-const latestOpenInCommandBundle =
-  "function pP(e){return e.targets}function iP(e,t){return{target:t}}class App{constructor(){this.getOpenInWorker=()=>async()=>({command:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:`get-target-command`,params:iP(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
-const openInAvailabilityBundle =
-  "function pP(e){return e.targets}function eP(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}function rP(e){return eP(pP(e))}function iP(e,t){return{target:t}}function tP(){return{error(){},warning(){}}}async function aP(e,t){let n=await Promise.all(rP(e).map(async n=>{let r=iP(e,n.id),[i,a]=await Promise.all([t({method:`get-target-command`,params:r}).then(e=>e.command).catch(e=>(tP().error(`Failed to detect open target`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===`win32`?t({method:`load-target-icon`,params:r}).then(e=>e.icon).catch(e=>(tP().warning(`Failed to resolve open target icon`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}";
+const currentAppRegistryFunction =
+  "function QN(e){let t=e.getEffective(`customFileHandlers`);if(t==null)return PN;let r=BN.get(t);if(r!=null)return r;let i=t,a=i.length===0?PN:[...PN,...i];return BN.set(t,a),a}";
 const currentAppOpenTargetPrelude =
-  "var FN={source:`shortcut-reader`};function RN(e){return e.map(({id:e,label:t,icon:n,kind:r})=>({id:e,label:t,icon:n,kind:r}))}function HN(e){return RN(QN(e))}function UN(e,t){let n=QN(e).find(e=>e.id===t);return n?.configuredCommand==null?{target:t}:{target:t,customTarget:{command:n.configuredCommand}}}function QN(e){return e.targets}async function LN(e){let t=e.targets[0];return await t.detect(FN)}function zN(){return{error(){},warning(){}}}";
+  `var PN=[],FN=async e=>\`shortcut:\${e}\`,BN=new WeakMap;function RN(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}function HN(e){return RN(QN(e))}function UN(e,t){let n=QN(e).find(e=>e.id===t);return n?.configuredCommand==null||n.configuredIcon==null?{target:t}:{target:t,customTarget:{command:n.configuredCommand,icon:n.configuredIcon}}}${currentAppRegistryFunction}async function LN(e,t,{detectedCommand:r,targets:c=PN}={}){let l=c.find(t=>t.id===e);if(!l)throw Error(\`Unknown open target "\${e}"\`);let u=r??await l.detect(FN);if(!u)throw Error(\`Open target "\${e}" is not available\`);return u}var WRONG={};async function unrelated(e){return await e.detect(WRONG)}function zN(){return{error(){},warning(){}}}`;
 const currentAppOpenInCommandBundle =
-  `${currentAppOpenTargetPrelude}function iP(){throw Error(\`unrelated helper called\`)}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}getSettingsStore(){return this.settingsStore}getOpenInWorker(){return this.requestOpenInWorker}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:\`get-target-command\`,params:UN(this.getSettingsStore(),e)});if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}}`;
+  `${currentAppOpenTargetPrelude}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}getSettingsStore(){return this.settingsStore}getOpenInWorker(){return this.requestOpenInWorker}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:\`get-target-command\`,params:UN(this.getSettingsStore(),e)});if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}}`;
 const currentAppOpenInAvailabilityBundle =
   `${currentAppOpenTargetPrelude}async function WN(e,t){let n=await Promise.all(HN(e).map(async n=>{let r=UN(e,n.id),[i,a]=await Promise.all([t({method:\`get-target-command\`,params:r}).then(e=>e.command).catch(e=>(zN().error(\`Failed to detect open target\`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===\`win32\`?t({method:\`load-target-icon\`,params:r}).then(e=>e.icon).catch(e=>(zN().warning(\`Failed to resolve open target icon\`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}`;
 const currentAppOpenInBridgeBundle =
   `${currentAppOpenTargetPrelude}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}async detectTarget({target:e}){if(this.requestOpenInWorker==null)throw Error(\`Open in worker unavailable\`);let{command:t}=await this.requestOpenInWorker({method:\`get-target-command\`,params:UN(this.settingsStore,e)});return{available:t!=null}}}`;
-const openInBridgeBundle =
-  "async function JN(){}function iP(e){return e.targets}var IN={};var bridge={options:{settingsStore:{targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]},requestOpenInWorker:async()=>({command:`worker-command`})},openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:JN(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
-const latestOpenInBridgeBundle =
-  "function pP(e){return e.targets}function iP(e,t){return{target:t}}var bridge={options:{settingsStore:{targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]},requestOpenInWorker:async()=>({command:null})},openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:iP(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
-const openInExecuteBundle =
-  "function iP(e){return e.targets}async function BN(e,t,n){return n}async function ZN(e,t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c}={}){await BN(t,n,{appPath:r,detectedCommand:i,hostConfig:a,location:o,remotePath:s,remoteWorkspaceRoot:c})}";
-const openInTargetsBundle =
-  '"open-in-targets":async({cwd:e,deferEnrichment:n=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();let[c,l]=await Promise.all([XN(s),YN(s)]),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&_F(u)&&!t.Ta(o.hostConfig),f=u==null||d||t.Ta(o.hostConfig)?null:this.resolveOpenFilePath(this.mapAgentPathToLocalPath(u,o.hostConfig)??u,this.mapAgentPathToLocalPath(e,o.hostConfig)??this.getWorkspaceRoot()),p=oj(o.hostConfig,c,l),m=new Set(p),h=tP(s,e,m),g=d||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}';
-const latestOpenInTargetsBundle =
-  '"open-in-targets":async({cwd:e,deferEnrichment:n=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();if(n&&a==null){let t=dP(s,e);return{preferredTarget:t,availableTargets:[],mode:`editor`,targets:Ej(rP(s),o.hostConfig).map(({id:e,label:n,icon:r,kind:i,hidden:a})=>({id:e,target:e,label:n,icon:r,kind:i,hidden:a,default:t===e||void 0}))}}let{allAvailableTargets:c,targetMetadata:l}=await aP(s,this.getOpenInWorker()),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&PF(u)&&!t.Ha(o.hostConfig),f=u==null||d||t.Ha(o.hostConfig)?null:this.resolveOpenFilePath(this.mapAgentPathToLocalPath(u,o.hostConfig)??u,this.mapAgentPathToLocalPath(e,o.hostConfig)??this.getWorkspaceRoot()),p=Tj(o.hostConfig,c,l),m=new Set(p),h=uP(s,e,m),g=d||f!=null&&t.rs(f),_=f!=null&&cj(f),v=f!=null&&uj(f),y=g?await MF(i):_?await jF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}';
 const currentAppOpenInTargetsBundle =
   '"open-in-targets":async({cwd:e,deferEnrichment:t=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();if(t&&a==null){let t=XN(s,e);return{preferredTarget:t,availableTargets:[],mode:`editor`,targets:uj(HN(s),o.hostConfig)}}let{allAvailableTargets:c,targetMetadata:l}=await WN(s,this.getOpenInWorker()),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&xF(u)&&!n.eo(o.hostConfig),f=u==null||d||n.eo(o.hostConfig)?null:this.resolveOpenFilePath(u,e),p=lj(o.hostConfig,c,l),m=new Set(p),h=YN(s,e,m),g=d||f!=null&&n.ys(f),_=f!=null&&KA(f),v=f!=null&&JA(f),y=g?await yF(i):_?await vF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:l}}';
-const openTargetSelectionBundle =
-  "function e({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}function t({preferredTarget:t,targets:n,availableTargets:r,includeHiddenTargets:i=!0,mode:a=`editor`}){let o=e({targets:n,availableTargets:r,includeHiddenTargets:i,mode:a});return o.length===0?null:t?o.find(e=>e.target===t)??o[0]??null:o[0]??null}function n(e){return e.appPath==null&&e.kind===`editor`}export{e as n,t as r,n as t};";
-const latestOpenTargetSelectionBundle =
-  "function O9({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}function mNe({preferredTarget:e,targets:t,availableTargets:n,includeHiddenTargets:r=!0,mode:i=`editor`}){let a=O9({targets:t,availableTargets:n,includeHiddenTargets:r,mode:i});return a.length===0?null:e?a.find(t=>t.target===e)??a[0]??null:a[0]??null}function hNe(e){return e.appPath==null&&e.kind===`editor`}";
+const currentAppOpenTargetSelectionBundle =
+  "function lQ({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}function uQ({preferredTarget:e,targets:t,availableTargets:n,includeHiddenTargets:r=!0,mode:i=`editor`}){let a=lQ({targets:t,availableTargets:n,includeHiddenTargets:r,mode:i});return a.length===0?null:e?a.find(t=>t.target===e)??a[0]??null:a[0]??null}function jnr(e){return e.appPath==null&&e.kind===`editor`}";
 
 function applyPatchTwice(patchFn, source, ...args) {
   const patched = patchFn(source, ...args);
@@ -98,6 +77,15 @@ function captureWarns(fn) {
   } finally {
     console.warn = originalWarn;
   }
+}
+
+function currentAppSettingsStore(targets) {
+  return {
+    getEffective(key) {
+      assert.equal(key, "customFileHandlers");
+      return targets;
+    },
+  };
 }
 
 function makeExecutable(dir, name) {
@@ -800,42 +788,6 @@ test("open-target discovery follows symlinked desktop entry icons", () => {
   });
 });
 
-test("open-target discovery resolves iconPath on Linux", async () => {
-  const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${iconResolverBundle}`);
-  const iconPath = path.join(os.tmpdir(), "codex-open-target-icon.png");
-  fs.writeFileSync(iconPath, "codex");
-  const electron = {
-    app: {
-      getFileIcon: async () => {
-        throw new Error("should prefer direct data URL for image files");
-      },
-    },
-    nativeImage: {
-      createFromPath: () => {
-        throw new Error("should not need nativeImage for image files");
-      },
-    },
-  };
-
-  const targets = [
-    {
-      id: "linux-desktop-agent",
-      label: "Agent",
-      icon: "apps/terminal.png",
-      kind: "editor",
-      iconPath: () => iconPath,
-    },
-  ];
-  const result = await new Function("require", "process", `${patched};return c_('linux', arguments[2], new Map());`)(
-    (name) => (name === "electron" ? electron : require(name)),
-    { platform: "linux", env: {} },
-    targets,
-  );
-
-  assert.equal(result[0].icon, `data:image/png;base64,${Buffer.from("codex").toString("base64")}`);
-  fs.rmSync(iconPath, { force: true });
-});
-
 test("open-target discovery resolves iconPath on current upstream bundle shape", async () => {
   const patched = applyPatchTwice(applyMainBundlePatch, `${mainBundlePrefix}${currentIconResolverBundle}`);
   const iconPath = path.join(os.tmpdir(), "codex-current-open-target-icon.svg");
@@ -1130,174 +1082,110 @@ test("open-target discovery resolves SVG iconPath in Linux target summaries", as
   fs.rmSync(iconPath, { force: true });
 });
 
-test("open-target discovery uses main registry for Linux command lookup", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, openInCommandBundle);
-  const app = new Function(`${patched};return new App();`)();
-
-  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
-  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
-  await assert.rejects(() => app.getOpenInTargetCommand("missing"), /not available/);
-});
-
-test("open-target discovery patches current command lookup shape", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, currentOpenInCommandBundle);
-  const app = new Function(`${patched};return new App();`)();
-
-  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
-  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
-});
-
-test("open-target discovery patches latest command lookup shape", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, latestOpenInCommandBundle);
-  const app = new Function(`${patched};return new App();`)();
-
-  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
-  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
-});
-
 test("open-target discovery patches current app command lookup through its registry", async () => {
   let workerCalls = 0;
-  const settingsStore = {
-    targets: [
-      {
-        id: "linux-desktop-agent",
-        detect: async (context) => context?.source === "shortcut-reader" ? "main-command" : null,
-      },
-      { id: "broken", detect: async () => { throw new Error("probe failed"); } },
-    ],
-  };
+  const settingsStore = currentAppSettingsStore([
+    {
+      id: "linux-desktop-agent",
+      detect: async (readShortcutLink) =>
+        typeof readShortcutLink === "function" && await readShortcutLink("entry") === "shortcut:entry"
+          ? "main-command"
+          : null,
+    },
+    { id: "broken", detect: async () => { throw new Error("probe failed"); } },
+  ]);
   const patched = applyPatchTwice(applyOpenInTargetCommandPatch, currentAppOpenInCommandBundle);
-  const app = new Function(`${patched};return new App(arguments[0],arguments[1]);`)(settingsStore, async () => {
-    workerCalls += 1;
-    return { command: "worker-command" };
-  });
+  const app = new Function("process", `${patched};return new App(arguments[1],arguments[2]);`)(
+    { platform: "linux" },
+    settingsStore,
+    async () => {
+      workerCalls += 1;
+      return { command: "worker-command" };
+    },
+  );
 
   assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
   await assert.rejects(() => app.getOpenInTargetCommand("broken"), /not available/);
   assert.equal(workerCalls, 0);
-  assert.match(patched, /if\(process\.platform===`linux`\)\{let t=await codexLinuxOpenTargetRegistryCommand/);
-});
+  assert.match(patched, /n\.detect\(FN\)/);
+  assert.doesNotMatch(patched, /n\.detect\(WRONG\)|n\.detect\(void 0\)/);
 
-test("open-target discovery command lookup tolerates param-builder target helper", async () => {
-  const source =
-    "function pP(e){return e.targets}function JN(e,t){return{target:t}}function iP(e,t){return{target:t}}var IN={};class App{constructor(){this.requestOpenInWorker=async({params:e})=>({command:e.target===`vscode`?`worker-command`:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
-  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, source);
-  const app = new Function(`${patched};return new App();`)();
-
-  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
-  await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
-});
-
-test("open-target discovery uses main registry for target availability", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetsAvailabilityPatch, openInAvailabilityBundle);
-  const worker = async () => ({ command: null });
-  const result = await new Function(
-    `${patched};return aP({targets:[{id:'linux-desktop-agent',label:'Agent',icon:'apps/terminal.png',kind:'editor',detect:async()=>'/usr/bin/agent'},{id:'missing',label:'Missing',icon:'apps/terminal.png',kind:'editor',detect:async()=>null}]}, arguments[0]);`,
-  )(worker);
-
-  assert.deepEqual(result.allAvailableTargets, ["linux-desktop-agent"]);
-  assert.deepEqual(result.targetMetadata.map((target) => target.id), ["linux-desktop-agent", "missing"]);
+  const darwinApp = new Function("process", `${patched};return new App(arguments[1],arguments[2]);`)(
+    { platform: "darwin" },
+    settingsStore,
+    async () => {
+      workerCalls += 1;
+      return { command: "worker-command" };
+    },
+  );
+  assert.equal(await darwinApp.getOpenInTargetCommand("linux-desktop-agent"), "worker-command");
+  assert.equal(workerCalls, 1);
 });
 
 test("open-target discovery patches current app availability through its registry", async () => {
   let workerCalls = 0;
-  const settingsStore = {
-    targets: [
-      {
-        id: "linux-desktop-agent",
-        label: "Agent",
-        icon: "apps/terminal.png",
-        kind: "editor",
-        detect: async (context) => context?.source === "shortcut-reader" ? "/usr/bin/agent" : null,
-      },
-      {
-        id: "missing",
-        label: "Missing",
-        icon: "apps/terminal.png",
-        kind: "editor",
-        detect: async () => null,
-      },
-      {
-        id: "broken",
-        label: "Broken",
-        icon: "apps/terminal.png",
-        kind: "editor",
-        detect: async () => { throw new Error("probe failed"); },
-      },
-    ],
-  };
+  const settingsStore = currentAppSettingsStore([
+    {
+      id: "linux-desktop-agent",
+      label: "Agent",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      detect: async (readShortcutLink) =>
+        typeof readShortcutLink === "function" && await readShortcutLink("entry") === "shortcut:entry"
+          ? "/usr/bin/agent"
+          : null,
+    },
+    {
+      id: "missing",
+      label: "Missing",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      detect: async () => null,
+    },
+    {
+      id: "broken",
+      label: "Broken",
+      icon: "apps/terminal.png",
+      kind: "editor",
+      detect: async () => { throw new Error("probe failed"); },
+    },
+  ]);
   const patched = applyPatchTwice(applyOpenInTargetsAvailabilityPatch, currentAppOpenInAvailabilityBundle);
-  const result = await new Function(`${patched};return WN(arguments[0],arguments[1]);`)(settingsStore, async () => {
+  const result = await new Function(
+    "process",
+    `${patched};return WN(arguments[1],arguments[2]);`,
+  )({ platform: "linux" }, settingsStore, async () => {
     workerCalls += 1;
     return { command: "worker-command" };
   });
 
   assert.deepEqual(result.allAvailableTargets, ["linux-desktop-agent"]);
+  assert.deepEqual(result.targetMetadata.map((target) => target.id), ["linux-desktop-agent", "missing", "broken"]);
   assert.equal(workerCalls, 0);
-});
-
-test("open-target discovery bridge detection uses main registry on Linux", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, openInBridgeBundle);
-  const options = {
-    settingsStore: {
-      targets: [
-        { id: "linux-desktop-agent", detect: async () => "main-command" },
-        { id: "missing", detect: async () => null },
-      ],
-    },
-    requestOpenInWorker: async () => ({ command: "worker-command" }),
-  };
-  const bridge = new Function(`${patched};return bridge;`).call({ options });
-
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "linux-desktop-agent" }), {
-    available: true,
-  });
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "missing" }), {
-    available: false,
-  });
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "vscode" }), {
-    available: false,
-  });
-});
-
-test("open-target discovery patches latest bridge detection shape", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, latestOpenInBridgeBundle);
-  const options = {
-    settingsStore: {
-      targets: [
-        { id: "linux-desktop-agent", detect: async () => "main-command" },
-        { id: "missing", detect: async () => null },
-      ],
-    },
-    requestOpenInWorker: async () => ({ command: null }),
-  };
-  const bridge = new Function(`${patched};return bridge;`).call({ options });
-
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "linux-desktop-agent" }), {
-    available: true,
-  });
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "missing" }), {
-    available: false,
-  });
 });
 
 test("open-target discovery patches current app bridge detection through its registry", async () => {
   let workerCalls = 0;
-  const settingsStore = {
-    targets: [
-      {
-        id: "linux-desktop-agent",
-        detect: async (context) => context?.source === "shortcut-reader" ? "main-command" : null,
-      },
-      { id: "missing", detect: async () => null },
-      { id: "broken", detect: async () => { throw new Error("probe failed"); } },
-    ],
-  };
+  const settingsStore = currentAppSettingsStore([
+    {
+      id: "linux-desktop-agent",
+      detect: async (readShortcutLink) =>
+        typeof readShortcutLink === "function" && await readShortcutLink("entry") === "shortcut:entry"
+          ? "main-command"
+          : null,
+    },
+    { id: "missing", detect: async () => null },
+    { id: "broken", detect: async () => { throw new Error("probe failed"); } },
+  ]);
   const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, currentAppOpenInBridgeBundle);
-  const app = new Function(`${patched};return new App(arguments[0],arguments[1]);`)(settingsStore, async () => {
-    workerCalls += 1;
-    return { command: "worker-command" };
-  });
+  const app = new Function("process", `${patched};return new App(arguments[1],arguments[2]);`)(
+    { platform: "linux" },
+    settingsStore,
+    async () => {
+      workerCalls += 1;
+      return { command: "worker-command" };
+    },
+  );
 
   assert.deepEqual(await app.detectTarget({ target: "linux-desktop-agent" }), { available: true });
   assert.deepEqual(await app.detectTarget({ target: "missing" }), { available: false });
@@ -1306,75 +1194,31 @@ test("open-target discovery patches current app bridge detection through its reg
   assert.match(patched, /if\(process\.platform===`linux`\)\{let t=await codexLinuxOpenTargetRegistryCommand/);
 });
 
-test("open-target discovery bridge detection tolerates param-builder target helper", async () => {
-  const source =
-    "function pP(e){return e.targets}function iP(e,t){return{target:t}}var IN={};var bridge={openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:iP(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
-  const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, source);
-  const options = {
-    settingsStore: {
-      targets: [
-        { id: "linux-desktop-agent", detect: async () => "main-command" },
-        { id: "missing", detect: async () => null },
-      ],
-    },
-    requestOpenInWorker: async () => ({ command: "worker-command" }),
-  };
-  const bridge = new Function(`${patched};return bridge;`).call({ options });
-
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "linux-desktop-agent" }), {
-    available: true,
-  });
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "missing" }), {
-    available: false,
-  });
-  assert.deepEqual(await bridge.openInTargets.detectTarget.call(bridge, { target: "vscode" }), {
-    available: false,
-  });
-});
-
 test("open-target discovery inserts shared Linux registry command helper", async () => {
-  const patched = applyPatchTwice(applyOpenInTargetRegistryCommandPatch, openInCommandBundle);
-  const command = await new Function(`${patched};return codexLinuxOpenTargetRegistryCommand({targets:[{id:'kate',detect:async()=>'/usr/bin/kate'}]}, 'kate');`)();
+  const patched = applyPatchTwice(applyOpenInTargetRegistryCommandPatch, currentAppOpenTargetPrelude);
+  const settingsStore = currentAppSettingsStore([
+    {
+      id: "kate",
+      detect: async (readShortcutLink) => await readShortcutLink("kate") === "shortcut:kate" ? "/usr/bin/kate" : null,
+    },
+  ]);
+  const command = await new Function(
+    "process",
+    `${patched};return codexLinuxOpenTargetRegistryCommand(arguments[1], 'kate');`,
+  )({ platform: "linux" }, settingsStore);
 
   assert.match(patched, /async function codexLinuxOpenTargetRegistryCommand/);
-  assert.equal(command, "/usr/bin/kate");
-});
-
-test("open-target discovery registry helper uses pP before worker params helper", async () => {
-  const source = "function pP(e){return e.targets}function iP(e,t){return{target:t}}async function demo(){}";
-  const patched = applyPatchTwice(applyOpenInTargetRegistryCommandPatch, source);
-  const command = await new Function(`${patched};return codexLinuxOpenTargetRegistryCommand({targets:[{id:'kate',detect:async()=>'/usr/bin/kate'}]}, 'kate');`)();
-
+  assert.match(patched, /n\.detect\(FN\)/);
   assert.equal(command, "/usr/bin/kate");
 });
 
 test("open-target discovery reports missing current registry once per main patch", () => {
   const source =
     mainBundlePrefix +
-    currentAppOpenInAvailabilityBundle.replace("function QN(e){return e.targets}", "");
+    currentAppOpenInAvailabilityBundle.replace(currentAppRegistryFunction, "");
   const { warnings } = captureWarns(() => applyMainBundlePatch(source));
 
   assert.equal(warnings.filter((warning) => warning.includes("Could not find open target registry")).length, 1);
-});
-
-test("open-target discovery passes main registry into open execution", () => {
-  const patched = applyPatchTwice(applyOpenInTargetExecutePatch, openInExecuteBundle);
-
-  assert.match(patched, /targets:iP\(e\)/);
-});
-
-test("open-target discovery treats directories as native open targets", () => {
-  const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, openInTargetsBundle);
-
-  assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
-  assert.match(patched, /_codexLinuxDirectory=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
-});
-
-test("open-target discovery patches latest directory mode expression", () => {
-  const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, latestOpenInTargetsBundle);
-
-  assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
-  assert.match(patched, /_codexLinuxDirectory=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
 });
 
 test("open-target discovery patches current app directory mode expression", () => {
@@ -1386,9 +1230,8 @@ test("open-target discovery patches current app directory mode expression", () =
 });
 
 test("open-target discovery native selector includes available directory-capable targets", () => {
-  const patched = applyPatchTwice(applyNativeOpenTargetSelectionPatch, openTargetSelectionBundle)
-    .replace(/export\{[^}]+\};/u, "return {selectTargets:e,selectTarget:t,isEditor:n};");
-  const { selectTargets } = new Function(patched)();
+  const patched = applyPatchTwice(applyNativeOpenTargetSelectionPatch, currentAppOpenTargetSelectionBundle);
+  const { selectTargets } = new Function(`${patched};return {selectTargets:lQ};`)();
   const targets = [
     { target: "fileManager", appPath: "/usr/bin/dolphin" },
     { target: "systemDefault", appPath: "/usr/share/applications/kate.desktop" },
@@ -1405,26 +1248,6 @@ test("open-target discovery native selector includes available directory-capable
       mode: "native",
     }).map((target) => target.target),
     ["fileManager", "systemDefault", "terminal", "vscode", "linux-desktop-kate"],
-  );
-});
-
-test("open-target discovery patches latest native selector chunk shape", () => {
-  const patched = applyPatchTwice(applyNativeOpenTargetSelectionPatch, latestOpenTargetSelectionBundle);
-  const { selectTargets } = new Function(`${patched};return {selectTargets:O9};`)();
-  const targets = [
-    { target: "fileManager", appPath: "/usr/bin/dolphin" },
-    { target: "systemDefault", appPath: "/usr/share/applications/kate.desktop" },
-    { target: "terminal", available: true, kind: "terminal" },
-    { target: "vscode", available: true, kind: "editor" },
-  ];
-
-  assert.deepEqual(
-    selectTargets({
-      targets,
-      availableTargets: targets.map((target) => target.target),
-      mode: "native",
-    }).map((target) => target.target),
-    ["fileManager", "systemDefault", "terminal", "vscode"],
   );
 });
 

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -56,6 +56,14 @@ const latestOpenInCommandBundle =
   "function pP(e){return e.targets}function iP(e,t){return{target:t}}class App{constructor(){this.getOpenInWorker=()=>async()=>({command:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:`get-target-command`,params:iP(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
 const openInAvailabilityBundle =
   "function pP(e){return e.targets}function eP(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}function rP(e){return eP(pP(e))}function iP(e,t){return{target:t}}function tP(){return{error(){},warning(){}}}async function aP(e,t){let n=await Promise.all(rP(e).map(async n=>{let r=iP(e,n.id),[i,a]=await Promise.all([t({method:`get-target-command`,params:r}).then(e=>e.command).catch(e=>(tP().error(`Failed to detect open target`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===`win32`?t({method:`load-target-icon`,params:r}).then(e=>e.icon).catch(e=>(tP().warning(`Failed to resolve open target icon`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}";
+const currentAppOpenTargetPrelude =
+  "var FN={source:`shortcut-reader`};function RN(e){return e.map(({id:e,label:t,icon:n,kind:r})=>({id:e,label:t,icon:n,kind:r}))}function HN(e){return RN(QN(e))}function UN(e,t){let n=QN(e).find(e=>e.id===t);return n?.configuredCommand==null?{target:t}:{target:t,customTarget:{command:n.configuredCommand}}}function QN(e){return e.targets}async function LN(e){let t=e.targets[0];return await t.detect(FN)}function zN(){return{error(){},warning(){}}}";
+const currentAppOpenInCommandBundle =
+  `${currentAppOpenTargetPrelude}function iP(){throw Error(\`unrelated helper called\`)}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}getSettingsStore(){return this.settingsStore}getOpenInWorker(){return this.requestOpenInWorker}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:\`get-target-command\`,params:UN(this.getSettingsStore(),e)});if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}}`;
+const currentAppOpenInAvailabilityBundle =
+  `${currentAppOpenTargetPrelude}async function WN(e,t){let n=await Promise.all(HN(e).map(async n=>{let r=UN(e,n.id),[i,a]=await Promise.all([t({method:\`get-target-command\`,params:r}).then(e=>e.command).catch(e=>(zN().error(\`Failed to detect open target\`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===\`win32\`?t({method:\`load-target-icon\`,params:r}).then(e=>e.icon).catch(e=>(zN().warning(\`Failed to resolve open target icon\`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}`;
+const currentAppOpenInBridgeBundle =
+  `${currentAppOpenTargetPrelude}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}async detectTarget({target:e}){if(this.requestOpenInWorker==null)throw Error(\`Open in worker unavailable\`);let{command:t}=await this.requestOpenInWorker({method:\`get-target-command\`,params:UN(this.settingsStore,e)});return{available:t!=null}}}`;
 const openInBridgeBundle =
   "async function JN(){}function iP(e){return e.targets}var IN={};var bridge={options:{settingsStore:{targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]},requestOpenInWorker:async()=>({command:`worker-command`})},openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:JN(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
 const latestOpenInBridgeBundle =
@@ -66,6 +74,8 @@ const openInTargetsBundle =
   '"open-in-targets":async({cwd:e,deferEnrichment:n=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();let[c,l]=await Promise.all([XN(s),YN(s)]),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&_F(u)&&!t.Ta(o.hostConfig),f=u==null||d||t.Ta(o.hostConfig)?null:this.resolveOpenFilePath(this.mapAgentPathToLocalPath(u,o.hostConfig)??u,this.mapAgentPathToLocalPath(e,o.hostConfig)??this.getWorkspaceRoot()),p=oj(o.hostConfig,c,l),m=new Set(p),h=tP(s,e,m),g=d||f!=null&&t.wo(f),_=f!=null&&UA(f),v=f!=null&&GA(f),y=g?await gF({nativeBrowserDiscovery:i}):_?await hF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}';
 const latestOpenInTargetsBundle =
   '"open-in-targets":async({cwd:e,deferEnrichment:n=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();if(n&&a==null){let t=dP(s,e);return{preferredTarget:t,availableTargets:[],mode:`editor`,targets:Ej(rP(s),o.hostConfig).map(({id:e,label:n,icon:r,kind:i,hidden:a})=>({id:e,target:e,label:n,icon:r,kind:i,hidden:a,default:t===e||void 0}))}}let{allAvailableTargets:c,targetMetadata:l}=await aP(s,this.getOpenInWorker()),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&PF(u)&&!t.Ha(o.hostConfig),f=u==null||d||t.Ha(o.hostConfig)?null:this.resolveOpenFilePath(this.mapAgentPathToLocalPath(u,o.hostConfig)??u,this.mapAgentPathToLocalPath(e,o.hostConfig)??this.getWorkspaceRoot()),p=Tj(o.hostConfig,c,l),m=new Set(p),h=uP(s,e,m),g=d||f!=null&&t.rs(f),_=f!=null&&cj(f),v=f!=null&&uj(f),y=g?await MF(i):_?await jF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:[...l.map(({id:e,label:t,icon:n,kind:r,hidden:i})=>({id:e,target:e,label:t,icon:n,kind:r,hidden:i,available:m.has(e),default:h===e||void 0})),...y]}}';
+const currentAppOpenInTargetsBundle =
+  '"open-in-targets":async({cwd:e,deferEnrichment:t=!1,hostId:r,nativeBrowserDiscovery:i=`scan`,path:a})=>{let o=this.getRequestAppServerClient(r??void 0),s=this.getSettingsStore();if(t&&a==null){let t=XN(s,e);return{preferredTarget:t,availableTargets:[],mode:`editor`,targets:uj(HN(s),o.hostConfig)}}let{allAvailableTargets:c,targetMetadata:l}=await WN(s,this.getOpenInWorker()),u=a?.replace(/^([ab])[\\\\/]/,``)??null,d=u!=null&&xF(u)&&!n.eo(o.hostConfig),f=u==null||d||n.eo(o.hostConfig)?null:this.resolveOpenFilePath(u,e),p=lj(o.hostConfig,c,l),m=new Set(p),h=YN(s,e,m),g=d||f!=null&&n.ys(f),_=f!=null&&KA(f),v=f!=null&&JA(f),y=g?await yF(i):_?await vF({filePath:f}):[];return{preferredTarget:h,availableTargets:Array.from(m),mode:g||v?`native`:`editor`,targets:l}}';
 const openTargetSelectionBundle =
   "function e({targets:e,availableTargets:t,includeHiddenTargets:n=!1,mode:r=`editor`}){let i=e.filter(e=>e.appPath!=null);if(i.length>0)return i;if(r===`native`)return e.filter(e=>e.target===`systemDefault`||e.target===`fileManager`);let a=new Set(t);return e.filter(e=>a.has(e.target)&&(n||!e.hidden))}function t({preferredTarget:t,targets:n,availableTargets:r,includeHiddenTargets:i=!0,mode:a=`editor`}){let o=e({targets:n,availableTargets:r,includeHiddenTargets:i,mode:a});return o.length===0?null:t?o.find(e=>e.target===t)??o[0]??null:o[0]??null}function n(e){return e.appPath==null&&e.kind===`editor`}export{e as n,t as r,n as t};";
 const latestOpenTargetSelectionBundle =
@@ -1145,9 +1155,32 @@ test("open-target discovery patches latest command lookup shape", async () => {
   await assert.rejects(() => app.getOpenInTargetCommand("vscode"), /not available/);
 });
 
+test("open-target discovery patches current app command lookup through its registry", async () => {
+  let workerCalls = 0;
+  const settingsStore = {
+    targets: [
+      {
+        id: "linux-desktop-agent",
+        detect: async (context) => context?.source === "shortcut-reader" ? "main-command" : null,
+      },
+      { id: "broken", detect: async () => { throw new Error("probe failed"); } },
+    ],
+  };
+  const patched = applyPatchTwice(applyOpenInTargetCommandPatch, currentAppOpenInCommandBundle);
+  const app = new Function(`${patched};return new App(arguments[0],arguments[1]);`)(settingsStore, async () => {
+    workerCalls += 1;
+    return { command: "worker-command" };
+  });
+
+  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
+  await assert.rejects(() => app.getOpenInTargetCommand("broken"), /not available/);
+  assert.equal(workerCalls, 0);
+  assert.match(patched, /if\(process\.platform===`linux`\)\{let t=await codexLinuxOpenTargetRegistryCommand/);
+});
+
 test("open-target discovery command lookup tolerates param-builder target helper", async () => {
   const source =
-    "function JN(e,t){return{target:t}}function iP(e,t){return{target:t}}var IN={};class App{constructor(){this.requestOpenInWorker=async({params:e})=>({command:e.target===`vscode`?`worker-command`:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
+    "function pP(e){return e.targets}function JN(e,t){return{target:t}}function iP(e,t){return{target:t}}var IN={};class App{constructor(){this.requestOpenInWorker=async({params:e})=>({command:e.target===`vscode`?`worker-command`:null});this.settingsStore={targets:[{id:`linux-desktop-agent`,detect:async()=>`main-command`},{id:`missing`,detect:async()=>null}]}}getSettingsStore(){return this.settingsStore}async getOpenInTargetCommand(e){if(this.requestOpenInWorker==null)return;let{command:t}=await this.requestOpenInWorker({method:`get-target-command`,params:JN(this.getSettingsStore(),e)});if(t==null)throw Error(`Open target \"${e}\" is not available`);return t}}";
   const patched = applyPatchTwice(applyOpenInTargetCommandPatch, source);
   const app = new Function(`${patched};return new App();`)();
 
@@ -1164,6 +1197,43 @@ test("open-target discovery uses main registry for target availability", async (
 
   assert.deepEqual(result.allAvailableTargets, ["linux-desktop-agent"]);
   assert.deepEqual(result.targetMetadata.map((target) => target.id), ["linux-desktop-agent", "missing"]);
+});
+
+test("open-target discovery patches current app availability through its registry", async () => {
+  let workerCalls = 0;
+  const settingsStore = {
+    targets: [
+      {
+        id: "linux-desktop-agent",
+        label: "Agent",
+        icon: "apps/terminal.png",
+        kind: "editor",
+        detect: async (context) => context?.source === "shortcut-reader" ? "/usr/bin/agent" : null,
+      },
+      {
+        id: "missing",
+        label: "Missing",
+        icon: "apps/terminal.png",
+        kind: "editor",
+        detect: async () => null,
+      },
+      {
+        id: "broken",
+        label: "Broken",
+        icon: "apps/terminal.png",
+        kind: "editor",
+        detect: async () => { throw new Error("probe failed"); },
+      },
+    ],
+  };
+  const patched = applyPatchTwice(applyOpenInTargetsAvailabilityPatch, currentAppOpenInAvailabilityBundle);
+  const result = await new Function(`${patched};return WN(arguments[0],arguments[1]);`)(settingsStore, async () => {
+    workerCalls += 1;
+    return { command: "worker-command" };
+  });
+
+  assert.deepEqual(result.allAvailableTargets, ["linux-desktop-agent"]);
+  assert.equal(workerCalls, 0);
 });
 
 test("open-target discovery bridge detection uses main registry on Linux", async () => {
@@ -1211,9 +1281,34 @@ test("open-target discovery patches latest bridge detection shape", async () => 
   });
 });
 
+test("open-target discovery patches current app bridge detection through its registry", async () => {
+  let workerCalls = 0;
+  const settingsStore = {
+    targets: [
+      {
+        id: "linux-desktop-agent",
+        detect: async (context) => context?.source === "shortcut-reader" ? "main-command" : null,
+      },
+      { id: "missing", detect: async () => null },
+      { id: "broken", detect: async () => { throw new Error("probe failed"); } },
+    ],
+  };
+  const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, currentAppOpenInBridgeBundle);
+  const app = new Function(`${patched};return new App(arguments[0],arguments[1]);`)(settingsStore, async () => {
+    workerCalls += 1;
+    return { command: "worker-command" };
+  });
+
+  assert.deepEqual(await app.detectTarget({ target: "linux-desktop-agent" }), { available: true });
+  assert.deepEqual(await app.detectTarget({ target: "missing" }), { available: false });
+  assert.deepEqual(await app.detectTarget({ target: "broken" }), { available: false });
+  assert.equal(workerCalls, 0);
+  assert.match(patched, /if\(process\.platform===`linux`\)\{let t=await codexLinuxOpenTargetRegistryCommand/);
+});
+
 test("open-target discovery bridge detection tolerates param-builder target helper", async () => {
   const source =
-    "function iP(e,t){return{target:t}}var IN={};var bridge={openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:iP(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
+    "function pP(e){return e.targets}function iP(e,t){return{target:t}}var IN={};var bridge={openInTargets:{detectTarget:async({target:e})=>{if(this.options.requestOpenInWorker==null)throw Error(`Open in worker unavailable`);let{command:t}=await this.options.requestOpenInWorker({method:`get-target-command`,params:iP(this.options.settingsStore,e)});return{available:t!=null}},loadTargetIcon:()=>{}}}";
   const patched = applyPatchTwice(applyOpenInTargetsBridgeDetectionPatch, source);
   const options = {
     settingsStore: {
@@ -1253,6 +1348,15 @@ test("open-target discovery registry helper uses pP before worker params helper"
   assert.equal(command, "/usr/bin/kate");
 });
 
+test("open-target discovery reports missing current registry once per main patch", () => {
+  const source =
+    mainBundlePrefix +
+    currentAppOpenInAvailabilityBundle.replace("function QN(e){return e.targets}", "");
+  const { warnings } = captureWarns(() => applyMainBundlePatch(source));
+
+  assert.equal(warnings.filter((warning) => warning.includes("Could not find open target registry")).length, 1);
+});
+
 test("open-target discovery passes main registry into open execution", () => {
   const patched = applyPatchTwice(applyOpenInTargetExecutePatch, openInExecuteBundle);
 
@@ -1263,14 +1367,22 @@ test("open-target discovery treats directories as native open targets", () => {
   const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, openInTargetsBundle);
 
   assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
-  assert.match(patched, /w=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
+  assert.match(patched, /_codexLinuxDirectory=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
 });
 
 test("open-target discovery patches latest directory mode expression", () => {
   const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, latestOpenInTargetsBundle);
 
   assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
-  assert.match(patched, /w=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
+  assert.match(patched, /_codexLinuxDirectory=f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
+});
+
+test("open-target discovery patches current app directory mode expression", () => {
+  const patched = applyPatchTwice(applyOpenInTargetsDirectoryModePatch, currentAppOpenInTargetsBundle);
+
+  assert.match(patched, /codexLinuxOpenTargetIsDirectory/);
+  assert.match(patched, /f!=null&&codexLinuxOpenTargetIsDirectory\(f\)/);
+  assert.match(patched, /g=d\|\|[^,]+\|\|f!=null&&n\.ys\(f\)/);
 });
 
 test("open-target discovery native selector includes available directory-capable targets", () => {

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -16,6 +16,7 @@ const {
   applyOpenInTargetsBridgeDetectionPatch,
   applyOpenInTargetsAvailabilityPatch,
   applyOpenInTargetsDirectoryModePatch,
+  descriptors,
 } = require("./patch.js");
 const {
   enabledLinuxFeatureIds,
@@ -1363,6 +1364,23 @@ test("open-target discovery stays disabled until listed in features.json", () =>
       assert.doesNotMatch(patched, /codexLinuxOpenFileManager\(e\)/);
     });
   });
+});
+
+test("open-target discovery targets only the current native selector bundle", () => {
+  const descriptor = descriptors.find(
+    (candidate) => candidate.id === "webview-native-open-target-selection",
+  );
+
+  assert.ok(descriptor);
+  assert.match(
+    "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+    descriptor.pattern,
+  );
+  assert.doesNotMatch("open-target-selection-legacy.js", descriptor.pattern);
+  assert.doesNotMatch(
+    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-current.js",
+    descriptor.pattern,
+  );
 });
 
 test("open-target discovery participates in feature loading and patch reports", () => {


### PR DESCRIPTION
## Summary

- follow the current main-process open-target registry and detection context
- keep worker-backed detection unchanged on macOS and Windows while resolving Linux targets locally
- restore current availability, bridge detection, and directory-mode matching
- contain failed Linux target probes so one broken desktop entry cannot break the full menu

The feature remains opt-in and no tracked feature configuration changes.

## Validation

- `node --test linux-features/open-target-discovery/test.js`
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js`
- `cargo check --workspace`
- `cargo test --workspace`
- `bash tests/scripts_smoke.sh`
- full rebuild from the current `26.707.31428` DMG
- packed ASAR syntax and marker checks
- fresh five-job GitHub Actions matrix on the published head