### PR TITLE
Avoid parented project picker on Linux X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The Add Project folder picker is no longer parented to the Codex window on
+  Linux X11. This avoids a GNOME Shell modal input grab that could lock desktop
+  input and flood system logs, while preserving parented dialogs on Wayland,
+  macOS, and Windows.
 - Resuming a completed thread no longer leaves it registered as streaming when
   the app server reports no active runtime. This clears stale stream ownership
   before the next message instead of leaving the renderer in a repeated thread

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -94,6 +94,7 @@ const {
   applyLinuxTerminalUserPathPatch,
   applyLinuxWorkerFileManagerPatch,
   applyLinuxXdgDocumentsDirPatch,
+  applyLinuxX11ProjectPickerPatch,
   patchLinuxOwlFeatureBindingFallbackAssets,
 } = require("./patches/impl/main-process/misc.js");
 const {
@@ -1050,6 +1051,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-skills-list-dedupe",
     "linux-config-write-version-conflict",
     "linux-application-menu",
+    "linux-x11-project-picker",
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
     "linux-window-controls-safe-area",
@@ -1815,6 +1817,54 @@ test("adds Linux file manager support without relying on exact minified variable
   assert.match(patched, /linux:\{label:`File Manager`/);
   assert.match(patched, /detect:\(\)=>`linux-file-manager`/);
   assert.match(patched, /n\.shell\.openPath\(__codexOpenTarget\)/);
+});
+
+test("opens the project picker without a parent window on Linux X11", async () => {
+  const source =
+    "class T{async pickLocalWorkspaceRoots(e,t=!1){if(this.host.id!==`local`)throw Error(`local only`);let n=[`openDirectory`,`createDirectory`];t&&n.push(`multiSelections`),await this.shouldShowHiddenFilesInPicker()&&n.push(`showHiddenFiles`);let r={properties:n,title:`Select Project Root`},i=c.BrowserWindow.fromWebContents(e),a=i==null?await c.dialog.showOpenDialog(r):await c.dialog.showOpenDialog(i,r);return a.canceled?[]:(await Promise.all(a.filePaths.map(e=>this.resolveWorkspaceRoot(e)))).filter(e=>e!=null)}}";
+  const patched = applyPatchTwice(applyLinuxX11ProjectPickerPatch, source);
+
+  assert.match(patched, /codexLinuxUseUnparentedX11ProjectPicker/);
+
+  async function run(platform, env) {
+    const calls = [];
+    const context = {
+      process: { platform, env },
+      calls,
+      c: {
+        BrowserWindow: { fromWebContents: () => ({ id: "parent" }) },
+        dialog: {
+          showOpenDialog: async (...args) => {
+            calls.push(args);
+            return { canceled: false, filePaths: ["/tmp/project"] };
+          },
+        },
+      },
+    };
+    vm.runInNewContext(
+      `${patched};manager=new T;manager.host={id:\`local\`};manager.shouldShowHiddenFilesInPicker=async()=>false;manager.resolveWorkspaceRoot=async e=>e`,
+      context,
+    );
+    const roots = await context.manager.pickLocalWorkspaceRoots({});
+    return { argumentCount: calls[0].length, roots: Array.from(roots) };
+  }
+
+  assert.deepEqual(await run("linux", { XDG_SESSION_TYPE: " X11 ", DISPLAY: ":0" }), {
+    argumentCount: 1,
+    roots: ["/tmp/project"],
+  });
+  assert.deepEqual(await run("linux", { DISPLAY: ":0" }), {
+    argumentCount: 1,
+    roots: ["/tmp/project"],
+  });
+  assert.deepEqual(
+    await run("linux", { XDG_SESSION_TYPE: "wayland", DISPLAY: ":0", WAYLAND_DISPLAY: "wayland-0" }),
+    { argumentCount: 2, roots: ["/tmp/project"] },
+  );
+  assert.deepEqual(await run("darwin", {}), {
+    argumentCount: 2,
+    roots: ["/tmp/project"],
+  });
 });
 
 test("adds Linux file manager support to the worker open target registry", () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1096,6 +1096,10 @@ test("default core patch descriptors are grouped and unique", () => {
     "optional",
   );
   assert.equal(
+    descriptors.find((descriptor) => descriptor.id === "linux-x11-project-picker")?.ciPolicy,
+    "optional",
+  );
+  assert.equal(
     descriptors.find((descriptor) => descriptor.id === "linux-computer-use-native-desktop-apps")?.ciPolicy,
     "opt-in",
   );
@@ -1855,6 +1859,22 @@ test("opens the project picker without a parent window on Linux X11", async () =
   });
   assert.deepEqual(await run("linux", { DISPLAY: ":0" }), {
     argumentCount: 1,
+    roots: ["/tmp/project"],
+  });
+  assert.deepEqual(await run("linux", { DISPLAY: ":0", WAYLAND_DISPLAY: "wayland-0" }), {
+    argumentCount: 2,
+    roots: ["/tmp/project"],
+  });
+  assert.deepEqual(await run("linux", { XDG_SESSION_TYPE: "unknown", DISPLAY: ":0" }), {
+    argumentCount: 1,
+    roots: ["/tmp/project"],
+  });
+  assert.deepEqual(
+    await run("linux", { XDG_SESSION_TYPE: "unknown", DISPLAY: ":0", WAYLAND_DISPLAY: "wayland-0" }),
+    { argumentCount: 2, roots: ["/tmp/project"] },
+  );
+  assert.deepEqual(await run("linux", { XDG_SESSION_TYPE: " Wayland ", DISPLAY: ":0" }), {
+    argumentCount: 2,
     roots: ["/tmp/project"],
   });
   assert.deepEqual(

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -20,6 +20,7 @@ const {
   patchLinuxWorkerFileManagerTarget,
   applyLinuxTerminalUserPathPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
+  applyLinuxX11ProjectPickerPatch,
 } = require("../../../../impl/main-process/misc.js");
 const {
   applyLinuxBuildInfoTrayPatch,
@@ -91,6 +92,13 @@ module.exports = [
     order: 80,
     ciPolicy: "required-upstream",
     apply: applyLinuxOpaqueBackgroundPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-x11-project-picker",
+    phase: "main-bundle",
+    order: 82,
+    ciPolicy: "required-upstream",
+    apply: applyLinuxX11ProjectPickerPatch,
   }),
   mainBundlePatch({
     id: "linux-avatar-overlay-mouse-passthrough",

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -97,7 +97,7 @@ module.exports = [
     id: "linux-x11-project-picker",
     phase: "main-bundle",
     order: 82,
-    ciPolicy: "required-upstream",
+    ciPolicy: "optional",
     apply: applyLinuxX11ProjectPickerPatch,
   }),
   mainBundlePatch({

--- a/scripts/patches/impl/main-process/misc.js
+++ b/scripts/patches/impl/main-process/misc.js
@@ -79,7 +79,7 @@ function applyLinuxX11ProjectPickerPatch(currentSource) {
   const [, optionsVar, propertiesVar, parentVar, electronVar, webContentsVar, resultVar] = match;
   return currentSource.replace(
     pickerPattern,
-    `let ${optionsVar}={properties:${propertiesVar},title:\`Select Project Root\`},${parentVar}=${electronVar}.BrowserWindow.fromWebContents(${webContentsVar}),codexLinuxUseUnparentedX11ProjectPicker=process.platform===\`linux\`&&((process.env.XDG_SESSION_TYPE||\`\`).trim().toLowerCase()===\`x11\`||!process.env.WAYLAND_DISPLAY&&!!process.env.DISPLAY),${resultVar}=codexLinuxUseUnparentedX11ProjectPicker||${parentVar}==null?await ${electronVar}.dialog.showOpenDialog(${optionsVar}):await ${electronVar}.dialog.showOpenDialog(${parentVar},${optionsVar})`,
+    `let ${optionsVar}={properties:${propertiesVar},title:\`Select Project Root\`},${parentVar}=${electronVar}.BrowserWindow.fromWebContents(${webContentsVar}),codexLinuxSessionType=(process.env.XDG_SESSION_TYPE||\`\`).trim().toLowerCase(),codexLinuxUseUnparentedX11ProjectPicker=process.platform===\`linux\`&&(codexLinuxSessionType===\`x11\`||codexLinuxSessionType!==\`wayland\`&&!process.env.WAYLAND_DISPLAY&&!!process.env.DISPLAY),${resultVar}=codexLinuxUseUnparentedX11ProjectPicker||${parentVar}==null?await ${electronVar}.dialog.showOpenDialog(${optionsVar}):await ${electronVar}.dialog.showOpenDialog(${parentVar},${optionsVar})`,
   );
 }
 

--- a/scripts/patches/impl/main-process/misc.js
+++ b/scripts/patches/impl/main-process/misc.js
@@ -56,6 +56,33 @@ function applyLinuxFileManagerPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxX11ProjectPickerPatch(currentSource) {
+  if (currentSource.includes("codexLinuxUseUnparentedX11ProjectPicker")) {
+    return currentSource;
+  }
+
+  const pickerPattern =
+    /let ([A-Za-z_$][\w$]*)=\{properties:([A-Za-z_$][\w$]*),title:`Select Project Root`\},([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\.BrowserWindow\.fromWebContents\(([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)=\3==null\?await \4\.dialog\.showOpenDialog\(\1\):await \4\.dialog\.showOpenDialog\(\3,\1\)/u;
+  const match = pickerPattern.exec(currentSource);
+  if (match == null) {
+    if (
+      currentSource.includes("Select Project Root") &&
+      currentSource.includes("showOpenDialog")
+    ) {
+      console.warn(
+        "WARN: Could not find X11 project picker insertion point — skipping unparented X11 project picker patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [, optionsVar, propertiesVar, parentVar, electronVar, webContentsVar, resultVar] = match;
+  return currentSource.replace(
+    pickerPattern,
+    `let ${optionsVar}={properties:${propertiesVar},title:\`Select Project Root\`},${parentVar}=${electronVar}.BrowserWindow.fromWebContents(${webContentsVar}),codexLinuxUseUnparentedX11ProjectPicker=process.platform===\`linux\`&&((process.env.XDG_SESSION_TYPE||\`\`).trim().toLowerCase()===\`x11\`||!process.env.WAYLAND_DISPLAY&&!!process.env.DISPLAY),${resultVar}=codexLinuxUseUnparentedX11ProjectPicker||${parentVar}==null?await ${electronVar}.dialog.showOpenDialog(${optionsVar}):await ${electronVar}.dialog.showOpenDialog(${parentVar},${optionsVar})`,
+  );
+}
+
 function applyLinuxWorkerFileManagerPatch(currentSource) {
   const block = findCallBlock(currentSource, "id:`fileManager`");
   if (block == null) {
@@ -440,6 +467,7 @@ function applyLinuxLocalAppServerFeatureEnablementHandlerPatch(currentSource) {
 
 module.exports = {
   applyLinuxFileManagerPatch,
+  applyLinuxX11ProjectPickerPatch,
   applyLinuxGitOriginsSourceFallbackPatch,
   applyLinuxTerminalUserPathPatch,
   applyLinuxLocalAppServerFeatureEnablementHandlerPatch,


### PR DESCRIPTION
## Summary

- open the Add Project folder picker without a parent window on Linux X11
- preserve the parented dialog on Wayland, macOS, and Windows
- cover explicit and fallback X11 detection against the current main bundle

## Why

The current picker attaches the native directory dialog to the primary `BrowserWindow`. The evidence in #838 points to that modal path entering a GNOME Shell input grab that never recovers. Using the existing unparented Electron overload on X11 avoids that relationship without changing project selection or persistence.

Thanks to @ChanJoon for tracing the packaged handler and narrowing the A/B test.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (363 passed)
- `bash tests/scripts_smoke.sh`
- current `main-BOrkpaTV.js` patch and second-run idempotence check
- `git diff --check`

Addresses #838
