### PR TITLE
Announce upstream builds on Discord

### DIFF
--- a/.github/workflows/discord-build-announcement.yml
+++ b/.github/workflows/discord-build-announcement.yml
@@ -1,0 +1,40 @@
+name: Announce upstream build on Discord
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    name: Announce merged upstream build
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'codex/upstream-dmg-')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: discord-build-announcement-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out trusted announcement code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Post build announcement
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL: ${{ secrets.DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL }}
+        with:
+          script: |
+            const { announceMergedBuild } = require('./scripts/ci/discord-build-announcement.js');
+            await announceMergedBuild({
+              context,
+              core,
+              webhookUrl: process.env.DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL,
+            });

--- a/docs/upstream-dmg-watchdog.md
+++ b/docs/upstream-dmg-watchdog.md
@@ -87,6 +87,20 @@ core patches, the shared feature loader, installer, updater, packaging, or a
 mixture of feature and shared paths. Reuse the immutable DMG download, feature
 snapshot, extracted app, native-module cache, and Nix store within a round.
 
+## Discord build announcements
+
+The `discord-build-announcement.yml` workflow announces a completed upstream
+build campaign when its canonical repair pull request is merged. It accepts
+only an internal `codex/upstream-dmg-SHA` branch targeting `main`, requires the
+matching `upstream-dmg-sha256` body marker and the versioned
+`Fix upstream DMG drift for VERSION` title, and extracts the announcement text
+from the pull request's `Summary` section.
+
+Create an incoming webhook for the announcements channel and store its URL as
+the repository Actions secret `DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL`. The
+workflow reads the pull request event with trusted default-branch code and does
+not allow Discord mentions from pull request content.
+
 ## Nix refresh and recovery
 
 The probe adopts the exact workflow run and stores its run ID, head SHA,

--- a/scripts/ci/discord-build-announcement.js
+++ b/scripts/ci/discord-build-announcement.js
@@ -1,0 +1,108 @@
+"use strict";
+
+const DISCORD_DESCRIPTION_LIMIT = 4096;
+const DMG_MARKER_PATTERN = /<!--\s*upstream-dmg-sha256:([a-f0-9]{64})\s*-->/i;
+const BUILD_TITLE_PATTERN = /^Fix upstream DMG drift for (\d+(?:\.\d+)+)$/;
+
+function stripHtmlComments(value) {
+  return String(value || "")
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/\n(?:[ \t]*\n){2,}/g, "\n\n")
+    .trim();
+}
+
+function extractSummary(body) {
+  const content = String(body || "");
+  const summaryHeading = /^##\s+Summary\s*$/im.exec(content);
+  if (!summaryHeading) return stripHtmlComments(content);
+
+  const afterHeading = content.slice(summaryHeading.index + summaryHeading[0].length);
+  const nextHeading = /^##\s+/m.exec(afterHeading);
+  return stripHtmlComments(nextHeading ? afterHeading.slice(0, nextHeading.index) : afterHeading);
+}
+
+function buildAnnouncement(pullRequest, repository) {
+  if (!pullRequest || pullRequest.merged !== true || pullRequest.base?.ref !== "main") return null;
+  if (pullRequest.head?.repo?.full_name !== repository) return null;
+
+  const titleMatch = BUILD_TITLE_PATTERN.exec(String(pullRequest.title || ""));
+  const markerMatch = DMG_MARKER_PATTERN.exec(String(pullRequest.body || ""));
+  if (!titleMatch || !markerMatch) return null;
+
+  const dmgSha256 = markerMatch[1].toLowerCase();
+  if (pullRequest.head?.ref !== `codex/upstream-dmg-${dmgSha256.slice(0, 12)}`) return null;
+
+  return {
+    dmgSha256,
+    mergedAt: pullRequest.merged_at,
+    number: pullRequest.number,
+    summary: extractSummary(pullRequest.body) || "Linux compatibility has been updated for the latest upstream build.",
+    title: pullRequest.title,
+    url: pullRequest.html_url,
+    version: titleMatch[1],
+  };
+}
+
+function truncate(value, limit) {
+  const text = String(value || "");
+  if (text.length <= limit) return text;
+  return `${text.slice(0, limit - 3)}...`;
+}
+
+function buildDiscordPayload(announcement) {
+  return {
+    content: "A new ChatGPT Desktop for Linux build is available.",
+    allowed_mentions: { parse: [] },
+    embeds: [{
+      title: announcement.title,
+      url: announcement.url,
+      description: truncate(announcement.summary, DISCORD_DESCRIPTION_LIMIT),
+      color: 0x57f287,
+      fields: [
+        { name: "Version", value: `\`${announcement.version}\``, inline: true },
+        { name: "Pull request", value: `[#${announcement.number}](${announcement.url})`, inline: true },
+        { name: "DMG SHA-256", value: `\`${announcement.dmgSha256.slice(0, 12)}...\``, inline: true },
+      ],
+      footer: { text: "ChatGPT Desktop for Linux" },
+      timestamp: announcement.mergedAt,
+    }],
+  };
+}
+
+function normalizedWebhookUrl(rawUrl) {
+  const url = new URL(String(rawUrl || ""));
+  if (url.protocol !== "https:" || url.hostname !== "discord.com" || !url.pathname.startsWith("/api/webhooks/")) {
+    throw new Error("DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL must be a discord.com webhook URL");
+  }
+  url.searchParams.set("wait", "true");
+  return url;
+}
+
+async function announceMergedBuild({ context, core, webhookUrl, fetchImpl = globalThis.fetch }) {
+  const announcement = buildAnnouncement(context.payload.pull_request, `${context.repo.owner}/${context.repo.repo}`);
+  if (!announcement) {
+    core.info("Pull request is not a canonical upstream DMG build campaign; skipping Discord announcement.");
+    return { action: "skipped" };
+  }
+
+  const response = await fetchImpl(normalizedWebhookUrl(webhookUrl), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(buildDiscordPayload(announcement)),
+  });
+  if (!response.ok) {
+    const responseBody = truncate(await response.text(), 500);
+    throw new Error(`Discord webhook returned HTTP ${response.status}: ${responseBody}`);
+  }
+
+  core.info(`Announced upstream build ${announcement.version} from PR #${announcement.number}.`);
+  return { action: "announced", announcement };
+}
+
+module.exports = {
+  announceMergedBuild,
+  buildAnnouncement,
+  buildDiscordPayload,
+  extractSummary,
+  normalizedWebhookUrl,
+};

--- a/scripts/ci/discord-build-announcement.test.js
+++ b/scripts/ci/discord-build-announcement.test.js
@@ -1,0 +1,197 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  announceMergedBuild,
+  buildDiscordPayload,
+  buildAnnouncement,
+  extractSummary,
+  normalizedWebhookUrl,
+} = require("./discord-build-announcement.js");
+
+const DMG_SHA = "40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6";
+
+function pullRequest(overrides = {}) {
+  return {
+    merged: true,
+    merged_at: "2026-07-14T15:47:25Z",
+    number: 975,
+    title: "Fix upstream DMG drift for 26.707.72221",
+    body: `<!-- upstream-dmg-sha256:${DMG_SHA} -->
+
+## Summary
+- repair Linux compatibility drift for the current upstream DMG
+- remove obsolete compatibility paths replaced by the current DMG shape
+
+## Validation
+- exact current-DMG acceptance recorded by the watchdog`,
+    html_url: "https://github.com/ilysenko/codex-desktop-linux/pull/975",
+    base: { ref: "main" },
+    head: {
+      ref: `codex/upstream-dmg-${DMG_SHA.slice(0, 12)}`,
+      repo: { full_name: "ilysenko/codex-desktop-linux" },
+    },
+    ...overrides,
+  };
+}
+
+test("builds an announcement for a merged canonical upstream DMG repair", () => {
+  assert.deepEqual(
+    buildAnnouncement(pullRequest(), "ilysenko/codex-desktop-linux"),
+    {
+      dmgSha256: DMG_SHA,
+      mergedAt: "2026-07-14T15:47:25Z",
+      number: 975,
+      summary: [
+        "- repair Linux compatibility drift for the current upstream DMG",
+        "- remove obsolete compatibility paths replaced by the current DMG shape",
+      ].join("\n"),
+      title: "Fix upstream DMG drift for 26.707.72221",
+      url: "https://github.com/ilysenko/codex-desktop-linux/pull/975",
+      version: "26.707.72221",
+    },
+  );
+});
+
+test("rejects events that do not prove a canonical internal build campaign", () => {
+  const invalid = [
+    pullRequest({ merged: false }),
+    pullRequest({ base: { ref: "release" } }),
+    pullRequest({ title: "Fix feature drift for current upstream DMG" }),
+    pullRequest({ head: { ref: `codex/upstream-dmg-${DMG_SHA.slice(0, 12)}`, repo: { full_name: "fork/repo" } } }),
+    pullRequest({ head: { ref: "fix/unrelated", repo: { full_name: "ilysenko/codex-desktop-linux" } } }),
+    pullRequest({ body: "## Summary\n- no fingerprint" }),
+    pullRequest({ head: { ref: "codex/upstream-dmg-aaaaaaaaaaaa", repo: { full_name: "ilysenko/codex-desktop-linux" } } }),
+  ];
+
+  for (const candidate of invalid) {
+    assert.equal(buildAnnouncement(candidate, "ilysenko/codex-desktop-linux"), null);
+  }
+});
+
+test("extractSummary removes automation comments and excludes later sections", () => {
+  assert.equal(
+    extractSummary(`<!-- hidden -->
+## Summary
+User-facing line.
+
+<!-- another hidden comment -->
+- Safe @everyone text.
+
+## Tests
+- private implementation detail`),
+    "User-facing line.\n\n- Safe @everyone text.",
+  );
+});
+
+test("buildDiscordPayload creates a bounded embed with mentions disabled", () => {
+  const announcement = buildAnnouncement(pullRequest(), "ilysenko/codex-desktop-linux");
+  const payload = buildDiscordPayload(announcement);
+
+  assert.deepEqual(payload.allowed_mentions, { parse: [] });
+  assert.equal(payload.content, "A new ChatGPT Desktop for Linux build is available.");
+  assert.equal(payload.embeds.length, 1);
+  assert.equal(payload.embeds[0].title, announcement.title);
+  assert.equal(payload.embeds[0].url, announcement.url);
+  assert.equal(payload.embeds[0].description, announcement.summary);
+  assert.equal(payload.embeds[0].timestamp, announcement.mergedAt);
+  assert.ok(payload.embeds[0].description.length <= 4096);
+  assert.deepEqual(payload.embeds[0].fields, [
+    { name: "Version", value: "`26.707.72221`", inline: true },
+    { name: "Pull request", value: "[#975](https://github.com/ilysenko/codex-desktop-linux/pull/975)", inline: true },
+    { name: "DMG SHA-256", value: "`40e34814e74e...`", inline: true },
+  ]);
+});
+
+test("buildDiscordPayload truncates oversized summaries without splitting the limit", () => {
+  const payload = buildDiscordPayload({
+    ...buildAnnouncement(pullRequest(), "ilysenko/codex-desktop-linux"),
+    summary: "x".repeat(5000),
+  });
+
+  assert.equal(payload.embeds[0].description.length, 4096);
+  assert.match(payload.embeds[0].description, /\.\.\.$/);
+});
+
+test("normalizedWebhookUrl accepts only Discord HTTPS webhook URLs", () => {
+  assert.equal(
+    normalizedWebhookUrl("https://discord.com/api/webhooks/123/token").href,
+    "https://discord.com/api/webhooks/123/token?wait=true",
+  );
+  assert.throws(
+    () => normalizedWebhookUrl("https://example.test/api/webhooks/123/token"),
+    /must be a discord\.com webhook URL/,
+  );
+});
+
+test("announceMergedBuild posts the rendered payload", async () => {
+  const calls = [];
+  const messages = [];
+  const context = {
+    payload: { pull_request: pullRequest() },
+    repo: { owner: "ilysenko", repo: "codex-desktop-linux" },
+  };
+
+  const result = await announceMergedBuild({
+    context,
+    core: { info: (message) => messages.push(message) },
+    webhookUrl: "https://discord.com/api/webhooks/123/token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url: url.href, options });
+      return { ok: true, status: 200, text: async () => "" };
+    },
+  });
+
+  assert.equal(result.action, "announced");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://discord.com/api/webhooks/123/token?wait=true");
+  assert.deepEqual(JSON.parse(calls[0].options.body), buildDiscordPayload(result.announcement));
+  assert.match(messages[0], /26\.707\.72221/);
+});
+
+test("announceMergedBuild skips unrelated pull requests before reading the webhook", async () => {
+  const result = await announceMergedBuild({
+    context: {
+      payload: { pull_request: pullRequest({ title: "Fix an unrelated bug" }) },
+      repo: { owner: "ilysenko", repo: "codex-desktop-linux" },
+    },
+    core: { info: () => {} },
+    webhookUrl: "",
+    fetchImpl: async () => { throw new Error("unexpected request"); },
+  });
+
+  assert.deepEqual(result, { action: "skipped" });
+});
+
+test("announceMergedBuild fails when Discord rejects the message", async () => {
+  await assert.rejects(
+    announceMergedBuild({
+      context: {
+        payload: { pull_request: pullRequest() },
+        repo: { owner: "ilysenko", repo: "codex-desktop-linux" },
+      },
+      core: { info: () => {} },
+      webhookUrl: "https://discord.com/api/webhooks/123/token",
+      fetchImpl: async () => ({ ok: false, status: 429, text: async () => "rate limited" }),
+    }),
+    /HTTP 429: rate limited/,
+  );
+});
+
+test("workflow reads only trusted default-branch code before using the webhook secret", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/discord-build-announcement.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /pull_request_target:\n\s+types: \[closed\]/);
+  assert.match(workflow, /permissions:\n\s+contents: read/);
+  assert.match(workflow, /head\.repo\.full_name == github\.repository/);
+  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.doesNotMatch(workflow, /github\.event\.pull_request\.head\.sha/);
+});


### PR DESCRIPTION
## Summary
- post a Discord embed when a canonical upstream DMG campaign pull request is merged
- derive the title, summary, version, pull request link, and DMG fingerprint from trusted event metadata
- reject unrelated, external, or inconsistently marked pull requests before reading the webhook
- document the repository secret required to enable delivery

## Behavior
A merged campaign matching the shape of #975 posts the pull request title and its `Summary` section to Discord, with version, source link, and abbreviated DMG SHA-256 fields. Pull request content cannot trigger Discord mentions.

The workflow checks out only the trusted default branch before using `DISCORD_BUILD_ANNOUNCEMENTS_WEBHOOK_URL`. The repository owner must create the channel webhook and add that Actions secret before the workflow can deliver announcements.

## Validation
- `node --test scripts/ci/discord-build-announcement.test.js`
- `node --test scripts/ci/*.test.js` (85 passed)
- `bash tests/scripts_smoke.sh`
- `node --check scripts/ci/discord-build-announcement.js`
- YAML parse of `.github/workflows/discord-build-announcement.yml`
- rendered the real #975 event payload locally without sending a webhook
- `git diff --check`

## Not validated
- no live Discord message was sent because the repository webhook secret is intentionally unavailable in the contributor environment
