### PR TITLE
Fix new turns in unowned resumed threads

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5957,6 +5957,49 @@ test("does not retain streaming ownership when a completed thread resumes withou
   });
 });
 
+test("claims an unowned completed thread when starting a new turn", async () => {
+  const source = [
+    "async function start(e,t,c){",
+    "let p=await MF({conversationId:t,getStreamRole:t=>e.getStreamRole(t),sendRequest:r=>e.sendThreadFollowerRequest(r,`thread-follower-start-turn`,{conversationId:t})});",
+    "if(p)return UP.abort(c,`follower_window_forwarded`),p.result;",
+    "if(e.getStreamRole(t)?.role!==`owner`)throw Error(Kw);",
+    "if(!e.isConversationStreaming(t))throw K.error(`Conversation is not being streamed.`,{safe:{conversationId:t},sensitive:{}}),Error(`Conversation ${t} is not being streamed.`);",
+    "return e.sendRequest(`turn/start`,{threadId:t})",
+    "}",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxAppServerConversationHydrationPatch, source);
+
+  assert.match(patched, /codexLinuxClaimUnownedTurn/);
+  const context = {};
+  vm.runInNewContext(
+    [
+      "var Kw=`wrong window`,K={error:()=>{}},UP={abort:()=>{}};",
+      "async function MF({conversationId:e,getStreamRole:t,sendRequest:n}){return n(t(e))}",
+      patched,
+      "function manager(role){let state={role,marked:false,started:false,forwarded:false};return {state,getStreamRole:()=>state.role==null?null:state.role,setConversationStreamRole:(id,value)=>{state.role=value},markConversationStreaming:()=>{state.marked=true},isConversationStreaming:()=>state.marked||state.role?.role===`follower`,sendThreadFollowerRequest:async role=>{if(role?.role===`follower`){state.forwarded=true;return{result:`forwarded`}}return null},sendRequest:async()=>{state.started=true;return`started`}}}",
+      "result=(async()=>{let unowned=manager(null),follower=manager({role:`follower`,ownerClientId:`window-2`});let unownedResult=await start(unowned,`thread-1`,`message-1`),followerResult=await start(follower,`thread-2`,`message-2`);return{unowned:{state:unowned.state,result:unownedResult},follower:{state:follower.state,result:followerResult}}})()",
+    ].join(""),
+    context,
+  );
+
+  assert.deepEqual(JSON.parse(JSON.stringify(await context.result)), {
+    unowned: {
+      state: { role: { role: "owner" }, marked: true, started: true, forwarded: false },
+      result: "started",
+    },
+    follower: {
+      state: {
+        role: { role: "follower", ownerClientId: "window-2" },
+        marked: false,
+        started: false,
+        forwarded: true,
+      },
+      result: "forwarded",
+    },
+  });
+});
+
 test("recovers completed stream items that arrive after local state lost their started item", () => {
   const source = [
     "class T{onNotification(e,t){let n={method:e,params:t};switch(n.method){case`item/completed`:{if(this.frameTextDeltaQueue.drainBefore(()=>{this.onNotification(`item/completed`,n.params)}))break;",

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -22,6 +22,7 @@ const LINUX_APP_SERVER_CONVERSATION_HYDRATION_QUEUE_MARKER = "codexLinuxRemoteMo
 const LINUX_APP_SERVER_CONVERSATION_HYDRATION_IN_FLIGHT_MARKER = "codexLinuxRemoteMobileHydrationInFlight";
 const LINUX_APP_SERVER_CONVERSATION_HYDRATION_LATE_EVENT_MARKER = "codexLinuxRemoteMobileHydrateLateEvent";
 const LINUX_APP_SERVER_COMPLETED_RESUME_MARKER = "codexLinuxResumeShouldStream";
+const LINUX_APP_SERVER_UNOWNED_TURN_CLAIM_MARKER = "codexLinuxClaimUnownedTurn";
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -931,6 +932,28 @@ function applyLinuxAppServerConversationHydrationPatch(currentSource) {
     ) {
       console.warn(
         "WARN: Could not find completed resume streaming insertion point — skipping Linux completed resume recovery patch",
+      );
+    }
+  }
+
+  if (!patchedSource.includes(LINUX_APP_SERVER_UNOWNED_TURN_CLAIM_MARKER)) {
+    const unownedTurnNeedle =
+      /if\(([A-Za-z_$][\w$]*)\)return ([A-Za-z_$][\w$]*)\.abort\(([A-Za-z_$][\w$]*),`follower_window_forwarded`\),\1\.result;if\(([A-Za-z_$][\w$]*)\.getStreamRole\(([A-Za-z_$][\w$]*)\)\?\.role!==`owner`\)throw Error\(([A-Za-z_$][\w$]*)\);if\(!\4\.isConversationStreaming\(\5\)\)/u;
+    const unownedTurnMatch = unownedTurnNeedle.exec(patchedSource);
+
+    if (unownedTurnMatch != null) {
+      const [, forwardedVar, abortManagerVar, userMessageIdVar, managerVar, conversationIdVar, errorVar] =
+        unownedTurnMatch;
+      patchedSource = patchedSource.replace(
+        unownedTurnNeedle,
+        `if(${forwardedVar})return ${abortManagerVar}.abort(${userMessageIdVar},\`follower_window_forwarded\`),${forwardedVar}.result;/*${LINUX_APP_SERVER_UNOWNED_TURN_CLAIM_MARKER}*/${managerVar}.getStreamRole(${conversationIdVar})==null&&(${managerVar}.markConversationStreaming(${conversationIdVar}),${managerVar}.setConversationStreamRole(${conversationIdVar},{role:\`owner\`}));if(${managerVar}.getStreamRole(${conversationIdVar})?.role!==\`owner\`)throw Error(${errorVar});if(!${managerVar}.isConversationStreaming(${conversationIdVar}))`,
+      );
+    } else if (
+      patchedSource.includes("follower_window_forwarded") &&
+      patchedSource.includes("Conversation is not being streamed.")
+    ) {
+      console.warn(
+        "WARN: Could not find unowned turn claim insertion point — completed resumed threads may reject new turns",
       );
     }
   }


### PR DESCRIPTION
## What changed

- claim local stream ownership when a resumed thread has no owner and the user starts a new turn
- keep real follower windows forwarding to their existing `ownerClientId`
- add regression coverage for both the unowned and follower paths

## Why

The completed-thread resume fix correctly leaves an idle completed thread non-streaming, but that also leaves its stream role unset. The new-turn path treated the null role like a follower and rejected submission with “Please continue this conversation on the window where it was started,” even when the thread originated in Codex CLI and no Desktop owner existed.

Fixes #850.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (365 passed)
- current staged webview asset matches the new patch needle
- applying the patch twice to the current asset is idempotent
- `git diff --check`