### PR TITLE
Reject incompatible ydotool fallback commands

### DIFF
--- a/computer-use-linux/src/diagnostics.rs
+++ b/computer-use-linux/src/diagnostics.rs
@@ -2,6 +2,7 @@ use crate::windowing::registry::{
     self, COSMIC_WAYLAND_BACKEND, GNOME_SHELL_EXTENSION_BACKEND, GNOME_SHELL_INTROSPECT_BACKEND,
     HYPRLAND_BACKEND, KWIN_BACKEND, NIRI_BACKEND,
 };
+use crate::ydotool;
 use schemars::JsonSchema;
 use serde::Serialize;
 use std::{
@@ -211,7 +212,7 @@ fn capability_map(
     if portals.remote_desktop.ok {
         input_backends.push("portal".to_string());
     }
-    if input.ydotool_socket.ok {
+    if input.ydotool.ok && input.ydotoold.ok && input.ydotool_socket.ok {
         input_backends.push("ydotool".to_string());
     }
 
@@ -635,7 +636,10 @@ fn check_from_backend_probe(probe: &registry::BackendProbe) -> Check {
 
 fn input_report() -> InputReport {
     InputReport {
-        ydotool: command_path_check("ydotool"),
+        ydotool: match ydotool::ensure_supported() {
+            Ok(detail) => Check::ok(detail),
+            Err(detail) => Check::fail(detail),
+        },
         ydotoold: process_check("ydotoold"),
         ydotool_socket: ydotool_socket_check(),
         uinput: read_write_path_check(Path::new("/dev/uinput")),
@@ -803,10 +807,6 @@ fn user_id() -> Option<String> {
         .success()
         .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
         .filter(|value| !value.is_empty())
-}
-
-fn command_path_check(command: &str) -> Check {
-    command_check("sh", &["-c", &format!("command -v {command}")])
 }
 
 fn process_check(process_name: &str) -> Check {
@@ -1243,6 +1243,29 @@ mod tests {
             capabilities.preferred.window_control.as_deref(),
             Some(NIRI_BACKEND)
         );
+    }
+
+    #[test]
+    fn capability_map_rejects_incompatible_ydotool_with_live_daemon() {
+        let platform = platform_report();
+        let portals = portal_report(Check::fail("missing"));
+        let accessibility = accessibility_report(Check::ok("bus"), Check::ok("true"));
+        let windowing = windowing_report(true, true);
+        let input = input_report_parts(
+            Check::fail("unsupported legacy ydotool CLI"),
+            Check::ok("ydotoold"),
+            Check::ok("connectable socket"),
+            Check::fail("/dev/uinput: Permission denied"),
+        );
+
+        let capabilities = capability_map(&platform, &portals, &accessibility, &windowing, &input);
+        let readiness = readiness_report(&platform, &portals, &accessibility, &windowing, &input);
+
+        assert!(!capabilities
+            .input
+            .iter()
+            .any(|backend| backend == "ydotool"));
+        assert!(!readiness.can_send_development_input);
     }
 
     #[test]

--- a/computer-use-linux/src/lib.rs
+++ b/computer-use-linux/src/lib.rs
@@ -10,3 +10,4 @@ pub mod server;
 pub mod terminal;
 pub mod windowing;
 pub mod windows;
+pub(crate) mod ydotool;

--- a/computer-use-linux/src/main.rs
+++ b/computer-use-linux/src/main.rs
@@ -17,6 +17,7 @@ mod server;
 mod terminal;
 mod windowing;
 mod windows;
+mod ydotool;
 
 use anyhow::{Context, Result};
 

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -1906,8 +1906,9 @@ impl ComputerUseLinux {
     }
 
     // The Wayland remote-desktop portal is now a *fallback* for input: when a
-    // working `ydotoold` socket is present we prefer ydotool, because it injects
-    // input without a permission prompt. GNOME refuses to persist remote-desktop
+    // compatible ydotool CLI and working `ydotoold` socket are present we prefer
+    // ydotool, because it injects input without a permission prompt. GNOME
+    // refuses to persist remote-desktop
     // grants (`org.freedesktop.portal.Error: Remote desktop sessions cannot
     // persist`), so the portal would otherwise re-prompt on every new session.
     // `COMPUTER_USE_LINUX_FORCE_YDOTOOL_*=1` always uses ydotool;
@@ -1927,7 +1928,10 @@ impl ComputerUseLinux {
         ]) {
             return self.is_wayland_session();
         }
-        self.is_wayland_session() && ydotool_socket().is_none()
+        should_prefer_portal_backend_by_default(
+            self.is_wayland_session(),
+            ydotool_backend_available(),
+        )
     }
 
     fn should_prefer_portal_keyboard_backend(&self) -> bool {
@@ -1943,7 +1947,11 @@ impl ComputerUseLinux {
         ]) {
             return self.is_wayland_session() && !self.is_kde_wayland_session();
         }
-        self.is_wayland_session() && !self.is_kde_wayland_session() && ydotool_socket().is_none()
+        !self.is_kde_wayland_session()
+            && should_prefer_portal_backend_by_default(
+                self.is_wayland_session(),
+                ydotool_backend_available(),
+            )
     }
 
     fn should_prefer_kde_clipboard_text_backend(&self) -> bool {
@@ -3554,6 +3562,28 @@ fn ydotool_socket() -> Option<String> {
         .map(|path| path.display().to_string())
 }
 
+fn ydotool_backend_available() -> bool {
+    ydotool_backend_available_from(
+        ydotool_socket_connectable(),
+        ydotool::ensure_supported().is_ok(),
+    )
+}
+
+fn ydotool_socket_connectable() -> bool {
+    if let Some(socket) = explicit_ydotool_socket() {
+        return ydotool_socket_connects(&PathBuf::from(socket));
+    }
+    connectable_ydotool_socket_from(fallback_ydotool_socket_candidates()).is_some()
+}
+
+fn ydotool_backend_available_from(socket_available: bool, cli_supported: bool) -> bool {
+    socket_available && cli_supported
+}
+
+fn should_prefer_portal_backend_by_default(is_wayland: bool, ydotool_available: bool) -> bool {
+    is_wayland && !ydotool_available
+}
+
 fn explicit_ydotool_socket() -> Option<String> {
     if let Ok(socket) = env::var("YDOTOOL_SOCKET") {
         let socket = socket.trim();
@@ -4528,6 +4558,25 @@ mod tests {
                 "930".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn legacy_ydotool_socket_does_not_suppress_portal_fallback() {
+        let legacy_ydotool_available = ydotool_backend_available_from(true, false);
+        let current_ydotool_available = ydotool_backend_available_from(true, true);
+
+        assert!(should_prefer_portal_backend_by_default(
+            true,
+            legacy_ydotool_available
+        ));
+        assert!(!should_prefer_portal_backend_by_default(
+            true,
+            current_ydotool_available
+        ));
+        assert!(!should_prefer_portal_backend_by_default(
+            false,
+            legacy_ydotool_available
+        ));
     }
 
     #[test]

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -21,6 +21,7 @@ use crate::windows::{
     window_permission_hint, WindowFocusResult, WindowInfo, WindowTarget,
     GNOME_SHELL_INTROSPECT_BACKEND,
 };
+use crate::ydotool;
 use anyhow::Result;
 use rmcp::{
     handler::server::wrapper::{Json, Parameters},
@@ -3281,6 +3282,7 @@ async fn run_ydotool_sequence(
 }
 
 async fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
+    ydotool::ensure_supported()?;
     let mut command = TokioCommand::new("ydotool");
     command.args(args);
     if let Some(socket) = ydotool_socket() {
@@ -3291,7 +3293,13 @@ async fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
 
     match command.spawn() {
         Ok(child) => match wait_for_ydotool_output(child).await {
-            Ok(output) if output.status.success() => Ok(output),
+            Ok(output) if output.status.success() => {
+                if let Some(error) = ydotool::cli_error(&output.stderr) {
+                    Err(error)
+                } else {
+                    Ok(output)
+                }
+            }
             Ok(output) => Err(ydotool_output_error(output)),
             Err(error) => Err(error),
         },
@@ -3300,6 +3308,7 @@ async fn run_ydotool(args: &[String]) -> std::result::Result<Output, String> {
 }
 
 async fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String> {
+    ydotool::ensure_supported()?;
     let mut command = TokioCommand::new("ydotool");
     command.args(["type", "--file", "-"]);
     if let Some(socket) = ydotool_socket() {
@@ -3320,7 +3329,11 @@ async fn run_ydotool_type_text(text: &str) -> std::result::Result<Output, String
             let output =
                 wait_for_ydotool_output_with_timeout(child, ydotool_type_timeout(text)).await?;
             if output.status.success() {
-                Ok(output)
+                if let Some(error) = ydotool::cli_error(&output.stderr) {
+                    Err(error)
+                } else {
+                    Ok(output)
+                }
             } else {
                 Err(ydotool_output_error(output))
             }

--- a/computer-use-linux/src/ydotool.rs
+++ b/computer-use-linux/src/ydotool.rs
@@ -1,0 +1,100 @@
+use std::{process::Command, sync::OnceLock};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CliGeneration {
+    RawEvents,
+    LegacyNamed,
+}
+
+const UNSUPPORTED_MESSAGE: &str = "unsupported legacy ydotool CLI; Computer Use requires ydotool 1.0 or newer with raw key events and absolute mouse movement";
+
+pub(crate) fn ensure_supported() -> Result<String, String> {
+    static RESULT: OnceLock<Result<String, String>> = OnceLock::new();
+    RESULT.get_or_init(probe).clone()
+}
+
+fn probe() -> Result<String, String> {
+    let mut output_text = String::new();
+    for argument in ["help", "--help"] {
+        let output = Command::new("ydotool")
+            .arg(argument)
+            .output()
+            .map_err(|error| format!("failed to run ydotool: {error}"))?;
+        output_text.push_str(&String::from_utf8_lossy(&output.stdout));
+        output_text.push_str(&String::from_utf8_lossy(&output.stderr));
+        if let Some(generation) = classify_help(&output_text) {
+            return match generation {
+                CliGeneration::RawEvents => Ok("compatible raw-event CLI detected".to_string()),
+                CliGeneration::LegacyNamed => Err(UNSUPPORTED_MESSAGE.to_string()),
+            };
+        }
+    }
+    Err("unrecognized ydotool CLI; Computer Use requires ydotool 1.0 or newer".to_string())
+}
+
+pub(crate) fn classify_help(help: &str) -> Option<CliGeneration> {
+    let commands = help
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if commands.contains(&"debug") && commands.contains(&"stdin") {
+        Some(CliGeneration::RawEvents)
+    } else if commands.contains(&"recorder") {
+        Some(CliGeneration::LegacyNamed)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn cli_error(stderr: &[u8]) -> Option<String> {
+    let detail = String::from_utf8_lossy(stderr).trim().to_string();
+    let normalized = detail.to_ascii_lowercase();
+    [
+        "unrecognised option",
+        "unrecognized option",
+        "unknown option",
+        "invalid option",
+        "unknown command",
+    ]
+    .iter()
+    .any(|needle| normalized.contains(needle))
+    .then_some(detail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_legacy_named_cli_from_ubuntu_ydotool() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  type\n  recorder\n  mousemove\n  key\n  click\n";
+
+        assert_eq!(classify_help(help), Some(CliGeneration::LegacyNamed));
+    }
+
+    #[test]
+    fn classifies_raw_event_cli_from_current_ydotool() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  stdin\n";
+
+        assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn rejects_unknown_cli_shape() {
+        assert_eq!(classify_help("Usage: ydotool <cmd>"), None);
+    }
+
+    #[test]
+    fn recognizes_cli_errors_even_when_exit_status_is_success() {
+        assert_eq!(
+            cli_error(b"error: unrecognised option '--absolute'\n"),
+            Some("error: unrecognised option '--absolute'".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_non_error_stderr() {
+        assert_eq!(cli_error(b"ydotoold socket ready\n"), None);
+    }
+}

--- a/docs/linux-computer-use.md
+++ b/docs/linux-computer-use.md
@@ -15,7 +15,10 @@ It supports:
 
 ## Runtime Dependencies
 
-Install `ydotool` when you need the fallback input path:
+Install `ydotool` 1.0 or newer when you need the fallback input path. Some
+Debian and Ubuntu releases still package the incompatible pre-1.0 CLI; the
+Computer Use readiness report detects and rejects it instead of sending unsafe
+input commands.
 
 ```bash
 # Debian / Ubuntu


### PR DESCRIPTION
## Summary

- detect whether the installed `ydotool` exposes the raw-event CLI required by Computer Use
- reject legacy pre-1.0 commands before sending input and catch CLI errors that exit with status 0
- advertise `ydotool` only when the binary, daemon, and socket are all usable
- document the minimum compatible version

## Root cause

Ubuntu/Kubuntu 25.10 ships `ydotool` 0.1.8. Its CLI accepts named keys and relative mouse movement, while the backend emits the raw key events and absolute movement syntax introduced in 1.0. The legacy binary prints errors such as `unrecognised option '--absolute'` but exits successfully, so Computer Use previously reported an action even though no input occurred.

This change fails closed instead of attempting unsafe coordinate emulation. Portal and direct `/dev/uinput` input remain unchanged.

Closes #949.

## Validation

- reproduced with `ydotool 0.1.8-3build1`, a live `ydotoold`, and a connectable `/tmp/.ydotool_socket` on KDE Plasma Wayland
- confirmed the updated doctor report rejects the legacy CLI and removes it from `capabilities.input` while retaining the available portal backend
- called `press_key` through the isolated MCP server with the keyboard fallback forced to the live legacy installation; it returned `ok: false` before sending input
- called `click` through the isolated MCP server with the pointer fallback forced to the live legacy installation; it returned `ok: false` before sending input
- confirmed the default Wayland selector prefers the portal when a connectable socket belongs to an incompatible legacy CLI, while preserving the current-CLI preference
- `cargo fmt --all -- --check`
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `cargo test -p codex-computer-use-linux` (357 passed)
- `bash tests/scripts_smoke.sh`
- `git diff --check`

## Scope

This does not change AT-SPI extraction or attempt to work around Electron applications that expose incomplete accessibility trees.
