### PR TITLE
fix(copilot-reasoning-effort): stop pinning webview chunk hashes

### DIFF
--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -154,7 +154,8 @@ module.exports = {
       id: "settings",
       name: "copilot-reasoning-effort-settings",
       phase: "webview-asset",
-      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/,
+      // Match app-initial chunks; content-scan fallback ensures correct target
+      pattern: /^app-initial~app-main~.*\.js$/,
       missingDescription: "model settings bundle",
       skipDescription: "Copilot reasoning effort settings patch",
       apply: applyCopilotReasoningEffortSettingsPatch,
@@ -163,7 +164,8 @@ module.exports = {
       id: "model-list",
       name: "copilot-reasoning-effort-model-list",
       phase: "webview-asset",
-      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/,
+      // Match app-initial chunks; content-scan fallback ensures correct target
+      pattern: /^app-initial~app-main~.*\.js$/,
       missingDescription: "font settings bundle",
       skipDescription: "Copilot reasoning effort model list patch",
       apply: applyCopilotReasoningEffortModelListPatch,
@@ -172,7 +174,8 @@ module.exports = {
       id: "ui",
       name: "copilot-reasoning-effort-ui",
       phase: "webview-asset",
-      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
+      // Match app-initial chunks; content-scan fallback ensures correct target
+      pattern: /^app-initial~app-main~.*\.js$/,
       missingDescription: "webview index bundle",
       skipDescription: "Copilot reasoning effort UI patch",
       apply: applyCopilotReasoningEffortUiPatch,

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -183,9 +183,9 @@ test("feature descriptor loader exposes the Copilot webview asset patches only w
     );
     assert.ok(descriptors.every((descriptor) => descriptor.ciPolicy === "optional"));
     const currentSettingsChunk =
-      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-current.js";
+      "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-current.js";
     const currentUiChunk =
-      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js";
+      "app-initial~app-main~page-current.js";
     assert.match(currentSettingsChunk, descriptors[0].pattern);
     assert.match(currentSettingsChunk, descriptors[1].pattern);
     assert.match(currentUiChunk, descriptors[2].pattern);
@@ -196,9 +196,9 @@ test("feature descriptor loader exposes the Copilot webview asset patches only w
 test("enabled feature descriptors patch the current app settings chunk", () => {
   const featuresRoot = path.resolve(__dirname, "..");
   const currentSettingsChunk =
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js";
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-CqMu8hJo.js";
   const currentUiChunk =
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-Cdmi2Vi6.js";
+    "app-initial~app-main~page-hSvsQcNf.js";
 
   withTempFeatureConfig(["copilot-reasoning-effort"], () => {
     withTempDir((extractedDir) => {


### PR DESCRIPTION
## Summary

Replaced hardcoded content-hash segments in the three webview asset patterns with wildcards so they survive upstream chunk structure changes.

## Root cause

The chunk patterns pinned 8-character Vite content-hash segments (e.g., `k0ede4gb`, `iufn7mg3`):

```javascript
pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/
```

These segments reshuffle with every upstream release when Vite rebuilds, causing the patterns to miss their target chunks.

## Changes

Broadened all three patterns to:

```javascript
pattern: /^app-initial~app-main~.*\.js$/
```

This is safe because:
- Each patch function already includes content-scan fallback that checks for marker strings (e.g., `copilot-default-model`) before applying
- The broader pattern matches the stable prefix (`app-initial~app-main~`) while allowing route order and hash segments to vary
- Tests verify that unrelated bundles don't get patched

## Validation

- ✅ Test suite passes (all 6 tests green)
- ✅ Patterns match old fixture names: `app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-current.js`
- ✅ Patterns match new 26.707 chunks: `app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-CqMu8hJo.js`
- ✅ Double-apply remains idempotent (already-patched chunks detected via marker strings)