### PR TITLE
Read Aloud captures function-local child-process alias when Agent Workspace is enabled

### DIFF
--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -44,12 +44,12 @@ function applyMainBundlePatch(source) {
     return source;
   }
 
-  const childProcessVar = requireName(source, "node:child_process") ?? requireName(source, "child_process");
+  const childProcessVar = "require(`node:child_process`)";
   const fsVar = requireName(source, "node:fs");
   const pathVar = requireName(source, "node:path");
   const osVar = requireName(source, "node:os") ?? requireName(source, "os");
-  if (childProcessVar == null || fsVar == null || pathVar == null || osVar == null) {
-    warn("Could not find node:child_process/node:fs/node:path/node:os dependencies", "read aloud main-bundle patch");
+  if (fsVar == null || pathVar == null || osVar == null) {
+    warn("Could not find node:fs/node:path/node:os dependencies", "read aloud main-bundle patch");
     return source;
   }
 

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -137,6 +137,7 @@ test("main bundle patch adds a Linux read aloud handler", () => {
   assert.match(patched, /source===`button`/);
   assert.match(patched, /codexLinuxReadAloudSpeak\(e\.text,\{requireEnabled:!1\}\)/);
   assert.match(patched, /constants\.X_OK/);
+  assert.match(patched, /require\(`node:child_process`\)\.spawn/);
   assert.match(patched, /kokoro-stdin/);
   assert.match(patched, /kokoro-v1\.0\.onnx/);
   assert.match(patched, /huggingface\.co\/zijuncheng\/kokoro_model_v1\.0\/resolve\/main\/kokoro-v1\.0\.onnx/);
@@ -151,6 +152,18 @@ test("main bundle patch adds a Linux read aloud handler", () => {
   // parentheses any custom voice forced the Hebrew espeak voice.
   assert.match(patched, /let espeakVoice=voice\|\|\(hasHebrew\?`he`:`en-us`\);/);
   assert.doesNotThrow(() => new Function("require", "process", patched));
+});
+
+test("main handler does not capture a function-local child-process alias from another feature", () => {
+  const source = [
+    'function injectedFeature(){let __codexChild=require(`node:child_process`);return __codexChild}',
+    'let e=require(`node:child_process`),f=require(`node:fs`),p=require(`node:path`),o=require(`node:os`);',
+    'var h={handlers:{"set-vs-context":async()=>{},"native-desktop-apps":async()=>({apps:[]})}};',
+  ].join("");
+  const patched = applyMainBundlePatch(source);
+
+  assert.match(patched, /require\(`node:child_process`\)\.spawn\(command,args/);
+  assert.doesNotMatch(patched, /let child=__codexChild\.spawn\(command,args/);
 });
 
 test("main bundle helper preserves the core Electron binding across patch reruns", () => {


### PR DESCRIPTION
The Linux Read Aloud speaker button fails when both agent-workspace and read-aloud are enabled.

Read Aloud incorrectly discovers a function-local node:child_process alias injected by Agent Workspace and uses it from module scope. This generates references to an inaccessible variable:

__codexChild is not defined

Environment

    Arch Linux / Omarchy
    Wayland / Hyprland
    Codex Desktop upstream app: 26.707.51957
    Repository commit: https://github.com/ilysenko/codex-desktop-linux/commit/0fe4408b52e73bf3815e83ab2b682a107bf6d33e
    Electron: 42.1.0
    Enabled relevant features:
    agent-workspace
    read-aloud
    read-aloud-mcp
    conversation-mode

Steps to reproduce

    Enable both agent-workspace and read-aloud.
    Build and install the Linux app.
    Configure a valid Kokoro runtime, model, and voices.
    Confirm the bundled Kokoro runner works directly.
    Click the speaker button beneath an assistant response.

Expected behavior
The assistant response is spoken through the configured Read Aloud backend.

Actual behavior
No audio is produced. The launcher log reports:

  "spoken": false,
  "reason": "spawn-exception",
  "message": "__codexChild is not defined"
}

The resulting generated bundle contains code similar to:

  let child = __codexChild.spawn(...);
}

However, __codexChild was declared only inside an Agent Workspace handler and is not available to the Read Aloud module-level helper.

Root cause
read-aloud/patch.js uses requireName() to discover the minified node:child_process binding. When another feature has already injected a function-local require("node:child_process"), requireName() can select that local alias instead of a module-scope binding.
This makes the result dependent on feature ordering and produces an invalid cross-scope reference.

Proposed fix
Use an explicit module expression for Read Aloud child-process operations:
require("node:child_process")

From Issue: https://github.com/ilysenko/codex-desktop-linux/issues/898