### PR TITLE
fix(build): ignore next candidate runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ codex-app.backup-*/
 .codex-app.candidate-*/
 .codex-app.promotion.json
 .codex-app.promotion.lock
+codex-app-next.backup-*/
+.codex-app-next.candidate-*/
+.codex-app-next.promotion.json
+.codex-app-next.promotion.lock
 codex-*-app/
 codex-app-next/
 bin/codex-*


### PR DESCRIPTION
## Summary
- ignore generated `codex-app-next` candidate, promotion, and backup state
- keep upstream-DMG watchdog acceptance provenance clean during side-by-side rebuilds

<!-- upstream-dmg-sha256:40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6 -->

## Validation
- current upstream DMG `26.707.72221`: accepted_with_warnings (no blockers)
- `./scripts/ci-local.sh pr`
- watchdog Nix preflight
