### PR TITLE
Finish Conversation Mode cleanup when switching tasks

### DIFF
--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const HANDLER_NAME = "linux-read-aloud";
-const RUNTIME_VERSION = "conversation-mode-v25";
+const RUNTIME_VERSION = "conversation-mode-v26";
 const CURRENT_COMPOSER_ASSET_PATTERN =
   /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~[A-Za-z0-9_-]+\.js$/;
 
@@ -63,7 +63,7 @@ function conversationRuntimeSource() {
     `function stopConversation(){if(!state.active)return false;deactivate("discard");return true}`,
     `function cancelInterruptMonitor(){state.interruptSerial++;state.interruptPendingEpoch=0;stopInterruptMonitor()}`,
     `function toggleMute(force){if(!state.active)return false;let muted=typeof force==="boolean"?force:!state.muted;if(muted===state.muted){updateUi();return true}state.muted=muted;state.speechCooldownUntil=0;clearTimeout(state.restartTimer);state.restartTimer=null;if(state.muted){cancelInterruptMonitor();state.listening=false;state.controls?.stopDictation?.("discard")}else if(isResponseInProgress()||state.speaking||state.queue.length>0)startInterruptMonitor();else{state.listening=false;startListeningSoon(0,!0)}updateUi();return true}`,
-    `function deactivate(stopAction="insert"){if(!state.active)return;state.active=false;state.muted=false;state.epoch++;state.interruptPendingEpoch=0;clearTimeout(state.restartTimer);state.restartTimer=null;stopSpeech();cancelInterruptMonitor();state.controls?.stopDictation?.(stopAction);state.controls=null;state.activeConversationId=null;state.seenAssistantKeys.clear();state.spokenAssistant.clear();state.spokenAssistantTexts=[];state.cursorSentAtMs=0;resetTranscriptState();resetTurnState();updateUi()}`,
+    `function deactivate(stopAction="insert"){if(!state.active)return;let controls=state.controls;state.active=false;state.muted=false;state.epoch++;state.interruptPendingEpoch=0;clearTimeout(state.restartTimer);state.restartTimer=null;stopSpeech();cancelInterruptMonitor();state.controls=null;state.activeConversationId=null;state.seenAssistantKeys.clear();state.spokenAssistant.clear();state.spokenAssistantTexts=[];state.cursorSentAtMs=0;resetTranscriptState();resetTurnState();updateUi();try{controls?.stopDictation?.(stopAction)}catch{}}`,
     `function mergeControls(controls){if(controls&&typeof controls==="object")state.controls={...state.controls,...controls}}`,
     `function sync(conversation,controls){updateTrigger();if(!state.active)return false;let id=conversationId(conversation);if(id!==state.activeConversationId){deactivate("insert");return false}let was=isResponseInProgress();mergeControls(controls);let now=isResponseInProgress();if(now&&!was){(!state.allowAssistant||state.awaitingUserTranscript)&&stopSpeech(!0);state.awaitingUserTranscript=false;state.allowAssistant=true;state.muted||startInterruptMonitor()}else if(now&&!state.muted)startInterruptMonitor();if(was&&!now){state.finalizing=true;finishAssistantSoon(650)}updateComposerAura();return true}`,
     `function isActive(conversation){return state.active&&conversationId(conversation)===state.activeConversationId}`,

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -447,7 +447,7 @@ test("main bundle patch preserves explicit button speech while adding conversati
 
 test("composer runtime appends one browser-side conversation controller", () => {
   const patched = twice(applyComposerRuntimePatch, "console.log(`composer`);");
-  assert.match(patched, /conversation-mode-v25/);
+  assert.match(patched, /conversation-mode-v26/);
   assert.match(patched, /activeConversationId/);
   assert.match(patched, /seenAssistantKeys/);
   assert.match(patched, /assistantKey/);
@@ -550,6 +550,35 @@ test("conversation runtime is scoped to the active conversation id", () => {
     assert.equal(bodies.filter((body) => body.action === "speak").length, speakCountBeforeSwitch);
     assert.ok(bodies.filter((body) => body.action === "stop").length >= 2);
   });
+});
+
+test("conversation runtime completes task switch cleanup when the dictation callback rejects render-time calls", () => {
+  const fakeDocument = createFakeDocument();
+  withConversationRuntime(() => {
+    let stopCalls = 0;
+    const controls = {
+      conversationId: "thread-a",
+      isResponseInProgress: false,
+      startDictation() {},
+      stopDictation() {
+        stopCalls++;
+        throw new Error("A function wrapped in useStableCallback can't be called during rendering.");
+      },
+      onStop() {},
+    };
+
+    assert.equal(globalThis.codexLinuxConversationToggle(controls), true);
+    assert.equal(fakeDocument.bodyClassList.contains("codex-linux-conversation-active"), true);
+
+    assert.doesNotThrow(() => globalThis.codexLinuxConversationSync("thread-b", controls));
+    assert.equal(globalThis.codexLinuxConversationIsActive("thread-a"), false);
+    assert.equal(globalThis.codexLinuxConversationStop(), false);
+    assert.equal(fakeDocument.bodyClassList.contains("codex-linux-conversation-active"), false);
+    assert.equal(fakeDocument.composerClassList.contains("codex-linux-conversation-composer-aura"), false);
+    assert.equal(fakeDocument.getElementById("codex-linux-conversation-stop").hidden, true);
+    assert.equal(fakeDocument.getElementById("codex-linux-conversation-mute").hidden, true);
+    assert.equal(stopCalls, 1);
+  }, { document: fakeDocument });
 });
 
 test("conversation runtime can be explicitly exited from the active voice control", () => {


### PR DESCRIPTION
## Summary

- finish Conversation Mode teardown before invoking the composer-owned dictation callback
- keep task switching safe when React rejects that callback during render
- add a regression test covering runtime state and visible control cleanup

## Problem

With Conversation Mode active, switching to another Codex task calls
`codexLinuxConversationSync()` while the new composer is rendering. The runtime
deactivates the old conversation and then calls its `stopDictation` callback.
The current unified app wraps that callback in `useStableCallback`, which throws:

```text
A function wrapped in useStableCallback can't be called during rendering.
```

Because `state.active` was cleared before the callback but the rest of
`deactivate()` had not run yet, the recorder eventually stopped while the old
aura and floating stop/mute controls remained visible over the next task.

## Fix

`deactivate()` now clears its owned state and UI first, then invokes the captured
dictation callback defensively. A composer callback can no longer interrupt the
Conversation Mode teardown. The runtime marker advances to
`conversation-mode-v26` so idempotence identifies this implementation.

## Visible behavior

Switching tasks while Conversation Mode is listening now:

- stops the active recorder and media track
- removes the composer aura and floating controls
- leaves the destination task with a normal `Start conversation mode` trigger
- emits no render-time `useStableCallback` error

Quick Chat deactivation, explicit stop, quit, and restart remain clean.

## Environment

- repository baseline: `336b17ab3b6ccc23d920b3a4315657afbd5fefac`
- ChatGPT Desktop: `26.707.51957`
- Electron: `42.1.0`
- DMG SHA-256: `a66a0645fd4de6f4f22e75ca87bedb1585aeb57f3457a3df55509bf8da110879`
- DMG ETag: `0x8DEDFD6908B6AB0`
- DMG size: `560735555` bytes
- KDE Plasma Wayland, side-by-side identity
- enabled features: `read-aloud`, `conversation-mode`

## Validation

- red/green regression for a render-time throwing `stopDictation`
- `node --test linux-features/conversation-mode/test.js` (`54/54`)
- `node --test linux-features/read-aloud/test.js` (`58/58`)
- `node --test linux-features/*/test.js`
- `node --test scripts/patch-linux-window-ui.test.js` (`368/368`)
- `bash tests/scripts_smoke.sh`
- isolated current-DMG build and accepted patch report
- all Conversation Mode and Read Aloud descriptors applied on the clean pass
- second patch pass byte-stable with complete `already-applied` markers
- `node --check` on generated current assets
- runtime task switch, Quick Chat, quit, restart, recorder, and track cleanup
- `git diff --check`

## Limitations

The host exposed no physical PipeWire input, so this PR does not claim a full
physical microphone to transcription to spoken-response roundtrip. A valid
isolated virtual source exercised MediaRecorder lifecycle, mute/unmute, stop,
task switching, Quick Chat, track cleanup, and restart.
