### PR TITLE
Fix current DMG optional core patch drift

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1115,6 +1115,41 @@ test("window controls safe-area descriptor matches current app shell chunks", ()
   );
 });
 
+test("optional webview descriptors follow the current upstream chunk split", () => {
+  const descriptors = corePatchDescriptors();
+  const automationUpdate = descriptors.find(
+    (descriptor) => descriptor.id === "automation-update-eager-tool",
+  );
+  const tooltipCollision = descriptors.find(
+    (descriptor) => descriptor.id === "linux-tooltip-window-controls-collision",
+  );
+
+  assert.ok(automationUpdate);
+  assert.equal(
+    automationUpdate.pattern.test("app-initial~app-main~onboarding-page-CIkoyvFz.js"),
+    true,
+  );
+  assert.equal(
+    automationUpdate.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~legacy.js",
+    ),
+    false,
+  );
+  assert.ok(tooltipCollision);
+  assert.equal(
+    tooltipCollision.pattern.test(
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+    ),
+    true,
+  );
+  assert.equal(
+    tooltipCollision.pattern.test(
+      "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~legacy.js",
+    ),
+    false,
+  );
+});
+
 test("patch descriptors reject unsupported ciPolicy values", () => {
   assert.throws(
     () =>

--- a/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
+++ b/scripts/patches/core/all-linux/extracted-app/workspace-root-open-targets/patch.js
@@ -303,7 +303,7 @@ function patchWorkspaceRootOpenTargets(extractedDir) {
   let changed = 0;
 
   for (const name of fs.readdirSync(assetsDir)) {
-    if (!/^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/u.test(name)) {
+    if (!/^app-initial~app-main~page-[^.]+\.js$/u.test(name)) {
       continue;
     }
     const filePath = path.join(assetsDir, name);

--- a/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
+++ b/scripts/patches/core/all-linux/webview/automation-update-eager-tool/patch.js
@@ -13,7 +13,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1045,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
+    pattern: /^app-initial~app-main~onboarding-page-[^.]+\.js$/,
     missingDescription: "dynamic Codex app tools bundle",
     skipDescription: "automation_update eager dynamic tool patch",
     apply: applyAutomationUpdateEagerToolPatch,

--- a/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
+++ b/scripts/patches/core/all-linux/webview/theme-and-sunset/patch.js
@@ -57,7 +57,7 @@ module.exports = [
     phase: "webview-asset",
     order: 1050,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~[^.]+\.js$/,
+    pattern: /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-[^.]+\.js$/,
     missingDescription: "tooltip bundle",
     skipDescription: "Linux tooltip titlebar collision patch",
     apply: applyLinuxTooltipWindowControlsCollisionPatch,

--- a/scripts/workspace-root-open-targets-patch.test.js
+++ b/scripts/workspace-root-open-targets-patch.test.js
@@ -124,7 +124,7 @@ test("workspace root dropdown follows aliased File Manager callbacks", () => {
   assert.equal(applyWorkspaceRootOpenTargetsPatch(patched, targets), patched);
 });
 
-test("workspace root open targets patch scans current shared app main project chunks", () => {
+test("workspace root open targets patch scans the current app page chunk", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-workspace-root-open-targets-"));
   try {
     const buildDir = path.join(root, ".vite", "build");
@@ -145,7 +145,7 @@ test("workspace root open targets patch scans current shared app main project ch
       path.join(assetsDir, "app-main-current.js"),
       "function decoy(){return{target:`fileManager`}}",
     );
-    const sharedChunkName = "app-initial~app-main~projects-index-page~remote-conversation-page-current.js";
+    const sharedChunkName = "app-initial~app-main~page-current.js";
     fs.writeFileSync(
       path.join(assetsDir, sharedChunkName),
       [


### PR DESCRIPTION
## Summary

- retarget the eager `automation_update` and tooltip collision patches to the current upstream webview chunks
- retarget workspace-root open actions to the current app page chunk
- add coverage that accepts the current chunk split and rejects the removed legacy DMG shape

## Why

The latest upstream CODEX.DMG rechunked these three optional core patch surfaces. The patches still matched the current source shapes, but their asset selectors no longer reached those sources, producing optional drift warnings.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js scripts/workspace-root-open-targets-patch.test.js` (376 passed)
- `node scripts/ci/validate-patch-report.js codex-app/.codex-linux/patch-report.json`
- `./install.sh /home/igor/codex-desktop-linux/Codex.dmg` with eight locally enabled Linux features
  - upstream app version `26.707.72221`
  - acceptance verdict `accepted`
  - all three affected patches reported `applied`
  - no blockers or warnings

## Notes / risk

This changes only current-DMG asset routing for optional core patches. It intentionally removes the old chunk selectors instead of retaining compatibility fallbacks. The patch implementations and package-format-specific paths are unchanged.
