### PR TITLE
fix(nix): make mcp-helper-reaper declaratively selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- Nix module configurations can select the opt-in `mcp-helper-reaper`
+  feature. Its Rust helper is supplied by a reproducible Nix derivation and is
+  not added to the default package closure.
+
 ### Fixed
 
 - Read Aloud no longer crashes the generated Linux desktop settings page after

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -197,6 +197,7 @@ The Home Manager and NixOS modules accept these feature IDs through
 | Feature ID | Purpose |
 | --- | --- |
 | `appshots` | Linux AppShots capture integration |
+| `mcp-helper-reaper` | Cleanup for stale configured MCP helper processes |
 | `node-repl-reaper` | Cleanup for leaked Browser Use `node_repl` helpers |
 | `open-target-discovery` | Linux terminal, editor, and file-manager discovery |
 | `persistent-status-panel` | Persistent `/status` panel state |

--- a/flake.nix
+++ b/flake.nix
@@ -161,6 +161,16 @@
           '';
         };
 
+        codexMcpHelperReaper = pkgs.rustPlatform.buildRustPackage {
+          pname = "codex-mcp-helper-reaper";
+          version = "0.1.0";
+          src = ./linux-features/mcp-helper-reaper/reaper;
+
+          cargoLock = {
+            lockFile = ./linux-features/mcp-helper-reaper/reaper/Cargo.lock;
+          };
+        };
+
         nativeModulesNodeModules = pkgs.importNpmLock.buildNodeModules {
           npmRoot = ./nix/native-modules;
           inherit (pkgs) nodejs;
@@ -457,6 +467,9 @@ PY
             export CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-linux"
             export CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-cosmic"
             export CODEX_CHROME_EXTENSION_HOST_SOURCE="${codexComputerUseBinaries}/bin/codex-chrome-extension-host"
+            ${pkgs.lib.optionalString (builtins.elem "mcp-helper-reaper" linuxFeatureIds) ''
+            export CODEX_MCP_HELPER_REAPER_SOURCE="${codexMcpHelperReaper}/bin/codex-mcp-helper-reaper"
+            ''}
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
 
             source_dir="$TMPDIR/codex-source"
@@ -530,10 +543,30 @@ PY
               --unpack "{*.node,*.so,*.dylib}"
             rm -rf "$resources_dir/app-extracted"
 
-            if [ -f "$resources_dir/node_repl" ]; then
-              patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
-                --set-rpath "${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib pkgs.glibc ]}" \
-                "$resources_dir/node_repl"
+            for node_repl_binary in \
+              "$resources_dir/node_repl" \
+              "$resources_dir/node_repl.codex-linux-original"; do
+              if [ -f "$node_repl_binary" ] \
+                  && [ "$(dd if="$node_repl_binary" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')" = "7f454c46" ]; then
+                patchelf --set-interpreter "$(cat ${pkgs.stdenv.cc}/nix-support/dynamic-linker)" \
+                  --set-rpath "${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib pkgs.glibc ]}" \
+                  "$node_repl_binary"
+              fi
+            done
+
+            if [ -f "$resources_dir/node_repl.codex-linux-original" ]; then
+              node_repl_interpreter="$(patchelf --print-interpreter \
+                "$resources_dir/node_repl.codex-linux-original")"
+              node_repl_rpath="$(patchelf --print-rpath \
+                "$resources_dir/node_repl.codex-linux-original")"
+              case "$node_repl_interpreter" in
+                /nix/store/*) ;;
+                *) echo "node_repl backup has non-Nix interpreter: $node_repl_interpreter" >&2; exit 1 ;;
+              esac
+              case "$node_repl_rpath" in
+                *"/nix/store/"*) ;;
+                *) echo "node_repl backup has non-Nix RPATH: $node_repl_rpath" >&2; exit 1 ;;
+              esac
             fi
 
             ${patchNixInstalledApp "$out/opt/codex-desktop"}
@@ -591,6 +624,7 @@ PY
         codexDesktopNixFeatureCheck = codexDesktop.override {
           linuxFeatureIds = [
             "appshots"
+            "mcp-helper-reaper"
             "node-repl-reaper"
             "open-target-discovery"
             "persistent-status-panel"

--- a/linux-features/mcp-helper-reaper/test.js
+++ b/linux-features/mcp-helper-reaper/test.js
@@ -25,13 +25,15 @@ function writeExecutable(file, body) {
 }
 
 function hostTool(name) {
-  for (const dir of ["/usr/bin", "/bin"]) {
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (!dir || !path.isAbsolute(dir)) continue;
     const candidate = path.join(dir, name);
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      if (fs.statSync(candidate).isFile()) return candidate;
+    } catch {}
   }
-  return name;
+  throw new Error(`could not resolve executable from PATH: ${name}`);
 }
 
 function symlinkHostTools(targetDir, names) {

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -13,12 +13,14 @@ let
   testFeatureIds = [
     "persistent-status-panel"
     "appshots"
+    "mcp-helper-reaper"
     "remote-mobile-control"
     "open-target-discovery"
     "appshots"
   ];
   normalizedTestFeatureIds = [
     "appshots"
+    "mcp-helper-reaper"
     "open-target-discovery"
     "persistent-status-panel"
     "remote-mobile-control"
@@ -118,6 +120,7 @@ let
     linuxFeatureIds = [
       "remote-mobile-control"
       "persistent-status-panel"
+      "mcp-helper-reaper"
       "open-target-discovery"
       "appshots"
       "appshots"

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -2,6 +2,7 @@
 let
   supportedFeatureIds = [
     "appshots"
+    "mcp-helper-reaper"
     "node-repl-reaper"
     "open-target-discovery"
     "persistent-status-panel"


### PR DESCRIPTION
## Summary

Merged PR #782 added the allowlisted `programs.codexDesktopLinux.linuxFeatures`
option and one canonical multi-feature build. The existing opt-in
`mcp-helper-reaper` feature was not included; its Rust helper requires an
explicit hermetic Nix input.

This follow-up:

- builds the existing reaper crate with `buildRustPackage`;
- adds `mcp-helper-reaper` to the Nix compatibility allowlist;
- supplies `CODEX_MCP_HELPER_REAPER_SOURCE` only when the feature is selected;
- covers it in normalized module evaluation and the canonical multi-feature
  build;
- preserves the `node_repl` shell wrapper while patching its backed-up ELF for
  NixOS, with a build-time interpreter/RPATH invariant;
- resolves test fixture executables from absolute directories in the active
  `PATH`.

The default package remains independent of the optional helper derivation. No
new named package or app output is added. This follows the design agreed in
#780: an allowlist in the Nix layer, the shared builder, and one canonical
multi-feature check rather than a combinatorial output matrix.

## Root cause

The feature's stage hook builds a Rust binary and replaces `resources/node_repl`
with a shell wrapper that executes `node_repl.codex-linux-original`. Nix needs
both an explicit prebuilt helper source and Nix-store interpreter/RPATH patching
for the effective ELF payload. Merely allowing the feature ID would therefore
either build impurely or leave the wrapped binary unusable on stock NixOS.

## Validation

- `node --test linux-features/mcp-helper-reaper/test.js` — passed
- `cargo test --manifest-path linux-features/mcp-helper-reaper/reaper/Cargo.toml` — passed
- `cargo fmt --manifest-path linux-features/mcp-helper-reaper/reaper/Cargo.toml -- --check`
- `nix flake check --no-build`
- `nix build .#checks.x86_64-linux.nix-linux-features-multi-feature`
- `nix build .#default --no-link`
- current GitHub CI is green, including `Nix Package Builds`
- collaborator review reproduced the focused Node, Rust, formatting, and diff
  checks and reported no blocker in the allowlist/helper wiring
- selected derivation graph contains the helper input; default derivation graph
  and runtime closure do not
- selected `resources/node_repl` is an executable Nix-store Bash wrapper; its
  backup ELF has a Nix-store interpreter and RUNPATH

Follow-up to #780 and merged PR #782.

## Checklist

- [x] I followed `CONTRIBUTING.md`, kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] I preserved the declarative API and canonical-check design merged in PR #782.
- [x] I added or updated relevant tests and ran the validation listed above.
