### PR TITLE
Repair swallowed wrapper updater runtime

### DIFF
--- a/linux-features/codex-wrapper-updater/patch.js
+++ b/linux-features/codex-wrapper-updater/patch.js
@@ -99,6 +99,15 @@ function wrapperRuntimeSource() {
 
 function applyWebviewRuntimePatch(source) {
   if (source.includes(`codexLinuxWrapperUpdaterVersion=`)) {
+    const runtimeNeedle = `;(()=>{const VERSION=${JSON.stringify(RUNTIME_VERSION)};`;
+    const runtimeIndex = source.indexOf(runtimeNeedle);
+    if (runtimeIndex > 0) {
+      const lineStart = source.lastIndexOf("\n", runtimeIndex - 1) + 1;
+      const sameLinePrefix = source.slice(lineStart, runtimeIndex);
+      if (sameLinePrefix.startsWith("//# sourceMappingURL=")) {
+        return `${source.slice(0, runtimeIndex)}\n${source.slice(runtimeIndex)}`;
+      }
+    }
     return source;
   }
   return source.endsWith("\n") ? source + wrapperRuntimeSource() : `${source}\n${wrapperRuntimeSource()}`;

--- a/linux-features/codex-wrapper-updater/test.js
+++ b/linux-features/codex-wrapper-updater/test.js
@@ -108,6 +108,18 @@ test("webview runtime is not swallowed by a trailing sourcemap comment", () => {
   assert.doesNotMatch(patched, /sourceMappingURL=index\.js\.map;\(\(\)=>/);
 });
 
+test("webview runtime repairs previously swallowed sourcemap runtime", () => {
+  const patched = applyWebviewRuntimePatch("console.log('codex');\n//# sourceMappingURL=index.js.map");
+  const swallowed = patched.replace(
+    /sourceMappingURL=index\.js\.map\n;\(\(\)=>/,
+    "sourceMappingURL=index.js.map;(()=>",
+  );
+
+  const repaired = applyWebviewRuntimePatch(swallowed);
+
+  assert.equal(repaired, patched);
+});
+
 test("settings patch adds wrapper update toggle", () => {
   const source =
     `var KEYS={autoUpdateOnExit:"codex-linux-auto-update-on-exit"};` +


### PR DESCRIPTION
## Summary

- Make the wrapper updater webview patch repair a runtime that was already appended on the same line as a trailing `//# sourceMappingURL=...` comment.
- Add a regression test for the previously-swallowed runtime shape.

## Context

Follow-up to #860. That PR fixed current-DMG clean builds by appending the runtime on a fresh line. This keeps the patch idempotent while also self-healing the exact bad generated shape if the patch is reapplied to an asset that already contains the swallowed runtime.

No open PR overlap was found for wrapper updater sourcemap/runtime repair.

## Validation

- `node --test linux-features/codex-wrapper-updater/test.js`
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `node --check linux-features/codex-wrapper-updater/patch.js`
- `node --check linux-features/codex-wrapper-updater/test.js`
- `git diff --check`

## Out of scope

- No updater Rust changes.
- No settings contract changes.
- No other Linux features.
