### PR TITLE
test: resolve feature fixture tools from PATH

### DIFF
--- a/linux-features/node-repl-reaper/test.js
+++ b/linux-features/node-repl-reaper/test.js
@@ -11,6 +11,21 @@ const test = require("node:test");
 const REAPER = path.join(__dirname, "reaper.sh");
 const LONG_RUNNING_NODE_ARGS = ["-e", "setInterval(() => {}, 1000)"];
 
+function commandPath(name) {
+  for (const directory of (process.env.PATH || "").split(path.delimiter)) {
+    if (!directory || !path.isAbsolute(directory)) continue;
+    const candidate = path.join(directory, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      if (!fs.statSync(candidate).isFile()) continue;
+      return candidate;
+    } catch {}
+  }
+  throw new Error(`could not resolve executable from PATH: ${name}`);
+}
+
+const BASH = commandPath("bash");
+
 function makeFakeApp() {
   const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-node-repl-reaper-test-"));
   fs.mkdirSync(path.join(appDir, "resources"));
@@ -34,7 +49,7 @@ function pidAlive(pid) {
 }
 
 function runReaperOnce(appDir) {
-  const result = spawnSync("bash", [REAPER, appDir, "once"], {
+  const result = spawnSync(BASH, [REAPER, appDir, "once"], {
     encoding: "utf8",
     env: { ...process.env, CODEX_NODE_REPL_REAPER_KILL_GRACE: "1" },
   });
@@ -96,7 +111,7 @@ test("leaves a node_repl with a live codex app-server parent alone", async () =>
   const fakeCodex = path.join(appDir, "codex");
   fs.writeFileSync(
     fakeCodex,
-    `#!/bin/bash\n"${nodeReplBin}" -e 'setInterval(() => {}, 1000)' &\necho "child=$!"\nwait\n`,
+    `#!${BASH}\n"${nodeReplBin}" -e 'setInterval(() => {}, 1000)' &\necho "child=$!"\nwait\n`,
   );
   fs.chmodSync(fakeCodex, 0o755);
   const appServer = spawn(fakeCodex, ["app-server"], { stdio: ["ignore", "pipe", "ignore"] });
@@ -133,7 +148,7 @@ test("leaves a node_repl with a live codex resume parent alone", async () => {
   const fakeCodex = path.join(appDir, "codex");
   fs.writeFileSync(
     fakeCodex,
-    `#!/bin/bash\n"${nodeReplBin}" -e 'setInterval(() => {}, 1000)' &\necho "child=$!"\nwait\n`,
+    `#!${BASH}\n"${nodeReplBin}" -e 'setInterval(() => {}, 1000)' &\necho "child=$!"\nwait\n`,
   );
   fs.chmodSync(fakeCodex, 0o755);
   const cliSession = spawn(fakeCodex, ["resume"], { stdio: ["ignore", "pipe", "ignore"] });

--- a/linux-features/omarchy-theme/test.js
+++ b/linux-features/omarchy-theme/test.js
@@ -27,6 +27,21 @@ const {
 const FEATURE_DIR = __dirname;
 const REPO_ROOT = path.resolve(FEATURE_DIR, "..", "..");
 
+function commandPath(name) {
+  for (const directory of (process.env.PATH || "").split(path.delimiter)) {
+    if (!directory || !path.isAbsolute(directory)) continue;
+    const candidate = path.join(directory, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      if (!fs.statSync(candidate).isFile()) continue;
+      return candidate;
+    } catch {}
+  }
+  throw new Error(`could not resolve executable from PATH: ${name}`);
+}
+
+const BASH = commandPath("bash");
+
 function withFeatureConfig(enabled, fn) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-omarchy-theme-config-"));
   const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
@@ -342,18 +357,18 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
     const fakeOmarchy = path.join(binDir, "omarchy");
     fs.writeFileSync(
       fakeOmarchy,
-      `#!/usr/bin/env bash\nset -e\nprintf '%s\\n' "$*" >> "$OMARCHY_TEST_LOG"\nmkdir -p "$HOME/.config/omarchy/current/theme"\nprintf 'generated' > "$HOME/.config/omarchy/current/theme/codex-desktop.css"\n`,
+      `#!${BASH}\nset -e\nprintf '%s\\n' "$*" >> "$OMARCHY_TEST_LOG"\nmkdir -p "$HOME/.config/omarchy/current/theme"\nprintf 'generated' > "$HOME/.config/omarchy/current/theme/codex-desktop.css"\n`,
     );
     fs.chmodSync(fakeOmarchy, 0o755);
 
     const env = {
       ...process.env,
       HOME: home,
-      PATH: `${binDir}:/usr/bin:/bin`,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
       CODEX_LINUX_FEATURES_DIR: featuresDir,
       OMARCHY_TEST_LOG: callLog,
     };
-    const first = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+    const first = spawnSync(BASH, [path.join(FEATURE_DIR, "install-template.sh")], {
       env,
       encoding: "utf8",
     });
@@ -364,7 +379,7 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
 
     fs.writeFileSync(target, "/* local customization */\n");
     fs.rmSync(generated);
-    const second = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+    const second = spawnSync(BASH, [path.join(FEATURE_DIR, "install-template.sh")], {
       env,
       encoding: "utf8",
     });
@@ -377,10 +392,10 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
     fs.rmSync(generated);
     fs.writeFileSync(
       fakeOmarchy,
-      "#!/usr/bin/env bash\nsleep 30\n",
+      `#!${BASH}\nsleep 30\n`,
     );
     const startedAt = Date.now();
-    const hanging = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+    const hanging = spawnSync(BASH, [path.join(FEATURE_DIR, "install-template.sh")], {
       env: {
         ...env,
         CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS: "1",
@@ -395,10 +410,10 @@ test("prelaunch hook installs the template, refreshes missing CSS, and preserves
     const timeoutLog = path.join(tempDir, "timeout.log");
     fs.writeFileSync(
       path.join(binDir, "timeout"),
-      `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "$OMARCHY_TEST_TIMEOUT_LOG"\nexit 124\n`,
+      `#!${BASH}\nprintf '%s\\n' "$*" > "$OMARCHY_TEST_TIMEOUT_LOG"\nexit 124\n`,
     );
     fs.chmodSync(path.join(binDir, "timeout"), 0o755);
-    const oversizedTimeout = spawnSync("bash", [path.join(FEATURE_DIR, "install-template.sh")], {
+    const oversizedTimeout = spawnSync(BASH, [path.join(FEATURE_DIR, "install-template.sh")], {
       env: {
         ...env,
         CODEX_OMARCHY_THEME_REFRESH_TIMEOUT_SECONDS: "999999999999999999999",


### PR DESCRIPTION
## Summary

- resolve Bash from executable regular files in absolute directories from the
  active `PATH`;
- use that absolute path for spawned shell scripts and generated fixture
  shebangs;
- preserve the caller's host tool directories when prepending the temporary
  Omarchy fixture directory;
- ignore empty and relative `PATH` entries so tests cannot resolve tools from
  the current working directory.

## Why

The two optional-feature suites assumed FHS paths such as `/bin/bash` or
`/usr/bin`, even though the implementation being tested does not require those
locations. On NixOS and other non-FHS systems, the fixtures could fail before
exercising feature behavior.

This is test-only. It does not change either feature's runtime implementation
or CI policy.

## Scope

- `linux-features/node-repl-reaper/test.js`
- `linux-features/omarchy-theme/test.js`

The similar open-target and MCP helper fixture failures are intentionally not
included; they belong to separate functional changes and reproduce unchanged
on clean `origin/main`.

## Validation

- `node --check linux-features/node-repl-reaper/test.js`
- `node --check linux-features/omarchy-theme/test.js`
- `node --test linux-features/node-repl-reaper/test.js linux-features/omarchy-theme/test.js` — 10/10
- `env PATH=":.:$PATH" node --test linux-features/node-repl-reaper/test.js linux-features/omarchy-theme/test.js` — 10/10
- GitHub Rust and Smoke Tests job, including the full Node runner
- `git diff --check`

This remains a focused fixture portability change; a shared test-tool resolver
may make sense only if more suites converge on the same contract.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] The change is test-only and limited to the two sister fixtures.
- [x] The focused tests pass with normal and adversarial `PATH` values.
- [x] GitHub CI is green, including the full Node runner.
