### PR TITLE
Preserve portable upstream bundled plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ workarounds.
 | GUI install prompts | If installed | Uses `kdialog` / `zenity`, then terminal fallback | [Native setup](docs/native-setup.md) |
 | Linux file manager integration | Always | Built into core Linux patches | [Architecture](docs/architecture.md) |
 | Chrome plugin native host | Always | Installed with bundled plugins | [Architecture](docs/architecture.md) |
+| Portable upstream plugins | When shipped upstream | Sites, Deep Research, and Visualize are staged automatically; upstream rollout still applies | [Architecture](docs/architecture.md#bundled-plugins) |
 | Browser annotations | Always | Built into the patched webview | [Architecture](docs/architecture.md) |
 | Tray and warm-start handoff | Always | Normal app launch | [Architecture](docs/architecture.md) |
 | Multiple app instances | Opt-in | `./codex-app/start.sh --new-instance` | [Build and packaging](docs/build-and-packaging.md#running-the-generated-app) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,20 @@ packaging/linux/codex-packaged-runtime.sh
 The current evaluation for a future Rust replacement of the local webview
 server lives in [webview-server-evaluation.md](webview-server-evaluation.md).
 
-## Chrome Plugin
+## Bundled Plugins
+
+The build preserves portable upstream Sites, Deep Research, and Visualize
+plugins when they are listed in the official DMG marketplace. Their payloads
+must match the expected local path and contain no symlinks, privileged entries,
+native executables, or platform-specific bundles. Availability in the app can
+still depend on upstream account entitlements or rollout gates.
+
+Plugins with native macOS payloads are not copied through this portable path.
+Linux Computer Use and opt-in Record and Replay use repository-owned Linux
+replacements instead. The bundled LaTeX plugin remains excluded until its
+Tectonic runtime has a verified Linux staging path.
+
+### Chrome Plugin
 
 The build stages the upstream Chrome plugin, patches its Linux compatibility
 paths, builds the native messaging host from Rust, and installs browser

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1110,6 +1110,7 @@ sync_extra_bundled_plugin_cache() {
     local cache_plugin
     local cache_parent
     local tmp_plugin
+    local backup_plugin
     local marketplace_root
     local marketplace_plugins_dir
     local marketplace_plugin_link
@@ -1135,28 +1136,66 @@ sync_extra_bundled_plugin_cache() {
         cache_plugin="$cache_root/$version"
         cache_parent="$(dirname "$cache_plugin")"
         tmp_plugin="$cache_parent/.$plugin_name-$version.tmp.$$"
-        remove_tree_if_exists "$tmp_plugin"
-        mkdir -p "$cache_parent"
+        backup_plugin="$cache_parent/.$plugin_name-$version.backup.$$"
+        if ! remove_tree_if_exists "$tmp_plugin" || \
+           ! remove_tree_if_exists "$backup_plugin" || \
+           ! mkdir -p "$cache_parent"; then
+            echo "Extra bundled plugin cache preparation failed for $plugin_name; continuing with existing cache."
+            continue
+        fi
 
         if cp -R "$source_plugin" "$tmp_plugin"; then
             make_tree_owner_writable "$tmp_plugin"
-            find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
-            remove_tree_if_exists "$cache_plugin"
-            mv "$tmp_plugin" "$cache_plugin"
+            if ! find "$tmp_plugin" -type f -name '*:com.apple.*' -delete; then
+                remove_tree_if_exists "$tmp_plugin" || true
+                echo "Extra bundled plugin cache cleanup failed for $plugin_name; continuing with existing cache."
+                continue
+            fi
+            if [ -e "$cache_plugin" ] || [ -L "$cache_plugin" ]; then
+                if ! mv -- "$cache_plugin" "$backup_plugin"; then
+                    remove_tree_if_exists "$tmp_plugin" || true
+                    echo "Extra bundled plugin cache sync failed for $plugin_name; existing cache was preserved."
+                    continue
+                fi
+            else
+                backup_plugin=""
+            fi
+            if ! mv -- "$tmp_plugin" "$cache_plugin"; then
+                remove_tree_if_exists "$tmp_plugin" || true
+                if [ -n "$backup_plugin" ]; then
+                    if mv -- "$backup_plugin" "$cache_plugin"; then
+                        echo "Extra bundled plugin cache sync failed for $plugin_name; previous cache was restored."
+                    else
+                        echo "Extra bundled plugin cache sync failed for $plugin_name and the previous cache could not be restored."
+                    fi
+                else
+                    echo "Extra bundled plugin cache sync failed for $plugin_name; continuing without a new cache."
+                fi
+                continue
+            fi
+            if [ -n "$backup_plugin" ]; then
+                remove_tree_if_exists "$backup_plugin" || \
+                    echo "Extra bundled plugin cache backup cleanup failed for $plugin_name: $backup_plugin"
+            fi
             echo "Extra bundled plugin cache synced from bundled resources: $cache_plugin"
         else
-            remove_tree_if_exists "$tmp_plugin"
+            remove_tree_if_exists "$tmp_plugin" || true
             echo "Extra bundled plugin cache sync failed for $plugin_name; continuing with existing cache."
             continue
         fi
 
-        replace_symlink "$version" "$cache_root/latest"
+        if ! replace_symlink "$version" "$cache_root/latest"; then
+            echo "Extra bundled plugin latest link failed for $plugin_name; continuing with the staged cache."
+            continue
+        fi
 
         marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"
         marketplace_plugins_dir="$marketplace_root/.agents/plugins"
         marketplace_plugin_link="$marketplace_root/plugins/$plugin_dir_name"
-        mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
-        replace_symlink "$cache_root/latest" "$marketplace_plugin_link"
+        if ! mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins" || \
+           ! replace_symlink "$cache_root/latest" "$marketplace_plugin_link"; then
+            echo "Extra bundled plugin marketplace link failed for $plugin_name; continuing with the staged cache."
+        fi
     done
 }
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1152,7 +1152,7 @@ sync_extra_bundled_plugin_cache() {
                 continue
             fi
             if [ -e "$cache_plugin" ] || [ -L "$cache_plugin" ]; then
-                if ! mv -- "$cache_plugin" "$backup_plugin"; then
+                if ! mv -T -- "$cache_plugin" "$backup_plugin"; then
                     remove_tree_if_exists "$tmp_plugin" || true
                     echo "Extra bundled plugin cache sync failed for $plugin_name; existing cache was preserved."
                     continue
@@ -1160,10 +1160,10 @@ sync_extra_bundled_plugin_cache() {
             else
                 backup_plugin=""
             fi
-            if ! mv -- "$tmp_plugin" "$cache_plugin"; then
+            if ! mv -T -- "$tmp_plugin" "$cache_plugin"; then
                 remove_tree_if_exists "$tmp_plugin" || true
                 if [ -n "$backup_plugin" ]; then
-                    if mv -- "$backup_plugin" "$cache_plugin"; then
+                    if mv -T -- "$backup_plugin" "$cache_plugin"; then
                         echo "Extra bundled plugin cache sync failed for $plugin_name; previous cache was restored."
                     else
                         echo "Extra bundled plugin cache sync failed for $plugin_name and the previous cache could not be restored."

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -5,6 +5,226 @@
 # shellcheck shell=bash
 
 # ---- Install Linux-safe bundled plugin resources ----
+list_portable_bundled_plugins() {
+    local marketplace="$1"
+
+    node - "$marketplace" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const marketplacePath = process.argv[2];
+const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8"));
+const plugins = Array.isArray(marketplace.plugins) ? marketplace.plugins : [];
+const portableNames = new Set(["sites", "deep-research", "visualize"]);
+const emittedNames = new Set();
+
+for (const plugin of plugins) {
+  if (plugin == null || typeof plugin !== "object" || !portableNames.has(plugin.name)) {
+    continue;
+  }
+  const source = plugin.source;
+  if (source == null || source.source !== "local" || typeof source.path !== "string") {
+    continue;
+  }
+  const normalized = path.posix.normalize(source.path.replace(/\\/g, "/"));
+  if (normalized === `plugins/${plugin.name}` && !emittedNames.has(plugin.name)) {
+    emittedNames.add(plugin.name);
+    process.stdout.write(`${plugin.name}\n`);
+  }
+}
+NODE
+}
+
+validate_portable_bundled_plugin() {
+    local plugin_dir="$1"
+    local expected_name="$2"
+
+    python3 - "$plugin_dir" "$expected_name" <<'PY'
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import sys
+
+root = Path(sys.argv[1])
+expected_name = sys.argv[2]
+manifest_path = root / ".codex-plugin" / "plugin.json"
+
+if root.is_symlink():
+    print("plugin root cannot be a symlink", file=sys.stderr)
+    sys.exit(1)
+if not root.is_dir():
+    print("plugin root must be a directory", file=sys.stderr)
+    sys.exit(1)
+if manifest_path.is_symlink():
+    print("plugin manifest cannot be a symlink", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+    print(f"invalid plugin manifest: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if manifest.get("name") != expected_name:
+    print("plugin manifest name does not match its marketplace entry", file=sys.stderr)
+    sys.exit(1)
+version = manifest.get("version")
+if not isinstance(version, str) or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._+-]{0,127}", version.strip()) is None:
+    print("plugin manifest version is missing or invalid", file=sys.stderr)
+    sys.exit(1)
+
+native_suffixes = {
+    ".app",
+    ".dll",
+    ".dylib",
+    ".exe",
+    ".framework",
+    ".node",
+    ".so",
+}
+native_magics = {
+    b"\x7fELF",
+    b"\xca\xfe\xba\xbe",
+    b"\xbe\xba\xfe\xca",
+    b"\xca\xfe\xba\xbf",
+    b"\xbf\xba\xfe\xca",
+    b"\xfe\xed\xfa\xce",
+    b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf",
+    b"\xcf\xfa\xed\xfe",
+}
+
+def fail_walk(error):
+    print(f"cannot inspect plugin tree: {error}", file=sys.stderr)
+    sys.exit(1)
+
+
+for current_root, directories, files in os.walk(root, followlinks=False, onerror=fail_walk):
+    current = Path(current_root)
+    for name in directories:
+        path = current / name
+        if path.is_symlink():
+            print(f"symlink is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            print(f"cannot inspect {path.relative_to(root)}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not stat.S_ISDIR(metadata.st_mode):
+            print(f"non-directory entry is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        if metadata.st_mode & 0o6000:
+            print(f"privileged mode is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        if path.suffix.lower() in native_suffixes:
+            print(f"native bundle is not portable: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+
+    for name in files:
+        path = current / name
+        if path.is_symlink():
+            print(f"symlink is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            print(f"cannot inspect {path.relative_to(root)}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not stat.S_ISREG(metadata.st_mode):
+            print(f"non-regular file is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        if metadata.st_mode & 0o6000:
+            print(f"privileged mode is not allowed: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        if path.suffix.lower() in native_suffixes:
+            print(f"native file is not portable: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+        try:
+            with path.open("rb") as stream:
+                header = stream.read(4)
+        except OSError as exc:
+            print(f"cannot read {path.relative_to(root)}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if header in native_magics or header[:2] == b"MZ":
+            print(f"native executable is not portable: {path.relative_to(root)}", file=sys.stderr)
+            sys.exit(1)
+PY
+}
+
+stage_portable_bundled_plugin_from_upstream() {
+    local source_plugin="$1"
+    local target_plugins="$2"
+    local plugin_name="$3"
+    local target_plugin="$target_plugins/$plugin_name"
+    local staging_plugin=""
+    local backup_plugin="$target_plugins/.${plugin_name}.backup.$$"
+
+    if [ ! -d "$source_plugin" ]; then
+        info "Portable bundled plugin $plugin_name not present in upstream app; skipping"
+        return 1
+    fi
+    if ! validate_portable_bundled_plugin "$source_plugin" "$plugin_name"; then
+        warn "Portable bundled plugin $plugin_name contains unsupported content; skipping"
+        return 1
+    fi
+
+    if ! staging_plugin="$(mktemp -d "$target_plugins/.${plugin_name}.tmp.XXXXXX")"; then
+        warn "Failed to create staging directory for portable bundled plugin $plugin_name"
+        return 1
+    fi
+    if ! cp -R "$source_plugin/." "$staging_plugin/"; then
+        rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+        warn "Failed to stage portable bundled plugin $plugin_name"
+        return 1
+    fi
+    if ! remove_macos_sidecar_files "$staging_plugin"; then
+        rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+        warn "Failed to clean macOS sidecar files for portable bundled plugin $plugin_name"
+        return 1
+    fi
+    if ! validate_portable_bundled_plugin "$staging_plugin" "$plugin_name"; then
+        rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+        warn "Portable bundled plugin $plugin_name failed post-copy validation"
+        return 1
+    fi
+
+    if ! rm -rf -- "$backup_plugin"; then
+        rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+        warn "Failed to prepare backup for portable bundled plugin $plugin_name"
+        return 1
+    fi
+    if [ -e "$target_plugin" ] || [ -L "$target_plugin" ]; then
+        if ! mv -- "$target_plugin" "$backup_plugin"; then
+            rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+            warn "Failed to preserve existing portable bundled plugin $plugin_name"
+            return 1
+        fi
+    else
+        backup_plugin=""
+    fi
+    if ! mv -- "$staging_plugin" "$target_plugin"; then
+        rm -rf -- "$staging_plugin" || warn "Failed to clean staging directory for portable bundled plugin $plugin_name"
+        if [ -n "$backup_plugin" ]; then
+            if mv -- "$backup_plugin" "$target_plugin"; then
+                warn "Failed to install portable bundled plugin $plugin_name; previous target was restored"
+            else
+                warn "Failed to install portable bundled plugin $plugin_name and previous target could not be restored"
+            fi
+        else
+            warn "Failed to install portable bundled plugin $plugin_name"
+        fi
+        return 1
+    fi
+    if [ -n "$backup_plugin" ] && ! rm -rf -- "$backup_plugin"; then
+        warn "Failed to clean previous portable bundled plugin backup: $backup_plugin"
+    fi
+    info "Portable bundled plugin $plugin_name staged from upstream DMG"
+    return 0
+}
+
 find_cargo_for_linux_computer_use() {
     if command -v cargo >/dev/null 2>&1; then
         command -v cargo
@@ -1098,7 +1318,9 @@ write_bundled_plugins_marketplace() {
     local include_chrome="$4"
     local include_computer_use="$5"
 
-    node - "$source" "$destination" "$include_browser" "$include_chrome" "$include_computer_use" <<'NODE'
+    shift 5
+
+    node - "$source" "$destination" "$include_browser" "$include_chrome" "$include_computer_use" "$@" <<'NODE'
 const fs = require("fs");
 const path = require("path");
 
@@ -1107,6 +1329,7 @@ const destinationPath = process.argv[3];
 const includeBrowser = process.argv[4] === "1";
 const includeChrome = process.argv[5] === "1";
 const includeComputerUse = process.argv[6] === "1";
+const portablePluginNames = process.argv.slice(7);
 const marketplace = JSON.parse(fs.readFileSync(sourcePath, "utf8"));
 const sourcePlugins = marketplace.plugins || [];
 const plugins = [];
@@ -1236,6 +1459,37 @@ if (includeComputerUse) {
   });
 }
 
+for (const name of portablePluginNames) {
+  const plugin = sourcePlugins.find((entry) => {
+    if (entry == null || typeof entry !== "object" || entry.name !== name) {
+      return false;
+    }
+    const source = entry.source;
+    if (source == null || source.source !== "local" || typeof source.path !== "string") {
+      return false;
+    }
+    const normalized = path.posix.normalize(source.path.replace(/\\/g, "/"));
+    return normalized === `plugins/${name}`;
+  });
+  if (plugin == null) {
+    throw new Error(`Bundled marketplace does not contain ${name} plugin`);
+  }
+  plugins.push({
+    ...plugin,
+    source: {
+      source: "local",
+      path: `./plugins/${name}`,
+    },
+  });
+}
+
+const sourceOrder = new Map(sourcePlugins.map((plugin, index) => [plugin?.name, index]));
+plugins.sort((left, right) => {
+  const leftIndex = sourceOrder.get(left.name) ?? Number.MAX_SAFE_INTEGER;
+  const rightIndex = sourceOrder.get(right.name) ?? Number.MAX_SAFE_INTEGER;
+  return leftIndex - rightIndex;
+});
+
 marketplace.plugins = plugins;
 fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
 fs.writeFileSync(destinationPath, `${JSON.stringify(marketplace, null, 2)}\n`);
@@ -1254,6 +1508,8 @@ install_bundled_plugin_resources() {
     local include_browser=0
     local include_chrome=0
     local include_computer_use=0
+    local portable_plugin_names=""
+    local portable_plugins=()
 
     if [ ! -f "$source_marketplace" ]; then
         warn "Bundled plugin marketplace not found in upstream app; skipping bundled plugins"
@@ -1261,6 +1517,20 @@ install_bundled_plugin_resources() {
     fi
 
     mkdir -p "$bundled_plugins_dir/plugins" "$bundled_plugins_dir/.agents/plugins"
+
+    if ! portable_plugin_names="$(list_portable_bundled_plugins "$source_marketplace")"; then
+        warn "Could not parse portable bundled plugins from upstream marketplace"
+        portable_plugin_names=""
+    fi
+    while IFS= read -r plugin_name; do
+        [ -n "$plugin_name" ] || continue
+        if stage_portable_bundled_plugin_from_upstream \
+            "$bundled_source_root/plugins/$plugin_name" \
+            "$bundled_plugins_dir/plugins" \
+            "$plugin_name"; then
+            portable_plugins+=("$plugin_name")
+        fi
+    done <<< "$portable_plugin_names"
 
     if source_browser_plugin="$(find_browser_plugin_source "$bundled_source_root" "$source_marketplace")" &&
         stage_browser_plugin_from_upstream "$source_browser_plugin" "$bundled_plugins_dir/plugins"; then
@@ -1279,12 +1549,18 @@ install_bundled_plugin_resources() {
         warn "Linux Computer Use plugin will be unavailable"
     fi
 
-    if [ "$include_browser" -eq 0 ] && [ "$include_chrome" -eq 0 ] && [ "$include_computer_use" -eq 0 ]; then
+    if [ "$include_browser" -eq 0 ] && [ "$include_chrome" -eq 0 ] && [ "$include_computer_use" -eq 0 ] && [ "${#portable_plugins[@]}" -eq 0 ]; then
         warn "No Linux-safe bundled plugins were staged"
         return 0
     fi
 
-    write_bundled_plugins_marketplace "$source_marketplace" "$bundled_plugins_dir/.agents/plugins/marketplace.json" "$include_browser" "$include_chrome" "$include_computer_use"
+    write_bundled_plugins_marketplace \
+        "$source_marketplace" \
+        "$bundled_plugins_dir/.agents/plugins/marketplace.json" \
+        "$include_browser" \
+        "$include_chrome" \
+        "$include_computer_use" \
+        "${portable_plugins[@]}"
 
     install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" "info" || true
     install_browser_use_node_repl_resource "$upstream_resources" "$resources_dir/node_repl" || true

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3952,12 +3952,9 @@ test_launcher_extra_bundled_plugin_cache_rollback() {
 
         mv() {
             local args=("$@")
-            local offset=0
-            if [ "${args[0]}" = "--" ]; then
-                offset=1
-            fi
-            local source="${args[$offset]}"
-            local destination="${args[$((offset + 1))]}"
+            local argc="${#args[@]}"
+            local source="${args[$((argc - 2))]}"
+            local destination="${args[$((argc - 1))]}"
             if [[ "$source" == *".tmp."* ]] && [ "$destination" = "$cache_plugin" ]; then
                 return 73
             fi
@@ -3989,6 +3986,70 @@ test_launcher_extra_bundled_plugin_cache_rollback() {
         || fail "Expected failed first cache install to leave no marketplace link"
     [ -z "$(find "${visualize_cache%/*}" -mindepth 1 -maxdepth 1 -type d \( -name '*.tmp.*' -o -name '*.backup.*' \) -print -quit)" ] \
         || fail "Expected failed first cache install to clean temporary and backup directories"
+}
+
+test_launcher_extra_bundled_plugin_cache_concurrent_destination() {
+    info "Checking extra bundled plugin cache concurrent destination handling"
+    local workspace="$TMP_DIR/extra-bundled-plugin-cache-concurrent-destination"
+    local app_dir="$workspace/app"
+    local fake_home="$workspace/home"
+    local source_plugin="$app_dir/resources/plugins/openai-bundled/plugins/sites"
+    local cache_root="$fake_home/.codex/plugins/cache/openai-bundled/sites"
+    local cache_plugin="$cache_root/1.2.3"
+    local launcher_defs="$workspace/launcher-defs.sh"
+    local race_log="$workspace/race.log"
+    local backup_plugin=""
+
+    mkdir -p "$source_plugin/.codex-plugin" "$fake_home"
+    printf '%s\n' '{"name":"sites","version":"1.2.3"}' > "$source_plugin/.codex-plugin/plugin.json"
+    printf '%s\n' "initial" > "$source_plugin/content.txt"
+    sed '/^hydrate_graphical_session_env$/,$d' "$REPO_DIR/launcher/start.sh.template" > "$launcher_defs"
+
+    (
+        export HOME="$fake_home"
+        export CODEX_HOME="$fake_home/.codex"
+        export CODEX_LINUX_APP_ID="codex-desktop"
+        export CODEX_LINUX_APP_DISPLAY_NAME="ChatGPT Desktop"
+        export CODEX_LINUX_WEBVIEW_PORT="5175"
+        exec 7>&1 8>&2
+        # shellcheck disable=SC1090
+        source "$launcher_defs"
+        exec 1>&7 2>&8
+        SCRIPT_DIR="$app_dir"
+
+        sync_extra_bundled_plugin_cache >/dev/null 2>&1
+        printf '%s\n' "replacement" > "$source_plugin/content.txt"
+
+        concurrent_destination_injected=0
+        mv() {
+            local args=("$@")
+            local argc="${#args[@]}"
+            local source="${args[$((argc - 2))]}"
+            local destination="${args[$((argc - 1))]}"
+            if [[ "$source" == *".tmp."* ]] && \
+               [ "$destination" = "$cache_plugin" ] && \
+               [ "$concurrent_destination_injected" -eq 0 ]; then
+                mkdir -p "$cache_plugin"
+                printf '%s\n' "concurrent" > "$cache_plugin/content.txt"
+                concurrent_destination_injected=1
+            fi
+            command mv "$@"
+        }
+
+        sync_extra_bundled_plugin_cache > "$race_log" 2>&1
+    )
+
+    assert_contains "$race_log" "previous cache could not be restored"
+    assert_not_contains "$race_log" "Extra bundled plugin cache synced from bundled resources"
+    assert_contains "$cache_plugin/content.txt" "concurrent"
+    assert_not_contains "$cache_plugin/content.txt" "replacement"
+    [ -z "$(find "$cache_plugin" -mindepth 1 -maxdepth 1 -type d -name '*.tmp.*' -print -quit)" ] \
+        || fail "Expected collision-safe move to avoid nesting the temporary payload"
+    [ -z "$(find "$cache_root" -mindepth 1 -maxdepth 1 -type d -name '*.tmp.*' -print -quit)" ] \
+        || fail "Expected failed concurrent cache install to clean its temporary directory"
+    backup_plugin="$(find "$cache_root" -mindepth 1 -maxdepth 1 -type d -name '*.backup.*' -print -quit)"
+    [ -n "$backup_plugin" ] || fail "Expected concurrent cache collision to preserve the previous cache backup"
+    assert_contains "$backup_plugin/content.txt" "initial"
 }
 
 test_launcher_template_sanity() {
@@ -8241,6 +8302,7 @@ main() {
     test_chrome_native_host_manifest_writer
     test_launcher_managed_node_handles_unset_path
     test_launcher_extra_bundled_plugin_cache_rollback
+    test_launcher_extra_bundled_plugin_cache_concurrent_destination
     test_launcher_rejects_missing_webview_entrypoint
     test_launcher_template_sanity
     test_launcher_cli_resolution_policy

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -132,6 +132,42 @@ function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:voi
 JS
 }
 
+make_fake_portable_plugins_upstream_app() {
+    local app_dir="$1"
+    local resources_dir="$app_dir/Contents/Resources"
+    local plugins_dir="$resources_dir/plugins/openai-bundled/plugins"
+
+    mkdir -p \
+        "$resources_dir/plugins/openai-bundled/.agents/plugins" \
+        "$plugins_dir/sites/.codex-plugin" \
+        "$plugins_dir/sites/scripts" \
+        "$plugins_dir/sites/mcp" \
+        "$plugins_dir/deep-research/.codex-plugin" \
+        "$plugins_dir/deep-research/skills/deep-research" \
+        "$plugins_dir/visualize/.codex-plugin" \
+        "$plugins_dir/visualize/skills/visualize/scripts" \
+        "$plugins_dir/latex/.codex-plugin" \
+        "$plugins_dir/latex/bin" \
+        "$plugins_dir/record-and-replay/.codex-plugin" \
+        "$plugins_dir/record-and-replay/Codex Computer Use.app"
+
+    cat > "$resources_dir/plugins/openai-bundled/.agents/plugins/marketplace.json" <<'JSON'
+{"plugins":[{"name":"sites","source":{"source":"local","path":"./plugins/sites"},"policy":{"installation":"AVAILABLE","authentication":"ON_INSTALL"},"category":"Productivity"},{"name":"record-and-replay","source":{"source":"local","path":"./plugins/record-and-replay"},"policy":{"installation":"AVAILABLE"}},{"name":"latex","source":{"source":"local","path":"./plugins/latex"},"policy":{"installation":"AVAILABLE"}},{"name":"deep-research","source":{"source":"local","path":"./plugins/deep-research"},"policy":{"installation":"AVAILABLE"},"category":"Research"},{"name":"visualize","source":{"source":"local","path":"./plugins/visualize"},"policy":{"installation":"AVAILABLE"},"category":"Productivity"}]}
+JSON
+    printf '%s\n' '{"name":"sites","version":"1.0.0","mcpServers":"./.mcp.json"}' > "$plugins_dir/sites/.codex-plugin/plugin.json"
+    printf '%s\n' '#!/bin/bash' 'set -euo pipefail' > "$plugins_dir/sites/scripts/init-site.sh"
+    chmod 0755 "$plugins_dir/sites/scripts/init-site.sh"
+    printf '%s\n' 'console.log("sites");' > "$plugins_dir/sites/mcp/server.mjs"
+    printf '%s\n' '{"name":"deep-research","version":"1.0.0"}' > "$plugins_dir/deep-research/.codex-plugin/plugin.json"
+    printf '%s\n' '# Deep Research' > "$plugins_dir/deep-research/skills/deep-research/SKILL.md"
+    printf '%s\n' '{"name":"visualize","version":"1.0.0"}' > "$plugins_dir/visualize/.codex-plugin/plugin.json"
+    printf '%s\n' 'print("visualize")' > "$plugins_dir/visualize/skills/visualize/scripts/render.py"
+    printf '%s\n' '{"name":"latex","version":"1.0.0"}' > "$plugins_dir/latex/.codex-plugin/plugin.json"
+    printf '\xcf\xfa\xed\xfe' > "$plugins_dir/latex/bin/tectonic"
+    chmod 0755 "$plugins_dir/latex/bin/tectonic"
+    printf '%s\n' '{"name":"record-and-replay","version":"1.0.0"}' > "$plugins_dir/record-and-replay/.codex-plugin/plugin.json"
+}
+
 make_fake_app() {
     local app_dir="$1"
     bash "$REPO_DIR/tests/fixtures/create-packaged-app-fixture.sh" "$app_dir"
@@ -3879,6 +3915,82 @@ SCRIPT
     assert_contains "$launcher_log" "Skipping packaged webview setup because ELECTRON_RENDERER_URL override is enabled"
 }
 
+test_launcher_extra_bundled_plugin_cache_rollback() {
+    info "Checking extra bundled plugin cache rollback"
+    local workspace="$TMP_DIR/extra-bundled-plugin-cache-rollback"
+    local app_dir="$workspace/app"
+    local fake_home="$workspace/home"
+    local source_plugin="$app_dir/resources/plugins/openai-bundled/plugins/sites"
+    local cache_root="$fake_home/.codex/plugins/cache/openai-bundled/sites"
+    local cache_plugin="$cache_root/1.2.3"
+    local launcher_defs="$workspace/launcher-defs.sh"
+    local initial_log="$workspace/initial.log"
+    local failure_log="$workspace/failure.log"
+    local no_cache_log="$workspace/no-cache.log"
+    local visualize_source="$app_dir/resources/plugins/openai-bundled/plugins/visualize"
+    local visualize_cache="$fake_home/.codex/plugins/cache/openai-bundled/visualize/2.0.0"
+
+    mkdir -p "$source_plugin/.codex-plugin" "$fake_home"
+    printf '%s\n' '{"name":"sites","version":"1.2.3"}' > "$source_plugin/.codex-plugin/plugin.json"
+    printf '%s\n' "initial" > "$source_plugin/content.txt"
+    sed '/^hydrate_graphical_session_env$/,$d' "$REPO_DIR/launcher/start.sh.template" > "$launcher_defs"
+
+    (
+        export HOME="$fake_home"
+        export CODEX_HOME="$fake_home/.codex"
+        export CODEX_LINUX_APP_ID="codex-desktop"
+        export CODEX_LINUX_APP_DISPLAY_NAME="Codex Desktop"
+        export CODEX_LINUX_WEBVIEW_PORT="5175"
+        exec 7>&1 8>&2
+        # shellcheck disable=SC1090
+        source "$launcher_defs"
+        exec 1>&7 2>&8
+        SCRIPT_DIR="$app_dir"
+
+        sync_extra_bundled_plugin_cache > "$initial_log" 2>&1
+        printf '%s\n' "replacement" > "$source_plugin/content.txt"
+
+        mv() {
+            local args=("$@")
+            local offset=0
+            if [ "${args[0]}" = "--" ]; then
+                offset=1
+            fi
+            local source="${args[$offset]}"
+            local destination="${args[$((offset + 1))]}"
+            if [[ "$source" == *".tmp."* ]] && [ "$destination" = "$cache_plugin" ]; then
+                return 73
+            fi
+            command mv "$@"
+        }
+
+        sync_extra_bundled_plugin_cache > "$failure_log" 2>&1
+
+        rm -rf "$source_plugin"
+        mkdir -p "$visualize_source/.codex-plugin"
+        printf '%s\n' '{"name":"visualize","version":"2.0.0"}' > "$visualize_source/.codex-plugin/plugin.json"
+        printf '%s\n' "visualize" > "$visualize_source/content.txt"
+        sync_extra_bundled_plugin_cache > "$no_cache_log" 2>&1
+    )
+
+    assert_contains "$initial_log" "Extra bundled plugin cache synced from bundled resources"
+    assert_contains "$failure_log" "previous cache was restored"
+    assert_contains "$cache_plugin/content.txt" "initial"
+    assert_not_contains "$cache_plugin/content.txt" "replacement"
+    [ "$(readlink "$cache_root/latest")" = "1.2.3" ] || fail "Expected latest to keep the restored plugin version"
+    [ -L "$fake_home/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/sites" ] \
+        || fail "Expected marketplace plugin link to remain available"
+    [ -z "$(find "$cache_root" -mindepth 1 -maxdepth 1 -type d \( -name '*.tmp.*' -o -name '*.backup.*' \) -print -quit)" ] \
+        || fail "Expected failed extra plugin sync to clean temporary and backup directories"
+    assert_contains "$no_cache_log" "continuing without a new cache"
+    [ ! -e "$visualize_cache" ] || fail "Expected failed first cache install to leave no plugin payload"
+    [ ! -L "${visualize_cache%/*}/latest" ] || fail "Expected failed first cache install to leave no latest link"
+    [ ! -L "$fake_home/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/visualize" ] \
+        || fail "Expected failed first cache install to leave no marketplace link"
+    [ -z "$(find "${visualize_cache%/*}" -mindepth 1 -maxdepth 1 -type d \( -name '*.tmp.*' -o -name '*.backup.*' \) -print -quit)" ] \
+        || fail "Expected failed first cache install to clean temporary and backup directories"
+}
+
 test_launcher_template_sanity() {
     info "Checking launcher template markers"
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
@@ -5365,6 +5477,295 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_contains "$marketplace" '"path": "./plugins/browser"'
     assert_contains "$output_log" "Browser plugin staged from upstream DMG"
     assert_not_contains "$output_log" "Browser bundled plugin resources not present"
+}
+
+test_portable_bundled_plugins_staging() {
+    info "Checking portable upstream bundled plugin staging"
+    local workspace="$TMP_DIR/portable-bundled-plugins"
+    local app_dir="$workspace/ChatGPT.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local marketplace="$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json"
+    local plugins_dir="$install_dir/resources/plugins/openai-bundled/plugins"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_portable_plugins_upstream_app "$app_dir"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        stage_browser_plugin_from_upstream() { return 1; }
+        stage_chrome_plugin_from_upstream() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$plugins_dir/sites/.codex-plugin/plugin.json"
+    assert_file_exists "$plugins_dir/deep-research/.codex-plugin/plugin.json"
+    assert_file_exists "$plugins_dir/visualize/.codex-plugin/plugin.json"
+    assert_mode "$plugins_dir/sites/scripts/init-site.sh" "755"
+    [ ! -e "$plugins_dir/latex" ] || fail "Expected native LaTeX plugin to remain unstaged"
+    [ ! -e "$plugins_dir/record-and-replay" ] || fail "Expected native Record and Replay plugin to remain unstaged"
+    assert_contains "$output_log" "Portable bundled plugin sites staged from upstream DMG"
+    assert_contains "$output_log" "Portable bundled plugin deep-research staged from upstream DMG"
+    assert_contains "$output_log" "Portable bundled plugin visualize staged from upstream DMG"
+
+    node - "$marketplace" <<'NODE'
+const fs = require("fs");
+const marketplace = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const names = marketplace.plugins.map((plugin) => plugin.name);
+const expected = ["sites", "deep-research", "visualize"];
+if (JSON.stringify(names) !== JSON.stringify(expected)) {
+  throw new Error(`expected ${JSON.stringify(expected)}, got ${JSON.stringify(names)}`);
+}
+for (const plugin of marketplace.plugins) {
+  if (plugin.source?.source !== "local" || plugin.source.path !== `./plugins/${plugin.name}`) {
+    throw new Error(`unsafe marketplace source for ${plugin.name}`);
+  }
+}
+NODE
+    node --check "$plugins_dir/sites/mcp/server.mjs"
+    python3 -m py_compile "$plugins_dir/visualize/skills/visualize/scripts/render.py"
+}
+
+test_portable_bundled_plugins_reject_unsafe_content() {
+    info "Checking unsafe portable bundled plugin rejection"
+    local workspace="$TMP_DIR/portable-bundled-plugins-unsafe"
+    local app_dir="$workspace/ChatGPT.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local source_plugins="$app_dir/Contents/Resources/plugins/openai-bundled/plugins"
+    local target_plugins="$install_dir/resources/plugins/openai-bundled/plugins"
+    local victim="$workspace/private.txt"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_portable_plugins_upstream_app "$app_dir"
+    printf '%s\n' 'do-not-copy' > "$victim"
+    ln -s "$victim" "$source_plugins/sites/private-link"
+    printf '\x7fELF' > "$source_plugins/deep-research/native-helper"
+    chmod 0755 "$source_plugins/deep-research/native-helper"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        stage_browser_plugin_from_upstream() { return 1; }
+        stage_chrome_plugin_from_upstream() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    [ ! -e "$target_plugins/sites" ] || fail "Expected symlink-bearing Sites plugin to be rejected"
+    [ ! -e "$target_plugins/deep-research" ] || fail "Expected native Deep Research payload to be rejected"
+    assert_file_exists "$target_plugins/visualize/.codex-plugin/plugin.json"
+    assert_contains "$output_log" "symlink is not allowed: private-link"
+    assert_contains "$output_log" "native executable is not portable: native-helper"
+    assert_contains "$victim" "do-not-copy"
+}
+
+test_portable_bundled_plugin_validator_guards() {
+    info "Checking portable bundled plugin manifest and filesystem guards"
+    local workspace="$TMP_DIR/portable-bundled-plugin-validator-guards"
+    local base_plugin="$workspace/base"
+    local case_dir=""
+    local case_name=""
+    local output_log=""
+
+    mkdir -p "$base_plugin/.codex-plugin"
+    printf '%s\n' '{"name":"sites","version":"1.0.0"}' > "$base_plugin/.codex-plugin/plugin.json"
+    printf '%s\n' "portable" > "$base_plugin/content.txt"
+
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+
+    for case_name in invalid-version manifest-symlink privileged-directory native-bundle named-pipe; do
+        case_dir="$workspace/$case_name"
+        output_log="$workspace/$case_name.log"
+        cp -R "$base_plugin" "$case_dir"
+
+        case "$case_name" in
+            invalid-version)
+                printf '%s\n' '{"name":"sites","version":"../invalid"}' > "$case_dir/.codex-plugin/plugin.json"
+                ;;
+            manifest-symlink)
+                printf '%s\n' '{"name":"sites","version":"1.0.0"}' > "$workspace/external-manifest.json"
+                rm "$case_dir/.codex-plugin/plugin.json"
+                ln -s "$workspace/external-manifest.json" "$case_dir/.codex-plugin/plugin.json"
+                ;;
+            privileged-directory)
+                mkdir "$case_dir/privileged"
+                chmod 2755 "$case_dir/privileged"
+                ;;
+            native-bundle)
+                mkdir "$case_dir/helper.app"
+                ;;
+            named-pipe)
+                mkfifo "$case_dir/channel"
+                ;;
+        esac
+
+        if validate_portable_bundled_plugin "$case_dir" sites >"$output_log" 2>&1; then
+            fail "Expected portable plugin validator to reject $case_name"
+        fi
+    done
+
+    assert_contains "$workspace/invalid-version.log" "plugin manifest version is missing or invalid"
+    assert_contains "$workspace/manifest-symlink.log" "plugin manifest cannot be a symlink"
+    assert_contains "$workspace/privileged-directory.log" "privileged mode is not allowed: privileged"
+    assert_contains "$workspace/native-bundle.log" "native bundle is not portable: helper.app"
+    assert_contains "$workspace/named-pipe.log" "non-regular file is not allowed: channel"
+}
+
+test_portable_bundled_plugin_stage_failures() {
+    info "Checking portable bundled plugin stage failure propagation"
+    local workspace="$TMP_DIR/portable-bundled-plugin-stage-failures"
+    local failure=""
+
+    for failure in sidecar-cleanup target-backup final-move; do
+        local case_dir="$workspace/$failure"
+        local app_dir="$case_dir/ChatGPT.app"
+        local source_plugin="$app_dir/Contents/Resources/plugins/openai-bundled/plugins/sites"
+        local target_plugins="$case_dir/target"
+        local output_log="$case_dir/output.log"
+
+        mkdir -p "$target_plugins"
+        make_fake_portable_plugins_upstream_app "$app_dir"
+        if [ "$failure" = "target-backup" ] || [ "$failure" = "final-move" ]; then
+            mkdir -p "$target_plugins/sites"
+            printf '%s\n' "keep-existing" > "$target_plugins/sites/existing.txt"
+        fi
+
+        if ! (
+            warn() { echo "[WARN] $*" >&2; }
+            info() { echo "[INFO] $*" >&2; }
+            # shellcheck disable=SC1091
+            source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+
+            case "$failure" in
+                sidecar-cleanup)
+                    remove_macos_sidecar_files() { return 71; }
+                    ;;
+                target-backup)
+                    mv() {
+                        local args=("$@")
+                        local offset=0
+                        if [ "${args[0]}" = "--" ]; then
+                            offset=1
+                        fi
+                        if [ "${args[$offset]}" = "$target_plugins/sites" ]; then
+                            return 72
+                        fi
+                        command mv "$@"
+                    }
+                    ;;
+                final-move)
+                    mv() {
+                        local args=("$@")
+                        local offset=0
+                        if [ "${args[0]}" = "--" ]; then
+                            offset=1
+                        fi
+                        local source="${args[$offset]}"
+                        local destination="${args[$((offset + 1))]}"
+                        if [[ "$source" == *".sites.tmp."* ]] && [ "$destination" = "$target_plugins/sites" ]; then
+                            return 73
+                        fi
+                        command mv "$@"
+                    }
+                    ;;
+            esac
+
+            if stage_portable_bundled_plugin_from_upstream "$source_plugin" "$target_plugins" sites; then
+                echo "stage unexpectedly succeeded for $failure" >&2
+                exit 1
+            fi
+        ) >"$output_log" 2>&1; then
+            fail "Expected $failure to propagate as a staging failure"
+        fi
+
+        assert_not_contains "$output_log" "Portable bundled plugin sites staged from upstream DMG"
+        [ -z "$(find "$target_plugins" -mindepth 1 -maxdepth 1 -type d \( -name '.sites.tmp.*' -o -name '.sites.backup.*' \) -print -quit)" ] \
+            || fail "Expected $failure staging and backup cleanup"
+
+        case "$failure" in
+            sidecar-cleanup)
+                assert_contains "$output_log" "Failed to clean macOS sidecar files for portable bundled plugin sites"
+                [ ! -e "$target_plugins/sites" ] || fail "Expected sidecar cleanup failure to leave no target"
+                ;;
+            target-backup)
+                assert_contains "$output_log" "Failed to preserve existing portable bundled plugin sites"
+                assert_contains "$target_plugins/sites/existing.txt" "keep-existing"
+                ;;
+            final-move)
+                assert_contains "$output_log" "previous target was restored"
+                assert_contains "$target_plugins/sites/existing.txt" "keep-existing"
+                ;;
+        esac
+    done
+}
+
+test_portable_bundled_plugin_marketplace_path_guard() {
+    info "Checking portable bundled plugin marketplace path guard"
+    local workspace="$TMP_DIR/portable-bundled-plugin-path-guard"
+    local marketplace="$workspace/marketplace.json"
+    local listed="$workspace/listed.txt"
+    local rewritten="$workspace/rewritten/.agents/plugins/marketplace.json"
+
+    mkdir -p "$workspace"
+    cat > "$marketplace" <<'JSON'
+{"plugins":[{"name":"sites","source":{"source":"local","path":"../../outside"},"category":"unsafe-first"},{"name":"sites","source":{"source":"local","path":"./plugins/sites"},"category":"safe-sites"},{"name":"sites","source":{"source":"local","path":"./plugins/sites"},"category":"duplicate-safe"},{"name":"deep-research","source":{"source":"git","path":"./plugins/deep-research"}},{"name":"visualize","source":{"source":"local","path":".\\plugins\\visualize"},"category":"safe-visualize"}]}
+JSON
+
+    (
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        list_portable_bundled_plugins "$marketplace"
+    ) > "$listed"
+
+    [ "$(grep -Fxc 'sites' "$listed")" -eq 1 ] || fail "Expected one safe Sites marketplace entry"
+    [ "$(grep -Fxc 'visualize' "$listed")" -eq 1 ] || fail "Expected one safe Visualize marketplace entry"
+    assert_not_contains "$listed" "deep-research"
+
+    (
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        write_bundled_plugins_marketplace "$marketplace" "$rewritten" 0 0 0 sites visualize
+    )
+    node - "$rewritten" <<'NODE'
+const fs = require("fs");
+const marketplace = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const byName = new Map(marketplace.plugins.map((plugin) => [plugin.name, plugin]));
+if (byName.get("sites")?.category !== "safe-sites") {
+  throw new Error("Sites metadata did not come from the accepted marketplace entry");
+}
+if (byName.get("visualize")?.category !== "safe-visualize") {
+  throw new Error("Visualize metadata did not come from the accepted marketplace entry");
+}
+for (const [name, plugin] of byName) {
+  if (plugin.source?.source !== "local" || plugin.source.path !== `./plugins/${name}`) {
+    throw new Error(`unsafe rewritten source for ${name}`);
+  }
+}
+NODE
 }
 
 test_browser_use_node_repl_glibc_pidfd_patch_static() {
@@ -7827,6 +8228,11 @@ main() {
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_file_url_policy_patch_behavior
     test_browser_plugin_renamed_upstream_staging
+    test_portable_bundled_plugins_staging
+    test_portable_bundled_plugins_reject_unsafe_content
+    test_portable_bundled_plugin_validator_guards
+    test_portable_bundled_plugin_stage_failures
+    test_portable_bundled_plugin_marketplace_path_guard
     test_browser_use_node_repl_glibc_pidfd_patch_static
     test_browser_use_node_repl_ldd_output_compatibility
     test_chrome_plugin_staging
@@ -7834,6 +8240,7 @@ main() {
     test_chrome_marketplace_fallback_synthesis
     test_chrome_native_host_manifest_writer
     test_launcher_managed_node_handles_unset_path
+    test_launcher_extra_bundled_plugin_cache_rollback
     test_launcher_rejects_missing_webview_entrypoint
     test_launcher_template_sanity
     test_launcher_cli_resolution_policy


### PR DESCRIPTION
## Summary

- preserve the upstream Sites, Deep Research, and Visualize plugins in Linux builds
- keep marketplace metadata aligned with the exact portable entries that were staged
- make build staging and launcher cache replacement preserve the previous payload on failure
- reject invalid manifests, symlinks, privileged entries, special files, native executables, and platform-specific bundles from the portable path
- document which bundled plugins use this path and which still require Linux-specific replacements

The allowlist is intentionally explicit. The macOS-native LaTeX and Record and Replay payloads are not copied by this change.

## Validation

- `bash tests/scripts_smoke.sh`
- `node --test scripts/patch-linux-window-ui.test.js linux-features/*/test.js` — 755 tests passed
- `cargo check --workspace`
- `cargo test --workspace`
- `shellcheck -s bash --severity=error -x launcher/start.sh.template scripts/lib/bundled-plugins.sh tests/scripts_smoke.sh`
- Semgrep default rules on the modified runtime scripts — no findings
- full isolated build from the current `26.707.31428` DMG
- Sites design picker initialize and tool-list smoke test
- Visualize render smoke test
- isolated launcher cache hydration for all three plugins

The fresh package matrix for this head is green, including Nix.
