### PR TITLE
fix(remote-mobile): reset current setup after revoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 - Remote mobile control now patches the current upstream webview chunks for
   feature sync, settings visibility, host enablement, and active conversation
-  status. The enablement bridge also accepts the current bundle ordering where
-  its log marker is declared after the request handler.
+  status. Revoking the final controller now also clears the current mobile setup
+  state. The enablement bridge accepts the current bundle ordering where its log
+  marker is declared after the request handler.
 - Automated user-local updates no longer inherit or set developer overrides
   that could replace a running Electron app or bypass DMG acceptance. Manual
   and timer rebuilds now fail safely at promotion, transactional installs retain

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -506,72 +506,60 @@ function applyLinuxRemoteControlClientRevokeSetupResetPatch(source) {
     return source;
   }
 
-  const currentStateKeysVar = source.match(/([A-Za-z_$][\w$]*)\.CODEX_MOBILE_SETUP_COMPLETED/u)?.[1] ?? null;
-  const currentStateSetterVar =
-    source.match(/([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.keepRemoteControlAwakeWhilePluggedIn,/u)?.[1] ??
-    null;
-  const currentScopeMatch = source.match(
-    /function [A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\)\{let [A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.c\)\(\d+\),[\s\S]*?([A-Za-z_$][\w$]*)=a\(s\)[\s\S]*?`local_remote_control_client_id`[\s\S]*?onRevoked:[A-Za-z_$][\w$]*=>\{[A-Za-z_$][\w$]*\.setData[\s\S]*?onRevokeResult:/u,
+  const currentStateKeysMatch = source.match(/([A-Za-z_$][\w$]*)\.CODEX_MOBILE_SETUP_COMPLETED/u);
+  const currentStateSetterMatch = source.match(
+    /([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.keepRemoteControlAwakeWhilePluggedIn,/u,
   );
-  const currentLocalRevokePattern =
-    /onRevoked:([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\3\?\.filter\(\3=>\3\.clientId!==\1\)\),\2\.invalidate\(\)\},onRevokeResult:/u;
-  if (
-    currentStateKeysVar != null &&
-    currentStateSetterVar != null &&
-    currentScopeMatch != null &&
-    currentLocalRevokePattern.test(source)
-  ) {
-    const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
-    if (helperNeedle == null) {
+  const currentStateKeysVar = currentStateKeysMatch?.[1] ?? null;
+  const currentStateSetterVar = currentStateSetterMatch?.[1] ?? null;
+  const currentRevokePattern =
+    /onRevoked:([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\3\?\.filter\(\3=>\3\.clientId!==\1\)\),\2\.invalidate\(\)\},onRevokeResult:([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*),\{result:\4\}\)\}/u;
+  const currentRevokeMatch = source.match(currentRevokePattern);
+  if (currentStateKeysVar != null && currentStateSetterVar != null && currentRevokeMatch != null) {
+    const ownerFunctionStart = source.lastIndexOf("function ", currentRevokeMatch.index);
+    if (
+      ownerFunctionStart < 0 ||
+      !/^function [A-Za-z_$][\w$]*\(/u.test(source.slice(ownerFunctionStart, ownerFunctionStart + 128))
+    ) {
+      console.warn("WARN: Could not find remote-control revoke helper insertion point - skipping setup reset patch");
+      return source;
+    }
+    const ownerPrefix = source.slice(ownerFunctionStart, currentRevokeMatch.index);
+    const localClientIdMatch = ownerPrefix.match(
+      /\[([A-Za-z_$][\w$]*)\]=[A-Za-z_$][\w$]*\(`local_remote_control_client_id`\)/u,
+    );
+    if (localClientIdMatch == null) {
+      console.warn("WARN: Could not find local remote-control client id - skipping setup reset patch");
+      return source;
+    }
+    const localClientIdVar = localClientIdMatch[1];
+    const anchorPositions = [
+      currentStateKeysMatch.index,
+      currentStateSetterMatch.index,
+      currentRevokeMatch.index,
+      ownerFunctionStart,
+      ownerFunctionStart + localClientIdMatch.index,
+    ];
+    if (Math.max(...anchorPositions) - Math.min(...anchorPositions) > 16_384) {
+      console.warn("WARN: Remote-control revoke setup-reset anchors are too far apart - skipping setup reset patch");
       return source;
     }
     const helper = [
-      `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n,r,i){`,
+      `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n,r,i,o){`,
       "let a=e?.filter(e=>(e.clientId??e.client_id)!==t);",
-      "return a?.length===0&&i(n,r.CODEX_MOBILE_SETUP_COMPLETED,!1),a",
+      "let s=a?.filter(e=>(e.clientId??e.client_id)!==o);",
+      "return s?.length===0&&i(n,r.CODEX_MOBILE_SETUP_COMPLETED,!1),a",
       "}",
     ].join("");
-    return source
-      .replace(helperNeedle, `${helper}${helperNeedle}`)
+    return `${source.slice(0, ownerFunctionStart)}${helper}${source.slice(ownerFunctionStart)}`
       .replace(
-        currentLocalRevokePattern,
-        (_needle, clientIdVar, querySnapshotVar, dataVar) =>
-          `onRevoked:${clientIdVar}=>{${querySnapshotVar}.setData(${dataVar}=>${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(${dataVar},${clientIdVar},${currentScopeMatch[1]},${currentStateKeysVar},${currentStateSetterVar})),${querySnapshotVar}.invalidate()},onRevokeResult:`,
+        currentRevokePattern,
+        (_needle, clientIdVar, querySnapshotVar, dataVar, resultVar, trackFn, desktopHostVar, revokeEventVar) =>
+          `onRevoked:${clientIdVar}=>{${querySnapshotVar}.setData(${dataVar}=>${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(${dataVar},${clientIdVar},${desktopHostVar},${currentStateKeysVar},${currentStateSetterVar},${localClientIdVar})),${querySnapshotVar}.invalidate()},onRevokeResult:${resultVar}=>{${trackFn}(${desktopHostVar},${revokeEventVar},{result:${resultVar}})}`,
       );
   }
-
-  const setGlobalStateMatch = source.match(
-    /mutationFn:[A-Za-z_$][\w$]*=>([A-Za-z_$][\w$]*)\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\.ADDED_REMOTE_CONTROL_ENV_IDS,/u,
-  );
-  if (setGlobalStateMatch == null) {
-    return source;
-  }
-
-  const setGlobalStateFn = setGlobalStateMatch[1];
-  const helperNeedle = source.match(/var [A-Za-z_$][\w$]*=`remote-control-client-revoke-success`/u)?.[0] ?? null;
-  if (helperNeedle == null) {
-    return source;
-  }
-
-  const helper = [
-    `function ${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(e,t,n){`,
-    "let r=e?.filter(e=>(e.client_id??e.clientId)!==t);",
-    `return r?.length===0&&${setGlobalStateFn}(n,\`codex-mobile-has-connected-device\`,!1),r`,
-    "}",
-  ].join("");
-
-  const patched = source.replace(helperNeedle, `${helper}${helperNeedle}`);
-  const successPattern =
-    /([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),\{eventName:`codex_remote_control_client_revoke_result`,metadata:\{result:`succeeded`\}\}\),([A-Za-z_$][\w$]*)\.setData\(([A-Za-z_$][\w$]*)=>\4\?\.filter\(\4=>\4\.client_id!==([A-Za-z_$][\w$]*)\)\)/u;
-  if (!successPattern.test(patched)) {
-    return source;
-  }
-
-  return patched.replace(
-    successPattern,
-    (_needle, trackFn, queryClientVar, querySnapshotVar, dataVar, clientIdVar) =>
-      `${trackFn}(${queryClientVar},{eventName:\`codex_remote_control_client_revoke_result\`,metadata:{result:\`succeeded\`}}),${querySnapshotVar}.setData(${dataVar}=>${REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER}(${dataVar},${clientIdVar},${queryClientVar}))`,
-  );
+  console.warn("WARN: Could not find remote-control revoke success handler - skipping setup reset patch");
+  return source;
 }
 
 function applyLinuxRemoteControlLoadGatePatch(source) {

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -249,17 +249,17 @@ function syntheticCurrentSettingsRefreshBundle() {
   ].join("");
 }
 
-function syntheticRevokeSetupResetBundle() {
+function syntheticCurrentRevokeSetupResetBundle() {
   return [
-    "function b(e,t){e.events.push(t)}",
-    "let J={},t={ADDED_REMOTE_CONTROL_ENV_IDS:`added-remote-control-env-ids`},e={},ye=[];",
-    "function ie(e,t,n){e.globalState[t]=n}",
-    "function ee(e){return e}",
-    "var vt=`remote-control-client-revoke-success`,yt=`remote-control-client-revoke-error`;",
-    "function Ct(){let i={events:[],globalState:{\"codex-mobile-has-connected-device\":!0},get(){return{success(){}}},query:{snapshot(){return{data:[],setData(e){this.data=e(this.data)},invalidate(){this.invalidated=!0}}}}},v=i.query.snapshot(tt),y;",
-    "y=(e,t)=>{let{clientId:n}=t;b(i,{eventName:`codex_remote_control_client_revoke_result`,metadata:{result:`succeeded`}}),v.setData(e=>e?.filter(e=>e.client_id!==n)),v.invalidate(),i.get(J).success(`Revoked device access`,{id:vt})};",
-    "return{handler:y,query:v,store:i}}",
-    "var Ue=ee({mutationFn:n=>ie(e,t.ADDED_REMOTE_CONTROL_ENV_IDS,[...ye,...n])}),tt={};",
+    "let Rt={},_r={},ht={},ot={CODEX_MOBILE_SETUP_COMPLETED:`mobile-setup-completed`,keepRemoteControlAwakeWhilePluggedIn:`keep-awake`};",
+    "function we(){return{globalState:{\"mobile-setup-completed\":!0},query:{snapshot(){return{data:[],setData(e){this.data=e(this.data)},invalidate(){this.invalidated=!0}}}},events:[]}}",
+    "function Fe(e,t,n){e.globalState[t]=n}",
+    "function qe(e,t,n){e.events.push(n)}",
+    "function i(){return[`desktop_1`]}",
+    "var Kr=`remote-control-client-revoke-success`,qr=`remote-control-client-revoke-error`;",
+    "function $r(){return ot.CODEX_MOBILE_SETUP_COMPLETED}",
+    "function ei(){let i=we(Rt),s=!1,m=e=>{Fe(i,ot.keepRemoteControlAwakeWhilePluggedIn,e)};return{s,m}}",
+    "function ni(e){let t={},{mode:n,oneToOnePairingInAppEnabled:r}=e,a=we(Rt),[m]=i(`local_remote_control_client_id`),k=a.query.snapshot(_r),Se={onRevoked:e=>{k.setData(t=>t?.filter(t=>t.clientId!==e)),k.invalidate()},onRevokeResult:e=>{qe(a,ht,{result:e})}};return{handler:Se.onRevoked,query:k,store:a}}",
   ].join("");
 }
 
@@ -1069,38 +1069,102 @@ test("Linux remote mobile app-server launch keeps a leading use strict directive
   assert.equal(applyLinuxRemoteMobileAppServerRemoteControlPatch(patched), patched);
 });
 
-test("Linux remote-control client revoke clears setup completion after last client is removed", () => {
-  const source = syntheticRevokeSetupResetBundle();
-  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(source);
+test("Linux remote-control client revoke resets current setup state after the last client is removed", () => {
+  const source = syntheticCurrentRevokeSetupResetBundle();
+  const { result: patched, warnings } = captureWarnings(() =>
+    applyLinuxRemoteControlClientRevokeSetupResetPatch(source),
+  );
 
   assert.notEqual(patched, source);
+  assert.deepEqual(warnings, []);
   assert.match(patched, /codexLinuxRemoteControlResetMobileSetupAfterRevoke/);
-  assert.match(patched, /codex-mobile-has-connected-device/);
   assert.equal(applyLinuxRemoteControlClientRevokeSetupResetPatch(patched), patched);
 
   const context = { module: { exports: {} } };
-  vm.runInNewContext(`${patched};module.exports=Ct();`, context);
+  vm.runInNewContext(`${patched};module.exports=ni({mode:\`manage\`,oneToOnePairingInAppEnabled:true});`, context);
   const { handler, query, store } = context.module.exports;
-  query.data = [{ client_id: "phone_1" }];
+  query.data = [{ clientId: "desktop_1" }, { clientId: "phone_1" }];
 
-  handler(null, { clientId: "phone_1" });
+  handler("phone_1");
 
-  assert.deepEqual(query.data, []);
-  assert.equal(store.globalState["codex-mobile-has-connected-device"], false);
+  assert.deepEqual(query.data, [{ clientId: "desktop_1" }]);
+  assert.equal(store.globalState["mobile-setup-completed"], false);
   assert.equal(query.invalidated, true);
 });
 
-test("Linux remote-control client revoke keeps setup completion while other clients remain", () => {
-  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticRevokeSetupResetBundle());
+test("Linux remote-control client revoke handles snake-case cached client identities", () => {
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticCurrentRevokeSetupResetBundle());
   const context = { module: { exports: {} } };
-  vm.runInNewContext(`${patched};module.exports=Ct();`, context);
+  vm.runInNewContext(`${patched};module.exports=ni({mode:\`manage\`,oneToOnePairingInAppEnabled:true});`, context);
   const { handler, query, store } = context.module.exports;
-  query.data = [{ client_id: "phone_1" }, { client_id: "tablet_1" }];
+  query.data = [{ client_id: "desktop_1" }, { client_id: "phone_1" }];
 
-  handler(null, { clientId: "phone_1" });
+  handler("phone_1");
 
-  assert.deepEqual(query.data, [{ client_id: "tablet_1" }]);
-  assert.equal(store.globalState["codex-mobile-has-connected-device"], true);
+  assert.deepEqual(query.data, [{ client_id: "desktop_1" }]);
+  assert.equal(store.globalState["mobile-setup-completed"], false);
+});
+
+test("Linux remote-control client revoke keeps current setup state while another client remains", () => {
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticCurrentRevokeSetupResetBundle());
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=ni({mode:\`manage\`,oneToOnePairingInAppEnabled:true});`, context);
+  const { handler, query, store } = context.module.exports;
+  query.data = [{ clientId: "desktop_1" }, { clientId: "phone_1" }, { clientId: "tablet_1" }];
+
+  handler("phone_1");
+
+  assert.deepEqual(query.data, [{ clientId: "desktop_1" }, { clientId: "tablet_1" }]);
+  assert.equal(store.globalState["mobile-setup-completed"], true);
+});
+
+test("Linux remote-control client revoke resets current setup when the cache omits the local client", () => {
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticCurrentRevokeSetupResetBundle());
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=ni({mode:\`manage\`,oneToOnePairingInAppEnabled:true});`, context);
+  const { handler, query, store } = context.module.exports;
+  query.data = [{ clientId: "phone_1" }];
+
+  handler("phone_1");
+
+  assert.deepEqual(query.data, []);
+  assert.equal(store.globalState["mobile-setup-completed"], false);
+});
+
+test("Linux remote-control client revoke preserves current setup when the cache is unknown", () => {
+  const patched = applyLinuxRemoteControlClientRevokeSetupResetPatch(syntheticCurrentRevokeSetupResetBundle());
+  const context = { module: { exports: {} } };
+  vm.runInNewContext(`${patched};module.exports=ni({mode:\`manage\`,oneToOnePairingInAppEnabled:true});`, context);
+  const { handler, query, store } = context.module.exports;
+  query.data = undefined;
+
+  handler("phone_1");
+
+  assert.equal(query.data, undefined);
+  assert.equal(store.globalState["mobile-setup-completed"], true);
+  assert.equal(query.invalidated, true);
+});
+
+test("Linux remote-control client revoke warns when a recognized bundle shape drifts", () => {
+  const source = syntheticCurrentRevokeSetupResetBundle().replace(
+    "onRevoked:e=>{k.setData(t=>t?.filter(t=>t.clientId!==e)),k.invalidate()}",
+    "onRevoked:e=>{k.invalidate(),k.setData(t=>t?.filter(t=>t.clientId!==e))}",
+  );
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteControlClientRevokeSetupResetPatch(source));
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("revoke success handler")));
+});
+
+test("Linux remote-control client revoke rejects distant current-bundle anchors", () => {
+  const source = syntheticCurrentRevokeSetupResetBundle().replace(
+    "function ni(e)",
+    `${"x".repeat(16_385)}function ni(e)`,
+  );
+  const { result, warnings } = captureWarnings(() => applyLinuxRemoteControlClientRevokeSetupResetPatch(source));
+
+  assert.equal(result, source);
+  assert.ok(warnings.some((warning) => warning.includes("anchors are too far apart")));
 });
 
 test("Linux remote-control load gate enables remote-control environment loading", () => {
@@ -2725,7 +2789,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           syntheticSettingsBundle() +
             syntheticRemoteConnectionsSettingsCopyBundle() +
             syntheticSettingsRefreshBundle() +
-            syntheticRevokeSetupResetBundle(),
+            syntheticCurrentRevokeSetupResetBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "codex-mobile-setup-flow-test.js"),


### PR DESCRIPTION
## Summary

- recognize the current remote-controller revoke callback and clear mobile setup state after the final controller is removed
- exclude the Desktop's own local client identity when counting remaining controllers
- report callback or anchor drift instead of silently classifying an unchanged source as already patched
- remove the obsolete callback fallbacks and preserve second-pass idempotence

## Why

After the current asset retargeting, this descriptor reaches the correct settings chunk but still returns it unchanged because the revoke callback changed upstream. The raw cache also retains the Desktop's local client entry, while the upstream UI filters that entry before presenting the controller list. Counting the raw cache would therefore fail to reset setup state after the last phone or tablet is revoked.

The patch reuses the current state key and setter, stays within the disabled-by-default feature, and leaves failure handling, telemetry, and cache invalidation unchanged.

## Validation

- current DMG `26.707.51957`: first pass reports `applied`, second pass reports `already-applied`
- extracted-app tree hash is unchanged by the second pass
- last-controller and remaining-controller behavior with the local Desktop identity present
- current, drifted-callback, distant-anchor, and idempotence cases
- 529 Linux feature tests
- complete script smoke suite
- `nix flake check --no-build`
- Nix package build for `codex-desktop-remote-mobile-control`
- Semgrep JavaScript scan with zero findings

Related to #639 and follows #872.
