### PR TITLE
Suppress tray icons for multi-launch instances

### DIFF
--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -144,6 +144,14 @@ CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh --new-instance
 CODEX_MULTI_LAUNCH=1 CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh
 ```
 
+Secondary instances do not create a system-tray icon by default, and closing
+their last window exits normally. To keep an individual secondary instance in
+the tray and retain close-to-tray behavior, set `CODEX_MULTI_LAUNCH_TRAY=1`:
+
+```bash
+CODEX_MULTI_LAUNCH_TRAY=1 ./codex-app/start.sh --new-instance
+```
+
 ## Package Formats
 
 After `make build-app` or `make build-app-fresh`, build a package from

--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -133,6 +133,10 @@ Open an independent app process:
 ./codex-app/start.sh --new-instance
 ```
 
+Secondary instances do not register system tray items. This keeps temporary
+development and test instances from adding indistinguishable icons alongside
+the primary app's tray item.
+
 Configure the port range or make every launch use multi-instance mode:
 
 ```bash

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -219,7 +219,7 @@ Launches the $CODEX_LINUX_APP_DISPLAY_NAME app.
 
 Options:
   -h, --help                  Show this help message and exit
-  --new-instance              Start a separate app instance on the first free port in the multi-launch range
+  --new-instance              Start a separate trayless app instance on the first free port in the multi-launch range
   --new-chat                  Open the main window on a new chat
   --quick-chat                Open a projectless quick chat
   --prompt-chat               Show the compact prompt for a new chat

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -53,8 +53,8 @@ MULTI_LAUNCH_ACTIVE=0
 CODEX_LINUX_INSTANCE_ID=""
 LAUNCHER_ARGS=()
 
-# Internal marker consumed by patched Electron bundles; never trust inheritance.
-unset CODEX_LINUX_MULTI_LAUNCH
+# Internal markers consumed by patched Electron bundles; never trust inheritance.
+unset CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_MULTI_LAUNCH_TRAY
 
 early_truthy_env_value() {
     case "${1:-}" in
@@ -178,6 +178,15 @@ configure_multi_launch_instance() {
     MULTI_LAUNCH_ACTIVE=1
     CODEX_LINUX_MULTI_LAUNCH=1
 
+    case "${CODEX_MULTI_LAUNCH_TRAY:-0}" in
+        0|"") ;;
+        1) CODEX_LINUX_MULTI_LAUNCH_TRAY=1 ;;
+        *)
+            echo "CODEX_MULTI_LAUNCH_TRAY must be 0 or 1" >&2
+            exit 1
+            ;;
+    esac
+
     APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"
     APP_PID_FILE="$APP_STATE_DIR/app.pid"
     WEBVIEW_PID_FILE="$APP_STATE_DIR/webview.pid"
@@ -194,7 +203,7 @@ configure_multi_launch_instance() {
     else
         CODEX_ELECTRON_USER_DATA_DIR="$APP_STATE_DIR/electron-user-data"
     fi
-    export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_WEBVIEW_PORT
+    export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_MULTI_LAUNCH_TRAY CODEX_LINUX_WEBVIEW_PORT
 }
 
 configure_multi_launch_instance "$@"
@@ -255,6 +264,7 @@ Environment:
                               Override --force-renderer-accessibility; auto forces it only when assistive
                               technology is detected and never under WSLg or native wayland-gpu
   CODEX_MULTI_LAUNCH=1        Treat normal launches like --new-instance
+  CODEX_MULTI_LAUNCH_TRAY=0|1 Show a system tray item for --new-instance (default: 0)
   CODEX_MULTI_LAUNCH_PORT_RANGE=START-END
                               Port allocation range for --new-instance (default: CODEX_WEBVIEW_PORT through +4)
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3452,7 +3452,7 @@ test("adds Linux tray support including the platform guard", () => {
   );
   assert.match(
     patched,
-    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)/,
+    /\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)/,
   );
   assert.match(patched, /setLinuxTrayContextMenu\(\)\{let e=n\.Menu\.buildFromTemplate/);
   assert.match(
@@ -3470,7 +3470,7 @@ test("adds Linux tray support including the platform guard", () => {
   );
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
+    /\(E\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
   );
   assert.doesNotMatch(patched, /process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)/);
 });
@@ -3705,7 +3705,7 @@ test("adds Linux tray support for current minified window and startup identifier
   assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
+    /\(E\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
   assert.match(
     patched,
@@ -3728,7 +3728,7 @@ test("adds Linux tray startup support for current appBrand initializer", () => {
   assert.deepEqual(warnings.filter((warning) => warning.includes("tray startup")), []);
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ye\(\);/,
+    /\(E\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ye\(\);/,
   );
   assert.match(
     patched,
@@ -3750,11 +3750,11 @@ test("scopes dynamic tray startup matching to the tray initializer", () => {
   assert.match(patched, /U&&startOther\(\);/);
   assert.doesNotMatch(
     patched,
-    /\(U\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&startOther\(\);/,
+    /\(U\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&startOther\(\);/,
   );
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
+    /\(E\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
   assert.match(patched, /catch\(e\)\{A=!1\}\};U&&startOther\(\);/);
   assert.match(
@@ -3774,7 +3774,7 @@ test("logs Linux tray setup failures when the catch body contains nested objects
 
   assert.match(
     patched,
-    /\(D\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&_e\(\);/,
+    /\(D\|\|process\.platform===`linux`&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&_e\(\);/,
   );
   assert.match(
     patched,
@@ -3793,7 +3793,7 @@ test("scopes close-to-tray already-patched detection to the handler", () => {
 
   assert.match(
     patched,
-    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&!t\)\{e\.preventDefault\(\),j\.hide\(\);return\}/,
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&!t\)\{e\.preventDefault\(\),j\.hide\(\);return\}/,
   );
 });
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -3470,7 +3470,7 @@ test("adds Linux tray support including the platform guard", () => {
   );
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
+    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&oe\(\);/,
   );
   assert.doesNotMatch(patched, /process\.platform===`linux`&&codexLinuxIsTrayEnabled\(\)/);
 });
@@ -3705,7 +3705,7 @@ test("adds Linux tray support for current minified window and startup identifier
   assert.match(patched, /e\.preventDefault\(\),j\.hide\(\);return/);
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
+    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
   assert.match(
     patched,
@@ -3728,7 +3728,7 @@ test("adds Linux tray startup support for current appBrand initializer", () => {
   assert.deepEqual(warnings.filter((warning) => warning.includes("tray startup")), []);
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ye\(\);/,
+    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ye\(\);/,
   );
   assert.match(
     patched,
@@ -3750,11 +3750,11 @@ test("scopes dynamic tray startup matching to the tray initializer", () => {
   assert.match(patched, /U&&startOther\(\);/);
   assert.doesNotMatch(
     patched,
-    /\(U\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&startOther\(\);/,
+    /\(U\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&startOther\(\);/,
   );
   assert.match(
     patched,
-    /\(E\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
+    /\(E\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&ce\$\(\);/,
   );
   assert.match(patched, /catch\(e\)\{A=!1\}\};U&&startOther\(\);/);
   assert.match(
@@ -3774,7 +3774,7 @@ test("logs Linux tray setup failures when the catch body contains nested objects
 
   assert.match(
     patched,
-    /\(D\|\|process\.platform===`linux`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&_e\(\);/,
+    /\(D\|\|process\.platform===`linux`&&process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`&&\(typeof codexLinuxIsTrayEnabled!==`function`\|\|codexLinuxIsTrayEnabled\(\)\)\)&&_e\(\);/,
   );
   assert.match(
     patched,

--- a/scripts/patches/impl/main-process/tray.js
+++ b/scripts/patches/impl/main-process/tray.js
@@ -244,7 +244,10 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
     console.warn("WARN: Could not find tray menu thread update handler — skipping Linux tray context refresh patch");
   }
 
-  const trayEnabledExpression = "process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
+  // Multi-launch instances use isolated profiles, so their tray preference
+  // starts enabled independently. Keep secondary/dev instances out of SNI;
+  // otherwise every --new-instance launch adds another identical tray item.
+  const trayEnabledExpression = "process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
   const traySetup = findDynamicTraySetup(patchedSource);
   const dynamicTrayStartupMatch = traySetup == null
     ? null

--- a/scripts/patches/impl/main-process/tray.js
+++ b/scripts/patches/impl/main-process/tray.js
@@ -102,6 +102,10 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   }
   const packagedTrayIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop-tray.png`";
   const packagedAppIconPathExpression = "process.resourcesPath+`/../.codex-linux/codex-desktop.png`";
+  // The launcher sets these internal markers only for an explicit multi-launch
+  // invocation. A secondary instance needs both a tray item and close-to-tray
+  // enabled, otherwise closing its last window would leave it inaccessible.
+  const multiLaunchTrayEnabledExpression = "(process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`||process.env.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`)";
 
   const trayGuardNeedle =
     "process.platform!==`win32`&&process.platform!==`darwin`?null:";
@@ -143,7 +147,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   }
 
   const patchedCloseToTrayRegex =
-    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
+    /if\(\(process\.platform===`win32`\|\|process\.platform===`linux`\)&&!this\.isAppQuitting&&!\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)&&\(process\.env\.CODEX_LINUX_MULTI_LAUNCH!==`1`\|\|process\.env\.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`\)&&this\.options\.canHideLastWindowToTray\?\.\(\)===!0&&![A-Za-z_$][\w$]*\)\{[A-Za-z_$][\w$]*\.preventDefault\(\),[A-Za-z_$][\w$]*\.hide\(\);return\}/;
   if (patchedCloseToTrayRegex.test(patchedSource)) {
     // Already patched with a newer minifier's window variable.
   } else {
@@ -154,7 +158,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
       const [, gateMethodName, hasOtherWindowVar, eventVar, windowVar] = closeToTrayMatch;
       patchedSource = patchedSource.replace(
         closeToTrayRegex,
-        `if((process.platform===\`win32\`||process.platform===\`linux\`)&&!this.isAppQuitting&&!(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress())&&this.options.${gateMethodName}?.()===!0&&!${hasOtherWindowVar}){${eventVar}.preventDefault(),${windowVar}.hide();return}`,
+        `if((process.platform===\`win32\`||process.platform===\`linux\`)&&!this.isAppQuitting&&!(typeof codexLinuxIsQuitInProgress===\`function\`&&codexLinuxIsQuitInProgress())&&${multiLaunchTrayEnabledExpression}&&this.options.${gateMethodName}?.()===!0&&!${hasOtherWindowVar}){${eventVar}.preventDefault(),${windowVar}.hide();return}`,
       );
     } else {
       console.warn("WARN: Could not find close-to-tray condition — skipping Linux close-to-tray patch");
@@ -247,7 +251,7 @@ function applyLinuxTrayPatch(currentSource, iconPathExpression) {
   // Multi-launch instances use isolated profiles, so their tray preference
   // starts enabled independently. Keep secondary/dev instances out of SNI;
   // otherwise every --new-instance launch adds another identical tray item.
-  const trayEnabledExpression = "process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled())";
+  const trayEnabledExpression = `process.platform===\`linux\`&&${multiLaunchTrayEnabledExpression}&&(typeof codexLinuxIsTrayEnabled!==\`function\`||codexLinuxIsTrayEnabled())`;
   const traySetup = findDynamicTraySetup(patchedSource);
   const dynamicTrayStartupMatch = traySetup == null
     ? null

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4846,7 +4846,7 @@ if 'CODEX_LINUX_MULTI_LAUNCH=1' not in multi_body:
     raise SystemExit("multi-launch must export an app-visible multi-launch marker")
 if 'case "${CODEX_MULTI_LAUNCH_TRAY:-0}" in' not in multi_body or '1) CODEX_LINUX_MULTI_LAUNCH_TRAY=1 ;;' not in multi_body:
     raise SystemExit("multi-launch must resolve the optional tray override")
-if 'export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_WEBVIEW_PORT' not in multi_body:
+if 'export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_MULTI_LAUNCH_TRAY CODEX_LINUX_WEBVIEW_PORT' not in multi_body:
     raise SystemExit("multi-launch must export instance identity for Electron")
 if 'APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
     raise SystemExit("multi-launch must isolate app pid/webview state per allocated port")

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4828,7 +4828,7 @@ if 'export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINU
     raise SystemExit("launcher must export CODEX_HOME and Linux feature resource directory")
 if 'configure_multi_launch_instance "$@"' not in source:
     raise SystemExit("launcher must configure multi-launch before deriving WEBVIEW_ORIGIN")
-if 'unset CODEX_LINUX_MULTI_LAUNCH' not in source.split('parse_launcher_args() {', 1)[0]:
+if 'unset CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_MULTI_LAUNCH_TRAY' not in source.split('parse_launcher_args() {', 1)[0]:
     raise SystemExit("launcher must clear inherited internal multi-launch markers before parsing args")
 if '$((CODEX_LINUX_WEBVIEW_PORT + 4))' not in source:
     raise SystemExit("multi-launch default range must cap the default at five ports")
@@ -4844,6 +4844,8 @@ if 'CODEX_LINUX_INSTANCE_ID="port-$CODEX_LINUX_WEBVIEW_PORT"' not in multi_body:
     raise SystemExit("multi-launch must derive a stable instance id from the allocated port")
 if 'CODEX_LINUX_MULTI_LAUNCH=1' not in multi_body:
     raise SystemExit("multi-launch must export an app-visible multi-launch marker")
+if 'case "${CODEX_MULTI_LAUNCH_TRAY:-0}" in' not in multi_body or '1) CODEX_LINUX_MULTI_LAUNCH_TRAY=1 ;;' not in multi_body:
+    raise SystemExit("multi-launch must resolve the optional tray override")
 if 'export CODEX_ELECTRON_USER_DATA_DIR CODEX_LINUX_INSTANCE_ID CODEX_LINUX_MULTI_LAUNCH CODEX_LINUX_WEBVIEW_PORT' not in multi_body:
     raise SystemExit("multi-launch must export instance identity for Electron")
 if 'APP_STATE_DIR="$base_state_dir/instances/$CODEX_LINUX_INSTANCE_ID"' not in multi_body:
@@ -6995,7 +6997,7 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate'
     assert_contains "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`'
     assert_contains "$extracted/.vite/build/main-test.js" 'this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()'
-    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe();'
+    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`&&(process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`||process.env.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`)&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe();'
     assert_not_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)'
     assert_not_contains "$output_log" 'WARN: Could not find tray'
 
@@ -7008,7 +7010,7 @@ if (!closeSnippet) {
   throw new Error("Could not extract patched Linux close handler");
 }
 
-function registerCloseHandler({ quitInProgress = false, isAppQuitting = false, trayEnabled = true } = {}) {
+function registerCloseHandler({ quitInProgress = false, isAppQuitting = false, trayEnabled = true, multiLaunch = false, multiLaunchTray = false } = {}) {
   const state = { hideCalls: 0 };
   const controller = {
     isAppQuitting,
@@ -7024,12 +7026,12 @@ function registerCloseHandler({ quitInProgress = false, isAppQuitting = false, t
     "state",
     `return function(){const v=true;const f=\`local\`;const k={handlers:{},on(event,handler){this.handlers[event]=handler},hide(){state.hideCalls+=1}};${closeSnippet};return k.handlers.close;};`,
   );
-  const makeHandler = factory({ platform: "linux" }, () => quitInProgress, state);
+  const makeHandler = factory({ platform: "linux", env: { ...(multiLaunch ? { CODEX_LINUX_MULTI_LAUNCH: "1" } : {}), ...(multiLaunchTray ? { CODEX_LINUX_MULTI_LAUNCH_TRAY: "1" } : {}) } }, () => quitInProgress, state);
   const handler = makeHandler.call(controller);
   return { handler, state };
 }
 
-function runCloseWithoutHelper({ trayEnabled = true, isAppQuitting = false } = {}) {
+function runCloseWithoutHelper({ trayEnabled = true, isAppQuitting = false, multiLaunch = false, multiLaunchTray = false } = {}) {
   const event = {
     prevented: false,
     preventDefault() {
@@ -7050,7 +7052,7 @@ function runCloseWithoutHelper({ trayEnabled = true, isAppQuitting = false } = {
     "state",
     `return function(){const v=true;const f=\`local\`;const k={handlers:{},on(event,handler){this.handlers[event]=handler},hide(){state.hideCalls+=1}};${closeSnippet};return k.handlers.close;};`,
   );
-  const handler = factory({ platform: "linux" }, state).call(controller);
+  const handler = factory({ platform: "linux", env: { ...(multiLaunch ? { CODEX_LINUX_MULTI_LAUNCH: "1" } : {}), ...(multiLaunchTray ? { CODEX_LINUX_MULTI_LAUNCH_TRAY: "1" } : {}) } }, state).call(controller);
   handler(event);
   return { event, state };
 }
@@ -7086,6 +7088,16 @@ result = runCloseWithoutHelper({ trayEnabled: true, isAppQuitting: false });
 if (!result.event.prevented || result.state.hideCalls !== 1) {
   throw new Error("Linux close should still hide to tray when the quit helper is unavailable");
 }
+
+result = runClose({ trayEnabled: true, multiLaunch: true });
+if (result.event.prevented || result.state.hideCalls !== 0) {
+  throw new Error("trayless multi-launch close should exit normally");
+}
+
+result = runClose({ trayEnabled: true, multiLaunch: true, multiLaunchTray: true });
+if (!result.event.prevented || result.state.hideCalls !== 1) {
+  throw new Error("multi-launch tray override should retain close-to-tray");
+}
 NODE
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
@@ -7103,7 +7115,7 @@ NODE
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&(process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`||process.env.CODEX_LINUX_MULTI_LAUNCH_TRAY===`1`)&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe' '1'
 }
 
 test_linux_explicit_quit_patch_smoke() {
@@ -7852,6 +7864,13 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
     CODEX_LINUX_MULTI_LAUNCH: "1",
   });
   assert(state.trayStartupCalls === 0, "multi-launch instances should not start an additional Linux tray item");
+
+  await boot({}, {
+    CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "/tmp/codex-multi-tray.sock",
+    CODEX_LINUX_MULTI_LAUNCH: "1",
+    CODEX_LINUX_MULTI_LAUNCH_TRAY: "1",
+  });
+  assert(state.trayStartupCalls === 1, "multi-launch tray override should start a tray item");
 })().catch((error) => {
   console.error(error.stack || error);
   process.exit(1);

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6995,7 +6995,7 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate'
     assert_contains "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`'
     assert_contains "$extracted/.vite/build/main-test.js" 'this.trayMenuThreads=e.trayMenuThreads,process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()'
-    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe();'
+    assert_contains "$extracted/.vite/build/main-test.js" '(E||process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe();'
     assert_not_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&this.tray.setContextMenu?.(e),this.tray.popUpContextMenu(e)'
     assert_not_contains "$output_log" 'WARN: Could not find tray'
 
@@ -7103,7 +7103,7 @@ NODE
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'let e=process.platform===`linux`&&this.setLinuxTrayContextMenu?this.setLinuxTrayContextMenu():n.Menu.buildFromTemplate' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'if(process.platform===`linux`)return;e.once(`menu-will-show`' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&!(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())&&this.setLinuxTrayContextMenu?.()' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&process.env.CODEX_LINUX_MULTI_LAUNCH!==`1`&&(typeof codexLinuxIsTrayEnabled!==`function`||codexLinuxIsTrayEnabled()))&&oe' '1'
 }
 
 test_linux_explicit_quit_patch_smoke() {
@@ -7846,6 +7846,12 @@ async function boot(settings = {}, env = { CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "
 
   await boot({ trayEnabled: false });
   assert(state.trayStartupCalls === 0, "disabled tray gate should not start the Linux tray during startup");
+
+  await boot({}, {
+    CODEX_DESKTOP_LAUNCH_ACTION_SOCKET: "/tmp/codex-multi.sock",
+    CODEX_LINUX_MULTI_LAUNCH: "1",
+  });
+  assert(state.trayStartupCalls === 0, "multi-launch instances should not start an additional Linux tray item");
 })().catch((error) => {
   console.error(error.stack || error);
   process.exit(1);


### PR DESCRIPTION
## Summary
- suppress tray creation for secondary `--new-instance` launches by default
- keep close-to-tray behavior aligned with whether that instance owns a tray icon
- allow opting back in with `CODEX_MULTI_LAUNCH_TRAY=1`

## Tests
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh`
- `git diff --check origin/main...HEAD`

## Notes
This carries the final reviewed fix from #794 onto the current `main`, because the original fork branch does not allow maintainer edits.