### PR TITLE
[codex] Sync avatar settings across Linux windows

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -49,6 +49,7 @@ const {
 } = require("./patches/impl/keybinds-settings.js");
 const {
   applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxQueryCacheInvalidationBroadcastPatch,
 } = require("./patches/impl/avatar-overlay.js");
 const {
   applyBrowserUseNodeReplApprovalPatch,
@@ -922,6 +923,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-opaque-background",
     "linux-owl-feature-binding-fallback",
     "linux-avatar-overlay-mouse-passthrough",
+    "linux-avatar-settings-sync",
     "linux-browser-use-availability",
     "linux-browser-use-non-local-navigation",
     "linux-browser-use-external-availability",
@@ -3142,6 +3144,28 @@ test("adds Linux avatar overlay mouse passthrough recovery", () => {
   assert.match(patched, /e\.moveTop\(\),e\.showInactive\(\),process\.platform===`linux`&&this\.codexLinuxApplyAvatarCompositorHints\(e\),process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)/);
   assert.doesNotMatch(patched, /codexLinuxRecoverAvatarPointerInteractivity/);
   assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\),this\.codexLinuxAvatarInputShapeKey=null,this\.codexLinuxAvatarCompositorHintsApplied=!1,this\.codexLinuxAvatarCompositorHintsApplying=!1,this\.cancelMomentum\(\)/);
+});
+
+test("broadcasts query cache invalidations to the avatar overlay window", () => {
+  const source = [
+    "const n={fc:e=>1};",
+    "class Handler{constructor(){this.hostId=`local`,this.windowManager={sendMessageToAllRegisteredWindows(){}}}getAppServerConnection(){return null}getIpcClientForWebContents(){return{sendBroadcast:async()=>{}}}async handle(e,t){switch(t.type){case`query-cache-invalidate`:{t.queryKey[0]===`plugins`&&Sr(this.getAppServerConnection(this.hostId));let n=this.getIpcClientForWebContents(e);n&&await n.sendBroadcast(`query-cache-invalidate`,{queryKey:t.queryKey});break}}}}",
+    "let config={version:n.fc(`query-cache-invalidate`)};",
+  ].join("");
+
+  const patched = applyPatchTwice(
+    applyLinuxQueryCacheInvalidationBroadcastPatch,
+    source,
+  );
+
+  assert.match(
+    patched,
+    /let r=this\.getIpcClientForWebContents\(e\);r&&await r\.sendBroadcast\(`query-cache-invalidate`,\{queryKey:t\.queryKey\}\);process\.platform===`linux`&&this\.windowManager\.sendMessageToAllRegisteredWindows\(/,
+  );
+  assert.match(
+    patched,
+    /sourceClientId:`desktop`,version:n\.fc\(`query-cache-invalidate`\),params:\{queryKey:t\.queryKey\}/,
+  );
 });
 
 test("keeps the avatar overlay core patch idempotent after pet overlay composition", () => {

--- a/scripts/patches/core/all-linux/main-process/window-shell/patch.js
+++ b/scripts/patches/core/all-linux/main-process/window-shell/patch.js
@@ -29,7 +29,10 @@ const {
   applyLinuxTrayPatch,
   applyLinuxSingleInstancePatch,
 } = require("../../../../impl/main-process/tray.js");
-const { applyLinuxAvatarOverlayMousePassthroughPatch } = require("../../../../impl/avatar-overlay.js");
+const {
+  applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxQueryCacheInvalidationBroadcastPatch,
+} = require("../../../../impl/avatar-overlay.js");
 
 module.exports = [
   extractedAppPatch({
@@ -124,6 +127,13 @@ module.exports = [
     order: 90,
     ciPolicy: "required-upstream",
     apply: applyLinuxAvatarOverlayMousePassthroughPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-avatar-settings-sync",
+    phase: "main-bundle",
+    order: 92,
+    ciPolicy: "optional",
+    apply: applyLinuxQueryCacheInvalidationBroadcastPatch,
   }),
   mainBundlePatch({
     id: "linux-file-manager",

--- a/scripts/patches/impl/avatar-overlay.js
+++ b/scripts/patches/impl/avatar-overlay.js
@@ -100,6 +100,40 @@ function patchAvatarOverlayWindowOptions(source) {
   );
 }
 
+function applyLinuxQueryCacheInvalidationBroadcastPatch(currentSource) {
+  const marker = "process.platform===`linux`&&this.windowManager.sendMessageToAllRegisteredWindows({type:`ipc-broadcast`,method:`query-cache-invalidate`";
+  if (currentSource.includes(marker)) {
+    return currentSource;
+  }
+
+  const original =
+    "case`query-cache-invalidate`:{t.queryKey[0]===`plugins`&&Sr(this.getAppServerConnection(this.hostId));let n=this.getIpcClientForWebContents(e);n&&await n.sendBroadcast(`query-cache-invalidate`,{queryKey:t.queryKey});break}";
+  if (!currentSource.includes(original)) {
+    console.warn(
+      "WARN: Could not find query cache invalidation handler - skipping Linux avatar settings sync patch",
+    );
+    return currentSource;
+  }
+
+  const versionMatch = currentSource.match(
+    /version:([A-Za-z_$][\w$]*)\.fc\(`query-cache-invalidate`\)/,
+  );
+  if (versionMatch == null) {
+    console.warn(
+      "WARN: Could not find query cache invalidation protocol version - skipping Linux avatar settings sync patch",
+    );
+    return currentSource;
+  }
+
+  const protocol = versionMatch[1];
+  const replacement =
+    "case`query-cache-invalidate`:{t.queryKey[0]===`plugins`&&Sr(this.getAppServerConnection(this.hostId));let r=this.getIpcClientForWebContents(e);r&&await r.sendBroadcast(`query-cache-invalidate`,{queryKey:t.queryKey});process.platform===`linux`&&this.windowManager.sendMessageToAllRegisteredWindows({type:`ipc-broadcast`,method:`query-cache-invalidate`,sourceClientId:`desktop`,version:" +
+    protocol +
+    ".fc(`query-cache-invalidate`),params:{queryKey:t.queryKey}});break}";
+  recordStrategy("avatar-settings-sync", "upstream");
+  return currentSource.replace(original, replacement);
+}
+
 function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
   if (!currentSource.includes("`/avatar-overlay`")) {
     return currentSource;
@@ -390,4 +424,5 @@ function applyLinuxAvatarOverlayMousePassthroughPatch(currentSource) {
 
 module.exports = {
   applyLinuxAvatarOverlayMousePassthroughPatch,
+  applyLinuxQueryCacheInvalidationBroadcastPatch,
 };


### PR DESCRIPTION
## Summary

- broadcast Linux `query-cache-invalidate` events to every registered Electron window
- let the avatar overlay refresh settings immediately after changes in the main settings window
- add a regression test for the cross-window invalidation path

## Root Cause

The settings window optimistically updates its own cache and persists the value, but the avatar overlay is a separate renderer with an independent settings cache. The existing internal IPC broadcast does not deliver to sibling Electron windows, so the overlay retained its startup value until restart.

## Scope

This is Linux-only wrapper behavior. It does not change the settings schema, skill staging, Ozone mode, Wayland behavior, window positioning, or drag handling.

## Current Upstream Validation

- rebased onto current `main` at `52e9701`
- validated against upstream DMG `26.707.72221`
- DMG SHA-256: `40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6`
- current bundle: `main-UDW_FlxC.js`, Electron `42.1.0`
- full transactional candidate build: `accepted`
- patch report: `linux-avatar-settings-sync` = `applied`, strategy = `upstream`
- generated bundle parses successfully and contains exactly one settings-sync marker
- complete diff reviewed independently with a local LLM; no findings

## Tests

- `node --test scripts/patch-linux-window-ui.test.js` (`385/385` passed)
- `bash tests/scripts_smoke.sh` (passed)
- `git diff --check` (passed)

Required CI checks will be allowed to complete before maintainer review or merge is requested.
