### PR TITLE
chore(nix): update vulnerable native-module build dependencies

### DIFF
--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -983,9 +983,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "optional": true,
       "engines": {


### PR DESCRIPTION
## Summary

Refresh the vulnerable transitive dependencies in `nix/native-modules/package-lock.json`:

- `undici` 7.25.0 → 7.28.0
- nested `undici` 6.25.0 → 6.27.0
- `tar` 7.5.15 → 7.5.20

This keeps Electron, `better-sqlite3`, `node-pty`, `node-abi`, and `@electron/rebuild` at their current versions. These dependencies are used by the Nix native-module build path; there is no confirmed packaged-runtime exposure.

## Validation

- `npm ci --ignore-scripts`
- `npm audit --package-lock-only --omit=dev` — 0 vulnerabilities
- deterministic lockfile regeneration
- Electron native-module rebuild
- packaged Electron runtime load of `better-sqlite3` and `node-pty`
- `nix flake check`
- `nix build .#codex-desktop`
- `nix build .#installer`

Fixes #1012
