### PR TITLE
Fix Chrome runtime cache permissions

### DIFF
--- a/computer-use-linux/src/bin/codex-chrome-extension-host.rs
+++ b/computer-use-linux/src/bin/codex-chrome-extension-host.rs
@@ -1239,7 +1239,9 @@ while True:
         fs::set_permissions(&fake_node, fs::Permissions::from_mode(0o700)).unwrap();
 
         let extension_id = "abcdefghijklmnopabcdefghijklmnop";
-        let extension_host_path = trusted_current_exe_link(&root);
+        let extension_host_path = root.join("extension-host");
+        fs::copy(env::current_exe().unwrap(), &extension_host_path).unwrap();
+        fs::set_permissions(&extension_host_path, fs::Permissions::from_mode(0o700)).unwrap();
         let manifest_path = root.join("chrome-native-hosts-v2.json");
         fs::write(
             &manifest_path,
@@ -1275,10 +1277,11 @@ while True:
         .unwrap();
         fs::set_permissions(&manifest_path, fs::Permissions::from_mode(0o600)).unwrap();
 
-        let runtime_manager = Arc::new(RuntimeManager::for_test(
+        let runtime_manager = Arc::new(RuntimeManager::for_test_with_current_executable_path(
             extension_id.to_string(),
             runtime_root.clone(),
             manifest_path,
+            &extension_host_path,
         ));
         let (mut host_state, output) = test_host_state_with_output();
         host_state.runtime_manager = Arc::clone(&runtime_manager);
@@ -1339,15 +1342,6 @@ while True:
                 })
             })
             .unwrap_or_else(|| panic!("could not resolve test executable from PATH: {name}"))
-    }
-
-    fn trusted_current_exe_link(root: &Path) -> PathBuf {
-        let target = root.join("extension-host");
-        fs::hard_link(env::current_exe().unwrap(), &target)
-            .expect("extension host tests require hard-link support in the temp directory");
-        let mode = fs::metadata(&target).unwrap().permissions().mode() & !0o022;
-        fs::set_permissions(&target, fs::Permissions::from_mode(mode)).unwrap();
-        target
     }
 
     #[test]

--- a/computer-use-linux/src/bin/codex-chrome-extension-host.rs
+++ b/computer-use-linux/src/bin/codex-chrome-extension-host.rs
@@ -1234,9 +1234,12 @@ while True:
         )
         .unwrap();
         fs::set_permissions(&fake_cli, fs::Permissions::from_mode(0o700)).unwrap();
+        let fake_node = root.join("fake-node");
+        fs::write(&fake_node, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&fake_node, fs::Permissions::from_mode(0o700)).unwrap();
 
         let extension_id = "abcdefghijklmnopabcdefghijklmnop";
-        let current_exe = env::current_exe().unwrap();
+        let extension_host_path = trusted_current_exe_link(&root);
         let manifest_path = root.join("chrome-native-hosts-v2.json");
         fs::write(
             &manifest_path,
@@ -1258,8 +1261,8 @@ while True:
                     "paths": {
                         "codexCliPath": fake_cli,
                         "codexHome": codex_home,
-                        "extensionHostPath": current_exe.clone(),
-                        "nodePath": current_exe,
+                        "extensionHostPath": extension_host_path,
+                        "nodePath": fake_node,
                         "resourcesPath": resources
                     },
                     "proxyHost": "127.0.0.1",
@@ -1336,6 +1339,15 @@ while True:
                 })
             })
             .unwrap_or_else(|| panic!("could not resolve test executable from PATH: {name}"))
+    }
+
+    fn trusted_current_exe_link(root: &Path) -> PathBuf {
+        let target = root.join("extension-host");
+        fs::hard_link(env::current_exe().unwrap(), &target)
+            .expect("extension host tests require hard-link support in the temp directory");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & !0o022;
+        fs::set_permissions(&target, fs::Permissions::from_mode(mode)).unwrap();
+        target
     }
 
     #[test]

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -1061,7 +1061,7 @@ impl RuntimeManager {
     fn current_executable_identity(&self) -> RuntimeResult<FileIdentity> {
         #[cfg(test)]
         if let Some(identity) = &self.current_executable_identity_override {
-            return Ok(identity.clone());
+            return Ok(*identity);
         }
 
         current_executable_identity()
@@ -1128,6 +1128,7 @@ fn parse_constraints(value: &Value) -> RuntimeResult<RuntimeConstraints> {
         .map_err(|_| RuntimeError::invalid_params("Invalid Codex runtime constraints"))
 }
 
+#[cfg(test)]
 fn select_runtime_entry(
     constraints: &RuntimeConstraints,
     manifest_paths_override: Option<&[PathBuf]>,

--- a/computer-use-linux/src/chrome_runtime.rs
+++ b/computer-use-linux/src/chrome_runtime.rs
@@ -314,6 +314,8 @@ pub struct RuntimeManager {
     cleanup_join: Mutex<Option<thread::JoinHandle<()>>>,
     cleanup_timing: ProcessCleanupTiming,
     extension_id: Option<String>,
+    #[cfg(test)]
+    current_executable_identity_override: Option<FileIdentity>,
     lifecycle: Mutex<()>,
     manifest_paths_override: Option<Vec<PathBuf>>,
     next_process_instance: AtomicU64,
@@ -352,6 +354,8 @@ impl RuntimeManager {
             cleanup_join: Mutex::new(None),
             cleanup_timing,
             extension_id,
+            #[cfg(test)]
+            current_executable_identity_override: None,
             lifecycle: Mutex::new(()),
             manifest_paths_override,
             next_process_instance: AtomicU64::new(1),
@@ -414,9 +418,13 @@ impl RuntimeManager {
         })?)?;
         self.validate_invocation(&constraints)?;
         let client_id = normalized_client_id(params.get("clientId"))?;
-        let mut entry =
-            select_runtime_entry(&constraints, self.manifest_paths_override.as_deref())?;
-        validate_runtime_entry(&mut entry)?;
+        let current_executable_identity = self.current_executable_identity()?;
+        let mut entry = select_runtime_entry_for_host(
+            &constraints,
+            self.manifest_paths_override.as_deref(),
+            &current_executable_identity,
+        )?;
+        validate_runtime_entry_for_host(&mut entry, &current_executable_identity)?;
         let _lifecycle = self
             .lifecycle
             .lock()
@@ -1036,6 +1044,30 @@ impl RuntimeManager {
     }
 
     #[cfg(test)]
+    pub(crate) fn for_test_with_current_executable_path(
+        extension_id: String,
+        runtime_root: PathBuf,
+        manifest_path: PathBuf,
+        current_executable_path: &Path,
+    ) -> Self {
+        let mut manager = Self::for_test(extension_id, runtime_root, manifest_path);
+        manager.current_executable_identity_override = Some(
+            file_identity(current_executable_path)
+                .expect("test current executable path should identify a file"),
+        );
+        manager
+    }
+
+    fn current_executable_identity(&self) -> RuntimeResult<FileIdentity> {
+        #[cfg(test)]
+        if let Some(identity) = &self.current_executable_identity_override {
+            return Ok(identity.clone());
+        }
+
+        current_executable_identity()
+    }
+
+    #[cfg(test)]
     pub(crate) fn running_process_count(&self) -> usize {
         let processes = self
             .processes
@@ -1100,6 +1132,15 @@ fn select_runtime_entry(
     constraints: &RuntimeConstraints,
     manifest_paths_override: Option<&[PathBuf]>,
 ) -> RuntimeResult<RuntimeEntry> {
+    let current_host = current_executable_identity()?;
+    select_runtime_entry_for_host(constraints, manifest_paths_override, &current_host)
+}
+
+fn select_runtime_entry_for_host(
+    constraints: &RuntimeConstraints,
+    manifest_paths_override: Option<&[PathBuf]>,
+    current_host: &FileIdentity,
+) -> RuntimeResult<RuntimeEntry> {
     let manifest_paths = manifest_paths_override
         .map(<[PathBuf]>::to_vec)
         .unwrap_or_else(manifest_paths);
@@ -1140,7 +1181,6 @@ fn select_runtime_entry(
         ));
     }
 
-    let current_host = current_executable_identity()?;
     let mut matching = entries
         .into_iter()
         .filter_map(|entry| serde_json::from_value::<RuntimeEntry>(entry).ok())
@@ -1149,7 +1189,7 @@ fn select_runtime_entry(
                 && fs::canonicalize(&entry.paths.extension_host_path)
                     .ok()
                     .and_then(|path| file_identity(&path).ok())
-                    .is_some_and(|identity| identity == current_host)
+                    .is_some_and(|identity| &identity == current_host)
         })
         .collect::<Vec<_>>();
     matching.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
@@ -1188,7 +1228,10 @@ fn manifest_paths() -> Vec<PathBuf> {
     paths
 }
 
-fn validate_runtime_entry(entry: &mut RuntimeEntry) -> RuntimeResult<()> {
+fn validate_runtime_entry_for_host(
+    entry: &mut RuntimeEntry,
+    current_exe: &FileIdentity,
+) -> RuntimeResult<()> {
     if entry.entry_id.trim().is_empty()
         || entry.install_id.trim().is_empty()
         || entry.app_version.trim().is_empty()
@@ -1215,10 +1258,9 @@ fn validate_runtime_entry(entry: &mut RuntimeEntry) -> RuntimeResult<()> {
         validate_owned_dir(path, false)?;
     }
 
-    let current_exe = current_executable_identity()?;
     let configured_host = file_identity(&entry.paths.extension_host_path)
         .map_err(|_| required_path_error("extensionHostPath"))?;
-    if current_exe != configured_host {
+    if current_exe != &configured_host {
         return Err(RuntimeError::typed(
             "no_matching_codex_install",
             "No compatible Codex app-server entry was found",

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -380,16 +380,44 @@ make_path_owner_trusted() {
     local path
 
     for path in "$@"; do
+        [ ! -L "$path" ] || return 1
         [ -e "$path" ] || continue
-        chmod u+rwX,go-w "$path" 2>/dev/null || true
+        chmod u+rwX,go-w "$path" 2>/dev/null || return 1
     done
 }
 
 make_tree_owner_trusted() {
     local path="$1"
 
+    [ ! -L "$path" ] || return 1
     [ -e "$path" ] || return 0
-    chmod -R u+rwX,go-w "$path" 2>/dev/null || true
+    if find "$path" -xdev -type l -print -quit 2>/dev/null | grep -q .; then
+        return 1
+    fi
+    chmod -R u+rwX,go-w "$path" 2>/dev/null || return 1
+}
+
+path_has_unsafe_write() {
+    local path
+
+    for path in "$@"; do
+        if [ -L "$path" ]; then
+            return 0
+        fi
+        [ -e "$path" ] || continue
+        if find "$path" -maxdepth 0 -perm /022 -print -quit 2>/dev/null | grep -q .; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+tree_has_unsafe_write() {
+    local path="$1"
+
+    [ ! -L "$path" ] || return 0
+    [ -e "$path" ] || return 1
+    find "$path" -xdev \( -type l -o -perm /022 \) -print -quit 2>/dev/null | grep -q .
 }
 
 remove_tree_if_exists() {
@@ -954,6 +982,7 @@ sync_chrome_bundled_plugin_cache() {
     local marketplace_plugin_link
     local host_path
     local needs_copy=1
+    local cache_was_untrusted=0
 
     [ -f "$plugin_json" ] || return 0
     [ -d "$source_plugin" ] || return 0
@@ -969,14 +998,16 @@ sync_chrome_bundled_plugin_cache() {
     [ -f "$source_client" ] || return 0
     [ -f "$source_install_manifest" ] || return 0
 
-    make_path_owner_trusted \
+    if path_has_unsafe_write \
         "$SCRIPT_DIR" \
         "$SCRIPT_DIR/resources" \
         "$SCRIPT_DIR/resources/plugins" \
         "$SCRIPT_DIR/resources/plugins/openai-bundled" \
         "$SCRIPT_DIR/resources/plugins/openai-bundled/plugins" \
-        "$source_plugin"
-    make_tree_owner_trusted "$source_plugin"
+        "$source_plugin" || tree_has_unsafe_write "$source_plugin"; then
+        echo "Chrome bundled plugin source is not trusted; skipping cache and native-host manifest sync."
+        return 0
+    fi
 
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
@@ -987,14 +1018,27 @@ sync_chrome_bundled_plugin_cache() {
     cache_client="$cache_plugin/scripts/browser-client.mjs"
     cache_install_manifest="$cache_plugin/scripts/installManifest.mjs"
 
-    make_path_owner_trusted \
+    if path_has_unsafe_write \
         "$codex_home" \
         "$codex_home/plugins" \
         "$codex_home/plugins/cache" \
         "$codex_home/plugins/cache/openai-bundled" \
-        "$cache_root"
+        "$cache_root" || tree_has_unsafe_write "$cache_plugin"; then
+        cache_was_untrusted=1
+    fi
 
-    if [ -f "$cache_plugin/.codex-plugin/plugin.json" ] && \
+    if ! make_path_owner_trusted \
+        "$codex_home" \
+        "$codex_home/plugins" \
+        "$codex_home/plugins/cache" \
+        "$codex_home/plugins/cache/openai-bundled" \
+        "$cache_root"; then
+        echo "Chrome plugin cache ancestors could not be hardened; skipping cache and native-host manifest sync."
+        return 0
+    fi
+
+    if [ "$cache_was_untrusted" -eq 0 ] && \
+        [ -f "$cache_plugin/.codex-plugin/plugin.json" ] && \
         [ -f "$cache_host" ] && \
         [ -f "$cache_client" ] && \
         [ -f "$cache_install_manifest" ] && \
@@ -1027,16 +1071,23 @@ sync_chrome_bundled_plugin_cache() {
         tmp_plugin="$cache_parent/.chrome-$version.tmp.$$"
         remove_tree_if_exists "$tmp_plugin"
         mkdir -p "$cache_parent"
-        make_path_owner_trusted \
+        if ! make_path_owner_trusted \
             "$codex_home" \
             "$codex_home/plugins" \
             "$codex_home/plugins/cache" \
             "$codex_home/plugins/cache/openai-bundled" \
             "$cache_root" \
-            "$cache_parent"
+            "$cache_parent"; then
+            echo "Chrome plugin cache parent could not be hardened; skipping cache and native-host manifest sync."
+            return 0
+        fi
 
         if cp -R "$source_plugin" "$tmp_plugin"; then
-            make_tree_owner_trusted "$tmp_plugin"
+            if ! make_tree_owner_trusted "$tmp_plugin"; then
+                remove_tree_if_exists "$tmp_plugin"
+                echo "Chrome plugin cache copy could not be hardened; continuing without a new cache."
+                return 0
+            fi
             find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
             remove_tree_if_exists "$cache_plugin"
             mv "$tmp_plugin" "$cache_plugin"
@@ -1048,7 +1099,10 @@ sync_chrome_bundled_plugin_cache() {
         fi
     fi
 
-    make_tree_owner_trusted "$cache_plugin"
+    if ! make_tree_owner_trusted "$cache_plugin"; then
+        echo "Chrome plugin cache could not be hardened; skipping native-host manifest sync."
+        return 0
+    fi
     replace_symlink "$version" "$cache_root/latest"
 
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -969,6 +969,15 @@ sync_chrome_bundled_plugin_cache() {
     [ -f "$source_client" ] || return 0
     [ -f "$source_install_manifest" ] || return 0
 
+    make_path_owner_trusted \
+        "$SCRIPT_DIR" \
+        "$SCRIPT_DIR/resources" \
+        "$SCRIPT_DIR/resources/plugins" \
+        "$SCRIPT_DIR/resources/plugins/openai-bundled" \
+        "$SCRIPT_DIR/resources/plugins/openai-bundled/plugins" \
+        "$source_plugin"
+    make_tree_owner_trusted "$source_plugin"
+
     version="$(bundled_plugin_version "$plugin_json" 2>/dev/null || true)"
     [ -n "$version" ] || return 0
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -376,6 +376,22 @@ make_tree_owner_writable() {
     chmod -R u+rwX "$path" 2>/dev/null || true
 }
 
+make_path_owner_trusted() {
+    local path
+
+    for path in "$@"; do
+        [ -e "$path" ] || continue
+        chmod u+rwX,go-w "$path" 2>/dev/null || true
+    done
+}
+
+make_tree_owner_trusted() {
+    local path="$1"
+
+    [ -e "$path" ] || return 0
+    chmod -R u+rwX,go-w "$path" 2>/dev/null || true
+}
+
 remove_tree_if_exists() {
     local path="$1"
 
@@ -962,6 +978,13 @@ sync_chrome_bundled_plugin_cache() {
     cache_client="$cache_plugin/scripts/browser-client.mjs"
     cache_install_manifest="$cache_plugin/scripts/installManifest.mjs"
 
+    make_path_owner_trusted \
+        "$codex_home" \
+        "$codex_home/plugins" \
+        "$codex_home/plugins/cache" \
+        "$codex_home/plugins/cache/openai-bundled" \
+        "$cache_root"
+
     if [ -f "$cache_plugin/.codex-plugin/plugin.json" ] && \
         [ -f "$cache_host" ] && \
         [ -f "$cache_client" ] && \
@@ -995,9 +1018,16 @@ sync_chrome_bundled_plugin_cache() {
         tmp_plugin="$cache_parent/.chrome-$version.tmp.$$"
         remove_tree_if_exists "$tmp_plugin"
         mkdir -p "$cache_parent"
+        make_path_owner_trusted \
+            "$codex_home" \
+            "$codex_home/plugins" \
+            "$codex_home/plugins/cache" \
+            "$codex_home/plugins/cache/openai-bundled" \
+            "$cache_root" \
+            "$cache_parent"
 
         if cp -R "$source_plugin" "$tmp_plugin"; then
-            make_tree_owner_writable "$tmp_plugin"
+            make_tree_owner_trusted "$tmp_plugin"
             find "$tmp_plugin" -type f -name '*:com.apple.*' -delete
             remove_tree_if_exists "$cache_plugin"
             mv "$tmp_plugin" "$cache_plugin"
@@ -1009,6 +1039,7 @@ sync_chrome_bundled_plugin_cache() {
         fi
     fi
 
+    make_tree_owner_trusted "$cache_plugin"
     replace_symlink "$version" "$cache_root/latest"
 
     marketplace_root="$codex_home/.tmp/bundled-marketplaces/openai-bundled"

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1643,5 +1643,10 @@ install_bundled_plugin_resources() {
     install_linux_executable_resource "$upstream_resources/node" "$resources_dir/node" "node runtime" "info" || true
     install_browser_use_node_repl_resource "$upstream_resources" "$resources_dir/node_repl" || true
 
+    # These files become the trust root for user-cache refreshes at runtime.
+    # Normalize them while staging from the accepted DMG instead of blessing a
+    # potentially modified installed tree during launcher startup.
+    chmod -R u+rwX,go-w "$bundled_plugins_dir"
+
     info "Linux-safe bundled plugins installed"
 }

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5979,6 +5979,7 @@ assertCacheLinks({
 const chromeBody = functionBody("sync_chrome_bundled_plugin_cache", "sync_computer_use_bundled_plugin_cache");
 for (const required of [
   'make_path_owner_trusted',
+  'make_tree_owner_trusted "$source_plugin"',
   'make_tree_owner_trusted "$tmp_plugin"',
   'make_tree_owner_trusted "$cache_plugin"',
   'write_chrome_native_host_manifests "$host_path" "$cache_root/latest"',
@@ -6020,29 +6021,56 @@ set -euo pipefail
 root="$1"
 cache="$root/.codex/plugins/cache/openai-bundled/chrome"
 plugin="$cache/26.test"
+source_plugin="$root/app/resources/plugins/openai-bundled/plugins/chrome"
 mkdir -p "$plugin/extension-host"
+mkdir -p "$source_plugin/scripts" "$source_plugin/extension-host/linux/x64"
 touch "$plugin/extension-host/host"
+touch "$source_plugin/scripts/browser-client.mjs" "$source_plugin/extension-host/linux/x64/extension-host"
 chmod 775 "$root/.codex" \
-    "$root/.codex/plugins" \
-    "$root/.codex/plugins/cache" \
-    "$root/.codex/plugins/cache/openai-bundled" \
-    "$cache" \
-    "$plugin" \
-    "$plugin/extension-host"
+  "$root/.codex/plugins" \
+  "$root/.codex/plugins/cache" \
+  "$root/.codex/plugins/cache/openai-bundled" \
+  "$cache" \
+  "$plugin" \
+  "$plugin/extension-host"
 chmod 664 "$plugin/extension-host/host"
+chmod 775 "$root/app" \
+  "$root/app/resources" \
+  "$root/app/resources/plugins" \
+  "$root/app/resources/plugins/openai-bundled" \
+  "$root/app/resources/plugins/openai-bundled/plugins" \
+  "$source_plugin" \
+  "$source_plugin/scripts" \
+  "$source_plugin/extension-host" \
+  "$source_plugin/extension-host/linux" \
+  "$source_plugin/extension-host/linux/x64" \
+  "$source_plugin/extension-host/linux/x64/extension-host"
+chmod 664 "$source_plugin/scripts/browser-client.mjs"
 
 make_path_owner_trusted \
-    "$root/.codex" \
-    "$root/.codex/plugins" \
-    "$root/.codex/plugins/cache" \
-    "$root/.codex/plugins/cache/openai-bundled" \
-    "$cache"
+  "$root/.codex" \
+  "$root/.codex/plugins" \
+  "$root/.codex/plugins/cache" \
+  "$root/.codex/plugins/cache/openai-bundled" \
+  "$cache"
 make_tree_owner_trusted "$plugin"
+make_path_owner_trusted \
+  "$root/app" \
+  "$root/app/resources" \
+  "$root/app/resources/plugins" \
+  "$root/app/resources/plugins/openai-bundled" \
+  "$root/app/resources/plugins/openai-bundled/plugins" \
+  "$source_plugin"
+make_tree_owner_trusted "$source_plugin"
 
 if find "$root/.codex" -perm /022 -print -quit | grep -q .; then
-    exit 1
+  exit 1
+fi
+if find "$root/app" -perm /022 -print -quit | grep -q .; then
+  exit 1
 fi
 test -w "$plugin/extension-host/host"
+test -w "$source_plugin/scripts/browser-client.mjs"
 '''
 )
 PY

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5856,6 +5856,8 @@ EOF
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_chrome_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "sync_read_aloud_bundled_plugin_cache"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "make_tree_owner_writable"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "make_path_owner_trusted"
+    assert_contains "$REPO_DIR/launcher/start.sh.template" "make_tree_owner_trusted"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "clear_bundled_marketplace_tmp_cache"
     assert_not_contains "$REPO_DIR/launcher/start.sh.template" "monitor_bundled_marketplace_tmp_permissions"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "extension-id.json"
@@ -5974,10 +5976,78 @@ assertCacheLinks({
   body: functionBody("sync_read_aloud_bundled_plugin_cache", "resolve_browser_use_runtime_env"),
   plugin: "read-aloud",
 });
+const chromeBody = functionBody("sync_chrome_bundled_plugin_cache", "sync_computer_use_bundled_plugin_cache");
+for (const required of [
+  'make_path_owner_trusted',
+  'make_tree_owner_trusted "$tmp_plugin"',
+  'make_tree_owner_trusted "$cache_plugin"',
+  'write_chrome_native_host_manifests "$host_path" "$cache_root/latest"',
+]) {
+  if (!chromeBody.includes(required)) {
+    throw new Error(`Chrome plugin runtime cache sync missing ${required}`);
+  }
+}
+const mkdirCacheParent = chromeBody.indexOf('mkdir -p "$cache_parent"');
+if (mkdirCacheParent === -1 || chromeBody.indexOf('"$cache_parent"', mkdirCacheParent) === -1) {
+  throw new Error("Chrome plugin runtime cache sync must harden newly created cache parents");
+}
 if (!launcher.includes('ln -sfnT "$target" "$link_path"')) {
   throw new Error("replace_symlink must replace plugin links as paths, not as directory children");
 }
 NODE
+
+    local trust_probe="$TMP_DIR/chrome-cache-permissions-probe.sh"
+    python3 - "$REPO_DIR/launcher/start.sh.template" "$trust_probe" <<'PY'
+import pathlib
+import re
+import sys
+
+launcher = pathlib.Path(sys.argv[1]).read_text()
+helpers = []
+for name in ("make_path_owner_trusted", "make_tree_owner_trusted"):
+    match = re.search(rf"{name}\(\) \{{[\s\S]*?\n\}}\n", launcher)
+    if match is None:
+        raise SystemExit(f"missing {name}")
+    helpers.append(match.group(0))
+
+pathlib.Path(sys.argv[2]).write_text(
+    """#!/usr/bin/env bash
+set -euo pipefail
+
+"""
+    + "\n".join(helpers)
+    + r'''
+root="$1"
+cache="$root/.codex/plugins/cache/openai-bundled/chrome"
+plugin="$cache/26.test"
+mkdir -p "$plugin/extension-host"
+touch "$plugin/extension-host/host"
+chmod 775 "$root/.codex" \
+    "$root/.codex/plugins" \
+    "$root/.codex/plugins/cache" \
+    "$root/.codex/plugins/cache/openai-bundled" \
+    "$cache" \
+    "$plugin" \
+    "$plugin/extension-host"
+chmod 664 "$plugin/extension-host/host"
+
+make_path_owner_trusted \
+    "$root/.codex" \
+    "$root/.codex/plugins" \
+    "$root/.codex/plugins/cache" \
+    "$root/.codex/plugins/cache/openai-bundled" \
+    "$cache"
+make_tree_owner_trusted "$plugin"
+
+if find "$root/.codex" -perm /022 -print -quit | grep -q .; then
+    exit 1
+fi
+test -w "$plugin/extension-host/host"
+'''
+)
+PY
+    chmod +x "$trust_probe"
+    "$trust_probe" "$TMP_DIR/chrome-cache-permissions"
 }
 
 test_launcher_cli_resolution_policy() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5979,7 +5979,9 @@ assertCacheLinks({
 const chromeBody = functionBody("sync_chrome_bundled_plugin_cache", "sync_computer_use_bundled_plugin_cache");
 for (const required of [
   'make_path_owner_trusted',
-  'make_tree_owner_trusted "$source_plugin"',
+  'path_has_unsafe_write',
+  'tree_has_unsafe_write "$cache_plugin"',
+  'cache_was_untrusted=1',
   'make_tree_owner_trusted "$tmp_plugin"',
   'make_tree_owner_trusted "$cache_plugin"',
   'write_chrome_native_host_manifests "$host_path" "$cache_root/latest"',
@@ -5987,6 +5989,9 @@ for (const required of [
   if (!chromeBody.includes(required)) {
     throw new Error(`Chrome plugin runtime cache sync missing ${required}`);
   }
+}
+if (chromeBody.includes('make_tree_owner_trusted "$source_plugin"')) {
+  throw new Error("Chrome plugin sync must not bless an installed writable source tree");
 }
 const mkdirCacheParent = chromeBody.indexOf('mkdir -p "$cache_parent"');
 if (mkdirCacheParent === -1 || chromeBody.indexOf('"$cache_parent"', mkdirCacheParent) === -1) {
@@ -6005,11 +6010,26 @@ import sys
 
 launcher = pathlib.Path(sys.argv[1]).read_text()
 helpers = []
-for name in ("make_path_owner_trusted", "make_tree_owner_trusted"):
+for name in (
+    "make_tree_owner_writable",
+    "make_path_owner_trusted",
+    "make_tree_owner_trusted",
+    "path_has_unsafe_write",
+    "tree_has_unsafe_write",
+    "remove_tree_if_exists",
+):
     match = re.search(rf"{name}\(\) \{{[\s\S]*?\n\}}\n", launcher)
     if match is None:
         raise SystemExit(f"missing {name}")
     helpers.append(match.group(0))
+
+sync_match = re.search(
+    r"sync_chrome_bundled_plugin_cache\(\) \{[\s\S]*?\n\}\n\nsync_computer_use_bundled_plugin_cache\(\)",
+    launcher,
+)
+if sync_match is None:
+    raise SystemExit("missing Chrome cache sync")
+sync_function = sync_match.group(0).rsplit("\n\nsync_computer_use_bundled_plugin_cache()", 1)[0]
 
 pathlib.Path(sys.argv[2]).write_text(
     """#!/usr/bin/env bash
@@ -6017,60 +6037,66 @@ set -euo pipefail
 
 """
     + "\n".join(helpers)
+    + "\n"
+    + sync_function
     + r'''
 root="$1"
-cache="$root/.codex/plugins/cache/openai-bundled/chrome"
-plugin="$cache/26.test"
-source_plugin="$root/app/resources/plugins/openai-bundled/plugins/chrome"
-mkdir -p "$plugin/extension-host"
-mkdir -p "$source_plugin/scripts" "$source_plugin/extension-host/linux/x64"
-touch "$plugin/extension-host/host"
-touch "$source_plugin/scripts/browser-client.mjs" "$source_plugin/extension-host/linux/x64/extension-host"
-chmod 775 "$root/.codex" \
-  "$root/.codex/plugins" \
-  "$root/.codex/plugins/cache" \
-  "$root/.codex/plugins/cache/openai-bundled" \
-  "$cache" \
-  "$plugin" \
-  "$plugin/extension-host"
-chmod 664 "$plugin/extension-host/host"
-chmod 775 "$root/app" \
-  "$root/app/resources" \
-  "$root/app/resources/plugins" \
-  "$root/app/resources/plugins/openai-bundled" \
-  "$root/app/resources/plugins/openai-bundled/plugins" \
-  "$source_plugin" \
-  "$source_plugin/scripts" \
-  "$source_plugin/extension-host" \
-  "$source_plugin/extension-host/linux" \
+SCRIPT_DIR="$root/app"
+HOME="$root/home"
+CODEX_HOME="$HOME/.codex"
+source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/chrome"
+cache_root="$CODEX_HOME/plugins/cache/openai-bundled/chrome"
+cache_plugin="$cache_root/26.test"
+
+chrome_extension_host_arch() { printf '%s\n' x64; }
+bundled_plugin_version() { printf '%s\n' 26.test; }
+replace_symlink() { ln -sfnT "$1" "$2"; }
+write_chrome_native_host_manifests() { :; }
+
+mkdir -p \
+  "$source_plugin/.codex-plugin" \
   "$source_plugin/extension-host/linux/x64" \
-  "$source_plugin/extension-host/linux/x64/extension-host"
-chmod 664 "$source_plugin/scripts/browser-client.mjs"
+  "$source_plugin/scripts/node_modules" \
+  "$cache_plugin/.codex-plugin" \
+  "$cache_plugin/extension-host/linux/x64" \
+  "$cache_plugin/scripts/node_modules"
+printf '%s\n' '{"name":"chrome","version":"26.test"}' > "$source_plugin/.codex-plugin/plugin.json"
+printf '%s\n' trusted-host > "$source_plugin/extension-host/linux/x64/extension-host"
+printf '%s\n' trusted-client > "$source_plugin/scripts/browser-client.mjs"
+printf '%s\n' trusted-manifest > "$source_plugin/scripts/installManifest.mjs"
+printf '%s\n' trusted-module > "$source_plugin/scripts/node_modules/classic-level.mjs"
+chmod +x "$source_plugin/extension-host/linux/x64/extension-host"
+cp -R "$source_plugin/." "$cache_plugin/"
+printf '%s\n' tampered-module > "$cache_plugin/scripts/node_modules/classic-level.mjs"
 
-make_path_owner_trusted \
-  "$root/.codex" \
-  "$root/.codex/plugins" \
-  "$root/.codex/plugins/cache" \
-  "$root/.codex/plugins/cache/openai-bundled" \
-  "$cache"
-make_tree_owner_trusted "$plugin"
-make_path_owner_trusted \
-  "$root/app" \
-  "$root/app/resources" \
-  "$root/app/resources/plugins" \
-  "$root/app/resources/plugins/openai-bundled" \
-  "$root/app/resources/plugins/openai-bundled/plugins" \
-  "$source_plugin"
-make_tree_owner_trusted "$source_plugin"
+# Simulate a cache and relevant ancestor created under umask 0002. The four
+# files used by the old partial comparison still match, while an imported
+# module that was not compared has been changed.
+chmod 775 "$CODEX_HOME" "$CODEX_HOME/plugins" "$CODEX_HOME/plugins/cache" \
+  "$CODEX_HOME/plugins/cache/openai-bundled" "$cache_root" "$cache_plugin"
+chmod 664 "$cache_plugin/scripts/node_modules/classic-level.mjs"
+chmod -R go-w "$SCRIPT_DIR"
 
-if find "$root/.codex" -perm /022 -print -quit | grep -q .; then
+sync_chrome_bundled_plugin_cache
+
+grep -qx trusted-module "$cache_plugin/scripts/node_modules/classic-level.mjs"
+for trusted_path in \
+  "$CODEX_HOME" \
+  "$CODEX_HOME/plugins" \
+  "$CODEX_HOME/plugins/cache" \
+  "$CODEX_HOME/plugins/cache/openai-bundled" \
+  "$cache_root"; do
+  if find "$trusted_path" -maxdepth 0 ! -type l -perm /022 -print -quit | grep -q .; then
+    echo "Chrome cache ancestor remained group/world writable: $trusted_path" >&2
+    exit 1
+  fi
+done
+if find "$cache_plugin" ! -type l -perm /022 -print -quit | grep -q .; then
+  echo "Chrome plugin cache remained group/world writable" >&2
   exit 1
 fi
-if find "$root/app" -perm /022 -print -quit | grep -q .; then
-  exit 1
-fi
-test -w "$plugin/extension-host/host"
-test -w "$source_plugin/scripts/browser-client.mjs"
+test -L "$cache_root/latest"
+test "$(readlink "$cache_root/latest")" = 26.test
 '''
 )
 PY
@@ -7146,6 +7172,8 @@ test_chrome_plugin_staging() {
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "agent.browsers.list()"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "browser.tabs.new()"
     assert_contains "$install_dir/resources/plugins/openai-bundled/.agents/plugins/marketplace.json" '"name": "chrome"'
+    [ -z "$(find "$install_dir/resources/plugins/openai-bundled" -perm /022 -print -quit)" ] \
+        || fail "Expected staged bundled plugin resources to reject group/other writes"
     assert_contains "$output_log" "Chrome plugin staged from upstream DMG"
 }
 


### PR DESCRIPTION
This follows the side-panel runtime work from #768 and the report in #849.

On my local install the native host already answers `codexRuntime/hello`, but `codexRuntime/ensure` can still fail when the user plugin cache was created with a group-writable umask. The runtime trust checks then reject `~/.codex` or the Chrome plugin cache before the app-server starts.

This keeps those trust checks strict and makes the launcher harden the Chrome plugin runtime cache before writing the browser native-host manifests. Existing cache hits and first-time cache copies both get group/other write removed.

Tests run:
- `cargo fmt --check --all`
- `cargo test -p codex-computer-use-linux`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template && bash -n tests/scripts_smoke.sh && git diff --check`
