### PR TITLE
Fix latest DMG optional feature drift

### DIFF
--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -342,7 +342,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~page-[^.]+\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -139,16 +139,16 @@ test("appshots availability descriptor matches the current bundle", () => {
   );
 
   assert.equal(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"), false);
-  assert.equal(
-    descriptor.pattern.test(
-      "app-initial~app-main~page-hSvsQcNf.js",
-    ),
-    false,
-  );
   assert.ok(
+    descriptor.pattern.test(
+      "app-initial~app-main~page-CMpPiY3-.js",
+    ),
+  );
+  assert.equal(
     descriptor.pattern.test(
       "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     ),
+    false,
   );
 });
 

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -829,7 +829,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
+      pattern: /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1404,6 +1404,10 @@ test("open-target discovery targets only the current native selector bundle", ()
     descriptor.pattern,
   );
   assert.match(
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-_t04Xpau.js",
+    descriptor.pattern,
+  );
+  assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
     descriptor.pattern,
   );

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -303,7 +303,7 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
   let changed = 0;
 
   for (const name of fs.readdirSync(assetsDir)) {
-    if (!/^(?:app-main-.*|app-initial~app-main~.*projects-index.*)\.js$/u.test(name)) {
+    if (!/^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/u.test(name)) {
       continue;
     }
     const filePath = path.join(assetsDir, name);

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -14,6 +14,17 @@ const {
   enabledWorkspaceRootTargets,
 } = workspaceRootOpenTargetsPatch;
 
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    return { result: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 test("workspace root dropdown adds Linux open targets alongside File Manager", () => {
   const mainSource = [
     "function codexLinuxIdeCommand(){}",
@@ -130,8 +141,11 @@ test("workspace root open targets patch scans current shared app main project ch
         "var Hj={id:`terminal`,platforms:{linux:{label:`Terminal`}}};",
       ].join(""),
     );
-    fs.writeFileSync(path.join(assetsDir, "app-main-current.js"), "console.log(`shell`);");
-    const sharedChunkName = "app-initial~app-main~remote-conversation-page~projects-index-page-current.js";
+    fs.writeFileSync(
+      path.join(assetsDir, "app-main-current.js"),
+      "function decoy(){return{target:`fileManager`}}",
+    );
+    const sharedChunkName = "app-initial~app-main~projects-index-page~remote-conversation-page-current.js";
     fs.writeFileSync(
       path.join(assetsDir, sharedChunkName),
       [
@@ -145,14 +159,20 @@ test("workspace root open targets patch scans current shared app main project ch
       ].join(""),
     );
 
-    const result = patchWorkspaceRootOpenTargets(root);
+    const first = captureWarnings(() => patchWorkspaceRootOpenTargets(root));
     const patched = fs.readFileSync(path.join(assetsDir, sharedChunkName), "utf8");
 
-    assert.equal(result.changed, 1);
+    assert.equal(first.result.changed, 1);
+    assert.deepEqual(first.warnings, []);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscode/);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:vscodeInsiders/);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:zed/);
     assert.match(patched, /codexLinuxWorkspaceRootOpenTarget:terminal/);
+
+    const second = captureWarnings(() => patchWorkspaceRootOpenTargets(root));
+    assert.equal(second.result.changed, 0);
+    assert.deepEqual(second.warnings, []);
+    assert.equal(workspaceRootOpenTargetsPatch.status(second.result, second.warnings), "already-applied");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- retarget the AppShots availability patch to the current `app-initial~app-main~page-*` bundle
- retarget native open-target selection to the current `gpgl9un5` shared bundle
- narrow workspace-root open-target patching to the current project/remote-conversation chunk so unrelated File Manager call sites no longer produce drift warnings
- update selector and idempotency regression coverage for the current DMG shape

## Root cause

The `26.707.61608` DMG rechunked the AppShots availability atom and native open-target selector, so the enabled features still looked for an obsolete shared asset name. The workspace-root patch still applied, but its broad asset scan also inspected unrelated File Manager call sites and reported a misleading warning.

## User impact

Installs and updater rebuilds with `appshots` and `open-target-discovery` enabled no longer reject the current DMG for feature drift. The workspace-root patch also reports `applied` without the false optional warning.

## Validation

- `node --test linux-features/appshots/test.js linux-features/open-target-discovery/test.js scripts/workspace-root-open-targets-patch.test.js` (61 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (368 passed)
- `./install.sh --inspect --report-dir /tmp/codex-dmg-61608/install-inspect-final Codex.dmg`
  - AppShots: 4 patches applied
  - open-target discovery: 2 patches applied
  - workspace-root open targets: applied without warnings
- `node scripts/ci/validate-patch-report.js /tmp/codex-dmg-61608/install-inspect-final/patch-report.json`

## Environment limitations

- the broad feature suite reached 553/554 tests; the unrelated Thorium stage-hook test attempted a disabled `mcp-helper-reaper` cleanup against sandbox-read-only `~/.codex/hooks.json`
- `tests/scripts_smoke.sh` reached the existing generated-launcher `--help` probe, where the temporary launcher exited under the restricted local environment; the touched patch and feature suites above are green
