### PR TITLE
Fix Appshots availability and X11 monitor lifecycle

### DIFF
--- a/linux-features/appshots/README.md
+++ b/linux-features/appshots/README.md
@@ -40,8 +40,9 @@ Privacy and correctness constraints:
 - `Alt + Alt` and `Shift + Shift` are backed by a feature-local
   `bare-modifier-monitor` helper staged into `resources/native/`. It requires
   the left and right modifier keycodes, so tapping only one physical modifier
-  twice does not trigger AppShots. It uses `xinput` and `xmodmap`, so it is
-  expected to work on X11 sessions and fail closed elsewhere.
+  twice does not trigger AppShots. It reads one root XInput2 event stream and
+  stops that listener when its Electron parent exits. It uses `xinput` and
+  `xmodmap`, so it is expected to work on X11 sessions and fail closed elsewhere.
 - On Wayland, the feature stages an Electron args hook that enables
   `GlobalShortcutsPortal`, and the settings dropdown hides the X11-only bare
   modifier shortcuts.

--- a/linux-features/appshots/bin/bare-modifier-monitor
+++ b/linux-features/appshots/bin/bare-modifier-monitor
@@ -165,6 +165,17 @@ else
 fi
 monitor_pid="$APPSHOT_XINPUT_PID"
 event_fd="${APPSHOT_XINPUT[0]}"
+
+sleep 0.1
+if ! kill -0 "$monitor_pid" >/dev/null 2>&1; then
+    monitor_status=0
+    wait "$monitor_pid" || monitor_status=$?
+    monitor_pid=""
+    [ "$monitor_status" -ne 0 ] || monitor_status=1
+    echo "permission-denied"
+    exit "$monitor_status"
+fi
+
 echo "ready"
 
 pending=""

--- a/linux-features/appshots/bin/bare-modifier-monitor
+++ b/linux-features/appshots/bin/bare-modifier-monitor
@@ -140,87 +140,72 @@ last_tap_ms=0
 last_tap_code=""
 active=0
 
-keyboard_ids="$(
-    xinput list --short |
-        awk '
-            /\[slave[[:space:]]+keyboard/ {
-                if (match($0, /id=[0-9]+/)) {
-                    print substr($0, RSTART + 3, RLENGTH - 3)
-                }
-            }
-        '
-)"
-
-if [ -z "$keyboard_ids" ]; then
-    echo "permission-denied"
-    exit 1
-fi
-
-event_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-bare-modifier.XXXXXX")"
-event_fifo="$event_dir/events"
-monitor_pids=()
+parent_pid="$PPID"
+monitor_pid=""
+event_fd=""
+cleanup_started=0
 
 cleanup() {
-    for pid in "${monitor_pids[@]:-}"; do
-        if command -v pkill >/dev/null 2>&1; then
-            pkill -TERM -P "$pid" >/dev/null 2>&1 || true
-        fi
-        kill "$pid" >/dev/null 2>&1 || true
-    done
+    [ "$cleanup_started" -eq 0 ] || return
+    cleanup_started=1
+
+    [ -n "$monitor_pid" ] || return
+    kill "$monitor_pid" >/dev/null 2>&1 || true
     sleep 0.05
-    for pid in "${monitor_pids[@]:-}"; do
-        if command -v pkill >/dev/null 2>&1; then
-            pkill -KILL -P "$pid" >/dev/null 2>&1 || true
-        fi
-        kill -KILL "$pid" >/dev/null 2>&1 || true
-    done
-    wait "${monitor_pids[@]:-}" >/dev/null 2>&1 || true
-    rm -f "$event_fifo"
-    rmdir "$event_dir" 2>/dev/null || true
+    kill -KILL "$monitor_pid" >/dev/null 2>&1 || true
+    wait "$monitor_pid" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
-trap 'cleanup; exit 143' INT TERM
+trap 'exit 143' INT TERM
 
-mkfifo "$event_fifo"
-exec 4<>"$event_fifo"
-
-for device_id in $keyboard_ids; do
-    (
-        xinput_cmd=(xinput test "$device_id")
-        if command -v stdbuf >/dev/null 2>&1; then
-            xinput_cmd=(stdbuf -oL "${xinput_cmd[@]}")
-        fi
-
-        "${xinput_cmd[@]}" 2>/dev/null |
-            while IFS= read -r line; do
-                set -- $line
-                [ "${1:-}" = "key" ] || continue
-                case "${2:-}" in
-                    press|release)
-                        printf '%s %s\n' "$2" "${3:-}"
-                        ;;
-                esac
-            done
-    ) >"$event_fifo" 2>/dev/null &
-    monitor_pids+=("$!")
-done
-
-exec 3<"$event_fifo"
+if command -v stdbuf >/dev/null 2>&1; then
+    coproc APPSHOT_XINPUT { exec stdbuf -oL xinput test-xi2 --root 2>/dev/null; }
+else
+    coproc APPSHOT_XINPUT { exec xinput test-xi2 --root 2>/dev/null; }
+fi
+monitor_pid="$APPSHOT_XINPUT_PID"
+event_fd="${APPSHOT_XINPUT[0]}"
 echo "ready"
 
-while read -r pending code <&3; do
+pending=""
+while kill -0 "$parent_pid" >/dev/null 2>&1 && kill -0 "$monitor_pid" >/dev/null 2>&1; do
+    if ! IFS= read -r -t 1 -u "$event_fd" line; then
+        continue
+    fi
+
+    case "$line" in
+        *"(RawKeyPress)")
+            pending="press"
+            continue
+            ;;
+        *"(RawKeyRelease)")
+            pending="release"
+            continue
+            ;;
+        EVENT\ type*)
+            pending=""
+            continue
+            ;;
+    esac
+
+    [ -n "$pending" ] || continue
+    set -- $line
+    [ "${1:-}" = "detail:" ] || continue
+    code="${2:-}"
+    action="$pending"
+    pending=""
     code="${code//[[:space:]]/}"
     [ -n "$code" ] || continue
 
     if ! is_target_keycode "$code"; then
-        if [ "$pending" = "press" ]; then
+        if [ "$action" = "press" ]; then
             last_tap_ms=0
             last_tap_code=""
         fi
         continue
     fi
 
-    if [ "$pending" = "press" ]; then
+    if [ "$action" = "press" ]; then
         current_ms="$(now_ms)"
         elapsed_ms=$((current_ms - last_tap_ms))
         if [ "$last_tap_ms" -gt 0 ] && [ "$elapsed_ms" -le "$double_tap_ms" ] && [ "$code" != "$last_tap_code" ]; then
@@ -237,7 +222,7 @@ while read -r pending code <&3; do
         continue
     fi
 
-    if [ "$pending" = "release" ] && [ "$active" -eq 1 ]; then
+    if [ "$action" = "release" ] && [ "$active" -eq 1 ]; then
         if [ "$trigger_mode" = "release" ]; then
             echo "down"
         fi

--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -342,7 +342,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*\.js$/,
+    pattern: /^app-initial~app-main~page-.*\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -214,7 +214,7 @@ test("bare modifier monitor emits one transition from one XInput2 stream", () =>
       "  'EVENT type 14 (RawKeyRelease)' '    detail: 50' \\",
       "  'EVENT type 13 (RawKeyPress)' '    detail: 62' \\",
       "  'EVENT type 14 (RawKeyRelease)' '    detail: 62'",
-      "sleep 0.1",
+      "sleep 0.25",
     ].join("\n"),
     { mode: 0o755 },
   );
@@ -231,6 +231,39 @@ test("bare modifier monitor emits one transition from one XInput2 stream", () =>
     });
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(result.stdout.trim().split("\n"), ["ready", "down", "up"]);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("bare modifier monitor fails before ready when XInput2 exits during startup", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "appshots-xinput2-startup-"));
+  const binDir = path.join(tempDir, "bin");
+  const helper = path.join(__dirname, "bin", "bare-modifier-monitor");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(
+    path.join(binDir, "xmodmap"),
+    "#!/bin/sh\nprintf '%s\\n' 'keycode 50 = Shift_L' 'keycode 62 = Shift_R'\n",
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(binDir, "xinput"),
+    "#!/bin/sh\n[ \"$1 $2\" = \"test-xi2 --root\" ] || exit 2\nexit 2\n",
+    { mode: 0o755 },
+  );
+
+  try {
+    const result = spawnSync(helper, ["--key", "DoubleShift", "--immediate"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DISPLAY: ":99",
+        PATH: `${binDir}:${process.env.PATH}`,
+      },
+      timeout: 2_000,
+    });
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.equal(result.stdout, "permission-denied\n");
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { execFileSync } = require("node:child_process");
+const { execFileSync, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -141,12 +141,12 @@ test("appshots availability descriptor matches the current bundle", () => {
   assert.equal(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"), false);
   assert.ok(
     descriptor.pattern.test(
-      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+      "app-initial~app-main~page-hSvsQcNf.js",
     ),
   );
   assert.equal(
     descriptor.pattern.test(
-      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-Bty5T9_s.js",
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     ),
     false,
   );
@@ -175,28 +175,65 @@ test("stages the Linux bare modifier monitor helper and Wayland portal hook", ()
     },
   });
   assert.equal(electronArgsSource.trim(), "--enable-features=GlobalShortcutsPortal");
-  assert.match(helperSource, /xinput test "\$device_id"/);
+  assert.match(helperSource, /xinput test-xi2 --root/);
   assert.match(helperSource, /stdbuf -oL/);
   assert.doesNotMatch(helperSource, /\bmktemp\s+-u\b/);
-  assert.match(
-    helperSource,
-    /event_dir="\$\(mktemp -d "\$\{TMPDIR:-\/tmp\}\/codex-bare-modifier\.XXXXXX"\)"/,
-  );
-  assert.match(helperSource, /event_fifo="\$event_dir\/events"/);
-  assert.match(helperSource, /mkfifo "\$event_fifo"/);
-  assert.match(helperSource, /rmdir "\$event_dir" 2>\/dev\/null \|\| true/);
-  assert.match(helperSource, /exec 4<>"\$event_fifo"/);
-  assert.match(helperSource, /pkill -TERM -P "\$pid"/);
-  assert.match(helperSource, /while read -r pending code <&3; do/);
-  assert.match(helperSource, /\) >"\$event_fifo" 2>\/dev\/null &/);
+  assert.doesNotMatch(helperSource, /xinput list --short/);
+  assert.doesNotMatch(helperSource, /xinput test "\$device_id"/);
+  assert.doesNotMatch(helperSource, /mkfifo/);
+  assert.match(helperSource, /parent_pid="\$PPID"/);
+  assert.match(helperSource, /kill -0 "\$parent_pid"/);
+  assert.match(helperSource, /read -r -t 1 -u "\$event_fd" line/);
+  assert.match(helperSource, /kill "\$monitor_pid"/);
   assert.match(helperSource, /doublealt\|doubleoption\|alt\+alt/);
   assert.match(helperSource, /doubleshift\|shift\+shift\|leftshift\+rightshift/);
   assert.match(helperSource, /Shift_L Shift_R/);
   assert.match(helperSource, /last_tap_code=""/);
   assert.match(helperSource, /\[ "\$code" != "\$last_tap_code" \]/);
   assert.doesNotMatch(helperSource, /while IFS= read -r pending code/);
-  assert.doesNotMatch(helperSource, /test-xi2 --root/);
   execFileSync("bash", ["-n", path.join(__dirname, "bin", "bare-modifier-monitor")]);
+});
+
+test("bare modifier monitor emits one transition from one XInput2 stream", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "appshots-xinput2-"));
+  const binDir = path.join(tempDir, "bin");
+  const helper = path.join(__dirname, "bin", "bare-modifier-monitor");
+  fs.mkdirSync(binDir);
+  fs.writeFileSync(
+    path.join(binDir, "xmodmap"),
+    "#!/bin/sh\nprintf '%s\\n' 'keycode 50 = Shift_L' 'keycode 62 = Shift_R'\n",
+    { mode: 0o755 },
+  );
+  fs.writeFileSync(
+    path.join(binDir, "xinput"),
+    [
+      "#!/bin/sh",
+      "[ \"$1 $2\" = \"test-xi2 --root\" ] || exit 2",
+      "printf '%s\\n' \\",
+      "  'EVENT type 13 (RawKeyPress)' '    detail: 50' \\",
+      "  'EVENT type 14 (RawKeyRelease)' '    detail: 50' \\",
+      "  'EVENT type 13 (RawKeyPress)' '    detail: 62' \\",
+      "  'EVENT type 14 (RawKeyRelease)' '    detail: 62'",
+      "sleep 0.1",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  try {
+    const result = spawnSync(helper, ["--key", "DoubleShift", "--immediate"], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DISPLAY: ":99",
+        PATH: `${binDir}:${process.env.PATH}`,
+      },
+      timeout: 2_000,
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.stdout.trim().split("\n"), ["ready", "down", "up"]);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("enables AppShots availability atom on Linux", () => {


### PR DESCRIPTION
## Summary

- retarget the Appshots availability descriptor to the current upstream app page bundle and remove the obsolete bundle shape
- replace the per-device X11 monitor/FIFO fanout with one root XInput2 event stream
- stop the XInput2 listener when its Electron parent exits and terminate it during unregister cleanup
- add executable XInput2 event coverage and document the runtime lifecycle

## Root cause

The current `26.707.41301` DMG moved the Appshots availability atom into `app-initial~app-main~page-*.js`. The optional descriptor still targeted the previous long-form chunk name, so the installed patch report marked availability as skipped while the main-process and settings patches applied.

The X11 bare-modifier helper also started one shell pipeline and `xinput test` process for every slave keyboard device, including virtual devices. Failed or replaced Electron instances could leave those grandchildren adopted by init.

## User impact

Linux Appshots becomes available again on the current DMG. On X11, `Alt + Alt` and `Shift + Shift` now use one XInput2 listener instead of a process tree per keyboard device, and the listener exits with its owning Electron process.

## Source of truth

- `linux-features/appshots/patch.js`
- `linux-features/appshots/bin/bare-modifier-monitor`
- `linux-features/appshots/test.js`
- `linux-features/appshots/README.md`

Generated `codex-app/` and package output are not included.

## Validation

- `bash -n linux-features/appshots/bin/bare-modifier-monitor`
- `node --test linux-features/appshots/test.js` — 17 passed
- `node --test linux-features/*/test.js` — 481 passed
- `git diff --check`
- rebuilt from the current official `Codex.dmg`; installed patch report showed all four Appshots descriptors as `applied`
- built and installed the pacman package on Arch Linux/X11
- verified the installed helper exactly matched the source helper

## Scope and limitations

This remains inside the opt-in `appshots` Linux feature. Wayland behavior is unchanged and continues to use the existing non-bare shortcut/GlobalShortcuts portal path.

