### PR TITLE
fix(browser): isolate IAB socket discovery

### DIFF
--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -275,6 +275,7 @@ run_deb_job() {
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/scripts/lib/upstream-dmg-intel.js'
+    assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/update-builder/scripts/lib/patch-browser-client-iab-socket-scope.js'
     assert_contains_file /tmp/deb-contents.txt './opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist
@@ -331,6 +332,7 @@ run_rpm_job() {
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/scripts/lib/upstream-dmg-intel.js'
+    assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/update-builder/scripts/lib/patch-browser-client-iab-socket-scope.js'
     assert_contains_file /tmp/rpm-contents.txt '/opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist
@@ -381,6 +383,7 @@ run_pacman_job() {
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/install.sh'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/launcher/webview-server.py'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/scripts/lib/upstream-dmg-intel.js'
+    assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/update-builder/scripts/lib/patch-browser-client-iab-socket-scope.js'
     assert_contains_file /tmp/pacman-contents.txt 'opt/codex-desktop/.codex-linux/codex-packaged-runtime.sh'
 
     rm -rf dist

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -780,6 +780,20 @@ patch_chrome_plugin_for_linux() {
     fi
 }
 
+patch_browser_client_iab_socket_scope() {
+    local client="$1"
+    local patcher="$SCRIPT_DIR/scripts/lib/patch-browser-client-iab-socket-scope.js"
+
+    if [ ! -f "$patcher" ]; then
+        warn "IAB Browser socket scope patch helper not found at $patcher; leaving browser-client.mjs unchanged"
+        return 0
+    fi
+
+    if ! node "$patcher" "$client" >&2; then
+        warn "IAB Browser socket scope patch helper failed; leaving browser-client.mjs unchanged"
+    fi
+}
+
 normalize_plugin_script_executable_modes() {
     local target_plugin="$1"
     local scripts_dir="$target_plugin/scripts"
@@ -1306,6 +1320,7 @@ stage_browser_plugin_from_upstream() {
     patch_browser_use_native_pipe_import_meta_bridge "$target_client"
     patch_browser_use_site_status_allowlist_fallback "$target_client"
     patch_browser_use_file_url_policy "$target_client"
+    patch_browser_client_iab_socket_scope "$target_client"
 
     info "Browser plugin staged from upstream DMG"
     return 0

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -833,6 +833,8 @@ stage_update_builder_bundle() {
     cp "$REPO_DIR/scripts/lib/asar-patch.sh" "$update_builder_root/scripts/lib/asar-patch.sh"
     cp "$REPO_DIR/scripts/lib/webview-install.sh" "$update_builder_root/scripts/lib/webview-install.sh"
     cp "$REPO_DIR/scripts/lib/bundled-plugins.sh" "$update_builder_root/scripts/lib/bundled-plugins.sh"
+    cp "$REPO_DIR/scripts/lib/patch-browser-client-iab-socket-scope.js" \
+        "$update_builder_root/scripts/lib/patch-browser-client-iab-socket-scope.js"
     cp "$REPO_DIR/scripts/lib/linux-features.js" "$update_builder_root/scripts/lib/linux-features.js"
     cp "$REPO_DIR/scripts/lib/linux-features.sh" "$update_builder_root/scripts/lib/linux-features.sh"
     cp "$REPO_DIR/scripts/lib/linux-target-context.js" "$update_builder_root/scripts/lib/linux-target-context.js"

--- a/scripts/lib/patch-browser-client-iab-socket-scope.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+
+const clientPath = process.argv[2];
+if (!clientPath) {
+  throw new Error("Usage: patch-browser-client-iab-socket-scope.js /path/to/browser-client.mjs");
+}
+
+const marker = "/*codexLinuxIabSocketScope*/";
+const source = fs.readFileSync(clientPath, "utf8");
+if (source.includes(marker)) {
+  process.exit(0);
+}
+
+const socketListingPattern =
+  /([A-Za-z_$][\w$]*)=\(\)=>\s*([A-Za-z_$][\w$]*)\(\)==="win32"\?([A-Za-z_$][\w$]*)\(\):([A-Za-z_$][\w$]*)\(\),\4=async\(\)=>\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\)\.map\(([A-Za-z_$][\w$]*)=>([A-Za-z_$][\w$]*)\.resolve\(\6,\7\)\),\3=async\(\)=>/g;
+const matches = [...source.matchAll(socketListingPattern)];
+if (matches.length !== 1) {
+  if (source.includes("codex-browser-use")) {
+    process.stderr.write(
+      `WARN: Expected one IAB Browser socket listing target, found ${matches.length}; leaving browser-client.mjs unchanged\n`,
+    );
+  }
+  process.exit(0);
+}
+
+const [
+  target,
+  dispatcher,
+  platform,
+  windowsListing,
+  unixListing,
+  readDirectory,
+  socketDirectory,
+  entry,
+  pathModule,
+] = matches[0];
+const replacement =
+  `${dispatcher}=()=>${platform}()==="win32"?${windowsListing}():${unixListing}(),` +
+  `${unixListing}=async()=>(await ${readDirectory}(${socketDirectory}))` +
+  `.filter(${entry}=>!${entry}.startsWith("extension-")${marker})` +
+  `.map(${entry}=>${pathModule}.resolve(${socketDirectory},${entry})),` +
+  `${windowsListing}=async()=>`;
+fs.writeFileSync(clientPath, source.replace(target, replacement), "utf8");

--- a/scripts/lib/patch-browser-client-iab-socket-scope.test.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.test.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const { pathToFileURL } = require("node:url");
+
+const patcher = path.join(__dirname, "patch-browser-client-iab-socket-scope.js");
+
+test("IAB discovery excludes extension sockets before connecting", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-iab-socket-scope-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+const fixture = `
+const Cb="/tmp/codex-browser-use";
+const entries=["extension-123.sock","iab-session.sock","extension-stale.sock"];
+const yP=async()=>entries;
+const wP={resolve:(root,entry)=>root+"/"+entry};
+const _P=()=>"linux";
+export const EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];
+`;
+
+  try {
+    fs.writeFileSync(clientPath, fixture, "utf8");
+    const firstPatch = spawnSync(process.execPath, [patcher, clientPath], { encoding: "utf8" });
+    assert.equal(firstPatch.status, 0, firstPatch.stderr);
+    const patched = fs.readFileSync(clientPath, "utf8");
+    assert.match(patched, /codexLinuxIabSocketScope/);
+
+    const secondPatch = spawnSync(process.execPath, [patcher, clientPath], { encoding: "utf8" });
+    assert.equal(secondPatch.status, 0, secondPatch.stderr);
+    assert.equal(fs.readFileSync(clientPath, "utf8"), patched);
+
+    const module = await import(`${pathToFileURL(clientPath).href}?patched=1`);
+    assert.deepEqual(await module.CV(), ["/tmp/codex-browser-use/iab-session.sock"]);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("leaves an unrelated socket-directory map unchanged", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-iab-unrelated-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+  const fixture =
+    'const Cb="/tmp/codex-browser-use";const CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e));';
+
+  try {
+    fs.writeFileSync(clientPath, fixture, "utf8");
+    const result = spawnSync(process.execPath, [patcher, clientPath], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    const actual = fs.readFileSync(clientPath, "utf8");
+    assert.equal(actual, fixture);
+    assert.doesNotMatch(actual, /codexLinuxIabSocketScope/);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("leaves ambiguous IAB discovery chains unchanged", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-iab-ambiguous-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+  const chain = (suffix) =>
+    `EV${suffix}=()=>P${suffix}()==="win32"?TV${suffix}():CV${suffix}(),` +
+    `CV${suffix}=async()=>(await Y${suffix}(C${suffix})).map(e=>W${suffix}.resolve(C${suffix},e)),` +
+    `TV${suffix}=async()=>[]`;
+  const fixture = `const root="/tmp/codex-browser-use";${chain("A")};${chain("B")};`;
+
+  try {
+    fs.writeFileSync(clientPath, fixture, "utf8");
+    const result = spawnSync(process.execPath, [patcher, clientPath], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(clientPath, "utf8"), fixture);
+    assert.match(result.stderr, /found 2/);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -163,7 +163,7 @@ JSON
 {"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
     cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
-function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}export function setupAtlasRuntime() {}
+function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {}
 JS
 }
 
@@ -5878,6 +5878,7 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" "let e=import.meta.__codexNativePipe;return"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxFileUrlPolicy"
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
     assert_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="file:"'
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="data:"'
     assert_contains "$marketplace" '"name": "browser"'
@@ -6235,6 +6236,7 @@ MD
 JSON
     cat > "$chrome_dir/scripts/browser-client.mjs" <<'JS'
 const browserPreference={};function preferredWindowIdFor(){}function getForUrl(){}const extensionInstanceId=null;
+var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}
 function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}
 import{platform as yT}from"node:os";function eh(){return"privileged native pipe bridge is not available; browser-client is not trusted"}function th(){let e=globalThis.nodeRepl?.nativePipe;return e==null||typeof e.createConnection!="function"?null:e}var ml=class e{constructor(t){this.socket=t}static async create(t){let r=th();if(r!=null){let n=await r.createConnection(t);return new e(n)}throw new Error(eh())}};
@@ -6429,6 +6431,7 @@ test_chrome_plugin_staging() {
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxNativePipeFallback"
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" 'await import("node:net")'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "agent.browsers.list()"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "browser.tabs.new()"
     assert_contains "$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json" '"name": "chrome"'

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -622,6 +622,7 @@ SCRIPT
     assert_file_exists "$pkg_root/DEBIAN/postrm"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/package-common.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/patch-chrome-plugin.js"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/patch-browser-client-iab-socket-scope.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/node-runtime.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/upstream-dmg-intel.js"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/lib/linux-update-bridge-patch.js"


### PR DESCRIPTION
## Summary

- keep IAB discovery away from live Chrome extension sockets on Linux
- patch only the bundled `browser` plugin; leave the `chrome` plugin unchanged
- include the helper in packaged update-builder bundles for deb, rpm, and pacman rebuilds

## Why

The bundled Browser and Chrome clients share `/tmp/codex-browser-use`. Before selecting its IAB backend, the Browser client probes every Unix socket in that directory. Probing a live `extension-*` socket makes the Chrome native host accept a second client, evict the active Chrome client, and clear its pending requests. The IAB task then discards that backend, while the Chrome task fails with `Browser is not available` even though Chrome is still running.

The failure was reproduced with two concurrent tasks: IAB setup began at `16:22:04.814Z`, and the active Chrome task lost its binding at `16:22:05.145Z`.

This change filters `extension-*` entries before the IAB client opens candidate sockets. Unknown or ambiguous bundle shapes are left unchanged with a warning. The native host's single-client behavior and Chrome discovery are not changed.

Fixes #841.

## Validation

- focused socket-scope tests: 3/3
- complete Node test set: 384/384
- `cargo test -p codex-computer-use-linux`: all suites pass, including Chrome native host 57/57
- `nix develop -c bash tests/scripts_smoke.sh`: pass
- `nix flake check --no-build`: pass with existing output warnings
- exact application to Browser `26.707.41301`: one target and idempotent; Chrome staging remains unmodified
- live check: the same Chrome binding returned an identical ordered snapshot of 155 tabs before and after a second client ran IAB setup/discovery
- update-builder staging smoke: helper present
- real deb and rpm builds: helper present in both package payloads
- deb, rpm, and pacman CI payload assertions added; local pacman packaging reached `makepkg` but could not complete in the NixOS host environment, so the Arch CI job is the package-format gate
- independent review of the complete final diff: no code blockers; wording and packaging validation findings addressed
