### PR TITLE
refactor(remote-mobile): keep config preservation core-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Remote notification hydration, replay, completed-item recovery, and remote
   terminal-status recovery are no longer part of the default Linux patch set and
   remain owned by the disabled-by-default `remote-mobile-control` feature.
+- The `remote-mobile-control` feature no longer duplicates the generic Linux
+  `remote_control` config preservation patch already owned by the core patch
+  set.
 
 ### Fixed
 

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -179,33 +179,6 @@ function applyLinuxRemoteControlDeviceKeyPatch(source) {
     .replace(DEVICE_KEY_GUARD, DEVICE_KEY_GUARD_REPLACEMENT);
 }
 
-function applyLinuxRemoteControlPreserveConfigPatch(source) {
-  const stripperGuardRegex =
-    /async function [A-Za-z_$][\w$]*\(\{codexHome:[A-Za-z_$][\w$]*,hostConfig:([A-Za-z_$][\w$]*),logger:[A-Za-z_$][\w$]*=[^}]*\}\)\{if\(\1\.kind===`local`\)try\{/gu;
-  const patched = source.replace(stripperGuardRegex, (needle, hostConfigVar) =>
-    needle.replace(
-      `if(${hostConfigVar}.kind===\`local\`)try{`,
-      `if(${hostConfigVar}.kind===\`local\`&&process.platform!==\`linux\`)try{`,
-    ),
-  );
-  if (patched !== source) {
-    return patched;
-  }
-
-  const alreadyPatchedRegex =
-    /async function [A-Za-z_$][\w$]*\(\{codexHome:[A-Za-z_$][\w$]*,hostConfig:([A-Za-z_$][\w$]*),logger:[A-Za-z_$][\w$]*=[^}]*\}\)\{if\(\1\.kind===`local`&&process\.platform!==`linux`\)try\{/u;
-  if (
-    alreadyPatchedRegex.test(source) ||
-    !source.includes("Removed remote_control from config before app-server start") &&
-      !source.includes("Failed to remove remote_control before app-server start")
-  ) {
-    return source;
-  }
-
-  console.warn("WARN: Could not find remote-control config stripping needle - skipping Linux remote-control config patch");
-  return source;
-}
-
 function applyLinuxRemoteControlClientAccountCompatibilityPatch(source) {
   if (source.includes(CLIENT_ACCOUNT_COMPAT_MARKER)) {
     return source;
@@ -1692,13 +1665,6 @@ module.exports = [
     apply: applyLinuxRemoteControlDeviceKeyPatch,
   },
   {
-    id: "linux-remote-control-preserve-config",
-    phase: "main-bundle",
-    order: 20_110,
-    ciPolicy: "optional",
-    apply: applyLinuxRemoteControlPreserveConfigPatch,
-  },
-  {
     id: "linux-remote-control-client-account-compatibility",
     phase: "main-bundle",
     order: 20_115,
@@ -1895,7 +1861,6 @@ module.exports.applyLinuxRemoteControlEnablementBridgePatch = applyLinuxRemoteCo
 module.exports.applyLinuxRemoteControlEnableForHostParamsPatch =
   applyLinuxRemoteControlEnableForHostParamsPatch;
 module.exports.applyLinuxRemoteMobileActiveStatusPatch = applyLinuxRemoteMobileActiveStatusPatch;
-module.exports.applyLinuxRemoteControlPreserveConfigPatch = applyLinuxRemoteControlPreserveConfigPatch;
 module.exports.applyLinuxRemoteControlClientAccountCompatibilityPatch =
   applyLinuxRemoteControlClientAccountCompatibilityPatch;
 module.exports.applyLinuxRemoteControlClientRevocationRecoveryPatch =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -25,7 +25,6 @@ const {
   applyLinuxRemoteControlClientRevokeSetupResetPatch,
   applyLinuxRemoteControlClientRevocationRecoveryPatch,
   applyLinuxRemoteControlCopyPatch,
-  applyLinuxRemoteControlPreserveConfigPatch,
   applyLinuxRemoteControlFeatureSyncPatch,
   applyLinuxRemoteControlEnableForHostParamsPatch,
   applyLinuxRemoteControlLoadGatePatch,
@@ -735,7 +734,6 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     const descriptors = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
     assert.deepEqual(descriptors.map((descriptor) => descriptor.id), [
       "feature:remote-mobile-control:linux-remote-control-device-key",
-      "feature:remote-mobile-control:linux-remote-control-preserve-config",
       "feature:remote-mobile-control:linux-remote-control-client-account-compatibility",
       "feature:remote-mobile-control:linux-remote-control-client-revocation-recovery",
       "feature:remote-mobile-control:linux-remote-mobile-app-server-remote-control",
@@ -757,7 +755,6 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       "feature:remote-mobile-control:linux-remote-mobile-active-status",
     ]);
     assert.deepEqual(descriptors.map((descriptor) => descriptor.phase), [
-      "main-bundle",
       "main-bundle",
       "main-bundle",
       "main-bundle",
@@ -847,31 +844,26 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
   });
 });
 
-test("Linux remote-control patches update the device-key provider and preserve config", () => {
+test("Linux remote-control feature patch updates the device-key provider", () => {
   const source = syntheticMainBundle();
-  const patched = applyLinuxRemoteControlPreserveConfigPatch(
-    applyLinuxRemoteControlDeviceKeyPatch(source),
-  );
+  const patched = applyLinuxRemoteControlDeviceKeyPatch(source);
 
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxRemoteControlDeviceKeyClient/);
   assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
-  assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
-  assert.equal(
-    applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)),
-    patched,
-  );
+  assert.doesNotMatch(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
+  assert.equal(applyLinuxRemoteControlDeviceKeyPatch(patched), patched);
 });
 
 test("Linux remote-control device-key patch handles current minified aliases", () => {
   const source = syntheticCurrentMainBundle();
-  const patched = applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(source));
+  const patched = applyLinuxRemoteControlDeviceKeyPatch(source);
 
   assert.notEqual(patched, source);
   assert.match(patched, /codexLinuxRemoteControlDeviceKeyClient/);
   assert.match(patched, /process\.platform===`linux`\)return codexLinuxRemoteControlDeviceKeyClient\(\)/);
-  assert.match(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
-  assert.equal(applyLinuxRemoteControlPreserveConfigPatch(applyLinuxRemoteControlDeviceKeyPatch(patched)), patched);
+  assert.doesNotMatch(patched, /n\.kind===`local`&&process\.platform!==`linux`/);
+  assert.equal(applyLinuxRemoteControlDeviceKeyPatch(patched), patched);
 });
 
 test("Linux remote-control device-key provider avoids upstream minified alias collisions", async () => {
@@ -2774,11 +2766,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             patch.status === "applied",
           ),
         );
-        assert.ok(
-          report.patches.some((patch) =>
-            patch.name === "feature:remote-mobile-control:linux-remote-control-preserve-config" &&
-            patch.status === "already-applied",
+        assert.equal(
+          report.patches.some(
+            (patch) => patch.name === "feature:remote-mobile-control:linux-remote-control-preserve-config",
           ),
+          false,
         );
         assert.ok(
           report.patches.some((patch) =>


### PR DESCRIPTION
Summary
- remove the duplicate `remote-mobile-control` config-preservation descriptor
- keep the generic Linux `remote_control` config preservation owned by the core patch set
- update the feature patch-report coverage and changelog

Tests
- `node --test linux-features/remote-mobile-control/test.js`
- `node --test scripts/patch-linux-window-ui.test.js`
- `bash scripts/ci/run-node-checks.sh`
- `bash tests/scripts_smoke.sh`
- `semgrep scan --config p/javascript linux-features/remote-mobile-control/patch.js linux-features/remote-mobile-control/test.js scripts/patches/impl/main-process/misc.js scripts/patch-linux-window-ui.test.js`
