### PR TITLE
Restart updater daemon when a package upgrade replaces its binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The updater daemon now detects that a package upgrade replaced its binary
+  on disk and exits with a nonzero status so systemd's `Restart=on-failure`
+  relaunches it on the new binary. Previously a running daemon survived every
+  upgrade and kept staging rebuild workspaces with outdated logic, failing
+  each periodic update until the next reboot.
 - Launcher startup no longer requires Python's pidfd wrappers for normal
   launcher lock acquire and release. Pidfd remains reserved for the
   identity-verified stale Electron termination path.

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -5,7 +5,8 @@ use crate::{
     cli::{Cli, Commands},
     codex_cli,
     config::{RuntimeConfig, RuntimePaths},
-    diagnostics, feature_picker, install, install_rollback, liveness, logging, notify, rollback,
+    diagnostics, feature_picker, install, install_rollback, liveness, logging, notify, restart,
+    rollback,
     state::{CliStatus, PersistedState, UpdateStatus},
     upstream, wrapper, wrapper_apply,
 };
@@ -28,6 +29,8 @@ const CLI_MISSING_NOTIFICATION_EVENT: &str = "cli_missing";
 const CLI_MISSING_PROMPT_DISMISS_TTL: ChronoDuration = ChronoDuration::minutes(10);
 const PROMPT_INSTALL_CLI_CANCELLED_EXIT_CODE: i32 = 10;
 const PROMPT_INSTALL_CLI_NO_BACKEND_EXIT_CODE: i32 = 11;
+// Nonzero so `Restart=on-failure` relaunches the daemon on the new binary.
+const BINARY_REPLACED_RESTART_EXIT_CODE: i32 = 12;
 const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
     "budgie-polkit",
     "cinnamon-polkit",
@@ -467,6 +470,14 @@ async fn run_daemon(
         if packaged_runtime_removed(config) {
             info!("packaged app files are gone; stopping updater daemon");
             break;
+        }
+
+        if let Some(installed_binary) = restart::replacement_binary() {
+            info!(
+                installed_binary = %installed_binary.display(),
+                "updater binary was replaced on disk; exiting so systemd restarts the daemon"
+            );
+            std::process::exit(BINARY_REPLACED_RESTART_EXIT_CODE);
         }
 
         tokio::select! {

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -15,6 +15,7 @@ mod install_rollback;
 mod liveness;
 mod logging;
 mod notify;
+mod restart;
 mod rollback;
 mod state;
 #[cfg(test)]

--- a/updater/src/restart.rs
+++ b/updater/src/restart.rs
@@ -1,0 +1,108 @@
+//! Detects when the running updater binary has been replaced on disk.
+//!
+//! Package upgrades replace `/usr/bin/codex-update-manager` while the daemon
+//! keeps running the old, now-deleted image. The daemon polls this check and
+//! exits so systemd relaunches it on the new binary; a stale daemon would
+//! otherwise stage rebuild workspaces with outdated logic indefinitely.
+
+use std::{
+    ffi::OsStr,
+    fs,
+    os::unix::ffi::OsStrExt,
+    os::unix::fs::MetadataExt,
+    path::{Path, PathBuf},
+};
+
+const PROC_SELF_EXE: &str = "/proc/self/exe";
+const DELETED_SUFFIX: &str = " (deleted)";
+
+/// Returns the installed path of a replacement updater binary when the
+/// running process image no longer matches the file on disk. Returns `None`
+/// while the binary is current, or when no on-disk binary exists to restart
+/// into (package removal is handled by the packaged-runtime check instead).
+pub fn replacement_binary() -> Option<PathBuf> {
+    let link_target = fs::read_link(PROC_SELF_EXE).ok()?;
+    let installed_path = strip_deleted_suffix(&link_target);
+    replacement_at(Path::new(PROC_SELF_EXE), &installed_path)
+}
+
+/// Returns `installed_path` when it points at a different inode than the
+/// running process image referenced by `running_image`.
+fn replacement_at(running_image: &Path, installed_path: &Path) -> Option<PathBuf> {
+    let running = fs::metadata(running_image).ok()?;
+    let installed = fs::metadata(installed_path).ok()?;
+    if running.dev() == installed.dev() && running.ino() == installed.ino() {
+        return None;
+    }
+    Some(installed_path.to_path_buf())
+}
+
+fn strip_deleted_suffix(target: &Path) -> PathBuf {
+    let bytes = target.as_os_str().as_bytes();
+    match bytes.strip_suffix(DELETED_SUFFIX.as_bytes()) {
+        Some(stripped) => PathBuf::from(OsStr::from_bytes(stripped)),
+        None => target.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn strips_deleted_suffix_from_replaced_binary_link() {
+        assert_eq!(
+            strip_deleted_suffix(Path::new("/usr/bin/codex-update-manager (deleted)")),
+            PathBuf::from("/usr/bin/codex-update-manager")
+        );
+    }
+
+    #[test]
+    fn keeps_link_target_without_deleted_suffix() {
+        assert_eq!(
+            strip_deleted_suffix(Path::new("/usr/bin/codex-update-manager")),
+            PathBuf::from("/usr/bin/codex-update-manager")
+        );
+    }
+
+    #[test]
+    fn same_file_is_not_a_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let binary = temp.path().join("codex-update-manager");
+        fs::write(&binary, b"current")?;
+
+        assert_eq!(replacement_at(&binary, &binary), None);
+        Ok(())
+    }
+
+    #[test]
+    fn different_inode_is_a_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let running = temp.path().join("codex-update-manager.old");
+        let installed = temp.path().join("codex-update-manager");
+        fs::write(&running, b"old")?;
+        fs::write(&installed, b"new")?;
+
+        assert_eq!(replacement_at(&running, &installed), Some(installed));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_installed_binary_is_not_a_replacement() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let running = temp.path().join("codex-update-manager.old");
+        fs::write(&running, b"old")?;
+
+        assert_eq!(
+            replacement_at(&running, &temp.path().join("codex-update-manager")),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn current_test_binary_is_not_reported_as_replaced() {
+        assert_eq!(replacement_binary(), None);
+    }
+}


### PR DESCRIPTION
## Summary

The updater daemon now detects that a package upgrade replaced its binary on disk and exits with a dedicated nonzero status code, so the already-deployed `Restart=on-failure` unit relaunches it on the new binary.

## Problem

Package upgrades replace `/usr/bin/codex-update-manager` while the daemon keeps running the old, now-deleted image. The post-install/post-upgrade hooks deliberately leave an active service untouched (`codex_start_one_enabled_user_service` returns early when the unit is active — reasonable, since the daemon itself may have triggered the pacman transaction and restarting it mid-install would kill the install). The result is that a running daemon survives **every** upgrade until the next reboot.

Observed on Arch (pacman package): a daemon started at boot predated the `record-replay-linux` workspace member (6ed86d4) and the manifest-based rebuild staging (751e912). On every periodic check it staged a builder workspace using its old hardcoded copy list, while copying the current bundle's `Cargo.toml` — which references crates the old list never copies. Every rebuild then failed with:

```
error: failed to load manifest for workspace member `.../builder/record-replay-linux`
Caused by: No such file or directory (os error 2)
```

producing a "update failed" notification every 6 hours, with `/proc/<pid>/exe → /usr/bin/codex-update-manager (deleted)` confirming the stale image. Manually rebuilding (`make update-native`) installs a fresh binary but never restarts the daemon, so the cycle repeats after the next upstream release. Any future divergence between a long-running daemon and the installed builder bundle can re-trigger the same class of failure.

## Fix

- New `updater/src/restart.rs`: reads `/proc/self/exe`, strips the kernel's ` (deleted)` suffix, and compares device+inode of the running image against the installed path. Returns the replacement path only when a different binary actually exists on disk, so package *removal* still flows through the existing packaged-runtime shutdown path instead of a restart loop.
- `run_daemon` checks this at the top of each loop iteration and exits with new code `12` (`BINARY_REPLACED_RESTART_EXIT_CODE`) when a replacement is found. With the 15s reconcile tick, a replaced binary is picked up within seconds regardless of whether the daemon or a manual package install performed the upgrade.

Exiting nonzero (rather than switching the unit to `Restart=always` with a clean exit) was chosen deliberately: it works retroactively on machines still running the old unit file, and it does not interfere with the daemon's intentional clean-exit paths (packaged runtime removed, shutdown signal). No packaging or unit-file changes are needed.

## User-visible behavior change

After a package upgrade, the updater daemon restarts itself onto the new binary within ~25 seconds (systemd `RestartSec=10` + reconcile tick) instead of running the old binary until reboot. The journal shows one intentional `exit-code` service restart per upgrade.

## Validation

- `cargo check -p codex-update-manager` and `cargo clippy -p codex-update-manager --all-targets` clean.
- New unit tests in `restart.rs` (6): ` (deleted)` suffix stripping and pass-through, same-inode → no replacement, different-inode → replacement, missing on-disk binary → no replacement, and a live check that the running test binary is not reported as replaced.
- `cargo test -p codex-update-manager`: 268 passed. 5 pre-existing failures (`codex_cli`/CLI-probe tests) fail identically on a clean `main` checkout on this host — they probe the host's real npm-installed Codex CLI and are unrelated to this change.
- Real-world root cause verified on the affected machine: stale daemon (deleted inode) staged workspaces missing `record-replay-linux`/`notification-actions-linux`; after restarting the service onto the current binary, the next check cycle succeeded.
