### PR TITLE
ci: pin privileged workflow actions

### DIFF
--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -38,7 +38,7 @@ jobs:
         .#checks.x86_64-linux.watchdog-linux-features
         .#installer
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.expected_main_sha }}
@@ -75,17 +75,17 @@ jobs:
             echo "skip_refresh=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         if: steps.dedupe.outputs.skip_refresh != 'true'
         with:
           node-version: 24
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
         if: steps.dedupe.outputs.skip_refresh != 'true'
 
       - name: Configure Cachix for hash refresh builds
         if: steps.dedupe.outputs.skip_refresh != 'true' && env.CACHIX_AUTH_TOKEN != ''
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ${{ env.CACHIX_CACHE_NAME }}
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- pin every external Action in the privileged Nix hash refresh workflow to a full commit SHA
- retain the corresponding major-version comments for maintainability and dependency update tooling
- preserve the existing Action versions and workflow behavior

## Security impact

The workflow has `actions: write`, `contents: write`, and `pull-requests: write`, and can access `CACHIX_AUTH_TOKEN`. Mutable major-version tags could resolve to different code in a future trusted run if a tag were moved or an upstream Action repository were compromised. Full commit pins make the reviewed Action code immutable until the repository deliberately updates it.

There is no evidence that any referenced Action or tag is currently compromised; this is preventive supply-chain hardening.

Closes #1013.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/update-codex-hash.yml`
- verified all four external `uses:` references are pinned to full 40-character commit SHAs
- `git diff --check`
