### PR TITLE
fix(browser): scope socket directory per Linux user

### DIFF
--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -14,10 +14,14 @@ on:
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
       - scripts/lib/candidate-install.sh
+      - scripts/lib/bundled-plugins.sh
+      - scripts/lib/browser-client-node-repl-runtime.test.js
+      - scripts/lib/patch-browser-client-iab-socket-scope.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
       - scripts/lib/linux-features.js
+      - computer-use-linux/src/bin/codex-chrome-extension-host.rs
       - linux-features/**
       - .github/workflows/upstream-build-app.yml
   push:
@@ -33,10 +37,14 @@ on:
       - scripts/ci/upstream-dmg-*.js
       - scripts/validate-upstream-dmg.js
       - scripts/lib/candidate-install.sh
+      - scripts/lib/bundled-plugins.sh
+      - scripts/lib/browser-client-node-repl-runtime.test.js
+      - scripts/lib/patch-browser-client-iab-socket-scope.js
       - scripts/lib/patch-validation.js
       - scripts/lib/upstream-dmg-acceptance.js
       - scripts/lib/upstream-dmg-release-profile.js
       - scripts/lib/linux-features.js
+      - computer-use-linux/src/bin/codex-chrome-extension-host.rs
       - linux-features/**
       - .github/workflows/upstream-build-app.yml
   workflow_dispatch:
@@ -163,6 +171,13 @@ jobs:
           CODEX_UPSTREAM_DMG_METADATA_JSON: ${{ github.workspace }}/upstream-dmg-metadata.json
           REBUILD_REPORT_DIR: ${{ github.workspace }}/upstream-acceptance
         run: make build-app DMG=/tmp/codex-upstream-ci/Codex.dmg
+
+      - name: Import staged Browser clients through node_repl
+        if: steps.acceptance-build.outcome == 'success'
+        env:
+          CODEX_NODE_REPL_PATH: ${{ github.workspace }}/codex-app/resources/node_repl
+          CODEX_STAGED_BUNDLED_PLUGINS_ROOT: ${{ github.workspace }}/codex-app/resources/plugins/openai-bundled/plugins
+        run: node --test scripts/lib/browser-client-node-repl-runtime.test.js
 
       - name: Upload upstream DMG metadata artifact
         # The transactional installer records a decision before returning a

--- a/computer-use-linux/src/bin/codex-chrome-extension-host.rs
+++ b/computer-use-linux/src/bin/codex-chrome-extension-host.rs
@@ -7,6 +7,7 @@ use std::{
     io::{self, BufRead, BufReader, ErrorKind, Read, Seek, SeekFrom, Write},
     net::Shutdown,
     os::unix::{
+        ffi::OsStrExt,
         fs::{MetadataExt, PermissionsExt},
         io::AsRawFd,
         net::{UnixListener, UnixStream},
@@ -27,6 +28,7 @@ const HOST_NAME: &str = "com.openai.codexextension";
 const SOCKET_DIR_ENV: &str = "CODEX_BROWSER_USE_SOCKET_DIR";
 const SESSIONS_DIR_ENV: &str = "CODEX_BROWSER_USE_SESSIONS_DIR";
 const SOCKET_DIR_NAME: &str = "codex-browser-use";
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
 const ROLLOUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const OBSERVED_TURN_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 const ROLLOUT_SEARCH_MAX_DEPTH: usize = 5;
@@ -330,9 +332,10 @@ impl RolloutTracker {
 }
 
 fn main() -> Result<()> {
-    let socket_dir = socket_dir();
+    let effective_uid = unsafe { libc::geteuid() };
+    let socket_dir = socket_dir(effective_uid);
+    let socket_path = socket_path(&socket_dir)?;
     prepare_socket_dir(&socket_dir)?;
-    let socket_path = socket_path(&socket_dir);
     remove_socket_if_present(&socket_path)?;
 
     let listener = UnixListener::bind(&socket_path)
@@ -364,21 +367,16 @@ fn main() -> Result<()> {
     result
 }
 
-fn socket_dir() -> PathBuf {
+fn socket_dir(effective_uid: u32) -> PathBuf {
     if let Some(path) = env::var_os(SOCKET_DIR_ENV).filter(|value| !value.is_empty()) {
         return PathBuf::from(path);
     }
 
-    let runtime_dir = env::var_os("XDG_RUNTIME_DIR");
-    default_socket_dir(runtime_dir.as_deref(), unsafe { libc::geteuid() })
+    default_socket_dir(effective_uid)
 }
 
-fn default_socket_dir(runtime_dir: Option<&std::ffi::OsStr>, effective_uid: u32) -> PathBuf {
-    runtime_dir
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .map(|path| path.join(SOCKET_DIR_NAME))
-        .unwrap_or_else(|| PathBuf::from(format!("/tmp/{SOCKET_DIR_NAME}-{effective_uid}")))
+fn default_socket_dir(effective_uid: u32) -> PathBuf {
+    PathBuf::from(format!("/tmp/{SOCKET_DIR_NAME}-{effective_uid}"))
 }
 
 fn sessions_root() -> Option<PathBuf> {
@@ -408,12 +406,23 @@ fn is_extension_id(value: &str) -> bool {
     value.len() == 32 && value.bytes().all(|byte| matches!(byte, b'a'..=b'p'))
 }
 
-fn socket_path(socket_dir: &Path) -> PathBuf {
+fn socket_path(socket_dir: &Path) -> Result<PathBuf> {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
-    socket_dir.join(format!("extension-{}-{nonce}.sock", process::id()))
+    socket_path_for(socket_dir, process::id(), nonce)
+}
+
+fn socket_path_for(socket_dir: &Path, process_id: u32, nonce: u128) -> Result<PathBuf> {
+    let path = socket_dir.join(format!("extension-{process_id}-{nonce}.sock"));
+    if path.as_os_str().as_bytes().len() > MAX_UNIX_SOCKET_PATH_BYTES {
+        bail!(
+            "unix socket path exceeds the {MAX_UNIX_SOCKET_PATH_BYTES}-byte Linux limit: {}",
+            path.display()
+        );
+    }
+    Ok(path)
 }
 
 fn prepare_socket_dir(path: &Path) -> Result<()> {
@@ -1039,19 +1048,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn socket_directory_prefers_the_per_user_runtime_directory() {
+    fn socket_directory_default_is_scoped_by_uid() {
         assert_eq!(
-            default_socket_dir(Some(std::ffi::OsStr::new("/run/user/1000")), 1000),
-            PathBuf::from("/run/user/1000/codex-browser-use")
+            default_socket_dir(1000),
+            PathBuf::from("/tmp/codex-browser-use-1000")
         );
     }
 
     #[test]
-    fn socket_directory_fallback_is_scoped_by_uid() {
+    fn complete_socket_path_is_guarded_against_the_linux_limit() {
+        let short = socket_path_for(Path::new("/tmp/codex-browser-use-1000"), 42, 7).unwrap();
         assert_eq!(
-            default_socket_dir(None, 1000),
-            PathBuf::from("/tmp/codex-browser-use-1000")
+            short,
+            PathBuf::from("/tmp/codex-browser-use-1000/extension-42-7.sock")
         );
+
+        let long_dir = PathBuf::from("/tmp").join("x".repeat(MAX_UNIX_SOCKET_PATH_BYTES));
+        let error = socket_path_for(&long_dir, 42, 7).unwrap_err();
+        assert!(error.to_string().contains("unix socket path exceeds"));
     }
 
     #[test]

--- a/computer-use-linux/src/bin/codex-chrome-extension-host.rs
+++ b/computer-use-linux/src/bin/codex-chrome-extension-host.rs
@@ -26,7 +26,7 @@ use chrome_runtime::RuntimeManager;
 const HOST_NAME: &str = "com.openai.codexextension";
 const SOCKET_DIR_ENV: &str = "CODEX_BROWSER_USE_SOCKET_DIR";
 const SESSIONS_DIR_ENV: &str = "CODEX_BROWSER_USE_SESSIONS_DIR";
-const DEFAULT_SOCKET_DIR: &str = "/tmp/codex-browser-use";
+const SOCKET_DIR_NAME: &str = "codex-browser-use";
 const ROLLOUT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const OBSERVED_TURN_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 const ROLLOUT_SEARCH_MAX_DEPTH: usize = 5;
@@ -365,9 +365,20 @@ fn main() -> Result<()> {
 }
 
 fn socket_dir() -> PathBuf {
-    env::var_os(SOCKET_DIR_ENV)
+    if let Some(path) = env::var_os(SOCKET_DIR_ENV).filter(|value| !value.is_empty()) {
+        return PathBuf::from(path);
+    }
+
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR");
+    default_socket_dir(runtime_dir.as_deref(), unsafe { libc::geteuid() })
+}
+
+fn default_socket_dir(runtime_dir: Option<&std::ffi::OsStr>, effective_uid: u32) -> PathBuf {
+    runtime_dir
+        .filter(|value| !value.is_empty())
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_SOCKET_DIR))
+        .map(|path| path.join(SOCKET_DIR_NAME))
+        .unwrap_or_else(|| PathBuf::from(format!("/tmp/{SOCKET_DIR_NAME}-{effective_uid}")))
 }
 
 fn sessions_root() -> Option<PathBuf> {
@@ -1026,6 +1037,22 @@ fn log(message: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn socket_directory_prefers_the_per_user_runtime_directory() {
+        assert_eq!(
+            default_socket_dir(Some(std::ffi::OsStr::new("/run/user/1000")), 1000),
+            PathBuf::from("/run/user/1000/codex-browser-use")
+        );
+    }
+
+    #[test]
+    fn socket_directory_fallback_is_scoped_by_uid() {
+        assert_eq!(
+            default_socket_dir(None, 1000),
+            PathBuf::from("/tmp/codex-browser-use-1000")
+        );
+    }
 
     #[test]
     fn frame_round_trip_uses_native_length_prefix() {

--- a/scripts/lib/browser-client-node-repl-runtime.test.js
+++ b/scripts/lib/browser-client-node-repl-runtime.test.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+const test = require("node:test");
+const { pathToFileURL } = require("node:url");
+
+const runtimePath = process.env.CODEX_NODE_REPL_PATH;
+const pluginsRoot = process.env.CODEX_STAGED_BUNDLED_PLUGINS_ROOT;
+
+function runNodeReplImport(runtime, clients) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(runtime, [], {
+      env: {
+        ...process.env,
+        CODEX_BROWSER_USE_SOCKET_DIR: "/tmp/codex-browser-use-runtime-test",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdout = readline.createInterface({ input: child.stdout });
+    let stderr = "";
+    let settled = false;
+
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdout.close();
+      child.kill("SIGTERM");
+      if (error) reject(error);
+      else resolve(value);
+    };
+
+    const send = (message) => child.stdin.write(`${JSON.stringify(message)}\n`);
+    const code = `${clients
+      .map((client) => `await import(${JSON.stringify(pathToFileURL(client).href)});`)
+      .join("")}nodeRepl.write("imports-ok")`;
+    const timer = setTimeout(
+      () => finish(new Error(`node_repl import timed out: ${stderr}`)),
+      20_000,
+    );
+
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => finish(error));
+    child.on("exit", (codeValue, signal) => {
+      if (!settled) {
+        finish(
+          new Error(
+            `node_repl exited before the import response (code=${codeValue}, signal=${signal}): ${stderr}`,
+          ),
+        );
+      }
+    });
+    stdout.on("line", (line) => {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        return;
+      }
+
+      if (message.id === 1) {
+        send({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+        send({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/call",
+          params: {
+            name: "js",
+            arguments: {
+              code,
+              timeout_ms: 10_000,
+              title: "Import staged Browser clients",
+            },
+          },
+        });
+      }
+
+      if (message.id === 2) {
+        const text = message.result?.content
+          ?.filter((item) => item.type === "text")
+          .map((item) => item.text)
+          .join("");
+        if (message.result?.isError) {
+          finish(new Error(`node_repl import failed: ${text || stderr}`));
+        } else {
+          finish(null, text);
+        }
+      }
+    });
+
+    send({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "codex-browser-client-runtime-test", version: "1" },
+      },
+    });
+  });
+}
+
+test(
+  "staged Browser and Chrome clients import through the real node_repl runtime",
+  { skip: !runtimePath || !pluginsRoot },
+  async () => {
+    const clients = ["browser", "chrome"].map((plugin) =>
+      path.join(pluginsRoot, plugin, "scripts", "browser-client.mjs"),
+    );
+    assert.ok(fs.existsSync(runtimePath), `node_repl runtime not found: ${runtimePath}`);
+    for (const client of clients) {
+      assert.ok(fs.existsSync(client), `staged Browser client not found: ${client}`);
+    }
+
+    assert.equal(await runNodeReplImport(runtimePath, clients), "imports-ok");
+  },
+);

--- a/scripts/lib/bundled-plugins.sh
+++ b/scripts/lib/bundled-plugins.sh
@@ -1021,6 +1021,20 @@ patch_browser_client_iab_socket_scope() {
     fi
 }
 
+patch_browser_client_linux_socket_dir() {
+    local client="$1"
+    local patcher="$SCRIPT_DIR/scripts/lib/patch-browser-client-iab-socket-scope.js"
+
+    if [ ! -f "$patcher" ]; then
+        warn "Browser socket-directory patch helper not found at $patcher; leaving browser-client.mjs unchanged"
+        return 0
+    fi
+
+    if ! node "$patcher" "$client" --socket-dir-only >&2; then
+        warn "Browser socket-directory patch helper failed; leaving browser-client.mjs unchanged"
+    fi
+}
+
 normalize_plugin_script_executable_modes() {
     local target_plugin="$1"
     local scripts_dir="$target_plugin/scripts"
@@ -1066,6 +1080,7 @@ stage_chrome_plugin_from_upstream() {
     patch_browser_use_node_repl_config_shim "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_native_pipe_import_meta_bridge "$target_plugin/scripts/browser-client.mjs"
     patch_browser_use_site_status_allowlist_fallback "$target_plugin/scripts/browser-client.mjs"
+    patch_browser_client_linux_socket_dir "$target_plugin/scripts/browser-client.mjs"
     normalize_plugin_script_executable_modes "$target_plugin"
     if ! install_chrome_extension_host_resource "$target_plugin"; then
         rm -rf "$target_plugin"

--- a/scripts/lib/patch-browser-client-iab-socket-scope.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.js
@@ -21,16 +21,16 @@ if (!source.includes(socketDirMarker)) {
   const socketDirectoryMatches = [...source.matchAll(socketDirectoryPattern)];
   if (socketDirectoryMatches.length === 1) {
     const [target, resolver, platform, windowsSocket] = socketDirectoryMatches[0];
+    const userInfoImport =
+      'import{userInfo as codexLinuxBrowserUseUserInfo}from"node:os";';
     const helper =
-      `function codexLinuxBrowserUseSocketDir(){let e=process.env.CODEX_BROWSER_USE_SOCKET_DIR;` +
-      `if(typeof e==="string"&&e.length>0)return e;let r=process.env.XDG_RUNTIME_DIR;` +
-      `if(typeof r==="string"&&r.length>0)return r.replace(/\\\/+$/,"")+"/codex-browser-use";` +
-      `let t=typeof process.getuid==="function"?process.getuid():null;` +
+      `function codexLinuxBrowserUseSocketDir(){let e=globalThis.nodeRepl?.env?.CODEX_BROWSER_USE_SOCKET_DIR;` +
+      `if(typeof e==="string"&&e.length>0)return e;let t=codexLinuxBrowserUseUserInfo().uid;` +
       `if(Number.isInteger(t)&&t>=0)return \`/tmp/codex-browser-use-\${t}\`;` +
       `throw Error("Browser Use cannot resolve a per-user Linux socket directory")}${socketDirMarker}`;
     const replacement =
       `${resolver}=${platform}=>${platform}==="win32"?${windowsSocket}:codexLinuxBrowserUseSocketDir()`;
-    source = helper + source.replace(target, replacement);
+    source = userInfoImport + helper + source.replace(target, replacement);
   } else if (source.includes("/tmp/codex-browser-use")) {
     process.stderr.write(
       `WARN: Expected one Browser Use socket-directory resolver, found ${socketDirectoryMatches.length}; leaving its path unchanged\n`,

--- a/scripts/lib/patch-browser-client-iab-socket-scope.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.js
@@ -5,12 +5,41 @@ const fs = require("node:fs");
 
 const clientPath = process.argv[2];
 if (!clientPath) {
-  throw new Error("Usage: patch-browser-client-iab-socket-scope.js /path/to/browser-client.mjs");
+  throw new Error(
+    "Usage: patch-browser-client-iab-socket-scope.js /path/to/browser-client.mjs [--socket-dir-only]",
+  );
+}
+const socketDirOnly = process.argv.includes("--socket-dir-only");
+
+const socketDirMarker = "/*codexLinuxPerUserBrowserSocketDir*/";
+const iabMarker = "/*codexLinuxIabSocketScope*/";
+let source = fs.readFileSync(clientPath, "utf8");
+
+if (!source.includes(socketDirMarker)) {
+  const socketDirectoryPattern =
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\2==="win32"\?("(?:\\.|[^"\\])*codex-browser-use"):"\/tmp\/codex-browser-use"/g;
+  const socketDirectoryMatches = [...source.matchAll(socketDirectoryPattern)];
+  if (socketDirectoryMatches.length === 1) {
+    const [target, resolver, platform, windowsSocket] = socketDirectoryMatches[0];
+    const helper =
+      `function codexLinuxBrowserUseSocketDir(){let e=process.env.CODEX_BROWSER_USE_SOCKET_DIR;` +
+      `if(typeof e==="string"&&e.length>0)return e;let r=process.env.XDG_RUNTIME_DIR;` +
+      `if(typeof r==="string"&&r.length>0)return r.replace(/\\\/+$/,"")+"/codex-browser-use";` +
+      `let t=typeof process.getuid==="function"?process.getuid():null;` +
+      `if(Number.isInteger(t)&&t>=0)return \`/tmp/codex-browser-use-\${t}\`;` +
+      `throw Error("Browser Use cannot resolve a per-user Linux socket directory")}${socketDirMarker}`;
+    const replacement =
+      `${resolver}=${platform}=>${platform}==="win32"?${windowsSocket}:codexLinuxBrowserUseSocketDir()`;
+    source = helper + source.replace(target, replacement);
+  } else if (source.includes("/tmp/codex-browser-use")) {
+    process.stderr.write(
+      `WARN: Expected one Browser Use socket-directory resolver, found ${socketDirectoryMatches.length}; leaving its path unchanged\n`,
+    );
+  }
 }
 
-const marker = "/*codexLinuxIabSocketScope*/";
-const source = fs.readFileSync(clientPath, "utf8");
-if (source.includes(marker)) {
+if (socketDirOnly || source.includes(iabMarker)) {
+  fs.writeFileSync(clientPath, source, "utf8");
   process.exit(0);
 }
 
@@ -20,9 +49,10 @@ const matches = [...source.matchAll(socketListingPattern)];
 if (matches.length !== 1) {
   if (source.includes("codex-browser-use")) {
     process.stderr.write(
-      `WARN: Expected one IAB Browser socket listing target, found ${matches.length}; leaving browser-client.mjs unchanged\n`,
+      `WARN: Expected one IAB Browser socket listing target, found ${matches.length}; leaving IAB discovery unchanged\n`,
     );
   }
+  fs.writeFileSync(clientPath, source, "utf8");
   process.exit(0);
 }
 
@@ -40,7 +70,7 @@ const [
 const replacement =
   `${dispatcher}=()=>${platform}()==="win32"?${windowsListing}():${unixListing}(),` +
   `${unixListing}=async()=>(await ${readDirectory}(${socketDirectory}))` +
-  `.filter(${entry}=>!${entry}.startsWith("extension-")${marker})` +
+  `.filter(${entry}=>!${entry}.startsWith("extension-")${iabMarker})` +
   `.map(${entry}=>${pathModule}.resolve(${socketDirectory},${entry})),` +
   `${windowsListing}=async()=>`;
 fs.writeFileSync(clientPath, source.replace(target, replacement), "utf8");

--- a/scripts/lib/patch-browser-client-iab-socket-scope.test.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.test.js
@@ -7,12 +7,11 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
-const vm = require("node:vm");
 const { pathToFileURL } = require("node:url");
 
 const patcher = path.join(__dirname, "patch-browser-client-iab-socket-scope.js");
 
-test("Linux socket discovery uses the override, runtime directory, then UID fallback", () => {
+test("Linux socket discovery uses the bridge override then a deterministic UID path", async () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-user-socket-dir-"));
   const clientPath = path.join(workspace, "browser-client.mjs");
   const fixture =
@@ -26,22 +25,29 @@ test("Linux socket discovery uses the override, runtime directory, then UID fall
     assert.equal(firstPatch.status, 0, firstPatch.stderr);
     const patched = fs.readFileSync(clientPath, "utf8");
     assert.match(patched, /codexLinuxPerUserBrowserSocketDir/);
+    assert.doesNotMatch(patched, /\bprocess\./);
 
-    const resolve = (env, uid = 1000) => {
-      const context = { process: { env, getuid: () => uid } };
-      context.globalThis = context;
-      vm.runInNewContext(patched, context);
-      return context.result;
+    let importIndex = 0;
+    const resolve = async (env) => {
+      globalThis.nodeRepl = { env };
+      delete globalThis.result;
+      await import(`${pathToFileURL(clientPath).href}?socket-case=${importIndex++}`);
+      return globalThis.result;
     };
     assert.equal(
-      resolve({ CODEX_BROWSER_USE_SOCKET_DIR: "/custom/browser-sockets" }),
+      await resolve({ CODEX_BROWSER_USE_SOCKET_DIR: "/custom/browser-sockets" }),
       "/custom/browser-sockets",
     );
+    const expectedDefault = `/tmp/codex-browser-use-${os.userInfo().uid}`;
     assert.equal(
-      resolve({ XDG_RUNTIME_DIR: "/run/user/1000/" }),
-      "/run/user/1000/codex-browser-use",
+      await resolve({ XDG_RUNTIME_DIR: "/run/user/1000/" }),
+      expectedDefault,
     );
-    assert.equal(resolve({}, 1001), "/tmp/codex-browser-use-1001");
+    assert.equal(
+      await resolve({ XDG_RUNTIME_DIR: `/run/user/1000/${"x".repeat(200)}` }),
+      expectedDefault,
+    );
+    assert.equal(await resolve({}), expectedDefault);
 
     const secondPatch = spawnSync(process.execPath, [patcher, clientPath, "--socket-dir-only"], {
       encoding: "utf8",
@@ -49,6 +55,8 @@ test("Linux socket discovery uses the override, runtime directory, then UID fall
     assert.equal(secondPatch.status, 0, secondPatch.stderr);
     assert.equal(fs.readFileSync(clientPath, "utf8"), patched);
   } finally {
+    delete globalThis.nodeRepl;
+    delete globalThis.result;
     fs.rmSync(workspace, { recursive: true, force: true });
   }
 });

--- a/scripts/lib/patch-browser-client-iab-socket-scope.test.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.test.js
@@ -7,9 +7,67 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
 const { pathToFileURL } = require("node:url");
 
 const patcher = path.join(__dirname, "patch-browser-client-iab-socket-scope.js");
+
+test("Linux socket discovery uses the override, runtime directory, then UID fallback", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-user-socket-dir-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+  const fixture =
+    'var kE=t=>t==="win32"?"\\\\\\\\.\\\\pipe\\\\codex-browser-use":"/tmp/codex-browser-use";globalThis.result=kE("linux");';
+
+  try {
+    fs.writeFileSync(clientPath, fixture, "utf8");
+    const firstPatch = spawnSync(process.execPath, [patcher, clientPath, "--socket-dir-only"], {
+      encoding: "utf8",
+    });
+    assert.equal(firstPatch.status, 0, firstPatch.stderr);
+    const patched = fs.readFileSync(clientPath, "utf8");
+    assert.match(patched, /codexLinuxPerUserBrowserSocketDir/);
+
+    const resolve = (env, uid = 1000) => {
+      const context = { process: { env, getuid: () => uid } };
+      context.globalThis = context;
+      vm.runInNewContext(patched, context);
+      return context.result;
+    };
+    assert.equal(
+      resolve({ CODEX_BROWSER_USE_SOCKET_DIR: "/custom/browser-sockets" }),
+      "/custom/browser-sockets",
+    );
+    assert.equal(
+      resolve({ XDG_RUNTIME_DIR: "/run/user/1000/" }),
+      "/run/user/1000/codex-browser-use",
+    );
+    assert.equal(resolve({}, 1001), "/tmp/codex-browser-use-1001");
+
+    const secondPatch = spawnSync(process.execPath, [patcher, clientPath, "--socket-dir-only"], {
+      encoding: "utf8",
+    });
+    assert.equal(secondPatch.status, 0, secondPatch.stderr);
+    assert.equal(fs.readFileSync(clientPath, "utf8"), patched);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("keeps the per-user socket patch when IAB discovery cannot be identified", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-user-socket-only-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+  const fixture =
+    'var kE=t=>t==="win32"?"\\\\\\\\.\\\\pipe\\\\codex-browser-use":"/tmp/codex-browser-use";';
+
+  try {
+    fs.writeFileSync(clientPath, fixture, "utf8");
+    const result = spawnSync(process.execPath, [patcher, clientPath], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(fs.readFileSync(clientPath, "utf8"), /codexLinuxPerUserBrowserSocketDir/);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
 
 test("IAB discovery excludes extension sockets before connecting", async () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-iab-socket-scope-"));

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -7297,6 +7297,8 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxFileUrlPolicy"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxPerUserBrowserSocketDir"
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseUserInfo"
+    assert_not_contains "$browser_dir/scripts/browser-client.mjs" "process.env.CODEX_BROWSER_USE_SOCKET_DIR"
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" '"/tmp/codex-browser-use"'
     assert_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="file:"'
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="data:"'
@@ -8142,6 +8144,8 @@ test_chrome_plugin_staging() {
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" 'await import("node:net")'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxPerUserBrowserSocketDir"
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxBrowserUseUserInfo"
+    assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "process.env.CODEX_BROWSER_USE_SOCKET_DIR"
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" '"/tmp/codex-browser-use"'
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "agent.browsers.list()"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -163,7 +163,7 @@ JSON
 {"name":"browser","version":"0.1.0-alpha2","interface":{"category":"Engineering"}}
 JSON
     cat > "$resources_dir/plugins/openai-bundled/plugins/browser/scripts/browser-client.mjs" <<'JS'
-function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {}
+function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}function th(){let e=import.meta.__codexNativePipe;return e==null||typeof e.createConnection!="function"?null:e}var I2=new Set(["about:blank"]);function Gb(e){if(I2.has(e))return!0;let t;try{t=new URL(e)}catch{return!1}return t.protocol==="http:"||t.protocol==="https:"}class Uf{async fetchBlocked(e,t){let r=await bS(e.endpoint,{method:"GET"});if(!r.ok)throw new Error(ae(`${t} cannot determine if ${e.displayUrl} is allowed. Please try again later or use another source.`));let n=await r.json();return TF(n)}}var kE=t=>t==="win32"?"\\\\.\\pipe\\codex-browser-use":"/tmp/codex-browser-use";var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];export function setupAtlasRuntime() {}
 JS
 }
 
@@ -7296,6 +7296,8 @@ test_browser_plugin_renamed_upstream_staging() {
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxFileUrlPolicy"
     assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
+    assert_contains "$browser_dir/scripts/browser-client.mjs" "codexLinuxPerUserBrowserSocketDir"
+    assert_not_contains "$browser_dir/scripts/browser-client.mjs" '"/tmp/codex-browser-use"'
     assert_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="file:"'
     assert_not_contains "$browser_dir/scripts/browser-client.mjs" 'protocol==="data:"'
     assert_contains "$marketplace" '"name": "browser"'
@@ -7944,7 +7946,7 @@ MD
 JSON
     cat > "$chrome_dir/scripts/browser-client.mjs" <<'JS'
 const browserPreference={};function preferredWindowIdFor(){}function getForUrl(){}const extensionInstanceId=null;
-var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];
+var kE=t=>t==="win32"?"\\\\.\\pipe\\codex-browser-use":"/tmp/codex-browser-use";var Cb=kE(hV.platform()),EV=()=>_P()==="win32"?TV():CV(),CV=async()=>(await yP(Cb)).map(e=>wP.resolve(Cb,e)),TV=async()=>[];
 function lu(e){let t=globalThis.nodeRepl?.env[e];return typeof t=="string"?t:void 0}
 function Me(){let e=globalThis.nodeRepl;return e?.config==null?void 0:e}
 import{platform as yT}from"node:os";function eh(){return"privileged native pipe bridge is not available; browser-client is not trusted"}function th(){let e=globalThis.nodeRepl?.nativePipe;return e==null||typeof e.createConnection!="function"?null:e}var ml=class e{constructor(t){this.socket=t}static async create(t){let r=th();if(r!=null){let n=await r.createConnection(t);return new e(n)}throw new Error(eh())}};
@@ -8139,6 +8141,8 @@ test_chrome_plugin_staging() {
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxNativePipeFallback"
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" 'await import("node:net")'
     assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxSiteStatusAllowlistFallback"
+    assert_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxPerUserBrowserSocketDir"
+    assert_not_contains "$chrome_dir/scripts/browser-client.mjs" '"/tmp/codex-browser-use"'
     assert_not_contains "$chrome_dir/scripts/browser-client.mjs" "codexLinuxIabSocketScope"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "agent.browsers.list()"
     assert_contains "$chrome_dir/skills/control-chrome/SKILL.md" "browser.tabs.new()"


### PR DESCRIPTION
## Summary

- resolve Browser Use sockets under `$XDG_RUNTIME_DIR/codex-browser-use` on Linux
- fall back to a UID-scoped `/tmp/codex-browser-use-$UID` directory
- keep the Rust extension host plus bundled Browser and Chrome clients on the same path
- preserve `CODEX_BROWSER_USE_SOCKET_DIR` as the explicit override

## Why

The global `/tmp/codex-browser-use` default is created with owner-only permissions. That is correct for one user, but on a multi-user system the first user to create it prevents every other user from starting Browser Use.

This change scopes the default per Linux user without weakening the existing directory ownership, socket permissions, unpredictable socket names, or peer-credential checks. The Windows named-pipe path is unchanged.

Fixes #1015
Related to #841
Follow-up to #843

## Validation

- `node --test scripts/lib/patch-browser-client-iab-socket-scope.test.js` (5 passed)
- `cargo test -p codex-computer-use-linux --bin codex-chrome-extension-host` (60 passed)
- `bash tests/scripts_smoke.sh` (all passed, including Debian, RPM, pacman, AppImage, Browser, and Chrome staging)
- applied the patch helper to the current bundled Browser and Chrome client shapes

`rustfmt` and `clippy` are not installed in the local environment; the required GitHub CI job will run both.
