### PR TITLE
fix(nix): include libnotify for desktop notifications

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -294,6 +294,7 @@
           libxi
           libxtst
           libxscrnsaver
+          libnotify
           libglvnd
           systemd
           wayland


### PR DESCRIPTION
## Summary

- add `libnotify` to the Nix Electron runtime library set
- make Electron's dynamically loaded Linux notification backend available through the existing RPATH and `LD_LIBRARY_PATH` wiring

## Root cause

Electron loads `libnotify.so.*` with `dlopen()` before creating its Linux notification presenter. Because `libnotify` was absent from `electronLibs`, NixOS could not resolve the library and `Notification.isSupported()` returned `false` before the desktop notification daemon was contacted.

## Impact

Native permission and turn-complete notifications can reach the active `org.freedesktop.Notifications` service on NixOS. Other package formats are unchanged.

Fixes #827

## Checks

- `git diff --check`
- Nix evaluation/build not run locally because the `nix` CLI is unavailable in the agent environment; the draft PR's `Nix Package Builds` check will validate the package
