### PR TITLE
Restore Agent Workspaces in current settings navigation

### DIFF
--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -1918,6 +1918,40 @@ function isAgentWorkspaceSettingsNavigationBundleSource(currentSource) {
   );
 }
 
+const CURRENT_SETTINGS_CATALOG_SLUGS = "local-environments.worktrees.environments";
+const PATCHED_SETTINGS_CATALOG_SLUGS = "local-environments.agent-workspaces.worktrees.environments";
+const CURRENT_SETTINGS_CATALOG_ITEMS = "{slug:`local-environments`},{slug:`worktrees`}";
+const PATCHED_SETTINGS_CATALOG_ITEMS = "{slug:`local-environments`},{slug:`agent-workspaces`},{slug:`worktrees`}";
+
+function isAgentWorkspaceSettingsCatalogBundleSource(currentSource) {
+  return (
+    (currentSource.includes(CURRENT_SETTINGS_CATALOG_SLUGS) ||
+      currentSource.includes(PATCHED_SETTINGS_CATALOG_SLUGS)) &&
+    (currentSource.includes(CURRENT_SETTINGS_CATALOG_ITEMS) ||
+      currentSource.includes(PATCHED_SETTINGS_CATALOG_ITEMS))
+  );
+}
+
+function applyAgentWorkspaceSettingsCatalogPatch(currentSource) {
+  const slugsPatched = currentSource.includes(PATCHED_SETTINGS_CATALOG_SLUGS);
+  const itemsPatched = currentSource.includes(PATCHED_SETTINGS_CATALOG_ITEMS);
+  if (slugsPatched && itemsPatched) {
+    return currentSource;
+  }
+  if (slugsPatched !== itemsPatched) {
+    throw new Error("agent workspace settings catalog is partially patched");
+  }
+  if (
+    currentSource.split(CURRENT_SETTINGS_CATALOG_SLUGS).length !== 2 ||
+    currentSource.split(CURRENT_SETTINGS_CATALOG_ITEMS).length !== 2
+  ) {
+    throw new Error("could not add agent workspace to current settings catalog");
+  }
+  return currentSource
+    .replace(CURRENT_SETTINGS_CATALOG_SLUGS, PATCHED_SETTINGS_CATALOG_SLUGS)
+    .replace(CURRENT_SETTINGS_CATALOG_ITEMS, PATCHED_SETTINGS_CATALOG_ITEMS);
+}
+
 function addAgentWorkspaceToSettingsSlugLists(currentSource) {
   return currentSource
     .replaceAll(
@@ -2063,6 +2097,7 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   let metadataMatched = false;
   let routeMatched = false;
   let navigationMatched = false;
+  let catalogMatched = false;
   const patches = [];
 
   for (const candidate of candidates) {
@@ -2081,6 +2116,10 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
       navigationMatched = true;
       patchedSource = applyAgentWorkspaceSettingsPagePatch(patchedSource);
     }
+    if (isAgentWorkspaceSettingsCatalogBundleSource(currentSource)) {
+      catalogMatched = true;
+      patchedSource = applyAgentWorkspaceSettingsCatalogPatch(patchedSource);
+    }
     if (patchedSource !== currentSource) {
       patches.push({ filePath, currentSource, patchedSource });
     }
@@ -2094,6 +2133,9 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   }
   if (!navigationMatched) {
     throw new Error("could not find webview settings navigation bundle");
+  }
+  if (!catalogMatched) {
+    throw new Error("could not find current webview settings catalog bundle");
   }
 
   return patches;
@@ -2155,6 +2197,7 @@ module.exports = {
   SETTINGS_SLUG,
   applyAgentWorkspaceMainBridgePatch,
   applyAgentWorkspaceSettingsIndexPatch,
+  applyAgentWorkspaceSettingsCatalogPatch,
   applyAgentWorkspaceSettingsPagePatch,
   applyAgentWorkspaceSettingsSharedPatch,
   buildAgentWorkspaceSettingsSource,

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -161,6 +161,13 @@ function syntheticCurrentAppMainRouteRegistry() {
   ].join("");
 }
 
+function syntheticCurrentSettingsCatalog() {
+  return [
+    "var Vr=`general-settings.linux-desktop.import.profile.keyboard-shortcuts.codex-micro.appshots.appearance.voice.pets.agent.git-settings.data-controls.cloud-settings.cloud-environments.code-review.personalization.usage.debug.browser-use.computer-use.local-environments.worktrees.environments.mcp-settings.hooks-settings.connections.plugins-settings.skills-settings`.split(`.`);",
+    "var Gr=[{slug:`general-settings`},{slug:`linux-desktop`},{slug:`local-environments`},{slug:`worktrees`},{slug:`agent`},{slug:`data-controls`}];",
+  ].join("");
+}
+
 function syntheticComposerBundle() {
   return "const YH={default:e=>e};function sU(e,t){return t??(e==null?[]:Object.entries(e).map(([e,t])=>({name:e,value:t,displayName:(0,YH.default)(e.trim())})))}";
 }
@@ -229,6 +236,10 @@ function rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir) {
   fs.writeFileSync(
     path.join(assetsDir, "app-initial~app-main~automations-page-test.js"),
     syntheticCurrentAppMainRouteRegistry(),
+  );
+  fs.writeFileSync(
+    path.join(assetsDir, "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js"),
+    syntheticCurrentSettingsCatalog(),
   );
 }
 
@@ -1724,7 +1735,48 @@ test("agent-workspace settings patch supports consolidated current settings bund
     const routeSource = fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8");
     assert.match(routeSource, new RegExp(SETTINGS_ASSET));
     assert.match(routeSource, /"agent-workspaces":BN\(async\(\)=>\(await Y\(/);
+
+    const catalogSource = fs.readFileSync(
+      path.join(assetsDir, "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js"),
+      "utf8",
+    );
+    assert.match(catalogSource, /local-environments\.agent-workspaces\.worktrees/);
+    assert.match(catalogSource, /\{slug:`local-environments`\},\{slug:`agent-workspaces`\},\{slug:`worktrees`\}/);
     assert.equal(patchAgentWorkspaceSettingsAssets(tempApp).changed, 0);
+  } finally {
+    fs.rmSync(tempApp, { recursive: true, force: true });
+  }
+});
+
+test("agent-workspace settings patch rejects a partially patched current catalog atomically", () => {
+  const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-agent-workspace-partial-catalog-"));
+  try {
+    const { assetsDir } = writeSyntheticExtractedApp(tempApp);
+    const catalogPath = path.join(
+      assetsDir,
+      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js",
+    );
+    fs.writeFileSync(
+      catalogPath,
+      syntheticCurrentSettingsCatalog().replace(
+        "local-environments.worktrees.environments",
+        "local-environments.agent-workspaces.worktrees.environments",
+      ),
+    );
+    const before = new Map(
+      fs.readdirSync(assetsDir).map((name) => [name, fs.readFileSync(path.join(assetsDir, name))]),
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchAgentWorkspaceSettingsAssets(tempApp));
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /catalog is partially patched/);
+    assert.ok(warnings.some((warning) => warning.includes("catalog is partially patched")));
+    assert.equal(fs.existsSync(path.join(assetsDir, SETTINGS_ASSET)), false);
+    for (const [name, source] of before) {
+      assert.deepEqual(fs.readFileSync(path.join(assetsDir, name)), source);
+    }
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- patch the current Settings catalog that owns the visible navigation list
- insert `agent-workspaces` into both current catalog representations
- reject mixed or incomplete catalog state without writing any assets

## Problem

The existing patch creates the Agent Workspaces route, metadata, and settings page, but the current shared Settings catalog still omits `agent-workspaces`. The active renderer filters the route out, so the patch report reports the feature as applied while the navigation entry remains invisible.

## Current upstream validation

- base repository: `c06cd5ab3d658becb1cb57f1728c850b3b4a7dd0`
- app: ChatGPT Desktop `26.707.72221`
- Electron: `42.1.0`
- DMG SHA-256: `40e34814e74e30943c209ebd4da94cd4de3581a52c5bffbe2bcf2e488d6361c6`
- DMG size: `615731826` bytes

An isolated build with only `agent-workspace` enabled reports both feature descriptors as `applied`. In a side-by-side runtime, Agent Workspaces appears between Environments and Worktrees and the settings page renders successfully.

The branch was rebased after the prior administrative closure and revalidated against the current `main`. No open or merged PR supersedes this fix.

## Tests

- `node --test linux-features/agent-workspace/test.js` (32 passed)
- `node --test linux-features/*/test.js` (599 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (396 passed)
- `bash tests/scripts_smoke.sh`
- current-DMG isolated build and patch-report acceptance
- `node --check` on generated assets containing Agent Workspaces markers
- `git diff --check`
