### PR TITLE
Use aria2c for parallel DMG downloads when available

### DIFF
--- a/scripts/lib/dmg.sh
+++ b/scripts/lib/dmg.sh
@@ -167,6 +167,42 @@ write_cached_dmg_metadata() {
     fi
 }
 
+download_dmg() {
+    local tmp_dest="$1"
+    local tmp_dir
+    local tmp_name
+
+    tmp_dir="$(dirname "$tmp_dest")"
+    tmp_name="$(basename "$tmp_dest")"
+
+    if command -v aria2c >/dev/null 2>&1; then
+        info "Using aria2c for parallel DMG download..."
+        if aria2c \
+                --max-connection-per-server=16 \
+                --split=16 \
+                --max-tries=3 \
+                --retry-wait=10 \
+                --connect-timeout=30 \
+                --timeout=600 \
+                --allow-overwrite=true \
+                --auto-file-renaming=false \
+                --console-log-level=warn \
+                --summary-interval=0 \
+                --dir="$tmp_dir" \
+                --out="$tmp_name" \
+                -- "$DMG_URL" >/dev/null \
+                && [ -s "$tmp_dest" ]; then
+            return 0
+        fi
+
+        warn "aria2c download failed; falling back to curl"
+        rm -f "$tmp_dest" "$tmp_dest.aria2"
+    fi
+
+    curl -L --progress-bar --max-time 600 --connect-timeout 30 \
+        -o "$tmp_dest" -- "$DMG_URL"
+}
+
 get_dmg() {
     local dmg_dest="$CACHED_DMG_PATH"
     local metadata_path="$CACHED_DMG_METADATA_PATH"
@@ -209,9 +245,8 @@ get_dmg() {
     info "URL: $(redact_dmg_url "$DMG_URL")"
 
     rm -f "$tmp_dest"
-    if ! curl -L --progress-bar --max-time 600 --connect-timeout 30 \
-            -o "$tmp_dest" -- "$DMG_URL"; then
-        rm -f "$tmp_dest"
+    if ! download_dmg "$tmp_dest"; then
+        rm -f "$tmp_dest" "$tmp_dest.aria2"
         error "Download failed. Download manually and place as: $dmg_dest"
     fi
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1629,6 +1629,12 @@ printf '%s' "${TEST_DOWNLOAD_CONTENT:-new}" >"$out"
 SCRIPT
     chmod +x "$bin_dir/curl"
 
+    cat >"$bin_dir/aria2c" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 127
+SCRIPT
+    chmod +x "$bin_dir/aria2c"
+
     run_dmg_cache_case() {
         local source_dir="$1"
         local output_log="$2"
@@ -1818,6 +1824,67 @@ EOF
     assert_not_contains "$secret_url/output.log" "fragsecret"
     assert_not_contains "$secret_url/Codex.dmg.metadata" "topsecret"
     assert_not_contains "$secret_url/Codex.dmg.metadata" "fragsecret"
+
+    cat >"$bin_dir/aria2c" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+
+download_dir=""
+download_name=""
+for arg in "$@"; do
+    printf '%s\n' "$arg" >>"$TEST_ARIA2_LOG"
+    case "$arg" in
+        --dir=*)
+            download_dir="${arg#--dir=}"
+            ;;
+        --out=*)
+            download_name="${arg#--out=}"
+            ;;
+    esac
+done
+
+[ -n "$download_dir" ] || exit 2
+[ -n "$download_name" ] || exit 2
+
+if [ "${TEST_ARIA2_MODE:-success}" = "fail" ]; then
+    printf '%s' "partial" >"$download_dir/$download_name"
+    printf '%s' "control" >"$download_dir/$download_name.aria2"
+    exit 1
+fi
+
+printf '%s' "aria2-download" >"$download_dir/$download_name"
+SCRIPT
+    chmod +x "$bin_dir/aria2c"
+
+    local aria2_success="$workspace/aria2-success"
+    mkdir -p "$aria2_success"
+    : >"$aria2_success/aria2.log"
+    run_dmg_cache_case "$aria2_success" "$aria2_success/output.log" \
+        TEST_ARIA2_LOG="$aria2_success/aria2.log" \
+        TEST_ETAG=aria2-etag \
+        TEST_CONTENT_LENGTH=14
+    [ "$(cat "$aria2_success/Codex.dmg")" = "aria2-download" ] || fail "Expected aria2c to download the DMG"
+    assert_not_contains "$aria2_success/curl.log" "GET"
+    assert_contains "$aria2_success/aria2.log" "--max-connection-per-server=16"
+    assert_contains "$aria2_success/aria2.log" "--split=16"
+    assert_contains "$aria2_success/aria2.log" "--dir=$aria2_success"
+    assert_contains "$aria2_success/aria2.log" "--out=Codex.dmg.part"
+    assert_contains "$aria2_success/output.log" "Using aria2c for parallel DMG download"
+
+    local aria2_fallback="$workspace/aria2-fallback"
+    mkdir -p "$aria2_fallback"
+    : >"$aria2_fallback/aria2.log"
+    run_dmg_cache_case "$aria2_fallback" "$aria2_fallback/output.log" \
+        TEST_ARIA2_LOG="$aria2_fallback/aria2.log" \
+        TEST_ARIA2_MODE=fail \
+        TEST_ETAG=fallback-etag \
+        TEST_CONTENT_LENGTH=13 \
+        TEST_DOWNLOAD_CONTENT=curl-fallback
+    [ "$(cat "$aria2_fallback/Codex.dmg")" = "curl-fallback" ] || fail "Expected curl fallback after aria2c failure"
+    assert_contains "$aria2_fallback/curl.log" "GET"
+    assert_contains "$aria2_fallback/output.log" "aria2c download failed; falling back to curl"
+    assert_file_not_exists "$aria2_fallback/Codex.dmg.part"
+    assert_file_not_exists "$aria2_fallback/Codex.dmg.part.aria2"
 
     local invalid_url="$workspace/invalid-url"
     mkdir -p "$invalid_url"


### PR DESCRIPTION
## Summary
- prefer `aria2c` with 16 connections for the current upstream DMG when it is installed
- clean partial aria2 state and fall back to the existing `curl` path on any failure
- add smoke coverage for successful aria2 downloads and curl fallback

## Tests/checks run
- `bash -n scripts/lib/dmg.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh`
- real `aria2c` dry-run against the current upstream URL with the configured arguments
- verified the current upstream server advertises byte-range support
- `git diff --check`

## Notes / risks
- `aria2c` remains optional and is not added to distro dependencies; `curl` remains the required baseline downloader
- proxy environment variables are preserved; a proxy-related aria2 failure falls back to curl
- ShellCheck is not installed in the local validation environment

Closes #754
