### PR TITLE
Allow trusted Nix store CLI paths

### DIFF
--- a/launcher/cli-launch-path.py
+++ b/launcher/cli-launch-path.py
@@ -67,11 +67,7 @@ def validate_parent_chain(path: Path, subject: str) -> None:
                 f"{subject} ancestor {parent} is owned by untrusted uid {metadata.st_uid}"
             )
         writable = metadata.st_mode & 0o022
-        root_owned_sticky = (
-            metadata.st_uid == 0
-            and metadata.st_mode & stat.S_ISVTX
-            and metadata.st_mode & 0o002
-        )
+        root_owned_sticky = metadata.st_uid == 0 and metadata.st_mode & stat.S_ISVTX
         if writable and not root_owned_sticky:
             raise TrustError(
                 f"{subject} ancestor {parent} is group/world-writable and therefore untrusted"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6716,7 +6716,10 @@ SCRIPT
 import importlib.util
 import os
 import pathlib
+import stat
 import sys
+from types import SimpleNamespace
+from unittest import mock
 
 spec = importlib.util.spec_from_file_location("cli_launch_path", pathlib.Path(sys.argv[1]))
 module = importlib.util.module_from_spec(spec)
@@ -6727,6 +6730,31 @@ untrusted_uid = 2 if euid == 1 else 1
 assert module.trusted_owner(euid)
 assert module.trusted_owner(0)
 assert not module.trusted_owner(untrusted_uid)
+
+trusted_ancestors = {
+    pathlib.Path("/"): SimpleNamespace(st_mode=stat.S_IFDIR | 0o755, st_uid=0),
+    pathlib.Path("/nix"): SimpleNamespace(st_mode=stat.S_IFDIR | 0o755, st_uid=0),
+    pathlib.Path("/nix/store"): SimpleNamespace(st_mode=stat.S_IFDIR | stat.S_ISVTX | 0o775, st_uid=0),
+    pathlib.Path("/nix/store/example"): SimpleNamespace(st_mode=stat.S_IFDIR | 0o555, st_uid=0),
+    pathlib.Path("/nix/store/example/bin"): SimpleNamespace(st_mode=stat.S_IFDIR | 0o555, st_uid=0),
+}
+with mock.patch.object(pathlib.Path, "lstat", autospec=True, side_effect=trusted_ancestors.__getitem__):
+    module.validate_parent_chain(
+        pathlib.Path("/nix/store/example/bin/codex"),
+        "Selected Codex CLI target",
+    )
+
+trusted_ancestors[pathlib.Path("/nix/store")].st_mode = stat.S_IFDIR | 0o775
+with mock.patch.object(pathlib.Path, "lstat", autospec=True, side_effect=trusted_ancestors.__getitem__):
+    try:
+        module.validate_parent_chain(
+            pathlib.Path("/nix/store/example/bin/codex"),
+            "Selected Codex CLI target",
+        )
+    except module.TrustError:
+        pass
+    else:
+        raise AssertionError("root-owned group-writable ancestors without sticky must remain untrusted")
 PY
 
     rm "$visible_cli"


### PR DESCRIPTION
Summary:
- accept root-owned sticky ancestors that are group-writable, matching the standard `/nix/store` 1775 mode
- retain owner, file type, target mode, and non-sticky writable-directory checks
- add launcher regression coverage for trusted and untrusted ancestor modes

Tests/checks:
- `bash tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template`
- `python3 -m py_compile launcher/cli-launch-path.py`
- `git diff --check`

Notes:
- Nix tooling is unavailable in the local environment, so `nix flake check` was not run.

Fixes #990