### PR TITLE
Keep API key drift patches atomic

### DIFF
--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -13,6 +13,7 @@ const PATCHED_SERVICE_TIER_GATE = new RegExp(
     `${JS_IDENT}\\?\\.requirements\\?\\.featureRequirements\\?\\.fast_mode!==!1:` +
     `${JS_IDENT}===\`apikey\`\\)`,
 );
+const PATCHED_MODEL_MARKER = new RegExp(`${MODEL_MARKER}:${JS_IDENT}===\\\`apikey\\\``);
 const MODEL_LIST_MAPPING_SHAPE = new RegExp(
   `function ${JS_IDENT}\\(\\{authMethod:${JS_IDENT},availableModels:${JS_IDENT},` +
     `defaultModel:${JS_IDENT},enabledReasoningEfforts:${JS_IDENT},` +
@@ -55,7 +56,7 @@ function hasApiKeyServiceTierGateShape(source) {
 }
 
 function applyApiKeyModelMarkerPatch(source) {
-  if (new RegExp(`${MODEL_MARKER}:${JS_IDENT}===\\\`apikey\\\``).test(source)) {
+  if (PATCHED_MODEL_MARKER.test(source)) {
     return source;
   }
 
@@ -139,7 +140,7 @@ function applyApiKeyServiceTierPatch(source) {
 
 function applyCurrentGateAndModelPatch(source) {
   const gateAlreadyPatched = PATCHED_SERVICE_TIER_GATE.test(source);
-  const modelAlreadyPatched = source.includes(MODEL_MARKER);
+  const modelAlreadyPatched = PATCHED_MODEL_MARKER.test(source);
   const gateCandidate = gateAlreadyPatched ? source : applyApiKeyServiceTierGatePatch(source);
   const modelCandidate = modelAlreadyPatched ? source : applyApiKeyModelMarkerPatch(source);
   const gateReady = gateAlreadyPatched || gateCandidate !== source;

--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -138,13 +138,29 @@ function applyApiKeyServiceTierPatch(source) {
 }
 
 function applyCurrentGateAndModelPatch(source) {
-  if (!PATCHED_SERVICE_TIER_GATE.test(source) && !hasApiKeyServiceTierGateShape(source)) {
+  const gateAlreadyPatched = PATCHED_SERVICE_TIER_GATE.test(source);
+  const modelAlreadyPatched = source.includes(MODEL_MARKER);
+  const gateCandidate = gateAlreadyPatched ? source : applyApiKeyServiceTierGatePatch(source);
+  const modelCandidate = modelAlreadyPatched ? source : applyApiKeyModelMarkerPatch(source);
+  const gateReady = gateAlreadyPatched || gateCandidate !== source;
+  const modelReady = modelAlreadyPatched || modelCandidate !== source;
+
+  if (!gateReady && !hasApiKeyServiceTierGateShape(source)) {
     warn("Could not identify current service tier auth gate", "API key service tier gate patch");
   }
-  if (!source.includes(MODEL_MARKER) && !hasApiKeyModelListMappingShape(source)) {
+  if (!modelReady && !hasApiKeyModelListMappingShape(source)) {
     warn("Could not identify current model list mapping", "API key model service tier marker patch");
   }
-  return applyApiKeyModelMarkerPatch(applyApiKeyServiceTierGatePatch(source));
+  if (!gateReady || !modelReady) {
+    return source;
+  }
+  if (gateAlreadyPatched) {
+    return modelCandidate;
+  }
+  if (modelAlreadyPatched) {
+    return gateCandidate;
+  }
+  return applyApiKeyModelMarkerPatch(gateCandidate);
 }
 
 function applyCurrentFallbackFastTierPatch(source) {

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -176,7 +176,7 @@ test("gate and model current contract fails closed when either side is missing",
         "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-partial.js",
       );
       const gateOnlySource =
-        "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}";
+        "const diagnostic=`codexLinuxApiKeyServiceTierModel`;function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}";
       fs.mkdirSync(assetsDir, { recursive: true });
       fs.writeFileSync(targetPath, gateOnlySource);
 
@@ -192,11 +192,16 @@ test("gate and model current contract fails closed when either side is missing",
 
       const modelOnlySource =
         "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
-      assert.deepEqual(captureWarnings(() => {
-        assert.equal(applyCurrentGateAndModelPatch(modelOnlySource), modelOnlySource);
-      }), [
-        "WARN: Could not identify current service tier auth gate - skipping API key service tier gate patch",
-      ]);
+      fs.writeFileSync(targetPath, modelOnlySource);
+      const modelOnlyReport = createPatchReport();
+      const modelOnlyWarnings = captureWarnings(() => patchExtractedApp(tempApp, { report: modelOnlyReport }));
+      const modelOnlyGateModel = modelOnlyReport.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
+      );
+
+      assert.ok(modelOnlyWarnings.some((warning) => warning.includes("current service tier auth gate")));
+      assert.equal(modelOnlyGateModel?.status, "skipped-optional");
+      assert.equal(fs.readFileSync(targetPath, "utf8"), modelOnlySource);
     } finally {
       fs.rmSync(tempApp, { recursive: true, force: true });
     }

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -166,6 +166,43 @@ test("partial current drift is reported when the other exact target still applie
   });
 });
 
+test("gate and model current contract fails closed when either side is missing", () => {
+  withFeatureConfig(["api-key-service-tier"], () => {
+    const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-service-tier-internal-partial-"));
+    try {
+      const assetsDir = path.join(tempApp, "webview", "assets");
+      const targetPath = path.join(
+        assetsDir,
+        "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-partial.js",
+      );
+      const gateOnlySource =
+        "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}";
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(targetPath, gateOnlySource);
+
+      const report = createPatchReport();
+      const warnings = captureWarnings(() => patchExtractedApp(tempApp, { report }));
+      const gateModel = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
+      );
+
+      assert.ok(warnings.some((warning) => warning.includes("current model list mapping")));
+      assert.equal(gateModel?.status, "skipped-optional");
+      assert.equal(fs.readFileSync(targetPath, "utf8"), gateOnlySource);
+
+      const modelOnlySource =
+        "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
+      assert.deepEqual(captureWarnings(() => {
+        assert.equal(applyCurrentGateAndModelPatch(modelOnlySource), modelOnlySource);
+      }), [
+        "WARN: Could not identify current service tier auth gate - skipping API key service tier gate patch",
+      ]);
+    } finally {
+      fs.rmSync(tempApp, { recursive: true, force: true });
+    }
+  });
+});
+
 test("a missing exact current target gets its own skipped report entry", () => {
   withFeatureConfig(["api-key-service-tier"], () => {
     const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-service-tier-missing-target-"));


### PR DESCRIPTION
## Summary

- Keep the current gate/model descriptor atomic when either internal contract drifts.
- Preserve the original asset and report the optional patch as skipped instead of writing a partial result.
- Cover both gate-only and model-only drift, including the runner's final file and status.

## Validation

- `node --test linux-features/api-key-service-tier/test.js`
- `bash scripts/ci/run-node-checks.sh`
- `bash tests/scripts_smoke.sh`
- Semgrep on the changed JavaScript files
- Exact-target and two-pass scan of the `26.707.31428` packed ASAR
- Isolated build with `api-key-service-tier` enabled
