### PR TITLE
Fix feature drift for current upstream DMG

### DIFF
--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -156,7 +156,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_730,
     ciPolicy: "optional",
-    pattern: /^(?:app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz|app-initial~artifact-tab-content\.electron~app-main~appgen-settings-page~page~pull-request-r~napudbu0)-[^.]+\.js$/,
+    pattern: /^(?:app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar|app-initial~app-main~onboarding-page)-[^.]+\.js$/,
     missingDescription: "main app chrome bundle",
     skipDescription: "frameless titlebar webview layout patch",
     apply: applyFramelessTitlebarWebviewPatch,

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -66,10 +66,18 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
       (descriptor) => descriptor.id === "feature:frameless-titlebar:webview-window-controls-layout",
     );
     assert.match(
-      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-CnQKtQ6U.js",
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
       webviewPatch.pattern,
     );
     assert.match(
+      "app-initial~app-main~onboarding-page-CIkoyvFz.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-CnQKtQ6U.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
       "app-initial~artifact-tab-content.electron~app-main~appgen-settings-page~page~pull-request-r~napudbu0-BLPFEZVT.js",
       webviewPatch.pattern,
     );
@@ -81,7 +89,6 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
       "app-initial~artifact-tab-content.electron~app-main~new-thread-panel-page~onboarding-page~pr~el73lghr-qHKfocxV.js",
       webviewPatch.pattern,
     );
-    assert.doesNotMatch("app-initial~app-main~onboarding-page-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("use-window-controls-safe-area-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("app-initial~app-main~onboarding-page~debug-window-page-abc.js", webviewPatch.pattern);
     assert.doesNotMatch("app-main-abc.js", webviewPatch.pattern);

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -829,7 +829,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-[^.]+\.js$/,
+      pattern: /^app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~nrw3o0ql-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1400,6 +1400,10 @@ test("open-target discovery targets only the current native selector bundle", ()
 
   assert.ok(descriptor);
   assert.match(
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~nrw3o0ql-CI1_Z0oj.js",
+    descriptor.pattern,
+  );
+  assert.doesNotMatch(
     "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-CnQKtQ6U.js",
     descriptor.pattern,
   );

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -52,7 +52,7 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_RUNTIME_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-[^.]+\.js$/u;
+  /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-[^.]+\.js$/u;
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -44,8 +44,6 @@ const {
 const remoteMobilePatchDescriptors = require("./patch.js");
 
 const REPO_ROOT = path.resolve(__dirname, "../..");
-const OLD_REMOTE_CONTROL_GATE_ASSET =
-  "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-test.js";
 const OLD_APP_SERVER_MANAGER_ASSET =
   "app-initial~app-main~hotkey-window-thread-page~thread-app-shell-chrome~header~remote-conver~test.js";
 const CURRENT_REMOTE_CONVERSATION_ASSET =
@@ -53,9 +51,9 @@ const CURRENT_REMOTE_CONVERSATION_ASSET =
 const LATEST_REMOTE_CONVERSATION_ASSET =
   "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~glxlkd48-test.js";
 const OLD_REMOTE_RUNTIME_ASSET =
-  "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-test.js";
-const CURRENT_REMOTE_RUNTIME_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
+const CURRENT_REMOTE_RUNTIME_ASSET =
+  "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-test.js";
 const CURRENT_APP_MAIN_PAGE_ASSET =
   "app-initial~app-main~page-test.js";
 const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET = CURRENT_APP_MAIN_PAGE_ASSET;
@@ -1104,7 +1102,6 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test(LATEST_REMOTE_CONVERSATION_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_RUNTIME_ASSET), false);
-    assert.equal(loadGateDescriptor.pattern.test(OLD_REMOTE_CONTROL_GATE_ASSET), false);
     assert.equal(loadGateDescriptor.pattern.test("remote-connection-visibility-test.js"), false);
     assert.equal(loadGateDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
 

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -3,9 +3,9 @@
 const MODEL_PICKER_STATE_ASSET_PATTERN =
   /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
 const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page-[^.]+\.js$/;
+  /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/;
 const MODEL_PICKER_MENU_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page-[^.]+\.js$/;
+  /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -183,7 +183,7 @@ test("model picker descriptors target the current state and menu bundles", () =>
   const stateAsset =
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
   const allowlistAsset =
-    "app-initial~app-main~onboarding-page-qmFVRsFx.js";
+    "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-BjNKtmac.js";
   const menuAsset = allowlistAsset;
 
   assert.match(stateAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
@@ -214,7 +214,7 @@ test("model picker descriptors target the current state and menu bundles", () =>
     MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-EGSyoZAU.js",
+    "app-initial~app-main~onboarding-page-qmFVRsFx.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
 });


### PR DESCRIPTION
<!-- upstream-dmg-sha256:40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6 -->

## Summary
- retarget remote mobile control patches to the current runtime bundle
- retarget UI model-picker patches to the current model-picker bundle
- retarget open-target discovery and frameless-titlebar patches used by the Nix multi-feature build
- remove obsolete selectors for earlier DMG layouts

## Tests
- `node --test linux-features/open-target-discovery/test.js linux-features/frameless-titlebar/test.js linux-features/remote-mobile-control/test.js linux-features/ui-tweaks/test.js`
- current-DMG acceptance: `accepted_with_warnings` (two unrelated optional core warnings)
- focused Nix preflight: `.#checks.x86_64-linux.nix-linux-features-multi-feature`