### PR TITLE
Fix upstream DMG drift

### DIFF
--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -156,7 +156,7 @@ const patches = [
     phase: "webview-asset",
     order: 20_730,
     ciPolicy: "optional",
-    pattern: /^(?:app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar|app-initial~app-main~onboarding-page)-[^.]+\.js$/,
+    pattern: /^(?:app-initial~app-main~projects-index-page~remote-conversation-page|app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27)-[^.]+\.js$/,
     missingDescription: "main app chrome bundle",
     skipDescription: "frameless titlebar webview layout patch",
     apply: applyFramelessTitlebarWebviewPatch,

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -66,10 +66,18 @@ test("frameless-titlebar stays disabled until listed in features.json", () => {
       (descriptor) => descriptor.id === "feature:frameless-titlebar:webview-window-controls-layout",
     );
     assert.match(
-      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+      "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js",
       webviewPatch.pattern,
     );
     assert.match(
+      "app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27-Cg6hAhRO.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+      webviewPatch.pattern,
+    );
+    assert.doesNotMatch(
       "app-initial~app-main~onboarding-page-CIkoyvFz.js",
       webviewPatch.pattern,
     );

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -829,7 +829,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20520,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~nrw3o0ql-[^.]+\.js$/,
+      pattern: /^app-initial~artifact-tab-content\.electron~app-main~pull-request-route~pull-request-code-rev~jgoqfqy2-[^.]+\.js$/,
       missingDescription: "open target selection webview bundle",
       skipDescription: "native open-target selection patch",
       apply: applyNativeOpenTargetSelectionPatch,

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1400,7 +1400,7 @@ test("open-target discovery targets only the current native selector bundle", ()
 
   assert.ok(descriptor);
   assert.match(
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~nrw3o0ql-CI1_Z0oj.js",
+    "app-initial~artifact-tab-content.electron~app-main~pull-request-route~pull-request-code-rev~jgoqfqy2-gdph-otp.js",
     descriptor.pattern,
   );
   assert.doesNotMatch(
@@ -1413,6 +1413,10 @@ test("open-target discovery targets only the current native selector bundle", ()
   );
   assert.doesNotMatch(
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-MXsOJYYa.js",
+    descriptor.pattern,
+  );
+  assert.doesNotMatch(
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~nrw3o0ql-CI1_Z0oj.js",
     descriptor.pattern,
   );
   assert.doesNotMatch("open-target-selection-legacy.js", descriptor.pattern);

--- a/linux-features/remote-control-ui/patch.js
+++ b/linux-features/remote-control-ui/patch.js
@@ -63,7 +63,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20500,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-[^.]+\.js$/,
+      pattern: /^(?:app-initial~app-main~projects-index-page~remote-conversation-page|app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27)-[^.]+\.js$/,
       missingDescription: "remote connection visibility bundle",
       skipDescription: "remote control UI remote connections visibility patch",
       apply: applyRemoteConnectionsVisibilityPatch,

--- a/linux-features/remote-control-ui/test.js
+++ b/linux-features/remote-control-ui/test.js
@@ -173,12 +173,17 @@ test("remote-control UI descriptors match the current app chunks", () => {
 
   assert.ok(
     remoteConnectionsPatch.pattern.test(
-      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+      "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js",
+    ),
+  );
+  assert.ok(
+    remoteConnectionsPatch.pattern.test(
+      "app-initial~app-main~pull-request-route~new-thread-panel-page~onboarding-page~settings-page~i2dgsl27-Cg6hAhRO.js",
     ),
   );
   assert.equal(
     remoteConnectionsPatch.pattern.test(
-      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~cf704xib-BhQogfRL.js",
+      "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
     ),
     false,
   );
@@ -217,7 +222,7 @@ test("remote-control UI feature patches matching webview assets and records patc
         fs.writeFileSync(
           path.join(
             assetsDir,
-            "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+            "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js",
           ),
           "function Twt(){let e=(0,kwt.c)(3),{data:t}=Vr(y4,Br(B2)),n=BN(`4114442250`);if(t?.config[`features.remote_connections`]===!0)return!0;let r=t?.config.features;if(typeof r!=`object`||!r||Array.isArray(r))return n;let i;return e[0]!==r||e[1]!==n?(i=Object.getOwnPropertyDescriptor(r,`remote_connections`)?.value===!0||n,e[0]=r,e[1]=n,e[2]=i):i=e[2],i}function D8(e){return e(RN,`4114442250`)?`enabled`:`disabled`}",
         );
@@ -244,7 +249,7 @@ test("remote-control UI feature patches matching webview assets and records patc
           fs.readFileSync(
             path.join(
               assetsDir,
-              "app-initial~app-main~hotkey-window-new-thread-page~hotkey-window-home-page~composer-utility-bar-D9zyQF1n.js",
+              "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js",
             ),
             "utf8",
           ),

--- a/linux-features/ui-tweaks/patches/model-picker-model-list.js
+++ b/linux-features/ui-tweaks/patches/model-picker-model-list.js
@@ -3,9 +3,9 @@
 const MODEL_PICKER_STATE_ASSET_PATTERN =
   /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
 const MODEL_PICKER_ALLOWLIST_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/;
+  /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/;
 const MODEL_PICKER_MENU_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-[^.]+\.js$/;
+  /^app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-[^.]+\.js$/;
 const SIMPLE_MENU_VIEW_PATTERN =
   /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`composer-model-picker-menu-view-v1`,`simple`\)/;
 const ADVANCED_MENU_VIEW_PATTERN =

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -2,7 +2,7 @@
 
 const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN =
-  /^app-initial~app-main~page-[^.]+\.js$/;
+  /^app-initial~app-main~projects-index-page~remote-conversation-page-[^.]+\.js$/;
 const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pr-1";
 const STYLE_ID = "codex-linux-ui-tweaks-sidebar-project-name-style";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSidebarProjectNameStyleRuntime";

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -183,8 +183,9 @@ test("model picker descriptors target the current state and menu bundles", () =>
   const stateAsset =
     "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
   const allowlistAsset =
-    "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-BjNKtmac.js";
-  const menuAsset = allowlistAsset;
+    "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js";
+  const menuAsset =
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-BiQtt1Kd.js";
 
   assert.match(stateAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
   assert.match(allowlistAsset, MODEL_PICKER_ALLOWLIST_ASSET_PATTERN);
@@ -195,8 +196,7 @@ test("model picker descriptors target the current state and menu bundles", () =>
   assert.doesNotMatch(allowlistAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
   assert.doesNotMatch(menuAsset, MODEL_PICKER_STATE_ASSET_PATTERN);
 
-  // The previous DMG split these patches across different chunks.
-  // Current-DMG-only targeting must not retain those chunks as fallbacks.
+  // Current-DMG-only targeting must not retain previous chunks as fallbacks.
   assert.doesNotMatch(
     "app-initial~app-main~page-CMpPiY3-.js",
     MODEL_PICKER_STATE_ASSET_PATTERN,
@@ -206,7 +206,7 @@ test("model picker descriptors target the current state and menu bundles", () =>
     MODEL_PICKER_ALLOWLIST_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~new-thread-panel-page~onboarding-page~projects-index-page~appgen-libra~lpb6mnim-Bawo32lF.js",
+    "app-initial~app-main~onboarding-page~projects-index-page~hotkey-window-thread-page~quick-ch~iiv1g666-BjNKtmac.js",
     MODEL_PICKER_MENU_ASSET_PATTERN,
   );
   assert.doesNotMatch(
@@ -396,11 +396,11 @@ test("English reasoning effort labels can be disabled", () => {
 
 test("sidebar project descriptor targets only the current project sidebar asset", () => {
   assert.match(
-    "app-initial~app-main~page-kMhXWEru.js",
+    "app-initial~app-main~projects-index-page~remote-conversation-page-ClV_ycdc.js",
     PROJECTS_SIDEBAR_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~projects-index-page~remote-conversation-page-CFT2LLOB.js",
+    "app-initial~app-main~page-kMhXWEru.js",
     PROJECTS_SIDEBAR_ASSET_PATTERN,
   );
   assert.doesNotMatch(


### PR DESCRIPTION
<!-- upstream-dmg-sha256:5a2ab9689f4ba38fcb135565246d5ca2f124d539336a0a32afcdb72040d21466 -->

## Summary
- repair Linux compatibility drift for the current upstream DMG
- remove obsolete compatibility paths replaced by the current DMG shape

## Validation
- exact current-DMG acceptance recorded by watchdog v2
- GitHub CI must pass, including Nix Package Builds
