### PR TITLE
Restore compatible CLI launch validation

### DIFF
--- a/launcher/cli-launch-path.py
+++ b/launcher/cli-launch-path.py
@@ -1,284 +1,37 @@
 #!/usr/bin/env python3
-"""Resolve a Codex CLI path without executing an untrusted standalone tree."""
+"""Resolve a Codex CLI path to a canonical executable without running it."""
 
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import shutil
 import stat
 import sys
-import tempfile
-from pathlib import Path
-from typing import Optional
 
 
-class TrustError(RuntimeError):
+class LaunchPathError(RuntimeError):
     pass
-
-
-PROVENANCE_FILE = ".codex-standalone-provenance"
-
-
-def standalone_home_from_path(path: Path) -> Optional[Path]:
-    parts = path.parts
-    for index in range(len(parts) - 2):
-        if parts[index : index + 2] != ("packages", "standalone"):
-            continue
-        if parts[index + 2] not in ("current", "releases"):
-            continue
-        if index == 0:
-            return None
-        return Path(*parts[:index])
-    return None
-
-
-def unresolved_symlink_target(path: Path) -> Optional[Path]:
-    try:
-        target = Path(os.readlink(path))
-    except OSError:
-        return None
-    if not target.is_absolute():
-        target = path.parent / target
-    return Path(os.path.abspath(target))
-
-
-def path_is_within(path: Path, root: Path) -> bool:
-    try:
-        path.relative_to(root)
-    except ValueError:
-        return False
-    return True
-
-
-def trusted_owner(uid: int) -> bool:
-    return uid in (os.geteuid(), 0)
-
-
-def validate_parent_chain(path: Path, subject: str) -> None:
-    parent = path.parent
-    while True:
-        metadata = parent.lstat()
-        if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
-            raise TrustError(
-                f"{subject} ancestor {parent} is not a trusted directory"
-            )
-        if not trusted_owner(metadata.st_uid):
-            raise TrustError(
-                f"{subject} ancestor {parent} is owned by untrusted uid {metadata.st_uid}"
-            )
-        writable = metadata.st_mode & 0o022
-        root_owned_sticky = (
-            metadata.st_uid == 0
-            and metadata.st_mode & stat.S_ISVTX
-            and metadata.st_mode & 0o002
-        )
-        if writable and not root_owned_sticky:
-            raise TrustError(
-                f"{subject} ancestor {parent} is group/world-writable and therefore untrusted"
-            )
-        if parent.parent == parent:
-            break
-        parent = parent.parent
-
-
-def validate_cli_target(lexical_path: Path, canonical_path: Path) -> Path:
-    canonical_path = validate_cli_identity(lexical_path, canonical_path)
-    validate_parent_chain(lexical_path, "Selected Codex CLI")
-    return canonical_path
-
-
-def validate_cli_identity(lexical_path: Path, canonical_path: Path) -> Path:
-    entry_metadata = lexical_path.lstat()
-    if not trusted_owner(entry_metadata.st_uid):
-        raise TrustError(
-            f"Selected Codex CLI entry {lexical_path} is owned by untrusted uid {entry_metadata.st_uid}"
-        )
-    target_metadata = canonical_path.stat()
-    if not stat.S_ISREG(target_metadata.st_mode) or not os.access(canonical_path, os.X_OK):
-        raise TrustError(f"Selected Codex CLI target {canonical_path} is not an executable file")
-    if not trusted_owner(target_metadata.st_uid):
-        raise TrustError(
-            f"Selected Codex CLI target {canonical_path} is owned by untrusted uid {target_metadata.st_uid}"
-        )
-    if target_metadata.st_mode & 0o022:
-        raise TrustError(
-            f"Selected Codex CLI target {canonical_path} is group/world-writable and therefore untrusted"
-        )
-    validate_parent_chain(canonical_path, "Selected Codex CLI target")
-    return canonical_path
-
-
-def validate_standalone_tree(standalone_root: Path) -> Path:
-    root_metadata = standalone_root.lstat()
-    if not stat.S_ISDIR(root_metadata.st_mode) or stat.S_ISLNK(root_metadata.st_mode):
-        raise TrustError(
-            f"Managed standalone Codex CLI root {standalone_root} is not a trusted directory"
-        )
-
-    canonical_root = standalone_root.resolve(strict=True)
-    validate_parent_chain(canonical_root, "Managed standalone Codex CLI")
-
-    pending = [standalone_root]
-    while pending:
-        path = pending.pop()
-        metadata = path.lstat()
-        if stat.S_ISLNK(metadata.st_mode):
-            try:
-                target = path.resolve(strict=True)
-            except OSError as error:
-                raise TrustError(
-                    f"Managed standalone Codex CLI contains a broken symlink at {path}"
-                ) from error
-            if not path_is_within(target, canonical_root):
-                raise TrustError(
-                    f"Managed standalone Codex CLI contains an external symlink at {path}"
-                )
-            continue
-
-        if not (stat.S_ISDIR(metadata.st_mode) or stat.S_ISREG(metadata.st_mode)):
-            raise TrustError(
-                f"Managed standalone Codex CLI contains an unsupported file type at {path}"
-            )
-        if not trusted_owner(metadata.st_uid):
-            raise TrustError(
-                f"Managed standalone Codex CLI path {path} is owned by untrusted uid {metadata.st_uid}"
-            )
-        if metadata.st_mode & 0o022:
-            raise TrustError(
-                f"Managed standalone Codex CLI path {path} is group/world-writable and therefore untrusted"
-            )
-        if stat.S_ISDIR(metadata.st_mode):
-            pending.extend(path.iterdir())
-
-    return canonical_root
-
-
-def existing_default_standalone_home() -> Optional[Path]:
-    raw_codex_home = os.environ.get("CODEX_HOME")
-    if raw_codex_home:
-        codex_home = Path(raw_codex_home)
-    else:
-        raw_home = os.environ.get("HOME")
-        if not raw_home:
-            return None
-        codex_home = Path(raw_home) / ".codex"
-    try:
-        (codex_home / "packages" / "standalone").lstat()
-    except OSError:
-        return None
-    return codex_home
-
-
-def provenance_path() -> Optional[Path]:
-    raw_home = os.environ.get("HOME")
-    if not raw_home:
-        return None
-    try:
-        canonical_home = Path(raw_home).resolve(strict=True)
-    except OSError as error:
-        raise TrustError(f"Failed to resolve HOME for standalone CLI provenance: {error}") from error
-    return canonical_home / PROVENANCE_FILE
-
-
-def read_standalone_provenance() -> Optional[Path]:
-    path = provenance_path()
-    if path is None:
-        return None
-    try:
-        metadata = path.lstat()
-    except FileNotFoundError:
-        return None
-    if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
-        raise TrustError(f"Standalone Codex CLI provenance {path} is not a regular file")
-    if not trusted_owner(metadata.st_uid) or metadata.st_mode & 0o022:
-        raise TrustError(f"Standalone Codex CLI provenance {path} is not trusted")
-    validate_parent_chain(path, "Standalone Codex CLI provenance")
-    value = path.read_text(encoding="utf-8").strip()
-    codex_home = Path(value)
-    if not value or not codex_home.is_absolute():
-        raise TrustError(f"Standalone Codex CLI provenance {path} is invalid")
-    return codex_home
-
-
-def record_standalone_provenance(codex_home: Path, lexical_cli: Path) -> None:
-    path = provenance_path()
-    if path is None:
-        return
-    entry_metadata = lexical_cli.lstat()
-    if not trusted_owner(entry_metadata.st_uid):
-        raise TrustError(
-            f"Selected Codex CLI entry {lexical_cli} is owned by untrusted uid {entry_metadata.st_uid}"
-        )
-    validate_parent_chain(path, "Standalone Codex CLI provenance")
-    with tempfile.NamedTemporaryFile(
-        mode="w", encoding="utf-8", dir=path.parent, prefix=f".{PROVENANCE_FILE}.", delete=False
-    ) as handle:
-        temp_path = Path(handle.name)
-        os.chmod(temp_path, 0o600)
-        handle.write(f"{codex_home}\n")
-        handle.flush()
-        os.fsync(handle.fileno())
-    try:
-        os.replace(temp_path, path)
-        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
-    finally:
-        try:
-            temp_path.unlink()
-        except FileNotFoundError:
-            pass
 
 
 def resolve_cli_launch_path(raw_path: str) -> Path:
     if os.sep not in raw_path:
         discovered = shutil.which(raw_path)
         if discovered is None:
-            raise TrustError(f"Codex CLI command {raw_path!r} was not found in PATH")
+            raise LaunchPathError(f"Codex CLI command {raw_path!r} was not found in PATH")
         selected_path = Path(discovered)
     else:
         selected_path = Path(raw_path)
-    lexical_path = Path(os.path.abspath(selected_path))
+
     try:
         canonical_cli = selected_path.resolve(strict=True)
+        metadata = canonical_cli.stat()
     except OSError as error:
-        raise TrustError(f"Failed to resolve Codex CLI path {selected_path}: {error}") from error
-    candidates = [canonical_cli, lexical_path]
-    raw_target = unresolved_symlink_target(lexical_path)
-    if raw_target is not None:
-        candidates.append(raw_target)
+        raise LaunchPathError(f"Failed to resolve Codex CLI path {selected_path}: {error}") from error
 
-    detected_home = next(
-        (home for candidate in candidates if (home := standalone_home_from_path(candidate))),
-        None,
-    )
-    if detected_home is None:
-        detected_home = existing_default_standalone_home()
-    codex_home = read_standalone_provenance()
-    if codex_home is None:
-        if detected_home is None:
-            return validate_cli_identity(lexical_path, canonical_cli)
-        codex_home = detected_home
-    elif detected_home is not None and detected_home != codex_home:
-        raise TrustError(
-            f"Selected Codex CLI provenance {detected_home} conflicts with recorded standalone home {codex_home}"
-        )
-
-    def validate_selection() -> Path:
-        canonical_root = validate_standalone_tree(codex_home / "packages" / "standalone")
-        if not path_is_within(canonical_cli, canonical_root):
-            raise TrustError(
-                f"Managed standalone Codex CLI path {selected_path} resolves outside its trusted root"
-            )
-        return validate_cli_target(lexical_path, canonical_cli)
-
-    launch_path = validate_selection()
-    if read_standalone_provenance() is None:
-        record_standalone_provenance(codex_home, lexical_path)
-        launch_path = validate_selection()
-    return launch_path
+    if not stat.S_ISREG(metadata.st_mode) or not os.access(canonical_cli, os.X_OK):
+        raise LaunchPathError(f"Selected Codex CLI target {canonical_cli} is not an executable file")
+    return canonical_cli
 
 
 def main() -> int:
@@ -287,8 +40,8 @@ def main() -> int:
         return 64
     try:
         print(resolve_cli_launch_path(sys.argv[1]))
-    except (OSError, TrustError) as error:
-        print(f"Codex CLI trust check failed: {error}", file=sys.stderr)
+    except (OSError, LaunchPathError) as error:
+        print(error, file=sys.stderr)
         return 1
     return 0
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -4193,7 +4193,7 @@ fi
 
 if [ -n "$CODEX_CLI_PATH" ]; then
     if ! verify_cli_launch_path; then
-        notify_error "The selected Codex CLI failed its execution-free trust check and will not be executed. If it is a rejected managed standalone install, stop active Codex installers and remove its standalone tree. Updater-enabled native packages can then run: codex-update-manager recover-standalone-cli --print-path. With AppImage, Nix, or updaterless packages, reinstall from a verified package channel into a fresh path owned by you or root with no group/world-writable file or parent directory; do not reuse the rejected tree. To switch away from standalone intentionally, also remove ~/.codex-standalone-provenance."
+        notify_error "The selected Codex CLI path does not resolve to an executable file. Reinstall the CLI or set CODEX_CLI_PATH to a working executable."
         exit 1
     fi
     log_phase "cli_launch_path_verified"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6508,9 +6508,9 @@ PY
     mkdir -p "$resolve_bin"
     printf '#!/usr/bin/env bash\nprintf "codex-cli 0.170.0\\n"\n' > "$resolve_bin/codex"
     chmod 0775 "$resolve_bin" "$resolve_bin/codex"
-    if env -i PATH="$resolve_bin:$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" resolve codex >/dev/null 2>&1; then
-        fail "CLI trust helper must reject group-writable PATH executables"
-    fi
+    resolved_cli="$(env -i PATH="$resolve_bin:$HOST_TOOL_PATH" HOME="$fake_home" "$launcher_probe" resolve codex)"
+    [ "$resolved_cli" = "$(realpath "$resolve_bin/codex")" ] || \
+        fail "CLI resolver must accept an executable created under umask 0002"
 
     local external_cli="$workspace/external-codex"
     local visible_cli="$workspace/visible-codex"
@@ -6673,12 +6673,12 @@ PY
         ROUTING_CLI_PATH="$workspace/missing-routing-codex" \
         UPDATE_MANAGER_AVAILABLE=0 TRUST_RESULT=failure BROKEN_CLI=1 \
         "$routing_probe"; then
-        fail "standalone trust failure must abort launcher startup"
+        fail "invalid CLI path must abort launcher startup"
     fi
-    grep -q '^notify=The selected Codex CLI failed its execution-free trust check' "$routing_log" || \
-        fail "standalone trust failure must show safe recovery guidance"
+    grep -q '^notify=The selected Codex CLI path does not resolve to an executable file' "$routing_log" || \
+        fail "invalid CLI path must show actionable recovery guidance"
     if grep -qE '^(probe=|background=|version=|electron=)' "$routing_log"; then
-        fail "standalone trust failure must block every CLI probe, final version log, and Electron startup"
+        fail "invalid CLI path must block every CLI probe, final version log, and Electron startup"
     fi
 
     : > "$routing_log"
@@ -6686,10 +6686,10 @@ PY
         ROUTING_CLI_PATH="$workspace/missing-routing-codex" \
         COLD_START=0 UPDATE_MANAGER_AVAILABLE=0 TRUST_RESULT=failure \
         "$routing_probe"; then
-        fail "standalone trust failure must also abort second-instance handoff"
+        fail "invalid CLI path must also abort second-instance handoff"
     fi
     if grep -qE '^(probe=|background=|version=|electron=)' "$routing_log"; then
-        fail "second-instance trust failure must not reach any CLI probe or Electron startup"
+        fail "second-instance invalid CLI path must not reach any CLI probe or Electron startup"
     fi
 
     : > "$routing_log"
@@ -6782,6 +6782,10 @@ SCRIPT
     stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
     [ "$stable_path" = "$(realpath "$release/bin/codex")" ] || \
         fail "launcher trust helper must return the canonical standalone release target"
+    printf '%s\n' '/tmp/removed-standalone-home/.codex' > "$trust_workspace/home/.codex-standalone-provenance"
+    stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
+    [ "$stable_path" = "$(realpath "$release/bin/codex")" ] || \
+        fail "launcher CLI resolution must ignore stale standalone provenance"
 
     local replacement_marker="$trust_workspace/replacement-executed"
     local replacement_cli="$trust_workspace/replacement-codex"
@@ -6796,40 +6800,21 @@ SCRIPT
 
     chmod 0775 "$(dirname "$visible_cli")"
     mv "$codex_home/packages/standalone" "$codex_home/packages/standalone-rejected"
-    if HOME="$trust_workspace/home" CODEX_HOME="$codex_home" \
-        python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli" >/dev/null 2>&1; then
-        fail "launcher trust helper must reject an unsafe visible replacement before classification"
-    fi
+    stable_path="$(HOME="$trust_workspace/home" CODEX_HOME="$codex_home" \
+        python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
+    [ "$stable_path" = "$(realpath "$replacement_cli")" ] || \
+        fail "launcher CLI resolution must follow the currently selected executable"
     [ ! -e "$replacement_marker" ] || \
-        fail "launcher trust helper must not execute an unsafe pre-validation replacement"
+        fail "launcher CLI resolution must remain execution-free"
     mv "$codex_home/packages/standalone-rejected" "$codex_home/packages/standalone"
-
-    python3 - "$REPO_DIR/launcher/cli-launch-path.py" <<'PY'
-import importlib.util
-import os
-import pathlib
-import sys
-
-path = pathlib.Path(sys.argv[1])
-spec = importlib.util.spec_from_file_location("cli_launch_path", path)
-assert spec is not None
-module = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-spec.loader.exec_module(module)
-euid = os.geteuid()
-untrusted_uid = 2 if euid == 1 else 1
-assert module.trusted_owner(euid)
-assert module.trusted_owner(0)
-assert not module.trusted_owner(untrusted_uid)
-PY
 
     rm "$visible_cli"
     ln -s "$codex_home/packages/standalone/current/bin/codex" "$visible_cli"
     chmod 0755 "$(dirname "$visible_cli")"
     chmod 0775 "$release/bin/codex"
-    if HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli" >/dev/null 2>&1; then
-        fail "launcher trust helper must reject a group-writable standalone binary"
-    fi
+    stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
+    [ "$stable_path" = "$(realpath "$release/bin/codex")" ] || \
+        fail "launcher CLI resolution must accept existing umask-0002 standalone installs"
     chmod 0755 "$release/bin/codex"
 
     local external_root="$trust_workspace/external"
@@ -6837,9 +6822,9 @@ PY
     cp "$release/bin/codex" "$external_root/bin/codex"
     rm "$codex_home/packages/standalone/current"
     ln -s "$external_root" "$codex_home/packages/standalone/current"
-    if python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli" >/dev/null 2>&1; then
-        fail "launcher trust helper must reject an external standalone current symlink"
-    fi
+    stable_path="$(HOME="$trust_workspace/home" python3 "$REPO_DIR/launcher/cli-launch-path.py" "$visible_cli")"
+    [ "$stable_path" = "$(realpath "$external_root/bin/codex")" ] || \
+        fail "launcher CLI resolution must follow external package-manager symlink targets"
 }
 
 test_webview_server_cache_policy() {

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -20,13 +20,12 @@ use std::{
     process::{Command, ExitStatus, Output, Stdio},
     sync::mpsc::{self, Receiver, RecvTimeoutError},
     thread,
-    time::{Duration as StdDuration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration as StdDuration, Instant},
 };
 use tracing::{info, warn};
 
 const CLI_PACKAGE_NAME: &str = "@openai/codex";
 const STANDALONE_INSTALLER_URL: &str = "https://chatgpt.com/codex/install.sh";
-const STANDALONE_PROVENANCE_FILE: &str = ".codex-standalone-provenance";
 const CLI_NOT_INSTALLED_MESSAGE: &str =
     "Codex CLI is required but not currently installed. Open the app to retry the automatic install flow, or install it manually with npm optional dependencies enabled.";
 const CLI_VERSION_CHECK_TTL: Duration = Duration::hours(1);
@@ -91,8 +90,8 @@ fn preflight_with_version_timeout(
     };
     let cli_path = match stable_cli_launch_path(&selected_cli_path) {
         Ok(path) => path,
-        Err(trust_error) => {
-            let error = cli_trust_error(&selected_cli_path, trust_error);
+        Err(resolution_error) => {
+            let error = cli_launch_path_error(&selected_cli_path, resolution_error);
             state.cli_path = Some(selected_cli_path);
             state.cli_install_channel = None;
             state.cli_installed_version = None;
@@ -382,8 +381,8 @@ pub fn refresh_cached_status(state: &mut PersistedState, paths: &RuntimePaths) -
     };
     let cli_path = match stable_cli_launch_path(&selected_cli_path) {
         Ok(path) => path,
-        Err(trust_error) => {
-            let error = cli_trust_error(&selected_cli_path, trust_error);
+        Err(resolution_error) => {
+            let error = cli_launch_path_error(&selected_cli_path, resolution_error);
             state.cli_path = Some(selected_cli_path);
             state.cli_install_channel = None;
             state.cli_installed_version = None;
@@ -446,8 +445,8 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
     };
     let cli_path = match stable_cli_launch_path(&selected_cli_path) {
         Ok(path) => path,
-        Err(trust_error) => {
-            let error = cli_trust_error(&selected_cli_path, trust_error);
+        Err(resolution_error) => {
+            let error = cli_launch_path_error(&selected_cli_path, resolution_error);
             state.cli_path = Some(selected_cli_path);
             state.cli_install_channel = None;
             state.cli_installed_version = None;
@@ -1445,8 +1444,7 @@ fn standalone_cli_install(cli_path: &Path) -> Option<StandaloneCliInstall> {
             unresolved_symlink_target(cli_path)
                 .as_deref()
                 .and_then(standalone_home_from_path)
-        })
-        .or_else(existing_default_standalone_home)?;
+        })?;
     let cli_path_is_standalone = standalone_home_from_path(cli_path).is_some();
     let install_dir = if cli_path_is_standalone {
         None
@@ -1464,16 +1462,6 @@ fn standalone_cli_install(cli_path: &Path) -> Option<StandaloneCliInstall> {
         codex_home,
         install_dir,
     })
-}
-
-fn existing_default_standalone_home() -> Option<PathBuf> {
-    #[cfg(test)]
-    std::env::var_os("CODEX_UPDATE_MANAGER_TEST_STANDALONE_PROVENANCE")?;
-
-    let codex_home = default_codex_home().ok()?;
-    fs::symlink_metadata(codex_home.join("packages/standalone"))
-        .ok()
-        .map(|_| codex_home)
 }
 
 fn unresolved_symlink_target(path: &Path) -> Option<PathBuf> {
@@ -1513,280 +1501,12 @@ fn standalone_home_from_path(path: &Path) -> Option<PathBuf> {
 }
 
 fn stable_cli_launch_path(cli_path: &Path) -> Result<PathBuf> {
-    let detected_install = standalone_cli_install(cli_path);
-    let recorded_home = read_standalone_provenance()?;
-    let should_record = recorded_home.is_none() && detected_install.is_some();
-    let install = match (detected_install, recorded_home) {
-        (None, None) => return validate_cli_target(cli_path),
-        (Some(install), None) => install,
-        (detected, Some(codex_home)) => {
-            if let Some(ref detected) = detected {
-                anyhow::ensure!(
-                    detected.codex_home == codex_home,
-                    "Selected Codex CLI provenance {} conflicts with recorded standalone home {}",
-                    detected.codex_home.display(),
-                    codex_home.display()
-                );
-            }
-            StandaloneCliInstall {
-                codex_home,
-                install_dir: detected
-                    .and_then(|install| install.install_dir)
-                    .or_else(|| {
-                        cli_path
-                            .parent()
-                            .filter(|parent| !parent.as_os_str().is_empty())
-                            .map(Path::to_path_buf)
-                    }),
-            }
-        }
-    };
-
-    let validate_selection = || -> Result<PathBuf> {
-        let canonical_cli = fs::canonicalize(cli_path)
-            .with_context(|| format!("Failed to resolve Codex CLI path {}", cli_path.display()))?;
-        validate_standalone_cli_tree(&install)?;
-        let canonical_root = fs::canonicalize(install.standalone_root()).with_context(|| {
-            format!(
-                "Failed to resolve managed standalone Codex CLI root {}",
-                install.standalone_root().display()
-            )
-        })?;
-        anyhow::ensure!(
-            canonical_cli.starts_with(&canonical_root),
-            "Managed standalone Codex CLI path {} resolves outside its trusted root",
-            cli_path.display()
-        );
-        validate_cli_target(cli_path)
-    };
-    let mut launch_path = validate_selection()?;
-    if should_record {
-        record_standalone_provenance(&install.codex_home, cli_path)?;
-        launch_path = validate_selection()?;
-    }
-    Ok(launch_path)
+    canonical_cli_launch_path(cli_path)
 }
 
 fn canonical_cli_launch_path(cli_path: &Path) -> Result<PathBuf> {
-    stable_cli_launch_path(cli_path)
-}
-
-fn trusted_owner(uid: u32, euid: u32) -> bool {
-    uid == euid || uid == 0
-}
-
-fn cli_trust_error(cli_path: &Path, trust_error: anyhow::Error) -> anyhow::Error {
-    trust_error.context(format!(
-        "Refusing to execute the untrusted Codex CLI at {}; for a rejected managed standalone install, stop active Codex installers, remove its standalone tree, then run the official Codex installer through codex-update-manager recover-standalone-cli",
-        cli_path.display()
-    ))
-}
-
-fn validate_standalone_cli_tree(install: &StandaloneCliInstall) -> Result<()> {
-    let standalone_root = install.standalone_root();
-    let root_metadata = fs::symlink_metadata(&standalone_root).with_context(|| {
-        format!(
-            "Managed standalone Codex CLI root {} is missing",
-            standalone_root.display()
-        )
-    })?;
-    anyhow::ensure!(
-        root_metadata.is_dir() && !root_metadata.file_type().is_symlink(),
-        "Managed standalone Codex CLI root {} is not a trusted directory",
-        standalone_root.display()
-    );
-    let canonical_root = fs::canonicalize(&standalone_root).with_context(|| {
-        format!(
-            "Failed to resolve managed standalone Codex CLI root {}",
-            standalone_root.display()
-        )
-    })?;
-    validate_standalone_parent_chain(&canonical_root)?;
-
-    let mut pending = vec![standalone_root];
-    while let Some(path) = pending.pop() {
-        let metadata = fs::symlink_metadata(&path).with_context(|| {
-            format!(
-                "Failed to inspect managed standalone Codex CLI path {}",
-                path.display()
-            )
-        })?;
-
-        if metadata.file_type().is_symlink() {
-            let target = fs::canonicalize(&path).with_context(|| {
-                format!(
-                    "Managed standalone Codex CLI contains a broken symlink at {}",
-                    path.display()
-                )
-            })?;
-            anyhow::ensure!(
-                target.starts_with(&canonical_root),
-                "Managed standalone Codex CLI contains an external symlink at {}",
-                path.display()
-            );
-            continue;
-        }
-
-        anyhow::ensure!(
-            metadata.is_dir() || metadata.is_file(),
-            "Managed standalone Codex CLI contains an unsupported file type at {}",
-            path.display()
-        );
-        let euid = unsafe { libc::geteuid() };
-        anyhow::ensure!(
-            trusted_owner(metadata.uid(), euid),
-            "Managed standalone Codex CLI path {} is owned by untrusted uid {}",
-            path.display(),
-            metadata.uid()
-        );
-        anyhow::ensure!(
-            metadata.permissions().mode() & 0o022 == 0,
-            "Managed standalone Codex CLI path {} is group/world-writable and therefore untrusted",
-            path.display()
-        );
-
-        if metadata.is_dir() {
-            let entries = fs::read_dir(&path).with_context(|| {
-                format!(
-                    "Failed to enumerate managed standalone Codex CLI directory {}",
-                    path.display()
-                )
-            })?;
-            for entry in entries {
-                pending.push(entry?.path());
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn validate_standalone_parent_chain(path: &Path) -> Result<()> {
-    validate_trusted_parent_chain(path, "Managed standalone Codex CLI")
-}
-
-fn standalone_provenance_path() -> Result<PathBuf> {
-    let home = std::env::var_os("HOME").context("HOME is not set")?;
-    let canonical_home = fs::canonicalize(&home).with_context(|| {
-        format!(
-            "Failed to resolve HOME for standalone CLI provenance: {}",
-            Path::new(&home).display()
-        )
-    })?;
-    Ok(canonical_home.join(STANDALONE_PROVENANCE_FILE))
-}
-
-fn read_standalone_provenance() -> Result<Option<PathBuf>> {
-    #[cfg(test)]
-    if std::env::var_os("CODEX_UPDATE_MANAGER_TEST_STANDALONE_PROVENANCE").is_none() {
-        return Ok(None);
-    }
-
-    let path = standalone_provenance_path()?;
-    let metadata = match fs::symlink_metadata(&path) {
-        Ok(metadata) => metadata,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error).context("Failed to inspect standalone CLI provenance"),
-    };
-    let euid = unsafe { libc::geteuid() };
-    anyhow::ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "Standalone Codex CLI provenance {} is not a regular file",
-        path.display()
-    );
-    anyhow::ensure!(
-        trusted_owner(metadata.uid(), euid) && metadata.permissions().mode() & 0o022 == 0,
-        "Standalone Codex CLI provenance {} is not trusted",
-        path.display()
-    );
-    validate_trusted_parent_chain(&path, "Standalone Codex CLI provenance")?;
-    let value = fs::read_to_string(&path)?;
-    let codex_home = PathBuf::from(value.trim());
-    anyhow::ensure!(
-        codex_home.is_absolute(),
-        "Standalone Codex CLI provenance {} is invalid",
-        path.display()
-    );
-    Ok(Some(codex_home))
-}
-
-fn record_standalone_provenance(codex_home: &Path, cli_path: &Path) -> Result<()> {
-    #[cfg(test)]
-    if std::env::var_os("CODEX_UPDATE_MANAGER_TEST_STANDALONE_PROVENANCE").is_none() {
-        return Ok(());
-    }
-
-    let path = standalone_provenance_path()?;
-    let entry_metadata = fs::symlink_metadata(cli_path)
-        .with_context(|| format!("Failed to inspect Codex CLI entry {}", cli_path.display()))?;
-    let euid = unsafe { libc::geteuid() };
-    anyhow::ensure!(
-        trusted_owner(entry_metadata.uid(), euid),
-        "Selected Codex CLI entry {} is owned by untrusted uid {}",
-        cli_path.display(),
-        entry_metadata.uid()
-    );
-    validate_trusted_parent_chain(&path, "Standalone Codex CLI provenance")?;
-    let temp_path = path.with_file_name(format!(
-        ".{STANDALONE_PROVENANCE_FILE}.{}-{}",
-        std::process::id(),
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos()
-    ));
-    let mut file = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(&temp_path)
-        .context("Failed to create standalone CLI provenance")?;
-    let write_result = (|| -> Result<()> {
-        writeln!(file, "{}", codex_home.display())?;
-        file.sync_all()?;
-        fs::rename(&temp_path, &path)?;
-        fs::File::open(path.parent().context("Provenance path has no parent")?)?.sync_all()?;
-        Ok(())
-    })();
-    if write_result.is_err() {
-        let _ = fs::remove_file(&temp_path);
-    }
-    write_result
-}
-
-fn validate_cli_target(cli_path: &Path) -> Result<PathBuf> {
-    let canonical_cli = validate_cli_identity(cli_path)?;
-    let lexical_cli = absolute_lexical_cli_path(cli_path)?;
-    validate_trusted_parent_chain(&lexical_cli, "Selected Codex CLI")?;
-    Ok(canonical_cli)
-}
-
-fn absolute_lexical_cli_path(cli_path: &Path) -> Result<PathBuf> {
-    if cli_path.is_absolute() {
-        return Ok(cli_path.to_path_buf());
-    }
-    Ok(std::env::current_dir()
-        .context("Failed to resolve the current directory for Codex CLI validation")?
-        .join(cli_path))
-}
-
-fn validate_cli_identity(cli_path: &Path) -> Result<PathBuf> {
-    let lexical_cli = absolute_lexical_cli_path(cli_path)?;
-    let entry_metadata = fs::symlink_metadata(&lexical_cli).with_context(|| {
-        format!(
-            "Failed to inspect Codex CLI entry {}",
-            lexical_cli.display()
-        )
-    })?;
-    let euid = unsafe { libc::geteuid() };
-    anyhow::ensure!(
-        trusted_owner(entry_metadata.uid(), euid),
-        "Selected Codex CLI entry {} is owned by untrusted uid {}",
-        lexical_cli.display(),
-        entry_metadata.uid()
-    );
-    let canonical_cli = fs::canonicalize(&lexical_cli)
-        .with_context(|| format!("Failed to resolve Codex CLI path {}", lexical_cli.display()))?;
+    let canonical_cli = fs::canonicalize(cli_path)
+        .with_context(|| format!("Failed to resolve Codex CLI path {}", cli_path.display()))?;
     let target_metadata = fs::metadata(&canonical_cli).with_context(|| {
         format!(
             "Failed to inspect Codex CLI target {}",
@@ -1798,53 +1518,14 @@ fn validate_cli_identity(cli_path: &Path) -> Result<PathBuf> {
         "Selected Codex CLI target {} is not an executable file",
         canonical_cli.display()
     );
-    anyhow::ensure!(
-        trusted_owner(target_metadata.uid(), euid),
-        "Selected Codex CLI target {} is owned by untrusted uid {}",
-        canonical_cli.display(),
-        target_metadata.uid()
-    );
-    anyhow::ensure!(
-        target_metadata.permissions().mode() & 0o022 == 0,
-        "Selected Codex CLI target {} is group/world-writable and therefore untrusted",
-        canonical_cli.display()
-    );
-    validate_trusted_parent_chain(&canonical_cli, "Selected Codex CLI target")?;
     Ok(canonical_cli)
 }
 
-fn validate_trusted_parent_chain(path: &Path, subject: &str) -> Result<()> {
-    let euid = unsafe { libc::geteuid() };
-    for parent in path.ancestors().skip(1) {
-        let metadata = fs::symlink_metadata(parent).with_context(|| {
-            format!(
-                "Failed to inspect managed standalone Codex CLI ancestor {}",
-                parent.display()
-            )
-        })?;
-        anyhow::ensure!(
-            metadata.is_dir() && !metadata.file_type().is_symlink(),
-            "{subject} ancestor {} is not a trusted directory",
-            parent.display()
-        );
-        anyhow::ensure!(
-            trusted_owner(metadata.uid(), euid),
-            "{subject} ancestor {} is owned by untrusted uid {}",
-            parent.display(),
-            metadata.uid()
-        );
-
-        let mode = metadata.permissions().mode();
-        let root_owned_sticky_directory =
-            metadata.uid() == 0 && mode & libc::S_ISVTX != 0 && mode & 0o002 != 0;
-        anyhow::ensure!(
-            mode & 0o022 == 0 || root_owned_sticky_directory,
-            "{subject} ancestor {} is group/world-writable and therefore untrusted",
-            parent.display()
-        );
-    }
-
-    Ok(())
+fn cli_launch_path_error(cli_path: &Path, resolution_error: anyhow::Error) -> anyhow::Error {
+    resolution_error.context(format!(
+        "Could not resolve the selected Codex CLI at {} to an executable file",
+        cli_path.display()
+    ))
 }
 
 fn update_standalone_cli(install: &StandaloneCliInstall, latest_version: &str) -> Result<()> {
@@ -3932,7 +3613,7 @@ exit 1
     }
 
     #[test]
-    fn group_writable_standalone_cli_is_rejected_by_preflight() -> Result<()> {
+    fn group_writable_standalone_cli_is_accepted_by_preflight() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
@@ -3966,17 +3647,40 @@ exit 1
         state.cli_official_latest_version = Some("0.42.0".to_string());
         state.cli_last_check_at = Some(Utc::now());
 
-        let error = preflight(&mut state, &paths, Some(visible_codex), false)
-            .expect_err("preflight must reject a group-writable standalone CLI before execution");
+        let outcome = preflight(&mut state, &paths, Some(visible_codex), false)?;
 
-        assert!(error.to_string().contains("untrusted Codex CLI"));
-        assert_eq!(state.cli_status, CliStatus::Failed);
-        assert!(!probe_marker.exists());
+        assert_eq!(outcome.installed_version, "0.42.0");
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert!(probe_marker.exists());
         Ok(())
     }
 
     #[test]
-    fn group_writable_standalone_cli_ancestor_is_rejected_by_preflight() -> Result<()> {
+    fn existing_standalone_tree_does_not_reclassify_an_external_cli() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        fs::create_dir_all(home.join(".codex/packages/standalone"))?;
+        let external_cli = temp.path().join("npm/bin/codex");
+        fs::create_dir_all(
+            external_cli
+                .parent()
+                .context("external CLI has no parent")?,
+        )?;
+        write_executable_script(&external_cli, "#!/bin/sh\necho 'codex-cli v0.42.0'\n")?;
+
+        let _restore_env = EnvRestoreGuard::capture(&["HOME"]);
+        std::env::set_var("HOME", &home);
+
+        assert_eq!(
+            classify_cli_install(&external_cli, &external_cli, None, None),
+            CliInstallKind::Npm
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn group_writable_standalone_cli_ancestor_is_accepted_by_preflight() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
@@ -4008,18 +3712,16 @@ exit 1
         state.cli_official_latest_version = Some("0.42.0".to_string());
         state.cli_last_check_at = Some(Utc::now());
 
-        let error = preflight(&mut state, &paths, Some(visible_codex), false)
-            .expect_err("preflight must reject a group-writable standalone ancestor");
+        let outcome = preflight(&mut state, &paths, Some(visible_codex), false)?;
 
-        assert!(error.to_string().contains("untrusted Codex CLI"));
-        assert_eq!(state.cli_status, CliStatus::Failed);
-        assert!(!execution_marker.exists());
+        assert_eq!(outcome.installed_version, "0.42.0");
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert!(execution_marker.exists());
         Ok(())
     }
 
     #[test]
-    fn canonical_cli_launch_path_rejects_visible_symlink_replacement_after_provenance() -> Result<()>
-    {
+    fn canonical_cli_launch_path_follows_visible_symlink_replacement() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o755))?;
@@ -4028,15 +3730,6 @@ exit 1
         let codex_home = home.join(".codex");
         let release = write_standalone_codex_release(&codex_home, "0.42.0", "test-target")?;
         let visible_codex = link_standalone_cli(&codex_home, &install_dir, &release)?;
-        let _restore_env = EnvRestoreGuard::capture(&[
-            "HOME",
-            "CODEX_HOME",
-            "CODEX_UPDATE_MANAGER_TEST_STANDALONE_PROVENANCE",
-        ]);
-        std::env::set_var("HOME", &home);
-        std::env::set_var("CODEX_HOME", &codex_home);
-        std::env::set_var("CODEX_UPDATE_MANAGER_TEST_STANDALONE_PROVENANCE", "1");
-
         let launch_path = canonical_cli_launch_path(&visible_codex)?;
         assert_eq!(launch_path, fs::canonicalize(release.join("bin/codex"))?);
 
@@ -4052,17 +3745,15 @@ exit 1
         fs::remove_file(&visible_codex)?;
         std::os::unix::fs::symlink(&replacement, &visible_codex)?;
 
-        let error = canonical_cli_launch_path(&visible_codex)
-            .expect_err("trusted standalone provenance must block visible replacement");
-        assert!(error
-            .to_string()
-            .contains("resolves outside its trusted root"));
-        assert!(!replacement_marker.exists());
+        let replacement_launch_path = canonical_cli_launch_path(&visible_codex)?;
+        assert_eq!(replacement_launch_path, fs::canonicalize(&replacement)?);
+        assert_eq!(read_installed_version(&replacement_launch_path)?, "9.9.9");
+        assert!(replacement_marker.exists());
         Ok(())
     }
 
     #[test]
-    fn canonical_cli_launch_path_rejects_external_standalone_current_symlink() -> Result<()> {
+    fn canonical_cli_launch_path_accepts_external_standalone_current_symlink() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         fs::set_permissions(temp.path(), fs::Permissions::from_mode(0o755))?;
@@ -4086,10 +3777,10 @@ exit 1
         fs::remove_file(&current)?;
         std::os::unix::fs::symlink(temp.path().join("external"), &current)?;
 
-        let error = canonical_cli_launch_path(&visible_codex)
-            .expect_err("standalone current symlink must stay inside the managed tree");
-        assert!(error.to_string().contains("external symlink"));
-        assert!(!external_marker.exists());
+        let launch_path = canonical_cli_launch_path(&visible_codex)?;
+        assert_eq!(launch_path, fs::canonicalize(external_dir.join("codex"))?);
+        assert_eq!(read_installed_version(&launch_path)?, "9.9.9");
+        assert!(external_marker.exists());
         Ok(())
     }
 
@@ -4408,7 +4099,7 @@ exit 1
     }
 
     #[test]
-    fn refresh_status_rejects_group_writable_standalone_cli_without_execution() -> Result<()> {
+    fn refresh_status_accepts_group_writable_standalone_cli() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
@@ -4438,14 +4129,9 @@ exit 1
         state.cli_path = Some(visible_codex);
         refresh_status(&mut state, &paths)?;
 
-        assert_eq!(state.cli_status, CliStatus::Failed);
-        assert_eq!(state.cli_installed_version, None);
-        assert!(state
-            .cli_error_message
-            .as_deref()
-            .unwrap_or_default()
-            .contains("untrusted Codex CLI"));
-        assert!(!probe_marker.exists());
+        assert_eq!(state.cli_status, CliStatus::Unknown);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert!(probe_marker.exists());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- restore execution-free CLI launch validation to a canonical regular executable check
- accept normal group-writable user installations and ignore stale standalone provenance during launch
- classify a CLI as standalone only when the selected path actually belongs to the standalone layout

## Why

Normal user installations created under umask 0002 can contain 0775 directories and files. The strict launch trust check rejected these paths before Electron startup, causing a silent launch failure. An unrelated Nix, AppImage, or npm CLI could also inherit stale standalone state.

Strict guards for destructive standalone mutation paths remain unchanged; this PR only relaxes launch-time path resolution.

## Validation

- cargo test -p codex-update-manager
- bash tests/scripts_smoke.sh
- ./scripts/ci-local.sh pr
- cargo fmt --all -- --check
- bash -n launcher/start.sh.template tests/scripts_smoke.sh
- git diff --check