### PR TITLE
chore: establish staff-managed label governance

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,337 @@
+{
+  "schemaVersion": 1,
+  "staffManaged": true,
+  "groups": [
+    {
+      "id": "type",
+      "appliesTo": ["issue", "pull_request"],
+      "cardinality": "exactly_one"
+    },
+    {
+      "id": "area",
+      "appliesTo": ["issue", "pull_request"],
+      "cardinality": "one_or_more"
+    },
+    {
+      "id": "status",
+      "appliesTo": ["issue"],
+      "cardinality": "exactly_one"
+    },
+    {
+      "id": "impact",
+      "appliesTo": ["issue"],
+      "cardinality": "zero_or_one"
+    },
+    {
+      "id": "risk",
+      "appliesTo": ["pull_request"],
+      "cardinality": "exactly_one"
+    },
+    {
+      "id": "community",
+      "appliesTo": ["issue"],
+      "cardinality": "zero_or_more"
+    },
+    {
+      "id": "workflow",
+      "appliesTo": ["issue", "pull_request"],
+      "cardinality": "zero_or_one"
+    },
+    {
+      "id": "resolution",
+      "appliesTo": ["issue", "pull_request"],
+      "cardinality": "zero_or_one"
+    },
+    {
+      "id": "sync",
+      "appliesTo": ["issue"],
+      "cardinality": "zero_or_more"
+    }
+  ],
+  "labels": [
+    {
+      "name": "type: bug",
+      "color": "D73A4A",
+      "description": "A reproducible defect or regression in supported behavior.",
+      "group": "type"
+    },
+    {
+      "name": "type: feature",
+      "color": "A2EEEF",
+      "description": "A new user-facing capability or opt-in Linux feature.",
+      "group": "type"
+    },
+    {
+      "name": "type: documentation",
+      "color": "0075CA",
+      "description": "A documentation-only improvement or correction.",
+      "group": "type"
+    },
+    {
+      "name": "type: maintenance",
+      "color": "6F42C1",
+      "description": "Tests, refactoring, dependencies, CI, or repository maintenance.",
+      "group": "type"
+    },
+    {
+      "name": "type: question",
+      "color": "D876E3",
+      "description": "A usage or contribution question that needs an answer.",
+      "group": "type"
+    },
+    {
+      "name": "type: security",
+      "color": "B60205",
+      "description": "Public security hardening or a disclosed security concern.",
+      "group": "type"
+    },
+    {
+      "name": "area: build and install",
+      "color": "C5DEF5",
+      "description": "DMG extraction, dependencies, native modules, or installation flow.",
+      "group": "area"
+    },
+    {
+      "name": "area: launcher and runtime",
+      "color": "C5DEF5",
+      "description": "Launcher, process lifecycle, webview, or packaged runtime behavior.",
+      "group": "area"
+    },
+    {
+      "name": "area: updater",
+      "color": "C5DEF5",
+      "description": "Update detection, rebuild, install, rollback, or updater state.",
+      "group": "area"
+    },
+    {
+      "name": "area: native packaging",
+      "color": "C5DEF5",
+      "description": "Debian, RPM, or pacman package build and installation.",
+      "group": "area"
+    },
+    {
+      "name": "area: appimage",
+      "color": "C5DEF5",
+      "description": "AppImage build, runtime, or desktop integration.",
+      "group": "area"
+    },
+    {
+      "name": "area: nix",
+      "color": "C5DEF5",
+      "description": "Nix flake, modules, hashes, or package outputs.",
+      "group": "area"
+    },
+    {
+      "name": "area: upstream dmg",
+      "color": "C5DEF5",
+      "description": "Compatibility or drift in the latest supported upstream DMG.",
+      "group": "area"
+    },
+    {
+      "name": "area: linux features",
+      "color": "C5DEF5",
+      "description": "The opt-in linux-features framework or one of its modules.",
+      "group": "area"
+    },
+    {
+      "name": "area: computer use",
+      "color": "C5DEF5",
+      "description": "Linux Computer Use backends, helpers, or desktop control.",
+      "group": "area"
+    },
+    {
+      "name": "area: integrations",
+      "color": "C5DEF5",
+      "description": "Browser, desktop environment, portal, or external integration.",
+      "group": "area"
+    },
+    {
+      "name": "area: ci and tooling",
+      "color": "C5DEF5",
+      "description": "GitHub Actions, developer tooling, fixtures, or validation infrastructure.",
+      "group": "area"
+    },
+    {
+      "name": "status: needs triage",
+      "color": "EDEDED",
+      "description": "Not yet classified or validated through project triage.",
+      "group": "status"
+    },
+    {
+      "name": "status: needs information",
+      "color": "FBCA04",
+      "description": "Waiting for specific details from the reporter or author.",
+      "group": "status"
+    },
+    {
+      "name": "status: needs reproduction",
+      "color": "F9D0C4",
+      "description": "Needs a reliable reproduction or a failing test.",
+      "group": "status"
+    },
+    {
+      "name": "status: ready for work",
+      "color": "0E8A16",
+      "description": "Confirmed, scoped, and ready for implementation.",
+      "group": "status"
+    },
+    {
+      "name": "status: awaiting upstream",
+      "color": "D4C5F9",
+      "description": "Blocked on an upstream DMG, dependency, or external project.",
+      "group": "status"
+    },
+    {
+      "name": "status: needs maintainer decision",
+      "color": "5319E7",
+      "description": "Requires a product, architecture, scope, or policy decision.",
+      "group": "status"
+    },
+    {
+      "name": "status: blocked",
+      "color": "B60205",
+      "description": "Cannot progress until the documented blocker is resolved.",
+      "group": "status"
+    },
+    {
+      "name": "impact: critical",
+      "color": "B60205",
+      "description": "Security exposure, data loss, privilege failure, or widespread breakage.",
+      "group": "impact"
+    },
+    {
+      "name": "impact: high",
+      "color": "D93F0B",
+      "description": "A major supported workflow is broken without a reasonable workaround.",
+      "group": "impact"
+    },
+    {
+      "name": "impact: medium",
+      "color": "FBCA04",
+      "description": "Supported behavior is impaired, but a workaround or limited scope exists.",
+      "group": "impact"
+    },
+    {
+      "name": "impact: low",
+      "color": "98D362",
+      "description": "Minor, cosmetic, or narrowly scoped impact.",
+      "group": "impact"
+    },
+    {
+      "name": "risk: low",
+      "color": "0E8A16",
+      "description": "Small, isolated change with straightforward validation and rollback.",
+      "group": "risk"
+    },
+    {
+      "name": "risk: medium",
+      "color": "FBCA04",
+      "description": "Behavioral change with bounded compatibility or cross-surface risk.",
+      "group": "risk"
+    },
+    {
+      "name": "risk: high",
+      "color": "D93F0B",
+      "description": "Touches security, privileges, updates, persistence, or multiple package paths.",
+      "group": "risk"
+    },
+    {
+      "name": "good first issue",
+      "color": "7057FF",
+      "description": "Small, well-scoped work with clear acceptance criteria.",
+      "group": "community"
+    },
+    {
+      "name": "help wanted",
+      "color": "008672",
+      "description": "Maintainers welcome a contributor to take ownership.",
+      "group": "community"
+    },
+    {
+      "name": "feedback wanted",
+      "color": "96DB3E",
+      "description": "Community input is requested before a decision or implementation.",
+      "group": "community"
+    },
+    {
+      "name": "workflow: manual only",
+      "color": "6A737D",
+      "description": "Automation may inspect, but must not comment, edit, label, or merge.",
+      "group": "workflow"
+    },
+    {
+      "name": "resolution: duplicate",
+      "color": "CFD3D7",
+      "description": "Another issue or pull request already tracks the same work.",
+      "group": "resolution"
+    },
+    {
+      "name": "sync: computer use",
+      "color": "FBCA04",
+      "description": "Pending synchronization with agent-sh/computer-use-linux.",
+      "group": "sync"
+    }
+  ],
+  "migrations": [
+    { "from": "autoreview/area-bug", "to": "type: bug" },
+    { "from": "bug", "to": "type: bug" },
+    { "from": "autoreview/area-feature", "to": "type: feature" },
+    { "from": "enhancement", "to": "type: feature" },
+    { "from": "documentation", "to": "type: documentation" },
+    { "from": "autoreview/area-question", "to": "type: question" },
+    { "from": "question", "to": "type: question" },
+    { "from": "autoreview/needs-info", "to": "status: needs information" },
+    { "from": "autoreview/severity-high", "to": "impact: high" },
+    { "from": "autoreview/severity-medium", "to": "impact: medium" },
+    { "from": "autoreview/severity-low", "to": "impact: low" },
+    { "from": "autoreview/risk-high", "to": "risk: high" },
+    { "from": "autoreview/risk-medium", "to": "risk: medium" },
+    { "from": "autoreview/risk-low", "to": "risk: low" },
+    { "from": "autoreview/risk-trivial", "to": "risk: low" },
+    { "from": "users-feedback-needed", "to": "feedback wanted" },
+    { "from": "autoreview/skip", "to": "workflow: manual only" },
+    { "from": "duplicate", "to": "resolution: duplicate" },
+    { "from": "computer-use-sync", "to": "sync: computer use" },
+    { "from": "upstream-dmg-drift", "to": "area: upstream dmg" }
+  ],
+  "retiredLabels": [
+    { "name": "autoreview/area-bug", "reason": "Replaced by type: bug." },
+    { "name": "autoreview/area-feature", "reason": "Replaced by type: feature." },
+    { "name": "autoreview/area-question", "reason": "Replaced by type: question." },
+    { "name": "autoreview/auto-merged", "reason": "Use the native merged state." },
+    { "name": "autoreview/awaiting-tests", "reason": "Use GitHub Checks." },
+    { "name": "autoreview/changes-requested", "reason": "Use the native review state." },
+    { "name": "autoreview/conflict", "reason": "Use the native mergeability state." },
+    { "name": "autoreview/draft", "reason": "Use the native draft state." },
+    { "name": "autoreview/dryrun-would-merge", "reason": "Keep dry-run results in checks or logs." },
+    { "name": "autoreview/duplicate-suspect", "reason": "A suspicion is not a staff-confirmed resolution." },
+    { "name": "autoreview/error", "reason": "Keep automation errors in checks or logs." },
+    { "name": "autoreview/fork", "reason": "Use native pull request metadata." },
+    { "name": "autoreview/in-progress", "reason": "Use GitHub Checks." },
+    { "name": "autoreview/needs-human", "reason": "Replace through staff triage based on the actual decision needed." },
+    { "name": "autoreview/needs-info", "reason": "Replaced by status: needs information." },
+    { "name": "autoreview/queued", "reason": "Use GitHub Checks." },
+    { "name": "autoreview/risk-high", "reason": "Replaced by risk: high." },
+    { "name": "autoreview/risk-low", "reason": "Replaced by risk: low." },
+    { "name": "autoreview/risk-medium", "reason": "Replaced by risk: medium." },
+    { "name": "autoreview/risk-trivial", "reason": "Merged into risk: low." },
+    { "name": "autoreview/secrets-detected", "reason": "Use a blocking private security check, never a public label." },
+    { "name": "autoreview/severity-high", "reason": "Replaced by impact: high." },
+    { "name": "autoreview/severity-low", "reason": "Replaced by impact: low." },
+    { "name": "autoreview/severity-medium", "reason": "Replaced by impact: medium." },
+    { "name": "autoreview/skip", "reason": "Replaced by workflow: manual only." },
+    { "name": "autoreview/stale", "reason": "Use native activity timestamps." },
+    { "name": "autoreview/tests-failed", "reason": "Use GitHub Checks." },
+    { "name": "autoreview/triaged", "reason": "Triage completion is represented by the current governed status." },
+    { "name": "bug", "reason": "Replaced by type: bug." },
+    { "name": "computer-use-sync", "reason": "Replaced by sync: computer use." },
+    { "name": "documentation", "reason": "Replaced by type: documentation." },
+    { "name": "duplicate", "reason": "Replaced by resolution: duplicate." },
+    { "name": "enhancement", "reason": "Replaced by type: feature." },
+    { "name": "invalid", "reason": "Use the native not-planned close reason and a staff explanation." },
+    { "name": "question", "reason": "Replaced by type: question." },
+    { "name": "upstream-dmg-drift", "reason": "Replaced by area: upstream dmg." },
+    { "name": "users-feedback-needed", "reason": "Replaced by feedback wanted." },
+    { "name": "wontfix", "reason": "Use the native not-planned close reason and a staff explanation." }
+  ]
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,10 @@
 ## Summary
 
 <!-- What changed, why, and which issue it resolves. -->
+<!--
+Repository labels are assigned by maintainers and authorized collaborators
+during triage. Describe the facts and scope; do not self-classify.
+-->
 
 ## Validation
 

--- a/.github/workflows/computer-use-sync-reminder.yml
+++ b/.github/workflows/computer-use-sync-reminder.yml
@@ -16,15 +16,53 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: computer-use-sync-reminder
+  cancel-in-progress: false
+
 jobs:
   remind:
     name: open sync reminder
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - name: Check out the label policy
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Open or update the sync reminder
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const label = 'computer-use-sync';
+            const policy = require(
+              `${process.env.GITHUB_WORKSPACE}/.github/labels.json`,
+            );
+            const labelDefinition = policy.labels.find(
+              ({ name }) => name === 'sync: computer use',
+            );
+            if (!labelDefinition) {
+              throw new Error(
+                'Missing sync: computer use in .github/labels.json',
+              );
+            }
+            const label = labelDefinition.name;
+            const issueLabelNames = [
+              'type: maintenance',
+              'area: computer use',
+              'status: ready for work',
+              label,
+            ];
+            const issueLabelDefinitions = issueLabelNames.map((name) => {
+              const definition = policy.labels.find((candidate) => candidate.name === name);
+              if (!definition) throw new Error(`Missing ${name} in .github/labels.json`);
+              return definition;
+            });
+            const legacyLabels = policy.migrations
+              .filter(({ to }) => to === label)
+              .map(({ from }) => from);
+            const hasLabel = (issue, name) => (issue.labels || []).some(
+              (entry) => typeof entry === 'string' ? entry === name : entry.name === name,
+            );
             const otherRepo = 'agent-sh/computer-use-linux';
             const compare = context.payload.compare || '';
             const sha = context.sha.slice(0, 8);
@@ -41,23 +79,52 @@ jobs:
               'Once synced, bump both crates to the same enumeration. A version mismatch',
               'between this crate and the standalone one means a sync is still pending.',
             ].join('\n');
-            try {
-              await github.rest.issues.getLabel({ ...context.repo, name: label });
-            } catch (e) {
-              await github.rest.issues.createLabel({
-                ...context.repo,
-                name: label,
-                color: 'fbca04',
-                description: 'Pending Linux Computer Use sync to the other repo',
-              });
+            for (const definition of issueLabelDefinitions) {
+              try {
+                await github.rest.issues.getLabel({
+                  ...context.repo,
+                  name: definition.name,
+                });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  ...context.repo,
+                  name: definition.name,
+                  color: definition.color,
+                  description: definition.description,
+                });
+              }
             }
-            const existing = await github.rest.issues.listForRepo({
+            let existing = await github.rest.issues.listForRepo({
               ...context.repo,
               state: 'open',
               labels: label,
               per_page: 1,
             });
+            for (const legacyLabel of legacyLabels) {
+              if (existing.data.length > 0) break;
+              const legacy = await github.rest.issues.listForRepo({
+                ...context.repo,
+                state: 'open',
+                labels: legacyLabel,
+                per_page: 1,
+              });
+              if (legacy.data.length > 0) {
+                existing = legacy;
+              }
+            }
             if (existing.data.length > 0) {
+              if (hasLabel(existing.data[0], 'workflow: manual only')) {
+                core.notice(
+                  `Sync reminder #${existing.data[0].number} is manual-only; no item mutation was performed.`,
+                );
+                return;
+              }
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: existing.data[0].number,
+                labels: issueLabelNames,
+              });
               await github.rest.issues.createComment({
                 ...context.repo,
                 issue_number: existing.data[0].number,
@@ -67,7 +134,7 @@ jobs:
               await github.rest.issues.create({
                 ...context.repo,
                 title: 'Sync Linux Computer Use → agent-sh/computer-use-linux',
-                labels: [label],
+                labels: issueLabelNames,
                 body,
               });
             }

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -1,0 +1,169 @@
+name: Manage repository labels
+run-name: Labels ${{ inputs.operation }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      operation:
+        description: Plan triage and catalog changes, converge labels, or retire obsolete labels
+        required: true
+        default: plan
+        type: choice
+        options:
+          - plan
+          - apply
+          - retire
+      confirmation:
+        description: Enter APPLY or RETIRE for the matching write operation
+        required: false
+        type: string
+
+permissions: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: repository-label-governance
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    if: inputs.operation == 'plan'
+    name: plan labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Check out trusted governance code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate read-only operation and policy
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          test -z "$CONFIRMATION" || {
+            echo "Plan requires an empty confirmation." >&2
+            exit 2
+          }
+          node scripts/ci/manage-labels.js --check
+
+      - name: Show the live plan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/manage-labels.js --repo "$GITHUB_REPOSITORY"
+
+      - name: Record the result
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Repository label governance"
+            echo
+            echo "- Operation: \`plan\`"
+            echo "- Trusted ref: \`$DEFAULT_BRANCH\`"
+            echo "- Result: read-only; no repository label was changed."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  mutate:
+    if: inputs.operation != 'plan'
+    name: ${{ inputs.operation }} labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      # A write-capable dispatch must run only code already reviewed on the
+      # default branch, even when the dispatcher selects another ref in the UI.
+      - name: Check out trusted governance code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Validate write operation and policy
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          case "$OPERATION:$CONFIRMATION" in
+            apply:APPLY|retire:RETIRE) ;;
+            *)
+              echo "Use APPLY for apply or RETIRE for retire." >&2
+              exit 2
+              ;;
+          esac
+          node scripts/ci/manage-labels.js --check
+
+      - name: Show the live plan
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/manage-labels.js --repo "$GITHUB_REPOSITORY"
+
+      - name: Capture the pre-change audit snapshot
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/manage-labels.js \
+            --repo "$GITHUB_REPOSITORY" \
+            --snapshot "$RUNNER_TEMP/repository-labels-before.json"
+
+      - name: Preserve the pre-change audit snapshot
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: repository-labels-before-${{ github.run_id }}
+          path: ${{ runner.temp }}/repository-labels-before.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Converge desired labels and migrate associations
+        if: inputs.operation == 'apply'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/manage-labels.js \
+            --repo "$GITHUB_REPOSITORY" \
+            --apply \
+            --confirm APPLY
+
+      - name: Retire obsolete labels
+        if: inputs.operation == 'retire'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/manage-labels.js \
+            --repo "$GITHUB_REPOSITORY" \
+            --retire "$RUNNER_TEMP/repository-labels-before.json" \
+            --confirm RETIRE
+
+      - name: Record the result
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          OPERATION: ${{ inputs.operation }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Repository label governance"
+            echo
+            echo "- Operation: \`$OPERATION\`"
+            echo "- Trusted ref: \`$DEFAULT_BRANCH\`"
+            echo "- Result: completed with a pre-change audit snapshot."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -61,10 +61,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -111,7 +111,7 @@ jobs:
 
       - name: Restore cached upstream DMG
         id: dmg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/codex-upstream-ci/Codex.dmg
           key: upstream-dmg-${{ env.DMG_CACHE_SCHEMA_VERSION }}-${{ steps.upstream-metadata.outputs.cache_segment }}
@@ -169,7 +169,7 @@ jobs:
         # The transactional installer records a decision before returning a
         # rejected status, so diagnostics remain available on failed runs.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: upstream-dmg-metadata
           path: |
@@ -182,9 +182,11 @@ jobs:
         if: always()
         run: |
           if [ ! -f upstream-dmg-decision.json ]; then
-            echo "## Upstream DMG acceptance" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "No decision artifact was produced; the run is inconclusive." >> "$GITHUB_STEP_SUMMARY"
+            {
+              echo "## Upstream DMG acceptance"
+              echo
+              echo "No decision artifact was produced; the run is inconclusive."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Enforce shared acceptance decision
@@ -208,12 +210,16 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out trusted reconciliation code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Download acceptance artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: upstream-dmg-metadata
           path: acceptance-artifact
@@ -244,7 +250,7 @@ jobs:
 
       - name: Create, update, or close the drift issue
         if: steps.current-identity.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,37 @@ update-builder bundle.
   cross-format changes unless the code explicitly scopes them to one package
   format or desktop target.
 
+## Issue And Pull Request Labels
+
+- [`.github/labels.json`](.github/labels.json) is the source of truth for label
+  names, colors, descriptions, groups, migrations, and retirements. Follow
+  [label governance](docs/label-governance.md) when classifying an issue or
+  pull request.
+- Labels are staff-managed. Contributors without repository label permission
+  do not determine their own labels. An agent without explicit delegated label
+  authority may propose a classification to an authorized maintainer or
+  collaborator, but it must not mutate repository labels.
+- An authorized agent operation must show a read-only plan first and use the
+  trusted manual workflow or `scripts/ci/manage-labels.js` with the required
+  typed confirmation. Never run write-capable label code from a fork pull
+  request or other untrusted ref.
+- After triage starts, issues have one `type:`, one or more `area:`, and one
+  active `status:` label. Pull requests have one `type:`, one or more `area:`,
+  and one `risk:` label. Use multiple areas only for real ownership boundaries.
+- Read native checks, draft state, mergeability, reviews, timestamps, and
+  open/closed state directly from GitHub. Do not duplicate them with labels.
+- `workflow: manual only` is a hard stop for item-specific automation: it may
+  inspect the item but must not comment, edit, classify, close, or merge it.
+  Only an owner-approved catalog migration declared in `.github/labels.json`
+  may preserve an existing classification under a replacement name.
+  `risk: low` never grants merge authority.
+- Do not infer labels from a title alone. Preserve uncertainty with the
+  appropriate triage status. Apply `resolution: duplicate` only after the
+  canonical item is verified and linked.
+- Never expose suspected secrets or an undisclosed vulnerability through a
+  public label. Use `type: security` only for public hardening or an already
+  disclosed concern.
+
 ## Source Routing
 
 Use source files, not generated artifacts. Main routing:
@@ -67,6 +98,8 @@ Primary human docs: [architecture](docs/architecture.md),
 [Linux features](docs/linux-features-architecture.md),
 [updater](docs/updater.md), [Linux Computer Use](docs/linux-computer-use.md),
 [Nix](docs/nix.md), and [troubleshooting](docs/troubleshooting.md).
+
+Repository governance: [issue and pull request labels](docs/label-governance.md).
 
 ## Patch And Feature Rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,22 @@ Good issue reports usually include:
 - expected behavior
 - actual behavior
 
+### Labels and maintainer triage
+
+Repository labels are assigned by maintainers and authorized collaborators
+during triage. Contributors without repository label permission should provide
+the facts needed to classify the work; they should not self-assign, request,
+or guess labels. A new item with no labels is waiting for triage, not rejected.
+
+Coding agents follow the same boundary. Without explicit delegated label
+authority, an agent may propose a classification to authorized staff but must
+not create, apply, remove, or rename labels. Staff-authorized repository
+automation may apply deterministic classifications from the policy. Bulk
+catalog changes remain restricted to the trusted manual workflow.
+
+Read [issue and pull request label governance](docs/label-governance.md) for
+the authority model, taxonomy, selection rules, and migration process.
+
 ## Development Setup
 
 The recommended local setup is:

--- a/docs/label-governance.md
+++ b/docs/label-governance.md
@@ -1,0 +1,295 @@
+# Issue and pull request label governance
+
+Repository labels are a maintainer-owned triage layer. They give people a
+quick view of what an item is, where it belongs, what is holding it up, and how
+carefully a pull request must be reviewed. They also give repository
+automation a small, deterministic vocabulary without exposing internal job
+states in the issue and pull request lists.
+
+[`.github/labels.json`](../.github/labels.json) is the machine-readable source
+of truth for names, colors, descriptions, groups, migrations, and retirements.
+This document defines how those labels are selected and who may change them.
+
+## Authority
+
+Label decisions belong to the repository owner and collaborators who have the
+GitHub permission required to manage labels. Contributors without that
+permission provide evidence; they do not choose, apply, remove, or rename
+labels for their own work.
+
+The same boundary applies to coding agents and automation:
+
+| Actor | Allowed behavior |
+| --- | --- |
+| Reporter or pull request author without label permission | Supply reproduction details, scope, affected paths, and validation results. Do not self-classify. |
+| Maintainer or authorized collaborator | Make the final classification and apply or remove labels. |
+| Agent without delegated label authority | Read labels and native GitHub state. It may propose a classification to authorized staff, but must not mutate labels. |
+| Authorized repository workflow or agent operation | Apply a reviewed deterministic plan from the trusted default branch, with the permissions and confirmation required by the manual workflow. |
+
+A proposal from an agent is not a repository decision. The label changes only
+when authorized staff accepts it or explicitly runs the staff-controlled
+workflow. Authors must never be asked to add a label themselves. An unlabeled
+new item is awaiting triage, not rejected.
+
+## Classification contract
+
+New issues and pull requests can be unlabeled while they wait for authorized
+triage. Once classification starts, use the following cardinality rules.
+
+### Issues
+
+- exactly one `type:` label
+- one or more `area:` labels
+- exactly one active `status:` label
+- zero or one `impact:` label; use it for confirmed bugs and public security
+  work when impact can be supported by evidence
+- optional community, workflow, resolution, and sync labels when their stated
+  conditions are met
+
+### Pull requests
+
+- exactly one `type:` label
+- one or more `area:` labels
+- exactly one `risk:` label
+- optional `workflow: manual only` or `resolution: duplicate` when applicable
+
+Multiple area labels are expected when a change crosses a real ownership
+boundary. Do not add extra areas for files that are only incidentally touched.
+For example, a shared updater change that affects native packages may need
+both `area: updater` and `area: native packaging`; a test fixture changed only
+to support that updater fix does not automatically add `area: ci and tooling`.
+
+## Taxonomy
+
+### Type
+
+Type answers one question: what kind of work is this?
+
+| Label | Use and justification |
+| --- | --- |
+| `type: bug` | A reproducible defect or regression. Keeping defects separate from requests makes reliability work visible. |
+| `type: feature` | New user-facing behavior, including an opt-in Linux feature. This keeps product additions distinct from repairs. |
+| `type: documentation` | A documentation-only correction or addition. Use another type if code behavior changes too. |
+| `type: maintenance` | Tests, refactoring, dependencies, CI, or repository upkeep without a new user-facing capability. |
+| `type: question` | A usage or contribution question that needs an answer rather than a code change. |
+| `type: security` | Public hardening or an already disclosed security concern. Undisclosed vulnerabilities do not belong in a public issue. |
+
+### Area
+
+Area identifies the source-of-truth surface a reviewer must inspect.
+
+| Label | Use and justification |
+| --- | --- |
+| `area: build and install` | DMG extraction, dependencies, native modules, installer orchestration, or initial setup. |
+| `area: launcher and runtime` | Process lifecycle, the generated launcher source, webview serving, or packaged runtime behavior. |
+| `area: updater` | Update detection, rebuilds, installation, rollback, or persisted updater state. |
+| `area: native packaging` | Shared or format-specific `.deb`, RPM, or pacman package behavior. |
+| `area: appimage` | AppImage construction, runtime behavior, or desktop integration. |
+| `area: nix` | Flake outputs, Nix modules, fixed-output hashes, or Nix-only packaging. |
+| `area: upstream dmg` | Compatibility with, or drift in, the latest supported upstream DMG. |
+| `area: linux features` | The opt-in feature framework or one of its modules. |
+| `area: computer use` | Linux Computer Use backends, helpers, capture, input, or desktop control. |
+| `area: integrations` | Browser, desktop environment, portal, or other external integration boundaries. |
+| `area: ci and tooling` | GitHub Actions, validation scripts, developer tooling, fixtures, or repository governance. |
+
+The list deliberately avoids one label per distribution, desktop, package
+version, or feature module. Those details belong in the issue body until the
+volume proves that a stable routing label is useful.
+
+### Issue status
+
+Status records the single next condition needed to move an issue forward.
+
+| Label | Use and justification |
+| --- | --- |
+| `status: needs triage` | Staff has not yet validated and classified the report. This is the intake state. |
+| `status: needs information` | The reporter must provide named missing details, such as logs, versions, or commands. |
+| `status: needs reproduction` | The report is understandable but still needs a reliable reproduction or failing test. |
+| `status: ready for work` | The problem is confirmed, scoped, and has enough acceptance criteria to implement. |
+| `status: awaiting upstream` | Progress depends on an upstream DMG, dependency, or external project. Name that dependency in the thread. |
+| `status: needs maintainer decision` | Product direction, architecture, scope, or policy must be decided by a maintainer. |
+| `status: blocked` | A documented non-upstream blocker prevents progress. Replace it when the blocker clears. |
+
+Do not combine status labels. Choose the immediate gating condition. A broad
+request that still lacks scope is `status: needs maintainer decision`, not
+`status: ready for work` plus a warning in a comment.
+
+### Issue impact
+
+Impact measures observed user harm. It is not scheduling priority.
+
+| Label | Use and justification |
+| --- | --- |
+| `impact: critical` | Security exposure, data loss, privilege failure, or widespread breakage. Evidence must support the consequence. |
+| `impact: high` | A major supported workflow is broken and no reasonable workaround exists. |
+| `impact: medium` | Supported behavior is impaired, but the scope is limited or a workable workaround exists. |
+| `impact: low` | Minor, cosmetic, or narrowly scoped harm. |
+
+There are no `priority:` labels. Priority is an owner decision that can change
+without the technical impact changing; milestones or GitHub Projects are a
+better place to schedule work.
+
+### Pull request risk
+
+Risk tells reviewers how widely to validate a change. It never grants merge
+permission and never replaces required review or checks.
+
+| Label | Use and justification |
+| --- | --- |
+| `risk: low` | A small isolated change with straightforward validation and rollback. |
+| `risk: medium` | A behavioral change with bounded compatibility or cross-surface risk. |
+| `risk: high` | Security, privileges, updates, persistence, lifecycle, or several package paths are involved. |
+
+Documentation-only work can be low risk. A small diff can still be high risk
+when it changes an authorization, update, or rollback boundary.
+
+### Community, control, resolution, and synchronization
+
+| Label | Use and justification |
+| --- | --- |
+| `good first issue` | Staff has confirmed small scope, `status: ready for work`, and explicit acceptance criteria suitable for a first contribution. |
+| `help wanted` | Staff wants a contributor to take ownership of confirmed and scoped work. |
+| `feedback wanted` | Community input is requested before a decision or implementation. This is not a substitute for a maintainer decision. |
+| `workflow: manual only` | Item-specific automation may inspect the item but must not comment, edit, classify, close, or merge it. This is a hard stop until staff removes it. |
+| `resolution: duplicate` | Staff has verified that another issue or pull request tracks the same work and links the canonical item. A similarity score is not enough. |
+| `sync: computer use` | A merged change under the vendored Computer Use crate still needs assessment or propagation to `agent-sh/computer-use-linux`. |
+
+## Native GitHub state stays authoritative
+
+Labels must add repository meaning, not copy state GitHub already exposes.
+
+| Do not create a label for | Authoritative source |
+| --- | --- |
+| queued, running, passed, or failed tests | GitHub Checks |
+| draft or ready for review | Pull request draft state |
+| merge conflicts or fork origin | Pull request metadata |
+| requested changes or approvals | Review state |
+| merged or closed | Native issue and pull request state |
+| stale activity | Timeline and timestamps |
+| an automation error or dry-run result | Check, run summary, or log |
+
+Potential secret detection must be a blocking private security signal, never a
+public label. `resolution: duplicate` is applied only after an authorized human
+or explicitly authorized staff operation verifies and links the canonical
+item.
+
+## Agent and automation rules
+
+An agent classifying an item must read the body, linked discussion, changed
+files, checks, review state, and the current label policy. A title alone is not
+enough. When evidence is missing, preserve that uncertainty with
+`status: needs triage`, `status: needs information`, or
+`status: needs reproduction`; do not guess a stronger state.
+
+Without explicit delegated staff authority, the output is a proposal only.
+With delegated authority, the operation must still use the trusted manual
+workflow or the repository script, show its plan first, and keep the typed
+confirmation boundary. A fork pull request never receives a write token for
+label governance.
+
+The `workflow: manual only` label overrides every item-specific automation
+path. The only exception is an owner-approved catalog migration declared in
+`.github/labels.json`; it may rename a label or transfer the same existing
+classification, but it may not infer a new classification or change the item
+itself. A low-risk classification does not authorize automatic merge. Branch
+protection, review requirements, and the contributor workflow in
+`CONTRIBUTING.md` remain in force.
+
+Repository-owned issue producers must read their labels from the policy and
+apply a complete deterministic classification. The Computer Use sync reminder
+and upstream DMG drift reconciler follow this rule. Existing item automation,
+including the contributor pull request limit, must inspect
+`workflow: manual only` before any comment, edit, classification, close, or
+merge operation and leave that item for staff.
+
+## Color system
+
+Colors are consistent by purpose so the issue and pull request lists remain
+scannable:
+
+- established GitHub colors are retained for bug, feature, documentation,
+  question, newcomer, and help labels
+- pale blue identifies ownership areas without competing with urgency
+- green, yellow, orange, and red carry increasing impact or review risk
+- gray marks intake or manual workflow control
+- purple marks maintenance and maintainer decisions
+
+Color never carries meaning by itself. Every label has an English name and a
+short description for accessibility, search, and API consumers.
+
+## Safe synchronization and migration
+
+The manual [Manage repository labels](../.github/workflows/manage-labels.yml)
+workflow is the only repository-supplied bulk mutation path. It checks out the
+trusted default branch even if another ref is selected in the dispatch UI.
+Only a user with the repository permission required to run the workflow can
+start it.
+
+The migration is intentionally split:
+
+1. Merge the reviewed policy, documentation, script, tests, and workflow.
+2. Update or disable any external automation that still writes retired names.
+   The committed Computer Use and upstream DMG issue producers read their
+   classifications from the policy.
+3. Run `plan`. It is read-only and needs no confirmation text.
+   It also reports open items whose migrated labels still need a required
+   staff classification; these are triage notices, not inferred labels.
+4. Run `apply` with confirmation `APPLY`. This creates or updates desired
+   labels, renames the primary legacy labels, and transfers associations from
+   secondary legacy labels. It does not delete labels outside the explicit
+   retirement list.
+5. Resolve every open-item retirement blocker. An old label can be removed
+   from an open item only when its governed replacement is already attached;
+   labels without a direct replacement must be reviewed by staff first.
+6. Run `retire` with confirmation `RETIRE`. The workflow captures and uploads
+   a pre-change snapshot before deletion. It aborts if the live labels or their
+   associations change after that snapshot.
+
+The script is idempotent. A failed apply can be rerun: completed renames are
+recognized, existing desired labels are updated in place, and already migrated
+associations are skipped. Convergence stops before its first write if projected
+labels would violate an exclusive group or apply to the wrong item type.
+Open migrated items with an incomplete required classification are listed for
+staff triage instead of being guessed by the migration.
+Retirement is fail-closed; it checks every blocker before deleting the first
+label. An interrupted retirement can resume from the same snapshot: already
+absent retired labels count as completed, while every remaining source and
+migration target must still match the snapshot. Unknown labels are never
+pruned.
+
+For a local read-only plan:
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" node scripts/ci/manage-labels.js \
+  --repo ilysenko/codex-desktop-linux
+```
+
+Keep tokens in the environment, not in command arguments. For an emergency
+non-destructive restore, download a workflow snapshot and run:
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" node scripts/ci/manage-labels.js \
+  --repo ilysenko/codex-desktop-linux \
+  --restore /path/to/repository-labels-before.json \
+  --confirm RESTORE
+```
+
+Restore recreates only labels in the policy's explicit retirement list and
+reapplies their saved issue and pull request associations. It does not remove
+the new taxonomy or alter native GitHub state.
+
+## Examples
+
+A confirmed latest-DMG regression in an opt-in feature could be classified as
+`type: bug`, `area: upstream dmg`, `area: linux features`,
+`status: ready for work`, and an evidence-based impact.
+
+A pull request that changes this label policy is `type: maintenance`,
+`area: ci and tooling`, and normally `risk: medium` because it changes a
+write-capable repository workflow even though it does not change application
+runtime behavior.
+
+A setup question missing the distribution and exact command is
+`type: question`, `area: build and install`, and
+`status: needs information`. Staff should name the missing facts in the issue
+thread; the reporter is not asked to choose the labels.

--- a/docs/upstream-dmg-acceptance.md
+++ b/docs/upstream-dmg-acceptance.md
@@ -64,14 +64,16 @@ symlinks are ignored.
 ## Drift Issue Lifecycle
 
 Scheduled runs use the DMG SHA-256 as the identity and the app version only as
-a display value. One `upstream-dmg-drift` issue is kept per rejected fingerprint.
+a display value. One `area: upstream dmg` issue is kept per rejected fingerprint.
 When a new fingerprint arrives, open issues for older DMGs are closed as
 superseded. An accepted new DMG closes all remaining drift issues. Before any
 mutation, the issue job compares the tested HTTP identity with the current DMG
 headers so rerunning an obsolete workflow cannot reopen an old issue. The
 identity must contain an ETag or both Last-Modified and Content-Length. If
 either the tested or current identity is unavailable, reconciliation makes no
-issue changes.
+issue changes. The reconciler reads its classification from
+`.github/labels.json` and leaves any issue carrying `workflow: manual only`
+untouched.
 Only issues carrying both the label and a valid hidden 64-character fingerprint
 marker are managed. Manually created labeled issues and malformed markers are
 never updated, reopened, superseded, or closed by the workflow.

--- a/scripts/ci/computer-use-sync-reminder.test.js
+++ b/scripts/ci/computer-use-sync-reminder.test.js
@@ -1,0 +1,148 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+const repositoryRoot = path.resolve(__dirname, "../..");
+const workflowPath = path.join(
+  repositoryRoot,
+  ".github/workflows/computer-use-sync-reminder.yml",
+);
+const policy = require(path.join(repositoryRoot, ".github/labels.json"));
+
+function workflowScript() {
+  const lines = fs.readFileSync(workflowPath, "utf8").split("\n");
+  const marker = lines.findIndex((line) => line.trim() === "script: |");
+  assert.notEqual(marker, -1, "workflow must contain a github-script block");
+  return lines
+    .slice(marker + 1)
+    .map((line) => line.replace(/^ {12}/, ""))
+    .join("\n");
+}
+
+function harness({
+  getLabelError = Object.assign(new Error("missing"), { status: 404 }),
+  legacyIssue = { number: 944 },
+} = {}) {
+  const calls = [];
+  const issues = {
+    addLabels: async (options) => calls.push(["addLabels", options]),
+    create: async (options) => calls.push(["create", options]),
+    createComment: async (options) => calls.push(["createComment", options]),
+    createLabel: async (options) => calls.push(["createLabel", options]),
+    getLabel: async (options) => {
+      calls.push(["getLabel", options]);
+      if (getLabelError) throw getLabelError;
+    },
+    listForRepo: async (options) => {
+      calls.push(["listForRepo", options]);
+      if (options.labels === "computer-use-sync") {
+        return { data: legacyIssue ? [legacyIssue] : [] };
+      }
+      return { data: [] };
+    },
+  };
+  return {
+    calls,
+    core: { notice: (message) => calls.push(["notice", message]) },
+    context: {
+      payload: { compare: "https://github.com/owner/repository/compare/old...new" },
+      repo: { owner: "owner", repo: "repository" },
+      sha: "0123456789abcdef",
+    },
+    github: { rest: { issues } },
+  };
+}
+
+async function runWorkflow(harnessValue) {
+  const originalWorkspace = process.env.GITHUB_WORKSPACE;
+  process.env.GITHUB_WORKSPACE = repositoryRoot;
+  const requirePolicy = (requestedPath) => {
+    assert.equal(requestedPath, path.join(repositoryRoot, ".github/labels.json"));
+    return policy;
+  };
+  try {
+    const execute = new AsyncFunction("github", "context", "require", "core", workflowScript());
+    await execute(
+      harnessValue.github,
+      harnessValue.context,
+      requirePolicy,
+      harnessValue.core,
+    );
+  } finally {
+    if (originalWorkspace === undefined) delete process.env.GITHUB_WORKSPACE;
+    else process.env.GITHUB_WORKSPACE = originalWorkspace;
+  }
+}
+
+test("sync reminder adopts the legacy open issue during label rollout", async () => {
+  const value = harness();
+
+  await runWorkflow(value);
+
+  assert.deepEqual(
+    value.calls
+      .filter(([operation]) => operation === "createLabel")
+      .map(([, options]) => options.name),
+    ["type: maintenance", "area: computer use", "status: ready for work", "sync: computer use"],
+  );
+  const addLabels = value.calls.find(([operation]) => operation === "addLabels");
+  assert.deepEqual(addLabels[1], {
+    owner: "owner",
+    repo: "repository",
+    issue_number: 944,
+    labels: [
+      "type: maintenance",
+      "area: computer use",
+      "status: ready for work",
+      "sync: computer use",
+    ],
+  });
+  const comment = value.calls.find(([operation]) => operation === "createComment");
+  assert.equal(comment[1].issue_number, 944);
+  assert.equal(value.calls.some(([operation]) => operation === "create"), false);
+});
+
+test("sync reminder creates new issues with a complete governed classification", async () => {
+  const value = harness({ legacyIssue: null });
+
+  await runWorkflow(value);
+
+  assert.deepEqual(value.calls.find(([operation]) => operation === "create")[1].labels, [
+    "type: maintenance",
+    "area: computer use",
+    "status: ready for work",
+    "sync: computer use",
+  ]);
+});
+
+test("sync reminder fails closed when label lookup fails for a non-404 reason", async () => {
+  const value = harness({ getLabelError: Object.assign(new Error("forbidden"), { status: 403 }) });
+
+  await assert.rejects(() => runWorkflow(value), /forbidden/);
+
+  assert.equal(value.calls.some(([operation]) => operation === "createLabel"), false);
+  assert.equal(value.calls.some(([operation]) => operation === "create"), false);
+});
+
+test("sync reminder preserves a manual-only item without commenting", async () => {
+  const value = harness({
+    legacyIssue: { number: 944, labels: [{ name: "workflow: manual only" }] },
+  });
+
+  await runWorkflow(value);
+
+  assert.equal(value.calls.some(([operation]) => operation === "addLabels"), false);
+  assert.equal(value.calls.some(([operation]) => operation === "createComment"), false);
+  assert.equal(value.calls.some(([operation]) => operation === "create"), false);
+});
+
+test("sync reminder workflow serializes runs and pins third-party actions", () => {
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  assert.match(workflow, /group: computer-use-sync-reminder/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d/);
+});

--- a/scripts/ci/enforce-pr-limit.js
+++ b/scripts/ci/enforce-pr-limit.js
@@ -2,6 +2,13 @@
 
 const DEFAULT_MAX_OPEN_PRS = 2;
 const LIMIT_COMMENT_MARKER = "<!-- contributor-pr-limit -->";
+const MANUAL_ONLY_LABEL = "workflow: manual only";
+
+function hasLabel(pullRequest, name) {
+  return (pullRequest.labels || []).some((label) => (
+    typeof label === "string" ? label === name : label?.name === name
+  ));
+}
 
 function parsePositiveInteger(rawValue) {
   const value = typeof rawValue === "string" ? rawValue.trim() : "";
@@ -181,7 +188,14 @@ async function enforcePullRequestLimits({ context, core, github, rawLimit, rawOv
     );
 
     const body = buildLimitComment(limit, pullRequests.length);
+    const closedForAuthor = [];
     for (const excessPullRequest of pullRequestsToClose) {
+      if (hasLabel(excessPullRequest, MANUAL_ONLY_LABEL)) {
+        core.notice(
+          `Skipped pull request #${excessPullRequest.number} because it is marked ${MANUAL_ONLY_LABEL}.`,
+        );
+        continue;
+      }
       await ensureLimitComment({
         body,
         context,
@@ -195,6 +209,7 @@ async function enforcePullRequestLimits({ context, core, github, rawLimit, rawOv
         pullNumber: excessPullRequest.number,
       });
       closedPullRequests.push(excessPullRequest.number);
+      closedForAuthor.push(excessPullRequest.number);
       core.notice(
         `Closed pull request #${excessPullRequest.number} because ${author} exceeded the limit.`,
       );
@@ -202,7 +217,7 @@ async function enforcePullRequestLimits({ context, core, github, rawLimit, rawOv
 
     authors.push({
       author,
-      closedPullRequests: pullRequestsToClose.map((candidate) => candidate.number),
+      closedPullRequests: closedForAuthor,
       count: pullRequests.length,
       limit,
     });

--- a/scripts/ci/enforce-pr-limit.test.js
+++ b/scripts/ci/enforce-pr-limit.test.js
@@ -341,6 +341,26 @@ test("enforcePullRequestLimits closes every excess PR left by a burst of events"
   );
 });
 
+test("enforcePullRequestLimits never mutates an excess manual-only PR", async () => {
+  const manualOnly = pullRequest(3, "contributor", {
+    labels: [{ name: "workflow: manual only" }],
+  });
+  const harness = createHarness({
+    current: pullRequest(4),
+    open: [pullRequest(1), pullRequest(2), manualOnly, pullRequest(4)],
+  });
+
+  const result = await enforcePullRequestLimits({ ...harness, rawLimit: "2" });
+
+  assert.deepEqual(result.closedPullRequests, [4]);
+  assert.deepEqual(result.authors[0].closedPullRequests, [4]);
+  assert.equal(
+    harness.calls.some(([, options]) => options.issue_number === 3 || options.pull_number === 3),
+    false,
+  );
+  assert.match(harness.messages.notice[0], /manual only/);
+});
+
 test("enforcePullRequestLimits reconciles every newer PR after a limit decrease", async () => {
   const current = pullRequest(4);
   const harness = createHarness({

--- a/scripts/ci/manage-labels.js
+++ b/scripts/ci/manage-labels.js
@@ -1,0 +1,1074 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const API_BASE_URL = "https://api.github.com";
+const API_VERSION = "2022-11-28";
+const DEFAULT_POLICY_PATH = ".github/labels.json";
+const MAX_PAGES = 100;
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 20_000;
+const VALID_APPLIES_TO = new Set(["issue", "pull_request"]);
+const VALID_CARDINALITIES = new Set([
+  "exactly_one",
+  "one_or_more",
+  "zero_or_one",
+  "zero_or_more",
+]);
+
+function validRepository(value) {
+  if (typeof value !== "string") return false;
+  const segments = value.split("/");
+  return (
+    segments.length === 2 &&
+    segments.every((segment) => (
+      /^[A-Za-z0-9_.-]{1,100}$/.test(segment) &&
+      segment !== "." &&
+      segment !== ".."
+    ))
+  );
+}
+
+function normalizeName(value) {
+  return value.toLowerCase();
+}
+
+function itemKey(item) {
+  return `${item.kind}:${item.number}`;
+}
+
+function stableState(state, names) {
+  const selected = new Set(names.map(normalizeName));
+  const labels = state.labels
+    .filter((entry) => selected.has(normalizeName(entry.name)))
+    .map((entry) => ({
+      color: entry.color.toUpperCase(),
+      description: entry.description || "",
+      name: entry.name,
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+  const associations = {};
+
+  for (const labelEntry of labels) {
+    const actualName = Object.keys(state.associations || {}).find(
+      (name) => normalizeName(name) === normalizeName(labelEntry.name),
+    );
+    associations[labelEntry.name] = [...((actualName && state.associations[actualName]) || [])]
+      .map((item) => ({
+        kind: item.kind,
+        number: item.number,
+        state: item.state,
+        url: item.url,
+      }))
+      .sort((left, right) => itemKey(left).localeCompare(itemKey(right)));
+  }
+
+  return { associations, labels };
+}
+
+function stateFingerprint(state, names) {
+  return crypto.createHash("sha256").update(JSON.stringify(stableState(state, names))).digest("hex");
+}
+
+function validatePolicy(policy) {
+  if (!policy || typeof policy !== "object" || Array.isArray(policy)) {
+    throw new Error("Label policy must be a JSON object.");
+  }
+  if (policy.schemaVersion !== 1) {
+    throw new Error("schemaVersion must be 1.");
+  }
+  if (policy.staffManaged !== true) {
+    throw new Error("staffManaged must be true.");
+  }
+  for (const key of ["groups", "labels", "migrations", "retiredLabels"]) {
+    if (!Array.isArray(policy[key])) {
+      throw new Error(`${key} must be an array.`);
+    }
+  }
+
+  const groups = new Map();
+  for (const group of policy.groups) {
+    if (!group || typeof group !== "object" || !/^[a-z][a-z0-9-]*$/.test(group.id || "")) {
+      throw new Error("Each group id must use lowercase letters, digits, and hyphens.");
+    }
+    if (groups.has(group.id)) {
+      throw new Error(`Duplicate group id: ${group.id}.`);
+    }
+    if (!VALID_CARDINALITIES.has(group.cardinality)) {
+      throw new Error(`Group ${group.id} has an unsupported cardinality.`);
+    }
+    if (
+      !Array.isArray(group.appliesTo) ||
+      group.appliesTo.length === 0 ||
+      group.appliesTo.some((value) => !VALID_APPLIES_TO.has(value)) ||
+      new Set(group.appliesTo).size !== group.appliesTo.length
+    ) {
+      throw new Error(`Group ${group.id} has invalid appliesTo values.`);
+    }
+    groups.set(group.id, group);
+  }
+
+  const desiredNames = new Map();
+  for (const labelEntry of policy.labels) {
+    if (!labelEntry || typeof labelEntry !== "object") {
+      throw new Error("Each label must be an object.");
+    }
+    if (
+      typeof labelEntry.name !== "string" ||
+      labelEntry.name !== labelEntry.name.trim() ||
+      labelEntry.name.length === 0 ||
+      labelEntry.name.length > 50 ||
+      /[\u0000-\u001f\u007f,]/.test(labelEntry.name)
+    ) {
+      throw new Error("Each label name must be printable, trimmed, and 50 characters or fewer.");
+    }
+    const normalized = normalizeName(labelEntry.name);
+    if (desiredNames.has(normalized)) {
+      throw new Error(`Duplicate label name: ${labelEntry.name}.`);
+    }
+    if (!/^[0-9A-F]{6}$/.test(labelEntry.color || "")) {
+      throw new Error(`Label ${labelEntry.name} color must be six uppercase hexadecimal characters.`);
+    }
+    if (
+      typeof labelEntry.description !== "string" ||
+      labelEntry.description.length === 0 ||
+      labelEntry.description.length > 100 ||
+      /[\u0000-\u001f\u007f]/.test(labelEntry.description)
+    ) {
+      throw new Error(`Label ${labelEntry.name} description must be printable and 100 characters or fewer.`);
+    }
+    if (!groups.has(labelEntry.group)) {
+      throw new Error(`Label ${labelEntry.name} references unknown group ${labelEntry.group}.`);
+    }
+    desiredNames.set(normalized, labelEntry);
+  }
+
+  for (const groupId of groups.keys()) {
+    if (!policy.labels.some((labelEntry) => labelEntry.group === groupId)) {
+      throw new Error(`Group ${groupId} has no labels.`);
+    }
+  }
+
+  const migrationSources = new Set();
+  for (const migration of policy.migrations) {
+    if (
+      !migration ||
+      typeof migration.from !== "string" ||
+      typeof migration.to !== "string" ||
+      migration.from.length === 0 ||
+      migration.from.length > 50 ||
+      /[\u0000-\u001f\u007f,]/.test(migration.from)
+    ) {
+      throw new Error("Each migration needs printable from and to label names.");
+    }
+    const source = normalizeName(migration.from);
+    const target = normalizeName(migration.to);
+    if (source === target) {
+      throw new Error(`Migration source and target are identical: ${migration.from}.`);
+    }
+    if (migrationSources.has(source)) {
+      throw new Error(`Duplicate migration source: ${migration.from}.`);
+    }
+    if (!desiredNames.has(target)) {
+      throw new Error(`Migration target ${migration.to} is not a desired label.`);
+    }
+    migrationSources.add(source);
+  }
+
+  const retiredNames = new Set();
+  for (const retired of policy.retiredLabels) {
+    if (
+      !retired ||
+      typeof retired.name !== "string" ||
+      retired.name.length === 0 ||
+      retired.name.length > 50 ||
+      /[\u0000-\u001f\u007f,]/.test(retired.name) ||
+      typeof retired.reason !== "string" ||
+      retired.reason.length === 0 ||
+      retired.reason.length > 200
+    ) {
+      throw new Error("Each retired label needs a valid name and a reason of 200 characters or fewer.");
+    }
+    const normalized = normalizeName(retired.name);
+    if (retiredNames.has(normalized)) {
+      throw new Error(`Duplicate retired label: ${retired.name}.`);
+    }
+    if (desiredNames.has(normalized)) {
+      throw new Error(`Desired label ${retired.name} cannot also be retired.`);
+    }
+    retiredNames.add(normalized);
+  }
+
+  for (const migration of policy.migrations) {
+    if (!retiredNames.has(normalizeName(migration.from))) {
+      throw new Error(`Migration source ${migration.from} must also be listed as retired.`);
+    }
+  }
+
+  return policy;
+}
+
+function validateSnapshot(snapshot) {
+  if (
+    !snapshot ||
+    snapshot.schemaVersion !== 1 ||
+    !validRepository(snapshot.repository) ||
+    !snapshot.state ||
+    !Array.isArray(snapshot.state.labels) ||
+    !snapshot.state.associations ||
+    typeof snapshot.state.associations !== "object" ||
+    Array.isArray(snapshot.state.associations)
+  ) {
+    throw new Error("Snapshot does not contain a valid repository label state.");
+  }
+
+  const labels = new Map();
+  for (const entry of snapshot.state.labels) {
+    if (
+      !entry ||
+      typeof entry.name !== "string" ||
+      entry.name.length === 0 ||
+      entry.name.length > 50 ||
+      /[\u0000-\u001f\u007f]/.test(entry.name) ||
+      !/^[0-9A-Fa-f]{6}$/.test(entry.color || "") ||
+      typeof entry.description !== "string" ||
+      entry.description.length > 100 ||
+      /[\u0000-\u001f\u007f]/.test(entry.description)
+    ) {
+      throw new Error("Snapshot contains an invalid label definition.");
+    }
+    const normalized = normalizeName(entry.name);
+    if (labels.has(normalized)) {
+      throw new Error(`Snapshot contains duplicate label ${entry.name}.`);
+    }
+    labels.set(normalized, entry);
+  }
+
+  for (const [name, items] of Object.entries(snapshot.state.associations)) {
+    if (!labels.has(normalizeName(name)) || !Array.isArray(items)) {
+      throw new Error(`Snapshot associations reference unknown label ${name}.`);
+    }
+    const seen = new Set();
+    for (const item of items) {
+      const validKind = item?.kind === "issue" || item?.kind === "pull_request";
+      const expectedPath = item?.kind === "pull_request" ? "pull" : "issues";
+      const expectedUrl = validKind
+        ? `https://github.com/${snapshot.repository}/${expectedPath}/${item.number}`
+        : "";
+      if (
+        !validKind ||
+        !Number.isSafeInteger(item.number) ||
+        item.number < 1 ||
+        !["open", "closed"].includes(item.state) ||
+        item.url !== expectedUrl
+      ) {
+        throw new Error(`Snapshot contains an invalid association for ${name}.`);
+      }
+      const key = itemKey(item);
+      if (seen.has(key)) {
+        throw new Error(`Snapshot contains duplicate association ${key} for ${name}.`);
+      }
+      seen.add(key);
+    }
+  }
+  return snapshot;
+}
+
+async function loadJson(filePath, maxBytes = MAX_RESPONSE_BYTES) {
+  const stat = await fs.stat(filePath);
+  if (stat.size > maxBytes) {
+    throw new Error(`${filePath} exceeds the ${maxBytes}-byte safety limit.`);
+  }
+  const raw = await fs.readFile(filePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error(`${filePath} is not valid JSON.`);
+  }
+}
+
+async function loadPolicy(filePath) {
+  return validatePolicy(await loadJson(filePath, 1024 * 1024));
+}
+
+function currentLabelMap(state) {
+  return new Map(state.labels.map((entry) => [normalizeName(entry.name), entry]));
+}
+
+function associationList(state, name) {
+  const actualName = Object.keys(state.associations || {}).find(
+    (candidate) => normalizeName(candidate) === normalizeName(name),
+  );
+  return actualName ? state.associations[actualName] : [];
+}
+
+function desiredLabel(labelEntry) {
+  return {
+    name: labelEntry.name,
+    color: labelEntry.color,
+    description: labelEntry.description,
+  };
+}
+
+function buildClassificationAssessment(policy, state) {
+  const groups = new Map(policy.groups.map((group) => [group.id, group]));
+  const desired = new Map(
+    policy.labels.map((labelEntry) => [normalizeName(labelEntry.name), labelEntry]),
+  );
+  const projected = new Map();
+
+  function attach(labelEntry, item) {
+    const key = itemKey(item);
+    const classification = projected.get(key) || { groups: new Map(), item };
+    const labels = classification.groups.get(labelEntry.group) || new Set();
+    labels.add(labelEntry.name);
+    classification.groups.set(labelEntry.group, labels);
+    projected.set(key, classification);
+  }
+
+  for (const labelEntry of policy.labels) {
+    for (const item of associationList(state, labelEntry.name)) attach(labelEntry, item);
+  }
+  for (const migration of policy.migrations) {
+    const target = desired.get(normalizeName(migration.to));
+    for (const item of associationList(state, migration.from)) attach(target, item);
+  }
+
+  const blockers = [];
+  const warnings = [];
+  for (const { groups: itemGroups, item } of projected.values()) {
+    for (const [groupId, names] of itemGroups) {
+      const group = groups.get(groupId);
+      if (!group.appliesTo.includes(item.kind)) {
+        blockers.push({
+          item,
+          label: groupId,
+          reason: `${[...names].join(", ")} does not apply to ${item.kind}`,
+        });
+        continue;
+      }
+      if (
+        ["exactly_one", "zero_or_one"].includes(group.cardinality) &&
+        names.size > 1
+      ) {
+        blockers.push({
+          item,
+          label: groupId,
+          reason: `projected ${groupId} labels conflict: ${[...names].sort().join(", ")}`,
+        });
+      }
+    }
+    if (item.state === "open") {
+      for (const group of groups.values()) {
+        if (
+          group.appliesTo.includes(item.kind) &&
+          ["exactly_one", "one_or_more"].includes(group.cardinality) &&
+          !itemGroups.has(group.id)
+        ) {
+          warnings.push({
+            item,
+            label: group.id,
+            reason: `open item still needs required ${group.id} classification`,
+          });
+        }
+      }
+    }
+  }
+  const order = (left, right) => (
+    itemKey(left.item).localeCompare(itemKey(right.item)) ||
+    left.label.localeCompare(right.label)
+  );
+  return { blockers: blockers.sort(order), warnings: warnings.sort(order) };
+}
+
+function buildApplyPlan(policy, state) {
+  validatePolicy(policy);
+  const assessment = buildClassificationAssessment(policy, state);
+  if (assessment.blockers.length !== 0) {
+    return { ...assessment, operations: [] };
+  }
+  const operations = [];
+  const current = currentLabelMap(state);
+  const migrationsByTarget = new Map();
+
+  for (const migration of policy.migrations) {
+    const target = normalizeName(migration.to);
+    const entries = migrationsByTarget.get(target) || [];
+    entries.push(migration);
+    migrationsByTarget.set(target, entries);
+  }
+
+  for (const configured of policy.labels) {
+    const normalizedTarget = normalizeName(configured.name);
+    const migrations = migrationsByTarget.get(normalizedTarget) || [];
+    let existingTarget = current.get(normalizedTarget);
+    let renamedSource = null;
+    let targetAssociations = new Set(associationList(state, configured.name).map(itemKey));
+
+    if (!existingTarget) {
+      const primary = migrations.find((migration) => current.has(normalizeName(migration.from)));
+      if (primary) {
+        const source = current.get(normalizeName(primary.from));
+        operations.push({
+          kind: "rename",
+          from: source.name,
+          to: configured.name,
+          color: configured.color,
+          description: configured.description,
+        });
+        renamedSource = normalizeName(primary.from);
+        for (const item of associationList(state, source.name)) {
+          targetAssociations.add(itemKey(item));
+        }
+        current.delete(renamedSource);
+        existingTarget = desiredLabel(configured);
+        current.set(normalizedTarget, existingTarget);
+      } else {
+        operations.push({ kind: "create", label: desiredLabel(configured) });
+        existingTarget = desiredLabel(configured);
+        current.set(normalizedTarget, existingTarget);
+      }
+    } else if (
+      existingTarget.name !== configured.name ||
+      existingTarget.color.toUpperCase() !== configured.color ||
+      (existingTarget.description || "") !== configured.description
+    ) {
+      const operation = {
+        kind: "update",
+        name: configured.name,
+        color: configured.color,
+        description: configured.description,
+      };
+      if (existingTarget.name !== configured.name) {
+        operation.from = existingTarget.name;
+      }
+      operations.push(operation);
+    }
+
+    for (const migration of migrations) {
+      const normalizedSource = normalizeName(migration.from);
+      const source = current.get(normalizedSource);
+      if (!source || normalizedSource === renamedSource) {
+        continue;
+      }
+      for (const item of associationList(state, source.name)) {
+        const key = itemKey(item);
+        if (!targetAssociations.has(key)) {
+          operations.push({ kind: "add", name: configured.name, item });
+          targetAssociations.add(key);
+        }
+      }
+    }
+  }
+
+  return assessment.warnings.length === 0
+    ? { operations }
+    : { operations, warnings: assessment.warnings };
+}
+
+function buildRetirementPlan(policy, state) {
+  validatePolicy(policy);
+  const current = currentLabelMap(state);
+  const migrationBySource = new Map(
+    policy.migrations.map((migration) => [normalizeName(migration.from), migration]),
+  );
+  const blockers = [];
+  const candidates = [];
+
+  for (const retired of policy.retiredLabels) {
+    const normalizedSource = normalizeName(retired.name);
+    const source = current.get(normalizedSource);
+    if (!source) {
+      continue;
+    }
+    const sourceAssociations = associationList(state, source.name);
+    const migration = migrationBySource.get(normalizedSource);
+    const target = migration ? current.get(normalizeName(migration.to)) : null;
+    const targetAssociations = new Set(
+      target ? associationList(state, target.name).map(itemKey) : [],
+    );
+
+    for (const item of sourceAssociations.filter((entry) => entry.state === "open")) {
+      if (!target || !targetAssociations.has(itemKey(item))) {
+        blockers.push({
+          label: source.name,
+          item,
+          reason: migration
+            ? `open item is missing replacement ${migration.to}`
+            : "open item has no governed replacement",
+        });
+      }
+    }
+    candidates.push({ kind: "delete", name: source.name, associationCount: sourceAssociations.length });
+  }
+
+  return { blockers, operations: blockers.length === 0 ? candidates : [] };
+}
+
+function buildRestorePlan(policy, snapshot, currentState) {
+  validatePolicy(policy);
+  validateSnapshot(snapshot);
+  const current = currentLabelMap(currentState);
+  const snapshotLabels = currentLabelMap(snapshot.state);
+  const operations = [];
+
+  for (const retired of policy.retiredLabels) {
+    const normalized = normalizeName(retired.name);
+    const saved = snapshotLabels.get(normalized);
+    if (!saved) {
+      continue;
+    }
+    const existing = current.get(normalized);
+    if (!existing) {
+      operations.push({ kind: "create", label: desiredLabel(saved) });
+    } else if (
+      existing.name !== saved.name ||
+      existing.color.toUpperCase() !== saved.color.toUpperCase() ||
+      (existing.description || "") !== saved.description
+    ) {
+      const operation = {
+        kind: "update",
+        name: saved.name,
+        color: saved.color.toUpperCase(),
+        description: saved.description,
+      };
+      if (existing.name !== saved.name) operation.from = existing.name;
+      operations.push(operation);
+    }
+    const currentItems = new Set(associationList(currentState, retired.name).map(itemKey));
+    for (const item of associationList(snapshot.state, saved.name)) {
+      if (!currentItems.has(itemKey(item))) {
+        operations.push({ kind: "add", name: saved.name, item });
+      }
+    }
+  }
+  return { operations };
+}
+
+function assertSnapshotMatches(snapshot, repository, currentState, names) {
+  validateSnapshot(snapshot);
+  if (!snapshot || snapshot.repository !== repository) {
+    throw new Error(`Snapshot belongs to ${snapshot?.repository || "an unknown repository"}, not ${repository}.`);
+  }
+  if (!snapshot.state || !Array.isArray(snapshot.state.labels)) {
+    throw new Error("Snapshot does not contain a valid label state.");
+  }
+  if (stateFingerprint(snapshot.state, names) !== stateFingerprint(currentState, names)) {
+    throw new Error("Live labels changed after the snapshot; capture a new snapshot before retirement.");
+  }
+}
+
+function assertRetirementSnapshotMatches(
+  snapshot,
+  repository,
+  currentState,
+  retiredNames,
+) {
+  validateSnapshot(snapshot);
+  if (snapshot.repository !== repository) {
+    throw new Error(`Snapshot belongs to ${snapshot.repository}, not ${repository}.`);
+  }
+  const retired = new Set(retiredNames.map(normalizeName));
+  const protectedNames = new Set();
+  for (const entry of [...snapshot.state.labels, ...currentState.labels]) {
+    if (!retired.has(normalizeName(entry.name))) protectedNames.add(entry.name);
+  }
+  if (
+    stateFingerprint(snapshot.state, [...protectedNames]) !==
+    stateFingerprint(currentState, [...protectedNames])
+  ) {
+    throw new Error("Non-retired labels changed after the snapshot; capture a new snapshot.");
+  }
+
+  const current = currentLabelMap(currentState);
+  for (const name of retiredNames) {
+    if (!current.has(normalizeName(name))) {
+      continue;
+    }
+    if (stateFingerprint(snapshot.state, [name]) !== stateFingerprint(currentState, [name])) {
+      throw new Error(`Retired label ${name} changed after the snapshot; capture a new snapshot.`);
+    }
+  }
+}
+
+function parseArguments(argv) {
+  const result = {
+    action: "plan",
+    confirmation: "",
+    policyPath: DEFAULT_POLICY_PATH,
+    repository: "",
+    snapshotPath: "",
+  };
+  let explicitAction = false;
+
+  function setAction(action, snapshotPath = "") {
+    if (explicitAction) {
+      throw new Error("Choose exactly one action.");
+    }
+    explicitAction = true;
+    result.action = action;
+    result.snapshotPath = snapshotPath;
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const next = () => {
+      index += 1;
+      if (index >= argv.length) {
+        throw new Error(`${argument} requires a value.`);
+      }
+      return argv[index];
+    };
+    if (argument === "--repo") result.repository = next();
+    else if (argument === "--policy") result.policyPath = next();
+    else if (argument === "--confirm") result.confirmation = next();
+    else if (argument === "--check") setAction("check");
+    else if (argument === "--plan") setAction("plan");
+    else if (argument === "--apply") setAction("apply");
+    else if (argument === "--snapshot") setAction("snapshot", next());
+    else if (argument === "--retire") setAction("retire", next());
+    else if (argument === "--restore") setAction("restore", next());
+    else throw new Error(`Unknown argument: ${argument}.`);
+  }
+
+  if (result.action !== "check" && !validRepository(result.repository)) {
+    throw new Error("--repo must use the owner/repository form.");
+  }
+  const expectedConfirmations = { apply: "APPLY", retire: "RETIRE", restore: "RESTORE" };
+  const expected = expectedConfirmations[result.action];
+  if (expected && result.confirmation !== expected) {
+    throw new Error(`${result.action} requires --confirm ${expected}.`);
+  }
+  return result;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+class GitHubClient {
+  constructor({ fetchImpl = globalThis.fetch, repository, token = "" }) {
+    if (typeof fetchImpl !== "function") {
+      throw new Error("This command requires a Node.js runtime with fetch support.");
+    }
+    if (!validRepository(repository)) {
+      throw new Error("Repository must use the owner/repository form.");
+    }
+    this.fetchImpl = fetchImpl;
+    this.repository = repository;
+    this.token = token;
+  }
+
+  async request(method, endpoint, body = undefined) {
+    const retryable = method === "GET";
+    const maxAttempts = retryable ? 3 : 1;
+    let lastError;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      try {
+        const headers = {
+          accept: "application/vnd.github+json",
+          "x-github-api-version": API_VERSION,
+        };
+        if (this.token) headers.authorization = `Bearer ${this.token}`;
+        if (body !== undefined) headers["content-type"] = "application/json";
+        const response = await this.fetchImpl(`${API_BASE_URL}${endpoint}`, {
+          body: body === undefined ? undefined : JSON.stringify(body),
+          headers,
+          method,
+          signal: controller.signal,
+        });
+        const contentLength = Number(response.headers.get("content-length") || 0);
+        if (contentLength > MAX_RESPONSE_BYTES) {
+          throw new Error("GitHub API response exceeded the safety limit.");
+        }
+        const raw = await response.text();
+        if (Buffer.byteLength(raw) > MAX_RESPONSE_BYTES) {
+          throw new Error("GitHub API response exceeded the safety limit.");
+        }
+        if (!response.ok) {
+          const error = new Error(`GitHub API ${method} ${endpoint} failed with HTTP ${response.status}.`);
+          error.status = response.status;
+          throw error;
+        }
+        if (raw === "") return null;
+        try {
+          return JSON.parse(raw);
+        } catch {
+          throw new Error(`GitHub API ${method} ${endpoint} returned invalid JSON.`);
+        }
+      } catch (error) {
+        lastError = error;
+        const shouldRetry =
+          retryable &&
+          attempt < maxAttempts &&
+          (error.name === "AbortError" || [429, 502, 503, 504].includes(error.status));
+        if (!shouldRetry) throw error;
+        await delay(250 * 4 ** (attempt - 1));
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    throw lastError;
+  }
+
+  async listLabels() {
+    const labels = [];
+    const names = new Set();
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const entries = await this.request(
+        "GET",
+        `/repos/${this.repository}/labels?per_page=100&page=${page}`,
+      );
+      if (!Array.isArray(entries) || entries.length > 100) {
+        throw new Error("GitHub label response was not a bounded array.");
+      }
+      for (const entry of entries) {
+        const description = entry?.description === null ? "" : entry?.description;
+        if (
+          typeof entry?.name !== "string" ||
+          entry.name.length === 0 ||
+          entry.name.length > 50 ||
+          /[\u0000-\u001f\u007f]/.test(entry.name) ||
+          !/^[0-9A-Fa-f]{6}$/.test(entry.color || "") ||
+          typeof description !== "string" ||
+          description.length > 100 ||
+          /[\u0000-\u001f\u007f]/.test(description)
+        ) {
+          throw new Error("GitHub returned an invalid label definition.");
+        }
+        const normalized = normalizeName(entry.name);
+        if (names.has(normalized)) {
+          throw new Error(`GitHub returned duplicate label ${entry.name}.`);
+        }
+        names.add(normalized);
+        labels.push({
+          color: entry.color.toUpperCase(),
+          description,
+          name: entry.name,
+        });
+      }
+      if (entries.length < 100) return labels;
+    }
+    throw new Error(`GitHub label pagination exceeded ${MAX_PAGES} pages.`);
+  }
+
+  async listAssociations(labelName) {
+    const items = [];
+    const seen = new Set();
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const query = new URLSearchParams({
+        labels: labelName,
+        page: String(page),
+        per_page: "100",
+        state: "all",
+      });
+      const entries = await this.request(
+        "GET",
+        `/repos/${this.repository}/issues?${query.toString()}`,
+      );
+      if (!Array.isArray(entries) || entries.length > 100) {
+        throw new Error("GitHub issue response was not a bounded array.");
+      }
+      for (const entry of entries) {
+        const kind = entry?.pull_request ? "pull_request" : "issue";
+        const pathName = kind === "pull_request" ? "pull" : "issues";
+        const expectedUrl = `https://github.com/${this.repository}/${pathName}/${entry?.number}`;
+        const item = {
+          kind,
+          number: entry?.number,
+          state: entry?.state,
+          url: entry?.html_url,
+        };
+        if (
+          !Number.isSafeInteger(item.number) ||
+          item.number < 1 ||
+          !["open", "closed"].includes(item.state) ||
+          item.url !== expectedUrl
+        ) {
+          throw new Error(`GitHub returned an invalid association for ${labelName}.`);
+        }
+        const key = itemKey(item);
+        if (seen.has(key)) {
+          throw new Error(`GitHub returned duplicate association ${key} for ${labelName}.`);
+        }
+        seen.add(key);
+        items.push(item);
+      }
+      if (entries.length < 100) return items;
+    }
+    throw new Error(`GitHub association pagination exceeded ${MAX_PAGES} pages for ${labelName}.`);
+  }
+
+  createLabel(labelEntry) {
+    return this.request("POST", `/repos/${this.repository}/labels`, labelEntry);
+  }
+
+  updateLabel(currentName, labelEntry) {
+    const { name: newName, ...properties } = labelEntry;
+    return this.request(
+      "PATCH",
+      `/repos/${this.repository}/labels/${encodeURIComponent(currentName)}`,
+      { ...properties, new_name: newName },
+    );
+  }
+
+  deleteLabel(name) {
+    return this.request(
+      "DELETE",
+      `/repos/${this.repository}/labels/${encodeURIComponent(name)}`,
+    );
+  }
+
+  addLabel(number, name) {
+    return this.request("POST", `/repos/${this.repository}/issues/${number}/labels`, {
+      labels: [name],
+    });
+  }
+}
+
+async function mapWithConcurrency(values, concurrency, mapper) {
+  const results = new Array(values.length);
+  let cursor = 0;
+
+  async function worker() {
+    while (cursor < values.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await mapper(values[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, () => worker()));
+  return results;
+}
+
+async function readCurrentState(client, associationNames) {
+  const labels = await client.listLabels();
+  const current = new Map(labels.map((entry) => [normalizeName(entry.name), entry]));
+  const actualNames = [];
+  const seen = new Set();
+  for (const requested of associationNames) {
+    const labelEntry = current.get(normalizeName(requested));
+    if (labelEntry && !seen.has(normalizeName(labelEntry.name))) {
+      actualNames.push(labelEntry.name);
+      seen.add(normalizeName(labelEntry.name));
+    }
+  }
+  const associationEntries = await mapWithConcurrency(actualNames, 4, async (name) => [
+    name,
+    await client.listAssociations(name),
+  ]);
+  return { associations: Object.fromEntries(associationEntries), labels };
+}
+
+function operationSummary(operation) {
+  if (operation.kind === "rename") return `rename ${operation.from} -> ${operation.to}`;
+  if (operation.kind === "create") return `create ${operation.label.name}`;
+  if (operation.kind === "update") return `update ${operation.name}`;
+  if (operation.kind === "add") {
+    return `add ${operation.name} to ${operation.item.kind} #${operation.item.number}`;
+  }
+  if (operation.kind === "delete") {
+    return `delete ${operation.name} (${operation.associationCount} historical association(s))`;
+  }
+  return operation.kind;
+}
+
+function printPlan(title, plan) {
+  process.stdout.write(`${title}: ${plan.operations.length} operation(s)\n`);
+  for (const operation of plan.operations) {
+    process.stdout.write(`  - ${operationSummary(operation)}\n`);
+  }
+  for (const blocker of plan.blockers || []) {
+    process.stdout.write(
+      `  BLOCKED: ${blocker.label} on ${blocker.item.kind} #${blocker.item.number}: ${blocker.reason}\n`,
+    );
+  }
+  for (const warning of plan.warnings || []) {
+    process.stdout.write(
+      `  TRIAGE: ${warning.label} on ${warning.item.kind} #${warning.item.number}: ${warning.reason}\n`,
+    );
+  }
+}
+
+async function executeOperations(client, operations) {
+  for (const [index, operation] of operations.entries()) {
+    try {
+      if (operation.kind === "rename") {
+        await client.updateLabel(operation.from, {
+          name: operation.to,
+          color: operation.color,
+          description: operation.description,
+        });
+      } else if (operation.kind === "create") {
+        await client.createLabel(operation.label);
+      } else if (operation.kind === "update") {
+        await client.updateLabel(operation.from || operation.name, {
+          name: operation.name,
+          color: operation.color,
+          description: operation.description,
+        });
+      } else if (operation.kind === "add") {
+        await client.addLabel(operation.item.number, operation.name);
+      } else if (operation.kind === "delete") {
+        await client.deleteLabel(operation.name);
+      } else {
+        throw new Error(`Unsupported operation ${operation.kind}.`);
+      }
+    } catch (error) {
+      throw new Error(
+        `Operation ${index + 1}/${operations.length} failed (${operationSummary(operation)}): ${error.message}`,
+      );
+    }
+  }
+}
+
+async function writeSnapshot(filePath, repository, state) {
+  const snapshot = {
+    schemaVersion: 1,
+    repository,
+    capturedAt: new Date().toISOString(),
+    state,
+  };
+  validateSnapshot(snapshot);
+  const absolutePath = path.resolve(filePath);
+  const temporaryPath = `${absolutePath}.tmp-${process.pid}`;
+  let created = false;
+  try {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(snapshot, null, 2)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    created = true;
+    await fs.link(temporaryPath, absolutePath);
+    await fs.rm(temporaryPath);
+    created = false;
+  } catch (error) {
+    if (created) await fs.rm(temporaryPath, { force: true });
+    throw error;
+  }
+  return absolutePath;
+}
+
+function relevantNames(policy) {
+  return [
+    ...policy.labels.map((entry) => entry.name),
+    ...policy.migrations.flatMap((entry) => [entry.from, entry.to]),
+    ...policy.retiredLabels.map((entry) => entry.name),
+  ];
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const parsed = parseArguments(argv);
+  const policy = await loadPolicy(parsed.policyPath);
+  if (parsed.action === "check") {
+    process.stdout.write(
+      `Label policy is valid: ${policy.labels.length} labels, ${policy.migrations.length} migrations, ${policy.retiredLabels.length} retirements.\n`,
+    );
+    return;
+  }
+
+  const credential = env.GITHUB_TOKEN || env.GH_TOKEN || "";
+  if (["apply", "snapshot", "retire", "restore"].includes(parsed.action) && !credential) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required for this action.");
+  }
+  const client = new GitHubClient({ repository: parsed.repository, token: credential });
+
+  if (parsed.action === "snapshot") {
+    const state = await readCurrentState(client, relevantNames(policy));
+    const written = await writeSnapshot(parsed.snapshotPath, parsed.repository, state);
+    process.stdout.write(`Snapshot written to ${written}.\n`);
+    return;
+  }
+
+  if (parsed.action === "restore") {
+    const snapshot = validateSnapshot(await loadJson(parsed.snapshotPath));
+    if (snapshot.repository !== parsed.repository) {
+      throw new Error(`Snapshot belongs to ${snapshot.repository}, not ${parsed.repository}.`);
+    }
+    const names = policy.retiredLabels.map((entry) => entry.name);
+    const current = await readCurrentState(client, names);
+    const plan = buildRestorePlan(policy, snapshot, current);
+    printPlan("Restore plan", plan);
+    await executeOperations(client, plan.operations);
+    const verified = await readCurrentState(client, names);
+    const remaining = buildRestorePlan(policy, snapshot, verified);
+    if (remaining.operations.length !== 0) {
+      throw new Error("Restore verification found remaining operations.");
+    }
+    return;
+  }
+
+  const names = relevantNames(policy);
+  const current = await readCurrentState(client, names);
+  const applyPlan = buildApplyPlan(policy, current);
+  const retirementPlan = buildRetirementPlan(policy, current);
+  printPlan("Convergence plan", applyPlan);
+  printPlan("Retirement plan", retirementPlan);
+
+  if (parsed.action === "plan") return;
+
+  if (parsed.action === "apply") {
+    if ((applyPlan.blockers || []).length !== 0) {
+      throw new Error("Apply is blocked by conflicting or inapplicable projected classifications.");
+    }
+    await executeOperations(client, applyPlan.operations);
+    const verified = await readCurrentState(client, names);
+    const remaining = buildApplyPlan(policy, verified);
+    if (remaining.operations.length !== 0 || (remaining.blockers || []).length !== 0) {
+      throw new Error("Apply verification found remaining operations.");
+    }
+    return;
+  }
+
+  if (parsed.action === "retire") {
+    if (applyPlan.operations.length !== 0 || (applyPlan.blockers || []).length !== 0) {
+      throw new Error("Desired labels are not converged; run the apply phase before retirement.");
+    }
+    const snapshot = await loadJson(parsed.snapshotPath);
+    assertRetirementSnapshotMatches(
+      snapshot,
+      parsed.repository,
+      current,
+      policy.retiredLabels.map((entry) => entry.name),
+    );
+    if (retirementPlan.blockers.length !== 0) {
+      throw new Error("Retirement is blocked by open items that would lose governed classification.");
+    }
+    await executeOperations(client, retirementPlan.operations);
+    const verified = await readCurrentState(client, names);
+    const remaining = buildRetirementPlan(policy, verified);
+    if (remaining.operations.length !== 0 || remaining.blockers.length !== 0) {
+      throw new Error("Retirement verification found remaining retired labels.");
+    }
+  }
+}
+
+module.exports = {
+  GitHubClient,
+  assertRetirementSnapshotMatches,
+  assertSnapshotMatches,
+  buildApplyPlan,
+  buildRestorePlan,
+  buildRetirementPlan,
+  loadPolicy,
+  main,
+  parseArguments,
+  readCurrentState,
+  validatePolicy,
+  validateSnapshot,
+  writeSnapshot,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`manage-labels: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci/manage-labels.test.js
+++ b/scripts/ci/manage-labels.test.js
@@ -1,0 +1,563 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  GitHubClient,
+  assertRetirementSnapshotMatches,
+  assertSnapshotMatches,
+  buildApplyPlan,
+  buildRestorePlan,
+  buildRetirementPlan,
+  parseArguments,
+  validatePolicy,
+  validateSnapshot,
+  writeSnapshot,
+} = require("./manage-labels.js");
+
+function label(name, color = "ABCDEF", description = `${name} description`) {
+  return { name, color, description };
+}
+
+function association(number, kind = "issue", state = "closed") {
+  return {
+    kind,
+    number,
+    state,
+    url: `https://github.com/owner/repository/${kind === "pull_request" ? "pull" : "issues"}/${number}`,
+  };
+}
+
+function policy(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    staffManaged: true,
+    groups: [
+      {
+        id: "type",
+        appliesTo: ["issue", "pull_request"],
+        cardinality: "exactly_one",
+      },
+      {
+        id: "status",
+        appliesTo: ["issue"],
+        cardinality: "zero_or_one",
+      },
+    ],
+    labels: [
+      { ...label("type: bug", "D73A4A", "A reproducible defect."), group: "type" },
+      { ...label("type: feature", "A2EEEF", "A new user-facing capability."), group: "type" },
+      {
+        ...label("status: needs information", "FBCA04", "Waiting for specific details."),
+        group: "status",
+      },
+    ],
+    migrations: [
+      { from: "autoreview/area-bug", to: "type: bug" },
+      { from: "bug", to: "type: bug" },
+    ],
+    retiredLabels: [
+      { name: "autoreview/area-bug", reason: "Replaced by type: bug." },
+      { name: "bug", reason: "Replaced by type: bug." },
+      { name: "autoreview/queued", reason: "Use native checks." },
+    ],
+    ...overrides,
+  };
+}
+
+function state({ labels = [], associations = {} } = {}) {
+  return { labels, associations };
+}
+
+test("validatePolicy accepts the governed schema", () => {
+  assert.doesNotThrow(() => validatePolicy(policy()));
+});
+
+test("validatePolicy enforces staff ownership and supported schema version", () => {
+  assert.throws(() => validatePolicy(policy({ staffManaged: false })), /staffManaged must be true/);
+  assert.throws(() => validatePolicy(policy({ schemaVersion: 2 })), /schemaVersion must be 1/);
+});
+
+test("validatePolicy rejects ambiguous names, invalid colors, and long descriptions", () => {
+  const duplicate = policy();
+  duplicate.labels.push({ ...label("TYPE: BUG"), group: "type" });
+  assert.throws(() => validatePolicy(duplicate), /duplicate label name/i);
+
+  const badColor = policy();
+  badColor.labels[0].color = "#d73a4a";
+  assert.throws(() => validatePolicy(badColor), /six uppercase hexadecimal/);
+
+  const longDescription = policy();
+  longDescription.labels[0].description = "x".repeat(101);
+  assert.throws(() => validatePolicy(longDescription), /100 characters or fewer/);
+});
+
+test("validatePolicy rejects invalid group and migration references", () => {
+  const unknownGroup = policy();
+  unknownGroup.labels[0].group = "unknown";
+  assert.throws(() => validatePolicy(unknownGroup), /unknown group/);
+
+  const missingTarget = policy();
+  missingTarget.migrations[0].to = "type: missing";
+  assert.throws(() => validatePolicy(missingTarget), /migration target.*not a desired label/i);
+
+  const duplicateSource = policy();
+  duplicateSource.migrations.push({ from: "bug", to: "type: feature" });
+  assert.throws(() => validatePolicy(duplicateSource), /duplicate migration source/i);
+});
+
+test("buildApplyPlan renames the primary source, creates missing labels, and transfers secondary associations", () => {
+  const current = state({
+    labels: [label("autoreview/area-bug", "000000", "Old"), label("bug", "111111", "Old")],
+    associations: {
+      "autoreview/area-bug": [association(1), association(2, "pull_request", "open")],
+      bug: [association(3, "issue", "open")],
+    },
+  });
+
+  assert.deepEqual(buildApplyPlan(policy(), current), {
+    operations: [
+      {
+        kind: "rename",
+        from: "autoreview/area-bug",
+        to: "type: bug",
+        color: "D73A4A",
+        description: "A reproducible defect.",
+      },
+      {
+        kind: "add",
+        name: "type: bug",
+        item: association(3, "issue", "open"),
+      },
+      {
+        kind: "create",
+        label: label("type: feature", "A2EEEF", "A new user-facing capability."),
+      },
+      {
+        kind: "create",
+        label: label(
+          "status: needs information",
+          "FBCA04",
+          "Waiting for specific details.",
+        ),
+      },
+    ],
+  });
+});
+
+test("buildApplyPlan transfers associations when source and target both exist", () => {
+  const current = state({
+    labels: [
+      label("type: bug", "000000", "Drifted"),
+      label("autoreview/area-bug"),
+      label("bug"),
+      label("type: feature", "A2EEEF", "A new user-facing capability."),
+      label("status: needs information", "FBCA04", "Waiting for specific details."),
+    ],
+    associations: {
+      "type: bug": [association(1)],
+      "autoreview/area-bug": [association(1), association(2)],
+      bug: [association(3)],
+    },
+  });
+
+  assert.deepEqual(buildApplyPlan(policy(), current), {
+    operations: [
+      {
+        kind: "update",
+        name: "type: bug",
+        color: "D73A4A",
+        description: "A reproducible defect.",
+      },
+      { kind: "add", name: "type: bug", item: association(2) },
+      { kind: "add", name: "type: bug", item: association(3) },
+    ],
+  });
+});
+
+test("buildApplyPlan is idempotent and never prunes unknown labels", () => {
+  const current = state({
+    labels: [
+      label("type: bug", "D73A4A", "A reproducible defect."),
+      label("type: feature", "A2EEEF", "A new user-facing capability."),
+      label("status: needs information", "FBCA04", "Waiting for specific details."),
+      label("third-party/integration"),
+    ],
+  });
+
+  assert.deepEqual(buildApplyPlan(policy(), current), { operations: [] });
+});
+
+test("buildApplyPlan blocks conflicting or inapplicable projected classifications", () => {
+  const item = association(12, "issue");
+  const conflictPolicy = policy();
+  conflictPolicy.migrations.push({ from: "enhancement", to: "type: feature" });
+  conflictPolicy.retiredLabels.push({ name: "enhancement", reason: "Replaced by type: feature." });
+  const conflict = buildApplyPlan(conflictPolicy, state({
+    labels: [label("type: bug"), label("enhancement")],
+    associations: {
+      "type: bug": [item],
+      enhancement: [item],
+    },
+  }));
+  assert.equal(conflict.operations.length, 0);
+  assert.match(conflict.blockers[0].reason, /type: bug, type: feature/);
+
+  const pullRequest = association(13, "pull_request");
+  const wrongKind = buildApplyPlan(policy(), state({
+    labels: [label("status: needs information")],
+    associations: { "status: needs information": [pullRequest] },
+  }));
+  assert.equal(wrongKind.operations.length, 0);
+  assert.match(wrongKind.blockers[0].reason, /does not apply to pull_request/);
+});
+
+test("buildApplyPlan reports incomplete required classification on open items", () => {
+  const item = association(14, "issue", "open");
+  const plan = buildApplyPlan(policy(), state({
+    labels: [label(
+      "status: needs information",
+      "FBCA04",
+      "Waiting for specific details.",
+    )],
+    associations: { "status: needs information": [item] },
+  }));
+
+  assert.equal(plan.operations.length, 2);
+  assert.deepEqual(plan.warnings, [{
+    item,
+    label: "type",
+    reason: "open item still needs required type classification",
+  }]);
+});
+
+test("buildRetirementPlan blocks open items that have no replacement", () => {
+  const current = state({
+    labels: [
+      label("type: bug", "D73A4A", "A reproducible defect."),
+      label("autoreview/queued"),
+    ],
+    associations: { "autoreview/queued": [association(10, "pull_request", "open")] },
+  });
+
+  assert.deepEqual(buildRetirementPlan(policy(), current), {
+    blockers: [
+      {
+        label: "autoreview/queued",
+        item: association(10, "pull_request", "open"),
+        reason: "open item has no governed replacement",
+      },
+    ],
+    operations: [],
+  });
+});
+
+test("buildRetirementPlan permits migrated open items only after the target is attached", () => {
+  const sourceItem = association(12, "issue", "open");
+  const current = state({
+    labels: [label("type: bug", "D73A4A", "A reproducible defect."), label("bug")],
+    associations: {
+      bug: [sourceItem, association(13)],
+      "type: bug": [sourceItem],
+    },
+  });
+
+  assert.deepEqual(buildRetirementPlan(policy(), current), {
+    blockers: [],
+    operations: [{ kind: "delete", name: "bug", associationCount: 2 }],
+  });
+});
+
+test("assertSnapshotMatches detects label or association drift before retirement", () => {
+  const snapshot = {
+    schemaVersion: 1,
+    repository: "owner/repository",
+    state: state({
+      labels: [label("bug")],
+      associations: { bug: [association(1)] },
+    }),
+  };
+  const current = state({
+    labels: [label("bug")],
+    associations: { bug: [association(1)] },
+  });
+
+  assert.doesNotThrow(() =>
+    assertSnapshotMatches(snapshot, "owner/repository", current, ["bug"]),
+  );
+
+  current.associations.bug.push(association(2));
+  assert.throws(
+    () => assertSnapshotMatches(snapshot, "owner/repository", current, ["bug"]),
+    /live labels changed after the snapshot/i,
+  );
+  assert.throws(
+    () => assertSnapshotMatches(snapshot, "other/repository", snapshot.state, ["bug"]),
+    /belongs to owner\/repository/,
+  );
+});
+
+test("retirement snapshot matching permits a partial-delete resume but protects targets", () => {
+  const snapshot = {
+    schemaVersion: 1,
+    repository: "owner/repository",
+    state: state({
+      labels: [
+        label("bug"),
+        label("type: bug", "D73A4A", "A reproducible defect."),
+      ],
+      associations: {
+        bug: [association(1)],
+        "type: bug": [association(1)],
+      },
+    }),
+  };
+  const afterPartialDelete = state({
+    labels: [label("type: bug", "D73A4A", "A reproducible defect.")],
+    associations: { "type: bug": [association(1)] },
+  });
+
+  assert.doesNotThrow(() =>
+    assertRetirementSnapshotMatches(
+      snapshot,
+      "owner/repository",
+      afterPartialDelete,
+      ["bug"],
+    ),
+  );
+
+  afterPartialDelete.labels[0].description = "Changed after snapshot";
+  assert.throws(
+    () =>
+      assertRetirementSnapshotMatches(
+        snapshot,
+        "owner/repository",
+        afterPartialDelete,
+        ["bug"],
+      ),
+    /non-retired labels changed/i,
+  );
+
+  const unexpectedLabel = state({
+    labels: [
+      label("type: bug", "D73A4A", "A reproducible defect."),
+      label("unexpected"),
+    ],
+    associations: { "type: bug": [association(1)] },
+  });
+  assert.throws(
+    () =>
+      assertRetirementSnapshotMatches(
+        snapshot,
+        "owner/repository",
+        unexpectedLabel,
+        ["bug"],
+      ),
+    /non-retired labels changed/i,
+  );
+});
+
+test("validateSnapshot rejects path injection and cross-label association drift", () => {
+  const maliciousNumber = {
+    schemaVersion: 1,
+    repository: "owner/repository",
+    state: state({
+      labels: [label("bug")],
+      associations: {
+        bug: [{
+          kind: "issue",
+          number: "../../labels",
+          state: "open",
+          url: "https://github.com/owner/repository/issues/../../labels",
+        }],
+      },
+    }),
+  };
+  assert.throws(() => validateSnapshot(maliciousNumber), /invalid association/);
+
+  const unknownLabel = {
+    schemaVersion: 1,
+    repository: "owner/repository",
+    state: state({ labels: [label("bug")], associations: { unknown: [] } }),
+  };
+  assert.throws(() => validateSnapshot(unknownLabel), /unknown label/);
+
+  const maliciousRepository = {
+    schemaVersion: 1,
+    repository: "../..",
+    state: state(),
+  };
+  assert.throws(() => validateSnapshot(maliciousRepository), /valid repository label state/);
+});
+
+test("writeSnapshot uses private permissions and never overwrites an audit snapshot", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "label-snapshot-"));
+  const snapshotPath = path.join(directory, "before.json");
+  try {
+    await writeSnapshot(snapshotPath, "owner/repository", state());
+    assert.equal((await fs.stat(snapshotPath)).mode & 0o777, 0o600);
+    await assert.rejects(
+      writeSnapshot(snapshotPath, "owner/repository", state()),
+      (error) => error?.code === "EEXIST",
+    );
+  } finally {
+    await fs.rm(directory, { force: true, recursive: true });
+  }
+});
+
+test("label management workflow keeps writes manual, trusted, and snapshotted", async () => {
+  const workflow = await fs.readFile(
+    path.resolve(__dirname, "../../.github/workflows/manage-labels.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /Plan triage and catalog changes/);
+  assert.doesNotMatch(workflow, /pull_request(?:_target)?:/);
+  assert.match(workflow, /^permissions: \{\}$/m);
+  assert.equal(
+    (workflow.match(/ref: \$\{\{ github\.event\.repository\.default_branch \}\}/g) || []).length,
+    2,
+  );
+  assert.match(workflow, /issues: read\n\s+pull-requests: read/);
+  assert.match(workflow, /issues: write\n\s+pull-requests: write/);
+  assert.match(workflow, /apply:APPLY\|retire:RETIRE/);
+  assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d/);
+
+  const snapshot = workflow.indexOf("Capture the pre-change audit snapshot");
+  const artifact = workflow.indexOf("Preserve the pre-change audit snapshot");
+  const apply = workflow.indexOf("Converge desired labels and migrate associations");
+  const retire = workflow.indexOf("Retire obsolete labels");
+  assert.ok(snapshot > 0 && snapshot < artifact && artifact < apply && apply < retire);
+});
+
+test("buildRestorePlan restores only explicitly retired labels and their saved associations", () => {
+  const snapshot = {
+    schemaVersion: 1,
+    repository: "owner/repository",
+    state: state({
+      labels: [label("bug", "D73A4A", "Old bug label"), label("third-party/integration")],
+      associations: {
+        bug: [association(7), association(8, "pull_request", "open")],
+      },
+    }),
+  };
+  const empty = state();
+
+  assert.deepEqual(buildRestorePlan(policy(), snapshot, empty), {
+    operations: [
+      { kind: "create", label: label("bug", "D73A4A", "Old bug label") },
+      { kind: "add", name: "bug", item: association(7) },
+      { kind: "add", name: "bug", item: association(8, "pull_request", "open") },
+    ],
+  });
+
+  const restored = state({
+    labels: [label("bug", "D73A4A", "Old bug label")],
+    associations: { bug: [association(7), association(8, "pull_request", "open")] },
+  });
+  assert.deepEqual(buildRestorePlan(policy(), snapshot, restored), { operations: [] });
+
+  restored.labels[0].color = "000000";
+  assert.deepEqual(buildRestorePlan(policy(), snapshot, restored).operations[0], {
+    kind: "update",
+    name: "bug",
+    color: "D73A4A",
+    description: "Old bug label",
+  });
+});
+
+test("parseArguments defaults to a read-only plan and requires typed mutation confirmation", () => {
+  assert.deepEqual(parseArguments(["--repo", "owner/repository"]), {
+    action: "plan",
+    confirmation: "",
+    policyPath: ".github/labels.json",
+    repository: "owner/repository",
+    snapshotPath: "",
+  });
+  assert.throws(
+    () => parseArguments(["--repo", "owner/repository", "--apply", "--confirm", "wrong"]),
+    /--confirm APPLY/,
+  );
+  assert.throws(
+    () => parseArguments(["--repo", "owner/repository", "--retire", "snapshot.json"]),
+    /--confirm RETIRE/,
+  );
+  assert.throws(
+    () => parseArguments(["--repo", "owner/repository", "--restore", "snapshot.json"]),
+    /--confirm RESTORE/,
+  );
+  assert.throws(() => parseArguments(["--repo", "../.."]), /owner\/repository form/);
+});
+
+test("GitHubClient paginates label associations and does not expose response bodies on errors", async () => {
+  const calls = [];
+  const firstPage = Array.from({ length: 100 }, (_, index) => ({
+    html_url: `https://github.com/owner/repository/issues/${index + 1}`,
+    number: index + 1,
+    state: "closed",
+  }));
+  const fetchImpl = async (url, options) => {
+    calls.push([url, options]);
+    const page = new URL(url).searchParams.get("page");
+    return new Response(JSON.stringify(page === "1" ? firstPage : [{
+      html_url: "https://github.com/owner/repository/pull/101",
+      number: 101,
+      pull_request: {},
+      state: "open",
+    }]), { status: 200, headers: { "content-type": "application/json" } });
+  };
+  const client = new GitHubClient({ fetchImpl, repository: "owner/repository", token: "secret" });
+
+  const items = await client.listAssociations("type: bug");
+
+  assert.equal(calls.length, 2);
+  assert.equal(items.length, 101);
+  assert.equal(items[100].kind, "pull_request");
+  assert.match(calls[0][0], /labels=type%3A\+bug/);
+  assert.equal(calls[0][1].headers.authorization, "Bearer secret");
+
+  await client.updateLabel("old label", label("type: bug", "D73A4A", "A defect."));
+  assert.match(calls[2][0], /labels\/old%20label$/);
+  assert.deepEqual(JSON.parse(calls[2][1].body), {
+    color: "D73A4A",
+    description: "A defect.",
+    new_name: "type: bug",
+  });
+
+  const failed = new GitHubClient({
+    fetchImpl: async () => new Response('{"message":"secret leaked"}', { status: 500 }),
+    repository: "owner/repository",
+    token: "secret",
+  });
+  await assert.rejects(() => failed.listLabels(), (error) => {
+    assert.doesNotMatch(error.message, /secret leaked/);
+    assert.match(error.message, /GitHub API GET .* failed with HTTP 500/);
+    return true;
+  });
+});
+
+test("GitHubClient rejects malformed live label and association data", async () => {
+  const badLabel = new GitHubClient({
+    fetchImpl: async () => new Response(JSON.stringify([{
+      color: "not-hex",
+      description: "Broken",
+      name: "bad",
+    }]), { status: 200 }),
+    repository: "owner/repository",
+  });
+  await assert.rejects(() => badLabel.listLabels(), /invalid label definition/);
+
+  const badItem = new GitHubClient({
+    fetchImpl: async () => new Response(JSON.stringify([{
+      html_url: "https://example.invalid/redirect",
+      number: 1,
+      state: "open",
+    }]), { status: 200 }),
+    repository: "owner/repository",
+  });
+  await assert.rejects(() => badItem.listAssociations("bug"), /invalid association/);
+});

--- a/scripts/ci/run-node-checks.sh
+++ b/scripts/ci/run-node-checks.sh
@@ -25,6 +25,8 @@ run_node_tests() {
     local file
     local -a test_files=()
 
+    node scripts/ci/manage-labels.js --check
+
     while IFS= read -r file; do
         test_files+=("$file")
     done < <(git ls-files '*.test.js' 'linux-features/*/test.js')

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -169,6 +169,9 @@ test("upstream workflow concurrency is isolated per PR or ref", () => {
   assert.doesNotMatch(workflow, /group: upstream-dmg-acceptance-\$\{\{ github\.event_name \}\}\s*$/m);
   assert.equal((workflow.match(/- linux-features\/\*\*/g) ?? []).length, 2);
   assert.equal((workflow.match(/- scripts\/lib\/linux-features\.js/g) ?? []).length, 2);
+  assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d/);
+  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
 });
 
 test("Nix refresh serializes campaigns and deduplicates refresh and exact-head CI", () => {

--- a/scripts/ci/upstream-dmg-issue.js
+++ b/scripts/ci/upstream-dmg-issue.js
@@ -1,7 +1,30 @@
 "use strict";
 
-const LABEL = "upstream-dmg-drift";
+const labelPolicy = require("../../.github/labels.json");
+
+const LABEL = "area: upstream dmg";
+const MANUAL_ONLY_LABEL = "workflow: manual only";
+const ISSUE_LABELS = ["type: bug", LABEL, "status: ready for work"];
+const LEGACY_LABELS = labelPolicy.migrations
+  .filter(({ to }) => to === LABEL)
+  .map(({ from }) => from);
 const FINGERPRINT_PATTERN = /<!-- upstream-dmg-fingerprint:([a-f0-9]{64}) -->/i;
+
+function labelDefinition(name) {
+  const definition = labelPolicy.labels.find((candidate) => candidate.name === name);
+  if (!definition) {
+    throw new Error(`Missing ${name} in .github/labels.json`);
+  }
+  return definition;
+}
+
+const ISSUE_LABEL_DEFINITIONS = ISSUE_LABELS.map(labelDefinition);
+
+function hasLabel(issue, name) {
+  return (issue.labels || []).some((label) => (
+    typeof label === "string" ? label === name : label?.name === name
+  ));
+}
 
 function fingerprintMarker(fingerprint) {
   return `<!-- upstream-dmg-fingerprint:${fingerprint} -->`;
@@ -47,27 +70,41 @@ function issueBody(decision) {
 }
 
 async function listTrackingIssues(github, repo) {
-  const params = { ...repo, state: "all", labels: LABEL, per_page: 100 };
-  const issues = github.paginate
-    ? await github.paginate(github.rest.issues.listForRepo, params)
-    : (await github.rest.issues.listForRepo(params)).data;
+  const issuesByNumber = new Map();
+  for (const label of [LABEL, ...LEGACY_LABELS]) {
+    const params = { ...repo, state: "all", labels: label, per_page: 100 };
+    let issues;
+    try {
+      issues = github.paginate
+        ? await github.paginate(github.rest.issues.listForRepo, params)
+        : (await github.rest.issues.listForRepo(params)).data;
+    } catch (error) {
+      if (error?.status === 404) continue;
+      throw error;
+    }
+    for (const issue of issues) issuesByNumber.set(issue.number, issue);
+  }
   // The label is public repository metadata and may also be useful on a
   // maintainer-created issue. Only the hidden fingerprint marker proves that
   // this automation owns an issue and may mutate its lifecycle.
-  return issues.filter((issue) => issue.pull_request == null && issueFingerprint(issue) !== null);
+  return [...issuesByNumber.values()].filter(
+    (issue) => issue.pull_request == null && issueFingerprint(issue) !== null,
+  );
 }
 
-async function ensureLabel(github, repo) {
-  try {
-    await github.rest.issues.getLabel({ ...repo, name: LABEL });
-  } catch (error) {
-    if (error?.status !== 404) throw error;
-    await github.rest.issues.createLabel({
-      ...repo,
-      name: LABEL,
-      color: "d93f0b",
-      description: "Current upstream DMG failed the shared acceptance profile",
-    });
+async function ensureLabels(github, repo) {
+  for (const definition of ISSUE_LABEL_DEFINITIONS) {
+    try {
+      await github.rest.issues.getLabel({ ...repo, name: definition.name });
+    } catch (error) {
+      if (error?.status !== 404) throw error;
+      await github.rest.issues.createLabel({
+        ...repo,
+        name: definition.name,
+        color: definition.color,
+        description: definition.description,
+      });
+    }
   }
 }
 
@@ -96,18 +133,12 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
     return { action: "ignored-stale-candidate" };
   }
 
-  let issues;
-  try {
-    issues = await listTrackingIssues(github, repo);
-  } catch (error) {
-    if (error?.status === 404 && decision.verdict !== "rejected") {
-      return { action: "no-tracking-label" };
-    }
-    throw error;
-  }
+  const issues = await listTrackingIssues(github, repo);
 
   if (decision.verdict === "accepted" || decision.verdict === "accepted_with_warnings") {
-    const openIssues = issues.filter((issue) => issue.state === "open");
+    const openIssues = issues.filter(
+      (issue) => issue.state === "open" && !hasLabel(issue, MANUAL_ONLY_LABEL),
+    );
     for (const issue of openIssues) {
       await closeIssue(
         github,
@@ -120,10 +151,14 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
     return { action: "closed-resolved", count: openIssues.length };
   }
 
-  await ensureLabel(github, repo);
+  await ensureLabels(github, repo);
   const fingerprint = decision.dmg.sha256.toLowerCase();
   const matching = issues.find((issue) => issueFingerprint(issue) === fingerprint);
-  const obsolete = issues.filter((issue) => issue.state === "open" && issueFingerprint(issue) !== fingerprint);
+  const obsolete = issues.filter((issue) => (
+    issue.state === "open" &&
+    issueFingerprint(issue) !== fingerprint &&
+    !hasLabel(issue, MANUAL_ONLY_LABEL)
+  ));
   for (const issue of obsolete) {
     await closeIssue(
       github,
@@ -137,8 +172,16 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
   const title = issueTitle(decision);
   const body = issueBody(decision);
   if (matching) {
+    if (hasLabel(matching, MANUAL_ONLY_LABEL)) {
+      return { action: "manual-only", issueNumber: matching.number };
+    }
     const wasOpen = matching.state === "open";
     const alreadyReported = matching.body?.includes(runMarker(decision.run.id));
+    await github.rest.issues.addLabels({
+      ...repo,
+      issue_number: matching.number,
+      labels: ISSUE_LABELS,
+    });
     await github.rest.issues.update({
       ...repo,
       issue_number: matching.number,
@@ -156,7 +199,7 @@ async function reconcileUpstreamDmgIssue({ github, repo, decision, currentHttpId
     return { action: wasOpen ? "updated" : "reopened", issueNumber: matching.number };
   }
 
-  const created = await github.rest.issues.create({ ...repo, title, body, labels: [LABEL] });
+  const created = await github.rest.issues.create({ ...repo, title, body, labels: ISSUE_LABELS });
   return { action: "created", issueNumber: created.data.number };
 }
 

--- a/scripts/ci/upstream-dmg-issue.test.js
+++ b/scripts/ci/upstream-dmg-issue.test.js
@@ -23,6 +23,7 @@ function fakeGithub(initialIssues = []) {
   rest.issues.listForRepo = async () => ({ data: issues });
   rest.issues.getLabel = async () => ({ data: {} });
   rest.issues.createLabel = async (args) => { calls.push(["createLabel", args]); return { data: {} }; };
+  rest.issues.addLabels = async (args) => { calls.push(["addLabels", args]); return { data: {} }; };
   rest.issues.createComment = async (args) => { calls.push(["comment", args]); return { data: {} }; };
   rest.issues.update = async (args) => {
     calls.push(["update", args]);
@@ -47,6 +48,11 @@ test("creates one issue for a rejected current fingerprint", async () => {
   });
   assert.equal(result.action, "created");
   assert.equal(fixture.calls.filter(([name]) => name === "create").length, 1);
+  assert.deepEqual(fixture.calls.find(([name]) => name === "create")[1].labels, [
+    "type: bug",
+    "area: upstream dmg",
+    "status: ready for work",
+  ]);
 });
 
 test("closes old fingerprints before creating the new issue", async () => {
@@ -87,6 +93,35 @@ test("does not add a duplicate comment for the same workflow run", async () => {
   });
   assert.equal(result.action, "updated");
   assert.equal(fixture.calls.filter(([name]) => name === "comment").length, 0);
+  assert.deepEqual(fixture.calls.find(([name]) => name === "addLabels")[1].labels, [
+    "type: bug",
+    "area: upstream dmg",
+    "status: ready for work",
+  ]);
+});
+
+test("manual-only tracking issues are never edited, commented on, or closed", async () => {
+  const sha = "9".repeat(64);
+  for (const verdict of ["accepted", "rejected"]) {
+    const fixture = fakeGithub([{
+      number: 30,
+      state: "open",
+      body: fingerprintMarker(sha),
+      labels: [{ name: "workflow: manual only" }],
+    }]);
+    const result = await reconcileUpstreamDmgIssue({
+      github: fixture.github,
+      repo: { owner: "o", repo: "r" },
+      decision: decision(verdict, sha),
+      currentHttpIdentityKey: "current",
+    });
+
+    if (verdict === "rejected") assert.equal(result.action, "manual-only");
+    assert.equal(
+      fixture.calls.some(([name]) => ["addLabels", "comment", "update"].includes(name)),
+      false,
+    );
+  }
 });
 
 test("does not mutate issues for stale or inconclusive runs", async () => {


### PR DESCRIPTION
## Summary

This PR proposes a staff-managed label system for issues and pull requests, together with the governance and migration tooling needed to keep it consistent.

The current repository has 40 labels, including 28 `autoreview/*` labels that largely expose automation state or duplicate information GitHub already provides. The proposed catalog replaces that with 37 human-readable labels organized by type, area, issue status, impact, pull request risk, community, workflow control, resolution, and synchronization.

The change also:

- makes `.github/labels.json` the reviewed source of truth for names, colors, descriptions, cardinalities, migrations, and retirements
- documents in `CONTRIBUTING.md`, `AGENTS.md`, and the pull request template that labels are assigned by maintainers and authorized collaborators, not self-selected by contributors
- gives authorized repository automation a deterministic vocabulary while preserving native checks, draft state, mergeability, reviews, and timestamps as GitHub state
- adds a trusted manual workflow with separate `plan`, `apply`, and `retire` phases, typed confirmations, a pre-change snapshot, and a bounded restore path
- updates the Computer Use and upstream DMG issue producers to read complete classifications from the policy
- makes existing item automation respect `workflow: manual only`

## Why this helps

For maintainers and contributors, the issue and pull request lists become easier to scan: labels answer what the work is, which source area owns it, what an issue needs next, and how broadly a pull request should be validated.

For authorized triage automation, the same catalog provides stable names and explicit cardinality rules without turning internal job states into public labels. Uncertainty remains visible through triage statuses instead of being guessed from a title.

## Authority boundary

Contributors without repository label permission provide facts, reproduction details, scope, and validation results. They do not choose or apply labels to their own issues or pull requests.

Maintainers and authorized collaborators make the final classification. An agent without explicit delegated authority may propose a classification, but it cannot mutate repository labels. Bulk catalog changes run only from reviewed code on the trusted default branch.

## Safe rollout

This PR does not change any live repository label.

After merge, the intended staff-controlled sequence is:

1. Update or disable external automation that still writes retired `autoreview/*` names.
2. Run the read-only `plan` operation.
   Review its triage notices for open migrated items that still need a required staff classification.
3. Run `apply` with the typed `APPLY` confirmation to create or rename desired labels and transfer governed associations.
4. Review any retirement blocker. Today, issue #944 remains on `computer-use-sync`; the updated producer and migration path prevent a duplicate reminder during the transition.
5. Run `retire` with the typed `RETIRE` confirmation only after the snapshot and blocker checks pass.

Unknown labels are never pruned. Retirement is limited to the 38 names explicitly listed in the policy and stops before deletion if an open item would lose its governed replacement.

## Discussion

@ilysenko, @joshyorko, and @avifenesh: these names, group boundaries, colors, cardinalities, and migration choices are proposals for discussion, not immutable decisions. Please challenge anything that would make day-to-day triage less clear. Contributions are welcome, and please feel free to suggest or push edits directly to this PR as the decisions are refined.

## Validation

- 1,071 repository Node tests
- focused migration, snapshot, producer, manual-only, workflow-order, and REST contract tests
- live read-only plan against the current 40-label repository state
- actionlint, yamllint, ShellCheck, Semgrep, policy validation, and diff checks
- public contribution impact, security, review, and fact-check gates

The only external prerequisite is the existing autoreview configuration, which is not stored in this repository. The committed retirement phase therefore remains blocked until staff confirms that producer has been updated or disabled.
