### PR TITLE
Fix upstream DMG drift for 26.707.62119

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -52,7 +52,7 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_RUNTIME_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/u;
+  /^app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-[^.]+\.js$/u;
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -53,7 +53,7 @@ const CURRENT_REMOTE_CONVERSATION_ASSET =
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
 const CURRENT_REMOTE_RUNTIME_ASSET =
-  "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-test.js";
+  "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-test.js";
 const UNIFIED_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
 const CURRENT_APP_MAIN_PAGE_ASSET =

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -1,10 +1,11 @@
 "use strict";
 
-const MODEL_PICKER_STATE_ASSET_PATTERN = /^app-initial~app-main~page-[^.]+\.js$/;
+const MODEL_PICKER_STATE_ASSET_PATTERN =
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
 const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/;
+  /^app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-[^.]+\.js$/;
 const MODEL_PICKER_MENU_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-[^.]+\.js$/;
+  /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -180,11 +180,12 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
 });
 
 test("model picker descriptors target the current state and menu bundles", () => {
-  const stateAsset = "app-initial~app-main~page-CMpPiY3-.js";
+  const stateAsset =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
   const allowlistAsset =
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-_t04Xpau.js";
+    "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BpnUyB2R.js";
   const menuAsset =
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-Bawo32lF.js";
+    "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-EGSyoZAU.js";
 
   assert.match(stateAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
   assert.match(allowlistAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
@@ -197,18 +198,18 @@ test("model picker descriptors target the current state and menu bundles", () =>
   assert.doesNotMatch(menuAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
   assert.doesNotMatch(menuAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
 
-  // The previous DMG colocated all four patches in this chunk. Current-DMG-only
-  // targeting must not retain it as a compatibility fallback.
+  // The previous DMG split these patches across different chunks.
+  // Current-DMG-only targeting must not retain those chunks as fallbacks.
   assert.doesNotMatch(
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
+    "app-initial~app-main~page-CMpPiY3-.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-_t04Xpau.js",
     MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-k1satKyX.js",
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-Bawo32lF.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
 });


### PR DESCRIPTION
Summary
- retarget enabled remote-mobile-control runtime patches to the current upstream conversation bundle
- retarget ui-tweaks model-picker patches to the current upstream chunks
- remove previous-DMG bundle routing and update current-only coverage

Tests/checks
- current DMG acceptance: accepted_with_warnings (all enabled feature patches applied)
- node --test scripts/patch-linux-window-ui.test.js
- node --test linux-features/*/test.js
- bash tests/scripts_smoke.sh
- ci-local rpm and pacman package jobs

Notes
- The local Ubuntu 24.04 CI harness still uses Node 18 and trips on the existing GNOME extension ESM syntax check; required GitHub CI is the merge gate.
- One unrelated optional core tooltip patch remains a non-blocking acceptance warning.

<!-- upstream-dmg-sha256:c243c94f8de6a51f5530ffe1f8d0c1588733d890ac692e34aaca06d95ba637ca -->