### PR TITLE
Fix AppShots private capture tempdir shadowing

### DIFF
--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -281,8 +281,8 @@ if(!n.existsSync(d)){codexLinuxAppshotWarn(\`screenshot-output-missing\`,{source
 let e=n.statSync(d);if(e.size<=0){codexLinuxAppshotWarn(\`screenshot-output-empty\`,{source:c.source,program:l});continue}
 let t=await codexLinuxAppshotCropWithImageMagick({childProcess:a,fs:n,sourcePath:d,tmpPath:f,cropRects:s});
 if(t!=null)return{dataURL:t.dataURL,width:t.width,height:t.height,source:\`\${c.source}:imagemagick-window-crop\`};
-let r=codexLinuxAppshotCropNativeImage(o,d,s);
-if(r!=null)return{dataURL:r.image.toDataURL(),width:r.width,height:r.height,source:\`\${c.source}:feature-window-crop\`}
+let h=codexLinuxAppshotCropNativeImage(o,d,s);
+if(h!=null)return{dataURL:h.image.toDataURL(),width:h.width,height:h.height,source:\`\${c.source}:feature-window-crop\`}
 }catch(e){codexLinuxAppshotWarn(\`screenshot-command-failed\`,{source:c.source,program:l,message:e instanceof Error?e.message:String(e),stderr:typeof e?.codexStderr===\`string\`?e.codexStderr.slice(0,200):\`\`})}
 finally{if(u!=null)try{n.rmSync(u,{recursive:true,force:true})}catch{}}
 }

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -270,6 +270,102 @@ test("routes AppShots capture through the self-contained Linux feature", () => {
   assert.match(patched, /type:`completed`,transitionSnapshotDataURL:s\.dataURL/);
 });
 
+test("AppShots capture uses and removes its private temporary directory", async () => {
+  const patched = applyLinuxAppshotMainProcessPatch(appshotMainProcessBundleFixture());
+  const helperStart = patched.lastIndexOf(";function codexLinuxAppshotRequire");
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "appshots-private-capture-"));
+  const captureDirs = [];
+  const chmodModes = [];
+  let failCaptures = false;
+
+  assert.ok(helperStart >= 0);
+
+  const fakeFs = {
+    ...fs,
+    mkdtempSync(prefix) {
+      const captureDir = fs.mkdtempSync(prefix);
+      captureDirs.push(captureDir);
+      return captureDir;
+    },
+    chmodSync(target, mode) {
+      chmodModes.push(mode);
+      fs.chmodSync(target, mode);
+    },
+  };
+  const fakeChildProcess = {
+    execFile(program, args, options, callback) {
+      if (failCaptures) {
+        callback(new Error("Expected capture failure"), "", "expected failure");
+        return;
+      }
+      if (program.endsWith("grim")) {
+        fs.writeFileSync(args.at(-1), "source");
+        callback(null, "", "");
+        return;
+      }
+      if (program.endsWith("identify")) {
+        callback(null, "100 100", "");
+        return;
+      }
+      if (program.endsWith("convert")) {
+        fs.writeFileSync(args.at(-1), "crop");
+        callback(null, "", "");
+        return;
+      }
+      callback(new Error(`Unexpected program: ${program}`), "", "unexpected program");
+    },
+  };
+  const context = vm.createContext({
+    Buffer,
+    console: { warn() {} },
+    process: { env: {}, pid: process.pid, platform: "linux", resourcesPath: "" },
+    require(moduleName) {
+      if (moduleName === "node:fs") return fakeFs;
+      if (moduleName === "node:os") return { tmpdir: () => tempRoot };
+      if (moduleName === "node:path") return path;
+      if (moduleName === "node:child_process") return fakeChildProcess;
+      if (moduleName === "electron") {
+        return {
+          nativeImage: {
+            createFromPath: () => ({
+              getSize: () => ({ width: 0, height: 0 }),
+            }),
+          },
+        };
+      }
+      throw new Error(`Unexpected module: ${moduleName}`);
+    },
+    setTimeout,
+  });
+
+  try {
+    vm.runInContext(patched.slice(helperStart), context, { timeout: 1_000 });
+    const result = await context.codexLinuxAppshotScreenshot(
+      { bounds: { height: 40, width: 50, x: 0, y: 0 } },
+      [],
+    );
+
+    assert.equal(result?.width, 50);
+    assert.equal(result?.height, 40);
+    assert.match(result?.dataURL ?? "", /^data:image\/png;base64,/);
+    assert.equal(captureDirs.length, 1);
+    assert.equal(fs.existsSync(captureDirs[0]), false);
+
+    failCaptures = true;
+    const failedResult = await context.codexLinuxAppshotScreenshot(
+      { bounds: { height: 40, width: 50, x: 0, y: 0 } },
+      [],
+    );
+
+    assert.equal(failedResult, null);
+    assert.ok(captureDirs.length > 1);
+    assert.deepEqual(chmodModes, captureDirs.map(() => 0o700));
+    assert.ok(captureDirs.every((captureDir) => !fs.existsSync(captureDir)));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test("enables the current AppShots hotkey class and bare modifiers on Linux", () => {
   const patched = applyPatchTwice(
     applyLinuxAppshotHotkeyPatch,


### PR DESCRIPTION
## Summary

- avoid shadowing the `node:os` binding in the private AppShots capture block
- keep the native crop result in a distinct local so `os.tmpdir()` remains executable
- execute the generated helper in tests across successful capture and all-backend failure, including 0700 temp permissions and cleanup

## Why

The generated helper stores `node:os` in `r`, then declares another block-scoped `r` for the native crop result inside the same `try` block. That inner binding is in the temporal dead zone when `r.tmpdir()` runs, so capture fails before any screenshot backend can start.

## Validation

- `node --test linux-features/appshots/test.js` (15/15)
- `bash scripts/ci/run-node-checks.sh` (814/814)
- `bash tests/scripts_smoke.sh`
- Semgrep JavaScript rules (68 rules, 0 findings)
- direct two-pass application to the raw `26.707.31428` app bundle, with all four AppShots descriptors applying cleanly and the second pass byte-stable
