### PR TITLE
feat(appimage): support an optional bundled Codex CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ UPSTREAM_INTEL_PATCH_REPORT ?= $(REBUILD_REPORT_DIR)/patch-report.json
 UPSTREAM_INTEL_IMAGE ?= codex-desktop-linux-devcontainer:local
 PACKAGE_NAME := codex-desktop
 PACKAGE_WITH_UPDATER ?= 1
+CODEX_CLI_BUNDLE_SOURCE ?=
 MAX_BUILD_THREADS ?= 0
 MAX_BUILD_THREADS_VALUE := $(strip $(MAX_BUILD_THREADS))
 MAX_BUILD_THREADS_ENABLED := $(filter-out 0,$(MAX_BUILD_THREADS_VALUE))
@@ -110,6 +111,7 @@ help:
 	@printf '  %-18s %s\n' "DEV_APP_NAME=..." "Override side-by-side test app display name"
 	@printf '  %-18s %s\n' "PACKAGE_VERSION=..." "Override the package version for make deb / make rpm / make pacman / make appimage"
 	@printf '  %-18s %s\n' "PACKAGE_WITH_UPDATER=0" "Build packages without codex-update-manager or the updater service"
+	@printf '  %-18s %s\n' "CODEX_CLI_BUNDLE_SOURCE=..." "Embed an installed Codex CLI package in a local AppImage"
 	@printf '  %-18s %s\n' "MAX_BUILD_THREADS=8" "Set supported build jobs/compression threads (default: 0, tool/user defaults)"
 	@printf '  %-18s %s\n' "RPM_BINARY_PAYLOAD=..." "Advanced RPM payload flags override (default follows MAX_BUILD_THREADS)"
 	@printf '  %-18s %s\n' "APPIMAGETOOL=..." "Override the appimagetool executable for make appimage"
@@ -126,6 +128,7 @@ help:
 	@printf '  %s\n' "make bootstrap-native"
 	@printf '  %s\n' "make install-native"
 	@printf '  %s\n' "PACKAGE_WITH_UPDATER=0 make update-native"
+	@printf '  %s\n' "CODEX_CLI_BUNDLE_SOURCE=/path/to/node_modules/@openai/codex make appimage"
 	@printf '  %s\n' "make inspect-upstream DMG=/tmp/Codex.dmg"
 	@printf '  %s\n' "make inspect-upstream-intel DMG=/tmp/Codex-new.dmg"
 	@printf '  %s\n' "make inspect-upstream-intel-devcontainer"
@@ -282,7 +285,7 @@ pacman: maybe-build-updater
 
 appimage:
 	@echo "[make] Building AppImage"
-	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" ./scripts/build-appimage.sh
+	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" PACKAGE_VERSION="$(or $(PACKAGE_VERSION),)" CODEX_CLI_BUNDLE_SOURCE="$(CODEX_CLI_BUNDLE_SOURCE)" ./scripts/build-appimage.sh
 
 package: maybe-build-updater
 	@echo "[make] Building native package (auto-detecting distro)"

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ order, and logs the resolved CLI path plus best-effort version so GUI PATH
 issues are visible. Set `CODEX_CLI_PATH=/path/to/codex` when you want to pin a
 specific binary.
 
+Local AppImage builds can optionally embed that CLI and its matching Linux
+platform package. Set `CODEX_CLI_BUNDLE_SOURCE` to an installed
+`node_modules/@openai/codex` directory when running `make appimage`; explicit
+`CODEX_CLI_PATH` values still take precedence at runtime. See
+[Build and packaging](docs/build-and-packaging.md#appimage-local-self-build).
+
 X11 and Wayland sessions are supported. The launcher prefers XWayland on
 Wayland when available for better Electron popup positioning, then falls back
 to Electron's automatic Wayland handling. See

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -164,6 +164,22 @@ make appimage
 The AppImage flow does not include `codex-update-manager`, the systemd user
 service, polkit policy, or the native-package update builder.
 
+To make a local AppImage self-contained, install the CLI with its optional
+Linux package and pass the package directory to the AppImage build:
+
+```bash
+cli_prefix="$HOME/.cache/codex-desktop-linux/appimage-cli"
+npm install --prefix "$cli_prefix" --include=optional @openai/codex
+CODEX_CLI_BUNDLE_SOURCE="$cli_prefix/node_modules/@openai/codex" make appimage
+```
+
+The build copies only `@openai/codex` and the matching Linux architecture
+package on x86-64 and ARM64. It does not fetch packages itself. The bundled CLI
+is used when `CODEX_CLI_PATH` is unset and takes precedence over a host
+installation. This adds the native CLI payload to the AppImage, which is several
+hundred MiB for current releases. Rebuild the AppImage when you want to update
+the embedded CLI.
+
 When upstream ChatGPT Desktop changes:
 
 ```bash

--- a/packaging/appimage/AppRun
+++ b/packaging/appimage/AppRun
@@ -20,4 +20,10 @@ resolve_appdir() {
 APPDIR="${APPDIR:-$(resolve_appdir)}"
 export APPDIR
 
+bundled_cli="$APPDIR/opt/__PACKAGE_NAME__/resources/codex-cli/bin/codex"
+if [ -z "${CODEX_CLI_PATH:-}" ] && [ -x "$bundled_cli" ]; then
+    CODEX_CLI_PATH="$bundled_cli"
+    export CODEX_CLI_PATH
+fi
+
 exec "$APPDIR/opt/__PACKAGE_NAME__/start.sh" "$@"

--- a/packaging/appimage/codex-cli-wrapper.sh
+++ b/packaging/appimage/codex-cli-wrapper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOURCES_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NODE_BIN="$RESOURCES_DIR/node-runtime/bin/node"
+CODEX_ENTRYPOINT="$RESOURCES_DIR/codex-cli/node_modules/@openai/codex/bin/codex.js"
+
+[ -x "$NODE_BIN" ] || {
+    echo "Bundled Codex CLI cannot find the managed Node.js runtime: $NODE_BIN" >&2
+    exit 127
+}
+[ -f "$CODEX_ENTRYPOINT" ] || {
+    echo "Bundled Codex CLI entrypoint is missing: $CODEX_ENTRYPOINT" >&2
+    exit 127
+}
+
+exec "$NODE_BIN" "$CODEX_ENTRYPOINT" "$@"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -11,6 +11,7 @@ APPDIR="${APPIMAGE_APPDIR_OVERRIDE:-$REPO_DIR/dist/appimage.AppDir}"
 APPRUN_TEMPLATE="$REPO_DIR/packaging/appimage/AppRun"
 DESKTOP_TEMPLATE="$REPO_DIR/packaging/appimage/codex-desktop.desktop"
 APPIMAGE_RUNTIME_TEMPLATE="$REPO_DIR/packaging/appimage/codex-appimage-runtime.sh"
+CODEX_CLI_WRAPPER_TEMPLATE="$REPO_DIR/packaging/appimage/codex-cli-wrapper.sh"
 PACKAGE_NAME="${PACKAGE_NAME:-codex-desktop}"
 PACKAGE_DISPLAY_NAME="${PACKAGE_DISPLAY_NAME:-ChatGPT}"
 PACKAGE_COMMENT="${PACKAGE_COMMENT:-Run ChatGPT Desktop on Linux}"
@@ -59,7 +60,100 @@ render_template() {
         "$source" > "$target"
 }
 
+stage_bundled_codex_cli() {
+    local arch="$1"
+    local target="$APPDIR/opt/$PACKAGE_NAME/resources/codex-cli"
+    local cli_source="${CODEX_CLI_BUNDLE_SOURCE:-}"
+    local platform_package
+    local platform_suffix
+    local target_triple
+    local platform_source
+    local unsupported_path
+    local symlink_path
+
+    [ -n "$cli_source" ] || return 0
+    rm -rf "$target"
+
+    case "$arch" in
+        x86_64)
+            platform_package="codex-linux-x64"
+            platform_suffix="linux-x64"
+            target_triple="x86_64-unknown-linux-musl"
+            ;;
+        aarch64)
+            platform_package="codex-linux-arm64"
+            platform_suffix="linux-arm64"
+            target_triple="aarch64-unknown-linux-musl"
+            ;;
+        *)
+            error "Bundling the Codex CLI is not supported for AppImage architecture: $arch"
+            ;;
+    esac
+
+    [ -d "$cli_source" ] || error "Missing bundled Codex CLI package: $cli_source"
+    cli_source="$(readlink -f -- "$cli_source")" \
+        || error "Unable to resolve bundled Codex CLI package: $cli_source"
+    platform_source="$(dirname "$cli_source")/$platform_package"
+    [ -d "$platform_source" ] || error "Missing bundled Codex CLI platform package: $platform_source"
+    platform_source="$(readlink -f -- "$platform_source")" \
+        || error "Unable to resolve bundled Codex CLI platform package: $platform_source"
+
+    ensure_file_exists "$cli_source/package.json" "bundled Codex CLI package metadata"
+    ensure_file_exists "$cli_source/bin/codex.js" "bundled Codex CLI entrypoint"
+    ensure_file_exists "$platform_source/package.json" "bundled Codex CLI platform metadata"
+    [ -x "$platform_source/vendor/$target_triple/bin/codex" ] \
+        || error "Missing executable bundled Codex CLI binary: $platform_source/vendor/$target_triple/bin/codex"
+
+    for source_dir in "$cli_source" "$platform_source"; do
+        symlink_path="$(find "$source_dir" -type l -print -quit 2>/dev/null || true)"
+        [ -z "$symlink_path" ] \
+            || error "Bundled Codex CLI package contains a symlink: $symlink_path"
+        unsupported_path="$(find "$source_dir" ! -type d ! -type f -print -quit 2>/dev/null || true)"
+        [ -z "$unsupported_path" ] \
+            || error "Bundled Codex CLI package contains an unsupported filesystem entry: $unsupported_path"
+    done
+
+    command -v python3 >/dev/null 2>&1 || error "python3 is required to validate bundled Codex CLI metadata"
+    python3 - \
+        "$cli_source/package.json" \
+        "$platform_source/package.json" \
+        "$platform_package" \
+        "$platform_suffix" <<'PY'
+import json
+import sys
+
+cli_path, platform_path, platform_package, platform_suffix = sys.argv[1:]
+try:
+    with open(cli_path, encoding="utf-8") as handle:
+        cli = json.load(handle)
+    with open(platform_path, encoding="utf-8") as handle:
+        platform = json.load(handle)
+except (OSError, ValueError) as exc:
+    raise SystemExit(f"Invalid bundled Codex CLI package metadata: {exc}")
+
+version = cli.get("version")
+dependency = cli.get("optionalDependencies", {}).get(f"@openai/{platform_package}")
+expected_dependency = f"npm:@openai/codex@{version}-{platform_suffix}"
+if cli.get("name") != "@openai/codex" or not isinstance(version, str) or not version:
+    raise SystemExit("Invalid bundled Codex CLI package identity")
+if dependency != expected_dependency:
+    raise SystemExit(
+        f"Bundled Codex CLI does not require the matching {platform_package} package"
+    )
+if platform.get("name") != "@openai/codex" or platform.get("version") != f"{version}-{platform_suffix}":
+    raise SystemExit("Bundled Codex CLI platform package version does not match the CLI package")
+PY
+
+    info "Bundling Codex CLI from $cli_source"
+    mkdir -p "$target/bin" "$target/node_modules/@openai"
+    cp -aT "$cli_source" "$target/node_modules/@openai/codex"
+    cp -aT "$platform_source" "$target/node_modules/@openai/$platform_package"
+    cp "$CODEX_CLI_WRAPPER_TEMPLATE" "$target/bin/codex"
+    chmod 0755 "$target/bin/codex"
+}
+
 prepare_appdir() {
+    local arch="$1"
     info "Preparing AppDir at $APPDIR"
     rm -rf "$APPDIR"
     mkdir -p \
@@ -69,6 +163,7 @@ prepare_appdir() {
 
     cp -aT "$APP_DIR" "$APPDIR/opt/$PACKAGE_NAME"
     mkdir -p "$APPDIR/opt/$PACKAGE_NAME/.codex-linux"
+    stage_bundled_codex_cli "$arch"
 
     render_template "$APPRUN_TEMPLATE" "$APPDIR/AppRun"
     chmod 0755 "$APPDIR/AppRun"
@@ -93,6 +188,7 @@ main() {
     ensure_file_exists "$APPRUN_TEMPLATE" "AppImage AppRun template"
     ensure_file_exists "$DESKTOP_TEMPLATE" "AppImage desktop template"
     ensure_file_exists "$APPIMAGE_RUNTIME_TEMPLATE" "AppImage runtime helper template"
+    ensure_file_exists "$CODEX_CLI_WRAPPER_TEMPLATE" "AppImage Codex CLI wrapper template"
     ensure_file_exists "$ICON_SOURCE" "icon"
 
     local arch
@@ -102,7 +198,7 @@ main() {
     appimagetool="$(resolve_appimagetool)"
     output_file="$DIST_DIR/${PACKAGE_NAME}-${PACKAGE_VERSION}-${arch}.AppImage"
 
-    prepare_appdir
+    prepare_appdir "$arch"
 
     mkdir -p "$DIST_DIR"
     rm -f "$output_file"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1378,11 +1378,27 @@ test_appimage_builder_smoke() {
     local dist_dir="$workspace/dist"
     local appdir="$workspace/codex-desktop.AppDir"
     local capture_dir="$workspace/capture"
+    local cli_root="$workspace/cli/node_modules/@openai"
+    local cli_source="$cli_root/codex"
+    local platform_source
+    local platform_package
+    local target_triple
+    local platform_version_suffix
     local arch
 
     case "$(uname -m)" in
-        x86_64) arch="x86_64" ;;
-        aarch64|arm64) arch="aarch64" ;;
+        x86_64)
+            arch="x86_64"
+            platform_package="codex-linux-x64"
+            target_triple="x86_64-unknown-linux-musl"
+            platform_version_suffix="linux-x64"
+            ;;
+        aarch64|arm64)
+            arch="aarch64"
+            platform_package="codex-linux-arm64"
+            target_triple="aarch64-unknown-linux-musl"
+            platform_version_suffix="linux-arm64"
+            ;;
         armv7l|armhf) arch="armhf" ;;
         *) fail "Unsupported AppImage smoke-test architecture: $(uname -m)" ;;
     esac
@@ -1390,6 +1406,8 @@ test_appimage_builder_smoke() {
     mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
+    mkdir -p "$app_dir/resources/codex-cli"
+    printf '%s\n' 'upstream-payload' > "$app_dir/resources/codex-cli/preserve.txt"
 
     cat > "$bin_dir/appimagetool" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -1438,6 +1456,8 @@ SCRIPT
     assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-desktop.png"
     assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh"
     assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/resources/node-runtime/bin/node"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/preserve.txt"
+    assert_file_not_exists "$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/bin/codex"
     assert_file_not_exists "$capture_dir/AppDir/usr/bin/codex-update-manager"
     assert_file_not_exists "$capture_dir/AppDir/usr/lib/systemd/user/codex-update-manager.service"
     assert_file_not_exists "$capture_dir/AppDir/usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy"
@@ -1452,6 +1472,131 @@ SCRIPT
     assert_not_contains "$capture_dir/AppDir/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh" "/usr/share/applications"
     [ "$(cat "$capture_dir/arch")" = "$arch" ] || fail "Expected appimagetool ARCH=$arch"
     [ "$(cat "$capture_dir/version")" = "2026.03.24.120000+appimage" ] || fail "Expected appimagetool VERSION override"
+
+    if [ "$arch" = "armhf" ]; then
+        return 0
+    fi
+
+    platform_source="$cli_root/$platform_package"
+    mkdir -p \
+        "$cli_source/bin" \
+        "$platform_source/vendor/$target_triple/bin"
+    printf '%s\n' \
+        '{' \
+        '  "name": "@openai/codex",' \
+        '  "version": "0.144.1",' \
+        '  "bin": {"codex": "bin/codex.js"},' \
+        "  \"optionalDependencies\": {\"@openai/$platform_package\": \"npm:@openai/codex@0.144.1-$platform_version_suffix\"}" \
+        '}' > "$cli_source/package.json"
+    printf '%s\n' '#!/usr/bin/env node' 'console.log("fixture");' > "$cli_source/bin/codex.js"
+    printf '%s\n' \
+        '{' \
+        '  "name": "@openai/codex",' \
+        "  \"version\": \"0.144.1-$platform_version_suffix\"" \
+        '}' > "$platform_source/package.json"
+    printf '%s\n' '#!/usr/bin/env bash' 'echo fixture-native-codex' > "$platform_source/vendor/$target_triple/bin/codex"
+    chmod 0755 "$platform_source/vendor/$target_triple/bin/codex"
+
+    rm -rf "$capture_dir"
+    mkdir -p "$capture_dir"
+    PATH="$bin_dir:$PATH" \
+    CAPTURE_DIR="$capture_dir" \
+    APP_DIR_OVERRIDE="$app_dir" \
+    DIST_DIR_OVERRIDE="$dist_dir" \
+    APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+    CODEX_CLI_BUNDLE_SOURCE="$cli_source" \
+    PACKAGE_VERSION="2026.03.24.120000+appimage-cli" \
+    bash "$REPO_DIR/scripts/build-appimage.sh"
+
+    local bundled_cli="$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/bin/codex"
+    assert_file_exists "$bundled_cli"
+    assert_file_not_exists "$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/preserve.txt"
+    [ -x "$bundled_cli" ] || fail "Expected bundled Codex CLI wrapper to be executable"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/node_modules/@openai/codex/bin/codex.js"
+    assert_file_exists "$capture_dir/AppDir/opt/codex-desktop/resources/codex-cli/node_modules/@openai/$platform_package/vendor/$target_triple/bin/codex"
+    assert_contains "$capture_dir/AppDir/AppRun" "resources/codex-cli/bin/codex"
+    assert_contains "$capture_dir/AppDir/AppRun" "export CODEX_CLI_PATH"
+
+    printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "${CODEX_CLI_PATH:-}"' > "$capture_dir/AppDir/opt/codex-desktop/start.sh"
+    chmod 0755 "$capture_dir/AppDir/opt/codex-desktop/start.sh"
+    local app_run_output
+    app_run_output="$(env -i PATH=/usr/bin:/bin HOME="$workspace/home" APPDIR="$capture_dir/AppDir" "$capture_dir/AppDir/AppRun")"
+    [ "$app_run_output" = "$bundled_cli" ] || fail "Expected AppRun to select bundled Codex CLI: $app_run_output"
+    app_run_output="$(env -i PATH=/usr/bin:/bin HOME="$workspace/home" APPDIR="$capture_dir/AppDir" CODEX_CLI_PATH=/custom/codex "$capture_dir/AppDir/AppRun")"
+    [ "$app_run_output" = "/custom/codex" ] || fail "Expected explicit CODEX_CLI_PATH to override bundled CLI: $app_run_output"
+    [ "$("$bundled_cli" --version)" = "v22.22.2" ] || fail "Expected bundled CLI wrapper to use the managed Node runtime"
+
+    rm -rf "$platform_source" "$capture_dir"
+    mkdir -p "$capture_dir"
+    local missing_platform_log="$workspace/missing-platform.log"
+    if PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+        CODEX_CLI_BUNDLE_SOURCE="$cli_source" \
+        PACKAGE_VERSION="2026.03.24.120000+appimage-cli-missing" \
+        bash "$REPO_DIR/scripts/build-appimage.sh" >"$missing_platform_log" 2>&1; then
+        fail "AppImage build should reject a Codex CLI bundle without its Linux platform package"
+    fi
+    assert_contains "$missing_platform_log" "Missing bundled Codex CLI platform package"
+
+    mkdir -p "$platform_source/vendor/$target_triple/bin"
+    printf '%s\n' \
+        '{' \
+        '  "name": "@openai/codex",' \
+        "  \"version\": \"0.144.1-$platform_version_suffix\"" \
+        '}' > "$platform_source/package.json"
+    printf '%s\n' '#!/usr/bin/env bash' 'echo fixture-native-codex' > "$platform_source/vendor/$target_triple/bin/codex"
+    chmod 0755 "$platform_source/vendor/$target_triple/bin/codex"
+    ln -s package.json "$cli_source/package-link.json"
+
+    local symlink_log="$workspace/symlink.log"
+    if PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+        CODEX_CLI_BUNDLE_SOURCE="$cli_source" \
+        PACKAGE_VERSION="2026.03.24.120000+appimage-cli-symlink" \
+        bash "$REPO_DIR/scripts/build-appimage.sh" >"$symlink_log" 2>&1; then
+        fail "AppImage build should reject symlinks inside a bundled Codex CLI package"
+    fi
+    assert_contains "$symlink_log" "Bundled Codex CLI package contains a symlink"
+    rm "$cli_source/package-link.json"
+
+    mkfifo "$cli_source/unsupported.pipe"
+    local unsupported_entry_log="$workspace/unsupported-entry.log"
+    if PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+        CODEX_CLI_BUNDLE_SOURCE="$cli_source" \
+        PACKAGE_VERSION="2026.03.24.120000+appimage-cli-fifo" \
+        bash "$REPO_DIR/scripts/build-appimage.sh" >"$unsupported_entry_log" 2>&1; then
+        fail "AppImage build should reject unsupported filesystem entries in a bundled Codex CLI package"
+    fi
+    assert_contains "$unsupported_entry_log" "Bundled Codex CLI package contains an unsupported filesystem entry"
+    rm "$cli_source/unsupported.pipe"
+
+    printf '%s\n' \
+        '{' \
+        '  "name": "@openai/codex",' \
+        "  \"version\": \"0.143.0-$platform_version_suffix\"" \
+        '}' > "$platform_source/package.json"
+    local version_log="$workspace/version.log"
+    if PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        APPIMAGE_APPDIR_OVERRIDE="$appdir" \
+        CODEX_CLI_BUNDLE_SOURCE="$cli_source" \
+        PACKAGE_VERSION="2026.03.24.120000+appimage-cli-version" \
+        bash "$REPO_DIR/scripts/build-appimage.sh" >"$version_log" 2>&1; then
+        fail "AppImage build should reject mismatched Codex CLI package versions"
+    fi
+    assert_contains "$version_log" "Bundled Codex CLI platform package version does not match"
 }
 
 test_missing_input_failure() {


### PR DESCRIPTION
Thanks for the detailed AppImage report in #824.

This adds an opt-in AppImage-only path for bundling the Codex CLI. `make appimage` can now take `CODEX_CLI_BUNDLE_SOURCE` pointing at an installed `node_modules/@openai/codex` package. The builder validates the matching Linux optional package, stages both package trees under `resources/codex-cli`, and lets AppRun use the bundled wrapper when `CODEX_CLI_PATH` is not already set.

I kept the build explicit. It does not fetch npm packages by itself, and native packages keep their current updater/install flow.

Fixes #824.

Checks run

- `bash -n scripts/build-appimage.sh packaging/appimage/AppRun packaging/appimage/codex-cli-wrapper.sh tests/scripts_smoke.sh`
- `git diff --check`
- `bash tests/scripts_smoke.sh`
- `make check`
- `make test`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- real npm install dry-run for `@openai/codex@0.144.1`, then AppImage build dry-run with the captured AppDir
