### PR TITLE
fix(open-target): preserve helper scope and spawn env

### DIFF
--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -196,6 +196,7 @@ function findOpenTargetRegistryBindings(source) {
   }
 
   return {
+    registryName,
     registryExpression: `${registryName}(e)`,
     detectContext: detectContextMatch[3],
   };
@@ -213,7 +214,7 @@ function insertOpenTargetHelpers(currentSource, insertionIndex, { fsVar, pathVar
     `function codexLinuxFindExecutable(e){if(process.platform!==\`linux\`||!e)return null;for(let t of codexLinuxExecutableSearchDirs()){let n=(0,${pathVar}.join)(t,e);try{if((0,${fsVar}.existsSync)(n)){let e=(0,${fsVar}.statSync)(n);if(e.isFile())try{(0,${fsVar}.accessSync)(n,${fsVar}.constants.X_OK);return n}catch{}}}catch{}}return null}` +
     `function codexLinuxResolveExistingTarget(e){if(typeof e!==\`string\`||e.length===0)return null;let t=e;for(;;){try{if((0,${fsVar}.existsSync)(t))return t}catch{}let n=(0,${pathVar}.dirname)(t);if(n===t)return null;t=n}}` +
     `function codexLinuxShouldDropXdgConfigHome(e){let t=e.XDG_CONFIG_HOME,n=e.CODEX_ELECTRON_USER_DATA_DIR;if(typeof t!==\`string\`)return!1;if(typeof n===\`string\`&&t===(0,${pathVar}.join)((0,${pathVar}.dirname)(n),\`xdg-config\`))return!0;let r=e.CODEX_LINUX_APP_ID;return!!(r&&t.endsWith(\`/\${r}/xdg-config\`))}` +
-    `function codexLinuxOpenTargetEnv(){let e={...process.env};codexLinuxShouldDropXdgConfigHome(e)&&delete e.XDG_CONFIG_HOME;for(let t of [\`NODE_OPTIONS\`,\`NODE_PATH\`,\`NODE_REPL_EXTERNAL_MODULE\`,\`ELECTRON_RUN_AS_NODE\`,\`ELECTRON_NO_ASAR\`,\`ELECTRON_ENABLE_LOGGING\`,\`VSCODE_NODE_OPTIONS\`,\`VSCODE_NODE_REPL_EXTERNAL_MODULE\`,\`npm_config_node_options\`,\`NPM_CONFIG_NODE_OPTIONS\`,\`CHROME_DESKTOP\`,\`ELECTRON_RENDERER_URL\`,\`CODEX_ELECTRON_RESOURCES_PATH\`,\`CODEX_ELECTRON_USER_DATA_DIR\`,\`CODEX_LINUX_APP_ID\`,\`CODEX_LINUX_APP_DISPLAY_NAME\`,\`CODEX_LINUX_WEBVIEW_PORT\`])delete e[t];return e}` +
+    `function codexLinuxOpenTargetEnv(){let e={...process.env};codexLinuxShouldDropXdgConfigHome(e)&&delete e.XDG_CONFIG_HOME;for(let t of [\`LD_LIBRARY_PATH\`,\`LD_PRELOAD\`,\`NODE_OPTIONS\`,\`NODE_PATH\`,\`NODE_REPL_EXTERNAL_MODULE\`,\`ELECTRON_RUN_AS_NODE\`,\`ELECTRON_NO_ASAR\`,\`ELECTRON_ENABLE_LOGGING\`,\`VSCODE_NODE_OPTIONS\`,\`VSCODE_NODE_REPL_EXTERNAL_MODULE\`,\`npm_config_node_options\`,\`NPM_CONFIG_NODE_OPTIONS\`,\`CHROME_DESKTOP\`,\`ELECTRON_RENDERER_URL\`,\`CODEX_ELECTRON_RESOURCES_PATH\`,\`CODEX_ELECTRON_USER_DATA_DIR\`,\`CODEX_LINUX_APP_ID\`,\`CODEX_LINUX_APP_DISPLAY_NAME\`,\`CODEX_LINUX_WEBVIEW_PORT\`])delete e[t];return e}` +
     `function codexLinuxLaunchDetached(e,t,n={}){return new Promise((r,i)=>{let a=!1,o;try{let s=require(\`node:child_process\`).spawn(e,t,{detached:!0,stdio:\`ignore\`,windowsHide:!0,cwd:n.cwd,env:codexLinuxOpenTargetEnv()});o=setTimeout(()=>{a=!0,s.unref?.(),r()},400),o.unref?.(),s.on(\`error\`,e=>{a||(clearTimeout(o),i(e))}),s.on(\`close\`,e=>{a||(clearTimeout(o),e===0?r():i(Error(\`Linux open target launch failed\`)))})}catch(e){clearTimeout(o),i(e)}})}` +
     `function codexLinuxTryReveal(e,t){return new Promise((n,r)=>{let i=!1,a;try{let o=require(\`node:child_process\`).spawn(e,t,{stdio:\`ignore\`,windowsHide:!0,env:codexLinuxOpenTargetEnv()});a=setTimeout(()=>{i=!0,o.unref?.(),n()},400),a.unref?.(),o.on(\`error\`,e=>{i||(clearTimeout(a),r(e))}),o.on(\`close\`,e=>{i||(clearTimeout(a),e===0?n():r(Error(\`Linux file manager reveal failed\`)))})}catch(e){clearTimeout(a),r(e)}})}` +
     `async function codexLinuxOpenFileManager(e){let t=codexLinuxResolveExistingTarget(e)??e;if(typeof t!==\`string\`||t.length===0)throw Error(\`No Linux file manager target available\`);let n=!1;try{n=(0,${fsVar}.existsSync)(t)&&(0,${fsVar}.statSync)(t).isFile()}catch{}if(n)for(let e of [[\`dolphin\`,[\`--select\`,t]],[\`nautilus\`,[\`--select\`,t]]]){let t=codexLinuxFindExecutable(e[0]);if(t)try{await codexLinuxTryReveal(t,e[1]);return}catch{}}t=n?(0,${pathVar}.dirname)(t):t;for(let e of [\`nemo\`,\`thunar\`,\`pcmanfm\`,\`caja\`,\`xdg-open\`]){let n=codexLinuxFindExecutable(e);if(n)try{await codexLinuxLaunchDetached(n,[t]);return}catch{}}throw Error(\`No Linux file manager available\`)}`;
@@ -605,11 +606,16 @@ function applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing = 
 
   const helper =
     `async function codexLinuxOpenTargetRegistryCommand(e,t){if(process.platform!==\`linux\`)return;try{let n=${bindings.registryExpression}.find(e=>e.id===t);return typeof n?.detect===\`function\`?await n.detect(${bindings.detectContext}):null}catch{return null}}`;
+  const registryDeclaration = `function ${bindings.registryName}(`;
+  const insertionIndex = currentSource.indexOf(registryDeclaration);
+  if (insertionIndex === -1) {
+    if (warnOnMissing) {
+      warn("Could not find open target registry declaration");
+    }
+    return currentSource;
+  }
 
-  const insertionIndex = currentSource.indexOf("async function");
-  const helperInsertionIndex = insertionIndex === -1 ? 0 : insertionIndex;
-
-  return currentSource.slice(0, helperInsertionIndex) + helper + currentSource.slice(helperInsertionIndex);
+  return currentSource.slice(0, insertionIndex) + helper + currentSource.slice(insertionIndex);
 }
 
 function applyOpenInTargetCommandPatch(currentSource) {

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -432,7 +432,7 @@ const tryExecCases = [
   [false, "sh -c '! command -v cursor >/dev/null 2>&1'", ["sh", "cursor"]],
   [false, "sh -c 'which /bin/ls >/dev/null 2>&1'", ["sh"]],
   [false, "bash", []],
-  [true, "sh -c 'exec /bin/true && false'", ["sh"]],
+  [true, "sh -c 'exec true && false'", ["sh", "true"]],
   [false, "sh -c 'exec /missing/cursor || true'", ["sh"]],
   [false, "missing-wrapper bash -lc 'command -v cursor >/dev/null 2>&1'", ["bash", "cursor"]],
   [false, "fish -C 'hash cursor >/dev/null 2>&1'", ["fish", "cursor"]],
@@ -643,6 +643,8 @@ test("open-target discovery sanitizes desktop launch environment", async () => {
         PATH: `${binDir}:${path.dirname(editorCommand)}`,
         XDG_DATA_HOME: dataHome,
         XDG_DATA_DIRS: path.join(tmp, "empty"),
+        LD_LIBRARY_PATH: "/codex/electron/lib",
+        LD_PRELOAD: "/codex/electron/lib/libhook.so",
         CHROME_DESKTOP: "codex-open-target-launchers.desktop",
         ELECTRON_RENDERER_URL: "http://127.0.0.1:5203/",
         CODEX_ELECTRON_USER_DATA_DIR: path.join(
@@ -662,6 +664,8 @@ test("open-target discovery sanitizes desktop launch environment", async () => {
 
     assert.equal(spawnRecorder.calls[0].command, gio);
     assert.equal(spawnRecorder.calls[0].options.cwd, tmp);
+    assert.equal(spawnRecorder.calls[0].options.env.LD_LIBRARY_PATH, undefined);
+    assert.equal(spawnRecorder.calls[0].options.env.LD_PRELOAD, undefined);
     assert.equal(spawnRecorder.calls[0].options.env.CHROME_DESKTOP, undefined);
     assert.equal(spawnRecorder.calls[0].options.env.ELECTRON_RENDERER_URL, undefined);
     assert.equal(spawnRecorder.calls[0].options.env.CODEX_ELECTRON_USER_DATA_DIR, undefined);
@@ -1210,6 +1214,29 @@ test("open-target discovery inserts shared Linux registry command helper", async
 
   assert.match(patched, /async function codexLinuxOpenTargetRegistryCommand/);
   assert.match(patched, /n\.detect\(FN\)/);
+  assert.equal(command, "/usr/bin/kate");
+});
+
+test("open-target discovery inserts registry helper in the registry module scope", async () => {
+  const source =
+    `function codexLinuxPatchExternalOpen(){async function __codexOpenExternal(){}}` +
+    currentAppOpenTargetPrelude;
+  const patched = applyPatchTwice(applyOpenInTargetRegistryCommandPatch, source);
+  const settingsStore = currentAppSettingsStore([
+    {
+      id: "kate",
+      detect: async () => "/usr/bin/kate",
+    },
+  ]);
+  const command = await new Function(
+    "process",
+    `${patched};return codexLinuxOpenTargetRegistryCommand(arguments[1], 'kate');`,
+  )({ platform: "linux" }, settingsStore);
+
+  assert.match(
+    patched,
+    /async function codexLinuxOpenTargetRegistryCommand[\s\S]*?function QN\(e\)/,
+  );
   assert.equal(command, "/usr/bin/kate");
 });
 


### PR DESCRIPTION
## Summary

- insert the Linux open-target registry helper immediately before the detected
  registry declaration, so it remains in module scope even when an earlier
  patch injected an async function inside another helper;
- remove `LD_LIBRARY_PATH` and `LD_PRELOAD` from the environment used to spawn
  editors and file managers;
- make the feature-owned `TryExec` fixture independent of `/bin/true`.

## Root cause

PR #761 binds Linux target discovery to the current registry and context, but
the helper insertion point is still the first `async function` in the bundle.
If another patch has already injected an async function inside a helper, the
registry command helper becomes lexically nested and open-target handlers fail
before launching an external process.

Separately, the feature-owned spawn helper removed Electron and Node variables
but retained dynamic-loader paths from the packaged launcher. A file manager
could then load libraries from the Desktop closure instead of its system
environment.

This change anchors the helper to the registry declaration already discovered
from the current bundle shape and sanitizes loader variables at the existing
external-process boundary. The feature remains optional and disabled by
default.

## Validation

- `node --check linux-features/open-target-discovery/patch.js`
- `node --check linux-features/open-target-discovery/test.js`
- `node --test linux-features/open-target-discovery/test.js` — 38/38 passed
- `git diff --check`
- rebuilt NixOS runtime: default-application open succeeded; file-manager open
  reached Nemo without the Desktop loader environment; subsequent `Super+E`
  opened another visible Nemo window after the previously poisoned singleton
  was cleared

## Scope

Only `linux-features/open-target-discovery/patch.js` and its test change. No
core launcher behavior, MIME association, file-manager selection order, feature
enablement, or CI policy changes.

## Architecture note

A semantic module-scope insertion primitive in the patch framework could
enforce the same anchor centrally. This feature keeps the change local by using
the exact registry declaration it already detects.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] The change is limited to the optional open-target feature and its tests.
- [x] The focused checks pass on the current `origin/main` base.
