### PR TITLE
Optimize Cachix population for DMG hash changes

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '37 7 * * *'
-  workflow_dispatch: {}
+    paths:
+      - flake.nix
 
 permissions:
   contents: read
@@ -19,24 +18,86 @@ env:
   CACHIX_CACHE_NAME: codex-desktop-linux
   CARGO_TERM_COLOR: always
   NIX_CONFIG: experimental-features = nix-command flakes
-  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
 jobs:
+  detect-codex-dmg-hash:
+    name: Detect Codex DMG hash change
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.codex-dmg-hash.outputs.changed }}
+      current: ${{ steps.codex-dmg-hash.outputs.current }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Compare Codex DMG hashes
+        id: codex-dmg-hash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+
+          current_hash="$(
+            scripts/ci/update-nix-hashes.sh \
+              read-flake-hash "codexDmg = pkgs.fetchurl {" "hash = "
+          )"
+          previous_flake="$(mktemp)"
+          trap 'rm -f "$previous_flake"' EXIT
+
+          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            changed=true
+            previous_hash=missing
+          else
+            if ! git cat-file -e "$BEFORE_SHA:flake.nix" 2>/dev/null; then
+              git fetch --no-tags --depth=1 origin "$BEFORE_SHA"
+            fi
+            git show "$BEFORE_SHA:flake.nix" > "$previous_flake"
+            previous_hash="$(
+              FLAKE_FILE="$previous_flake" scripts/ci/update-nix-hashes.sh \
+                read-flake-hash "codexDmg = pkgs.fetchurl {" "hash = "
+            )"
+            if [ "$current_hash" = "$previous_hash" ]; then
+              changed=false
+            else
+              changed=true
+            fi
+          fi
+
+          {
+            echo "changed=$changed"
+            echo "current=$current_hash"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Codex DMG hash"
+            echo
+            echo "- Previous: \`$previous_hash\`"
+            echo "- Current: \`$current_hash\`"
+            echo "- Populate Cachix: \`$changed\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   populate:
     name: Build Nix flake outputs
+    needs: detect-codex-dmg-hash
+    if: needs.detect-codex-dmg-hash.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: cachix/install-nix-action@v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
 
-      - name: Configure Cachix for push
-        if: env.CACHIX_AUTH_TOKEN != ''
-        uses: cachix/cachix-action@v17
+      - name: Configure Cachix for explicit uploads
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: ${{ env.CACHIX_CACHE_NAME }}
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          skipPush: true
 
       - name: Warn when Cachix push token is missing
         if: env.CACHIX_AUTH_TOKEN == ''
@@ -48,26 +109,41 @@ jobs:
           Add a write token for the `codex-desktop-linux` Cachix cache as a repository secret to populate it automatically.
           EOF
 
-      - name: Build cacheable Nix outputs
+      - name: Build, upload, and collect cacheable Nix outputs
         run: |
           set -euo pipefail
-          nix build \
-            .#codex-desktop \
-            .#codex-desktop-computer-use-ui \
-            .#codex-desktop-remote-mobile-control \
-            .#codex-desktop-computer-use-ui-remote-mobile-control \
-            .#checks.x86_64-linux.watchdog-linux-features \
-            .#installer \
-            --no-link \
-            --print-build-logs
+
+          outputs=(
+            .#codex-desktop
+            .#codex-desktop-computer-use-ui
+            .#codex-desktop-remote-mobile-control
+            .#codex-desktop-computer-use-ui-remote-mobile-control
+            .#checks.x86_64-linux.watchdog-linux-features
+            .#installer
+          )
+
+          for output in "${outputs[@]}"; do
+            echo "Building $output"
+            store_paths_file="$RUNNER_TEMP/cachix-store-paths"
+            nix build "$output" \
+              --no-link \
+              --print-build-logs \
+              --print-out-paths > "$store_paths_file"
+            mapfile -t store_paths < "$store_paths_file"
+            if [ "${#store_paths[@]}" -eq 0 ]; then
+              echo "Nix did not return a store path for $output." >&2
+              exit 1
+            fi
+            if [ -n "$CACHIX_AUTH_TOKEN" ]; then
+              printf '%s\n' "${store_paths[@]}" | cachix push "$CACHIX_CACHE_NAME"
+            fi
+            nix store gc
+          done
+
           {
             echo "## Cachix population"
-            echo ""
-            echo "- Cache: \`${CACHIX_CACHE_NAME}\`"
-            echo "- Built: \`.#codex-desktop\`"
-            echo "- Built: \`.#codex-desktop-computer-use-ui\`"
-            echo "- Built: \`.#codex-desktop-remote-mobile-control\`"
-            echo "- Built: \`.#codex-desktop-computer-use-ui-remote-mobile-control\`"
-            echo "- Built: \`.#checks.x86_64-linux.watchdog-linux-features\`"
-            echo "- Built: \`.#installer\`"
+            echo
+            echo "- Triggering Codex DMG hash: \`${{ needs.detect-codex-dmg-hash.outputs.current }}\`"
+            echo "- Cache: \`$CACHIX_CACHE_NAME\`"
+            printf -- '- Built and collected: `%s`\n' "${outputs[@]}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -276,5 +276,8 @@ Users can opt in locally with:
 cachix use codex-desktop-linux
 ```
 
-The scheduled `Populate Cachix` workflow builds the default package,
-feature-specific package variants, and `.#installer`.
+When a merge to `main` changes the pinned `Codex.dmg` hash, the `Populate
+Cachix` workflow builds the default package, feature-specific package variants,
+the watchdog feature check, and `.#installer`. It uploads and garbage-collects
+each output before starting the next one so the hosted runner does not retain
+every large app variant at once.

--- a/scripts/ci/cachix-workflow.test.js
+++ b/scripts/ci/cachix-workflow.test.js
@@ -1,0 +1,35 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const workflow = fs.readFileSync(
+  path.resolve(__dirname, "../../.github/workflows/cachix.yml"),
+  "utf8",
+);
+
+test("Cachix population runs only for an actual Codex DMG hash change", () => {
+  assert.match(workflow, /paths:\n\s+- flake\.nix/);
+  assert.doesNotMatch(workflow, /schedule:/);
+  assert.doesNotMatch(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /id: codex-dmg-hash/);
+  assert.match(workflow, /BEFORE_SHA: \$\{\{ github\.event\.before \}\}/);
+  assert.match(workflow, /read-flake-hash "codexDmg = pkgs\.fetchurl \{" "hash = "/);
+  assert.match(workflow, /if: needs\.detect-codex-dmg-hash\.outputs\.changed == 'true'/);
+});
+
+test("Cachix population pushes each output before collecting the Nix store", () => {
+  assert.match(workflow, /skipPush: true/);
+  assert.match(workflow, /nix build "\$output"[\s\S]*--print-out-paths/);
+  assert.doesNotMatch(workflow, /mapfile[^\n]*< <\(/);
+  assert.match(workflow, /printf '%s\\n' "\$\{store_paths\[@\]\}" \| cachix push "\$CACHIX_CACHE_NAME"/);
+  assert.match(workflow, /nix store gc/);
+  assert.ok(
+    workflow.indexOf("cachix push") < workflow.indexOf("nix store gc"),
+    "Cachix upload must complete before garbage collection",
+  );
+});
+
+test("Cachix population pins every third-party action", () => {
+  assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d/);
+});


### PR DESCRIPTION
## Summary
- populate Cachix only when the pinned Codex DMG hash changes on main
- build and upload Nix outputs sequentially, then garbage-collect each completed output
- pin the workflow actions and document the new behavior

## Tests
- bash scripts/ci/run-node-checks.sh tests
- bash scripts/ci/run-node-checks.sh syntax
- node --test scripts/ci/cachix-workflow.test.js scripts/ci/github-actions-runtime.test.js
- git diff --check

## Notes
- the workflow no longer runs on a daily schedule or for unrelated main pushes
- explicit uploads finish before garbage collection to avoid deleting paths while Cachix is still reading them