### PR TITLE
Hide unavailable settings search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Linux settings search no longer shows unavailable macOS Dock icon controls or
+  Suggested prompts results that do not render in the generated Linux settings
+  page.
 - Read Aloud no longer crashes the generated Linux desktop settings page after
   its shared controls moved from React hooks to class components. The feature's
   enabled state, voice setup actions, and speech pace now use the same

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -167,6 +167,7 @@ const {
   applyLinuxI18nGatePatch,
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSafeMonospaceFontStackPatch,
+  applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
@@ -384,6 +385,109 @@ test("Linux safe monospace font stack patch warns when the unsafe stack drifts",
   assert.equal(value, source);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /Could not find Linux monospace font stack insertion point/);
+});
+
+test("Linux settings search hides controls that cannot render", () => {
+  const source = [
+    'import{E$ as l}from"./app-current.js";',
+    "function qn(e){let t=(0,Zn.c)(17),n=re(),r=Bn(e),{data:i}=_(e),a=i?.isSystemBackdropSupported!==!1,o=i?.platform===`darwin`,{data:s}=T(k,e.selectedHostId),c,l=c;if(a){let e;e=e=>e.sectionSlug===`appearance`&&!a?{...e,messages:e.messages.filter(Jn)}:e.sectionSlug===`agent`?{...e,terms:[]}:e,m=r.map(e)}else m=r;return m}",
+    "function Jn(e){return!Qn.includes(e.id)}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxSettingsSearchVisibilityPatch, source);
+
+  assert.match(patched, /function codexLinuxFilterSettingsSearchSection\(/);
+  assert.match(patched, /settings\.general\.appearance\.dockIcon\.label/);
+  assert.match(
+    patched,
+    /function codexLinuxSuggestedPromptsSearchEnabled\(\)\{return l\(`2425897452`\)\}/,
+  );
+  assert.match(
+    patched,
+    /let codexLinuxSuggestedPromptsEnabled=codexLinuxSuggestedPromptsSearchEnabled\(\);/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /let codexLinuxSuggestedPromptsEnabled=l\(`2425897452`\);/,
+  );
+  assert.match(
+    patched,
+    /return m\.map\(e=>codexLinuxFilterSettingsSearchSection\(e,o,codexLinuxSuggestedPromptsEnabled\)\)/,
+  );
+  assert.equal(
+    (patched.match(/function codexLinuxFilterSettingsSearchSection\(/g) || []).length,
+    1,
+  );
+
+  const helperStart = patched.indexOf(
+    "var codexLinuxDarwinOnlySettingsSearchMessageIds",
+  );
+  const helperEnd = patched.indexOf("function qn", helperStart);
+  const context = {};
+  vm.runInNewContext(
+    `${patched.slice(helperStart, helperEnd)};globalThis.filter=codexLinuxFilterSettingsSearchSection`,
+    context,
+  );
+  const dockMessage = {
+    id: "settings.general.appearance.dockIcon.label",
+  };
+  const themeMessage = {
+    id: "settings.general.appearance.theme",
+  };
+  const suggestedPromptMessage = {
+    id: "settings.agent.ambientSuggestions.groupTitle",
+  };
+  const permissionsMessage = {
+    id: "settings.agent.permissionsMode.groupTitle",
+  };
+
+  assert.deepEqual(
+    Array.from(context.filter({
+      sectionSlug: "appearance",
+      messages: [dockMessage, themeMessage],
+    }, false, false).messages, (message) => message.id),
+    [themeMessage.id],
+  );
+  assert.deepEqual(
+    Array.from(context.filter({
+      sectionSlug: "appearance",
+      messages: [dockMessage, themeMessage],
+    }, true, false).messages, (message) => message.id),
+    [dockMessage.id, themeMessage.id],
+  );
+  assert.deepEqual(
+    Array.from(context.filter({
+      sectionSlug: "agent",
+      messages: [suggestedPromptMessage, permissionsMessage],
+    }, false, false).messages, (message) => message.id),
+    [permissionsMessage.id],
+  );
+  assert.deepEqual(
+    Array.from(context.filter({
+      sectionSlug: "agent",
+      messages: [suggestedPromptMessage, permissionsMessage],
+    }, false, true).messages, (message) => message.id),
+    [suggestedPromptMessage.id, permissionsMessage.id],
+  );
+  assert.deepEqual(
+    Array.from(context.filter({
+      sectionSlug: "general-settings",
+      messages: [suggestedPromptMessage, permissionsMessage],
+    }, false, true).messages, (message) => message.id),
+    [permissionsMessage.id],
+  );
+});
+
+test("Linux settings search visibility patch warns on current-bundle drift", () => {
+  const source =
+    'import{E$ as h}from"./app-current.js";function qn(e){return settingsSearchDocuments}';
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxSettingsSearchVisibilityPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /settings search visibility insertion point/);
 });
 
 test("subagent nickname metadata patch accepts session metadata shape", () => {
@@ -877,6 +981,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-xdg-documents-dir",
     "linux-projectless-xdg-documents-dir",
     "linux-workspace-root-open-targets",
+    "linux-settings-search-visibility",
     "linux-i18n-gate",
     "automation-schedule-multi-time-rrule",
     "automation-update-eager-tool",

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -404,15 +404,19 @@ test("Linux settings search hides controls that cannot render", () => {
   );
   assert.match(
     patched,
-    /let codexLinuxSuggestedPromptsEnabled=codexLinuxSuggestedPromptsSearchEnabled\(\);/,
-  );
-  assert.doesNotMatch(
-    patched,
-    /let codexLinuxSuggestedPromptsEnabled=l\(`2425897452`\);/,
+    /T2 as codexLinuxAccountInfoQuery,j7 as codexLinuxSuggestedPromptsEligible,qk as codexLinuxUseAuthSession/,
   );
   assert.match(
     patched,
-    /return m\.map\(e=>codexLinuxFilterSettingsSearchSection\(e,o,codexLinuxSuggestedPromptsEnabled\)\)/,
+    /let codexLinuxSuggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible\(e\.enabled\);/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /let codexLinuxSuggestedPromptsVisible=l\(`2425897452`\);/,
+  );
+  assert.match(
+    patched,
+    /return m\.map\(e=>codexLinuxFilterSettingsSearchSection\(e,o,codexLinuxSuggestedPromptsVisible\)\)/,
   );
   assert.equal(
     (patched.match(/function codexLinuxFilterSettingsSearchSection\(/g) || []).length,
@@ -423,9 +427,30 @@ test("Linux settings search hides controls that cannot render", () => {
     "var codexLinuxDarwinOnlySettingsSearchMessageIds",
   );
   const helperEnd = patched.indexOf("function qn", helperStart);
-  const context = {};
+  const context = {
+    accountData: null,
+    authSnapshot: {
+      authMethod: "chatgpt",
+      email: "fallback@example.com",
+      planAtLogin: "free",
+    },
+    eligibilityCalls: [],
+    gateEnabled: false,
+    isEligible: false,
+    l: () => context.gateEnabled,
+    queryCalls: [],
+    codexLinuxAccountInfoQuery: (key, config) => {
+      context.queryCalls.push({ key, config });
+      return { data: context.accountData };
+    },
+    codexLinuxSuggestedPromptsEligible: (input) => {
+      context.eligibilityCalls.push(input);
+      return context.isEligible;
+    },
+    codexLinuxUseAuthSession: () => context.authSnapshot,
+  };
   vm.runInNewContext(
-    `${patched.slice(helperStart, helperEnd)};globalThis.filter=codexLinuxFilterSettingsSearchSection`,
+    `${patched.slice(helperStart, helperEnd)};globalThis.filter=codexLinuxFilterSettingsSearchSection;globalThis.suggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible`,
     context,
   );
   const dockMessage = {
@@ -462,20 +487,47 @@ test("Linux settings search hides controls that cannot render", () => {
     }, false, false).messages, (message) => message.id),
     [permissionsMessage.id],
   );
-  assert.deepEqual(
+  const filterSuggestedPromptIds = (sectionSlug) =>
     Array.from(context.filter({
-      sectionSlug: "agent",
+      sectionSlug,
       messages: [suggestedPromptMessage, permissionsMessage],
-    }, false, true).messages, (message) => message.id),
-    [suggestedPromptMessage.id, permissionsMessage.id],
-  );
-  assert.deepEqual(
-    Array.from(context.filter({
-      sectionSlug: "general-settings",
-      messages: [suggestedPromptMessage, permissionsMessage],
-    }, false, true).messages, (message) => message.id),
-    [permissionsMessage.id],
-  );
+    }, false, context.suggestedPromptsVisible(true)).messages, (message) => message.id);
+
+  context.gateEnabled = true;
+  context.isEligible = true;
+  assert.equal(context.suggestedPromptsVisible(false), false);
+  assert.deepEqual(JSON.parse(JSON.stringify(context.queryCalls.at(-1).config)), {
+    queryConfig: {
+      enabled: false,
+    },
+  });
+
+  context.gateEnabled = false;
+  context.isEligible = true;
+  assert.equal(context.suggestedPromptsVisible(true), false);
+  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [permissionsMessage.id]);
+
+  context.gateEnabled = true;
+  context.isEligible = true;
+  context.accountData = {
+    email: "account@example.com",
+    plan: "pro",
+  };
+  assert.equal(context.suggestedPromptsVisible(true), true);
+  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [
+    suggestedPromptMessage.id,
+    permissionsMessage.id,
+  ]);
+  assert.deepEqual(JSON.parse(JSON.stringify(context.eligibilityCalls.at(-1))), {
+    authMethod: "chatgpt",
+    email: "account@example.com",
+    plan: "pro",
+  });
+
+  context.gateEnabled = true;
+  context.isEligible = false;
+  assert.equal(context.suggestedPromptsVisible(true), false);
+  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [permissionsMessage.id]);
 });
 
 test("Linux settings search visibility patch warns on current-bundle drift", () => {

--- a/scripts/patches/core/all-linux/webview/settings-search-visibility/patch.js
+++ b/scripts/patches/core/all-linux/webview/settings-search-visibility/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxSettingsSearchVisibilityPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-settings-search-visibility",
+    phase: "webview-asset",
+    order: 1044,
+    ciPolicy: "optional",
+    pattern: /^settings-page-.*\.js$/,
+    missingDescription: "settings search bundle",
+    skipDescription: "Linux settings search visibility patch",
+    apply: applyLinuxSettingsSearchVisibilityPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -46,6 +46,87 @@ function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
+  if (currentSource.includes("function codexLinuxFilterSettingsSearchSection(")) {
+    return currentSource;
+  }
+
+  const featureGateImport = currentSource.match(
+    /\bE\$ as ([A-Za-z_$][\w$]*)\b/u,
+  );
+  const functionPattern =
+    /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let [A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.c\)\(\d+\),/gu;
+  let settingsSearchFunction = null;
+  let match;
+  while ((match = functionPattern.exec(currentSource)) != null) {
+    const openBrace = currentSource.indexOf("{", match.index);
+    const closeBrace = findMatchingBrace(currentSource, openBrace);
+    if (closeBrace === -1) {
+      continue;
+    }
+    const text = currentSource.slice(match.index, closeBrace + 1);
+    if (
+      text.includes("isSystemBackdropSupported") &&
+      text.includes("?.platform===`darwin`") &&
+      text.includes("sectionSlug===`appearance`") &&
+      text.includes("sectionSlug===`agent`")
+    ) {
+      settingsSearchFunction = {
+        start: match.index,
+        end: closeBrace + 1,
+        name: match[1],
+        param: match[2],
+        text,
+      };
+      break;
+    }
+  }
+
+  const darwinVariable = settingsSearchFunction?.text.match(
+    /,([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\?\.platform===`darwin`,/u,
+  )?.[1];
+  const resultVariable = settingsSearchFunction?.text.match(
+    /return ([A-Za-z_$][\w$]*)\}$/u,
+  )?.[1];
+  if (
+    featureGateImport == null ||
+    settingsSearchFunction == null ||
+    darwinVariable == null ||
+    resultVariable == null
+  ) {
+    if (
+      currentSource.includes("settingsSearchDocuments") ||
+      currentSource.includes("isSystemBackdropSupported")
+    ) {
+      console.warn(
+        "WARN: Could not find settings search visibility insertion point — skipping Linux settings search visibility patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const helper =
+    `var codexLinuxDarwinOnlySettingsSearchMessageIds=new Set([\`settings.general.appearance.dockIcon.chatGPT.ariaLabel\`,\`settings.general.appearance.dockIcon.codex.ariaLabel\`,\`settings.general.appearance.dockIcon.label\`,\`settings.general.appearance.dockIcon.row.description\`]);function codexLinuxSuggestedPromptsSearchEnabled(){return ${featureGateImport[1]}(\`2425897452\`)}function codexLinuxFilterSettingsSearchSection(e,t,n){let r=e.messages;return e.sectionSlug===\`appearance\`&&!t&&(r=r.filter(e=>!codexLinuxDarwinOnlySettingsSearchMessageIds.has(e.id))),((e.sectionSlug===\`agent\`&&!n)||e.sectionSlug===\`general-settings\`)&&(r=r.filter(e=>!e.id.startsWith(\`settings.agent.ambientSuggestions.\`))),r===e.messages?e:{...e,messages:r}}`;
+  const functionStart = `function ${settingsSearchFunction.name}(${settingsSearchFunction.param}){`;
+  const functionPatch =
+    `${functionStart}let codexLinuxSuggestedPromptsEnabled=codexLinuxSuggestedPromptsSearchEnabled();`;
+  const returnNeedle = `return ${resultVariable}}`;
+  const returnPatch =
+    `return ${resultVariable}.map(e=>codexLinuxFilterSettingsSearchSection(e,${darwinVariable},codexLinuxSuggestedPromptsEnabled))}`;
+  const patchedFunction = settingsSearchFunction.text
+    .replace(functionStart, functionPatch)
+    .replace(returnNeedle, returnPatch);
+
+  if (patchedFunction === settingsSearchFunction.text) {
+    console.warn(
+      "WARN: Could not find settings search visibility insertion point — skipping Linux settings search visibility patch",
+    );
+    return currentSource;
+  }
+
+  return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`;
+}
+
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
   if (
     /navigator\.userAgent\.includes\(`Linux`\)&&[A-Za-z_$][\w$]*\?\.opaqueWindows==null/u.test(
@@ -2023,6 +2104,7 @@ module.exports = {
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
   applyLinuxSafeMonospaceFontStackPatch,
+  applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxSkillsListDedupePatch,
   applyLocalEnvironmentActionModalDraftPatch,

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -51,9 +51,20 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
-  const featureGateImport = currentSource.match(
-    /\bE\$ as ([A-Za-z_$][\w$]*)\b/u,
-  );
+  let sharedSettingsImport = null;
+  let featureGateImport = null;
+  for (const match of currentSource.matchAll(/import\{([^}]*)\}from"[^"]+"/gu)) {
+    const featureGateMatch = match[1].match(/\bE\$ as ([A-Za-z_$][\w$]*)\b/u);
+    if (featureGateMatch == null) {
+      continue;
+    }
+    sharedSettingsImport = {
+      text: match[0],
+      specifiers: match[1],
+    };
+    featureGateImport = featureGateMatch;
+    break;
+  }
   const functionPattern =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let [A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.c\)\(\d+\),/gu;
   let settingsSearchFunction = null;
@@ -105,14 +116,25 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
+  const importAdditions = [
+    "T2 as codexLinuxAccountInfoQuery",
+    "j7 as codexLinuxSuggestedPromptsEligible",
+    "qk as codexLinuxUseAuthSession",
+  ].filter((specifier) => !sharedSettingsImport.specifiers.includes(specifier));
+  const patchedImport = importAdditions.length === 0
+    ? sharedSettingsImport.text
+    : sharedSettingsImport.text.replace(
+        sharedSettingsImport.specifiers,
+        `${sharedSettingsImport.specifiers},${importAdditions.join(",")}`,
+      );
   const helper =
-    `var codexLinuxDarwinOnlySettingsSearchMessageIds=new Set([\`settings.general.appearance.dockIcon.chatGPT.ariaLabel\`,\`settings.general.appearance.dockIcon.codex.ariaLabel\`,\`settings.general.appearance.dockIcon.label\`,\`settings.general.appearance.dockIcon.row.description\`]);function codexLinuxSuggestedPromptsSearchEnabled(){return ${featureGateImport[1]}(\`2425897452\`)}function codexLinuxFilterSettingsSearchSection(e,t,n){let r=e.messages;return e.sectionSlug===\`appearance\`&&!t&&(r=r.filter(e=>!codexLinuxDarwinOnlySettingsSearchMessageIds.has(e.id))),((e.sectionSlug===\`agent\`&&!n)||e.sectionSlug===\`general-settings\`)&&(r=r.filter(e=>!e.id.startsWith(\`settings.agent.ambientSuggestions.\`))),r===e.messages?e:{...e,messages:r}}`;
+    `var codexLinuxDarwinOnlySettingsSearchMessageIds=new Set([\`settings.general.appearance.dockIcon.chatGPT.ariaLabel\`,\`settings.general.appearance.dockIcon.codex.ariaLabel\`,\`settings.general.appearance.dockIcon.label\`,\`settings.general.appearance.dockIcon.row.description\`]);function codexLinuxSuggestedPromptsSearchEnabled(){return ${featureGateImport[1]}(\`2425897452\`)}function codexLinuxSuggestedPromptsSearchVisible(e){let t=codexLinuxSuggestedPromptsSearchEnabled(),n=codexLinuxUseAuthSession(),{authMethod:r,email:i,planAtLogin:a}=n,o=e&&t&&r===\`chatgpt\`,s={queryConfig:{enabled:o}},{data:c}=codexLinuxAccountInfoQuery(\`account-info\`,s);return e&&t&&codexLinuxSuggestedPromptsEligible({authMethod:r,email:c?.email??i,plan:c?.plan??a})}function codexLinuxFilterSettingsSearchSection(e,t,n){let r=e.messages;return e.sectionSlug===\`appearance\`&&!t&&(r=r.filter(e=>!codexLinuxDarwinOnlySettingsSearchMessageIds.has(e.id))),((e.sectionSlug===\`agent\`||e.sectionSlug===\`general-settings\`)&&!n)&&(r=r.filter(e=>!e.id.startsWith(\`settings.agent.ambientSuggestions.\`))),r===e.messages?e:{...e,messages:r}}`;
   const functionStart = `function ${settingsSearchFunction.name}(${settingsSearchFunction.param}){`;
   const functionPatch =
-    `${functionStart}let codexLinuxSuggestedPromptsEnabled=codexLinuxSuggestedPromptsSearchEnabled();`;
+    `${functionStart}let codexLinuxSuggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible(${settingsSearchFunction.param}.enabled);`;
   const returnNeedle = `return ${resultVariable}}`;
   const returnPatch =
-    `return ${resultVariable}.map(e=>codexLinuxFilterSettingsSearchSection(e,${darwinVariable},codexLinuxSuggestedPromptsEnabled))}`;
+    `return ${resultVariable}.map(e=>codexLinuxFilterSettingsSearchSection(e,${darwinVariable},codexLinuxSuggestedPromptsVisible))}`;
   const patchedFunction = settingsSearchFunction.text
     .replace(functionStart, functionPatch)
     .replace(returnNeedle, returnPatch);
@@ -124,7 +146,10 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
-  return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`;
+  return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`.replace(
+    sharedSettingsImport.text,
+    patchedImport,
+  );
 }
 
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {


### PR DESCRIPTION
## Summary

- hide Linux settings search results for macOS-only Dock icon controls
- hide Suggested prompts search hits when they only point at a non-rendered settings row
- add a core webview patch descriptor and regression coverage for minified alias collisions

## Root cause

The upstream settings search documents include message IDs for controls that do not always render in the generated Linux settings page. Dock icon entries are macOS-only, and Suggested prompts can be indexed under general-settings even when the real row is gated away by account eligibility. The first implementation also exposed a minifier TDZ risk by calling an imported feature-gate alias inside a function that declares the same local name; this version routes that call through a top-level helper.

## Validation

- node --test --test-name-pattern="Linux settings search" scripts/patch-linux-window-ui.test.js
- node --test scripts/patch-linux-window-ui.test.js (348/348)
- bash tests/scripts_smoke.sh
- node --test linux-features/*/test.js (479/479)
- git diff --check
- rebuilt the generated Linux app from the current official DMG with the opt-in feature set enabled
- launched the generated app on Kubuntu/Wayland and verified Settings search via CDP screenshots:
  - prompt keeps real Prompt/Git hits and no longer shows Suggested prompts
  - dock icon returns no Linux result
