### PR TITLE
fix(webview): coalesce duplicate turn/start submits

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -157,6 +157,7 @@ const {
   applyLocalEnvironmentActionModalDraftPatch,
   applyPersistentRateLimitFooterPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxTurnStartDuplicateGuardPatch,
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,
@@ -1046,6 +1047,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-app-sunset-gate",
     "linux-app-server-feature-enablement",
     "linux-app-server-backfill-wait",
+    "linux-turn-start-duplicate-guard",
     "linux-completed-item-recovery",
     "linux-remote-terminal-status-recovery",
     "linux-skills-list-dedupe",
@@ -5627,6 +5629,67 @@ test("extends app-server startup waits in current manager signals bundle", () =>
   assert.match(patched, /i=codexLinuxAppServerBackfillTimeoutMs\(e,i\);let a=si\(t\)/);
 });
 
+test("coalesces duplicate queued turn starts before request creation", async () => {
+  const source = [
+    "class RequestClient{constructor(){this.requests=[];this.queuedRequests=[];this.dispatched=[]}async sendRequest(e,t,n){if(e===`config/read`)return this.sendConfigReadRequest(t,n);return this.enqueueRequest(e,t,n)}sendConfigReadRequest(e,t){return Promise.resolve({config:e,options:t})}createRequest(e,t,n){let r=this.requests.length+1,i,a,o=new Promise((e,t)=>{i=e,a=t});return this.requests.push({request:{id:r,method:e,params:t},resolve:i,reject:a,options:n}),{request:{id:r,method:e,params:t},promise:o}}enqueueRequest(e,t,n,r=e=>{this.dispatched.push(e)}){let i=n?.priority??`interactive`;if(i===`background`&&this.queuedRequests.filter(({priority:e})=>e===`background`).length>=1)return Promise.reject(Error(`App server request queue is full`));let{request:a,promise:o}=this.createRequest(e,t,n);return this.queuedRequests.push({dispatch:()=>{this.startRequest(a),r(a)},priority:i}),this.pumpQueue(),o}startRequest(e){this.started=e}pumpQueue(){}}",
+  ].join("");
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxTurnStartDuplicateGuardPatch, source),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(patched, /codexLinuxTurnStartDuplicateKey/);
+  assert.match(patched, /codexLinuxTurnStartPendingRequests/);
+
+  const context = {};
+  vm.runInNewContext(`${patched};client=new RequestClient();`, context);
+
+  assert.equal(
+    JSON.stringify(await context.client.sendRequest("config/read", { key: "theme" }, { timeoutMs: 1 })),
+    JSON.stringify({ config: { key: "theme" }, options: { timeoutMs: 1 } }),
+  );
+  assert.equal(context.client.requests.length, 0);
+
+  const first = context.client.sendRequest("turn/start", {
+    thread_id: "thread-1",
+    turn_id: "turn-1",
+    message: { client_id: "client-a", content: "same message" },
+  }, {});
+  const second = context.client.sendRequest("turn/start", {
+    thread_id: "thread-1",
+    turn_id: "turn-1",
+    message: { client_id: "client-b", content: "same message" },
+  }, {});
+  assert.equal(context.client.requests.length, 1);
+  assert.equal(context.client.queuedRequests.length, 1);
+  context.client.requests[0].resolve({ ok: true });
+  assert.deepEqual(await first, { ok: true });
+  assert.deepEqual(await second, { ok: true });
+  await Promise.resolve();
+
+  const retry = context.client.sendRequest("turn/start", {
+    thread_id: "thread-1",
+    turn_id: "turn-1",
+    message: { client_id: "client-c", content: "same message" },
+  }, {});
+  assert.equal(context.client.requests.length, 2);
+  assert.equal(context.client.queuedRequests.length, 2);
+  context.client.requests[1].reject(new Error("boom"));
+  await assert.rejects(retry, /boom/);
+  await Promise.resolve();
+
+  const afterFailure = context.client.sendRequest("turn/start", {
+    thread_id: "thread-1",
+    turn_id: "turn-1",
+    message: { client_id: "client-d", content: "same message" },
+  }, {});
+  assert.equal(context.client.requests.length, 3);
+  assert.equal(context.client.queuedRequests.length, 3);
+  context.client.requests[2].resolve({ afterFailure: true });
+  assert.deepEqual(await afterFailure, { afterFailure: true });
+});
+
 test("keeps current app-server backfill helpers visible outside the Sentry handler", () => {
   const source =
     "function fi(e,t){let n=hi(t.originalException);return n==null?e:{...e,...n,extra:{...e.extra,...n.extra}}}var gi=e(oi(),1),_i=z({code:Pe([He(),I()]),message:I().min(1)}).passthrough(),vi=class{requestLifecycleListeners=new Set;requestPromises=new Map;createRequest(e,t,n){let r=F(V()),i=n?.timeoutMs??0,a=si(t),o=this.requestPromises.size,s=Date.now();return{request:{id:r,method:e,params:t},conversationId:a,pending:o,startedAtMs:s,timeoutMs:i}}};";
@@ -5670,6 +5733,37 @@ test("keeps remote conversation hydration out of core", () => {
     );
   }
   assert.ok(descriptors.some((patch) => patch.id === "linux-completed-item-recovery"));
+});
+
+test("turn/start duplicate guard descriptor follows current request client chunks", () => {
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-turn-start-duplicate-guard",
+  );
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.phase, "webview-asset");
+  assert.equal(descriptor.ciPolicy, "optional");
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+    ),
+    true,
+  );
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-Bj9ubaFn.js",
+    ),
+    true,
+  );
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(descriptor.pattern.test("app-server-manager-signals-test.js"), true);
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(descriptor.pattern.test("src-CoIhwwHr.js"), true);
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(descriptor.pattern.test("remote-conversation-page-fPJAD_qJ.js"), false);
+  descriptor.pattern.lastIndex = 0;
+  assert.equal(descriptor.pattern.test("local-conversation-thread-imfIBhy0.js"), false);
 });
 
 test("recovers completed stream items that arrive after local state lost their started item", () => {

--- a/scripts/patches/core/all-linux/webview/turn-start-duplicate-guard/patch.js
+++ b/scripts/patches/core/all-linux/webview/turn-start-duplicate-guard/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxTurnStartDuplicateGuardPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "linux-turn-start-duplicate-guard",
+    phase: "webview-asset",
+    order: 1043,
+    ciPolicy: "optional",
+    pattern: /^(?:app-initial~app-main~(?:pull-request-code-review~)?onboarding-page~hotkey-window-thread-page~.*|app-server-manager-.*|src-.*)\.js$/,
+    missingDescription: "turn/start request client webview bundle",
+    skipDescription: "Linux turn/start duplicate submit guard",
+    apply: applyLinuxTurnStartDuplicateGuardPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -869,6 +869,71 @@ function applyLinuxAppServerBackfillWaitPatch(currentSource) {
   return patchedSource;
 }
 
+function applyLinuxTurnStartDuplicateGuardPatch(currentSource) {
+  if (currentSource.includes("codexLinuxTurnStartDuplicateKey")) {
+    return currentSource;
+  }
+
+  const buildDuplicateKeyExpression = (methodVar, paramsVar) =>
+    "((codexLinuxTurnStartMethod,codexLinuxTurnStartParams)=>{" +
+    "if(codexLinuxTurnStartMethod!==`turn/start`||codexLinuxTurnStartParams==null||typeof codexLinuxTurnStartParams!==`object`)return null;" +
+    "let codexLinuxTurnStartRead=(e,t)=>{for(let n of t){let t=e?.[n];if(t!=null)return t}return null}," +
+    "codexLinuxTurnStartString=e=>{if(e==null)return null;if(typeof e===`string`)return e;if(typeof e===`number`||typeof e===`boolean`)return String(e);try{return JSON.stringify(e)}catch{return null}}," +
+    "codexLinuxTurnStartId=codexLinuxTurnStartRead(codexLinuxTurnStartParams,[`turn_id`,`turnId`])??codexLinuxTurnStartRead(codexLinuxTurnStartParams.turn,[`id`,`turn_id`,`turnId`])," +
+    "codexLinuxTurnStartThread=codexLinuxTurnStartRead(codexLinuxTurnStartParams,[`thread_id`,`threadId`,`conversation_id`,`conversationId`])??codexLinuxTurnStartRead(codexLinuxTurnStartParams.thread,[`id`,`thread_id`,`threadId`])??codexLinuxTurnStartRead(codexLinuxTurnStartParams.turn,[`thread_id`,`threadId`])," +
+    "codexLinuxTurnStartMessage=codexLinuxTurnStartRead(codexLinuxTurnStartParams,[`message`,`user_message`,`userMessage`,`input`,`text`])??codexLinuxTurnStartRead(codexLinuxTurnStartParams.item,[`content`,`text`])??codexLinuxTurnStartRead(codexLinuxTurnStartParams.turn,[`message`,`input`,`text`])," +
+    "codexLinuxTurnStartMessageBody=typeof codexLinuxTurnStartMessage===`object`&&codexLinuxTurnStartMessage!=null?codexLinuxTurnStartRead(codexLinuxTurnStartMessage,[`content`,`text`,`input`,`message`])??codexLinuxTurnStartMessage:codexLinuxTurnStartMessage," +
+    "codexLinuxTurnStartText=codexLinuxTurnStartString(codexLinuxTurnStartMessageBody);" +
+    "return codexLinuxTurnStartId==null||codexLinuxTurnStartText==null?null:`${codexLinuxTurnStartThread??``}\\n${codexLinuxTurnStartId}\\n${codexLinuxTurnStartText.slice(0,4096)}`" +
+    `})(${methodVar},${paramsVar})`;
+  const buildGuardPrefix = (keyExpression) =>
+    `let codexLinuxTurnStartDuplicateKey=${keyExpression};` +
+    "if(codexLinuxTurnStartDuplicateKey!=null){" +
+    "let codexLinuxTurnStartPending=this.codexLinuxTurnStartPendingRequests?.get(codexLinuxTurnStartDuplicateKey);" +
+    "if(codexLinuxTurnStartPending!=null)return codexLinuxTurnStartPending}";
+  const buildTrackPending = (promiseVar) =>
+    "if(codexLinuxTurnStartDuplicateKey!=null){" +
+    "let codexLinuxTurnStartPendingMap=this.codexLinuxTurnStartPendingRequests??=new Map;" +
+    `codexLinuxTurnStartPendingMap.set(codexLinuxTurnStartDuplicateKey,${promiseVar});` +
+    `let codexLinuxTurnStartCleanup=()=>{codexLinuxTurnStartPendingMap.get(codexLinuxTurnStartDuplicateKey)===${promiseVar}&&codexLinuxTurnStartPendingMap.delete(codexLinuxTurnStartDuplicateKey)};` +
+    `${promiseVar}.then(codexLinuxTurnStartCleanup,codexLinuxTurnStartCleanup)}`;
+  const enqueueRequestNeedle =
+    /let\{request:([A-Za-z_$][\w$]*),promise:([A-Za-z_$][\w$]*)\}=this\.createRequest\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\);return this\.queuedRequests\.push\(\{dispatch:\(\)=>\{this\.startRequest\(\1\),([A-Za-z_$][\w$]*)\(\1\)\},priority:([A-Za-z_$][\w$]*)\}\),this\.pumpQueue\(\),\2/;
+  let patchedSource = currentSource;
+  let changed = false;
+
+  if (enqueueRequestNeedle.test(patchedSource)) {
+    patchedSource = patchedSource.replace(
+      enqueueRequestNeedle,
+      (_match, requestVar, promiseVar, methodVar, paramsVar, optionsVar, dispatchVar, priorityVar) => {
+        const duplicateKey = buildDuplicateKeyExpression(methodVar, paramsVar);
+        return (
+          buildGuardPrefix(duplicateKey) +
+          `let{request:${requestVar},promise:${promiseVar}}=this.createRequest(${methodVar},${paramsVar},${optionsVar});` +
+          buildTrackPending(promiseVar) +
+          `return this.queuedRequests.push({dispatch:()=>{this.startRequest(${requestVar}),${dispatchVar}(${requestVar})},priority:${priorityVar}}),this.pumpQueue(),${promiseVar}`
+        );
+      },
+    );
+    changed = true;
+  }
+
+  if (!changed) {
+    if (
+      currentSource.includes("enqueueRequest(") &&
+      currentSource.includes("queuedRequests") &&
+      currentSource.includes("createRequest(")
+    ) {
+      console.warn(
+        "WARN: Could not find turn/start request guard insertion point — duplicate submit guard not applied",
+      );
+    }
+    return currentSource;
+  }
+
+  return patchedSource;
+}
+
 function applyLinuxCompletedItemRecoveryPatch(currentSource) {
   if (currentSource.includes("codexLinuxCompletedItemExists=")) {
     return currentSource;
@@ -2009,6 +2074,7 @@ function patchCommentPreloadBundle(extractedDir) {
 module.exports = {
   applyBrowserAnnotationScreenshotPatch,
   applyLinuxAppServerBackfillWaitPatch,
+  applyLinuxTurnStartDuplicateGuardPatch,
   applyLinuxCompletedItemRecoveryPatch,
   applyLinuxRemoteTerminalStatusRecoveryPatch,
   applyLinuxAppServerFeatureEnablementPatch,


### PR DESCRIPTION
## Summary

Fixes #851.

- Add an optional Linux webview patch that reuses an in-flight `turn/start` request when the same turn and message body are submitted twice before the first request settles.
- Target the current queued request-client path before request creation.
- Register the patch for the current `hotkey-window-thread-page` webview chunks while keeping it fail-soft if upstream drifts again.

## Validation

- `node --test --test-name-pattern "coalesces duplicate queued turn starts|turn/start duplicate guard descriptor|remote conversation hydration out of core|default core patch descriptors" scripts/patch-linux-window-ui.test.js` (`4` tests)
- `node --test scripts/patch-linux-window-ui.test.js` (`362` tests)
- `bash scripts/ci/run-node-checks.sh` (`945` tests)
- `bash tests/scripts_smoke.sh`
- `cargo fmt --check`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager` (`235` tests)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
