### PR TITLE
Test changed Linux Features against upstream DMG

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -5,15 +5,19 @@ on:
     - cron: '30 6 * * *'
   pull_request:
     paths:
+      - linux-features/*/**
+      - '!linux-features/local/**'
       - install.sh
       - Makefile
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
       - scripts/ci/validate-patch-report.js
+      - scripts/ci/changed-linux-features*.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
       - scripts/lib/candidate-install.sh
+      - scripts/lib/linux-features.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
@@ -28,9 +32,11 @@ on:
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
       - scripts/ci/validate-patch-report.js
+      - scripts/ci/changed-linux-features*.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
       - scripts/lib/candidate-install.sh
+      - scripts/lib/linux-features.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
@@ -58,11 +64,24 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 24
+
+      - name: Configure changed Linux Features
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git diff --no-renames --name-only -z "$BASE_SHA...$HEAD_SHA" \
+            | node scripts/ci/changed-linux-features.js --output "$GITHUB_WORKSPACE/upstream-linux-features.json"
+          echo "CODEX_LINUX_FEATURES_CONFIG=$GITHUB_WORKSPACE/upstream-linux-features.json" >> "$GITHUB_ENV"
 
       - name: Install build dependencies
         run: |
@@ -171,6 +190,7 @@ jobs:
           path: |
             upstream-dmg-metadata.json
             upstream-dmg-decision.json
+            upstream-linux-features.json
             upstream-acceptance/**/*.json
           if-no-files-found: ignore
 

--- a/docs/upstream-dmg-acceptance.md
+++ b/docs/upstream-dmg-acceptance.md
@@ -20,6 +20,22 @@ feature for diagnostics. Disabled features are not checked; any patch drift in
 a user-enabled feature rejects the candidate so the working installation keeps
 that feature intact. The user can disable the feature and retry the update.
 
+## Pull Request Feature Acceptance
+
+Pull requests that change tracked files under `linux-features/<id>/` run the
+upstream DMG workflow with those repository features enabled. The workflow
+maps changed paths through the existing feature manifest loader, expands
+transitive `requires`, rejects conflicting combinations, and writes an
+uncommitted temporary feature config for one current-DMG build. Changes under
+`linux-features/local/` does not trigger this workflow. Top-level feature
+documentation, unknown directories, and non-feature paths do not enable a
+feature when another relevant change triggers the workflow.
+
+The scheduled workflow and normal pushes keep the default feature config and
+do not probe disabled opt-ins. A scheduled canary rotation across compatible
+feature groups remains a separate follow-up so its runtime cost and grouping
+can be measured independently.
+
 ## Transactional Local Install
 
 `install.sh` builds into a hidden sibling candidate directory. It evaluates the

--- a/scripts/ci/changed-linux-features.js
+++ b/scripts/ci/changed-linux-features.js
@@ -1,0 +1,134 @@
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  discoverLinuxFeatureManifests,
+  loadEnabledLinuxFeatures,
+} = require("../lib/linux-features.js");
+
+function repositoryFeatureDirectory(feature) {
+  return ["linux-features", ...feature.relativeDir.split(/[\\/]+/)].join("/");
+}
+
+function changedRepositoryFeatureIds(changedPaths, features) {
+  const featureByDirectory = new Map(
+    features
+      .filter((feature) => !feature.local)
+      .map((feature) => [repositoryFeatureDirectory(feature), feature.id]),
+  );
+  const changed = new Set();
+  for (const changedPath of changedPaths) {
+    const normalized = String(changedPath).replaceAll("\\", "/").replace(/^\.\//, "");
+    const parts = normalized.split("/");
+    if (parts.length < 3 || parts[0] !== "linux-features" || parts[1] === "local") {
+      continue;
+    }
+    const id = featureByDirectory.get(parts.slice(0, 2).join("/"));
+    if (id != null) {
+      changed.add(id);
+    }
+  }
+  return [...changed].sort();
+}
+
+function expandedFeatureIds(initialIds, features) {
+  const featureById = new Map(features.map((feature) => [feature.id, feature]));
+  const enabled = new Set();
+  function enable(id) {
+    if (enabled.has(id)) {
+      return;
+    }
+    const feature = featureById.get(id);
+    if (feature == null) {
+      throw new Error(`Linux feature '${id}' requires a feature that does not exist in this checkout`);
+    }
+    enabled.add(id);
+    for (const required of feature.manifest.requires) {
+      enable(required);
+    }
+  }
+  for (const id of initialIds) {
+    enable(id);
+  }
+  return [...enabled].sort();
+}
+
+function validateGeneratedConfig(config, options) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "changed-linux-features-config-"));
+  const configPath = path.join(tempRoot, "features.json");
+  try {
+    fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+    loadEnabledLinuxFeatures({ ...options, featuresConfigPath: configPath });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function configForChangedLinuxFeatures(changedPaths, options = {}) {
+  const repositoryOptions = { ...options, includeLocal: false };
+  const features = discoverLinuxFeatureManifests(repositoryOptions);
+  const changedIds = changedRepositoryFeatureIds(changedPaths, features);
+  const config = { enabled: expandedFeatureIds(changedIds, features) };
+  validateGeneratedConfig(config, repositoryOptions);
+  return config;
+}
+
+function writeChangedLinuxFeaturesConfig(outputPath, changedPaths, options = {}) {
+  const config = configForChangedLinuxFeatures(changedPaths, options);
+  const resolvedOutput = path.resolve(outputPath);
+  const temporaryPath = `${resolvedOutput}.tmp-${process.pid}-${Date.now()}`;
+  fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true });
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(config, null, 2)}\n`);
+    fs.renameSync(temporaryPath, resolvedOutput);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+  return config;
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--output") {
+      options.outputPath = argv[++index];
+    } else if (argument === "--features-root") {
+      options.featuresRoot = argv[++index];
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  if (!options.outputPath) {
+    throw new Error("Usage: changed-linux-features.js --output PATH [--features-root PATH]");
+  }
+  return options;
+}
+
+function main() {
+  const { outputPath, featuresRoot } = parseArgs(process.argv.slice(2));
+  const changedPaths = fs.readFileSync(0).toString("utf8").split("\0").filter(Boolean);
+  const config = writeChangedLinuxFeaturesConfig(outputPath, changedPaths, {
+    ...(featuresRoot ? { featuresRoot } : {}),
+  });
+  process.stdout.write(`Changed Linux Features enabled for upstream acceptance: ${config.enabled.join(", ") || "none"}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  changedRepositoryFeatureIds,
+  configForChangedLinuxFeatures,
+  expandedFeatureIds,
+  writeChangedLinuxFeaturesConfig,
+};

--- a/scripts/ci/changed-linux-features.test.js
+++ b/scripts/ci/changed-linux-features.test.js
@@ -165,7 +165,7 @@ test("upstream workflow runs feature-aware acceptance for feature PRs only", () 
   assert.match(pullRequestBlock, /- scripts\/lib\/linux-features\.js/);
   assert.doesNotMatch(pushBlock, /- linux-features\//);
   assert.match(pushBlock, /- scripts\/lib\/linux-features\.js/);
-  assert.match(workflow, /fetch-depth: \$\{\{ github\.event_name == 'pull_request' && 0 \|\| 1 \}\}/);
+  assert.match(workflow, /fetch-depth: \$\{\{ github\.event_name == 'pull_request' && '0' \|\| '1' \}\}/);
   assert.match(configureStep, /if: github\.event_name == 'pull_request'/);
   assert.match(configureStep, /git diff --no-renames --name-only -z/);
   assert.match(configureStep, /changed-linux-features\.js/);

--- a/scripts/ci/changed-linux-features.test.js
+++ b/scripts/ci/changed-linux-features.test.js
@@ -1,0 +1,174 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const {
+  configForChangedLinuxFeatures,
+  writeChangedLinuxFeaturesConfig,
+} = require("./changed-linux-features.js");
+
+function withFeatureRoot(fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "changed-linux-features-"));
+  const featuresRoot = path.join(root, "linux-features");
+  fs.mkdirSync(featuresRoot, { recursive: true });
+  try {
+    return fn({ root, featuresRoot });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function addFeature(featuresRoot, id, manifest = {}, relativeDir = id) {
+  const featureDir = path.join(featuresRoot, relativeDir);
+  fs.mkdirSync(featureDir, { recursive: true });
+  fs.writeFileSync(path.join(featureDir, "README.md"), `# ${id}\n`);
+  fs.writeFileSync(path.join(featureDir, "feature.json"), `${JSON.stringify({
+    id,
+    title: id,
+    ...manifest,
+  }, null, 2)}\n`);
+}
+
+test("enables the repository feature containing a changed file", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "alpha");
+
+  const config = configForChangedLinuxFeatures(["linux-features/alpha/patch.js"], { featuresRoot });
+
+  assert.deepEqual(config, { enabled: ["alpha"] });
+}));
+
+test("enables multiple compatible changed features in stable order", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "zulu");
+  addFeature(featuresRoot, "alpha");
+
+  const config = configForChangedLinuxFeatures([
+    "linux-features/zulu/test.js",
+    "linux-features/alpha/feature.json",
+  ], { featuresRoot });
+
+  assert.deepEqual(config, { enabled: ["alpha", "zulu"] });
+}));
+
+test("treats documentation inside a feature as a feature change", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "alpha");
+
+  const config = configForChangedLinuxFeatures(["linux-features/alpha/README.md"], { featuresRoot });
+
+  assert.deepEqual(config, { enabled: ["alpha"] });
+}));
+
+test("ignores local, top-level, core, unknown, and invalid feature paths", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "alpha");
+  addFeature(featuresRoot, "private-feature", {}, path.join("local", "private-feature"));
+  fs.writeFileSync(path.join(featuresRoot, "local", "private-feature", "feature.json"), "{broken-json\n");
+
+  const config = configForChangedLinuxFeatures([
+    "linux-features/local/private-feature/patch.js",
+    "linux-features/README.md",
+    "linux-features/not-a-feature/notes.md",
+    "linux-features/INVALID_ID/patch.js",
+    "scripts/patches/engine.js",
+  ], { featuresRoot });
+
+  assert.deepEqual(config, { enabled: [] });
+}));
+
+test("expands transitive feature requirements", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "base");
+  addFeature(featuresRoot, "middle", { requires: ["base"] });
+  addFeature(featuresRoot, "leaf", { requires: ["middle"] });
+
+  const config = configForChangedLinuxFeatures(["linux-features/leaf/patch.js"], { featuresRoot });
+
+  assert.deepEqual(config, { enabled: ["base", "leaf", "middle"] });
+}));
+
+test("rejects conflicts in the combined changed feature set", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "alpha", { conflicts: ["beta"] });
+  addFeature(featuresRoot, "beta");
+
+  assert.throws(
+    () => configForChangedLinuxFeatures([
+      "linux-features/alpha/patch.js",
+      "linux-features/beta/patch.js",
+    ], { featuresRoot }),
+    /Linux feature 'alpha' conflicts with 'beta'/,
+  );
+}));
+
+test("uses the manifest loader to reject invalid feature ids", () => withFeatureRoot(({ featuresRoot }) => {
+  addFeature(featuresRoot, "INVALID_ID", {}, "broken");
+
+  assert.throws(
+    () => configForChangedLinuxFeatures(["linux-features/broken/patch.js"], { featuresRoot }),
+    /Linux feature id .* must match/,
+  );
+}));
+
+test("does not replace an existing config when validation fails", () => withFeatureRoot(({ root, featuresRoot }) => {
+  addFeature(featuresRoot, "alpha", { conflicts: ["beta"] });
+  addFeature(featuresRoot, "beta");
+  const outputPath = path.join(root, "features.json");
+  fs.writeFileSync(outputPath, "original\n");
+
+  assert.throws(
+    () => writeChangedLinuxFeaturesConfig(outputPath, [
+      "linux-features/alpha/patch.js",
+      "linux-features/beta/patch.js",
+    ], { featuresRoot }),
+    /Linux feature 'alpha' conflicts with 'beta'/,
+  );
+  assert.equal(fs.readFileSync(outputPath, "utf8"), "original\n");
+}));
+
+test("CLI writes a build-ready config from NUL-delimited changed paths", () => withFeatureRoot(({ root, featuresRoot }) => {
+  addFeature(featuresRoot, "base");
+  addFeature(featuresRoot, "leaf", { requires: ["base"] });
+  const outputPath = path.join(root, "features.json");
+  const cli = path.join(__dirname, "changed-linux-features.js");
+
+  const result = spawnSync(process.execPath, [
+    cli,
+    "--features-root", featuresRoot,
+    "--output", outputPath,
+  ], {
+    encoding: "utf8",
+    input: "linux-features/leaf/README.md\0scripts/core.js\0",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(fs.readFileSync(outputPath, "utf8")), {
+    enabled: ["base", "leaf"],
+  });
+  assert.match(result.stdout, /base, leaf/);
+}));
+
+test("upstream workflow runs feature-aware acceptance for feature PRs only", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/upstream-build-app.yml"),
+    "utf8",
+  );
+
+  const pullRequestBlock = workflow.slice(workflow.indexOf("  pull_request:"), workflow.indexOf("  push:"));
+  const pushBlock = workflow.slice(workflow.indexOf("  push:"), workflow.indexOf("  workflow_dispatch:"));
+  const configureStep = workflow.slice(
+    workflow.indexOf("      - name: Configure changed Linux Features"),
+    workflow.indexOf("      - name: Install build dependencies"),
+  );
+  assert.match(pullRequestBlock, /- linux-features\/\*\/\*\*/);
+  assert.match(pullRequestBlock, /- '!linux-features\/local\/\*\*'/);
+  assert.match(pullRequestBlock, /- scripts\/lib\/linux-features\.js/);
+  assert.doesNotMatch(pushBlock, /- linux-features\//);
+  assert.match(pushBlock, /- scripts\/lib\/linux-features\.js/);
+  assert.match(workflow, /fetch-depth: \$\{\{ github\.event_name == 'pull_request' && 0 \|\| 1 \}\}/);
+  assert.match(configureStep, /if: github\.event_name == 'pull_request'/);
+  assert.match(configureStep, /git diff --no-renames --name-only -z/);
+  assert.match(configureStep, /changed-linux-features\.js/);
+  assert.match(configureStep, /CODEX_LINUX_FEATURES_CONFIG/);
+  assert.equal(workflow.match(/CODEX_LINUX_FEATURES_CONFIG/g)?.length, 1);
+});

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -193,7 +193,7 @@ function isDirectory(filePath) {
   }
 }
 
-function featureManifestCandidates(featuresRoot) {
+function featureManifestCandidates(featuresRoot, options = {}) {
   if (!fs.existsSync(featuresRoot)) {
     return [];
   }
@@ -210,7 +210,7 @@ function featureManifestCandidates(featuresRoot) {
   }
 
   const localRoot = path.join(featuresRoot, LOCAL_FEATURES_DIR);
-  if (isDirectory(localRoot)) {
+  if (options.includeLocal !== false && isDirectory(localRoot)) {
     for (const name of fs.readdirSync(localRoot).sort()) {
       if (name.startsWith(".")) {
         continue;
@@ -262,7 +262,7 @@ function discoverLinuxFeatureManifests(options = {}) {
   const featuresRoot = linuxFeaturesRoot(options);
   const features = [];
   const seen = new Map();
-  for (const candidate of featureManifestCandidates(featuresRoot)) {
+  for (const candidate of featureManifestCandidates(featuresRoot, options)) {
     const feature = normalizeLinuxFeatureManifest(featuresRoot, candidate);
     const previous = seen.get(feature.id);
     if (previous != null) {

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  discoverLinuxFeatureManifests,
   stageEnabledLinuxFeatureInstall,
 } = require("./linux-features.js");
 
@@ -34,6 +35,25 @@ function writeStagedManifest(appDir, manifest) {
   fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 }
+
+test("Linux feature discovery can exclude local manifests", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-repo-only-discovery-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const featuresRoot = path.join(root, "linux-features");
+  const featureDir = path.join(featuresRoot, "alpha");
+  const localDir = path.join(featuresRoot, "local", "broken");
+  fs.mkdirSync(featureDir, { recursive: true });
+  fs.mkdirSync(localDir, { recursive: true });
+  fs.writeFileSync(path.join(featureDir, "README.md"), "# Alpha\n");
+  fs.writeFileSync(path.join(featureDir, "feature.json"), '{"id":"alpha","title":"Alpha"}\n');
+  fs.writeFileSync(path.join(localDir, "README.md"), "# Broken\n");
+  fs.writeFileSync(path.join(localDir, "feature.json"), "{broken-json\n");
+
+  const features = discoverLinuxFeatureManifests({ featuresRoot, includeLocal: false });
+
+  assert.deepEqual(features.map((feature) => feature.id), ["alpha"]);
+});
 
 test("Linux feature staging rejects duplicate resource targets", (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-duplicate-resource-"));


### PR DESCRIPTION
## Summary

- run the upstream DMG workflow when a pull request changes a tracked Linux Feature
- derive changed feature ids from the complete PR diff, expand transitive `requires`, and reject conflicts through the existing manifest loader
- generate an uncommitted feature config for one current-DMG build and include it in the diagnostic artifact
- exclude `linux-features/local`, preserve default feature behavior for scheduled and push runs, and keep normal installs/updater rebuilds unchanged

## Why

The shared acceptance gate rejects drift only for features enabled in the candidate patch report. The regular upstream build used the empty feature config, so an opt-in descriptor could stop matching the published DMG while synthetic feature tests and the default build remained green.

This change makes PR-time acceptance aware of the repository features changed by that PR without adding an all-features matrix or changing user configuration.

## Source of truth

- `.github/workflows/upstream-build-app.yml`
- `scripts/ci/changed-linux-features.js`
- `scripts/lib/linux-features.js`
- `docs/upstream-dmg-acceptance.md`

## Current-DMG validation

- repository base: `2752ba912cfa3be48caa081f2fa4b225d71a05f4`
- app: `26.707.41301`
- Electron: `42.1.0`
- DMG SHA-256: `467a25381af2943f2c9b8794adae28b36400bd6da2753daf4889a5fd550c4d65`
- ETag: `0x8DEDED0CF5BF674`
- size: `560409764` bytes
- real isolated build with `ui-tweaks`: verdict `accepted`, all 6 feature patches `applied`, no blockers or warnings
- synthetic drift injected into a copy of that real patch report: verdict `rejected` with `enabled-feature-drift`

## Tests

- `node --test scripts/ci/*.test.js scripts/lib/linux-features.test.js` (42 passed)
- `node --test linux-features/*/test.js` (519 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (360 passed)
- `bash tests/scripts_smoke.sh`
- Node syntax checks for the new helper and tests
- YAML parse for `upstream-build-app.yml`
- generator byte-stability check
- `scripts/ci/validate-patch-report.js` against the real build report
- `git diff --check`

## Out of scope

- scheduled canary rotation across all opt-ins
- changes to local installs, updater rebuilds, patch discovery, or the patch engine
- removing GitHub's documented 300-file path-filter limit; that would require a separate lightweight detector job and broader workflow architecture
