### PR TITLE
Fix updater fallback bundle inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -122,12 +122,7 @@ pub async fn build_update_from(
     state.artifact_paths.workspace_dir = Some(workspace.workspace_dir.clone());
     state.save(&paths.state_file)?;
 
-    let feature_config = crate::config::effective_feature_config_path(config);
-    copy_builder_bundle(
-        bundle_source,
-        &workspace.bundle_dir,
-        feature_config.as_deref(),
-    )?;
+    copy_builder_bundle(bundle_source, &workspace.bundle_dir)?;
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
@@ -151,7 +146,7 @@ pub async fn build_update_from(
     // writes it to a stable per-user path) so the rebuild stages exactly those
     // features. Only set it when the file actually exists; an absent path would
     // make linux-features.js see an empty enabled set and stage nothing.
-    if let Some(feature_config) = feature_config {
+    if let Some(feature_config) = crate::config::effective_feature_config_path(config) {
         install.env("CODEX_LINUX_FEATURES_CONFIG", &feature_config);
     }
     run_and_log(&mut install, &workspace.install_log)
@@ -251,11 +246,7 @@ fn package_build_script(bundle_dir: &Path) -> PathBuf {
     }
 }
 
-fn copy_builder_bundle(
-    source_root: &Path,
-    destination_root: &Path,
-    feature_config: Option<&Path>,
-) -> Result<()> {
+fn copy_builder_bundle(source_root: &Path, destination_root: &Path) -> Result<()> {
     let manifest_path = source_root.join(UPDATE_BUILDER_MANIFEST);
     if manifest_path.exists() {
         return copy_builder_bundle_from_manifest(source_root, destination_root, &manifest_path);
@@ -277,32 +268,7 @@ fn copy_builder_bundle(
         )?;
     }
 
-    if linux_feature_enabled_in_config(feature_config, "global-dictation") {
-        copy_entry(
-            &source_root.join("global-dictation-linux"),
-            &destination_root.join("global-dictation-linux"),
-            false,
-        )?;
-    }
-
     Ok(())
-}
-
-fn linux_feature_enabled_in_config(feature_config: Option<&Path>, feature_id: &str) -> bool {
-    let Some(feature_config) = feature_config else {
-        return false;
-    };
-    let Ok(contents) = fs::read_to_string(feature_config) else {
-        return false;
-    };
-    let Ok(config) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return false;
-    };
-
-    config
-        .get("enabled")
-        .and_then(serde_json::Value::as_array)
-        .is_some_and(|enabled| enabled.iter().any(|id| id.as_str() == Some(feature_id)))
 }
 
 fn copy_builder_bundle_from_manifest(
@@ -984,14 +950,19 @@ fi
         Ok(())
     }
 
-    fn write_fake_fallback_bundle(source_root: &Path) -> Result<()> {
+    #[test]
+    fn bundle_copy_skips_missing_optional_package_scripts() -> Result<()> {
+        let temp = tempdir()?;
+        let source_root = temp.path().join("source");
+        let destination_root = temp.path().join("destination");
+
         fs::create_dir_all(source_root.join("scripts/lib"))?;
         fs::create_dir_all(source_root.join("launcher"))?;
         fs::create_dir_all(source_root.join("packaging/linux"))?;
         fs::create_dir_all(source_root.join("assets"))?;
-        write_fake_computer_use_bundle(source_root)?;
-        write_fake_linux_features_bundle(source_root)?;
-        write_fake_patch_bundle(source_root)?;
+        write_fake_computer_use_bundle(&source_root)?;
+        write_fake_linux_features_bundle(&source_root)?;
+        write_fake_patch_bundle(&source_root)?;
         fs::write(source_root.join("install.sh"), b"#!/bin/bash\n")?;
         fs::write(
             source_root.join("launcher/cli-launch-path.py"),
@@ -1032,18 +1003,8 @@ fi
         )?;
         fs::write(source_root.join("assets/codex.png"), b"png")?;
         fs::write(source_root.join("assets/codex-linux.png"), b"linux png")?;
-        Ok(())
-    }
 
-    #[test]
-    fn bundle_copy_skips_missing_optional_package_scripts() -> Result<()> {
-        let temp = tempdir()?;
-        let source_root = temp.path().join("source");
-        let destination_root = temp.path().join("destination");
-
-        write_fake_fallback_bundle(&source_root)?;
-
-        copy_builder_bundle(&source_root, &destination_root, None)?;
+        copy_builder_bundle(&source_root, &destination_root)?;
 
         assert!(destination_root.join("scripts/build-deb.sh").exists());
         assert!(destination_root
@@ -1081,36 +1042,6 @@ fi
     }
 
     #[test]
-    fn fallback_bundle_copies_global_dictation_source_when_enabled() -> Result<()> {
-        let temp = tempdir()?;
-        let source_root = temp.path().join("source");
-        let destination_root = temp.path().join("destination");
-        let feature_config = temp.path().join("linux-features.json");
-
-        write_fake_fallback_bundle(&source_root)?;
-        fs::create_dir_all(source_root.join("global-dictation-linux/src"))?;
-        fs::write(
-            source_root.join("global-dictation-linux/Cargo.toml"),
-            b"[package]\nname = \"codex-global-dictation-linux\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
-        )?;
-        fs::write(
-            source_root.join("global-dictation-linux/src/main.rs"),
-            b"fn main() {}\n",
-        )?;
-        fs::write(&feature_config, b"{\"enabled\":[\"global-dictation\"]}\n")?;
-
-        copy_builder_bundle(&source_root, &destination_root, Some(&feature_config))?;
-
-        assert!(destination_root
-            .join("global-dictation-linux/Cargo.toml")
-            .exists());
-        assert!(destination_root
-            .join("global-dictation-linux/src/main.rs")
-            .exists());
-        Ok(())
-    }
-
-    #[test]
     fn bundle_copy_prefers_packaged_update_builder_manifest() -> Result<()> {
         let temp = tempdir()?;
         let source_root = temp.path().join("source");
@@ -1131,7 +1062,7 @@ fi
             b"# generated\nassets/codex-linux.png\nrecord-replay-linux/Cargo.toml\n",
         )?;
 
-        copy_builder_bundle(&source_root, &destination_root, None)?;
+        copy_builder_bundle(&source_root, &destination_root)?;
 
         assert!(destination_root.join("assets/codex-linux.png").exists());
         assert!(destination_root
@@ -1151,7 +1082,7 @@ fi
         fs::create_dir_all(source_root.join(".codex-linux"))?;
         fs::write(source_root.join(UPDATE_BUILDER_MANIFEST), b"../escape\n")?;
 
-        let error = copy_builder_bundle(&source_root, &destination_root, None)
+        let error = copy_builder_bundle(&source_root, &destination_root)
             .expect_err("manifest parent path should be rejected");
         assert!(error
             .to_string()
@@ -1168,7 +1099,7 @@ fi
         fs::create_dir_all(source_root.join(".codex-linux"))?;
         fs::write(source_root.join(UPDATE_BUILDER_MANIFEST), b"/tmp/escape\n")?;
 
-        let error = copy_builder_bundle(&source_root, &destination_root, None)
+        let error = copy_builder_bundle(&source_root, &destination_root)
             .expect_err("manifest absolute path should be rejected");
         assert!(error
             .to_string()

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -16,10 +16,11 @@ use tracing::info;
 
 const UPDATE_BUILDER_MANIFEST: &str = ".codex-linux/update-builder-manifest.txt";
 
-const REQUIRED_BUNDLE_FILES: [(&str, &str); 20] = [
+const REQUIRED_BUNDLE_FILES: [(&str, &str); 22] = [
     ("Cargo.toml", "Cargo.toml"),
     ("Cargo.lock", "Cargo.lock"),
     ("computer-use-linux", "computer-use-linux"),
+    ("notification-actions-linux", "notification-actions-linux"),
     ("read-aloud-linux", "read-aloud-linux"),
     ("record-replay-linux", "record-replay-linux"),
     ("updater", "updater"),
@@ -32,6 +33,7 @@ const REQUIRED_BUNDLE_FILES: [(&str, &str); 20] = [
         "plugins/openai-bundled/plugins/read-aloud",
     ),
     ("install.sh", "install.sh"),
+    ("launcher/cli-launch-path.py", "launcher/cli-launch-path.py"),
     ("launcher/start.sh.template", "launcher/start.sh.template"),
     ("launcher/webview-server.py", "launcher/webview-server.py"),
     ("scripts/build-deb.sh", "scripts/build-deb.sh"),
@@ -616,7 +618,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
     fn write_fake_computer_use_bundle(root: &Path) -> Result<()> {
         fs::write(
             root.join("Cargo.toml"),
-            b"[workspace]\nmembers = [\"computer-use-linux\", \"read-aloud-linux\", \"record-replay-linux\", \"updater\"]\n",
+            b"[workspace]\nmembers = [\"computer-use-linux\", \"notification-actions-linux\", \"read-aloud-linux\", \"record-replay-linux\", \"updater\"]\n",
         )?;
         fs::write(root.join("Cargo.lock"), b"# fake lock\n")?;
         fs::create_dir_all(root.join("computer-use-linux/src"))?;
@@ -626,6 +628,15 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         )?;
         fs::write(
             root.join("computer-use-linux/src/main.rs"),
+            b"fn main() {}\n",
+        )?;
+        fs::create_dir_all(root.join("notification-actions-linux/src"))?;
+        fs::write(
+            root.join("notification-actions-linux/Cargo.toml"),
+            b"[package]\nname = \"codex-notification-actions-linux\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(
+            root.join("notification-actions-linux/src/main.rs"),
             b"fn main() {}\n",
         )?;
         fs::create_dir_all(root.join("read-aloud-linux/src"))?;
@@ -734,6 +745,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         fs::write(
             bundle_root.join(".codex-linux/source-info.json"),
             b"{\"commit\":\"0123456789012345678901234567890123456789\",\"version\":\"0.8.1\"}\n",
+        )?;
+        fs::write(
+            bundle_root.join("launcher/cli-launch-path.py"),
+            b"# fake CLI launch path helper\n",
         )?;
         fs::write(
             bundle_root.join("launcher/start.sh.template"),
@@ -950,6 +965,10 @@ fi
         write_fake_patch_bundle(&source_root)?;
         fs::write(source_root.join("install.sh"), b"#!/bin/bash\n")?;
         fs::write(
+            source_root.join("launcher/cli-launch-path.py"),
+            b"# fake CLI launch path helper\n",
+        )?;
+        fs::write(
             source_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
         )?;
@@ -994,10 +1013,16 @@ fi
         assert!(destination_root.join("launcher/webview-server.py").exists());
         assert_fresh_patch_bundle(&destination_root);
         assert!(destination_root.join("computer-use-linux").exists());
+        assert!(destination_root
+            .join("notification-actions-linux/Cargo.toml")
+            .exists());
         assert!(!destination_root.join("global-dictation-linux").exists());
         assert!(destination_root.join("read-aloud-linux").exists());
         assert!(destination_root.join("record-replay-linux").exists());
         assert!(destination_root.join("updater").exists());
+        assert!(destination_root
+            .join("launcher/cli-launch-path.py")
+            .exists());
         assert!(destination_root.join("assets/codex-linux.png").exists());
         assert!(destination_root
             .join("plugins/openai-bundled/plugins/computer-use/.mcp.json")

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -122,7 +122,12 @@ pub async fn build_update_from(
     state.artifact_paths.workspace_dir = Some(workspace.workspace_dir.clone());
     state.save(&paths.state_file)?;
 
-    copy_builder_bundle(bundle_source, &workspace.bundle_dir)?;
+    let feature_config = crate::config::effective_feature_config_path(config);
+    copy_builder_bundle(
+        bundle_source,
+        &workspace.bundle_dir,
+        feature_config.as_deref(),
+    )?;
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
@@ -146,7 +151,7 @@ pub async fn build_update_from(
     // writes it to a stable per-user path) so the rebuild stages exactly those
     // features. Only set it when the file actually exists; an absent path would
     // make linux-features.js see an empty enabled set and stage nothing.
-    if let Some(feature_config) = crate::config::effective_feature_config_path(config) {
+    if let Some(feature_config) = feature_config {
         install.env("CODEX_LINUX_FEATURES_CONFIG", &feature_config);
     }
     run_and_log(&mut install, &workspace.install_log)
@@ -246,7 +251,11 @@ fn package_build_script(bundle_dir: &Path) -> PathBuf {
     }
 }
 
-fn copy_builder_bundle(source_root: &Path, destination_root: &Path) -> Result<()> {
+fn copy_builder_bundle(
+    source_root: &Path,
+    destination_root: &Path,
+    feature_config: Option<&Path>,
+) -> Result<()> {
     let manifest_path = source_root.join(UPDATE_BUILDER_MANIFEST);
     if manifest_path.exists() {
         return copy_builder_bundle_from_manifest(source_root, destination_root, &manifest_path);
@@ -268,7 +277,32 @@ fn copy_builder_bundle(source_root: &Path, destination_root: &Path) -> Result<()
         )?;
     }
 
+    if linux_feature_enabled_in_config(feature_config, "global-dictation") {
+        copy_entry(
+            &source_root.join("global-dictation-linux"),
+            &destination_root.join("global-dictation-linux"),
+            false,
+        )?;
+    }
+
     Ok(())
+}
+
+fn linux_feature_enabled_in_config(feature_config: Option<&Path>, feature_id: &str) -> bool {
+    let Some(feature_config) = feature_config else {
+        return false;
+    };
+    let Ok(contents) = fs::read_to_string(feature_config) else {
+        return false;
+    };
+    let Ok(config) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+
+    config
+        .get("enabled")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|enabled| enabled.iter().any(|id| id.as_str() == Some(feature_id)))
 }
 
 fn copy_builder_bundle_from_manifest(
@@ -950,12 +984,7 @@ fi
         Ok(())
     }
 
-    #[test]
-    fn bundle_copy_skips_missing_optional_package_scripts() -> Result<()> {
-        let temp = tempdir()?;
-        let source_root = temp.path().join("source");
-        let destination_root = temp.path().join("destination");
-
+    fn write_fake_fallback_bundle(source_root: &Path) -> Result<()> {
         fs::create_dir_all(source_root.join("scripts/lib"))?;
         fs::create_dir_all(source_root.join("launcher"))?;
         fs::create_dir_all(source_root.join("packaging/linux"))?;
@@ -1003,8 +1032,18 @@ fi
         )?;
         fs::write(source_root.join("assets/codex.png"), b"png")?;
         fs::write(source_root.join("assets/codex-linux.png"), b"linux png")?;
+        Ok(())
+    }
 
-        copy_builder_bundle(&source_root, &destination_root)?;
+    #[test]
+    fn bundle_copy_skips_missing_optional_package_scripts() -> Result<()> {
+        let temp = tempdir()?;
+        let source_root = temp.path().join("source");
+        let destination_root = temp.path().join("destination");
+
+        write_fake_fallback_bundle(&source_root)?;
+
+        copy_builder_bundle(&source_root, &destination_root, None)?;
 
         assert!(destination_root.join("scripts/build-deb.sh").exists());
         assert!(destination_root
@@ -1042,6 +1081,36 @@ fi
     }
 
     #[test]
+    fn fallback_bundle_copies_global_dictation_source_when_enabled() -> Result<()> {
+        let temp = tempdir()?;
+        let source_root = temp.path().join("source");
+        let destination_root = temp.path().join("destination");
+        let feature_config = temp.path().join("linux-features.json");
+
+        write_fake_fallback_bundle(&source_root)?;
+        fs::create_dir_all(source_root.join("global-dictation-linux/src"))?;
+        fs::write(
+            source_root.join("global-dictation-linux/Cargo.toml"),
+            b"[package]\nname = \"codex-global-dictation-linux\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )?;
+        fs::write(
+            source_root.join("global-dictation-linux/src/main.rs"),
+            b"fn main() {}\n",
+        )?;
+        fs::write(&feature_config, b"{\"enabled\":[\"global-dictation\"]}\n")?;
+
+        copy_builder_bundle(&source_root, &destination_root, Some(&feature_config))?;
+
+        assert!(destination_root
+            .join("global-dictation-linux/Cargo.toml")
+            .exists());
+        assert!(destination_root
+            .join("global-dictation-linux/src/main.rs")
+            .exists());
+        Ok(())
+    }
+
+    #[test]
     fn bundle_copy_prefers_packaged_update_builder_manifest() -> Result<()> {
         let temp = tempdir()?;
         let source_root = temp.path().join("source");
@@ -1062,7 +1131,7 @@ fi
             b"# generated\nassets/codex-linux.png\nrecord-replay-linux/Cargo.toml\n",
         )?;
 
-        copy_builder_bundle(&source_root, &destination_root)?;
+        copy_builder_bundle(&source_root, &destination_root, None)?;
 
         assert!(destination_root.join("assets/codex-linux.png").exists());
         assert!(destination_root
@@ -1082,7 +1151,7 @@ fi
         fs::create_dir_all(source_root.join(".codex-linux"))?;
         fs::write(source_root.join(UPDATE_BUILDER_MANIFEST), b"../escape\n")?;
 
-        let error = copy_builder_bundle(&source_root, &destination_root)
+        let error = copy_builder_bundle(&source_root, &destination_root, None)
             .expect_err("manifest parent path should be rejected");
         assert!(error
             .to_string()
@@ -1099,7 +1168,7 @@ fi
         fs::create_dir_all(source_root.join(".codex-linux"))?;
         fs::write(source_root.join(UPDATE_BUILDER_MANIFEST), b"/tmp/escape\n")?;
 
-        let error = copy_builder_bundle(&source_root, &destination_root)
+        let error = copy_builder_bundle(&source_root, &destination_root, None)
             .expect_err("manifest absolute path should be rejected");
         assert!(error
             .to_string()

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -989,9 +989,9 @@ fi
         fs::create_dir_all(source_root.join("launcher"))?;
         fs::create_dir_all(source_root.join("packaging/linux"))?;
         fs::create_dir_all(source_root.join("assets"))?;
-        write_fake_computer_use_bundle(&source_root)?;
-        write_fake_linux_features_bundle(&source_root)?;
-        write_fake_patch_bundle(&source_root)?;
+        write_fake_computer_use_bundle(source_root)?;
+        write_fake_linux_features_bundle(source_root)?;
+        write_fake_patch_bundle(source_root)?;
         fs::write(source_root.join("install.sh"), b"#!/bin/bash\n")?;
         fs::write(
             source_root.join("launcher/cli-launch-path.py"),


### PR DESCRIPTION
## Summary

- include `notification-actions-linux` in fallback update-builder copies
- include `launcher/cli-launch-path.py` in the same fallback path
- extend the fallback bundle fixtures and assertions to cover both required inputs
- bump `codex-update-manager` to `0.10.1`

## Root cause

The packaged update-builder manifest already captures these files, but the fallback `REQUIRED_BUNDLE_FILES` list used by source checkouts without that manifest was stale.

`notification-actions-linux` became a Cargo workspace member in #895, while `launcher/cli-launch-path.py` became an installer input in #962. A fallback rebuild therefore copied the root workspace manifest without the notification crate and later omitted the CLI launch helper expected by `install.sh`.

This caused rebuilds to fail first while Cargo loaded the workspace and then, after working around that missing crate, while the installer copied the CLI launch helper.

## User impact

Updater rebuilds from a manifest-less builder checkout now receive the complete Cargo workspace and launcher inputs instead of failing partway through local package generation.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-update-manager`
- `cargo test -p codex-update-manager` (261 passed)
- `bash tests/scripts_smoke.sh`
- Fedora 44 end-to-end updater rebuild produced the RPM and reached `waiting_for_app_exit`
