### PR TITLE
feat(nix): support the frameless titlebar feature

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -197,6 +197,7 @@ The Home Manager and NixOS modules accept these feature IDs through
 | Feature ID | Purpose |
 | --- | --- |
 | `appshots` | Linux AppShots capture integration |
+| `frameless-titlebar` | Hide app-provided titlebar controls for compositor-managed decorations |
 | `mcp-helper-reaper` | Cleanup for stale configured MCP helper processes |
 | `node-repl-reaper` | Cleanup for leaked Browser Use `node_repl` helpers |
 | `open-target-discovery` | Linux terminal, editor, and file-manager discovery |

--- a/flake.nix
+++ b/flake.nix
@@ -658,6 +658,7 @@ PY
         codexDesktopNixFeatureCheck = codexDesktop.override {
           linuxFeatureIds = [
             "appshots"
+            "frameless-titlebar"
             "global-dictation"
             "mcp-helper-reaper"
             "node-repl-reaper"

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -156,7 +156,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_730,
     ciPolicy: "optional",
-    pattern: /^(?:app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb|app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu)-.*\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*\.js$/,
     missingDescription: "main app chrome bundle",
     skipDescription: "frameless titlebar webview layout patch",
     apply: applyFramelessTitlebarWebviewPatch,

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -66,10 +66,14 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
       (descriptor) => descriptor.id === "feature:frameless-titlebar:webview-window-controls-layout",
     );
     assert.match(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-abc.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
       "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-abc.js",
       webviewPatch.pattern,
     );
-    assert.match(
+    assert.doesNotMatch(
       "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-abc.js",
       webviewPatch.pattern,
     );

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -13,6 +13,7 @@ let
   testFeatureIds = [
     "persistent-status-panel"
     "appshots"
+    "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
     "remote-mobile-control"
@@ -22,6 +23,7 @@ let
   ];
   normalizedTestFeatureIds = [
     "appshots"
+    "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
     "open-target-discovery"
@@ -123,6 +125,7 @@ let
     enableComputerUseUi = true;
     linuxFeatureIds = [
       "remote-mobile-control"
+      "frameless-titlebar"
       "global-dictation"
       "persistent-status-panel"
       "mcp-helper-reaper"

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -2,6 +2,7 @@
 let
   supportedFeatureIds = [
     "appshots"
+    "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
     "node-repl-reaper"


### PR DESCRIPTION
## Summary

- add `frameless-titlebar` to the Nix Linux feature allowlist
- update its webview asset descriptor for the latest upstream DMG
- include it in the Nix feature evaluation and multi-feature build checks
- document the feature in the Nix feature table

## User-visible behavior

NixOS and Home Manager users can now enable the feature declaratively:

```nix
programs.codexDesktopLinux.linuxFeatures = [
  "frameless-titlebar"
];
```

The feature removes the Electron-provided titlebar controls from the primary window so window decorations and controls can be managed by the compositor.

## Validation

- `node --test linux-features/frameless-titlebar/test.js`
- `nix build .#checks.x86_64-linux.nix-linux-features-evaluation --no-link`
- `nix build .#checks.x86_64-linux.nix-linux-features-multi-feature --no-link`
- manually verified the resulting build on NixOS/Hyprland