### PR TITLE
test(appimage): resolve smoke launchers from host Bash

### DIFF
--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1520,11 +1520,13 @@ SCRIPT
     printf '%s\n' '#!/usr/bin/env bash' 'printf "%s\n" "${CODEX_CLI_PATH:-}"' > "$capture_dir/AppDir/opt/codex-desktop/start.sh"
     chmod 0755 "$capture_dir/AppDir/opt/codex-desktop/start.sh"
     local app_run_output
-    app_run_output="$(env -i PATH=/usr/bin:/bin HOME="$workspace/home" APPDIR="$capture_dir/AppDir" "$capture_dir/AppDir/AppRun")"
+    local app_run_path
+    app_run_path="$(dirname "$BASH_BIN")"
+    app_run_output="$(env -i PATH="$app_run_path" HOME="$workspace/home" APPDIR="$capture_dir/AppDir" "$BASH_BIN" "$capture_dir/AppDir/AppRun")"
     [ "$app_run_output" = "$bundled_cli" ] || fail "Expected AppRun to select bundled Codex CLI: $app_run_output"
-    app_run_output="$(env -i PATH=/usr/bin:/bin HOME="$workspace/home" APPDIR="$capture_dir/AppDir" CODEX_CLI_PATH=/custom/codex "$capture_dir/AppDir/AppRun")"
+    app_run_output="$(env -i PATH="$app_run_path" HOME="$workspace/home" APPDIR="$capture_dir/AppDir" CODEX_CLI_PATH=/custom/codex "$BASH_BIN" "$capture_dir/AppDir/AppRun")"
     [ "$app_run_output" = "/custom/codex" ] || fail "Expected explicit CODEX_CLI_PATH to override bundled CLI: $app_run_output"
-    [ "$("$bundled_cli" --version)" = "v22.22.2" ] || fail "Expected bundled CLI wrapper to use the managed Node runtime"
+    [ "$("$BASH_BIN" "$bundled_cli" --version)" = "v22.22.2" ] || fail "Expected bundled CLI wrapper to use the managed Node runtime"
 
     rm -rf "$platform_source" "$capture_dir"
     mkdir -p "$capture_dir"


### PR DESCRIPTION
## Summary

- run the AppImage `AppRun` smoke fixture through the absolute host Bash already resolved by the test harness
- restrict the isolated fixture `PATH` to that Bash directory
- exercise the bundled Codex CLI wrapper through the same host Bash

## Why

The bundled-CLI AppImage smoke test directly executed generated scripts whose production shebang is `#!/bin/bash`. On hosts without `/bin/bash`, including NixOS, the test stopped with `ENOENT` before it could verify bundled CLI selection or the explicit override.

This changes only the host-side smoke fixture. Production `AppRun` and CLI wrapper scripts remain unchanged, and their executable modes are still asserted.

## Validation

- reproduced the NixOS failure at the first direct `AppRun` invocation
- verified the same failure independently at the second `AppRun` invocation and bundled CLI wrapper before updating each sister call site
- `nix develop -c bash tests/scripts_smoke.sh`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`
- independent full-diff review: pass; no findings

## Checklist

- [x] The change is limited to the host-side AppImage smoke fixture.
- [x] Production AppImage scripts remain unchanged.
- [x] Full local validation and independent review passed.
- [x] All required GitHub checks passed.
