### PR TITLE
fix(remote-mobile): follow current webview chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Remote mobile control now patches the current upstream webview chunks for
+  feature sync, settings visibility, host enablement, and active conversation
+  status. The enablement bridge also accepts the current bundle ordering where
+  its log marker is declared after the request handler.
 - Automated user-local updates no longer inherit or set developer overrides
   that could replace a running Electron app or bypass DMG acceptance. Manual
   and timer rebuilds now fail safely at promotion, transactional installs retain

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -57,6 +57,12 @@ const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
   /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/u;
+const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
+  /^app-initial~app-main~page-[^.]+\.js$/u;
+const REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN =
+  /^app-initial~app-main~appgen-settings-page~plugin-detail-page~new-thread-panel-page~onboardi~[^.]+\.js$/u;
+const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
+  /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =
   "function rr({selectedConnectionsTab:e,showControlThisMacTab:t,showRemoteControlConnectionsSection:n,showTabbedSshPage:r}){return n?e===`control-this-mac`&&!t||e===`ssh`&&!r?`access-other-devices`:e:`ssh`}";
 const REMOTE_CONTROL_SELECTED_TAB_REPLACEMENT =
@@ -1543,11 +1549,20 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
   patched = applyLinuxRemoteControlEnableForHostParamsPatch(patched);
 
   const markerIndex = patched.indexOf("[remote-connections/slingshot-gate-bridge]");
-  if (markerIndex < 0 || patched.indexOf("set-remote-control-connections-enabled", markerIndex) < 0) {
+  const enablementIndex = patched.indexOf("set-remote-control-connections-enabled");
+  if (markerIndex < 0 || enablementIndex < 0) {
+    return patched;
+  }
+  if (Math.abs(markerIndex - enablementIndex) > 4_500) {
+    console.warn("WARN: Remote-control enablement bridge anchors are too far apart - skipping Linux remote-control bridge patch");
     return patched;
   }
 
-  let region = patched.slice(markerIndex, markerIndex + 4_500);
+  const regionStart = Math.max(0, Math.min(markerIndex, enablementIndex) - 1_000);
+  const regionEnd = Math.min(patched.length, Math.max(markerIndex, enablementIndex) + 4_500);
+  const prefix = patched.slice(0, regionStart);
+  const suffix = patched.slice(regionEnd);
+  let region = patched.slice(regionStart, regionEnd);
 
   if (!patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER)) {
     const currentBridgePattern =
@@ -1572,12 +1587,11 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
       return patched;
     }
 
-    patched = patched.slice(0, markerIndex) + patchedRegion + patched.slice(markerIndex + region.length);
-    region = patched.slice(markerIndex, markerIndex + 4_500);
+    region = patchedRegion;
   }
 
-  if (patched.includes(REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER)) {
-    return patched;
+  if (region.includes(REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER)) {
+    return prefix + region + suffix;
   }
 
   const selfAutoConnectReplacement = (desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
@@ -1602,10 +1616,10 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
 
   if (selfAutoConnectRegion === region) {
     console.warn("WARN: Could not find remote-control self auto-connect needle - skipping Linux remote-control auto-connect patch");
-    return patched;
+    return prefix + region + suffix;
   }
 
-  return patched.slice(0, markerIndex) + selfAutoConnectRegion + patched.slice(markerIndex + region.length);
+  return prefix + selfAutoConnectRegion + suffix;
 }
 
 function applyLinuxRemoteControlEnableForHostParamsPatch(source) {
@@ -1698,7 +1712,7 @@ module.exports = [
   {
     id: "linux-remote-control-feature-sync",
     phase: "webview-asset",
-    pattern: /^(?:app-main|index)-.*\.js$/,
+    pattern: REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN,
     order: 20_119,
     ciPolicy: "optional",
     missingDescription: "webview app main bundle",
@@ -1708,7 +1722,7 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: /^(?:remote-control-connections-visibility|remote-connections-settings|use-plugin-install-flow)-.*\.js$/,
+    pattern: REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",
@@ -1818,7 +1832,7 @@ module.exports = [
   {
     id: "linux-remote-control-enable-for-host-params",
     phase: "webview-asset",
-    pattern: /^(?:app-main|app-initial~app-main~automations-page)-.*\.js$/,
+    pattern: REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN,
     order: 20_155,
     ciPolicy: "optional",
     missingDescription: "app main remote-control host toggle bundle",
@@ -1828,7 +1842,7 @@ module.exports = [
   {
     id: "linux-remote-control-enablement-bridge",
     phase: "webview-asset",
-    pattern: /^app-main-.*\.js$/,
+    pattern: REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN,
     order: 20_156,
     ciPolicy: "optional",
     missingDescription: "app main bundle",
@@ -1838,7 +1852,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-active-status",
     phase: "webview-asset",
-    pattern: /^(?:app-main|avatar-overlay-realtime-voice-button)-.*\.js$/,
+    pattern: REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN,
     order: 20_160,
     ciPolicy: "optional",
     missingDescription: "app main bundle",

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -20,8 +20,6 @@ const REMOTE_CONTROL_VISIBILITY_NEEDLE =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
   "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return(n||t)&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
-const REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT =
-  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return t&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)(?:&&\2\?\.accessRequired!==!0)?\}/u;
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
@@ -607,12 +605,10 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
     return source;
   }
 
-  // 26.527.x builds the per-host feature enablement in a helper that copies the
-  // supported defaults, then unconditionally adds remote_plugin (n[vI]=t), and
-  // never includes remote_control. Current app servers support remote_plugin and
-  // use it for remote marketplace data, so Linux only adds remote_control.
-  // Older core Linux patches may already have removed the remote_plugin tail;
-  // compose with that sanitized shape instead of treating it as drift.
+  // The current per-host feature enablement helper copies the supported
+  // defaults, then adds remote_plugin without remote_control. Current app
+  // servers use remote_plugin for remote marketplace data, so Linux adds only
+  // remote_control while preserving the upstream remote_plugin assignment.
   let patched = source;
   let changed = false;
   const enablementRegex =
@@ -628,19 +624,6 @@ function applyLinuxRemoteControlFeatureSyncPatch(source) {
         `function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
       patched = patched.replace(enablementRegex, replacement);
       changed = true;
-    } else {
-      const sanitizedEnablementRegex =
-        /(for\(let ([A-Za-z_$][\w$]*) of [A-Za-z_$][\w$]*\)\{let ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\[\2\];\3!=null&&\(([A-Za-z_$][\w$]*)\[\2\]=\3\)\})return \4\}/u;
-      const sanitizedMatch = patched.match(sanitizedEnablementRegex);
-      if (sanitizedMatch != null) {
-        const [, loopBlock, , , enablementVar] = sanitizedMatch;
-        const replacement =
-          `${loopBlock}return typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)` +
-          `?(${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(arguments[2],arguments[3])&&(${enablementVar}.remote_control=!0),${enablementVar})` +
-          `:${enablementVar}}function ${REMOTE_CONTROL_FEATURE_SYNC_MARKER}(e,t){return e==null||t==null||e===t}`;
-        patched = patched.replace(sanitizedEnablementRegex, replacement);
-        changed = true;
-      }
     }
   }
 
@@ -711,9 +694,6 @@ function applyLinuxRemoteControlVisibilityPatch(source) {
       source.includes("navigator.userAgent.includes(`Linux`)")
   ) {
     return source;
-  }
-  if (source.includes(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT)) {
-    return source.replace(REMOTE_CONTROL_VISIBILITY_OLD_REPLACEMENT, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
   }
   if (!source.includes(REMOTE_CONTROL_VISIBILITY_NEEDLE)) {
     if (!source.includes("remoteControlConnectionsState")) {
@@ -1572,16 +1552,6 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
       (_needle, functionName, cacheVar, compilerVar, checkGateVar, isLoadingVar, gateHookVar, gateValueVar, enabledVar, callbackVar, depsVar) =>
         `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(6),{checkGate:${checkGateVar},isLoading:${isLoadingVar}}=${gateHookVar}(),${gateValueVar};${cacheVar}[0]===${checkGateVar}?${gateValueVar}=${cacheVar}[1]:(${gateValueVar}=${checkGateVar}(\`1042620455\`),${cacheVar}[0]=${checkGateVar},${cacheVar}[1]=${gateValueVar});let ${enabledVar}=${gateValueVar}||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return `,
     );
-    const bridgePattern =
-      /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(3\),([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return \2\[0\]===\4\?/u;
-    if (patchedRegion === region) {
-      patchedRegion = region.replace(
-        bridgePattern,
-        (_needle, functionName, cacheVar, compilerVar, enabledVar, gateVar, callbackVar, depsVar) =>
-          `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(3),${enabledVar}=${gateVar}()||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return ${cacheVar}[0]===${enabledVar}?`,
-      );
-    }
-
     if (patchedRegion === region) {
       console.warn("WARN: Could not find remote-control enablement bridge needle - skipping Linux remote-control bridge patch");
       return patched;
@@ -1597,22 +1567,13 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
   const selfAutoConnectReplacement = (desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
     `${desktopHostRequestFn}(\`set-remote-control-connections-enabled\`,{params:{enabled:${enabledVar}}}).then(async e=>{if(${enabledVar}&&typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){let t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null;if(t.length===0)try{let e=await ${desktopHostRequestFn}(\`refresh-remote-control-connections\`,{params:{}});t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=n??e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_refresh_failed\`,{safe:{},sensitive:{error:e}})}if(n==null)try{let e=await ${desktopHostRequestFn}(\`get-global-state\`,{params:{key:\`electron-local-remote-control-installation-id\`}});n=e?.value??e?.state?.value??e?.globalState?.[\`electron-local-remote-control-installation-id\`]??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_identity_failed\`,{safe:{},sensitive:{error:e}})}let r=t.filter(e=>typeof e?.hostId==\`string\`&&e.hostId.startsWith(\`remote-control:\`)),i=new Set(r.filter(e=>n!=null&&(e.installationId??e.installation_id)===n).map(e=>e.hostId));await Promise.all(r.map(e=>${desktopHostRequestFn}(\`set-remote-connection-auto-connect\`,{params:{hostId:e.hostId,autoConnect:i.has(e.hostId)}}).catch(t=>{${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_failed\`,{safe:{hostId:e.hostId,autoConnect:i.has(e.hostId)},sensitive:{error:t}})})))}}/*${REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER}*/).catch(${errorVar}=>{${loggerVar}.warning(\`\${${logPrefixVar}} sync_failed\`,{safe:{enabled:${enabledVar}},sensitive:{error:${errorVar}}})})`;
 
-  const previousAutoConnectCleanupPattern =
-    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.then\(async ([A-Za-z_$][\w$]*)=>\{[\s\S]*?\/\*codexLinuxRemoteControlAutoConnectCleanup\*\/\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{(?:enabled|slingshotEnabled):\2\},sensitive:\{error:\4\}\}\)\}\)/u;
   const selfAutoConnectPattern =
     /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{(?:enabled|slingshotEnabled):\2\},sensitive:\{error:\3\}\}\)\}\)/u;
-  let selfAutoConnectRegion = region.replace(
-    previousAutoConnectCleanupPattern,
-    (_needle, desktopHostRequestFn, enabledVar, _resultVar, errorVar, loggerVar, logPrefixVar) =>
+  const selfAutoConnectRegion = region.replace(
+    selfAutoConnectPattern,
+    (_needle, desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
       selfAutoConnectReplacement(desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar),
   );
-  if (selfAutoConnectRegion === region) {
-    selfAutoConnectRegion = region.replace(
-      selfAutoConnectPattern,
-      (_needle, desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
-        selfAutoConnectReplacement(desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar),
-    );
-  }
 
   if (selfAutoConnectRegion === region) {
     console.warn("WARN: Could not find remote-control self auto-connect needle - skipping Linux remote-control auto-connect patch");

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -343,23 +343,15 @@ function syntheticAppMainActiveStatusBundle() {
 
 function syntheticAppMainEnablementBridgeBundle() {
   return [
+    "function OF(){let e=(0,Z.c)(6),{checkGate:t,isLoading:n}=sc(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||$o(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,Q.useEffect)(a,o),null}",
     "var DF=`[remote-connections/slingshot-gate-bridge]`;",
-    "function OF(){let e=(0,Z.c)(3),t=sc(),n,r;return e[0]===t?(n=e[1],r=e[2]):(n=()=>{$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})},r=[t],e[0]=t,e[1]=n,e[2]=r),(0,Q.useEffect)(n,r),null}",
   ].join("");
 }
 
 function syntheticCurrentAppMainEnablementBridgeBundle() {
   return [
-    "var fH=`[remote-connections/slingshot-gate-bridge]`;",
-    "function mH(){let e=(0,Q.c)(6),{checkGate:t,isLoading:n}=eo(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||qt(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{Y.warning(`${fH} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,$.useEffect)(a,o),null}",
+    syntheticAppMainEnablementBridgeBundle(),
     "var handlers={\"set-remote-control-enabled-for-host\":pU((e,{enabled:t})=>e.sendRequest(t?`remoteControl/enable`:`remoteControl/disable`,null))};",
-  ].join("");
-}
-
-function syntheticLatestAppMainEnablementBridgeBundle() {
-  return [
-    "function vZe(){let e=(0,m7.c)(6),{checkGate:t,isLoading:n}=Wp(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||Qm(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{yu.warning(`${_7} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,h7.useEffect)(a,o),null}",
-    "var _7=`[remote-connections/slingshot-gate-bridge]`;",
   ].join("");
 }
 
@@ -1109,18 +1101,6 @@ test("Linux remote-control feature sync forces remote_control and preserves remo
   assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)\?\(/);
   assert.match(patched, /\?\(codexLinuxRemoteControlFeatureSyncEnabled\(arguments\[2\],arguments\[3\]\)&&\(n\.remote_control=!0\),n\[vI\]=t,n\)/);
   assert.match(patched, /:\(n\[vI\]=t,n\)\}/);
-  assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
-});
-
-test("Linux remote-control feature sync composes with core-sanitized dynamic builder", () => {
-  const source = syntheticAppMainFeatureSyncBundle().replace("return n[vI]=t,n}", "return n}");
-  const patched = applyLinuxRemoteControlFeatureSyncPatch(source);
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /\.remote_control=!0/);
-  assert.match(patched, /codexLinuxRemoteControlFeatureSyncEnabled/);
-  assert.doesNotMatch(patched, /n\[vI\]=t/);
-  assert.match(patched, /:n\}/);
   assert.equal(applyLinuxRemoteControlFeatureSyncPatch(patched), patched);
 });
 
@@ -2499,7 +2479,7 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
     navigator: { userAgent: "X11; Linux x86_64" },
     q: { warning() {} },
     Q: { useEffect(callback) { callback(); } },
-    sc: () => false,
+    sc: () => ({ checkGate: () => false, isLoading: false }),
     Z: { c: () => [] },
     $o: (method, { params }) => {
       calls.push({ method, params });
@@ -2511,16 +2491,6 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
   assert.equal(calls.length, 1);
   assert.equal(calls[0].method, "set-remote-control-connections-enabled");
   assert.equal(calls[0].params.enabled, true);
-});
-
-test("Linux remote-control enablement bridge handles the current marker order", () => {
-  const source = syntheticLatestAppMainEnablementBridgeBundle();
-  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /codexLinuxRemoteControlEnablementBridge/);
-  assert.match(patched, /codexLinuxRemoteControlSelfAutoConnect/);
-  assert.equal(applyLinuxRemoteControlEnablementBridgePatch(patched), patched);
 });
 
 test("Linux remote-control enablement bridge rejects distant anchors", () => {
@@ -2599,19 +2569,6 @@ test("Linux remote-control enablement bridge warns when host toggle params needl
   assert.ok(warnings.some((warning) => warning.includes("enable-for-host params needle")));
 });
 
-test("Linux remote-control enablement bridge migrates old auto-connect cleanup patch", () => {
-  const source = syntheticAppMainEnablementBridgeBundle().replace(
-    "$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})",
-    "$o(`set-remote-control-connections-enabled`,{params:{enabled:t}}).then(async e=>{if(t&&typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`)){await Promise.resolve(e)}}/*codexLinuxRemoteControlAutoConnectCleanup*/).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{enabled:t},sensitive:{error:e}})})",
-  );
-
-  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
-
-  assert.match(patched, /codexLinuxRemoteControlSelfAutoConnect/);
-  assert.match(patched, /electron-local-remote-control-installation-id/);
-  assert.doesNotMatch(patched, /codexLinuxRemoteControlAutoConnectCleanup/);
-});
-
 test("Linux remote-control enablement bridge auto-connects only this Desktop host", async () => {
   const source = syntheticAppMainEnablementBridgeBundle();
   const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
@@ -2627,7 +2584,7 @@ test("Linux remote-control enablement bridge auto-connects only this Desktop hos
         callback();
       },
     },
-    sc: () => false,
+    sc: () => ({ checkGate: () => false, isLoading: false }),
     Z: { c: () => [] },
     $o: (method, { params }) => {
       calls.push({ method, params });

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -56,6 +56,12 @@ const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
+const CURRENT_APP_MAIN_PAGE_ASSET =
+  "app-initial~app-main~page-test.js";
+const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET =
+  "app-initial~app-main~appgen-settings-page~plugin-detail-page~new-thread-panel-page~onboardi~lxr449xn-test.js";
+const CURRENT_REMOTE_CONVERSATION_STATUS_ASSET =
+  "app-initial~app-main~projects-index-page~remote-conversation-page-test.js";
 
 function syntheticMainBundle() {
   return [
@@ -347,6 +353,13 @@ function syntheticCurrentAppMainEnablementBridgeBundle() {
     "var fH=`[remote-connections/slingshot-gate-bridge]`;",
     "function mH(){let e=(0,Q.c)(6),{checkGate:t,isLoading:n}=eo(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||qt(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{Y.warning(`${fH} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,$.useEffect)(a,o),null}",
     "var handlers={\"set-remote-control-enabled-for-host\":pU((e,{enabled:t})=>e.sendRequest(t?`remoteControl/enable`:`remoteControl/disable`,null))};",
+  ].join("");
+}
+
+function syntheticLatestAppMainEnablementBridgeBundle() {
+  return [
+    "function vZe(){let e=(0,m7.c)(6),{checkGate:t,isLoading:n}=Wp(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||Qm(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{yu.warning(`${_7} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,h7.useEffect)(a,o),null}",
+    "var _7=`[remote-connections/slingshot-gate-bridge]`;",
   ].join("");
 }
 
@@ -781,9 +794,38 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-visibility"
     );
     assert.ok(visibilityDescriptor);
-    assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), true);
-    assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), true);
+    assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
+    assert.equal(visibilityDescriptor.pattern.test(CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET), true);
+    assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), false);
     assert.equal(visibilityDescriptor.pattern.test("app-main-fixture.js"), false);
+
+    const featureSyncDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-feature-sync"
+    );
+    assert.ok(featureSyncDescriptor);
+    assert.equal(featureSyncDescriptor.pattern.test(CURRENT_APP_MAIN_PAGE_ASSET), true);
+    assert.equal(featureSyncDescriptor.pattern.test("app-main-fixture.js"), false);
+
+    const enableForHostDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-enable-for-host-params"
+    );
+    assert.ok(enableForHostDescriptor);
+    assert.equal(enableForHostDescriptor.pattern.test(CURRENT_APP_MAIN_PAGE_ASSET), true);
+    assert.equal(enableForHostDescriptor.pattern.test("app-main-fixture.js"), false);
+
+    const enablementBridgeDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-enablement-bridge"
+    );
+    assert.ok(enablementBridgeDescriptor);
+    assert.equal(enablementBridgeDescriptor.pattern.test(CURRENT_APP_MAIN_PAGE_ASSET), true);
+    assert.equal(enablementBridgeDescriptor.pattern.test("app-main-fixture.js"), false);
+
+    const activeStatusDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-active-status"
+    );
+    assert.ok(activeStatusDescriptor);
+    assert.equal(activeStatusDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_STATUS_ASSET), true);
+    assert.equal(activeStatusDescriptor.pattern.test("app-main-fixture.js"), false);
 
     const statusGuardDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-read-guard"
@@ -2325,13 +2367,23 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
         path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
-        syntheticRemoteConnectionVisibilityBundle() +
-          syntheticAppServerManagerSignalsBundle() +
+        syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle() +
           syntheticCompletedItemRecoveryBundle() +
           syntheticRemoteTerminalStatusBundle(),
       );
-      fs.writeFileSync(path.join(assetsDir, "app-main-test.js"), syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle() + syntheticAppMainActiveStatusBundle());
+      fs.writeFileSync(
+        path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
+        syntheticRemoteConnectionVisibilityBundle(),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
+        syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle(),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_STATUS_ASSET),
+        syntheticAppMainActiveStatusBundle(),
+      );
       fs.writeFileSync(
         path.join(assetsDir, "remote-connections-settings-test.js"),
         (syntheticSettingsBundle() + syntheticSshInstallSettingsBundle()).replace(
@@ -2459,6 +2511,30 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
   assert.equal(calls.length, 1);
   assert.equal(calls[0].method, "set-remote-control-connections-enabled");
   assert.equal(calls[0].params.enabled, true);
+});
+
+test("Linux remote-control enablement bridge handles the current marker order", () => {
+  const source = syntheticLatestAppMainEnablementBridgeBundle();
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlEnablementBridge/);
+  assert.match(patched, /codexLinuxRemoteControlSelfAutoConnect/);
+  assert.equal(applyLinuxRemoteControlEnablementBridgePatch(patched), patched);
+});
+
+test("Linux remote-control enablement bridge rejects distant anchors", () => {
+  const source = [
+    "var DF=`[remote-connections/slingshot-gate-bridge]`;",
+    "x".repeat(4_501),
+    "function OF(){return $o(`set-remote-control-connections-enabled`,{params:{enabled:true}})}",
+  ].join("");
+  const { result, warnings } = captureWarnings(() =>
+    applyLinuxRemoteControlEnablementBridgePatch(source),
+  );
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("anchors are too far apart")));
 });
 
 test("Linux remote-control enablement bridge omits params for current host toggle handler", async () => {
@@ -2660,7 +2736,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             syntheticRemoteTerminalStatusBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
           syntheticVisibilityBundle(),
         );
         fs.writeFileSync(
@@ -2687,10 +2763,13 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticAppServerManagerSignalsBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, "app-main-test.js"),
+          path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
           syntheticAppMainFeatureSyncBundle() +
-            syntheticAppMainEnablementBridgeBundle() +
-            syntheticAppMainActiveStatusBundle(),
+            syntheticAppMainEnablementBridgeBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_STATUS_ASSET),
+          syntheticAppMainActiveStatusBundle(),
         );
         const report = createPatchReport();
         patchExtractedApp(tempApp, { report });
@@ -2701,7 +2780,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, "remote-control-connections-visibility-test.js"),
+          path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
           "utf8",
         );
         const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
@@ -2709,7 +2788,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedAppMainFile = fs.readFileSync(
-          path.join(assetsDir, "app-main-test.js"),
+          path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
+          "utf8",
+        );
+        const patchedActiveStatusFile = fs.readFileSync(
+          path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_STATUS_ASSET),
           "utf8",
         );
         const patchedRemoteConnectionsSettingsFile = fs.readFileSync(
@@ -2753,7 +2836,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedStatusFile, /codexLinuxRemoteControlShouldReadStatus/);
         assert.match(patchedStatusFile, /codexLinuxRemoteControlStatusWaitMs/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteControlEnablementBridge/);
-        assert.match(patchedAppMainFile, /codexLinuxRemoteMobileActiveStatus/);
+        assert.match(patchedActiveStatusFile, /codexLinuxRemoteMobileActiveStatus/);
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-control-device-key" &&


### PR DESCRIPTION
## Summary

- target the current upstream webview chunks for remote-control feature sync, settings visibility, host enablement, and active conversation status
- handle the current enablement bundle ordering where the log marker is declared after the request handler
- keep the bridge search bounded and add coverage for current, legacy, distant-anchor, and second-run cases

## Why

The previous filename patterns still matched older or unrelated chunks, so these descriptors were reported as `already-applied` even though their current target symbols had moved. On the current DMG, that left five `remote-mobile-control` transformations unapplied.

This keeps the fix within the repository's current-DMG policy and does not add a content-scan fallback. The feature remains disabled by default.

## Validation

- current DMG `26.707.41301`: all five descriptors apply on the first pass and report `already-applied` on the second
- extracted app tree hash is unchanged by the second pass
- `node --test $(rg --files -g '*.test.js')` (421 passed)
- `node --test linux-features/*/test.js` (526 passed)
- `bash tests/scripts_smoke.sh`
- `nix flake check --no-build`

Related to #639.
