### PR TITLE
test(updater): resolve fixture tools from PATH

### DIFF
--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -525,6 +525,7 @@ mod tests {
     use super::*;
     use crate::config::RuntimePaths;
     use anyhow::Result;
+    use std::os::unix::fs::PermissionsExt;
     use tempfile::tempdir;
 
     enum FakePackageOutput {
@@ -545,25 +546,38 @@ mod tests {
         "scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js",
     ];
 
+    fn host_tool(name: &str) -> Result<PathBuf> {
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+            .filter(|directory| directory.is_absolute())
+            .map(|directory| directory.join(name))
+            .find(|candidate| {
+                fs::metadata(candidate).is_ok_and(|metadata| {
+                    metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+                })
+            })
+            .with_context(|| format!("host tool {name} not found in PATH"))
+    }
+
+    fn host_bash_script(body: &str) -> Result<String> {
+        Ok(format!("#!{}\n{body}", host_tool("bash")?.display()))
+    }
+
     fn write_fake_build_script(path: &Path, output: FakePackageOutput) -> Result<()> {
         let script_body = match output {
             FakePackageOutput::Deb => {
-                r#"#!/bin/bash
-set -euo pipefail
+                r#"set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop_${PACKAGE_VERSION}_amd64.deb"
 "#
             }
             FakePackageOutput::Rpm => {
-                r#"#!/bin/bash
-set -euo pipefail
+                r#"set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop-${PACKAGE_VERSION}.x86_64.rpm"
 "#
             }
             FakePackageOutput::Pacman => {
-                r#"#!/bin/bash
-set -euo pipefail
+                r#"set -euo pipefail
 VER="${PACKAGE_VERSION%%+*}"
 mkdir -p "${DIST_DIR_OVERRIDE}"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
@@ -571,7 +585,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
             }
         };
 
-        fs::write(path, script_body)?;
+        fs::write(path, host_bash_script(script_body)?)?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -681,8 +695,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         );
     }
 
-    #[tokio::test]
-    async fn builds_update_with_fake_bundle() -> Result<()> {
+    #[test]
+    fn builds_update_with_fake_bundle() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let runtime = tokio::runtime::Runtime::new()?;
         let temp = tempdir()?;
         let bundle_root = temp.path().join("bundle");
         let state_root = temp.path().join("state");
@@ -756,8 +772,8 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         )?;
         fs::write(
             bundle_root.join("install.sh"),
-            r#"#!/bin/bash
-set -euo pipefail
+            host_bash_script(
+                r#"set -euo pipefail
 mkdir -p "${CODEX_INSTALL_DIR}"
 echo launcher > "${CODEX_INSTALL_DIR}/start.sh"
 chmod +x "${CODEX_INSTALL_DIR}/start.sh"
@@ -770,6 +786,7 @@ if [ -n "${CODEX_REBUILD_REPORT_JSON:-}" ]; then
   printf '{"appDir":"%s"}\n' "${CODEX_INSTALL_DIR}" > "${CODEX_REBUILD_REPORT_JSON}"
 fi
 "#,
+            )?,
         )?;
         #[cfg(unix)]
         {
@@ -808,7 +825,6 @@ fi
             bundle_root.join("scripts/lib/node-runtime.sh"),
             b"#!/bin/bash\n",
         )?;
-
         let paths = RuntimePaths {
             config_file: temp.path().join("config/config.toml"),
             state_file: state_root.join("state.json"),
@@ -837,14 +853,13 @@ fi
         fs::write(&dmg_path, b"dmg")?;
 
         let mut state = PersistedState::new(true);
-        let artifacts = build_update(
+        let artifacts = runtime.block_on(build_update(
             &config,
             &mut state,
             &paths,
             "2026.03.24+abcd1234",
             &dmg_path,
-        )
-        .await?;
+        ))?;
         assert_eq!(state.status, UpdateStatus::ReadyToInstall);
         assert!(artifacts.workspace_dir.exists());
         assert!(artifacts.package_path.exists());

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -1612,18 +1612,16 @@ mod tests {
     }
 
     fn link_test_system_tool(tool_bin: &Path, name: &str) -> Result<()> {
-        let target = [
-            PathBuf::from("/bin").join(name),
-            PathBuf::from("/usr/bin").join(name),
-        ]
-        .into_iter()
-        .find(|candidate| candidate.is_file())
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("system tool {name} not found"),
-            )
-        })?;
+        let target = std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default())
+            .filter(|directory| directory.is_absolute())
+            .map(|directory| directory.join(name))
+            .find(|candidate| is_executable(candidate))
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("system tool {name} not found"),
+                )
+            })?;
         let link_path = tool_bin.join(name);
         if !link_path.exists() {
             std::os::unix::fs::symlink(target, link_path)?;


### PR DESCRIPTION
## Summary

- resolve fixture executables from regular executable files in absolute
  directories from the active `PATH`;
- generate fake updater build/install scripts with the resolved absolute Bash
  shebang;
- stop assuming fixture tools such as `cat`, `mkdir`, and `chmod` live in
  `/bin` or `/usr/bin`;
- serialize the process-global `PATH` read with the updater test suite's
  existing environment lock while running async build work through a local
  Tokio runtime.

## Why

The updater implementation does not require an FHS filesystem layout, but two
test helpers did. On NixOS, the fake update bundle failed to spawn because it
used `#!/bin/bash`, and standalone CLI tests failed before their assertions
because their tool fixture searched only `/bin` and `/usr/bin`.

This changes test fixtures only. Production updater lookup, bundle contents,
and command execution are unchanged.

## Validation

- `cargo test -p codex-update-manager builder::tests::builds_update_with_fake_bundle -- --exact`
- `cargo test -p codex-update-manager codex_cli::tests::standalone_cli_symlink_updates_with_standalone_installer -- --exact`
- full `cargo test -p codex-update-manager` reaches and passes every affected
  builder/CLI case on NixOS; its only remaining failure is the separate
  Desktop-settings isolation case
- `cargo fmt --all -- --check`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `git diff --check`

## Scope

Only test modules in `updater/src/builder.rs` and `updater/src/codex_cli.rs`
change. PR #802 also touches `builder.rs`, but its global-dictation bundle hunks
do not overlap these fixture helpers.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] The change is test-only and limited to updater fixtures.
- [x] Focused tests, formatting, and clippy pass on current `origin/main`.
