### PR TITLE
Fix current DMG Nix feature drift

### DIFF
--- a/linux-features/appshots/patch.js
+++ b/linux-features/appshots/patch.js
@@ -342,7 +342,7 @@ const descriptors = [
     id: "linux-appshots-availability",
     phase: "webview-asset",
     order: 1090,
-    pattern: /^app-initial~app-main~page-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
     missingDescription: "AppShots availability bundle",
     skipDescription: "Linux AppShots availability patch",
     apply: applyLinuxAppshotAvailabilityPatch,

--- a/linux-features/appshots/test.js
+++ b/linux-features/appshots/test.js
@@ -139,16 +139,16 @@ test("appshots availability descriptor matches the current bundle", () => {
   );
 
   assert.equal(descriptor.pattern.test("appshot-availability-BoK-Z77O.js"), false);
-  assert.ok(
+  assert.equal(
     descriptor.pattern.test(
       "app-initial~app-main~page-CMpPiY3-.js",
     ),
-  );
-  assert.equal(
-    descriptor.pattern.test(
-      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
-    ),
     false,
+  );
+  assert.ok(
+    descriptor.pattern.test(
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js",
+    ),
   );
 });
 

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -156,7 +156,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_730,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-.*\.js$/,
+    pattern: /^(?:app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page|app-initial~artifact-tab-content\.electron~app-main~new-thread-panel-page~onboarding-page~pr~el73lghr)-[^.]+\.js$/,
     missingDescription: "main app chrome bundle",
     skipDescription: "frameless titlebar webview layout patch",
     apply: applyFramelessTitlebarWebviewPatch,

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -65,16 +65,16 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
     const webviewPatch = descriptors.find(
       (descriptor) => descriptor.id === "feature:frameless-titlebar:webview-window-controls-layout",
     );
-    assert.match(
+    assert.doesNotMatch(
       "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-abc.js",
       webviewPatch.pattern,
     );
-    assert.doesNotMatch(
-      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-abc.js",
+    assert.match(
+      "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-BqLP6EDd.js",
       webviewPatch.pattern,
     );
-    assert.doesNotMatch(
-      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-abc.js",
+    assert.match(
+      "app-initial~artifact-tab-content.electron~app-main~new-thread-panel-page~onboarding-page~pr~el73lghr-qHKfocxV.js",
       webviewPatch.pattern,
     );
     assert.doesNotMatch(

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -829,7 +829,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-[^.]+\.js$/,
+      pattern: /^app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1399,11 +1399,11 @@ test("open-target discovery targets only the current native selector bundle", ()
   );
 
   assert.ok(descriptor);
-  assert.doesNotMatch(
-    "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-Bj9ubaFn.js",
+  assert.match(
+    "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-BqLP6EDd.js",
     descriptor.pattern,
   );
-  assert.match(
+  assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~onboarding-page~login-route~appgen-library-page~~gpgl9un5-_t04Xpau.js",
     descriptor.pattern,
   );


### PR DESCRIPTION
Summary
- refresh current-DMG-only bundle selectors for appshots, open-target-discovery, and frameless-titlebar
- remove obsolete selectors without adding compatibility fallbacks
- add selector coverage for the current upstream bundle split

Tests/checks
- focused feature tests: 61 passed
- patcher suite: 368 passed
- current DMG Nix multi-feature acceptance: accepted_with_warnings, no blockers
- nix flake check --no-build: passed
- local Debian, RPM, and pacman package jobs: passed

Notes
- Nix pin PR #925 is intentionally untouched; its existing DMG pin mismatch remains owned by that refresh.
- Local Ubuntu 24.04 full PR wrapper reached green Node/Rust tests, then hit the known distro Node 18 ESM syntax-check limitation for the GNOME extension.

<!-- upstream-dmg-sha256:c243c94f8de6a51f5530ffe1f8d0c1588733d890ac692e34aaca06d95ba637ca -->