### PR TITLE
fix: refresh patches for Codex 26.707.51957

### DIFF
--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -1,11 +1,10 @@
 "use strict";
 
-const MODEL_PICKER_STATE_ASSET_PATTERN =
-  /^app-initial~app-main~page-[^.]+\.js$/;
-const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-[^.]+\.js$/;
-const MODEL_PICKER_MENU_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-[^.]+\.js$/;
+const MODEL_PICKER_BUNDLE_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
+const MODEL_PICKER_STATE_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
+const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
+const MODEL_PICKER_MENU_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =
@@ -170,9 +169,9 @@ function applyDynamicSupportedReasoningEffortsPatch(source, context = {}) {
     }
 
     const powerSelectionPattern = new RegExp(
-      `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{let (${JS_IDENT})=(${JS_IDENT})` +
-        `\\((${JS_IDENT}),\\2\\);if\\(\\3\\.length>=4\\)return \\3;let (${JS_IDENT})=` +
-        `\\4\\((${JS_IDENT}),\\2\\);return \\6\\.length>=4\\?\\6:\\[\\]\\}`,
+      `function (${JS_IDENT})\\((${JS_IDENT}),(${JS_IDENT})=!1\\)\\{let (${JS_IDENT})=` +
+        `(${JS_IDENT})\\((.+?),\\2\\);if\\(\\4\\.length>=4\\)return \\4;let (${JS_IDENT})=` +
+        `\\5\\((${JS_IDENT}),\\2\\);return \\7\\.length>=4\\?\\7:\\[\\]\\}`,
     );
     const match = source.match(powerSelectionPattern);
     if (match == null) {
@@ -186,6 +185,7 @@ function applyDynamicSupportedReasoningEffortsPatch(source, context = {}) {
       original,
       resolverFunction,
       modelsVar,
+      includeUltraVar,
       primarySelectionsVar,
       supportedSelectionsFilter,
       primaryCandidates,
@@ -193,8 +193,8 @@ function applyDynamicSupportedReasoningEffortsPatch(source, context = {}) {
       fallbackCandidates,
     ] = match;
     const patched =
-      `function ${resolverFunction}(${modelsVar}){` +
-      `let ${primarySelectionsVar}=${supportedSelectionsFilter}(${primaryCandidates}.filter(` +
+      `function ${resolverFunction}(${modelsVar},${includeUltraVar}=!1){` +
+      `let ${primarySelectionsVar}=${supportedSelectionsFilter}((${primaryCandidates}).filter(` +
       `${modelsVar}=>${modelsVar}.model!==\`gpt-5.6-sol\`),${modelsVar}),` +
       `codexLinuxSolModel=${modelsVar}?.find(${modelsVar}=>${modelsVar}.model===\`gpt-5.6-sol\`),` +
       `codexLinuxSolSelections=codexLinuxSolModel==null?[]:` +

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -72,10 +72,11 @@ function modelPickerMenuBundleFixture() {
 
 function modelPickerPowerBundleFixture() {
   return [
-    "function ARe(e){let t=PRe(FRe,e);if(t.length>=4)return t;let n=PRe(IRe,e);return n.length>=4?n:[]}",
+    "function ARe(e,t=!1){let n=PRe(t?[...FRe,URe]:FRe,e);if(n.length>=4)return n;let r=PRe(IRe,e);return r.length>=4?r:[]}",
     "function MRe(e){return e?.flatMap(({displayName:e,model:t,supportedReasoningEfforts:n})=>{let r=e==null?`Custom`:e,i=n.flatMap(({reasoningEffort:e})=>[e]);return(i.length>0?i:[`medium`]).map(e=>({id:`${t}:${e}`,model:t,modelLabel:r,reasoningEffort:e}))})??[]}",
     "function PRe(e,t){return e.flatMap((e,n)=>t?.some(t=>t.model===e.model&&t.supportedReasoningEfforts.some(({reasoningEffort:t})=>t===e.reasoningEffort))?[{...e,powerSettingIndex:n}]:[])}",
-    "var FRe=[{id:`gpt-5.6-terra:low`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`low`},{id:`gpt-5.6-sol:low`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`low`},{id:`gpt-5.6-sol:medium`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`medium`},{id:`gpt-5.6-sol:high`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`high`},{id:`gpt-5.6-sol:xhigh`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`xhigh`},{id:`gpt-5.6-sol:ultra`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`ultra`}];",
+    "var FRe=[{id:`gpt-5.6-terra:low`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`low`},{id:`gpt-5.6-sol:low`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`low`},{id:`gpt-5.6-sol:medium`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`medium`},{id:`gpt-5.6-sol:high`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`high`},{id:`gpt-5.6-sol:xhigh`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`xhigh`}];",
+    "var URe={id:`gpt-5.6-sol:ultra`,model:`gpt-5.6-sol`,modelLabel:`5.6 Sol`,reasoningEffort:`ultra`};",
     "var IRe=[{id:`gpt-5.6-terra:low`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`low`},{id:`gpt-5.6-terra:medium`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`medium`},{id:`gpt-5.6-terra:high`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`high`},{id:`gpt-5.6-terra:xhigh`,model:`gpt-5.6-terra`,modelLabel:`5.6 Terra`,reasoningEffort:`xhigh`}];",
   ].join("");
 }
@@ -180,19 +181,19 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
 
 test("model picker descriptors target the current state and menu bundles", () => {
   assert.match(
-    "app-initial~app-main~page-hSvsQcNf.js",
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
   assert.match(
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-CqMu8hJo.js",
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
     MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   );
   assert.match(
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-BqYcBFmq.js",
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    "app-initial~app-main~page-hSvsQcNf.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
   assert.doesNotMatch(
@@ -283,6 +284,20 @@ test("GPT-5.6 Power slider follows reasoning efforts enabled in settings", () =>
       "gpt-5.6-sol:medium",
       "gpt-5.6-sol:high",
       "gpt-5.6-sol:xhigh",
+    ],
+  );
+  assert.deepEqual(
+    resolvePowerSelections(
+      filteredGpt56Models(["low", "medium", "high", "xhigh", "ultra"]),
+      true,
+    ).map(({ id }) => id),
+    [
+      "gpt-5.6-terra:low",
+      "gpt-5.6-sol:low",
+      "gpt-5.6-sol:medium",
+      "gpt-5.6-sol:high",
+      "gpt-5.6-sol:xhigh",
+      "gpt-5.6-sol:ultra",
     ],
   );
 });

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -396,7 +396,6 @@ test("Linux safe monospace font stack patch warns when the unsafe stack drifts",
 
 test("Linux settings search hides controls that cannot render", () => {
   const source = [
-    'import{aG as l}from"./app-current.js";',
     "function qn(e){let t=(0,Zn.c)(17),n=re(),r=Bn(e),{data:i}=_(e),a=i?.isSystemBackdropSupported!==!1,o=i?.platform===`darwin`,{data:s}=T(k,e.selectedHostId),c,l=c;if(a){let e;e=e=>e.sectionSlug===`appearance`&&!a?{...e,messages:e.messages.filter(Jn)}:e.sectionSlug===`agent`?{...e,terms:[]}:e,m=r.map(e)}else m=r;return m}",
     "function Jn(e){return!Qn.includes(e.id)}",
   ].join("");
@@ -407,23 +406,7 @@ test("Linux settings search hides controls that cannot render", () => {
   assert.match(patched, /settings\.general\.appearance\.dockIcon\.label/);
   assert.match(
     patched,
-    /function codexLinuxSuggestedPromptsSearchEnabled\(\)\{return l\(`2425897452`\)\}/,
-  );
-  assert.match(
-    patched,
-    /oJ as codexLinuxAccountInfoQuery,y1 as codexLinuxSuggestedPromptsEligible,lS as codexLinuxUseAuthSession/,
-  );
-  assert.match(
-    patched,
-    /let codexLinuxSuggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible\(e\.enabled\);/,
-  );
-  assert.doesNotMatch(
-    patched,
-    /let codexLinuxSuggestedPromptsVisible=l\(`2425897452`\);/,
-  );
-  assert.match(
-    patched,
-    /return m\.map\(e=>codexLinuxFilterSettingsSearchSection\(e,o,codexLinuxSuggestedPromptsVisible\)\)/,
+    /return m\.map\(e=>codexLinuxFilterSettingsSearchSection\(e,o\)\)/,
   );
   assert.equal(
     (patched.match(/function codexLinuxFilterSettingsSearchSection\(/g) || []).length,
@@ -434,30 +417,9 @@ test("Linux settings search hides controls that cannot render", () => {
     "var codexLinuxDarwinOnlySettingsSearchMessageIds",
   );
   const helperEnd = patched.indexOf("function qn", helperStart);
-  const context = {
-    accountData: null,
-    authSnapshot: {
-      authMethod: "chatgpt",
-      email: "fallback@example.com",
-      planAtLogin: "free",
-    },
-    eligibilityCalls: [],
-    gateEnabled: false,
-    isEligible: false,
-    l: () => context.gateEnabled,
-    queryCalls: [],
-    codexLinuxAccountInfoQuery: (key, config) => {
-      context.queryCalls.push({ key, config });
-      return { data: context.accountData };
-    },
-    codexLinuxSuggestedPromptsEligible: (input) => {
-      context.eligibilityCalls.push(input);
-      return context.isEligible;
-    },
-    codexLinuxUseAuthSession: () => context.authSnapshot,
-  };
+  const context = {};
   vm.runInNewContext(
-    `${patched.slice(helperStart, helperEnd)};globalThis.filter=codexLinuxFilterSettingsSearchSection;globalThis.suggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible`,
+    `${patched.slice(helperStart, helperEnd)};globalThis.filter=codexLinuxFilterSettingsSearchSection`,
     context,
   );
   const dockMessage = {
@@ -466,75 +428,20 @@ test("Linux settings search hides controls that cannot render", () => {
   const themeMessage = {
     id: "settings.general.appearance.theme",
   };
-  const suggestedPromptMessage = {
-    id: "settings.agent.ambientSuggestions.groupTitle",
-  };
-  const permissionsMessage = {
-    id: "settings.agent.permissionsMode.groupTitle",
-  };
-
   assert.deepEqual(
     Array.from(context.filter({
       sectionSlug: "appearance",
       messages: [dockMessage, themeMessage],
-    }, false, false).messages, (message) => message.id),
+    }, false).messages, (message) => message.id),
     [themeMessage.id],
   );
   assert.deepEqual(
     Array.from(context.filter({
       sectionSlug: "appearance",
       messages: [dockMessage, themeMessage],
-    }, true, false).messages, (message) => message.id),
+    }, true).messages, (message) => message.id),
     [dockMessage.id, themeMessage.id],
   );
-  assert.deepEqual(
-    Array.from(context.filter({
-      sectionSlug: "agent",
-      messages: [suggestedPromptMessage, permissionsMessage],
-    }, false, false).messages, (message) => message.id),
-    [permissionsMessage.id],
-  );
-  const filterSuggestedPromptIds = (sectionSlug) =>
-    Array.from(context.filter({
-      sectionSlug,
-      messages: [suggestedPromptMessage, permissionsMessage],
-    }, false, context.suggestedPromptsVisible(true)).messages, (message) => message.id);
-
-  context.gateEnabled = true;
-  context.isEligible = true;
-  assert.equal(context.suggestedPromptsVisible(false), false);
-  assert.deepEqual(JSON.parse(JSON.stringify(context.queryCalls.at(-1).config)), {
-    queryConfig: {
-      enabled: false,
-    },
-  });
-
-  context.gateEnabled = false;
-  context.isEligible = true;
-  assert.equal(context.suggestedPromptsVisible(true), false);
-  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [permissionsMessage.id]);
-
-  context.gateEnabled = true;
-  context.isEligible = true;
-  context.accountData = {
-    email: "account@example.com",
-    plan: "pro",
-  };
-  assert.equal(context.suggestedPromptsVisible(true), true);
-  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [
-    suggestedPromptMessage.id,
-    permissionsMessage.id,
-  ]);
-  assert.deepEqual(JSON.parse(JSON.stringify(context.eligibilityCalls.at(-1))), {
-    authMethod: "chatgpt",
-    email: "account@example.com",
-    plan: "pro",
-  });
-
-  context.gateEnabled = true;
-  context.isEligible = false;
-  assert.equal(context.suggestedPromptsVisible(true), false);
-  assert.deepEqual(filterSuggestedPromptIds("general-settings"), [permissionsMessage.id]);
 });
 
 test("Linux settings search visibility patch warns on current-bundle drift", () => {

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -46,20 +46,6 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
-  let sharedSettingsImport = null;
-  let featureGateImport = null;
-  for (const match of currentSource.matchAll(/import\{([^}]*)\}from"[^"]+"/gu)) {
-    const featureGateMatch = match[1].match(/\baG as ([A-Za-z_$][\w$]*)\b/u);
-    if (featureGateMatch == null) {
-      continue;
-    }
-    sharedSettingsImport = {
-      text: match[0],
-      specifiers: match[1],
-    };
-    featureGateImport = featureGateMatch;
-    break;
-  }
   const functionPattern =
     /function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let [A-Za-z_$][\w$]*=\(0,[A-Za-z_$][\w$]*\.c\)\(\d+\),/gu;
   let settingsSearchFunction = null;
@@ -74,8 +60,7 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     if (
       text.includes("isSystemBackdropSupported") &&
       text.includes("?.platform===`darwin`") &&
-      text.includes("sectionSlug===`appearance`") &&
-      text.includes("sectionSlug===`agent`")
+      text.includes("sectionSlug===`appearance`")
     ) {
       settingsSearchFunction = {
         start: match.index,
@@ -95,7 +80,6 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     /return ([A-Za-z_$][\w$]*)\}$/u,
   )?.[1];
   if (
-    featureGateImport == null ||
     settingsSearchFunction == null ||
     darwinVariable == null ||
     resultVariable == null
@@ -111,27 +95,12 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
-  const importAdditions = [
-    "oJ as codexLinuxAccountInfoQuery",
-    "y1 as codexLinuxSuggestedPromptsEligible",
-    "lS as codexLinuxUseAuthSession",
-  ].filter((specifier) => !sharedSettingsImport.specifiers.includes(specifier));
-  const patchedImport = importAdditions.length === 0
-    ? sharedSettingsImport.text
-    : sharedSettingsImport.text.replace(
-        sharedSettingsImport.specifiers,
-        `${sharedSettingsImport.specifiers},${importAdditions.join(",")}`,
-      );
   const helper =
-    `var codexLinuxDarwinOnlySettingsSearchMessageIds=new Set([\`settings.general.appearance.dockIcon.chatGPT.ariaLabel\`,\`settings.general.appearance.dockIcon.codex.ariaLabel\`,\`settings.general.appearance.dockIcon.label\`,\`settings.general.appearance.dockIcon.row.description\`]);function codexLinuxSuggestedPromptsSearchEnabled(){return ${featureGateImport[1]}(\`2425897452\`)}function codexLinuxSuggestedPromptsSearchVisible(e){let t=codexLinuxSuggestedPromptsSearchEnabled(),n=codexLinuxUseAuthSession(),{authMethod:r,email:i,planAtLogin:a}=n,o=e&&t&&r===\`chatgpt\`,s={queryConfig:{enabled:o}},{data:c}=codexLinuxAccountInfoQuery(\`account-info\`,s);return e&&t&&codexLinuxSuggestedPromptsEligible({authMethod:r,email:c?.email??i,plan:c?.plan??a})}function codexLinuxFilterSettingsSearchSection(e,t,n){let r=e.messages;return e.sectionSlug===\`appearance\`&&!t&&(r=r.filter(e=>!codexLinuxDarwinOnlySettingsSearchMessageIds.has(e.id))),((e.sectionSlug===\`agent\`||e.sectionSlug===\`general-settings\`)&&!n)&&(r=r.filter(e=>!e.id.startsWith(\`settings.agent.ambientSuggestions.\`))),r===e.messages?e:{...e,messages:r}}`;
-  const functionStart = `function ${settingsSearchFunction.name}(${settingsSearchFunction.param}){`;
-  const functionPatch =
-    `${functionStart}let codexLinuxSuggestedPromptsVisible=codexLinuxSuggestedPromptsSearchVisible(${settingsSearchFunction.param}.enabled);`;
+    `var codexLinuxDarwinOnlySettingsSearchMessageIds=new Set([\`settings.general.appearance.dockIcon.chatGPT.ariaLabel\`,\`settings.general.appearance.dockIcon.codex.ariaLabel\`,\`settings.general.appearance.dockIcon.label\`,\`settings.general.appearance.dockIcon.row.description\`]);function codexLinuxFilterSettingsSearchSection(e,t){if(e.sectionSlug!==\`appearance\`||t)return e;let n=e.messages.filter(e=>!codexLinuxDarwinOnlySettingsSearchMessageIds.has(e.id));return n.length===e.messages.length?e:{...e,messages:n}}`;
   const returnNeedle = `return ${resultVariable}}`;
   const returnPatch =
-    `return ${resultVariable}.map(e=>codexLinuxFilterSettingsSearchSection(e,${darwinVariable},codexLinuxSuggestedPromptsVisible))}`;
+    `return ${resultVariable}.map(e=>codexLinuxFilterSettingsSearchSection(e,${darwinVariable}))}`;
   const patchedFunction = settingsSearchFunction.text
-    .replace(functionStart, functionPatch)
     .replace(returnNeedle, returnPatch);
 
   if (patchedFunction === settingsSearchFunction.text) {
@@ -141,10 +110,7 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
     return currentSource;
   }
 
-  return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`.replace(
-    sharedSettingsImport.text,
-    patchedImport,
-  );
+  return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`;
 }
 
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {


### PR DESCRIPTION
## Summary

- retarget the ui-tweaks model picker descriptors to the current upstream bundle
- adapt the dynamic reasoning effort patch to the current Ultra-aware resolver
- remove the obsolete settings-search auth/feature-gate workaround and retain only the current Darwin-only search filtering

## Validation

- `node --test scripts/patch-linux-window-ui.test.js linux-features/ui-tweaks/test.js` (387 tests)
- `bash tests/scripts_smoke.sh`
- `git diff --check`
- extracted and patched the current Codex 26.707.51957 DMG; all four ui-tweaks model picker patches and `linux-settings-search-visibility` report `applied`