### PR TITLE
Fix launcher recovery after webview parent death

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -252,8 +252,11 @@ ADOPTED_WEBVIEW_PID=""
 ELECTRON_PID=""
 RUNNING_APP_PID=""
 WARM_START=0
-LAUNCHER_LOCK_FD_OPEN=0
+LAUNCHER_LOCK_HELD=0
 LAUNCHER_LOCK_TIMED_OUT=0
+LAUNCHER_LOCK_HELPER_PID=""
+LAUNCHER_LOCK_HELPER_START_TIME=""
+LAUNCHER_LOCK_STATUS_PATH=""
 
 if [[ "${LAUNCHER_ARGS[0]:-}" == "--help" || "${LAUNCHER_ARGS[0]:-}" == "-h" ]]; then
     cat <<HELP
@@ -1948,6 +1951,34 @@ pid_environ_lines() {
     tr '\0' '\n' 2>/dev/null < "/proc/$pid/environ" || true
 }
 
+pid_environ_value() {
+    local pid="$1"
+    local key="$2"
+    local entry
+
+    [ -r "/proc/$pid/environ" ] || return 1
+    while IFS= read -r -d '' entry; do
+        case "$entry" in
+            "$key="*) printf '%s\n' "${entry#*=}"; return 0 ;;
+        esac
+    done < "/proc/$pid/environ" 2>/dev/null
+    return 1
+}
+
+pid_start_time() {
+    local pid="$1"
+    local stat_line
+    local rest
+
+    [ -r "/proc/$pid/stat" ] || return 1
+    stat_line=$(< "/proc/$pid/stat") || return 1
+    rest=${stat_line##*) }
+    set -- $rest
+    # /proc/<pid>/stat field 22 is token 20 after stripping pid and comm.
+    [ -n "${20:-}" ] || return 1
+    printf '%s\n' "${20}"
+}
+
 pid_matches_executable() {
     local pid="$1"
     local expected="$2"
@@ -2082,45 +2113,6 @@ pid_summary() {
     printf 'pid=%s exe=%s cmd=%s' "$pid" "${exe:-unknown}" "${cmdline:-unknown}"
 }
 
-pid_is_orphaned_runtime_process() {
-    local pid="$1"
-    local cmdline
-    local arg0
-
-    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
-    [ "$pid" != "$$" ] || return 1
-    [ -d "/proc/$pid" ] || return 1
-
-    arg0="$(pid_cmdline_arg0_path "$pid")"
-    case "$arg0" in
-        "$SCRIPT_DIR/electron"|"$SCRIPT_DIR/electron "*)
-            pid_is_current_user "$pid" || return 1
-            pid_matches_app_identity "$pid" || return 1
-            pid_is_electron_helper "$pid"
-            ;;
-        "$SCRIPT_DIR/chrome_crashpad_handler"|"$SCRIPT_DIR/chrome_crashpad_handler "*|"$SCRIPT_DIR/resources/node-runtime/bin/node"|"$SCRIPT_DIR/resources/node-runtime/bin/node "*|"$SCRIPT_DIR/resources/node_repl"|"$SCRIPT_DIR/resources/node_repl "*)
-            pid_is_current_user "$pid" || return 1
-            pid_matches_app_identity "$pid" || return 1
-            return 0
-            ;;
-        *)
-            case "$arg0" in
-                "$SCRIPT_DIR"/*) ;;
-                *) return 1 ;;
-            esac
-            cmdline="$(pid_cmdline "$pid")"
-            case "$cmdline" in
-                *"$SCRIPT_DIR/resources/node-runtime/bin/node"*|*"$SCRIPT_DIR/resources/node_repl"*)
-                    pid_is_current_user "$pid" || return 1
-                    pid_matches_app_identity "$pid" || return 1
-                    return 0
-                    ;;
-            esac
-            return 1
-            ;;
-    esac
-}
-
 detect_cross_install_conflict() {
     local pid
     local install_dir
@@ -2189,6 +2181,182 @@ detect_warm_start() {
         WARM_START=0
         echo "Warm-start handoff disabled by $APP_SETTINGS_FILE"
     fi
+}
+
+running_app_uses_renderer_url_override() {
+    local allow_override
+    local renderer_url
+
+    running_app_is_active || return 1
+    allow_override="$(pid_environ_value "$RUNNING_APP_PID" CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE 2>/dev/null || true)"
+    truthy_env_value "$allow_override" || return 1
+    renderer_url="$(pid_environ_value "$RUNNING_APP_PID" ELECTRON_RENDERER_URL 2>/dev/null || true)"
+    [ -n "$renderer_url" ] && [ "$renderer_url" != "$WEBVIEW_ORIGIN/" ]
+}
+
+terminate_stale_electron_with_pidfd() {
+    local pid="$1"
+    local expected_start_time
+
+    pid_matches_executable "$pid" "$SCRIPT_DIR/electron" || return 1
+    expected_start_time="$(pid_start_time "$pid")" || return 1
+
+    python3 - \
+        "$pid" \
+        "$expected_start_time" \
+        "$SCRIPT_DIR/electron" \
+        "$CODEX_LINUX_APP_ID" \
+        "$CODEX_LINUX_INSTANCE_ID" \
+        "$MULTI_LAUNCH_ACTIVE" <<'PY'
+import os
+import select
+import signal
+import sys
+
+pid = int(sys.argv[1])
+expected_start_time = sys.argv[2]
+expected_executable = sys.argv[3]
+expected_app_id = sys.argv[4]
+expected_instance_id = sys.argv[5]
+expected_multi_launch = sys.argv[6] == "1"
+
+if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+    print("pidfd APIs are unavailable; refusing to terminate the stale Electron process", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    pidfd = os.pidfd_open(pid, 0)
+except OSError as exc:
+    print(f"could not open pidfd for stale Electron pid {pid}: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    with open(f"/proc/{pid}/stat", "r", encoding="utf-8") as handle:
+        stat_fields = handle.read().rsplit(") ", 1)[1].split()
+    actual_start_time = stat_fields[19]
+    with open(f"/proc/{pid}/status", "r", encoding="utf-8") as handle:
+        status_lines = handle.read().splitlines()
+    uid_line = next(line for line in status_lines if line.startswith("Uid:"))
+    actual_uid = int(uid_line.split()[1])
+    with open(f"/proc/{pid}/cmdline", "rb") as handle:
+        cmdline = [part for part in handle.read().split(b"\0") if part]
+    with open(f"/proc/{pid}/environ", "rb") as handle:
+        environ_entries = [part for part in handle.read().split(b"\0") if b"=" in part]
+except (OSError, IndexError, StopIteration, ValueError) as exc:
+    print(f"could not revalidate stale Electron pid {pid}: {exc}", file=sys.stderr)
+    os.close(pidfd)
+    sys.exit(1)
+
+environ = {}
+for entry in environ_entries:
+    key, value = entry.split(b"=", 1)
+    environ[os.fsdecode(key)] = os.fsdecode(value)
+
+identity_matches = (
+    actual_start_time == expected_start_time
+    and actual_uid == os.geteuid()
+    and bool(cmdline)
+    and os.fsdecode(cmdline[0]) == expected_executable
+    and not any(part.startswith(b"--type=") for part in cmdline[1:])
+    and expected_app_id in {
+        environ.get("CODEX_LINUX_APP_ID"),
+        environ.get("CODEX_APP_ID"),
+    }
+)
+if expected_multi_launch:
+    identity_matches = identity_matches and environ.get("CODEX_LINUX_INSTANCE_ID") == expected_instance_id
+else:
+    identity_matches = identity_matches and environ.get("CODEX_LINUX_MULTI_LAUNCH") != "1"
+
+if not identity_matches:
+    print(f"stale Electron pid {pid} failed identity revalidation", file=sys.stderr)
+    os.close(pidfd)
+    sys.exit(1)
+
+poller = select.poll()
+poller.register(pidfd, select.POLLIN)
+try:
+    signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+except ProcessLookupError:
+    os.close(pidfd)
+    sys.exit(0)
+except OSError as exc:
+    print(f"could not terminate stale Electron pid {pid}: {exc}", file=sys.stderr)
+    os.close(pidfd)
+    sys.exit(1)
+
+if not poller.poll(2000):
+    try:
+        signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    except OSError as exc:
+        print(f"could not kill stale Electron pid {pid}: {exc}", file=sys.stderr)
+        os.close(pidfd)
+        sys.exit(1)
+    if not poller.poll(1000):
+        print(f"stale Electron pid {pid} did not exit", file=sys.stderr)
+        os.close(pidfd)
+        sys.exit(1)
+
+os.close(pidfd)
+PY
+}
+
+recover_unhealthy_running_app() {
+    running_app_is_active || return 0
+
+    if running_app_uses_renderer_url_override; then
+        echo "Skipping packaged webview recovery because an explicit renderer URL override is active"
+        return 0
+    fi
+    webview_origin_is_reachable && return 0
+
+    if webview_port_is_open; then
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME packaged webview origin is unhealthy, but port $CODEX_LINUX_WEBVIEW_PORT is occupied. Keeping the live Electron process untouched. Close it manually and retry."
+        exit 1
+    fi
+
+    echo "Detected live Electron pid=$RUNNING_APP_PID with an unavailable packaged webview origin; preparing a safe cold-start recovery"
+    acquire_launcher_lock
+    if [ "$LAUNCHER_LOCK_HELD" -ne 1 ] || [ "$LAUNCHER_LOCK_TIMED_OUT" -eq 1 ]; then
+        release_launcher_lock
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME could not lock launcher state for safe webview recovery. Keeping the live Electron process untouched; close it manually and retry."
+        exit 1
+    fi
+
+    refresh_launch_state_quick
+    if ! running_app_is_active; then
+        WARM_START=0
+        reconcile_runtime_state
+        return 0
+    fi
+    if running_app_uses_renderer_url_override; then
+        release_launcher_lock
+        echo "Skipping packaged webview recovery because the running app uses an explicit renderer URL override"
+        return 0
+    fi
+    if webview_origin_is_reachable; then
+        release_launcher_lock
+        echo "Packaged webview origin recovered while waiting for launcher state"
+        return 0
+    fi
+    if webview_port_is_open; then
+        release_launcher_lock
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME packaged webview port became occupied during recovery. Keeping the live Electron process untouched; close it manually and retry."
+        exit 1
+    fi
+
+    if ! terminate_stale_electron_with_pidfd "$RUNNING_APP_PID"; then
+        release_launcher_lock
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME could not safely verify and stop stale Electron pid $RUNNING_APP_PID. Close it manually and retry."
+        exit 1
+    fi
+
+    echo "Stopped identity-verified stale Electron pid=$RUNNING_APP_PID; continuing with a cold start"
+    WARM_START=0
+    RUNNING_APP_PID=""
+    rm -f "$APP_PID_FILE" "$WEBVIEW_PID_FILE" "$LAUNCH_ACTION_SOCKET"
 }
 
 send_warm_start_launch_action() {
@@ -2625,68 +2793,6 @@ clear_stale_pid_file() {
     if [ -z "$pid" ] || ! pid_matches_executable "$pid" "$SCRIPT_DIR/electron"; then
         rm -f "$APP_PID_FILE"
     fi
-}
-
-reap_orphaned_runtime_processes() {
-    local pid
-    local proc_cmdline
-    local pids=()
-    local still_running=0
-
-    for proc_cmdline in /proc/[0-9]*/cmdline; do
-        [ -r "$proc_cmdline" ] || continue
-        pid="${proc_cmdline#/proc/}"
-        pid="${pid%/cmdline}"
-        if pid_is_orphaned_runtime_process "$pid"; then
-            pids+=("$pid")
-        fi
-    done
-
-    [ "${#pids[@]}" -gt 0 ] || return 0
-
-    for pid in "${pids[@]}"; do
-        if [ -d "/proc/$pid" ]; then
-            echo "Stopping orphaned Codex runtime process after stale launch state: $(pid_summary "$pid")"
-            kill "$pid" 2>/dev/null || true
-        fi
-    done
-
-    for _ in $(seq 1 20); do
-        still_running=0
-        for pid in "${pids[@]}"; do
-            if kill -0 "$pid" 2>/dev/null; then
-                still_running=1
-                break
-            fi
-        done
-        [ "$still_running" -eq 0 ] && return 0
-        sleep 0.05
-    done
-
-    for pid in "${pids[@]}"; do
-        if kill -0 "$pid" 2>/dev/null; then
-            echo "WARN: orphaned Codex runtime process is still running after SIGTERM; sending SIGKILL: $(pid_summary "$pid")"
-            kill -9 "$pid" 2>/dev/null || true
-        fi
-    done
-
-    for _ in $(seq 1 10); do
-        still_running=0
-        for pid in "${pids[@]}"; do
-            if kill -0 "$pid" 2>/dev/null; then
-                still_running=1
-                break
-            fi
-        done
-        [ "$still_running" -eq 0 ] && return 0
-        sleep 0.05
-    done
-
-    for pid in "${pids[@]}"; do
-        if kill -0 "$pid" 2>/dev/null; then
-            echo "WARN: orphaned Codex runtime process is still running after SIGKILL: $(pid_summary "$pid")"
-        fi
-    done
 }
 
 reconcile_runtime_state() {
@@ -3715,41 +3821,203 @@ launcher_lock_wait_seconds() {
 # Serialize the running-app detection -> Electron spawn -> app.pid write
 # critical section across concurrent launchers. Without this, two launches
 # racing through detection can both cold-start, and the loser's cleanup later
-# deletes the survivor's app.pid marker, making it undetectable. Fd 9 must not
-# survive into Electron or plugin children, otherwise a stale child can keep the
-# flock alive after this launcher has moved on.
+# deletes the survivor's app.pid marker, making it undetectable. A dedicated
+# parent-death-bound helper owns the flock so no launcher child can inherit it.
 acquire_launcher_lock() {
     local wait_seconds
+    local status=""
+    local attempts
 
-    command -v flock >/dev/null 2>&1 || return 0
+    [ "$LAUNCHER_LOCK_HELD" -eq 0 ] || return 0
     LAUNCHER_LOCK_TIMED_OUT=0
-    exec 9>"$APP_STATE_DIR/launcher.lock" || return 0
-    LAUNCHER_LOCK_FD_OPEN=1
-    if flock -n 9; then
+    wait_seconds="$(launcher_lock_wait_seconds)"
+    LAUNCHER_LOCK_STATUS_PATH="$APP_STATE_DIR/.launcher.lock.status.$$"
+    rm -f "$LAUNCHER_LOCK_STATUS_PATH"
+
+    # A dedicated helper owns the flock, so arbitrary launcher children never
+    # inherit the locked file description. PR_SET_PDEATHSIG releases it even
+    # when the launcher is SIGKILLed while a hook or cache worker survives.
+    ( trap - EXIT
+      exec python3 - \
+          "$$" \
+          "$APP_STATE_DIR/launcher.lock" \
+          "$wait_seconds" \
+          "$LAUNCHER_LOCK_STATUS_PATH" <<'PY'
+import ctypes
+import ctypes.util
+import fcntl
+import os
+import signal
+import sys
+import time
+
+parent_pid = int(sys.argv[1])
+lock_path, wait_text, status_path = sys.argv[2:]
+wait_seconds = int(wait_text)
+
+if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+    sys.exit(1)
+
+libc_name = ctypes.util.find_library("c") or "libc.so.6"
+try:
+    libc = ctypes.CDLL(libc_name, use_errno=True)
+    if libc.prctl(1, signal.SIGTERM, 0, 0, 0) != 0:
+        sys.exit(1)
+except OSError:
+    sys.exit(1)
+if os.getppid() != parent_pid:
+    sys.exit(1)
+
+def release_lock(_signum, _frame):
+    raise SystemExit(0)
+
+
+signal.signal(signal.SIGTERM, release_lock)
+signal.signal(signal.SIGUSR1, release_lock)
+lock_fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+try:
+    deadline = time.monotonic() + wait_seconds
+    locked = False
+    while True:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            locked = True
+            break
+        except BlockingIOError:
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.05)
+
+    with open(status_path, "w", encoding="utf-8") as status_file:
+        status_file.write("locked\n" if locked else "timeout\n")
+
+    if locked:
+        while True:
+            signal.pause()
+finally:
+    os.close(lock_fd)
+    try:
+        os.unlink(status_path)
+    except FileNotFoundError:
+        pass
+PY
+    ) >/dev/null 2>&1 &
+    LAUNCHER_LOCK_HELPER_PID=$!
+    LAUNCHER_LOCK_HELPER_START_TIME="$(pid_start_time "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || true)"
+    if [ -z "$LAUNCHER_LOCK_HELPER_START_TIME" ]; then
+        LAUNCHER_LOCK_TIMED_OUT=1
         return 0
     fi
 
-    wait_seconds="$(launcher_lock_wait_seconds)"
-    launcher_notice "Another $CODEX_LINUX_APP_DISPLAY_NAME launcher is holding $APP_STATE_DIR/launcher.lock; waiting up to ${wait_seconds}s."
+    attempts=$((wait_seconds * 20 + 20))
+    for _ in $(seq 1 "$attempts"); do
+        if [ -s "$LAUNCHER_LOCK_STATUS_PATH" ]; then
+            status="$(cat "$LAUNCHER_LOCK_STATUS_PATH" 2>/dev/null || true)"
+            break
+        fi
+        kill -0 "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || break
+        sleep 0.05
+    done
 
-    if ! flock -w "$wait_seconds" 9; then
+    if [ "$status" != "locked" ]; then
         LAUNCHER_LOCK_TIMED_OUT=1
-        launcher_notice "WARN: timed out waiting for launcher.lock after ${wait_seconds}s; continuing after a quick state refresh."
-    else
-        echo "Acquired launcher lock after waiting"
+        if stop_launcher_lock_helper; then
+            wait "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || true
+        fi
+        LAUNCHER_LOCK_HELPER_PID=""
+        LAUNCHER_LOCK_HELPER_START_TIME=""
+        rm -f "$LAUNCHER_LOCK_STATUS_PATH"
+        launcher_notice "WARN: timed out waiting for launcher.lock after ${wait_seconds}s; refusing to start another app process."
+        return 0
     fi
+
+    LAUNCHER_LOCK_HELD=1
+    if ! launcher_lock_helper_is_active; then
+        LAUNCHER_LOCK_HELD=0
+        if stop_launcher_lock_helper; then
+            wait "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || true
+        fi
+        LAUNCHER_LOCK_HELPER_PID=""
+        LAUNCHER_LOCK_HELPER_START_TIME=""
+        LAUNCHER_LOCK_TIMED_OUT=1
+        rm -f "$LAUNCHER_LOCK_STATUS_PATH"
+        return 0
+    fi
+    rm -f "$LAUNCHER_LOCK_STATUS_PATH"
 }
 
-close_launcher_lock_fd_for_child() {
-    [ "$LAUNCHER_LOCK_FD_OPEN" -eq 1 ] || return 0
-    { exec 9>&-; } 2>/dev/null || true
+launcher_lock_helper_is_active() {
+    local actual_start_time
+    local cmdline
+
+    [ "$LAUNCHER_LOCK_HELD" -eq 1 ] || return 1
+    [[ "$LAUNCHER_LOCK_HELPER_PID" =~ ^[0-9]+$ ]] || return 1
+    actual_start_time="$(pid_start_time "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || true)"
+    [ -n "$actual_start_time" ] && [ "$actual_start_time" = "$LAUNCHER_LOCK_HELPER_START_TIME" ] || return 1
+    pid_parent_matches "$LAUNCHER_LOCK_HELPER_PID" "${BASHPID:-$$}" || return 1
+    cmdline="$(pid_cmdline "$LAUNCHER_LOCK_HELPER_PID")"
+    [[ "$cmdline" == *" $APP_STATE_DIR/launcher.lock "*" $LAUNCHER_LOCK_STATUS_PATH"* ]]
+}
+
+stop_launcher_lock_helper() {
+    python3 - \
+        "$LAUNCHER_LOCK_HELPER_PID" \
+        "$LAUNCHER_LOCK_HELPER_START_TIME" \
+        "${BASHPID:-$$}" <<'PY'
+import os
+import select
+import signal
+import sys
+
+pid = int(sys.argv[1])
+expected_start_time = sys.argv[2]
+expected_parent = int(sys.argv[3])
+
+if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+    sys.exit(1)
+try:
+    pidfd = os.pidfd_open(pid, 0)
+    with open(f"/proc/{pid}/stat", "r", encoding="utf-8") as handle:
+        fields = handle.read().rsplit(") ", 1)[1].split()
+    if fields[19] != expected_start_time or int(fields[1]) != expected_parent:
+        os.close(pidfd)
+        sys.exit(1)
+    poller = select.poll()
+    poller.register(pidfd, select.POLLIN)
+    exited = False
+    for requested_signal, wait_ms in (
+        (signal.SIGUSR1, 500),
+        (signal.SIGTERM, 500),
+        (signal.SIGKILL, 500),
+    ):
+        try:
+            signal.pidfd_send_signal(pidfd, requested_signal)
+        except ProcessLookupError:
+            exited = True
+            break
+        if poller.poll(wait_ms):
+            exited = True
+            break
+    os.close(pidfd)
+    sys.exit(0 if exited else 1)
+except (OSError, IndexError, ValueError):
+    sys.exit(1)
+PY
 }
 
 release_launcher_lock() {
-    [ "$LAUNCHER_LOCK_FD_OPEN" -eq 1 ] || return 0
-    flock -u 9 2>/dev/null || true
-    { exec 9>&-; } 2>/dev/null || true
-    LAUNCHER_LOCK_FD_OPEN=0
+    [ "$LAUNCHER_LOCK_HELD" -eq 1 ] || return 0
+    LAUNCHER_LOCK_HELD=0
+    if [ -n "$LAUNCHER_LOCK_HELPER_PID" ]; then
+        if stop_launcher_lock_helper; then
+            wait "$LAUNCHER_LOCK_HELPER_PID" 2>/dev/null || true
+        else
+            echo "WARN: launcher lock helper did not exit after bounded pidfd signals" >&2
+        fi
+    fi
+    LAUNCHER_LOCK_HELPER_PID=""
+    LAUNCHER_LOCK_HELPER_START_TIME=""
+    rm -f "$LAUNCHER_LOCK_STATUS_PATH"
 }
 
 refresh_launch_state() {
@@ -3766,6 +4034,36 @@ refresh_launch_state_quick() {
     RUNNING_APP_PID=""
     if pid="$(find_running_app_pid)"; then
         set_detected_running_app "$pid"
+    fi
+}
+
+prepare_launch_state_under_lock() {
+    running_app_is_active && return 0
+
+    acquire_launcher_lock
+    if [ "$LAUNCHER_LOCK_HELD" -ne 1 ] || [ "$LAUNCHER_LOCK_TIMED_OUT" -eq 1 ]; then
+        release_launcher_lock
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME could not acquire launcher state within the configured timeout. No new app process was started; retry after the current launch finishes."
+        exit 1
+    fi
+
+    log_phase "launcher_lock_ready"
+    refresh_launch_state_quick
+    log_phase "launch_state_refreshed_under_lock"
+    recover_unhealthy_running_app
+
+    # A healthy app discovered while waiting owns its webview already. Cold
+    # starts keep the lock through webview readiness and app.pid publication.
+    if running_app_is_active; then
+        release_launcher_lock
+    fi
+}
+
+require_active_launcher_lock() {
+    [ "$LAUNCHER_LOCK_HELD" -eq 1 ] || return 0
+    if ! launcher_lock_helper_is_active; then
+        notify_error "$CODEX_LINUX_APP_DISPLAY_NAME lost launcher serialization before Electron startup. No app process was started; retry the launch."
+        exit 1
     fi
 }
 
@@ -3795,8 +4093,8 @@ launch_electron() {
     if [ "$ELECTRON_GPU_COMPOSITING_DISABLED" = "0" ] && [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
         echo "Rendering hint: if the side panel flickers or appears transparent on Wayland, retry with CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1"
     fi
+    require_active_launcher_lock
     (
-        close_launcher_lock_fd_for_child
         unset ELECTRON_RUN_AS_NODE
         exec "$SCRIPT_DIR/electron" "${ELECTRON_LAUNCH_ARGS[@]}" "${ELECTRON_ARGS[@]}"
     ) &
@@ -3835,6 +4133,9 @@ trap cleanup_launcher EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'exit 129' HUP
+
+recover_unhealthy_running_app
+prepare_launch_state_under_lock
 
 if send_warm_start_launch_action "${LAUNCHER_ARGS[@]}"; then
     echo "Sent launch args over warm-start IPC"
@@ -3954,17 +4255,6 @@ if needs_cold_start; then
 fi
 resolve_browser_use_runtime_env
 log_phase "browser_use_runtime_env_resolved"
-
-if needs_cold_start; then
-    acquire_launcher_lock
-    log_phase "launcher_lock_ready"
-    refresh_launch_state_quick
-    log_phase "launch_state_refreshed_under_lock"
-    if [ "$LAUNCHER_LOCK_TIMED_OUT" -eq 1 ]; then
-        reap_orphaned_runtime_processes
-        detect_cross_install_conflict
-    fi
-fi
 
 log_codex_cli_path
 echo "Using managed Node.js runtime=${CODEX_MANAGED_NODE_RUNTIME_DIR:-$SCRIPT_DIR/resources/node-runtime}"

--- a/tests/launcher_warm_start_recovery.sh
+++ b/tests/launcher_warm_start_recovery.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+APP_DIR="$TMP_DIR/app"
+HOME_DIR="$TMP_DIR/home"
+RUNTIME_DIR="$TMP_DIR/runtime"
+STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
+SOCKET_PATH="$RUNTIME_DIR/codex-desktop/launch-action.sock"
+FIRST_LOG="$TMP_DIR/first-launch.log"
+SECOND_LOG="$TMP_DIR/second-launch.log"
+APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
+LAUNCHER_PID=""
+SOCKET_PID=""
+HOOK_PID=""
+
+cleanup() {
+    local pid
+    if [ -f "$STATE_DIR/app.pid" ]; then
+        pid="$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)"
+        [ -z "$pid" ] || kill "$pid" 2>/dev/null || true
+    fi
+    [ -z "$LAUNCHER_PID" ] || kill "$LAUNCHER_PID" 2>/dev/null || true
+    [ -z "$SOCKET_PID" ] || kill "$SOCKET_PID" 2>/dev/null || true
+    [ -z "$HOOK_PID" ] || kill "$HOOK_PID" 2>/dev/null || true
+    for cmdline in /proc/[0-9]*/cmdline; do
+        [ -r "$cmdline" ] || continue
+        pid="${cmdline#/proc/}"
+        pid="${pid%/cmdline}"
+        IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
+        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
+            kill "$pid" 2>/dev/null || true
+        fi
+        arg0=""
+    done
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    printf 'launcher warm-start recovery test failed: %s\n' "$*" >&2
+    printf '%s\n' '--- first launch ---' >&2
+    sed -n '1,240p' "$FIRST_LOG" >&2 2>/dev/null || true
+    printf '%s\n' '--- second launch ---' >&2
+    sed -n '1,280p' "$SECOND_LOG" >&2 2>/dev/null || true
+    printf '%s\n' '--- app launcher log ---' >&2
+    sed -n '1,360p' "$APP_LOG" >&2 2>/dev/null || true
+    exit 1
+}
+
+wait_for() {
+    local description="$1"
+    shift
+    local attempt
+    for attempt in $(seq 1 100); do
+        "$@" && return 0
+        sleep 0.05
+    done
+    fail "timed out waiting for $description"
+}
+
+read_live_app_pid() {
+    local pid
+    pid="$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)"
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    printf '%s\n' "$pid"
+}
+
+pid_file_is_live() {
+    read_live_app_pid >/dev/null
+}
+
+webview_is_ready() {
+    curl --disable --noproxy 127.0.0.1,localhost --silent --fail --max-time 0.2 \
+        "http://127.0.0.1:$PORT/index.html" | grep -q 'startup-loader'
+}
+
+webview_is_down() {
+    ! curl --disable --noproxy 127.0.0.1,localhost --silent --fail --max-time 0.2 \
+        "http://127.0.0.1:$PORT/index.html" >/dev/null 2>&1
+}
+
+mkdir -p \
+    "$APP_DIR/.codex-linux/cold-start.d" \
+    "$APP_DIR/.codex-linux/env.d" \
+    "$APP_DIR/.codex-linux/features" \
+    "$APP_DIR/.codex-linux/prelaunch.d" \
+    "$APP_DIR/.codex-linux/electron-args.d" \
+    "$APP_DIR/.codex-linux/launcher.d" \
+    "$APP_DIR/.codex-linux/after-exit.d" \
+    "$APP_DIR/content/webview" \
+    "$APP_DIR/resources/node-runtime/bin" \
+    "$HOME_DIR/.config/codex-desktop" \
+    "$HOME_DIR" \
+    "$RUNTIME_DIR/codex-desktop"
+
+if [ "${CODEX_TEST_DISABLE_WARM_START:-0}" = "1" ]; then
+    printf '%s\n' '{"codex-linux-warm-start-enabled":false}' \
+        > "$HOME_DIR/.config/codex-desktop/settings.json"
+fi
+
+PORT="$(python3 - <<'PY'
+import socket
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+
+{
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -Eeuo pipefail' \
+        'CODEX_LINUX_APP_ID=codex-desktop' \
+        'CODEX_LINUX_APP_DISPLAY_NAME="ChatGPT Desktop"' \
+        'CODEX_LINUX_WEBVIEW_PORT="${CODEX_WEBVIEW_PORT:-5175}"'
+    cat "$REPO_DIR/launcher/start.sh.template"
+} > "$APP_DIR/start.sh"
+chmod +x "$APP_DIR/start.sh"
+cp "$REPO_DIR/launcher/webview-server.py" "$APP_DIR/.codex-linux/webview-server.py"
+ln -s "$(command -v node)" "$APP_DIR/resources/node-runtime/bin/node"
+printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader"></div>' \
+    > "$APP_DIR/content/webview/index.html"
+
+g++ -x c++ -O2 -o "$APP_DIR/electron" - <<'CPP'
+#include <csignal>
+#include <unistd.h>
+
+static volatile sig_atomic_t running = 1;
+static void stop(int) { running = 0; }
+
+int main() {
+    std::signal(SIGTERM, stop);
+    std::signal(SIGINT, stop);
+    while (running) pause();
+    return 0;
+}
+CPP
+
+if [ "${CODEX_TEST_KILL_DURING_PRELAUNCH:-0}" = "1" ]; then
+    cat > "$APP_DIR/.codex-linux/prelaunch.d/blocking-test-hook" <<'HOOK'
+#!/usr/bin/env bash
+printf '%s\n' "$$" > "$CODEX_TEST_HOOK_PID_FILE"
+exec sleep 30
+HOOK
+    chmod +x "$APP_DIR/.codex-linux/prelaunch.d/blocking-test-hook"
+fi
+
+python3 - "$SOCKET_PATH" <<'PY' &
+import os
+import socket
+import sys
+
+path = sys.argv[1]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+    server.bind(path)
+    server.listen()
+    while True:
+        client, _ = server.accept()
+        with client:
+            client.recv(65536)
+            client.sendall(b"ok\n")
+PY
+SOCKET_PID=$!
+wait_for "launch-action socket" test -S "$SOCKET_PATH"
+
+COMMON_ENV=(
+    env -i
+    "PATH=$PATH"
+    "HOME=$HOME_DIR"
+    "XDG_RUNTIME_DIR=$RUNTIME_DIR"
+    "CODEX_CLI_PATH=$(command -v true)"
+    "CODEX_WEBVIEW_PORT=$PORT"
+    "CODEX_TEST_HOOK_PID_FILE=$TMP_DIR/hook.pid"
+)
+
+"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
+LAUNCHER_PID=$!
+
+if [ "${CODEX_TEST_KILL_DURING_PRELAUNCH:-0}" = "1" ]; then
+    wait_for "blocking prelaunch hook" test -s "$TMP_DIR/hook.pid"
+    HOOK_PID="$(cat "$TMP_DIR/hook.pid")"
+    kill -KILL "$LAUNCHER_PID"
+    wait "$LAUNCHER_PID" 2>/dev/null || true
+    LAUNCHER_PID=""
+    rm -f "$APP_DIR/.codex-linux/prelaunch.d/blocking-test-hook"
+
+    SECONDS=0
+    "${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
+    LAUNCHER_PID=$!
+    replacement_is_ready() {
+        pid_file_is_live && webview_is_ready
+    }
+    wait_for "replacement launch after parent-death lock release" replacement_is_ready
+    [ "$SECONDS" -lt 5 ] || fail "replacement launcher waited for the stale lock timeout"
+
+    SECOND_ELECTRON_PID="$(read_live_app_pid)"
+    kill "$SECOND_ELECTRON_PID"
+    wait "$LAUNCHER_PID"
+    LAUNCHER_PID=""
+    kill "$HOOK_PID" 2>/dev/null || true
+    HOOK_PID=""
+    printf '%s\n' "launcher parent-death lock release test passed"
+    exit 0
+fi
+
+wait_for "first Electron" pid_file_is_live
+wait_for "first packaged webview" webview_is_ready
+FIRST_ELECTRON_PID="$(read_live_app_pid)"
+
+kill -KILL "$LAUNCHER_PID"
+wait "$LAUNCHER_PID" 2>/dev/null || true
+LAUNCHER_PID=""
+wait_for "webview parent-death cleanup" webview_is_down
+kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+    || fail "Electron should survive the launcher SIGKILL"
+
+"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$SECOND_LOG" 2>&1 &
+LAUNCHER_PID=$!
+
+new_electron_is_ready() {
+    local pid
+    pid="$(read_live_app_pid)" || return 1
+    [ "$pid" != "$FIRST_ELECTRON_PID" ] || return 1
+    webview_is_ready
+}
+wait_for "cold-start recovery" new_electron_is_ready
+
+if kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null; then
+    fail "identity-verified stale Electron was not terminated"
+fi
+grep -q "Stopped identity-verified stale Electron pid=$FIRST_ELECTRON_PID" "$APP_LOG" \
+    || fail "launcher did not report stale Electron recovery"
+
+SECOND_ELECTRON_PID="$(read_live_app_pid)"
+kill "$SECOND_ELECTRON_PID"
+wait "$LAUNCHER_PID"
+LAUNCHER_PID=""
+
+printf '%s\n' "launcher recovery test passed (warm-start disabled=${CODEX_TEST_DISABLE_WARM_START:-0})"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5278,13 +5278,13 @@ multi_body = source.split("configure_multi_launch_instance() {", 1)[1].split('WE
 adopt_body = source.split("adopt_existing_webview_server() {", 1)[1].split("start_webview_server() {", 1)[0]
 ensure_body = source.split("start_webview_server() {", 1)[1].split("wait_for_webview_server", 1)[0]
 reconcile_body = source.split("reconcile_runtime_state() {", 1)[1].split("set_electron_defaults() {", 1)[0]
-orphan_body = source.split("pid_is_orphaned_runtime_process() {", 1)[1].split("detect_cross_install_conflict() {", 1)[0]
-reap_body = source.split("reap_orphaned_runtime_processes() {", 1)[1].split("reconcile_runtime_state() {", 1)[0]
 match_executable_body = source.split("pid_matches_executable() {", 1)[1].split("find_running_app_pid() {", 1)[0]
 arg0_path_body = source.split("pid_cmdline_arg0_path() {", 1)[1].split("pid_arg0_matches_path() {", 1)[0]
 arg0_match_body = source.split("pid_arg0_matches_path() {", 1)[1].split("pid_environ_lines() {", 1)[0]
 foreign_body = source.split("pid_is_foreign_codex_electron() {", 1)[1].split("discover_running_app_pid() {", 1)[0]
-summary_body = source.split("pid_summary() {", 1)[1].split("pid_is_orphaned_runtime_process() {", 1)[0]
+summary_body = source.split("pid_summary() {", 1)[1].split("detect_cross_install_conflict() {", 1)[0]
+warm_recovery_body = source.split("recover_unhealthy_running_app() {", 1)[1].split("send_warm_start_launch_action() {", 1)[0]
+terminate_body = source.split("terminate_stale_electron_with_pidfd() {", 1)[1].split("recover_unhealthy_running_app() {", 1)[0]
 if 'LAUNCHER_ARGS=()' not in source:
     raise SystemExit("launcher must keep a sanitized argv for launcher-only flags")
 if 'CODEX_LINUX_FEATURES_DIR="$SCRIPT_DIR/.codex-linux/features"' not in source:
@@ -5341,6 +5341,25 @@ if not re.search(r'if ! linux_setting_enabled "codex-linux-warm-start-enabled" 1
     raise SystemExit("detect_warm_start must not fail when warm start is disabled")
 if "preserving liveness marker for second-instance handoff" not in source:
     raise SystemExit("detect_warm_start must preserve the live app liveness marker")
+if "running_app_uses_renderer_url_override" not in warm_recovery_body:
+    raise SystemExit("warm-start recovery must preserve explicit renderer URL overrides")
+if "webview_origin_is_reachable" not in warm_recovery_body or "webview_port_is_open" not in warm_recovery_body:
+    raise SystemExit("warm-start recovery must verify the packaged origin and fail closed on an occupied port")
+if "acquire_launcher_lock" not in warm_recovery_body or "refresh_launch_state_quick" not in warm_recovery_body:
+    raise SystemExit("warm-start recovery must revalidate the stale app while holding the launcher lock")
+if "terminate_stale_electron_with_pidfd" not in warm_recovery_body:
+    raise SystemExit("warm-start recovery must terminate only an identity-verified stale Electron")
+if "os.pidfd_open" not in terminate_body or "signal.pidfd_send_signal" not in terminate_body:
+    raise SystemExit("stale Electron termination must bind signals to a pidfd")
+for identity_guard in ("expected_start_time", "expected_executable", "expected_app_id", "expected_instance_id"):
+    if identity_guard not in terminate_body:
+        raise SystemExit(f"pidfd termination is missing identity guard: {identity_guard}")
+if 'running_app_is_active || return 0' not in warm_recovery_body or '[ "$WARM_START" -eq 1 ]' in warm_recovery_body:
+    raise SystemExit("unhealthy origin recovery must also cover Electron second-instance handoff")
+if "renderer_url_override_is_active" in warm_recovery_body:
+    raise SystemExit("a new-launch renderer override must not preserve a stale packaged-origin Electron")
+if not re.search(r'trap cleanup_launcher EXIT.*?recover_unhealthy_running_app.*?prepare_launch_state_under_lock.*?send_warm_start_launch_action', source, re.S):
+    raise SystemExit("launcher must recover an unhealthy packaged origin before warm-start IPC")
 if launch_body.count("unset ELECTRON_RUN_AS_NODE") != 2:
     raise SystemExit("launch_electron must clear ELECTRON_RUN_AS_NODE before both Electron launch paths")
 if 'pid_matches_executable "$RUNNING_APP_PID" "$SCRIPT_DIR/electron"' not in launch_body:
@@ -5373,13 +5392,12 @@ warm_log_pos = launch_body.index(warm_log)
 warm_unset_pos = launch_body.index("unset ELECTRON_RUN_AS_NODE", warm_log_pos)
 warm_launch_pos = launch_body.index(electron_launch, warm_unset_pos)
 normal_log_pos = launch_body.index(normal_log)
-normal_close_pos = launch_body.index("close_launcher_lock_fd_for_child", normal_log_pos)
 normal_unset_pos = launch_body.index("unset ELECTRON_RUN_AS_NODE", normal_log_pos)
 normal_launch_pos = launch_body.index(electron_exec, normal_unset_pos)
 if electron_launch + " &" in launch_body:
-    raise SystemExit("cold Electron launch must close launcher fd in a child before exec, not background the binary directly")
-if not (warm_log_pos < warm_unset_pos < warm_launch_pos < normal_log_pos < normal_close_pos < normal_unset_pos < normal_launch_pos):
-    raise SystemExit("launch_electron must close the launcher fd and clear ELECTRON_RUN_AS_NODE immediately before cold Electron exec")
+    raise SystemExit("cold Electron launch must exec from a child, not background the binary directly")
+if not (warm_log_pos < warm_unset_pos < warm_launch_pos < normal_log_pos < normal_unset_pos < normal_launch_pos):
+    raise SystemExit("launch_electron must clear ELECTRON_RUN_AS_NODE immediately before cold Electron exec")
 if "using_second_instance_handoff" not in source or "needs_cold_start" not in source:
     raise SystemExit("launcher must have an explicit second-instance handoff mode")
 if "second_instance_handoff_ready" not in runtime_body:
@@ -5430,8 +5448,8 @@ if "version unknown; set CODEX_CLI_PATH=/path/to/codex" not in source:
     raise SystemExit("CLI lookup diagnostics must explain explicit CODEX_CLI_PATH pinning")
 if 'local self_pid="${BASHPID:-$$}"' not in source or 'pid_parent_matches "$probe_pid" "$self_pid"' not in source:
     raise SystemExit("CLI version probe watchdog must guard kills against PID reuse")
-if source.count('{ exec 9>&-; } 2>/dev/null || true') < 3:
-    raise SystemExit("CLI version probe children and Electron child must close launcher lock fd 9")
+if source.count('{ exec 9>&-; } 2>/dev/null || true') < 2:
+    raise SystemExit("CLI version probe children must close their inherited watchdog fd 9")
 for unexpected in ("find_codex_cli_entry", "codex_cli_version_compare", "codex_cli_version_gt", "sort -V"):
     if unexpected in source:
         raise SystemExit(f"launcher must not rank discovered CLI candidates with {unexpected}")
@@ -5512,9 +5530,8 @@ overlap_start = cold_flow.index("\n    start_webview_server\n")
 overlap_sync = cold_flow.index('log_phase "cold_start_cache_sync_start"')
 overlap_last_sync = cold_flow.index("sync_extra_bundled_plugin_cache")
 overlap_await = cold_flow.index("\n    await_webview_server_ready\n")
-overlap_lock = cold_flow.index("acquire_launcher_lock")
-if not (overlap_start < overlap_sync < overlap_last_sync < overlap_await < overlap_lock):
-    raise SystemExit("webview readiness wait must overlap the plugin cache syncs and finish before the launcher lock")
+if not (overlap_start < overlap_sync < overlap_last_sync < overlap_await):
+    raise SystemExit("webview readiness wait must overlap the plugin cache syncs and finish before Electron")
 await_body = source.split("await_webview_server_ready() {", 1)[1].split("clear_stale_pid_file() {", 1)[0]
 if "wait_for_webview_server" not in await_body or "verify_webview_origin" not in await_body:
     raise SystemExit("await_webview_server_ready must keep readiness and origin verification before Electron")
@@ -5540,31 +5557,33 @@ if not re.search(r'log_phase "initial_launch_state_refresh_start"\s+refresh_laun
     raise SystemExit("launcher must do an initial runtime-state refresh before warm-start IPC")
 if "trap 'exit 130' INT" not in source or "trap 'exit 143' TERM" not in source or "trap 'exit 129' HUP" not in source:
     raise SystemExit("launcher must cleanup through EXIT after INT/TERM/HUP")
-if not re.search(r'if needs_cold_start; then\s+acquire_launcher_lock\s+log_phase "launcher_lock_ready"\s+refresh_launch_state_quick\s+log_phase "launch_state_refreshed_under_lock"', source):
-    raise SystemExit("launcher must do only a quick state refresh under the launcher lock")
+prepare_body = source.split("prepare_launch_state_under_lock() {", 1)[1].split("launch_electron() {", 1)[0]
+if "acquire_launcher_lock" not in prepare_body or "refresh_launch_state_quick" not in prepare_body:
+    raise SystemExit("launcher must refresh launch state under the launcher lock before cold-start work")
+if not re.search(r'prepare_launch_state_under_lock.*?elif needs_cold_start; then.*?start_webview_server', source, re.S):
+    raise SystemExit("launcher must acquire the cold-start lock before spawning the packaged webview")
+if "No new app process was started" not in prepare_body:
+    raise SystemExit("launcher lock timeout must fail closed instead of continuing a duplicate cold start")
 if 'CODEX_LAUNCHER_LOCK_WAIT_SECONDS:-5' not in source:
     raise SystemExit("launcher lock wait must default to 5 seconds so duplicate launches do not look hung")
-if 'flock -n 9' not in source or 'flock -w "$wait_seconds" 9' not in source:
-    raise SystemExit("launcher lock must first probe and then use a bounded wait")
-if "Another $CODEX_LINUX_APP_DISPLAY_NAME launcher is holding" not in source:
-    raise SystemExit("launcher lock waits must emit visible diagnostics")
+if "fcntl.flock" not in source or "PR_SET_PDEATHSIG" not in source:
+    raise SystemExit("launcher lock must be held by a parent-death-bound helper instead of an inherited fd")
+if 'wait_seconds * 20 + 20' not in source:
+    raise SystemExit("launcher lock helper status wait must remain bounded")
 if "detect_cross_install_conflict" not in source or "Both use app id" not in source:
     raise SystemExit("launcher must still support same-identity cross-install diagnostics")
-if "reap_orphaned_runtime_processes" in reconcile_body:
-    raise SystemExit("reconcile_runtime_state must not reap orphaned processes on the normal startup path")
-if "LAUNCHER_LOCK_TIMED_OUT" not in source or "reap_orphaned_runtime_processes" not in source:
-    raise SystemExit("orphan cleanup should remain available only for exceptional lock-timeout recovery")
-if (
-    "pid_is_orphaned_runtime_process" not in source
-    or '"$SCRIPT_DIR/chrome_crashpad_handler"' not in source
-    or '"$SCRIPT_DIR/resources/node-runtime/bin/node"' not in source
-    or '"$SCRIPT_DIR/resources/node_repl"' not in source
-):
-    raise SystemExit("orphan cleanup must cover same-app Electron helpers, crashpad, and managed Node children")
-if "launcher_lock_holder_pids" in reap_body:
-    raise SystemExit("orphan cleanup must not require fuser-based lock holder discovery")
-if "LAUNCHER_LOCK_FD_OPEN=1" not in source or "exec 9>&-" not in source:
-    raise SystemExit("launcher lock fd must be tracked and closed after the critical section")
+if "LAUNCHER_LOCK_TIMED_OUT" not in source:
+    raise SystemExit("launcher must track bounded lock timeout failures")
+if "reap_orphaned_runtime_processes" in source or "pid_is_orphaned_runtime_process" in source:
+    raise SystemExit("lock timeout must not kill processes belonging to the active serialized cold start")
+if "LAUNCHER_LOCK_HELD=1" not in source or "stop_launcher_lock_helper" not in source:
+    raise SystemExit("launcher must explicitly release and reap its dedicated lock helper")
+if "signal.SIGUSR1, 500" not in source or "signal.SIGTERM, 500" not in source or "signal.SIGKILL, 500" not in source:
+    raise SystemExit("launcher lock helper shutdown must use bounded identity-bound pidfd escalation")
+if "launcher_lock_helper_is_active" not in source or "require_active_launcher_lock" not in launch_body:
+    raise SystemExit("launcher must fail closed if the identity-bound lock helper exits before Electron")
+if "LAUNCHER_LOCK_CONTROL_PATH" in source or "mkfifo" in source:
+    raise SystemExit("launcher lock release must not expose an inherited FIFO capability")
 if "CODEX_ELECTRON_DISABLE_GPU_COMPOSITING=1" not in launch_body:
     raise SystemExit("launcher must log the GPU compositing workaround hint for side-panel flicker")
 if launch_body.count("release_launcher_lock") != 2:
@@ -9874,6 +9893,13 @@ EOF
     )
 }
 
+test_launcher_warm_start_recovery() {
+    info "Checking warm-start recovery after launcher SIGKILL"
+    bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+    CODEX_TEST_DISABLE_WARM_START=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+    CODEX_TEST_KILL_DURING_PRELAUNCH=1 bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
+}
+
 test_notification_actions_bridge_accepts_prebuilt_binary() {
     local workspace="$TMP_DIR/notification-actions-bridge"
     local source_binary="$workspace/prebuilt/codex-notification-actions-linux"
@@ -10018,6 +10044,7 @@ main() {
     test_launcher_rejects_missing_webview_entrypoint
     test_launcher_marketplace_metadata_atomic_staging
     test_launcher_template_sanity
+    test_launcher_warm_start_recovery
     test_launcher_cli_resolution_policy
     test_webview_server_cache_policy
     test_process_detection_helper_cmdline_shapes


### PR DESCRIPTION
## Summary
- verify the packaged webview origin before warm/second-instance handoff
- safely replace only an identity-verified stale Electron through pidfd signaling
- serialize cold starts with a parent-death-bound lock helper that children cannot inherit
- add regressions for warm-start enabled/disabled and launcher SIGKILL while the lock is held

Fixes #963

## Tests
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh tests/launcher_warm_start_recovery.sh`
- `bash tests/launcher_warm_start_recovery.sh`
- `CODEX_TEST_DISABLE_WARM_START=1 bash tests/launcher_warm_start_recovery.sh`
- `CODEX_TEST_KILL_DURING_PRELAUNCH=1 bash tests/launcher_warm_start_recovery.sh`
- `bash tests/webview_probe_equivalence.sh`
- `bash tests/scripts_smoke.sh`
- `git diff --check origin/main...HEAD`