### PR TITLE
Fix enabled feature drift for latest upstream DMG

### DIFF
--- a/linux-features/api-key-service-tier/patch.js
+++ b/linux-features/api-key-service-tier/patch.js
@@ -204,7 +204,8 @@ const descriptors = [
     phase: "webview-asset",
     order: 20605,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-[^.]+\.js$/,
+    pattern:
+      /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/,
     missingDescription: "current API key service tier model bundle",
     skipDescription: "API key model service tier marker patch",
     apply: applyCurrentModelPatch,
@@ -214,7 +215,8 @@ const descriptors = [
     phase: "webview-asset",
     order: 20610,
     ciPolicy: "optional",
-    pattern: /^app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-[^.]+\.js$/,
+    pattern:
+      /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-[^.]+\.js$/,
     missingDescription: "current API key service tier fallback bundle",
     skipDescription: "API key fallback fast tier patch",
     apply: applyCurrentFallbackFastTierPatch,

--- a/linux-features/api-key-service-tier/test.js
+++ b/linux-features/api-key-service-tier/test.js
@@ -100,15 +100,27 @@ test("current DMG descriptors target the three owning app bundles", () => {
   );
   assert.equal(
     descriptors[1].pattern.test(
-      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BpnUyB2R.js",
+      "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-BjNKtmac.js",
     ),
     true,
   );
   assert.equal(
     descriptors[2].pattern.test(
-      "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-BqLP6EDd.js",
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
     ),
     true,
+  );
+  assert.equal(
+    descriptors[1].pattern.test(
+      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BhQogfRL.js",
+    ),
+    false,
+  );
+  assert.equal(
+    descriptors[2].pattern.test(
+      "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-C3751cTh.js",
+    ),
+    false,
   );
   assert.equal(
     descriptors.some((descriptor) =>
@@ -159,14 +171,14 @@ test("partial current drift is reported when the other exact target still applie
       fs.writeFileSync(
         path.join(
           assetsDir,
-          "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-current.js",
+          "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-current.js",
         ),
         "function vbe({authMethod:e,availableModels:t,defaultModel:n,enabledReasoningEfforts:r,includeUltraReasoningEffort:i,models:a,useHiddenModels:o}){let s=[],c=null,l=o&&e!==`amazonBedrock`,u=a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`max`)),d=i&&a.some(e=>e.supportedReasoningEfforts.some(({reasoningEffort:e})=>e===`ultra`));return a.forEach(n=>{if(l?t.has(n.model):!n.hidden){let t=i?n.supportedReasoningEfforts:n.supportedReasoningEfforts.filter(({reasoningEffort:e})=>e!==`ultra`),a=(e===`copilot`?[t.find(e=>e.reasoningEffort===`medium`)??{reasoningEffort:`medium`,description:`medium effort`}]:t).filter(({reasoningEffort:e})=>Gx(e)&&r.has(e)),o={...n,supportedReasoningEfforts:a};s.push(o),n.isDefault&&(c=o)}}),c??=s.find(e=>e.model===n)??null,{models:s,defaultModel:c}}",
       );
       fs.writeFileSync(
         path.join(
           assetsDir,
-          "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-current.js",
+          "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-current.js",
         ),
         [
           "let defaultServiceTier=null;",
@@ -347,7 +359,7 @@ test("fallback descriptor reports skipped when one insertion point drifts", () =
       const assetsDir = path.join(tempApp, "webview", "assets");
       const targetPath = path.join(
         assetsDir,
-        "app-initial~app-main~quick-chat-window-page~work-home-page~chatgpt-conversation-page-drifted.js",
+        "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-drifted.js",
       );
       const source = [
         "let defaultServiceTier=null;",

--- a/linux-features/project-task-sort/patch.js
+++ b/linux-features/project-task-sort/patch.js
@@ -45,8 +45,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_900,
     ciPolicy: "optional",
-    pattern:
-      /^app-initial~app-main~projects-index-page~remote-conversation-page-[A-Za-z0-9_-]+\.js$/,
+    pattern: /^app-initial~app-main~page-[^.]+\.js$/,
     missingDescription: "project task sort webview bundle",
     skipDescription: "project task creation timestamp feature patch",
     apply: applyProjectTaskSortPatch,

--- a/linux-features/project-task-sort/test.js
+++ b/linux-features/project-task-sort/test.js
@@ -177,7 +177,7 @@ test("descriptor targets and patches the current project chunk", () => {
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~projects-index-page~remote-conversation-page-y7pwA1Hj.js",
+      "app-initial~app-main~page-Cmd9LUYY.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentProjectSource);
@@ -193,7 +193,7 @@ test("descriptor targets and patches the current project chunk", () => {
     assert.notEqual(fs.readFileSync(assetPath, "utf8"), currentProjectSource);
     assert.equal(
       descriptors[0].pattern.test(
-        "app-initial~app-main~projects-index-page~settings-page-y7pwA1Hj.js",
+        "app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~iqsnin5k-CcY42RXW.js",
       ),
       false,
     );


### PR DESCRIPTION
## What changed

- retarget the API-key service-tier model and fallback descriptors to the current `26.707.72221` webview bundles
- retarget project task sorting to the current `page-*` asset
- update the current sort-state markers used to fail closed on upstream drift
- remove the superseded bundle shapes instead of retaining compatibility fallbacks

## Why

The current pinned upstream DMG built successfully but acceptance rejected promotion because the enabled `api-key-service-tier` and `project-task-sort` patches could not find their owning assets.

## User impact

Users with these optional features enabled can rebuild and promote the current DMG without dropping either feature.

## Source-of-truth files

- `linux-features/api-key-service-tier/patch.js`
- `linux-features/project-task-sort/patch.js`
- adjacent feature tests

## Validation

- `node --test linux-features/api-key-service-tier/test.js linux-features/project-task-sort/test.js`
- the repaired fork integration was rebuilt against DMG `40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6` with the saved 24-feature profile
- acceptance changed from three enabled-feature blockers to `accepted`; these features reported 3 applied patches and 1 applied patch respectively

Additional review and isolated acceptance confirmation are still in progress; this PR intentionally remains draft.
