### PR TITLE
fix(plugins): make bundled staging writable on Linux

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -375,17 +375,6 @@ clear_bundled_marketplace_tmp_cache() {
     done
 }
 
-monitor_bundled_marketplace_tmp_permissions() {
-    (
-        local i=0
-        while [ "$i" -lt 300 ]; do
-            fix_bundled_marketplace_tmp_permissions
-            sleep 0.1
-            i=$((i + 1))
-        done
-    ) &
-}
-
 import_graphical_env_entry() {
     local entry="$1"
     local name="${entry%%=*}"
@@ -3742,10 +3731,6 @@ if needs_cold_start; then
     log_phase "cold_start_cache_sync_start"
     clear_bundled_marketplace_tmp_cache
     log_phase "bundled_marketplace_tmp_cleared"
-    # The runtime marketplace is populated asynchronously and can briefly
-    # recreate read-only plugin cache trees before the sync below replaces them.
-    monitor_bundled_marketplace_tmp_permissions
-    log_phase "bundled_marketplace_tmp_monitor_started"
     stage_bundled_marketplace_metadata
     log_phase "bundled_marketplace_metadata_staged"
     sync_browser_use_bundled_plugin_cache &

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -53,6 +53,7 @@ const {
 const {
   applyBrowserUseNodeReplApprovalPatch,
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
@@ -1024,6 +1025,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-chrome-native-host-runtime",
     "browser-use-node-repl-approval",
     "linux-bundled-plugin-reconcile-stale-snapshot",
+    "linux-bundled-plugin-copy-permissions",
     "linux-browser-use-route-liveness",
     "linux-chrome-extension-status",
     "linux-local-app-server-feature-enablement-handler",
@@ -1313,6 +1315,15 @@ function currentChromePluginGateBundleFixture() {
     "var o={c:`chrome`,s:`chrome-dev`},n={Cs:e=>!0};",
     "var Kr=[{forceReload:!0,name:o.s,syncInstallStateWithChromeExtension:!0,isAvailable:({buildFlavor:e,env:t,features:r})=>Ar(e,t)&&r.externalBrowserUseAllowed},{forceReload:!0,name:o.c,syncInstallStateWithChromeExtension:!0,isAvailable:({buildFlavor:e,features:t})=>t.externalBrowserUseAllowed&&n.Cs(e)}];",
   ].join("");
+}
+
+function currentBundledPluginCopyBundleFixture() {
+  return (
+    "let p=require(`node:path`);" +
+    "let m=require(`node:fs/promises`);m={default:m};" +
+    "let g={default:{platform:process.platform}};" +
+    "async function fl(e,t){if(g.default.platform===`darwin`){return}if(g.default.platform!==`win32`){await m.default.cp(e,t,{recursive:!0,verbatimSymlinks:!0});return}}"
+  );
 }
 
 function chromeNativeHostRuntimeBundleFixture() {
@@ -6551,6 +6562,50 @@ test("auto-installs the current Chrome plugin gate shape", () => {
   assert.match(patched, /name:o\.s,syncInstallStateWithChromeExtension:!0,isAvailable:\(\{buildFlavor:e,env:t,features:r\}\)=>Ar\(e,t\)&&r\.externalBrowserUseAllowed/);
   assert.equal((patched.match(/installWhenMissing:!0,name:o\.c/g) || []).length, 1);
   assert.equal((patched.match(/installWhenMissing:!0,name:o\.s/g) || []).length, 0);
+});
+
+test("makes Linux bundled plugin staging writable after copying read-only resources", async () => {
+  const patched = applyPatchTwice(
+    applyLinuxBundledPluginCopyPermissionsPatch,
+    currentBundledPluginCopyBundleFixture(),
+  );
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-bundled-plugin-permissions-"));
+  const sourcePlugin = path.join(root, "source-plugin");
+  const sourceManifestDir = path.join(sourcePlugin, ".codex-plugin");
+  const sourceManifest = path.join(sourceManifestDir, "plugin.json");
+  const externalFile = path.join(root, "external-read-only-file");
+  const sourceLink = path.join(sourcePlugin, "external-link");
+  const targetPlugin = path.join(root, "target-plugin");
+  const targetManifest = path.join(targetPlugin, ".codex-plugin", "plugin.json");
+  const targetLink = path.join(targetPlugin, "external-link");
+
+  try {
+    fs.mkdirSync(sourceManifestDir, { recursive: true });
+    fs.writeFileSync(sourceManifest, '{"name":"computer-use"}\n');
+    fs.writeFileSync(externalFile, "external\n");
+    fs.chmodSync(externalFile, 0o444);
+    fs.symlinkSync(externalFile, sourceLink);
+    fs.chmodSync(sourceManifest, 0o444);
+    fs.chmodSync(sourceManifestDir, 0o555);
+    fs.chmodSync(sourcePlugin, 0o555);
+
+    const copyPlugin = new Function("process", "require", `${patched};return fl;`)(
+      { platform: "linux" },
+      require,
+    );
+    await copyPlugin(sourcePlugin, targetPlugin);
+    fs.appendFileSync(targetManifest, "\n");
+
+    assert.match(patched, /async function codexLinuxMakeBundledPluginTreeWritable/);
+    assert.equal(fs.statSync(targetPlugin).mode & 0o200, 0o200);
+    assert.equal(fs.statSync(targetManifest).mode & 0o200, 0o200);
+    assert.equal(fs.lstatSync(targetLink).isSymbolicLink(), true);
+    assert.equal(fs.statSync(externalFile).mode & 0o200, 0);
+  } finally {
+    fs.chmodSync(sourcePlugin, 0o755);
+    fs.chmodSync(sourceManifestDir, 0o755);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 function bundledPluginReconcileRaceFixture({

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -7,6 +7,7 @@ const {
 const { patchStatusFromChange } = require("../../../../../lib/patch-report.js");
 const {
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
   applyLinuxChromeExtensionStatusPatch,
@@ -44,6 +45,13 @@ module.exports = [
     order: 164,
     ciPolicy: "optional",
     apply: applyLinuxBundledPluginReconcileStaleSnapshotPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-bundled-plugin-copy-permissions",
+    phase: "main-bundle",
+    order: 165,
+    ciPolicy: "optional",
+    apply: applyLinuxBundledPluginCopyPermissionsPatch,
   }),
   mainBundlePatch({
     id: "linux-browser-use-route-liveness",

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -8,6 +8,54 @@ const {
   requireName,
 } = require("../../lib/minified-js.js");
 
+function applyLinuxBundledPluginCopyPermissionsPatch(currentSource) {
+  const helperName = "codexLinuxMakeBundledPluginTreeWritable";
+  if (currentSource.includes(`async function ${helperName}(`)) {
+    return currentSource;
+  }
+
+  const pathVar = requireName(currentSource, "node:path");
+  if (pathVar == null) {
+    if (currentSource.includes("verbatimSymlinks")) {
+      console.warn(
+        "WARN: Could not find node:path binding — skipping Linux plugin permissions patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const copyBranchRegex =
+    /if\(([A-Za-z_$][\w$]*)\.default\.platform!==`win32`\)\{await ([A-Za-z_$][\w$]*)\.default\.cp\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),\{recursive:!0,verbatimSymlinks:!0\}\);return\}/;
+  let patchedCopyBranch = false;
+  const patchedSource = currentSource.replace(
+    copyBranchRegex,
+    (_match, platformVar, fsPromisesVar, sourceVar, targetVar) => {
+      patchedCopyBranch = true;
+      return `if(${platformVar}.default.platform!==\`win32\`){await ${fsPromisesVar}.default.cp(${sourceVar},${targetVar},{recursive:!0,verbatimSymlinks:!0});if(process.platform===\`linux\`)await ${helperName}(${targetVar},${fsPromisesVar}.default);return}`;
+    },
+  );
+  if (!patchedCopyBranch) {
+    if (currentSource.includes("verbatimSymlinks")) {
+      console.warn(
+        "WARN: Could not find bundled plugin copy branch — skipping Linux plugin permissions patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const helper =
+    `async function ${helperName}(e,t){let n=await t.lstat(e);if(n.isSymbolicLink())return;await t.chmod(e,n.mode|128);if(n.isDirectory())for(let n of await t.readdir(e))await ${helperName}((0,${pathVar}.join)(e,n),t)}`;
+  const strictDirective = '"use strict";';
+  const helperInsertionIndex = currentSource.startsWith(strictDirective)
+    ? strictDirective.length
+    : 0;
+  return (
+    patchedSource.slice(0, helperInsertionIndex) +
+    helper +
+    patchedSource.slice(helperInsertionIndex)
+  );
+}
+
 function applyLinuxBundledPluginReconcileStaleSnapshotPatch(currentSource) {
   const marker = "/*codex-linux-skip-stale-bundled-plugin-reconcile*/";
   if (currentSource.includes(marker)) {
@@ -465,6 +513,7 @@ function applyLinuxExternalOpenEnvPatch(currentSource) {
 module.exports = {
   applyBrowserUseNodeReplApprovalPatch,
   applyBrowserUseNodeReplApprovalAssets,
+  applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxExternalOpenEnvPatch,
   applyLinuxBrowserUseRouteLivenessPatch,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4589,9 +4589,9 @@ if "using_second_instance_handoff" not in source or "needs_cold_start" not in so
     raise SystemExit("launcher must have an explicit second-instance handoff mode")
 if "second_instance_handoff_ready" not in runtime_body:
     raise SystemExit("second-instance handoff must skip cold-start setup")
-if "clear_bundled_marketplace_tmp_cache\nmonitor_bundled_marketplace_tmp_permissions\nreconcile_runtime_state" in runtime_body:
+if "clear_bundled_marketplace_tmp_cache\nreconcile_runtime_state" in runtime_body:
     raise SystemExit("warm-start path must not clear bundled marketplace temp cache")
-if not re.search(r'if needs_cold_start; then\s+log_phase "cold_start_cache_sync_start"\s+clear_bundled_marketplace_tmp_cache.*?monitor_bundled_marketplace_tmp_permissions.*?stage_bundled_marketplace_metadata.*?sync_browser_use_bundled_plugin_cache &.*?sync_chrome_bundled_plugin_cache &.*?sync_computer_use_bundled_plugin_cache &.*?sync_read_aloud_bundled_plugin_cache &.*?sync_extra_bundled_plugin_cache &.*?run_cold_start_hooks.*?log_phase "cold_start_hooks_dispatched"\s+await_webview_server_ready\s+fi', runtime_body, re.S):
+if not re.search(r'if needs_cold_start; then\s+log_phase "cold_start_cache_sync_start"\s+clear_bundled_marketplace_tmp_cache.*?stage_bundled_marketplace_metadata.*?sync_browser_use_bundled_plugin_cache &.*?sync_chrome_bundled_plugin_cache &.*?sync_computer_use_bundled_plugin_cache &.*?sync_read_aloud_bundled_plugin_cache &.*?sync_extra_bundled_plugin_cache &.*?run_cold_start_hooks.*?log_phase "cold_start_hooks_dispatched"\s+await_webview_server_ready\s+fi', runtime_body, re.S):
     raise SystemExit("bundled marketplace cleanup, staged metadata, concurrent plugin syncs, cold-start hooks, and the webview readiness wait must run only on cold start")
 # The plugin syncs run concurrently, so the shared marketplace.json is staged
 # exactly once beforehand instead of racing rm+cp per sync, and every sync is
@@ -5247,7 +5247,7 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_read_aloud_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "make_tree_owner_writable"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "clear_bundled_marketplace_tmp_cache"
-    assert_contains "$REPO_DIR/launcher/start.sh.template" "monitor_bundled_marketplace_tmp_permissions"
+    assert_not_contains "$REPO_DIR/launcher/start.sh.template" "monitor_bundled_marketplace_tmp_permissions"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-id.json"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts"
     assert_contains "$REPO_DIR/launcher/start.sh.template" ".config/chromium/NativeMessagingHosts"


### PR DESCRIPTION
## Summary

- make Linux runtime marketplace copies owner-writable immediately after copying bundled plugin resources
- preserve existing mode bits and skip symbolic links while walking the copied tree
- remove the superseded 30-second launcher permission polling loop while retaining cold-start cleanup
- cover read-only directories, a read-only manifest, and an external symlink with a regression test

Packaged plugin resources can be read-only, notably when installed from the Nix store. The current materializer preserves those modes with `fs.promises.cp(..., { recursive: true, verbatimSymlinks: true })`, then rewrites plugin metadata. That write fails with `EACCES`, leaving the bundled marketplace incomplete and making installed MCP plugins unavailable; in a live NixOS reproduction this surfaced as `Transport closed` for Computer Use.

The launcher permission monitor races the asynchronous materializer. This change enforces the writable-staging invariant at the producer immediately after the copy. It adds only the owner-write bit, preserves execute and other permission bits, and never follows copied symlinks.

This targets the current `26.707.41301` DMG bundle shape. It does not change plugin selection, install policy, cache invalidation, or Browser availability.

## Validation

- `node --test --test-name-pattern='bundled plugin staging writable' scripts/patch-linux-window-ui.test.js` — pass
- `node --test scripts/patch-linux-window-ui.test.js` — 363/363 pass
- `bash scripts/ci/run-node-checks.sh` — 910/910 pass
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh` — pass
- `nix develop -c bash tests/scripts_smoke.sh` — pass
- `nix flake check --no-build` — pass (existing app metadata/Home Manager warnings only)
- `cargo test -p codex-computer-use-linux` — pass
- `cargo fmt --all -- --check` — pass
- exact patch application against the current installed bundle — applied once and idempotent
- live NixOS rebuild: marketplace reconcile changed from `EACCES` to successful four-plugin sync; direct MCP `doctor` reported no blockers and `get_app_state` extracted the Telegram accessibility tree without performing actions
- independent coding-agent review of the final five-file diff — no actionable findings

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
