### PR TITLE
fix(ui-tweaks): match both sidebar chunk orderings and class variants

### DIFF
--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -2,15 +2,21 @@
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN =
-  /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/;
-const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pr-1";
+  /^app-initial~app-main~(?:remote-conversation-page~projects-index-page|projects-index-page~remote-conversation-page)-[^.]+\.js$/;
+const PROJECT_NAME_SELECTOR =
+  ".group\\/folder-row .min-w-0.truncate.pr-1,.group\\/folder-row .text-fade-truncate.pr-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";
 const UNSAFE_PROJECT_NAME_STYLE_PATTERN = /[{}@<>]|\r|\n|\/\*|\*\/|\burl\s*\(/i;
 
+// Each entry lists interchangeable shapes of the same marker; a bundle counts
+// as the projects sidebar bundle when every entry has at least one hit.
+// 26.623 rendered the project name as `min-w-0 truncate pr-1`; 26.707 renamed
+// it to `text-fade-truncate pr-1`.
 const SIDEBAR_PROJECT_NAME_MARKERS = [
-  "group/folder-row",
-  "className:`text-fade-truncate pr-1`",
+  ["sidebarElectron.projectsNavLink"],
+  ["group/folder-row"],
+  ["className:`min-w-0 truncate pr-1`", "className:`text-fade-truncate pr-1`"],
 ];
 
 function warn(message) {
@@ -77,11 +83,15 @@ function normalizedProjectNameStyle(context) {
 }
 
 function looksLikeSidebarProjectBundle(source) {
-  return SIDEBAR_PROJECT_NAME_MARKERS.every((marker) => source.includes(marker));
+  return SIDEBAR_PROJECT_NAME_MARKERS.every((alternatives) =>
+    alternatives.some((marker) => source.includes(marker)),
+  );
 }
 
 function hasPartialSidebarProjectMarkers(source) {
-  return SIDEBAR_PROJECT_NAME_MARKERS.some((marker) => source.includes(marker));
+  return SIDEBAR_PROJECT_NAME_MARKERS.some((alternatives) =>
+    alternatives.some((marker) => source.includes(marker)),
+  );
 }
 
 function applySidebarProjectNameStylePatch(source, context = {}) {

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -43,8 +43,17 @@ const {
 
 function projectBundleFixture() {
   return [
+    "function Hd(){return {id:`sidebarElectron.projectsNavLink`,defaultMessage:`Projects`}}",
     "function row(){let j=Pn(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
     "let V=(0,Iy.jsx)(`span`,{className:`text-fade-truncate pr-1`,children:p});return [j,V]}",
+  ].join("");
+}
+
+function projectBundleFixture26707() {
+  return [
+    "function Hd(){return {id:`sidebarElectron.projectsNavLink`,defaultMessage:`Projects`}}",
+    "function row(){let N=X(`group/folder-row group relative flex h-[var(--height-token-row)] text-sm text-token-foreground`);",
+    "let H=(0,Qu.jsx)(`span`,{className:`text-fade-truncate pr-1`,children:g});return [N,H]}",
   ].join("");
 }
 
@@ -362,6 +371,11 @@ test("sidebar project descriptor targets only the current project sidebar asset"
     "app-initial~app-main~projects-index-page~remote-conversation-page-CFT2LLOB.js",
     PROJECTS_SIDEBAR_ASSET_PATTERN,
   );
+  // 26.707 reshuffled the chunk name segment order.
+  assert.match(
+    "app-initial~app-main~remote-conversation-page~projects-index-page-By2_tGIM.js",
+    PROJECTS_SIDEBAR_ASSET_PATTERN,
+  );
   assert.doesNotMatch(
     "app-initial~app-main~page-BF1QkwFT.js",
     PROJECTS_SIDEBAR_ASSET_PATTERN,
@@ -371,10 +385,16 @@ test("sidebar project descriptor targets only the current project sidebar asset"
     PROJECTS_SIDEBAR_ASSET_PATTERN,
   );
   assert.doesNotMatch("projects-index-page-TFjtVwC4.js", PROJECTS_SIDEBAR_ASSET_PATTERN);
-  assert.doesNotMatch(
-    "app-initial~app-main~remote-conversation-page~projects-index-page-By2_tGIM.js",
-    PROJECTS_SIDEBAR_ASSET_PATTERN,
-  );
+});
+
+test("patch recognizes the 26.707 text-fade-truncate project name markup", () => {
+  const patched = applyPatchTwice(projectBundleFixture26707(), {});
+
+  assert.match(patched, new RegExp(STYLE_ID));
+  assert.match(patched, new RegExp(RUNTIME_MARKER));
+  assert.ok(patched.includes(JSON.stringify(sidebarProjectNameCss())));
+  assert.match(PROJECT_NAME_SELECTOR, /\.text-fade-truncate\.pr-1/);
+  assert.match(PROJECT_NAME_SELECTOR, /\.min-w-0\.truncate\.pr-1/);
 });
 
 test("patch injects sidebar project-name stylesheet runtime once", () => {


### PR DESCRIPTION
## Summary

The `sidebar-project-name` patch now handles both Vite chunk segment orderings and both CSS class variants used across releases:
- Chunk patterns accept both `projects-index-page~remote-conversation-page` and `remote-conversation-page~projects-index-page` (Vite reorders merged-chunk segments)
- Content markers recognize both `min-w-0 truncate pr-1` (26.623) and `text-fade-truncate pr-1` (26.707)
- CSS selector targets both class variants under `.group/folder-row`

## Root cause

The original pattern matched only one hardcoded chunk segment ordering and one class name, breaking when:
1. Vite's deterministic ordering changed between builds
2. The app renamed classes between releases (26.623 → 26.707)

## Validation

- All existing tests pass
- New test fixture added for 26.707 class variant
- Pattern now explicitly tests both orderings
- Verified against real 26.707 chunk file (`app-initial~app-main~projects-index-page~remote-conversation-page-THP8fcuf.js`)
- Idempotence confirmed: patch applies once and only once