### PR TITLE
Fix CLI optional dependency repair before startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,9 +101,10 @@ Primary human docs: [architecture](docs/architecture.md),
   set too.
 - GUI launchers often do not inherit shell `PATH`. The generated launcher
   searches common Codex CLI and `nvm` locations and respects `CODEX_CLI_PATH`.
-- CLI preflight is launcher-scoped and best-effort. It can prompt to install
-  or update the Codex CLI, but failures should warn rather than block app
-  launch.
+- CLI preflight is launcher-scoped and normally best-effort. A detected npm CLI
+  missing its required Linux optional dependency is the exception: the launcher
+  performs one bounded synchronous repair and blocks Electron startup if that
+  repair fails or times out, because the known-broken CLI cannot serve the app.
 - The generated launcher starts the local webview server before Electron and
   verifies the expected startup markers. See
   [webview server evaluation](docs/webview-server-evaluation.md) before

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/agents/generated-and-runtime-notes.md
+++ b/docs/agents/generated-and-runtime-notes.md
@@ -55,9 +55,10 @@ that agents need without keeping them in the main quick-start.
   URL.
 - GUI launchers often do not inherit shell `PATH`. The generated launcher
   searches common Codex CLI and `nvm` locations and respects `CODEX_CLI_PATH`.
-- CLI preflight is launcher-scoped and best-effort. It can prompt to install
-  or update the Codex CLI, but failures should warn rather than block app
-  launch.
+- CLI preflight is launcher-scoped and normally best-effort. A detected npm CLI
+  missing its required Linux optional dependency is the exception: the launcher
+  performs one bounded synchronous repair and blocks Electron startup if that
+  repair fails or times out, because the known-broken CLI cannot serve the app.
 - ASAR patches are fail-soft unless intentionally marked required. Each patch
   should be idempotent and report warnings when upstream drift prevents a
   needle from matching.

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -110,3 +110,14 @@ runs with stdout/stderr detached (`>/dev/null 2>&1`), which cut the
 ~74 ms. When adding bounded probes, keep watchdog subshells detached from any
 caller pipe — an orphaned `sleep` holding an inherited fd blocks command
 substitution until it exits.
+
+The default preflight remains asynchronous; `CODEX_SYNC_CLI_PREFLIGHT=1` still
+opts into the existing synchronous check while preserving fail-soft behavior for
+a CLI that is not known broken. A detected npm-managed CLI missing
+`@openai/codex-linux-x64` or `@openai/codex-linux-arm64` is the blocking
+exception: Electron cannot use that CLI, so the launcher waits for one repair
+attempt. The repair is bounded to 90 seconds, the repaired CLI version probe to
+5 seconds, and the follow-up npm registry lookup to 20 seconds. Each command
+runs in a dedicated process group that is terminated on timeout, including child
+processes; failure then stops startup with manual reinstall instructions instead
+of leaving the loading screen stuck.

--- a/docs/launcher-performance.md
+++ b/docs/launcher-performance.md
@@ -116,8 +116,8 @@ opts into the existing synchronous check while preserving fail-soft behavior for
 a CLI that is not known broken. A detected npm-managed CLI missing
 `@openai/codex-linux-x64` or `@openai/codex-linux-arm64` is the blocking
 exception: Electron cannot use that CLI, so the launcher waits for one repair
-attempt. The repair is bounded to 90 seconds, the repaired CLI version probe to
-5 seconds, and the follow-up npm registry lookup to 20 seconds. Each command
-runs in a dedicated process group that is terminated on timeout, including child
-processes; failure then stops startup with manual reinstall instructions instead
-of leaving the loading screen stuck.
+attempt. The updater's initial and post-repair CLI version probes are each
+bounded to 5 seconds, the repair to 90 seconds, and the follow-up npm registry
+lookup to 20 seconds. Each command runs in a dedicated process group that is
+terminated on timeout, including child processes; failure then stops startup
+with manual reinstall instructions instead of leaving the loading screen stuck.

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1672,9 +1672,9 @@ pid_parent_matches() {
 
 codex_cli_version_probe() {
     local output_file="$1"
-    shift
+    local stderr_file="$2"
+    shift 2
     local marker="${output_file}.timed-out"
-    local stderr_file="${CODEX_CLI_PROBE_STDERR_FILE:-/dev/null}"
     local probe_pid
     local watchdog_pid
     # Under command substitution, $$ stays the top-level launcher PID.
@@ -1735,7 +1735,7 @@ codex_cli_version() {
 
     for version_arg in --version version; do
         : > "$probe_file"
-        if codex_cli_version_probe "$probe_file" "$cli_path" "$version_arg"; then
+        if codex_cli_version_probe "$probe_file" /dev/null "$cli_path" "$version_arg"; then
             output="$(sed -n '1,3p' "$probe_file" 2>/dev/null || true)"
             version="$(printf '%s\n' "$output" | sed -nE '
 s/^v?([0-9]+([.][0-9]+)+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?)([^0-9A-Za-z._+-].*)?$/\1/p
@@ -1773,8 +1773,7 @@ codex_cli_missing_optional_dependency() {
         return 1
     }
 
-    if CODEX_CLI_PROBE_STDERR_FILE="$stderr_file" \
-        codex_cli_version_probe "$output_file" "$cli_path" --version; then
+    if codex_cli_version_probe "$output_file" "$stderr_file" "$cli_path" --version; then
         probe_status=0
     else
         probe_status=$?

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1778,7 +1778,7 @@ codex_cli_missing_optional_dependency() {
     else
         probe_status=$?
     fi
-    if [ "$probe_status" -ne 124 ] && \
+    if [ "$probe_status" -ne 0 ] && [ "$probe_status" -ne 124 ] && \
         grep -Eq 'Missing optional dependency[[:space:]]*@openai/codex-linux-(x64|arm64)([[:space:].,:;)]|$)' "$output_file" "$stderr_file"; then
         rm -f "$output_file" "$stderr_file" "${output_file}.timed-out"
         return 0

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -3895,10 +3895,21 @@ if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then
 fi
 
 if needs_cold_start; then
+    cli_repair_required=0
+    if codex_cli_missing_optional_dependency "$CODEX_CLI_PATH"; then
+        cli_repair_required=1
+    fi
     if [ "${CODEX_SYNC_CLI_PREFLIGHT:-0}" = "1" ]; then
-        run_cli_preflight 0
-        log_phase "cli_preflight_sync"
-    elif codex_cli_missing_optional_dependency "$CODEX_CLI_PATH"; then
+        if ! run_cli_preflight 0 "$cli_repair_required"; then
+            notify_error "The selected Codex CLI is missing its Linux optional dependency and could not be repaired automatically. Reinstall it with: npm i -g --include=optional @openai/codex@latest or npm i -g --include=optional --prefix ~/.local @openai/codex@latest"
+            exit 1
+        fi
+        if [ "$cli_repair_required" = "1" ]; then
+            log_phase "cli_preflight_repair_sync"
+        else
+            log_phase "cli_preflight_sync"
+        fi
+    elif [ "$cli_repair_required" = "1" ]; then
         if ! run_cli_preflight 0 1; then
             notify_error "The selected Codex CLI is missing its Linux optional dependency and could not be repaired automatically. Reinstall it with: npm i -g --include=optional @openai/codex@latest or npm i -g --include=optional --prefix ~/.local @openai/codex@latest"
             exit 1

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -1444,8 +1444,9 @@ run_feature_after_exit_hooks() {
 
 run_cli_preflight() {
     local allow_install_missing="${1:-0}"
+    local require_success="${2:-0}"
     if ! has_update_manager; then
-        if [ "$allow_install_missing" = "1" ]; then
+        if [ "$allow_install_missing" = "1" ] || [ "$require_success" = "1" ]; then
             return 1
         fi
         return 0
@@ -1464,7 +1465,7 @@ run_cli_preflight() {
 
     local refreshed_path=""
     if ! refreshed_path="$(run_update_manager "${preflight_args[@]}")"; then
-        if [ "$allow_install_missing" = "1" ]; then
+        if [ "$allow_install_missing" = "1" ] || [ "$require_success" = "1" ]; then
             return 1
         fi
         notify_error "Codex CLI prelaunch check failed. Continuing with the current CLI state. Check the launcher and updater logs if ChatGPT Desktop misbehaves."
@@ -1673,6 +1674,7 @@ codex_cli_version_probe() {
     local output_file="$1"
     shift
     local marker="${output_file}.timed-out"
+    local stderr_file="${CODEX_CLI_PROBE_STDERR_FILE:-/dev/null}"
     local probe_pid
     local watchdog_pid
     # Under command substitution, $$ stays the top-level launcher PID.
@@ -1682,7 +1684,7 @@ codex_cli_version_probe() {
     rm -f "$marker"
     ( trap - EXIT
       { exec 9>&-; } 2>/dev/null || true
-      codex_exec_host_command "$@" >"$output_file" 2>/dev/null
+      codex_exec_host_command "$@" >"$output_file" 2>"$stderr_file"
     ) &
     probe_pid="$!"
     # The watchdog (and its sleep child, which outlives the kill below) must
@@ -1754,6 +1756,36 @@ s/.*[^0-9A-Za-z._+-]v?([0-9]+([.][0-9]+)+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?)
     done
 
     rm -f "$probe_file" "${probe_file}.timed-out"
+    return 1
+}
+
+codex_cli_missing_optional_dependency() {
+    local cli_path="$1"
+    local output_file
+    local stderr_file
+    local probe_status
+
+    [ -n "$cli_path" ] || return 1
+    [ -x "$cli_path" ] || return 1
+    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-cli-output.XXXXXX" 2>/dev/null)" || return 1
+    stderr_file="$(mktemp "${TMPDIR:-/tmp}/codex-cli-error.XXXXXX" 2>/dev/null)" || {
+        rm -f "$output_file"
+        return 1
+    }
+
+    if CODEX_CLI_PROBE_STDERR_FILE="$stderr_file" \
+        codex_cli_version_probe "$output_file" "$cli_path" --version; then
+        probe_status=0
+    else
+        probe_status=$?
+    fi
+    if [ "$probe_status" -ne 124 ] && \
+        grep -Eq 'Missing optional dependency[[:space:]]*@openai/codex-linux-(x64|arm64)([[:space:].,:;)]|$)' "$output_file" "$stderr_file"; then
+        rm -f "$output_file" "$stderr_file" "${output_file}.timed-out"
+        return 0
+    fi
+
+    rm -f "$output_file" "$stderr_file" "${output_file}.timed-out"
     return 1
 }
 
@@ -3867,6 +3899,12 @@ if needs_cold_start; then
     if [ "${CODEX_SYNC_CLI_PREFLIGHT:-0}" = "1" ]; then
         run_cli_preflight 0
         log_phase "cli_preflight_sync"
+    elif codex_cli_missing_optional_dependency "$CODEX_CLI_PATH"; then
+        if ! run_cli_preflight 0 1; then
+            notify_error "The selected Codex CLI is missing its Linux optional dependency and could not be repaired automatically. Reinstall it with: npm i -g --include=optional @openai/codex@latest or npm i -g --include=optional --prefix ~/.local @openai/codex@latest"
+            exit 1
+        fi
+        log_phase "cli_preflight_repair_sync"
     else
         run_cli_preflight_background
         log_phase "cli_preflight_backgrounded"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5354,6 +5354,8 @@ if 'codex_run_host_command "$hook"' not in after_exit_hooks_body:
     raise SystemExit("launcher after-exit hooks must not inherit packaged LD_LIBRARY_PATH")
 if 'codex_exec_host_command "$@"' not in cli_probe_body:
     raise SystemExit("launcher CLI version probes must not inherit packaged LD_LIBRARY_PATH")
+if "CODEX_CLI_PROBE_STDERR_FILE" in source:
+    raise SystemExit("launcher CLI probes must not expose stderr redirection through inherited environment")
 if 'local require_success="${2:-0}"' not in cli_preflight_body:
     raise SystemExit("CLI preflight must support a required-success repair mode")
 if not re.search(r'elif codex_cli_missing_optional_dependency "\$CODEX_CLI_PATH"; then\s+if ! run_cli_preflight 0 1; then.*?exit 1.*?cli_preflight_repair_sync', runtime_body, re.S):
@@ -6296,6 +6298,11 @@ PY
     [ "$version_output" = "0.150.0" ] || fail "CLI version probe must read --version output, got $version_output"
     version_output="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" version "$fallback_version_cli")"
     [ "$version_output" = "0.151.0" ] || fail "CLI version probe must fall back to version output, got $version_output"
+
+    local inherited_stderr_target="$workspace/inherited-stderr-target"
+    version_output="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" CODEX_CLI_PROBE_STDERR_FILE="$inherited_stderr_target" "$launcher_probe" version "$dash_version_cli")"
+    [ "$version_output" = "0.150.0" ] || fail "inherited probe environment must not affect version output"
+    [ ! -e "$inherited_stderr_target" ] || fail "inherited environment must not control CLI probe stderr files"
 
     local missing_x64_cli="$workspace/missing-x64-codex"
     local missing_arm64_cli="$workspace/missing-arm64-codex"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6307,10 +6307,12 @@ PY
     local missing_x64_cli="$workspace/missing-x64-codex"
     local missing_arm64_cli="$workspace/missing-arm64-codex"
     local unrelated_failure_cli="$workspace/unrelated-failure-codex"
+    local successful_warning_cli="$workspace/successful-warning-codex"
     printf '#!/usr/bin/env bash\nprintf "Error: Missing optional dependency@openai/codex-linux-x64. Reinstall Codex.\\n" >&2\nexit 1\n' > "$missing_x64_cli"
     printf '#!/usr/bin/env bash\nprintf "Missing optional dependency @openai/codex-linux-arm64\\n" >&2\nexit 1\n' > "$missing_arm64_cli"
     printf '#!/usr/bin/env bash\nprintf "network unavailable\\n" >&2\nexit 1\n' > "$unrelated_failure_cli"
-    chmod +x "$missing_x64_cli" "$missing_arm64_cli" "$unrelated_failure_cli"
+    printf '#!/usr/bin/env bash\nprintf "Missing optional dependency @openai/codex-linux-x64.\\n" >&2\nprintf "codex-cli 0.200.0\\n"\n' > "$successful_warning_cli"
+    chmod +x "$missing_x64_cli" "$missing_arm64_cli" "$unrelated_failure_cli" "$successful_warning_cli"
     env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$missing_x64_cli" || fail "x64 optional dependency failure must request synchronous repair"
     env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$missing_arm64_cli" || fail "arm64 optional dependency failure must request synchronous repair"
     if compgen -G "$workspace/codex-cli-output.*" >/dev/null || compgen -G "$workspace/codex-cli-error.*" >/dev/null; then
@@ -6318,6 +6320,9 @@ PY
     fi
     if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$unrelated_failure_cli"; then
         fail "unrelated CLI failures must not request synchronous npm repair"
+    fi
+    if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$successful_warning_cli"; then
+        fail "successful CLI probes must not request repair based on diagnostic text alone"
     fi
     if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" missing-optional "$fallback_version_cli"; then
         fail "working CLI versions must keep the background preflight"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5358,7 +5358,9 @@ if "CODEX_CLI_PROBE_STDERR_FILE" in source:
     raise SystemExit("launcher CLI probes must not expose stderr redirection through inherited environment")
 if 'local require_success="${2:-0}"' not in cli_preflight_body:
     raise SystemExit("CLI preflight must support a required-success repair mode")
-if not re.search(r'elif codex_cli_missing_optional_dependency "\$CODEX_CLI_PATH"; then\s+if ! run_cli_preflight 0 1; then.*?exit 1.*?cli_preflight_repair_sync', runtime_body, re.S):
+if not re.search(r'cli_repair_required=0\s+if codex_cli_missing_optional_dependency "\$CODEX_CLI_PATH"; then\s+cli_repair_required=1\s+fi\s+if \[ "\$\{CODEX_SYNC_CLI_PREFLIGHT:-0\}" = "1" \]; then\s+if ! run_cli_preflight 0 "\$cli_repair_required"; then.*?exit 1.*?cli_preflight_repair_sync', runtime_body, re.S):
+    raise SystemExit("sync CLI preflight must detect a required repair first and preserve fail-closed semantics")
+if not re.search(r'elif \[ "\$cli_repair_required" = "1" \]; then\s+if ! run_cli_preflight 0 1; then.*?exit 1.*?cli_preflight_repair_sync', runtime_body, re.S):
     raise SystemExit("a known broken Linux CLI must be repaired synchronously or abort before Electron launch")
 if 'codex_run_host_command notify-send' not in notify_body:
     raise SystemExit("desktop notifications must not inherit packaged LD_LIBRARY_PATH")
@@ -6221,7 +6223,8 @@ PY
 test_launcher_cli_resolution_policy() {
     info "Checking launcher CLI resolution policy"
     local launcher_probe="$TMP_DIR/launcher-cli-policy-probe.sh"
-    python3 - "$REPO_DIR/launcher/start.sh.template" "$launcher_probe" <<'PY'
+    local routing_probe="$TMP_DIR/launcher-cli-preflight-routing-probe.sh"
+    python3 - "$REPO_DIR/launcher/start.sh.template" "$launcher_probe" "$routing_probe" <<'PY'
 import pathlib
 import re
 import sys
@@ -6264,8 +6267,39 @@ esac
 ''',
     encoding="utf-8",
 )
+
+preflight_match = re.search(r"^run_cli_preflight\(\) \{[\s\S]*?^\}\n", source, re.M)
+if preflight_match is None:
+    raise SystemExit("missing run_cli_preflight")
+routing_start = source.index('if needs_cold_start; then\n    cli_repair_required=0')
+routing_end = source.index("\nexport_packaged_runtime_env", routing_start)
+pathlib.Path(sys.argv[3]).write_text(
+    "#!/usr/bin/env bash\n"
+    "set -Eeuo pipefail\n\n"
+    + r'''
+CODEX_CLI_PATH=/tmp/codex
+has_update_manager() { [ "${UPDATE_MANAGER_AVAILABLE:-0}" = "1" ]; }
+run_update_manager() {
+    if [ "${UPDATE_MANAGER_RESULT:-failure}" = "success" ]; then
+        printf '%s\n' /tmp/repaired-codex
+        return 0
+    fi
+    return 1
+}
+notify_error() { printf 'notify=%s\n' "$1" >> "$ROUTING_LOG"; }
+log_phase() { printf 'phase=%s\n' "$1" >> "$ROUTING_LOG"; }
+needs_cold_start() { return 0; }
+codex_cli_missing_optional_dependency() { [ "${BROKEN_CLI:-0}" = "1" ]; }
+run_cli_preflight_background() { printf 'background=1\n' >> "$ROUTING_LOG"; }
+'''
+    + preflight_match.group(0)
+    + "\n"
+    + source[routing_start:routing_end]
+    + "\n",
+    encoding="utf-8",
+)
 PY
-    chmod +x "$launcher_probe"
+    chmod +x "$launcher_probe" "$routing_probe"
 
     local workspace="$TMP_DIR/launcher-cli-policy"
     local fake_home="$workspace/home"
@@ -6409,6 +6443,43 @@ PY
         kill -9 "$hanging_log_pid" 2>/dev/null || true
         fail "hanging CLI log probe left process $hanging_log_pid alive"
     fi
+
+    local routing_log="$workspace/preflight-routing.log"
+    if env -i PATH="$HOST_TOOL_PATH" ROUTING_LOG="$routing_log" \
+        CODEX_SYNC_CLI_PREFLIGHT=1 BROKEN_CLI=1 UPDATE_MANAGER_AVAILABLE=0 \
+        "$routing_probe"; then
+        fail "sync preflight must abort when a known-broken CLI cannot be repaired"
+    fi
+    grep -q '^notify=The selected Codex CLI is missing' "$routing_log" || \
+        fail "sync required repair failure must show actionable reinstall guidance"
+
+    : > "$routing_log"
+    env -i PATH="$HOST_TOOL_PATH" ROUTING_LOG="$routing_log" \
+        CODEX_SYNC_CLI_PREFLIGHT=1 BROKEN_CLI=1 UPDATE_MANAGER_AVAILABLE=1 \
+        UPDATE_MANAGER_RESULT=success "$routing_probe"
+    grep -qx 'phase=cli_preflight_repair_sync' "$routing_log" || \
+        fail "sync preflight must record a successful required repair"
+
+    : > "$routing_log"
+    env -i PATH="$HOST_TOOL_PATH" ROUTING_LOG="$routing_log" \
+        CODEX_SYNC_CLI_PREFLIGHT=1 BROKEN_CLI=0 UPDATE_MANAGER_AVAILABLE=0 \
+        "$routing_probe"
+    grep -qx 'phase=cli_preflight_sync' "$routing_log" || \
+        fail "sync preflight must remain fail-soft for a CLI that is not known broken"
+
+    : > "$routing_log"
+    if env -i PATH="$HOST_TOOL_PATH" ROUTING_LOG="$routing_log" \
+        BROKEN_CLI=1 UPDATE_MANAGER_AVAILABLE=0 "$routing_probe"; then
+        fail "default preflight must abort when a known-broken CLI cannot be repaired"
+    fi
+
+    : > "$routing_log"
+    env -i PATH="$HOST_TOOL_PATH" ROUTING_LOG="$routing_log" \
+        BROKEN_CLI=0 UPDATE_MANAGER_AVAILABLE=0 "$routing_probe"
+    grep -qx 'background=1' "$routing_log" || \
+        fail "healthy default preflight must stay asynchronous"
+    grep -qx 'phase=cli_preflight_backgrounded' "$routing_log" || \
+        fail "healthy default preflight must record the background path"
 }
 
 test_webview_server_cache_policy() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5173,6 +5173,7 @@ launcher_hooks_body = source.split("run_feature_launcher_hooks() {", 1)[1].split
 cold_start_hooks_body = source.split("run_cold_start_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 after_exit_hooks_body = source.split("run_feature_after_exit_hooks() {", 1)[1].split("run_cli_preflight() {", 1)[0]
 cli_probe_body = source.split("codex_cli_version_probe() {", 1)[1].split("codex_cli_version() {", 1)[0]
+cli_preflight_body = source.split("run_cli_preflight() {", 1)[1].split("run_cli_preflight_background() {", 1)[0]
 notify_body = source.split("notify_error() {", 1)[1].split("canonical_path() {", 1)[0]
 update_manager_body = source.split("run_update_manager() {", 1)[1].split("pid_is_current_user() {", 1)[0]
 stop_body = source.split("stop_owned_webview_server() {", 1)[1].split("owned_webview_server_pid() {", 1)[0]
@@ -5327,7 +5328,7 @@ if 'if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then' not in runtime_body:
     raise SystemExit("second-instance handoff must skip missing-CLI failure")
 if '"$HOME/.bun/bin/codex"' not in source:
     raise SystemExit("CLI lookup must include bun global install path")
-if "codex_cli_version_probe()" not in source or "codex_cli_version()" not in source:
+if "codex_cli_version_probe()" not in source or "codex_cli_version()" not in source or "codex_cli_missing_optional_dependency()" not in source:
     raise SystemExit("CLI lookup must log a bounded best-effort resolved CLI version probe")
 if "version unknown; set CODEX_CLI_PATH=/path/to/codex" not in source:
     raise SystemExit("CLI lookup diagnostics must explain explicit CODEX_CLI_PATH pinning")
@@ -5353,6 +5354,10 @@ if 'codex_run_host_command "$hook"' not in after_exit_hooks_body:
     raise SystemExit("launcher after-exit hooks must not inherit packaged LD_LIBRARY_PATH")
 if 'codex_exec_host_command "$@"' not in cli_probe_body:
     raise SystemExit("launcher CLI version probes must not inherit packaged LD_LIBRARY_PATH")
+if 'local require_success="${2:-0}"' not in cli_preflight_body:
+    raise SystemExit("CLI preflight must support a required-success repair mode")
+if not re.search(r'elif codex_cli_missing_optional_dependency "\$CODEX_CLI_PATH"; then\s+if ! run_cli_preflight 0 1; then.*?exit 1.*?cli_preflight_repair_sync', runtime_body, re.S):
+    raise SystemExit("a known broken Linux CLI must be repaired synchronously or abort before Electron launch")
 if 'codex_run_host_command notify-send' not in notify_body:
     raise SystemExit("desktop notifications must not inherit packaged LD_LIBRARY_PATH")
 if 'codex_run_host_command "$CODEX_UPDATE_MANAGER_PATH" "$@"' not in update_manager_body:
@@ -6224,7 +6229,7 @@ functions = [source[
     source.index("codex_restore_original_ld_library_path() {"):
     source.index("# Capture before package-specific launcher patches")
 ]]
-for name in ("find_codex_cli", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "log_codex_cli_path"):
+for name in ("find_codex_cli", "pid_parent_matches", "codex_cli_version_probe", "codex_cli_version", "codex_cli_missing_optional_dependency", "log_codex_cli_path"):
     match = re.search(r"^" + re.escape(name) + r"\(\) \{[\s\S]*?^\}\n", source, re.M)
     if match is None:
         raise SystemExit(f"missing {name}")
@@ -6241,6 +6246,9 @@ case "${1:?}" in
         ;;
     version)
         codex_cli_version "$2"
+        ;;
+    missing-optional)
+        codex_cli_missing_optional_dependency "$2"
         ;;
     log)
         CODEX_CLI_PATH="${2:-}"
@@ -6288,6 +6296,25 @@ PY
     [ "$version_output" = "0.150.0" ] || fail "CLI version probe must read --version output, got $version_output"
     version_output="$(env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" version "$fallback_version_cli")"
     [ "$version_output" = "0.151.0" ] || fail "CLI version probe must fall back to version output, got $version_output"
+
+    local missing_x64_cli="$workspace/missing-x64-codex"
+    local missing_arm64_cli="$workspace/missing-arm64-codex"
+    local unrelated_failure_cli="$workspace/unrelated-failure-codex"
+    printf '#!/usr/bin/env bash\nprintf "Error: Missing optional dependency@openai/codex-linux-x64. Reinstall Codex.\\n" >&2\nexit 1\n' > "$missing_x64_cli"
+    printf '#!/usr/bin/env bash\nprintf "Missing optional dependency @openai/codex-linux-arm64\\n" >&2\nexit 1\n' > "$missing_arm64_cli"
+    printf '#!/usr/bin/env bash\nprintf "network unavailable\\n" >&2\nexit 1\n' > "$unrelated_failure_cli"
+    chmod +x "$missing_x64_cli" "$missing_arm64_cli" "$unrelated_failure_cli"
+    env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$missing_x64_cli" || fail "x64 optional dependency failure must request synchronous repair"
+    env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$missing_arm64_cli" || fail "arm64 optional dependency failure must request synchronous repair"
+    if compgen -G "$workspace/codex-cli-output.*" >/dev/null || compgen -G "$workspace/codex-cli-error.*" >/dev/null; then
+        fail "optional dependency probes must remove temporary output files"
+    fi
+    if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$unrelated_failure_cli"; then
+        fail "unrelated CLI failures must not request synchronous npm repair"
+    fi
+    if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" missing-optional "$fallback_version_cli"; then
+        fail "working CLI versions must keep the background preflight"
+    fi
 
     # The version probe result is read through command substitution on the
     # launch path. The watchdog subshell (and its sleep child) must not
@@ -6343,6 +6370,9 @@ PY
     if kill -0 "$hanging_pid" 2>/dev/null; then
         kill -9 "$hanging_pid" 2>/dev/null || true
         fail "hanging CLI probe left process $hanging_pid alive"
+    fi
+    if env -i PATH="$HOST_TOOL_PATH" HOME="$fake_home" TMPDIR="$workspace" "$launcher_probe" missing-optional "$hanging_cli"; then
+        fail "timed-out CLI probes must not request synchronous npm repair"
     fi
 
     local hanging_log_cli="$workspace/hanging-log-codex"

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.9.6"
+version = "0.9.7"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -788,7 +788,6 @@ fn missing_platform_optional_dependency(error: &anyhow::Error) -> Option<String>
     let dependency = message
         .split_once(ERROR_PREFIX)?
         .1
-        .trim_start()
         .split_whitespace()
         .next()?
         .trim_end_matches('.');

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -13,10 +13,14 @@ use std::{
     collections::BTreeMap,
     ffi::{OsStr, OsString},
     fs,
-    io::Write,
+    io::{Read, Write},
     os::unix::fs::PermissionsExt,
+    os::unix::process::CommandExt,
     path::{Path, PathBuf},
-    process::{Command, Output, Stdio},
+    process::{Command, ExitStatus, Output, Stdio},
+    sync::mpsc::{self, Receiver, RecvTimeoutError},
+    thread,
+    time::{Duration as StdDuration, Instant},
 };
 use tracing::{info, warn};
 
@@ -25,8 +29,21 @@ const STANDALONE_INSTALLER_URL: &str = "https://chatgpt.com/codex/install.sh";
 const CLI_NOT_INSTALLED_MESSAGE: &str =
     "Codex CLI is required but not currently installed. Open the app to retry the automatic install flow, or install it manually with npm optional dependencies enabled.";
 const CLI_VERSION_CHECK_TTL: Duration = Duration::hours(1);
+const NPM_REPAIR_INSTALL_TIMEOUT: StdDuration = StdDuration::from_secs(90);
+const NPM_REPAIR_REGISTRY_TIMEOUT: StdDuration = StdDuration::from_secs(20);
+const NPM_REPAIR_CLI_VERIFY_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const BOUNDED_COMMAND_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
+const BOUNDED_COMMAND_TERMINATION_GRACE: StdDuration = StdDuration::from_millis(500);
+const BOUNDED_COMMAND_OUTPUT_DRAIN_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+const BOUNDED_COMMAND_OUTPUT_LIMIT: usize = 64 * 1024;
+const SIGTERM: i32 = 15;
+const SIGKILL: i32 = 9;
 #[cfg(test)]
 const CLI_INSTALLED_VERSION_TTL: Duration = Duration::hours(1);
+
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreflightOutcome {
@@ -88,7 +105,12 @@ pub fn preflight(
             persist_state(paths, state)?;
 
             let repaired_version = repair_npm_optional_dependency(&npm_install)
-                .and_then(|()| read_installed_version(&cli_path))
+                .and_then(|()| {
+                    read_installed_version_bounded(
+                        &cli_path,
+                        NPM_REPAIR_CLI_VERIFY_TIMEOUT,
+                    )
+                })
                 .with_context(|| {
                     format!(
                         "Failed to repair npm-managed Codex CLI at {} after its version probe failed: {probe_error}",
@@ -149,11 +171,16 @@ pub fn preflight(
     state.cli_status = CliStatus::Checking;
     persist_state(paths, state)?;
 
-    let latest_version_result = repaired_npm_install
-        .as_ref()
-        .map_or_else(read_latest_version, |install| {
-            read_latest_version_with_npm(&install.npm_program, &install.command_path_env())
-        });
+    let latest_version_result =
+        repaired_npm_install
+            .as_ref()
+            .map_or_else(read_latest_version, |install| {
+                read_latest_version_with_npm_bounded(
+                    &install.npm_program,
+                    &install.command_path_env(),
+                    NPM_REPAIR_REGISTRY_TIMEOUT,
+                )
+            });
     let official_latest_version = match latest_version_result {
         Ok(version) => Some(version),
         Err(error) => {
@@ -782,6 +809,31 @@ fn read_installed_version(cli_path: &Path) -> Result<String> {
     })
 }
 
+fn read_installed_version_bounded(cli_path: &Path, timeout: StdDuration) -> Result<String> {
+    let primary = run_bounded_command(
+        cli_path,
+        &command_path_env(),
+        &[OsString::from("--version")],
+        timeout,
+    )?;
+    if let Some(version) = extract_version(&primary) {
+        return Ok(version);
+    }
+
+    let fallback = run_bounded_command(
+        cli_path,
+        &command_path_env(),
+        &[OsString::from("version")],
+        timeout,
+    )?;
+    extract_version(&fallback).ok_or_else(|| {
+        anyhow!(
+            "Codex CLI returned an unparseable version string: {}",
+            fallback.trim()
+        )
+    })
+}
+
 fn missing_platform_optional_dependency(error: &anyhow::Error) -> Option<String> {
     const ERROR_PREFIX: &str = "Missing optional dependency";
     let message = error.to_string();
@@ -809,6 +861,25 @@ fn read_latest_version_with_npm(npm: &Path, path_env: &OsString) -> Result<Strin
         .output()
         .with_context(|| format!("Failed to spawn {}", npm.display()))?;
 
+    parse_latest_version_output(npm, &output)
+}
+
+fn read_latest_version_with_npm_bounded(
+    npm: &Path,
+    path_env: &OsString,
+    timeout: StdDuration,
+) -> Result<String> {
+    let args = [
+        OsString::from("view"),
+        OsString::from(CLI_PACKAGE_NAME),
+        OsString::from("version"),
+    ];
+    let output = run_bounded_command_output(npm, path_env, None, &args, timeout)?;
+
+    parse_latest_version_output(npm, &output)
+}
+
+fn parse_latest_version_output(npm: &Path, output: &Output) -> Result<String> {
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         anyhow::bail!(
@@ -937,16 +1008,24 @@ fn path_is_system_managed_location(path: &Path) -> bool {
 }
 
 fn repair_npm_optional_dependency(install: &NpmCliInstall) -> Result<()> {
+    repair_npm_optional_dependency_with_timeout(install, NPM_REPAIR_INSTALL_TIMEOUT)
+}
+
+fn repair_npm_optional_dependency_with_timeout(
+    install: &NpmCliInstall,
+    timeout: StdDuration,
+) -> Result<()> {
     let args = [
         OsString::from("install"),
         OsString::from("--include=optional"),
     ];
-    let output = Command::new(&install.npm_program)
-        .current_dir(&install.package_root)
-        .env("PATH", install.command_path_env())
-        .args(&args)
-        .output()
-        .with_context(|| format!("Failed to spawn {}", install.npm_program.display()))?;
+    let output = run_bounded_command_output(
+        &install.npm_program,
+        &install.command_path_env(),
+        Some(&install.package_root),
+        &args,
+        timeout,
+    )?;
 
     anyhow::ensure!(
         output.status.success(),
@@ -958,6 +1037,164 @@ fn repair_npm_optional_dependency(install: &NpmCliInstall) -> Result<()> {
     );
 
     Ok(())
+}
+
+fn run_bounded_command(
+    program: &Path,
+    path_env: &OsString,
+    args: &[OsString],
+    timeout: StdDuration,
+) -> Result<String> {
+    let output = run_bounded_command_output(program, path_env, None, args, timeout)?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "{} exited with {}{}",
+            program.display(),
+            output.status,
+            format_command_output(&output)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_bounded_command_output(
+    program: &Path,
+    path_env: &OsString,
+    current_dir: Option<&Path>,
+    args: &[OsString],
+    timeout: StdDuration,
+) -> Result<Output> {
+    let mut command = Command::new(program);
+    command
+        .env("PATH", path_env)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+    command.process_group(0);
+
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("Failed to spawn {}", program.display()))?;
+    let process_group = child.id() as i32;
+    let stdout = child
+        .stdout
+        .take()
+        .context("bounded npm command did not expose stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("bounded npm command did not expose stderr")?;
+    let stdout_rx = spawn_bounded_output_reader(stdout);
+    let stderr_rx = spawn_bounded_output_reader(stderr);
+    let started = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Ok(collect_bounded_output(
+                    status,
+                    process_group,
+                    &stdout_rx,
+                    &stderr_rx,
+                ));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                terminate_process_group(&mut child, process_group);
+                let _ = child.wait();
+                anyhow::bail!(
+                    "Failed while waiting for {} {}: {error}",
+                    program.display(),
+                    format_command_args(args)
+                );
+            }
+        }
+
+        if started.elapsed() >= timeout {
+            terminate_process_group(&mut child, process_group);
+            let _ = child.wait();
+            let _ = receive_bounded_output(&stdout_rx, process_group);
+            let _ = receive_bounded_output(&stderr_rx, process_group);
+            anyhow::bail!(
+                "{} {} timed out after {} seconds",
+                program.display(),
+                format_command_args(args),
+                timeout.as_secs_f64()
+            );
+        }
+
+        thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
+    }
+}
+
+fn spawn_bounded_output_reader<R>(mut reader: R) -> Receiver<Vec<u8>>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let mut retained = Vec::new();
+        let mut chunk = [0_u8; 8192];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(read) => {
+                    let remaining = BOUNDED_COMMAND_OUTPUT_LIMIT.saturating_sub(retained.len());
+                    retained.extend_from_slice(&chunk[..read.min(remaining)]);
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = tx.send(retained);
+    });
+    rx
+}
+
+fn collect_bounded_output(
+    status: ExitStatus,
+    process_group: i32,
+    stdout_rx: &Receiver<Vec<u8>>,
+    stderr_rx: &Receiver<Vec<u8>>,
+) -> Output {
+    Output {
+        status,
+        stdout: receive_bounded_output(stdout_rx, process_group),
+        stderr: receive_bounded_output(stderr_rx, process_group),
+    }
+}
+
+fn receive_bounded_output(receiver: &Receiver<Vec<u8>>, process_group: i32) -> Vec<u8> {
+    match receiver.recv_timeout(BOUNDED_COMMAND_OUTPUT_DRAIN_TIMEOUT) {
+        Ok(output) => output,
+        Err(RecvTimeoutError::Disconnected) => Vec::new(),
+        Err(RecvTimeoutError::Timeout) => {
+            signal_process_group(process_group, SIGKILL);
+            receiver
+                .recv_timeout(BOUNDED_COMMAND_OUTPUT_DRAIN_TIMEOUT)
+                .unwrap_or_default()
+        }
+    }
+}
+
+fn terminate_process_group(child: &mut std::process::Child, process_group: i32) {
+    signal_process_group(process_group, SIGTERM);
+    thread::sleep(BOUNDED_COMMAND_TERMINATION_GRACE);
+    signal_process_group(process_group, SIGKILL);
+    let _ = child.kill();
+}
+
+fn signal_process_group(process_group: i32, signal: i32) {
+    // SAFETY: the process was spawned into a dedicated group whose id is the
+    // child pid. Timeout cleanup signals it before reaping the child; after a
+    // successful parent exit this is called only if a descendant still holds a
+    // captured output pipe open.
+    unsafe {
+        let _ = kill(-process_group, signal);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1573,6 +1810,8 @@ mod tests {
             "FAKE_CODEX_ENTRYPOINT",
             "NPM_LOG",
             "NPM_REPAIR_LOG",
+            "NPM_CHILD_MARKER",
+            "NPM_CHILD_PID",
         ]);
         std::env::set_var("HOME", home);
         std::env::set_var("PATH", std::env::join_paths(path_entries)?);
@@ -2835,6 +3074,80 @@ exit 1
         let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
         assert_eq!(persisted.cli_status, CliStatus::Failed);
         assert_eq!(persisted.cli_error_message, state.cli_error_message);
+        Ok(())
+    }
+
+    #[test]
+    fn hanging_npm_repair_times_out_and_terminates_its_process_group() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let npm_program = temp.path().join("npm");
+        let child_marker = temp.path().join("child-terminated");
+        let child_pid = temp.path().join("child.pid");
+        write_executable_script(
+            &npm_program,
+            r#"#!/bin/sh
+if [ "$1" = "install" ]; then
+  sh -c 'trap '\''printf terminated > "$NPM_CHILD_MARKER"; exit 0'\'' TERM; while :; do sleep 1; done' &
+  echo "$!" > "$NPM_CHILD_PID"
+  wait
+fi
+exit 1
+"#,
+        )?;
+        let _restore_env = EnvRestoreGuard::capture(&["NPM_CHILD_MARKER", "NPM_CHILD_PID"]);
+        std::env::set_var("NPM_CHILD_MARKER", &child_marker);
+        std::env::set_var("NPM_CHILD_PID", &child_pid);
+        let install = NpmCliInstall {
+            package_root: temp.path().to_path_buf(),
+            npm_program,
+        };
+
+        let started = Instant::now();
+        let error =
+            repair_npm_optional_dependency_with_timeout(&install, StdDuration::from_millis(100))
+                .expect_err("a hanging npm repair must time out");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
+        assert!(child_pid.exists(), "the nested npm child must have started");
+        assert_eq!(fs::read_to_string(child_marker)?, "terminated");
+        Ok(())
+    }
+
+    #[test]
+    fn repaired_cli_registry_lookup_is_bounded() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let npm_program = temp.path().join("npm");
+        write_executable_script(&npm_program, "#!/bin/sh\nwhile :; do sleep 1; done\n")?;
+
+        let started = Instant::now();
+        let error = read_latest_version_with_npm_bounded(
+            &npm_program,
+            &command_path_env(),
+            StdDuration::from_millis(100),
+        )
+        .expect_err("a hanging npm registry lookup must time out");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
+        Ok(())
+    }
+
+    #[test]
+    fn repaired_cli_version_probe_is_bounded() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let cli_program = temp.path().join("codex");
+        write_executable_script(&cli_program, "#!/bin/sh\nwhile :; do sleep 1; done\n")?;
+
+        let started = Instant::now();
+        let error = read_installed_version_bounded(&cli_program, StdDuration::from_millis(100))
+            .expect_err("a hanging repaired CLI version probe must time out");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -31,7 +31,7 @@ const CLI_NOT_INSTALLED_MESSAGE: &str =
 const CLI_VERSION_CHECK_TTL: Duration = Duration::hours(1);
 const NPM_REPAIR_INSTALL_TIMEOUT: StdDuration = StdDuration::from_secs(90);
 const NPM_REPAIR_REGISTRY_TIMEOUT: StdDuration = StdDuration::from_secs(20);
-const NPM_REPAIR_CLI_VERIFY_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+const CLI_PREFLIGHT_VERSION_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 const BOUNDED_COMMAND_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
 const BOUNDED_COMMAND_TERMINATION_GRACE: StdDuration = StdDuration::from_millis(500);
 const BOUNDED_COMMAND_OUTPUT_DRAIN_TIMEOUT: StdDuration = StdDuration::from_secs(1);
@@ -60,6 +60,22 @@ pub fn preflight(
     explicit_cli_path: Option<PathBuf>,
     allow_install_missing: bool,
 ) -> Result<PreflightOutcome> {
+    preflight_with_version_timeout(
+        state,
+        paths,
+        explicit_cli_path,
+        allow_install_missing,
+        CLI_PREFLIGHT_VERSION_TIMEOUT,
+    )
+}
+
+fn preflight_with_version_timeout(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    explicit_cli_path: Option<PathBuf>,
+    allow_install_missing: bool,
+    version_timeout: StdDuration,
+) -> Result<PreflightOutcome> {
     let requested_path = explicit_cli_path.as_deref();
     let (cli_path, installed_missing_cli) = match resolve_cli_path(requested_path) {
         Some(path) => (path, false),
@@ -75,7 +91,7 @@ pub fn preflight(
     let path_env = command_path_env();
     let managed_cli = cli_management::detect_system_package_managed_cli(&cli_path, &path_env);
     let mut repaired_npm_install = None;
-    let installed_version = match read_installed_version(&cli_path) {
+    let installed_version = match read_installed_version_bounded(&cli_path, version_timeout) {
         Ok(version) => version,
         Err(probe_error) => {
             let Some(missing_dependency) = missing_platform_optional_dependency(&probe_error)
@@ -106,10 +122,7 @@ pub fn preflight(
 
             let repaired_version = repair_npm_optional_dependency(&npm_install)
                 .and_then(|()| {
-                    read_installed_version_bounded(
-                        &cli_path,
-                        NPM_REPAIR_CLI_VERIFY_TIMEOUT,
-                    )
+                    read_installed_version_bounded(&cli_path, version_timeout)
                 })
                 .with_context(|| {
                     format!(
@@ -2909,6 +2922,35 @@ exit 1
             .contains("standalone Codex CLI installer failed"));
         assert!(curl_call_log.exists());
         assert!(!npm_install_log.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn initial_cli_version_probe_is_bounded_before_repair() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        let codex_path = bin_dir.join("codex");
+        write_executable_script(&codex_path, "#!/bin/sh\nwhile :; do sleep 1; done\n")?;
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+
+        let mut state = PersistedState::new(true);
+        let started = Instant::now();
+        let error = preflight_with_version_timeout(
+            &mut state,
+            &paths,
+            Some(codex_path),
+            false,
+            StdDuration::from_millis(100),
+        )
+        .expect_err("the initial CLI probe must not block synchronous preflight");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -783,11 +783,12 @@ fn read_installed_version(cli_path: &Path) -> Result<String> {
 }
 
 fn missing_platform_optional_dependency(error: &anyhow::Error) -> Option<String> {
-    const ERROR_PREFIX: &str = "Missing optional dependency ";
+    const ERROR_PREFIX: &str = "Missing optional dependency";
     let message = error.to_string();
     let dependency = message
         .split_once(ERROR_PREFIX)?
         .1
+        .trim_start()
         .split_whitespace()
         .next()?
         .trim_end_matches('.');
@@ -2683,7 +2684,7 @@ exit 1
         let prefix = temp.path().join("npm-prefix");
         let fixture = write_npm_cli_install(
             &prefix,
-            "#!/bin/sh\necho 'Missing optional dependency @openai/codex-linux-x64. Reinstall Codex: npm install -g @openai/codex' >&2\nexit 1\n",
+            "#!/bin/sh\necho 'Missing optional dependency@openai/codex-linux-x64. Reinstall Codex: npm install -g @openai/codex' >&2\nexit 1\n",
         )?;
         let repair_log = temp.path().join("npm-repair.log");
         write_executable_script(
@@ -2748,9 +2749,17 @@ exit 1
             missing_platform_optional_dependency(&linux_error).as_deref(),
             Some("@openai/codex-linux-x64")
         );
+        let compact_linux_error = anyhow::anyhow!(
+            "Error: Missing optional dependency@openai/codex-linux-arm64. Reinstall Codex"
+        );
+        assert_eq!(
+            missing_platform_optional_dependency(&compact_linux_error).as_deref(),
+            Some("@openai/codex-linux-arm64")
+        );
         for message in [
             "Codex CLI configuration is invalid",
             "Missing optional dependency @openai/codex-darwin-arm64",
+            "Missing optional dependency@openai/codex-linux-x64-evil",
         ] {
             assert_eq!(
                 missing_platform_optional_dependency(&anyhow::anyhow!(message)),


### PR DESCRIPTION
Fixes #929.

The launcher previously ran CLI preflight in the background, so Electron could start against a known-broken npm CLI before its missing Linux optional dependency was repaired. The failure message also exists in both spaced and compact forms, including `Missing optional dependency@openai/...`.

This change keeps repair restricted to verified npm layouts and the exact Linux x64/arm64 platform packages. A detected broken CLI is repaired before Electron starts; if repair cannot complete, startup stops with an actionable reinstall command. Valid CLIs, unrelated failures, warm starts, system-managed installs, standalone installs, and unverified layouts retain their existing behavior.

The synchronous exception is fully bounded. The updater's initial and post-repair CLI probes each have a 5-second limit, npm repair has a 90-second limit, and the registry lookup has a 20-second limit. Each command runs in a dedicated process group with child cleanup and bounded retained output.

`CODEX_SYNC_CLI_PREFLIGHT=1` now detects the broken CLI first and preserves the same required repair semantics. `codex-update-manager` is bumped to `0.9.7`, with the lockfile and runtime/performance documentation updated.

Regression coverage includes both message formats and architectures, unrelated failures, every blocking timeout path, nested process cleanup, and healthy/broken CLI routing in default and explicit-sync modes.

Local validation passes with 242 updater tests, the complete script smoke suite, Clippy with warnings denied, formatting, shell syntax, diff checks, and the public preflight. GitHub CI also passes on `8997d3b`, including Rust and smoke tests plus Debian, RPM, pacman, and Nix package builds.
