### PR TITLE
fix(remote-mobile): validate daemon pid identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   Explicit systemd user-service configuration takes precedence over the
   Desktop app-server and standalone fallback, while a versioned Desktop marker
   prevents stale or forged marker content from suppressing the fallback.
+- Remote mobile cleanup now validates daemon PID records against the process
+  owner, recorded start time, and managed standalone executable before
+  preserving them. Recycled or foreign PIDs no longer make stale state appear
+  live, while incomplete in-flight reservations are left untouched.
 - Remote mobile control now patches the current upstream webview chunks for
   feature sync, settings visibility, host enablement, and active conversation
   status. Revoking the final controller now also clears the current mobile setup

--- a/linux-features/remote-mobile-control/cold-start-hook.sh
+++ b/linux-features/remote-mobile-control/cold-start-hook.sh
@@ -99,18 +99,90 @@ remote_mobile_control_daemon_pid() {
     sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "$pid_file" | head -n 1
 }
 
+remote_mobile_control_daemon_start_time() {
+    local pid_file="$1"
+
+    [ -f "$pid_file" ] || return 1
+    sed -n 's/.*"processStartTime"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$pid_file" | head -n 1
+}
+
+remote_mobile_control_pid_record_is_active() {
+    local pid_file="$1"
+    local standalone_root="$2"
+    local pid=""
+    local pid_file_owner=""
+    local pid_file_size=""
+    local recorded_start_time=""
+    local current_start_time=""
+    local process_owner=""
+    local current_owner=""
+    local process_executable=""
+
+    [ -f "$pid_file" ] && [ ! -L "$pid_file" ] || return 1
+    current_owner="$(id -u 2>/dev/null || true)"
+    pid_file_owner="$(stat -c '%u' "$pid_file" 2>/dev/null || true)"
+    pid_file_size="$(stat -c '%s' "$pid_file" 2>/dev/null || true)"
+    if [ -z "$current_owner" ] || [ -z "$pid_file_owner" ] ||
+        [ "$pid_file_owner" != "$current_owner" ]; then
+        return 2
+    fi
+    case "$pid_file_size" in
+        ''|*[!0-9]*) return 2 ;;
+    esac
+    if [ "$pid_file_size" -gt 4096 ]; then
+        return 1
+    fi
+    pid="$(remote_mobile_control_daemon_pid "$pid_file" || true)"
+    recorded_start_time="$(remote_mobile_control_daemon_start_time "$pid_file" || true)"
+    if [ -z "$pid" ] || [ -z "$recorded_start_time" ]; then
+        return 2
+    fi
+    if [ "$pid" -le 1 ]; then
+        return 1
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+        return 1
+    fi
+
+    process_owner="$(stat -c '%u' "/proc/$pid" 2>/dev/null || true)"
+    current_start_time="$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null | sed -n '1{s/^[[:space:]]*//;s/[[:space:]]*$//;p;}')"
+    process_executable="$(readlink -f "/proc/$pid/exe" 2>/dev/null || true)"
+    process_executable="${process_executable% (deleted)}"
+    standalone_root="$(readlink -f "$standalone_root" 2>/dev/null || true)"
+
+    if [ -z "$process_owner" ] || [ -z "$current_owner" ] ||
+        [ -z "$current_start_time" ] || [ -z "$process_executable" ] ||
+        [ -z "$standalone_root" ]; then
+        return 2
+    fi
+    if [ "$process_owner" != "$current_owner" ] ||
+        [ "$current_start_time" != "$recorded_start_time" ]; then
+        return 1
+    fi
+    case "$process_executable" in
+        "$standalone_root"/releases/*/bin/codex) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 cleanup_stale_remote_mobile_daemon_state() {
     local codex_home="$1"
     local pid_file=""
-    local pid=""
+    local record_status=0
+    local standalone_root="$codex_home/packages/standalone"
 
     for pid_file in \
         "$codex_home/app-server-daemon/app-server.pid" \
         "$codex_home/app-server-daemon/app-server-updater.pid"
     do
         [ -e "$pid_file" ] || continue
-        pid="$(remote_mobile_control_daemon_pid "$pid_file" || true)"
-        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        record_status=0
+        remote_mobile_control_pid_record_is_active "$pid_file" "$standalone_root" || record_status=$?
+        if [ "$record_status" -eq 0 ]; then
+            continue
+        fi
+        if [ "$record_status" -eq 2 ]; then
+            echo "Preserved remote mobile control daemon pid file with unverifiable identity: $pid_file" >&2
             continue
         fi
         if rm -f "$pid_file"; then

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const assert = require("node:assert/strict");
-const { spawnSync } = require("node:child_process");
+const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -403,6 +403,7 @@ const COLD_START_TEST_ENV_KEYS = [
   "TEST_SYSTEMCTL_ACTIVE_STATUS",
   "TEST_SYSTEMCTL_CAT_STATUS",
   "TEST_SYSTEMCTL_ENABLED_STATUS",
+  "TEST_REQUIRE_C_LOCALE",
 ];
 
 function coldStartTestEnv(env) {
@@ -429,6 +430,24 @@ function runColdStartHook(env) {
     ].join("\n"));
     fs.chmodSync(systemctl, 0o755);
 
+    const hostPs = (process.env.PATH ?? "")
+      .split(path.delimiter)
+      .filter((directory) => path.isAbsolute(directory))
+      .map((directory) => path.join(directory, "ps"))
+      .find((candidate) => fs.existsSync(candidate));
+    assert.ok(hostPs, "ps must be available for cold-start tests");
+    const ps = path.join(tempBin, "ps");
+    fs.writeFileSync(ps, [
+      "#!/usr/bin/env sh",
+      "if [ \"${TEST_REQUIRE_C_LOCALE:-}\" = 1 ] && [ \"${LC_ALL:-}\" != C ]; then",
+      "  printf '%s\\n' 'localized timestamp'",
+      "  exit 0",
+      "fi",
+      `exec ${JSON.stringify(fs.realpathSync(hostPs))} \"$@\"`,
+      "",
+    ].join("\n"));
+    fs.chmodSync(ps, 0o755);
+
     const childEnv = coldStartTestEnv(env);
     childEnv.PATH = `${tempBin}${path.delimiter}${childEnv.PATH ?? ""}`;
     return spawnSync("bash", [path.join(__dirname, "cold-start-hook.sh"), "--run-main"], {
@@ -451,6 +470,12 @@ function writeDesktopAppServerRemoteControlMarker(appDir) {
   const marker = path.join(appDir, ".codex-linux", "desktop-app-server-remote-control-enabled");
   fs.mkdirSync(path.dirname(marker), { recursive: true });
   fs.writeFileSync(marker, "version=1\nowner=desktop\n");
+}
+
+function processStartTime(pid) {
+  const result = spawnSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
 }
 
 test("remote mobile control feature stays disabled until listed in features.json", () => {
@@ -886,29 +911,187 @@ test("remote mobile cold-start hook removes dead standalone daemon pid files whe
 
 test("remote mobile cold-start hook preserves live standalone daemon pid files when Desktop app-server owns remote-control", () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  let child;
   try {
     const home = path.join(tempRoot, "home");
     const codexHome = path.join(tempRoot, "codex-home");
     const daemonDir = path.join(codexHome, "app-server-daemon");
     const appDir = path.join(tempRoot, "package", "share", "codex-desktop", "app");
     const pidFile = path.join(daemonDir, "app-server.pid");
+    const managedExecutable = path.join(codexHome, "packages", "standalone", "releases", "test", "bin", "codex");
 
     fs.mkdirSync(home, { recursive: true });
     fs.mkdirSync(daemonDir, { recursive: true });
     fs.mkdirSync(appDir, { recursive: true });
+    fs.mkdirSync(path.dirname(managedExecutable), { recursive: true });
+    fs.copyFileSync("/bin/sleep", managedExecutable);
+    fs.chmodSync(managedExecutable, 0o755);
     writeDesktopAppServerRemoteControlMarker(appDir);
-    fs.writeFileSync(pidFile, JSON.stringify({ pid: process.pid, processStartTime: "fixture" }));
+    child = spawn(managedExecutable, ["30"], { stdio: "ignore" });
+    fs.writeFileSync(pidFile, JSON.stringify({ pid: child.pid, processStartTime: processStartTime(child.pid) }));
 
     const result = runColdStartHook({
       CODEX_HOME: codexHome,
       CODEX_LINUX_APP_DIR: appDir,
       HOME: home,
+      TEST_REQUIRE_C_LOCALE: "1",
     });
 
     assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(fs.existsSync(pidFile), true);
     assert.doesNotMatch(result.stdout, /Removed stale remote mobile control daemon pid file/);
     assert.match(result.stdout, /owner: desktop \(app-server launches with remote-control enabled\)/);
+  } finally {
+    child?.kill("SIGTERM");
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes a recycled daemon pid record", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(path.join(codexHome, "packages", "standalone", "releases"), { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, JSON.stringify({ pid: process.pid, processStartTime: "recycled" }));
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes a pid record for an executable outside managed standalone", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    fs.mkdirSync(path.join(codexHome, "packages", "standalone", "releases"), { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, JSON.stringify({ pid: process.pid, processStartTime: processStartTime(process.pid) }));
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook preserves an incomplete pid reservation", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, "");
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), true);
+    assert.match(result.stderr, /pid file with unverifiable identity/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes an oversized pid record without parsing it", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, "x".repeat(4097));
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook removes a non-process pid record", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(pidFile, JSON.stringify({ pid: 0, processStartTime: "fixture" }));
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("remote mobile cold-start hook unlinks a pid-file symlink without touching its target", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-remote-mobile-cold-start-"));
+  try {
+    const home = path.join(tempRoot, "home");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const daemonDir = path.join(codexHome, "app-server-daemon");
+    const appDir = path.join(tempRoot, "app");
+    const pidFile = path.join(daemonDir, "app-server.pid");
+    const target = path.join(tempRoot, "pid-record-target");
+    const contents = JSON.stringify({ pid: process.pid, processStartTime: processStartTime(process.pid) });
+
+    fs.mkdirSync(home, { recursive: true });
+    fs.mkdirSync(daemonDir, { recursive: true });
+    writeDesktopAppServerRemoteControlMarker(appDir);
+    fs.writeFileSync(target, contents);
+    fs.symlinkSync(target, pidFile);
+
+    const result = runColdStartHook({ CODEX_HOME: codexHome, CODEX_LINUX_APP_DIR: appDir, HOME: home });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(fs.existsSync(pidFile), false);
+    assert.equal(fs.readFileSync(target, "utf8"), contents);
+    assert.match(result.stdout, /Removed stale remote mobile control daemon pid file/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- validate daemon PID records against their owner, start time, and managed Codex executable
- bound PID-file parsing and reject invalid process identifiers
- remove stale records without signaling unrelated processes, while preserving incomplete or unverifiable reservations

## Why

The Desktop-owner cleanup currently relies on `kill -0`. A recycled PID can therefore make stale daemon state look active even when it belongs to another process. This change verifies the record and live process identity before deciding whether the PID file is still authoritative.

## Validation

- remote-mobile feature tests: 92 passed
- full Node test suite: 974 passed
- script smoke suite: passed
- `bash -n` and ShellCheck
- `nix flake check --no-build`
- `nix build .#codex-desktop-remote-mobile-control --no-link`
- Semgrep changed-files scan: 0 findings
- reproduced the PID record and process identity with Codex 0.144.1 in an isolated `CODEX_HOME`

Part of #639.
