### PR TITLE
Fix Remote Mobile patch targeting for current app bundle

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -52,7 +52,7 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_RUNTIME_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/u;
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/u;
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
@@ -73,6 +73,8 @@ const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
   ["Control Mac apps from your phone", "Control Linux apps from your phone"],
   ["Let Codex control the apps on your Mac.", "Let Codex control apps on this Linux desktop."],
   ["Let Codex control the apps on your Mac", "Let Codex control apps on this Linux desktop"],
+  ["Let ChatGPT control apps on your Mac", "Let ChatGPT control apps on this Linux desktop"],
+  ["connected to ChatGPT on a Mac", "connected to ChatGPT on this Linux desktop"],
   ["Connect a device to this Mac", "Connect a device to this Linux desktop"],
   ["Connect your phone to this Mac", "Connect your phone to this Linux desktop"],
   ["Add device to control this Mac remotely", "Add a device to control this Linux desktop remotely"],
@@ -1378,7 +1380,7 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
+    pattern: REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",
@@ -1388,7 +1390,7 @@ module.exports = [
   {
     id: "linux-remote-control-copy",
     phase: "webview-asset",
-    pattern: /^(?:codex-mobile-setup-flow|remote-connections-settings|use-codex-mobile-connected-settings)-.*\.js$/,
+    pattern: /^(?:codex-mobile-setup-dialog|remote-connections-settings)-.*\.js$/,
     order: 20_130,
     ciPolicy: "optional",
     missingDescription: "remote-control settings or mobile setup bundle",

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -46,15 +46,15 @@ const REMOTE_MOBILE_ACTIVE_STATUS_MARKER = "codexLinuxRemoteMobileActiveStatus";
 const REMOTE_CONTROL_STATUS_READ_GUARD_MARKER = "codexLinuxRemoteControlShouldReadStatus";
 const REMOTE_CONTROL_STATUS_WAIT_MARKER = "codexLinuxRemoteControlStatusWaitMs";
 const REMOTE_CONTROL_REVOKE_SETUP_RESET_MARKER = "codexLinuxRemoteControlResetMobileSetupAfterRevoke";
+const REMOTE_CONTROL_VISIBILITY_MARKER = "codexLinuxRemoteControlVisibilityEnabled";
+const REMOTE_CONTROL_COPY_MARKER = "codexLinuxRemoteControlCopy";
 const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAppServerArgs";
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
-const REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/u;
+const REMOTE_MOBILE_RUNTIME_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/u;
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
-const REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
   /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [
@@ -439,18 +439,15 @@ function applyLinuxRemoteControlFeatureSyncHostScopePatch(source) {
 }
 
 function applyLinuxRemoteControlVisibilityPatch(source) {
-  if (
-    source.includes("remoteControlConnectionsState") &&
-      source.includes("navigator.userAgent.includes(`Linux`)")
-  ) {
-    return source;
-  }
   if (!source.includes("remoteControlConnectionsState")) {
     return source;
   }
 
   const settingsVisibilityMatch = source.match(REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE);
   if (settingsVisibilityMatch == null) {
+    if (source.includes(REMOTE_CONTROL_VISIBILITY_MARKER)) {
+      return source;
+    }
     console.warn("WARN: Could not find remote-control visibility gate - skipping Linux remote-control visibility patch");
     return source;
   }
@@ -458,7 +455,7 @@ function applyLinuxRemoteControlVisibilityPatch(source) {
   const [, functionName, stateVar, slingshotVar] = settingsVisibilityMatch;
   return source.replace(
     REMOTE_CONTROL_SETTINGS_VISIBILITY_NEEDLE,
-    `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
+    `function ${functionName}({remoteControlConnectionsState:${stateVar},slingshotEnabled:${slingshotVar}}){let n=typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`);/*${REMOTE_CONTROL_VISIBILITY_MARKER}*/return(n||${slingshotVar})&&(n||(${stateVar}?.available??!0))&&${stateVar}?.accessRequired!==!0}`,
   );
 }
 
@@ -487,8 +484,12 @@ function replaceLinuxRemoteControlCopy(source) {
 }
 
 function applyLinuxRemoteControlCopyPatch(source) {
+  const hasMarker = source.includes(REMOTE_CONTROL_COPY_MARKER);
   const { patched, changed } = replaceLinuxRemoteControlCopy(source);
   if (!changed) {
+    if (hasMarker) {
+      return source;
+    }
     if (
       !source.includes("this Mac") &&
       !source.includes("Keep this Mac awake") &&
@@ -501,7 +502,7 @@ function applyLinuxRemoteControlCopyPatch(source) {
     console.warn("WARN: Could not find remote-control Mac copy - skipping Linux remote-control copy patch");
     return source;
   }
-  return patched;
+  return hasMarker ? patched : `/*${REMOTE_CONTROL_COPY_MARKER}*/${patched}`;
 }
 
 function applyLinuxRemoteControlSshInstallActionPatch(source) {
@@ -1357,7 +1358,7 @@ module.exports = [
   {
     id: "linux-remote-control-load-gate",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_118,
     ciPolicy: "optional",
     missingDescription: "remote-control loader gate bundle",
@@ -1377,7 +1378,7 @@ module.exports = [
   {
     id: "linux-remote-control-visibility",
     phase: "webview-asset",
-    pattern: REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_120,
     ciPolicy: "optional",
     missingDescription: "remote-control connections visibility bundle",
@@ -1427,7 +1428,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-conversation-hydration",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_150,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1437,7 +1438,7 @@ module.exports = [
   {
     id: "linux-remote-mobile-completed-item-recovery",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_151,
     ciPolicy: "optional",
     missingDescription: "app-server conversation manager bundle",
@@ -1447,7 +1448,7 @@ module.exports = [
   {
     id: "linux-remote-terminal-status-recovery",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_152,
     ciPolicy: "optional",
     missingDescription: "app-server conversation manager bundle",
@@ -1457,7 +1458,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-read-guard",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_CONVERSATION_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_153,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",
@@ -1467,7 +1468,7 @@ module.exports = [
   {
     id: "linux-remote-control-status-wait",
     phase: "webview-asset",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
+    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
     order: 20_154,
     ciPolicy: "optional",
     missingDescription: "app-server manager signals bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -53,11 +53,12 @@ const CURRENT_REMOTE_CONVERSATION_ASSET =
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
 const CURRENT_REMOTE_RUNTIME_ASSET =
-  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
+  "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
 const CURRENT_APP_MAIN_PAGE_ASSET =
   "app-initial~app-main~page-test.js";
+const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET = CURRENT_APP_MAIN_PAGE_ASSET;
 const CURRENT_REMOTE_CONVERSATION_STATUS_ASSET =
   "app-initial~app-main~projects-index-page~remote-conversation-page-test.js";
 
@@ -204,8 +205,8 @@ function syntheticCurrentUsePluginVisibilityBundle() {
   return "function ke({remoteControlConnectionsState:e,slingshotEnabled:t}){return t&&(e?.available??!0)&&e?.accessRequired!==!0}export{ke as l};";
 }
 
-function syntheticMobileConnectedSettingsBundle() {
-  return "let y={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let Codex control the apps on your Mac.`,description:`Description for enabling Computer Use after mobile setup`};";
+function syntheticMobileSetupDialogComputerUseBundle() {
+  return "let y={id:`codexMobile.setupDialog.connected.computerUse.description`,defaultMessage:`Let ChatGPT control apps on your Mac`,description:`Description for enabling Computer Use after mobile setup`};";
 }
 
 function syntheticRemoteConnectionsSettingsCopyBundle() {
@@ -217,10 +218,11 @@ function syntheticRemoteConnectionsSettingsCopyBundle() {
     "let c={id:`settings.remoteConnections.accessOtherDevices.header.title`,defaultMessage:`Devices you can control from this Mac`,description:`Header title for the devices this computer can access`};",
     "let d={id:`settings.remoteConnections.ssh.header.title`,defaultMessage:`SSH connections from this Mac`,description:`Header title for SSH connections from this Mac`};",
     "let e={id:`settings.remoteControlConnections.keepAwake.title`,defaultMessage:`Keep this Mac awake`,description:`Keep awake title`};",
+    "let f={id:`settings.remoteConnections.connectedDevices.description`,defaultMessage:`iPhone Pro and Samsung Galaxy devices connected to ChatGPT on a Mac`,description:`Connected device description`};",
   ].join("");
 }
 
-function syntheticMobileSetupFlowCopyBundle() {
+function syntheticMobileSetupDialogCopyBundle() {
   return [
     "let a={id:`codexMobile.setupDialog.connected.lockedComputerUse.title`,defaultMessage:`Use your Mac apps while locked`,description:`Title for enabling Locked Computer Use after mobile setup`};",
     "let b={id:`codexMobile.setupDialog.connected.lockedComputerUse.description`,defaultMessage:`Control Mac apps from your phone`,description:`Description for enabling Locked Computer Use after mobile setup`};",
@@ -1004,9 +1006,18 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(visibilityDescriptor);
     assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
-    assert.equal(visibilityDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
+    assert.equal(visibilityDescriptor.pattern.test(CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET), true);
     assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), false);
     assert.equal(visibilityDescriptor.pattern.test("app-main-fixture.js"), false);
+
+    const copyDescriptor = descriptors.find((descriptor) =>
+      descriptor.id === "feature:remote-mobile-control:linux-remote-control-copy"
+    );
+    assert.ok(copyDescriptor);
+    assert.equal(copyDescriptor.pattern.test("codex-mobile-setup-dialog-test.js"), true);
+    assert.equal(copyDescriptor.pattern.test("remote-connections-settings-test.js"), true);
+    assert.equal(copyDescriptor.pattern.test("codex-mobile-setup-flow-test.js"), false);
+    assert.equal(copyDescriptor.pattern.test("use-codex-mobile-connected-settings-test.js"), false);
 
     const featureSyncDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-feature-sync"
@@ -1392,45 +1403,15 @@ test("Linux remote-control visibility patch handles current use-plugin gate shap
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
 });
 
-test("Linux remote-control visibility patch ignores unrelated Linux user-agent checks", () => {
-  const source = `const platform=()=>navigator.userAgent.includes(\`Linux\`);${syntheticCurrentUsePluginVisibilityBundle()}`;
-  const { result: patched, warnings } = captureWarnings(() =>
-    applyLinuxRemoteControlVisibilityPatch(source)
-  );
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /codexLinuxRemoteControlVisibilityEnabled/);
-  assert.deepEqual(warnings, []);
-  const secondPass = captureWarnings(() => applyLinuxRemoteControlVisibilityPatch(patched));
-  assert.equal(secondPass.result, patched);
-  assert.deepEqual(secondPass.warnings, []);
-});
-
-test("Linux remote-control visibility patch handles a new gate beside an existing marker", () => {
-  const source = `/*codexLinuxRemoteControlVisibilityEnabled*/${syntheticCurrentUsePluginVisibilityBundle()}`;
-  const patched = applyLinuxRemoteControlVisibilityPatch(source);
-
-  assert.notEqual(patched, source);
-  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
-});
-
 test("Linux mobile setup copy does not refer to Mac-only Computer Use", () => {
-  const source = syntheticMobileConnectedSettingsBundle();
+  const source = syntheticMobileSetupDialogComputerUseBundle();
   const patched = applyLinuxRemoteControlCopyPatch(source);
 
   assert.notEqual(patched, source);
   assert.doesNotMatch(patched, /apps on your Mac/);
   assert.match(patched, /apps on this Linux desktop/);
-  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
-  assert.equal(secondPass.result, patched);
-  assert.deepEqual(secondPass.warnings, []);
-});
-
-test("Linux remote-control copy handles new known copy beside an existing marker", () => {
-  const source = "/*codexLinuxRemoteControlCopy*/Keep this Mac awake";
-  const patched = applyLinuxRemoteControlCopyPatch(source);
-
-  assert.equal(patched, "/*codexLinuxRemoteControlCopy*/Keep this Linux desktop awake");
+  assert.match(patched, /codexLinuxRemoteControlCopy/);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
 test("Linux remote-control settings copy does not refer to this Mac", () => {
@@ -1445,13 +1426,13 @@ test("Linux remote-control settings copy does not refer to this Mac", () => {
   assert.match(patched, /SSH connections from this Linux desktop/);
   assert.match(patched, /Keep this Linux desktop awake/);
   assert.match(patched, /defaultMessage:`Linux`/);
-  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
-  assert.equal(secondPass.result, patched);
-  assert.deepEqual(secondPass.warnings, []);
+  assert.match(patched, /connected to ChatGPT on this Linux desktop/);
+  assert.doesNotMatch(patched, /connected to ChatGPT on a Mac/);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
-test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
-  const source = syntheticMobileSetupFlowCopyBundle();
+test("Linux mobile setup dialog copy does not refer to Mac-only setup", () => {
+  const source = syntheticMobileSetupDialogCopyBundle();
   const patched = applyLinuxRemoteControlCopyPatch(source);
 
   assert.notEqual(patched, source);
@@ -1460,9 +1441,7 @@ test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
   assert.match(patched, /Control Linux apps from your phone/);
   assert.match(patched, /apps on this Linux desktop/);
   assert.match(patched, /Connect your phone to this Linux desktop/);
-  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
-  assert.equal(secondPass.result, patched);
-  assert.deepEqual(secondPass.warnings, []);
+  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
 });
 
 test("Linux remote-control settings UX patch keeps outbound tab visible and removes Mac copy", () => {
@@ -2483,17 +2462,16 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
         path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
-        syntheticRemoteConnectionVisibilityBundle() +
-          syntheticCurrentUsePluginVisibilityBundle() +
-          syntheticAppServerManagerSignalsBundle() +
+        syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle() +
-          syntheticCurrentStatusWaitBundle() +
           syntheticCompletedItemRecoveryBundle() +
           syntheticRemoteTerminalStatusBundle(),
       );
       fs.writeFileSync(
         path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
-        syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle(),
+        syntheticRemoteConnectionVisibilityBundle() +
+          syntheticAppMainFeatureSyncBundle() +
+          syntheticAppMainEnablementBridgeBundle(),
       );
       fs.writeFileSync(
         path.join(assetsDir, CURRENT_REMOTE_CONVERSATION_STATUS_ASSET),
@@ -2517,8 +2495,10 @@ test("remote mobile feature patch report records feature metadata and partial wa
           "if(!this.conversations.get(r)){z.error(`Received turn/completed for unknown conversation`,{safe:{id:r},sensitive:{}});break}",
         ),
       );
-      fs.writeFileSync(path.join(assetsDir, "codex-mobile-setup-flow-test.js"), syntheticMobileSetupFlowCopyBundle());
-      fs.writeFileSync(path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"), syntheticMobileConnectedSettingsBundle());
+      fs.writeFileSync(
+        path.join(assetsDir, "codex-mobile-setup-dialog-test.js"),
+        syntheticMobileSetupDialogCopyBundle() + syntheticMobileSetupDialogComputerUseBundle(),
+      );
 
       const report = createPatchReport();
       withFeatureRootEnv(root, () => patchExtractedApp(tempApp, { report }));
@@ -3174,7 +3154,6 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.writeFileSync(
           path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           syntheticRemoteConnectionVisibilityBundle() +
-            syntheticCurrentUsePluginVisibilityBundle() +
             syntheticAppServerManagerSignalsBundle() +
             syntheticAppServerManagerStatusBundle() +
             syntheticCurrentStatusWaitBundle() +
@@ -3189,12 +3168,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             syntheticCurrentRevokeSetupResetBundle(),
         );
         fs.writeFileSync(
-          path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
-          syntheticMobileSetupFlowCopyBundle(),
-        );
-        fs.writeFileSync(
-          path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
-          syntheticMobileConnectedSettingsBundle(),
+          path.join(assetsDir, "codex-mobile-setup-dialog-test.js"),
+          syntheticMobileSetupDialogCopyBundle() + syntheticMobileSetupDialogComputerUseBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, OLD_APP_SERVER_MANAGER_ASSET),
@@ -3206,7 +3181,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         );
         fs.writeFileSync(
           path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
-          syntheticAppMainFeatureSyncBundle() +
+          syntheticCurrentUsePluginVisibilityBundle() +
+            syntheticAppMainFeatureSyncBundle() +
             syntheticAppMainEnablementBridgeBundle(),
         );
         fs.writeFileSync(
@@ -3222,7 +3198,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
           "utf8",
         );
         const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
@@ -3241,12 +3217,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, "remote-connections-settings-test.js"),
           "utf8",
         );
-        const patchedMobileSetupFlowFile = fs.readFileSync(
-          path.join(assetsDir, "codex-mobile-setup-flow-test.js"),
-          "utf8",
-        );
-        const patchedMobileConnectedSettingsFile = fs.readFileSync(
-          path.join(assetsDir, "use-codex-mobile-connected-settings-test.js"),
+        const patchedMobileSetupDialogFile = fs.readFileSync(
+          path.join(assetsDir, "codex-mobile-setup-dialog-test.js"),
           "utf8",
         );
         const patchedSignalsFile = fs.readFileSync(
@@ -3270,8 +3242,8 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedRemoteConnectionsSettingsFile, /Qn=5e3/);
         assert.match(patchedRemoteConnectionsSettingsFile, /Control this Linux desktop/);
         assert.match(patchedRemoteConnectionsSettingsFile, /SSH connections from this Linux desktop/);
-        assert.match(patchedMobileSetupFlowFile, /Connect your phone to this Linux desktop/);
-        assert.match(patchedMobileConnectedSettingsFile, /apps on this Linux desktop/);
+        assert.match(patchedMobileSetupDialogFile, /Connect your phone to this Linux desktop/);
+        assert.match(patchedMobileSetupDialogFile, /apps on this Linux desktop/);
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileHydrateUnknownTurn/);
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileThreadRuntimeStatus/);
         assert.match(patchedSignalsFile, /codexLinuxCompletedItemExists=/);
@@ -3399,48 +3371,20 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           ),
         );
 
-        const firstPassFeaturePatches = report.patches.filter((patch) =>
-          patch.name.startsWith("feature:remote-mobile-control:")
-        );
-        assert.equal(firstPassFeaturePatches.length, 18);
-        const firstPassWebviewPatches = firstPassFeaturePatches.filter((patch) =>
-          patch.phase === "webview-asset"
-        );
-        assert.equal(firstPassWebviewPatches.length, 15);
-        const currentRuntimePatchNames = new Set([
-          "linux-remote-control-load-gate",
-          "linux-remote-control-visibility",
-          "linux-remote-mobile-conversation-hydration",
-          "linux-remote-mobile-completed-item-recovery",
-          "linux-remote-terminal-status-recovery",
-          "linux-remote-control-status-read-guard",
-          "linux-remote-control-status-wait",
-        ].map((name) => `feature:remote-mobile-control:${name}`));
-        assert.deepEqual(
-          firstPassWebviewPatches
-            .filter((patch) => currentRuntimePatchNames.has(patch.name))
-            .map((patch) => patch.status),
-          Array(currentRuntimePatchNames.size).fill("applied"),
-        );
-        const firstPassAssets = new Map(
-          fs.readdirSync(assetsDir)
-            .filter((name) => name.endsWith(".js"))
-            .map((name) => [name, fs.readFileSync(path.join(assetsDir, name))]),
-        );
-
         const secondReport = createPatchReport();
         patchExtractedApp(tempApp, { report: secondReport });
-        const secondPassFeaturePatches = secondReport.patches.filter((patch) =>
-          patch.name.startsWith("feature:remote-mobile-control:")
+        assert.ok(
+          secondReport.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-mobile-completed-item-recovery" &&
+            patch.status === "already-applied",
+          ),
         );
-        assert.equal(secondPassFeaturePatches.length, 18);
-        assert.deepEqual(
-          [...new Set(secondPassFeaturePatches.map((patch) => patch.status))],
-          ["already-applied"],
+        assert.ok(
+          secondReport.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-terminal-status-recovery" &&
+            patch.status === "already-applied",
+          ),
         );
-        for (const [name, content] of firstPassAssets) {
-          assert.deepEqual(fs.readFileSync(path.join(assetsDir, name)), content, name);
-        }
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });
       }

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -52,14 +52,12 @@ const CURRENT_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~worktree-init-v2-page~remote-conversation-page~new-thread-panel-page~o~test.js";
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
-const CURRENT_PROJECTLESS_REMOTE_TASK_ASSET =
+const CURRENT_REMOTE_RUNTIME_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
 const CURRENT_APP_MAIN_PAGE_ASSET =
   "app-initial~app-main~page-test.js";
-const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET =
-  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-test.js";
 const CURRENT_REMOTE_CONVERSATION_STATUS_ASSET =
   "app-initial~app-main~projects-index-page~remote-conversation-page-test.js";
 
@@ -1006,7 +1004,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(visibilityDescriptor);
     assert.equal(visibilityDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
-    assert.equal(visibilityDescriptor.pattern.test(CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET), true);
+    assert.equal(visibilityDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
     assert.equal(visibilityDescriptor.pattern.test("use-plugin-install-flow-fixture.js"), false);
     assert.equal(visibilityDescriptor.pattern.test("app-main-fixture.js"), false);
 
@@ -1044,16 +1042,17 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(statusGuardDescriptor);
     assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
-    assert.equal(statusGuardDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
-    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
 
     const statusWaitDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-wait"
     );
     assert.ok(statusWaitDescriptor);
-    assert.equal(statusWaitDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(statusWaitDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(statusWaitDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
     assert.equal(statusWaitDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
 
     const hydrationDescriptor = descriptors.find((descriptor) =>
@@ -1062,24 +1061,26 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(hydrationDescriptor);
     assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
-    assert.equal(hydrationDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(hydrationDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(hydrationDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(hydrationDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
-    assert.equal(hydrationDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(hydrationDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
 
     const completedItemDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-mobile-completed-item-recovery"
     );
     assert.ok(completedItemDescriptor);
-    assert.equal(completedItemDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(completedItemDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(completedItemDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
     assert.equal(completedItemDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
 
     const terminalStatusDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-terminal-status-recovery"
     );
     assert.ok(terminalStatusDescriptor);
-    assert.equal(terminalStatusDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(terminalStatusDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
+    assert.equal(terminalStatusDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
     assert.equal(terminalStatusDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(terminalStatusDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
 
@@ -1089,10 +1090,10 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.ok(loadGateDescriptor);
     assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
-    assert.equal(loadGateDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), true);
+    assert.equal(loadGateDescriptor.pattern.test(UNIFIED_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
-    assert.equal(loadGateDescriptor.pattern.test(CURRENT_PROJECTLESS_REMOTE_TASK_ASSET), false);
+    assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
 
   });
 });
@@ -1391,6 +1392,28 @@ test("Linux remote-control visibility patch handles current use-plugin gate shap
   assert.equal(applyLinuxRemoteControlVisibilityPatch(patched), patched);
 });
 
+test("Linux remote-control visibility patch ignores unrelated Linux user-agent checks", () => {
+  const source = `const platform=()=>navigator.userAgent.includes(\`Linux\`);${syntheticCurrentUsePluginVisibilityBundle()}`;
+  const { result: patched, warnings } = captureWarnings(() =>
+    applyLinuxRemoteControlVisibilityPatch(source)
+  );
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /codexLinuxRemoteControlVisibilityEnabled/);
+  assert.deepEqual(warnings, []);
+  const secondPass = captureWarnings(() => applyLinuxRemoteControlVisibilityPatch(patched));
+  assert.equal(secondPass.result, patched);
+  assert.deepEqual(secondPass.warnings, []);
+});
+
+test("Linux remote-control visibility patch handles a new gate beside an existing marker", () => {
+  const source = `/*codexLinuxRemoteControlVisibilityEnabled*/${syntheticCurrentUsePluginVisibilityBundle()}`;
+  const patched = applyLinuxRemoteControlVisibilityPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.match(patched, /navigator\.userAgent\.includes\(`Linux`\)/);
+});
+
 test("Linux mobile setup copy does not refer to Mac-only Computer Use", () => {
   const source = syntheticMobileConnectedSettingsBundle();
   const patched = applyLinuxRemoteControlCopyPatch(source);
@@ -1398,7 +1421,16 @@ test("Linux mobile setup copy does not refer to Mac-only Computer Use", () => {
   assert.notEqual(patched, source);
   assert.doesNotMatch(patched, /apps on your Mac/);
   assert.match(patched, /apps on this Linux desktop/);
-  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
+  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
+  assert.equal(secondPass.result, patched);
+  assert.deepEqual(secondPass.warnings, []);
+});
+
+test("Linux remote-control copy handles new known copy beside an existing marker", () => {
+  const source = "/*codexLinuxRemoteControlCopy*/Keep this Mac awake";
+  const patched = applyLinuxRemoteControlCopyPatch(source);
+
+  assert.equal(patched, "/*codexLinuxRemoteControlCopy*/Keep this Linux desktop awake");
 });
 
 test("Linux remote-control settings copy does not refer to this Mac", () => {
@@ -1413,7 +1445,9 @@ test("Linux remote-control settings copy does not refer to this Mac", () => {
   assert.match(patched, /SSH connections from this Linux desktop/);
   assert.match(patched, /Keep this Linux desktop awake/);
   assert.match(patched, /defaultMessage:`Linux`/);
-  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
+  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
+  assert.equal(secondPass.result, patched);
+  assert.deepEqual(secondPass.warnings, []);
 });
 
 test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
@@ -1426,7 +1460,9 @@ test("Linux mobile setup flow copy does not refer to Mac-only setup", () => {
   assert.match(patched, /Control Linux apps from your phone/);
   assert.match(patched, /apps on this Linux desktop/);
   assert.match(patched, /Connect your phone to this Linux desktop/);
-  assert.equal(applyLinuxRemoteControlCopyPatch(patched), patched);
+  const secondPass = captureWarnings(() => applyLinuxRemoteControlCopyPatch(patched));
+  assert.equal(secondPass.result, patched);
+  assert.deepEqual(secondPass.warnings, []);
 });
 
 test("Linux remote-control settings UX patch keeps outbound tab visible and removes Mac copy", () => {
@@ -2446,15 +2482,14 @@ test("remote mobile feature patch report records feature metadata and partial wa
       fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
       fs.writeFileSync(path.join(assetsDir, "app-test.png"), "");
       fs.writeFileSync(
-        path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
-        syntheticAppServerManagerSignalsBundle() +
+        path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
+        syntheticRemoteConnectionVisibilityBundle() +
+          syntheticCurrentUsePluginVisibilityBundle() +
+          syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle() +
+          syntheticCurrentStatusWaitBundle() +
           syntheticCompletedItemRecoveryBundle() +
           syntheticRemoteTerminalStatusBundle(),
-      );
-      fs.writeFileSync(
-        path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
-        syntheticRemoteConnectionVisibilityBundle(),
       );
       fs.writeFileSync(
         path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
@@ -3137,17 +3172,14 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         fs.writeFileSync(path.join(buildDir, "main.js"), source);
         fs.writeFileSync(path.join(buildDir, "workspace-root-drop-handler-test.js"), syntheticAppServerLaunchBundle());
         fs.writeFileSync(
-          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           syntheticRemoteConnectionVisibilityBundle() +
+            syntheticCurrentUsePluginVisibilityBundle() +
             syntheticAppServerManagerSignalsBundle() +
             syntheticAppServerManagerStatusBundle() +
             syntheticCurrentStatusWaitBundle() +
             syntheticCompletedItemRecoveryBundle() +
             syntheticRemoteTerminalStatusBundle(),
-        );
-        fs.writeFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
-          syntheticCurrentUsePluginVisibilityBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
@@ -3190,11 +3222,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           "utf8",
         );
         const patchedRemoteConnectionVisibilityFile = fs.readFileSync(
-          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           "utf8",
         );
         const patchedAppMainFile = fs.readFileSync(
@@ -3218,11 +3250,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           "utf8",
         );
         const patchedSignalsFile = fs.readFileSync(
-          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           "utf8",
         );
         const patchedStatusFile = fs.readFileSync(
-          path.join(assetsDir, UNIFIED_REMOTE_CONVERSATION_ASSET),
+          path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           "utf8",
         );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
@@ -3367,20 +3399,48 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           ),
         );
 
+        const firstPassFeaturePatches = report.patches.filter((patch) =>
+          patch.name.startsWith("feature:remote-mobile-control:")
+        );
+        assert.equal(firstPassFeaturePatches.length, 18);
+        const firstPassWebviewPatches = firstPassFeaturePatches.filter((patch) =>
+          patch.phase === "webview-asset"
+        );
+        assert.equal(firstPassWebviewPatches.length, 15);
+        const currentRuntimePatchNames = new Set([
+          "linux-remote-control-load-gate",
+          "linux-remote-control-visibility",
+          "linux-remote-mobile-conversation-hydration",
+          "linux-remote-mobile-completed-item-recovery",
+          "linux-remote-terminal-status-recovery",
+          "linux-remote-control-status-read-guard",
+          "linux-remote-control-status-wait",
+        ].map((name) => `feature:remote-mobile-control:${name}`));
+        assert.deepEqual(
+          firstPassWebviewPatches
+            .filter((patch) => currentRuntimePatchNames.has(patch.name))
+            .map((patch) => patch.status),
+          Array(currentRuntimePatchNames.size).fill("applied"),
+        );
+        const firstPassAssets = new Map(
+          fs.readdirSync(assetsDir)
+            .filter((name) => name.endsWith(".js"))
+            .map((name) => [name, fs.readFileSync(path.join(assetsDir, name))]),
+        );
+
         const secondReport = createPatchReport();
         patchExtractedApp(tempApp, { report: secondReport });
-        assert.ok(
-          secondReport.patches.some((patch) =>
-            patch.name === "feature:remote-mobile-control:linux-remote-mobile-completed-item-recovery" &&
-            patch.status === "already-applied",
-          ),
+        const secondPassFeaturePatches = secondReport.patches.filter((patch) =>
+          patch.name.startsWith("feature:remote-mobile-control:")
         );
-        assert.ok(
-          secondReport.patches.some((patch) =>
-            patch.name === "feature:remote-mobile-control:linux-remote-terminal-status-recovery" &&
-            patch.status === "already-applied",
-          ),
+        assert.equal(secondPassFeaturePatches.length, 18);
+        assert.deepEqual(
+          [...new Set(secondPassFeaturePatches.map((patch) => patch.status))],
+          ["already-applied"],
         );
+        for (const [name, content] of firstPassAssets) {
+          assert.deepEqual(fs.readFileSync(path.join(assetsDir, name)), content, name);
+        }
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- retarget the seven Remote Mobile runtime patches to the current `iufn7mg3` webview chunk
- use patch-specific completion markers for visibility and Linux copy transforms
- cover unrelated Linux user-agent checks, incremental upstream copy/gates, and byte-identical repeat application

## Verification

- `node --test linux-features/remote-mobile-control/test.js` (100 passed)
- `node --test linux-features/*/test.js` (557 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (368 passed)
- `bash tests/scripts_smoke.sh`
- exact 26.707.51957 DMG build: 18 Remote Mobile patches applied, then 18 already applied on a byte-identical second pass
- Semgrep baseline scan: no introduced findings

Addresses the current-DMG patch-report regression reported in #639.
