### PR TITLE
fix(nix): align watchdog Linux feature profile

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -56,7 +56,7 @@ jobs:
             .#codex-desktop-computer-use-ui \
             .#codex-desktop-remote-mobile-control \
             .#codex-desktop-computer-use-ui-remote-mobile-control \
-            .#checks.x86_64-linux.nix-linux-features-multi-feature \
+            .#checks.x86_64-linux.watchdog-linux-features \
             .#installer \
             --no-link \
             --print-build-logs
@@ -68,6 +68,6 @@ jobs:
             echo "- Built: \`.#codex-desktop-computer-use-ui\`"
             echo "- Built: \`.#codex-desktop-remote-mobile-control\`"
             echo "- Built: \`.#codex-desktop-computer-use-ui-remote-mobile-control\`"
-            echo "- Built: \`.#checks.x86_64-linux.nix-linux-features-multi-feature\`"
+            echo "- Built: \`.#checks.x86_64-linux.watchdog-linux-features\`"
             echo "- Built: \`.#installer\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
             .#codex-desktop-computer-use-ui
             .#codex-desktop-remote-mobile-control
             .#codex-desktop-computer-use-ui-remote-mobile-control
-            .#checks.x86_64-linux.nix-linux-features-multi-feature
+            .#checks.x86_64-linux.watchdog-linux-features
           )
           for output in "${outputs[@]}"; do
             build_log="$(mktemp)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           changed=false
@@ -143,14 +145,24 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
               --paginate \
               --jq '.[].filename' | tee "$changed_files"
-            if grep -Eq '^(flake\.nix|flake\.lock|nix/native-modules/package\.json|nix/native-modules/package-lock\.json|scripts/ci/update-nix-hashes\.sh|scripts/ci/validate-nix-pins\.sh)$' "$changed_files"; then
+            guarded_paths='^(flake\.lock|nix/native-modules/package\.json|nix/native-modules/package-lock\.json|scripts/ci/update-nix-hashes\.sh|scripts/ci/validate-nix-pins\.sh)$'
+            if grep -Eq "$guarded_paths" "$changed_files"; then
               changed=true
+            elif grep -qx 'flake.nix' "$changed_files"; then
+              git fetch --no-tags --depth=1 origin "$PR_BASE_SHA" "$PR_HEAD_SHA"
+              if git diff --unified=0 "$PR_BASE_SHA" "$PR_HEAD_SHA" -- flake.nix \
+                  | grep -Eq '^[+-][[:space:]]*(codexVersion|electronVersion|hash) = '; then
+                changed=true
+              fi
+            fi
+
+            if [ "$changed" = "true" ]; then
               {
                 echo "## Nix Pin File Changes"
                 echo ""
-                echo "- Rollout skip is disabled because this PR changes Nix pin source-of-truth files."
+                echo "- Rollout skip is disabled because this PR changes Nix pin source-of-truth content."
                 echo "- Changed guarded files:"
-                grep -E '^(flake\.nix|flake\.lock|nix/native-modules/package\.json|nix/native-modules/package-lock\.json|scripts/ci/update-nix-hashes\.sh|scripts/ci/validate-nix-pins\.sh)$' "$changed_files" | sed 's/^/  - `/' | sed 's/$/`/'
+                grep -E "$guarded_paths|^flake\.nix$" "$changed_files" | sed 's/^/  - `/' | sed 's/$/`/'
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           fi

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -30,6 +30,13 @@ jobs:
       NIX_CONFIG: experimental-features = nix-command flakes
       CACHIX_CACHE_NAME: codex-desktop-linux
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      NIX_VERIFY_OUTPUTS: |
+        .#codex-desktop
+        .#codex-desktop-computer-use-ui
+        .#codex-desktop-remote-mobile-control
+        .#codex-desktop-computer-use-ui-remote-mobile-control
+        .#checks.x86_64-linux.watchdog-linux-features
+        .#installer
     steps:
       - uses: actions/checkout@v7
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -464,10 +464,25 @@ PY
           fi
         '';
 
+        linuxFeaturesConfigFile = config:
+          pkgs.writeText "codex-linux-features.json" (builtins.toJSON config);
+
         linuxFeaturesConfig = linuxFeatureIds:
-          pkgs.writeText "codex-linux-features.json" (builtins.toJSON {
+          linuxFeaturesConfigFile {
             enabled = linuxFeatureIds;
-          });
+          };
+
+        normalizeLinuxFeaturesConfig = config:
+          let
+            enabled = nixLinuxFeatures.normalize (config.enabled or [ ]);
+          in
+          config // {
+            inherit enabled;
+          };
+
+        watchdogLinuxFeaturesConfig = normalizeLinuxFeaturesConfig (
+          builtins.fromJSON (builtins.readFile ./scripts/ci/watchdog-linux-features.json)
+        );
 
         enabledFeatureIds = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
           pkgs.lib.optionals enableComputerUseUi [ "computer-use-ui" ]
@@ -479,9 +494,17 @@ PY
           in
           if featureIds == [ ] then "" else "-${pkgs.lib.concatStringsSep "-" featureIds}";
 
-        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+        mkCodexDesktopPayload = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], linuxFeaturesConfigOverride ? null }:
+        let
+          effectiveLinuxFeaturesConfig =
+            if linuxFeaturesConfigOverride == null then
+              normalizeLinuxFeaturesConfig { enabled = linuxFeatureIds; }
+            else
+              normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
+          effectiveLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
+        in
         pkgs.stdenv.mkDerivation {
-          pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi linuxFeatureIds; }}-payload";
+          pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi; linuxFeatureIds = effectiveLinuxFeatureIds; }}-payload";
           version = codexVersion;
           src = sourceRoot;
           __structuredAttrs = true;
@@ -528,7 +551,7 @@ PY
             export CXXFLAGS="''${CXXFLAGS:-} -ffile-prefix-map=$TMPDIR=/build -fdebug-prefix-map=$TMPDIR=/build -fmacro-prefix-map=$TMPDIR=/build"
             export RUSTFLAGS="''${RUSTFLAGS:-} --remap-path-prefix=$TMPDIR=/build -C link-arg=-Wl,--build-id=none"
             export CODEX_MANAGED_NODE_SOURCE="${pkgs.nodejs}"
-            export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfig linuxFeatureIds}"
+            export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfigFile effectiveLinuxFeaturesConfig}"
             export CODEX_ELECTRON_ZIP_SOURCE="${electronZip}"
             export CODEX_NATIVE_MODULES_SOURCE="${codexNativeModules}"
             ${pkgs.lib.optionalString (browserUseNodeRepl != null) ''
@@ -538,10 +561,10 @@ PY
             export CODEX_LINUX_COMPUTER_USE_COSMIC_SOURCE="${codexComputerUseBinaries}/bin/codex-computer-use-cosmic"
             export CODEX_CHROME_EXTENSION_HOST_SOURCE="${codexComputerUseBinaries}/bin/codex-chrome-extension-host"
             export CODEX_NOTIFICATION_ACTIONS_SOURCE="${codexNotificationActionsBinary}/bin/codex-notification-actions-linux"
-            ${pkgs.lib.optionalString (builtins.elem "mcp-helper-reaper" linuxFeatureIds) ''
+            ${pkgs.lib.optionalString (builtins.elem "mcp-helper-reaper" effectiveLinuxFeatureIds) ''
             export CODEX_MCP_HELPER_REAPER_SOURCE="${codexMcpHelperReaper}/bin/codex-mcp-helper-reaper"
             ''}
-            ${pkgs.lib.optionalString (builtins.elem "global-dictation" linuxFeatureIds) ''
+            ${pkgs.lib.optionalString (builtins.elem "global-dictation" effectiveLinuxFeatureIds) ''
             export CODEX_GLOBAL_DICTATION_LINUX_SOURCE="${codexGlobalDictationBinary}/bin/codex-global-dictation-linux"
             ''}
             mkdir -p "$HOME" "$npm_config_cache" "$CARGO_HOME"
@@ -571,9 +594,14 @@ PY
           '';
         };
 
-        buildCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ] }:
+        buildCodexDesktop = { enableComputerUseUi ? false, linuxFeatureIds ? [ ], linuxFeaturesConfigOverride ? null }:
         let
-          normalizedLinuxFeatureIds = nixLinuxFeatures.normalize linuxFeatureIds;
+          effectiveLinuxFeaturesConfig =
+            if linuxFeaturesConfigOverride == null then
+              normalizeLinuxFeaturesConfig { enabled = linuxFeatureIds; }
+            else
+              normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
+          normalizedLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
           featureArgs = {
             inherit enableComputerUseUi;
             linuxFeatureIds = normalizedLinuxFeatureIds;
@@ -581,6 +609,7 @@ PY
           payload = mkCodexDesktopPayload {
             inherit enableComputerUseUi;
             linuxFeatureIds = normalizedLinuxFeatureIds;
+            linuxFeaturesConfigOverride = effectiveLinuxFeaturesConfig;
           };
           payloadLauncherPath = launcherPath + pkgs.lib.optionalString
             (builtins.elem "global-dictation" normalizedLinuxFeatureIds)
@@ -696,16 +725,8 @@ PY
           linuxFeatureIds = [ "remote-mobile-control" ];
         };
 
-        codexDesktopNixFeatureCheck = codexDesktop.override {
-          linuxFeatureIds = [
-            "appshots"
-            "frameless-titlebar"
-            "global-dictation"
-            "mcp-helper-reaper"
-            "node-repl-reaper"
-            "open-target-discovery"
-            "persistent-status-panel"
-          ];
+        codexDesktopWatchdogFeatureCheck = codexDesktop.override {
+          linuxFeaturesConfigOverride = watchdogLinuxFeaturesConfig;
         };
 
         installer = pkgs.writeShellApplication {
@@ -769,7 +790,8 @@ PY
           nix-linux-features-evaluation = import ./nix/linux-features-test.nix {
             inherit pkgs self system;
           };
-          nix-linux-features-multi-feature = codexDesktopNixFeatureCheck;
+          watchdog-linux-features = codexDesktopWatchdogFeatureCheck;
+          nix-linux-features-multi-feature = codexDesktopWatchdogFeatureCheck;
         };
 
         apps.default = {

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -13,23 +13,43 @@ let
   testFeatureIds = [
     "persistent-status-panel"
     "appshots"
+    "codex-wrapper-updater"
     "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
     "remote-mobile-control"
     "pet-overlay"
     "open-target-discovery"
+    "remote-control-ui"
+    "ui-tweaks"
     "appshots"
   ];
   normalizedTestFeatureIds = [
     "appshots"
+    "codex-wrapper-updater"
     "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
     "open-target-discovery"
     "persistent-status-panel"
     "pet-overlay"
+    "remote-control-ui"
     "remote-mobile-control"
+    "ui-tweaks"
+  ];
+  watchdogFeatureIds = (builtins.fromJSON (builtins.readFile ../scripts/ci/watchdog-linux-features.json)).enabled;
+  normalizedWatchdogFeatureIds = [
+    "appshots"
+    "codex-wrapper-updater"
+    "frameless-titlebar"
+    "global-dictation"
+    "mcp-helper-reaper"
+    "node-repl-reaper"
+    "open-target-discovery"
+    "persistent-status-panel"
+    "remote-control-ui"
+    "remote-mobile-control"
+    "ui-tweaks"
   ];
 
   evalHomeManager = moduleConfig:
@@ -126,11 +146,14 @@ let
     linuxFeatureIds = [
       "remote-mobile-control"
       "frameless-titlebar"
+      "codex-wrapper-updater"
       "global-dictation"
       "persistent-status-panel"
       "mcp-helper-reaper"
       "pet-overlay"
       "open-target-discovery"
+      "remote-control-ui"
+      "ui-tweaks"
       "appshots"
       "appshots"
     ];
@@ -260,6 +283,9 @@ in
 assert lib.assertMsg
   (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
   "Nix Linux feature IDs must be sorted and deduplicated";
+assert lib.assertMsg
+  (linuxFeatures.normalize watchdogFeatureIds == normalizedWatchdogFeatureIds)
+  "the committed watchdog Linux feature profile drifted from the Nix-supported profile";
 assert lib.assertMsg
   ((homePackage defaultConfig).drvPath == packages.codex-desktop.drvPath)
   "the Home Manager default package changed";

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -2,6 +2,7 @@
 let
   supportedFeatureIds = [
     "appshots"
+    "codex-wrapper-updater"
     "frameless-titlebar"
     "global-dictation"
     "mcp-helper-reaper"
@@ -9,7 +10,9 @@ let
     "open-target-discovery"
     "persistent-status-panel"
     "pet-overlay"
+    "remote-control-ui"
     "remote-mobile-control"
+    "ui-tweaks"
   ];
 
   sortAndDeduplicate = featureIds:

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -15,7 +15,6 @@ PACKAGE_OUTPUTS=(
     ".#codex-desktop-computer-use-ui"
     ".#codex-desktop-remote-mobile-control"
     ".#codex-desktop-computer-use-ui-remote-mobile-control"
-    ".#checks.x86_64-linux.watchdog-linux-features"
     ".#installer"
 )
 

--- a/scripts/ci/update-nix-hashes.sh
+++ b/scripts/ci/update-nix-hashes.sh
@@ -15,6 +15,7 @@ PACKAGE_OUTPUTS=(
     ".#codex-desktop-computer-use-ui"
     ".#codex-desktop-remote-mobile-control"
     ".#codex-desktop-computer-use-ui-remote-mobile-control"
+    ".#checks.x86_64-linux.watchdog-linux-features"
     ".#installer"
 )
 

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -202,9 +202,32 @@ test("Nix hash refresh accepts a validated focused output override", () => {
     path.resolve(__dirname, "update-nix-hashes.sh"),
     "utf8",
   );
+  const workflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/ci.yml"),
+    "utf8",
+  );
+  const watchdogProfile = JSON.parse(fs.readFileSync(
+    path.resolve(__dirname, "watchdog-linux-features.json"),
+    "utf8",
+  ));
 
+  assert.deepEqual(watchdogProfile.enabled, [
+    "appshots",
+    "codex-wrapper-updater",
+    "frameless-titlebar",
+    "global-dictation",
+    "mcp-helper-reaper",
+    "node-repl-reaper",
+    "open-target-discovery",
+    "persistent-status-panel",
+    "remote-control-ui",
+    "remote-mobile-control",
+    "ui-tweaks",
+  ]);
   assert.match(script, /NIX_VERIFY_OUTPUTS/);
   assert.match(script, /NIX_COMPARE_REF/);
+  assert.match(script, /\.#checks\.x86_64-linux\.watchdog-linux-features/);
+  assert.match(workflow, /\.#checks\.x86_64-linux\.watchdog-linux-features/);
   assert.match(script, /Invalid Nix verification output/);
   assert.match(script, /run_nix_build "\$VERIFY_LOG" "\$\{PACKAGE_OUTPUTS\[@\]\}"/);
 });

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -206,6 +206,10 @@ test("Nix hash refresh accepts a validated focused output override", () => {
     path.resolve(__dirname, "../../.github/workflows/ci.yml"),
     "utf8",
   );
+  const refreshWorkflow = fs.readFileSync(
+    path.resolve(__dirname, "../../.github/workflows/update-codex-hash.yml"),
+    "utf8",
+  );
   const watchdogProfile = JSON.parse(fs.readFileSync(
     path.resolve(__dirname, "watchdog-linux-features.json"),
     "utf8",
@@ -226,8 +230,9 @@ test("Nix hash refresh accepts a validated focused output override", () => {
   ]);
   assert.match(script, /NIX_VERIFY_OUTPUTS/);
   assert.match(script, /NIX_COMPARE_REF/);
-  assert.match(script, /\.#checks\.x86_64-linux\.watchdog-linux-features/);
   assert.match(workflow, /\.#checks\.x86_64-linux\.watchdog-linux-features/);
+  assert.match(refreshWorkflow, /NIX_VERIFY_OUTPUTS/);
+  assert.match(refreshWorkflow, /\.#checks\.x86_64-linux\.watchdog-linux-features/);
   assert.match(script, /Invalid Nix verification output/);
   assert.match(script, /run_nix_build "\$VERIFY_LOG" "\$\{PACKAGE_OUTPUTS\[@\]\}"/);
 });

--- a/scripts/ci/watchdog-linux-features.json
+++ b/scripts/ci/watchdog-linux-features.json
@@ -1,0 +1,16 @@
+{
+  "enabled": [
+    "appshots",
+    "codex-wrapper-updater",
+    "frameless-titlebar",
+    "global-dictation",
+    "mcp-helper-reaper",
+    "node-repl-reaper",
+    "open-target-discovery",
+    "persistent-status-panel",
+    "remote-control-ui",
+    "remote-mobile-control",
+    "ui-tweaks"
+  ],
+  "settings": {}
+}


### PR DESCRIPTION
## Summary
- add a committed watchdog Linux feature profile used as the release/watchdog feature set
- make Nix import that profile for the watchdog feature build check
- switch CI, Cachix, and hash refresh verification to the same watchdog feature check

## Why
The upstream DMG watchdog validated the locally enabled Linux feature config, while Nix CI built a different hard-coded multi-feature output. That allowed the source repair PR to pass while the Nix refresh PR failed on optional feature drift. This change gives watchdog/Nix one committed feature profile so future repair loops target the same surface that Nix verifies.

## Validation
- node --test scripts/ci/upstream-dmg-acceptance.test.js
- bash -n scripts/ci/update-nix-hashes.sh
- git diff --check origin/main..HEAD
- nix flake check --no-build was not available locally because nix is not installed in this environment; GitHub CI will run the Nix build in the runner environment.
