### PR TITLE
Fix Linux desktop settings toggle initialization

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -4700,7 +4700,11 @@ test("keeps Linux desktop toggles visible with native Keyboard Shortcuts", () =>
     assert.match(linuxDesktopSource, /codex-linux-auto-update-on-exit/);
     assert.match(linuxDesktopSource, /import\{r as SettingsRow\}from"\.\/settings-row-A\.js"/);
     assert.match(linuxDesktopSource, /import\{z as __post\}from"\.\/shared-app-A\.js"/);
-    assert.match(linuxDesktopSource, /import\{t as Toggle\}from"\.\/toggle-A\.js"/);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-toggle-linux.js")), true);
+    assert.match(
+      linuxDesktopSource,
+      /import\{t as Toggle\}from"\.\/linux-settings-toggle-linux\.js"/,
+    );
     assert.doesNotMatch(linuxDesktopSource, /React\.use(State|Effect|Callback)/);
     assert.doesNotMatch(linuxDesktopSource, /function useLinuxSetting/);
     assert.match(linuxDesktopSource, /class LinuxToggle extends React\.Component/);
@@ -4871,7 +4875,7 @@ test("ignores settings row and toggle icon decoys from the current DMG", () => {
   }
 });
 
-test("infers the current upstream settings toggle from settings row controls", () => {
+test("does not import an upstream settings toggle with private lazy initialization", () => {
   const { extractedDir, assetsDir } = createModernNativeKeyboardShortcutsSettingsFixture();
   try {
     fs.rmSync(path.join(assetsDir, "toggle-A.js"));
@@ -4886,13 +4890,17 @@ test("infers the current upstream settings toggle from settings row controls", (
 
     assert.equal(result.matched, true);
     assert.deepEqual(warnings, []);
-    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-toggle-linux.js")), false);
+    assert.equal(fs.existsSync(path.join(assetsDir, "linux-settings-toggle-linux.js")), true);
 
     const linuxDesktopSource = fs.readFileSync(
       path.join(assetsDir, linuxDesktopSettingsAsset),
       "utf8",
     );
-    assert.match(linuxDesktopSource, /import\{vn as Toggle\}from"\.\/shared-toggle-A\.js"/);
+    assert.match(
+      linuxDesktopSource,
+      /import\{t as Toggle\}from"\.\/linux-settings-toggle-linux\.js"/,
+    );
+    assert.doesNotMatch(linuxDesktopSource, /shared-toggle-A\.js/);
     assert.match(
       linuxDesktopSource,
       /control:\$\.jsx\(Toggle,\{checked:value,disabled:isLoading,onChange:this\.update,ariaLabel:label\}\)/,
@@ -4950,7 +4958,10 @@ test("adds Linux desktop settings when native shortcuts use a consolidated setti
     assert.match(linuxDesktopSource, /href:url/);
     assert.doesNotMatch(linuxDesktopSource, /Source commit URL/);
     assert.match(linuxDesktopSource, /import\{R as __reactFactory,I as __jsxFactory\}from"\.\/shared-runtime-A\.js"/);
-    assert.match(linuxDesktopSource, /import\{t as Toggle\}from"\.\/toggle-A\.js"/);
+    assert.match(
+      linuxDesktopSource,
+      /import\{t as Toggle\}from"\.\/linux-settings-toggle-linux\.js"/,
+    );
     assert.doesNotMatch(linuxDesktopSource, /function LinuxSwitch/);
 
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-A.js"), "utf8");
@@ -4998,7 +5009,10 @@ test("adds Linux desktop settings when the lazy route map is hoisted into a sepa
       path.join(assetsDir, linuxDesktopSettingsAsset),
       "utf8",
     );
-    assert.match(linuxDesktopSource, /import\{t as Toggle\}from"\.\/toggle-A\.js"/);
+    assert.match(
+      linuxDesktopSource,
+      /import\{t as Toggle\}from"\.\/linux-settings-toggle-linux\.js"/,
+    );
     assert.doesNotMatch(linuxDesktopSource, /function LinuxSwitch/);
 
     // The icon/navigation bundle must reuse the general-settings icon for the new

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -326,115 +326,6 @@ function linuxSettingsFallbackComponents({ jsxRuntimeAsset, jsxRuntimeExportName
   };
 }
 
-function inferToggleExportName(source) {
-  const functionPattern = /function\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/g;
-  let match;
-  while ((match = functionPattern.exec(source)) != null) {
-    const nextFunctionIndex = source.indexOf("function ", functionPattern.lastIndex);
-    const functionSource = source.slice(
-      match.index,
-      nextFunctionIndex === -1 ? source.length : nextFunctionIndex,
-    );
-    if (
-      !functionSource.includes("checked") ||
-      !functionSource.includes("onChange") ||
-      !(
-        functionSource.includes("ariaLabel") ||
-        functionSource.includes("aria-label") ||
-        functionSource.includes("aria-checked") ||
-        functionSource.includes('role:"switch"') ||
-        functionSource.includes("role:`switch`")
-      )
-    ) {
-      continue;
-    }
-
-    const exportMatch = source.match(/export\{([^}]*)\}/);
-    if (exportMatch == null) {
-      return null;
-    }
-    for (const rawExport of exportMatch[1].split(",")) {
-      const exportPart = rawExport.trim();
-      const aliasedMatch = exportPart.match(
-        new RegExp(`^${escapeRegExp(match[1])}\\s+as\\s+([A-Za-z_$][\\w$]*)$`),
-      );
-      if (aliasedMatch != null) {
-        return aliasedMatch[1];
-      }
-      if (exportPart === match[1]) {
-        return match[1];
-      }
-    }
-  }
-  return null;
-}
-
-function inferToggleDependencyFromSettingsSource(source) {
-  const bindings = importBindings(source);
-  const controlPattern = /control:(?:\(0,[A-Za-z_$][\w$]*\.jsx\)|[A-Za-z_$][\w$]*\.jsx)\(([A-Za-z_$][\w$]*),\{/g;
-  let match;
-  while ((match = controlPattern.exec(source)) != null) {
-    const localName = match[1];
-    const sample = source.slice(match.index, match.index + 1000);
-    if (!sample.includes("checked:") || !sample.includes("onChange:") || !sample.includes("ariaLabel:")) {
-      continue;
-    }
-    const binding = bindings.get(localName);
-    if (binding != null) {
-      return {
-        assetName: binding.assetName,
-        exportName: binding.exportName,
-      };
-    }
-  }
-  return null;
-}
-
-function resolveSettingsToggleDependency(webviewAssetsDir, fallbackComponents, generatedAssets) {
-  const directToggleAssets = fs
-    .readdirSync(webviewAssetsDir)
-    .filter((name) => /^toggle-.*\.js$/.test(name))
-    .sort();
-  for (const directToggleAsset of directToggleAssets) {
-    const source = fs.readFileSync(path.join(webviewAssetsDir, directToggleAsset), "utf8");
-    const exportName = inferToggleExportName(source);
-    if (exportName != null) {
-      return {
-        assetName: directToggleAsset,
-        exportName,
-      };
-    }
-  }
-
-  const settingsAssets = fs
-    .readdirSync(webviewAssetsDir)
-    .filter((name) =>
-      name.endsWith(".js") &&
-        name.includes("settings") &&
-        name !== linuxDesktopSettingsAsset &&
-        name !== keybindsSettingsAsset &&
-        !name.startsWith("linux-settings-")
-    )
-    .sort();
-  for (const assetName of settingsAssets) {
-    const source = fs.readFileSync(path.join(webviewAssetsDir, assetName), "utf8");
-    const dependency = inferToggleDependencyFromSettingsSource(source);
-    if (dependency != null) {
-      return dependency;
-    }
-  }
-
-  const fallback = fallbackComponents.settingsToggle;
-  generatedAssets.push({
-    filePath: path.join(webviewAssetsDir, fallback.assetName),
-    source: fallback.source,
-  });
-  return {
-    assetName: fallback.assetName,
-    exportName: fallback.exportName,
-  };
-}
-
 function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings = true } = {}) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -525,7 +416,12 @@ function resolveSettingsAssetDependencies(extractedDir, { includeHotkeySettings 
     .sort()[0] ?? null;
   const settingsSectionFallback = settingsGroupCandidate == null ? useFallbackComponent("settingsSection") : null;
   const settingsGroupFallback = settingsSurfaceCandidate == null ? useFallbackComponent("settingsGroup") : null;
-  const toggleDependency = resolveSettingsToggleDependency(webviewAssetsDir, fallbackComponents, generatedAssets);
+  // Upstream settings controls are often exported from lazy Rolldown modules
+  // whose private initializer is only invoked by their original consumer.
+  // Importing those controls directly can therefore succeed while rendering
+  // crashes inside an uninitialized React compiler runtime. Keep this small
+  // control self-contained instead of depending on upstream module internals.
+  const toggleDependency = useFallbackComponent("settingsToggle");
 
   return {
     chunkAsset,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6930,6 +6930,7 @@ JS
 
     node "$REPO_DIR/scripts/patch-linux-window-ui.js" "$extracted" >"$output_log" 2>&1
     assert_file_exists "$extracted/webview/assets/linux-desktop-settings-linux.js"
+    assert_file_exists "$extracted/webview/assets/linux-settings-toggle-linux.js"
     [ ! -f "$extracted/webview/assets/keybinds-settings-linux.js" ] || fail "Old Keybinds settings asset should not be written for current native Keyboard Shortcuts"
     assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "function LinuxDesktopSettings"
     assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "Linux desktop"
@@ -6939,7 +6940,7 @@ JS
     assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-system-tray-enabled"
     assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-warm-start-enabled"
     assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "codex-linux-prompt-window-enabled"
-    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" ' as Toggle}from"./'
+    assert_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" 'import{t as Toggle}from"./linux-settings-toggle-linux.js"'
     assert_not_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "function LinuxSwitch"
     assert_not_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "bg-token-text-primary"
     assert_not_contains "$extracted/webview/assets/linux-desktop-settings-linux.js" "translate-x-4"


### PR DESCRIPTION
## Summary

- always generate and use the self-contained Linux settings toggle
- remove upstream toggle inference that depended on private lazy-module initialization
- add unit and smoke coverage ensuring upstream toggle exports are ignored

## Root cause

The generated Linux desktop settings page imported an upstream toggle component from a lazy Rolldown module. The export existed and the module loaded, but its private React compiler runtime initializer only ran through the upstream consumer. Rendering the standalone Linux page therefore failed while reading the uninitialized compiler runtime.

## Impact

The Linux desktop settings page renders reliably across current upstream bundles without depending on unexported initialization behavior.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (361 passing)
- focused `test_keybinds_settings_tab_patch_smoke`
- focused `test_keybinds_settings_patch_warns_on_bundle_shape_miss`
- `bash -n tests/scripts_smoke.sh`
- `node --check scripts/patches/impl/keybinds-settings.js`
- `git diff --check`
- browser render against upstream 26.707.41301 assets: four settings switches rendered with no uncaught errors