### PR TITLE
Ignore transactional install state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 *.py[cod]
 codex-app/
 codex-app.backup-*/
+.codex-app.candidate-*/
+.codex-app.promotion.json
+.codex-app.promotion.lock
 codex-*-app/
 codex-app-next/
 bin/codex-*


### PR DESCRIPTION
## Summary

- ignore transactional candidate directories, recovery journals, and promotion locks
- prevent normal local builds from dirtying the checkout

Follow-up to #834.

## Validation

- `git diff --check`
- verified all three paths with `git check-ignore`

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.