### PR TITLE
Fix current DMG feature patch drift

### DIFF
--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -138,30 +138,26 @@ function applyApiKeyServiceTierPatch(source) {
   return applyFallbackFastTierPatch(applyApiKeyModelMarkerPatch(applyApiKeyServiceTierGatePatch(source)));
 }
 
-function applyCurrentGateAndModelPatch(source) {
+function applyCurrentGatePatch(source) {
   const gateAlreadyPatched = PATCHED_SERVICE_TIER_GATE.test(source);
-  const modelAlreadyPatched = PATCHED_MODEL_MARKER.test(source);
   const gateCandidate = gateAlreadyPatched ? source : applyApiKeyServiceTierGatePatch(source);
-  const modelCandidate = modelAlreadyPatched ? source : applyApiKeyModelMarkerPatch(source);
   const gateReady = gateAlreadyPatched || gateCandidate !== source;
-  const modelReady = modelAlreadyPatched || modelCandidate !== source;
 
   if (!gateReady && !hasApiKeyServiceTierGateShape(source)) {
     warn("Could not identify current service tier auth gate", "API key service tier gate patch");
   }
+  return gateCandidate;
+}
+
+function applyCurrentModelPatch(source) {
+  const modelAlreadyPatched = PATCHED_MODEL_MARKER.test(source);
+  const modelCandidate = modelAlreadyPatched ? source : applyApiKeyModelMarkerPatch(source);
+  const modelReady = modelAlreadyPatched || modelCandidate !== source;
+
   if (!modelReady && !hasApiKeyModelListMappingShape(source)) {
     warn("Could not identify current model list mapping", "API key model service tier marker patch");
   }
-  if (!gateReady || !modelReady) {
-    return source;
-  }
-  if (gateAlreadyPatched) {
-    return modelCandidate;
-  }
-  if (modelAlreadyPatched) {
-    return gateCandidate;
-  }
-  return applyApiKeyModelMarkerPatch(gateCandidate);
+  return modelCandidate;
 }
 
 function applyCurrentFallbackFastTierPatch(source) {
@@ -176,21 +172,31 @@ function applyCurrentFallbackFastTierPatch(source) {
 
 const descriptors = [
   {
-    id: "api-key-service-tier-gate-model",
+    id: "api-key-service-tier-gate",
     phase: "webview-asset",
     order: 20600,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-[^.]+\.js$/,
-    missingDescription: "current API key service tier gate/model bundle",
-    skipDescription: "API key service tier gate/model patch",
-    apply: applyCurrentGateAndModelPatch,
+    pattern: /^app-initial~app-main~onboarding-page-[^.]+\.js$/,
+    missingDescription: "current API key service tier gate bundle",
+    skipDescription: "API key service tier gate patch",
+    apply: applyCurrentGatePatch,
+  },
+  {
+    id: "api-key-service-tier-model",
+    phase: "webview-asset",
+    order: 20605,
+    ciPolicy: "optional",
+    pattern: /^app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-[^.]+\.js$/,
+    missingDescription: "current API key service tier model bundle",
+    skipDescription: "API key model service tier marker patch",
+    apply: applyCurrentModelPatch,
   },
   {
     id: "api-key-service-tier-fallback",
     phase: "webview-asset",
     order: 20610,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-[^.]+\.js$/,
+    pattern: /^app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-[^.]+\.js$/,
     missingDescription: "current API key service tier fallback bundle",
     skipDescription: "API key fallback fast tier patch",
     apply: applyCurrentFallbackFastTierPatch,
@@ -202,7 +208,8 @@ module.exports = {
   applyApiKeyServiceTierGatePatch,
   applyFallbackFastTierPatch,
   applyApiKeyServiceTierPatch,
-  applyCurrentGateAndModelPatch,
+  applyCurrentGatePatch,
+  applyCurrentModelPatch,
   applyCurrentFallbackFastTierPatch,
   hasApiKeyServiceTierGateShape,
   hasApiKeyModelListMappingShape,

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -20,7 +20,8 @@ const {
   applyApiKeyModelMarkerPatch,
   applyApiKeyServiceTierPatch,
   applyApiKeyServiceTierGatePatch,
-  applyCurrentGateAndModelPatch,
+  applyCurrentGatePatch,
+  applyCurrentModelPatch,
   applyCurrentFallbackFastTierPatch,
   applyFallbackFastTierPatch,
   descriptors,
@@ -76,42 +77,66 @@ test("api-key-service-tier stays disabled until listed in features.json", () => 
     assert.deepEqual(
       loaded.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
       [
-        ["feature:api-key-service-tier:api-key-service-tier-gate-model", "webview-asset", "optional"],
+        ["feature:api-key-service-tier:api-key-service-tier-gate", "webview-asset", "optional"],
+        ["feature:api-key-service-tier:api-key-service-tier-model", "webview-asset", "optional"],
         ["feature:api-key-service-tier:api-key-service-tier-fallback", "webview-asset", "optional"],
       ],
     );
   });
 });
 
-test("descriptors are optional and target only the two current app bundles", () => {
+test("current DMG descriptors target the three owning app bundles", () => {
   assert.deepEqual(
-    descriptors.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+    descriptors.map((descriptor) => descriptor.id),
     [
-      ["api-key-service-tier-gate-model", "webview-asset", "optional"],
-      ["api-key-service-tier-fallback", "webview-asset", "optional"],
+      "api-key-service-tier-gate",
+      "api-key-service-tier-model",
+      "api-key-service-tier-fallback",
     ],
   );
   assert.equal(
-    descriptors[0].pattern.test(
-      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
-    ),
+    descriptors[0].pattern.test("app-initial~app-main~onboarding-page-DjTNhJXu.js"),
     true,
   );
   assert.equal(
     descriptors[1].pattern.test(
-      "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BpnUyB2R.js",
     ),
     true,
   );
-  assert.equal(descriptors[0].pattern.test("app-initial~app-main~onboarding-page-abc.js"), false);
-  assert.equal(descriptors[1].pattern.test("app-initial~app-main~onboarding-page-abc.js"), false);
+  assert.equal(
+    descriptors[2].pattern.test(
+      "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-BqLP6EDd.js",
+    ),
+    true,
+  );
+  assert.equal(
+    descriptors.some((descriptor) =>
+      descriptor.pattern.test(
+        "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-C17KDkOa.js",
+      ),
+    ),
+    false,
+  );
+  assert.equal(
+    descriptors.some((descriptor) =>
+      descriptor.pattern.test(
+        "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-y0KJWbm3.js",
+      ),
+    ),
+    false,
+  );
 });
 
 test("current target wrappers warn when an exact contract disappears", () => {
   assert.deepEqual(captureWarnings(() => {
-    assert.equal(applyCurrentGateAndModelPatch("function driftedGateAndModel(){}"), "function driftedGateAndModel(){}");
+    assert.equal(applyCurrentGatePatch("function driftedGate(){}"), "function driftedGate(){}");
   }), [
     "WARN: Could not identify current service tier auth gate - skipping API key service tier gate patch",
+  ]);
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyCurrentModelPatch("function driftedModel(){}"), "function driftedModel(){}");
+  }), [
     "WARN: Could not identify current model list mapping - skipping API key model service tier marker patch",
   ]);
   assert.deepEqual(captureWarnings(() => {
@@ -128,16 +153,20 @@ test("partial current drift is reported when the other exact target still applie
       const assetsDir = path.join(tempApp, "webview", "assets");
       fs.mkdirSync(assetsDir, { recursive: true });
       fs.writeFileSync(
-        path.join(
-          assetsDir,
-          "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-drifted.js",
-        ),
-        "function driftedGateAndModel(){return `priority_mode reasoningEfforts`}",
+        path.join(assetsDir, "app-initial~app-main~onboarding-page-drifted.js"),
+        "function driftedGate(){return `priority_mode`}",
       );
       fs.writeFileSync(
         path.join(
           assetsDir,
-          "app-initial~app-main~pull-request-code-review~onboarding-page~hotkey-window-thread-page~cha~b76hmflu-current.js",
+          "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-current.js",
+        ),
+        "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}",
+      );
+      fs.writeFileSync(
+        path.join(
+          assetsDir,
+          "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-current.js",
         ),
         [
           "let defaultServiceTier=null;",
@@ -149,59 +178,20 @@ test("partial current drift is reported when the other exact target still applie
 
       const report = createPatchReport();
       const warnings = captureWarnings(() => patchExtractedApp(tempApp, { report }));
-      const gateModel = report.patches.find(
-        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
+      const gate = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate",
+      );
+      const model = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-model",
       );
       const fallback = report.patches.find(
         (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-fallback",
       );
 
       assert.ok(warnings.some((warning) => warning.includes("current service tier auth gate")));
-      assert.ok(warnings.some((warning) => warning.includes("current model list mapping")));
-      assert.equal(gateModel?.status, "skipped-optional");
+      assert.equal(gate?.status, "skipped-optional");
+      assert.equal(model?.status, "applied");
       assert.equal(fallback?.status, "applied");
-    } finally {
-      fs.rmSync(tempApp, { recursive: true, force: true });
-    }
-  });
-});
-
-test("gate and model current contract fails closed when either side is missing", () => {
-  withFeatureConfig(["api-key-service-tier"], () => {
-    const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-service-tier-internal-partial-"));
-    try {
-      const assetsDir = path.join(tempApp, "webview", "assets");
-      const targetPath = path.join(
-        assetsDir,
-        "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~k0ede4gb-partial.js",
-      );
-      const gateOnlySource =
-        "const diagnostic=`codexLinuxApiKeyServiceTierModel`;function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}";
-      fs.mkdirSync(assetsDir, { recursive: true });
-      fs.writeFileSync(targetPath, gateOnlySource);
-
-      const report = createPatchReport();
-      const warnings = captureWarnings(() => patchExtractedApp(tempApp, { report }));
-      const gateModel = report.patches.find(
-        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
-      );
-
-      assert.ok(warnings.some((warning) => warning.includes("current model list mapping")));
-      assert.equal(gateModel?.status, "skipped-optional");
-      assert.equal(fs.readFileSync(targetPath, "utf8"), gateOnlySource);
-
-      const modelOnlySource =
-        "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}";
-      fs.writeFileSync(targetPath, modelOnlySource);
-      const modelOnlyReport = createPatchReport();
-      const modelOnlyWarnings = captureWarnings(() => patchExtractedApp(tempApp, { report: modelOnlyReport }));
-      const modelOnlyGateModel = modelOnlyReport.patches.find(
-        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
-      );
-
-      assert.ok(modelOnlyWarnings.some((warning) => warning.includes("current service tier auth gate")));
-      assert.equal(modelOnlyGateModel?.status, "skipped-optional");
-      assert.equal(fs.readFileSync(targetPath, "utf8"), modelOnlySource);
     } finally {
       fs.rmSync(tempApp, { recursive: true, force: true });
     }
@@ -215,16 +205,21 @@ test("a missing exact current target gets its own skipped report entry", () => {
       fs.mkdirSync(path.join(tempApp, "webview", "assets"), { recursive: true });
       const report = createPatchReport();
       const warnings = captureWarnings(() => patchExtractedApp(tempApp, { report }));
-      const gateModel = report.patches.find(
-        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate-model",
+      const gate = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-gate",
+      );
+      const model = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-model",
       );
       const fallback = report.patches.find(
         (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-fallback",
       );
 
-      assert.ok(warnings.some((warning) => warning.includes("current API key service tier gate/model bundle")));
+      assert.ok(warnings.some((warning) => warning.includes("current API key service tier gate bundle")));
+      assert.ok(warnings.some((warning) => warning.includes("current API key service tier model bundle")));
       assert.ok(warnings.some((warning) => warning.includes("current API key service tier fallback bundle")));
-      assert.equal(gateModel?.status, "skipped-optional");
+      assert.equal(gate?.status, "skipped-optional");
+      assert.equal(model?.status, "skipped-optional");
       assert.equal(fallback?.status, "skipped-optional");
     } finally {
       fs.rmSync(tempApp, { recursive: true, force: true });

--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -2,8 +2,10 @@
 
 const HANDLER_NAME = "linux-read-aloud";
 const RUNTIME_VERSION = "conversation-mode-v26";
+const CURRENT_DICTATION_ASSET_PATTERN =
+  /^app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-[^.]+\.js$/;
 const CURRENT_COMPOSER_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~[A-Za-z0-9_-]+\.js$/;
+  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
 
 function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
@@ -358,8 +360,8 @@ module.exports = {
       phase: "webview-asset",
       order: 20690,
       ciPolicy: "optional",
-      pattern: CURRENT_COMPOSER_ASSET_PATTERN,
-      missingDescription: "current primary composer dictation bundle",
+      pattern: CURRENT_DICTATION_ASSET_PATTERN,
+      missingDescription: "current primary dictation bundle",
       skipDescription: "conversation mode dictation endpoint patch",
       apply: applyDictationEndpointPatch,
     },

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -90,6 +90,8 @@ const explicitButtonMainBundleSource =
 
 const currentComposerAsset =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js";
+const currentDictationAsset =
+  "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-current.js";
 
 const dictationSource =
   "function Lke({onTranscriptInsert:i,onTranscriptSend:a}){let h={current:null},g={current:null},y={current:[]},b={current:null};let P=async({action:t,handlers:r})=>{let a=`hello`;a.length>0&&(df.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:a}),t===`send`?r.onTranscriptSend(a):r.onTranscriptInsert(a))},F=async()=>{let e=b.current??`insert`,r=h.current,i=y.current;y.current=[],r&&(r.ondataavailable=null,r.onstop=null),h.current=null,A();await P({action:e,audio:i,handlers:{onTranscriptInsert:i,onTranscriptSend:a}})},L=e=>{b.current=e;let t=h.current;t.state!==`inactive`&&t.stop()};return{startDictation:async()=>{let e=await _Oe({channelCount:1});let t=new MediaRecorder(e);if(h.current=t,y.current=[],t.ondataavailable=e=>{e.data.size>0&&y.current.push(e.data)},t.onstop=()=>{F()},t.start(),u(!0),b.current!=null){t.stop();return}},stopDictation:L}}";
@@ -115,10 +117,11 @@ const conversationGlobals = [
   "codexLinuxConversationVersion",
 ];
 
-test("dictation endpoint descriptor targets the current composer bundle", () => {
+test("dictation endpoint descriptor targets the current dictation bundle", () => {
   const descriptor = featurePatches.find((patch) => patch.id === "dictation-endpoint");
   assert.ok(descriptor);
-  assert.equal(descriptor.pattern.test(currentComposerAsset), true);
+  assert.equal(descriptor.pattern.test(currentDictationAsset), true);
+  assert.equal(descriptor.pattern.test(currentComposerAsset), false);
   assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-BUwCKIcU.js"), false);
   assert.equal(descriptor.pattern.test("use-dictation-BUwCKIcU.js"), false);
   assert.equal(descriptor.pattern.test("use-dictation-hotkey-BUwCKIcU.js"), false);
@@ -130,6 +133,23 @@ test("composer descriptor targets only the current primary app bundle", () => {
   assert.equal(descriptor.pattern.test(currentComposerAsset), true);
   assert.equal(descriptor.pattern.test("app-initial~app-main~page-hSvsQcNf.js"), false);
   assert.equal(descriptor.pattern.test("composer-old.js"), false);
+});
+
+test("current DMG separates dictation and composer ownership", () => {
+  const dictation = featurePatches.find((patch) => patch.id === "dictation-endpoint");
+  const composer = featurePatches.find((patch) => patch.id === "composer-control");
+  const dictationAsset =
+    "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-BqLP6EDd.js";
+  const composerAsset =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
+  const adjacentComposerAsset =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~lhgjoyjn-CMTECkzu.js";
+
+  assert.equal(dictation.pattern.test(dictationAsset), true);
+  assert.equal(dictation.pattern.test(composerAsset), false);
+  assert.equal(composer.pattern.test(composerAsset), true);
+  assert.equal(composer.pattern.test(dictationAsset), false);
+  assert.equal(composer.pattern.test(adjacentComposerAsset), false);
 });
 
 function fetchBodies(events) {
@@ -2014,7 +2034,7 @@ test("current dictation drift is reported as skipped instead of already applied"
   try {
     const assetsDir = path.join(root, "webview", "assets");
     fs.mkdirSync(assetsDir, { recursive: true });
-    const assetPath = path.join(assetsDir, currentComposerAsset);
+    const assetPath = path.join(assetsDir, currentDictationAsset);
     const drifted = dictationSource.replace("new MediaRecorder", "new AudioRecorder");
     fs.writeFileSync(assetPath, drifted);
     const descriptor = featurePatches.find((patch) => patch.id === "dictation-endpoint");
@@ -2210,7 +2230,8 @@ test("conversation mode patches matching app assets and records report entries",
         fs.mkdirSync(assetsDir, { recursive: true });
         fs.writeFileSync(path.join(buildDir, "main.js"), mainBundleSource);
         fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
-        fs.writeFileSync(path.join(assetsDir, currentComposerAsset), `${dictationSource}${currentComposerControlSource}`);
+        fs.writeFileSync(path.join(assetsDir, currentDictationAsset), dictationSource);
+        fs.writeFileSync(path.join(assetsDir, currentComposerAsset), currentComposerControlSource);
         fs.writeFileSync(path.join(assetsDir, "app-initial~app-main~onboarding-page-current.js"), assistantRenderSource);
 
         const report = createPatchReport();
@@ -2224,7 +2245,7 @@ test("conversation mode patches matching app assets and records report entries",
           /codexLinuxReadAloudSpeak\(e\.text,\{requireEnabled:!1\}\)/,
         );
         assert.match(
-          fs.readFileSync(path.join(assetsDir, currentComposerAsset), "utf8"),
+          fs.readFileSync(path.join(assetsDir, currentDictationAsset), "utf8"),
           /codexLinuxConversationEndpoint/,
         );
         assert.match(

--- a/linux-features/copilot-reasoning-effort/README.md
+++ b/linux-features/copilot-reasoning-effort/README.md
@@ -25,10 +25,10 @@ feature to the generated app.
 
 ## What It Patches
 
-- The current `...quick-chat-window-page~chatg~k0ede4gb-*.js` bundle reads and
+- The current `...thread-app-shell~cf704xib-*.js` bundle reads and
   writes `copilot-default-reasoning-effort` next to `copilot-default-model` and
   keeps the model's full `supportedReasoningEfforts` list for Copilot auth.
-- The current `...hotkey-window-thread-page~ho~iufn7mg3-*.js` bundle keeps the
+- The current `...~ho~iufn7mg3-*.js` bundle keeps the
   reasoning effort controls and `/reasoning` command enabled when the normal
   model and effort prerequisites are present.
 

--- a/linux-features/copilot-reasoning-effort/patch.js
+++ b/linux-features/copilot-reasoning-effort/patch.js
@@ -34,7 +34,7 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
 
   const copilotSavePatchMarker = "copilot-default-reasoning-effort`,";
   const copilotAsyncSaveRegex =
-    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2,\{throwOnFailure:!0\}\);return\}if\(([A-Za-z_$][\w$]*)\.info\(`Setting default model and reasoning effort`,\{safe:\{newModel:\2,newEffort:\3,profile:([A-Za-z_$][\w$]*)\.profile\}\}\),!([A-Za-z_$][\w$]*)\)(throw Error\(`Model settings host is unavailable`\);|return;)/;
+    /if\(await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\)return;if\(([A-Za-z_$][\w$]*)\)\{await ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),`copilot-default-model`,\2,\{throwOnFailure:!0\}\);return\}/;
   if (patchedSource.includes(copilotSavePatchMarker)) {
     // Already patched.
   } else if (copilotAsyncSaveRegex.test(patchedSource)) {
@@ -48,12 +48,8 @@ function applyCopilotReasoningEffortSettingsPatch(currentSource) {
         isCopilotVar,
         persistStateVar,
         stateScopeVar,
-        loggerVar,
-        configVar,
-        hostReadyVar,
-        unavailableTail,
       ) =>
-        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){await ${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar},{throwOnFailure:!0});await ${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar},{throwOnFailure:!0});return}if(${loggerVar}.info(\`Setting default model and reasoning effort\`,{safe:{newModel:${modelArgVar},newEffort:${effortArgVar},profile:${configVar}.profile}}),!${hostReadyVar})${unavailableTail}`,
+        `if(await ${updateConversationVar}(${modelArgVar},${effortArgVar}))return;if(${isCopilotVar}){await ${persistStateVar}(${stateScopeVar},\`copilot-default-model\`,${modelArgVar},{throwOnFailure:!0});await ${persistStateVar}(${stateScopeVar},\`copilot-default-reasoning-effort\`,${effortArgVar},{throwOnFailure:!0});return}`,
     );
   } else if (patchedSource.includes("copilot-default-model")) {
     console.warn(
@@ -154,8 +150,7 @@ module.exports = {
       id: "settings",
       name: "copilot-reasoning-effort-settings",
       phase: "webview-asset",
-      // Match app-initial chunks; content-scan fallback ensures correct target
-      pattern: /^app-initial~app-main~.*\.js$/,
+      pattern: /^app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-[^.]+\.js$/,
       missingDescription: "model settings bundle",
       skipDescription: "Copilot reasoning effort settings patch",
       apply: applyCopilotReasoningEffortSettingsPatch,
@@ -164,9 +159,8 @@ module.exports = {
       id: "model-list",
       name: "copilot-reasoning-effort-model-list",
       phase: "webview-asset",
-      // Match app-initial chunks; content-scan fallback ensures correct target
-      pattern: /^app-initial~app-main~.*\.js$/,
-      missingDescription: "font settings bundle",
+      pattern: /^app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-[^.]+\.js$/,
+      missingDescription: "model list bundle",
       skipDescription: "Copilot reasoning effort model list patch",
       apply: applyCopilotReasoningEffortModelListPatch,
     },
@@ -174,9 +168,8 @@ module.exports = {
       id: "ui",
       name: "copilot-reasoning-effort-ui",
       phase: "webview-asset",
-      // Match app-initial chunks; content-scan fallback ensures correct target
-      pattern: /^app-initial~app-main~.*\.js$/,
-      missingDescription: "webview index bundle",
+      pattern: /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/,
+      missingDescription: "current composer bundle",
       skipDescription: "Copilot reasoning effort UI patch",
       apply: applyCopilotReasoningEffortUiPatch,
     },

--- a/linux-features/copilot-reasoning-effort/test.js
+++ b/linux-features/copilot-reasoning-effort/test.js
@@ -43,6 +43,13 @@ function copilotReasoningEffortSettingsFixture() {
   ].join("");
 }
 
+function currentCopilotReasoningEffortSettingsFixture() {
+  return [
+    "function Va(){let e=(0,Ya.c)(3),t=ua(),{data:n,isLoading:r}=hn(`copilot-default-model`),i=n??t.defaultModel,a;return e[0]!==r||e[1]!==i?(a={model:i,reasoningEffort:`medium`,profile:null,isLoading:r},e[0]=r,e[1]=i,e[2]=a):a=e[2],a}",
+    "function currentWriter(){let u=!0,l=!0,n={},m={profile:null},a=`host`,f=`/tmp`,r={cancelQueries:async()=>{},getQueryData:()=>null},E=async()=>!1,ln=async()=>{},za=()=>[],Xe={info:()=>{}},j=()=>{};return async(e,t)=>{let i=null,o;try{if(await E(e,t))return;if(u){await ln(n,`copilot-default-model`,e,{throwOnFailure:!0});return}if(!l)throw Error(`Model settings host is unavailable`);i=za(a,f);let s={hostId:a,cwd:f};await r.cancelQueries({exact:!0,queryKey:i}),o=r.getQueryData(i),Xe.info(`Setting default model and reasoning effort`,{safe:{newModel:e,newEffort:t,profile:m.profile}})}catch(e){j(e)}}}",
+  ].join("");
+}
+
 function currentFilteredCopilotReasoningEffortModelListFixture() {
   return "function Jv({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>vg(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c,hasModelSupportingMaxReasoningEffort:u,hasModelSupportingUltraReasoningEffort:d}}";
 }
@@ -107,6 +114,37 @@ test("persists Copilot reasoning effort with the default Copilot model", () => {
   );
   assert.doesNotMatch(patched, /reasoningEffort:`medium`,profile:null,isLoading:r/);
   assert.doesNotMatch(patched, /await Jn\(t,`copilot-default-model`,e,\{throwOnFailure:!0\}\);return/);
+});
+
+test("persists Copilot reasoning effort through the current default writer", () => {
+  const patched = applyPatchTwice(
+    applyCopilotReasoningEffortSettingsPatch,
+    currentCopilotReasoningEffortSettingsFixture(),
+  );
+
+  assert.match(
+    patched,
+    /await ln\(n,`copilot-default-model`,e,\{throwOnFailure:!0\}\);await ln\(n,`copilot-default-reasoning-effort`,t,\{throwOnFailure:!0\}\);return/,
+  );
+  assert.doesNotMatch(
+    patched,
+    /await ln\(n,`copilot-default-model`,e,\{throwOnFailure:!0\}\);return/,
+  );
+});
+
+test("current DMG descriptors target only the owning Copilot chunks", () => {
+  const settingsChunk =
+    "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BpnUyB2R.js";
+  const uiChunk =
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
+  const adjacentChunk =
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~d4kxte0o-BsjKAgmz.js";
+  const loaded = require("./patch.js").descriptors;
+
+  assert.equal(loaded[0].pattern.test(settingsChunk), true);
+  assert.equal(loaded[1].pattern.test(settingsChunk), true);
+  assert.equal(loaded[2].pattern.test(uiChunk), true);
+  assert.ok(loaded.every((descriptor) => descriptor.pattern.test(adjacentChunk) === false));
 });
 
 test("keeps filtered current app reasoning efforts for Copilot auth", () => {
@@ -183,9 +221,9 @@ test("feature descriptor loader exposes the Copilot webview asset patches only w
     );
     assert.ok(descriptors.every((descriptor) => descriptor.ciPolicy === "optional"));
     const currentSettingsChunk =
-      "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-current.js";
+      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-current.js";
     const currentUiChunk =
-      "app-initial~app-main~page-current.js";
+      "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js";
     assert.match(currentSettingsChunk, descriptors[0].pattern);
     assert.match(currentSettingsChunk, descriptors[1].pattern);
     assert.match(currentUiChunk, descriptors[2].pattern);
@@ -196,16 +234,16 @@ test("feature descriptor loader exposes the Copilot webview asset patches only w
 test("enabled feature descriptors patch the current app settings chunk", () => {
   const featuresRoot = path.resolve(__dirname, "..");
   const currentSettingsChunk =
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~ggy53w99-CqMu8hJo.js";
+    "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BpnUyB2R.js";
   const currentUiChunk =
-    "app-initial~app-main~page-hSvsQcNf.js";
+    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
 
   withTempFeatureConfig(["copilot-reasoning-effort"], () => {
     withTempDir((extractedDir) => {
       writeAsset(
         extractedDir,
         currentSettingsChunk,
-        `${copilotReasoningEffortSettingsFixture()};${currentFilteredCopilotReasoningEffortModelListFixture()}`,
+        `${currentCopilotReasoningEffortSettingsFixture()};${currentFilteredCopilotReasoningEffortModelListFixture()}`,
       );
       writeAsset(extractedDir, currentUiChunk, currentCopilotReasoningEffortUiFixture());
 


### PR DESCRIPTION
Fixes #936

## Summary

- retarget API-key service-tier patches to the current gate, model-list, and service-tier helper chunks
- update the current Copilot default writer and narrow Copilot descriptors to their owning settings and composer chunks
- move Conversation Mode dictation patching to the current dictation chunk and narrow composer patching to the owning chunk
- replace obsolete current-DMG fixtures and chunk targets instead of retaining compatibility fallbacks

## Root cause

Codex DMG 26.707.62119 moved the affected minified contracts across webview chunks, and the Copilot default writer changed shape. Broad or obsolete descriptor patterns either missed the owner chunk or emitted enabled-feature drift from adjacent chunks.

## Impact

The full enabled Linux feature profile can again build and promote the current upstream DMG. API-key Fast tier behavior, Copilot reasoning-effort persistence/selection, and Conversation Mode dictation/composer behavior remain intact.

## Validation

- `node --test linux-features/*/test.js` — 562 passed, 0 failed
- direct patch of a pristine 26.707.62119 ASAR with the full Homebrew feature profile — no enabled-feature warnings
- shared upstream DMG validator — `accepted_with_warnings`, 0 blockers
- remaining warning: optional core `linux-tooltip-window-controls-collision`
- `git diff --check`
