### PR TITLE
Stage current DMG bundled skills for Hatch Pet

### DIFF
--- a/docs/upstream-dmg-intelligence.md
+++ b/docs/upstream-dmg-intelligence.md
@@ -114,6 +114,7 @@ It currently protects the surfaces Linux mirrors or patches most aggressively:
 - `event_stream_mcp`
 - `record_and_replay_plugin`
 - `computer_use_plugin`
+- `hatch_pet_skill`
 - `chrome_native_messaging`
 - `dictation_transcript_finalization`
 - `browser_window_metadata`

--- a/scripts/dev/upstream-dmg-intel.test.js
+++ b/scripts/dev/upstream-dmg-intel.test.js
@@ -7,6 +7,8 @@ const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 const test = require("node:test");
 
+const productionRegistry = require("./upstream-dmg-protected-surfaces.json");
+
 const {
   buildIntelReports,
   compareProtectedSurfaces,
@@ -244,6 +246,11 @@ function createFixtureApp(root, variant = "baseline") {
   const recordPlugin = path.join(resources, "plugins/openai-bundled/plugins/record-and-replay");
   const chromePlugin = path.join(resources, "plugins/openai-bundled/plugins/chrome");
 
+  writeFile(
+    path.join(resources, "skills/skills/.curated/hatch-pet/SKILL.md"),
+    "---\nname: hatch-pet\ndescription: Create Codex-compatible animated pets with spriteVersionNumber 2.\n---\n",
+  );
+
   writeJson(path.join(resources, "package.json"), {
     name: "codex-desktop",
     version: variant === "candidate" ? "2026.7.3" : "2026.7.2",
@@ -413,6 +420,32 @@ test("extracts protected surfaces, plugins, native binaries, and bridge calls fr
         binary.relativePath.endsWith("native/sky.node"),
       ),
     );
+  }));
+
+test("protects the current Hatch Pet skill and Linux bundled-skill staging owner", () =>
+  withTempDir((workspace) => {
+    const hatchPetSurface = productionRegistry.surfaces.find(
+      (surface) => surface.id === "hatch_pet_skill",
+    );
+    assert.ok(hatchPetSurface, "expected production registry to protect Hatch Pet");
+
+    const appDir = createFixtureApp(workspace, "baseline");
+    const protectedSurfaces = extractProtectedSurfaces({
+      inventory: createInventory({
+        registry: { version: productionRegistry.version, surfaces: [hatchPetSurface] },
+        sourcePath: appDir,
+      }),
+      registry: { version: productionRegistry.version, surfaces: [hatchPetSurface] },
+      repoRoot: process.cwd(),
+    });
+    const surface = protectedSurfaces.surfacesById.hatch_pet_skill;
+
+    assert.equal(surface.status, "PRESENT");
+    assert.ok(surface.satisfiedAnchors.some((anchor) => anchor.id === "hatch-pet-skill-root"));
+    assert.deepEqual(hatchPetSurface.linuxSubstrate.requiredPaths, [
+      "scripts/lib/bundled-plugins.sh",
+      "tests/scripts_smoke.sh",
+    ]);
   }));
 
 test("marks Chronicle settings toggle surface partial when the Memory master toggle path disappears", () =>

--- a/scripts/dev/upstream-dmg-protected-surfaces.json
+++ b/scripts/dev/upstream-dmg-protected-surfaces.json
@@ -372,6 +372,40 @@
       }
     },
     {
+      "id": "hatch_pet_skill",
+      "title": "Hatch Pet recommended skill and Linux bundled-skill staging",
+      "category": "skill",
+      "pathPatterns": [
+        "(^|/)skills/skills/\\.curated/hatch-pet/"
+      ],
+      "contentNeedles": [
+        "name: hatch-pet",
+        "spriteVersionNumber"
+      ],
+      "patchNamePatterns": [
+        "hatch.*pet",
+        "bundled.*skills"
+      ],
+      "requiredEvidence": [
+        {
+          "id": "hatch-pet-skill-root",
+          "pathPatterns": [
+            "(^|/)skills/skills/\\.curated/hatch-pet/SKILL\\.md$"
+          ],
+          "contentNeedles": [
+            "name: hatch-pet",
+            "spriteVersionNumber"
+          ]
+        }
+      ],
+      "linuxSubstrate": {
+        "requiredPaths": [
+          "scripts/lib/bundled-plugins.sh",
+          "tests/scripts_smoke.sh"
+        ]
+      }
+    },
+    {
       "id": "browser_use_plugin",
       "title": "Browser Use plugin manifest, client script, and skill shell",
       "category": "plugin",

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -768,6 +768,91 @@ remove_macos_sidecar_files() {
     find "$root" -type f -name '*:com.apple.*' -delete
 }
 
+validate_upstream_bundled_skills() {
+    local skills_dir="$1"
+
+    python3 - "$skills_dir" <<'PY'
+import os
+from pathlib import Path
+import stat
+import sys
+
+root = Path(sys.argv[1])
+
+try:
+    root_metadata = root.lstat()
+except OSError as exc:
+    print(f"cannot inspect bundled skills root: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+if stat.S_ISLNK(root_metadata.st_mode):
+    print("bundled skills root cannot be a symlink", file=sys.stderr)
+    sys.exit(1)
+if not stat.S_ISDIR(root_metadata.st_mode):
+    print("bundled skills root must be a directory", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    resolved_root = root.resolve(strict=True)
+except (OSError, RuntimeError) as exc:
+    print(f"cannot resolve bundled skills root: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+
+def fail_walk(error):
+    print(f"cannot inspect bundled skills tree: {error}", file=sys.stderr)
+    sys.exit(1)
+
+
+for current_root, directories, files in os.walk(root, followlinks=False, onerror=fail_walk):
+    current = Path(current_root)
+    for name in directories + files:
+        path = current / name
+        relative_path = path.relative_to(root)
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            print(f"cannot inspect {relative_path}: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        if stat.S_ISLNK(metadata.st_mode):
+            try:
+                target = os.readlink(path)
+            except OSError as exc:
+                print(f"cannot read symlink {relative_path}: {exc}", file=sys.stderr)
+                sys.exit(1)
+            if os.path.isabs(target):
+                print(f"absolute symlink is not allowed: {relative_path}", file=sys.stderr)
+                sys.exit(1)
+            try:
+                resolved_target = path.resolve(strict=True)
+            except (OSError, RuntimeError) as exc:
+                print(f"cannot resolve symlink {relative_path}: {exc}", file=sys.stderr)
+                sys.exit(1)
+            try:
+                resolved_target.relative_to(resolved_root)
+            except ValueError:
+                print(f"symlink escapes bundled skills root: {relative_path}", file=sys.stderr)
+                sys.exit(1)
+            try:
+                target_metadata = resolved_target.stat()
+            except OSError as exc:
+                print(f"cannot inspect symlink target {relative_path}: {exc}", file=sys.stderr)
+                sys.exit(1)
+            if not (stat.S_ISDIR(target_metadata.st_mode) or stat.S_ISREG(target_metadata.st_mode)):
+                print(f"unsupported symlink target type: {relative_path}", file=sys.stderr)
+                sys.exit(1)
+            continue
+
+        if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
+            print(f"unsupported file type: {relative_path}", file=sys.stderr)
+            sys.exit(1)
+        if metadata.st_mode & 0o6000:
+            print(f"privileged mode is not allowed: {relative_path}", file=sys.stderr)
+            sys.exit(1)
+PY
+}
+
 stage_upstream_bundled_skills() {
     local source_skills="$1"
     local target_skills="$2"
@@ -778,6 +863,10 @@ stage_upstream_bundled_skills() {
     if [ ! -d "$source_skills" ]; then
         info "Bundled skills not present in upstream resources; skipping"
         return 0
+    fi
+    if ! validate_upstream_bundled_skills "$source_skills"; then
+        warn "Bundled skills source contains unsupported content"
+        return 1
     fi
 
     target_parent="$(dirname "$target_skills")"
@@ -794,6 +883,11 @@ stage_upstream_bundled_skills() {
     if ! remove_macos_sidecar_files "$staging_skills"; then
         rm -rf -- "$staging_skills"
         warn "Failed to clean macOS sidecar files from bundled skills"
+        return 1
+    fi
+    if ! validate_upstream_bundled_skills "$staging_skills"; then
+        rm -rf -- "$staging_skills" || warn "Failed to clean bundled skills staging directory"
+        warn "Bundled skills failed post-copy validation"
         return 1
     fi
     if ! chmod -R u+rwX,go-w "$staging_skills"; then
@@ -832,6 +926,7 @@ stage_upstream_bundled_skills() {
     fi
     if [ -n "$backup_skills" ] && ! rm -rf -- "$backup_skills"; then
         warn "Failed to clean previous bundled skills backup: $backup_skills"
+        return 1
     fi
 
     info "Bundled skills staged from upstream DMG"
@@ -1658,7 +1753,9 @@ install_bundled_plugin_resources() {
     local portable_plugin_names=""
     local portable_plugins=()
 
-    stage_upstream_bundled_skills "$upstream_resources/skills" "$resources_dir/skills"
+    if ! stage_upstream_bundled_skills "$upstream_resources/skills" "$resources_dir/skills"; then
+        return 1
+    fi
 
     if [ ! -f "$source_marketplace" ]; then
         warn "Bundled plugin marketplace not found in upstream app; skipping bundled plugins"

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -768,6 +768,75 @@ remove_macos_sidecar_files() {
     find "$root" -type f -name '*:com.apple.*' -delete
 }
 
+stage_upstream_bundled_skills() {
+    local source_skills="$1"
+    local target_skills="$2"
+    local target_parent
+    local staging_skills=""
+    local backup_skills=""
+
+    if [ ! -d "$source_skills" ]; then
+        info "Bundled skills not present in upstream resources; skipping"
+        return 0
+    fi
+
+    target_parent="$(dirname "$target_skills")"
+    mkdir -p "$target_parent"
+    if ! staging_skills="$(mktemp -d "$target_parent/.skills.tmp.XXXXXX")"; then
+        warn "Failed to create staging directory for bundled skills"
+        return 1
+    fi
+    if ! cp -R "$source_skills/." "$staging_skills/"; then
+        rm -rf -- "$staging_skills"
+        warn "Failed to stage bundled skills from upstream resources"
+        return 1
+    fi
+    if ! remove_macos_sidecar_files "$staging_skills"; then
+        rm -rf -- "$staging_skills"
+        warn "Failed to clean macOS sidecar files from bundled skills"
+        return 1
+    fi
+    if ! chmod -R u+rwX,go-w "$staging_skills"; then
+        rm -rf -- "$staging_skills"
+        warn "Failed to normalize bundled skills permissions"
+        return 1
+    fi
+
+    backup_skills="$target_parent/.skills.backup.$$"
+    if ! rm -rf -- "$backup_skills"; then
+        rm -rf -- "$staging_skills"
+        warn "Failed to prepare bundled skills backup"
+        return 1
+    fi
+    if [ -e "$target_skills" ] || [ -L "$target_skills" ]; then
+        if ! mv -- "$target_skills" "$backup_skills"; then
+            rm -rf -- "$staging_skills"
+            warn "Failed to preserve existing bundled skills"
+            return 1
+        fi
+    else
+        backup_skills=""
+    fi
+    if ! mv -- "$staging_skills" "$target_skills"; then
+        rm -rf -- "$staging_skills"
+        if [ -n "$backup_skills" ]; then
+            if mv -- "$backup_skills" "$target_skills"; then
+                warn "Failed to install bundled skills; previous target was restored"
+            else
+                warn "Failed to install bundled skills and previous target could not be restored"
+            fi
+        else
+            warn "Failed to install bundled skills"
+        fi
+        return 1
+    fi
+    if [ -n "$backup_skills" ] && ! rm -rf -- "$backup_skills"; then
+        warn "Failed to clean previous bundled skills backup: $backup_skills"
+    fi
+
+    info "Bundled skills staged from upstream DMG"
+}
+
 chrome_extension_host_arch() {
     case "$ARCH" in
         x86_64) echo "x64" ;;
@@ -1588,6 +1657,8 @@ install_bundled_plugin_resources() {
     local include_computer_use=0
     local portable_plugin_names=""
     local portable_plugins=()
+
+    stage_upstream_bundled_skills "$upstream_resources/skills" "$resources_dir/skills"
 
     if [ ! -f "$source_marketplace" ]; then
         warn "Bundled plugin marketplace not found in upstream app; skipping bundled plugins"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6956,6 +6956,7 @@ test_upstream_bundled_skills_staging() {
     printf '%s\n' '# Animation rows' > "$source_skill/references/animation-rows.md"
     printf '%s\n' 'print("render")' > "$source_skill/scripts/render_animation_previews.py"
     printf '%s\n' 'finder metadata' > "$source_skill/scripts/render_animation_previews.py:com.apple.FinderInfo"
+    ln -s "../references/animation-rows.md" "$source_skill/scripts/animation-rows.md"
 
     (
         SCRIPT_DIR="$REPO_DIR"
@@ -6979,9 +6980,221 @@ test_upstream_bundled_skills_staging() {
     assert_file_exists "$target_skill/SKILL.md"
     assert_file_exists "$target_skill/references/animation-rows.md"
     assert_file_exists "$target_skill/scripts/render_animation_previews.py"
+    [ -L "$target_skill/scripts/animation-rows.md" ] \
+        || fail "Expected internal bundled-skill symlink to be preserved"
+    [ "$(readlink "$target_skill/scripts/animation-rows.md")" = "../references/animation-rows.md" ] \
+        || fail "Expected internal bundled-skill symlink target to remain relative"
+    [ "$(readlink -f "$target_skill/scripts/animation-rows.md")" = "$target_skill/references/animation-rows.md" ] \
+        || fail "Expected internal bundled-skill symlink to remain inside the staged root"
     [ ! -e "$target_skill/scripts/render_animation_previews.py:com.apple.FinderInfo" ] \
         || fail "Expected macOS sidecar metadata to be removed from staged bundled skills"
     assert_contains "$output_log" "Bundled skills staged from upstream DMG"
+}
+
+test_upstream_bundled_skills_validator_guards() {
+    info "Checking bundled skills filesystem guards"
+    local workspace="$TMP_DIR/upstream-bundled-skills-validator"
+    local case_name=""
+    local case_dir=""
+    local output_log=""
+
+    mkdir -p "$workspace"
+    printf '%s\n' 'outside' > "$workspace/outside.txt"
+
+    # shellcheck disable=SC1091
+    source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+
+    for case_name in internal-relative absolute escaping chained-escape dangling named-pipe privileged-file root-symlink; do
+        case_dir="$workspace/$case_name"
+        output_log="$workspace/$case_name.log"
+        mkdir -p "$case_dir/skills/.curated/hatch-pet/references"
+        printf '%s\n' '# Hatch Pet' > "$case_dir/skills/.curated/hatch-pet/SKILL.md"
+
+        case "$case_name" in
+            internal-relative)
+                printf '%s\n' '# Shared reference' > "$case_dir/skills/.curated/shared.md"
+                ln -s "../../shared.md" "$case_dir/skills/.curated/hatch-pet/references/shared.md"
+                ;;
+            absolute)
+                ln -s "$workspace/outside.txt" "$case_dir/skills/.curated/hatch-pet/references/outside.md"
+                ;;
+            escaping)
+                ln -s "../../../../../outside.txt" "$case_dir/skills/.curated/hatch-pet/references/outside.md"
+                ;;
+            chained-escape)
+                ln -s "../../../outside.txt" "$case_dir/skills/.curated/escape"
+                ln -s "../../escape" "$case_dir/skills/.curated/hatch-pet/references/outside.md"
+                ;;
+            dangling)
+                ln -s "missing.md" "$case_dir/skills/.curated/hatch-pet/references/missing.md"
+                ;;
+            named-pipe)
+                mkfifo "$case_dir/skills/.curated/hatch-pet/channel"
+                ;;
+            privileged-file)
+                chmod 4755 "$case_dir/skills/.curated/hatch-pet/SKILL.md"
+                ;;
+            root-symlink)
+                mv "$case_dir" "$case_dir.real"
+                ln -s "$case_dir.real" "$case_dir"
+                ;;
+        esac
+
+        if [ "$case_name" = "internal-relative" ]; then
+            validate_upstream_bundled_skills "$case_dir" >"$output_log" 2>&1 \
+                || fail "Expected internal relative bundled-skill symlink to be accepted"
+        elif validate_upstream_bundled_skills "$case_dir" >"$output_log" 2>&1; then
+            fail "Expected bundled skills validator to reject $case_name"
+        fi
+    done
+
+    assert_contains "$workspace/absolute.log" "absolute symlink is not allowed"
+    assert_contains "$workspace/escaping.log" "symlink escapes bundled skills root"
+    assert_contains "$workspace/chained-escape.log" "symlink escapes bundled skills root"
+    assert_contains "$workspace/dangling.log" "cannot resolve symlink"
+    assert_contains "$workspace/named-pipe.log" "unsupported file type"
+    assert_contains "$workspace/privileged-file.log" "privileged mode is not allowed"
+    assert_contains "$workspace/root-symlink.log" "bundled skills root cannot be a symlink"
+}
+
+test_upstream_bundled_skills_rejects_unsafe_source() {
+    info "Checking bundled skills unsafe source rejection is propagated"
+    local workspace="$TMP_DIR/upstream-bundled-skills-unsafe-source"
+    local app_dir="$workspace/ChatGPT.app"
+    local install_dir="$workspace/install"
+    local source_skills="$app_dir/Contents/Resources/skills"
+    local target_skills="$install_dir/resources/skills"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$source_skills/skills/.curated/hatch-pet" "$target_skills/skills/.curated/hatch-pet"
+    printf '%s\n' 'new skill' > "$source_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'previous skill' > "$target_skills/skills/.curated/hatch-pet/SKILL.md"
+    ln -s "$workspace/outside.txt" "$source_skills/skills/.curated/hatch-pet/outside"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        if install_bundled_plugin_resources "$app_dir"; then
+            fail "Expected bundled plugin installation to propagate unsafe skills rejection"
+        fi
+    ) >"$output_log" 2>&1
+
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "previous skill"
+    assert_not_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    assert_contains "$output_log" "Bundled skills source contains unsupported content"
+    [ -z "$(find "$(dirname "$target_skills")" -mindepth 1 -maxdepth 1 -type d -name '.skills.tmp.*' -print -quit)" ] \
+        || fail "Expected unsafe bundled skills source rejection to leave no staging directory"
+}
+
+test_upstream_bundled_skills_post_copy_validation() {
+    info "Checking bundled skills post-copy validation preserves the target"
+    local workspace="$TMP_DIR/upstream-bundled-skills-post-copy"
+    local source_skills="$workspace/source-skills"
+    local target_skills="$workspace/install/resources/skills"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$source_skills/skills/.curated/hatch-pet" "$target_skills/skills/.curated/hatch-pet"
+    printf '%s\n' 'new skill' > "$source_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'previous skill' > "$target_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'outside' > "$workspace/outside.txt"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        cp() {
+            command cp "$@" || return
+            if [ "$#" -eq 3 ] && [ "$1" = "-R" ] && [ "$2" = "$source_skills/." ] &&
+                [[ "$3" == "$(dirname "$target_skills")/.skills.tmp."* ]]; then
+                ln -s "$workspace/outside.txt" "$3/post-copy-link"
+            fi
+        }
+        if stage_upstream_bundled_skills "$source_skills" "$target_skills"; then
+            fail "Expected post-copy bundled skills validation to reject injected content"
+        fi
+    ) >"$output_log" 2>&1
+
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "previous skill"
+    assert_not_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    assert_contains "$output_log" "Bundled skills failed post-copy validation"
+    [ -z "$(find "$(dirname "$target_skills")" -mindepth 1 -maxdepth 1 -type d -name '.skills.tmp.*' -print -quit)" ] \
+        || fail "Expected post-copy validation failure to leave no staging directory"
+}
+
+test_upstream_bundled_skills_replaces_target_symlink_safely() {
+    info "Checking bundled skills target symlink replacement"
+    local workspace="$TMP_DIR/upstream-bundled-skills-target-symlink"
+    local source_skills="$workspace/source-skills"
+    local target_skills="$workspace/install/resources/skills"
+    local external_target="$workspace/external-target"
+
+    mkdir -p "$source_skills/skills/.curated/hatch-pet" "$external_target" "$(dirname "$target_skills")"
+    printf '%s\n' 'new skill' > "$source_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'external state' > "$external_target/existing.txt"
+    ln -s "$external_target" "$target_skills"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_upstream_bundled_skills "$source_skills" "$target_skills"
+    )
+
+    [ ! -L "$target_skills" ] || fail "Expected target symlink to be replaced, not followed"
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    assert_contains "$external_target/existing.txt" "external state"
+    [ ! -e "$external_target/skills" ] || fail "Expected external symlink target to remain untouched"
+}
+
+test_upstream_bundled_skills_backup_cleanup_failure_is_recoverable() {
+    info "Checking bundled skills backup cleanup failure is fail-closed and recoverable"
+    local workspace="$TMP_DIR/upstream-bundled-skills-cleanup-failure"
+    local source_skills="$workspace/source-skills"
+    local target_skills="$workspace/install/resources/skills"
+    local backup_skills="$(dirname "$target_skills")/.skills.backup.$$"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$source_skills/skills/.curated/hatch-pet" "$target_skills/skills/.curated/hatch-pet"
+    printf '%s\n' 'new skill' > "$source_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'previous skill' > "$target_skills/skills/.curated/hatch-pet/SKILL.md"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        rm() {
+            if [ "$#" -eq 3 ] && [ "$1" = "-rf" ] && [ "$2" = "--" ] &&
+                [ "$3" = "$backup_skills" ] && { [ -e "$backup_skills" ] || [ -L "$backup_skills" ]; }; then
+                return 1
+            fi
+            command rm "$@"
+        }
+        if stage_upstream_bundled_skills "$source_skills" "$target_skills"; then
+            fail "Expected bundled skills backup cleanup failure to fail staging"
+        fi
+    ) >"$output_log" 2>&1
+
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    assert_contains "$backup_skills/skills/.curated/hatch-pet/SKILL.md" "previous skill"
+    assert_contains "$output_log" "Failed to clean previous bundled skills backup"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_upstream_bundled_skills "$source_skills" "$target_skills"
+    )
+
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    [ ! -e "$backup_skills" ] || fail "Expected second staging run to clean the stale backup"
 }
 
 test_upstream_bundled_skills_stage_failure_restores_target() {
@@ -9781,6 +9994,11 @@ main() {
     test_browser_use_file_url_policy_patch_behavior
     test_browser_plugin_renamed_upstream_staging
     test_upstream_bundled_skills_staging
+    test_upstream_bundled_skills_validator_guards
+    test_upstream_bundled_skills_rejects_unsafe_source
+    test_upstream_bundled_skills_post_copy_validation
+    test_upstream_bundled_skills_replaces_target_symlink_safely
+    test_upstream_bundled_skills_backup_cleanup_failure_is_recoverable
     test_upstream_bundled_skills_stage_failure_restores_target
     test_portable_bundled_plugins_staging
     test_portable_bundled_plugins_reject_unsafe_content

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6940,6 +6940,84 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_not_contains "$output_log" "Browser bundled plugin resources not present"
 }
 
+test_upstream_bundled_skills_staging() {
+    info "Checking current upstream bundled skills staging"
+    local workspace="$TMP_DIR/upstream-bundled-skills"
+    local app_dir="$workspace/ChatGPT.app"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+    local source_skill="$app_dir/Contents/Resources/skills/skills/.curated/hatch-pet"
+    local target_skill="$install_dir/resources/skills/skills/.curated/hatch-pet"
+
+    mkdir -p "$workspace" "$install_dir/resources"
+    make_fake_browser_upstream_app "$app_dir"
+    mkdir -p "$source_skill/references" "$source_skill/scripts"
+    printf '%s\n' '# Hatch Pet' > "$source_skill/SKILL.md"
+    printf '%s\n' '# Animation rows' > "$source_skill/references/animation-rows.md"
+    printf '%s\n' 'print("render")' > "$source_skill/scripts/render_animation_previews.py"
+    printf '%s\n' 'finder metadata' > "$source_skill/scripts/render_animation_previews.py:com.apple.FinderInfo"
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        INSTALL_DIR="$install_dir"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        ICON_SOURCE="$workspace/missing-icon.png"
+        CODEX_APP_ID="codex-desktop"
+        mkdir -p "$WORK_DIR"
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        stage_linux_computer_use_plugin() { return 1; }
+        stage_browser_plugin_from_upstream() { return 1; }
+        stage_chrome_plugin_from_upstream() { return 1; }
+        install_browser_use_node_repl_resource() { return 0; }
+        install_bundled_plugin_resources "$app_dir"
+    ) >"$output_log" 2>&1
+
+    assert_file_exists "$target_skill/SKILL.md"
+    assert_file_exists "$target_skill/references/animation-rows.md"
+    assert_file_exists "$target_skill/scripts/render_animation_previews.py"
+    [ ! -e "$target_skill/scripts/render_animation_previews.py:com.apple.FinderInfo" ] \
+        || fail "Expected macOS sidecar metadata to be removed from staged bundled skills"
+    assert_contains "$output_log" "Bundled skills staged from upstream DMG"
+}
+
+test_upstream_bundled_skills_stage_failure_restores_target() {
+    info "Checking bundled skills staging restores the previous target on failure"
+    local workspace="$TMP_DIR/upstream-bundled-skills-failure"
+    local source_skills="$workspace/source-skills"
+    local target_skills="$workspace/install/resources/skills"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$source_skills/skills/.curated/hatch-pet" "$target_skills/skills/.curated/hatch-pet"
+    printf '%s\n' 'new skill' > "$source_skills/skills/.curated/hatch-pet/SKILL.md"
+    printf '%s\n' 'previous skill' > "$target_skills/skills/.curated/hatch-pet/SKILL.md"
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        mv() {
+            if [ "$#" -eq 3 ] && [ "$1" = "--" ] &&
+                [[ "$2" == "$(dirname "$target_skills")/.skills.tmp."* ]] &&
+                [ "$3" = "$target_skills" ]; then
+                return 1
+            fi
+            command mv "$@"
+        }
+        if stage_upstream_bundled_skills "$source_skills" "$target_skills"; then
+            fail "Expected bundled skills staging to fail when target promotion fails"
+        fi
+    ) >"$output_log" 2>&1
+
+    assert_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "previous skill"
+    assert_not_contains "$target_skills/skills/.curated/hatch-pet/SKILL.md" "new skill"
+    assert_contains "$output_log" "previous target was restored"
+}
+
 test_portable_bundled_plugins_staging() {
     info "Checking portable upstream bundled plugin staging"
     local workspace="$TMP_DIR/portable-bundled-plugins"
@@ -9702,6 +9780,8 @@ main() {
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_file_url_policy_patch_behavior
     test_browser_plugin_renamed_upstream_staging
+    test_upstream_bundled_skills_staging
+    test_upstream_bundled_skills_stage_failure_restores_target
     test_portable_bundled_plugins_staging
     test_portable_bundled_plugins_reject_unsafe_content
     test_portable_bundled_plugin_validator_guards


### PR DESCRIPTION
Closes #945.

## Summary

- stage the current DMG's complete bundled `Resources/skills` tree at the packaged Linux `resources/skills` root
- preserve the nested `skills/.curated/hatch-pet` path expected by the packaged runtime
- replace the staged skills target safely, remove macOS metadata sidecars, and normalize permissions
- protect the Hatch Pet skill and Linux staging owner in the upstream DMG intelligence registry

## Why

The current DMG ships Hatch Pet at `Contents/Resources/skills/skills/.curated/hatch-pet`, and the packaged app resolves its bundled skills root to `process.resourcesPath/skills`. The previous Linux staging path flattened the skill to `resources/skills/.curated/hatch-pet`, so the Pets update flow failed with `Recommended skill not found at skills/.curated/hatch-pet`.

This change copies the current upstream skills root without adding a legacy layout fallback.

## Source of truth

- `scripts/lib/bundled-plugins.sh`
- `tests/scripts_smoke.sh`
- `scripts/dev/upstream-dmg-protected-surfaces.json`
- `scripts/dev/upstream-dmg-intel.test.js`
- `docs/upstream-dmg-intelligence.md`

## Current DMG evidence

- App version: `26.707.62119`
- SHA-256: `c243c94f8de6a51f5530ffe1f8d0c1588733d890ac692e34aaca06d95ba637ca`
- verified DMG paths:
  - `Contents/Resources/skills/skills/.curated/hatch-pet/SKILL.md`
  - `Contents/Resources/skills/skills/.curated/hatch-pet/scripts/prepare_pet_run.py`

## Validation

- `bash -n scripts/lib/bundled-plugins.sh tests/scripts_smoke.sh`
- focused smoke coverage for current-DMG skills staging, sidecar cleanup, and failed-promotion rollback
- `node --test scripts/dev/upstream-dmg-intel.test.js`
- `jq empty scripts/dev/upstream-dmg-protected-surfaces.json`
- `git diff --check`
- current-DMG protected-surface probe: `PRESENT`, high confidence, all anchors satisfied, Linux substrate present
- independent local `codex review --uncommitted`: no introduced defects

The full script smoke suite reaches the existing unrelated `test_launcher_marketplace_metadata_atomic_staging` destination-symlink failure. The two focused bundled-skill smoke tests pass independently.

## Scope

Current DMG bundled-skill staging only. No custom pet assets, Pets UI changes, package-format-specific behavior, or legacy DMG compatibility paths are included.

