### PR TITLE
Fix optional DMG argument for rebuild targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ rebuild:
 	MAX_BUILD_THREADS="$(MAX_BUILD_THREADS)" \
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
-		./scripts/rebuild-candidate.sh "$(DMG)"
+		./scripts/rebuild-candidate.sh $(if $(strip $(DMG)),"$(DMG)")
 
 rebuild-install:
 	@echo "[make] Running rebuild and local install flow"
@@ -183,7 +183,7 @@ rebuild-install:
 	REBUILD_REPORT_DIR="$(REBUILD_REPORT_DIR)" \
 	CODEX_NEXT_APP_DIR="$(NEXT_APP_DIR)" \
 	CODEX_FINAL_APP_DIR="$(APP_DIR)" \
-		./scripts/rebuild-candidate.sh --install "$(DMG)"
+		./scripts/rebuild-candidate.sh --install $(if $(strip $(DMG)),"$(DMG)")
 
 inspect-upstream:
 	@echo "[make] Inspecting upstream DMG"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2422,6 +2422,43 @@ SCRIPT
     [[ "$first_line" == *"<$explicit_realpath>"* ]] || fail "Explicit transactional build should receive explicit DMG: $first_line"
 }
 
+test_make_rebuild_targets_omit_empty_dmg_argument() {
+    info "Checking make rebuild targets omit an unset DMG argument"
+    local workspace="$TMP_DIR/make-rebuild-dmg"
+    local repo="$workspace/repo"
+    local explicit_dmg="$workspace/explicit.dmg"
+
+    mkdir -p "$repo/scripts"
+    cp "$REPO_DIR/Makefile" "$repo/Makefile"
+    printf '%s' "explicit" >"$explicit_dmg"
+
+    cat >"$repo/scripts/rebuild-candidate.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+set -eu
+printf 'CALL:'
+for arg in "$@"; do
+    printf '<%s>' "$arg"
+done
+printf '\n'
+SCRIPT
+    chmod +x "$repo/scripts/rebuild-candidate.sh"
+
+    make -C "$repo" rebuild >"$workspace/rebuild-default.out"
+    assert_contains "$workspace/rebuild-default.out" "CALL:"
+    assert_not_contains "$workspace/rebuild-default.out" "CALL:< >"
+    assert_not_contains "$workspace/rebuild-default.out" "CALL:<"
+
+    make -C "$repo" rebuild-install >"$workspace/install-default.out"
+    assert_contains "$workspace/install-default.out" "CALL:<--install>"
+    assert_not_contains "$workspace/install-default.out" "CALL:<--install><"
+
+    make -C "$repo" rebuild DMG="$explicit_dmg" >"$workspace/rebuild-explicit.out"
+    assert_contains "$workspace/rebuild-explicit.out" "CALL:<$explicit_dmg>"
+
+    make -C "$repo" rebuild-install DMG="$explicit_dmg" >"$workspace/install-explicit.out"
+    assert_contains "$workspace/install-explicit.out" "CALL:<--install><$explicit_dmg>"
+}
+
 test_candidate_install_is_transactional() {
     info "Checking atomic candidate promotion, first install, and rollback"
     local workspace="$TMP_DIR/candidate-install"
@@ -9325,6 +9362,7 @@ main() {
     test_fresh_pinned_dmg_preserves_cached_dmg_metadata
     test_fresh_reuse_dmg_uses_cache_when_metadata_matches
     test_rebuild_candidate_uses_validated_default_dmg
+    test_make_rebuild_targets_omit_empty_dmg_argument
     test_candidate_install_is_transactional
     test_candidate_promotion_refuses_a_running_final_app
     test_candidate_backup_retention_is_bounded


### PR DESCRIPTION
## Summary
- omit the positional DMG argument from `make rebuild` and `make update`/`rebuild-install` when `DMG` is unset
- preserve explicit `DMG=/path/to/Codex.dmg` forwarding
- add smoke coverage for both default and explicit-DMG flows

Fixes #903.

## Tests
- `bash tests/scripts_smoke.sh`
- `bash -n tests/scripts_smoke.sh`
- `git diff --check`