### PR TITLE
Preserve renderer error stacks in structured logs

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -174,6 +174,7 @@ const {
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
   applyLinuxSkillsListDedupePatch,
+  applyRendererErrorStackPreservationPatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
   applyLinuxWindowControlsSafeAreaPatch,
@@ -454,6 +455,49 @@ test("Linux settings search visibility patch warns on current-bundle drift", () 
   assert.equal(value, source);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /settings search visibility insertion point/);
+});
+
+test("renderer error boundary preserves the original stack before logging", () => {
+  const source =
+    "var bA=class extends React.Component{componentDidCatch(e,{componentStack:t}){try{Bt.error(`error boundary`,{safe:{name:this.props.name},sensitive:{error:e,componentStack:t??``}})}catch{}}}";
+  const patched = applyPatchTwice(applyRendererErrorStackPreservationPatch, source);
+
+  assert.match(
+    patched,
+    /originalErrorStack:typeof e\?\.stack===`string`\?e\.stack:``/,
+  );
+
+  const captured = [];
+  const context = {
+    React: { Component: class {} },
+    Bt: {
+      error(message, tags) {
+        captured.push({ message, tags });
+      },
+    },
+  };
+  vm.runInNewContext(`${patched};globalThis.Boundary=bA`, context);
+  const error = new Error("original renderer failure");
+  const boundary = new context.Boundary();
+  boundary.props = { name: "LinuxDesktopSettings" };
+  boundary.componentDidCatch(error, { componentStack: "at LinuxToggle" });
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].tags.sensitive.error, error);
+  assert.equal(captured[0].tags.sensitive.originalErrorStack, error.stack);
+  assert.equal(captured[0].tags.sensitive.componentStack, "at LinuxToggle");
+});
+
+test("renderer error stack preservation warns and stays atomic on current-bundle drift", () => {
+  const source =
+    "componentDidCatch(e,{componentStack:t}){diagnostics.error(`error boundary`,{sensitive:{error:e,componentStack:t}})}";
+  const { value, warnings } = captureWarns(() =>
+    applyRendererErrorStackPreservationPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /renderer error stack preservation insertion point/);
 });
 
 test("subagent nickname metadata patch accepts session metadata shape", () => {
@@ -970,6 +1014,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-thread-side-panel-native-tooltip",
     "linux-fast-mode-model-guard",
     "linux-safe-monospace-font-stack",
+    "renderer-error-stack-preservation",
     "subagent-nickname-metadata-shape",
     "local-environment-action-modal-draft",
     "linux-computer-use-ui-availability",

--- a/scripts/patches/core/all-linux/webview/renderer-error-stack/patch.js
+++ b/scripts/patches/core/all-linux/webview/renderer-error-stack/patch.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyRendererErrorStackPreservationPatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = [
+  webviewAssetPatch({
+    id: "renderer-error-stack-preservation",
+    phase: "webview-asset",
+    order: 1046,
+    ciPolicy: "optional",
+    pattern: /^app-initial~artifact-tab-content\.electron~app-main~new-thread-panel-page~onboarding-page~pr~[^.]+\.js$/,
+    missingDescription: "renderer error boundary bundle",
+    skipDescription: "renderer error stack preservation patch",
+    apply: applyRendererErrorStackPreservationPatch,
+  }),
+];

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -113,6 +113,44 @@ function applyLinuxSettingsSearchVisibilityPatch(currentSource) {
   return `${currentSource.slice(0, settingsSearchFunction.start)}${helper}${patchedFunction}${currentSource.slice(settingsSearchFunction.end)}`;
 }
 
+function applyRendererErrorStackPreservationPatch(currentSource) {
+  const markerPattern =
+    /originalErrorStack:typeof ([A-Za-z_$][\w$]*)\?\.stack===`string`\?\1\.stack:``/u;
+  if (markerPattern.test(currentSource)) {
+    return currentSource;
+  }
+
+  const errorBoundaryLogPattern =
+    /try\{([A-Za-z_$][\w$]*)\.error\(`error boundary`,\{safe:\{name:this\.props\.name\},sensitive:\{error:([A-Za-z_$][\w$]*),componentStack:([A-Za-z_$][\w$]*)\?\?``\}\}\)\}catch\{\}/u;
+  const match = errorBoundaryLogPattern.exec(currentSource);
+  if (match == null) {
+    if (
+      currentSource.includes("componentDidCatch") &&
+      currentSource.includes("error boundary") &&
+      currentSource.includes("componentStack")
+    ) {
+      console.warn(
+        "WARN: Could not find renderer error stack preservation insertion point — skipping renderer error stack preservation patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const errorVar = match[2];
+  const patchedLog = match[0].replace(
+    `sensitive:{error:${errorVar},componentStack:`,
+    `sensitive:{error:${errorVar},originalErrorStack:typeof ${errorVar}?.stack===\`string\`?${errorVar}.stack:\`\`,componentStack:`,
+  );
+  if (patchedLog === match[0]) {
+    console.warn(
+      "WARN: Could not find renderer error stack preservation insertion point — skipping renderer error stack preservation patch",
+    );
+    return currentSource;
+  }
+
+  return `${currentSource.slice(0, match.index)}${patchedLog}${currentSource.slice(match.index + match[0].length)}`;
+}
+
 function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
   if (
     /navigator\.userAgent\.includes\(`Linux`\)&&[A-Za-z_$][\w$]*\?\.opaqueWindows==null/u.test(
@@ -1824,6 +1862,7 @@ module.exports = {
   applyLinuxWindowControlsSafeAreaPatch,
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyRendererErrorStackPreservationPatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxSkillsListDedupePatch,
   applyLocalEnvironmentActionModalDraftPatch,


### PR DESCRIPTION
## Summary

- preserve the original JavaScript stack as a primitive string before renderer error-boundary logs cross the Electron bridge
- target only the active error-boundary bundle in the current unified app
- keep the patch optional, atomic, and idempotent, with an explicit drift warning

## Why

Issue #892 now has a structured `errorStack`, but current-DMG runtime probes show that nested `Error` objects are reserialized by the renderer logger bridge. Unrelated failures therefore acquire the same `Object.postMessage -> dispatchMessage` transport frames.

A live probe logged both a nested `Error` and a primitive copy of `Error.stack`. The nested `errorStack` pointed at the transport, while the primitive field retained the original `issue892OriginalThrowSite` frame. This change adds that primitive `originalErrorStack` field at the error boundary so the next reproduction can identify the actual caller.

This is observability only. It does not claim to fix the Linux Desktop Settings crash or alter WebContents/React lifecycle behavior.

## Current-DMG validation

- repo base: `bce8d36f72eda4cabfbf32a95054e6fc79737722`
- ChatGPT Desktop: `26.707.62119`
- Electron: `42.1.0`
- DMG SHA-256: `c243c94f8de6a51f5530ffe1f8d0c1588733d890ac692e34aaca06d95ba637ca`
- DMG ETag: `0x8DEE0AB667193CC`
- DMG size: `615738501` bytes
- environment: KDE Plasma / Wayland
- isolated no-feature build: accepted with only the pre-existing optional tooltip collision warning
- patch report: `renderer-error-stack-preservation: applied`
- generated asset: syntax-valid and byte-stable on the second pass

## Tests

- `node --test scripts/patch-linux-window-ui.test.js` (370 passed)
- `node --test linux-features/*/test.js` (560 passed)
- `bash tests/scripts_smoke.sh`
- `node --check` on the generated current-DMG asset
- `git diff --check`

Closes no issue; follow-up evidence for #892.