### PR TITLE
Fix stale streaming state after completed thread resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Resuming a completed thread no longer leaves it registered as streaming when
+  the app server reports no active runtime. This clears stale stream ownership
+  before the next message instead of leaving the renderer in a repeated thread
+  history refresh path.
 - Linux settings search no longer shows unavailable macOS Dock icon controls or
   Suggested prompts results that do not render in the generated Linux settings
   page.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5815,6 +5815,67 @@ test("discovers current app-server conversation core Linux webview patches", () 
   }
 });
 
+test("does not retain streaming ownership when a completed thread resumes without an active runtime", () => {
+  const source = [
+    "async function resume(e,t,L,ue,b){",
+    "e.updateConversationState(t,t=>{t.threadRuntimeStatus=L.thread.status});",
+    "let de=ue.at(-1)??null;e.markConversationStreaming(t),e.setConversationStreamRole(t,{role:`owner`}),b&&e.releaseResumeNotificationBuffer(t);",
+    "let fe=e.broadcastConversationSnapshot(t);",
+    "K.info(`maybe_resume_success`,{safe:{conversationId:t,turnCount:ue.length,latestTurnId:de?.turnId??null,latestTurnStatus:de?.status??null,markedStreaming:!0,assignedStreamRole:e.getStreamRole(t)?.role??null}})",
+    "}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerConversationHydrationPatch, source);
+
+  assert.match(patched, /let codexLinuxResumeShouldStream=/);
+  assert.match(patched, /markedStreaming:codexLinuxResumeShouldStream/);
+
+  const context = {};
+  vm.runInNewContext(
+    [
+      "var logs=[];var K={info:(message,details)=>logs.push({message,details})};",
+      patched,
+      "function run(turnStatus,runtimeType){",
+      "logs=[];let state={marked:false,role:null,removed:false,broadcasts:0};",
+      "let manager={",
+      "conversation:{threadRuntimeStatus:{type:runtimeType}},",
+      "updateConversationState:(id,fn)=>fn(manager.conversation),",
+      "getConversation:()=>manager.conversation,",
+      "markConversationStreaming:()=>{state.marked=true},",
+      "setConversationStreamRole:(id,role)=>{state.role=role.role},",
+      "getStreamRole:()=>state.role==null?null:{role:state.role},",
+      "streamState:{removeConversation:()=>{state.removed=true;state.role=null}},",
+      "releaseResumeNotificationBuffer:()=>{},",
+      "broadcastConversationSnapshot:()=>{state.broadcasts+=1;return null}",
+      "};",
+      "resume(manager,`thread-1`,{thread:{status:{type:runtimeType}}},[{turnId:`turn-1`,status:turnStatus}],false);",
+      "return {state,markedStreaming:logs[0].details.safe.markedStreaming};",
+      "}",
+      "result={completedIdle:run(`completed`,`idle`),completedActive:run(`completed`,`active`),inProgressIdle:run(`inProgress`,`idle`),failedIdle:run(`failed`,`idle`)};",
+    ].join(""),
+    context,
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(context.result)), {
+    completedIdle: {
+      state: { marked: false, role: null, removed: true, broadcasts: 1 },
+      markedStreaming: false,
+    },
+    completedActive: {
+      state: { marked: true, role: "owner", removed: false, broadcasts: 1 },
+      markedStreaming: true,
+    },
+    inProgressIdle: {
+      state: { marked: true, role: "owner", removed: false, broadcasts: 1 },
+      markedStreaming: true,
+    },
+    failedIdle: {
+      state: { marked: true, role: "owner", removed: false, broadcasts: 1 },
+      markedStreaming: true,
+    },
+  });
+});
+
 test("recovers completed stream items that arrive after local state lost their started item", () => {
   const source = [
     "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;",

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -21,6 +21,7 @@ const LINUX_APP_SERVER_CONVERSATION_HYDRATION_UNKNOWN_TURN_MARKER = "codexLinuxR
 const LINUX_APP_SERVER_CONVERSATION_HYDRATION_QUEUE_MARKER = "codexLinuxRemoteMobileNotificationQueue";
 const LINUX_APP_SERVER_CONVERSATION_HYDRATION_IN_FLIGHT_MARKER = "codexLinuxRemoteMobileHydrationInFlight";
 const LINUX_APP_SERVER_CONVERSATION_HYDRATION_LATE_EVENT_MARKER = "codexLinuxRemoteMobileHydrateLateEvent";
+const LINUX_APP_SERVER_COMPLETED_RESUME_MARKER = "codexLinuxResumeShouldStream";
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -898,6 +899,41 @@ function buildLateUnknownConversationHydrationReplacement(eventName, conversatio
 
 function applyLinuxAppServerConversationHydrationPatch(currentSource) {
   let patchedSource = currentSource;
+
+  if (!patchedSource.includes(LINUX_APP_SERVER_COMPLETED_RESUME_MARKER)) {
+    const completedResumeStreamingNeedle =
+      /(let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.at\(-1\)\?\?null;)([A-Za-z_$][\w$]*)\.markConversationStreaming\(([A-Za-z_$][\w$]*)\),\4\.setConversationStreamRole\(\5,\{role:`owner`\}\),/u;
+    const resumeLogNeedle =
+      /latestTurnStatus:([A-Za-z_$][\w$]*)\?\.status\?\?null,markedStreaming:!0,assignedStreamRole:([A-Za-z_$][\w$]*)\.getStreamRole\(([A-Za-z_$][\w$]*)\)\?\.role\?\?null/u;
+    const streamMatch = completedResumeStreamingNeedle.exec(patchedSource);
+    const logMatch = resumeLogNeedle.exec(patchedSource);
+
+    if (
+      streamMatch != null &&
+      logMatch != null &&
+      logMatch[1] === streamMatch[2] &&
+      logMatch[2] === streamMatch[4] &&
+      logMatch[3] === streamMatch[5]
+    ) {
+      const [, prefix, latestTurnVar, , managerVar, conversationIdVar] = streamMatch;
+      patchedSource = patchedSource
+        .replace(
+          completedResumeStreamingNeedle,
+          `${prefix}let ${LINUX_APP_SERVER_COMPLETED_RESUME_MARKER}=${latestTurnVar}?.status!==\`completed\`||${managerVar}.getConversation(${conversationIdVar})?.threadRuntimeStatus?.type===\`active\`;${LINUX_APP_SERVER_COMPLETED_RESUME_MARKER}?(${managerVar}.markConversationStreaming(${conversationIdVar}),${managerVar}.setConversationStreamRole(${conversationIdVar},{role:\`owner\`})):${managerVar}.streamState.removeConversation(${conversationIdVar}),`,
+        )
+        .replace(
+          resumeLogNeedle,
+          `latestTurnStatus:${latestTurnVar}?.status??null,markedStreaming:${LINUX_APP_SERVER_COMPLETED_RESUME_MARKER},assignedStreamRole:${managerVar}.getStreamRole(${conversationIdVar})?.role??null`,
+        );
+    } else if (
+      patchedSource.includes("maybe_resume_success") &&
+      patchedSource.includes("markConversationStreaming")
+    ) {
+      console.warn(
+        "WARN: Could not find completed resume streaming insertion point — skipping Linux completed resume recovery patch",
+      );
+    }
+  }
 
   if (!patchedSource.includes(LINUX_APP_SERVER_CONVERSATION_HYDRATION_THREAD_RUNTIME_MARKER)) {
     const runtimeNeedle =


### PR DESCRIPTION
## Summary

- clear stale streaming ownership when a completed thread resumes without an active app-server runtime
- keep the existing ownership behavior for active runtimes and non-completed turns
- cover the resume states with a regression test and document the fix

## Why

The resume path currently marks every restored thread as streaming. For a completed thread with an idle runtime, that leaves an owner without an active turn and can trap the renderer in repeated history refreshes.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (362 passed)
- `bash tests/scripts_smoke.sh`
- `git diff --check`

Fixes #835
