### PR TITLE
feat(nix): support declarative Linux features

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -56,6 +56,7 @@ jobs:
             .#codex-desktop-computer-use-ui \
             .#codex-desktop-remote-mobile-control \
             .#codex-desktop-computer-use-ui-remote-mobile-control \
+            .#checks.x86_64-linux.nix-linux-features-multi-feature \
             .#installer \
             --no-link \
             --print-build-logs
@@ -67,5 +68,6 @@ jobs:
             echo "- Built: \`.#codex-desktop-computer-use-ui\`"
             echo "- Built: \`.#codex-desktop-remote-mobile-control\`"
             echo "- Built: \`.#codex-desktop-computer-use-ui-remote-mobile-control\`"
+            echo "- Built: \`.#checks.x86_64-linux.nix-linux-features-multi-feature\`"
             echo "- Built: \`.#installer\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
             .#codex-desktop-computer-use-ui
             .#codex-desktop-remote-mobile-control
             .#codex-desktop-computer-use-ui-remote-mobile-control
+            .#checks.x86_64-linux.nix-linux-features-multi-feature
           )
           for output in "${outputs[@]}"; do
             build_log="$(mktemp)"

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -169,7 +169,9 @@ sed -n '1,220p' ~/.cache/codex-desktop/launcher.log
 ## Feature Outputs
 
 Flakes do not include the git-ignored `linux-features/features.json` opt-in
-file, so Nix exposes feature-specific app variants.
+file. Nix therefore keeps the existing cache-friendly feature outputs and also
+lets module users select Linux features that have been verified to build
+hermetically.
 
 Remote mobile control:
 
@@ -189,6 +191,22 @@ Computer Use UI only:
 nix run github:ilysenko/codex-desktop-linux#codex-desktop-computer-use-ui
 ```
 
+The Home Manager and NixOS modules accept these feature IDs through
+`programs.codexDesktopLinux.linuxFeatures`:
+
+| Feature ID | Purpose |
+| --- | --- |
+| `appshots` | Linux AppShots capture integration |
+| `node-repl-reaper` | Cleanup for leaked Browser Use `node_repl` helpers |
+| `open-target-discovery` | Linux terminal, editor, and file-manager discovery |
+| `persistent-status-panel` | Persistent `/status` panel state |
+| `remote-mobile-control` | Experimental mobile remote-control host enrollment |
+
+The list is validated during module evaluation, then deduplicated and sorted so
+equivalent configurations produce the same derivation. Features that are not in
+this Nix allowlist remain available through the regular opt-in feature flow but
+cannot be selected from a pure flake configuration.
+
 ## Home Manager / NixOS Module
 
 For a declarative install with the mobile remote-control app-server managed by
@@ -204,10 +222,21 @@ systemd instead of the Desktop launcher:
     enable = true;
     computerUseUi.enable = true;
     remoteMobileControl.enable = true;
+    linuxFeatures = [
+      "appshots"
+      "open-target-discovery"
+    ];
     remoteControl.enable = true;
   };
 }
 ```
+
+`remoteMobileControl.enable` remains a compatibility shorthand for adding
+`remote-mobile-control` to the normalized feature list. `computerUseUi.enable`
+remains a dedicated option because it selects the Computer Use UI package path.
+The existing named package outputs use the same package builder with fixed
+arguments. Setting `programs.codexDesktopLinux.package` still selects that
+package directly and takes precedence over module-driven feature selection.
 
 This installs the selected ChatGPT Desktop package variant and starts a user
 `codex-remote-control.service` with:

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
             in
               !(pkgs.lib.hasSuffix "/.codex" pathStr || pkgs.lib.hasInfix "/.codex/" pathStr));
         };
+        nixLinuxFeatures = import ./nix/linux-features.nix { lib = pkgs.lib; };
         computerUseBuildSource = pkgs.runCommandLocal "codex-computer-use-linux-source" { } ''
           mkdir -p "$out"
           cp ${./Cargo.lock} "$out/Cargo.lock"
@@ -391,7 +392,8 @@ PY
           });
 
         enabledFeatureIds = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
-          pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ] ++ linuxFeatureIds;
+          pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ]
+          ++ nixLinuxFeatures.normalize linuxFeatureIds;
 
         packageSuffix = args:
           let
@@ -482,11 +484,16 @@ PY
           '';
         };
 
-        mkCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+        buildCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
         let
-          featureArgs = { inherit enableComputerUseUi linuxFeatureIds; };
+          normalizedLinuxFeatureIds = nixLinuxFeatures.normalize linuxFeatureIds;
+          featureArgs = {
+            inherit enableComputerUseUi;
+            linuxFeatureIds = normalizedLinuxFeatureIds;
+          };
           payload = mkCodexDesktopPayload {
-            inherit enableComputerUseUi linuxFeatureIds;
+            inherit enableComputerUseUi;
+            linuxFeatureIds = normalizedLinuxFeatureIds;
           };
         in
         pkgs.stdenv.mkDerivation {
@@ -566,19 +573,28 @@ PY
           };
         };
 
-        codexDesktop = mkCodexDesktop { };
+        codexDesktop = pkgs.lib.makeOverridable buildCodexDesktop { };
 
-        codexDesktopComputerUseUi = mkCodexDesktop {
+        codexDesktopComputerUseUi = codexDesktop.override {
           enableComputerUseUi = true;
         };
 
-        codexDesktopRemoteMobileControl = mkCodexDesktop {
+        codexDesktopRemoteMobileControl = codexDesktop.override {
           linuxFeatureIds = [ "remote-mobile-control" ];
         };
 
-        codexDesktopComputerUseUiRemoteMobileControl = mkCodexDesktop {
+        codexDesktopComputerUseUiRemoteMobileControl = codexDesktop.override {
           enableComputerUseUi = true;
           linuxFeatureIds = [ "remote-mobile-control" ];
+        };
+
+        codexDesktopNixFeatureCheck = codexDesktop.override {
+          linuxFeatureIds = [
+            "appshots"
+            "node-repl-reaper"
+            "open-target-discovery"
+            "persistent-status-panel"
+          ];
         };
 
         installer = pkgs.writeShellApplication {
@@ -630,6 +646,13 @@ PY
           codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
           codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
           installer = installer;
+        };
+
+        checks = {
+          nix-linux-features-evaluation = import ./nix/linux-features-test.nix {
+            inherit pkgs self system;
+          };
+          nix-linux-features-multi-feature = codexDesktopNixFeatureCheck;
         };
 
         apps.default = {

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -10,16 +10,11 @@ let
   remoteCfg = cfg.remoteControl;
   system = pkgs.stdenv.hostPlatform.system;
   flakePackages = self.packages.${system};
-  packageName =
-    if cfg.remoteMobileControl.enable && cfg.computerUseUi.enable then
-      "codex-desktop-computer-use-ui-remote-mobile-control"
-    else if cfg.remoteMobileControl.enable then
-      "codex-desktop-remote-mobile-control"
-    else if cfg.computerUseUi.enable then
-      "codex-desktop-computer-use-ui"
-    else
-      "codex-desktop";
-  basePackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  linuxFeatures = import ./linux-features.nix { inherit lib; };
+  packageSelection = import ./package-selection.nix {
+    inherit cfg flakePackages lib;
+  };
+  basePackage = packageSelection.package;
   codexCliPackage =
     if cfg.cliPackage != null then
       cfg.cliPackage
@@ -88,10 +83,13 @@ in
         inputs.codex-desktop-linux.packages.''${pkgs.stdenv.hostPlatform.system}.codex-desktop
       '';
       description = ''
-        ChatGPT Desktop package to install. When unset, the module selects one of
-        this flake's package variants from
+        ChatGPT Desktop package to install. When unset, the module builds the
+        selected configuration from
         {option}`programs.codexDesktopLinux.computerUseUi.enable` and
-        {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+        {option}`programs.codexDesktopLinux.linuxFeatures`. The
+        {option}`programs.codexDesktopLinux.remoteMobileControl.enable` option
+        remains a compatibility shorthand for the `remote-mobile-control`
+        feature.
       '';
     };
 
@@ -122,6 +120,22 @@ in
     computerUseUi.enable = lib.mkEnableOption "the Linux Computer Use UI package variant";
 
     remoteMobileControl.enable = lib.mkEnableOption "the experimental Linux mobile remote-control package variant";
+
+    linuxFeatures = lib.mkOption {
+      type = linuxFeatures.optionType;
+      default = [ ];
+      example = [
+        "appshots"
+        "open-target-discovery"
+      ];
+      description = ''
+        Nix-compatible optional Linux features to include in the package. IDs
+        are deduplicated and sorted before the package derivation is created.
+        Features not supported by the Nix packaging layer fail module
+        evaluation. This option does not affect an explicitly configured
+        {option}`programs.codexDesktopLinux.package`.
+      '';
+    };
 
     remoteControl = {
       enable = lib.mkEnableOption "a user systemd app-server with remote control enabled";

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -1,0 +1,189 @@
+{
+  pkgs,
+  self,
+  system,
+}:
+let
+  inherit (pkgs) lib;
+  packages = self.packages.${system};
+  linuxFeatures = import ./linux-features.nix { inherit lib; };
+  homeManagerModule = import ./home-manager-module.nix { inherit self; };
+  nixosModule = import ./nixos-module.nix { inherit self; };
+
+  testFeatureIds = [
+    "persistent-status-panel"
+    "appshots"
+    "remote-mobile-control"
+    "open-target-discovery"
+    "appshots"
+  ];
+  normalizedTestFeatureIds = [
+    "appshots"
+    "open-target-discovery"
+    "persistent-status-panel"
+    "remote-mobile-control"
+  ];
+
+  evalHomeManager = moduleConfig:
+    lib.evalModules {
+      specialArgs = { inherit pkgs; };
+      modules = [
+        homeManagerModule
+        ({ lib, ... }: {
+          options = {
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.anything;
+              default = [ ];
+            };
+            home.homeDirectory = lib.mkOption { type = lib.types.str; };
+            home.profileDirectory = lib.mkOption { type = lib.types.str; };
+            home.packages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [ ];
+            };
+            home.sessionVariables = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = { };
+            };
+            systemd.user.sessionVariables = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = { };
+            };
+            systemd.user.services = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = { };
+            };
+          };
+          config = {
+            home.homeDirectory = "/home/tester";
+            home.profileDirectory = "/home/tester/.nix-profile";
+            programs.codexDesktopLinux = moduleConfig;
+          };
+        })
+      ];
+    };
+
+  evalNixOS = moduleConfig:
+    lib.evalModules {
+      specialArgs = { inherit pkgs; };
+      modules = [
+        nixosModule
+        ({ lib, ... }: {
+          options = {
+            assertions = lib.mkOption {
+              type = lib.types.listOf lib.types.anything;
+              default = [ ];
+            };
+            environment.systemPackages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [ ];
+            };
+            environment.sessionVariables = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = { };
+            };
+            systemd.user.services = lib.mkOption {
+              type = lib.types.attrsOf lib.types.anything;
+              default = { };
+            };
+          };
+          config.programs.codexDesktopLinux = moduleConfig;
+        })
+      ];
+    };
+
+  homePackage = moduleConfig:
+    builtins.head (evalHomeManager moduleConfig).config.home.packages;
+  nixosPackage = moduleConfig:
+    builtins.head (evalNixOS moduleConfig).config.environment.systemPackages;
+
+  defaultConfig = { enable = true; };
+  legacyRemoteConfig = {
+    enable = true;
+    remoteMobileControl.enable = true;
+  };
+  combinedConfig = {
+    enable = true;
+    computerUseUi.enable = true;
+    remoteMobileControl.enable = true;
+    linuxFeatures = testFeatureIds;
+  };
+
+  expectedCombined = packages.codex-desktop.override {
+    enableComputerUseUi = true;
+    linuxFeatureIds = normalizedTestFeatureIds;
+  };
+  reorderedCombined = packages.codex-desktop.override {
+    enableComputerUseUi = true;
+    linuxFeatureIds = [
+      "remote-mobile-control"
+      "persistent-status-panel"
+      "open-target-discovery"
+      "appshots"
+      "appshots"
+    ];
+  };
+
+  customPackage = pkgs.runCommand "codex-desktop-custom-test-package" { } ''
+    mkdir -p "$out"
+  '';
+  customConfig = combinedConfig // { package = customPackage; };
+
+  invalidBuilder = builtins.tryEval (
+    (packages.codex-desktop.override {
+      linuxFeatureIds = [ "not-nix-compatible" ];
+    }).drvPath
+  );
+  invalidHomeManager = builtins.tryEval (
+    builtins.deepSeq
+      (evalHomeManager {
+        enable = true;
+        linuxFeatures = [ "not-nix-compatible" ];
+      }).config.home.packages
+      true
+  );
+  invalidNixOS = builtins.tryEval (
+    builtins.deepSeq
+      (evalNixOS {
+        enable = true;
+        linuxFeatures = [ "not-nix-compatible" ];
+      }).config.environment.systemPackages
+      true
+  );
+in
+assert lib.assertMsg
+  (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
+  "Nix Linux feature IDs must be sorted and deduplicated";
+assert lib.assertMsg
+  ((homePackage defaultConfig).drvPath == packages.codex-desktop.drvPath)
+  "the Home Manager default package changed";
+assert lib.assertMsg
+  ((nixosPackage defaultConfig).drvPath == packages.codex-desktop.drvPath)
+  "the NixOS default package changed";
+assert lib.assertMsg
+  ((homePackage legacyRemoteConfig).drvPath == packages.codex-desktop-remote-mobile-control.drvPath)
+  "the Home Manager remoteMobileControl shorthand changed";
+assert lib.assertMsg
+  ((nixosPackage legacyRemoteConfig).drvPath == packages.codex-desktop-remote-mobile-control.drvPath)
+  "the NixOS remoteMobileControl shorthand changed";
+assert lib.assertMsg
+  ((homePackage combinedConfig).drvPath == expectedCombined.drvPath)
+  "Home Manager did not select the normalized combined package";
+assert lib.assertMsg
+  ((nixosPackage combinedConfig).drvPath == expectedCombined.drvPath)
+  "NixOS did not select the normalized combined package";
+assert lib.assertMsg
+  (expectedCombined.drvPath == reorderedCombined.drvPath)
+  "equivalent feature lists produced different derivations";
+assert lib.assertMsg
+  ((homePackage customConfig).drvPath == customPackage.drvPath)
+  "the Home Manager custom package override lost precedence";
+assert lib.assertMsg
+  ((nixosPackage customConfig).drvPath == customPackage.drvPath)
+  "the NixOS custom package override lost precedence";
+assert lib.assertMsg (!invalidBuilder.success) "the package builder accepted an unsupported feature";
+assert lib.assertMsg (!invalidHomeManager.success) "Home Manager accepted an unsupported feature";
+assert lib.assertMsg (!invalidNixOS.success) "NixOS accepted an unsupported feature";
+pkgs.runCommand "nix-linux-features-evaluation" { } ''
+  touch "$out"
+''

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -1,0 +1,33 @@
+{ lib }:
+let
+  supportedFeatureIds = [
+    "appshots"
+    "node-repl-reaper"
+    "open-target-discovery"
+    "persistent-status-panel"
+    "remote-mobile-control"
+  ];
+
+  sortAndDeduplicate = featureIds:
+    lib.sort builtins.lessThan (lib.unique featureIds);
+
+  normalize = featureIds:
+    if !builtins.isList featureIds then
+      throw "Nix Linux feature IDs must be provided as a list"
+    else if !(lib.all builtins.isString featureIds) then
+      throw "Nix Linux feature IDs must all be strings"
+    else
+      let
+        normalized = sortAndDeduplicate featureIds;
+        unsupported = lib.filter (featureId: !(lib.elem featureId supportedFeatureIds)) normalized;
+      in
+      if unsupported != [ ] then
+        throw "Unsupported Nix Linux feature IDs: ${lib.concatStringsSep ", " unsupported}"
+      else
+        normalized;
+in
+{
+  inherit normalize supportedFeatureIds;
+
+  optionType = lib.types.listOf (lib.types.enum supportedFeatureIds);
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -10,16 +10,11 @@ let
   remoteCfg = cfg.remoteControl;
   system = pkgs.stdenv.hostPlatform.system;
   flakePackages = self.packages.${system};
-  packageName =
-    if cfg.remoteMobileControl.enable && cfg.computerUseUi.enable then
-      "codex-desktop-computer-use-ui-remote-mobile-control"
-    else if cfg.remoteMobileControl.enable then
-      "codex-desktop-remote-mobile-control"
-    else if cfg.computerUseUi.enable then
-      "codex-desktop-computer-use-ui"
-    else
-      "codex-desktop";
-  basePackage = if cfg.package != null then cfg.package else flakePackages.${packageName};
+  linuxFeatures = import ./linux-features.nix { inherit lib; };
+  packageSelection = import ./package-selection.nix {
+    inherit cfg flakePackages lib;
+  };
+  basePackage = packageSelection.package;
   codexCliPackage =
     if cfg.cliPackage != null then
       cfg.cliPackage
@@ -86,10 +81,13 @@ in
         inputs.codex-desktop-linux.packages.''${pkgs.stdenv.hostPlatform.system}.codex-desktop
       '';
       description = ''
-        ChatGPT Desktop package to install. When unset, the module selects one of
-        this flake's package variants from
+        ChatGPT Desktop package to install. When unset, the module builds the
+        selected configuration from
         {option}`programs.codexDesktopLinux.computerUseUi.enable` and
-        {option}`programs.codexDesktopLinux.remoteMobileControl.enable`.
+        {option}`programs.codexDesktopLinux.linuxFeatures`. The
+        {option}`programs.codexDesktopLinux.remoteMobileControl.enable` option
+        remains a compatibility shorthand for the `remote-mobile-control`
+        feature.
       '';
     };
 
@@ -120,6 +118,22 @@ in
     computerUseUi.enable = lib.mkEnableOption "the Linux Computer Use UI package variant";
 
     remoteMobileControl.enable = lib.mkEnableOption "the experimental Linux mobile remote-control package variant";
+
+    linuxFeatures = lib.mkOption {
+      type = linuxFeatures.optionType;
+      default = [ ];
+      example = [
+        "appshots"
+        "open-target-discovery"
+      ];
+      description = ''
+        Nix-compatible optional Linux features to include in the package. IDs
+        are deduplicated and sorted before the package derivation is created.
+        Features not supported by the Nix packaging layer fail module
+        evaluation. This option does not affect an explicitly configured
+        {option}`programs.codexDesktopLinux.package`.
+      '';
+    };
 
     remoteControl = {
       enable = lib.mkEnableOption "a system-wide user app-server unit with remote control enabled";

--- a/nix/package-selection.nix
+++ b/nix/package-selection.nix
@@ -1,0 +1,22 @@
+{
+  cfg,
+  flakePackages,
+  lib,
+}:
+let
+  linuxFeatures = import ./linux-features.nix { inherit lib; };
+  requestedFeatureIds = cfg.linuxFeatures ++ lib.optional cfg.remoteMobileControl.enable "remote-mobile-control";
+  normalizedFeatureIds = linuxFeatures.normalize requestedFeatureIds;
+in
+{
+  inherit normalizedFeatureIds;
+
+  package =
+    if cfg.package != null then
+      cfg.package
+    else
+      flakePackages.codex-desktop.override {
+        enableComputerUseUi = cfg.computerUseUi.enable;
+        linuxFeatureIds = normalizedFeatureIds;
+      };
+}

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -525,7 +525,7 @@ run_nix_job_as_root() {
 
     append_summary "Nix Validation" \
         "Flake check passed." \
-        "Built .#codex-desktop and .#installer without result links."
+        "Built the Nix checks, .#codex-desktop, and .#installer without result links."
 }
 
 run_job_as_current_user() {


### PR DESCRIPTION
This follows the direction from #780 and keeps the existing Nix API compatible.

## What changed

- adds an allowlisted `programs.codexDesktopLinux.linuxFeatures` option for Home Manager and NixOS
- keeps unsupported feature IDs failing during Nix evaluation
- sorts and deduplicates feature IDs before package derivations are created
- routes the modules and existing named package outputs through the same overridable package builder
- preserves `computerUseUi.enable`, `remoteMobileControl.enable`, `package`, and `cliPackage` behavior
- adds one canonical multi-feature Nix build to CI/Cachix instead of expanding the full combination matrix

## Validation

- `docker run ... nix flake check path:/work --all-systems --no-build --no-write-lock-file --option sandbox false`
- `docker run ... nix build path:/work#checks.x86_64-linux.nix-linux-features-multi-feature --no-link --no-write-lock-file --option sandbox false --max-jobs 1 --print-build-logs`
- negative `nix eval` check for `not-nix-compatible`
- `node --test linux-features/appshots/test.js linux-features/node-repl-reaper/test.js linux-features/open-target-discovery/test.js linux-features/persistent-status-panel/test.js`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- `bash -n scripts/ci/container-entrypoint.sh`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/cachix.yml`
- `git diff --check`

Addresses #780.
