### PR TITLE
ci(remote-mobile): validate opt-in feature against upstream DMG

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -10,6 +10,9 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - linux-features/remote-mobile-control/**
+      - scripts/ci/patch-rerun-check.js
+      - scripts/ci/patch-rerun-check.test.js
       - scripts/ci/validate-patch-report.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
@@ -27,6 +30,9 @@ on:
       - scripts/patch-linux-window-ui.js
       - scripts/patch-linux-window-ui.test.js
       - scripts/patches/**
+      - linux-features/remote-mobile-control/**
+      - scripts/ci/patch-rerun-check.js
+      - scripts/ci/patch-rerun-check.test.js
       - scripts/ci/validate-patch-report.js
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
@@ -161,6 +167,52 @@ jobs:
           REBUILD_REPORT_DIR: ${{ github.workspace }}/upstream-acceptance
         run: make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg
 
+      - name: Validate remote mobile feature against upstream DMG
+        run: |
+          set -euo pipefail
+
+          features_config="$(mktemp)"
+          report_dir="$GITHUB_WORKSPACE/remote-mobile-upstream-inspect"
+          trap 'rm -f "$features_config"' EXIT
+          printf '%s\n' '{"enabled":["remote-mobile-control"]}' > "$features_config"
+
+          CODEX_LINUX_FEATURES_CONFIG="$features_config" \
+          CODEX_PATCH_MATRIX_JSON="$report_dir/patch-matrix.json" \
+            make inspect-upstream DMG="$UPSTREAM_DMG_PATH" REBUILD_REPORT_DIR="$report_dir"
+
+          node scripts/validate-upstream-dmg.js \
+            --dmg "$UPSTREAM_DMG_PATH" \
+            --core-report "$report_dir/patch-report.json" \
+            --build-status success \
+            --metadata "$GITHUB_WORKSPACE/upstream-dmg-metadata.json" \
+            --output "$report_dir/decision.json" \
+            --source github-actions \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --require-enabled-feature remote-mobile-control \
+            --require-success feature:remote-mobile-control:linux-remote-control-device-key \
+            --require-success feature:remote-mobile-control:linux-remote-control-client-account-compatibility \
+            --require-success feature:remote-mobile-control:linux-remote-control-client-revocation-recovery \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-app-server-remote-control \
+            --require-success feature:remote-mobile-control:linux-remote-control-load-gate \
+            --require-success feature:remote-mobile-control:linux-remote-control-feature-sync \
+            --require-success feature:remote-mobile-control:linux-remote-control-visibility \
+            --require-success feature:remote-mobile-control:linux-remote-control-copy \
+            --require-success feature:remote-mobile-control:linux-remote-control-settings-ux \
+            --require-success feature:remote-mobile-control:linux-remote-control-selected-tab \
+            --require-success feature:remote-mobile-control:linux-remote-control-client-revoke-setup-reset \
+            --require-success feature:remote-mobile-control:linux-remote-connections-refresh \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-conversation-hydration \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-completed-item-recovery \
+            --require-success feature:remote-mobile-control:linux-remote-terminal-status-recovery \
+            --require-success feature:remote-mobile-control:linux-remote-control-status-read-guard \
+            --require-success feature:remote-mobile-control:linux-remote-control-status-wait \
+            --require-success feature:remote-mobile-control:linux-remote-control-enable-for-host-params \
+            --require-success feature:remote-mobile-control:linux-remote-control-enablement-bridge \
+            --require-success feature:remote-mobile-control:linux-remote-mobile-active-status \
+            --enforce
+
       - name: Upload upstream DMG metadata artifact
         # The transactional installer records a decision before returning a
         # rejected status, so diagnostics remain available on failed runs.
@@ -172,6 +224,7 @@ jobs:
             upstream-dmg-metadata.json
             upstream-dmg-decision.json
             upstream-acceptance/**/*.json
+            remote-mobile-upstream-inspect/*.json
           if-no-files-found: ignore
 
       - name: Record missing decision in the summary
@@ -244,9 +297,17 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { httpIdentity } = require('./scripts/lib/upstream-dmg-acceptance.js');
+            const { httpIdentity, selectAcceptanceDecision } = require('./scripts/lib/upstream-dmg-acceptance.js');
             const { reconcileUpstreamDmgIssue } = require('./scripts/ci/upstream-dmg-issue.js');
-            const decision = JSON.parse(fs.readFileSync('acceptance-artifact/upstream-dmg-decision.json', 'utf8'));
+            const decisions = [JSON.parse(fs.readFileSync('acceptance-artifact/upstream-dmg-decision.json', 'utf8'))];
+            const missingReasons = [];
+            const remoteDecisionPath = 'acceptance-artifact/remote-mobile-upstream-inspect/decision.json';
+            if (fs.existsSync(remoteDecisionPath)) {
+              decisions.push(JSON.parse(fs.readFileSync(remoteDecisionPath, 'utf8')));
+            } else {
+              missingReasons.push('remote-mobile compatibility decision missing');
+            }
+            const decision = selectAcceptanceDecision(decisions, missingReasons);
             const currentMetadata = JSON.parse(fs.readFileSync('current-upstream-identity.json', 'utf8'));
             const result = await reconcileUpstreamDmgIssue({
               github,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   rejections create one fingerprinted drift issue and supersede issues for
   older DMGs. Acceptance evaluates only the user's enabled Linux features and
   preserves the working app if any enabled feature drifts.
+- Upstream DMG CI now validates the opt-in `remote-mobile-control` descriptor
+  contract on the current app, records first- and second-pass patch statuses,
+  and rejects non-idempotent source transformations.
 - Nix module configurations can select the opt-in `mcp-helper-reaper`
   feature. Its Rust helper is supplied by a reproducible Nix derivation and is
   not added to the default package closure.

--- a/docs/upstream-dmg-acceptance.md
+++ b/docs/upstream-dmg-acceptance.md
@@ -20,6 +20,18 @@ feature for diagnostics. Disabled features are not checked; any patch drift in
 a user-enabled feature rejects the candidate so the working installation keeps
 that feature intact. The user can disable the feature and retry the update.
 
+The upstream workflow also runs a separate read-only compatibility probe for
+`remote-mobile-control` when that feature or the shared patch infrastructure
+changes. This does not enable the feature in normal builds. It checks the
+current DMG with the feature selected, requires its current descriptor contract,
+then reapplies the patcher and rejects a second pass that changes the extracted
+app tree. Both reports and the descriptor status matrix are uploaded with the
+workflow artifacts.
+
+The scheduled drift reconciler evaluates both the shared decision and this
+feature probe. A missing probe is inconclusive and cannot close an existing
+drift issue.
+
 ## Transactional Local Install
 
 `install.sh` builds into a hidden sibling candidate directory. It evaluates the

--- a/scripts/ci/patch-rerun-check.js
+++ b/scripts/ci/patch-rerun-check.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const { readPatchReport } = require("../lib/patch-validation.js");
+
+const USAGE = `Usage: scripts/ci/patch-rerun-check.js \\
+  --app PATH --patcher PATH --first-report PATH --second-report PATH --output PATH`;
+
+function parseArgs(argv) {
+  const options = {};
+  const valueOptions = new Map([
+    ["--app", "appDir"],
+    ["--patcher", "patcherPath"],
+    ["--first-report", "firstReportPath"],
+    ["--second-report", "secondReportPath"],
+    ["--output", "outputPath"],
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (valueOptions.has(arg)) {
+      const value = argv[++index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      options[valueOptions.get(arg)] = value;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function hashFile(hash, filePath) {
+  const descriptor = fs.openSync(filePath, "r");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    for (;;) {
+      const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function hashTree(rootPath) {
+  const root = path.resolve(rootPath);
+  const rootStat = fs.lstatSync(root);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error(`Extracted app path must be a real directory: ${root}`);
+  }
+
+  const hash = crypto.createHash("sha256");
+  const visit = (directory, relativeDirectory = "") => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      const relativePath = path.posix.join(relativeDirectory, entry.name);
+      const stat = fs.lstatSync(absolutePath);
+      const mode = (stat.mode & 0o7777).toString(8);
+      if (stat.isDirectory()) {
+        hash.update(`directory\0${relativePath}\0${mode}\0`);
+        visit(absolutePath, relativePath);
+      } else if (stat.isFile()) {
+        hash.update(`file\0${relativePath}\0${mode}\0${stat.size}\0`);
+        hashFile(hash, absolutePath);
+        hash.update("\0");
+      } else if (stat.isSymbolicLink()) {
+        hash.update(`symlink\0${relativePath}\0${mode}\0${fs.readlinkSync(absolutePath)}\0`);
+      } else {
+        hash.update(`special\0${relativePath}\0${mode}\0${stat.mode}\0`);
+      }
+    }
+  };
+  visit(root);
+  return hash.digest("hex");
+}
+
+function isInside(parentPath, candidatePath) {
+  const relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return relative === "" || (relative !== ".." && !relative.startsWith(`..${path.sep}`));
+}
+
+function canonicalOutputPath(filePath) {
+  const resolved = path.resolve(filePath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  return path.join(fs.realpathSync(path.dirname(resolved)), path.basename(resolved));
+}
+
+function rejectSymbolicLink(filePath, label) {
+  try {
+    if (fs.lstatSync(filePath).isSymbolicLink()) {
+      throw new Error(`${label} must not be a symbolic link`);
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+function patchMatrix(firstReport, secondReport, treeHashBefore, treeHashAfter) {
+  const firstPatches = firstReport.patches ?? [];
+  const secondPatches = secondReport.patches ?? [];
+  const firstByName = new Map(firstPatches.map((entry) => [entry.name, entry]));
+  const secondByName = new Map(secondPatches.map((entry) => [entry.name, entry]));
+  const duplicateNames = (patches) => {
+    const seen = new Set();
+    const duplicates = new Set();
+    for (const patch of patches) {
+      if (seen.has(patch.name)) duplicates.add(patch.name);
+      seen.add(patch.name);
+    }
+    return [...duplicates].sort();
+  };
+  const duplicateFirstPass = duplicateNames(firstPatches);
+  const duplicateSecondPass = duplicateNames(secondPatches);
+  const names = [...new Set([...firstByName.keys(), ...secondByName.keys()])].sort();
+  const firstFeatures = Array.isArray(firstReport.enabledFeatures)
+    ? [...new Set(firstReport.enabledFeatures)].sort()
+    : [];
+  const secondFeatures = Array.isArray(secondReport.enabledFeatures)
+    ? [...new Set(secondReport.enabledFeatures)].sort()
+    : [];
+  const missingFromSecondPass = [...firstByName.keys()]
+    .filter((name) => !secondByName.has(name))
+    .sort();
+  const unexpectedOnSecondPass = [...secondByName.keys()]
+    .filter((name) => !firstByName.has(name))
+    .sort();
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    enabledFeatures: firstFeatures,
+    secondPassEnabledFeatures: secondFeatures,
+    featureSetStable: JSON.stringify(firstFeatures) === JSON.stringify(secondFeatures),
+    descriptorSetStable: missingFromSecondPass.length === 0
+      && unexpectedOnSecondPass.length === 0
+      && duplicateFirstPass.length === 0
+      && duplicateSecondPass.length === 0,
+    duplicateFirstPass,
+    duplicateSecondPass,
+    missingFromSecondPass,
+    unexpectedOnSecondPass,
+    treeHashBefore,
+    treeHashAfter,
+    idempotent: treeHashBefore === treeHashAfter,
+    patches: names.map((name) => ({
+      name,
+      firstStatus: firstByName.get(name)?.status ?? "missing",
+      secondStatus: secondByName.get(name)?.status ?? "missing",
+    })),
+  };
+}
+
+function runPatchRerunCheck(options) {
+  const required = ["appDir", "patcherPath", "firstReportPath", "secondReportPath", "outputPath"];
+  for (const name of required) {
+    if (!options[name]) throw new Error(`${name} is required`);
+  }
+
+  const appDir = fs.realpathSync(path.resolve(options.appDir));
+  const firstReportPath = fs.realpathSync(path.resolve(options.firstReportPath));
+  const secondReportPath = canonicalOutputPath(options.secondReportPath);
+  const outputPath = canonicalOutputPath(options.outputPath);
+  rejectSymbolicLink(secondReportPath, "Second patch report");
+  rejectSymbolicLink(outputPath, "Patch matrix output");
+  if ([firstReportPath, secondReportPath, outputPath].some((candidate) => isInside(appDir, candidate))) {
+    throw new Error("Patch reports and matrix output must stay outside the extracted app directory");
+  }
+  if (new Set([firstReportPath, secondReportPath, outputPath]).size !== 3) {
+    throw new Error("First report, second report, and matrix output must use different paths");
+  }
+
+  const firstReport = readPatchReport(firstReportPath);
+  const treeHashBefore = hashTree(appDir);
+  fs.mkdirSync(path.dirname(secondReportPath), { recursive: true });
+  fs.rmSync(secondReportPath, { force: true });
+  const child = spawnSync(process.execPath, [
+    path.resolve(options.patcherPath),
+    "--report-json",
+    secondReportPath,
+    appDir,
+  ], { stdio: "inherit" });
+  if (child.error) throw child.error;
+  if (child.signal) {
+    throw new Error(`Second patch pass terminated by signal ${child.signal}`);
+  }
+  if (child.status !== 0) {
+    throw new Error(`Second patch pass exited with status ${child.status}`);
+  }
+
+  const secondReport = readPatchReport(secondReportPath);
+  const treeHashAfter = hashTree(appDir);
+  const matrix = patchMatrix(firstReport, secondReport, treeHashBefore, treeHashAfter);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.rmSync(outputPath, { force: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(matrix, null, 2)}\n`, "utf8");
+  if (!matrix.idempotent) {
+    throw new Error("Second patch pass changed the extracted app tree");
+  }
+  if (!matrix.featureSetStable) {
+    throw new Error("Second patch pass changed the enabled feature set");
+  }
+  if (!matrix.descriptorSetStable) {
+    throw new Error("Second patch pass changed the patch descriptor set");
+  }
+  return matrix;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+  runPatchRerunCheck(options);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  hashTree,
+  main,
+  parseArgs,
+  patchMatrix,
+  runPatchRerunCheck,
+};

--- a/scripts/ci/patch-rerun-check.test.js
+++ b/scripts/ci/patch-rerun-check.test.js
@@ -1,0 +1,317 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  hashTree,
+  runPatchRerunCheck,
+} = require("./patch-rerun-check.js");
+
+function withFixture(fn) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "patch-rerun-check-"));
+  try {
+    const appDir = path.join(root, "app");
+    fs.mkdirSync(appDir);
+    fs.writeFileSync(path.join(appDir, "asset.js"), "const value = 1;\n");
+    const firstReportPath = path.join(root, "first.json");
+    fs.writeFileSync(firstReportPath, `${JSON.stringify({
+      enabledFeatures: ["remote-mobile-control"],
+      patches: [{
+        name: "feature:remote-mobile-control:test-patch",
+        status: "applied",
+        sourceKind: "feature",
+        featureId: "remote-mobile-control",
+      }],
+    })}\n`);
+    return fn({ appDir, firstReportPath, root });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writePatcher(root, body) {
+  const patcherPath = path.join(root, "patcher.js");
+  fs.writeFileSync(patcherPath, `"use strict";\n${body}\n`);
+  return patcherPath;
+}
+
+function reportWriter(extra = "") {
+  return `
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const reportPath = args[args.indexOf("--report-json") + 1];
+const appDir = args.at(-1);
+${extra}
+fs.writeFileSync(reportPath, JSON.stringify({
+  enabledFeatures: ["remote-mobile-control"],
+  patches: [{
+    name: "feature:remote-mobile-control:test-patch",
+    status: "already-applied",
+    sourceKind: "feature",
+    featureId: "remote-mobile-control"
+  }]
+}));`;
+}
+
+test("accepts a second patch pass that leaves the extracted tree unchanged", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const result = runPatchRerunCheck({
+      appDir,
+      firstReportPath,
+      outputPath: path.join(root, "matrix.json"),
+      patcherPath: writePatcher(root, reportWriter()),
+      secondReportPath: path.join(root, "second.json"),
+    });
+
+    assert.equal(result.idempotent, true);
+    assert.equal(result.featureSetStable, true);
+    assert.equal(result.descriptorSetStable, true);
+    assert.equal(result.treeHashBefore, result.treeHashAfter);
+    assert.deepEqual(result.enabledFeatures, ["remote-mobile-control"]);
+    assert.deepEqual(result.patches, [{
+      firstStatus: "applied",
+      name: "feature:remote-mobile-control:test-patch",
+      secondStatus: "already-applied",
+    }]);
+  });
+});
+
+test("rejects a second patch pass that changes the extracted tree", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(
+      root,
+      reportWriter('fs.writeFileSync(require("node:path").join(appDir, "late.js"), "late\\n");'),
+    );
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /changed the extracted app tree/,
+    );
+  });
+});
+
+test("rejects a patcher that writes a credible report and then exits non-zero", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(root, `${reportWriter()}\nprocess.exitCode = 7;`);
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /exited with status 7/,
+    );
+  });
+});
+
+test("reports when the second patch pass is terminated by a signal", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath: writePatcher(root, 'process.kill(process.pid, "SIGTERM");'),
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /terminated by signal SIGTERM/,
+    );
+  });
+});
+
+test("rejects a second pass that changes the enabled feature set", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(root, reportWriter().replace(
+      '["remote-mobile-control"]',
+      "[]",
+    ));
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /changed the enabled feature set/,
+    );
+  });
+});
+
+test("rejects a second pass that omits a patch descriptor", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(root, reportWriter().replace(
+      /patches: \[\{[\s\S]*?\}\]/,
+      "patches: []",
+    ));
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /changed the patch descriptor set/,
+    );
+  });
+});
+
+test("rejects a second pass that adds a patch descriptor", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(root, reportWriter().replace(
+      "patches: [{",
+      'patches: [{ name: "unexpected", status: "already-applied" }, {',
+    ));
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /changed the patch descriptor set/,
+    );
+  });
+});
+
+test("rejects duplicate patch descriptors in the second report", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const patcherPath = writePatcher(root, reportWriter().replace(
+      "patches: [{",
+      'patches: [{ name: "feature:remote-mobile-control:test-patch", status: "already-applied" }, {',
+    ));
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath,
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /changed the patch descriptor set/,
+    );
+  });
+});
+
+test("does not accept a stale second report when the patcher writes nothing", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const secondReportPath = path.join(root, "second.json");
+    fs.copyFileSync(firstReportPath, secondReportPath);
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath: writePatcher(root, "// Deliberately writes no report."),
+        secondReportPath,
+      }),
+      /ENOENT|no such file/i,
+    );
+  });
+});
+
+test("hashes symlink targets without following them", () => {
+  withFixture(({ appDir }) => {
+    fs.symlinkSync("asset.js", path.join(appDir, "asset-link"));
+    const before = hashTree(appDir);
+    fs.unlinkSync(path.join(appDir, "asset-link"));
+    fs.symlinkSync("missing.js", path.join(appDir, "asset-link"));
+    assert.notEqual(hashTree(appDir), before);
+  });
+});
+
+test("rejects report outputs stored inside the tree being hashed", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath: writePatcher(root, reportWriter()),
+        secondReportPath: path.join(appDir, "second.json"),
+      }),
+      /outside the extracted app directory/,
+    );
+  });
+});
+
+test("rejects a first report stored inside the tree being hashed", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const nestedFirstReport = path.join(appDir, "first.json");
+    fs.copyFileSync(firstReportPath, nestedFirstReport);
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath: nestedFirstReport,
+        outputPath: path.join(root, "matrix.json"),
+        patcherPath: writePatcher(root, reportWriter()),
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /outside the extracted app directory/,
+    );
+  });
+});
+
+test("rejects aliased report and matrix output paths", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const sharedPath = path.join(root, "shared.json");
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: sharedPath,
+        patcherPath: writePatcher(root, reportWriter()),
+        secondReportPath: sharedPath,
+      }),
+      /must use different paths/,
+    );
+  });
+});
+
+test("rejects a matrix output symlink before it can mutate the app tree", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const outputPath = path.join(root, "matrix.json");
+    fs.symlinkSync(path.join(appDir, "asset.js"), outputPath);
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath,
+        patcherPath: writePatcher(root, reportWriter()),
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /must not be a symbolic link/,
+    );
+    assert.equal(fs.readFileSync(path.join(appDir, "asset.js"), "utf8"), "const value = 1;\n");
+  });
+});
+
+test("rejects an output directory symlink that resolves inside the app tree", () => {
+  withFixture(({ appDir, firstReportPath, root }) => {
+    const linkedDirectory = path.join(root, "linked-output");
+    fs.symlinkSync(appDir, linkedDirectory);
+    assert.throws(
+      () => runPatchRerunCheck({
+        appDir,
+        firstReportPath,
+        outputPath: path.join(linkedDirectory, "matrix.json"),
+        patcherPath: writePatcher(root, reportWriter()),
+        secondReportPath: path.join(root, "second.json"),
+      }),
+      /outside the extracted app directory/,
+    );
+  });
+});

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -7,7 +7,12 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
-const { evaluateUpstreamDmg, httpIdentity } = require("../lib/upstream-dmg-acceptance.js");
+const {
+  evaluateUpstreamDmg,
+  httpIdentity,
+  selectAcceptanceDecision,
+} = require("../lib/upstream-dmg-acceptance.js");
+const { parseArgs } = require("../validate-upstream-dmg.js");
 
 function withFixture(fn) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "upstream-acceptance-"));
@@ -45,6 +50,7 @@ function evaluate(root, dmg, overrides = {}) {
     coreReportPath: overrides.corePath ?? core,
     buildStatus: overrides.buildStatus ?? "success",
     repoRoot: root,
+    requirements: overrides.requirements,
   });
 }
 
@@ -85,6 +91,61 @@ test("rejects drift from a user-enabled feature", () => withFixture(({ root, dmg
   const decision = evaluate(root, dmg, { core });
   assert.equal(decision.verdict, "rejected");
   assert.ok(decision.blockers.some((item) => item.code === "enabled-feature-drift"));
+}));
+
+test("rejects a missing required descriptor from an enabled feature profile", () => withFixture(({ root, dmg }) => {
+  const core = requiredCoreReport();
+  core.enabledFeatures = ["remote-mobile-control"];
+  const decision = evaluate(root, dmg, {
+    core,
+    requirements: {
+      requiredEnabledFeatures: ["remote-mobile-control"],
+      requiredSuccessfulPatches: ["feature:remote-mobile-control:missing-patch"],
+    },
+  });
+  assert.equal(decision.verdict, "rejected");
+  assert.ok(decision.blockers.some((item) => item.name === "feature:remote-mobile-control:missing-patch"));
+}));
+
+test("parses repeatable feature-profile requirements", () => {
+  const args = parseArgs([
+    "--dmg", "/tmp/Codex.dmg",
+    "--core-report", "/tmp/report.json",
+    "--output", "/tmp/decision.json",
+    "--require-enabled-feature", "remote-mobile-control",
+    "--require-success", "feature:remote-mobile-control:first",
+    "--require-success", "feature:remote-mobile-control:second",
+    "--require-applied", "feature:remote-mobile-control:first",
+  ]);
+  assert.deepEqual(args.requirements, {
+    requiredAppliedPatches: ["feature:remote-mobile-control:first"],
+    requiredEnabledFeatures: ["remote-mobile-control"],
+    requiredSuccessfulPatches: [
+      "feature:remote-mobile-control:first",
+      "feature:remote-mobile-control:second",
+    ],
+  });
+});
+
+test("the CLI rejects a missing required feature descriptor", () => withFixture(({ root, dmg }) => {
+  const core = requiredCoreReport();
+  core.enabledFeatures = ["remote-mobile-control"];
+  const reportPath = writeJson(root, "required-cli-core.json", core);
+  const outputPath = path.join(root, "required-cli-decision.json");
+  const result = spawnSync(process.execPath, [
+    path.join(__dirname, "../validate-upstream-dmg.js"),
+    "--dmg", dmg,
+    "--core-report", reportPath,
+    "--build-status", "success",
+    "--output", outputPath,
+    "--require-enabled-feature", "remote-mobile-control",
+    "--require-success", "feature:remote-mobile-control:missing-patch",
+    "--enforce",
+  ], { encoding: "utf8" });
+  assert.equal(result.status, 2, result.stderr);
+  const decision = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.equal(decision.verdict, "rejected");
+  assert.ok(decision.blockers.some((item) => item.name === "feature:remote-mobile-control:missing-patch"));
 }));
 
 test("does not probe or block a disabled feature", () => withFixture(({ root, dmg }) => {
@@ -166,4 +227,49 @@ test("upstream workflow concurrency is isolated per PR or ref", () => {
     /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
   );
   assert.doesNotMatch(workflow, /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}\s*$/m);
+});
+
+test("upstream workflow pins the complete post-config-cleanup remote mobile descriptor contract", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/upstream-build-app.yml"),
+    "utf8",
+  );
+  const required = [...workflow.matchAll(
+    /--require-success feature:remote-mobile-control:([a-z0-9-]+)/g,
+  )].map((match) => match[1]).sort();
+  const expected = require("../../linux-features/remote-mobile-control/patch.js")
+    .map((descriptor) => descriptor.id)
+    .filter((id) => id !== "linux-remote-control-preserve-config")
+    .sort();
+  assert.deepEqual(required, expected);
+});
+
+test("reconciliation selects the most severe acceptance decision", () => {
+  const accepted = { verdict: "accepted", inconclusiveReasons: [] };
+  const warned = { verdict: "accepted_with_warnings", inconclusiveReasons: [] };
+  const rejected = { verdict: "rejected", inconclusiveReasons: [] };
+  assert.equal(selectAcceptanceDecision([accepted, warned]), warned);
+  assert.equal(selectAcceptanceDecision([accepted, rejected, warned]), rejected);
+});
+
+test("a missing compatibility decision makes reconciliation inconclusive", () => {
+  const accepted = { verdict: "accepted", inconclusiveReasons: [], dmg: { sha256: "a".repeat(64) } };
+  const selected = selectAcceptanceDecision(
+    [accepted],
+    ["remote-mobile compatibility decision missing"],
+  );
+  assert.equal(selected.verdict, "inconclusive");
+  assert.deepEqual(selected.inconclusiveReasons, ["remote-mobile compatibility decision missing"]);
+  assert.equal(selected.dmg.sha256, accepted.dmg.sha256);
+});
+
+test("a proven rejection remains selected when another probe is missing", () => {
+  const rejected = { verdict: "rejected", inconclusiveReasons: [] };
+  assert.equal(selectAcceptanceDecision([rejected], ["probe missing"]), rejected);
+});
+
+test("an unknown decision verdict is normalized to inconclusive", () => {
+  const selected = selectAcceptanceDecision([{ verdict: "partial", inconclusiveReasons: [] }]);
+  assert.equal(selected.verdict, "inconclusive");
+  assert.deepEqual(selected.inconclusiveReasons, ["unknown acceptance verdict: partial"]);
 });

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -133,6 +133,17 @@ inspect_rebuild_candidate() {
     fi
 
     node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" --report-json "$patch_report" "$inspect_dir"
+    if [ -n "${CODEX_PATCH_MATRIX_JSON:-}" ]; then
+        local second_patch_report="${CODEX_PATCH_SECOND_REPORT_JSON:-$report_dir/patch-report-second.json}"
+        node "$SCRIPT_DIR/scripts/ci/patch-rerun-check.js" \
+            --app "$inspect_dir" \
+            --patcher "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" \
+            --first-report "$patch_report" \
+            --second-report "$second_patch_report" \
+            --output "$CODEX_PATCH_MATRIX_JSON"
+        info "Second-pass patch report: $second_patch_report"
+        info "Patch matrix: $CODEX_PATCH_MATRIX_JSON"
+    fi
     write_rebuild_report_json "$rebuild_report" "$dmg_path" "$ELECTRON_VERSION" "$patch_report" ""
 
     info "Patch report: $patch_report"

--- a/scripts/lib/upstream-dmg-acceptance.js
+++ b/scripts/lib/upstream-dmg-acceptance.js
@@ -143,7 +143,10 @@ function evaluateUpstreamDmg(options) {
       ? enabledFeatureFailuresFromReport(core.report)
       : [];
     const enabledFeatureFailureNames = new Set(enabledFeatureFailures.map((failure) => failure.name));
-    blockers.push(...validationBlockers("core", validatePatchReport(core.report, profile.corePatchProfile)));
+    blockers.push(...validationBlockers(
+      "core",
+      validatePatchReport(core.report, profile.corePatchProfile, options.requirements),
+    ));
     blockers.push(...integrityFailures(core.report));
     blockers.push(...enabledFeatureFailures.map((failure) => ({
       code: "enabled-feature-drift",
@@ -201,6 +204,51 @@ function evaluateUpstreamDmg(options) {
   };
 }
 
+function selectAcceptanceDecision(decisions, missingReasons = []) {
+  const knownVerdicts = new Set(["accepted", "accepted_with_warnings", "inconclusive", "rejected"]);
+  const candidates = decisions
+    .filter((decision) => decision && typeof decision === "object")
+    .map((decision) => (
+      knownVerdicts.has(decision.verdict)
+        ? decision
+        : {
+          ...decision,
+          verdict: "inconclusive",
+          inconclusiveReasons: [
+            ...new Set([
+              ...(decision.inconclusiveReasons ?? []),
+              `unknown acceptance verdict: ${String(decision.verdict)}`,
+            ]),
+          ],
+        }
+    ));
+  if (candidates.length === 0) {
+    throw new Error("At least one upstream DMG acceptance decision is required");
+  }
+  const severity = new Map([
+    ["accepted", 0],
+    ["accepted_with_warnings", 1],
+    ["inconclusive", 2],
+    ["rejected", 3],
+  ]);
+  const selected = candidates.reduce((current, candidate) => (
+    severity.get(candidate.verdict) > severity.get(current.verdict)
+      ? candidate
+      : current
+  ));
+  const reasons = [...new Set(missingReasons.filter(Boolean))];
+  if (reasons.length === 0 || selected.verdict === "rejected") {
+    return selected;
+  }
+  return {
+    ...selected,
+    verdict: "inconclusive",
+    inconclusiveReasons: [
+      ...new Set([...(selected.inconclusiveReasons ?? []), ...reasons]),
+    ],
+  };
+}
+
 function decisionMarkdown(decision) {
   const lines = [
     "## Upstream DMG acceptance",
@@ -228,4 +276,5 @@ module.exports = {
   decisionMarkdown,
   evaluateUpstreamDmg,
   httpIdentity,
+  selectAcceptanceDecision,
 };

--- a/scripts/validate-upstream-dmg.js
+++ b/scripts/validate-upstream-dmg.js
@@ -19,12 +19,23 @@ Options:
   --run-id VALUE
   --run-attempt VALUE
   --run-url URL
+  --require-enabled-feature FEATURE_ID
+  --require-success PATCH_NAME
+  --require-applied PATCH_NAME
   --enforce
 `;
 }
 
 function parseArgs(argv) {
-  const args = { buildStatus: "unknown", source: "local" };
+  const args = {
+    buildStatus: "unknown",
+    source: "local",
+    requirements: {
+      requiredAppliedPatches: [],
+      requiredEnabledFeatures: [],
+      requiredSuccessfulPatches: [],
+    },
+  };
   const valueOptions = new Map([
     ["--dmg", "dmgPath"], ["--core-report", "coreReportPath"],
     ["--build-info", "buildInfoPath"],
@@ -37,6 +48,18 @@ function parseArgs(argv) {
     const arg = argv[index];
     if (arg === "--enforce") {
       args.enforce = true;
+    } else if (arg === "--require-enabled-feature") {
+      const value = argv[++index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      args.requirements.requiredEnabledFeatures.push(value);
+    } else if (arg === "--require-success") {
+      const value = argv[++index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      args.requirements.requiredSuccessfulPatches.push(value);
+    } else if (arg === "--require-applied") {
+      const value = argv[++index];
+      if (!value) throw new Error(`${arg} requires a value`);
+      args.requirements.requiredAppliedPatches.push(value);
     } else if (arg === "--help" || arg === "-h") {
       args.help = true;
     } else if (valueOptions.has(arg)) {
@@ -46,6 +69,9 @@ function parseArgs(argv) {
     } else {
       throw new Error(`Unknown option: ${arg}`);
     }
+  }
+  for (const name of Object.keys(args.requirements)) {
+    args.requirements[name] = [...new Set(args.requirements[name])];
   }
   return args;
 }


### PR DESCRIPTION
## Summary

- add a CI-only current-DMG compatibility probe for the opt-in `remote-mobile-control` feature
- verify a deterministic second patch pass with stable tree, feature, and descriptor sets
- preserve the feature result in workflow artifacts and include it in scheduled drift reconciliation

## Why

The shared acceptance gate correctly evaluates only the Linux features enabled by a user. The normal CI build has no optional features enabled, so changes under `remote-mobile-control` could otherwise merge without current-DMG coverage.

The probe uses a temporary feature config and `make inspect-upstream`; it does not change normal builds or user installations. Its static descriptor contract covers all 20 feature descriptors expected after the config-preservation cleanup in #869. Generic `remote_control` config preservation remains core-owned.

## Validation

- `bash scripts/ci/run-node-checks.sh` (953 tests)
- `bash tests/scripts_smoke.sh`
- `nix flake check --no-build --no-write-lock-file`
- Semgrep JavaScript scan (0 findings)
- workflow YAML, shell syntax, Node syntax, and `git diff --check`
- current `26.707.41301` DMG inspection with `remote-mobile-control` enabled

The current-DMG probe produced an accepted decision with no blockers or warnings. Both patch passes exposed the same 96 descriptors and the extracted tree SHA-256 remained unchanged.

Related to #639.
