### PR TITLE
fix(patches): match both published 26.707 webview chunk layouts

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -55,7 +55,7 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/u;
+  /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -1676,7 +1676,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-wait",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-.*\.js$/,
+    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
     order: 20_152,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -55,7 +55,7 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/u;
+  /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -1676,7 +1676,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-wait",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     order: 20_152,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -54,7 +54,7 @@ const LATEST_REMOTE_CONVERSATION_ASSET =
 const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
-  "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js";
+  "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
 
 function syntheticMainBundle() {
   return [

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1098,17 +1098,12 @@ test("default core patch descriptors are grouped and unique", () => {
   const computerUseInstallFlow = descriptors.find((descriptor) => descriptor.id === "linux-computer-use-install-flow");
   assert.equal(
     computerUseInstallFlow.pattern.test(
-      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-current.js",
-    ),
-    true,
-  );
-  assert.equal(
-    computerUseInstallFlow.pattern.test(
       "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-current.js",
     ),
     true,
   );
   for (const legacyName of [
+    "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-current.js",
     "app-initial~app-main~remote-conversation-page~new-thread-panel-page~onboarding-page~appgen-~current.js",
     "plugins-availability-current.js",
     "use-plugin-install-flow-current.js",
@@ -5610,13 +5605,13 @@ test("discovers current app-server conversation core Linux webview patches", () 
     assert.ok(descriptor);
     assert.equal(descriptor.phase, "webview-asset");
     assert.equal(descriptor.ciPolicy, "optional");
-    assert.equal(descriptor.pattern.test(currentConversationAsset), true);
     assert.equal(
       descriptor.pattern.test(
         "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-Bj9ubaFn.js",
       ),
       true,
     );
+    assert.equal(descriptor.pattern.test(currentConversationAsset), false);
     assert.equal(descriptor.pattern.test(legacyConversationAsset), false);
     assert.equal(descriptor.pattern.test(legacyLatestConversationAsset), false);
     assert.equal(descriptor.pattern.test(oldConversationAsset), false);
@@ -8131,7 +8126,7 @@ test("patchExtractedApp scans current Computer Use settings bundles when UI is e
       fs.writeFileSync(
         path.join(
           assetsDir,
-          "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-current.js",
+          "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-current.js",
         ),
         "function _p(e){return e===`macOS`||e===`windows`}" +
           "function vp(e){let t=(0,Sp.c)(16),{enabled:n,hostId:r}=e,i=n===void 0?!0:n,{isLoading:a,platform:o}=ba(),s=gr(`1506311413`),c;t[0]===r?c=t[1]:(c={featureName:`computer_use`,hostId:r},t[0]=r,t[1]=c);let l=mp(c),u=o===`windows`&&!a,d=i&&u,f;t[2]===d?f=t[3]:(f={enabled:d},t[2]=d,t[3]=f);let p=yp(f),m=l.isLoading||u&&p.isLoading,h=l.enabled&&(!u||p.enabled),g;t[4]!==h||t[5]!==i||t[6]!==m||t[7]!==s||t[8]!==a||t[9]!==o?(g=xp({areRequiredFeaturesEnabled:h,enabled:i,isAnyFeatureLoading:m,isComputerUseGateEnabled:s,isHostCompatiblePlatform:_p(o),isPlatformLoading:a,windowType:`electron`}),t[4]=h,t[5]=i,t[6]=m,t[7]=s,t[8]=a,t[9]=o,t[10]=g):g=t[10];return g}",
@@ -8162,7 +8157,7 @@ test("patchExtractedApp scans current Computer Use settings bundles when UI is e
         fs.readFileSync(
           path.join(
             assetsDir,
-            "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-current.js",
+            "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-current.js",
           ),
           "utf8",
         ),

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1102,8 +1102,13 @@ test("default core patch descriptors are grouped and unique", () => {
     ),
     true,
   );
+  assert.equal(
+    computerUseInstallFlow.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-current.js",
+    ),
+    true,
+  );
   for (const legacyName of [
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~current.js",
     "app-initial~app-main~remote-conversation-page~new-thread-panel-page~onboarding-page~appgen-~current.js",
     "plugins-availability-current.js",
     "use-plugin-install-flow-current.js",
@@ -5605,8 +5610,13 @@ test("discovers current app-server conversation core Linux webview patches", () 
     assert.ok(descriptor);
     assert.equal(descriptor.phase, "webview-asset");
     assert.equal(descriptor.ciPolicy, "optional");
-    assert.match(String(descriptor.pattern), /b76hmflu/);
     assert.equal(descriptor.pattern.test(currentConversationAsset), true);
+    assert.equal(
+      descriptor.pattern.test(
+        "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-Bj9ubaFn.js",
+      ),
+      true,
+    );
     assert.equal(descriptor.pattern.test(legacyConversationAsset), false);
     assert.equal(descriptor.pattern.test(legacyLatestConversationAsset), false);
     assert.equal(descriptor.pattern.test(oldConversationAsset), false);

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
+++ b/scripts/patches/core/all-linux/webview/app-server-conversation-hydration/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux app-server conversation hydration patch",
     apply: applyLinuxAppServerConversationHydrationPatch,

--- a/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
+++ b/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-.*\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     missingDescription: "dynamic Codex app tools bundle",
     skipDescription: "automation_update eager dynamic tool patch",
     apply: applyAutomationUpdateEagerToolPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,

--- a/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
+++ b/scripts/patches/core/all-linux/webview/completed-item-recovery/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1043,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     missingDescription: "app-server conversation manager bundle",
     skipDescription: "Linux completed item recovery patch",
     apply: applyLinuxCompletedItemRecoveryPatch,

--- a/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
+++ b/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
@@ -26,7 +26,7 @@ module.exports = [
     order: 1110,
     ciPolicy: "opt-in",
     enabled: (context) => context.enableComputerUseUi,
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
     missingDescription: "current Computer Use install flow bundle",
     skipDescription: "Linux Computer Use install flow patch",
     apply: applyLinuxComputerUseInstallFlowPatch,

--- a/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
+++ b/scripts/patches/core/all-linux/webview/computer-use-ui/patch.js
@@ -26,7 +26,7 @@ module.exports = [
     order: 1110,
     ciPolicy: "opt-in",
     enabled: (context) => context.enableComputerUseUi,
-    pattern: /^app-initial~app-main~(?:pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~[^.]+|onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     missingDescription: "current Computer Use install flow bundle",
     skipDescription: "Linux Computer Use install flow patch",
     apply: applyLinuxComputerUseInstallFlowPatch,

--- a/scripts/patches/core/all-linux/webview/font-settings/patch.js
+++ b/scripts/patches/core/all-linux/webview/font-settings/patch.js
@@ -11,7 +11,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^(?:font-settings-.*|app-initial~app-main~remote-conversation-page~.*)\.js$/,
+    pattern: /^(?:font-settings-.*|app-initial~app-main~remote-conversation-page~.*|app-initial~app-main~page-[^.]+)\.js$/,
     missingDescription: "font settings bundle",
     skipDescription: "Linux monospace font stack patch",
     apply: applyLinuxSafeMonospaceFontStackPatch,

--- a/scripts/patches/core/all-linux/webview/font-settings/patch.js
+++ b/scripts/patches/core/all-linux/webview/font-settings/patch.js
@@ -11,7 +11,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^(?:font-settings-.*|app-initial~app-main~remote-conversation-page~.*|app-initial~app-main~page-[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~page-[^.]+\.js$/,
     missingDescription: "font settings bundle",
     skipDescription: "Linux monospace font stack patch",
     apply: applyLinuxSafeMonospaceFontStackPatch,

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -57,7 +57,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*\.js$/,
+    pattern: /^(?:app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*|app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
     missingDescription: "tooltip bundle",
     skipDescription: "Linux tooltip titlebar collision patch",
     apply: applyLinuxTooltipWindowControlsCollisionPatch,

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -57,7 +57,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^(?:app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~.*|app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+)\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
     missingDescription: "tooltip bundle",
     skipDescription: "Linux tooltip titlebar collision patch",
     apply: applyLinuxTooltipWindowControlsCollisionPatch,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7433,7 +7433,7 @@ test_linux_computer_use_ui_opt_in_smoke() {
     local main_bundle="$extracted/.vite/build/main-test.js"
     local renderer_asset="$extracted/webview/assets/computer-use-settings-renderer-test.js"
     local current_renderer_asset="$extracted/webview/assets/computer-use-settings-current-test.js"
-    local install_flow_asset="$extracted/webview/assets/app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-test.js"
+    local install_flow_asset="$extracted/webview/assets/app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js"
     local native_apps_asset="$extracted/webview/assets/computer-use-settings-native-apps-test.js"
     local bundle_body
     local renderer_body


### PR DESCRIPTION
## Summary
- Un-breaks the `Build App Against Upstream DMG` job, red on `main` since the 2026-07-11 05:21 UTC run.
- Root cause: OpenAI briefly published a rebuilt `ChatGPT.dmg`, then rolled it back — the DMG served at `codex-app-prod/ChatGPT.dmg` today is byte-identical to the earlier 26.707.41301 build again. The July 10 pattern updates pinned the rebuilt build's chunk names (`cha~b76hmflu`, `chatg~k0ede4gb`), so when the CI header cache refreshed to the rolled-back build, these patches stopped matching:
  - `linux-app-server-conversation-hydration`, `linux-completed-item-recovery` (required by the `upstream-build` profile)
  - `feature:remote-mobile-control` load-gate, conversation-hydration, status-read-guard, status-wait (required by the remote-mobile inspect step)
  - `automation-update-eager-tool`, `linux-safe-monospace-font-stack`, `linux-tooltip-window-controls-collision`, `linux-computer-use-install-flow` (optional)
- Fix: widen the asset patterns to accept **both** published layouts instead of re-pinning — keep the rebuilt-DMG segment shape with its volatile hash wildcarded, add the rolled-back build's chunk shape. No impl changes; every impl already applies cleanly to the rolled-back build's chunks (verified individually).

## Still skipping (out of scope)
`linux-settings-search-visibility` remains an optional skip on the rolled-back build: its import specifiers pin the rebuilt DMG's export letters (`E$`, `T2`, `j7`, `qk`). Resolving those aliases semantically needs a deeper change — flagging to #784's author.

## Validation
- Downloaded the currently served DMG (sha256 matches CI's cache headers), extracted `app.asar`, ran the full patcher with `remote-mobile-control` enabled and `CODEX_LINUX_ENABLE_COMPUTER_USE_UI=1`:
  - `node scripts/ci/validate-patch-report.js --profile upstream-build --require-enabled-feature remote-mobile-control --require-applied ...` (the exact CI invocation) **passes**
  - second patch run: all 91 relevant patches report `already-applied` (idempotent)
- `node --test 'scripts/**/*.test.js'`: 394/394 pass (two tests updated — they asserted the rebuilt-DMG-only worldview, e.g. `assert.match(pattern, /b76hmflu/)` and rejecting the rolled-back chunk name as legacy)
- All linux-features suites pass except `appshots` XInput2 stream test, which fails identically on a clean checkout (environment-dependent, pre-existing)