### PR TITLE
Make GPT-5.6 Power slider follow enabled reasoning efforts

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -53,7 +53,11 @@ Each tweak documents its own config keys below.
 Makes the detailed model list the default Codex composer picker view. The model
 rows are rendered inline, so newly available families such as GPT-5.6 Luna,
 Terra, and Sol remain visible without first switching away from the compact
-Power slider or opening a nested Model submenu.
+Power slider or opening a nested Model submenu. The compact GPT-5.6 Power
+slider also derives Sol's positions from the model's `supportedReasoningEfforts`
+after the app filters that list through the reasoning efforts enabled in
+settings. Enabled efforts such as Max therefore appear without maintaining a
+separate hard-coded effort list.
 
 Config keys:
 

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -12,9 +12,12 @@ const MODEL_TITLE_MARKER = "composer.intelligenceDropdown.model.title";
 const MODEL_ROW_MARKER = "composer.intelligenceDropdown.model.rowLabel";
 const EFFORT_TITLE_MARKER = "composer.intelligenceDropdown.effort.title";
 const INLINE_MODEL_LIST_RUNTIME_MARKER = "codex-linux-inline-model-list";
+const DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER =
+  "codex-linux-dynamic-supported-reasoning-efforts";
 const MODEL_ALLOWLIST_MARKER = "l?t.has(n.model):!n.hidden";
 const GPT_56_ALLOWLIST_MARKER =
   "l?t.has(n.model)||n.model.startsWith(`gpt-5.6-`)&&!n.hidden:!n.hidden";
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
 
 function warn(message) {
   console.warn(`WARN: ${message} - skipping ui-tweaks model picker patch`);
@@ -137,9 +140,85 @@ function applyGpt56AllowlistPatch(source, context = {}) {
   }
 }
 
+function findDynamicPowerSelectionsFunction(source) {
+  const pattern = new RegExp(
+    `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{return \\2\\?\\.flatMap\\(\\(\\{` +
+      `displayName:${JS_IDENT},model:${JS_IDENT},supportedReasoningEfforts:${JS_IDENT}` +
+      `\\}\\)=>`,
+  );
+  return source.match(pattern)?.[1] ?? null;
+}
+
+function applyDynamicSupportedReasoningEffortsPatch(source, context = {}) {
+  try {
+    if (typeof source !== "string") {
+      warn("Asset source is not a string");
+      return source;
+    }
+    if (!enabled(context) || source.includes(DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER)) {
+      return source;
+    }
+
+    const dynamicPowerSelectionsFunction = findDynamicPowerSelectionsFunction(source);
+    if (dynamicPowerSelectionsFunction == null) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the supported reasoning effort mapper");
+      }
+      return source;
+    }
+
+    const powerSelectionPattern = new RegExp(
+      `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{let (${JS_IDENT})=(${JS_IDENT})` +
+        `\\((${JS_IDENT}),\\2\\);if\\(\\3\\.length>=4\\)return \\3;let (${JS_IDENT})=` +
+        `\\4\\((${JS_IDENT}),\\2\\);return \\6\\.length>=4\\?\\6:\\[\\]\\}`,
+    );
+    const match = source.match(powerSelectionPattern);
+    if (match == null) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Could not find the compact Power selection resolver");
+      }
+      return source;
+    }
+
+    const [
+      original,
+      resolverFunction,
+      modelsVar,
+      primarySelectionsVar,
+      supportedSelectionsFilter,
+      primaryCandidates,
+      fallbackSelectionsVar,
+      fallbackCandidates,
+    ] = match;
+    const patched =
+      `function ${resolverFunction}(${modelsVar}){` +
+      `let ${primarySelectionsVar}=${supportedSelectionsFilter}(${primaryCandidates}.filter(` +
+      `${modelsVar}=>${modelsVar}.model!==\`gpt-5.6-sol\`),${modelsVar}),` +
+      `codexLinuxSolModel=${modelsVar}?.find(${modelsVar}=>${modelsVar}.model===\`gpt-5.6-sol\`),` +
+      `codexLinuxSolSelections=codexLinuxSolModel==null?[]:` +
+      `${dynamicPowerSelectionsFunction}([codexLinuxSolModel]).map((${modelsVar},codexLinuxIndex)=>` +
+      `({...${modelsVar},powerSettingIndex:${primarySelectionsVar}.length+codexLinuxIndex})),` +
+      `codexLinuxPowerSelections=[...${primarySelectionsVar},...codexLinuxSolSelections]` +
+      `/*${DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER}*/;` +
+      `if(codexLinuxPowerSelections.length>=4)return codexLinuxPowerSelections;` +
+      `let codexLinuxCuratedSelections=${supportedSelectionsFilter}(${primaryCandidates},${modelsVar});` +
+      `if(codexLinuxCuratedSelections.length>=4)return codexLinuxCuratedSelections;` +
+      `let ${fallbackSelectionsVar}=${supportedSelectionsFilter}(${fallbackCandidates},${modelsVar});` +
+      `return ${fallbackSelectionsVar}.length>=4?${fallbackSelectionsVar}:[]}`;
+
+    return source.replace(original, patched);
+  } catch (error) {
+    warn(`Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+    return source;
+  }
+}
+
 function applyModelPickerModelListPatch(source, context = {}) {
-  return applyInlineModelListPatch(
-    applyGpt56AllowlistPatch(applyDefaultAdvancedViewPatch(source, context), context),
+  return applyDynamicSupportedReasoningEffortsPatch(
+    applyInlineModelListPatch(
+      applyGpt56AllowlistPatch(applyDefaultAdvancedViewPatch(source, context), context),
+      context,
+    ),
     context,
   );
 }
@@ -178,10 +257,25 @@ const descriptors = [
     apply: (source, context = {}) =>
       applyInlineModelListPatch(source, { ...context, warnOnMissingMarkers: true }),
   },
+  {
+    id: "model-picker-dynamic-supported-reasoning-efforts",
+    phase: "webview-asset",
+    order: 20_797,
+    ciPolicy: "optional",
+    pattern: MODEL_PICKER_MENU_ASSET_PATTERN,
+    missingDescription: "composer model picker menu bundle",
+    skipDescription: "ui-tweaks dynamic supported reasoning efforts patch",
+    apply: (source, context = {}) =>
+      applyDynamicSupportedReasoningEffortsPatch(source, {
+        ...context,
+        warnOnMissingMarkers: true,
+      }),
+  },
 ];
 
 module.exports = {
   ADVANCED_MENU_VIEW_PATTERN,
+  DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER,
   EFFORT_TITLE_MARKER,
   GPT_56_ALLOWLIST_MARKER,
   INLINE_MODEL_LIST_RUNTIME_MARKER,
@@ -192,9 +286,11 @@ module.exports = {
   MODEL_TITLE_MARKER,
   SIMPLE_MENU_VIEW_PATTERN,
   applyDefaultAdvancedViewPatch,
+  applyDynamicSupportedReasoningEffortsPatch,
   applyGpt56AllowlistPatch,
   applyInlineModelListPatch,
   applyModelPickerModelListPatch,
   descriptors,
+  findDynamicPowerSelectionsFunction,
   findInlineModelListVariable,
 };

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -13,6 +13,7 @@ const {
 } = require("../../scripts/lib/linux-features.js");
 const {
   ADVANCED_MENU_VIEW_PATTERN,
+  DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER,
   GPT_56_ALLOWLIST_MARKER,
   INLINE_MODEL_LIST_RUNTIME_MARKER,
   MODEL_ALLOWLIST_MARKER,
@@ -20,6 +21,7 @@ const {
   MODEL_PICKER_STATE_ASSET_PATTERN,
   SIMPLE_MENU_VIEW_PATTERN,
   applyDefaultAdvancedViewPatch,
+  applyDynamicSupportedReasoningEffortsPatch,
   applyGpt56AllowlistPatch,
   applyInlineModelListPatch,
 } = require("./patches/model-picker-model-list.js");
@@ -65,6 +67,36 @@ function modelPickerMenuBundleFixture() {
     "let we=(0,c6.jsxs)(c6.Fragment,{children:[ye,effort]});",
     "}",
   ].join("");
+}
+
+function modelPickerPowerBundleFixture() {
+  return [
+    "function ARe(e){let t=PRe(FRe,e);if(t.length>=4)return t;let n=PRe(IRe,e);return n.length>=4?n:[]}",
+    "function MRe(e){return e?.flatMap(({displayName:e,model:t,supportedReasoningEfforts:n})=>{let r=e==null?`Custom`:e,i=n.flatMap(({reasoningEffort:e})=>[e]);return(i.length>0?i:[`medium`]).map(e=>({id:`${t}:${e}`,model:t,modelLabel:r,reasoningEffort:e}))})??[]}",
+    "function PRe(e,t){return e.flatMap((e,n)=>t?.some(t=>t.model===e.model&&t.supportedReasoningEfforts.some(({reasoningEffort:t})=>t===e.reasoningEffort))?[{...e,powerSettingIndex:n}]:[])}",
+    "var FRe=[{id:`gpt-5.6-terra:low`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`low`},{id:`gpt-5.6-sol:low`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`low`},{id:`gpt-5.6-sol:medium`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`medium`},{id:`gpt-5.6-sol:high`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`high`},{id:`gpt-5.6-sol:xhigh`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`xhigh`},{id:`gpt-5.6-sol:ultra`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`ultra`}];",
+    "var IRe=[{id:`gpt-5.6-terra:low`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`low`},{id:`gpt-5.6-terra:medium`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`medium`},{id:`gpt-5.6-terra:high`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`high`},{id:`gpt-5.6-terra:xhigh`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`xhigh`}];",
+  ].join("");
+}
+
+function filteredGpt56Models(enabledReasoningEfforts) {
+  const enabled = new Set(enabledReasoningEfforts);
+  return [
+    {
+      displayName: "GPT-5.6-Terra",
+      model: "gpt-5.6-terra",
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh"]
+        .filter((reasoningEffort) => enabled.has(reasoningEffort))
+        .map((reasoningEffort) => ({ reasoningEffort })),
+    },
+    {
+      displayName: "GPT-5.6-Sol",
+      model: "gpt-5.6-sol",
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"]
+        .filter((reasoningEffort) => enabled.has(reasoningEffort))
+        .map((reasoningEffort) => ({ reasoningEffort })),
+    },
+  ];
 }
 
 function simplifiedChineseLocaleFixture() {
@@ -132,6 +164,11 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
         ["feature:ui-tweaks:model-picker-default-advanced-view", "webview-asset", "optional"],
         ["feature:ui-tweaks:model-picker-include-gpt-5-6", "webview-asset", "optional"],
         ["feature:ui-tweaks:model-picker-inline-model-list", "webview-asset", "optional"],
+        [
+          "feature:ui-tweaks:model-picker-dynamic-supported-reasoning-efforts",
+          "webview-asset",
+          "optional",
+        ],
         ["feature:ui-tweaks:reasoning-effort-labels-english", "webview-asset", "optional"],
       ],
     );
@@ -209,6 +246,49 @@ test("GPT-5.6 allowlist behavior admits only visible GPT-5.6 models", () => {
   );
 });
 
+test("GPT-5.6 Power slider follows reasoning efforts enabled in settings", () => {
+  const source = modelPickerPowerBundleFixture();
+  const patched = applyDynamicSupportedReasoningEffortsPatch(source);
+  const resolvePowerSelections = Function(`${patched};return ARe;`)();
+
+  assert.match(patched, new RegExp(DYNAMIC_POWER_EFFORTS_RUNTIME_MARKER));
+  assert.equal(applyDynamicSupportedReasoningEffortsPatch(patched), patched);
+  assert.deepEqual(
+    resolvePowerSelections(filteredGpt56Models(["low", "medium", "high", "xhigh", "max"]))
+      .map(({ id }) => id),
+    [
+      "gpt-5.6-terra:low",
+      "gpt-5.6-sol:low",
+      "gpt-5.6-sol:medium",
+      "gpt-5.6-sol:high",
+      "gpt-5.6-sol:xhigh",
+      "gpt-5.6-sol:max",
+    ],
+  );
+  assert.deepEqual(
+    resolvePowerSelections(filteredGpt56Models(["low", "medium", "high", "xhigh"]))
+      .map(({ id }) => id),
+    [
+      "gpt-5.6-terra:low",
+      "gpt-5.6-sol:low",
+      "gpt-5.6-sol:medium",
+      "gpt-5.6-sol:high",
+      "gpt-5.6-sol:xhigh",
+    ],
+  );
+});
+
+test("GPT-5.6 Power slider effort patch fails soft when upstream markers drift", () => {
+  const source = "function modelPickerPowerSelections(){return []}";
+  const { value, warnings } = withCapturedWarns(() =>
+    applyDynamicSupportedReasoningEffortsPatch(source, { warnOnMissingMarkers: true }),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /Could not find the supported reasoning effort mapper/);
+});
+
 test("model picker tweak can be disabled through feature settings", () => {
   const stateSource = modelPickerStateBundleFixture();
   const menuSource = modelPickerMenuBundleFixture();
@@ -229,6 +309,10 @@ test("model picker tweak can be disabled through feature settings", () => {
   assert.equal(applyDefaultAdvancedViewPatch(stateSource, context), stateSource);
   assert.equal(applyGpt56AllowlistPatch(menuSource, context), menuSource);
   assert.equal(applyInlineModelListPatch(menuSource, context), menuSource);
+  assert.equal(
+    applyDynamicSupportedReasoningEffortsPatch(modelPickerPowerBundleFixture(), context),
+    modelPickerPowerBundleFixture(),
+  );
 });
 
 test("model picker drift warns and leaves the asset unchanged", () => {


### PR DESCRIPTION
## Summary

- derive GPT-5.6 Sol Power slider positions from the model catalog after the desktop filters `supportedReasoningEfforts` through the efforts enabled in settings
- preserve the existing non-Sol curated Power entry and fallback behavior
- keep the optional UI tweak fail-soft and idempotent when upstream bundle markers drift
- document the behavior and cover toggling Max on and off

## Validation

- `node --test linux-features/ui-tweaks/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- verified the patch matches the current extracted model picker WebView asset