### PR TITLE
Cover native Linux shortcut fallback

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -41,6 +41,7 @@ const {
   keybindsSettingsAsset,
   linuxDesktopSettingsAsset,
   applyLinuxDesktopSettingsIndexPatch,
+  applyLinuxShortcutPhysicalKeyFallbackPatch,
   applyLinuxDesktopSettingsSectionsPatch,
   applyLinuxDesktopSettingsSharedPatch,
   applyLinuxKeybindOverridesRuntimePatch,
@@ -4428,6 +4429,75 @@ test("adds Linux desktop settings route when upstream owns Keyboard Shortcuts", 
   assert.doesNotMatch(patched, /codexLinuxKeybindOverridesRuntime/);
 });
 
+test("adds physical-key fallback for current native shortcut runtime", () => {
+  const source = [
+    "function Ie({altKey:e,code:t,key:n}){return!e||t==null?n:Be?.[t]??Re(t)??n}",
+    "function Re(e){return/^Key[A-Z]$/.test(e)?e.slice(3).toLowerCase():/^Digit[0-9]$/.test(e)?e.slice(5):ze.get(e)??null}",
+    "var ze=new Map([[`BracketLeft`,`[`],[`Slash`,`/`]]),Be=null;",
+  ].join("");
+  const patched = applyPatchTwice(applyLinuxShortcutPhysicalKeyFallbackPatch, source);
+
+  const sandbox = {};
+  vm.runInNewContext(
+    `${patched};this.press=(event)=>Ie(event);`,
+    sandbox,
+  );
+
+  assert.equal(sandbox.press({ ctrlKey: true, code: "KeyK", key: "л", altKey: false, metaKey: false }), "k");
+  assert.equal(sandbox.press({ ctrlKey: true, code: "Digit5", key: "(", altKey: false, metaKey: false }), "5");
+  assert.equal(sandbox.press({ ctrlKey: true, code: "BracketLeft", key: "х", altKey: false, metaKey: false }), "[");
+  assert.equal(sandbox.press({ ctrlKey: false, code: "KeyK", key: "л", altKey: false, metaKey: false }), "л");
+  assert.equal(
+    sandbox.press({
+      ctrlKey: true,
+      altKey: true,
+      code: "KeyQ",
+      key: "@",
+      metaKey: false,
+      getModifierState: (name) => name === "AltGraph",
+    }),
+    "@",
+  );
+});
+
+test("patches physical-key fallback through native Keyboard Shortcuts asset scan", () => {
+  const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
+  const shortcutRuntimeAsset = path.join(assetsDir, "app-initial~app-main~keyboard-shortcuts-runtime-A.js");
+  try {
+    fs.writeFileSync(
+      shortcutRuntimeAsset,
+      [
+        "function Ie({altKey:e,code:t,key:n}){return!e||t==null?n:Be?.[t]??Re(t)??n}",
+        "function Re(e){return/^Key[A-Z]$/.test(e)?e.slice(3).toLowerCase():/^Digit[0-9]$/.test(e)?e.slice(5):ze.get(e)??null}",
+        "var ze=new Map([[`BracketLeft`,`[`],[`Slash`,`/`]]),Be=null;",
+      ].join(""),
+      "utf8",
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, true);
+    assert.deepEqual(warnings, []);
+
+    const patchedSource = fs.readFileSync(shortcutRuntimeAsset, "utf8");
+    assert.match(patchedSource, /codexLinuxShortcutPhysicalKeyFallbackEvent/);
+
+    const sandbox = {};
+    vm.runInNewContext(
+      `${patchedSource};this.press=(event)=>Ie(event);`,
+      sandbox,
+    );
+    assert.equal(sandbox.press({ metaKey: true, code: "KeyB", key: "и", altKey: false, ctrlKey: false }), "b");
+    assert.equal(sandbox.press({ shiftKey: true, code: "KeyB", key: "И", altKey: false, ctrlKey: false, metaKey: false }), "И");
+
+    const secondResult = patchKeybindsSettingsAssets(extractedDir);
+    assert.equal(secondResult.matched, true);
+    assert.equal(secondResult.changed, 0);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
+});
+
 function runLinuxKeybindRuntimeEvent(eventInit) {
   const dispatched = [];
   const listeners = {};
@@ -4457,7 +4527,7 @@ function runLinuxKeybindRuntimeEvent(eventInit) {
   };
   const patched = applyPatchTwice(
     applyLinuxKeybindOverridesRuntimePatch,
-    "var Ct={openCommandMenu:`CmdOrCtrl+K`,settings:`CmdOrCtrl+,`};",
+    "var Ct={openCommandMenu:`CmdOrCtrl+K`,settings:`CmdOrCtrl+,`,copySessionId:`CmdOrCtrl+Alt+C`};",
   );
 
   vm.runInNewContext(patched, {
@@ -4523,6 +4593,19 @@ test("Linux keybind runtime maps physical punctuation codes for defaults", () =>
     { type: "show-settings", params: { section: "general-settings" } },
   ]);
   assert.equal(event.defaultPrevented, true);
+});
+
+test("Linux keybind runtime leaves AltGraph chords to text input", () => {
+  const { dispatched, event } = runLinuxKeybindRuntimeEvent({
+    altKey: true,
+    code: "KeyC",
+    ctrlKey: true,
+    getModifierState: (name) => name === "AltGraph",
+    key: "©",
+  });
+
+  assert.deepEqual(dispatched, []);
+  assert.equal(event.defaultPrevented, false);
 });
 
 test("finds a unique current Codex request API asset outside legacy vscode-api chunks", () => {

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -805,6 +805,11 @@ function patchKeybindsSettingsAssets(extractedDir) {
         isSettingsSharedMetadataBundleSource,
         applyLinuxDesktopSettingsSharedPatch,
       ),
+      ...collectOptionalMatchingAssetPatches(
+        extractedDir,
+        isLinuxShortcutPhysicalKeyFallbackBundleSource,
+        applyLinuxShortcutPhysicalKeyFallbackPatch,
+      ),
       ...collectLinuxDesktopRouteAndNavigationPatches(extractedDir),
     ];
 
@@ -821,7 +826,7 @@ function patchKeybindsSettingsAssets(extractedDir) {
     return {
       matched: true,
       changed,
-      reason: "upstream keyboard shortcuts settings are present; added Linux desktop settings",
+      reason: "upstream keyboard shortcuts settings are present; added Linux desktop settings and shortcut layout fallback",
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -971,8 +976,44 @@ function applyLinuxDesktopSettingsSharedPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxShortcutPhysicalKeyFallbackPatch(currentSource) {
+  const patchMarker = "codexLinuxShortcutPhysicalKeyFallbackEvent";
+  if (currentSource.includes(patchMarker)) {
+    return currentSource;
+  }
+
+  const physicalKeyResolverPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{altKey:([A-Za-z_$][\w$]*),code:([A-Za-z_$][\w$]*),key:([A-Za-z_$][\w$]*)\}\)\{return!\2\|\|\3==null\?\4:([^{};]+)\}/;
+  const match = currentSource.match(physicalKeyResolverPattern);
+  if (match == null) {
+    return currentSource;
+  }
+
+  const [
+    matchedSource,
+    functionName,
+    altKeyLocal,
+    codeLocal,
+    keyLocal,
+    physicalFallbackExpression,
+  ] = match;
+  const patchedSource =
+    `function ${functionName}(codexLinuxShortcutPhysicalKeyFallbackEvent){let{altKey:${altKeyLocal},code:${codeLocal},key:${keyLocal},ctrlKey:codexLinuxShortcutPhysicalKeyFallbackCtrl,metaKey:codexLinuxShortcutPhysicalKeyFallbackMeta}=codexLinuxShortcutPhysicalKeyFallbackEvent;return!(${altKeyLocal}||codexLinuxShortcutPhysicalKeyFallbackCtrl||codexLinuxShortcutPhysicalKeyFallbackMeta)||typeof codexLinuxShortcutPhysicalKeyFallbackEvent.getModifierState=="function"&&codexLinuxShortcutPhysicalKeyFallbackEvent.getModifierState("AltGraph")||${codeLocal}==null?${keyLocal}:${physicalFallbackExpression}}`;
+
+  return currentSource.replace(matchedSource, patchedSource);
+}
+
+function isLinuxShortcutPhysicalKeyFallbackBundleSource(currentSource) {
+  return currentSource.includes("altKey:")
+    && currentSource.includes("code:")
+    && currentSource.includes("key:")
+    && currentSource.includes("Key[A-Z]")
+    && currentSource.includes("Digit[0-9]")
+    && /function [A-Za-z_$][\w$]*\(\{altKey:[A-Za-z_$][\w$]*,code:[A-Za-z_$][\w$]*,key:[A-Za-z_$][\w$]*\}\)\{return![A-Za-z_$][\w$]*\|\|[A-Za-z_$][\w$]*==null\?[A-Za-z_$][\w$]*:/.test(currentSource);
+}
+
 function applyLinuxKeybindOverridesRuntimePatch(currentSource) {
-  const runtimePatch = `;function codexLinuxKeybindOverridesRuntime(){try{if(typeof window=="undefined")return;let storageKey=${JSON.stringify(linuxKeybindOverridesKey)},defaultMap=typeof Ct=="object"&&Ct?Ct:{},overrides={};function loadOverrides(){try{let value=JSON.parse(localStorage.getItem(storageKey)||"{}");overrides=value&&typeof value=="object"&&!Array.isArray(value)?value:{}}catch{overrides={}}}function isShortcutCaptureTarget(event){let target=event.target;return target instanceof Element&&target.closest("[data-codex-keybind-input]")!=null}function normalizeKeyName(key){let map={Space:" ",Esc:"Escape",Up:"ArrowUp",Down:"ArrowDown",Left:"ArrowLeft",Right:"ArrowRight",Plus:"+",Comma:",",Period:".",Slash:"/"};return map[key]??(/^.$/.test(key)?key.toUpperCase():key)}function keyNameFromCode(code){if(typeof code!="string")return null;if(/^Key[A-Z]$/.test(code))return code.slice(3);if(/^Digit[0-9]$/.test(code))return code.slice(5);let map={Backquote:"\`",Minus:"-",Equal:"=",BracketLeft:"[",BracketRight:"]",Backslash:"\\\\",Semicolon:";",Quote:"'",Comma:",",Period:".",Slash:"/",IntlBackslash:"\\\\"};return map[code]??null}function parseAccelerator(accelerator){if(typeof accelerator!="string"||accelerator.trim().length===0)return null;let isMac=/Mac/.test(navigator.platform||""),parts=accelerator.split("+").map(part=>part.trim()).filter(Boolean),parsed={ctrl:false,alt:false,shift:false,meta:false,key:null};for(let part of parts){switch(part){case"CmdOrCtrl":isMac?parsed.meta=true:parsed.ctrl=true;break;case"Command":case"Cmd":case"Meta":case"Super":case"Win":parsed.meta=true;break;case"Control":case"Ctrl":parsed.ctrl=true;break;case"Alt":case"Option":parsed.alt=true;break;case"Shift":parsed.shift=true;break;default:parsed.key=normalizeKeyName(part);break}}return parsed.key?parsed:null}function matchKind(event,parsed){if(event.ctrlKey!==parsed.ctrl||event.altKey!==parsed.alt||event.shiftKey!==parsed.shift||event.metaKey!==parsed.meta)return null;if(normalizeKeyName(event.key)===parsed.key)return"logical";if(!(parsed.ctrl||parsed.alt||parsed.meta))return null;let codeKey=keyNameFromCode(event.code);return codeKey!=null&&normalizeKeyName(codeKey)===parsed.key?"physical":null}function dispatchHost(message){if(typeof E=="object"&&E&&typeof E.dispatchHostMessage=="function"){E.dispatchHostMessage(message);return true}return false}function dispatchElectron(type,params={}){if(typeof E=="object"&&E&&typeof E.dispatchMessage=="function"){E.dispatchMessage(type,params);return true}return false}let hostActionTypes={newThread:"new-chat",quickChat:"new-quick-chat",newThreadAlt:"new-chat",toggleSidebar:"toggle-sidebar",toggleTerminal:"toggle-terminal",toggleBrowserPanel:"toggle-browser-panel",toggleDiffPanel:"toggle-diff-panel",findInThread:"find-in-thread",navigateBack:"navigate-back",navigateForward:"navigate-forward",previousThread:"previous-thread",nextThread:"next-thread",copyConversationPath:"copy-conversation-path",toggleThreadPin:"toggle-thread-pin",renameThread:"rename-thread",archiveThread:"archive-thread",copyWorkingDirectory:"copy-working-directory",copySessionId:"copy-session-id",copyDeeplink:"copy-deeplink",toggleFileTreePanel:"toggle-file-tree-panel"};function runAction(id){if(/^thread[1-9]$/.test(id))return dispatchHost({type:"go-to-thread-index",index:Number(id.slice(6))-1});switch(id){case"openCommandMenu":case"openCommandMenuAlt":return dispatchHost({type:"command-menu",query:""});case"searchChats":return dispatchHost({type:"chat-search-command-menu"});case"searchFiles":return dispatchHost({type:"file-search-command-menu"});case"openFolder":return dispatchElectron("electron-create-new-workspace-root-option",{});case"settings":return dispatchElectron("show-settings",{section:"general-settings"});case"openBrowserTab":return dispatchHost({type:"browser-sidebar-command",command:{type:"new-tab"}});case"reloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"reload"}});case"hardReloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"hard-reload"}});case"dictation":return dispatchElectron("global-dictation-start",{});default:return hostActionTypes[id]?dispatchHost({type:hostActionTypes[id]}):false}}loadOverrides();window.addEventListener("storage",event=>{event.key===storageKey&&loadOverrides()});window.addEventListener("codex-linux-keybind-overrides-changed",loadOverrides);window.addEventListener("keydown",event=>{if(event.defaultPrevented||event.repeat||isShortcutCaptureTarget(event))return;let accelerators={...defaultMap,...overrides};for(let[id,accelerator]of Object.entries(accelerators)){if(typeof accelerator!="string"||accelerator.trim().length===0)continue;let isDefault=accelerator.trim()===(defaultMap[id]||""),parsed=parseAccelerator(accelerator),kind=parsed?matchKind(event,parsed):null;if(kind&&(kind==="physical"||!isDefault)&&runAction(id)){event.preventDefault();event.stopPropagation();break}}},true)}catch{}}codexLinuxKeybindOverridesRuntime();`;
+  const runtimePatch = `;function codexLinuxKeybindOverridesRuntime(){try{if(typeof window=="undefined")return;let storageKey=${JSON.stringify(linuxKeybindOverridesKey)},defaultMap=typeof Ct=="object"&&Ct?Ct:{},overrides={};function loadOverrides(){try{let value=JSON.parse(localStorage.getItem(storageKey)||"{}");overrides=value&&typeof value=="object"&&!Array.isArray(value)?value:{}}catch{overrides={}}}function isShortcutCaptureTarget(event){let target=event.target;return target instanceof Element&&target.closest("[data-codex-keybind-input]")!=null}function normalizeKeyName(key){let map={Space:" ",Esc:"Escape",Up:"ArrowUp",Down:"ArrowDown",Left:"ArrowLeft",Right:"ArrowRight",Plus:"+",Comma:",",Period:".",Slash:"/"};return map[key]??(/^.$/.test(key)?key.toUpperCase():key)}function keyNameFromCode(code){if(typeof code!="string")return null;if(/^Key[A-Z]$/.test(code))return code.slice(3);if(/^Digit[0-9]$/.test(code))return code.slice(5);let map={Backquote:"\`",Minus:"-",Equal:"=",BracketLeft:"[",BracketRight:"]",Backslash:"\\\\",Semicolon:";",Quote:"'",Comma:",",Period:".",Slash:"/",IntlBackslash:"\\\\"};return map[code]??null}function parseAccelerator(accelerator){if(typeof accelerator!="string"||accelerator.trim().length===0)return null;let isMac=/Mac/.test(navigator.platform||""),parts=accelerator.split("+").map(part=>part.trim()).filter(Boolean),parsed={ctrl:false,alt:false,shift:false,meta:false,key:null};for(let part of parts){switch(part){case"CmdOrCtrl":isMac?parsed.meta=true:parsed.ctrl=true;break;case"Command":case"Cmd":case"Meta":case"Super":case"Win":parsed.meta=true;break;case"Control":case"Ctrl":parsed.ctrl=true;break;case"Alt":case"Option":parsed.alt=true;break;case"Shift":parsed.shift=true;break;default:parsed.key=normalizeKeyName(part);break}}return parsed.key?parsed:null}function matchKind(event,parsed){if(event.ctrlKey!==parsed.ctrl||event.altKey!==parsed.alt||event.shiftKey!==parsed.shift||event.metaKey!==parsed.meta)return null;if(normalizeKeyName(event.key)===parsed.key)return"logical";if(!(parsed.ctrl||parsed.alt||parsed.meta)||typeof event.getModifierState=="function"&&event.getModifierState("AltGraph"))return null;let codeKey=keyNameFromCode(event.code);return codeKey!=null&&normalizeKeyName(codeKey)===parsed.key?"physical":null}function dispatchHost(message){if(typeof E=="object"&&E&&typeof E.dispatchHostMessage=="function"){E.dispatchHostMessage(message);return true}return false}function dispatchElectron(type,params={}){if(typeof E=="object"&&E&&typeof E.dispatchMessage=="function"){E.dispatchMessage(type,params);return true}return false}let hostActionTypes={newThread:"new-chat",quickChat:"new-quick-chat",newThreadAlt:"new-chat",toggleSidebar:"toggle-sidebar",toggleTerminal:"toggle-terminal",toggleBrowserPanel:"toggle-browser-panel",toggleDiffPanel:"toggle-diff-panel",findInThread:"find-in-thread",navigateBack:"navigate-back",navigateForward:"navigate-forward",previousThread:"previous-thread",nextThread:"next-thread",copyConversationPath:"copy-conversation-path",toggleThreadPin:"toggle-thread-pin",renameThread:"rename-thread",archiveThread:"archive-thread",copyWorkingDirectory:"copy-working-directory",copySessionId:"copy-session-id",copyDeeplink:"copy-deeplink",toggleFileTreePanel:"toggle-file-tree-panel"};function runAction(id){if(/^thread[1-9]$/.test(id))return dispatchHost({type:"go-to-thread-index",index:Number(id.slice(6))-1});switch(id){case"openCommandMenu":case"openCommandMenuAlt":return dispatchHost({type:"command-menu",query:""});case"searchChats":return dispatchHost({type:"chat-search-command-menu"});case"searchFiles":return dispatchHost({type:"file-search-command-menu"});case"openFolder":return dispatchElectron("electron-create-new-workspace-root-option",{});case"settings":return dispatchElectron("show-settings",{section:"general-settings"});case"openBrowserTab":return dispatchHost({type:"browser-sidebar-command",command:{type:"new-tab"}});case"reloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"reload"}});case"hardReloadBrowserPage":return dispatchHost({type:"browser-sidebar-command",command:{type:"hard-reload"}});case"dictation":return dispatchElectron("global-dictation-start",{});default:return hostActionTypes[id]?dispatchHost({type:hostActionTypes[id]}):false}}loadOverrides();window.addEventListener("storage",event=>{event.key===storageKey&&loadOverrides()});window.addEventListener("codex-linux-keybind-overrides-changed",loadOverrides);window.addEventListener("keydown",event=>{if(event.defaultPrevented||event.repeat||isShortcutCaptureTarget(event))return;let accelerators={...defaultMap,...overrides};for(let[id,accelerator]of Object.entries(accelerators)){if(typeof accelerator!="string"||accelerator.trim().length===0)continue;let isDefault=accelerator.trim()===(defaultMap[id]||""),parsed=parseAccelerator(accelerator),kind=parsed?matchKind(event,parsed):null;if(kind&&(kind==="physical"||!isDefault)&&runAction(id)){event.preventDefault();event.stopPropagation();break}}},true)}catch{}}codexLinuxKeybindOverridesRuntime();`;
 
   const runtimeMarker = ";function codexLinuxKeybindOverridesRuntime()";
   const existingRuntimeIndex = currentSource.indexOf(runtimeMarker);
@@ -1192,6 +1233,7 @@ module.exports = {
   applyLinuxDesktopSettingsSectionsPatch,
   applyLinuxDesktopSettingsSharedPatch,
   applyLinuxKeybindOverridesRuntimePatch,
+  applyLinuxShortcutPhysicalKeyFallbackPatch,
   keybindsSettingsAsset,
   linuxDesktopSettingsAsset,
   linuxKeybindOverridesKey,


### PR DESCRIPTION
This is a small follow-up on top of #820, not a competing PR to main.

While checking the draft against the current installed 26.707 asset layout, I found that the legacy runtime fallback does not get injected into the native Keyboard Shortcuts path. On a fresh copy of the installed bundle, #820 reports `keybinds-settings` as already applied and leaves no physical-key fallback marker.

This adds the missing native chunk patch and keeps normal text input layout-aware, including Shift-only keys and AltGraph.

Changes
- patch the current native shortcut resolver when the bundle exposes the `altKey` / `code` / `key` resolver shape
- keep AltGraph out of the physical fallback so text input keeps working on layouts that expose AltGraph as Ctrl+Alt
- add regression coverage for native chunk scanning, idempotence, and the legacy runtime AltGraph case

Validation
- `node --test --test-name-pattern 'physical-key fallback|Linux keybind runtime|Linux desktop settings route|native Keyboard Shortcuts asset scan' scripts/patch-linux-window-ui.test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --test linux-features/*/test.js`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- `nix flake show --no-update-lock-file`
- `nix flake check --no-build --no-update-lock-file`

Relates to #819 and #820.
