### PR TITLE
Require Read Aloud for Conversation Mode

### DIFF
--- a/linux-features/conversation-mode/README.md
+++ b/linux-features/conversation-mode/README.md
@@ -21,8 +21,10 @@ rebuilding:
 ```
 
 The feature is disabled by default. A session starts only after the user clicks
-the composer voice control. `read-aloud` should be enabled too because
-conversation mode speaks through the local Kokoro Read Aloud handler.
+the composer voice control. Enable `read-aloud` explicitly alongside
+`conversation-mode`; it is required because conversation mode speaks through
+the local Read Aloud backend. The Read Aloud settings toggle can remain off
+because Conversation Mode invokes the backend for its own responses.
 
 ## Scope
 

--- a/linux-features/conversation-mode/feature.json
+++ b/linux-features/conversation-mode/feature.json
@@ -2,6 +2,9 @@
   "id": "conversation-mode",
   "name": "Conversation mode",
   "description": "Disabled-by-default Linux voice conversation loop for normal Codex turns using dictation and Read Aloud.",
+  "requires": [
+    "read-aloud"
+  ],
   "entrypoints": {
     "patchDescriptors": "./patch.js"
   }

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -436,11 +436,25 @@ test("conversation mode stays disabled until listed in features.json", () => {
   });
 });
 
-test("conversation mode exposes optional patch descriptors when enabled", () => {
+test("conversation mode requires Read Aloud to be enabled explicitly", () => {
   withTempFeatureConfig(["conversation-mode"], (root) => {
-    assert.deepEqual(enabledLinuxFeatureIds({ featuresRoot: root }), ["conversation-mode"]);
+    assert.throws(
+      () => loadLinuxFeaturePatchDescriptors({ featuresRoot: root }),
+      /requires 'read-aloud' to be enabled/,
+    );
+  });
+});
 
-    const patches = loadLinuxFeaturePatchDescriptors({ featuresRoot: root });
+test("conversation mode exposes optional patch descriptors when enabled", () => {
+  withTempFeatureConfig(["read-aloud", "conversation-mode"], (root) => {
+    assert.deepEqual(
+      enabledLinuxFeatureIds({ featuresRoot: root }),
+      ["read-aloud", "conversation-mode"],
+    );
+
+    const patches = loadLinuxFeaturePatchDescriptors({ featuresRoot: root }).filter(
+      (patch) => patch.featureId === "conversation-mode",
+    );
     assert.deepEqual(
       patches.map((patch) => [patch.name, patch.phase, patch.ciPolicy]),
       [
@@ -2220,7 +2234,7 @@ test("current assistant observer drift is reported as skipped instead of already
 });
 
 test("conversation mode patches matching app assets and records report entries", () => {
-  withTempFeatureConfig(["conversation-mode"], (root) => {
+  withTempFeatureConfig(["read-aloud", "conversation-mode"], (root) => {
     withLinuxFeatureRootEnv(root, () => {
       const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-conversation-mode-app-"));
       try {


### PR DESCRIPTION
## Summary

- declare Read Aloud as a required dependency of Conversation Mode
- document that both opt-in features must be enabled explicitly
- cover the missing-dependency error and valid explicit configuration in focused feature tests

## Behavior

Conversation Mode uses the local Read Aloud backend for assistant speech. Its manifest now declares `"requires": ["read-aloud"]`, so the existing feature validation rejects a configuration that enables Conversation Mode without Read Aloud.

Users continue to enable both features explicitly. This PR does not add automatic dependency resolution or change setup and updater behavior.

## Validation

- `node --test linux-features/conversation-mode/test.js` (56 passed)
- `node --test linux-features/conversation-mode/test.js linux-features/example-feature/test.js`
- `node --test --test-concurrency=1 linux-features/*/test.js scripts/patch-linux-window-ui.test.js` (931 passed)
- `bash tests/scripts_smoke.sh`
- `git diff --check`

## Scope

This PR changes only `linux-features/conversation-mode/README.md`, `feature.json`, and its focused test. It does not change Conversation Mode runtime, current-DMG asset matchers, the generic feature loader, setup wizard, or updater.
