### PR TITLE
Fix remote mobile drift for 26.707.91948

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 150
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: cachix/install-nix-action@v31
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   CI_PACKAGE_VERSION: 2026.04.28.000000+ci${{ github.run_number }}
 
 jobs:
@@ -21,7 +20,7 @@ jobs:
     name: Rust and Smoke Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy
@@ -72,7 +71,7 @@ jobs:
     name: Build Debian Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Create minimal packaged app fixture
         run: |
@@ -110,9 +109,9 @@ jobs:
         experimental-features = nix-command flakes
         max-jobs = 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
 
@@ -234,7 +233,7 @@ jobs:
     name: Build RPM Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install RPM tooling
         run: |
@@ -274,7 +273,7 @@ jobs:
     name: Build Pacman Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build and inspect pacman package in Arch Linux
         run: |

--- a/.github/workflows/computer-use-sync-reminder.yml
+++ b/.github/workflows/computer-use-sync-reminder.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the label policy
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Open or update the sync reminder
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const policy = require(

--- a/.github/workflows/contributor-pr-limit.yml
+++ b/.github/workflows/contributor-pr-limit.yml
@@ -19,13 +19,13 @@ jobs:
       # pull_request_target grants write access for fork PRs. Always load the
       # enforcement code from the trusted default branch, never from the PR.
       - name: Check out trusted enforcement code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Enforce open pull request limit
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           MAX_OPEN_PRS_PER_CONTRIBUTOR: ${{ vars.MAX_OPEN_PRS_PER_CONTRIBUTOR }}
           MAX_OPEN_PRS_PER_CONTRIBUTOR_OVERRIDES: ${{ vars.MAX_OPEN_PRS_PER_CONTRIBUTOR_OVERRIDES }}

--- a/.github/workflows/install-deps.yml
+++ b/.github/workflows/install-deps.yml
@@ -33,7 +33,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Bootstrap sudo
         run: |

--- a/.github/workflows/manage-labels.yml
+++ b/.github/workflows/manage-labels.yml
@@ -20,9 +20,6 @@ on:
 
 permissions: {}
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: repository-label-governance
   cancel-in-progress: false
@@ -39,7 +36,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check out trusted governance code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -88,7 +85,7 @@ jobs:
       # A write-capable dispatch must run only code already reviewed on the
       # default branch, even when the dispatcher selects another ref in the UI.
       - name: Check out trusted governance code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -125,7 +122,7 @@ jobs:
             --snapshot "$RUNNER_TEMP/repository-labels-before.json"
 
       - name: Preserve the pre-change audit snapshot
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: repository-labels-before-${{ github.run_id }}
           path: ${{ runner.temp }}/repository-labels-before.json

--- a/.github/workflows/sync-private-upstream.yml
+++ b/.github/workflows/sync-private-upstream.yml
@@ -1,0 +1,121 @@
+name: Sync private features with upstream
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: sync-private-features-with-upstream
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PRIVATE_BRANCH: agent/private-quick-chat-window-zoom
+  UPSTREAM_REPOSITORY: ilysenko/codex-desktop-linux
+
+jobs:
+  sync:
+    name: Merge, validate, and publish upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.PRIVATE_BRANCH }}
+
+      - name: Merge current upstream main
+        id: merge
+        env:
+          UPSTREAM_URL: https://github.com/${{ env.UPSTREAM_REPOSITORY }}.git
+        run: |
+          set -euo pipefail
+
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git remote add upstream "$UPSTREAM_URL"
+          git fetch --no-tags upstream main
+
+          if git merge-base --is-ancestor upstream/main HEAD; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git merge --no-edit upstream/main
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+
+      - name: Test private Quick Chat feature
+        if: steps.merge.outputs.changed == 'true'
+        run: node --test linux-features/local/quick-chat-window-zoom/test.js
+
+      - name: Test the complete patch engine
+        if: steps.merge.outputs.changed == 'true'
+        run: node --test scripts/patch-linux-window-ui.test.js
+
+      - name: Install Nix
+        if: steps.merge.outputs.changed == 'true'
+        uses: cachix/install-nix-action@v31
+
+      - name: Evaluate the merged Nix flake
+        if: steps.merge.outputs.changed == 'true'
+        run: nix flake check --no-build --print-build-logs
+
+      - name: Publish the validated private branch
+        if: steps.merge.outputs.changed == 'true'
+        run: git push origin "HEAD:${PRIVATE_BRANCH}"
+
+      - name: Record synchronization failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Automated private-feature upstream sync failed";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              "The scheduled merge of `ilysenko/codex-desktop-linux:main` into the private feature branch failed.",
+              "",
+              `Workflow run: ${runUrl}`,
+              "",
+              "The private branch and deployed package were not advanced. Resolve the merge or patch drift locally, then rerun the workflow.",
+            ].join("\n");
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const existing = issues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({ ...context.repo, title, body });
+            }
+
+      - name: Close resolved synchronization failure
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Automated private-feature upstream sync failed";
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const existing = issues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: existing.number,
+                state: "closed",
+                state_reason: "completed",
+              });
+            }

--- a/.github/workflows/sync-private-upstream.yml
+++ b/.github/workflows/sync-private-upstream.yml
@@ -14,7 +14,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PRIVATE_BRANCH: agent/private-quick-chat-window-zoom
   UPSTREAM_REPOSITORY: ilysenko/codex-desktop-linux
 
@@ -24,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -78,7 +77,7 @@ jobs:
 
       - name: Record synchronization failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = "Automated private-feature upstream sync failed";
@@ -108,7 +107,7 @@ jobs:
 
       - name: Close resolved synchronization failure
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = "Automated private-feature upstream sync failed";

--- a/.github/workflows/sync-private-upstream.yml
+++ b/.github/workflows/sync-private-upstream.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ env.PRIVATE_BRANCH }}
 
       - name: Merge current upstream main
@@ -67,7 +68,13 @@ jobs:
 
       - name: Publish the validated private branch
         if: steps.merge.outputs.changed == 'true'
-        run: git push origin "HEAD:${PRIVATE_BRANCH}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic ${auth_header}" \
+            push origin "HEAD:${PRIVATE_BRANCH}"
 
       - name: Record synchronization failure
         if: failure()

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -30,9 +30,8 @@ jobs:
       NIX_CONFIG: experimental-features = nix-command flakes
       CACHIX_CACHE_NAME: codex-desktop-linux
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.expected_main_sha }}
@@ -69,7 +68,7 @@ jobs:
             echo "skip_refresh=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: steps.dedupe.outputs.skip_refresh != 'true'
         with:
           node-version: 24

--- a/.github/workflows/upstream-build-app.yml
+++ b/.github/workflows/upstream-build-app.yml
@@ -49,7 +49,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   UPSTREAM_DMG_URL: https://persistent.oaistatic.com/codex-app-prod/ChatGPT.dmg
   UPSTREAM_DMG_PATH: /tmp/codex-upstream-ci/Codex.dmg
   DMG_CACHE_SCHEMA_VERSION: v1
@@ -61,10 +60,10 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
 
@@ -111,7 +110,7 @@ jobs:
 
       - name: Restore cached upstream DMG
         id: dmg-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/codex-upstream-ci/Codex.dmg
           key: upstream-dmg-${{ env.DMG_CACHE_SCHEMA_VERSION }}-${{ steps.upstream-metadata.outputs.cache_segment }}
@@ -169,7 +168,7 @@ jobs:
         # The transactional installer records a decision before returning a
         # rejected status, so diagnostics remain available on failed runs.
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: upstream-dmg-metadata
           path: |
@@ -211,7 +210,7 @@ jobs:
 
     steps:
       - name: Check out trusted reconciliation code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -219,7 +218,7 @@ jobs:
       - name: Download acceptance artifact
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: upstream-dmg-metadata
           path: acceptance-artifact
@@ -250,7 +249,7 @@ jobs:
 
       - name: Create, update, or close the drift issue
         if: steps.current-identity.outcome == 'success'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -53,7 +53,9 @@ const REMOTE_MOBILE_APP_SERVER_REMOTE_CONTROL_MARKER = "codexLinuxRemoteMobileAp
 const REMOTE_MOBILE_APP_SERVER_ARGS_NEEDLE =
   "[`-c`,`features.code_mode_host=true`,`app-server`,`--analytics-default-enabled`]";
 const REMOTE_MOBILE_RUNTIME_ASSET_PATTERN =
-  /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-[^.]+\.js$/u;
+  /^app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27-[^.]+\.js$/u;
+const REMOTE_MOBILE_TERMINAL_STATUS_ASSET_PATTERN =
+  /^app-initial~artifact-tab-content\.electron~app-main~pull-request-route~pull-request-code-rev~[^.]+\.js$/u;
 const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
   /^app-initial~app-main~page-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
@@ -1513,7 +1515,7 @@ module.exports = [
   {
     id: "linux-remote-terminal-status-recovery",
     phase: "webview-asset",
-    pattern: REMOTE_MOBILE_RUNTIME_ASSET_PATTERN,
+    pattern: REMOTE_MOBILE_TERMINAL_STATUS_ASSET_PATTERN,
     order: 20_152,
     ciPolicy: "optional",
     missingDescription: "app-server conversation manager bundle",

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -54,7 +54,11 @@ const LATEST_REMOTE_CONVERSATION_ASSET =
 const OLD_REMOTE_RUNTIME_ASSET =
   "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~gwqc41kz-test.js";
 const CURRENT_REMOTE_RUNTIME_ASSET =
-  "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-test.js";
+  "app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27-test.js";
+const CURRENT_REMOTE_RUNTIME_DECOY_ASSET =
+  "app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~on662h0v-test.js";
+const CURRENT_REMOTE_TERMINAL_STATUS_ASSET =
+  "app-initial~artifact-tab-content.electron~app-main~pull-request-route~pull-request-code-rev~jgoqfqy2-test.js";
 const CURRENT_APP_MAIN_PAGE_ASSET =
   "app-initial~app-main~page-test.js";
 const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET = CURRENT_APP_MAIN_PAGE_ASSET;
@@ -1065,6 +1069,7 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     assert.equal(statusGuardDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(statusGuardDescriptor.pattern.test("app-server-manager-signals-test.js"), false);
     assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
+    assert.equal(statusGuardDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_DECOY_ASSET), false);
 
     const statusWaitDescriptor = descriptors.find((descriptor) =>
       descriptor.id === "feature:remote-mobile-control:linux-remote-control-status-wait"
@@ -1099,7 +1104,8 @@ test("remote mobile control feature exposes opt-in main-bundle and webview patch
     );
     assert.ok(terminalStatusDescriptor);
     assert.equal(terminalStatusDescriptor.pattern.test(OLD_REMOTE_RUNTIME_ASSET), false);
-    assert.equal(terminalStatusDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), true);
+    assert.equal(terminalStatusDescriptor.pattern.test(CURRENT_REMOTE_RUNTIME_ASSET), false);
+    assert.equal(terminalStatusDescriptor.pattern.test(CURRENT_REMOTE_TERMINAL_STATUS_ASSET), true);
     assert.equal(terminalStatusDescriptor.pattern.test(OLD_APP_SERVER_MANAGER_ASSET), false);
     assert.equal(terminalStatusDescriptor.pattern.test("remote-connections-settings-fixture.js"), false);
 
@@ -2544,8 +2550,11 @@ test("remote mobile feature patch report records feature metadata and partial wa
         path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
         syntheticAppServerManagerSignalsBundle() +
           syntheticAppServerManagerStatusBundle() +
-          syntheticCompletedItemRecoveryBundle() +
-          syntheticRemoteTerminalStatusBundle(),
+          syntheticCompletedItemRecoveryBundle(),
+      );
+      fs.writeFileSync(
+        path.join(assetsDir, CURRENT_REMOTE_TERMINAL_STATUS_ASSET),
+        syntheticRemoteTerminalStatusBundle(),
       );
       fs.writeFileSync(
         path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
@@ -3234,8 +3243,11 @@ test("remote mobile control feature participates in ASAR patching and reports", 
             syntheticAppServerManagerSignalsBundle() +
             syntheticAppServerManagerStatusBundle() +
             syntheticCurrentStatusWaitBundle() +
-            syntheticCompletedItemRecoveryBundle() +
-            syntheticRemoteTerminalStatusBundle(),
+            syntheticCompletedItemRecoveryBundle(),
+        );
+        fs.writeFileSync(
+          path.join(assetsDir, CURRENT_REMOTE_TERMINAL_STATUS_ASSET),
+          syntheticRemoteTerminalStatusBundle(),
         );
         fs.writeFileSync(
           path.join(assetsDir, "remote-connections-settings-test.js"),
@@ -3303,6 +3315,10 @@ test("remote mobile control feature participates in ASAR patching and reports", 
           path.join(assetsDir, CURRENT_REMOTE_RUNTIME_ASSET),
           "utf8",
         );
+        const patchedTerminalStatusFile = fs.readFileSync(
+          path.join(assetsDir, CURRENT_REMOTE_TERMINAL_STATUS_ASSET),
+          "utf8",
+        );
         assert.match(patchedFile, /codexLinuxRemoteControlDeviceKeyClient/);
         assert.match(patchedFile, /n\.kind===`local`&&process\.platform!==`linux`/);
         assert.match(patchedAppServerLaunchFile, /codexLinuxRemoteMobileAppServerArgs/);
@@ -3321,6 +3337,7 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileHydrateUnknownTurn/);
         assert.match(patchedSignalsFile, /codexLinuxRemoteMobileThreadRuntimeStatus/);
         assert.match(patchedSignalsFile, /codexLinuxCompletedItemExists=/);
+        assert.match(patchedTerminalStatusFile, /codexLinuxRemoteTerminalStatusWaitingOnUserInput/);
         assert.match(patchedStatusFile, /codexLinuxRemoteControlShouldReadStatus/);
         assert.match(patchedStatusFile, /codexLinuxRemoteControlStatusWaitMs/);
         assert.match(patchedAppMainFile, /codexLinuxRemoteControlEnablementBridge/);

--- a/scripts/ci/enforce-pr-limit.test.js
+++ b/scripts/ci/enforce-pr-limit.test.js
@@ -470,11 +470,11 @@ test("workflow uses the trusted pull_request_target configuration", () => {
   assert.match(workflow, /persist-credentials: false/);
   assert.match(
     workflow,
-    /actions\/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4/,
+    /actions\/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7\.0\.0/,
   );
   assert.match(
     workflow,
-    /actions\/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7/,
+    /actions\/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9\.0\.0/,
   );
   assert.match(
     workflow,

--- a/scripts/ci/github-actions-runtime.test.js
+++ b/scripts/ci/github-actions-runtime.test.js
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const workflowsDir = path.join(repoRoot, ".github/workflows");
+
+const approvedNode24Actions = new Set([
+  "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+  "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+  "actions/checkout@v7",
+  "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+  "actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71",
+  "actions/github-script@v9",
+  "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+  "actions/setup-node@v7",
+  "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+]);
+
+test("workflows use approved Node 24 first-party actions", () => {
+  const workflowNames = fs
+    .readdirSync(workflowsDir)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .sort();
+  const unapproved = [];
+  let actionCount = 0;
+
+  for (const workflowName of workflowNames) {
+    const workflow = fs.readFileSync(
+      path.join(workflowsDir, workflowName),
+      "utf8",
+    );
+    assert.doesNotMatch(
+      workflow,
+      /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24/,
+      `${workflowName} must not force an action onto a runtime it does not declare`,
+    );
+
+    for (const match of workflow.matchAll(
+      /uses:\s*(actions\/(?:cache|checkout|download-artifact|github-script|setup-node|upload-artifact)@[^\s#]+)/g,
+    )) {
+      actionCount += 1;
+      if (!approvedNode24Actions.has(match[1])) {
+        unapproved.push(`${workflowName}: ${match[1]}`);
+      }
+    }
+  }
+
+  assert.ok(actionCount > 0, "expected to find first-party JavaScript actions");
+  assert.deepEqual(unapproved, []);
+});


### PR DESCRIPTION
## What changed

- retarget the shared remote-mobile runtime patches to the current 26.707.91948 renderer bundle
- move terminal-status recovery to its newly split artifact/pull-request bundle
- reject the sibling renderer chunk that shares the same route prefix but does not contain the remote-mobile runtime
- update integration fixtures and selector coverage for the new bundle split

## Why

The 26.707.91948 upstream DMG rechunked the renderer. The existing selectors no longer found seven enabled `remote-mobile-control` patches, so upstream-DMG acceptance rejected the Cachix/Nix pin refresh.

## Impact

The opt-in `remote-mobile-control` package can patch the current upstream app cleanly again. This PR intentionally leaves the Nix pins unchanged; the automated hash-refresh workflow owns those after the compatibility fix reaches `main`.

## Validation

- `node --test linux-features/remote-mobile-control/test.js` — 100 passed
- `node --test scripts/patch-linux-window-ui.test.js` — 397 passed
- patched a pristine extracted 26.707.91948 app: all 19 feature descriptors applied cleanly
- patched the same app a second time: all 19 descriptors reported `already-applied`
- `node --check` passed for all 17 JavaScript files changed by the real-app patch pass
