### PR TITLE
test(updater): isolate Desktop settings fixture

### DIFF
--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -2622,11 +2622,18 @@ mod tests {
     #[test]
     fn daemon_reconcile_reloads_waiting_state_written_by_another_process() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT",
+            "CODEX_LINUX_SETTINGS_FILE",
+        ]);
         let runtime = tokio::runtime::Runtime::new()?;
-        let previous_no_agent = std::env::var_os("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT");
         std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT", "1");
 
         let temp = tempfile::tempdir()?;
+        std::env::set_var(
+            "CODEX_LINUX_SETTINGS_FILE",
+            temp.path().join("isolated-settings.json"),
+        );
         let paths = test_paths(temp.path());
         paths.ensure_dirs()?;
         let config = test_config(temp.path());
@@ -2654,12 +2661,6 @@ mod tests {
             &mut stale_daemon_state,
             &paths,
         ));
-
-        if let Some(value) = previous_no_agent {
-            std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT", value);
-        } else {
-            std::env::remove_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT");
-        }
 
         result?;
         assert_eq!(stale_daemon_state.status, UpdateStatus::ReadyToInstall);


### PR DESCRIPTION
## Summary

- isolate the daemon reconciliation test from the developer's real Codex Desktop settings file;
- restore both process environment variables with the shared panic-safe test guard;
- keep the existing global environment lock for the full test lifetime.

## Why

`daemon_reconcile_reloads_waiting_state_written_by_another_process` configured auto-install in its fixture, but still allowed `CODEX_LINUX_SETTINGS_FILE` to resolve to the user's real Desktop settings. A local `autoInstallUpdates` value could override the fixture and make the test miss the expected no-polkit-agent transition.

The test now points the settings lookup at a nonexistent file inside its temporary directory. This preserves the intended default behavior and prevents workstation state from changing the assertion. Production updater behavior is unchanged.

## Validation

- focused regression test: 1 passed
- `cargo test -p codex-update-manager`: 228 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `git diff --check`

The final one-file diff also received an independent review with no findings.
