### PR TITLE
test: normalize skill fixture mode on DrvFS

### DIFF
--- a/record-replay-linux/tests/skills_import_fixtures.rs
+++ b/record-replay-linux/tests/skills_import_fixtures.rs
@@ -39,7 +39,13 @@ fn import_options(source: &Path, target_dir: &Path) -> SkillImportOptions {
 #[test]
 fn instruction_only_defaults_to_supported_importable_skill() {
     let temp = tempfile::tempdir().unwrap();
-    let skill = fixture_skill("instruction-only");
+    let fixture = fixture_skill("instruction-only");
+    let skill = temp.path().join("instruction-only");
+    // DrvFS can expose every tracked fixture file as executable, so materialize
+    // the mode this test is meant to classify.
+    fs::create_dir(&skill).unwrap();
+    fs::copy(fixture.join("SKILL.md"), skill.join("SKILL.md")).unwrap();
+    fs::set_permissions(skill.join("SKILL.md"), fs::Permissions::from_mode(0o644)).unwrap();
 
     let inspection = inspect_skill(&skill).unwrap();
     assert_eq!(inspection.status, SkillStatus::Supported);


### PR DESCRIPTION
## What changed

- copy the instruction-only skill fixture into the test temp directory
- set the fixture `SKILL.md` mode to `0644` before inspecting it

## Why

WSL DrvFS can report every tracked file as executable. When the repository is checked out under `/mnt/c`, the Record & Replay fixture test therefore classifies an instruction-only skill as conditional instead of supported.

Materializing the fixture with its intended mode keeps the capability test deterministic without changing importer behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p codex-record-replay-linux`
- `cargo clippy -p codex-record-replay-linux --all-targets -- -D warnings`