### PR TITLE
Fix ui-tweaks targets for current DMG

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -11,6 +11,7 @@ on:
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
       - linux-features/remote-mobile-control/**
+      - linux-features/ui-tweaks/**
       - scripts/ci/validate-patch-report.js
       - .github/workflows/upstream-build-app.yml
   push:
@@ -23,6 +24,7 @@ on:
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
       - linux-features/remote-mobile-control/**
+      - linux-features/ui-tweaks/**
       - scripts/ci/validate-patch-report.js
       - .github/workflows/upstream-build-app.yml
   workflow_dispatch:
@@ -142,7 +144,7 @@ jobs:
       - name: Validate required upstream patches
         run: node scripts/ci/validate-patch-report.js patch-report.json --profile upstream-build
 
-      - name: Inspect upstream DMG with remote mobile control enabled
+      - name: Inspect upstream DMG with drift-sensitive features enabled
         run: |
           set -euo pipefail
 
@@ -150,7 +152,7 @@ jobs:
           report_dir="$GITHUB_WORKSPACE/remote-mobile-upstream-inspect"
           trap 'rm -f "$features_config"' EXIT
 
-          printf '%s\n' '{"enabled":["remote-mobile-control"]}' > "$features_config"
+          printf '%s\n' '{"enabled":["remote-mobile-control","ui-tweaks"]}' > "$features_config"
 
           CODEX_LINUX_FEATURES_CONFIG="$features_config" \
             make inspect-upstream DMG="$UPSTREAM_DMG_PATH" REBUILD_REPORT_DIR="$report_dir"
@@ -158,12 +160,19 @@ jobs:
           node scripts/ci/validate-patch-report.js "$report_dir/patch-report.json" \
             --profile upstream-build \
             --require-enabled-feature remote-mobile-control \
+            --require-enabled-feature ui-tweaks \
             --require-applied linux-app-server-conversation-hydration \
             --require-applied linux-completed-item-recovery \
             --require-applied feature:remote-mobile-control:linux-remote-control-load-gate \
             --require-success feature:remote-mobile-control:linux-remote-mobile-conversation-hydration \
             --require-applied feature:remote-mobile-control:linux-remote-control-status-read-guard \
-            --require-applied feature:remote-mobile-control:linux-remote-control-status-wait
+            --require-applied feature:remote-mobile-control:linux-remote-control-status-wait \
+            --require-applied feature:ui-tweaks:sidebar-project-name-style \
+            --require-applied feature:ui-tweaks:model-picker-default-advanced-view \
+            --require-applied feature:ui-tweaks:model-picker-include-gpt-5-6 \
+            --require-applied feature:ui-tweaks:model-picker-inline-model-list \
+            --require-applied feature:ui-tweaks:model-picker-dynamic-supported-reasoning-efforts \
+            --require-applied feature:ui-tweaks:reasoning-effort-labels-english
 
       - name: Upload upstream DMG metadata artifact
         # The build step now aborts on critical patch failures; keep uploading

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -1,9 +1,11 @@
 "use strict";
 
 const MODEL_PICKER_STATE_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
+  /^app-initial~app-main~page-[^.]+\.js$/;
+const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-[^.]+\.js$/;
 const MODEL_PICKER_MENU_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/;
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-[^.]+\.js$/;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =
@@ -240,8 +242,8 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_795,
     ciPolicy: "optional",
-    pattern: MODEL_PICKER_MENU_ASSET_PATTERN,
-    missingDescription: "composer model picker menu bundle",
+    pattern: MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
+    missingDescription: "composer model picker allowlist bundle",
     skipDescription: "ui-tweaks GPT-5.6 model allowlist patch",
     apply: (source, context = {}) =>
       applyGpt56AllowlistPatch(source, { ...context, warnOnMissingMarkers: true }),
@@ -280,6 +282,7 @@ module.exports = {
   GPT_56_ALLOWLIST_MARKER,
   INLINE_MODEL_LIST_RUNTIME_MARKER,
   MODEL_ALLOWLIST_MARKER,
+  MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   MODEL_PICKER_MENU_ASSET_PATTERN,
   MODEL_PICKER_STATE_ASSET_PATTERN,
   MODEL_ROW_MARKER,

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -17,6 +17,7 @@ const {
   GPT_56_ALLOWLIST_MARKER,
   INLINE_MODEL_LIST_RUNTIME_MARKER,
   MODEL_ALLOWLIST_MARKER,
+  MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   MODEL_PICKER_MENU_ASSET_PATTERN,
   MODEL_PICKER_STATE_ASSET_PATTERN,
   SIMPLE_MENU_VIEW_PATTERN,
@@ -179,19 +180,27 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
 
 test("model picker descriptors target the current state and menu bundles", () => {
   assert.match(
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    "app-initial~app-main~page-hSvsQcNf.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
   assert.match(
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-CqMu8hJo.js",
+    MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
+  );
+  assert.match(
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-BqYcBFmq.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~page-BF1QkwFT.js",
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~page-BF1QkwFT.js",
+    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
+    MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
+  );
+  assert.doesNotMatch(
+    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
 });


### PR DESCRIPTION
## Summary

- retarget the UI Tweaks model-picker descriptors to the current upstream DMG chunks
- split the GPT-5.6 allowlist target from the inline model list and reasoning-effort target
- remove obsolete chunk shapes from the tests

## Root cause

The latest upstream DMG moved the model-picker state, allowlist, and menu implementations into three different chunks. Because `ui-tweaks` is disabled by default, the normal upstream-build job did not expose the four skipped optional patches.

## User impact

Builds with `ui-tweaks` enabled once again apply all six feature patches, including the advanced model picker, GPT-5.6 visibility, inline model list, and dynamic supported reasoning efforts.

## Validation

- `node --test linux-features/ui-tweaks/test.js` (21 passed)
- `node --test linux-features/*/test.js` (506 passed)
- clean `./install.sh` against the current DMG with `codex-wrapper-updater`, `remote-mobile-control`, `read-aloud`, and `ui-tweaks` enabled
- patch summary: `feature ui-tweaks: applied=6`, no skipped optional feature patches
- `git diff --check`
