### PR TITLE
Add optional Created task sorting for alternate project sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ workarounds.
 | Browser Use node_repl reaper | Opt-in | `node-repl-reaper` | [Docs](linux-features/node-repl-reaper/README.md) |
 | Open Target Discovery | Opt-in | `open-target-discovery` | [Docs](linux-features/open-target-discovery/README.md) |
 | Persistent status panel | Opt-in | `persistent-status-panel` | [Docs](linux-features/persistent-status-panel/README.md) |
+| Project task Created sorting | Opt-in | `project-task-sort` | [Docs](linux-features/project-task-sort/README.md) |
 | Read Aloud button | Opt-in | `read-aloud` | [Docs](linux-features/read-aloud/README.md) |
 | Read Aloud MCP | Opt-in | `read-aloud-mcp` | [Docs](linux-features/read-aloud-mcp/README.md) |
 | Remote Control UI gates | Opt-in | `remote-control-ui` | [Docs](linux-features/remote-control-ui/README.md) |

--- a/linux-features/project-task-sort/README.md
+++ b/linux-features/project-task-sort/README.md
@@ -1,0 +1,28 @@
+# Project Task Created Sorting
+
+Optional current-DMG patch for the alternate Projects sidebar.
+
+When the upstream sidebar rollout exposes `Created`, local task rows may omit
+`conversation.createdAt` even though their `local:<UUIDv7>` keys contain a
+creation timestamp. The unpatched comparator receives `undefined` and keeps
+the previous task order. This feature recovers that timestamp from valid UUIDv7
+keys while preserving explicit creation timestamps, remote tasks, and the
+existing Last updated behavior.
+
+The feature is disabled by default because the affected alternate sidebar is
+rollout-dependent upstream behavior. Enable it in
+`linux-features/features.json`:
+
+```json
+{
+  "enabled": [
+    "project-task-sort"
+  ]
+}
+```
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/project-task-sort/test.js
+```

--- a/linux-features/project-task-sort/feature.json
+++ b/linux-features/project-task-sort/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "project-task-sort",
+  "title": "Project Task Created Sorting",
+  "description": "Restores Created sorting for local tasks in the alternate Projects sidebar.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/project-task-sort/patch.js
+++ b/linux-features/project-task-sort/patch.js
@@ -1,0 +1,59 @@
+"use strict";
+
+const currentCreationTime =
+  "case`local`:return e.conversation==null?e.pendingWorktree.createdAt:t===`updated_at`?e.conversation.recencyAt??e.conversation.updatedAt:e.conversation.createdAt";
+const patchedCreationTime =
+  currentCreationTime +
+  "??(/^local:[\\da-f]{8}-[\\da-f]{4}-7[\\da-f]{3}-[89ab][\\da-f]{3}-[\\da-f]{12}$/i.test(e.key)?Number.parseInt(e.key.slice(6).replaceAll(`-`,``).slice(0,12),16):e.conversation.recencyAt??e.conversation.updatedAt)";
+
+function countOccurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+function applyProjectTaskSortPatch(source) {
+  const currentCount = countOccurrences(source, currentCreationTime);
+  const patchedCount = countOccurrences(source, patchedCreationTime);
+  const unpatchedCount = currentCount - patchedCount;
+
+  if (patchedCount === 1 && unpatchedCount === 0) {
+    return source;
+  }
+
+  if (
+    !source.includes("sidebarElectron.sortMenu.manual") ||
+    !source.includes("sidebarElectron.sortMenu.created")
+  ) {
+    console.warn(
+      "WARN: Could not find current project task sort menu markers - skipping project task sort feature patch",
+    );
+    return source;
+  }
+
+  if (unpatchedCount !== 1 || patchedCount !== 0) {
+    console.warn(
+      "WARN: Could not find current project task creation timestamp insertion point - skipping project task sort feature patch",
+    );
+    return source;
+  }
+
+  return source.replace(currentCreationTime, patchedCreationTime);
+}
+
+const descriptors = [
+  {
+    id: "creation-time",
+    phase: "webview-asset",
+    order: 20_900,
+    ciPolicy: "optional",
+    pattern:
+      /^app-initial~app-main~projects-index-page~remote-conversation-page-[A-Za-z0-9_-]+\.js$/,
+    missingDescription: "project task sort webview bundle",
+    skipDescription: "project task creation timestamp feature patch",
+    apply: applyProjectTaskSortPatch,
+  },
+];
+
+module.exports = {
+  applyProjectTaskSortPatch,
+  descriptors,
+};

--- a/linux-features/project-task-sort/test.js
+++ b/linux-features/project-task-sort/test.js
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const { patchAssetFiles } = require("../../scripts/patches/lib/assets.js");
+const {
+  applyProjectTaskSortPatch,
+  descriptors,
+} = require("./patch.js");
+
+const currentProjectSource = [
+  "function ms(e,t){switch(e.kind){case`local`:return e.conversation==null?e.pendingWorktree.createdAt:t===`updated_at`?e.conversation.recencyAt??e.conversation.updatedAt:e.conversation.createdAt;case`remote`:return((t===`updated_at`?e.task.updated_at??e.task.created_at:e.task.created_at??e.task.updated_at)??0)*1e3}}",
+  "const manualSortId=`sidebarElectron.sortMenu.manual`;",
+  "const createdSortId=`sidebarElectron.sortMenu.created`;",
+].join("");
+
+function captureWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(message);
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function applyPatchTwice(source) {
+  const patched = applyProjectTaskSortPatch(source);
+  const { value: secondPass, warnings } = captureWarns(() =>
+    applyProjectTaskSortPatch(patched),
+  );
+  assert.equal(secondPass, patched);
+  assert.deepEqual(warnings, []);
+  return patched;
+}
+
+function withFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "project-task-sort-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }));
+    return fn();
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("feature is disabled until selected", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+  withFeatureConfig([], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot })
+        .some((descriptor) => descriptor.id === "feature:project-task-sort:creation-time"),
+      false,
+    );
+  });
+  withFeatureConfig(["project-task-sort"], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot })
+        .some((descriptor) => descriptor.id === "feature:project-task-sort:creation-time"),
+      true,
+    );
+  });
+});
+
+test("patch recovers local UUIDv7 creation time", () => {
+  const patched = applyPatchTwice(currentProjectSource);
+
+  assert.ok(
+    patched.includes(
+      "e.conversation.createdAt??(/^local:[\\da-f]{8}-[\\da-f]{4}-7[\\da-f]{3}-[89ab][\\da-f]{3}-[\\da-f]{12}$/i.test(e.key)?Number.parseInt(e.key.slice(6).replaceAll(`-`,``).slice(0,12),16):e.conversation.recencyAt??e.conversation.updatedAt)",
+    ),
+  );
+
+  const context = {};
+  vm.runInNewContext(`${patched};globalThis.timestamp=ms`, context);
+  const older = {
+    key: "local:019e0000-0000-7000-8000-000000000001",
+    kind: "local",
+    conversation: { recencyAt: 400 },
+  };
+  const newer = {
+    key: "local:019f0000-0000-7000-8000-000000000002",
+    kind: "local",
+    conversation: { recencyAt: 100 },
+  };
+
+  assert.ok(context.timestamp(newer, "created_at") > context.timestamp(older, "created_at"));
+  assert.equal(context.timestamp(older, "updated_at"), 400);
+  assert.equal(
+    context.timestamp({ ...older, conversation: { createdAt: 123, recencyAt: 400 } }, "created_at"),
+    123,
+  );
+  assert.equal(
+    context.timestamp(
+      { ...older, key: "local:legacy-id", conversation: { recencyAt: 500 } },
+      "created_at",
+    ),
+    500,
+  );
+  assert.equal(
+    context.timestamp(
+      { ...older, key: "local:019e0000-0000-7garbage", conversation: { recencyAt: 600 } },
+      "created_at",
+    ),
+    600,
+  );
+  assert.equal(
+    context.timestamp(
+      {
+        ...older,
+        key: "local:019e0000-0000-7000-7000-000000000001",
+        conversation: { recencyAt: 700 },
+      },
+      "created_at",
+    ),
+    700,
+  );
+  const remote = { kind: "remote", task: { created_at: 10, updated_at: 20 } };
+  assert.equal(context.timestamp(remote, "created_at"), 10_000);
+  assert.equal(context.timestamp(remote, "updated_at"), 20_000);
+});
+
+test("drift leaves the asset byte-identical", () => {
+  const source = [
+    "function ms(e,t){return e.conversation?.createdTimestamp}",
+    "const manualSortId=`sidebarElectron.sortMenu.manual`;",
+    "const createdSortId=`sidebarElectron.sortMenu.created`;",
+  ].join("");
+  const { value, warnings } = captureWarns(() => applyProjectTaskSortPatch(source));
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project task creation timestamp insertion point/);
+});
+
+test("missing current menu markers leaves the asset byte-identical", () => {
+  const source = currentProjectSource.replace(
+    "const manualSortId=`sidebarElectron.sortMenu.manual`;const createdSortId=`sidebarElectron.sortMenu.created`;",
+    "",
+  );
+  const { value, warnings } = captureWarns(() => applyProjectTaskSortPatch(source));
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project task sort menu markers/);
+});
+
+test("mixed patched and clean helpers are rejected byte-identically", () => {
+  const mixed = `${applyProjectTaskSortPatch(currentProjectSource)}${currentProjectSource}`;
+  const { value, warnings } = captureWarns(() => applyProjectTaskSortPatch(mixed));
+
+  assert.equal(value, mixed);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project task creation timestamp insertion point/);
+});
+
+test("descriptor targets and patches the current project chunk", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "project-task-sort-assets-"));
+  try {
+    const assetsDir = path.join(tempDir, "webview", "assets");
+    const assetPath = path.join(
+      assetsDir,
+      "app-initial~app-main~projects-index-page~remote-conversation-page-y7pwA1Hj.js",
+    );
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(assetPath, currentProjectSource);
+
+    const result = patchAssetFiles(
+      tempDir,
+      descriptors[0].pattern,
+      descriptors[0].apply,
+      "missing",
+    );
+
+    assert.deepEqual(result, { matched: 1, changed: 1 });
+    assert.notEqual(fs.readFileSync(assetPath, "utf8"), currentProjectSource);
+    assert.equal(
+      descriptors[0].pattern.test(
+        "app-initial~app-main~projects-index-page~settings-page-y7pwA1Hj.js",
+      ),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #894.

The alternate Projects sidebar accepts `Created`, but current local task rows do not carry `conversation.createdAt`. The existing creation-time comparator therefore receives `undefined` and preserves the previous last-updated order.

This change adds a disabled-by-default `project-task-sort` Linux Feature that:

- recovers the creation timestamp from a complete RFC-compatible local UUIDv7 key when `createdAt` is absent;
- preserves explicit `createdAt`, `Last updated`, and remote-task behavior, while introducing an explicit `recencyAt ?? updatedAt` fallback for legacy or malformed local IDs;
- targets only the current project sidebar chunk;
- reports marker drift instead of allowing a false `already-applied`, and rejects mixed patched/unpatched source byte-identically.

The feature is opt-in because the affected alternate sidebar is rollout-dependent upstream behavior rather than required Linux compatibility. The visible behavior is task ordering inside expanded project groups; it does not change project-group ordering.

Enable it in `linux-features/features.json`:

```json
{
  "enabled": ["project-task-sort"]
}
```

## Validation

Environment:

- repo base: `413e484`
- commit: `abbc3d3`
- DMG SHA-256: `a66a0645fd4de6f4f22e75ca87bedb1585aeb57f3457a3df55509bf8da110879`
- DMG ETag: `0x8DEDFD6908B6AB0`
- DMG size: `560735555` bytes
- app: `26.707.51957`
- Electron: `42.1.0`
- KDE Plasma Wayland, isolated side-by-side identity

Checks:

- `node --test linux-features/project-task-sort/test.js` (6 passed)
- `node --test linux-features/*/test.js` (560 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (368 passed)
- `node --test scripts/lib/linux-features.test.js` (10 passed)
- `bash tests/scripts_smoke.sh`
- `node --check` on the feature source, tests, and generated current project sidebar asset
- `node scripts/ci/validate-patch-report.js` on the isolated build report
- `git diff --check`
- independent full-diff bug/security and maintainability reviews
- isolated current-DMG build accepted with `feature:project-task-sort:creation-time: applied`, no warnings, and clean source provenance
- direct second pass on the generated active asset was byte-stable with the complete UUIDv7 marker

Runtime validation forced only the alternate sidebar rollout in the isolated instance. `Created` sorted visible local tasks by UUIDv7 creation time in two projects; `Last updated` restored the known recency order; the orders differed, the console remained clean, and `Priority` was restored afterward. This account state exposed `Created` and `Last updated`; `Manual order` was not exposed and its upstream handler is unchanged. Moving the unchanged patch logic into the feature boundary was revalidated with a clean current-DMG build and patch report.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed the default core patch.
- [x] The feature is disabled by default and targets only the latest `CODEX.DMG` contract.
- [x] I added feature-local tests, ran the validation listed above, and confirmed current-DMG acceptance.
- [x] I reviewed the final diff with independent coding-agent passes and addressed all findings.
