### PR TITLE
ci: open a tracking issue with an agent playbook when a new upstream version ships

### DIFF
--- a/.github/NEW_VERSION_PLAYBOOK.md
+++ b/.github/NEW_VERSION_PLAYBOOK.md
@@ -1,0 +1,219 @@
+# New Upstream Version Agent Playbook
+
+This playbook guides an agent through addressing a newly detected upstream Codex Desktop version.
+
+## Overview
+
+When the scheduled upstream-build workflow detects a new upstream DMG version (via `CFBundleShortVersionString`), an issue is automatically opened with:
+
+- The new version number
+- DMG SHA-256 and HTTP metadata
+- A link to the workflow run and artifacts
+- This playbook
+
+Your goal is to verify the new version builds cleanly on Linux, identify any patch failures, fix them following repo conventions, validate the fixes, and open PRs for each fix.
+
+## Phase 1: Download and Inspect
+
+1. **Download the DMG** from the URL provided in the issue (typically `https://persistent.oaistatic.com/codex-app-prod/Codex.dmg`)
+
+2. **Run the DMG intelligence report** to understand what changed:
+   ```bash
+   node scripts/dev/upstream-dmg-intel.js --dmg Codex.dmg
+   ```
+   
+   This will extract the app, analyze platform gates, inventory protected surfaces, and run patch preflight checks. Review the output carefully for:
+   - New platform gates that may indicate missing Linux parity
+   - Changes to protected surfaces (Computer Use, Read Aloud, Chrome plugin, MCP servers)
+   - Patch preflight warnings or failures
+
+3. **Review the patch report artifact** from the workflow run linked in the issue. Check for:
+   - `failed-required` patches (these block the build)
+   - `skipped-optional` patches (these may degrade functionality)
+
+## Phase 2: Build and Validate
+
+1. **Run a clean build** against the new DMG:
+   ```bash
+   CODEX_PATCH_REPORT_JSON="$PWD/patch-report.json" ./install.sh ./Codex.dmg
+   ```
+
+2. **Examine the patch report**:
+   ```bash
+   cat patch-report.json | jq '.patches[] | select(.status != "applied")'
+   ```
+
+3. **Run the validation script** to check required patches:
+   ```bash
+   node scripts/ci/validate-patch-report.js patch-report.json --profile upstream-build
+   ```
+
+4. **If validation passes**, the version is compatible. Update the issue with confirmation and close it. No further work needed.
+
+5. **If validation fails**, continue to Phase 3.
+
+## Phase 3: Fix Patch Matchers
+
+For each failed or skipped patch, you need to update its matcher to handle the new upstream code shape.
+
+### Understanding Patch Descriptors
+
+Core patches live in `scripts/patches/core/`. Each patch descriptor exports:
+
+- `id`: unique identifier
+- `targetFilter`: when this patch applies (usually `() => true` for all-linux)
+- `replacement`: the code transformation
+
+Patches use needle-and-replacement patterns. When upstream changes, needles may no longer match.
+
+### Fixing Strategy
+
+Read `scripts/patches/core/README.md` for the full contract. Follow these conventions:
+
+1. **Keep old shapes working**: Don't remove old needle patterns. Add new branches for new shapes.
+
+2. **Make it idempotent**: Patches should succeed if the desired state is already present.
+
+3. **Graceful degradation**: Use `warn()` for non-critical failures, not hard errors.
+
+4. **Test your changes**:
+   ```bash
+   node --test scripts/patch-linux-window-ui.test.js
+   ```
+
+5. **Verify against the new DMG**:
+   ```bash
+   CODEX_PATCH_REPORT_JSON="$PWD/patch-report-fixed.json" ./install.sh ./Codex.dmg
+   node scripts/ci/validate-patch-report.js patch-report-fixed.json --profile upstream-build
+   ```
+
+### Example Fix Pattern
+
+If a patch that adds Linux Computer Use registration now fails because the upstream registration code changed shape:
+
+```javascript
+// OLD needle (keep this!)
+const oldShape = `
+  setupPlatformFeatures() {
+    this.registerFeature('computer-use', platformSpecific);
+  }
+`;
+
+// NEW needle for the new upstream shape
+const newShape = `
+  setupPlatformFeatures() {
+    const features = getPlatformFeatures();
+    this.registerAll(features);
+  }
+`;
+
+// Try old shape first, then new shape
+if (content.includes(oldShape)) {
+  return content.replace(oldShape, /* fixed version */);
+} else if (content.includes(newShape)) {
+  return content.replace(newShape, /* fixed version for new shape */);
+} else {
+  warn('Neither old nor new shape found - upstream may have changed significantly');
+  return content; // graceful no-op
+}
+```
+
+## Phase 4: Test Suite
+
+After fixing patches, run the full test suite:
+
+```bash
+# Patch tests
+node --test scripts/patch-linux-window-ui.test.js
+
+# Smoke tests
+bash tests/scripts_smoke.sh
+
+# Build validation
+./scripts/build-deb.sh
+dpkg-deb -I dist/codex-desktop_*.deb
+
+# If Rust changes were needed:
+cargo test -p codex-update-manager
+cargo test -p codex-computer-use-linux
+```
+
+## Phase 5: Create PRs
+
+For each distinct fix (e.g., one patch descriptor, one build script, one feature):
+
+1. **Create a focused branch** from `main`:
+   ```bash
+   git checkout -b fix/upstream-version-X.Y.Z-patch-name
+   ```
+
+2. **Commit with a clear message**:
+   ```bash
+   git commit -m "patch: handle new upstream shape in <patch-name>
+   
+   Upstream version X.Y.Z changed <what changed>. Updated the matcher
+   to recognize both old and new shapes, preserving idempotence.
+   
+   Fixes #<issue-number>"
+   ```
+
+3. **Push to your fork**:
+   ```bash
+   git push origin fix/upstream-version-X.Y.Z-patch-name
+   ```
+
+4. **Open a PR** with:
+   - **Title**: `patch: handle new upstream shape in <patch-name>`
+   - **Body**: Explain what changed upstream, how you fixed it, and link the validation results
+   - **Reference**: Link back to the version tracking issue
+
+5. **Repeat** for each independent fix
+
+## Phase 6: Update the Tracking Issue
+
+Once all PRs are open:
+
+1. **Comment on the tracking issue** with:
+   - A summary of what changed
+   - Links to all PRs
+   - Validation results (paste the patch report summary)
+
+2. **Apply label** `upstream-version` if not already present
+
+3. **Keep the issue open** until all PRs are merged and the version is confirmed working
+
+## Reference Documentation
+
+- `AGENTS.md` - Repository structure and source of truth
+- `scripts/patches/core/README.md` - Patch descriptor contract
+- `docs/architecture.md` - High-level architecture
+- `docs/build-and-packaging.md` - Build pipeline details
+- `CONTRIBUTING.md` - Contributor guidelines
+
+## Common Pitfalls
+
+- **Don't remove old needles**: Preserve backward compatibility for users on older DMGs
+- **Don't bypass the patch framework**: Always fix descriptors, not generated app code
+- **Don't guess at needle shapes**: Read the actual upstream code in the extracted app
+- **Don't batch unrelated fixes**: Each logical fix should be its own PR
+- **Don't force-push**: If CI fails, add fixup commits and let maintainers squash
+
+## Need Help?
+
+If you encounter:
+
+- **Systematic failures** across many patches: The upstream architecture may have changed significantly. Flag this in the issue and request maintainer review.
+- **Protected surface changes** (Computer Use, Read Aloud, Chrome): These require careful review. Open a PR marked as draft and request review before marking ready.
+- **Build system changes**: If `install.sh`, native module rebuilds, or Electron version detection fails, this is a deeper issue. Document the failure mode in the issue.
+
+## Exit Criteria
+
+The issue can be closed when:
+
+1. All required patches apply cleanly
+2. `node scripts/ci/validate-patch-report.js` passes with `--profile upstream-build`
+3. A clean build completes successfully
+4. Test suite passes
+5. All fix PRs are merged (or no fixes were needed)
+
+Update the issue with "✅ Version X.Y.Z validated and merged" before closing.

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -41,6 +41,9 @@ jobs:
     name: Build App Against Upstream DMG
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v4
@@ -139,6 +142,46 @@ jobs:
       - name: Build app from upstream DMG
         run: CODEX_PATCH_REPORT_JSON="$GITHUB_WORKSPACE/patch-report.json" make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg
 
+      - name: Extract upstream app version
+        id: app-version
+        run: |
+          set -euo pipefail
+
+          # The build extracts the app to codex-app/resources/app.asar.unpacked
+          # But we need the original macOS .app bundle for Info.plist
+          # Extract it from the DMG
+          extract_dir="$(mktemp -d)"
+          trap 'rm -rf "$extract_dir"' EXIT
+
+          7z x -o"$extract_dir" "$UPSTREAM_DMG_PATH" >/dev/null 2>&1 || true
+
+          # Find the .app bundle
+          app_bundle=$(find "$extract_dir" -maxdepth 2 -name "*.app" -type d | head -n 1)
+
+          if [ -z "$app_bundle" ]; then
+            echo "app_version=unknown" >> "$GITHUB_OUTPUT"
+            echo "Warning: Could not find .app bundle in DMG"
+            exit 0
+          fi
+
+          info_plist="$app_bundle/Contents/Info.plist"
+
+          if [ ! -f "$info_plist" ]; then
+            echo "app_version=unknown" >> "$GITHUB_OUTPUT"
+            echo "Warning: Info.plist not found at $info_plist"
+            exit 0
+          fi
+
+          # Use the existing appBundleVersion helper from build-info.js
+          app_version=$(node -e "
+            const { appBundleVersion } = require('./scripts/lib/build-info.js');
+            const version = appBundleVersion('$app_bundle');
+            console.log(version || 'unknown');
+          ")
+
+          echo "app_version=$app_version" >> "$GITHUB_OUTPUT"
+          echo "Extracted app version: $app_version"
+
       - name: Validate required upstream patches
         run: node scripts/ci/validate-patch-report.js patch-report.json --profile upstream-build
 
@@ -191,8 +234,88 @@ jobs:
             echo "- DMG Size (bytes): \`${{ steps.local-dmg.outputs.size_bytes }}\`"
             echo "- Tested At (UTC): \`${{ steps.local-dmg.outputs.tested_at_utc }}\`"
             echo "- Cache Hit: \`${{ steps.dmg-cache.outputs.cache-hit || 'false' }}\`"
+            echo "- App Version: \`${{ steps.app-version.outputs.app_version }}\`"
             echo "- Build command: \`make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg\`"
             echo "- Patch report: \`patch-report.json\`"
             echo "- Remote mobile inspect: \`make inspect-upstream DMG=$UPSTREAM_DMG_PATH\` with \`remote-mobile-control\` enabled"
             echo "- Remote mobile patch report: \`remote-mobile-upstream-inspect/patch-report.json\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open tracking issue for new version
+        if: github.event_name == 'schedule' && steps.app-version.outputs.app_version != 'unknown'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const appVersion = '${{ steps.app-version.outputs.app_version }}';
+            const label = 'upstream-version';
+            const title = `New upstream version ${appVersion} detected`;
+
+            // Check if an issue for this version already exists
+            const existingIssues = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+
+            const versionExists = existingIssues.data.some(issue =>
+              issue.title.includes(appVersion)
+            );
+
+            if (versionExists) {
+              console.log(`Issue for version ${appVersion} already exists, skipping creation.`);
+              return;
+            }
+
+            // Ensure the label exists
+            try {
+              await github.rest.issues.getLabel({ ...context.repo, name: label });
+            } catch (e) {
+              await github.rest.issues.createLabel({
+                ...context.repo,
+                name: label,
+                color: '0366d6',
+                description: 'New upstream version detected by scheduled build',
+              });
+            }
+
+            // Read the playbook
+            const playbook = fs.readFileSync('.github/NEW_VERSION_PLAYBOOK.md', 'utf8');
+
+            // Build the issue body
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `A new upstream Codex Desktop version has been detected by the scheduled build workflow.`,
+              '',
+              '## Version Information',
+              '',
+              `- **Version**: \`${appVersion}\``,
+              `- **DMG URL**: \`${{ env.UPSTREAM_DMG_URL }}\``,
+              `- **DMG SHA-256**: \`${{ steps.local-dmg.outputs.sha256 }}\``,
+              `- **DMG Last-Modified**: \`${{ steps.upstream-metadata.outputs.last_modified }}\``,
+              `- **DMG ETag**: \`${{ steps.upstream-metadata.outputs.etag }}\``,
+              `- **DMG Size**: \`${{ steps.local-dmg.outputs.size_bytes }}\` bytes`,
+              `- **Detected At**: \`${{ steps.local-dmg.outputs.tested_at_utc }}\``,
+              '',
+              '## Build Information',
+              '',
+              `- **Workflow Run**: ${runUrl}`,
+              `- **Artifacts**: [upstream-dmg-metadata](${runUrl}#artifacts) (includes \`patch-report.json\`)`,
+              '',
+              '## Agent Playbook',
+              '',
+              'Follow the playbook below to address this new version:',
+              '',
+              '---',
+              '',
+              playbook,
+            ].join('\n');
+
+            // Create the issue
+            await github.rest.issues.create({
+              ...context.repo,
+              title,
+              labels: [label],
+              body,
+            });


### PR DESCRIPTION
## Summary

- Extract `CFBundleShortVersionString` from the upstream DMG during scheduled builds
- Open a tracking issue when a new version is detected, deduplicated by version number
- Include comprehensive agent playbook for addressing the new version
- Provide direct links to workflow run, artifacts, and DMG metadata

## Motivation

The daily upstream-build workflow validates that the current patch set applies cleanly to the latest upstream DMG, but when a new version ships, there's no automated signal or guidance for maintainers. This PR adds scheduled version-detection and creates an issue containing:

1. **Version metadata**: CFBundleShortVersionString, DMG SHA-256, HTTP headers, detection timestamp
2. **Workflow context**: Direct links to the run and artifacts (including `patch-report.json`)
3. **Agent playbook**: Step-by-step guide for downloading the DMG, running the intelligence report, building against the new version, fixing patch matchers when upstream code shapes change, validating fixes, running tests, and opening PRs

The playbook documents repo conventions (keep old shapes, add new branches, idempotent patches, graceful warnings) and references `AGENTS.md`, `scripts/patches/core/README.md`, and other source-of-truth files.

Issues are deduplicated by the `upstream-version` label and version number in the title. The workflow only creates issues on scheduled runs when a valid version is extracted (skips `unknown` versions).

## Complementary to PR #737

This PR complements the DMG intelligence report work in PR #737:

- **#737** adds deep analysis tooling: platform gate classification, protected surface inventory, raw asar extraction, parity patch preflight, and release decision tables
- **This PR** adds scheduled version-detection + issue automation to make that tooling actionable when a new version ships

Both work together: the playbook references the intelligence report as a discovery step, and the issue links to the workflow artifacts containing the patch report.

## Validation

- YAML syntax validated with Python `yaml.safe_load`
- Issue creation logic follows `computer-use-sync-reminder.yml` pattern: label creation, deduplication by label + title, `github.rest.issues.create`
- Version extraction reuses existing `appBundleVersion()` helper from `scripts/lib/build-info.js`
- Playbook documents repo conventions from `AGENTS.md` and patch descriptor contract from `scripts/patches/core/README.md`
- Job-level `issues: write` permission scoped to the single job that needs it
- Schedule-only trigger prevents issue creation on PR/push/workflow_dispatch runs
- Deduplication prevents duplicate issues for the same version on subsequent runs

## Testing Plan

The workflow will be validated on the next scheduled run (daily at 6:30 UTC). Expected behavior:

1. If the upstream version has not changed, no issue is created (deduplication check passes)
2. If a new version is detected, an issue is created with version metadata, workflow links, and the full playbook
3. If the version cannot be extracted, no issue is created (skips `unknown` versions)

The issue creation can also be tested by triggering a manual workflow_dispatch run, observing that no issue is created (schedule-only guard), then temporarily removing the `if: github.event_name == 'schedule'` condition and re-running.