### PR TITLE
fix(browser): silence Aura allowlist fallback output

### DIFF
--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1090,33 +1090,17 @@ import sys
 
 path = Path(sys.argv[1])
 source = path.read_text(encoding="utf-8")
-patterns = [
-    re.compile(
-        r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*)\)\{'
-        r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
-        r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
-        r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
-        r'\(`Browser Use cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
-        r'Please try again later or use another source\.`\)\);'
-        r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
-        r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
-    ),
-    re.compile(
-        r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*),(?P<label>[A-Za-z_$][\w$]*)\)\{'
-        r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
-        r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
-        r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
-        r'\(`\$\{(?P=label)\} cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
-        r'Please try again later or use another source\.`\)\);'
-        r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
-        r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
-    ),
-]
-match = None
-for pattern in patterns:
-    match = pattern.search(source)
-    if match is not None:
-        break
+pattern = re.compile(
+    r'async fetchBlocked\((?P<url>[A-Za-z_$][\w$]*),(?P<label>[A-Za-z_$][\w$]*)\)\{'
+    r'let (?P<response>[A-Za-z_$][\w$]*)=await (?P<fetch>[A-Za-z_$][\w$]*)'
+    r'\((?P=url)\.endpoint,\{method:"GET"\}\);'
+    r'if\(!(?P=response)\.ok\)throw new Error\((?P<format>[A-Za-z_$][\w$]*)'
+    r'\(`\$\{(?P=label)\} cannot determine if \$\{(?P=url)\.displayUrl\} is allowed\. '
+    r'Please try again later or use another source\.`\)\);'
+    r'let (?P<json>[A-Za-z_$][\w$]*)=await (?P=response)\.json\(\);'
+    r'return (?P<status>[A-Za-z_$][\w$]*)\((?P=json)\)\}'
+)
+match = pattern.search(source)
 if match is None:
     if "/aura/site_status" not in source and "fetchBlocked(" not in source:
         raise SystemExit(0)
@@ -1132,19 +1116,14 @@ fetch = match.group("fetch")
 formatter = match.group("format")
 json_value = match.group("json")
 status = match.group("status")
-label = match.groupdict().get("label")
+label = match.group("label")
 error = "__codexLinuxErr"
-error_message = (
-    f'Browser Use cannot determine if ${{{url}.displayUrl}} is allowed. Please try again later or use another source.'
-    if label is None
-    else f'${{{label}}} cannot determine if ${{{url}.displayUrl}} is allowed. Please try again later or use another source.'
-)
-args = url if label is None else f"{url},{label}"
+error_message = f'${{{label}}} cannot determine if ${{{url}.displayUrl}} is allowed. Please try again later or use another source.'
 replacement = (
-    f'async fetchBlocked({args}){{let {response};try{{{response}=await {fetch}({url}.endpoint,{{method:"GET"}})}}'
+    f'async fetchBlocked({url},{label}){{let {response};try{{{response}=await {fetch}({url}.endpoint,{{method:"GET"}})}}'
     f'catch({error}){{if(String({url}?.endpoint??"").includes("/aura/site_status")&&'
-    f'String({error}?.message??{error}).toLowerCase().includes("allowlist"))return console.warn'
-    f'("codexLinuxSiteStatusAllowlistFallback",{url}.endpoint),!1;throw {error}}}'
+    f'String({error}?.message??{error}).toLowerCase().includes("allowlist"))'
+    f'return!1/*codexLinuxSiteStatusAllowlistFallback*/;throw {error}}}'
     f'if(!{response}.ok)throw new Error({formatter}(`{error_message}`));'
     f'let {json_value}=await {response}.json();return {status}({json_value})}}'
 )

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -163,7 +163,7 @@ JSON
 {"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
     cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
-function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {}
+function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {}
 JS
 }
 
@@ -7020,6 +7020,120 @@ for (const [key, value] of Object.entries(expected)) {
 NODE
 }
 
+test_browser_use_site_status_allowlist_fallback_patch_behavior() {
+    info "Checking Browser Use site_status allowlist fallback patch behavior"
+    local workspace="$TMP_DIR/browser-site-status-allowlist-fallback"
+    local client="$workspace/browser-client.mjs"
+    local first_patch="$workspace/browser-client.first-patch.mjs"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$workspace"
+    cat > "$client" <<'JS'
+var fetchImpl;function F(e,t){return fetchImpl(e,t)}function G(e){return e}function H(e){return e.blocked===!0}var policy={async fetchBlocked(e,t){let s=await F(e.endpoint,{method:"GET"});if(!s.ok)throw new Error(G(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await s.json();return H(n)}};
+JS
+
+    (
+        warn() { echo "[WARN] $*" >&2; }
+        info() { echo "[INFO] $*" >&2; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/bundled-plugins.sh"
+        patch_browser_use_site_status_allowlist_fallback "$client"
+        cp "$client" "$first_patch"
+        patch_browser_use_site_status_allowlist_fallback "$client"
+    ) >"$output_log" 2>&1
+
+    cmp -s "$first_patch" "$client" || fail "Expected Browser Use site_status fallback patch to be byte-identical on second application"
+    assert_occurrence_count "$client" "codexLinuxSiteStatusAllowlistFallback" 1
+    assert_not_contains "$client" "console.warn"
+    assert_not_contains "$output_log" "Could not find Browser Use site_status allowlist fallback insertion point"
+
+    node - "$client" <<'NODE'
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+const client = process.argv[2];
+const source = fs.readFileSync(client, "utf8");
+const warnings = [];
+const context = {
+  console: {
+    warn(...args) {
+      warnings.push(args);
+    },
+  },
+};
+vm.createContext(context);
+vm.runInContext(source, context);
+
+const matchingUrl = {
+  endpoint: "http://127.0.0.1/aura/site_status?url=https%3A%2F%2Fexample.com",
+  displayUrl: "https://example.com/",
+};
+const otherUrl = {
+  endpoint: "http://127.0.0.1/aura/other",
+  displayUrl: "https://example.com/",
+};
+
+(async () => {
+  const allowlistError = new Error("native ALLOWLIST is unavailable");
+  context.fetchImpl = async () => {
+    throw allowlistError;
+  };
+  assert.strictEqual(await context.policy.fetchBlocked(matchingUrl, "Chrome"), false);
+
+  await assert.rejects(
+    context.policy.fetchBlocked(otherUrl, "Chrome"),
+    (error) => error === allowlistError,
+  );
+
+  const otherError = new Error("native policy is unavailable");
+  context.fetchImpl = async () => {
+    throw otherError;
+  };
+  await assert.rejects(
+    context.policy.fetchBlocked(matchingUrl, "Chrome"),
+    (error) => error === otherError,
+  );
+
+  context.fetchImpl = async () => ({ ok: false });
+  await assert.rejects(
+    context.policy.fetchBlocked(matchingUrl, "Chrome"),
+    (error) => error.message === "Chrome cannot determine if https://example.com/ is allowed. Please try again later or use another source.",
+  );
+
+  const jsonError = new Error("invalid site_status JSON");
+  context.fetchImpl = async () => ({
+    ok: true,
+    json: async () => {
+      throw jsonError;
+    },
+  });
+  await assert.rejects(
+    context.policy.fetchBlocked(matchingUrl, "Chrome"),
+    (error) => error === jsonError,
+  );
+
+  let fetchedEndpoint;
+  let fetchedMethod;
+  context.fetchImpl = async (endpoint, options) => {
+    fetchedEndpoint = endpoint;
+    fetchedMethod = options.method;
+    return {
+      ok: true,
+      json: async () => ({ blocked: true }),
+    };
+  };
+  assert.strictEqual(await context.policy.fetchBlocked(matchingUrl, "Chrome"), true);
+  assert.strictEqual(fetchedEndpoint, matchingUrl.endpoint);
+  assert.strictEqual(fetchedMethod, "GET");
+  assert.strictEqual(warnings.length, 0);
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+NODE
+}
+
 test_browser_plugin_renamed_upstream_staging() {
     info "Checking Browser plugin staging from renamed upstream resources"
     local workspace="$TMP_DIR/browser-plugin-renamed"
@@ -7710,7 +7824,7 @@ var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(C
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}
 function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}
 import{platform as yT}from"node:os";function eh(){return"privileged native pipe bridge is not available; browser-client is not trusted"}function th(){let e=globalThis.nodeRepl?.nativePipe;return e==null||typeof e.createConnection!="function"?null:e}var ml=class e{constructor(t){this.socket=t}static async create(t){let r=th();if(r!=null){let n=await r.createConnection(t);return new e(n)}throw new Error(eh())}};
-async fetchBlocked(e){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`Browser Use cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}
+async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}
 JS
     cat > "$chrome_dir/scripts/check-native-host-manifest.js" <<'JS'
 #!/usr/bin/env node
@@ -10130,6 +10244,7 @@ main() {
     test_bundled_plugin_system_computer_use_preserves_cosmic_helper_name
     test_browser_use_node_repl_fallback_runtime
     test_browser_use_file_url_policy_patch_behavior
+    test_browser_use_site_status_allowlist_fallback_patch_behavior
     test_browser_plugin_renamed_upstream_staging
     test_upstream_bundled_skills_staging
     test_upstream_bundled_skills_validator_guards


### PR DESCRIPTION
## Summary

- Stop the Linux Browser Use `/aura/site_status` allowlist fallback from writing its diagnostic endpoint into user-visible tool output.
- Preserve the existing narrow endpoint/error predicate and strict fail-open `false` result.
- Keep patch idempotency with a non-executing marker and add direct behavior coverage for the current two-argument generated `fetchBlocked(url, label)` shape.

The generated Browser client starts its site-status fetch before consulting the hostname cache. On Linux, each rejected Aura request entered the compatibility fallback, whose `console.warn` was forwarded as plaintext in the Browser tool result. This change removes only that diagnostic side effect; it does not alter cache/request ordering or broaden the fallback.

## Validation

- `bash -n scripts/lib/bundled-plugins.sh tests/scripts_smoke.sh`
- `bash tests/scripts_smoke.sh` — passed with `All script smoke tests passed`
- Focused generated-client coverage verifies strict `false`, zero warnings, byte-identical second application, one marker, original-error propagation for both predicate-negative cases, HTTP non-OK behavior, same-object JSON rejection, and successful response parsing.
- Independent implementation review, automated test ownership, manual QA, and final validation passed with no findings.

Not tested: a live latest-DMG rebuild or installed Browser/Chrome runtime smoke. Four unrelated interactive setup-native smoke cases were skipped because `script(1)` is unavailable in this environment.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
