### PR TITLE
feat(patches): content-scan fallback when webview chunk names drift

### DIFF
--- a/scripts/patches/lib/assets.js
+++ b/scripts/patches/lib/assets.js
@@ -4,6 +4,25 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { findExportedAlias } = require("./minified-js.js");
 
+// Content cache for content-scan fallback. Entries are validated against mtime
+// and size before being served: patches write assets with plain fs.writeFileSync
+// between scans, and a stale cached read would make a later content-scan patch
+// "restore" the pre-patch bytes, silently reverting an earlier patch's edits to
+// the same chunk.
+const webviewAssetContentCache = new Map();
+
+function readWebviewAssetCached(filePath) {
+  const stat = fs.statSync(filePath);
+  const versionKey = `${stat.mtimeMs}:${stat.size}`;
+  const entry = webviewAssetContentCache.get(filePath);
+  if (entry !== undefined && entry.versionKey === versionKey) {
+    return entry.content;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  webviewAssetContentCache.set(filePath, { versionKey, content });
+  return content;
+}
+
 function readDirectoryNames(dir) {
   if (!fs.existsSync(dir)) {
     return [];
@@ -39,27 +58,58 @@ function patchAssetFiles(extractedDir, filenamePattern, patchFn, missingWarnMess
     return { matched: 0, changed: 0 };
   }
 
-  const candidates = fs
+  let candidates = fs
     .readdirSync(webviewAssetsDir)
     .filter((name) => regexpTest(filenamePattern, name))
     .sort();
+  let contentScan = false;
 
   if (candidates.length === 0) {
-    console.warn(missingWarnMessage);
-    return { matched: 0, changed: 0 };
+    contentScan = true;
+    candidates = fs
+      .readdirSync(webviewAssetsDir)
+      .filter((name) => name.endsWith(".js"))
+      .sort();
   }
 
+  // Buffer writes until every candidate has been patched so a throw partway
+  // through leaves no half-patched mix of assets on disk. During a content
+  // scan the patch function runs over unrelated bundles, so its per-file
+  // "could not find" warnings are meaningless — silence them and let the
+  // single missing warning below speak when nothing matched at all.
+  const originalWarn = console.warn;
+  if (contentScan) {
+    console.warn = () => {};
+  }
   const pendingWrites = [];
-  for (const candidate of candidates) {
-    const filePath = path.join(webviewAssetsDir, candidate);
-    const currentSource = fs.readFileSync(filePath, "utf8");
-    const patchedSource = patchFn(currentSource);
-    if (patchedSource !== currentSource) {
-      pendingWrites.push({ filePath, patchedSource });
+  try {
+    for (const candidate of candidates) {
+      const filePath = path.join(webviewAssetsDir, candidate);
+      const currentSource = contentScan
+        ? readWebviewAssetCached(filePath)
+        : fs.readFileSync(filePath, "utf8");
+      const patchedSource = patchFn(currentSource);
+      if (patchedSource !== currentSource) {
+        pendingWrites.push({ filePath, patchedSource });
+      }
     }
+  } finally {
+    console.warn = originalWarn;
   }
   for (const { filePath, patchedSource } of pendingWrites) {
     fs.writeFileSync(filePath, patchedSource, "utf8");
+    webviewAssetContentCache.delete(filePath);
+  }
+
+  if (contentScan && pendingWrites.length === 0) {
+    console.warn(missingWarnMessage);
+    return { matched: 0, changed: 0 };
+  }
+  if (contentScan) {
+    console.log(
+      `Asset filename pattern missed; content scan patched ${pendingWrites.length} asset(s)`,
+    );
+    return { matched: pendingWrites.length, changed: pendingWrites.length };
   }
 
   return { matched: candidates.length, changed: pendingWrites.length };
@@ -78,9 +128,21 @@ function findRequiredWebviewAsset(webviewAssetsDir, filenamePattern, marker, des
     .readdirSync(webviewAssetsDir)
     .filter((name) => regexpTest(filenamePattern, name))
     .sort();
-  const matches = marker == null
+  let matches = marker == null
     ? candidates
     : candidates.filter((name) => readWebviewAsset(webviewAssetsDir, name).includes(marker));
+
+  if (matches.length === 0 && marker != null) {
+    // Chunk names drift across upstream releases; fall back to locating the
+    // bundle by its content marker across every JS asset.
+    matches = fs
+      .readdirSync(webviewAssetsDir)
+      .filter((name) => name.endsWith(".js"))
+      .sort()
+      .filter((name) =>
+        readWebviewAssetCached(path.join(webviewAssetsDir, name)).includes(marker),
+      );
+  }
 
   if (matches.length === 0) {
     throw new Error(`Could not find ${description} in ${webviewAssetsDir}`);

--- a/scripts/patches/lib/assets.test.js
+++ b/scripts/patches/lib/assets.test.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  patchAssetFiles,
+  findRequiredWebviewAsset,
+} = require("./assets.js");
+
+test("patchAssetFiles falls back to content scan when filename pattern misses", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    // Create assets with unexpected names (simulating renamed chunks)
+    fs.writeFileSync(path.join(assetsDir, "chunk-xyz123.js"), "MARKER_A content here", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "bundle-abc456.js"), "unrelated content", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "other-def789.js"), "MARKER_A again", "utf8");
+
+    const patchFn = (source) => {
+      if (!source.includes("MARKER_A")) {
+        return source;
+      }
+      return source.replace("MARKER_A", "PATCHED");
+    };
+
+    const result = patchAssetFiles(
+      tempRoot,
+      /^expected-pattern-.*\.js$/,
+      patchFn,
+      "WARN: expected pattern not found",
+    );
+
+    // Should match 2 files via content scan
+    assert.deepEqual(result, { matched: 2, changed: 2 });
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "chunk-xyz123.js"), "utf8"),
+      "PATCHED content here",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "other-def789.js"), "utf8"),
+      "PATCHED again",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "bundle-abc456.js"), "utf8"),
+      "unrelated content",
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patchAssetFiles skips content scan when filename pattern matches", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(assetsDir, "expected-pattern-1.js"), "content A", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "expected-pattern-2.js"), "content B", "utf8");
+
+    const patchFn = (source) => source.toUpperCase();
+
+    const result = patchAssetFiles(
+      tempRoot,
+      /^expected-pattern-.*\.js$/,
+      patchFn,
+      "WARN: pattern not found",
+    );
+
+    // Should match via filename pattern, not content scan
+    assert.deepEqual(result, { matched: 2, changed: 2 });
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "expected-pattern-1.js"), "utf8"),
+      "CONTENT A",
+    );
+    assert.equal(
+      fs.readFileSync(path.join(assetsDir, "expected-pattern-2.js"), "utf8"),
+      "CONTENT B",
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("patchAssetFiles logs warning when content scan finds nothing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (msg) => warnings.push(msg);
+
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(assetsDir, "chunk-1.js"), "no match here", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "chunk-2.js"), "no match either", "utf8");
+
+    const patchFn = (source) => {
+      // Never matches anything
+      if (source.includes("NEVER_FOUND")) {
+        return source.replace("NEVER_FOUND", "PATCHED");
+      }
+      return source;
+    };
+
+    const result = patchAssetFiles(
+      tempRoot,
+      /^missing-pattern-.*\.js$/,
+      patchFn,
+      "WARN: test pattern not found",
+    );
+
+    assert.deepEqual(result, { matched: 0, changed: 0 });
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0], "WARN: test pattern not found");
+  } finally {
+    console.warn = originalWarn;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("findRequiredWebviewAsset falls back to content scan when filename pattern misses", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    // Create assets with unexpected names
+    fs.writeFileSync(path.join(assetsDir, "renamed-chunk-abc.js"), "some content UNIQUE_MARKER more", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "other-chunk.js"), "unrelated", "utf8");
+
+    const found = findRequiredWebviewAsset(
+      assetsDir,
+      /^old-pattern-.*\.js$/,
+      "UNIQUE_MARKER",
+      "test asset",
+    );
+
+    assert.equal(found, "renamed-chunk-abc.js");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("findRequiredWebviewAsset prefers filename pattern match over content scan", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(assetsDir, "expected-1.js"), "content with MARKER", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "expected-2.js"), "content with MARKER", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "other.js"), "content with MARKER", "utf8");
+
+    const found = findRequiredWebviewAsset(
+      assetsDir,
+      /^expected-.*\.js$/,
+      "MARKER",
+      "test asset",
+    );
+
+    // Should pick the first filename match, not scan all
+    assert.equal(found, "expected-1.js");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("findRequiredWebviewAsset throws when content scan finds nothing", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "assets-test-"));
+  try {
+    const assetsDir = path.join(tempRoot, "webview", "assets");
+    fs.mkdirSync(assetsDir, { recursive: true });
+
+    fs.writeFileSync(path.join(assetsDir, "chunk-1.js"), "no marker here", "utf8");
+    fs.writeFileSync(path.join(assetsDir, "chunk-2.js"), "no marker either", "utf8");
+
+    assert.throws(
+      () => {
+        findRequiredWebviewAsset(
+          assetsDir,
+          /^missing-pattern-.*\.js$/,
+          "MISSING_MARKER",
+          "test asset",
+        );
+      },
+      (err) => err.message.includes("Could not find test asset"),
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- `patchAssetFiles`: when the filename pattern matches nothing, falls back to probing every webview/assets/*.js with the patch function, suppressing console.warn during the probe, keeping files the patch actually changed
- `findRequiredWebviewAsset`: when the filename pattern misses and a content marker was provided, searches all .js assets for the marker before throwing
- Contents are cached per install run (validated against mtime+size) so multiple fallback scans only read the assets directory once

## Motivation

Upstream Vite chunk splitting reshuffles asset filenames on most releases. When a descriptor's filename pattern stops matching, patches silently no-op (`matched: 0`) until someone hand-updates patterns. This ports the release-survival mechanism proven in the sibling fork chatgpt-desktop-linux.

## Validation

- Added comprehensive test suite in `scripts/patches/lib/assets.test.js` covering:
  - Renamed-chunk fixtures proving the fallback finds and patches them
  - No-match fixtures proving graceful skip
  - Filename pattern match preference over content scan
- All existing tests pass: `make test` (217 passed, 0 failed)
- Behavior is identical when patterns match (zero overhead on the happy path)