### PR TITLE
fix: adapt Nix build to Codex 26.707.51957

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,10 +82,10 @@
 
         codexDmg = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg";
-          hash = "sha256-RnolOBrylD8sm4eUra4os2QAvW2idT2vSIml/VUMTWU=";
+          hash = "sha256-pmoGRf1N5vTyLnXKh77bFYWutX80V6PfVVCb+NoRCHk=";
         };
 
-        codexVersion = "26.707.41301";
+        codexVersion = "26.707.51957";
         electronVersion = "42.1.0";
         electronPlatform =
           {

--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -342,7 +342,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^app-initial~app-main~page-.*\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -139,16 +139,16 @@ test("appshots availability descriptor matches the current bundle", () => {
   );
 
   assert.equal(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"), false);
-  assert.ok(
+  assert.equal(
     descriptor.pattern.test(
       "app-initial~app-main~page-hSvsQcNf.js",
     ),
+    false,
   );
-  assert.equal(
+  assert.ok(
     descriptor.pattern.test(
       "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     ),
-    false,
   );
 });
 

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -829,7 +829,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-[^.]+\.js$/,
+      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1399,8 +1399,12 @@ test("open-target discovery targets only the current native selector bundle", ()
   );
 
   assert.ok(descriptor);
-  assert.match(
+  assert.doesNotMatch(
     "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-Bj9ubaFn.js",
+    descriptor.pattern,
+  );
+  assert.match(
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     descriptor.pattern,
   );
   assert.doesNotMatch("open-target-selection-legacy.js", descriptor.pattern);

--- a/linux-features/persistent-status-panel/patch.js
+++ b/linux-features/persistent-status-panel/patch.js
@@ -77,7 +77,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_800,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~page-.*\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
     missingDescription: "composer status panel bundle",
     skipDescription: "persistent status panel patch",
     apply: applyPersistentStatusPanelPatch,

--- a/linux-features/persistent-status-panel/test.js
+++ b/linux-features/persistent-status-panel/test.js
@@ -84,7 +84,7 @@ test("descriptor patches the current app-initial composer status bundle", () => 
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~page-hSvsQcNf.js",
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentComposerSource);

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -58,7 +58,7 @@ const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
 const REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN =
-  /^app-initial~app-main~appgen-settings-page~plugin-detail-page~new-thread-panel-page~onboardi~[^.]+\.js$/u;
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
   /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/u;
 const REMOTE_CONTROL_SELECTED_TAB_NEEDLE =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -60,7 +60,7 @@ const UNIFIED_REMOTE_CONVERSATION_ASSET =
 const CURRENT_APP_MAIN_PAGE_ASSET =
   "app-initial~app-main~page-test.js";
 const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET =
-  "app-initial~app-main~appgen-settings-page~plugin-detail-page~new-thread-panel-page~onboardi~lxr449xn-test.js";
+  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const CURRENT_REMOTE_CONVERSATION_STATUS_ASSET =
   "app-initial~app-main~projects-index-page~remote-conversation-page-test.js";
 


### PR DESCRIPTION
## Summary

- update the Codex app version pin to `26.707.51957`
- refresh the upstream `Codex.dmg` SRI hash
- retarget current-upstream webview patches for remote mobile control, AppShots, open-target discovery, and the persistent status panel

## Root cause

Upstream published a new Codex DMG, leaving the committed Nix version and source hash pinned to `26.707.41301`. After refreshing those pins, acceptance exposed that several opt-in feature targets had moved into the new shared `iufn7mg3` webview chunk. Their patches were skipped, so enabled-feature acceptance correctly rejected the remote-mobile and multi-feature Nix variants.

## Validation

- `nix shell nixpkgs#p7zip --command bash scripts/ci/validate-nix-pins.sh`
- `nix flake check --no-build`
- `node --test linux-features/remote-mobile-control/test.js` (82 passed)
- `node --test linux-features/appshots/test.js linux-features/open-target-discovery/test.js linux-features/persistent-status-panel/test.js` (61 passed)
- verified all four descriptors match and idempotently patch the extracted `26.707.51957` assets
- `nix build .#codex-desktop-remote-mobile-control --no-link -L` (acceptance: `accepted_with_warnings`, no blockers)
- `nix build .#checks.x86_64-linux.nix-linux-features-multi-feature --no-link -L` (acceptance: `accepted_with_warnings`, no blockers)