### PR TITLE
Fix upstream DMG drift for 26.707.61608

### DIFF
--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -1,10 +1,10 @@
 "use strict";
 
-const MODEL_PICKER_BUNDLE_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
-const MODEL_PICKER_STATE_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
-const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
-const MODEL_PICKER_MENU_ASSET_PATTERN = MODEL_PICKER_BUNDLE_PATTERN;
+const MODEL_PICKER_STATE_ASSET_PATTERN = /^app-initial~app-main~page-[^.]+\.js$/;
+const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/;
+const MODEL_PICKER_MENU_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-[^.]+\.js$/;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -180,28 +180,35 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
 });
 
 test("model picker descriptors target the current state and menu bundles", () => {
-  assert.match(
+  const stateAsset = "app-initial~app-main~page-CMpPiY3-.js";
+  const allowlistAsset =
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-_t04Xpau.js";
+  const menuAsset =
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-Bawo32lF.js";
+
+  assert.match(stateAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
+  assert.match(allowlistAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
+  assert.match(menuAsset, MODEL_PICKER_MENU_ASSET_PATTERN);
+
+  assert.doesNotMatch(stateAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
+  assert.doesNotMatch(stateAsset, MODEL_PICKER_MENU_ASSET_PATTERN);
+  assert.doesNotMatch(allowlistAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
+  assert.doesNotMatch(allowlistAsset, MODEL_PICKER_MENU_ASSET_PATTERN);
+  assert.doesNotMatch(menuAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
+  assert.doesNotMatch(menuAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
+
+  // The previous DMG colocated all four patches in this chunk. Current-DMG-only
+  // targeting must not retain it as a compatibility fallback.
+  assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
-  assert.match(
+  assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
     MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   );
-  assert.match(
+  assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
-    MODEL_PICKER_MENU_ASSET_PATTERN,
-  );
-  assert.doesNotMatch(
-    "app-initial~app-main~page-hSvsQcNf.js",
-    MODEL_PICKER_STATE_ASSET_PATTERN,
-  );
-  assert.doesNotMatch(
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
-    MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
-  );
-  assert.doesNotMatch(
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
 });


### PR DESCRIPTION
<!-- upstream-dmg-sha256:d4fc717a53fdecfa76a73147faa609f65e1bbaf52d5b43446ccca4c21a430347 -->

Summary:
- retarget the ui-tweaks model-picker patches to the current upstream asset split
- remove the previous single-bundle compatibility shape
- cover the current state, allowlist, and menu assets with regression tests

Tests/checks:
- accepted upstream build with synced enabled local features
- node --test linux-features/ui-tweaks/test.js
- node --test scripts/patch-linux-window-ui.test.js
- bash tests/scripts_smoke.sh
- cargo fmt, clippy, check, and workspace tests
- Debian, RPM, and pacman package validation

Notes:
- Current upstream DMG SHA-256: d4fc717a53fdecfa76a73147faa609f65e1bbaf52d5b43446ccca4c21a430347
- App version: 26.707.61608