### PR TITLE
Normalize Linux Browser sidebar user agent

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -57,6 +57,7 @@ const {
   applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
+  applyLinuxBrowserUseUserAgentPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExternalOpenEnvPatch,
 } = require("./patches/impl/main-process/browser.js");
@@ -947,6 +948,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-bundled-plugin-reconcile-stale-snapshot",
     "linux-bundled-plugin-copy-permissions",
     "linux-browser-use-route-liveness",
+    "linux-browser-use-user-agent",
     "linux-chrome-extension-status",
     "linux-notification-actions",
     "linux-local-app-server-feature-enablement-handler",
@@ -8242,6 +8244,163 @@ test("keeps Browser Use route liveness fallback inactive when ambiguous", () => 
 
   assert.equal(result, null);
   assert.equal(warnings, 1);
+});
+
+test("sets the Linux Browser sidebar user agent before navigation without mutating its session", () => {
+  const source =
+    '"use strict";' +
+    "function oB({configureBrowserSession:e,params:t,preloadPath:n,webPreferences:r}){t.partition=Ox(`app`),r.session=e(),r.preload=n,cB(t,r)}";
+  const patched = applyPatchTwice(applyLinuxBrowserUseUserAgentPatch, source);
+  const sessionUserAgent =
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) ChatGPT/26.707.71524 Chrome/148.0.7778.97 Electron/42.1.0 Safari/537.36";
+  let sessionSetUserAgentCalls = 0;
+  const browserSession = {
+    getUserAgent: () => sessionUserAgent,
+    setUserAgent: () => {
+      sessionSetUserAgentCalls += 1;
+    },
+  };
+  const params = {};
+  const webPreferences = {};
+  const context = {
+    Ox: (value) => `partition:${value}`,
+    cB: () => {},
+    browserSession,
+    params,
+    process: { platform: "linux" },
+    webPreferences,
+  };
+
+  vm.runInNewContext(
+    `${patched};oB({configureBrowserSession:()=>browserSession,params,preloadPath:"/browser-preload.js",webPreferences})`,
+    context,
+  );
+
+  assert.equal(
+    params.useragent,
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.97 Safari/537.36",
+  );
+  assert.equal(browserSession.getUserAgent(), sessionUserAgent);
+  assert.equal(sessionSetUserAgentCalls, 0);
+  assert.equal(params.partition, "partition:app");
+  assert.equal(webPreferences.session, browserSession);
+  assert.equal(webPreferences.preload, "/browser-preload.js");
+  assert.doesNotMatch(patched, /userAgentFallback|\.setUserAgent\(/);
+  assert.equal((patched.match(/function codexLinuxNormalizeBrowserUseUserAgent/g) || []).length, 1);
+  assert.equal((patched.match(/codexLinuxNormalizeBrowserUseUserAgent\(t,r\)/g) || []).length, 1);
+});
+
+test("leaves unrelated renderers, webviews, and sessions on their original user agents", () => {
+  const source =
+    "function oB({configureBrowserSession:e,params:t,preloadPath:n,webPreferences:r}){t.partition=Ox(`app`),r.session=e(),r.preload=n,cB(t,r)}" +
+    "function sB({configureBrowserSession:e,params:t,webPreferences:n}){t.partition=Ox(`app`),n.session=e(),delete n.preload,cB(t,n)}";
+  const patched = applyLinuxBrowserUseUserAgentPatch(source);
+  const browserUserAgent =
+    "Mozilla/5.0 (X11; Linux x86_64) ChatGPT/26.707.71524 Chrome/148.0.7778.97 Electron/42.1.0 Safari/537.36";
+  const unrelatedUserAgent =
+    "Mozilla/5.0 (X11; Linux x86_64) ChatGPT/unchanged Electron/unchanged";
+  const mainRenderer = { userAgent: unrelatedUserAgent };
+  let browserSessionSetCalls = 0;
+  let unrelatedSessionGetCalls = 0;
+  let unrelatedSessionSetCalls = 0;
+  const browserSession = {
+    getUserAgent: () => browserUserAgent,
+    setUserAgent: () => {
+      browserSessionSetCalls += 1;
+    },
+  };
+  const unrelatedSession = {
+    getUserAgent: () => {
+      unrelatedSessionGetCalls += 1;
+      return unrelatedUserAgent;
+    },
+    setUserAgent: () => {
+      unrelatedSessionSetCalls += 1;
+    },
+  };
+  const browserParams = {};
+  const browserPreferences = {};
+  const settingsParams = {};
+  const settingsPreferences = {};
+  const context = {
+    Ox: (value) => value,
+    browserParams,
+    browserPreferences,
+    browserSession,
+    cB: () => {},
+    process: { platform: "linux" },
+    settingsParams,
+    settingsPreferences,
+    unrelatedSession,
+  };
+
+  vm.runInNewContext(
+    `${patched};` +
+      `oB({configureBrowserSession:()=>browserSession,params:browserParams,preloadPath:"/browser.js",webPreferences:browserPreferences});` +
+      `sB({configureBrowserSession:()=>unrelatedSession,params:settingsParams,webPreferences:settingsPreferences})`,
+    context,
+  );
+
+  assert.equal(
+    browserParams.useragent,
+    "Mozilla/5.0 (X11; Linux x86_64) Chrome/148.0.7778.97 Safari/537.36",
+  );
+  assert.equal(browserSession.getUserAgent(), browserUserAgent);
+  assert.equal(browserSessionSetCalls, 0);
+  assert.equal(settingsParams.useragent, undefined);
+  assert.equal(unrelatedSessionGetCalls, 0);
+  assert.equal(unrelatedSessionSetCalls, 0);
+  assert.equal(unrelatedSession.getUserAgent(), unrelatedUserAgent);
+  assert.equal(mainRenderer.userAgent, unrelatedUserAgent);
+});
+
+test("leaves non-Linux and already-browser Browser sidebar user agents unchanged", () => {
+  const source =
+    "function oB({configureBrowserSession:e,params:t,preloadPath:n,webPreferences:r}){t.partition=Ox(`app`),r.session=e(),r.preload=n,cB(t,r)}";
+  const patched = applyLinuxBrowserUseUserAgentPatch(source);
+
+  for (const [platform, initialUserAgent] of [
+    [
+      "linux",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/148.0.7778.97 Safari/537.36",
+    ],
+    [
+      "win32",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) ChatGPT/26.707.71524 Chrome/148.0.7778.97 Electron/42.1.0 Safari/537.36",
+    ],
+  ]) {
+    const params = {};
+    const webPreferences = {};
+    const browserSession = { getUserAgent: () => initialUserAgent };
+    const context = {
+      Ox: (value) => value,
+      browserSession,
+      cB: () => {},
+      params,
+      process: { platform },
+      webPreferences,
+    };
+
+    vm.runInNewContext(
+      `${patched};oB({configureBrowserSession:()=>browserSession,params,preloadPath:"/browser.js",webPreferences})`,
+      context,
+    );
+
+    assert.equal(params.useragent, undefined);
+    assert.equal(browserSession.getUserAgent(), initialUserAgent);
+  }
+});
+
+test("warns and skips when the Browser sidebar webview preference seam drifts", () => {
+  const source =
+    "function oB({configureBrowserSession:e,params:t,preloadPath:n,webPreferences:r}){r.session=e(),r.preload=n,cB(t,r)}";
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxBrowserUseUserAgentPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /skipping Linux Browser Use user agent patch/);
 });
 
 test("Computer Use availability descriptor matches the current settings bundle name", () => {

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -10,6 +10,7 @@ const {
   applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
+  applyLinuxBrowserUseUserAgentPatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../impl/main-process/browser.js");
 const { applyLinuxChromePluginAutoInstallPatch } = require("../../../../impl/chrome-plugin.js");
@@ -59,6 +60,13 @@ module.exports = [
     order: 170,
     ciPolicy: "optional",
     apply: applyLinuxBrowserUseRouteLivenessPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-browser-use-user-agent",
+    phase: "main-bundle",
+    order: 171,
+    ciPolicy: "optional",
+    apply: applyLinuxBrowserUseUserAgentPatch,
   }),
   mainBundlePatch({
     id: "linux-chrome-extension-status",

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -371,6 +371,57 @@ function applyLinuxBrowserUseRouteLivenessPatch(currentSource) {
   return currentSource.replace(original, replacement);
 }
 
+function applyLinuxBrowserUseUserAgentPatch(currentSource) {
+  const helperName = "codexLinuxNormalizeBrowserUseUserAgent";
+  if (currentSource.includes(`function ${helperName}(`)) {
+    return currentSource;
+  }
+
+  const browserWebviewPreferencesPattern =
+    /function ([A-Za-z_$][\w$]*)\(\{configureBrowserSession:([A-Za-z_$][\w$]*),params:([A-Za-z_$][\w$]*),preloadPath:([A-Za-z_$][\w$]*),webPreferences:([A-Za-z_$][\w$]*)\}\)\{\3\.partition=([A-Za-z_$][\w$]*)\(`app`\),\5\.session=\2\(\),\5\.preload=\4,([A-Za-z_$][\w$]*)\(\3,\5\)\}/u;
+  const match = currentSource.match(browserWebviewPreferencesPattern);
+  if (match == null) {
+    if (
+      currentSource.includes("configureBrowserSession") &&
+      currentSource.includes("preloadPath")
+    ) {
+      console.warn(
+        "WARN: Could not find Browser sidebar webview preferences — skipping Linux Browser Use user agent patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const [
+    originalFunction,
+    functionName,
+    configureSessionVar,
+    paramsVar,
+    preloadPathVar,
+    webPreferencesVar,
+    partitionHelperVar,
+    hardenPreferencesVar,
+  ] = match;
+  const helper =
+    `function ${helperName}(e,t){if(process.platform!==\`linux\`||e==null||t?.session==null)return;try{let n=typeof e.useragent===\`string\`?e.useragent:t.session.getUserAgent?.();if(typeof n!==\`string\`)return;let r=n.replace(/\\s+(?:ChatGPT|Electron)\\/\\S+/g,\`\`);r!==n&&(e.useragent=r)}catch{}}`;
+  const patchedFunction =
+    `function ${functionName}({configureBrowserSession:${configureSessionVar},params:${paramsVar},preloadPath:${preloadPathVar},webPreferences:${webPreferencesVar}}){` +
+    `${paramsVar}.partition=${partitionHelperVar}(\`app\`),${webPreferencesVar}.session=${configureSessionVar}(),` +
+    `${webPreferencesVar}.preload=${preloadPathVar},${hardenPreferencesVar}(${paramsVar},${webPreferencesVar}),` +
+    `${helperName}(${paramsVar},${webPreferencesVar})}`;
+  const strictDirective = '"use strict";';
+  const helperInsertionIndex = currentSource.startsWith(strictDirective)
+    ? strictDirective.length
+    : 0;
+  const patchedSource = currentSource.replace(originalFunction, patchedFunction);
+
+  return (
+    patchedSource.slice(0, helperInsertionIndex) +
+    helper +
+    patchedSource.slice(helperInsertionIndex)
+  );
+}
+
 function applyLinuxChromeExtensionStatusPatch(currentSource) {
   if (currentSource.includes("codexLinuxChromeProfileRoots")) {
     return currentSource;
@@ -517,5 +568,6 @@ module.exports = {
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxExternalOpenEnvPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
+  applyLinuxBrowserUseUserAgentPatch,
   applyLinuxChromeExtensionStatusPatch,
 };


### PR DESCRIPTION
## Summary

- Normalize only the Linux Browser sidebar webview user agent.
- Set the webview's `params.useragent` during `will-attach-webview`, before its initial navigation.
- Leave `app.userAgentFallback`, the main renderer, Browser Settings webviews, and all session-level user agents unchanged.

## Root cause

The upstream desktop user agent includes `ChatGPT/<version>` and `Electron/<version>` product tokens. Some sites reject or alter their login flow when those tokens are present. The earlier implementation broadened the workaround to the app fallback and newly created web contents, which could affect unrelated renderers and sessions.

This revision uses the Browser sidebar's dedicated webview-preferences seam and writes only that guest's `useragent` parameter before navigation.

## Scope

This PR is intentionally limited to user-agent normalization. Window-open disposition routing and the obsolete navigation-patch cleanup are being moved to a separate focused PR.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` — 401/401 passing.
- Regression tests verify the main renderer, Browser Settings webview, unrelated session, and Browser session default user agent remain unchanged.
- Fresh upstream DMG 26.707.91948 candidate accepted with `linux-browser-use-user-agent: applied`.
