### PR TITLE
fix(linux): skip stale bundled-plugin reconcile workers

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -51,6 +51,7 @@ const {
 const {
   applyBrowserUseNodeReplApprovalPatch,
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExternalOpenEnvPatch,
@@ -864,6 +865,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-chrome-plugin-auto-install",
     "linux-chrome-native-host-runtime",
     "browser-use-node-repl-approval",
+    "linux-bundled-plugin-reconcile-stale-snapshot",
     "linux-browser-use-route-liveness",
     "linux-chrome-extension-status",
     "linux-local-app-server-feature-enablement-handler",
@@ -924,6 +926,12 @@ test("default core patch descriptors are grouped and unique", () => {
   );
   assert.equal(
     descriptors.find((descriptor) => descriptor.id === "local-environment-action-modal-draft")?.ciPolicy,
+    "optional",
+  );
+  assert.equal(
+    descriptors.find(
+      (descriptor) => descriptor.id === "linux-bundled-plugin-reconcile-stale-snapshot",
+    )?.ciPolicy,
     "optional",
   );
   assert.equal(
@@ -6127,6 +6135,88 @@ test("auto-installs the current Chrome plugin gate shape", () => {
   assert.match(patched, /name:o\.s,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,env:t,features:r\}\)=>Ar\(e,t\)&&r\.externalBrowserUseAllowed/);
   assert.equal((patched.match(/installWhenMissing:!0,name:o\.c/g) || []).length, 1);
   assert.equal((patched.match(/installWhenMissing:!0,name:o\.s/g) || []).length, 0);
+});
+
+function bundledPluginReconcileRaceFixture() {
+  return [
+    "let p=null,v=Promise.resolve(),h=null,calls=[],releasePreflight,preflightCount=0,markPreflightStarted;",
+    "let preflightStarted=new Promise(e=>{markPreflightStarted=e});",
+    "let L=()=>({info(){}});",
+    "let preflight=()=>++preflightCount===1?(markPreflightStarted(),new Promise(e=>{releasePreflight=e})):Promise.resolve();",
+    "let destructive=async({appServerConnection:e,desktopFeatureAvailability:t})=>{calls.push(t);return {}};",
+    "let E=({force:e,reason:t})=>{if(p==null)return L().info(`bundled_plugins_reconcile_skipped_features_unavailable`,{safe:{reason:t},sensitive:{}}),v;let n=p,c=JSON.stringify({inAppBrowserUse:n.inAppBrowserUse});if(!e&&h===c)return v;h=c;return v=v.catch(()=>{}).then(async()=>{L().info(`bundled_plugins_reconcile_started`,{safe:{reason:t},sensitive:{}});await j({desktopFeatureAvailability:n,reason:t})}),v};",
+    "let j=async t=>{await preflight();let v=async()=>{},y,h=`shadowed-worker-local`;try{y=await destructive({appServerConnection:null,desktopFeatureAvailability:t.desktopFeatureAvailability})}finally{await v()}};",
+    "function setFeatures(e){p=e;return E({force:!1,reason:`startup`})}",
+    "function getCalls(){return calls}",
+    "function release(){releasePreflight()}",
+    "function waitForPreflight(){return preflightStarted}",
+  ].join("");
+}
+
+function bundledPluginReconcileRaceApi(source) {
+  const patched = applyPatchTwice(
+    applyLinuxBundledPluginReconcileStaleSnapshotPatch,
+    source,
+  );
+  return {
+    api: new Function(
+      `${patched};return {setFeatures,getCalls,release,waitForPreflight};`,
+    )(),
+    patched,
+  };
+}
+
+test("skips a queued bundled plugin reconcile that captured a stale feature snapshot", async () => {
+  const { api, patched } = bundledPluginReconcileRaceApi(
+    bundledPluginReconcileRaceFixture(),
+  );
+
+  api.setFeatures({ inAppBrowserUse: false });
+  await api.waitForPreflight();
+  const latestReconcile = api.setFeatures({ inAppBrowserUse: true });
+  api.release();
+  await latestReconcile;
+
+  assert.deepEqual(api.getCalls(), [{ inAppBrowserUse: true }]);
+  assert.equal(
+    (patched.match(/codex-linux-skip-stale-bundled-plugin-reconcile/g) || []).length,
+    1,
+  );
+});
+
+test("reconciles an authoritative disabled bundled plugin snapshot", async () => {
+  const { api } = bundledPluginReconcileRaceApi(
+    bundledPluginReconcileRaceFixture(),
+  );
+
+  const reconcile = api.setFeatures({ inAppBrowserUse: false });
+  await api.waitForPreflight();
+  api.release();
+  await reconcile;
+
+  assert.deepEqual(api.getCalls(), [{ inAppBrowserUse: false }]);
+});
+
+test("fails closed when the bundled plugin reconcile worker is ambiguous", () => {
+  const source =
+    bundledPluginReconcileRaceFixture() +
+    "j=async q=>{let y;try{y=await destructive({appServerConnection:null})}finally{}};";
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxBundledPluginReconcileStaleSnapshotPatch(source),
+  );
+  assert.equal(value, source);
+  assert.match(warnings[0], /Expected one bundled plugin reconcile worker definition/);
+});
+
+test("fails closed when bundled plugin reconcile insertion order drifts", () => {
+  const source = bundledPluginReconcileRaceFixture()
+    .replace("h=c;return v=", "return v=")
+    .replace("let j=async", "h=c;let j=async");
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxBundledPluginReconcileStaleSnapshotPatch(source),
+  );
+  assert.equal(value, source);
+  assert.match(warnings[0], /insertion order drifted/);
 });
 
 test("uses Linux managed runtime paths for Chrome native host sync", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -6137,16 +6137,26 @@ test("auto-installs the current Chrome plugin gate shape", () => {
   assert.equal((patched.match(/installWhenMissing:!0,name:o\.s/g) || []).length, 0);
 });
 
-function bundledPluginReconcileRaceFixture() {
+function bundledPluginReconcileRaceFixture({
+  capturedHashVar = "c",
+  capturedSnapshotVar = "n",
+  featureStateVar = "p",
+  forceVar = "e",
+  latestHashVar = "h",
+  pendingVar = "v",
+  reasonVar = "t",
+  workerArgVar = "t",
+  workerVar = "j",
+} = {}) {
   return [
-    "let p=null,v=Promise.resolve(),h=null,calls=[],releasePreflight,preflightCount=0,markPreflightStarted;",
+    `let ${featureStateVar}=null,${pendingVar}=Promise.resolve(),${latestHashVar}=null,calls=[],releasePreflight,preflightCount=0,markPreflightStarted;`,
     "let preflightStarted=new Promise(e=>{markPreflightStarted=e});",
     "let L=()=>({info(){}});",
     "let preflight=()=>++preflightCount===1?(markPreflightStarted(),new Promise(e=>{releasePreflight=e})):Promise.resolve();",
     "let destructive=async({appServerConnection:e,desktopFeatureAvailability:t})=>{calls.push(t);return {}};",
-    "let E=({force:e,reason:t})=>{if(p==null)return L().info(`bundled_plugins_reconcile_skipped_features_unavailable`,{safe:{reason:t},sensitive:{}}),v;let n=p,c=JSON.stringify({inAppBrowserUse:n.inAppBrowserUse});if(!e&&h===c)return v;h=c;return v=v.catch(()=>{}).then(async()=>{L().info(`bundled_plugins_reconcile_started`,{safe:{reason:t},sensitive:{}});await j({desktopFeatureAvailability:n,reason:t})}),v};",
-    "let j=async t=>{await preflight();let v=async()=>{},y,h=`shadowed-worker-local`;try{y=await destructive({appServerConnection:null,desktopFeatureAvailability:t.desktopFeatureAvailability})}finally{await v()}};",
-    "function setFeatures(e){p=e;return E({force:!1,reason:`startup`})}",
+    `let E=({force:${forceVar},reason:${reasonVar}})=>{if(${featureStateVar}==null)return L().info(\`bundled_plugins_reconcile_skipped_features_unavailable\`,{safe:{reason:${reasonVar}},sensitive:{}}),${pendingVar};let ${capturedSnapshotVar}=${featureStateVar},${capturedHashVar}=JSON.stringify({externalBrowserUse:${capturedSnapshotVar}.externalBrowserUse,inAppBrowserUse:${capturedSnapshotVar}.inAppBrowserUse});if(!${forceVar}&&${latestHashVar}===${capturedHashVar})return ${pendingVar};${latestHashVar}=${capturedHashVar};return ${pendingVar}=${pendingVar}.catch(()=>{}).then(async()=>{L().info(\`bundled_plugins_reconcile_started\`,{safe:{reason:${reasonVar}},sensitive:{}});await ${workerVar}({desktopFeatureAvailability:${capturedSnapshotVar},reason:${reasonVar}})}),${pendingVar}};`,
+    `let ${workerVar}=async ${workerArgVar}=>{await preflight();let v=async()=>{},y,h=\`shadowed-worker-local\`;try{y=await destructive({appServerConnection:null,desktopFeatureAvailability:${workerArgVar}.desktopFeatureAvailability})}finally{await v()}};`,
+    `function setFeatures(e){${featureStateVar}=e;return E({force:!1,reason:\`startup\`})}`,
     "function getCalls(){return calls}",
     "function release(){releasePreflight()}",
     "function waitForPreflight(){return preflightStarted}",
@@ -6171,13 +6181,18 @@ test("skips a queued bundled plugin reconcile that captured a stale feature snap
     bundledPluginReconcileRaceFixture(),
   );
 
-  api.setFeatures({ inAppBrowserUse: false });
+  api.setFeatures({ externalBrowserUse: false, inAppBrowserUse: false });
   await api.waitForPreflight();
-  const latestReconcile = api.setFeatures({ inAppBrowserUse: true });
+  const latestReconcile = api.setFeatures({
+    externalBrowserUse: true,
+    inAppBrowserUse: true,
+  });
   api.release();
   await latestReconcile;
 
-  assert.deepEqual(api.getCalls(), [{ inAppBrowserUse: true }]);
+  assert.deepEqual(api.getCalls(), [
+    { externalBrowserUse: true, inAppBrowserUse: true },
+  ]);
   assert.equal(
     (patched.match(/codex-linux-skip-stale-bundled-plugin-reconcile/g) || []).length,
     1,
@@ -6189,12 +6204,50 @@ test("reconciles an authoritative disabled bundled plugin snapshot", async () =>
     bundledPluginReconcileRaceFixture(),
   );
 
-  const reconcile = api.setFeatures({ inAppBrowserUse: false });
+  const reconcile = api.setFeatures({
+    externalBrowserUse: false,
+    inAppBrowserUse: false,
+  });
   await api.waitForPreflight();
   api.release();
   await reconcile;
 
-  assert.deepEqual(api.getCalls(), [{ inAppBrowserUse: false }]);
+  assert.deepEqual(api.getCalls(), [
+    { externalBrowserUse: false, inAppBrowserUse: false },
+  ]);
+});
+
+test("escapes dollar-prefixed bundled plugin reconcile identifiers", async () => {
+  const { api, patched } = bundledPluginReconcileRaceApi(
+    bundledPluginReconcileRaceFixture({
+      capturedHashVar: "$c",
+      capturedSnapshotVar: "$n",
+      featureStateVar: "$p",
+      forceVar: "$force",
+      latestHashVar: "$h",
+      pendingVar: "$v",
+      reasonVar: "$reason",
+      workerArgVar: "$t",
+      workerVar: "$j",
+    }),
+  );
+
+  api.setFeatures({ externalBrowserUse: false, inAppBrowserUse: false });
+  await api.waitForPreflight();
+  const latestReconcile = api.setFeatures({
+    externalBrowserUse: true,
+    inAppBrowserUse: true,
+  });
+  api.release();
+  await latestReconcile;
+
+  assert.deepEqual(api.getCalls(), [
+    { externalBrowserUse: true, inAppBrowserUse: true },
+  ]);
+  assert.equal(
+    (patched.match(/codex-linux-skip-stale-bundled-plugin-reconcile/g) || []).length,
+    1,
+  );
 });
 
 test("fails closed when the bundled plugin reconcile worker is ambiguous", () => {

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -7,6 +7,7 @@ const {
 const { patchStatusFromChange } = require("../../../../../lib/patch-report.js");
 const {
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../impl/main-process/browser.js");
@@ -36,6 +37,13 @@ module.exports = [
           ? "Browser Use node_repl mcp config bundle not found"
           : warnings[0] ?? null,
     }),
+  }),
+  mainBundlePatch({
+    id: "linux-bundled-plugin-reconcile-stale-snapshot",
+    phase: "main-bundle",
+    order: 164,
+    ciPolicy: "optional",
+    apply: applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   }),
   mainBundlePatch({
     id: "linux-browser-use-route-liveness",

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -7,6 +7,140 @@ const {
   requireName,
 } = require("../../lib/minified-js.js");
 
+function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
+  const marker = "/*codex-linux-skip-stale-bundled-plugin-reconcile*/";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const reconcilerStartRegex =
+    /([A-Za-z_$][\w$]*)=\(\{force:([A-Za-z_$][\w$]*),reason:([A-Za-z_$][\w$]*)\}\)=>\{if\(([A-Za-z_$][\w$]*)==null\)return [A-Za-z_$][\w$]*\(\)\.info\(`bundled_plugins_reconcile_skipped_features_unavailable`/;
+  const match = currentSource.match(reconcilerStartRegex);
+  if (match == null || match.index == null) {
+    if (currentSource.includes("bundled_plugins_reconcile_skipped_features_unavailable")) {
+      console.warn(
+        "WARN: Could not find bundled plugin reconcile queue — skipping stale snapshot patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const featureSnapshotVar = match[4];
+  const reconcilerPrefix = currentSource.slice(match.index);
+  const snapshotMatch = reconcilerPrefix.match(
+    new RegExp(`;let ([A-Za-z_$][\\w$]*)=${featureSnapshotVar}(?:,|;)`),
+  );
+  const reconcileLogIndex = reconcilerPrefix.indexOf(
+    "bundled_plugins_reconcile_started",
+  );
+  if (snapshotMatch == null || snapshotMatch.index == null || reconcileLogIndex < 0) {
+    console.warn(
+      "WARN: Could not find bundled plugin reconcile snapshot — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+
+  const capturedSnapshotVar = snapshotMatch[1];
+  const hashMatch = reconcilerPrefix.match(
+    new RegExp(
+      `;if\\(!${match[2]}&&([A-Za-z_$][\\w$]*)===([A-Za-z_$][\\w$]*)\\)return`,
+    ),
+  );
+  if (hashMatch == null) {
+    console.warn(
+      "WARN: Could not find bundled plugin reconcile semantic hash — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+
+  const latestHashVar = hashMatch[1];
+  const capturedHashVar = hashMatch[2];
+  const reconcileCallMatch = reconcilerPrefix.match(
+    new RegExp(
+      `await ([A-Za-z_$][\\w$]*)\\(\\{desktopFeatureAvailability:${capturedSnapshotVar},`,
+    ),
+  );
+  if (reconcileCallMatch == null) {
+    console.warn(
+      "WARN: Could not find bundled plugin reconcile worker — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+
+  const reconcileWorkerVar = reconcileCallMatch[1];
+  const workerDefinitionRegex = new RegExp(
+    `${reconcileWorkerVar}=async ([A-Za-z_$][\\w$]*)=>\\{`,
+    "g",
+  );
+  const workerDefinitionMatches = [...reconcilerPrefix.matchAll(workerDefinitionRegex)];
+  if (
+    workerDefinitionMatches.length !== 1 ||
+    workerDefinitionMatches[0].index == null
+  ) {
+    console.warn(
+      "WARN: Expected one bundled plugin reconcile worker definition — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+  const workerDefinitionMatch = workerDefinitionMatches[0];
+
+  const workerArgumentVar = workerDefinitionMatch[1];
+  const workerPrefix = reconcilerPrefix.slice(workerDefinitionMatch.index);
+  const destructiveReconcileRegex =
+    /try\{([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\{appServerConnection:/;
+  const destructiveReconcileMatch = workerPrefix.match(destructiveReconcileRegex);
+  if (destructiveReconcileMatch == null || destructiveReconcileMatch.index == null) {
+    console.warn(
+      "WARN: Could not find bundled plugin destructive reconcile boundary — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+
+  const insertionIndex =
+    match.index +
+    workerDefinitionMatch.index +
+    destructiveReconcileMatch.index +
+    "try{".length;
+  const reconcileCallIndex = match.index + reconcileCallMatch.index;
+  const reconcileCallPrefix = `await ${reconcileWorkerVar}({`;
+  const reconcilePropertyIndex = reconcileCallIndex + reconcileCallPrefix.length;
+  const hashAssignment = `${latestHashVar}=${capturedHashVar};`;
+  const hashAssignmentIndex = reconcilerPrefix.indexOf(hashAssignment);
+  if (hashAssignmentIndex < 0) {
+    console.warn(
+      "WARN: Could not find bundled plugin reconcile hash assignment — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+  const globalHashInsertionIndex =
+    match.index + hashAssignmentIndex + hashAssignment.length;
+  if (
+    !(
+      globalHashInsertionIndex < reconcilePropertyIndex &&
+      reconcilePropertyIndex < insertionIndex
+    )
+  ) {
+    console.warn(
+      "WARN: Bundled plugin reconcile insertion order drifted — skipping stale snapshot patch",
+    );
+    return currentSource;
+  }
+
+  const guardedSource =
+    currentSource.slice(0, insertionIndex) +
+    `if(${workerArgumentVar}.codexLinuxReconcileSnapshot!==globalThis.__codexLinuxBundledPluginReconcileSnapshot)return;${marker}` +
+    currentSource.slice(insertionIndex);
+  const propertySource =
+    guardedSource.slice(0, reconcilePropertyIndex) +
+    `codexLinuxReconcileSnapshot:${capturedHashVar},` +
+    guardedSource.slice(reconcilePropertyIndex);
+  return (
+    propertySource.slice(0, globalHashInsertionIndex) +
+    `globalThis.__codexLinuxBundledPluginReconcileSnapshot=${capturedHashVar};` +
+    propertySource.slice(globalHashInsertionIndex)
+  );
+}
+
 function applyBrowserUseNodeReplApprovalPatch(currentSource) {
   let patchedSource = currentSource;
   let patchedTrustedHashes = false;
@@ -329,6 +463,7 @@ function applyLinuxExternalOpenEnvPatch(currentSource) {
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxExternalOpenEnvPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const {
+  escapeRegExp,
   requireName,
 } = require("../../lib/minified-js.js");
 
@@ -26,9 +27,10 @@ function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
   }
 
   const featureSnapshotVar = match[4];
+  const escapedFeatureSnapshotVar = escapeRegExp(featureSnapshotVar);
   const reconcilerPrefix = currentSource.slice(match.index);
   const snapshotMatch = reconcilerPrefix.match(
-    new RegExp(`;let ([A-Za-z_$][\\w$]*)=${featureSnapshotVar}(?:,|;)`),
+    new RegExp(`;let ([A-Za-z_$][\\w$]*)=${escapedFeatureSnapshotVar}(?:,|;)`),
   );
   const reconcileLogIndex = reconcilerPrefix.indexOf(
     "bundled_plugins_reconcile_started",
@@ -43,7 +45,7 @@ function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
   const capturedSnapshotVar = snapshotMatch[1];
   const hashMatch = reconcilerPrefix.match(
     new RegExp(
-      `;if\\(!${match[2]}&&([A-Za-z_$][\\w$]*)===([A-Za-z_$][\\w$]*)\\)return`,
+      `;if\\(!${escapeRegExp(match[2])}&&([A-Za-z_$][\\w$]*)===([A-Za-z_$][\\w$]*)\\)return`,
     ),
   );
   if (hashMatch == null) {
@@ -57,7 +59,7 @@ function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
   const capturedHashVar = hashMatch[2];
   const reconcileCallMatch = reconcilerPrefix.match(
     new RegExp(
-      `await ([A-Za-z_$][\\w$]*)\\(\\{desktopFeatureAvailability:${capturedSnapshotVar},`,
+      `await ([A-Za-z_$][\\w$]*)\\(\\{desktopFeatureAvailability:${escapeRegExp(capturedSnapshotVar)},`,
     ),
   );
   if (reconcileCallMatch == null) {
@@ -69,7 +71,7 @@ function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
 
   const reconcileWorkerVar = reconcileCallMatch[1];
   const workerDefinitionRegex = new RegExp(
-    `${reconcileWorkerVar}=async ([A-Za-z_$][\\w$]*)=>\\{`,
+    `${escapeRegExp(reconcileWorkerVar)}=async ([A-Za-z_$][\\w$]*)=>\\{`,
     "g",
   );
   const workerDefinitionMatches = [...reconcilerPrefix.matchAll(workerDefinitionRegex)];


### PR DESCRIPTION
Fixes #789.

## Summary

- carry the bundled-plugin reconciler's existing semantic snapshot hash into
  its async worker;
- skip a stale worker immediately before destructive marketplace mutation;
- keep the descriptor fail-soft as `optional` drift;
- cover stale `false -> true`, authoritative disable, ambiguous minified worker,
  insertion-order drift, dollar-prefixed minified identifiers, multi-field
  availability snapshots, and idempotence.

## Root cause

During Linux cold start, a newer feature snapshot can be scheduled while an
older bundled-plugin worker is still in async preflight. The older worker then
materializes an incomplete marketplace, uninstalls Browser, and the queued
worker installs it again. The renderer can remain in the transient unavailable
state.

The guard uses the semantic hash upstream already computes for reconcile
equivalence. It contains no Browser allowlist, cache retention, marketplace
reuse, or availability bypass. An explicit disable produces a new hash, so old
work becomes stale and the newest worker retains the normal uninstall behavior.

## User impact

Browser no longer disappears when this cold-start race occurs or requires a
manual reinstall from Settings after an affected launch.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js scripts/patches/impl/main-process/browser.test.js` — passed;
- current `26.707.31428` main bundle: patch applies once and is idempotent;
- GitHub CI for `eaf07db` is green;
- two consecutive rebuilt NixOS cold starts: runtime marketplace contained
  `browser`, `chrome`, `computer-use`, and `visualize`; Browser uninstall and
  install requests were both zero;
- `git diff --check` — passed.

## Architecture note

A typed generation token or source-level queue coalescing could enforce the
same invariant at another boundary. The current patch keeps that invariant
inside the existing Linux bundle patch without adding a Browser-specific rule.
