### PR TITLE
Make upstream DMG campaigns sequential and recoverable

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -1,9 +1,17 @@
 name: Update Nix upstream hashes
+run-name: Nix refresh ${{ inputs.expected_main_sha }}:${{ inputs.expected_dmg_sha256 }}
 
 on:
-  schedule:
-    - cron: '0 * * * *'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Main commit selected by the DMG campaign watcher
+        required: true
+        type: string
+      expected_dmg_sha256:
+        description: Raw SHA256 of the DMG selected by the campaign watcher
+        required: true
+        type: string
 
 permissions:
   actions: write
@@ -25,39 +33,113 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.expected_main_sha }}
+
+      - name: Deduplicate an already materialized campaign
+        id: dedupe
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          EXPECTED_DMG_SHA256: ${{ inputs.expected_dmg_sha256 }}
+          REFRESH_BRANCH: codex/nix-upstream-refresh
+        run: |
+          set -euo pipefail
+          echo "skip_refresh=false" >> "$GITHUB_OUTPUT"
+
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ -n "$EXPECTED_MAIN_SHA" ] && [ "$checked_out_sha" != "$EXPECTED_MAIN_SHA" ]; then
+            echo "Expected main $EXPECTED_MAIN_SHA, but workflow checked out $checked_out_sha." >&2
+            exit 1
+          fi
+
+          refresh_branch_available=false
+          if git fetch origin "$REFRESH_BRANCH:refs/remotes/origin/$REFRESH_BRANCH"; then
+            refresh_branch_available=true
+          fi
+          if [ -z "$EXPECTED_MAIN_SHA" ] || [ -z "$EXPECTED_DMG_SHA256" ] \
+              || [ "$refresh_branch_available" != "true" ]; then
+            exit 0
+          fi
+
+          source_main="$(git log -1 --format='%(trailers:key=Source-Main-SHA,valueonly)' "origin/$REFRESH_BRANCH" | tr -d '[:space:]')"
+          dmg_sha="$(git log -1 --format='%(trailers:key=Upstream-DMG-SHA256,valueonly)' "origin/$REFRESH_BRANCH" | tr -d '[:space:]')"
+          if [ "$source_main" = "$EXPECTED_MAIN_SHA" ] && [ "$dmg_sha" = "$EXPECTED_DMG_SHA256" ]; then
+            echo "Campaign $EXPECTED_MAIN_SHA:$EXPECTED_DMG_SHA256 is already present on $REFRESH_BRANCH."
+            echo "skip_refresh=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/setup-node@v4
+        if: steps.dedupe.outputs.skip_refresh != 'true'
         with:
           node-version: 24
 
       - uses: cachix/install-nix-action@v31
+        if: steps.dedupe.outputs.skip_refresh != 'true'
 
       - name: Configure Cachix for hash refresh builds
-        if: env.CACHIX_AUTH_TOKEN != ''
+        if: steps.dedupe.outputs.skip_refresh != 'true' && env.CACHIX_AUTH_TOKEN != ''
         uses: cachix/cachix-action@v17
         with:
           name: ${{ env.CACHIX_CACHE_NAME }}
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
 
       - name: Install validation dependencies
+        if: steps.dedupe.outputs.skip_refresh != 'true'
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y p7zip-full
 
       - name: Refresh Nix upstream hash
-        run: scripts/ci/update-nix-hashes.sh
+        if: steps.dedupe.outputs.skip_refresh != 'true'
+        env:
+          EXPECTED_DMG_SHA256: ${{ inputs.expected_dmg_sha256 }}
+          NIX_COMPARE_REF: origin/codex/nix-upstream-refresh
+        run: |
+          set -euo pipefail
+          scripts/ci/update-nix-hashes.sh
+          if [ -n "$EXPECTED_DMG_SHA256" ]; then
+            actual_dmg_sha256="$(sha256sum /tmp/Codex.dmg | awk '{print $1}')"
+            if [ "$actual_dmg_sha256" != "$EXPECTED_DMG_SHA256" ]; then
+              echo "Expected DMG $EXPECTED_DMG_SHA256, but downloaded $actual_dmg_sha256." >&2
+              exit 1
+            fi
+          fi
 
-      - name: Open refreshed hashes pull request
+      - name: Reconcile refreshed hashes pull request and exact-head CI
         env:
           GH_TOKEN: ${{ github.token }}
           REFRESH_BRANCH: codex/nix-upstream-refresh
+          SKIP_REFRESH: ${{ steps.dedupe.outputs.skip_refresh }}
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
         run: |
           set -euo pipefail
 
-          if git diff --quiet -- flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json; then
+          pin_paths=(flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json)
+
+          if [ "$SKIP_REFRESH" = "true" ]; then
+            git checkout -B "$REFRESH_BRANCH" "origin/$REFRESH_BRANCH"
+          elif git diff --quiet -- "${pin_paths[@]}"; then
             echo "Nix pins unchanged, nothing to do."
             exit 0
+          else
+            CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
+            CODEX_VERSION="$(scripts/ci/update-nix-hashes.sh read-flake-string codexVersion)"
+            DMG_SHA256="$(sha256sum /tmp/Codex.dmg | awk '{print $1}')"
+
+            git config user.name  "codex-dmg-hash-bot"
+            git config user.email "actions@github.com"
+            git checkout -B "$REFRESH_BRANCH"
+            git add "${pin_paths[@]}"
+            git commit \
+              -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
+              -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the current upstream DMG." \
+              -m "Verified all ChatGPT Desktop Nix package outputs against the refreshed DMG." \
+              -m "[skip ci]" \
+              -m "Source-Main-SHA: $EXPECTED_MAIN_SHA" \
+              -m "Upstream-DMG-SHA256: $DMG_SHA256"
+            git push --force-with-lease origin "$REFRESH_BRANCH"
           fi
 
           CODEX_DMG_HASH="$(scripts/ci/update-nix-hashes.sh read-flake-hash 'codexDmg = pkgs.fetchurl {' 'hash = ')"
@@ -70,17 +152,6 @@ jobs:
           else
             APPCAST_NOTE="- Sparkle appcast version could not be read during PR creation; pins follow the verified DMG payload."
           fi
-
-          git config user.name  "codex-dmg-hash-bot"
-          git config user.email "actions@github.com"
-          git checkout -B "$REFRESH_BRANCH"
-          git add flake.nix nix/native-modules/package.json nix/native-modules/package-lock.json
-          git commit \
-            -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
-            -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the current upstream DMG." \
-            -m "Verified all ChatGPT Desktop Nix package outputs against the refreshed DMG." \
-            -m "[skip ci]"
-          git push --force origin "$REFRESH_BRANCH"
 
           pr_body="$RUNNER_TEMP/nix-refresh-pr-body.md"
           cat >"$pr_body" <<EOF
@@ -114,4 +185,16 @@ jobs:
           # Branch pushes made with GITHUB_TOKEN do not trigger normal push/PR
           # workflows. Dispatch CI explicitly so required checks attach to the
           # bot branch head SHA and the PR can satisfy the repository ruleset.
-          gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$REFRESH_BRANCH"
+          # A serialized duplicate run adopts the existing exact-head CI rather
+          # than creating a second copy of the same matrix.
+          refresh_head="$(git rev-parse HEAD)"
+          exact_head_runs="$(
+            gh run list --repo "$GITHUB_REPOSITORY" --workflow ci.yml --branch "$REFRESH_BRANCH" \
+              --limit 20 --json headSha \
+              | python3 -c 'import json, sys; head=sys.argv[1]; print(sum(run.get("headSha") == head for run in json.load(sys.stdin)))' "$refresh_head"
+          )"
+          if [ "$exact_head_runs" -eq 0 ]; then
+            gh workflow run ci.yml --repo "$GITHUB_REPOSITORY" --ref "$REFRESH_BRANCH"
+          else
+            echo "Exact-head CI already exists for $refresh_head; skipping duplicate dispatch."
+          fi

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -17,6 +17,8 @@ on:
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
+      - scripts/lib/linux-features.js
+      - linux-features/**
       - .github/workflows/upstream-build-app.yml
   push:
     branches:
@@ -34,6 +36,8 @@ on:
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
+      - scripts/lib/linux-features.js
+      - linux-features/**
       - .github/workflows/upstream-build-app.yml
   workflow_dispatch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Use source files, not generated artifacts. Main routing:
 - Linux features: `linux-features/<id>/`.
 - Package builders: `scripts/build-*.sh` and `scripts/lib/package-common.sh`.
 - Updater: `updater/src/`.
+- Upstream DMG automation: `scripts/automation/upstream-dmg-watchdog/` and
+  `docs/upstream-dmg-watchdog.md`.
 - Computer Use: `computer-use-linux/`; compositor backends under
   `computer-use-linux/src/windowing/backends/`.
 - Nix: `flake.nix`, `flake.lock`, and `nix/`.

--- a/docs/upstream-dmg-watchdog.md
+++ b/docs/upstream-dmg-watchdog.md
@@ -1,0 +1,137 @@
+# Upstream DMG watchdog
+
+The local watchdog turns each upstream DMG SHA-256 into one persistent campaign:
+
+```text
+drift validation -> accepted source head -> Nix preflight -> repair merge
+-> deterministic Nix refresh -> optional Nix repair round -> completion
+```
+
+The versioned engine lives in `scripts/automation/upstream-dmg-watchdog/`.
+Personal Codex automation files are only adapters and must not contain a second
+copy of the state machine.
+
+## State and delivery
+
+State defaults to
+`~/.local/state/codex-automations/upstream-dmg-watchdog/state.json`. Never edit
+it manually. Schema 1 is migrated to schema 2 on first write without dropping
+an active campaign, lease, completed campaign, or Nix PR state. If schema 1
+marked the DMG repair complete while its Nix refresh was still unfinished, the
+migration resumes that campaign at `awaiting-nix` instead of losing the Nix PR.
+
+`probe` emits durable events with an `EVENT_ID`. The watcher sends a worker
+event first and then acknowledges it with `event-ack`. An unacknowledged event
+is returned again on the next heartbeat; `worker-acquire` also acknowledges the
+matching event. This prevents a heartbeat model from silently losing a
+detected DMG or Nix repair request.
+
+Nix refresh is gated by campaign phase. A newly detected DMG never dispatches
+`update-codex-hash.yml`; the campaign must first reach `awaiting-nix` after an
+accepted build and, for a changed source head, successful Nix preflight.
+
+## Worker flow
+
+1. Acquire the lease and create a managed worktree from current `origin/main`.
+2. Record the worktree, branch, base, and full head SHA with `campaign-update`.
+3. Run `sync-features` once with the user's primary checkout as
+   `--source-checkout`, not the managed repair worktree. It uses the repository Linux feature loader,
+   normalizes legacy aliases and settings, preserves supported symlinks, and
+   stores an immutable per-round snapshot. Later builds materialize that same
+   snapshot. Use `refresh-feature-snapshot` only before acceptance when an
+   explicit new local configuration is intended.
+4. Build the candidate from the campaign DMG. Repair only the latest DMG shape,
+   commit the source change, record the new head, build again, and call
+   `record-acceptance --decision FILE --head SHA`.
+5. `record-acceptance` requires an accepted verdict for the campaign DMG, a
+   clean matching source commit, the exact enabled feature snapshot, and a full
+   patch report. It copies immutable decision and patch-report evidence into
+   the state directory. Updating the campaign head invalidates this evidence.
+6. For a changed source head, run `nix-preflight`. An unchanged accepted
+   current `main` skips this step and advances directly to Nix refresh.
+   Preflight uses a disposable detached worktree, permits changes only to the
+   three Nix pin files, verifies the generated DMG SRI, retries transient
+   failures at most three times, and records its log against the accepted head.
+7. Create one repair PR for the round after checking the contributor PR limit.
+   The body must contain `<!-- upstream-dmg-sha256:SHA -->`.
+8. Wait for these exact gates: Rust and Smoke Tests, Debian, RPM, Pacman, Nix
+   Package Builds, and Build App Against Upstream DMG. Run
+   `validate-repair-pr` immediately before an expected-head admin merge.
+9. After GitHub confirms the merge, call `advance-to-nix --pr-number NUMBER`.
+   For an unchanged accepted `main`, omit `--pr-number`. This releases the
+   Worker lease and enables deterministic Nix refresh. `campaign-complete` is
+   intentionally not a Worker operation anymore.
+
+### Feature-only fast path
+
+A round is feature-only only when every changed tracked path is inside the
+affected `linux-features/<id>/` directories. For that scope:
+
+1. Run the affected feature tests, not every repository feature test.
+2. Rebuild and record acceptance against the exact campaign DMG and immutable
+   feature snapshot.
+3. Run the focused preflight:
+
+   ```bash
+   python3 scripts/automation/upstream-dmg-watchdog/watchdog.py nix-preflight \
+     --run-id RUN_ID \
+     --target .#checks.x86_64-linux.nix-linux-features-multi-feature
+   ```
+
+4. Publish the repair PR as soon as those focused checks pass. The normal CI
+   workflow and upstream-DMG build provide the six merge gates in parallel.
+
+Do not run the full local `ci-local.sh pr`, Debian, RPM, or pacman matrix for a
+feature-only repair. Those broad local checks are required when a round changes
+core patches, the shared feature loader, installer, updater, packaging, or a
+mixture of feature and shared paths. Reuse the immutable DMG download, feature
+snapshot, extracted app, native-module cache, and Nix store within a round.
+
+## Nix refresh and recovery
+
+The probe adopts the exact workflow run and stores its run ID, head SHA,
+conclusion, classification, URL, and a bounded failed-log excerpt.
+
+Each refresh dispatch is keyed by the exact `main SHA:DMG SHA`. Repeated
+heartbeats do not dispatch the same key twice. The GitHub workflow also runs in
+one non-cancelling concurrency group, recognizes an already materialized key
+from bot commit trailers, compares only the three allowed pin files, and adopts
+an existing exact-head CI run. It has no independent cron: only the watchdog
+may dispatch it, with the accepted exact `main SHA` and `DMG SHA` as required
+inputs. This prevents Nix refresh from racing drift validation or repair.
+
+- Cancelled, timed-out, runner, setup, and network failures are transient. The
+  campaign gets at most three total attempts, with 15- and 30-minute backoffs
+  between them, and then emits one durable `NIX_BLOCKED`.
+- Build and test failures are source failures. The campaign moves to
+  `nix-repair` and emits `NIX_REPAIR_READY SHA RUN_ID` to the same Worker.
+- The Worker starts a new repair round from current `origin/main`, inspects the
+  recorded run, and repeats acceptance, preflight, PR validation, and merge.
+- CI dispatched with `workflow_dispatch` may not populate a PR rollup. The
+  probe therefore resolves `ci.yml` runs by exact Nix PR head SHA and uses the
+  job conclusions as the merge gates. An active exact-head run remains pending;
+  it is never misreported as `required-checks-missing`.
+
+Only the bot-authored `codex/nix-upstream-refresh` PR is eligible for automatic
+Nix merge. It must contain the exact current SRI, touch only the three allowed
+pin files, keep an unchanged expected head, and pass all five repository CI
+jobs. Campaign completion happens only after the Nix PR merge is confirmed or
+`main` already contains the expected SRI.
+
+## Recovery commands
+
+Revalidate only the latest observed DMG:
+
+```bash
+python3 scripts/automation/upstream-dmg-watchdog/watchdog.py campaign-requeue \
+  --sha SHA --reason "manual revalidation"
+```
+
+Inspect state:
+
+```bash
+python3 scripts/automation/upstream-dmg-watchdog/watchdog.py status
+```
+
+Do not fabricate hashes, edit state, reuse merged campaign branches, remove
+user worktrees, or merge a repair/Nix PR without the deterministic guards.

--- a/scripts/automation/upstream-dmg-watchdog/SKILL.md
+++ b/scripts/automation/upstream-dmg-watchdog/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: upstream-dmg-watchdog
+description: Run the versioned upstream DMG probe, repair worker, guarded PR, and sequential Nix refresh flow.
+---
+
+# Upstream DMG watchdog
+
+Read and follow `docs/upstream-dmg-watchdog.md` and repository `AGENTS.md`.
+Use `scripts/automation/upstream-dmg-watchdog/watchdog.py` for every state
+transition. Never edit state directly.
+
+Probe mode runs only:
+
+```bash
+python3 scripts/automation/upstream-dmg-watchdog/watchdog.py probe
+```
+
+For `CHANGE_READY SHA EVENT_ID=ID` send `PROCESS_UPSTREAM_DMG SHA` to the
+dedicated Worker without model/thinking overrides, then acknowledge `ID`.
+For `NIX_REPAIR_READY SHA RUN_ID EVENT_ID=ID` send the complete event to that
+same Worker, then acknowledge `ID`. Keep `UNCHANGED`, `WORKER_ACTIVE`,
+`NIX_ACTIVE`, and `CAMPAIGN_WAITING` quiet.
+
+Worker mode follows the complete worker flow in the documentation. In
+particular, it must use immutable `sync-features`, commit before
+`record-acceptance`, pass `nix-preflight`, require all six named repair gates,
+call `validate-repair-pr` immediately before merge, and use `advance-to-nix`
+instead of `campaign-complete` after an accepted main or confirmed repair merge.
+
+Classify the changed paths before validation. When every changed path belongs
+to the affected `linux-features/<id>/` directories, use the documented
+feature-only fast path: run only their Node tests, current-DMG acceptance, and
+`nix-preflight --target .#checks.x86_64-linux.nix-linux-features-multi-feature`.
+Open the repair PR after these focused checks and let the six GitHub gates run
+in parallel. Do not run `ci-local.sh pr` or local Debian/RPM/pacman builds for a
+feature-only drift repair. Use the full local matrix for core, shared loader,
+installer, updater, packaging, or mixed-scope changes.
+
+Use the user's primary checkout as `sync-features --source-checkout`, not the
+managed repair worktree; this is how its gitignored `features.json` and enabled
+local feature trees enter the immutable round snapshot. When acceptance reports
+an unchanged source head, skip Nix preflight and call `advance-to-nix` directly.

--- a/scripts/automation/upstream-dmg-watchdog/feature-snapshot.js
+++ b/scripts/automation/upstream-dmg-watchdog/feature-snapshot.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+const {
+  enabledLinuxFeaturesConfig,
+  loadEnabledLinuxFeatures,
+} = require("../../lib/linux-features.js");
+
+function main() {
+  const checkout = process.argv[2];
+  if (!checkout) {
+    throw new Error("usage: feature-snapshot.js CHECKOUT");
+  }
+  const sourceCheckout = path.resolve(checkout);
+  const featuresRoot = path.join(sourceCheckout, "linux-features");
+  const config = enabledLinuxFeaturesConfig({ featuresRoot });
+  const features = loadEnabledLinuxFeatures({ featuresRoot });
+  process.stdout.write(`${JSON.stringify({
+    sourceCheckout,
+    featuresRoot,
+    config,
+    hasLocalConfig: fs.existsSync(path.join(featuresRoot, "features.json")),
+    enabled: features.map((feature) => feature.id),
+    local: features
+      .filter((feature) => feature.local)
+      .map((feature) => ({ id: feature.id, dir: feature.dir })),
+  }, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/automation/upstream-dmg-watchdog/install-local.sh
+++ b/scripts/automation/upstream-dmg-watchdog/install-local.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../../.." && pwd)"
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+skill_dir="$codex_home/skills/upstream-dmg-watchdog"
+
+rm -rf -- "$skill_dir/scripts"
+mkdir -p "$skill_dir/scripts"
+install -m 0644 "$script_dir/local-skill-adapter.md" "$skill_dir/SKILL.md"
+ln -sfn "$repo_root/scripts/automation/upstream-dmg-watchdog/watchdog.py" "$skill_dir/scripts/watchdog.py"
+ln -sfn "$repo_root/scripts/automation/upstream-dmg-watchdog/feature-snapshot.js" "$skill_dir/scripts/feature-snapshot.js"
+
+printf 'Installed repository-backed upstream-dmg-watchdog skill at %s\n' "$skill_dir"

--- a/scripts/automation/upstream-dmg-watchdog/local-skill-adapter.md
+++ b/scripts/automation/upstream-dmg-watchdog/local-skill-adapter.md
@@ -1,0 +1,11 @@
+---
+name: upstream-dmg-watchdog
+description: Monitor and repair the current upstream DMG through the repository-owned watchdog state machine.
+---
+
+# Upstream DMG watchdog adapter
+
+Resolve the target of `scripts/watchdog.py`, then read the `SKILL.md` beside
+that repository-owned implementation completely and follow it. The executable
+in this installed skill directory is a symlink to that implementation. Never
+maintain a second copy or edit watchdog state directly.

--- a/scripts/automation/upstream-dmg-watchdog/test_watchdog.py
+++ b/scripts/automation/upstream-dmg-watchdog/test_watchdog.py
@@ -1,0 +1,1364 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("watchdog.py")
+
+
+class WatchdogTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.state = self.root / "state"
+        self.dmg_a = self.root / "a.dmg"
+        self.dmg_b = self.root / "b.dmg"
+        self.dmg_a.write_bytes(b"first-dmg")
+        self.dmg_b.write_bytes(b"second-dmg")
+        self.fake_gh = self.root / "fake-gh"
+        self.fake_gh.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import base64
+                import json
+                import os
+                from pathlib import Path
+                import sys
+
+                scenario_path = Path(os.environ["FAKE_GH_SCENARIO"])
+                scenario = json.loads(scenario_path.read_text())
+                runtime_path = scenario_path.with_suffix(".runtime.json")
+                runtime = json.loads(runtime_path.read_text()) if runtime_path.exists() else {}
+                args = sys.argv[1:]
+                with scenario_path.with_suffix(".calls.jsonl").open("a") as log:
+                    log.write(json.dumps(args) + "\\n")
+
+                def save():
+                    runtime_path.write_text(json.dumps(runtime))
+
+                if args[:1] == ["api"]:
+                    if "/commits/" in args[1]:
+                        print(json.dumps({"sha": scenario.get("main_sha", "f" * 40)}))
+                    else:
+                        ref = args[1].split("?ref=", 1)[1]
+                        if ref == "main":
+                            content = scenario["main_flake"]
+                        else:
+                            content = scenario.get("head_flakes", {}).get(ref)
+                        if content is None:
+                            raise SystemExit(1)
+                        print(json.dumps({"content": base64.b64encode(content.encode()).decode()}))
+                elif args[:2] == ["pr", "list"]:
+                    print(json.dumps(scenario.get("prs", [])))
+                elif args[:2] == ["run", "list"]:
+                    key = "ci_runs" if "ci.yml" in args else "runs"
+                    print(json.dumps(scenario.get(key, [])))
+                elif args[:2] == ["run", "view"]:
+                    run_id = args[2]
+                    if "--log-failed" in args:
+                        print(scenario.get("run_logs", {}).get(run_id, ""))
+                    else:
+                        print(json.dumps(scenario.get("run_views", {}).get(run_id, {})))
+                elif args[:2] == ["workflow", "run"]:
+                    runtime["dispatches"] = runtime.get("dispatches", 0) + 1
+                    save()
+                elif args[:2] == ["pr", "merge"]:
+                    if scenario.get("merge_fails"):
+                        raise SystemExit(1)
+                    runtime["merged"] = True
+                    runtime["merge_args"] = args
+                    save()
+                elif args[:2] == ["pr", "view"]:
+                    if runtime.get("merged"):
+                        value = scenario["merged_pr"]
+                    else:
+                        views = scenario.get("pr_views") or scenario.get("prs", [])
+                        index = runtime.get("view_index", 0)
+                        value = views[min(index, len(views) - 1)]
+                        runtime["view_index"] = index + 1
+                        save()
+                    print(json.dumps(value))
+                else:
+                    raise SystemExit(f"unsupported fake gh command: {args}")
+                """
+            ),
+            encoding="utf-8",
+        )
+        self.fake_gh.chmod(0o755)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def headers(self, name: str, etag: str, source: Path) -> Path:
+        target = self.root / name
+        target.write_text(
+            "HTTP/1.1 200 OK\r\n"
+            f"ETag: \"{etag}\"\r\n"
+            f"Content-Length: {source.stat().st_size}\r\n\r\n",
+            encoding="utf-8",
+        )
+        return target
+
+    def run_cli(self, *args: str, check: bool = True, env: dict | None = None):
+        return subprocess.run(
+            ["python3", str(SCRIPT), *args, "--state-dir", str(self.state)],
+            check=check,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, **(env or {})},
+        )
+
+    def probe(self, headers: Path, source: Path, now: float = 1000, check: bool = True):
+        return self.run_cli(
+            "probe", "--headers-file", str(headers), "--source-file", str(source), "--now", str(now),
+            "--skip-nix", check=check
+        )
+
+    def load_state(self):
+        return json.loads((self.state / "state.json").read_text(encoding="utf-8"))
+
+    def sri(self, source: Path) -> str:
+        digest = hashlib.sha256(source.read_bytes()).digest()
+        return "sha256-" + base64.b64encode(digest).decode()
+
+    def flake(self, sri: str) -> str:
+        return f'''{{ pkgs }}: let\n  codexDmg = pkgs.fetchurl {{\n    url = "https://example.test/Codex.dmg";\n    hash = "{sri}";\n  }};\nin codexDmg\n'''
+
+    def checks(self, outcome: str = "SUCCESS") -> list[dict]:
+        names = [
+            "Rust and Smoke Tests",
+            "Build Debian Package",
+            "Build RPM Package",
+            "Build Pacman Package",
+            "Nix Package Builds",
+        ]
+        return [{"name": name, "status": "COMPLETED", "conclusion": outcome} for name in names]
+
+    def repair_checks(self, outcome: str = "SUCCESS") -> list[dict]:
+        return self.checks(outcome) + [{
+            "name": "Build App Against Upstream DMG", "status": "COMPLETED", "conclusion": outcome,
+        }]
+
+    def nix_pr(self, sri: str, *, head: str = "a" * 40, **overrides) -> dict:
+        value = {
+            "number": 99,
+            "url": "https://github.com/ilysenko/codex-desktop-linux/pull/99",
+            "state": "OPEN",
+            "author": {"login": "app/github-actions"},
+            "headRepositoryOwner": {"login": "ilysenko"},
+            "headRefName": "codex/nix-upstream-refresh",
+            "headRefOid": head,
+            "baseRefName": "main",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "BLOCKED",
+            "files": [{"path": "flake.nix"}],
+            "statusCheckRollup": self.checks(),
+        }
+        value.update(overrides)
+        return value
+
+    def write_scenario(self, value: dict) -> tuple[Path, dict]:
+        path = self.root / "scenario.json"
+        path.write_text(json.dumps(value), encoding="utf-8")
+        env = {"UPSTREAM_DMG_WATCHDOG_GH": str(self.fake_gh), "FAKE_GH_SCENARIO": str(path)}
+        return path, env
+
+    def fake_calls(self, scenario: Path) -> list[list[str]]:
+        path = scenario.with_suffix(".calls.jsonl")
+        return [json.loads(line) for line in path.read_text().splitlines()] if path.exists() else []
+
+    def complete_baseline(self, headers: Path) -> str:
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        state = self.load_state()
+        state["active_campaign"]["phase"] = "awaiting-nix"
+        state["active_campaign"]["campaign_phase"] = "awaiting-nix"
+        state["worker_lease"] = None
+        state["pending_notifications"] = []
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        return sha
+
+    def finish_baseline(self, headers: Path) -> str:
+        sha = self.complete_baseline(headers)
+        state = self.load_state()
+        campaign = state["active_campaign"]
+        state["last_completed_campaign"] = {**campaign, "phase": "completed", "campaign_phase": "completed"}
+        state["last_accepted_sha256"] = sha
+        state["active_campaign"] = None
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        return sha
+
+    def prepare_acceptance_fixture(self, headers: Path):
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+        worktree = self.state / "worktrees" / sha[:12]
+        feature = worktree / "linux-features" / "ui-tweaks"
+        feature.mkdir(parents=True)
+        (feature / "README.md").write_text("ui\n", encoding="utf-8")
+        (feature / "feature.json").write_text('{"id":"ui-tweaks"}\n', encoding="utf-8")
+        (worktree / ".gitignore").write_text("linux-features/features.json\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-b", "main", str(worktree)], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["git", "-C", str(worktree), "config", "user.name", "Test"], check=True)
+        subprocess.run(["git", "-C", str(worktree), "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "-C", str(worktree), "add", "."], check=True)
+        subprocess.run(["git", "-C", str(worktree), "commit", "-m", "fixture"], check=True, stdout=subprocess.DEVNULL)
+        head = subprocess.check_output(["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True).strip()
+        (worktree / "linux-features" / "features.json").write_text('{"enabled":["ui-tweaks"]}\n', encoding="utf-8")
+        self.run_cli(
+            "campaign-update", "--run-id", run_id, "--worktree", str(worktree), "--head-sha", head,
+            "--base-sha", head, "--now", "1001",
+        )
+        self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(worktree), "--now", "1002"
+        )
+        report = worktree / "patch-report.json"
+        report.write_text('{"enabledFeatures":["ui-tweaks"],"patches":[]}\n', encoding="utf-8")
+        decision = worktree / "decision.json"
+        decision.write_text(json.dumps({
+            "verdict": "accepted",
+            "dmg": {"sha256": sha},
+            "source": {"commit": head, "dirty": False},
+            "checks": {"patchReport": {"enabledFeatures": ["ui-tweaks"], "reportPath": str(report)}},
+        }), encoding="utf-8")
+        return sha, run_id, worktree, head, decision
+
+    def nix_probe(self, headers: Path, env: dict, now: float = 1100, *extra: str, check: bool = True):
+        return self.run_cli(
+            "probe", "--headers-file", str(headers), "--source-file", str(self.dmg_a), "--now", str(now),
+            *extra, check=check, env=env
+        )
+
+    def test_unfinished_campaign_is_redispatched_when_identity_is_unchanged(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        first = self.probe(headers, self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.assertTrue(first.stdout.strip().startswith(f"CHANGE_READY {sha} EVENT_ID="))
+        second = self.probe(headers, self.dmg_a, now=1100)
+        self.assertEqual(second.stdout.strip(), first.stdout.strip())
+        self.assertEqual(self.load_state()["active_campaign"]["sha256"], sha)
+
+    def test_changed_headers_with_same_sha_are_unchanged(self):
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+        result = self.probe(self.headers("b.headers", "etag-b", self.dmg_a), self.dmg_a, now=1100)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.assertTrue(result.stdout.strip().startswith(f"CHANGE_READY {sha} EVENT_ID="))
+        state = self.load_state()
+        self.assertEqual(state["http_identity"]["etag"], "etag-b")
+        self.assertEqual(state["active_campaign"]["http_identity"]["etag"], "etag-b")
+
+    def test_new_sha_supersedes_an_undelivered_old_campaign_event(self):
+        sha_b = hashlib.sha256(self.dmg_b.read_bytes()).hexdigest()
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+
+        changed = self.probe(self.headers("b.headers", "etag-b", self.dmg_b), self.dmg_b, now=1100)
+
+        self.assertTrue(changed.stdout.strip().startswith(f"CHANGE_READY {sha_b} EVENT_ID="))
+        notifications = self.load_state()["pending_notifications"]
+        old_event, new_event = notifications[-2:]
+        self.assertEqual(old_event["superseded_by_sha256"], sha_b)
+        self.assertIsNotNone(old_event["acked_at"])
+        self.assertIsNone(new_event["acked_at"])
+
+    def test_completed_campaign_with_same_identity_is_unchanged(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.finish_baseline(headers)
+        result = self.probe(headers, self.dmg_a, now=1100)
+        self.assertEqual(result.stdout.strip(), "UNCHANGED")
+
+    def test_active_worker_is_reported_for_unchanged_identity(self):
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.probe(headers, self.dmg_a)
+        self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        result = self.probe(headers, self.dmg_a, now=1001)
+        self.assertEqual(result.stdout.strip(), "WORKER_ACTIVE")
+
+    def test_acknowledged_campaign_event_is_not_requeued(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        first = self.probe(headers, self.dmg_a)
+        event_id = first.stdout.strip().split("EVENT_ID=", 1)[1]
+        self.run_cli("event-ack", "--event-id", event_id, "--now", "1001")
+        second = self.probe(headers, self.dmg_a, now=1002)
+        self.assertEqual(second.stdout.strip(), "CAMPAIGN_WAITING")
+
+    def test_worker_and_nix_notifications_are_delivered_in_order(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        first = self.probe(headers, self.dmg_a)
+        first_event = first.stdout.strip().split("EVENT_ID=", 1)[1]
+        state = self.load_state()
+        state["pending_notifications"].append({
+            "id": "nix-event",
+            "key": "nix-blocked:test",
+            "kind": "NIX_BLOCKED",
+            "payload": [925, "required-checks-missing"],
+            "created_at": "1970-01-01T00:16:41Z",
+            "acked_at": None,
+        })
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        self.run_cli("event-ack", "--event-id", first_event, "--now", "1001")
+        second = self.probe(headers, self.dmg_a, now=1002)
+
+        self.assertEqual(
+            second.stdout.strip(),
+            "NIX_BLOCKED 925 required-checks-missing EVENT_ID=nix-event",
+        )
+
+    def test_schema_v1_is_migrated_without_losing_campaign(self):
+        self.state.mkdir(parents=True)
+        (self.state / "state.json").write_text(json.dumps({
+            "schema": 1,
+            "last_observed_sha256": "a" * 64,
+            "active_campaign": {"sha256": "a" * 64, "phase": "building", "detected_at": "old"},
+            "nix_refresh": {"workflow_status": "waiting-for-pr", "pr_number": 925},
+        }), encoding="utf-8")
+        result = self.run_cli("status")
+        state = json.loads(result.stdout)
+        self.assertEqual(state["schema"], 2)
+        self.assertEqual(state["active_campaign"]["sha256"], "a" * 64)
+        self.assertEqual(state["active_campaign"]["campaign_phase"], "building")
+        self.assertEqual(state["nix_refresh"]["pr_number"], 925)
+
+    def test_schema_v1_completed_drift_campaign_resumes_unfinished_nix_phase(self):
+        sha = "a" * 64
+        completed = {
+            "sha256": sha,
+            "phase": "completed",
+            "verdict": "accepted",
+            "detected_at": "2026-01-01T00:00:00Z",
+            "head_sha": "b" * 40,
+        }
+        self.state.mkdir(parents=True)
+        (self.state / "state.json").write_text(json.dumps({
+            "schema": 1,
+            "last_observed_sha256": sha,
+            "last_accepted_sha256": sha,
+            "active_campaign": None,
+            "last_completed_campaign": completed,
+            "pending_notifications": None,
+            "nix_runs": None,
+            "nix_refresh": {
+                "expected_dmg_sha256": sha,
+                "workflow_status": "waiting-for-pr",
+                "pr_number": 925,
+            },
+            "last_merged_nix_pr": None,
+        }), encoding="utf-8")
+
+        state = json.loads(self.run_cli("status").stdout)
+
+        self.assertEqual(state["active_campaign"]["sha256"], sha)
+        self.assertEqual(state["active_campaign"]["campaign_phase"], "awaiting-nix")
+        self.assertEqual(state["active_campaign"]["phase"], "awaiting-nix")
+        self.assertEqual(state["nix_refresh"]["pr_number"], 925)
+        self.assertEqual(state["pending_notifications"], [])
+        self.assertEqual(state["nix_runs"], [])
+
+    def test_missing_stable_identity_retries_without_campaign(self):
+        headers = self.root / "bad.headers"
+        headers.write_text("HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\n", encoding="utf-8")
+        result = self.probe(headers, self.dmg_a, check=False)
+        self.assertEqual(result.returncode, 3)
+        self.assertEqual(result.stdout.strip(), "RETRY 1")
+        self.assertIsNone(self.load_state()["active_campaign"])
+
+    def test_worker_lease_conflict_and_crash_recovery(self):
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+        first = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000", "--ttl", "10")
+        run_id = first.stdout.split()[1]
+        busy = self.run_cli("worker-acquire", "--sha", sha, "--now", "1005", check=False)
+        self.assertEqual(busy.returncode, 2)
+        self.assertEqual(busy.stdout.strip(), "WORKER_ACTIVE")
+        recovered = self.run_cli("worker-acquire", "--sha", sha, "--now", "1011")
+        self.assertEqual(recovered.stdout.split()[0], "ACQUIRED")
+        self.assertNotEqual(recovered.stdout.split()[1], run_id)
+
+    def test_new_sha_is_pending_and_supersedes_after_release(self):
+        sha_a = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        sha_b = hashlib.sha256(self.dmg_b.read_bytes()).hexdigest()
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha_a, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+        changed = self.probe(self.headers("b.headers", "etag-b", self.dmg_b), self.dmg_b, now=1100)
+        self.assertTrue(changed.stdout.strip().startswith(f"CHANGE_READY {sha_b} EVENT_ID="))
+        self.assertEqual(self.load_state()["pending_campaign"]["sha256"], sha_b)
+        self.run_cli("release", "--run-id", run_id, "--now", "1101")
+        next_run = self.run_cli("worker-acquire", "--sha", sha_b, "--now", "1102")
+        self.assertEqual(next_run.stdout.split()[2], sha_b)
+        self.assertEqual(self.load_state()["last_completed_campaign"]["phase"], "superseded")
+
+    def test_non_owner_cannot_update_campaign(self):
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+        self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        result = self.run_cli(
+            "campaign-update", "--run-id", "not-owner", "--phase", "building", "--now", "1001", check=False
+        )
+        self.assertEqual(result.returncode, 5)
+        self.assertIn("owned by another run", result.stderr)
+
+    def test_worker_cannot_bypass_guarded_acceptance_and_nix_phases(self):
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(self.headers("a.headers", "etag-a", self.dmg_a), self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+
+        for command in ("campaign-update", "heartbeat"):
+            result = self.run_cli(
+                command, "--run-id", run_id, "--phase", "awaiting-nix", "--now", "1001", check=False
+            )
+            self.assertEqual(result.returncode, 5)
+            self.assertIn("guarded transition", result.stderr)
+
+        self.assertEqual(self.load_state()["active_campaign"]["campaign_phase"], "drift-validation")
+
+    def test_completed_campaign_can_be_requeued_and_acquired_again(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.finish_baseline(headers)
+        result = self.run_cli(
+            "campaign-requeue", "--sha", sha, "--reason", "feature drift revalidation", "--now", "1100"
+        )
+        self.assertEqual(result.stdout.strip(), f"CHANGE_READY {sha}")
+        state = self.load_state()
+        self.assertEqual(state["active_campaign"]["sha256"], sha)
+        self.assertEqual(state["active_campaign"]["requeue_reason"], "feature drift revalidation")
+        self.assertIsNone(state["last_accepted_sha256"])
+        self.assertTrue(state["revalidation_required"])
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1101")
+        self.assertEqual(acquired.stdout.split()[0], "ACQUIRED")
+
+    def test_requeue_refuses_to_replace_active_worker(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        result = self.run_cli("campaign-requeue", "--sha", sha, "--now", "1001", check=False)
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout.strip(), "WORKER_ACTIVE")
+
+    def test_requeue_rejects_a_stale_dmg_sha(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha_a = self.finish_baseline(headers)
+        sha_b = hashlib.sha256(self.dmg_b.read_bytes()).hexdigest()
+        state = self.load_state()
+        state["last_observed_sha256"] = sha_b
+        (self.state / "downloads" / f"{sha_b}.dmg").write_bytes(self.dmg_b.read_bytes())
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        result = self.run_cli("campaign-requeue", "--sha", sha_a, "--now", "1100", check=False)
+        self.assertEqual(result.returncode, 5)
+        self.assertIn("only the latest observed DMG", result.stderr)
+
+    def test_nix_repair_acquire_creates_a_new_round(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        state = self.load_state()
+        state["active_campaign"]["repair_rounds"][-1]["status"] = "merged"
+        state["active_campaign"]["acceptance_evidence"] = {"head_sha": "a" * 40}
+        state["active_campaign"]["feature_snapshot"] = {"round": 1}
+        state["active_campaign"]["head_sha"] = "a" * 40
+        state["active_campaign"]["worktree"] = "/old/worktree"
+        state["active_campaign"]["campaign_phase"] = "nix-repair"
+        state["active_campaign"]["phase"] = "nix-repair"
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1100")
+        self.assertEqual(acquired.stdout.split()[0], "ACQUIRED")
+        rounds = self.load_state()["active_campaign"]["repair_rounds"]
+        self.assertEqual([item["round"] for item in rounds], [1, 2])
+        self.assertEqual(rounds[-1]["status"], "active")
+        self.assertIsNone(self.load_state()["active_campaign"]["acceptance_evidence"])
+        self.assertIsNone(self.load_state()["active_campaign"]["feature_snapshot"])
+        self.assertIsNone(self.load_state()["active_campaign"]["head_sha"])
+        self.assertIsNone(self.load_state()["active_campaign"]["worktree"])
+
+    def test_nix_repair_after_accepted_main_also_creates_a_new_round(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        state = self.load_state()
+        state["active_campaign"]["repair_rounds"][-1]["status"] = "accepted-main"
+        state["active_campaign"]["campaign_phase"] = "nix-repair"
+        state["active_campaign"]["phase"] = "nix-repair"
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        self.run_cli("worker-acquire", "--sha", sha, "--now", "1100")
+
+        rounds = self.load_state()["active_campaign"]["repair_rounds"]
+        self.assertEqual([item["round"] for item in rounds], [1, 2])
+
+    def test_sync_features_copies_config_and_enabled_local_feature(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+
+        source = self.root / "source"
+        source_features = source / "linux-features"
+        tracked_feature = source_features / "ui-tweaks"
+        tracked_feature.mkdir(parents=True)
+        (tracked_feature / "README.md").write_text("tracked\n", encoding="utf-8")
+        (tracked_feature / "feature.json").write_text('{"id":"ui-tweaks"}\n', encoding="utf-8")
+        local_feature = source_features / "local" / "private-feature"
+        local_feature.mkdir(parents=True)
+        (local_feature / "README.md").write_text("private\n", encoding="utf-8")
+        (local_feature / "feature.json").write_text('{"id":"private-feature"}\n', encoding="utf-8")
+        (local_feature / "payload.txt").write_text("payload\n", encoding="utf-8")
+        (local_feature / "payload-link").symlink_to("payload.txt")
+        config = {
+            "enabled": ["ui-tweaks", "private-feature"],
+            "settings": {"ui-tweaks": {"example": True}},
+        }
+        source_features.mkdir(exist_ok=True)
+        (source_features / "features.json").write_text(json.dumps(config), encoding="utf-8")
+
+        worktree = self.state / "worktrees" / sha[:12]
+        target_features = worktree / "linux-features"
+        (target_features / "ui-tweaks").mkdir(parents=True)
+        self.run_cli(
+            "campaign-update", "--run-id", run_id, "--worktree", str(worktree), "--now", "1001"
+        )
+        result = self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(source), "--now", "1002"
+        )
+        self.assertEqual(result.stdout.strip(), "FEATURES_SYNCED ui-tweaks,private-feature")
+        copied = json.loads((target_features / "features.json").read_text(encoding="utf-8"))
+        self.assertEqual(copied, config)
+        self.assertEqual(
+            (target_features / "local" / "private-feature" / "README.md").read_text(encoding="utf-8"),
+            "private\n",
+        )
+        snapshot = self.load_state()["active_campaign"]["feature_snapshot"]
+        self.assertEqual(snapshot["enabled"], ["ui-tweaks", "private-feature"])
+        self.assertTrue((target_features / "local" / "private-feature" / "payload-link").is_symlink())
+        self.assertIn("private-feature", snapshot["local_feature_tree_hashes"])
+        (source_features / "features.json").write_text('{"enabled":[]}\n', encoding="utf-8")
+        (local_feature / "payload.txt").write_text("changed\n", encoding="utf-8")
+        self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(source), "--now", "1003"
+        )
+        self.assertEqual(json.loads((target_features / "features.json").read_text()), config)
+        self.assertEqual((target_features / "local" / "private-feature" / "payload.txt").read_text(), "payload\n")
+
+    def test_sync_features_normalizes_legacy_alias_and_rejects_missing_manifest(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+        source = self.root / "source-alias"
+        feature = source / "linux-features" / "open-target-discovery"
+        feature.mkdir(parents=True)
+        (feature / "README.md").write_text("feature\n", encoding="utf-8")
+        (feature / "feature.json").write_text('{"id":"open-target-discovery"}\n', encoding="utf-8")
+        (source / "linux-features" / "features.json").write_text(
+            '{"enabled":["zed-opener"],"settings":{"zed-opener":{"value":1}}}\n', encoding="utf-8"
+        )
+        worktree = self.state / "worktrees" / sha[:12]
+        target = worktree / "linux-features"
+        (target / "open-target-discovery").mkdir(parents=True)
+        self.run_cli("campaign-update", "--run-id", run_id, "--worktree", str(worktree), "--now", "1001")
+        self.run_cli("sync-features", "--run-id", run_id, "--source-checkout", str(source), "--now", "1002")
+        copied = json.loads((target / "features.json").read_text())
+        self.assertEqual(copied["enabled"], ["open-target-discovery"])
+        self.assertEqual(copied["settings"]["open-target-discovery"], {"value": 1})
+
+        self.run_cli("refresh-feature-snapshot", "--run-id", run_id, "--now", "1003")
+        missing = source / "linux-features" / "local" / "private-missing"
+        missing.mkdir(parents=True)
+        (missing / "README.md").write_text("missing\n", encoding="utf-8")
+        (source / "linux-features" / "features.json").write_text('{"enabled":["private-missing"]}\n', encoding="utf-8")
+        result = self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(source), "--now", "1004", check=False
+        )
+        self.assertEqual(result.returncode, 5)
+        self.assertIn("Enabled Linux feature ids not found", result.stderr)
+
+    def test_sync_features_snapshots_a_symlinked_local_feature_directory(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+
+        source = self.root / "source-symlink"
+        local_root = source / "linux-features" / "local"
+        local_root.mkdir(parents=True)
+        external = self.root / "external-private-feature"
+        external.mkdir()
+        (external / "README.md").write_text("private\n", encoding="utf-8")
+        (external / "feature.json").write_text('{"id":"private-feature"}\n', encoding="utf-8")
+        (external / "payload.txt").write_text("immutable\n", encoding="utf-8")
+        (local_root / "private-feature").symlink_to(external, target_is_directory=True)
+        (source / "linux-features" / "features.json").write_text(
+            '{"enabled":["private-feature"]}\n', encoding="utf-8"
+        )
+
+        worktree = self.state / "worktrees" / sha[:12]
+        (worktree / "linux-features").mkdir(parents=True)
+        self.run_cli("campaign-update", "--run-id", run_id, "--worktree", str(worktree), "--now", "1001")
+
+        result = self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(source), "--now", "1002"
+        )
+
+        self.assertEqual(result.stdout.strip(), "FEATURES_SYNCED private-feature")
+        copied = worktree / "linux-features" / "local" / "private-feature"
+        self.assertTrue(copied.is_dir())
+        self.assertFalse(copied.is_symlink())
+        self.assertEqual((copied / "payload.txt").read_text(), "immutable\n")
+
+    def test_sync_features_rejects_unmanaged_worktree(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = hashlib.sha256(self.dmg_a.read_bytes()).hexdigest()
+        self.probe(headers, self.dmg_a)
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1000")
+        run_id = acquired.stdout.split()[1]
+        outside = self.root / "outside"
+        (outside / "linux-features").mkdir(parents=True)
+        self.run_cli(
+            "campaign-update", "--run-id", run_id, "--worktree", str(outside), "--now", "1001"
+        )
+        result = self.run_cli(
+            "sync-features", "--run-id", run_id, "--source-checkout", str(self.root),
+            "--now", "1002", check=False,
+        )
+        self.assertEqual(result.returncode, 5)
+        self.assertIn("outside the managed worktree root", result.stderr)
+
+    def test_record_acceptance_binds_dmg_features_and_git_head(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha, run_id, _, head, decision = self.prepare_acceptance_fixture(headers)
+        result = self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1003",
+        )
+        self.assertEqual(result.stdout.strip(), f"ACCEPTANCE_RECORDED {head}")
+        evidence = self.load_state()["active_campaign"]["acceptance_evidence"]
+        self.assertEqual(evidence["dmg_sha256"], sha)
+        self.assertEqual(evidence["head_sha"], head)
+        self.assertEqual(evidence["enabled_features"], ["ui-tweaks"])
+        self.assertEqual(evidence["validation_scope"]["profile"], "unchanged")
+        self.assertTrue(Path(evidence["patch_report_path"]).is_file())
+
+    def test_record_acceptance_classifies_feature_only_repair_scope(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        _, run_id, worktree, base, decision = self.prepare_acceptance_fixture(headers)
+        (worktree / "linux-features" / "ui-tweaks" / "README.md").write_text("updated ui\n", encoding="utf-8")
+        subprocess.run([
+            "git", "-C", str(worktree), "add", "linux-features/ui-tweaks/README.md",
+        ], check=True)
+        subprocess.run(["git", "-C", str(worktree), "commit", "-m", "feature repair"], check=True, stdout=subprocess.DEVNULL)
+        head = subprocess.check_output(["git", "-C", str(worktree), "rev-parse", "HEAD"], text=True).strip()
+        payload = json.loads(decision.read_text())
+        payload["source"]["commit"] = head
+        decision.write_text(json.dumps(payload), encoding="utf-8")
+        self.run_cli(
+            "campaign-update", "--run-id", run_id, "--base-sha", base, "--head-sha", head,
+            "--now", "1003",
+        )
+
+        recorded = self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1004", check=False,
+        )
+        self.assertEqual(recorded.returncode, 0, recorded.stderr)
+
+        scope = self.load_state()["active_campaign"]["repair_rounds"][-1]["validation_scope"]
+        self.assertEqual(scope["profile"], "feature-only")
+        self.assertEqual(scope["feature_ids"], ["ui-tweaks"])
+        self.assertEqual(scope["paths"], ["linux-features/ui-tweaks/README.md"])
+
+    def test_unchanged_accepted_main_advances_without_nix_preflight(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha, run_id, _, head, decision = self.prepare_acceptance_fixture(headers)
+        self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1003",
+        )
+        _, env = self.write_scenario({"main_sha": head})
+
+        result = self.run_cli(
+            "advance-to-nix", "--run-id", run_id, "--now", "1004", env=env,
+        )
+
+        self.assertEqual(result.stdout.strip(), f"AWAITING_NIX {sha}")
+        self.assertEqual(self.load_state()["active_campaign"]["campaign_phase"], "awaiting-nix")
+
+    def test_record_acceptance_rejects_head_or_dmg_mismatch_and_new_head_invalidates_evidence(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        _, run_id, _, head, decision = self.prepare_acceptance_fixture(headers)
+        wrong_head = self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", "b" * 40,
+            "--now", "1003", check=False,
+        )
+        self.assertEqual(wrong_head.returncode, 5)
+        self.assertIn("does not match the campaign worktree", wrong_head.stderr)
+        self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1004",
+        )
+        self.run_cli("campaign-update", "--run-id", run_id, "--head-sha", "c" * 40, "--now", "1005")
+        self.assertIsNone(self.load_state()["active_campaign"]["acceptance_evidence"])
+
+        payload = json.loads(decision.read_text())
+        payload["dmg"]["sha256"] = "d" * 64
+        decision.write_text(json.dumps(payload), encoding="utf-8")
+        self.run_cli("campaign-update", "--run-id", run_id, "--head-sha", head, "--now", "1006")
+        wrong_dmg = self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1007", check=False,
+        )
+        self.assertEqual(wrong_dmg.returncode, 5)
+        self.assertIn("DMG SHA does not match", wrong_dmg.stderr)
+
+    def test_repair_pr_requires_all_six_gates_and_advances_only_after_confirmed_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha, run_id, _, head, decision = self.prepare_acceptance_fixture(headers)
+        self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", head,
+            "--now", "1003",
+        )
+        state = self.load_state()
+        campaign = state["active_campaign"]
+        campaign["repair_rounds"][-1]["nix_preflight"] = {"status": "success", "head_sha": head}
+        campaign["branch"] = f"codex/upstream-dmg-{sha[:12]}"
+        campaign["repair_rounds"][-1]["branch"] = campaign["branch"]
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        pr = {
+            "number": 123,
+            "url": "https://github.com/example/repo/pull/123",
+            "state": "OPEN",
+            "headRefName": campaign["branch"],
+            "headRefOid": head,
+            "baseRefName": "main",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "body": f"<!-- upstream-dmg-sha256:{sha} -->",
+            "statusCheckRollup": self.repair_checks(),
+        }
+        scenario, env = self.write_scenario({"prs": [pr], "pr_views": [pr]})
+        ready = self.run_cli(
+            "validate-repair-pr", "--run-id", run_id, "--pr-number", "123",
+            "--headers-file", str(headers), "--now", "1004", env=env,
+        )
+        self.assertEqual(ready.stdout.strip(), f"REPAIR_PR_READY 123 {head}")
+
+        missing = {**pr, "statusCheckRollup": self.checks()}
+        scenario.write_text(json.dumps({"prs": [missing], "pr_views": [missing]}), encoding="utf-8")
+        waiting = self.run_cli(
+            "validate-repair-pr", "--run-id", run_id, "--pr-number", "123",
+            "--headers-file", str(headers), "--now", "1005", env=env, check=False,
+        )
+        self.assertEqual(waiting.returncode, 8)
+        self.assertIn("Build App Against Upstream DMG", waiting.stdout)
+
+        merged = {
+            **pr,
+            "state": "MERGED",
+            "mergedAt": "2026-01-01T00:00:00Z",
+            "mergeCommit": {"oid": "e" * 40},
+        }
+        scenario.write_text(json.dumps({"prs": [merged], "pr_views": [merged]}), encoding="utf-8")
+        advanced = self.run_cli(
+            "advance-to-nix", "--run-id", run_id, "--pr-number", "123", "--now", "1006", env=env,
+        )
+        self.assertEqual(advanced.stdout.strip(), f"AWAITING_NIX {sha}")
+        state = self.load_state()
+        self.assertEqual(state["active_campaign"]["campaign_phase"], "awaiting-nix")
+        self.assertIsNone(state["worker_lease"])
+        self.assertEqual(state["active_campaign"]["repair_rounds"][-1]["merge_sha"], "e" * 40)
+
+    def test_sha256_is_converted_to_nix_sri(self):
+        expected = "sha256-" + base64.b64encode(hashlib.sha256(self.dmg_a.read_bytes()).digest()).decode()
+        self.assertEqual(self.sri(self.dmg_a), expected)
+
+    def test_current_main_hash_skips_pr_and_workflow_queries(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({"main_flake": self.flake(self.sri(self.dmg_a))})
+        result = self.nix_probe(headers, env)
+        self.assertEqual(result.stdout.strip(), "UNCHANGED")
+        calls = self.fake_calls(scenario)
+        self.assertEqual([call[0] for call in calls], ["api"])
+
+    def test_new_dmg_does_not_dispatch_nix_before_drift_acceptance(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [],
+        })
+        result = self.run_cli(
+            "probe", "--headers-file", str(headers), "--source-file", str(self.dmg_a), "--now", "1000",
+            env=env,
+        )
+        self.assertTrue(result.stdout.strip().startswith("CHANGE_READY "))
+        self.assertFalse(any(call[:2] == ["workflow", "run"] for call in self.fake_calls(scenario)))
+
+    def test_completed_source_failure_returns_same_campaign_to_worker(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 55, "status": "completed", "conclusion": "failure",
+                "createdAt": "1970-01-01T00:18:20Z", "headSha": "f" * 40, "url": "https://run/55",
+            }],
+            "run_views": {"55": {
+                "databaseId": 55, "status": "completed", "conclusion": "failure",
+                "headSha": "f" * 40, "url": "https://run/55",
+                "jobs": [{"steps": [{"name": "Refresh Nix upstream hash", "conclusion": "failure"}]}],
+            }},
+            "run_logs": {"55": "enabled-feature-drift"},
+        })
+        result = self.nix_probe(headers, env, now=1100)
+        self.assertTrue(result.stdout.strip().startswith(f"NIX_REPAIR_READY {sha} 55 EVENT_ID="))
+        state = self.load_state()
+        self.assertEqual(state["active_campaign"]["campaign_phase"], "nix-repair")
+        self.assertEqual(state["nix_runs"][-1]["classification"], "source")
+
+    def test_network_log_overrides_a_build_step_as_transient(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 56, "status": "completed", "conclusion": "failure",
+                "createdAt": "1970-01-01T00:18:20Z", "headSha": "f" * 40, "url": "https://run/56",
+            }],
+            "run_views": {"56": {
+                "databaseId": 56, "status": "completed", "conclusion": "failure",
+                "headSha": "f" * 40, "url": "https://run/56",
+                "jobs": [{"steps": [{"name": "Refresh Nix upstream hash", "conclusion": "failure"}]}],
+            }},
+            "run_logs": {"56": "curl: (6) Could not resolve host: persistent.oaistatic.com"},
+        })
+
+        result = self.nix_probe(headers, env, now=1100)
+
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        state = self.load_state()
+        self.assertEqual(state["nix_runs"][-1]["classification"], "transient")
+        self.assertNotEqual(state["active_campaign"]["campaign_phase"], "nix-repair")
+
+    def test_empty_pr_rollup_uses_dispatched_ci_run_and_returns_failure_to_worker(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head, statusCheckRollup=[])
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "ci_runs": [{"databaseId": 77, "status": "completed", "conclusion": "failure", "headSha": head}],
+            "run_views": {"77": {
+                "databaseId": 77, "status": "completed", "conclusion": "failure", "headSha": head,
+                "url": "https://run/77", "jobs": [
+                    {"name": "Rust and Smoke Tests", "status": "completed", "conclusion": "success"},
+                    {"name": "Nix Package Builds", "status": "completed", "conclusion": "failure", "url": "https://run/77"},
+                ],
+            }},
+            "run_logs": {"77": "frameless-titlebar enabled-feature-drift"},
+        })
+        result = self.nix_probe(headers, env, now=1100)
+        self.assertTrue(result.stdout.strip().startswith(f"NIX_REPAIR_READY {sha} 77 EVENT_ID="))
+        self.assertEqual(self.load_state()["nix_runs"][-1]["run_id"], 77)
+
+    def test_empty_pr_rollup_with_active_exact_head_ci_stays_pending(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head, statusCheckRollup=[])
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "ci_runs": [{
+                "databaseId": 76,
+                "status": "in_progress",
+                "conclusion": None,
+                "headSha": head,
+                "url": "https://run/76",
+            }],
+        })
+
+        result = self.nix_probe(headers, env, now=1100)
+
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        state = self.load_state()
+        self.assertEqual(state["nix_refresh"]["check_status"], "checks-pending")
+        self.assertEqual(state["pending_notifications"], [])
+
+    def test_transient_exact_head_ci_failure_retries_without_starting_source_repair(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head, statusCheckRollup=[])
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "ci_runs": [{
+                "databaseId": 78,
+                "status": "completed",
+                "conclusion": "cancelled",
+                "headSha": head,
+                "url": "https://run/78",
+            }],
+            "run_views": {"78": {
+                "databaseId": 78,
+                "status": "completed",
+                "conclusion": "cancelled",
+                "headSha": head,
+                "url": "https://run/78",
+                "jobs": [{
+                    "name": "Nix Package Builds",
+                    "status": "completed",
+                    "conclusion": "cancelled",
+                    "url": "https://run/78",
+                }],
+            }},
+        })
+
+        first = self.nix_probe(headers, env, now=1100)
+        second = self.nix_probe(headers, env, now=2001)
+
+        self.assertEqual(first.stdout.strip(), "NIX_ACTIVE")
+        self.assertEqual(second.stdout.strip(), "NIX_ACTIVE")
+        state = self.load_state()
+        self.assertNotEqual(state["active_campaign"]["campaign_phase"], "nix-repair")
+        self.assertEqual(state["nix_runs"][-1]["classification"], "transient")
+        dispatches = [call for call in self.fake_calls(scenario) if call[:2] == ["workflow", "run"]]
+        self.assertEqual(len(dispatches), 1)
+        self.assertIn("ci.yml", dispatches[0])
+
+    def test_hash_mismatch_dispatches_once_during_visibility_cooldown(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [],
+        })
+        self.assertEqual(self.nix_probe(headers, env, now=1100).stdout.strip(), "NIX_ACTIVE")
+        self.assertEqual(self.nix_probe(headers, env, now=1200).stdout.strip(), "NIX_ACTIVE")
+        calls = self.fake_calls(scenario)
+        dispatches = [call for call in calls if call[:2] == ["workflow", "run"]]
+        self.assertEqual(len(dispatches), 1)
+        self.assertIn("--ref", dispatches[0])
+        self.assertIn("expected_main_sha=" + "f" * 40, dispatches[0])
+        self.assertIn("expected_dmg_sha256=" + hashlib.sha256(self.dmg_a.read_bytes()).hexdigest(), dispatches[0])
+
+    def test_persisted_dispatch_key_prevents_duplicate_after_cooldown(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [],
+        })
+
+        self.nix_probe(headers, env, now=1100)
+        self.nix_probe(headers, env, now=4000)
+
+        dispatches = [call for call in self.fake_calls(scenario) if call[:2] == ["workflow", "run"]]
+        self.assertEqual(len(dispatches), 1)
+        state = self.load_state()
+        self.assertEqual(
+            state["nix_refresh"]["dispatch_key"],
+            "f" * 40 + ":" + hashlib.sha256(self.dmg_a.read_bytes()).hexdigest(),
+        )
+
+    def test_active_workflow_is_adopted_without_dispatch(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 7, "status": "in_progress", "conclusion": None,
+                "headSha": "f" * 40, "url": "https://run/7",
+            }],
+        })
+        self.nix_probe(headers, env)
+        calls = self.fake_calls(scenario)
+        self.assertFalse(any(call[:2] == ["workflow", "run"] for call in calls))
+        self.assertEqual(self.load_state()["nix_refresh"]["workflow_run_id"], 7)
+
+    def test_transient_workflow_failure_is_redispatched_after_backoff(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 8, "status": "completed", "conclusion": "failure",
+                "createdAt": "1970-01-01T00:18:20Z", "url": "https://run/8",
+            }],
+            "run_views": {"8": {
+                "databaseId": 8, "status": "completed", "conclusion": "failure",
+                "headSha": "f" * 40, "url": "https://run/8",
+                "jobs": [{"steps": [{"name": "Install validation dependencies", "conclusion": "failure"}]}],
+            }},
+        })
+        self.nix_probe(headers, env, now=1100)
+        self.nix_probe(headers, env, now=2001)
+        dispatches = [call for call in self.fake_calls(scenario) if call[:2] == ["workflow", "run"]]
+        self.assertEqual(len(dispatches), 1)
+
+    def test_three_transient_failures_stop_and_notify(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [], "runs": [], "run_views": {},
+        })
+        for run_id, now in ((1, 1100), (2, 2001), (3, 3802)):
+            value = json.loads(scenario.read_text())
+            value["runs"] = [{
+                "databaseId": run_id, "status": "completed", "conclusion": "failure",
+                "createdAt": "1970-01-01T00:18:20Z", "headSha": "f" * 40, "url": f"https://run/{run_id}",
+            }]
+            value["run_views"][str(run_id)] = {
+                "databaseId": run_id, "status": "completed", "conclusion": "failure",
+                "headSha": "f" * 40, "url": f"https://run/{run_id}",
+                "jobs": [{"steps": [{"name": "Install validation dependencies", "conclusion": "failure"}]}],
+            }
+            scenario.write_text(json.dumps(value), encoding="utf-8")
+            result = self.nix_probe(headers, env, now=now)
+        self.assertTrue(result.stdout.strip().startswith("NIX_BLOCKED 0 transient-retries-exhausted EVENT_ID="))
+        state = self.load_state()
+        self.assertEqual(state["nix_refresh"]["transient_failures"], 3)
+        self.assertEqual(state["active_campaign"]["campaign_phase"], "nix-blocked")
+
+    def test_green_matching_bot_pr_is_guarded_and_merged(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head)
+        merged = {**pr, "state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z", "mergeCommit": {"oid": "b" * 40}}
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "pr_views": [pr],
+            "merged_pr": merged,
+        })
+        result = self.nix_probe(headers, env)
+        self.assertTrue(result.stdout.strip().startswith(f"NIX_PR_MERGED 99 {pr['url']} EVENT_ID="))
+        calls = self.fake_calls(scenario)
+        merge = next(call for call in calls if call[:2] == ["pr", "merge"])
+        self.assertIn("--admin", merge)
+        self.assertEqual(merge[merge.index("--match-head-commit") + 1], head)
+        recorded = self.load_state()["last_merged_nix_pr"]
+        self.assertEqual(recorded["dmg_sha256"], sha)
+        self.assertEqual(recorded["merge_sha"], "b" * 40)
+
+    def test_active_refresh_prevents_merging_an_old_green_bot_head(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "runs": [{
+                "databaseId": 101,
+                "status": "in_progress",
+                "conclusion": None,
+                "headSha": "f" * 40,
+                "url": "https://run/101",
+            }],
+        })
+
+        result = self.nix_probe(headers, env, now=1100)
+
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+        self.assertEqual(self.load_state()["nix_refresh"]["workflow_run_id"], 101)
+
+    def test_refresh_run_is_adopted_by_campaign_key_when_main_moves(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha = self.complete_baseline(headers)
+        accepted_main = "a" * 40
+        newer_main = "b" * 40
+        state = self.load_state()
+        state["nix_refresh"].update({
+            "expected_dmg_sha256": sha,
+            "expected_dmg_sri": self.sri(self.dmg_a),
+            "expected_main_sha": accepted_main,
+            "dispatch_key": f"{accepted_main}:{sha}",
+            "last_dispatch_at": "1970-01-01T00:18:00Z",
+            "workflow_head_sha": accepted_main,
+        })
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        scenario, env = self.write_scenario({
+            "main_sha": newer_main,
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 102,
+                "status": "in_progress",
+                "conclusion": None,
+                "headSha": newer_main,
+                "displayTitle": f"Nix refresh {accepted_main}:{sha}",
+                "url": "https://run/102",
+            }],
+        })
+
+        result = self.nix_probe(headers, env, now=1100)
+
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        self.assertEqual(self.load_state()["nix_refresh"]["workflow_run_id"], 102)
+        self.assertFalse(any(call[:2] == ["workflow", "run"] for call in self.fake_calls(scenario)))
+
+    def test_wrong_author_is_blocked_and_never_merged(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head, author={"login": "someone"})
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+        })
+        self.nix_probe(headers, env, now=1100)
+        self.nix_probe(headers, env, now=1200)
+        result = self.nix_probe(headers, env, now=1300)
+        self.assertTrue(result.stdout.strip().startswith("NIX_BLOCKED 99 wrong-author EVENT_ID="))
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+
+    def test_dry_run_nix_source_failure_second_round_and_successful_campaign_completion(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        sha, run_id, _, main_head, decision = self.prepare_acceptance_fixture(headers)
+        self.run_cli(
+            "record-acceptance", "--run-id", run_id, "--decision", str(decision), "--head", main_head,
+            "--now", "1003",
+        )
+        _, main_env = self.write_scenario({"main_sha": main_head})
+        self.run_cli("advance-to-nix", "--run-id", run_id, "--now", "1004", env=main_env)
+
+        failure_scenario, failure_env = self.write_scenario({
+            "main_sha": main_head,
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "prs": [],
+            "runs": [{
+                "databaseId": 501,
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "1970-01-01T00:18:20Z",
+                "headSha": main_head,
+                "url": "https://run/501",
+            }],
+            "run_views": {"501": {
+                "databaseId": 501,
+                "status": "completed",
+                "conclusion": "failure",
+                "headSha": main_head,
+                "url": "https://run/501",
+                "jobs": [{"steps": [{"name": "Refresh Nix upstream hash", "conclusion": "failure"}]}],
+            }},
+            "run_logs": {"501": "enabled-feature-drift"},
+        })
+        repair_event = self.nix_probe(headers, failure_env, now=1100)
+        self.assertTrue(repair_event.stdout.startswith(f"NIX_REPAIR_READY {sha} 501 "))
+        acquired = self.run_cli("worker-acquire", "--sha", sha, "--now", "1101")
+        self.assertEqual(acquired.stdout.split()[0], "ACQUIRED")
+
+        state = self.load_state()
+        campaign = state["active_campaign"]
+        self.assertEqual([item["round"] for item in campaign["repair_rounds"]], [1, 2])
+        repaired_main = "c" * 40
+        campaign["repair_rounds"][-1].update({
+            "status": "merged",
+            "branch": f"codex/upstream-dmg-{sha[:12]}-nix-repair-2",
+            "head_sha": "d" * 40,
+            "merge_sha": repaired_main,
+        })
+        campaign["campaign_phase"] = "awaiting-nix"
+        campaign["phase"] = "awaiting-nix"
+        campaign["accepted_main_sha"] = repaired_main
+        state["worker_lease"] = None
+        state["nix_refresh"] = {
+            **state["nix_refresh"],
+            "expected_dmg_sha256": sha,
+            "expected_dmg_sri": self.sri(self.dmg_a),
+            "workflow_head_sha": repaired_main,
+            "workflow_status": "waiting-for-pr",
+        }
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        nix_head = "e" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=nix_head)
+        merged = {**pr, "state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z", "mergeCommit": {"oid": "f" * 40}}
+        success_scenario, success_env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {nix_head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "pr_views": [pr],
+            "merged_pr": merged,
+        })
+        completed = self.nix_probe(headers, success_env, now=1200)
+
+        self.assertTrue(completed.stdout.startswith(f"NIX_PR_MERGED 99 {pr['url']} "))
+        final = self.load_state()
+        self.assertIsNone(final["active_campaign"])
+        self.assertEqual(final["last_completed_campaign"]["verdict"], "accepted_with_nix_merged")
+        self.assertTrue(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(success_scenario)))
+
+    def test_failed_or_missing_checks_never_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        checks = self.checks()
+        checks[-1]["conclusion"] = "FAILURE"
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head, statusCheckRollup=checks)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+        })
+        for now in (1100, 1200, 1300):
+            result = self.nix_probe(headers, env, now=now)
+        self.assertTrue(result.stdout.strip().startswith(f"NIX_REPAIR_READY {self.load_state()['last_observed_sha256']} 99 EVENT_ID="))
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+
+    def test_force_push_between_checks_prevents_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        first_head = "a" * 40
+        second_head = "b" * 40
+        listed = self.nix_pr(self.sri(self.dmg_a), head=first_head)
+        changed = self.nix_pr(self.sri(self.dmg_a), head=second_head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {
+                first_head: self.flake(self.sri(self.dmg_a)),
+                second_head: self.flake(self.sri(self.dmg_a)),
+            },
+            "prs": [listed],
+            "pr_views": [changed],
+        })
+        result = self.nix_probe(headers, env)
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+
+    def test_upstream_change_before_merge_prevents_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        changed_headers = self.headers("b.headers", "etag-b", self.dmg_b)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+        })
+        result = self.nix_probe(headers, env, 1100, "--premerge-headers-file", str(changed_headers))
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+
+    def test_stale_nix_pr_hash_dispatches_refresh_and_does_not_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        stale_sri = "sha256-" + "A" * 43 + "="
+        pr = self.nix_pr(stale_sri, head=head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake(stale_sri),
+            "head_flakes": {head: self.flake(stale_sri)},
+            "prs": [pr],
+            "runs": [],
+        })
+        self.nix_probe(headers, env)
+        calls = self.fake_calls(scenario)
+        self.assertTrue(any(call[:2] == ["workflow", "run"] for call in calls))
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in calls))
+
+    def test_unexpected_file_and_missing_required_check_are_blockers(self):
+        for label, overrides, reason in (
+            ("extra", {"files": [{"path": "flake.nix"}, {"path": "README.md"}]}, "unexpected-files"),
+            ("missing", {"statusCheckRollup": self.checks()[:-1]}, "required-checks-missing"),
+        ):
+            with self.subTest(label=label):
+                self.state = self.root / f"state-{label}"
+                headers = self.headers(f"{label}.headers", f"etag-{label}", self.dmg_a)
+                self.complete_baseline(headers)
+                head = "a" * 40
+                pr = self.nix_pr(self.sri(self.dmg_a), head=head, **overrides)
+                scenario_path = self.root / f"scenario-{label}.json"
+                scenario_path.write_text(json.dumps({
+                    "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+                    "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+                    "prs": [pr],
+                }), encoding="utf-8")
+                env = {"UPSTREAM_DMG_WATCHDOG_GH": str(self.fake_gh), "FAKE_GH_SCENARIO": str(scenario_path)}
+                for now in (1100, 1200, 1300):
+                    result = self.nix_probe(headers, env, now=now)
+                self.assertTrue(result.stdout.strip().startswith(f"NIX_BLOCKED 99 {reason} EVENT_ID="))
+                self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario_path)))
+
+    def test_existing_nix_merge_lease_prevents_second_merge(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        state = self.load_state()
+        state["nix_merge_lease"] = {
+            "run_id": "other",
+            "pr_number": 99,
+            "head_sha": "a" * 40,
+            "acquired_at": "1970-01-01T00:16:40Z",
+            "expires_at": "1970-01-01T00:33:20Z",
+        }
+        (self.state / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+        })
+        result = self.nix_probe(headers, env, now=1100)
+        self.assertEqual(result.stdout.strip(), "NIX_ACTIVE")
+        self.assertFalse(any(call[:2] == ["pr", "merge"] for call in self.fake_calls(scenario)))
+
+    def test_merge_failure_notifies_once_after_three_attempts(self):
+        headers = self.headers("a.headers", "etag-a", self.dmg_a)
+        self.complete_baseline(headers)
+        head = "a" * 40
+        pr = self.nix_pr(self.sri(self.dmg_a), head=head)
+        scenario, env = self.write_scenario({
+            "main_flake": self.flake("sha256-" + "A" * 43 + "="),
+            "head_flakes": {head: self.flake(self.sri(self.dmg_a))},
+            "prs": [pr],
+            "pr_views": [pr],
+            "merge_fails": True,
+        })
+        for now in (1100, 1200, 1300):
+            result = self.nix_probe(headers, env, now=now)
+        self.assertTrue(result.stdout.strip().startswith("NIX_BLOCKED 99 merge-failed EVENT_ID="))
+        fourth = self.nix_probe(headers, env, now=1400)
+        self.assertEqual(fourth.stdout.strip(), result.stdout.strip())
+        self.assertEqual(len([call for call in self.fake_calls(scenario) if call[:2] == ["pr", "merge"]]), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/automation/upstream-dmg-watchdog/watchdog.py
+++ b/scripts/automation/upstream-dmg-watchdog/watchdog.py
@@ -1,0 +1,2195 @@
+#!/usr/bin/env python3
+"""Atomic local state and cheap upstream DMG probe for the Codex watchdog."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+
+DEFAULT_URL = "https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg"
+DEFAULT_TTL_SECONDS = 7200
+DEFAULT_REPOSITORY = "ilysenko/codex-desktop-linux"
+NIX_REFRESH_BRANCH = "codex/nix-upstream-refresh"
+NIX_REFRESH_WORKFLOW = "update-codex-hash.yml"
+NIX_ALLOWED_PATHS = {
+    "flake.nix",
+    "nix/native-modules/package.json",
+    "nix/native-modules/package-lock.json",
+}
+NIX_REQUIRED_CHECKS = {
+    "Rust and Smoke Tests",
+    "Build Debian Package",
+    "Build RPM Package",
+    "Build Pacman Package",
+    "Nix Package Builds",
+}
+NIX_MERGE_TTL_SECONDS = 300
+NIX_MAX_TRANSIENT_ATTEMPTS = 3
+NIX_TRANSIENT_BACKOFF_SECONDS = (900, 1800)
+REPAIR_REQUIRED_CHECKS = NIX_REQUIRED_CHECKS | {"Build App Against Upstream DMG"}
+PROTECTED_CAMPAIGN_PHASES = {
+    "accepted-head",
+    "nix-preflight-green",
+    "nix-preflight-failed",
+    "awaiting-nix",
+    "nix-refresh",
+    "nix-repair",
+    "nix-blocked",
+    "completed",
+}
+STATE_SCHEMA = 2
+
+
+def utc_iso(now: float | None = None) -> str:
+    value = dt.datetime.fromtimestamp(now if now is not None else time.time(), tz=dt.timezone.utc)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def parse_iso(value: str | None) -> float:
+    if not value:
+        return 0.0
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def default_state() -> dict:
+    return {
+        "schema": STATE_SCHEMA,
+        "http_identity": None,
+        "last_observed_sha256": None,
+        "last_accepted_sha256": None,
+        "probe_failures": 0,
+        "last_probe_at": None,
+        "worker_lease": None,
+        "active_campaign": None,
+        "pending_campaign": None,
+        "last_completed_campaign": None,
+        "revalidation_required": False,
+        "pending_notifications": [],
+        "nix_runs": [],
+        "nix_failure_class": None,
+        "nix_refresh": {
+            "expected_dmg_sha256": None,
+            "expected_dmg_sri": None,
+            "expected_main_sha": None,
+            "dispatch_key": None,
+            "workflow_status": None,
+            "last_dispatch_at": None,
+            "dispatch_attempts": 0,
+            "pr_number": None,
+            "pr_head_sha": None,
+            "check_status": None,
+            "merge_failures": 0,
+            "blocked_reason": None,
+            "blocked_count": 0,
+            "blocked_notified": False,
+            "workflow_run_id": None,
+            "workflow_url": None,
+            "workflow_head_sha": None,
+            "workflow_conclusion": None,
+            "last_seen_run_id": None,
+            "transient_failures": 0,
+            "next_retry_at": None,
+            "ci_last_seen_run_id": None,
+            "ci_transient_failures": 0,
+            "ci_next_retry_at": None,
+            "ci_retry_dispatched_for": None,
+        },
+        "nix_merge_lease": None,
+        "last_merged_nix_pr": None,
+    }
+
+
+def migrate_campaign(campaign: object) -> object:
+    if not isinstance(campaign, dict):
+        return campaign
+    migrated = dict(campaign)
+    migrated.setdefault("campaign_phase", migrated.get("phase", "detected"))
+    migrated.setdefault("acceptance_evidence", None)
+    migrated.setdefault("feature_snapshot", migrated.get("feature_snapshot"))
+    migrated.setdefault("repair_rounds", [])
+    migrated.setdefault("dispatch_key", f"migrated-{migrated.get('detected_at', 'unknown')}")
+    if not migrated["repair_rounds"] and any(
+        migrated.get(field) for field in ("base_sha", "branch", "worktree", "pr_number", "head_sha")
+    ):
+        migrated["repair_rounds"] = [{
+            "round": 1,
+            "base_sha": migrated.get("base_sha"),
+            "branch": migrated.get("branch"),
+            "worktree": migrated.get("worktree"),
+            "pr_number": migrated.get("pr_number"),
+            "pr_url": migrated.get("pr_url"),
+            "head_sha": migrated.get("head_sha"),
+            "status": "completed" if migrated.get("phase") == "completed" else migrated.get("phase", "unknown"),
+        }]
+    return migrated
+
+
+def migrate_v1_state(loaded: dict) -> dict:
+    migrated = dict(loaded)
+    migrated["schema"] = STATE_SCHEMA
+    migrated["active_campaign"] = migrate_campaign(migrated.get("active_campaign"))
+    migrated["pending_campaign"] = migrate_campaign(migrated.get("pending_campaign"))
+    migrated["last_completed_campaign"] = migrate_campaign(migrated.get("last_completed_campaign"))
+    migrated.setdefault("revalidation_required", False)
+    if not isinstance(migrated.get("pending_notifications"), list):
+        migrated["pending_notifications"] = []
+    if not isinstance(migrated.get("nix_runs"), list):
+        migrated["nix_runs"] = []
+    migrated.setdefault("nix_failure_class", None)
+    completed = migrated.get("last_completed_campaign")
+    observed_sha = migrated.get("last_observed_sha256")
+    merged_nix = migrated.get("last_merged_nix_pr")
+    nix_finished = (
+        isinstance(merged_nix, dict) and merged_nix.get("dmg_sha256") == observed_sha
+    ) or (migrated.get("nix_refresh") or {}).get("workflow_status") in {"current", "merged"}
+    if (
+        migrated.get("active_campaign") is None
+        and isinstance(completed, dict)
+        and completed.get("sha256") == observed_sha
+        and migrated.get("last_accepted_sha256") == observed_sha
+        and not nix_finished
+    ):
+        resumed = dict(completed)
+        resumed["phase"] = "awaiting-nix"
+        resumed["campaign_phase"] = "awaiting-nix"
+        resumed["updated_at"] = utc_iso()
+        migrated["active_campaign"] = resumed
+        migrated["worker_lease"] = None
+    return migrated
+
+
+class Store:
+    def __init__(self, root: Path):
+        self.root = root.expanduser().resolve()
+        self.state_path = self.root / "state.json"
+        self.guard_path = self.root / "state.guard"
+        self.downloads = self.root / "downloads"
+        self.worktrees = self.root / "worktrees"
+        self.snapshots = self.root / "feature-snapshots"
+        self.evidence = self.root / "acceptance-evidence"
+        self.preflight = self.root / "nix-preflight"
+
+    def ensure(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.downloads.mkdir(mode=0o700, exist_ok=True)
+        self.worktrees.mkdir(mode=0o700, exist_ok=True)
+        self.snapshots.mkdir(mode=0o700, exist_ok=True)
+        self.evidence.mkdir(mode=0o700, exist_ok=True)
+        self.preflight.mkdir(mode=0o700, exist_ok=True)
+
+    @contextlib.contextmanager
+    def locked(self):
+        self.ensure()
+        with self.guard_path.open("a+", encoding="utf-8") as guard:
+            os.chmod(self.guard_path, 0o600)
+            fcntl.flock(guard.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(guard.fileno(), fcntl.LOCK_UN)
+
+    def load(self) -> dict:
+        state = default_state()
+        if not self.state_path.exists():
+            return state
+        try:
+            loaded = json.loads(self.state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise RuntimeError(f"invalid watchdog state: {error}") from error
+        if not isinstance(loaded, dict) or loaded.get("schema") not in {1, STATE_SCHEMA}:
+            raise RuntimeError("unsupported watchdog state schema")
+        if loaded.get("schema") == 1:
+            loaded = migrate_v1_state(loaded)
+        state.update(loaded)
+        nix_refresh = default_state()["nix_refresh"]
+        if isinstance(state.get("nix_refresh"), dict):
+            nix_refresh.update(state["nix_refresh"])
+        state["nix_refresh"] = nix_refresh
+        return state
+
+    def save(self, state: dict) -> None:
+        self.ensure()
+        payload = (json.dumps(state, indent=2, sort_keys=True) + "\n").encode()
+        fd, temporary = tempfile.mkstemp(prefix=".state.", suffix=".tmp", dir=self.root)
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.state_path)
+            directory_fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temporary)
+
+
+def state_root(value: str | None) -> Path:
+    if value:
+        return Path(value)
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
+    return base / "codex-automations" / "upstream-dmg-watchdog"
+
+
+def parse_headers(payload: str) -> dict[str, str]:
+    blocks: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    saw_status = False
+    for raw in payload.replace("\r\n", "\n").split("\n"):
+        line = raw.strip("\r")
+        if line.startswith("HTTP/"):
+            if saw_status and current:
+                blocks.append(current)
+            current = {}
+            saw_status = True
+            continue
+        if not line:
+            if saw_status and current:
+                blocks.append(current)
+                current = {}
+                saw_status = False
+            continue
+        if saw_status and ":" in line:
+            key, value = line.split(":", 1)
+            current[key.strip().lower()] = value.strip()
+    if saw_status and current:
+        blocks.append(current)
+    if not blocks:
+        raise RuntimeError("upstream response contained no HTTP headers")
+    return blocks[-1]
+
+
+def http_identity(headers: dict[str, str]) -> dict | None:
+    def normalize(value: str | None) -> str | None:
+        if value is None or value in {"", "unknown", "no-etag"}:
+            return None
+        return value
+
+    etag = normalize(headers.get("etag"))
+    if etag and len(etag) >= 2 and etag[0] == etag[-1] == '"':
+        etag = etag[1:-1]
+    last_modified = normalize(headers.get("last-modified"))
+    content_length = normalize(headers.get("content-length"))
+    if etag is None and (last_modified is None or content_length is None):
+        return None
+    key_input = f"{last_modified or ''}|{etag or ''}|{content_length or ''}"
+    return {
+        "etag": etag,
+        "last_modified": last_modified,
+        "content_length": content_length,
+        "key": hashlib.sha256(key_input.encode()).hexdigest(),
+    }
+
+
+def curl_headers(url: str) -> str:
+    result = subprocess.run(
+        ["curl", "-fsSLI", "--retry", "3", "--retry-delay", "2", "--connect-timeout", "15", "--max-time", "60", url],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def download(url: str, destination: Path) -> None:
+    subprocess.run(
+        ["curl", "-fL", "--retry", "3", "--retry-delay", "2", "--connect-timeout", "15", "--max-time", "1800", "-o", str(destination), url],
+        check=True,
+    )
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_json(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_tree(root: Path) -> str:
+    digest = hashlib.sha256()
+    if not root.is_dir():
+        raise RuntimeError(f"tree does not exist: {root}")
+    for path in sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix()):
+        relative = path.relative_to(root).as_posix().encode()
+        digest.update(relative + b"\0")
+        if path.is_symlink():
+            digest.update(b"link\0" + os.readlink(path).encode() + b"\0")
+        elif path.is_dir():
+            digest.update(b"dir\0")
+        elif path.is_file():
+            digest.update(b"file\0")
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+def queue_notification(state: dict, kind: str, payload: list[object], key: str) -> str:
+    notifications = state.setdefault("pending_notifications", [])
+    for item in notifications:
+        if isinstance(item, dict) and item.get("key") == key:
+            return str(item["id"])
+    event_id = str(uuid.uuid4())
+    notifications.append({
+        "id": event_id,
+        "key": key,
+        "kind": kind,
+        "payload": payload,
+        "created_at": utc_iso(),
+        "acked_at": None,
+    })
+    return event_id
+
+
+def next_notification(state: dict) -> dict | None:
+    for item in state.get("pending_notifications") or []:
+        if isinstance(item, dict) and not item.get("acked_at"):
+            return item
+    return None
+
+
+def acknowledge_notification(state: dict, event_id: str, now: float) -> bool:
+    for item in state.get("pending_notifications") or []:
+        if isinstance(item, dict) and item.get("id") == event_id:
+            item["acked_at"] = item.get("acked_at") or utc_iso(now)
+            return True
+    return False
+
+
+def acknowledge_campaign_notifications(state: dict, sha: str, now: float) -> None:
+    for item in state.get("pending_notifications") or []:
+        if not isinstance(item, dict) or item.get("acked_at"):
+            continue
+        if item.get("kind") in {"CHANGE_READY", "NIX_REPAIR_READY"} and (item.get("payload") or [None])[0] == sha:
+            item["acked_at"] = utc_iso(now)
+
+
+def supersede_campaign_notifications(state: dict, sha: str, now: float) -> None:
+    for item in state.get("pending_notifications") or []:
+        if not isinstance(item, dict) or item.get("acked_at"):
+            continue
+        payload = item.get("payload") or [None]
+        if item.get("kind") in {"CHANGE_READY", "NIX_REPAIR_READY"} and payload[0] != sha:
+            item["acked_at"] = utc_iso(now)
+            item["superseded_by_sha256"] = sha
+
+
+def format_notification(item: dict) -> str:
+    payload = " ".join(str(value) for value in item.get("payload") or [])
+    return f"{item['kind']} {payload} EVENT_ID={item['id']}".strip()
+
+
+def current_round(campaign: dict, *, create: bool = False) -> dict | None:
+    rounds = campaign.setdefault("repair_rounds", [])
+    if rounds and rounds[-1].get("status") not in {"merged", "accepted-main", "completed", "superseded"}:
+        return rounds[-1]
+    if not create:
+        return rounds[-1] if rounds else None
+    repair_round = {
+        "round": len(rounds) + 1,
+        "status": "preparing",
+        "created_at": utc_iso(),
+        "base_sha": None,
+        "branch": None,
+        "worktree": None,
+        "pr_number": None,
+        "pr_url": None,
+        "head_sha": None,
+        "accepted_head_sha": None,
+        "merge_sha": None,
+    }
+    rounds.append(repair_round)
+    return repair_round
+
+
+def sha256_sri(sha256_hex: str) -> str:
+    if not re.fullmatch(r"[0-9a-f]{64}", sha256_hex):
+        raise RuntimeError("invalid DMG SHA-256")
+    return "sha256-" + base64.b64encode(bytes.fromhex(sha256_hex)).decode("ascii")
+
+
+def extract_codex_dmg_sri(flake: str) -> str:
+    match = re.search(
+        r"codexDmg\s*=\s*pkgs\.fetchurl\s*\{.*?\bhash\s*=\s*\"(sha256-[A-Za-z0-9+/=]{44})\"",
+        flake,
+        flags=re.DOTALL,
+    )
+    if not match:
+        raise RuntimeError("could not find codexDmg SRI in flake.nix")
+    return match.group(1)
+
+
+def gh_binary() -> str:
+    return os.environ.get("UPSTREAM_DMG_WATCHDOG_GH", "gh")
+
+
+def gh_command(arguments: list[str], *, json_output: bool = False) -> object:
+    result = subprocess.run(
+        [gh_binary(), *arguments],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if not json_output:
+        return result.stdout.strip()
+    try:
+        return json.loads(result.stdout or "null")
+    except json.JSONDecodeError as error:
+        raise RuntimeError(f"gh returned invalid JSON for {' '.join(arguments)}") from error
+
+
+def github_file(repository: str, path: str, ref: str) -> str:
+    value = gh_command(
+        ["api", f"repos/{repository}/contents/{path}?ref={ref}"],
+        json_output=True,
+    )
+    if not isinstance(value, dict) or not isinstance(value.get("content"), str):
+        raise RuntimeError(f"GitHub did not return {path} at {ref}")
+    try:
+        return base64.b64decode(value["content"].replace("\n", "")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as error:
+        raise RuntimeError(f"GitHub returned invalid content for {path} at {ref}") from error
+
+
+def github_ref_sha(repository: str, ref: str) -> str:
+    value = gh_command(["api", f"repos/{repository}/commits/{ref}"], json_output=True)
+    sha = value.get("sha") if isinstance(value, dict) else None
+    if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{40}", sha):
+        raise RuntimeError(f"GitHub did not return a full SHA for {ref}")
+    return sha
+
+
+def open_nix_prs(repository: str) -> list[dict]:
+    value = gh_command(
+        [
+            "pr", "list", "--repo", repository, "--state", "open", "--head", NIX_REFRESH_BRANCH,
+            "--json",
+            "number,url,author,headRepositoryOwner,headRefName,headRefOid,baseRefName,isDraft,mergeable,mergeStateStatus,files,statusCheckRollup",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, list):
+        raise RuntimeError("GitHub returned invalid Nix PR list")
+    return value
+
+
+def nix_pr_view(repository: str, number: int) -> dict:
+    value = gh_command(
+        [
+            "pr", "view", str(number), "--repo", repository,
+            "--json",
+            "number,url,state,mergedAt,mergeCommit,author,headRepositoryOwner,headRefName,headRefOid,baseRefName,isDraft,mergeable,mergeStateStatus,files,statusCheckRollup",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, dict):
+        raise RuntimeError("GitHub returned invalid Nix PR metadata")
+    return value
+
+
+def repair_pr_view(repository: str, number: int) -> dict:
+    value = gh_command(
+        [
+            "pr", "view", str(number), "--repo", repository,
+            "--json",
+            "number,url,state,mergedAt,mergeCommit,author,headRepositoryOwner,headRefName,headRefOid,baseRefName,isDraft,mergeable,mergeStateStatus,statusCheckRollup,body",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, dict):
+        raise RuntimeError("GitHub returned invalid repair PR metadata")
+    return value
+
+
+def nix_workflow_runs(repository: str) -> list[dict]:
+    value = gh_command(
+        [
+            "run", "list", "--repo", repository, "--workflow", NIX_REFRESH_WORKFLOW,
+            "--limit", "20", "--json", "databaseId,status,conclusion,event,createdAt,updatedAt,url,headSha,displayTitle",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, list):
+        raise RuntimeError("GitHub returned invalid Nix workflow list")
+    return [run for run in value if isinstance(run, dict)]
+
+
+def nix_ci_runs(repository: str) -> list[dict]:
+    value = gh_command(
+        [
+            "run", "list", "--repo", repository, "--workflow", "ci.yml", "--branch", NIX_REFRESH_BRANCH,
+            "--limit", "20", "--json", "databaseId,status,conclusion,event,createdAt,updatedAt,url,headSha",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, list):
+        raise RuntimeError("GitHub returned invalid Nix CI workflow list")
+    return [run for run in value if isinstance(run, dict)]
+
+
+def augment_nix_pr_checks(pr: dict, repository: str) -> tuple[dict, dict | None]:
+    head = pr.get("headRefOid")
+    outcomes = {
+        check.get("name") or check.get("context"): check_outcome(check)
+        for check in pr.get("statusCheckRollup") or []
+        if isinstance(check, dict)
+    }
+    if all(outcomes.get(name) == "pass" for name in NIX_REQUIRED_CHECKS):
+        return pr, None
+    run = next((item for item in nix_ci_runs(repository) if item.get("headSha") == head), None)
+    if run is None or run.get("status") != "completed":
+        return pr, run
+    details = nix_run_view(repository, int(run["databaseId"]))
+    synthetic = []
+    for job in details.get("jobs") or []:
+        if not isinstance(job, dict):
+            continue
+        synthetic.append({
+            "name": job.get("name"),
+            "status": str(job.get("status") or "").upper(),
+            "conclusion": str(job.get("conclusion") or "").upper(),
+            "detailsUrl": job.get("url") or details.get("url"),
+        })
+    return {**pr, "statusCheckRollup": synthetic}, details
+
+
+def nix_run_matches_campaign(run: dict, main_sha: str, dmg_sha: str) -> bool:
+    title = run.get("displayTitle")
+    if isinstance(title, str):
+        return title == f"Nix refresh {main_sha}:{dmg_sha}"
+    return run.get("headSha") == main_sha
+
+
+def active_nix_workflow(repository: str, main_sha: str | None = None, dmg_sha: str | None = None) -> dict | None:
+    value = nix_workflow_runs(repository)
+    for run in value:
+        if (
+            run.get("status") in {"queued", "in_progress", "waiting", "requested", "pending"}
+            and (main_sha is None or dmg_sha is None or nix_run_matches_campaign(run, main_sha, dmg_sha))
+        ):
+            return run
+    return None
+
+
+def nix_run_view(repository: str, run_id: int) -> dict:
+    value = gh_command(
+        [
+            "run", "view", str(run_id), "--repo", repository,
+            "--json", "databaseId,status,conclusion,createdAt,updatedAt,url,headSha,jobs",
+        ],
+        json_output=True,
+    )
+    if not isinstance(value, dict):
+        raise RuntimeError("GitHub returned invalid Nix workflow metadata")
+    return value
+
+
+def nix_failure_log(repository: str, run_id: int) -> str:
+    try:
+        return str(gh_command(["run", "view", str(run_id), "--repo", repository, "--log-failed"]))[-12000:]
+    except (RuntimeError, subprocess.SubprocessError):
+        return ""
+
+
+def classify_nix_run(run: dict, failure_log: str = "") -> str:
+    conclusion = str(run.get("conclusion") or "").lower()
+    if conclusion in {"cancelled", "canceled", "timed_out", "startup_failure", "action_required"}:
+        return "transient"
+    if transient_output(failure_log):
+        return "transient"
+    infrastructure_steps = {
+        "Set up job",
+        "Run actions/checkout@v4",
+        "Set up Node.js",
+        "Install Nix",
+        "Configure Cachix for hash refresh builds",
+        "Install validation dependencies",
+    }
+    failed_steps = {
+        step.get("name")
+        for job in run.get("jobs") or [] if isinstance(job, dict)
+        for step in job.get("steps") or [] if isinstance(step, dict)
+        if str(step.get("conclusion") or "").lower() == "failure"
+    }
+    if failed_steps and failed_steps.issubset(infrastructure_steps):
+        return "transient"
+    return "source"
+
+
+def ensure_nix_workflow(
+    args: argparse.Namespace,
+    refresh: dict,
+    repository: str,
+    now: float,
+    main_sha: str,
+    dmg_sha: str,
+) -> None:
+    dispatch_key = f"{main_sha}:{dmg_sha}"
+    active_run = active_nix_workflow(repository, main_sha, dmg_sha)
+    if active_run:
+        refresh["workflow_status"] = active_run.get("status") or "active"
+        refresh["workflow_run_id"] = active_run.get("databaseId")
+        refresh["workflow_url"] = active_run.get("url")
+        refresh["workflow_head_sha"] = active_run.get("headSha")
+    elif active_nix_workflow(repository):
+        refresh["workflow_status"] = "waiting-for-older-run"
+    elif refresh.get("dispatch_key") == dispatch_key:
+        refresh["workflow_status"] = "dispatch-recorded"
+    elif args.dry_run:
+        refresh["workflow_status"] = "dispatch-dry-run"
+    else:
+        gh_command([
+            "workflow", "run", NIX_REFRESH_WORKFLOW, "--repo", repository, "--ref", "main",
+            "-f", f"expected_main_sha={main_sha}",
+            "-f", f"expected_dmg_sha256={dmg_sha}",
+        ])
+        refresh["workflow_status"] = "dispatched"
+        refresh["last_dispatch_at"] = utc_iso(now)
+        refresh["dispatch_key"] = dispatch_key
+        refresh["expected_main_sha"] = main_sha
+        refresh["dispatch_attempts"] = int(refresh.get("dispatch_attempts") or 0) + 1
+        refresh["workflow_head_sha"] = main_sha
+        refresh["workflow_run_id"] = None
+        refresh["workflow_conclusion"] = None
+
+
+def actor_login(value: object) -> str | None:
+    return value.get("login") if isinstance(value, dict) else None
+
+
+def check_outcome(check: dict) -> str:
+    bucket = str(check.get("bucket") or "").lower()
+    if bucket in {"pass", "fail", "pending", "skipping", "cancel"}:
+        return bucket
+    status = str(check.get("status") or "").upper()
+    conclusion = str(check.get("conclusion") or check.get("state") or "").upper()
+    if status and status != "COMPLETED":
+        return "pending"
+    if conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+        return "pass" if conclusion == "SUCCESS" else "skipping"
+    if conclusion in {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}:
+        return "fail"
+    if conclusion in {"CANCELLED", "CANCELED"}:
+        return "cancel"
+    if conclusion in {"PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", ""}:
+        return "pending"
+    return "fail"
+
+
+def validate_nix_pr(pr: dict, expected_sri: str, repository: str) -> tuple[str, str]:
+    if pr.get("state", "OPEN") != "OPEN":
+        return "blocked", "pr-not-open"
+    if actor_login(pr.get("author")) != "app/github-actions":
+        return "blocked", "wrong-author"
+    if actor_login(pr.get("headRepositoryOwner")) != repository.split("/", 1)[0]:
+        return "blocked", "wrong-head-owner"
+    if pr.get("headRefName") != NIX_REFRESH_BRANCH or pr.get("baseRefName") != "main":
+        return "blocked", "wrong-branch"
+    if pr.get("isDraft") is True:
+        return "blocked", "draft"
+    files = {item.get("path") for item in pr.get("files") or [] if isinstance(item, dict)}
+    if "flake.nix" not in files or not files.issubset(NIX_ALLOWED_PATHS):
+        return "blocked", "unexpected-files"
+    head_sha = pr.get("headRefOid")
+    if not isinstance(head_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", head_sha):
+        return "waiting", "head-unavailable"
+    head_sri = extract_codex_dmg_sri(github_file(repository, "flake.nix", head_sha))
+    if head_sri != expected_sri:
+        return "blocked", "dmg-hash-mismatch"
+    mergeable = str(pr.get("mergeable") or "UNKNOWN").upper()
+    if mergeable == "CONFLICTING":
+        return "blocked", "merge-conflict"
+    if mergeable != "MERGEABLE":
+        return "waiting", "mergeability-pending"
+    checks = pr.get("statusCheckRollup") or []
+    seen: dict[str, str] = {}
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        name = check.get("name") or check.get("context")
+        outcome = check_outcome(check)
+        if isinstance(name, str):
+            seen[name] = outcome
+        if outcome in {"fail", "cancel"}:
+            return "blocked", f"check-{outcome}"
+        if outcome == "pending":
+            return "waiting", "checks-pending"
+    if any(seen.get(name) != "pass" for name in NIX_REQUIRED_CHECKS):
+        return "blocked", "required-checks-missing"
+    return "ready", "ready"
+
+
+def reset_nix_blocker(refresh: dict) -> None:
+    refresh["blocked_reason"] = None
+    refresh["blocked_count"] = 0
+    refresh["blocked_notified"] = False
+
+
+def record_nix_blocker(refresh: dict, reason: str) -> bool:
+    if refresh.get("blocked_reason") == reason:
+        refresh["blocked_count"] = int(refresh.get("blocked_count") or 0) + 1
+    else:
+        refresh["blocked_reason"] = reason
+        refresh["blocked_count"] = 1
+        refresh["blocked_notified"] = False
+    if refresh["blocked_count"] >= 3 and not refresh.get("blocked_notified"):
+        refresh["blocked_notified"] = True
+        return True
+    return False
+
+
+def campaign_for(sha: str, dmg_path: Path, identity: dict, now: float) -> dict:
+    return {
+        "sha256": sha,
+        "dmg_path": str(dmg_path),
+        "http_identity": identity,
+        "detected_at": utc_iso(now),
+        "phase": "detected",
+        "campaign_phase": "drift-validation",
+        "acceptance_evidence": None,
+        "feature_snapshot": None,
+        "repair_rounds": [],
+        "dispatch_key": str(uuid.uuid4()),
+        "base_sha": None,
+        "branch": f"codex/upstream-dmg-{sha[:12]}",
+        "worktree": None,
+        "pr_number": None,
+        "pr_url": None,
+        "head_sha": None,
+        "ci_state": None,
+        "last_error": None,
+        "attempts": 0,
+        "updated_at": utc_iso(now),
+    }
+
+
+def fail_probe(store: Store, now: float, message: str) -> int:
+    state = store.load()
+    state["probe_failures"] = int(state.get("probe_failures") or 0) + 1
+    state["last_probe_at"] = utc_iso(now)
+    state["last_probe_error"] = message[:500]
+    store.save(state)
+    print(f"RETRY {state['probe_failures']}")
+    return 3
+
+
+def process_nix_refresh(
+    args: argparse.Namespace,
+    store: Store,
+    state: dict,
+    identity: dict,
+    dmg_sha: str,
+    now: float,
+) -> None:
+    if args.skip_nix:
+        return
+    campaign = state.get("active_campaign")
+    if not isinstance(campaign, dict) or campaign.get("campaign_phase") not in {"awaiting-nix", "nix-refresh"}:
+        return
+    repository = args.repository
+    expected_sri = sha256_sri(dmg_sha)
+    refresh = state["nix_refresh"]
+    if refresh.get("expected_dmg_sha256") != dmg_sha:
+        refresh = default_state()["nix_refresh"]
+        state["nix_refresh"] = refresh
+        refresh["expected_dmg_sha256"] = dmg_sha
+        refresh["expected_dmg_sri"] = expected_sri
+
+    main_sri = extract_codex_dmg_sri(github_file(repository, "flake.nix", "main"))
+    if main_sri == expected_sri:
+        refresh["workflow_status"] = "current"
+        refresh["pr_number"] = None
+        refresh["pr_head_sha"] = None
+        refresh["check_status"] = "current"
+        reset_nix_blocker(refresh)
+        state["nix_merge_lease"] = None
+        finalize_campaign(state, "accepted_with_nix_current", now)
+        store.save(state)
+        return
+
+    expected_main_sha = refresh.get("expected_main_sha")
+    active_refresh = active_nix_workflow(repository)
+    if active_refresh:
+        refresh["workflow_status"] = (
+            active_refresh.get("status")
+            if isinstance(expected_main_sha, str)
+            and nix_run_matches_campaign(active_refresh, expected_main_sha, dmg_sha)
+            else "waiting-for-older-run"
+        )
+        refresh["workflow_run_id"] = active_refresh.get("databaseId")
+        refresh["workflow_url"] = active_refresh.get("url")
+        refresh["workflow_head_sha"] = active_refresh.get("headSha")
+        store.save(state)
+        return
+
+    prs = open_nix_prs(repository)
+    if len(prs) > 1:
+        refresh["workflow_status"] = "blocked"
+        refresh["check_status"] = "multiple-open-prs"
+        notify = record_nix_blocker(refresh, "multiple-open-prs")
+        if notify:
+            queue_notification(state, "NIX_BLOCKED", [0, "multiple-open-prs"], f"nix-blocked:{dmg_sha}:multiple-open-prs")
+        store.save(state)
+        return
+
+    if not prs:
+        refresh["pr_number"] = None
+        refresh["pr_head_sha"] = None
+        refresh["check_status"] = "waiting-for-pr"
+        runs = nix_workflow_runs(repository)
+        main_sha = github_ref_sha(repository, "main")
+        target_head = refresh.get("expected_main_sha") or refresh.get("workflow_head_sha") or main_sha
+        active_run = next((
+            run for run in runs
+            if run.get("status") in {"queued", "in_progress", "waiting", "requested", "pending"}
+            and nix_run_matches_campaign(run, target_head, dmg_sha)
+        ), None)
+        if active_run:
+            refresh["workflow_status"] = active_run.get("status") or "active"
+            refresh["workflow_run_id"] = active_run.get("databaseId")
+            refresh["workflow_url"] = active_run.get("url")
+            refresh["workflow_head_sha"] = active_run.get("headSha")
+            store.save(state)
+            return
+        older_active = next((
+            run for run in runs
+            if run.get("status") in {"queued", "in_progress", "waiting", "requested", "pending"}
+        ), None)
+        if older_active:
+            refresh["workflow_status"] = "waiting-for-older-run"
+            store.save(state)
+            return
+        dispatched_at = parse_iso(refresh.get("last_dispatch_at"))
+        completed = next(
+            (
+                run for run in runs
+                if run.get("status") == "completed"
+                and nix_run_matches_campaign(run, target_head, dmg_sha)
+                and parse_iso(run.get("createdAt")) + 5 >= dispatched_at
+                and run.get("databaseId") != refresh.get("last_seen_run_id")
+            ),
+            None,
+        )
+        if completed:
+            run_id = int(completed["databaseId"])
+            details = nix_run_view(repository, run_id)
+            failure_log = "" if str(details.get("conclusion") or "").lower() == "success" else nix_failure_log(repository, run_id)
+            classification = "success" if not failure_log and str(details.get("conclusion") or "").lower() == "success" else classify_nix_run(details, failure_log)
+            record_nix_run(state, details, classification, failure_log)
+            refresh["last_seen_run_id"] = run_id
+            refresh["workflow_run_id"] = run_id
+            refresh["workflow_url"] = details.get("url")
+            refresh["workflow_head_sha"] = details.get("headSha")
+            refresh["workflow_conclusion"] = details.get("conclusion")
+            if classification == "source":
+                state["nix_failure_class"] = "source"
+                campaign["nix_failure_class"] = "source"
+                campaign["campaign_phase"] = "nix-repair"
+                campaign["phase"] = "nix-repair"
+                campaign["updated_at"] = utc_iso(now)
+                queue_notification(state, "NIX_REPAIR_READY", [dmg_sha, run_id], f"nix-repair:{dmg_sha}:{run_id}")
+                store.save(state)
+                return
+            if classification == "transient":
+                failures = int(refresh.get("transient_failures") or 0) + 1
+                refresh["transient_failures"] = failures
+                state["nix_failure_class"] = "transient"
+                if failures >= NIX_MAX_TRANSIENT_ATTEMPTS:
+                    refresh["workflow_status"] = "blocked"
+                    campaign["campaign_phase"] = "nix-blocked"
+                    queue_notification(state, "NIX_BLOCKED", [0, "transient-retries-exhausted"], f"nix-blocked:{dmg_sha}:transient")
+                    store.save(state)
+                    return
+                refresh["next_retry_at"] = utc_iso(now + NIX_TRANSIENT_BACKOFF_SECONDS[failures - 1])
+                refresh["dispatch_key"] = None
+                refresh["workflow_status"] = "transient-backoff"
+                store.save(state)
+                return
+            refresh["workflow_status"] = "waiting-for-pr"
+            refresh["transient_failures"] = 0
+            refresh["next_retry_at"] = utc_iso(now + 300)
+            store.save(state)
+            return
+        if parse_iso(refresh.get("next_retry_at")) > now:
+            store.save(state)
+            return
+        ensure_nix_workflow(args, refresh, repository, now, main_sha, dmg_sha)
+        campaign["campaign_phase"] = "nix-refresh"
+        campaign["phase"] = "nix-refresh"
+        store.save(state)
+        return
+
+    pr, ci_run = augment_nix_pr_checks(prs[0], repository)
+    number = int(pr["number"])
+    refresh["pr_number"] = number
+    refresh["pr_head_sha"] = pr.get("headRefOid")
+    if isinstance(ci_run, dict) and ci_run.get("status") != "completed":
+        refresh["check_status"] = "checks-pending"
+        refresh["workflow_status"] = "pr-ci-active"
+        reset_nix_blocker(refresh)
+        store.save(state)
+        return
+    status, reason = validate_nix_pr(pr, expected_sri, repository)
+    refresh["check_status"] = reason
+    refresh["workflow_status"] = "pr-open"
+    if status == "waiting":
+        reset_nix_blocker(refresh)
+        store.save(state)
+        return
+    if status == "blocked":
+        if reason == "dmg-hash-mismatch":
+            ensure_nix_workflow(
+                args,
+                refresh,
+                repository,
+                now,
+                github_ref_sha(repository, "main"),
+                dmg_sha,
+            )
+        if reason.startswith("check-fail") or reason.startswith("check-cancel"):
+            run_id = (ci_run or {}).get("databaseId") or failed_check_run_id(pr) or number
+            details = ci_run
+            if isinstance(ci_run, dict) and ci_run.get("databaseId") and not ci_run.get("jobs"):
+                details = nix_run_view(repository, int(ci_run["databaseId"]))
+            failure_log = nix_failure_log(repository, int(run_id))
+            classification = classify_nix_run(details, failure_log) if isinstance(details, dict) else "source"
+            if classification == "transient":
+                if refresh.get("ci_last_seen_run_id") != run_id:
+                    failures = int(refresh.get("ci_transient_failures") or 0) + 1
+                    refresh["ci_transient_failures"] = failures
+                    refresh["ci_last_seen_run_id"] = run_id
+                    refresh["ci_retry_dispatched_for"] = None
+                    refresh["ci_next_retry_at"] = utc_iso(
+                        now + NIX_TRANSIENT_BACKOFF_SECONDS[min(failures - 1, len(NIX_TRANSIENT_BACKOFF_SECONDS) - 1)]
+                    )
+                    if isinstance(details, dict):
+                        record_nix_run(state, details, "transient", failure_log)
+                failures = int(refresh.get("ci_transient_failures") or 0)
+                if failures >= NIX_MAX_TRANSIENT_ATTEMPTS:
+                    campaign["campaign_phase"] = "nix-blocked"
+                    campaign["phase"] = "nix-blocked"
+                    queue_notification(
+                        state,
+                        "NIX_BLOCKED",
+                        [number, "ci-transient-retries-exhausted"],
+                        f"nix-blocked:{dmg_sha}:{number}:ci-transient",
+                    )
+                elif (
+                    parse_iso(refresh.get("ci_next_retry_at")) <= now
+                    and refresh.get("ci_retry_dispatched_for") != run_id
+                ):
+                    if not args.dry_run:
+                        gh_command([
+                            "workflow", "run", "ci.yml", "--repo", repository,
+                            "--ref", NIX_REFRESH_BRANCH,
+                        ])
+                    refresh["ci_retry_dispatched_for"] = run_id
+                    refresh["workflow_status"] = "ci-retry-dispatched"
+                else:
+                    refresh["workflow_status"] = "ci-transient-backoff"
+                reset_nix_blocker(refresh)
+                store.save(state)
+                return
+            if isinstance(details, dict):
+                record_nix_run(state, details, "source", failure_log)
+            state["nix_failure_class"] = "source"
+            campaign["nix_failure_class"] = "source"
+            campaign["campaign_phase"] = "nix-repair"
+            campaign["phase"] = "nix-repair"
+            queue_notification(state, "NIX_REPAIR_READY", [dmg_sha, run_id], f"nix-repair:{dmg_sha}:{run_id}")
+            store.save(state)
+            return
+        notify = record_nix_blocker(refresh, reason)
+        if notify:
+            queue_notification(state, "NIX_BLOCKED", [number, reason], f"nix-blocked:{dmg_sha}:{number}:{reason}")
+        store.save(state)
+        return
+
+    reset_nix_blocker(refresh)
+    if args.premerge_headers_file:
+        premerge_headers = Path(args.premerge_headers_file).read_text(encoding="utf-8")
+    elif args.headers_file:
+        premerge_headers = Path(args.headers_file).read_text(encoding="utf-8")
+    else:
+        premerge_headers = curl_headers(args.url)
+    premerge_identity = http_identity(parse_headers(premerge_headers))
+    if premerge_identity is None or premerge_identity.get("key") != identity.get("key"):
+        refresh["check_status"] = "upstream-changed-before-merge"
+        store.save(state)
+        return
+
+    lease = state.get("nix_merge_lease")
+    if lease_is_active(lease, now):
+        store.save(state)
+        return
+    merge_run_id = str(uuid.uuid4())
+    state["nix_merge_lease"] = {
+        "run_id": merge_run_id,
+        "pr_number": number,
+        "head_sha": pr.get("headRefOid"),
+        "acquired_at": utc_iso(now),
+        "expires_at": utc_iso(now + NIX_MERGE_TTL_SECONDS),
+    }
+    store.save(state)
+
+    try:
+        current, _ = augment_nix_pr_checks(nix_pr_view(repository, number), repository)
+        status, reason = validate_nix_pr(current, expected_sri, repository)
+        if status != "ready" or current.get("headRefOid") != pr.get("headRefOid"):
+            refresh["check_status"] = "head-or-gates-changed"
+            notify = record_nix_blocker(refresh, "head-or-gates-changed") if status == "blocked" else False
+            state["nix_merge_lease"] = None
+            if notify:
+                queue_notification(state, "NIX_BLOCKED", [number, "head-or-gates-changed"], f"nix-blocked:{dmg_sha}:{number}:head-changed")
+            store.save(state)
+            return
+        if args.dry_run:
+            refresh["check_status"] = "ready-dry-run"
+            state["nix_merge_lease"] = None
+            store.save(state)
+            return
+        gh_command(
+            [
+                "pr", "merge", str(number), "--repo", repository, "--squash", "--admin",
+                "--delete-branch", "--match-head-commit", current["headRefOid"],
+            ]
+        )
+        merged = nix_pr_view(repository, number)
+        if merged.get("state") != "MERGED" or not merged.get("mergedAt"):
+            raise RuntimeError("GitHub did not confirm the Nix PR merge")
+        merge_commit = merged.get("mergeCommit")
+        state["last_merged_nix_pr"] = {
+            "number": number,
+            "url": merged.get("url") or pr.get("url"),
+            "head_sha": current["headRefOid"],
+            "merge_sha": merge_commit.get("oid") if isinstance(merge_commit, dict) else None,
+            "dmg_sha256": dmg_sha,
+            "merged_at": merged.get("mergedAt"),
+            "recorded_at": utc_iso(now),
+        }
+        refresh["workflow_status"] = "merged"
+        refresh["check_status"] = "merged"
+        refresh["merge_failures"] = 0
+        state["nix_merge_lease"] = None
+        queue_notification(
+            state,
+            "NIX_PR_MERGED",
+            [number, state["last_merged_nix_pr"]["url"]],
+            f"nix-merged:{dmg_sha}:{number}",
+        )
+        finalize_campaign(state, "accepted_with_nix_merged", now)
+        store.save(state)
+        return
+    except (RuntimeError, subprocess.SubprocessError) as error:
+        state["nix_merge_lease"] = None
+        refresh["merge_failures"] = int(refresh.get("merge_failures") or 0) + 1
+        refresh["check_status"] = "merge-failed"
+        refresh["last_error"] = str(error)[:500]
+        notify = refresh["merge_failures"] >= 3 and not refresh.get("merge_failure_notified")
+        if notify:
+            refresh["merge_failure_notified"] = True
+            queue_notification(state, "NIX_BLOCKED", [number, "merge-failed"], f"nix-blocked:{dmg_sha}:{number}:merge-failed")
+        store.save(state)
+        return
+
+
+def record_nix_run(state: dict, run: dict, classification: str, log_excerpt: str) -> None:
+    item = {
+        "run_id": run.get("databaseId"),
+        "status": run.get("status"),
+        "conclusion": run.get("conclusion"),
+        "head_sha": run.get("headSha"),
+        "url": run.get("url"),
+        "created_at": run.get("createdAt"),
+        "updated_at": run.get("updatedAt"),
+        "classification": classification,
+        "failure_log_excerpt": log_excerpt[-4000:] if log_excerpt else None,
+        "recorded_at": utc_iso(),
+    }
+    runs = state.setdefault("nix_runs", [])
+    runs[:] = [existing for existing in runs if existing.get("run_id") != item["run_id"]]
+    runs.append(item)
+    del runs[:-50]
+
+
+def failed_check_run_id(pr: dict) -> int | None:
+    for check in pr.get("statusCheckRollup") or []:
+        if not isinstance(check, dict) or check_outcome(check) not in {"fail", "cancel"}:
+            continue
+        match = re.search(r"/actions/runs/(\d+)", str(check.get("detailsUrl") or check.get("targetUrl") or ""))
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def finalize_campaign(state: dict, verdict: str, now: float) -> None:
+    campaign = state.get("active_campaign")
+    if not isinstance(campaign, dict):
+        return
+    completed = {
+        **campaign,
+        "phase": "completed",
+        "campaign_phase": "completed",
+        "verdict": verdict,
+        "completed_at": utc_iso(now),
+    }
+    state["last_accepted_sha256"] = campaign.get("sha256")
+    state["last_completed_campaign"] = completed
+    state["active_campaign"] = None
+    state["worker_lease"] = None
+    state["revalidation_required"] = False
+
+
+def ensure_campaign_notification(state: dict, now: float) -> None:
+    pending = state.get("pending_campaign")
+    active = state.get("active_campaign")
+    if isinstance(pending, dict):
+        queue_notification(state, "CHANGE_READY", [pending["sha256"]], f"campaign:{pending['sha256']}:{pending.get('dispatch_key')}")
+        return
+    if not isinstance(active, dict) or lease_is_active(state.get("worker_lease"), now):
+        return
+    if active.get("campaign_phase") == "nix-repair":
+        latest = state.get("nix_runs")[-1] if state.get("nix_runs") else {}
+        run_id = latest.get("run_id") or (state.get("nix_refresh") or {}).get("workflow_run_id") or 0
+        queue_notification(state, "NIX_REPAIR_READY", [active["sha256"], run_id], f"nix-repair:{active['sha256']}:{run_id}")
+    elif active.get("campaign_phase") in {"drift-validation", "detected"}:
+        queue_notification(state, "CHANGE_READY", [active["sha256"]], f"campaign:{active['sha256']}:{active.get('dispatch_key')}")
+
+
+def emit_existing_campaign(state: dict, now: float, store: Store | None = None) -> bool:
+    ensure_campaign_notification(state, now)
+    if store is not None:
+        store.save(state)
+    notification = next_notification(state)
+    if notification:
+        print(format_notification(notification))
+        return True
+    active = state.get("active_campaign")
+    lease = state.get("worker_lease")
+    if active and lease_is_active(lease, now):
+        print("WORKER_ACTIVE")
+        return True
+    if active:
+        print("NIX_ACTIVE" if active.get("campaign_phase") in {"awaiting-nix", "nix-refresh"} else "CAMPAIGN_WAITING")
+        return True
+    return False
+
+
+def command_probe(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        try:
+            headers_payload = Path(args.headers_file).read_text(encoding="utf-8") if args.headers_file else curl_headers(args.url)
+            identity = http_identity(parse_headers(headers_payload))
+            if identity is None:
+                return fail_probe(store, now, "upstream response has no stable HTTP identity")
+            state = store.load()
+            if (state.get("http_identity") or {}).get("key") == identity["key"]:
+                state["probe_failures"] = 0
+                state["last_probe_at"] = utc_iso(now)
+                state.pop("last_probe_error", None)
+                store.save(state)
+                dmg_sha = state.get("last_observed_sha256")
+                if dmg_sha:
+                    process_nix_refresh(args, store, state, identity, dmg_sha, now)
+                if not emit_existing_campaign(state, now, store):
+                    print("UNCHANGED")
+                return 0
+
+            source = Path(args.source_file).resolve() if args.source_file else None
+            fd, temporary_name = tempfile.mkstemp(prefix=".download.", suffix=".dmg", dir=store.downloads)
+            os.close(fd)
+            temporary = Path(temporary_name)
+            try:
+                if source:
+                    shutil.copyfile(source, temporary)
+                else:
+                    download(args.url, temporary)
+                size = temporary.stat().st_size
+                if size <= 0:
+                    raise RuntimeError("downloaded DMG is empty")
+                expected = identity.get("content_length")
+                if expected and expected.isdigit() and size != int(expected):
+                    raise RuntimeError(f"downloaded DMG size {size} does not match Content-Length {expected}")
+                sha = sha256_file(temporary)
+                target = store.downloads / f"{sha}.dmg"
+                if target.exists():
+                    temporary.unlink()
+                else:
+                    with temporary.open("rb") as handle:
+                        os.fsync(handle.fileno())
+                    os.replace(temporary, target)
+                state = store.load()
+                previous_sha = state.get("last_observed_sha256")
+                state["http_identity"] = identity
+                state["last_observed_sha256"] = sha
+                state["probe_failures"] = 0
+                state["last_probe_at"] = utc_iso(now)
+                state.pop("last_probe_error", None)
+                if previous_sha == sha:
+                    for key in ("active_campaign", "pending_campaign"):
+                        same_campaign = state.get(key)
+                        if isinstance(same_campaign, dict) and same_campaign.get("sha256") == sha:
+                            same_campaign["http_identity"] = identity
+                            same_campaign["dmg_path"] = str(target)
+                            same_campaign["updated_at"] = utc_iso(now)
+                    store.save(state)
+                    process_nix_refresh(args, store, state, identity, sha, now)
+                    if not emit_existing_campaign(state, now, store):
+                        print("UNCHANGED")
+                    return 0
+
+                new_campaign = campaign_for(sha, target, identity, now)
+                lease = state.get("worker_lease")
+                active = state.get("active_campaign")
+                if active and active.get("sha256") == sha and lease and parse_iso(lease.get("expires_at")) > now:
+                    store.save(state)
+                    print("WORKER_ACTIVE")
+                    return 0
+                if active and active.get("sha256") != sha:
+                    state["pending_campaign"] = new_campaign
+                else:
+                    state["active_campaign"] = new_campaign
+                    state["pending_campaign"] = None
+                supersede_campaign_notifications(state, sha, now)
+                queue_notification(state, "CHANGE_READY", [sha], f"campaign:{sha}:{new_campaign.get('dispatch_key')}")
+                store.save(state)
+                emit_existing_campaign(state, now, store)
+                return 0
+            finally:
+                temporary.unlink(missing_ok=True)
+        except (OSError, RuntimeError, subprocess.SubprocessError) as error:
+            return fail_probe(store, now, str(error))
+
+
+def lease_is_active(lease: dict | None, now: float) -> bool:
+    return bool(lease and parse_iso(lease.get("expires_at")) > now)
+
+
+def require_owner(state: dict, run_id: str, now: float, allow_expired: bool = False) -> dict:
+    lease = state.get("worker_lease")
+    if not lease or lease.get("run_id") != run_id:
+        raise RuntimeError("worker lease is owned by another run")
+    if not allow_expired and not lease_is_active(lease, now):
+        raise RuntimeError("worker lease has expired")
+    return lease
+
+
+def require_worker_phase(phase: str | None) -> None:
+    if phase in PROTECTED_CAMPAIGN_PHASES:
+        raise RuntimeError(f"campaign phase is controlled by a guarded transition: {phase}")
+
+
+def command_worker_acquire(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        lease = state.get("worker_lease")
+        if lease_is_active(lease, now):
+            print("WORKER_ACTIVE")
+            return 2
+        pending = state.get("pending_campaign")
+        active = state.get("active_campaign")
+        if pending and (args.sha is None or pending.get("sha256") == args.sha):
+            if active and active.get("sha256") != pending.get("sha256"):
+                active = {**active, "phase": "superseded", "superseded_at": utc_iso(now)}
+                state["last_completed_campaign"] = active
+            active = pending
+            state["active_campaign"] = active
+            state["pending_campaign"] = None
+        if not active or (args.sha and active.get("sha256") != args.sha):
+            print("NO_CAMPAIGN")
+            return 4
+        run_id = str(uuid.uuid4())
+        state["worker_lease"] = {
+            "run_id": run_id,
+            "acquired_at": utc_iso(now),
+            "heartbeat_at": utc_iso(now),
+            "expires_at": utc_iso(now + args.ttl),
+        }
+        previous_round = current_round(active)
+        repair_round = current_round(active, create=True)
+        if previous_round is not None and repair_round is not previous_round:
+            active["acceptance_evidence"] = None
+            active["feature_snapshot"] = None
+            for field in ("base_sha", "branch", "worktree", "pr_number", "pr_url", "head_sha", "ci_state"):
+                active[field] = None
+        repair_round["status"] = "active"
+        repair_round["acquired_at"] = utc_iso(now)
+        acknowledge_campaign_notifications(state, active["sha256"], now)
+        active["attempts"] = int(active.get("attempts") or 0) + 1
+        active["updated_at"] = utc_iso(now)
+        store.save(state)
+        print(f"ACQUIRED {run_id} {active['sha256']} {active['dmg_path']}")
+        return 0
+
+
+def command_event_ack(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        if not acknowledge_notification(state, args.event_id, now):
+            raise RuntimeError("notification event was not found")
+        store.save(state)
+        print("EVENT_ACKED")
+    return 0
+
+
+def command_campaign_requeue(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        if lease_is_active(state.get("worker_lease"), now):
+            print("WORKER_ACTIVE")
+            return 2
+        if state.get("active_campaign") or state.get("pending_campaign"):
+            raise RuntimeError("cannot requeue while a campaign is already queued")
+        sha = args.sha or state.get("last_observed_sha256")
+        if not isinstance(sha, str) or not re.fullmatch(r"[0-9a-f]{64}", sha):
+            raise RuntimeError("no valid DMG SHA-256 is available to requeue")
+        if sha != state.get("last_observed_sha256"):
+            raise RuntimeError("only the latest observed DMG can be requeued")
+        completed = state.get("last_completed_campaign")
+        if isinstance(completed, dict) and completed.get("sha256") == sha:
+            dmg_path = Path(str(completed.get("dmg_path") or ""))
+            identity = completed.get("http_identity") or state.get("http_identity")
+        else:
+            dmg_path = store.downloads / f"{sha}.dmg"
+            identity = state.get("http_identity") if state.get("last_observed_sha256") == sha else None
+        if not dmg_path.is_file():
+            raise RuntimeError(f"downloaded DMG is missing for {sha}")
+        if sha256_file(dmg_path) != sha:
+            raise RuntimeError(f"downloaded DMG hash does not match {sha}")
+        if not isinstance(identity, dict):
+            raise RuntimeError(f"HTTP identity is missing for {sha}")
+        campaign = campaign_for(sha, dmg_path, identity, now)
+        campaign["requeued_at"] = utc_iso(now)
+        campaign["requeue_reason"] = (args.reason or "manual-revalidation")[:500]
+        state["active_campaign"] = campaign
+        state["pending_campaign"] = None
+        state["worker_lease"] = None
+        state["revalidation_required"] = True
+        if state.get("last_accepted_sha256") == sha:
+            state["last_accepted_sha256"] = None
+        store.save(state)
+        print(f"CHANGE_READY {sha}")
+        return 0
+
+
+def feature_snapshot_helper(source: Path) -> dict:
+    helper = Path(__file__).with_name("feature-snapshot.js")
+    result = subprocess.run(
+        ["node", str(helper), str(source)],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Linux feature snapshot failed: {result.stderr.strip()[:1000]}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("Linux feature snapshot helper returned invalid JSON") from error
+    if not isinstance(value, dict) or not isinstance(value.get("enabled"), list):
+        raise RuntimeError("Linux feature snapshot helper returned an invalid contract")
+    return value
+
+
+def create_feature_snapshot(store: Store, campaign: dict, source: Path, now: float) -> dict:
+    repair_round = current_round(campaign, create=True)
+    snapshot_dir = store.snapshots / campaign["sha256"] / f"round-{repair_round['round']}"
+    existing = campaign.get("feature_snapshot")
+    if isinstance(existing, dict) and existing.get("snapshot_dir") == str(snapshot_dir) and snapshot_dir.is_dir():
+        return existing
+
+    description = feature_snapshot_helper(source)
+    config = description.get("config") or {"enabled": []}
+    enabled = description["enabled"]
+    if config.get("enabled") != enabled:
+        raise RuntimeError("normalized feature config does not match enabled feature manifests")
+
+    snapshot_dir.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temporary = Path(tempfile.mkdtemp(prefix=f".round-{repair_round['round']}.", dir=snapshot_dir.parent))
+    local_hashes: dict[str, str] = {}
+    try:
+        if description.get("hasLocalConfig"):
+            (temporary / "features.json").write_bytes(canonical_json(config))
+            os.chmod(temporary / "features.json", 0o600)
+        local_root = temporary / "local"
+        for item in description.get("local") or []:
+            if not isinstance(item, dict) or item.get("id") not in enabled:
+                raise RuntimeError("Linux feature snapshot helper returned an invalid local feature")
+            feature_id = item["id"]
+            # Keep this lexical: the shared loader intentionally follows a
+            # local feature directory symlink. copytree snapshots its resolved
+            # contents while preserving supported links inside the tree.
+            feature_dir = Path(os.path.abspath(str(item.get("dir") or "")))
+            source_local_root = Path(os.path.abspath(source / "linux-features" / "local"))
+            if not feature_dir.is_relative_to(source_local_root) or not (feature_dir / "feature.json").is_file():
+                raise RuntimeError(f"enabled local feature is invalid: {feature_id}")
+            local_root.mkdir(mode=0o700, exist_ok=True)
+            shutil.copytree(feature_dir, local_root / feature_id, symlinks=True)
+            local_hashes[feature_id] = sha256_tree(local_root / feature_id)
+        if snapshot_dir.exists():
+            shutil.rmtree(temporary)
+        else:
+            os.replace(temporary, snapshot_dir)
+    finally:
+        shutil.rmtree(temporary, ignore_errors=True)
+
+    config_path = snapshot_dir / "features.json"
+    snapshot = {
+        "source_checkout": str(source),
+        "snapshot_dir": str(snapshot_dir),
+        "enabled": enabled,
+        "config": config,
+        "config_sha256": sha256_file(config_path) if config_path.is_file() else hashlib.sha256(b"").hexdigest(),
+        "local_feature_tree_hashes": local_hashes,
+        "created_at": utc_iso(now),
+        "round": repair_round["round"],
+    }
+    campaign["feature_snapshot"] = snapshot
+    repair_round["feature_snapshot"] = snapshot
+    return snapshot
+
+
+def materialize_feature_snapshot(snapshot: dict, worktree: Path) -> None:
+    snapshot_dir = Path(snapshot["snapshot_dir"])
+    target_features = worktree / "linux-features"
+    target_config = target_features / "features.json"
+    target_local = target_features / "local"
+    source_config = snapshot_dir / "features.json"
+    source_local = snapshot_dir / "local"
+    if source_config.is_file():
+        temporary = target_features / f".features.{uuid.uuid4().hex}.json"
+        try:
+            shutil.copyfile(source_config, temporary)
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, target_config)
+        finally:
+            temporary.unlink(missing_ok=True)
+    else:
+        target_config.unlink(missing_ok=True)
+    shutil.rmtree(target_local, ignore_errors=True)
+    if source_local.is_dir():
+        shutil.copytree(source_local, target_local, symlinks=True)
+
+
+def command_sync_features(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign or not campaign.get("worktree"):
+            raise RuntimeError("campaign worktree is not recorded")
+        source = Path(args.source_checkout).expanduser().resolve()
+        worktree = Path(campaign["worktree"]).expanduser().resolve()
+        managed_root = store.worktrees.resolve()
+        if not worktree.is_relative_to(managed_root):
+            raise RuntimeError("campaign worktree is outside the managed worktree root")
+        if not worktree.is_dir():
+            raise RuntimeError("campaign worktree does not exist")
+
+        target_features = worktree / "linux-features"
+        if not target_features.is_dir():
+            raise RuntimeError("managed worktree has no linux-features directory")
+        snapshot = create_feature_snapshot(store, campaign, source, now)
+        materialize_feature_snapshot(snapshot, worktree)
+        campaign["updated_at"] = utc_iso(now)
+        store.save(state)
+        print("FEATURES_SYNCED " + (",".join(snapshot["enabled"]) if snapshot["enabled"] else "none"))
+        return 0
+
+
+def command_refresh_feature_snapshot(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign:
+            raise RuntimeError("no active campaign")
+        if campaign.get("acceptance_evidence"):
+            raise RuntimeError("cannot refresh features after acceptance; start a new repair round")
+        snapshot = campaign.pop("feature_snapshot", None)
+        if isinstance(snapshot, dict) and snapshot.get("snapshot_dir"):
+            snapshot_dir = Path(snapshot["snapshot_dir"])
+            if snapshot_dir.is_relative_to(store.snapshots.resolve()):
+                shutil.rmtree(snapshot_dir, ignore_errors=True)
+        store.save(state)
+        print("FEATURE_SNAPSHOT_CLEARED")
+    return 0
+
+
+def git_head(worktree: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def git_tracked_clean(worktree: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--quiet", "HEAD", "--"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode not in {0, 1}:
+        raise RuntimeError(f"could not inspect campaign worktree: {result.stderr.strip()[:500]}")
+    return result.returncode == 0
+
+
+def repair_scope(worktree: Path, base_sha: str | None, head_sha: str) -> dict:
+    if not isinstance(base_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", base_sha):
+        return {"profile": "full", "paths": [], "feature_ids": [], "reason": "base-head-unavailable"}
+    result = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--name-only", f"{base_sha}..{head_sha}", "--"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    paths = sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+    if not paths:
+        return {"profile": "unchanged", "paths": [], "feature_ids": []}
+    feature_ids: set[str] = set()
+    for path in paths:
+        match = re.fullmatch(r"linux-features/([^/]+)/.+", path)
+        if not match or match.group(1) == "local":
+            return {"profile": "full", "paths": paths, "feature_ids": []}
+        feature_ids.add(match.group(1))
+    return {"profile": "feature-only", "paths": paths, "feature_ids": sorted(feature_ids)}
+
+
+def read_json_object(path: Path, label: str) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise RuntimeError(f"invalid {label}: {error}") from error
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{label} must contain a JSON object")
+    return value
+
+
+def command_record_acceptance(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign:
+            raise RuntimeError("no active campaign")
+        if campaign.get("sha256") != state.get("last_observed_sha256") or state.get("pending_campaign"):
+            raise RuntimeError("campaign is not the latest observed DMG")
+        if not re.fullmatch(r"[0-9a-f]{40}", args.head):
+            raise RuntimeError("acceptance head must be a full git SHA")
+        worktree = Path(str(campaign.get("worktree") or "")).expanduser().resolve()
+        if not worktree.is_relative_to(store.worktrees.resolve()) or not worktree.is_dir():
+            raise RuntimeError("campaign worktree is not a managed worktree")
+        if git_head(worktree) != args.head or campaign.get("head_sha") != args.head:
+            raise RuntimeError("acceptance head does not match the campaign worktree")
+        if not git_tracked_clean(worktree):
+            raise RuntimeError("campaign worktree has uncommitted tracked changes")
+        decision_path = Path(args.decision).expanduser().resolve()
+        if not decision_path.is_file() or not decision_path.is_relative_to(worktree):
+            raise RuntimeError("acceptance decision must be inside the managed worktree")
+        decision = read_json_object(decision_path, "acceptance decision")
+        if decision.get("verdict") not in {"accepted", "accepted_with_warnings"}:
+            raise RuntimeError("acceptance decision is not accepted")
+        if (decision.get("dmg") or {}).get("sha256") != campaign.get("sha256"):
+            raise RuntimeError("acceptance decision DMG SHA does not match the campaign")
+        source = decision.get("source") or {}
+        if source.get("commit") != args.head or source.get("dirty") is True:
+            raise RuntimeError("acceptance decision source does not match a clean campaign head")
+        snapshot = campaign.get("feature_snapshot")
+        if not isinstance(snapshot, dict):
+            raise RuntimeError("feature snapshot is missing")
+        decision_features = (((decision.get("checks") or {}).get("patchReport") or {}).get("enabledFeatures"))
+        if decision_features != snapshot.get("enabled"):
+            raise RuntimeError("acceptance decision enabled features do not match the snapshot")
+        snapshot_dir = Path(str(snapshot.get("snapshot_dir") or ""))
+        config_path = snapshot_dir / "features.json"
+        config_hash = sha256_file(config_path) if config_path.is_file() else hashlib.sha256(b"").hexdigest()
+        if config_hash != snapshot.get("config_sha256"):
+            raise RuntimeError("feature snapshot config changed after creation")
+        for feature_id, expected_hash in (snapshot.get("local_feature_tree_hashes") or {}).items():
+            if sha256_tree(snapshot_dir / "local" / feature_id) != expected_hash:
+                raise RuntimeError(f"local feature snapshot changed after creation: {feature_id}")
+        report_value = ((decision.get("checks") or {}).get("patchReport") or {}).get("reportPath")
+        report_path = Path(str(report_value or "")).expanduser().resolve()
+        if not report_path.is_file() or not report_path.is_relative_to(worktree):
+            raise RuntimeError("acceptance patch report must be inside the managed worktree")
+        read_json_object(report_path, "acceptance patch report")
+
+        repair_round = current_round(campaign, create=True)
+        scope = repair_scope(worktree, repair_round.get("base_sha") or campaign.get("base_sha"), args.head)
+        repair_round["validation_scope"] = scope
+        evidence_dir = store.evidence / campaign["sha256"] / f"round-{repair_round['round']}" / args.head
+        temporary = Path(tempfile.mkdtemp(prefix=".evidence.", dir=store.evidence))
+        try:
+            shutil.copy2(decision_path, temporary / "decision.json")
+            shutil.copy2(report_path, temporary / "patch-report.json")
+            evidence_dir.parent.mkdir(parents=True, exist_ok=True)
+            if evidence_dir.exists():
+                shutil.rmtree(evidence_dir)
+            os.replace(temporary, evidence_dir)
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+        evidence = {
+            "verdict": decision["verdict"],
+            "dmg_sha256": campaign["sha256"],
+            "head_sha": args.head,
+            "decision_path": str(evidence_dir / "decision.json"),
+            "decision_sha256": sha256_file(evidence_dir / "decision.json"),
+            "patch_report_path": str(evidence_dir / "patch-report.json"),
+            "patch_report_sha256": sha256_file(evidence_dir / "patch-report.json"),
+            "feature_config_sha256": snapshot["config_sha256"],
+            "local_feature_tree_hashes": snapshot.get("local_feature_tree_hashes") or {},
+            "enabled_features": snapshot["enabled"],
+            "validation_scope": scope,
+            "recorded_at": utc_iso(now),
+        }
+        campaign["acceptance_evidence"] = evidence
+        repair_round["acceptance_evidence"] = evidence
+        campaign["campaign_phase"] = "accepted-head"
+        campaign["phase"] = "accepted-head"
+        repair_round["accepted_head_sha"] = args.head
+        repair_round["status"] = "accepted-head"
+        campaign["updated_at"] = utc_iso(now)
+        store.save(state)
+        print(f"ACCEPTANCE_RECORDED {args.head}")
+    return 0
+
+
+def transient_output(payload: str) -> bool:
+    return bool(re.search(
+        r"timed? out|temporary failure|could not resolve host|connection (?:reset|refused)|network is unreachable|\b50[234]\b|rate.?limit",
+        payload,
+        flags=re.IGNORECASE,
+    ))
+
+
+def changed_tracked_paths(worktree: Path) -> set[str]:
+    result = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--name-only", "HEAD", "--"],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def command_nix_preflight(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    if args.target and not re.fullmatch(r"\.#[A-Za-z0-9._+-]+", args.target):
+        raise RuntimeError("Nix preflight target must be a flake output such as .#checks.x86_64-linux.example")
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign or not isinstance(campaign.get("acceptance_evidence"), dict):
+            raise RuntimeError("accepted campaign evidence is required before Nix preflight")
+        evidence = dict(campaign["acceptance_evidence"])
+        source_worktree = Path(str(campaign.get("worktree") or "")).resolve()
+        if not source_worktree.is_relative_to(store.worktrees.resolve()) or not source_worktree.is_dir():
+            raise RuntimeError("campaign worktree is not managed")
+        head = evidence["head_sha"]
+        if git_head(source_worktree) != head:
+            raise RuntimeError("campaign head changed after acceptance")
+        repair_round = current_round(campaign, create=True)
+        repair_round_number = repair_round["round"]
+        scope = repair_round.get("validation_scope") or evidence.get("validation_scope") or {"profile": "full"}
+        if args.target and scope.get("profile") != "feature-only":
+            raise RuntimeError("a focused Nix target is allowed only for a feature-only repair")
+        target = args.target
+        if scope.get("profile") == "feature-only" and not target:
+            target = ".#checks.x86_64-linux.nix-linux-features-multi-feature"
+
+    scratch = store.preflight / f"{campaign['sha256'][:12]}-round-{repair_round_number}-{uuid.uuid4().hex[:8]}"
+    log_payload = ""
+    classification = "source"
+    attempts = 0
+    success = False
+    try:
+        subprocess.run(
+            ["git", "-C", str(source_worktree), "worktree", "add", "--detach", str(scratch), head],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        command = [str(scratch / "scripts" / "ci" / "update-nix-hashes.sh")]
+        command_env = os.environ.copy()
+        if target:
+            command_env["NIX_VERIFY_OUTPUTS"] = target
+        for attempt in range(1, args.max_attempts + 1):
+            attempts = attempt
+            result = subprocess.run(
+                command,
+                cwd=scratch,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=command_env,
+            )
+            log_payload += f"\n===== attempt {attempt} =====\n{result.stdout}"
+            if result.returncode == 0:
+                changed = changed_tracked_paths(scratch)
+                unexpected = changed - NIX_ALLOWED_PATHS
+                if unexpected:
+                    log_payload += f"\nunexpected tracked paths: {sorted(unexpected)}\n"
+                    classification = "source"
+                    break
+                if extract_codex_dmg_sri((scratch / "flake.nix").read_text(encoding="utf-8")) != sha256_sri(campaign["sha256"]):
+                    log_payload += "\nrefreshed flake hash does not match campaign DMG\n"
+                    classification = "source"
+                    break
+                success = True
+                classification = "success"
+                break
+            classification = "transient" if transient_output(result.stdout) else "source"
+            if classification != "transient" or attempt >= args.max_attempts:
+                break
+            time.sleep(min(args.retry_delay * (2 ** (attempt - 1)), 60))
+    finally:
+        if scratch.exists():
+            subprocess.run(
+                ["git", "-C", str(source_worktree), "worktree", "remove", "--force", str(scratch)],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            shutil.rmtree(scratch, ignore_errors=True)
+
+    with store.locked():
+        state = store.load()
+        finish_now = args.now if args.now is not None else time.time()
+        require_owner(state, args.run_id, finish_now)
+        campaign = state.get("active_campaign")
+        if not campaign or (campaign.get("acceptance_evidence") or {}).get("head_sha") != head:
+            raise RuntimeError("campaign changed during Nix preflight")
+        repair_round = current_round(campaign, create=True)
+        report_dir = store.evidence / campaign["sha256"] / f"round-{repair_round['round']}" / head
+        report_dir.mkdir(parents=True, exist_ok=True)
+        log_path = report_dir / "nix-preflight.log"
+        log_path.write_text(log_payload, encoding="utf-8")
+        preflight = {
+            "status": "success" if success else "failed",
+            "classification": classification,
+            "target": target,
+            "head_sha": head,
+            "attempts": attempts,
+            "log_path": str(log_path),
+            "log_sha256": sha256_file(log_path),
+            "completed_at": utc_iso(),
+        }
+        repair_round["nix_preflight"] = preflight
+        campaign["nix_failure_class"] = None if success else classification
+        campaign["phase"] = "nix-preflight-green" if success else "nix-preflight-failed"
+        campaign["campaign_phase"] = campaign["phase"]
+        campaign["updated_at"] = utc_iso()
+        store.save(state)
+        if success:
+            print(f"NIX_PREFLIGHT_ACCEPTED {head}")
+            return 0
+        print(f"NIX_PREFLIGHT_{classification.upper()}_FAILURE {head}")
+        return 6
+
+
+def repair_pr_status(campaign: dict, pr: dict) -> tuple[str, str]:
+    if pr.get("state", "OPEN") != "OPEN":
+        return "blocked", "pr-not-open"
+    if pr.get("baseRefName") != "main" or pr.get("isDraft") is True:
+        return "blocked", "wrong-base-or-draft"
+    if pr.get("headRefName") != campaign.get("branch") or pr.get("headRefOid") != campaign.get("head_sha"):
+        return "blocked", "unexpected-head"
+    marker = f"<!-- upstream-dmg-sha256:{campaign['sha256']} -->"
+    if marker not in str(pr.get("body") or ""):
+        return "blocked", "missing-dmg-marker"
+    mergeable = str(pr.get("mergeable") or "UNKNOWN").upper()
+    if mergeable == "CONFLICTING":
+        return "blocked", "merge-conflict"
+    if mergeable != "MERGEABLE":
+        return "waiting", "mergeability-pending"
+    checks = pr.get("statusCheckRollup") or []
+    seen: dict[str, str] = {}
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        name = check.get("name") or check.get("context")
+        outcome = check_outcome(check)
+        if isinstance(name, str):
+            seen[name] = outcome
+        if outcome in {"fail", "cancel"}:
+            return "blocked", f"check-{outcome}:{name or 'unknown'}"
+        if outcome == "pending":
+            return "waiting", "checks-pending"
+    missing = sorted(name for name in REPAIR_REQUIRED_CHECKS if seen.get(name) != "pass")
+    if missing:
+        return "waiting", "required-checks-missing:" + ",".join(missing)
+    return "ready", "ready"
+
+
+def command_validate_repair_pr(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign or state.get("pending_campaign") or campaign.get("sha256") != state.get("last_observed_sha256"):
+            raise RuntimeError("repair campaign is no longer current")
+        evidence = campaign.get("acceptance_evidence")
+        if not isinstance(evidence, dict) or evidence.get("head_sha") != campaign.get("head_sha"):
+            raise RuntimeError("current PR head has no acceptance evidence")
+        repair_round = current_round(campaign, create=True)
+        preflight = repair_round.get("nix_preflight")
+        if not isinstance(preflight, dict) or preflight.get("status") != "success" or preflight.get("head_sha") != campaign.get("head_sha"):
+            raise RuntimeError("current PR head has no successful Nix preflight")
+        headers_payload = Path(args.headers_file).read_text(encoding="utf-8") if args.headers_file else curl_headers(args.url)
+        identity = http_identity(parse_headers(headers_payload))
+        if identity is None or identity.get("key") != (campaign.get("http_identity") or {}).get("key"):
+            raise RuntimeError("upstream DMG changed before repair PR merge")
+        pr = repair_pr_view(args.repository, args.pr_number)
+        status, reason = repair_pr_status(campaign, pr)
+        repair_round["pr_number"] = args.pr_number
+        repair_round["pr_url"] = pr.get("url")
+        repair_round["status"] = f"pr-{status}"
+        campaign["pr_number"] = str(args.pr_number)
+        campaign["pr_url"] = pr.get("url")
+        campaign["ci_state"] = reason
+        campaign["updated_at"] = utc_iso(now)
+        store.save(state)
+        if status != "ready":
+            print(f"REPAIR_PR_{status.upper()} {reason}")
+            return 7 if status == "blocked" else 8
+        print(f"REPAIR_PR_READY {args.pr_number} {campaign['head_sha']}")
+        return 0
+
+
+def reset_nix_refresh_for_campaign(state: dict, campaign: dict) -> None:
+    refresh = default_state()["nix_refresh"]
+    refresh["expected_dmg_sha256"] = campaign["sha256"]
+    refresh["expected_dmg_sri"] = sha256_sri(campaign["sha256"])
+    refresh["workflow_status"] = "ready-to-dispatch"
+    state["nix_refresh"] = refresh
+    state["nix_failure_class"] = None
+
+
+def command_advance_to_nix(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign or state.get("pending_campaign") or campaign.get("sha256") != state.get("last_observed_sha256"):
+            raise RuntimeError("campaign is no longer current")
+        evidence = campaign.get("acceptance_evidence")
+        if not isinstance(evidence, dict) or evidence.get("head_sha") != campaign.get("head_sha"):
+            raise RuntimeError("current campaign head has no acceptance evidence")
+        repair_round = current_round(campaign, create=True)
+        if args.pr_number is not None:
+            preflight = repair_round.get("nix_preflight")
+            if (
+                not isinstance(preflight, dict)
+                or preflight.get("status") != "success"
+                or preflight.get("head_sha") != campaign.get("head_sha")
+            ):
+                raise RuntimeError("successful Nix preflight is required")
+            pr = repair_pr_view(args.repository, args.pr_number)
+            if pr.get("state") != "MERGED" or pr.get("headRefOid") != evidence["head_sha"] or not pr.get("mergedAt"):
+                raise RuntimeError("GitHub did not confirm the accepted repair PR merge")
+            merge_commit = pr.get("mergeCommit") or {}
+            merge_sha = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
+            if not isinstance(merge_sha, str) or not re.fullmatch(r"[0-9a-f]{40}", merge_sha):
+                raise RuntimeError("repair PR merge commit is unavailable")
+            repair_round["pr_number"] = args.pr_number
+            repair_round["pr_url"] = pr.get("url")
+            repair_round["merge_sha"] = merge_sha
+            repair_round["status"] = "merged"
+            campaign["accepted_main_sha"] = merge_sha
+        else:
+            scope = repair_round.get("validation_scope") or evidence.get("validation_scope") or {}
+            if scope.get("profile") != "unchanged":
+                raise RuntimeError("only an unchanged accepted main may advance without a repair PR")
+            main_sha = github_ref_sha(args.repository, "main")
+            if main_sha != evidence["head_sha"]:
+                raise RuntimeError("accepted head is not the current main head")
+            repair_round["merge_sha"] = main_sha
+            repair_round["status"] = "accepted-main"
+            campaign["accepted_main_sha"] = main_sha
+        campaign["campaign_phase"] = "awaiting-nix"
+        campaign["phase"] = "awaiting-nix"
+        campaign["updated_at"] = utc_iso(now)
+        state["worker_lease"] = None
+        reset_nix_refresh_for_campaign(state, campaign)
+        store.save(state)
+        print(f"AWAITING_NIX {campaign['sha256']}")
+    return 0
+
+
+def command_assert_owner(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        print("OWNER_OK")
+    return 0
+
+
+def command_heartbeat(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        lease = require_owner(state, args.run_id, now)
+        lease["heartbeat_at"] = utc_iso(now)
+        lease["expires_at"] = utc_iso(now + args.ttl)
+        campaign = state.get("active_campaign")
+        if campaign and args.phase:
+            require_worker_phase(args.phase)
+            campaign["phase"] = args.phase
+            campaign["campaign_phase"] = args.phase
+            current_round(campaign, create=True)["status"] = args.phase
+            campaign["updated_at"] = utc_iso(now)
+        store.save(state)
+        print("RENEWED")
+    return 0
+
+
+CAMPAIGN_FIELDS = ("phase", "base_sha", "branch", "worktree", "pr_number", "pr_url", "head_sha", "ci_state", "last_error")
+
+
+def command_campaign_update(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now)
+        campaign = state.get("active_campaign")
+        if not campaign:
+            raise RuntimeError("no active campaign")
+        require_worker_phase(args.phase)
+        previous_head = campaign.get("head_sha")
+        for field in CAMPAIGN_FIELDS:
+            value = getattr(args, field)
+            if value is not None:
+                campaign[field] = value
+        repair_round = current_round(campaign, create=True)
+        for field in ("base_sha", "branch", "worktree", "pr_number", "pr_url", "head_sha"):
+            value = getattr(args, field)
+            if value is not None:
+                repair_round[field] = value
+        if args.phase is not None:
+            repair_round["status"] = args.phase
+            campaign["campaign_phase"] = args.phase
+        if args.head_sha is not None and previous_head not in {None, args.head_sha}:
+            campaign["acceptance_evidence"] = None
+            repair_round["accepted_head_sha"] = None
+            repair_round["nix_preflight"] = None
+        campaign["updated_at"] = utc_iso(now)
+        store.save(state)
+        print("UPDATED")
+    return 0
+
+
+def command_release(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        require_owner(state, args.run_id, now, allow_expired=True)
+        campaign = state.get("active_campaign")
+        if campaign and args.error:
+            campaign["last_error"] = args.error[:1000]
+            campaign["updated_at"] = utc_iso(now)
+        state["worker_lease"] = None
+        store.save(state)
+        print("RELEASED")
+    return 0
+
+
+def command_campaign_complete(args: argparse.Namespace, store: Store) -> int:
+    now = args.now if args.now is not None else time.time()
+    with store.locked():
+        state = store.load()
+        campaign = state.get("active_campaign")
+        if not campaign:
+            print("COMPLETED_ALREADY")
+            return 0
+        require_owner(state, args.run_id, now, allow_expired=True)
+        raise RuntimeError("campaign completion is automatic after Nix synchronization; use advance-to-nix")
+    return 0
+
+
+def command_status(args: argparse.Namespace, store: Store) -> int:
+    with store.locked():
+        print(json.dumps(store.load(), indent=2, sort_keys=True))
+    return 0
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--state-dir", help="Override the persistent state directory")
+    parser.add_argument("--now", type=float, help=argparse.SUPPRESS)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    probe = subparsers.add_parser("probe")
+    add_common(probe)
+    probe.add_argument("--url", default=DEFAULT_URL)
+    probe.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    probe.add_argument("--headers-file", help=argparse.SUPPRESS)
+    probe.add_argument("--premerge-headers-file", help=argparse.SUPPRESS)
+    probe.add_argument("--source-file", help=argparse.SUPPRESS)
+    probe.add_argument("--skip-nix", action="store_true", help=argparse.SUPPRESS)
+    probe.add_argument("--dry-run", action="store_true", help=argparse.SUPPRESS)
+    probe.set_defaults(handler=command_probe)
+
+    acquire = subparsers.add_parser("worker-acquire")
+    add_common(acquire)
+    acquire.add_argument("--sha")
+    acquire.add_argument("--ttl", type=int, default=DEFAULT_TTL_SECONDS)
+    acquire.set_defaults(handler=command_worker_acquire)
+
+    requeue = subparsers.add_parser("campaign-requeue")
+    add_common(requeue)
+    requeue.add_argument("--sha")
+    requeue.add_argument("--reason")
+    requeue.set_defaults(handler=command_campaign_requeue)
+
+    owner = subparsers.add_parser("assert-owner")
+    add_common(owner)
+    owner.add_argument("--run-id", required=True)
+    owner.set_defaults(handler=command_assert_owner)
+
+    heartbeat = subparsers.add_parser("heartbeat")
+    add_common(heartbeat)
+    heartbeat.add_argument("--run-id", required=True)
+    heartbeat.add_argument("--phase")
+    heartbeat.add_argument("--ttl", type=int, default=DEFAULT_TTL_SECONDS)
+    heartbeat.set_defaults(handler=command_heartbeat)
+
+    update = subparsers.add_parser("campaign-update")
+    add_common(update)
+    update.add_argument("--run-id", required=True)
+    for field in CAMPAIGN_FIELDS:
+        update.add_argument(f"--{field.replace('_', '-')}")
+    update.set_defaults(handler=command_campaign_update)
+
+    sync_features = subparsers.add_parser("sync-features")
+    add_common(sync_features)
+    sync_features.add_argument("--run-id", required=True)
+    sync_features.add_argument("--source-checkout", required=True)
+    sync_features.set_defaults(handler=command_sync_features)
+
+    refresh_features = subparsers.add_parser("refresh-feature-snapshot")
+    add_common(refresh_features)
+    refresh_features.add_argument("--run-id", required=True)
+    refresh_features.set_defaults(handler=command_refresh_feature_snapshot)
+
+    acceptance = subparsers.add_parser("record-acceptance")
+    add_common(acceptance)
+    acceptance.add_argument("--run-id", required=True)
+    acceptance.add_argument("--decision", required=True)
+    acceptance.add_argument("--head", required=True)
+    acceptance.set_defaults(handler=command_record_acceptance)
+
+    preflight = subparsers.add_parser("nix-preflight")
+    add_common(preflight)
+    preflight.add_argument("--run-id", required=True)
+    preflight.add_argument("--max-attempts", type=int, default=3)
+    preflight.add_argument("--retry-delay", type=int, default=30)
+    preflight.add_argument(
+        "--target",
+        help="Verify only one Nix flake output for a focused feature-only repair",
+    )
+    preflight.set_defaults(handler=command_nix_preflight)
+
+    validate_pr = subparsers.add_parser("validate-repair-pr")
+    add_common(validate_pr)
+    validate_pr.add_argument("--run-id", required=True)
+    validate_pr.add_argument("--pr-number", required=True, type=int)
+    validate_pr.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    validate_pr.add_argument("--url", default=DEFAULT_URL)
+    validate_pr.add_argument("--headers-file", help=argparse.SUPPRESS)
+    validate_pr.set_defaults(handler=command_validate_repair_pr)
+
+    advance = subparsers.add_parser("advance-to-nix")
+    add_common(advance)
+    advance.add_argument("--run-id", required=True)
+    advance.add_argument("--pr-number", type=int)
+    advance.add_argument("--repository", default=DEFAULT_REPOSITORY)
+    advance.set_defaults(handler=command_advance_to_nix)
+
+    event_ack = subparsers.add_parser("event-ack")
+    add_common(event_ack)
+    event_ack.add_argument("--event-id", required=True)
+    event_ack.set_defaults(handler=command_event_ack)
+
+    release = subparsers.add_parser("release")
+    add_common(release)
+    release.add_argument("--run-id", required=True)
+    release.add_argument("--error")
+    release.set_defaults(handler=command_release)
+
+    complete = subparsers.add_parser("campaign-complete")
+    add_common(complete)
+    complete.add_argument("--run-id", required=True)
+    complete.add_argument("--verdict", choices=("accepted", "accepted_with_warnings", "merged"))
+    complete.set_defaults(handler=command_campaign_complete)
+
+    status = subparsers.add_parser("status")
+    add_common(status)
+    status.set_defaults(handler=command_status)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    store = Store(state_root(args.state_dir))
+    try:
+        return args.handler(args, store)
+    except RuntimeError as error:
+        print(f"ERROR {error}", file=sys.stderr)
+        return 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -150,6 +150,15 @@ run_container_job() {
         -w /work
     )
 
+    # Linked worktrees keep only a pointer in /work/.git. Mount the shared Git
+    # metadata at its original absolute path so git ls-files/diff work inside
+    # the container without copying or mutating the user's primary checkout.
+    if [ -f "$REPO_DIR/.git" ]; then
+        local git_common_dir
+        git_common_dir="$(git -C "$REPO_DIR" rev-parse --path-format=absolute --git-common-dir)"
+        args+=(-v "$git_common_dir:$git_common_dir:ro")
+    fi
+
     if [ -n "${CI_DMG_PATH:-}" ]; then
         args+=(-e "CI_DMG_PATH=$CI_DMG_PATH")
     fi

--- a/scripts/ci/run-node-checks.sh
+++ b/scripts/ci/run-node-checks.sh
@@ -10,7 +10,14 @@ run_node_syntax_checks() {
     local file
 
     while IFS= read -r file; do
-        node --check "$file"
+        # GNOME Shell requires extension.js while its source is native ESM.
+        # Node 18 otherwise parses every .js file as CommonJS and makes the
+        # local Ubuntu 24.04 matrix fail after all Rust tests have completed.
+        if grep -Eq '^[[:space:]]*(import[[:space:]{*(]|export[[:space:]{*])' "$file"; then
+            node --input-type=module --check < "$file"
+        else
+            node --check "$file"
+        fi
     done < <(git ls-files '*.js')
 }
 

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -18,6 +18,22 @@ PACKAGE_OUTPUTS=(
     ".#installer"
 )
 
+if [ -n "${NIX_VERIFY_OUTPUTS:-}" ]; then
+    PACKAGE_OUTPUTS=()
+    while IFS= read -r output; do
+        [ -n "$output" ] || continue
+        if [[ ! "$output" =~ ^\.#[A-Za-z0-9._+-]+$ ]]; then
+            echo "Invalid Nix verification output: $output" >&2
+            exit 2
+        fi
+        PACKAGE_OUTPUTS+=("$output")
+    done <<< "$NIX_VERIFY_OUTPUTS"
+    if [ "${#PACKAGE_OUTPUTS[@]}" -eq 0 ]; then
+        echo "NIX_VERIFY_OUTPUTS did not contain any outputs." >&2
+        exit 2
+    fi
+fi
+
 NIX_PIN_DIFF_PATHS=(
     "flake.nix"
     "nix/native-modules/package.json"
@@ -204,6 +220,15 @@ main() {
     if ! nix_pin_files_changed; then
         echo "Nix pins unchanged; skipping package-output verification."
         return 0
+    fi
+
+    if [ -n "${NIX_COMPARE_REF:-}" ]; then
+        if ! git -C "$REPO_DIR" rev-parse --verify --quiet "$NIX_COMPARE_REF^{commit}" >/dev/null; then
+            echo "Nix comparison ref is unavailable; continuing with verification: $NIX_COMPARE_REF"
+        elif git -C "$REPO_DIR" diff --quiet "$NIX_COMPARE_REF" -- "${NIX_PIN_DIFF_PATHS[@]}"; then
+            echo "Nix pins already match $NIX_COMPARE_REF; skipping duplicate package-output verification."
+            return 0
+        fi
     fi
 
     # Seed the Nix store so the verification build can reuse the DMG that was

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -167,4 +167,51 @@ test("upstream workflow concurrency is isolated per PR or ref", () => {
     /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/,
   );
   assert.doesNotMatch(workflow, /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}\s*$/m);
+  assert.equal((workflow.match(/- linux-features\/\*\*/g) ?? []).length, 2);
+  assert.equal((workflow.match(/- scripts\/lib\/linux-features\.js/g) ?? []).length, 2);
+});
+
+test("Nix refresh serializes campaigns and deduplicates refresh and exact-head CI", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/update-codex-hash.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /expected_main_sha:/);
+  assert.match(workflow, /expected_dmg_sha256:/);
+  assert.match(workflow, /run-name: Nix refresh \$\{\{ inputs\.expected_main_sha \}\}:\$\{\{ inputs\.expected_dmg_sha256 \}\}/);
+  assert.match(workflow, /ref: \$\{\{ inputs\.expected_main_sha \}\}/);
+  assert.equal((workflow.match(/required: true/g) ?? []).length, 2);
+  assert.doesNotMatch(workflow, /schedule:/);
+  assert.doesNotMatch(workflow, /cron:/);
+  assert.match(workflow, /group: update-nix-upstream-hashes/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /Source-Main-SHA:/);
+  assert.match(workflow, /Source-Main-SHA: \$EXPECTED_MAIN_SHA/);
+  assert.match(workflow, /Upstream-DMG-SHA256:/);
+  assert.match(workflow, /git push --force-with-lease origin "\$REFRESH_BRANCH"/);
+  assert.match(workflow, /Exact-head CI already exists/);
+  assert.doesNotMatch(workflow, /git push --force origin "\$REFRESH_BRANCH"/);
+});
+
+test("Nix hash refresh accepts a validated focused output override", () => {
+  const script = fs.readFileSync(
+    path.resolve(__dirname, "update-nix-hashes.sh"),
+    "utf8",
+  );
+
+  assert.match(script, /NIX_VERIFY_OUTPUTS/);
+  assert.match(script, /NIX_COMPARE_REF/);
+  assert.match(script, /Invalid Nix verification output/);
+  assert.match(script, /run_nix_build "\$VERIFY_LOG" "\$\{PACKAGE_OUTPUTS\[@\]\}"/);
+});
+
+test("local Node syntax checks parse native .js ESM in module mode", () => {
+  const script = fs.readFileSync(
+    path.resolve(__dirname, "run-node-checks.sh"),
+    "utf8",
+  );
+
+  assert.match(script, /node --input-type=module --check/);
+  assert.match(script, /grep -Eq .*import.*export/);
 });

--- a/scripts/sudo-with-alert.sh
+++ b/scripts/sudo-with-alert.sh
@@ -12,7 +12,7 @@ play_sudo_alert_command() {
 play_sudo_alert() {
     local sound_file
 
-    sound_file="/usr/share/sounds/freedesktop/stereo/dialog-warning.oga"
+    sound_file="${CODEX_SUDO_ALERT_SOUND_FILE:-/usr/share/sounds/freedesktop/stereo/dialog-warning.oga}"
     if command -v pw-play >/dev/null 2>&1 \
         && [ -r "$sound_file" ] \
         && play_sudo_alert_command pw-play "$sound_file" >/dev/null 2>&1; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2822,8 +2822,10 @@ test_sudo_alert_wrapper() {
     local workspace="$TMP_DIR/sudo-alert"
     local bin_dir="$workspace/bin"
     local log_file="$workspace/events.log"
+    local sound_file="$workspace/dialog-warning.oga"
     local wrapper="$REPO_DIR/scripts/sudo-with-alert.sh"
     mkdir -p "$bin_dir"
+    : > "$sound_file"
 
     cat > "$bin_dir/sudo" <<'EOF'
 #!/usr/bin/env bash
@@ -2862,17 +2864,17 @@ EOF
     assert_contains "$log_file" 'sudo:true'
 
     : > "$log_file"
-    CODEX_SUDO_ALERT=1 SUDO_ALERT_TEST_CACHE_STATUS=1 \
+    CODEX_SUDO_ALERT=1 CODEX_SUDO_ALERT_SOUND_FILE="$sound_file" SUDO_ALERT_TEST_CACHE_STATUS=1 \
         PATH="$bin_dir:$HOST_TOOL_PATH" SUDO_ALERT_TEST_LOG="$log_file" \
         "$wrapper" true
     [ "$(sed -n '1p' "$log_file")" = 'sudo:-n -v' ] || fail "Expected cached sudo check first"
-    [ "$(sed -n '2p' "$log_file")" = 'alert:/usr/share/sounds/freedesktop/stereo/dialog-warning.oga' ] \
+    [ "$(sed -n '2p' "$log_file")" = "alert:$sound_file" ] \
         || fail "Expected alert before authentication"
     [ "$(sed -n '3p' "$log_file")" = 'sudo:-v' ] || fail "Expected sudo authentication after alert"
     [ "$(sed -n '4p' "$log_file")" = 'sudo:true' ] || fail "Expected command after authentication"
 
     : > "$log_file"
-    CODEX_SUDO_ALERT=1 SUDO_ALERT_TEST_CACHE_STATUS=1 SUDO_ALERT_TEST_SOUND_STATUS=1 \
+    CODEX_SUDO_ALERT=1 CODEX_SUDO_ALERT_SOUND_FILE="$sound_file" SUDO_ALERT_TEST_CACHE_STATUS=1 SUDO_ALERT_TEST_SOUND_STATUS=1 \
         PATH="$bin_dir:$HOST_TOOL_PATH" SUDO_ALERT_TEST_LOG="$log_file" \
         "$wrapper" true 2>/dev/null
     assert_contains "$log_file" 'sudo:-v'
@@ -3915,6 +3917,7 @@ run_update_nix_hash_fixture() {
         CALL_LOG="$fixture/calls.log" \
         VALIDATE_PIN_CHANGE="$validate_pin_change" \
         NIX_HASH="$nix_hash" \
+        NIX_VERIFY_OUTPUTS="${NIX_VERIFY_OUTPUTS:-}" \
         bash "$fixture/scripts/ci/update-nix-hashes.sh" > "$fixture/output.log" 2>&1
 }
 
@@ -3952,6 +3955,69 @@ test_update_nix_hashes_verifies_changed_dmg_hash() {
     assert_contains "$fixture/output.log" "Nix builds succeeded after refreshing the upstream pins and Codex.dmg hash."
     assert_contains "$fixture/calls.log" "nix-store --add-fixed"
     assert_contains "$fixture/calls.log" "nix build"
+}
+
+test_update_nix_hashes_supports_focused_verification_output() {
+    info "Checking Nix hash refresh can verify one focused feature output"
+    local fixture="$TMP_DIR/nix-hash-refresh-focused-output"
+    local hash_b="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+    NIX_VERIFY_OUTPUTS=".#checks.x86_64-linux.nix-linux-features-multi-feature" \
+        run_update_nix_hash_fixture "$(basename "$fixture")" 0 "$hash_b"
+
+    assert_contains "$fixture/calls.log" "nix build .#checks.x86_64-linux.nix-linux-features-multi-feature"
+    assert_not_contains "$fixture/calls.log" ".#codex-desktop-computer-use-ui"
+}
+
+test_update_nix_hashes_skips_output_build_when_refresh_ref_already_matches() {
+    info "Checking a serialized duplicate Nix refresh adopts matching pin files"
+    local fixture="$TMP_DIR/nix-hash-refresh-matching-ref"
+    local hash_b="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    local initial_branch
+
+    make_update_nix_hash_fixture "$fixture"
+    initial_branch="$(git -C "$fixture" branch --show-current)"
+    git -C "$fixture" checkout -q -b existing-refresh
+    python3 - "$fixture/flake.nix" "$hash_b" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+text = re.sub(
+    r'(codexDmg = pkgs\.fetchurl \{.*?hash = ")[^"]+(";)',
+    rf'\g<1>{sys.argv[2]}\2',
+    text,
+    count=1,
+    flags=re.DOTALL,
+)
+path.write_text(text)
+PY
+    git -C "$fixture" add flake.nix
+    git -C "$fixture" commit -q -m "existing refresh"
+    git -C "$fixture" checkout -q "$initial_branch"
+    : > "$fixture/calls.log"
+
+    PATH="$fixture/bin:$PATH" \
+        REPO_DIR="$fixture" \
+        FLAKE_FILE="$fixture/flake.nix" \
+        UPSTREAM_DMG_PATH="$fixture/Codex.dmg" \
+        VERIFY_LOG="$fixture/verify.log" \
+        CALL_LOG="$fixture/calls.log" \
+        NIX_HASH="$hash_b" \
+        NIX_COMPARE_REF=existing-refresh \
+        bash "$fixture/scripts/ci/update-nix-hashes.sh" > "$fixture/output.log" 2>&1
+
+    assert_contains "$fixture/output.log" "Nix pins already match existing-refresh"
+    assert_not_contains "$fixture/calls.log" "nix-store"
+    assert_not_contains "$fixture/calls.log" "nix build"
+}
+
+test_ci_local_mounts_shared_git_metadata_for_linked_worktrees() {
+    info "Checking ci-local supports linked Git worktrees"
+    assert_contains "$REPO_DIR/scripts/ci-local.sh" 'rev-parse --path-format=absolute --git-common-dir'
+    assert_contains "$REPO_DIR/scripts/ci-local.sh" 'git_common_dir:$git_common_dir:ro'
 }
 
 test_installer_detects_electron_version_from_plist() {
@@ -9405,6 +9471,9 @@ main() {
     test_update_nix_hashes_skips_unchanged_package_verification
     test_update_nix_hashes_verifies_changed_pins
     test_update_nix_hashes_verifies_changed_dmg_hash
+    test_update_nix_hashes_supports_focused_verification_output
+    test_update_nix_hashes_skips_output_build_when_refresh_ref_already_matches
+    test_ci_local_mounts_shared_git_metadata_for_linked_worktrees
     test_installer_detects_electron_version_from_plist
     test_installer_keeps_electron_fallback_for_bad_metadata
     test_port_validation_rejects_oversized_numeric_values


### PR DESCRIPTION
## Summary
- move the DMG watchdog into a versioned schema-v2 campaign engine with durable events, immutable feature snapshots, exact acceptance evidence, and guarded repair merges
- serialize drift repair and Nix refresh, bind runs to the exact accepted main/DMG pair, and return actionable Nix failures to the same Worker in a new repair round
- add focused feature-only validation, deterministic Nix preflight/refresh behavior, recovery documentation, and a thin local skill adapter
- make local CI reliable from linked worktrees and on Ubuntu Node 18

## Tests
- `python3 scripts/automation/upstream-dmg-watchdog/test_watchdog.py` (53 tests)
- `python3 -m ruff check ...`
- `node --test scripts/lib/linux-features.test.js scripts/ci/upstream-dmg-acceptance.test.js`
- `node --test linux-features/*/test.js` (560 tests)
- `bash tests/scripts_smoke.sh`
- local container Rust/Node core checks
- local Debian, RPM, and pacman package jobs

## Notes
- the Nix refresh workflow no longer has an independent cron; the accepted campaign dispatches it with exact SHA inputs
- watchdog-specific Python tests remain separate and are not added to the common CI matrix
