### PR TITLE
Fail closed on candidate promotion setup errors

### DIFF
--- a/scripts/lib/candidate-install.sh
+++ b/scripts/lib/candidate-install.sh
@@ -144,12 +144,17 @@ promote_candidate_install() {
         backup="$(candidate_backup_path "$final_dir")"
         journal_file="$(candidate_promotion_journal_path "$final_dir")"
         transaction_id="$(date -u +%Y%m%dT%H%M%S)-$$-${RANDOM:-0}"
-        python3 "$CANDIDATE_PROMOTION_HELPER" prepare \
+        if ! python3 "$CANDIDATE_PROMOTION_HELPER" prepare \
             --candidate "$candidate_dir" \
             --final "$final_dir" \
             --backup "$backup" \
             --journal "$journal_file" \
-            --transaction "$transaction_id"
+            --transaction "$transaction_id"; then
+            warn "Could not prepare the candidate promotion journal; the current app was not changed"
+            flock -u "$promotion_lock_fd"
+            exec {promotion_lock_fd}>&-
+            return 1
+        fi
         info "Atomically exchanging accepted candidate with the current app"
         if ! python3 "$CANDIDATE_PROMOTION_HELPER" exchange \
             --left "$candidate_dir" --right "$final_dir"; then
@@ -185,7 +190,12 @@ promote_candidate_install() {
         cleanup_managed_candidate_backups_locked "$final_dir" "$backup"
     else
         info "Promoting accepted candidate: $final_dir"
-        mv "$candidate_dir" "$final_dir"
+        if ! mv "$candidate_dir" "$final_dir"; then
+            warn "Could not promote the accepted candidate; the app was not installed"
+            flock -u "$promotion_lock_fd"
+            exec {promotion_lock_fd}>&-
+            return 1
+        fi
         backup=""
         cleanup_managed_candidate_backups_locked "$final_dir"
     fi

--- a/scripts/lib/candidate-promotion.py
+++ b/scripts/lib/candidate-promotion.py
@@ -91,6 +91,23 @@ def remove_journal(path: Path) -> None:
         pass
 
 
+def cleanup_failed_prepare(candidate: Path, journal_path: Path, transaction: str) -> None:
+    try:
+        journal = load_journal(journal_path)
+    except FileNotFoundError:
+        journal = None
+    if journal is not None:
+        if str(journal.get("transactionId")) != transaction:
+            raise RuntimeError(
+                f"Refusing to remove a promotion journal for another transaction: {journal_path}"
+            )
+        # Remove the journal first. If cleanup is interrupted afterward, a
+        # leftover marker on the disposable candidate cannot block recovery.
+        remove_journal(journal_path)
+    if read_marker(candidate) == transaction:
+        remove_marker(candidate)
+
+
 def atomic_exchange(left: Path, right: Path) -> None:
     libc = ctypes.CDLL(None, use_errno=True)
     try:
@@ -138,17 +155,28 @@ def prepare(args: argparse.Namespace) -> None:
     if old_identity is None or not candidate.is_dir():
         raise RuntimeError("Both the current app and candidate must exist before exchange")
 
-    write_file_durably(marker_path(candidate), f"{args.transaction}\n")
-    journal = {
-        "schemaVersion": 1,
-        "transactionId": args.transaction,
-        "candidate": str(candidate),
-        "final": str(final),
-        "backup": str(backup),
-        "oldDevice": old_identity[0],
-        "oldInode": old_identity[1],
-    }
-    write_file_durably(journal_path, f"{json.dumps(journal, indent=2, sort_keys=True)}\n")
+    try:
+        write_file_durably(marker_path(candidate), f"{args.transaction}\n")
+        journal = {
+            "schemaVersion": 1,
+            "transactionId": args.transaction,
+            "candidate": str(candidate),
+            "final": str(final),
+            "backup": str(backup),
+            "oldDevice": old_identity[0],
+            "oldInode": old_identity[1],
+        }
+        write_file_durably(journal_path, f"{json.dumps(journal, indent=2, sort_keys=True)}\n")
+        if os.environ.get("CODEX_PROMOTION_TEST_FAIL_PREPARE_AFTER_JOURNAL") == "1":
+            raise OSError("Simulated failure after writing the promotion journal")
+    except Exception as error:
+        try:
+            cleanup_failed_prepare(candidate, journal_path, args.transaction)
+        except Exception as cleanup_error:
+            raise RuntimeError(
+                f"{error}; additionally failed to clean up promotion preparation: {cleanup_error}"
+            ) from error
+        raise
 
 
 def abort(args: argparse.Namespace) -> None:

--- a/scripts/lib/candidate-promotion.py
+++ b/scripts/lib/candidate-promotion.py
@@ -66,7 +66,7 @@ def remove_marker(directory: Path) -> None:
 
 def identity(path: Path) -> tuple[int, int] | None:
     try:
-        value = path.stat(follow_symlinks=False)
+        value = path.lstat()
     except FileNotFoundError:
         return None
     return value.st_dev, value.st_ino

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2575,6 +2575,41 @@ PY
     [ "$(cat "$workspace/candidate/version")" = "new" ] || fail "Journal preparation failure changed the candidate"
 }
 
+test_candidate_prepare_failure_cleans_transaction_metadata() {
+    info "Checking failed journal preparation cleans its transaction metadata"
+    local workspace="$TMP_DIR/candidate-prepare-cleanup"
+    local journal="$workspace/.final.promotion.json"
+    mkdir -p "$workspace/final" "$workspace/candidate"
+    printf '%s' "old" >"$workspace/final/version"
+    printf '%s' "new" >"$workspace/candidate/version"
+
+    (
+        info() { :; }
+        warn() { :; }
+        error() { echo "$*" >&2; return 1; }
+        assert_install_target_not_running() { :; }
+        # shellcheck source=scripts/lib/candidate-install.sh
+        . "$REPO_DIR/scripts/lib/candidate-install.sh"
+        if CODEX_PROMOTION_TEST_FAIL_PREPARE_AFTER_JOURNAL=1 \
+            promote_candidate_install "$workspace/candidate" "$workspace/final"; then
+            fail "Expected simulated post-journal preparation failure"
+        fi
+    )
+    [ ! -e "$journal" ] || fail "Failed preparation left a promotion journal"
+    [ ! -e "$workspace/candidate/.codex-promotion-transaction" ] \
+        || fail "Failed preparation left a candidate transaction marker"
+    [ "$(cat "$workspace/final/version")" = "old" ] || fail "Failed preparation changed the current app"
+    [ "$(cat "$workspace/candidate/version")" = "new" ] || fail "Failed preparation changed the candidate"
+
+    python3 "$REPO_DIR/scripts/lib/candidate-promotion.py" prepare \
+        --candidate "$workspace/candidate" \
+        --final "$workspace/final" \
+        --backup "$workspace/final.backup-retry" \
+        --journal "$journal" \
+        --transaction retry
+    python3 "$REPO_DIR/scripts/lib/candidate-promotion.py" abort --journal "$journal"
+}
+
 test_candidate_first_install_rename_failure_propagates() {
     info "Checking first-install rename failure fails promotion"
     local workspace="$TMP_DIR/candidate-rename-failure"
@@ -9607,6 +9642,7 @@ main() {
     test_make_rebuild_targets_omit_empty_dmg_argument
     test_candidate_install_is_transactional
     test_candidate_promotion_stops_when_journal_prepare_fails
+    test_candidate_prepare_failure_cleans_transaction_metadata
     test_candidate_first_install_rename_failure_propagates
     test_candidate_promotion_refuses_a_running_final_app
     test_candidate_backup_retention_is_bounded

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -2536,6 +2536,67 @@ test_candidate_install_is_transactional() {
     )
 }
 
+test_candidate_promotion_stops_when_journal_prepare_fails() {
+    info "Checking journal preparation failure cannot reach atomic exchange"
+    local workspace="$TMP_DIR/candidate-prepare-failure"
+    local helper="$workspace/promotion-helper"
+    local helper_log="$workspace/promotion-helper.log"
+    mkdir -p "$workspace/final" "$workspace/candidate"
+    printf '%s' "old" >"$workspace/final/version"
+    printf '%s' "new" >"$workspace/candidate/version"
+    cat >"$helper" <<'PY'
+#!/usr/bin/env python3
+import os
+import sys
+
+with open(os.environ["CODEX_PROMOTION_TEST_HELPER_LOG"], "a", encoding="utf-8") as handle:
+    handle.write(f"{sys.argv[1]}\n")
+if sys.argv[1] == "prepare":
+    raise SystemExit(1)
+PY
+    chmod +x "$helper"
+
+    (
+        info() { :; }
+        warn() { :; }
+        error() { echo "$*" >&2; return 1; }
+        assert_install_target_not_running() { :; }
+        export CODEX_CANDIDATE_PROMOTION_HELPER="$helper"
+        export CODEX_PROMOTION_TEST_HELPER_LOG="$helper_log"
+        # shellcheck source=scripts/lib/candidate-install.sh
+        . "$REPO_DIR/scripts/lib/candidate-install.sh"
+        if promote_candidate_install "$workspace/candidate" "$workspace/final"; then
+            fail "Expected journal preparation failure to stop promotion"
+        fi
+    )
+    assert_contains "$helper_log" "prepare"
+    assert_not_contains "$helper_log" "exchange"
+    [ "$(cat "$workspace/final/version")" = "old" ] || fail "Journal preparation failure changed the current app"
+    [ "$(cat "$workspace/candidate/version")" = "new" ] || fail "Journal preparation failure changed the candidate"
+}
+
+test_candidate_first_install_rename_failure_propagates() {
+    info "Checking first-install rename failure fails promotion"
+    local workspace="$TMP_DIR/candidate-rename-failure"
+    mkdir -p "$workspace/candidate"
+    printf '%s' "new" >"$workspace/candidate/version"
+
+    (
+        info() { :; }
+        warn() { :; }
+        error() { echo "$*" >&2; return 1; }
+        assert_install_target_not_running() { :; }
+        mv() { return 1; }
+        # shellcheck source=scripts/lib/candidate-install.sh
+        . "$REPO_DIR/scripts/lib/candidate-install.sh"
+        if promote_candidate_install "$workspace/candidate" "$workspace/final"; then
+            fail "Expected first-install rename failure to fail promotion"
+        fi
+    )
+    [ "$(cat "$workspace/candidate/version")" = "new" ] || fail "Rename failure changed the candidate"
+    [ ! -e "$workspace/final" ] || fail "Rename failure unexpectedly created the final app"
+}
+
 test_candidate_promotion_refuses_a_running_final_app() {
     info "Checking user-local promotion cannot replace a running app"
     local workspace="$TMP_DIR/candidate-running-app"
@@ -9545,6 +9606,8 @@ main() {
     test_rebuild_candidate_uses_validated_default_dmg
     test_make_rebuild_targets_omit_empty_dmg_argument
     test_candidate_install_is_transactional
+    test_candidate_promotion_stops_when_journal_prepare_fails
+    test_candidate_first_install_rename_failure_propagates
     test_candidate_promotion_refuses_a_running_final_app
     test_candidate_backup_retention_is_bounded
     test_candidate_promotion_recovers_after_sigkill


### PR DESCRIPTION
## Summary

- stop candidate promotion before atomic exchange when recovery-journal preparation fails
- propagate first-install rename failures instead of reporting a successful promotion
- make failed preparation remove only journal and marker metadata owned by its transaction
- use `Path.lstat()` so journal identity capture works with Python 3.8/3.9
- add focused regression coverage for all fail-closed paths

## Root cause

`install.sh` checks `promote_candidate_install` from an `if !` condition. Bash suppresses `errexit` inside functions used in that context, so unchecked journal preparation and first-install rename failures could be ignored. The replacement path could proceed to atomic exchange without a durable recovery journal; the first-install path could report success without installing the app.

Preparation also needed to account for failure after the journal had already been atomically replaced. The helper now verifies transaction ownership, removes the journal before its matching disposable-candidate marker, and leaves foreign transaction metadata untouched.

## Impact

Promotion now fails before changing the working app when its journal cannot be prepared, failed initial renames propagate correctly, and partial preparation cannot leave metadata that blocks future installs after the candidate is discarded.

## Validation

- `bash -n scripts/lib/candidate-install.sh tests/scripts_smoke.sh`
- `/usr/bin/python3 -m py_compile scripts/lib/candidate-promotion.py` using Python 3.9.6
- focused smoke coverage for failed journal preparation, post-journal cleanup and retry, and failed first-install rename
- reviewed on the fork with the actionable Codex review finding addressed before upstream submission
