### PR TITLE
feat(computer-use): prefer system install before vendored build

### DIFF
--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -239,12 +239,37 @@ find_cargo_for_linux_computer_use() {
     return 1
 }
 
+find_system_computer_use_binary() {
+    local name="$1"
+    local candidate
+
+    for candidate in \
+        "$HOME/.cargo/bin/$name" \
+        "$HOME/.local/bin/$name"; do
+        if [ -x "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+
+    candidate="$(command -v "$name" 2>/dev/null || true)"
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+
+    return 1
+}
+
 build_linux_computer_use_backend() {
     local crate_dir="$SCRIPT_DIR/computer-use-linux"
     local backend_binary="$SCRIPT_DIR/target/release/codex-computer-use-linux"
     local cosmic_helper_binary="$SCRIPT_DIR/target/release/codex-computer-use-cosmic"
     local cargo_cmd=""
+    local system_backend=""
+    local system_cosmic=""
 
+    # Step 1: Environment override
     if [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ]; then
         [ -n "${CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE is not set"
         [ -n "${CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE:-}" ] || warn "CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE is not set"
@@ -255,6 +280,37 @@ build_linux_computer_use_backend() {
         return 0
     fi
 
+    # Step 2: System-installed binaries
+    if [ "${CODEX_LINUX_COMPUTER_USE_PREFER_VENDORED:-}" != "1" ]; then
+        if system_backend="$(find_system_computer_use_binary computer-use-linux)" &&
+            system_cosmic="$(find_system_computer_use_binary computer-use-linux-cosmic)"; then
+            info "Using system computer-use-linux MCP binaries: $system_backend"
+            printf '%s\n%s\n' "$system_backend" "$system_cosmic"
+            return 0
+        fi
+    fi
+
+    # Step 3: Install from crates.io
+    if [ "${CODEX_LINUX_COMPUTER_USE_PREFER_VENDORED:-}" != "1" ]; then
+        if ! cargo_cmd="$(find_cargo_for_linux_computer_use)"; then
+            warn "cargo not found; Linux Computer Use plugin will be unavailable"
+            return 1
+        fi
+
+        info "Installing computer-use-linux MCP from crates.io..."
+        if "$cargo_cmd" install --locked computer-use-linux >&2; then
+            if system_backend="$(find_system_computer_use_binary computer-use-linux)" &&
+                system_cosmic="$(find_system_computer_use_binary computer-use-linux-cosmic)"; then
+                printf '%s\n%s\n' "$system_backend" "$system_cosmic"
+                return 0
+            fi
+            warn "computer-use-linux binaries missing after crates.io install"
+        else
+            warn "Failed to install computer-use-linux from crates.io; falling back to vendored build"
+        fi
+    fi
+
+    # Step 4: Vendored build fallback
     if [ ! -d "$crate_dir" ]; then
         warn "Linux Computer Use backend source not found at $crate_dir"
         return 1
@@ -265,7 +321,7 @@ build_linux_computer_use_backend() {
         return 1
     fi
 
-    info "Building Linux Computer Use backend..."
+    info "Building Linux Computer Use backend from vendored source..."
     if ! (cd "$SCRIPT_DIR" && "$cargo_cmd" build --release -p codex-computer-use-linux >&2); then
         warn "Failed to build Linux Computer Use backend"
         return 1

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -280,33 +280,35 @@ build_linux_computer_use_backend() {
         return 0
     fi
 
-    # Step 2: System-installed binaries
-    if [ "${CODEX_LINUX_COMPUTER_USE_PREFER_VENDORED:-}" != "1" ]; then
+    # Steps 2-3 are opt-in: the vendored build stays the default so the
+    # repository only ships code it is responsible for. Set
+    # CODEX_LINUX_COMPUTER_USE_SYSTEM_INSTALL=1 to reuse a system-installed
+    # computer-use-linux (or install it from crates.io) instead of building
+    # the vendored crate.
+    if [ "${CODEX_LINUX_COMPUTER_USE_SYSTEM_INSTALL:-}" = "1" ]; then
+        # Step 2: System-installed binaries
         if system_backend="$(find_system_computer_use_binary computer-use-linux)" &&
             system_cosmic="$(find_system_computer_use_binary computer-use-linux-cosmic)"; then
             info "Using system computer-use-linux MCP binaries: $system_backend"
             printf '%s\n%s\n' "$system_backend" "$system_cosmic"
             return 0
         fi
-    fi
 
-    # Step 3: Install from crates.io
-    if [ "${CODEX_LINUX_COMPUTER_USE_PREFER_VENDORED:-}" != "1" ]; then
-        if ! cargo_cmd="$(find_cargo_for_linux_computer_use)"; then
-            warn "cargo not found; Linux Computer Use plugin will be unavailable"
-            return 1
-        fi
-
-        info "Installing computer-use-linux MCP from crates.io..."
-        if "$cargo_cmd" install --locked computer-use-linux >&2; then
-            if system_backend="$(find_system_computer_use_binary computer-use-linux)" &&
-                system_cosmic="$(find_system_computer_use_binary computer-use-linux-cosmic)"; then
-                printf '%s\n%s\n' "$system_backend" "$system_cosmic"
-                return 0
+        # Step 3: Install from crates.io
+        if cargo_cmd="$(find_cargo_for_linux_computer_use)"; then
+            info "Installing computer-use-linux MCP from crates.io..."
+            if "$cargo_cmd" install --locked computer-use-linux >&2; then
+                if system_backend="$(find_system_computer_use_binary computer-use-linux)" &&
+                    system_cosmic="$(find_system_computer_use_binary computer-use-linux-cosmic)"; then
+                    printf '%s\n%s\n' "$system_backend" "$system_cosmic"
+                    return 0
+                fi
+                warn "computer-use-linux binaries missing after crates.io install"
+            else
+                warn "Failed to install computer-use-linux from crates.io; falling back to vendored build"
             fi
-            warn "computer-use-linux binaries missing after crates.io install"
         else
-            warn "Failed to install computer-use-linux from crates.io; falling back to vendored build"
+            warn "cargo not found for crates.io install; falling back to vendored build"
         fi
     fi
 
@@ -367,6 +369,11 @@ stage_linux_computer_use_plugin() {
     cp "$cosmic_helper_binary" "$target_plugin/bin/codex-computer-use-cosmic"
     chmod 0755 "$target_plugin/bin/codex-computer-use-linux"
     chmod 0755 "$target_plugin/bin/codex-computer-use-cosmic"
+    if [ "${backend_binary##*/}" = "computer-use-linux" ]; then
+        # The published backend resolves its COSMIC helper by this sibling name.
+        cp "$cosmic_helper_binary" "$target_plugin/bin/computer-use-linux-cosmic"
+        chmod 0755 "$target_plugin/bin/computer-use-linux-cosmic"
+    fi
 
     local plugin_icon_source="${LINUX_ICON_SOURCE:-$ICON_SOURCE}"
     if [ -f "$plugin_icon_source" ]; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4384,6 +4384,46 @@ test_bundled_plugin_builders_accept_prebuilt_binaries() {
     assert_contains "$output_log" "$host"
     cmp -s "$chatgpt_icon" "$staged_plugins/computer-use/assets/app-icon.png" \
         || fail "Expected the bundled Computer Use plugin to use the selected ChatGPT icon"
+    [ ! -e "$staged_plugins/computer-use/bin/computer-use-linux-cosmic" ] \
+        || fail "Vendored/prebuilt Computer Use staging must not add the external helper alias"
+}
+
+test_bundled_plugin_system_computer_use_preserves_cosmic_helper_name() {
+    info "Checking opt-in system Computer Use staging preserves its helper contract"
+    local workspace="$TMP_DIR/bundled-plugin-system-computer-use"
+    local fake_home="$workspace/home"
+    local system_bin="$fake_home/.cargo/bin"
+    local backend="$system_bin/computer-use-linux"
+    local cosmic="$system_bin/computer-use-linux-cosmic"
+    local staged_plugins="$workspace/plugins"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$system_bin"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'helper="$(dirname "$0")/computer-use-linux-cosmic"' \
+        '[ -x "$helper" ] || { echo "missing COSMIC helper: $helper" >&2; exit 9; }' \
+        '"$helper"' > "$backend"
+    printf '%s\n' '#!/usr/bin/env bash' 'echo cosmic-ok' > "$cosmic"
+    chmod +x "$backend" "$cosmic"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        HOME="$fake_home"
+        CODEX_LINUX_COMPUTER_USE_SYSTEM_INSTALL=1
+        ICON_SOURCE="$REPO_DIR/assets/codex.png"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin "$staged_plugins"
+        "$staged_plugins/computer-use/bin/codex-computer-use-linux"
+    ) > "$output_log" 2>&1
+
+    assert_contains "$output_log" "Using system computer-use-linux MCP binaries"
+    assert_contains "$output_log" "cosmic-ok"
+    assert_file_exists "$staged_plugins/computer-use/bin/computer-use-linux-cosmic"
 }
 
 test_launcher_managed_node_handles_unset_path() {
@@ -9080,6 +9120,7 @@ main() {
     test_native_module_rebuild_uses_local_electron_rebuild_toolchain
     test_native_module_rebuild_accepts_prebuilt_source
     test_bundled_plugin_builders_accept_prebuilt_binaries
+    test_bundled_plugin_system_computer_use_preserves_cosmic_helper_name
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_file_url_policy_patch_behavior
     test_browser_plugin_renamed_upstream_staging


### PR DESCRIPTION
## Summary

Add an explicit opt-in path for staging the published/system-installed `computer-use-linux` backend instead of building the vendored backend.

The vendored source remains the unchanged default and the existing prebuilt source overrides keep highest priority. External discovery and `cargo install` are used only when `CODEX_LINUX_COMPUTER_USE_SYSTEM_INSTALL=1` is set.

## Resolution order

1. Explicit `CODEX_LINUX_COMPUTER_USE_BACKEND_SOURCE` and `CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE` overrides
2. Vendored build by default
3. With `CODEX_LINUX_COMPUTER_USE_SYSTEM_INSTALL=1` only:
   - existing `computer-use-linux` and `computer-use-linux-cosmic` binaries
   - `cargo install --locked computer-use-linux`
   - vendored build fallback if the external path is unavailable

## Compatibility fix

The published backend resolves its COSMIC helper through a sibling named `computer-use-linux-cosmic`. Staging now preserves that sibling name for the external backend while retaining the repository's `codex-computer-use-*` staged entrypoints. Vendored and existing prebuilt staging do not receive the external alias.

## Validation

- `bash -n scripts/lib/bundled-plugins.sh tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh` — passed
- Regression coverage verifies that the opt-in staged backend can find and execute its COSMIC helper, while the default/prebuilt path remains unchanged
