### PR TITLE
Fix persistent status panel on current DMG

### DIFF
--- a/linux-features/persistent-status-panel/patch.js
+++ b/linux-features/persistent-status-panel/patch.js
@@ -37,6 +37,7 @@ function applyPersistentStatusPanelPatch(source) {
   }
 
   if (!source.includes("composer.statusSlashCommand.description")) {
+    console.warn("WARN: Could not find Codex status panel bundle marker - skipping persistent status panel patch");
     return source;
   }
 
@@ -76,7 +77,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_800,
     ciPolicy: "optional",
-    pattern: /^composer-.*\.js$/,
+    pattern: /^app-initial~app-main~page-.*\.js$/,
     missingDescription: "composer status panel bundle",
     skipDescription: "persistent status panel patch",
     apply: applyPersistentStatusPanelPatch,

--- a/linux-features/persistent-status-panel/test.js
+++ b/linux-features/persistent-status-panel/test.js
@@ -10,13 +10,15 @@ const test = require("node:test");
 const {
   loadLinuxFeaturePatchDescriptors,
 } = require("../../scripts/lib/linux-features.js");
+const { patchAssetFiles } = require("../../scripts/patches/lib/assets.js");
 const {
   STORAGE_KEY,
   applyPersistentStatusPanelPatch,
+  descriptors,
 } = require("./patch.js");
 
-const composerSource =
-  "function av(e){let t=(0,$.c)(26),{conversationId:n,threadId:r,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=(0,Z.useState)(!1),p;t[0]===s&&(p=1);let b,x;t[10]===o?(b=t[11],x=t[12]):(b=async()=>{l(!0),o?.(!0)},x=[o]);let y=s.formatMessage({id:`composer.statusSlashCommand.description`});if(!c)return null;let C;t[18]===o?C=t[19]:(C=()=>{l(!1),o?.(!1)});return C}";
+const currentComposerSource =
+  "function nW(e){let t=(0,iW.c)(26),{conversationId:n,threadId:r,rateLimit:i,onOpenChange:a}=e,o=Wr(),[s,c]=(0,aW.useState)(!1),{activeMode:l}=vm(n),u=l?.settings.model??null,d=Pn(Bc,n),f;t[0]===d?f=t[1]:(f=nR(d),t[0]=d,t[1]=f);let y,b;t[10]===a?(y=t[11],b=t[12]):(y=async()=>{c(!0),a?.(!0)},b=[a],t[10]=a,t[11]=y,t[12]=b);let v=o.formatMessage({id:`composer.statusSlashCommand.description`,defaultMessage:`Show task id, context usage, and rate limits`,description:`Description for the status slash command`}),x={id:`status`,title:`Status`,description:v,requiresEmptyComposer:!1,Icon:rE,onSelect:y,dependencies:b};if(CS(x),!s)return null;let S;t[18]===a?S=t[19]:(S=()=>{c(!1),a?.(!1)},t[18]=a,t[19]=S);return FU({threadId:r,onClose:S})}";
 
 function captureWarns(fn) {
   const originalWarn = console.warn;
@@ -67,19 +69,42 @@ test("feature is disabled until selected", () => {
 });
 
 test("status panel preference survives component remounts", () => {
-  const patched = applyPersistentStatusPanelPatch(composerSource);
+  const patched = applyPersistentStatusPanelPatch(currentComposerSource);
 
-  assert.notEqual(patched, composerSource);
+  assert.notEqual(patched, currentComposerSource);
   assert.match(patched, new RegExp(`localStorage\\.getItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
   assert.match(patched, new RegExp(`localStorage\\.setItem\\(\\\`${STORAGE_KEY}\\\`,\\\`1\\\`\\)`));
   assert.match(patched, new RegExp(`localStorage\\.removeItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
   assert.equal(applyPersistentStatusPanelPatch(patched), patched);
 });
 
+test("descriptor patches the current app-initial composer status bundle", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "persistent-status-panel-assets-"));
+  try {
+    const assetsDir = path.join(tempDir, "webview", "assets");
+    const assetPath = path.join(
+      assetsDir,
+      "app-initial~app-main~page-hSvsQcNf.js",
+    );
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(assetPath, currentComposerSource);
+
+    const result = patchAssetFiles(tempDir, descriptors[0].pattern, descriptors[0].apply, "missing");
+    const patched = fs.readFileSync(assetPath, "utf8");
+
+    assert.deepEqual(result, { matched: 1, changed: 1 });
+    assert.match(patched, new RegExp(`localStorage\\.getItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
+    assert.match(patched, new RegExp(`localStorage\\.setItem\\(\\\`${STORAGE_KEY}\\\`,\\\`1\\\`\\)`));
+    assert.match(patched, new RegExp(`localStorage\\.removeItem\\(\\\`${STORAGE_KEY}\\\`\\)`));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("ambiguous status panel handler needles are unchanged", () => {
-  const ambiguousSource = composerSource.replace(
-    "let y=s.formatMessage",
-    "let extraOpen=async()=>{l(!0),o?.(!0)},extraClose=()=>{l(!1),o?.(!1)},y=s.formatMessage",
+  const ambiguousSource = currentComposerSource.replace(
+    "let v=o.formatMessage",
+    "let extraOpen=async()=>{c(!0),a?.(!0)},extraClose=()=>{c(!1),a?.(!1)},v=o.formatMessage",
   );
 
   const { value: patched, warnings } = captureWarns(() =>
@@ -93,9 +118,9 @@ test("ambiguous status panel handler needles are unchanged", () => {
 });
 
 test("composer bundle with changed status state shape is unchanged", () => {
-  const changedStateSource = composerSource.replace(
-    "{conversationId:n,threadId:r,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=(0,Z.useState)(!1),",
-    "{threadId:r,conversationId:n,rateLimit:i,onOpenChange:o}=e,s=Wt(),[c,l]=Z.useState(!1),",
+  const changedStateSource = currentComposerSource.replace(
+    "{conversationId:n,threadId:r,rateLimit:i,onOpenChange:a}=e,o=Wr(),[s,c]=(0,aW.useState)(!1),",
+    "{threadId:r,conversationId:n,rateLimit:i,onOpenChange:a}=e,o=Wr(),[s,c]=aW.useState(!1),",
   );
 
   const { value: patched, warnings } = captureWarns(() =>
@@ -108,11 +133,13 @@ test("composer bundle with changed status state shape is unchanged", () => {
   ]);
 });
 
-test("unknown composer bundle is unchanged", () => {
+test("target bundle without status marker is unchanged and warns", () => {
   const { value: patched, warnings } = captureWarns(() =>
     applyPersistentStatusPanelPatch("unrelated bundle"),
   );
 
   assert.equal(patched, "unrelated bundle");
-  assert.deepEqual(warnings, []);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find Codex status panel bundle marker - skipping persistent status panel patch",
+  ]);
 });


### PR DESCRIPTION
## Summary

- retarget `persistent-status-panel` to the current unified app status bundle, `app-initial~app-main~page-*.js`
- keep the patch fail-soft when the current status bundle marker is absent, instead of letting unrelated matched assets look successful
- add a current-DMG descriptor test that verifies the patch actually changes the current bundle shape

## Reproduction

With only `persistent-status-panel` enabled, the old descriptor no longer reached the current unified app status component. The `/status` panel still opened, but its open state stayed component-local, so leaving the current task and returning remounted the composer without restoring the panel.

I also verified there is no open issue or PR covering this same `persistent-status-panel` / `/status` / composer status panel problem.

## Visible behavior validated

Current DMG runtime validation used a side-by-side app id and user data directory:

- app version: `26.707.41301`
- Sparkle build: `5103`
- DMG SHA256: `467a25381af2943f2c9b8794adae28b36400bd6da2753daf4889a5fd550c4d65`
- Electron: `42.1.0`
- base repo SHA tested from: `2d2bdf6dea79179e376958d94fb6f1b5ce03be53`
- environment: Ubuntu 25.10, KDE, Wayland session with X11 rendering override for the side-by-side test app

Runtime checks performed:

- patch report records `feature:persistent-status-panel:composer-status-state` as `applied`
- modified asset is `/content/webview/assets/app-initial~app-main~page-hSvsQcNf.js`
- opening `/status` stores `codex-linux-persistent-status-panel-open=1`
- switching between Codex tasks keeps the status panel visible
- Quick Chat overlay does not break the Codex status panel state
- `Sites` and `Pull requests` remove the panel from non-task surfaces, while returning to `New task` restores it
- normal app restart with the key set restores the panel
- explicit `Close` removes the key and, after graceful app close/restart, the panel stays closed
- side-by-side identities stayed isolated during runtime validation

## Validation

- `node --test linux-features/persistent-status-panel/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `node --check /tmp/codex-persistent-status-app-fixed/content/webview/assets/app-initial~app-main~page-hSvsQcNf.js`
- `node scripts/ci/validate-patch-report.js dist-next/rebuild/patch-report.json`
- isolated build with the current DMG and only `persistent-status-panel` enabled
- runtime CDP validation with screenshots captured for baseline, open, task switch, Quick Chat, non-task routes, restart, close, and closed restart states
- `git diff --check`

## Limits

This is intentionally scoped to the current upstream DMG shape and only the opt-in `persistent-status-panel` feature. It does not touch generated `codex-app/` output or any unrelated feature.
