### PR TITLE
fix(remote-mobile): select one runtime owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Remote mobile cold starts now select one runtime owner deterministically.
+  Explicit systemd user-service configuration takes precedence over the
+  Desktop app-server and standalone fallback, while a versioned Desktop marker
+  prevents stale or forged marker content from suppressing the fallback.
 - Remote mobile control now patches the current upstream webview chunks for
   feature sync, settings visibility, host enablement, and active conversation
   status. Revoking the final controller now also clears the current mobile setup

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -112,6 +112,12 @@ The module installs the remote-mobile package variant and manages
 `CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED=1` so the launcher does not
 start a second mutable standalone daemon.
 
+At cold start, an active, enabled, or otherwise installed systemd user unit is
+the remote-control runtime owner. Without that unit, the launcher defers to a
+explicit autostart disablement, then to a valid Desktop app-server marker, and
+uses the standalone runtime only as the final fallback. The selected owner is
+written to the launcher log.
+
 This is compatible with immutable Linux systems such as Bluefin / Universal
 Blue because the managed daemon runtime is user-scoped state under
 `~/.codex/packages/standalone`. It does not require `dnf`, `rpm-ostree`, host

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -122,6 +122,7 @@ cleanup_stale_remote_mobile_daemon_state() {
 desktop_app_server_remote_control_enabled() {
     local app_dir="${CODEX_LINUX_APP_DIR:-}"
     local marker=""
+    local marker_value=""
 
     if truthy_env_value "${CODEX_REMOTE_CONTROL_FORCE_COLD_START_DAEMON:-}"; then
         return 1
@@ -129,28 +130,71 @@ desktop_app_server_remote_control_enabled() {
 
     [ -n "$app_dir" ] || return 1
     marker="$app_dir/.codex-linux/desktop-app-server-remote-control-enabled"
-    [ -f "$marker" ]
+    [ -f "$marker" ] && [ ! -L "$marker" ] || return 1
+    marker_value="$(cat "$marker" 2>/dev/null || true)"
+    if [ "$marker_value" = "version=1
+owner=desktop" ]; then
+        return 0
+    fi
+    echo "Ignoring invalid remote mobile control Desktop owner marker: $marker" >&2
+    return 1
+}
+
+remote_mobile_control_systemd_state() {
+    command -v systemctl >/dev/null 2>&1 || return 1
+    if systemctl --user is-active --quiet codex-remote-control.service 2>/dev/null; then
+        printf '%s\n' "active"
+    elif systemctl --user is-enabled --quiet codex-remote-control.service 2>/dev/null ||
+        systemctl --user cat codex-remote-control.service >/dev/null 2>&1; then
+        printf '%s\n' "configured"
+    else
+        return 1
+    fi
+}
+
+remote_mobile_control_owner() {
+    local systemd_state=""
+
+    if systemd_state="$(remote_mobile_control_systemd_state)"; then
+        printf '%s:%s\n' "systemd" "$systemd_state"
+    elif truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
+        printf '%s\n' "disabled"
+    elif desktop_app_server_remote_control_enabled; then
+        printf '%s\n' "desktop"
+    else
+        printf '%s\n' "standalone"
+    fi
 }
 
 remote_mobile_control_main() {
     local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local owner=""
 
     cleanup_remote_mobile_control_interactive_symlink "$codex_home"
+    owner="$(remote_mobile_control_owner)"
 
-    if truthy_env_value "${CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED:-}"; then
-        echo "Remote mobile control daemon autostart disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
-        return 0
-    fi
-    if command -v systemctl >/dev/null 2>&1 &&
-        systemctl --user is-active --quiet codex-remote-control.service 2>/dev/null; then
-        echo "Remote mobile control daemon autostart skipped; codex-remote-control.service is already active"
-        return 0
-    fi
-    if desktop_app_server_remote_control_enabled; then
-        cleanup_stale_remote_mobile_daemon_state "$codex_home"
-        echo "Remote mobile control daemon autostart skipped; Desktop app-server launches with remote-control enabled"
-        return 0
-    fi
+    case "$owner" in
+        systemd:active)
+            echo "Remote mobile control owner: systemd (codex-remote-control.service is active)"
+            return 0
+            ;;
+        systemd:configured)
+            echo "Remote mobile control owner: systemd (codex-remote-control.service is configured but inactive)"
+            return 0
+            ;;
+        disabled)
+            echo "Remote mobile control owner: disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED"
+            return 0
+            ;;
+        desktop)
+            cleanup_stale_remote_mobile_daemon_state "$codex_home"
+            echo "Remote mobile control owner: desktop (app-server launches with remote-control enabled)"
+            return 0
+            ;;
+        standalone)
+            echo "Remote mobile control owner: standalone fallback"
+            ;;
+    esac
 
     local standalone_codex="${CODEX_REMOTE_CONTROL_CODEX_PATH:-$codex_home/packages/standalone/current/codex}"
 

--- a/linux-features/remote-mobile-control/stage.sh
+++ b/linux-features/remote-mobile-control/stage.sh
@@ -15,7 +15,8 @@ install -m 0755 "$SCRIPT_DIR/linux-features/remote-mobile-control/cold-start-hoo
 
 if [ -d "$WORK_DIR/app-extracted/.vite/build" ] &&
     grep -R -q "codexLinuxRemoteMobileAppServerArgs" "$WORK_DIR/app-extracted/.vite/build" 2>/dev/null; then
-    printf '%s\n' "desktop-app-server-remote-control" > "$desktop_remote_control_marker"
+    rm -f "$desktop_remote_control_marker"
+    printf '%s\n' "version=1" "owner=desktop" > "$desktop_remote_control_marker"
 else
     rm -f "$desktop_remote_control_marker"
     echo "WARN: Desktop app-server remote-control marker not found; standalone remote mobile daemon remains enabled" >&2

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -419,6 +419,9 @@ const COLD_START_TEST_ENV_KEYS = [
   "CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_TIMEOUT_SECONDS",
   "CODEX_REMOTE_CONTROL_FORCE_COLD_START_DAEMON",
   "CODEX_REMOTE_CONTROL_RUNTIME_AUTO_INSTALL_DISABLED",
+  "TEST_SYSTEMCTL_ACTIVE_STATUS",
+  "TEST_SYSTEMCTL_CAT_STATUS",
+  "TEST_SYSTEMCTL_ENABLED_STATUS",
 ];
 
 function coldStartTestEnv(env) {
@@ -433,7 +436,16 @@ function runColdStartHook(env) {
   const tempBin = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-bin-"));
   try {
     const systemctl = path.join(tempBin, "systemctl");
-    fs.writeFileSync(systemctl, "#!/usr/bin/env sh\nexit 3\n");
+    fs.writeFileSync(systemctl, [
+      "#!/usr/bin/env sh",
+      "case \"$*\" in",
+      "  '--user is-active --quiet codex-remote-control.service') exit \"${TEST_SYSTEMCTL_ACTIVE_STATUS:-3}\" ;;",
+      "  '--user is-enabled --quiet codex-remote-control.service') exit \"${TEST_SYSTEMCTL_ENABLED_STATUS:-3}\" ;;",
+      "  '--user cat codex-remote-control.service') exit \"${TEST_SYSTEMCTL_CAT_STATUS:-3}\" ;;",
+      "esac",
+      "exit 3",
+      "",
+    ].join("\n"));
     fs.chmodSync(systemctl, 0o755);
 
     const childEnv = coldStartTestEnv(env);
@@ -457,7 +469,7 @@ function runStageHook(env) {
 function writeDesktopAppServerRemoteControlMarker(appDir) {
   const marker = path.join(appDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
   fs.mkdirSync(path.dirname(marker), { recursive: true });
-  fs.writeFileSync(marker, "desktop-app-server-remote-control\n");
+  fs.writeFileSync(marker, "version=1\nowner=desktop\n");
 }
 
 test("remote mobile control feature stays disabled until listed in features.json", () => {
@@ -504,7 +516,7 @@ test("remote mobile stage hook is idempotent and stages its markers and executab
     assert.equal(first.status, 0, first.stderr || first.stdout);
     assert.equal(second.status, 0, second.stderr || second.stdout);
     assert.equal(fs.readFileSync(featureMarker, "utf8"), "remote-mobile-control\n");
-    assert.equal(fs.readFileSync(marker, "utf8"), "desktop-app-server-remote-control\n");
+    assert.equal(fs.readFileSync(marker, "utf8"), "version=1\nowner=desktop\n");
     assert.equal(fs.statSync(coldStartHook).mode & 0o777, 0o755);
     assert.equal(
       fs.readFileSync(coldStartHook, "utf8"),
@@ -539,6 +551,38 @@ test("remote mobile stage hook removes a stale ownership marker when the patch m
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(fs.existsSync(marker), false);
     assert.match(result.stderr, /Desktop app-server remote-control marker not found/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile stage hook replaces an ownership marker symlink without following it", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-stage-"));
+  try {
+    const installDir = path.join(tempRoot, "package", "opt", "codex-desktop");
+    const workDir = path.join(tempRoot, "work");
+    const buildDir = path.join(workDir, "app-extracted", ".vite", "build");
+    const marker = path.join(installDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
+    const target = path.join(tempRoot, "must-not-change");
+
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.mkdirSync(path.dirname(marker), { recursive: true });
+    fs.writeFileSync(path.join(buildDir, "main.js"), "globalThis.codexLinuxRemoteMobileAppServerArgs=true;");
+    fs.writeFileSync(target, "preserved\n");
+    fs.symlinkSync(target, marker);
+
+    const result = runStageHook({
+      ARCH: "x64",
+      CODEX_UPSTREAM_APP_DIR: path.join(tempRoot, "upstream-app"),
+      INSTALL_DIR: installDir,
+      SCRIPT_DIR: REPO_ROOT,
+      WORK_DIR: workDir,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.readFileSync(target, "utf8"), "preserved\n");
+    assert.equal(fs.lstatSync(marker).isSymbolicLink(), false);
+    assert.equal(fs.readFileSync(marker, "utf8"), "version=1\nowner=desktop\n");
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -685,7 +729,138 @@ test("remote mobile cold-start hook skips daemon when Desktop app-server owns re
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(fs.existsSync(callsLog), false);
-    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+    assert.match(result.stdout, /owner: desktop \(app-server launches with remote-control enabled\)/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook rejects an invalid Desktop owner marker", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const appDir = path.join(tempRoot, "app");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "codex");
+    const callsLog = path.join(tempRoot, "calls.log");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(path.join(appDir, ".codex-linux"), { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(
+      path.join(appDir, ".codex-linux", "desktop-app-server-remote-control-enabled"),
+      "desktop-app-server-remote-control\n",
+    );
+    fs.writeFileSync(standaloneCodex, `#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsLog)}\n`);
+    fs.chmodSync(standaloneCodex, 0o755);
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stderr, /Ignoring invalid remote mobile control Desktop owner marker/);
+    assert.match(result.stdout, /owner: standalone fallback/);
+    assert.equal(fs.readFileSync(callsLog, "utf8"), "remote-control start\n");
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook keeps explicit disablement ahead of the Desktop marker", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const appDir = path.join(tempRoot, "app");
+    fs.mkdirSync(home, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_LINUX_APP_DIR: appDir,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /owner: disabled by CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook keeps an enabled inactive systemd owner without starting fallback", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "codex");
+    const callsLog = path.join(tempRoot, "calls.log");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(standaloneCodex, `#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsLog)}\n`);
+    fs.chmodSync(standaloneCodex, 0o755);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      CODEX_REMOTE_CONTROL_DAEMON_AUTOSTART_DISABLED: "1",
+      HOME: home,
+      TEST_SYSTEMCTL_ACTIVE_STATUS: "3",
+      TEST_SYSTEMCTL_ENABLED_STATUS: "0",
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /owner: systemd \(codex-remote-control.service is configured but inactive\)/);
+    assert.equal(fs.existsSync(callsLog), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook reports an active systemd owner", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    fs.mkdirSync(home, { recursive: true });
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      HOME: home,
+      TEST_SYSTEMCTL_ACTIVE_STATUS: "0",
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /owner: systemd \(codex-remote-control.service is active\)/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook does not bypass a present disabled systemd unit", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const standaloneCodex = path.join(codexHome, "packages", "standalone", "current", "codex");
+    const callsLog = path.join(tempRoot, "calls.log");
+
+    fs.mkdirSync(path.dirname(standaloneCodex), { recursive: true });
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(standaloneCodex, `#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(callsLog)}\n`);
+    fs.chmodSync(standaloneCodex, 0o755);
+
+    const result = runColdStartHook({
+      CODEX_HOME: codexHome,
+      HOME: home,
+      TEST_SYSTEMCTL_ACTIVE_STATUS: "3",
+      TEST_SYSTEMCTL_CAT_STATUS: "0",
+      TEST_SYSTEMCTL_ENABLED_STATUS: "1",
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /owner: systemd \(codex-remote-control.service is configured but inactive\)/);
+    assert.equal(fs.existsSync(callsLog), false);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -722,7 +897,7 @@ test("remote mobile cold-start hook removes dead standalone daemon pid files whe
     assert.equal(fs.existsSync(path.join(daemonDir, "app-server.pid")), false);
     assert.equal(fs.existsSync(path.join(daemonDir, "app-server-updater.pid")), false);
     assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
-    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+    assert.match(result.stdout, /owner: desktop \(app-server launches with remote-control enabled\)/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -752,7 +927,7 @@ test("remote mobile cold-start hook preserves live standalone daemon pid files w
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(fs.existsSync(pidFile), true);
     assert.doesNotMatch(result.stdout, /Removed stale remote mobile control daemon pid file/);
-    assert.match(result.stdout, /Desktop app-server launches with remote-control enabled/);
+    assert.match(result.stdout, /owner: desktop \(app-server launches with remote-control enabled\)/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- choose one remote-mobile runtime owner at cold start
- prefer an installed systemd user service over the Desktop app-server and standalone fallback
- validate a versioned Desktop owner marker and replace marker symlinks safely during staging
- log the selected owner and cover each precedence path with regression tests

## Why

The cold-start hook previously recognized systemd only while the unit was active. An installed unit that was restarting, disabled, or failed could therefore be bypassed by a second standalone daemon. The Desktop path also trusted the marker by existence alone.

This keeps the existing opt-in fallback behavior while making ownership deterministic and observable.

## Validation

- remote-mobile feature tests: 93 passed
- Node checks: 975 passed
- script smoke suite
- `nix flake check --no-build`
- Bash syntax and ShellCheck
- Semgrep JavaScript rules: 0 findings

Part of #639.
