### PR TITLE
fix(nix): reject store-backed remote control environment files

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -144,6 +144,14 @@ in
 }
 ```
 
+Set `remoteControl.environmentFile` to a quoted absolute runtime path such as
+`"/run/secrets/codex-remote-control.env"`. Prefix it with `-` only when systemd
+should ignore a missing file. Empty paths, relative paths, Nix path literals and
+strings that resolve inside the Nix store are rejected. Do not interpolate a
+path containing secrets: Nix can copy it into the store before module validation
+rejects the configuration. The referenced runtime file must be readable by the
+user service and should remain owner-only.
+
 Pinning `github:sadjow/codex-cli-nix` to a release tag or commit is
 recommended for fully reproducible configurations.
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -146,11 +146,11 @@ in
 
 Set `remoteControl.environmentFile` to a quoted absolute runtime path such as
 `"/run/secrets/codex-remote-control.env"`. Prefix it with `-` only when systemd
-should ignore a missing file. Empty paths, relative paths, Nix path literals and
-strings that resolve inside the Nix store are rejected. Do not interpolate a
-path containing secrets: Nix can copy it into the store before module validation
-rejects the configuration. The referenced runtime file must be readable by the
-user service and should remain owner-only.
+should ignore a missing file. Empty, relative, non-canonical, Nix-context, and
+store-backed paths are rejected. Do not interpolate a path containing secrets:
+Nix can copy it into the store before module validation rejects the
+configuration. The referenced runtime file must be readable by the user service
+and should remain owner-only.
 
 Pinning `github:sadjow/codex-cli-nix` to a release tag or commit is
 recommended for fully reproducible configurations.

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -187,11 +187,14 @@ in
       };
 
       environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/run/secrets/codex-remote-control.env";
         description = ''
-          Additional environment file as defined in {manpage}`systemd.exec(5)`.
+          Runtime path to an additional environment file as defined in
+          {manpage}`systemd.exec(5)`. Use a quoted runtime string. Nix path
+          literals or interpolations can copy contents into the Nix store
+          before module validation; store-backed values are rejected.
         '';
       };
 
@@ -235,6 +238,24 @@ in
       {
         assertion = !remoteCfg.enable || pkgs.stdenv.hostPlatform.isLinux;
         message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
+      }
+      {
+        assertion =
+          remoteCfg.environmentFile == null
+          || lib.hasPrefix "/" (lib.removePrefix "-" remoteCfg.environmentFile);
+        message = ''
+          `programs.codexDesktopLinux.remoteControl.environmentFile` must be an
+          absolute runtime path, optionally prefixed with `-`
+        '';
+      }
+      {
+        assertion =
+          remoteCfg.environmentFile == null
+          || !lib.hasPrefix builtins.storeDir (lib.removePrefix "-" remoteCfg.environmentFile);
+        message = ''
+          `programs.codexDesktopLinux.remoteControl.environmentFile` must be a
+          runtime path outside the Nix store
+        '';
       }
     ];
 

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -8,6 +8,14 @@
 let
   cfg = config.programs.codexDesktopLinux;
   remoteCfg = cfg.remoteControl;
+  remoteEnvironmentFilePath =
+    if remoteCfg.environmentFile == null then null else lib.removePrefix "-" remoteCfg.environmentFile;
+  remoteEnvironmentFileSegments =
+    if remoteEnvironmentFilePath == null then [ ] else lib.drop 1 (lib.splitString "/" remoteEnvironmentFilePath);
+  remoteEnvironmentFileIsCanonical =
+    remoteEnvironmentFilePath != null
+    && lib.hasPrefix "/" remoteEnvironmentFilePath
+    && lib.all (segment: segment != "" && segment != "." && segment != "..") remoteEnvironmentFileSegments;
   system = pkgs.stdenv.hostPlatform.system;
   flakePackages = self.packages.${system};
   linuxFeatures = import ./linux-features.nix { inherit lib; };
@@ -242,16 +250,20 @@ in
       {
         assertion =
           remoteCfg.environmentFile == null
-          || lib.hasPrefix "/" (lib.removePrefix "-" remoteCfg.environmentFile);
+          || (!builtins.hasContext remoteCfg.environmentFile && remoteEnvironmentFileIsCanonical);
         message = ''
           `programs.codexDesktopLinux.remoteControl.environmentFile` must be an
-          absolute runtime path, optionally prefixed with `-`
+          absolute canonical runtime path without Nix store context, optionally
+          prefixed with `-`
         '';
       }
       {
         assertion =
           remoteCfg.environmentFile == null
-          || !lib.hasPrefix builtins.storeDir (lib.removePrefix "-" remoteCfg.environmentFile);
+          || (
+            remoteEnvironmentFilePath != builtins.storeDir
+            && !lib.hasPrefix "${builtins.storeDir}/" remoteEnvironmentFilePath
+          );
         message = ''
           `programs.codexDesktopLinux.remoteControl.environmentFile` must be a
           runtime path outside the Nix store

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -210,6 +210,15 @@ let
     ""
     "secrets.env"
     "-secrets.env"
+    "//nix/store/example-secret"
+    "/run/../nix/store/example-secret"
+    "/nix//store/example-secret"
+    "/run/secrets/./codex-remote-control.env"
+    "/run/secrets/"
+  ];
+  contextEnvironmentFiles = [
+    "/run/secrets/${./linux-features-test.nix}"
+    "-/run/secrets/${./linux-features-test.nix}"
   ];
   homeManagerStoreEnvironmentFileAssertions = map (
     environmentFile:
@@ -235,6 +244,18 @@ let
       remoteControlConfigWithEnvironmentFile environmentFile
     )).config.assertions
   ) invalidRuntimeEnvironmentFiles;
+  homeManagerContextEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalHomeManager (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) contextEnvironmentFiles;
+  nixosContextEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalNixOS (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) contextEnvironmentFiles;
 in
 assert lib.assertMsg
   (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
@@ -295,10 +316,16 @@ assert lib.assertMsg
   "NixOS accepted a store path for the remote-control environment file";
 assert lib.assertMsg
   (lib.all (assertions: !lib.all (item: item.assertion) assertions) homeManagerRuntimeEnvironmentFileAssertions)
-  "Home Manager accepted an empty or relative remote-control environment-file path";
+  "Home Manager accepted an empty, relative, or non-canonical remote-control environment-file path";
 assert lib.assertMsg
   (lib.all (assertions: !lib.all (item: item.assertion) assertions) nixosRuntimeEnvironmentFileAssertions)
-  "NixOS accepted an empty or relative remote-control environment-file path";
+  "NixOS accepted an empty, relative, or non-canonical remote-control environment-file path";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) homeManagerContextEnvironmentFileAssertions)
+  "Home Manager accepted a context-bearing remote-control environment-file path";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) nixosContextEnvironmentFileAssertions)
+  "NixOS accepted a context-bearing remote-control environment-file path";
 pkgs.runCommand "nix-linux-features-evaluation" { } ''
   touch "$out"
 ''

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -140,6 +140,32 @@ let
     mkdir -p "$out"
   '';
   customConfig = combinedConfig // { package = customPackage; };
+  remoteControlConfig = {
+    enable = true;
+    package = customPackage;
+    remoteControl = {
+      enable = true;
+      package = pkgs.writeShellScriptBin "codex" "exit 0";
+      environmentFile = "/run/secrets/codex-remote-control.env";
+    };
+  };
+  remoteControlConfigWithEnvironmentFile = environmentFile:
+    remoteControlConfig
+    // {
+      remoteControl = remoteControlConfig.remoteControl // { inherit environmentFile; };
+    };
+  homeRemoteService =
+    (evalHomeManager remoteControlConfig).config.systemd.user.services.codex-remote-control;
+  nixosRemoteService =
+    (evalNixOS remoteControlConfig).config.systemd.user.services.codex-remote-control;
+  optionalHomeRemoteService =
+    (evalHomeManager (
+      remoteControlConfigWithEnvironmentFile "-/run/secrets/codex-remote-control.env"
+    )).config.systemd.user.services.codex-remote-control;
+  optionalNixOSRemoteService =
+    (evalNixOS (
+      remoteControlConfigWithEnvironmentFile "-/run/secrets/codex-remote-control.env"
+    )).config.systemd.user.services.codex-remote-control;
 
   invalidBuilder = builtins.tryEval (
     (packages.codex-desktop.override {
@@ -162,6 +188,53 @@ let
       }).config.environment.systemPackages
       true
   );
+  invalidHomeManagerEnvironmentFile = builtins.tryEval (
+    builtins.deepSeq
+      (evalHomeManager (
+        remoteControlConfigWithEnvironmentFile ./linux-features-test.nix
+      )).config.systemd.user.services.codex-remote-control
+      true
+  );
+  invalidNixOSEnvironmentFile = builtins.tryEval (
+    builtins.deepSeq
+      (evalNixOS (
+        remoteControlConfigWithEnvironmentFile ./linux-features-test.nix
+      )).config.systemd.user.services.codex-remote-control
+      true
+  );
+  storeEnvironmentFiles = [
+    "${./linux-features-test.nix}"
+    "-${./linux-features-test.nix}"
+  ];
+  invalidRuntimeEnvironmentFiles = [
+    ""
+    "secrets.env"
+    "-secrets.env"
+  ];
+  homeManagerStoreEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalHomeManager (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) storeEnvironmentFiles;
+  nixosStoreEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalNixOS (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) storeEnvironmentFiles;
+  homeManagerRuntimeEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalHomeManager (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) invalidRuntimeEnvironmentFiles;
+  nixosRuntimeEnvironmentFileAssertions = map (
+    environmentFile:
+    (evalNixOS (
+      remoteControlConfigWithEnvironmentFile environmentFile
+    )).config.assertions
+  ) invalidRuntimeEnvironmentFiles;
 in
 assert lib.assertMsg
   (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
@@ -196,6 +269,36 @@ assert lib.assertMsg
 assert lib.assertMsg (!invalidBuilder.success) "the package builder accepted an unsupported feature";
 assert lib.assertMsg (!invalidHomeManager.success) "Home Manager accepted an unsupported feature";
 assert lib.assertMsg (!invalidNixOS.success) "NixOS accepted an unsupported feature";
+assert lib.assertMsg
+  (homeRemoteService.Service.EnvironmentFile == "/run/secrets/codex-remote-control.env")
+  "Home Manager changed the runtime remote-control environment-file path";
+assert lib.assertMsg
+  (nixosRemoteService.serviceConfig.EnvironmentFile == "/run/secrets/codex-remote-control.env")
+  "NixOS changed the runtime remote-control environment-file path";
+assert lib.assertMsg
+  (optionalHomeRemoteService.Service.EnvironmentFile == "-/run/secrets/codex-remote-control.env")
+  "Home Manager rejected or changed an optional absolute environment-file path";
+assert lib.assertMsg
+  (optionalNixOSRemoteService.serviceConfig.EnvironmentFile == "-/run/secrets/codex-remote-control.env")
+  "NixOS rejected or changed an optional absolute environment-file path";
+assert lib.assertMsg
+  (!invalidHomeManagerEnvironmentFile.success)
+  "Home Manager accepted a Nix path that can copy remote-control secrets into the store";
+assert lib.assertMsg
+  (!invalidNixOSEnvironmentFile.success)
+  "NixOS accepted a Nix path that can copy remote-control secrets into the store";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) homeManagerStoreEnvironmentFileAssertions)
+  "Home Manager accepted a store path for the remote-control environment file";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) nixosStoreEnvironmentFileAssertions)
+  "NixOS accepted a store path for the remote-control environment file";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) homeManagerRuntimeEnvironmentFileAssertions)
+  "Home Manager accepted an empty or relative remote-control environment-file path";
+assert lib.assertMsg
+  (lib.all (assertions: !lib.all (item: item.assertion) assertions) nixosRuntimeEnvironmentFileAssertions)
+  "NixOS accepted an empty or relative remote-control environment-file path";
 pkgs.runCommand "nix-linux-features-evaluation" { } ''
   touch "$out"
 ''

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -185,11 +185,14 @@ in
       };
 
       environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/run/secrets/codex-remote-control.env";
         description = ''
-          Additional environment file as defined in {manpage}`systemd.exec(5)`.
+          Runtime path to an additional environment file as defined in
+          {manpage}`systemd.exec(5)`. Use a quoted runtime string. Nix path
+          literals or interpolations can copy contents into the Nix store
+          before module validation; store-backed values are rejected.
         '';
       };
 
@@ -234,6 +237,24 @@ in
       {
         assertion = !remoteCfg.enable || pkgs.stdenv.hostPlatform.isLinux;
         message = "`programs.codexDesktopLinux.remoteControl.enable` is only supported on Linux";
+      }
+      {
+        assertion =
+          remoteCfg.environmentFile == null
+          || lib.hasPrefix "/" (lib.removePrefix "-" remoteCfg.environmentFile);
+        message = ''
+          `programs.codexDesktopLinux.remoteControl.environmentFile` must be an
+          absolute runtime path, optionally prefixed with `-`
+        '';
+      }
+      {
+        assertion =
+          remoteCfg.environmentFile == null
+          || !lib.hasPrefix builtins.storeDir (lib.removePrefix "-" remoteCfg.environmentFile);
+        message = ''
+          `programs.codexDesktopLinux.remoteControl.environmentFile` must be a
+          runtime path outside the Nix store
+        '';
       }
     ];
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -8,6 +8,14 @@
 let
   cfg = config.programs.codexDesktopLinux;
   remoteCfg = cfg.remoteControl;
+  remoteEnvironmentFilePath =
+    if remoteCfg.environmentFile == null then null else lib.removePrefix "-" remoteCfg.environmentFile;
+  remoteEnvironmentFileSegments =
+    if remoteEnvironmentFilePath == null then [ ] else lib.drop 1 (lib.splitString "/" remoteEnvironmentFilePath);
+  remoteEnvironmentFileIsCanonical =
+    remoteEnvironmentFilePath != null
+    && lib.hasPrefix "/" remoteEnvironmentFilePath
+    && lib.all (segment: segment != "" && segment != "." && segment != "..") remoteEnvironmentFileSegments;
   system = pkgs.stdenv.hostPlatform.system;
   flakePackages = self.packages.${system};
   linuxFeatures = import ./linux-features.nix { inherit lib; };
@@ -241,16 +249,20 @@ in
       {
         assertion =
           remoteCfg.environmentFile == null
-          || lib.hasPrefix "/" (lib.removePrefix "-" remoteCfg.environmentFile);
+          || (!builtins.hasContext remoteCfg.environmentFile && remoteEnvironmentFileIsCanonical);
         message = ''
           `programs.codexDesktopLinux.remoteControl.environmentFile` must be an
-          absolute runtime path, optionally prefixed with `-`
+          absolute canonical runtime path without Nix store context, optionally
+          prefixed with `-`
         '';
       }
       {
         assertion =
           remoteCfg.environmentFile == null
-          || !lib.hasPrefix builtins.storeDir (lib.removePrefix "-" remoteCfg.environmentFile);
+          || (
+            remoteEnvironmentFilePath != builtins.storeDir
+            && !lib.hasPrefix "${builtins.storeDir}/" remoteEnvironmentFilePath
+          );
         message = ''
           `programs.codexDesktopLinux.remoteControl.environmentFile` must be a
           runtime path outside the Nix store


### PR DESCRIPTION
## Summary

- Treat `remoteControl.environmentFile` as a runtime string in both Nix modules.
- Reject direct and optional store-backed paths.
- Add Home Manager and NixOS evaluation coverage and document the safe syntax.

## Why

The option was typed as a Nix path. A path literal could therefore copy an
environment file into the world-readable Nix store before the generated user
service referenced it.

Quoted runtime paths such as `/run/secrets/codex-remote-control.env` keep the
file outside the store. The module now rejects path literals and strings that
resolve into the store, including systemd's optional `-` form.

## Testing

- `nix-instantiate --parse` for both modules and the evaluation test
- `nix flake check --no-build`
- `nix build --no-link .#checks.x86_64-linux.nix-linux-features-evaluation`
- `nix build --no-link .#checks.x86_64-linux.nix-linux-features-multi-feature`
