### PR TITLE
Fix updater builder DMG intel staging

### DIFF
--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -773,6 +773,7 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/lib/linux-features.js" "$update_builder_root/scripts/lib/linux-features.js"
     cp "$REPO_DIR/scripts/lib/linux-features.sh" "$update_builder_root/scripts/lib/linux-features.sh"
     cp "$REPO_DIR/scripts/lib/linux-target-context.js" "$update_builder_root/scripts/lib/linux-target-context.js"
+    cp "$REPO_DIR/scripts/lib/upstream-dmg-intel.js" "$update_builder_root/scripts/lib/upstream-dmg-intel.js"
     cp "$REPO_DIR/scripts/lib/linux-update-bridge-patch.js" "$update_builder_root/scripts/lib/linux-update-bridge-patch.js"
     cp "$REPO_DIR/scripts/lib/patch-report.js" "$update_builder_root/scripts/lib/patch-report.js"
     cp "$REPO_DIR/scripts/lib/rebuild-report.sh" "$update_builder_root/scripts/lib/rebuild-report.sh"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -380,6 +380,7 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-features.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-features.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-target-context.js"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/upstream-dmg-intel.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/descriptor.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/engine.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/runner.js"


### PR DESCRIPTION
## Summary

- stage `scripts/lib/upstream-dmg-intel.js` in native packages' update-builder bundle
- assert the helper is present in the Debian packaging smoke test

## Root cause

`scripts/patch-linux-window-ui.js` imports `./lib/upstream-dmg-intel.js`, but `stage_update_builder_bundle` did not copy that dependency into `/opt/codex-desktop/update-builder`. Local update rebuilds therefore failed at the Linux patch step with `MODULE_NOT_FOUND` after successfully extracting the upstream DMG and rebuilding native modules.

## Impact

Packaged installations can rebuild newer ChatGPT/Codex DMGs instead of repeatedly failing before package generation. The assertion protects the update-builder dependency from being omitted again.

## Validation

- verified the new smoke assertion fails before the staging change
- `bash tests/scripts_smoke.sh`
- `bash -n scripts/lib/package-common.sh`
- performed a live `codex-update-manager check-now` rebuild from the affected DMG
- inspected the resulting `.deb` and confirmed both the helper file and its generated manifest entry are present
