### PR TITLE
Keep service tier fallback patch atomic

### DIFF
--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -87,7 +87,20 @@ function hasApiKeyModelListMappingShape(source) {
   return MODEL_LIST_MAPPING_SHAPE.test(source);
 }
 
+function hasCompleteFallbackFastTierPatch(source) {
+  return (
+    source.includes(`function ${PATCH_MARKER}(`) &&
+    source.includes(`??${PATCH_MARKER}(`) &&
+    source.includes(`[${PATCH_MARKER}(`) &&
+    source.includes(".filter(Boolean)).map")
+  );
+}
+
 function applyFallbackFastTierPatch(source) {
+  if (hasCompleteFallbackFastTierPatch(source)) {
+    return source;
+  }
+
   let patched = source;
 
   if (!patched.includes(`function ${PATCH_MARKER}(`)) {
@@ -124,8 +137,13 @@ function applyFallbackFastTierPatch(source) {
     `...(($1?.serviceTiers?.length?$1.serviceTiers:[${PATCH_MARKER}($1)]).filter(Boolean)).map($2=>({description:$3($2),iconKind:$4($2.id,$2.name),label:$5($2),tier:$2,value:$2.id}))`,
   );
 
-  if (patched !== source || source.includes(PATCH_MARKER)) {
+  if (hasCompleteFallbackFastTierPatch(patched)) {
     return patched;
+  }
+
+  if (patched !== source || source.includes(PATCH_MARKER)) {
+    warn("Could not apply all current service tier option helpers", "API key fallback fast tier patch");
+    return source;
   }
 
   if (source.includes("serviceTiers") && source.includes("defaultServiceTier")) {

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -326,6 +326,52 @@ test("fallback fast tier is synthesized only for API-key model catalog entries",
   assert.doesNotMatch(patched, /\)\?\?null\}function nEe/);
 });
 
+test("fallback fast tier leaves the asset byte-identical when one insertion point drifts", () => {
+  const source = [
+    "let defaultServiceTier=null;",
+    "function Tdt(e,t){return t==null?null:t===`fast`?Odt(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
+    "function Odt(e){return e?.serviceTiers?.find(e=>gz(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
+  ].join("");
+
+  assert.deepEqual(captureWarnings(() => {
+    assert.equal(applyCurrentFallbackFastTierPatch(source), source);
+  }), [
+    "WARN: Could not apply all current service tier option helpers - skipping API key fallback fast tier patch",
+  ]);
+});
+
+test("fallback descriptor reports skipped when one insertion point drifts", () => {
+  withFeatureConfig(["api-key-service-tier"], () => {
+    const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "api-key-service-tier-fallback-drift-"));
+    try {
+      const assetsDir = path.join(tempApp, "webview", "assets");
+      const targetPath = path.join(
+        assetsDir,
+        "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-drifted.js",
+      );
+      const source = [
+        "let defaultServiceTier=null;",
+        "function Tdt(e,t){return t==null?null:t===`fast`?Odt(e):e?.serviceTiers?.find(e=>e.id===t)??null}",
+        "function Odt(e){return e?.serviceTiers?.find(e=>gz(e.id,e.name)===`fast`||e.name.trim().toLowerCase()===`priority`)??null}",
+      ].join("");
+      fs.mkdirSync(assetsDir, { recursive: true });
+      fs.writeFileSync(targetPath, source);
+
+      const report = createPatchReport();
+      const warnings = captureWarnings(() => patchExtractedApp(tempApp, { report }));
+      const fallback = report.patches.find(
+        (entry) => entry.name === "feature:api-key-service-tier:api-key-service-tier-fallback",
+      );
+
+      assert.ok(warnings.some((warning) => warning.includes("all current service tier option helpers")));
+      assert.equal(fallback?.status, "skipped-optional");
+      assert.equal(fs.readFileSync(targetPath, "utf8"), source);
+    } finally {
+      fs.rmSync(tempApp, { recursive: true, force: true });
+    }
+  });
+});
+
 test("combined patch updates both service tier gate and fallback options", () => {
   const source = [
     "function sxe(e){let t=(0,cxe.c)(6),n=X(os),r=e?.hostId??n,i=Cf(r),a=i?.authMethod===`chatgpt`,o=i?.authMethod??null,s;t[0]!==r||t[1]!==o?(s={authMethod:o,hostId:r},t[0]=r,t[1]=o,t[2]=s):s=t[2];let{data:c,isPending:l}=ye(is,s),u=!!i?.isLoading||a&&l,d=a&&!u&&c!=null&&c?.requirements?.featureRequirements?.fast_mode!==!1,f;return t[3]!==u||t[4]!==d?(f={isServiceTierAllowed:d,isLoading:u},t[3]=u,t[4]=d,t[5]=f):f=t[5],f}",


### PR DESCRIPTION
## Summary

- require the API-key fast-tier fallback patch to contain all current helper, resolver, and options markers before treating it as successful
- discard in-memory partial changes and emit a warning when one current insertion point drifts
- cover both the direct patch result and the patch-report `skipped-optional` status

## Behavior

When the current fallback helper and resolver match but the options insertion point does not, the feature now leaves the asset byte-identical and reports drift. Previously it returned a partial patch without a warning, so the descriptor was recorded as `applied` even though the fallback option was incomplete.

## Current DMG

- App: `26.707.62119`
- Electron: `42.1.0`
- SHA-256: `c243c94f8de6a51f5530ffe1f8d0c1588733d890ac692e34aaca06d95ba637ca`
- ETag: `0x8DEE0AB667193CC`
- Size: `615738501` bytes

An isolated build with only `api-key-service-tier` enabled applied all three feature descriptors. The generated current assets passed `node --check`. A second pass reported all three descriptors as `already-applied` and kept the asset tree byte-identical.

## Validation

- `node --test linux-features/api-key-service-tier/test.js` (`16/16`)
- `node --test --test-concurrency=1 linux-features/*/test.js scripts/patch-linux-window-ui.test.js` (`933/933`)
- `bash tests/scripts_smoke.sh`
- `node --check` on the changed source and generated current assets
- `scripts/ci/validate-patch-report.js` on the isolated current-DMG report
- `git diff --check`

## Scope

This changes only `linux-features/api-key-service-tier/patch.js` and its focused tests. The separate Copilot settings atomicity finding is intentionally out of scope.
