### PR TITLE
Preserve source remote in Nix builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
           ];
         };
         flakeSourceCommit = self.rev or (self.dirtyRev or "");
+        flakeSourceRemote = "https://github.com/ilysenko/codex-desktop-linux.git";
         flakeSourceDateEpoch = toString (self.lastModified or 1);
         sourceRoot = pkgs.lib.cleanSourceWith {
           src = ./.;
@@ -518,6 +519,7 @@ PY
             export SOURCE_DATE_EPOCH="${flakeSourceDateEpoch}"
             ${pkgs.lib.optionalString (flakeSourceCommit != "") ''
             export CODEX_LINUX_SOURCE_COMMIT="${flakeSourceCommit}"
+            export CODEX_LINUX_SOURCE_REMOTE="${flakeSourceRemote}"
             ''}
             ${pkgs.lib.optionalString enableComputerUseUi ''
             export CODEX_LINUX_ENABLE_COMPUTER_USE_UI=1

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5025,6 +5025,7 @@ test_launcher_template_sanity() {
     assert_contains "$REPO_DIR/launcher/start.sh.template" "codex_capture_original_ld_library_path"
     assert_contains "$REPO_DIR/flake.nix" 'export LD_LIBRARY_PATH="${electronLibPath}:${runtimeLibPath}'
     assert_not_contains "$REPO_DIR/flake.nix" '--prefix LD_LIBRARY_PATH'
+    assert_contains "$REPO_DIR/flake.nix" 'export CODEX_LINUX_SOURCE_REMOTE="${flakeSourceRemote}"'
     assert_contains "$REPO_DIR/install.sh" 'DEFAULT_CODEX_WEBVIEW_PORT=5175'
     assert_contains "$REPO_DIR/install.sh" "inspect_rebuild_candidate"
     assert_contains "$REPO_DIR/scripts/lib/install-helpers.sh" "--inspect"


### PR DESCRIPTION
## Summary

- pass the canonical repository remote into Nix package builds through `CODEX_LINUX_SOURCE_REMOTE`
- add smoke coverage for the Nix environment wiring

## Why

Nix clean-source builds retain the source revision but do not have Git repository metadata available at build time. Without an explicit remote, build info cannot reliably derive a clickable GitHub commit URL.

## Validation

- `nix flake check --no-build --no-write-lock-file` (passed)
- `bash tests/scripts_smoke.sh` (all package and source-metadata coverage passed; the suite later stopped at the pre-existing environment-dependent sudo sound assertion: `Expected alert before authentication`)
- `git diff --check`