### PR TITLE
fix(updater): persist missing CLI failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.9.4"
+version = "0.9.5"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -44,10 +44,10 @@ pub fn preflight(
     allow_install_missing: bool,
 ) -> Result<PreflightOutcome> {
     let requested_path = explicit_cli_path.as_deref();
-    let cli_path = match resolve_cli_path(requested_path) {
-        Some(path) => path,
+    let (cli_path, installed_missing_cli) = match resolve_cli_path(requested_path) {
+        Some(path) => (path, false),
         None if allow_install_missing => match install_missing_cli(state, paths, requested_path) {
-            Ok(path) => path,
+            Ok(path) => (path, true),
             Err(error) => {
                 persist_cli_failure(state, paths, &error)?;
                 return Err(error);
@@ -63,12 +63,15 @@ pub fn preflight(
         Err(probe_error) => {
             let Some(missing_dependency) = missing_platform_optional_dependency(&probe_error)
             else {
+                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
                 return Err(probe_error);
             };
             if managed_cli.is_some() {
+                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
                 return Err(probe_error);
             }
             let Some(npm_install) = npm_cli_install(&cli_path, &missing_dependency) else {
+                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
                 return Err(probe_error);
             };
 
@@ -451,6 +454,18 @@ fn persist_cli_failure(
     state.cli_status = CliStatus::Failed;
     state.cli_error_message = Some(format!("{error:#}"));
     persist_state(paths, state)
+}
+
+fn persist_new_cli_probe_failure(
+    installed_missing_cli: bool,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    error: &anyhow::Error,
+) -> Result<()> {
+    if installed_missing_cli {
+        persist_cli_failure(state, paths, error)?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -2841,6 +2856,41 @@ exit 1
             .cli_error_message
             .as_deref()
             .is_some_and(|message| message.contains("registry unavailable")));
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.cli_status, CliStatus::Failed);
+        assert_eq!(persisted.cli_error_message, state.cli_error_message);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_new_cli_version_probe_persists_failed_status() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_fake_cli_path = EnvRestoreGuard::capture(&["FAKE_CODEX_PATH"]);
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        let codex_path = bin_dir.join("codex");
+        write_executable_script(
+            &bin_dir.join("npm"),
+            "#!/bin/sh\nif [ \"$1\" = \"view\" ]; then\n  echo '0.42.1'\n  exit 0\nfi\nif [ \"$1\" = \"install\" ]; then\n  printf '%s\\n' '#!/bin/sh' \"echo 'version probe failed' >&2\" 'exit 43' > \"$FAKE_CODEX_PATH\"\n  /bin/chmod +x \"$FAKE_CODEX_PATH\"\n  exit 0\nfi\nexit 1\n",
+        )?;
+
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+        std::env::set_var("FAKE_CODEX_PATH", &codex_path);
+
+        let mut state = PersistedState::new(true);
+        let error = preflight(&mut state, &paths, None, true)
+            .expect_err("a failed version probe after installation should bubble up");
+
+        assert!(format!("{error:#}").contains("version probe failed"));
+        assert_eq!(state.cli_status, CliStatus::Failed);
+        assert!(state
+            .cli_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("version probe failed")));
         let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
         assert_eq!(persisted.cli_status, CliStatus::Failed);
         assert_eq!(persisted.cli_error_message, state.cli_error_message);

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -46,7 +46,13 @@ pub fn preflight(
     let requested_path = explicit_cli_path.as_deref();
     let cli_path = match resolve_cli_path(requested_path) {
         Some(path) => path,
-        None if allow_install_missing => install_missing_cli(state, paths, requested_path)?,
+        None if allow_install_missing => match install_missing_cli(state, paths, requested_path) {
+            Ok(path) => path,
+            Err(error) => {
+                persist_cli_failure(state, paths, &error)?;
+                return Err(error);
+            }
+        },
         None => anyhow::bail!("Codex CLI not found in PATH or known install locations"),
     };
     let path_env = command_path_env();
@@ -2803,6 +2809,38 @@ exit 1
             .cli_error_message
             .as_deref()
             .is_some_and(|message| message.contains("repair failed")));
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.cli_status, CliStatus::Failed);
+        assert_eq!(persisted.cli_error_message, state.cli_error_message);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_missing_cli_install_persists_failed_status() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        write_executable_script(
+            &bin_dir.join("npm"),
+            "#!/bin/sh\necho 'registry unavailable' >&2\nexit 42\n",
+        )?;
+
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+
+        let mut state = PersistedState::new(true);
+        let error = preflight(&mut state, &paths, None, true)
+            .expect_err("a failed missing CLI install should bubble up");
+
+        assert!(format!("{error:#}").contains("registry unavailable"));
+        assert_eq!(state.cli_status, CliStatus::Failed);
+        assert!(state
+            .cli_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("registry unavailable")));
         let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
         assert_eq!(persisted.cli_status, CliStatus::Failed);
         assert_eq!(persisted.cli_error_message, state.cli_error_message);


### PR DESCRIPTION
## Summary

Persist first-time Codex CLI installation failures as Failed instead of leaving updater state stuck at Updating after registry, npm install, or post-install discovery errors.

Add a regression test that verifies both in-memory and on-disk failure state after an npm registry error.

## Validation

- wsl.exe bash -lc 'cd /mnt/c/Users/nguye/projects/codex-desktop-linux-work && cargo test -p codex-update-manager failed_missing_cli_install_persists_failed_status'
- cargo fmt --all --check
- git diff --check

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest CODEX.DMG and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests and ran the validation listed above.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.