### PR TITLE
Fix wrapper updater current-DMG runtime

### DIFF
--- a/linux-features/codex-wrapper-updater/README.md
+++ b/linux-features/codex-wrapper-updater/README.md
@@ -10,8 +10,8 @@ upstream path tracks the official macOS DMG. This feature tracks newer builds of
 
 ## User-facing behavior
 
-- Settings -> General shows **Check for ChatGPT Desktop for Linux updates**.
-- Settings -> General also shows **Ask which features to enable on update**.
+- Settings -> Linux desktop shows **Check for ChatGPT Desktop for Linux updates**.
+- Settings -> Linux desktop also shows **Ask which features to enable on update**.
 - Both settings are off/on independently: wrapper update checks are off by
   default, and the feature picker prompt defaults on when this feature is built.
 - When wrapper update checks are on, `codex-update-manager` may check the
@@ -51,7 +51,7 @@ features the rebuild stages.
 - Feature ids that are currently enabled but absent from the candidate catalog
   are preserved.
 - The special **(Don't ask again on future updates)** row, or turning off
-  **Settings -> General -> Ask which features to enable on update**, suppresses
+  **Settings -> Linux desktop -> Ask which features to enable on update**, suppresses
   future prompts.
 - Cancelling the dialog keeps the current feature set and still proceeds with
   the update.
@@ -79,7 +79,7 @@ not a required compatibility patch for every Linux build. Core only provides the
 generic Linux feature loader and hook runner. This feature owns:
 
 - the in-app wrapper update button;
-- the Settings -> General runtime opt-ins;
+- the Settings -> Linux desktop runtime opt-ins;
 - the main-process bridge handler;
 - the pending-update marker;
 - the retry/apply hook;
@@ -105,9 +105,8 @@ When enabled, the feature contributes three patch descriptors:
   `codex-linux-wrapper-updater` bridge handler.
 - `webview-runtime`: injects the webview runtime that creates and refreshes the
   top-right **Update** button.
-- `settings-toggle`: patches the settings asset. Current upstream builds use
-  `general-settings-*.js`; older builds may still use
-  `keybinds-settings-linux.js`.
+- `settings-toggle`: patches the current Linux desktop settings asset,
+  `linux-desktop-settings-linux.js`.
 
 The feature also stages the same runtime hook twice:
 
@@ -247,10 +246,10 @@ Verify the settings patch landed in the installed webview bundle:
 
 ```bash
 rg "CodexLinuxWrapperUpdatesSetting|CodexLinuxFeaturePickerOnUpdateSetting|get-global-state|set-global-state" \
-  /opt/codex-desktop/content/webview/assets/general-settings-*.js
+  /opt/codex-desktop/content/webview/assets/linux-desktop-settings-linux.js
 ```
 
-Toggle the settings in Settings -> General, then verify:
+Toggle the settings in Settings -> Linux desktop, then verify:
 
 ```bash
 rg "codex-linux-wrapper-updates-enabled|codex-linux-feature-picker-on-update" \
@@ -273,7 +272,7 @@ upstream typed settings API, the app will reject the Linux-only keys.
 
 If the **Update** button does not appear, check:
 
-- the Settings -> General wrapper update toggle is on;
+- the Settings -> Linux desktop wrapper update toggle is on;
 - `check-wrapper --json` records `candidate_wrapper_commit`;
 - `~/.local/state/codex-update-manager/state.json` contains the candidate;
 - the installed build includes `codex-wrapper-updater` in
@@ -281,7 +280,7 @@ If the **Update** button does not appear, check:
 
 If the feature picker does not appear before the update:
 
-- the Settings -> General feature picker toggle may be off;
+- the Settings -> Linux desktop feature picker toggle may be off;
 - the app may not have a graphical display session;
 - neither `zenity` nor `kdialog` may be installed;
 - the recorded wrapper candidate may not include a readable feature catalog;

--- a/linux-features/codex-wrapper-updater/patch.js
+++ b/linux-features/codex-wrapper-updater/patch.js
@@ -3,11 +3,9 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { linuxSettingsKeys } = require("../../scripts/patches/lib/settings-keys.js");
-const { requireName } = require("../../scripts/patches/lib/minified-js.js");
 
 const HANDLER_NAME = "codex-linux-wrapper-updater";
 const RUNTIME_VERSION = "codex-wrapper-updater-v3";
-const KEYBINDS_ASSET = "keybinds-settings-linux.js";
 const LINUX_DESKTOP_SETTINGS_ASSET = "linux-desktop-settings-linux.js";
 const WRAPPER_UPDATES_SETTING_KEY = linuxSettingsKeys.wrapperUpdates;
 const FEATURE_PICKER_ON_UPDATE_SETTING_KEY = linuxSettingsKeys.featurePickerOnUpdate;
@@ -21,41 +19,32 @@ function applyMainBundlePatch(source) {
     return source;
   }
 
-  const fsVar = requireName(source, "node:fs");
-  const pathVar = requireName(source, "node:path");
-  const childProcessVar =
-    requireName(source, "node:child_process") ?? requireName(source, "child_process");
-  if (fsVar == null || pathVar == null || childProcessVar == null) {
-    warn(
-      "Could not find node:fs/node:path/node:child_process deps",
-      "codex wrapper updater main-bundle patch",
-    );
-    return source;
-  }
-
   const helper = [
+    `function codexLinuxWrapFs(){return require(\`node:fs\`)}`,
+    `function codexLinuxWrapPath(){return require(\`node:path\`)}`,
+    `function codexLinuxWrapChildProcess(){return require(\`node:child_process\`)}`,
     `function codexLinuxWrapHome(){return process.env.HOME||\`\`}`,
     `function codexLinuxWrapAppId(){let i=process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||\`codex-desktop\`;return /^[A-Za-z0-9._-]+$/.test(i)?i:\`codex-desktop\`}`,
-    `function codexLinuxWrapAppStateDir(){let e=process.env.CODEX_LINUX_APP_STATE_DIR;if(typeof e===\`string\`&&e.trim())return e;let h=codexLinuxWrapHome();let r=process.env.XDG_STATE_HOME||(h&&${pathVar}.join(h,\`.local\`,\`state\`));return r?${pathVar}.join(r,codexLinuxWrapAppId()):null}`,
-    `function codexLinuxWrapStatePath(){let h=codexLinuxWrapHome();let d=process.env.XDG_STATE_HOME||(h&&${pathVar}.join(h,\`.local\`,\`state\`));return d?${pathVar}.join(d,\`codex-update-manager\`,\`state.json\`):null}`,
-    `function codexLinuxWrapMarkerPath(){let d=codexLinuxWrapAppStateDir();return d?${pathVar}.join(d,\`codex-wrapper-updater\`,\`pending\`):null}`,
-    `function codexLinuxWrapReadStatus(){try{let p=codexLinuxWrapStatePath();if(!p||!${fsVar}.existsSync(p))return null;return JSON.parse(${fsVar}.readFileSync(p,\`utf8\`))}catch{return null}}`,
+    `function codexLinuxWrapAppStateDir(){let __codexWrapExplicitStateDir=process.env.CODEX_LINUX_APP_STATE_DIR;if(typeof __codexWrapExplicitStateDir===\`string\`&&__codexWrapExplicitStateDir.trim())return __codexWrapExplicitStateDir;let __codexWrapHome=codexLinuxWrapHome();let __codexWrapStateRoot=process.env.XDG_STATE_HOME||(__codexWrapHome&&codexLinuxWrapPath().join(__codexWrapHome,\`.local\`,\`state\`));return __codexWrapStateRoot?codexLinuxWrapPath().join(__codexWrapStateRoot,codexLinuxWrapAppId()):null}`,
+    `function codexLinuxWrapStatePath(){let __codexWrapHome=codexLinuxWrapHome();let __codexWrapStateRoot=process.env.XDG_STATE_HOME||(__codexWrapHome&&codexLinuxWrapPath().join(__codexWrapHome,\`.local\`,\`state\`));return __codexWrapStateRoot?codexLinuxWrapPath().join(__codexWrapStateRoot,\`codex-update-manager\`,\`state.json\`):null}`,
+    `function codexLinuxWrapMarkerPath(){let __codexWrapStateDir=codexLinuxWrapAppStateDir();return __codexWrapStateDir?codexLinuxWrapPath().join(__codexWrapStateDir,\`codex-wrapper-updater\`,\`pending\`):null}`,
+    `function codexLinuxWrapReadStatus(){try{let __codexWrapStatePath=codexLinuxWrapStatePath();if(!__codexWrapStatePath||!codexLinuxWrapFs().existsSync(__codexWrapStatePath))return null;return JSON.parse(codexLinuxWrapFs().readFileSync(__codexWrapStatePath,\`utf8\`))}catch{return null}}`,
     `function codexLinuxWrapShouldShow(s){return !!(s&&typeof s===\`object\`&&s.wrapper_dev_mode!==!0&&typeof s.candidate_wrapper_commit===\`string\`&&s.candidate_wrapper_commit.length>0)}`,
     `function codexLinuxWrapStatusPayload(){let s=codexLinuxWrapReadStatus();return{ok:!0,show:codexLinuxWrapShouldShow(s),dev_mode:!!(s&&s.wrapper_dev_mode===!0),changelog:s?s.wrapper_changelog||\`\`:\`\`,commit:s?s.candidate_wrapper_commit||\`\`:\`\`,installed_commit:s?s.installed_wrapper_commit||\`\`:\`\`}}`,
     `function codexLinuxWrapManagerPath(){let e=process.env.CODEX_UPDATE_MANAGER_PATH;return typeof e===\`string\`&&e.trim().length>0?e:\`codex-update-manager\`}`,
-    `function codexLinuxWrapSpawnCheck(){try{let c=${childProcessVar}.spawn(codexLinuxWrapManagerPath(),[\`check-wrapper\`],{stdio:\`ignore\`,detached:!0,env:process.env});c.on(\`error\`,()=>{});c.unref()}catch{}}`,
+    `function codexLinuxWrapSpawnCheck(){try{let __codexWrapCheckProcess=codexLinuxWrapChildProcess().spawn(codexLinuxWrapManagerPath(),[\`check-wrapper\`],{stdio:\`ignore\`,detached:!0,env:process.env});__codexWrapCheckProcess.on(\`error\`,()=>{});__codexWrapCheckProcess.unref()}catch{}}`,
     // Feature picker on update: resolve settings.json the same way the launcher
     // and launch-actions do, and gate the on-click picker on the
     // `codex-linux-feature-picker-on-update` toggle (absent ⇒ ask) plus a live
     // display. The picker runs synchronously here, at click time, because the
     // detached apply runs after the app exits with no display.
     `function codexLinuxWrapSettingsAppId(){let e=process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||\`codex-desktop\`;return/^[A-Za-z0-9._-]+$/.test(e)?e:\`codex-desktop\`}`,
-    `function codexLinuxWrapSettingsPath(){let e=process.env.CODEX_LINUX_SETTINGS_FILE;if(typeof e===\`string\`&&e.length>0)return e;let h=codexLinuxWrapHome();let t=process.env.XDG_CONFIG_HOME||(h&&${pathVar}.join(h,\`.config\`));return t?${pathVar}.join(t,codexLinuxWrapSettingsAppId(),\`settings.json\`):null}`,
-    `function codexLinuxWrapPickerEnabled(){try{let p=codexLinuxWrapSettingsPath();if(!p||!${fsVar}.existsSync(p))return!0;let s=JSON.parse(${fsVar}.readFileSync(p,\`utf8\`));if(!s||typeof s!==\`object\`)return!0;let v=s[\`codex-linux-feature-picker-on-update\`];if(v==null)return!0;if(typeof v===\`boolean\`)return v;if(typeof v===\`number\`)return v!==0;if(typeof v===\`string\`){let n=v.trim().toLowerCase();return!([\`0\`,\`false\`,\`no\`,\`off\`].includes(n))}return!0}catch{return!0}}`,
+    `function codexLinuxWrapSettingsPath(){let __codexWrapSettingsFile=process.env.CODEX_LINUX_SETTINGS_FILE;if(typeof __codexWrapSettingsFile===\`string\`&&__codexWrapSettingsFile.length>0)return __codexWrapSettingsFile;let __codexWrapHome=codexLinuxWrapHome();let __codexWrapConfigRoot=process.env.XDG_CONFIG_HOME||(__codexWrapHome&&codexLinuxWrapPath().join(__codexWrapHome,\`.config\`));return __codexWrapConfigRoot?codexLinuxWrapPath().join(__codexWrapConfigRoot,codexLinuxWrapSettingsAppId(),\`settings.json\`):null}`,
+    `function codexLinuxWrapPickerEnabled(){try{let __codexWrapSettingsPath=codexLinuxWrapSettingsPath();if(!__codexWrapSettingsPath||!codexLinuxWrapFs().existsSync(__codexWrapSettingsPath))return!0;let s=JSON.parse(codexLinuxWrapFs().readFileSync(__codexWrapSettingsPath,\`utf8\`));if(!s||typeof s!==\`object\`)return!0;let v=s[\`codex-linux-feature-picker-on-update\`];if(v==null)return!0;if(typeof v===\`boolean\`)return v;if(typeof v===\`number\`)return v!==0;if(typeof v===\`string\`){let n=v.trim().toLowerCase();return!([\`0\`,\`false\`,\`no\`,\`off\`].includes(n))}return!0}catch{return!0}}`,
     `function codexLinuxWrapHasDisplay(){let d=process.env.DISPLAY,w=process.env.WAYLAND_DISPLAY;return!!((d&&d.trim())||(w&&w.trim()))}`,
-    `function codexLinuxWrapRunPicker(){try{${childProcessVar}.spawnSync(codexLinuxWrapManagerPath(),[\`pick-features\`,\`--json\`],{stdio:\`ignore\`,env:process.env})}catch{}}`,
-    `function codexLinuxWrapWriteMarker(){let p=codexLinuxWrapMarkerPath();if(!p)return{ok:!1,reason:\`no-marker-path\`};try{${fsVar}.mkdirSync(${pathVar}.dirname(p),{recursive:!0});${fsVar}.writeFileSync(p,new Date().toISOString());return{ok:!0,path:p}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
-    `function codexLinuxWrapInstallNow(){if(codexLinuxWrapHasDisplay()&&codexLinuxWrapPickerEnabled())codexLinuxWrapRunPicker();let m=codexLinuxWrapWriteMarker();if(!m.ok)return m;try{let a=require(\`electron\`).app;setTimeout(()=>a.exit(0),120);return{ok:!0,path:m.path}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
+    `function codexLinuxWrapRunPicker(){try{codexLinuxWrapChildProcess().spawnSync(codexLinuxWrapManagerPath(),[\`pick-features\`,\`--json\`],{stdio:\`ignore\`,env:process.env})}catch{}}`,
+    `function codexLinuxWrapWriteMarker(){let __codexWrapMarkerPath=codexLinuxWrapMarkerPath();if(!__codexWrapMarkerPath)return{ok:!1,reason:\`no-marker-path\`};try{codexLinuxWrapFs().mkdirSync(codexLinuxWrapPath().dirname(__codexWrapMarkerPath),{recursive:!0});codexLinuxWrapFs().writeFileSync(__codexWrapMarkerPath,new Date().toISOString());return{ok:!0,path:__codexWrapMarkerPath}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
+    `function codexLinuxWrapInstallNow(){if(codexLinuxWrapHasDisplay()&&codexLinuxWrapPickerEnabled())codexLinuxWrapRunPicker();let __codexWrapMarker=codexLinuxWrapWriteMarker();if(!__codexWrapMarker.ok)return __codexWrapMarker;try{let __codexWrapElectronApp=require(\`electron\`).app;setTimeout(()=>__codexWrapElectronApp.exit(0),120);return{ok:!0,path:__codexWrapMarker.path}}catch(e){return{ok:!1,error:String(e?.message||e)}}}`,
     `function codexLinuxWrapHandle(e={}){let action=e&&e.action;if(action===\`status\`)return codexLinuxWrapStatusPayload();if(action===\`check\`){codexLinuxWrapSpawnCheck();return{ok:!0}}if(action===\`install\`)return codexLinuxWrapInstallNow();return{ok:!1,reason:\`unknown-action\`}}`,
     `(()=>{if(process.env.CODEX_LINUX_MULTI_LAUNCH!==\`1\`)codexLinuxWrapSpawnCheck()})();`,
   ].join("");
@@ -112,7 +101,7 @@ function applyWebviewRuntimePatch(source) {
   if (source.includes(`codexLinuxWrapperUpdaterVersion=`)) {
     return source;
   }
-  return source + wrapperRuntimeSource();
+  return source.endsWith("\n") ? source + wrapperRuntimeSource() : `${source}\n${wrapperRuntimeSource()}`;
 }
 
 function applyWrapperUpdateSettingsPatch(source) {
@@ -163,51 +152,6 @@ function applyWrapperUpdateSettingsPatch(source) {
   return next;
 }
 
-function applyWrapperUpdateGeneralSettingsPatch(source) {
-  const hasWrapperSetting = source.includes("Check for ChatGPT Desktop for Linux updates");
-  const hasFeaturePickerSetting = source.includes("Ask which features to enable on update");
-  if (hasWrapperSetting && hasFeaturePickerSetting) {
-    return source;
-  }
-
-  const functionNeedle = "function Br(){";
-  if (!source.includes(functionNeedle)) {
-    throw new Error("could not find general power settings function");
-  }
-
-  const wrapperSettingFunction = hasWrapperSetting
-    ? ""
-    :
-    `function CodexLinuxWrapperUpdatesSetting(){let[e,t]=(0,X.useState)(!1),[n,r]=(0,X.useState)(!0),[i,a]=(0,X.useState)(null),o=x();(0,X.useEffect)(()=>{let e=!0;return r(!0),N(\`get-global-state\`,{params:{key:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)}}}).then(n=>{e&&(t(n?.value??!1),a(null))}).catch(t=>{e&&a(t instanceof Error?t.message:String(t))}).finally(()=>{e&&r(!1)}),()=>{e=!1}},[]);let s=(0,$.jsx)(w,{id:\`settings.general.wrapperUpdates.label\`,defaultMessage:\`Check for ChatGPT Desktop for Linux updates\`,description:\`Label for Linux wrapper update checks setting\`}),c=(0,$.jsx)(w,{id:\`settings.general.wrapperUpdates.description\`,defaultMessage:\`Check for Linux wrapper updates from codex-desktop-linux in addition to upstream ChatGPT app updates.\`,description:\`Description for Linux wrapper update checks setting\`});i&&(c=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[c,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:i})]}));let l=o.formatMessage({id:\`settings.general.wrapperUpdates.label\`,defaultMessage:\`Check for ChatGPT Desktop for Linux updates\`,description:\`Label for Linux wrapper update checks setting\`});return(0,$.jsx)(J,{label:s,description:c,control:(0,$.jsx)(q,{checked:e===!0,disabled:n,onChange:o=>{let s=e;t(o),a(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(WRAPPER_UPDATES_SETTING_KEY)},value:o}}).catch(e=>{t(s),a(e instanceof Error?e.message:String(e))})},ariaLabel:l})})}`;
-  const featurePickerSettingFunction = hasFeaturePickerSetting
-    ? ""
-    :
-    `function CodexLinuxFeaturePickerOnUpdateSetting(){let[e,t]=(0,X.useState)(!0),[n,r]=(0,X.useState)(!0),[i,a]=(0,X.useState)(null),o=x();(0,X.useEffect)(()=>{let e=!0;return r(!0),N(\`get-global-state\`,{params:{key:${JSON.stringify(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)}}}).then(n=>{e&&(t(n?.value??!0),a(null))}).catch(t=>{e&&a(t instanceof Error?t.message:String(t))}).finally(()=>{e&&r(!1)}),()=>{e=!1}},[]);let s=(0,$.jsx)(w,{id:\`settings.general.featurePickerOnUpdate.label\`,defaultMessage:\`Ask which features to enable on update\`,description:\`Label for Linux feature picker on update setting\`}),c=(0,$.jsx)(w,{id:\`settings.general.featurePickerOnUpdate.description\`,defaultMessage:\`When on, clicking Update opens a checklist to pick optional Linux features before rebuilding. Turn off to keep your current feature selection without prompting.\`,description:\`Description for Linux feature picker on update setting\`});i&&(c=(0,$.jsxs)(\`div\`,{className:\`flex flex-col gap-1\`,children:[c,(0,$.jsx)(\`span\`,{className:\`text-token-error-foreground\`,children:i})]}));let l=o.formatMessage({id:\`settings.general.featurePickerOnUpdate.label\`,defaultMessage:\`Ask which features to enable on update\`,description:\`Label for Linux feature picker on update setting\`});return(0,$.jsx)(J,{label:s,description:c,control:(0,$.jsx)(q,{checked:e===!0,disabled:n,onChange:o=>{let s=e;t(o),a(null),N(\`set-global-state\`,{params:{key:${JSON.stringify(FEATURE_PICKER_ON_UPDATE_SETTING_KEY)},value:o}}).catch(e=>{t(s),a(e instanceof Error?e.message:String(e))})},ariaLabel:l})})}`;
-
-  let next = source.replace(
-    functionNeedle,
-    `${wrapperSettingFunction}${featurePickerSettingFunction}${functionNeedle}`,
-  );
-
-  const powerRowNeedle = `D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsx)(Br,{})})`;
-  const powerRowPatch =
-    `D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsxs)($.Fragment,{children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{}),(0,$.jsx)(CodexLinuxFeaturePickerOnUpdateSetting,{})]})})`;
-  if (next.includes(powerRowNeedle)) {
-    next = next.replace(powerRowNeedle, powerRowPatch);
-    return next;
-  }
-
-  const existingWrapperRowNeedle = `children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{})]`;
-  const existingWrapperRowPatch =
-    `children:[(0,$.jsx)(Br,{}),(0,$.jsx)(CodexLinuxWrapperUpdatesSetting,{}),(0,$.jsx)(CodexLinuxFeaturePickerOnUpdateSetting,{})]`;
-  if (next.includes(existingWrapperRowNeedle)) {
-    next = next.replace(existingWrapperRowNeedle, existingWrapperRowPatch);
-    return next;
-  }
-
-  throw new Error("could not find general power settings row");
-}
-
 function patchWrapperUpdateSettingsAssets(extractedDir) {
   try {
     const assetsDir = path.join(extractedDir, "webview", "assets");
@@ -215,58 +159,18 @@ function patchWrapperUpdateSettingsAssets(extractedDir) {
       return { matched: false, changed: 0, reason: `missing webview assets directory ${assetsDir}` };
     }
 
-    for (const settingsAsset of [LINUX_DESKTOP_SETTINGS_ASSET, KEYBINDS_ASSET]) {
-      const settingsPath = path.join(assetsDir, settingsAsset);
-      if (!fs.existsSync(settingsPath)) {
-        continue;
-      }
-      const current = fs.readFileSync(settingsPath, "utf8");
-      const patched = applyWrapperUpdateSettingsPatch(current);
-      if (patched === current) {
-        return { matched: true, changed: 0 };
-      }
-      fs.writeFileSync(settingsPath, patched, "utf8");
-      return { matched: true, changed: 1 };
+    const settingsPath = path.join(assetsDir, LINUX_DESKTOP_SETTINGS_ASSET);
+    if (!fs.existsSync(settingsPath)) {
+      return { matched: false, changed: 0, reason: `${LINUX_DESKTOP_SETTINGS_ASSET} is not present` };
     }
 
-    const generalSettingsAssets = fs
-      .readdirSync(assetsDir)
-      .filter((name) => /^general-settings-.*\.js$/.test(name));
-    if (generalSettingsAssets.length === 0) {
-      return { matched: false, changed: 0, reason: `${LINUX_DESKTOP_SETTINGS_ASSET}, ${KEYBINDS_ASSET}, and general settings asset are not present` };
+    const current = fs.readFileSync(settingsPath, "utf8");
+    const patched = applyWrapperUpdateSettingsPatch(current);
+    if (patched === current) {
+      return { matched: true, changed: 0 };
     }
-
-    let lastError = null;
-    for (const generalSettingsAsset of generalSettingsAssets) {
-      const generalPath = path.join(assetsDir, generalSettingsAsset);
-      const current = fs.readFileSync(generalPath, "utf8");
-      try {
-        const patched = applyWrapperUpdateGeneralSettingsPatch(current);
-        if (patched === current) {
-          return { matched: true, changed: 0 };
-        }
-        fs.writeFileSync(generalPath, patched, "utf8");
-        return { matched: true, changed: 1 };
-      } catch (error) {
-        lastError = error instanceof Error ? error.message : String(error);
-      }
-    }
-
-    if (
-      lastError != null &&
-      (
-        lastError.includes("could not find general power settings function") ||
-        lastError.includes("could not find general power settings row")
-      )
-    ) {
-      return {
-        matched: true,
-        changed: 0,
-        reason: "upstream settings shape does not expose the legacy wrapper update toggle extension point",
-      };
-    }
-
-    return { matched: false, changed: 0, reason: lastError ?? "could not patch general settings asset" };
+    fs.writeFileSync(settingsPath, patched, "utf8");
+    return { matched: true, changed: 1 };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.warn(`WARN: Wrapper update settings patch skipped: ${message}`);
@@ -281,7 +185,6 @@ module.exports = {
   WRAPPER_UPDATES_SETTING_KEY,
   applyMainBundlePatch,
   applyWebviewRuntimePatch,
-  applyWrapperUpdateGeneralSettingsPatch,
   applyWrapperUpdateSettingsPatch,
   patchWrapperUpdateSettingsAssets,
   descriptors: [

--- a/linux-features/codex-wrapper-updater/test.js
+++ b/linux-features/codex-wrapper-updater/test.js
@@ -10,7 +10,6 @@ const test = require("node:test");
 const {
   applyMainBundlePatch,
   applyWebviewRuntimePatch,
-  applyWrapperUpdateGeneralSettingsPatch,
   applyWrapperUpdateSettingsPatch,
   patchWrapperUpdateSettingsAssets,
 } = require("./patch.js");
@@ -47,6 +46,16 @@ function fakeManager(temp, body = "exit ${CODEX_FAKE_MANAGER_STATUS:-0}\n") {
   return manager;
 }
 
+function withoutWarnings(fn) {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    return fn();
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 test("main bundle patch writes app-state wrapper marker", () => {
   const source =
     `"use strict";var f=require("node:fs"),p=require("node:path"),c=require("node:child_process");` +
@@ -65,6 +74,23 @@ test("main bundle patch writes app-state wrapper marker", () => {
   assert.doesNotMatch(patched, /wrapper_status/);
 });
 
+test("main bundle helper does not shadow minified module variables", () => {
+  const source =
+    `"use strict";var p=require("node:fs"),u=require("node:path"),c=require("node:child_process");` +
+    `var handlers={"native-desktop-apps":async()=>({ok:true})};`;
+
+  const patched = applyMainBundlePatch(source);
+
+  assert.match(patched, /codexLinuxWrapFs\(\)\.existsSync\(__codexWrapStatePath\)/);
+  assert.match(patched, /codexLinuxWrapFs\(\)\.readFileSync\(__codexWrapStatePath,`utf8`\)/);
+  assert.match(patched, /codexLinuxWrapFs\(\)\.mkdirSync\(codexLinuxWrapPath\(\)\.dirname\(__codexWrapMarkerPath\),\{recursive:!0\}\)/);
+  assert.match(patched, /codexLinuxWrapFs\(\)\.writeFileSync\(__codexWrapMarkerPath,new Date\(\)\.toISOString\(\)\)/);
+  assert.match(patched, /let __codexWrapCheckProcess=codexLinuxWrapChildProcess\(\)\.spawn\(/);
+  assert.doesNotMatch(patched, /let p=codexLinuxWrapStatePath\(\)/);
+  assert.doesNotMatch(patched, /let c=c\.spawn\(/);
+  assert.doesNotMatch(patched, /__codexChild/);
+});
+
 test("webview runtime renders dev-mode and installed-sha chips", () => {
   const patched = applyWebviewRuntimePatch("console.log('codex');");
 
@@ -73,6 +99,13 @@ test("webview runtime renders dev-mode and installed-sha chips", () => {
   assert.match(patched, /dev-mode/);
   assert.match(patched, /\\u2699/);
   assert.match(patched, /\\u2193/);
+});
+
+test("webview runtime is not swallowed by a trailing sourcemap comment", () => {
+  const patched = applyWebviewRuntimePatch("console.log('codex');\n//# sourceMappingURL=index.js.map");
+
+  assert.match(patched, /sourceMappingURL=index\.js\.map\n;\(\(\)=>/);
+  assert.doesNotMatch(patched, /sourceMappingURL=index\.js\.map;\(\(\)=>/);
 });
 
 test("settings patch adds wrapper update toggle", () => {
@@ -89,44 +122,23 @@ test("settings patch adds wrapper update toggle", () => {
   assert.equal(applyWrapperUpdateSettingsPatch(patched), patched);
 });
 
-test("general settings patch adds wrapper update toggles for current upstream settings", () => {
-  const source =
-    `function $n(){let D,k,A,j,M;e[16]===Symbol.for(\`react.memo_cache_sentinel\`)?(D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsx)(Br,{})}),k=(0,$.jsx)(zr,{}),A=(0,$.jsx)(Hn,{}),j=(0,$.jsx)(Mr,{}),M=(0,$.jsx)(Pr,{}),e[16]=D,e[17]=k,e[18]=A,e[19]=j,e[20]=M):(D=e[16],k=e[17],A=e[18],j=e[19],M=e[20]);}` +
-    `function Br(){return null}function Vr(e,t){return e}`;
-
-  const patched = applyWrapperUpdateGeneralSettingsPatch(source);
-
-  assert.match(patched, /CodexLinuxWrapperUpdatesSetting/);
-  assert.match(patched, /CodexLinuxFeaturePickerOnUpdateSetting/);
-  assert.match(patched, /codex-linux-wrapper-updates-enabled/);
-  assert.match(patched, /codex-linux-feature-picker-on-update/);
-  assert.match(patched, /Check for ChatGPT Desktop for Linux updates/);
-  assert.match(patched, /Ask which features to enable on update/);
-  assert.match(patched, /get-global-state/);
-  assert.match(patched, /set-global-state/);
-  assert.doesNotMatch(patched, /set-setting/);
-  assert.match(
-    patched,
-    /children:\[\(0,\$\.jsx\)\(Br,\{\}\),\(0,\$\.jsx\)\(CodexLinuxWrapperUpdatesSetting,\{\}\),\(0,\$\.jsx\)\(CodexLinuxFeaturePickerOnUpdateSetting,\{\}\)\]/,
-  );
-  assert.equal(applyWrapperUpdateGeneralSettingsPatch(patched), patched);
-});
-
-test("settings asset patch skips re-exported general settings bundles", () => {
-  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-wrapper-updater-settings-assets-"));
+test("settings asset patch does not fall back to legacy settings bundles", () => {
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-wrapper-updater-legacy-settings-"));
   const assetsDir = path.join(appDir, "webview", "assets");
   fs.mkdirSync(assetsDir, { recursive: true });
-  fs.writeFileSync(path.join(assetsDir, "general-settings-a.js"), `export{e as GeneralSettings};`);
-  fs.writeFileSync(
-    path.join(assetsDir, "general-settings-z.js"),
-    `function $n(){let D,k,A,j,M;e[16]===Symbol.for(\`react.memo_cache_sentinel\`)?(D=(0,$.jsx)(K,{electron:!0,children:(0,$.jsx)(Br,{})}),k=(0,$.jsx)(zr,{}),A=(0,$.jsx)(Hn,{}),j=(0,$.jsx)(Mr,{}),M=(0,$.jsx)(Pr,{}),e[16]=D,e[17]=k,e[18]=A,e[19]=j,e[20]=M):(D=e[16],k=e[17],A=e[18],j=e[19],M=e[20]);}function Br(){return null}`,
-  );
+  const generalSettings = `function Br(){return null}`;
+  const keybindsSettings = `var KEYS={autoUpdateOnExit:"codex-linux-auto-update-on-exit"};`;
+  fs.writeFileSync(path.join(assetsDir, "general-settings-z.js"), generalSettings);
+  fs.writeFileSync(path.join(assetsDir, "keybinds-settings-linux.js"), keybindsSettings);
 
   try {
-    assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), { matched: true, changed: 1 });
-    assert.doesNotMatch(fs.readFileSync(path.join(assetsDir, "general-settings-a.js"), "utf8"), /WrapperUpdates/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"), /Check for ChatGPT Desktop for Linux updates/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"), /Ask which features to enable on update/);
+    assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), {
+      matched: false,
+      changed: 0,
+      reason: "linux-desktop-settings-linux.js is not present",
+    });
+    assert.equal(fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"), generalSettings);
+    assert.equal(fs.readFileSync(path.join(assetsDir, "keybinds-settings-linux.js"), "utf8"), keybindsSettings);
   } finally {
     fs.rmSync(appDir, { recursive: true, force: true });
   }
@@ -145,6 +157,7 @@ test("settings asset patch prefers generated Linux desktop settings bundle", () 
 
   try {
     assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), { matched: true, changed: 1 });
+    assert.deepEqual(patchWrapperUpdateSettingsAssets(appDir), { matched: true, changed: 0 });
     assert.match(
       fs.readFileSync(path.join(assetsDir, "linux-desktop-settings-linux.js"), "utf8"),
       /Check for ChatGPT Desktop for Linux updates/,
@@ -153,6 +166,26 @@ test("settings asset patch prefers generated Linux desktop settings bundle", () 
       fs.readFileSync(path.join(assetsDir, "general-settings-z.js"), "utf8"),
       generalSettings,
     );
+  } finally {
+    fs.rmSync(appDir, { recursive: true, force: true });
+  }
+});
+
+test("settings asset patch leaves current asset unchanged on synthetic drift", () => {
+  const appDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-wrapper-updater-settings-drift-"));
+  const assetsDir = path.join(appDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  const driftedSettings = `var KEYS={autoUpdateOnExit:"codex-linux-auto-update-on-exit"};function Settings(){return null}`;
+  const settingsPath = path.join(assetsDir, "linux-desktop-settings-linux.js");
+  fs.writeFileSync(settingsPath, driftedSettings);
+
+  try {
+    assert.deepEqual(withoutWarnings(() => patchWrapperUpdateSettingsAssets(appDir)), {
+      matched: false,
+      changed: 0,
+      reason: "could not find Linux update toggle",
+    });
+    assert.equal(fs.readFileSync(settingsPath, "utf8"), driftedSettings);
   } finally {
     fs.rmSync(appDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Fix the wrapper updater main-process helper so current minified bundles cannot shadow its filesystem/path/child_process bindings.
- Append the webview runtime on a fresh line so a trailing `//# sourceMappingURL=...` comment cannot swallow it.
- Target only the current Linux desktop settings asset and remove legacy `general-settings-*` / `keybinds-settings-linux.js` fallbacks.
- Update the feature README to describe the current Settings -> Linux desktop surface.

## Current-DMG audit

Validated against the current upstream DMG:

- app version: `26.707.41301`
- DMG SHA256: `467a25381af2943f2c9b8794adae28b36400bd6da2753daf4889a5fd550c4d65`
- Electron: `42.1.0`
- audited base: `e57dc934a8eaa5907fc86faac93c3d844c6a6113`

Findings:

- The active settings asset is `linux-desktop-settings-linux.js`.
- `keybinds-settings-linux.js` is not present in the current DMG.
- `general-settings-*` chunks are not the current Linux desktop settings extension point for this feature.
- The main bundle bridge handler is still reachable, but the injected helper could generate broken minified code such as `p.existsSync(...)` after `p` had been reused for a path string, and child-process calls could point at an undefined/shadowed binding.
- The webview runtime was appended directly after a sourcemap comment in the current index asset, so it was present in the file but commented out at runtime.

No open PR overlap was found for this specific wrapper updater runtime/settings issue.

## Runtime validation

Used an isolated install and fake update manager state only; no real update was applied to my daily driver.

- Built isolated app at `/tmp/codex-wrapper-updater-app-final` with `codex-wrapper-updater` enabled.
- Patch report shows all three feature descriptors applied: `main-handler`, `webview-runtime`, and `settings-toggle`.
- Verified generated webview/index asset is not sourcemap-swallowed and passes `node --check`.
- Verified generated `linux-desktop-settings-linux.js` passes `node --check`.
- Verified idempotence by reapplying the settings patch to generated assets: `matched: true`, `changed: 0`; webview runtime remained unchanged.
- With fake updater state, verified Settings rows, persisted toggles after restart, hidden button with no candidate, visible Update button with a valid candidate, dev-mode disabled button, installed SHA chip, changelog tooltip, narrow header layout, and no console errors.
- With a fake manager, clicking Update recorded `check-wrapper`, `pick-features --json`, and `apply-wrapper-update`, and left the retry marker when the fake apply failed.

## Validation

- `node --test linux-features/codex-wrapper-updater/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash tests/scripts_smoke.sh`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager`
- `bash -n linux-features/codex-wrapper-updater/apply-pending.sh`
- `node --check` on the generated current webview index asset
- `node --check` on the generated `linux-desktop-settings-linux.js`
- isolated current-DMG build accepted with `codex-wrapper-updater` enabled
- `git diff --check`

## Out of scope

- No Rust updater behavior changes.
- No launcher/package flow changes.
- No real install/update against a daily-driver app.
- No changes to other Linux features.
- This feature remains disabled by default.
