### PR TITLE
Apply zoom to popped-out Quick Chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - The opt-in `frameless-titlebar` feature now removes Electron-drawn window
   controls from Quick Chat as well as the primary window, keeping compositor-
   managed decoration behavior consistent across both window types.
+- Popped-out Quick Chat roots now consume the shared window zoom value, so Zoom
+  In, Zoom Out, and Actual Size scale content while preserving conversation
+  scrolling instead of updating only hidden state and titlebar geometry.
 - Remote mobile cold starts now select one runtime owner deterministically.
   Explicit systemd user-service configuration takes precedence over the
   Desktop app-server and standalone fallback, while a versioned Desktop marker

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -171,6 +171,7 @@ const {
   applyLinuxFastModeModelGuardPatch,
   applyLinuxI18nGatePatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxQuickChatWindowZoomPatch,
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxSkillsListDedupePatch,
@@ -965,6 +966,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-x11-project-picker",
     "opaque-window-default-general-settings",
     "opaque-window-default-webview-index",
+    "linux-quick-chat-window-zoom",
     "linux-window-controls-safe-area",
     "linux-tooltip-window-controls-collision",
     "linux-thread-side-panel-native-tooltip",
@@ -2635,6 +2637,215 @@ test("adds a right-side safe area for Linux window controls in application menu 
     patched,
     /applicationMenu:Object\.freeze\(\{left:0,right:0\}\)/,
   );
+});
+
+test("applies window zoom to the popped-out Quick Chat viewport", () => {
+  const source =
+    "c0={zoomedViewport:a0,floatingSurface:o0};st=vC(`flex flex-col overflow-hidden text-token-foreground`,c===`floating`&&vC(c0.floatingSurface,`fixed top-0 left-0`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`)";
+
+  const patched = applyPatchTwice(applyLinuxQuickChatWindowZoomPatch, source);
+
+  assert.match(
+    patched,
+    /c===`window`&&vC\(c0\.zoomedViewport,`relative overflow-hidden bg-token-editor-background\/55`\)/,
+  );
+  assert.doesNotMatch(patched, /c===`window`&&`relative h-dvh w-full/);
+  assert.doesNotMatch(patched, /data-codex-linux-quick-chat-zoom/);
+});
+
+test("applies window zoom to every popped-out Quick Chat root", () => {
+  const root =
+    "c===`floating`&&vC(c0.floatingSurface,`fixed top-0 left-0`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`";
+  const source = `c0={zoomedViewport:a0,floatingSurface:o0};first=${root};second=${root}`;
+
+  const patched = applyPatchTwice(applyLinuxQuickChatWindowZoomPatch, source);
+
+  assert.equal(
+    (patched.match(/c===`window`&&vC\(c0\.zoomedViewport/g) ?? []).length,
+    2,
+  );
+  assert.doesNotMatch(patched, /c===`window`&&`relative h-dvh w-full/);
+});
+
+test("patches an unpatched Quick Chat root beside an already patched root", () => {
+  const source = [
+    "c0={zoomedViewport:a0,floatingSurface:o0}",
+    "first=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&vC(c0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+    "second=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+
+  const patched = applyPatchTwice(applyLinuxQuickChatWindowZoomPatch, source);
+
+  assert.equal(
+    (patched.match(/c===`window`&&vC\(c0\.zoomedViewport/g) ?? []).length,
+    2,
+  );
+  assert.doesNotMatch(patched, /c===`window`&&`relative h-dvh w-full/);
+});
+
+test("does not mistake an unrelated zoomed viewport for a patched Quick Chat root", () => {
+  const source = [
+    "unrelated=x===`window`&&classes(s0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+    "c0={zoomedViewport:a0,floatingSurface:o0}",
+    "quick=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+
+  const patched = applyPatchTwice(applyLinuxQuickChatWindowZoomPatch, source);
+
+  assert.match(
+    patched,
+    /quick=c===`floating`[^;]+c===`window`&&vC\(c0\.zoomedViewport/,
+  );
+  assert.doesNotMatch(patched, /c===`window`&&`relative h-dvh w-full/);
+});
+
+test("reports a missing Quick Chat zoom style contract", () => {
+  const source = [
+    "unrelated=vC(c0.zoomedViewport,`relative`)",
+    "st=vC(`base`,c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`)",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => applyLinuxQuickChatWindowZoomPatch(source));
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("does not match a zoom contract on an identifier suffix", () => {
+  const source = [
+    "ba={zoomedViewport:a0,floatingSurface:o0}",
+    "quick=c===`floating`&&vC(a.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("does not use a distant unrelated zoom contract for a patchable root", () => {
+  const source = [
+    "unrelated=c0={zoomedViewport:a0,floatingSurface:o0}",
+    ";".repeat(24_001),
+    "quick=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("validates the zoom contract for an already patched Quick Chat root", () => {
+  const source = [
+    "unrelated=c0={zoomedViewport:a0,floatingSurface:o0}",
+    ";".repeat(24_001),
+    "quick=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&vC(c0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("leaves every Quick Chat root unchanged when one zoom contract is missing", () => {
+  const source = [
+    "c0={zoomedViewport:a0,floatingSurface:o0}",
+    "first=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+    "second=d===`floating`&&wC(d0.floatingSurface,`fixed`),d===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+  let patched;
+
+  const { warnings } = captureWarns(() => {
+    patched = applyLinuxQuickChatWindowZoomPatch(source);
+  });
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("reports an unpatchable Quick Chat root beside an already patched root", () => {
+  const source = [
+    "first=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&vC(c0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+    "second=d===`floating`&&wC(d0.floatingSurface,`fixed`),d===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("leaves a patchable Quick Chat root unchanged beside a drifted root", () => {
+  const source = [
+    "c0={zoomedViewport:a0,floatingSurface:o0}",
+    "d0={zoomedViewport:b0,floatingSurface:p0}",
+    "first=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`",
+    "second=d===`floating`&&wC(d0.floatingSurface,`fixed`),d===`window`&&wC(d0.zoomedViewport,`drifted-window-root`)",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("reports a drifted Quick Chat root beside an already patched root", () => {
+  const source = [
+    "first=c===`floating`&&vC(c0.floatingSurface,`fixed`),c===`window`&&vC(c0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+    "second=d===`floating`&&wC(d0.floatingSurface,`fixed`),d===`window`&&wC(d0.zoomedViewport,`drifted-window-root`)",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("reports Quick Chat drift beside an unrelated patched-looking viewport", () => {
+  const source = [
+    "unrelated=x===`window`&&classes(s0.zoomedViewport,`relative overflow-hidden bg-token-editor-background/55`)",
+    "quick=c===`floating`?classes(c0.floatingSurface,`fixed`):c===`window`?`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`:null",
+  ].join(";");
+
+  const { warnings } = captureWarns(() => {
+    assert.equal(applyLinuxQuickChatWindowZoomPatch(source), source);
+  });
+
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
+});
+
+test("reports popped-out Quick Chat zoom patch drift", () => {
+  const source =
+    "st=classes(`base`,c===`floating`?classes(c0.floatingSurface,`fixed`):c===`window`?`relative h-dvh w-full overflow-hidden bg-token-editor-background/55`:null)";
+
+  const { warnings } = captureWarns(() => applyLinuxQuickChatWindowZoomPatch(source));
+  assert.deepEqual(warnings, [
+    "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+  ]);
 });
 
 test("patches remaining Linux window controls safe areas when another copy is already patched", () => {

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -6,6 +6,7 @@ const {
 const {
   applyLinuxAppSunsetPatch,
   applyLinuxOpaqueWindowsDefaultPatch,
+  applyLinuxQuickChatWindowZoomPatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
@@ -41,6 +42,16 @@ module.exports = [
     missingDescription: "webview index bundle",
     skipDescription: "translucent sidebar default patch",
     apply: applyLinuxOpaqueWindowsDefaultPatch,
+  }),
+  webviewAssetPatch({
+    id: "linux-quick-chat-window-zoom",
+    phase: "webview-asset",
+    order: 1030,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~page-.*\.js$/,
+    missingDescription: "shared Quick Chat component bundle",
+    skipDescription: "popped-out Quick Chat zoom root patch",
+    apply: applyLinuxQuickChatWindowZoomPatch,
   }),
   webviewAssetPatch({
     id: "linux-window-controls-safe-area",

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -161,6 +161,83 @@ function applyLinuxWindowControlsSafeAreaPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxQuickChatWindowZoomPatch(currentSource) {
+  const zoomContractLookbehind = 12_000;
+  const quickChatWindowRootPrefixPattern =
+    /([A-Za-z_$][\w$]*)===`floating`&&([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.floatingSurface,`[^`]*`\),\1===`window`&&/gu;
+  const quickChatWindowRootPattern =
+    /(([A-Za-z_$][\w$]*)===`floating`&&([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.floatingSurface,`[^`]*`\),)\2===`window`&&`relative h-dvh w-full overflow-hidden bg-token-editor-background\/55`/gu;
+  const patchedQuickChatWindowPattern =
+    /([A-Za-z_$][\w$]*)===`floating`&&([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.floatingSurface,`[^`]*`\),\1===`window`&&\2\(\3\.zoomedViewport,`relative overflow-hidden bg-token-editor-background\/55`\)/gu;
+  const roots = [...currentSource.matchAll(quickChatWindowRootPrefixPattern)];
+  if (roots.length > 0) {
+    const patchableRoots = new Map(
+      [...currentSource.matchAll(quickChatWindowRootPattern)].map((match) => [match.index, match]),
+    );
+    const patchedRootIndexes = new Set(
+      [...currentSource.matchAll(patchedQuickChatWindowPattern)].map((match) => match.index),
+    );
+    const hasUnknownRoot = roots.some((root) => {
+      const patchableRoot = patchableRoots.get(root.index);
+      if (patchableRoot == null && !patchedRootIndexes.has(root.index)) {
+        return true;
+      }
+      const [, , , stylesAlias] = root;
+      const regionStart = Math.max(0, root.index - zoomContractLookbehind);
+      const quickChatPrefix = currentSource.slice(regionStart, root.index);
+      const bindingPattern = new RegExp(
+        `(?:^|[^A-Za-z0-9_$])${escapeRegExp(stylesAlias)}=\\{`,
+        "gu",
+      );
+      let bindingMatch = null;
+      for (const match of quickChatPrefix.matchAll(bindingPattern)) {
+        bindingMatch = match;
+      }
+      if (bindingMatch == null) {
+        return true;
+      }
+      const bindingStart = bindingMatch.index + bindingMatch[0].length - 1;
+      const bindingEnd = findMatchingBrace(quickChatPrefix, bindingStart);
+      if (bindingEnd === -1) {
+        return true;
+      }
+      const stylesBinding = quickChatPrefix.slice(bindingStart, bindingEnd + 1);
+      return !(
+        stylesBinding.includes("zoomedViewport:") &&
+        stylesBinding.includes("floatingSurface:")
+      );
+    });
+    if (hasUnknownRoot) {
+      console.warn(
+        "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+      );
+      return currentSource;
+    }
+
+    if (patchableRoots.size === 0) {
+      return currentSource;
+    }
+
+    return currentSource.replace(
+      quickChatWindowRootPattern,
+      (_match, floatingRoot, variantAlias, classNamesAlias, stylesAlias) =>
+        `${floatingRoot}${variantAlias}===\`window\`&&${classNamesAlias}(${stylesAlias}.zoomedViewport,\`relative overflow-hidden bg-token-editor-background/55\`)`,
+    );
+  }
+
+  if (
+    currentSource.includes(".floatingSurface") &&
+    currentSource.includes("relative h-dvh w-full overflow-hidden bg-token-editor-background/55")
+  ) {
+    console.warn(
+      "WARN: Could not find popped-out Quick Chat zoom root insertion point — skipping Quick Chat zoom patch",
+    );
+    return currentSource;
+  }
+
+  return currentSource;
+}
+
 function applyLinuxTooltipWindowControlsCollisionPatch(currentSource) {
   const currentPadding = `padding:{top:${LINUX_TOOLTIP_COLLISION_PADDING_TOP},right:8,bottom:8,left:8}`;
   const defaultMiddleware = "middleware:[a({mainAxis:C,crossAxis:t}),c({padding:8}),l({padding:8}),u({padding:8,apply({availableWidth:e,availableHeight:t,elements:n,rects:r})";
@@ -1822,6 +1899,7 @@ module.exports = {
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
+  applyLinuxQuickChatWindowZoomPatch,
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxFastModeModelGuardPatch,


### PR DESCRIPTION
## What changed

- apply the shared window zoom viewport to popped-out Quick Chat roots
- inventory every structurally discovered Quick Chat root and patch the asset atomically
- validate the exact per-root CSS-module binding before inserting `zoomedViewport`
- add idempotence, multi-root, partial-drift, alias-boundary, and contract-drift regression coverage

## Why

Popped-out Quick Chat received Zoom In, Zoom Out, and Actual Size commands, but its content did not scale. The route stored the shared `--codex-window-zoom` value while its root retained fixed `h-dvh w-full` sizing instead of consuming the existing `zoomedViewport` CSS module.

## Impact

Quick Chat content now follows the same zoom value as the rest of the app while preserving its conversation scroll container. The patch is Linux-only, fail-soft on upstream drift, and leaves the asset unchanged if any discovered Quick Chat root or style contract is unrecognized.

## Validation

- `node --test --test-name-pattern='Quick Chat|zoom contract' scripts/patch-linux-window-ui.test.js` (14 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (382 passed)
- `node --test linux-features/frameless-titlebar/test.js` (6 passed)
- `git diff --check`
- applied idempotently with no warnings to the current installed Quick Chat asset
- independent read-only local LLM review of the final implementation: no findings
- manual NixOS/Hyprland validation: Zoom In/Out/Actual Size scale Quick Chat and conversation scrolling remains functional

## Scope

This is the content-zoom follow-up requested after the separate `frameless-titlebar` Quick Chat change merged in #904.
