### PR TITLE
refactor(remote-mobile): remove legacy visibility fallback

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -16,10 +16,6 @@ const DEVICE_KEY_GUARD_REPLACEMENT =
   "if(process.platform===`linux`)return codexLinuxRemoteControlDeviceKeyClient();if(process.platform!==`darwin`)throw Error(`Remote control device keys are only available on macOS`);";
 const DEVICE_KEY_REQUIRE_NEEDLE =
   /(?:var|let|const)\s+[A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.createRequire\)\(__filename\),[A-Za-z_$][\w$]*=`remote-control-device-key\.node`/u;
-const REMOTE_CONTROL_VISIBILITY_NEEDLE =
-  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}";
-const REMOTE_CONTROL_VISIBILITY_REPLACEMENT =
-  "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){let n=typeof navigator!=`undefined`&&navigator.userAgent.includes(`Linux`);return(n||t)&&(n||(e?.available??!0))&&e?.accessRequired!==!0}";
 const REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE =
   /function ([A-Za-z_$][\w$]*)\(\{remoteControlConnectionsState:([A-Za-z_$][\w$]*),slingshotEnabled:([A-Za-z_$][\w$]*)\}\)\{return \3&&\(\2\?\.available\?\?!0\)(?:&&\2\?\.accessRequired!==!0)?\}/u;
 const REMOTE_CONTROL_SETTINGS_UX_MARKER = "codexLinuxRemoteControlSettingsTabs";
@@ -689,30 +685,26 @@ function applyLinuxRemoteControlFeatureSyncHostScopePatch(source) {
 
 function applyLinuxRemoteControlVisibilityPatch(source) {
   if (
-    source.includes(REMOTE_CONTROL_VISIBILITY_REPLACEMENT) ||
     source.includes("remoteControlConnectionsState") &&
       source.includes("navigator.userAgent.includes(`Linux`)")
   ) {
     return source;
   }
-  if (!source.includes(REMOTE_CONTROL_VISIBILITY_NEEDLE)) {
-    if (!source.includes("remoteControlConnectionsState")) {
-      return source;
-    }
-
-    const settingsVisibilityMatch = source.match(REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE);
-    if (settingsVisibilityMatch == null) {
-      console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
-      return source;
-    }
-
-    const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
-    return source.replace(
-      REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
-      `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
-    );
+  if (!source.includes("remoteControlConnectionsState")) {
+    return source;
   }
-  return source.replace(REMOTE_CONTROL_VISIBILITY_NEEDLE, REMOTE_CONTROL_VISIBILITY_REPLACEMENT);
+
+  const settingsVisibilityMatch = source.match(REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE);
+  if (settingsVisibilityMatch == null) {
+    console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
+    return source;
+  }
+
+  const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
+  return source.replace(
+    REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
+    `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
+  );
 }
 
 function wrapRemoteControlTabs(source, firstKey) {

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -74,10 +74,6 @@ function syntheticMainBundle() {
   ].join("");
 }
 
-function syntheticVisibilityBundle() {
-  return "function a({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{a as t};";
-}
-
 function syntheticCurrentMainBundle() {
   return [
     "let i=require(`node:path`),o=require(`node:fs`),s=require(`node:crypto`),b={createRequire:()=>()=>({})};",
@@ -1166,16 +1162,6 @@ test("Linux remote-control feature sync does not advertise SSH hosts to mobile",
   assert.equal(hostCalls[0].params.enablement.remote_control, true);
   assert.equal(hostCalls[1].params.hostId, "remote-ssh-discovered:devpod");
   assert.equal(hostCalls[1].params.enablement.remote_control, undefined);
-});
-
-test("Linux remote-control visibility patch allows Linux when upstream marks availability false", () => {
-  const source = syntheticVisibilityBundle();
-  const patched = applyLinuxRemoteControlVisibilityPatch(source);
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
-  assert.match(patched, /\(n\|\|t\)&&\(n\|\|\(e\?\.available\?\?!0\)\)&&e\?\.accessRequired!==!0/);
-  assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
 });
 
 test("Linux remote-control visibility patch handles current settings bundle shape", () => {
@@ -2718,7 +2704,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         fs.writeFileSync(
           path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
-          syntheticVisibilityBundle(),
+          syntheticCurrentUsePluginVisibilityBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),


### PR DESCRIPTION
## Summary

- remove the obsolete exact remote-control visibility needle/replacement fallback
- keep only the current generic visibility bundle matcher
- remove the legacy-shape test and exercise the current bundle shape in the integration fixture

## Context

Follow-up to the maintainer feedback on #876. The original PR merged before the review was submitted, so this isolates the requested current-DMG-only cleanup on top of the latest upstream `main`.

## Validation

- `node --test linux-features/remote-mobile-control/test.js` (81 passed)
- verified the current extracted `26.707.51957` visibility asset is matched, patched, and idempotent
- `nix build .#codex-desktop-remote-mobile-control .#checks.x86_64-linux.nix-linux-features-multi-feature --no-link -L` (both accepted with no blockers)