### PR TITLE
docs: add Discord community link and refresh guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,8 +95,10 @@ Detailed agent docs: [repository map](docs/agents/repository-map.md),
 
 Primary human docs: [architecture](docs/architecture.md),
 [build and packaging](docs/build-and-packaging.md),
+[native setup](docs/native-setup.md),
 [Linux features](docs/linux-features-architecture.md),
 [updater](docs/updater.md), [Linux Computer Use](docs/linux-computer-use.md),
+[Record and Replay](docs/record-and-replay-linux.md),
 [Nix](docs/nix.md), and [troubleshooting](docs/troubleshooting.md).
 
 Repository governance: [issue and pull request labels](docs/label-governance.md).

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <p align="center">
   <a href="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/ci.yml"><img src="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/upstream-build-app.yml"><img src="https://github.com/ilysenko/codex-desktop-linux/actions/workflows/upstream-build-app.yml/badge.svg" alt="Upstream Build App"></a>
+  <a href="https://discord.gg/skCB3DXqgw"><img src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white" alt="Join the Discord community"></a>
 </p>
 
 Unofficial Linux build wrapper for [OpenAI ChatGPT Desktop](https://chatgpt.com/features/desktop/).
@@ -21,7 +22,8 @@ rebuilds future Linux packages from newer upstream DMGs.
   <a href="#updates">Updates</a> ·
   <a href="#build-package-and-run">Build</a> ·
   <a href="#troubleshooting">Troubleshooting</a> ·
-  <a href="#project-docs">Docs</a>
+  <a href="#project-docs">Docs</a> ·
+  <a href="https://discord.gg/skCB3DXqgw">Discord</a>
 </p>
 
 Before opening a pull request, read [CONTRIBUTING.md](CONTRIBUTING.md). For
@@ -218,8 +220,10 @@ workarounds.
 | Global Dictation | Opt-in | `global-dictation` | [Docs](linux-features/global-dictation/README.md) |
 | MCP helper reaper | Opt-in | `mcp-helper-reaper` | [Docs](linux-features/mcp-helper-reaper/README.md) |
 | Browser Use node_repl reaper | Opt-in | `node-repl-reaper` | [Docs](linux-features/node-repl-reaper/README.md) |
+| Omarchy theme | Opt-in | `omarchy-theme` | [Docs](linux-features/omarchy-theme/README.md) |
 | Open Target Discovery | Opt-in | `open-target-discovery` | [Docs](linux-features/open-target-discovery/README.md) |
 | Persistent status panel | Opt-in | `persistent-status-panel` | [Docs](linux-features/persistent-status-panel/README.md) |
+| Pet overlay | Opt-in | `pet-overlay` | [Docs](linux-features/pet-overlay/README.md) |
 | Project task Created sorting | Opt-in | `project-task-sort` | [Docs](linux-features/project-task-sort/README.md) |
 | Read Aloud button | Opt-in | `read-aloud` | [Docs](linux-features/read-aloud/README.md) |
 | Read Aloud MCP | Opt-in | `read-aloud-mcp` | [Docs](linux-features/read-aloud-mcp/README.md) |

--- a/docs/agents/generated-and-runtime-notes.md
+++ b/docs/agents/generated-and-runtime-notes.md
@@ -85,8 +85,8 @@ that agents need without keeping them in the main quick-start.
 
 ## Runtime Expectations
 
-- `python3`, `7z`, `curl`, `unzip`, `tar`, `make`, and `g++` are required for
-  `install.sh`.
+- `python3`, `7z`, `curl`, `unzip`, `tar`, `flock`, `make`, and `g++` are
+  required for `install.sh`.
 - Native package builders require their format-specific tools (`dpkg-deb`,
   `rpmbuild`, `makepkg`/pacman tooling, or `appimagetool`).
 - `scripts/install-deps.sh` bootstraps common host dependencies. On apt-based

--- a/docs/agents/repository-map.md
+++ b/docs/agents/repository-map.md
@@ -303,9 +303,22 @@ plus a native package plus `codex-update-manager`.
   Linux Computer Use backend, windowing, and desktop integration notes.
 - `docs/record-and-replay-linux.md`
   Linux Record & Replay compatibility and tester acceptance notes.
+- `docs/upstream-dmg-acceptance.md`
+  Shared acceptance policy for local installs, updater rebuilds, and CI.
+- `docs/upstream-dmg-intelligence.md`
+  Protected-surface inspection and upstream drift intelligence.
+- `docs/upstream-dmg-watchdog.md`
+  Scheduled upstream DMG campaign and issue lifecycle.
 - `docs/nix.md`
   Nix flake, modules, and hash-pin workflow.
 - `docs/troubleshooting.md`
   Common install/runtime issues and diagnostics.
+- `docs/label-governance.md`
+  Staff-managed issue and pull request label policy.
+- `docs/github-cli-auth.md`
+  GitHub CLI authentication behavior in app-launched shells.
+- `docs/wayland-input-focus-investigation.md` and
+  `docs/linux-chronicle-skysight.md`
+  Focused investigation and integration notes for Linux-specific workflows.
 - `docs/webview-server-evaluation.md` and `docs/launcher-performance.md`
   Decision records for the webview server and launcher performance defaults.


### PR DESCRIPTION
## Summary
- add the Discord community badge beside the upstream build badge and link it from the README navigation
- restore missing Omarchy theme and Pet overlay entries in the feature matrix
- refresh agent-facing documentation links and runtime requirements

## Checks
- `git diff --check`
- verified all local Markdown link targets in touched files
- verified README coverage for all 26 repository feature IDs
- verified the Discord invite and badge endpoints