### PR TITLE
ci: run upstream DMG acceptance hourly

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -2,7 +2,7 @@ name: Upstream Build App
 
 on:
   schedule:
-    - cron: '30 6 * * *'
+    - cron: '30 * * * *'
   pull_request:
     paths:
       - install.sh

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -161,6 +161,7 @@ test("upstream workflow concurrency is isolated per PR or ref", () => {
     path.resolve(__dirname, "../../.github/workflows/upstream-build-app.yml"),
     "utf8",
   );
+  assert.match(workflow, /cron: '30 \* \* \* \*'/);
   assert.match(
     workflow,
     /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,


### PR DESCRIPTION
## Summary

- run the scheduled upstream DMG acceptance workflow every hour at minute 30
- add regression coverage for the hourly cron expression

## Checks

- `node --test scripts/ci/upstream-dmg-acceptance.test.js`
- workflow YAML parsed successfully with PyYAML
- `git diff --check`