### PR TITLE
feat(computer-use): add Niri window backend

### DIFF
--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -1,6 +1,6 @@
 use crate::windowing::registry::{
     self, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, KWIN_BACKEND,
+    HYPRLAND_BACKEND, KWIN_BACKEND, NIRI_BACKEND,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -21,6 +21,7 @@ const DESKTOP_ENV_KEYS: &[&str] = &[
     "DESKTOP_SESSION",
     "DISPLAY",
     "HYPRLAND_INSTANCE_SIGNATURE",
+    "NIRI_SOCKET",
     "XAUTHORITY",
     "YDOTOOL_SOCKET",
     "XDG_SESSION_DESKTOP",
@@ -110,6 +111,7 @@ pub struct WindowingReport {
     pub cosmic_helper: Check,
     pub kwin: Check,
     pub hyprland: Check,
+    pub niri: Check,
     pub backends: BTreeMap<String, Check>,
     pub can_list_windows: bool,
     pub can_focus_apps: bool,
@@ -240,6 +242,9 @@ fn capability_map(
     }
     if windowing.hyprland.ok {
         window_backends.push("hyprland".to_string());
+    }
+    if windowing.niri.ok {
+        window_backends.push(NIRI_BACKEND.to_string());
     }
     if windowing.cosmic_helper.ok {
         window_backends.push("cosmic".to_string());
@@ -579,6 +584,7 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
     let cosmic_helper = backend_check(COSMIC_WAYLAND_BACKEND);
     let kwin = backend_check(KWIN_BACKEND);
     let hyprland = backend_check(HYPRLAND_BACKEND);
+    let niri = backend_check(NIRI_BACKEND);
     let backends = probes
         .iter()
         .map(|probe| (probe.id.to_string(), check_from_backend_probe(probe)))
@@ -593,11 +599,13 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
             "A KWin/Plasma window backend is available for list_windows, focused_window, and targeted input verification."
         } else if hyprland.ok {
             "A Hyprland window backend is available for list_windows, focused_window, and targeted input verification."
+        } else if niri.ok {
+            "A Niri window backend is available for list_windows, focused_window, and targeted input verification."
         } else {
             "A GNOME window listing backend is available for list_windows, focused_window, and targeted input verification."
         }
     } else {
-        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On COSMIC, ensure the bundled COSMIC helper is present and can connect to the session. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session."
+        "Window listing is unavailable or denied. Computer Use can still use screenshots, AT-SPI, and global ydotool input, but targeted window input cannot be verified. On GNOME, run setup_window_targeting to install the optional GNOME Shell extension backend. On COSMIC, ensure the bundled COSMIC helper is present and can connect to the session. On KDE/Plasma, ensure KWin exposes org.kde.KWin scripting on the session bus. On Hyprland, ensure hyprctl is available in the session. On Niri, ensure NIRI_SOCKET is available and niri msg can reach the active compositor."
     }
     .to_string();
 
@@ -608,6 +616,7 @@ fn windowing_report(platform: &PlatformReport) -> WindowingReport {
         cosmic_helper,
         kwin,
         hyprland,
+        niri,
         backends,
         can_list_windows,
         can_focus_apps,
@@ -1054,6 +1063,7 @@ mod tests {
             cosmic_helper: Check::fail("missing"),
             kwin: Check::fail("not a KWin session"),
             hyprland: Check::fail("not a Hyprland session"),
+            niri: Check::fail("not a Niri session"),
             backends: BTreeMap::new(),
             can_list_windows,
             can_focus_apps: true,
@@ -1150,6 +1160,11 @@ mod tests {
     }
 
     #[test]
+    fn desktop_env_hydration_includes_niri_socket() {
+        assert!(DESKTOP_ENV_KEYS.contains(&"NIRI_SOCKET"));
+    }
+
+    #[test]
     fn graphical_process_env_requires_display() {
         let with_display = HashMap::from([("DISPLAY".to_string(), ":0".to_string())]);
         let with_wayland =
@@ -1210,6 +1225,24 @@ mod tests {
         assert!(readiness.can_focus_apps);
         assert!(readiness.can_focus_windows);
         assert!(readiness.blockers.is_empty());
+    }
+
+    #[test]
+    fn capability_map_reports_niri_window_control() {
+        let platform = platform_report();
+        let portals = portal_report(Check::fail("missing"));
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let mut windowing = windowing_report(false, false);
+        windowing.niri = Check::ok("niri msg returned windows");
+        let input = input_report(false);
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert_eq!(capabilities.window_control, vec![NIRI_BACKEND]);
+        assert_eq!(
+            capabilities.preferred.window_control.as_deref(),
+            Some(NIRI_BACKEND)
+        );
     }
 
     #[test]

--- a/computer-use-linux/src/windowing/backends/mod.rs
+++ b/computer-use-linux/src/windowing/backends/mod.rs
@@ -3,3 +3,4 @@ pub mod gnome;
 pub mod hyprland;
 pub mod i3;
 pub mod kwin;
+pub mod niri;

--- a/computer-use-linux/src/windowing/backends/niri.rs
+++ b/computer-use-linux/src/windowing/backends/niri.rs
@@ -115,7 +115,7 @@ struct NiriWindow {
     title: Option<String>,
     app_id: Option<String>,
     pid: Option<i64>,
-    workspace_id: Option<i64>,
+    workspace_id: Option<u64>,
     #[serde(default)]
     is_focused: bool,
     layout: Option<NiriWindowLayout>,

--- a/computer-use-linux/src/windowing/backends/niri.rs
+++ b/computer-use-linux/src/windowing/backends/niri.rs
@@ -1,0 +1,160 @@
+use crate::terminal::enrich_terminal_windows;
+use crate::windowing::registry::BackendProbe;
+use crate::windowing::types::{WindowBounds, WindowInfo};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::process::Command;
+
+pub const NIRI_BACKEND: &str = "niri";
+
+pub fn probe() -> BackendProbe {
+    match niri_output(&["msg", "--json", "windows"]) {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let ok = matches!(
+                serde_json::from_str::<serde_json::Value>(&stdout),
+                Ok(serde_json::Value::Array(_))
+            );
+            BackendProbe {
+                id: NIRI_BACKEND,
+                ok,
+                can_list_windows: ok,
+                can_focus_apps: ok,
+                can_focus_windows: ok,
+                detail: if ok {
+                    "niri msg --json windows returned a JSON array".to_string()
+                } else {
+                    "niri msg --json windows did not return a JSON array".to_string()
+                },
+            }
+        }
+        Ok(output) => BackendProbe {
+            id: NIRI_BACKEND,
+            ok: false,
+            can_list_windows: false,
+            can_focus_apps: false,
+            can_focus_windows: false,
+            detail: command_failure_detail(&output),
+        },
+        Err(error) => BackendProbe {
+            id: NIRI_BACKEND,
+            ok: false,
+            can_list_windows: false,
+            can_focus_apps: false,
+            can_focus_windows: false,
+            detail: error.to_string(),
+        },
+    }
+}
+
+pub fn list_windows() -> Result<Vec<WindowInfo>> {
+    let output = niri_output(&["msg", "--json", "windows"])
+        .context("failed to run niri msg --json windows")?;
+    if !output.status.success() {
+        bail!(
+            "niri msg --json windows failed: {}",
+            command_failure_detail(&output)
+        );
+    }
+
+    parse_niri_windows(&String::from_utf8_lossy(&output.stdout))
+}
+
+pub(crate) fn parse_niri_windows(json: &str) -> Result<Vec<WindowInfo>> {
+    let records: Vec<NiriWindow> =
+        serde_json::from_str(json).context("failed to parse niri msg --json windows output")?;
+    let mut windows = records
+        .into_iter()
+        .map(WindowInfo::from)
+        .collect::<Vec<_>>();
+    windows.sort_by_key(|window| window.window_id);
+    enrich_terminal_windows(&mut windows);
+    Ok(windows)
+}
+
+pub fn activate_window(window_id: u64) -> Result<()> {
+    let args = niri_focus_args(window_id);
+    let output = niri_output(&args.iter().map(String::as_str).collect::<Vec<_>>())
+        .with_context(|| format!("failed to focus Niri window {window_id}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        bail!(
+            "niri msg action focus-window --id {window_id} failed: {}",
+            command_failure_detail(&output)
+        );
+    }
+}
+
+pub(crate) fn niri_focus_args(window_id: u64) -> [String; 5] {
+    [
+        "msg".to_string(),
+        "action".to_string(),
+        "focus-window".to_string(),
+        "--id".to_string(),
+        window_id.to_string(),
+    ]
+}
+
+fn niri_output(args: &[&str]) -> std::io::Result<std::process::Output> {
+    Command::new("niri").args(args).output()
+}
+
+fn command_failure_detail(output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    } else {
+        stderr
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriWindow {
+    id: u64,
+    title: Option<String>,
+    app_id: Option<String>,
+    pid: Option<i64>,
+    workspace_id: Option<i64>,
+    #[serde(default)]
+    is_focused: bool,
+    layout: Option<NiriWindowLayout>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NiriWindowLayout {
+    window_size: Option<[i64; 2]>,
+}
+
+impl From<NiriWindow> for WindowInfo {
+    fn from(window: NiriWindow) -> Self {
+        let bounds = window.layout.and_then(|layout| {
+            let [width, height] = layout.window_size?;
+            let width = u32::try_from(width).ok().filter(|value| *value > 0)?;
+            let height = u32::try_from(height).ok().filter(|value| *value > 0)?;
+            Some(WindowBounds {
+                x: None,
+                y: None,
+                width,
+                height,
+            })
+        });
+
+        Self {
+            window_id: window.id,
+            title: window.title,
+            app_id: window.app_id.clone(),
+            wm_class: window.app_id,
+            pid: window.pid.and_then(|pid| u32::try_from(pid).ok()),
+            bounds,
+            workspace: window
+                .workspace_id
+                .and_then(|workspace| i32::try_from(workspace).ok()),
+            focused: window.is_focused,
+            hidden: false,
+            client_type: None,
+            backend: NIRI_BACKEND.to_string(),
+            terminal: None,
+        }
+    }
+}

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 #[allow(unused_imports)]
 pub use registry::{
     COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
-    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, WINDOW_PERMISSION_HINT,
+    HYPRLAND_BACKEND, I3_BACKEND, KWIN_BACKEND, NIRI_BACKEND, WINDOW_PERMISSION_HINT,
 };
 #[allow(unused_imports)]
 pub use target::{
@@ -25,9 +25,10 @@ mod tests {
         kwin_activate_script_source, kwin_window_id_from_uuid, kwin_window_script_source,
         parse_kwin_windows, KWIN_BACKEND,
     };
+    use super::backends::niri::{niri_focus_args, parse_niri_windows, NIRI_BACKEND};
     use super::registry::{
-        descriptors, list_note, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND,
-        GNOME_SHELL_INTROSPECT_BACKEND,
+        backend_can_exact_focus, descriptors, list_note, COSMIC_WAYLAND_BACKEND,
+        GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
     };
     use super::target::ensure_backend_can_focus_target;
     use super::*;
@@ -55,8 +56,92 @@ mod tests {
                 COSMIC_WAYLAND_BACKEND,
                 KWIN_BACKEND,
                 HYPRLAND_BACKEND,
+                NIRI_BACKEND,
                 I3_BACKEND,
             ]
+        );
+    }
+
+    #[test]
+    fn niri_backend_can_exact_focus_targets() {
+        assert!(backend_can_exact_focus(NIRI_BACKEND));
+    }
+
+    #[test]
+    fn niri_parses_window_records_without_inventing_global_coordinates() {
+        let json = r#"[
+          {
+            "id": 42,
+            "title": "Niri Computer Use Test",
+            "app_id": "com.mitchellh.ghostty",
+            "pid": 1234,
+            "workspace_id": 7,
+            "is_focused": true,
+            "is_floating": false,
+            "unknown_future_field": "ignored",
+            "layout": {
+              "window_size": [1200, 800],
+              "tile_pos_in_workspace_view": null,
+              "window_offset_in_tile": [0.0, 0.0]
+            }
+          }
+        ]"#;
+
+        let windows = parse_niri_windows(json).unwrap();
+
+        assert_eq!(windows.len(), 1);
+        let window = &windows[0];
+        assert_eq!(window.window_id, 42);
+        assert_eq!(window.title.as_deref(), Some("Niri Computer Use Test"));
+        assert_eq!(window.app_id.as_deref(), Some("com.mitchellh.ghostty"));
+        assert_eq!(window.wm_class.as_deref(), Some("com.mitchellh.ghostty"));
+        assert_eq!(window.pid, Some(1234));
+        assert_eq!(window.workspace, Some(7));
+        assert!(window.focused);
+        assert!(!window.hidden);
+        assert_eq!(window.client_type, None);
+        assert_eq!(window.backend, NIRI_BACKEND);
+        let bounds = window.bounds.as_ref().unwrap();
+        assert_eq!(bounds.x, None);
+        assert_eq!(bounds.y, None);
+        assert_eq!(bounds.width, 1200);
+        assert_eq!(bounds.height, 800);
+    }
+
+    #[test]
+    fn niri_tolerates_nullable_metadata_and_rejects_unsafe_numeric_values() {
+        let json = r#"[
+          {
+            "id": 9,
+            "title": null,
+            "app_id": null,
+            "pid": -1,
+            "workspace_id": 2147483648,
+            "is_focused": false,
+            "layout": { "window_size": [0, 600] }
+          }
+        ]"#;
+
+        let windows = parse_niri_windows(json).unwrap();
+        let window = &windows[0];
+
+        assert_eq!(window.title, None);
+        assert_eq!(window.app_id, None);
+        assert_eq!(window.pid, None);
+        assert_eq!(window.workspace, None);
+        assert!(window.bounds.is_none());
+    }
+
+    #[test]
+    fn niri_accepts_an_empty_window_list() {
+        assert!(parse_niri_windows("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn niri_builds_exact_focus_arguments() {
+        assert_eq!(
+            niri_focus_args(42),
+            ["msg", "action", "focus-window", "--id", "42"]
         );
     }
 

--- a/computer-use-linux/src/windowing/mod.rs
+++ b/computer-use-linux/src/windowing/mod.rs
@@ -133,6 +133,26 @@ mod tests {
     }
 
     #[test]
+    fn niri_keeps_listing_windows_when_workspace_id_exceeds_internal_range() {
+        let json = format!(
+            r#"[{{
+              "id": 10,
+              "title": "Large workspace id",
+              "app_id": "example",
+              "workspace_id": {},
+              "is_focused": false
+            }}]"#,
+            u64::MAX
+        );
+
+        let windows = parse_niri_windows(&json).unwrap();
+
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].window_id, 10);
+        assert_eq!(windows[0].workspace, None);
+    }
+
+    #[test]
     fn niri_accepts_an_empty_window_list() {
         assert!(parse_niri_windows("[]").unwrap().is_empty());
     }

--- a/computer-use-linux/src/windowing/registry.rs
+++ b/computer-use-linux/src/windowing/registry.rs
@@ -1,4 +1,4 @@
-use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin};
+use crate::windowing::backends::{cosmic, gnome, hyprland, i3, kwin, niri};
 use crate::windowing::types::WindowInfo;
 use anyhow::{anyhow, Result};
 
@@ -7,8 +7,9 @@ pub use gnome::{GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND};
 pub use hyprland::HYPRLAND_BACKEND;
 pub use i3::I3_BACKEND;
 pub use kwin::KWIN_BACKEND;
+pub use niri::NIRI_BACKEND;
 
-pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
+pub const WINDOW_PERMISSION_HINT: &str = "Computer Use could not access a supported window list backend. Targeted window input requires session-bus access plus GNOME Shell Introspect, the Codex GNOME Shell extension, the COSMIC Wayland helper, KWin/Plasma DBus scripting, Hyprland hyprctl, Niri IPC, or i3-msg. On GNOME, run setup_window_targeting to install the extension backend.";
 
 #[derive(Debug, Clone, Copy)]
 pub struct BackendDescriptor {
@@ -36,6 +37,7 @@ enum BackendKind {
     Cosmic,
     Kwin,
     Hyprland,
+    Niri,
     I3,
 }
 
@@ -45,6 +47,7 @@ const BACKEND_ORDER: &[BackendKind] = &[
     BackendKind::Cosmic,
     BackendKind::Kwin,
     BackendKind::Hyprland,
+    BackendKind::Niri,
     BackendKind::I3,
 ];
 
@@ -82,6 +85,13 @@ const DESCRIPTORS: &[BackendDescriptor] = &[
         failure_label: "Hyprland",
         list_note: "Window list came from Hyprland hyprctl. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
         missing_hint: "On Hyprland, ensure hyprctl is available in the session.",
+        can_exact_focus: true,
+    },
+    BackendDescriptor {
+        id: NIRI_BACKEND,
+        failure_label: "Niri",
+        list_note: "Window list came from Niri IPC. Terminal windows may include best-effort PTY and active-process context when the process tree is readable.",
+        missing_hint: "On Niri, ensure NIRI_SOCKET is available and niri msg can reach the active compositor.",
         can_exact_focus: true,
     },
     BackendDescriptor {
@@ -152,6 +162,7 @@ async fn list_windows_for(backend: BackendKind) -> Result<Vec<WindowInfo>> {
         BackendKind::Cosmic => cosmic::list_windows(),
         BackendKind::Kwin => kwin::list_windows().await,
         BackendKind::Hyprland => hyprland::list_windows(),
+        BackendKind::Niri => niri::list_windows(),
         BackendKind::I3 => i3::list_windows(),
     }
 }
@@ -175,6 +186,7 @@ pub async fn activate_window(window: &WindowInfo) -> Result<()> {
         COSMIC_WAYLAND_BACKEND => cosmic::activate_window(window.window_id),
         KWIN_BACKEND => kwin::activate_window(window.window_id).await,
         HYPRLAND_BACKEND => hyprland::activate_window(window.window_id),
+        NIRI_BACKEND => niri::activate_window(window.window_id),
         I3_BACKEND => i3::activate_window(window.window_id),
         backend => Err(anyhow!(
             "Unsupported window backend for activation: {backend}"
@@ -193,6 +205,7 @@ pub fn probe_backends() -> Vec<BackendProbe> {
         cosmic::probe(),
         kwin::probe(),
         hyprland::probe(),
+        niri::probe(),
         i3::probe(),
     ]
 }
@@ -205,6 +218,7 @@ impl BackendKind {
             BackendKind::Cosmic => COSMIC_WAYLAND_BACKEND,
             BackendKind::Kwin => KWIN_BACKEND,
             BackendKind::Hyprland => HYPRLAND_BACKEND,
+            BackendKind::Niri => NIRI_BACKEND,
             BackendKind::I3 => I3_BACKEND,
         }
     }

--- a/docs/linux-computer-use.md
+++ b/docs/linux-computer-use.md
@@ -8,7 +8,8 @@ It supports:
 
 - app listing and accessibility trees through AT-SPI
 - screenshots through GNOME Shell DBus, the Codex GNOME Shell extension, or XDG Desktop Portal
-- window listing and focusing on GNOME, KWin/Plasma, Hyprland, COSMIC, and i3
+- window listing and focusing on GNOME, KWin/Plasma, Hyprland, Niri, COSMIC,
+  and i3
 - keyboard, text, click, scroll, and drag input through `/dev/uinput`, XDG
   RemoteDesktop portal, or `ydotool`
 
@@ -55,6 +56,11 @@ or screenshots:
 - sway/wlroots: `xdg-desktop-portal-wlr`
 - Hyprland: `xdg-desktop-portal-hyprland`
 - GNOME: usually available by default
+
+Niri window listing and exact focus use the `niri` command and the active
+session's `NIRI_SOCKET`. The Computer Use backend hydrates `NIRI_SOCKET` for GUI
+starts, but the socket must still belong to the active Niri session and be
+reachable by the desktop user.
 
 ## Verify Readiness
 


### PR DESCRIPTION
## Summary

- add a first-class Niri window backend to Linux Computer Use
- enumerate Niri windows through `niri msg --json windows`
- focus exact Niri window IDs through `niri msg action focus-window --id`
- hydrate `NIRI_SOCKET` for GUI-launched Computer Use processes
- expose Niri in doctor readiness and preferred window-control capabilities
- update the current ChatGPT Desktop renderer patches so Linux receives the `Any App` row and native-app queries after the upstream bundle split

## Why

Linux Computer Use already supported GNOME, KWin/Plasma, Hyprland, COSMIC, and i3, but Niri sessions had no window enumeration or focus backend. Screenshots, AT-SPI, and input could be available while `can_query_windows` and exact focus remained unavailable, leaving the Computer Use settings surface with only the Chrome integration.

The current upstream ChatGPT Desktop DMG (`26.707.51957`) also moved the native-app query hook into an `app-initial~app-main~new-thread-panel...` bundle and changed the settings availability declaration to a comma-chained form. The existing descriptor patched another matching surface and reported success, but the active renderer still excluded Linux.

## Implementation

- `computer-use-linux/src/windowing/backends/niri.rs` owns Niri CLI probing, tolerant JSON parsing, enumeration, and exact focus.
- The existing registry selects Niri after Hyprland and before i3 without changing other desktop backends.
- Niri window sizes are reported when valid, but global `x`/`y` remain unset because Niri's scrolling layout does not reliably expose safe global coordinates.
- The Computer Use UI descriptor now scans the current app-initial bundle in addition to the settings bundle.
- The availability patch handles both semicolon-terminated and comma-chained current upstream declarations.

No generated application or package output is committed.

## User-visible behavior

On a Niri session with the Linux Computer Use UI enabled:

- `doctor` reports Niri window listing and exact focus as available.
- `windows` returns live Niri windows with stable IDs, app IDs, PIDs, workspace IDs, focus state, and safe size metadata.
- ChatGPT Desktop's Computer Use settings show `Any App` alongside Google Chrome.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `cargo check -p codex-computer-use-linux`
- `cargo test -p codex-computer-use-linux` — 140 tests passed per library/binary target
- `node --test scripts/patch-linux-window-ui.test.js` — 369 tests passed
- `bash tests/scripts_smoke.sh`
- packaged pacman update via `make update-native` on CachyOS/Niri
- live installed backend verification:
  - Niri probe succeeds
  - `window_control` and preferred backend are `niri`
  - Firefox, Ghostty, and ChatGPT windows enumerate successfully
  - Computer Use displays both `Any App` and Google Chrome

## Scope and limitations

- Tested on CachyOS with Niri 26.04 and the pacman package path.
- This adds enumeration and exact focus only; it does not add Niri layout management, move, resize, or close operations.
- Existing compositor backends and package formats are unchanged.

## Manual verification artifacts

The screenshots below show the same CachyOS/Niri installation before and after the change. Before, Computer Use exposed only the Chrome integration; after rebuilding, the native `Any App` control appears alongside Chrome.

| Before | After |
|---|---|
| ![Computer Use on Niri before this change](https://raw.githubusercontent.com/wazimmerman/codex-desktop-linux/pr-artifacts/.github/pr-artifacts/917-computer-use-before.png) | ![Computer Use on Niri after this change](https://raw.githubusercontent.com/wazimmerman/codex-desktop-linux/pr-artifacts/.github/pr-artifacts/917-computer-use-after.png) |