### PR TITLE
Retry interrupted updater rebuilds

### DIFF
--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -380,6 +380,21 @@ fn update_install_is_pending(status: &UpdateStatus) -> bool {
     )
 }
 
+// Failed attempts and transient states persisted before fallible download or
+// build work must retry after the next checker acquires the check lock. A
+// still-running checker continues to own that lock and prevents duplicate work.
+fn update_check_should_retry(status: &UpdateStatus) -> bool {
+    matches!(
+        status,
+        UpdateStatus::Failed
+            | UpdateStatus::DownloadingDmg
+            | UpdateStatus::UpdateDetected
+            | UpdateStatus::PreparingWorkspace
+            | UpdateStatus::PatchingApp
+            | UpdateStatus::BuildingPackage
+    )
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum PendingInstallRecovery {
     NoChange,
@@ -468,7 +483,10 @@ async fn run_check_now(
     normalize_workspace_dir_and_persist(state, paths)?;
     maybe_prune_caches(config, state);
     maybe_notify_cli_missing(state, paths, config.notifications)?;
-    if if_stale && upstream_check_is_fresh(config, state) {
+    if if_stale
+        && !update_check_should_retry(&state.status)
+        && upstream_check_is_fresh(config, state)
+    {
         if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
             warn!(
                 ?error,
@@ -941,7 +959,7 @@ async fn run_check_cycle(
         );
     }
 
-    let retrying_failed_update = state.status == UpdateStatus::Failed;
+    let retrying_update = update_check_should_retry(&state.status);
 
     let Some(_check_lock) = try_acquire_check_lock(paths)? else {
         return Ok(());
@@ -963,7 +981,7 @@ async fn run_check_cycle(
 
         if previous_headers_fingerprint.as_deref() == Some(metadata.headers_fingerprint.as_str())
             && state.dmg_sha256.is_some()
-            && !retrying_failed_update
+            && !retrying_update
         {
             set_status(state, paths, UpdateStatus::Idle)?;
             info!("upstream fingerprint unchanged; skipping download");
@@ -1001,9 +1019,7 @@ async fn run_check_cycle(
             return Ok(());
         }
 
-        if state.dmg_sha256.as_deref() == Some(downloaded.sha256.as_str())
-            && !retrying_failed_update
-        {
+        if state.dmg_sha256.as_deref() == Some(downloaded.sha256.as_str()) && !retrying_update {
             state.status = UpdateStatus::Idle;
             state.artifact_paths.dmg_path = Some(downloaded.path);
             persist_state(paths, state)?;
@@ -2009,6 +2025,31 @@ mod tests {
     }
 
     #[test]
+    fn interrupted_preinstall_states_retry_the_update_check() {
+        for status in [
+            UpdateStatus::Failed,
+            UpdateStatus::DownloadingDmg,
+            UpdateStatus::UpdateDetected,
+            UpdateStatus::PreparingWorkspace,
+            UpdateStatus::PatchingApp,
+            UpdateStatus::BuildingPackage,
+        ] {
+            assert!(update_check_should_retry(&status), "status: {status:?}");
+        }
+
+        for status in [
+            UpdateStatus::Idle,
+            UpdateStatus::CheckingUpstream,
+            UpdateStatus::ReadyToInstall,
+            UpdateStatus::WaitingForAppExit,
+            UpdateStatus::Installing,
+            UpdateStatus::Installed,
+        ] {
+            assert!(!update_check_should_retry(&status), "status: {status:?}");
+        }
+    }
+
+    #[test]
     fn disabled_wrapper_tracking_clears_stale_candidate() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let paths = test_paths(temp.path());
@@ -2363,6 +2404,55 @@ mod tests {
         assert_eq!(state.artifact_paths.package_path, None);
         assert_eq!(state.artifact_paths.workspace_dir, None);
         assert_eq!(state.error_message, None);
+        assert!(state.last_successful_check_at.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn interrupted_download_retries_an_unchanged_remote_fingerprint() -> Result<()> {
+        let server = MockServer::start().await;
+        let body = b"codex-dmg-test-payload";
+        let sha256 = "678cd508ffe0071e217020a7a4eecbebe25362c022ac78c13a5ae87b7a3a0c92";
+        let headers_fingerprint = format!(
+            "etag=\"same-dmg\"|last_modified=|content_length={}",
+            body.len()
+        );
+
+        Mock::given(method("HEAD"))
+            .and(path("/Codex.dmg"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("ETag", "\"same-dmg\"")
+                    .insert_header("Content-Length", body.len().to_string()),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/Codex.dmg"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let mut config = test_config(temp.path());
+        config.dmg_url = format!("{}/Codex.dmg", server.uri());
+        write_installed_build_info(&config, sha256)?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::DownloadingDmg;
+        state.remote_headers_fingerprint = Some(headers_fingerprint);
+        state.dmg_sha256 = Some(sha256.to_string());
+
+        run_check_cycle(&config, &mut state, &paths).await?;
+        server.verify().await;
+
+        assert_eq!(state.status, UpdateStatus::Idle);
+        assert_eq!(state.candidate_version, None);
+        assert_eq!(state.dmg_sha256.as_deref(), Some(sha256));
         assert!(state.last_successful_check_at.is_some());
         Ok(())
     }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -2455,7 +2455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn interrupted_download_retries_an_unchanged_remote_fingerprint() -> Result<()> {
+    async fn interrupted_download_with_cached_hash_reaches_build_path() -> Result<()> {
         let server = MockServer::start().await;
         let body = b"codex-dmg-test-payload";
         let sha256 = "678cd508ffe0071e217020a7a4eecbebe25362c022ac78c13a5ae87b7a3a0c92";
@@ -2486,19 +2486,32 @@ mod tests {
         paths.ensure_dirs()?;
         let mut config = test_config(temp.path());
         config.dmg_url = format!("{}/Codex.dmg", server.uri());
-        write_installed_build_info(&config, sha256)?;
+        write_installed_build_info(
+            &config,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )?;
 
         let mut state = PersistedState::new(true);
         state.status = UpdateStatus::DownloadingDmg;
         state.remote_headers_fingerprint = Some(headers_fingerprint);
         state.dmg_sha256 = Some(sha256.to_string());
 
-        run_check_cycle(&config, &mut state, &paths).await?;
+        let error = run_check_cycle(&config, &mut state, &paths)
+            .await
+            .expect_err("retry should reach the intentionally missing builder bundle");
         server.verify().await;
 
-        assert_eq!(state.status, UpdateStatus::Idle);
-        assert_eq!(state.candidate_version, None);
+        assert!(error
+            .to_string()
+            .contains("Required builder bundle path is missing"));
+        assert_eq!(state.status, UpdateStatus::Failed);
+        assert!(state.candidate_version.is_some());
         assert_eq!(state.dmg_sha256.as_deref(), Some(sha256));
+        assert!(state.artifact_paths.workspace_dir.is_some());
+        assert!(state
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("Required builder bundle path is missing")));
         assert!(state.last_successful_check_at.is_some());
         Ok(())
     }

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -395,6 +395,22 @@ fn update_check_should_retry(status: &UpdateStatus) -> bool {
     )
 }
 
+fn prepare_upstream_check(state: &mut PersistedState, paths: &RuntimePaths) -> Result<bool> {
+    let retrying_update = update_check_should_retry(&state.status);
+
+    // Keep a retryable status durable until the metadata request completes. If
+    // the updater exits while that request is in flight, the next run must not
+    // mistake the interrupted rebuild for an ordinary unchanged-upstream check.
+    if !retrying_update {
+        state.status = UpdateStatus::CheckingUpstream;
+    }
+    state.last_check_at = Some(Utc::now());
+    state.error_message = None;
+    persist_state(paths, state)?;
+
+    Ok(retrying_update)
+}
+
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum PendingInstallRecovery {
     NoChange,
@@ -959,8 +975,6 @@ async fn run_check_cycle(
         );
     }
 
-    let retrying_update = update_check_should_retry(&state.status);
-
     let Some(_check_lock) = try_acquire_check_lock(paths)? else {
         return Ok(());
     };
@@ -968,10 +982,7 @@ async fn run_check_cycle(
     let client = upstream::http_client()?;
 
     sync_runtime_state(config, state);
-    state.status = UpdateStatus::CheckingUpstream;
-    state.last_check_at = Some(Utc::now());
-    state.error_message = None;
-    persist_state(paths, state)?;
+    let retrying_update = prepare_upstream_check(state, paths)?;
 
     let result: Result<()> = async {
         let metadata = upstream::fetch_remote_metadata(&client, &config.dmg_url).await?;
@@ -2047,6 +2058,41 @@ mod tests {
         ] {
             assert!(!update_check_should_retry(&status), "status: {status:?}");
         }
+    }
+
+    #[test]
+    fn upstream_check_setup_preserves_persisted_retry_intent() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        for status in [
+            UpdateStatus::Failed,
+            UpdateStatus::DownloadingDmg,
+            UpdateStatus::UpdateDetected,
+            UpdateStatus::PreparingWorkspace,
+            UpdateStatus::PatchingApp,
+            UpdateStatus::BuildingPackage,
+        ] {
+            let mut state = PersistedState::new(true);
+            state.status = status.clone();
+            state.error_message = Some("previous failure".to_string());
+
+            assert!(prepare_upstream_check(&mut state, &paths)?);
+            assert_eq!(state.status, status);
+            assert!(state.last_check_at.is_some());
+            assert_eq!(state.error_message, None);
+
+            let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+            assert_eq!(persisted.status, status);
+        }
+
+        let mut fresh_state = PersistedState::new(true);
+        assert!(!prepare_upstream_check(&mut fresh_state, &paths)?);
+        assert_eq!(fresh_state.status, UpdateStatus::CheckingUpstream);
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.status, UpdateStatus::CheckingUpstream);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retry updater checks left in `downloading_dmg`, `update_detected`, `preparing_workspace`, `patching_app`, or `building_package`
- bypass the fresh-check and unchanged-fingerprint/hash shortcuts for those interrupted attempts
- add focused coverage for every retryable phase and for an interrupted download with unchanged remote metadata

## Root cause

The updater persists remote metadata and transient build phases before long-running download and package-build work. If the process or machine stops during that work, the next check does not treat the persisted phase as retryable. Unchanged remote headers or a matching cached DMG hash can then reset the updater to idle without rebuilding, leaving the current release skipped until upstream metadata changes again.

The existing check lock remains the concurrency boundary: a second checker cannot retry while the original download or build still owns the lock, while a checker after a crash can acquire it and restart the work.

## Validation

- Reviewed and merged through [tjdonley/codex-desktop-linux#6](https://github.com/tjdonley/codex-desktop-linux/pull/6)
- Fork CI passed all package, Nix, Rust, and smoke checks
- Both new updater regression tests passed in Linux CI
- `cargo fmt --all -- --check`
- `git diff --check`
