### PR TITLE
Fix Linux IAB socket discovery after per-user scoping

### DIFF
--- a/scripts/lib/patch-browser-client-iab-socket-scope.test.js
+++ b/scripts/lib/patch-browser-client-iab-socket-scope.test.js
@@ -8,8 +8,66 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const { pathToFileURL } = require("node:url");
+const vm = require("node:vm");
+
+const {
+  applyLinuxBrowserUseSocketDirectoryPatch,
+} = require("../patches/impl/main-process/browser.js");
 
 const patcher = path.join(__dirname, "patch-browser-client-iab-socket-scope.js");
+
+test("main-process producer and staged Browser client resolve the same Linux socket directory", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-socket-alignment-"));
+  const clientPath = path.join(workspace, "browser-client.mjs");
+  const clientFixture =
+    'var kE=t=>t==="win32"?"\\\\\\\\.\\\\pipe\\\\codex-browser-use":"/tmp/codex-browser-use";globalThis.clientSocketDirectory=kE("linux");';
+  const producerFixture =
+    '"use strict";' +
+    'var zt=e=>e===`win32`?`\\\\\\\\.\\\\pipe\\\\codex-browser-use`:`/tmp/codex-browser-use`;' +
+    'var Sd=class{server;pipePath;async start(){await new Promise((e,t)=>{this.server.once(`error`,t),this.server.listen(this.pipePath,()=>{this.server.off(`error`,t),e()})})}};' +
+    'globalThis.producerSocketDirectory=zt(`linux`);';
+
+  try {
+    fs.writeFileSync(clientPath, clientFixture, "utf8");
+    const clientPatch = spawnSync(
+      process.execPath,
+      [patcher, clientPath, "--socket-dir-only"],
+      { encoding: "utf8" },
+    );
+    assert.equal(clientPatch.status, 0, clientPatch.stderr);
+
+    globalThis.nodeRepl = { env: {} };
+    await import(`${pathToFileURL(clientPath).href}?alignment=1`);
+
+    const uid = os.userInfo().uid;
+    const producerContext = {
+      globalThis: {},
+      process: { env: {}, getuid: () => uid, platform: "linux" },
+      require: () => ({
+        mkdirSync() {},
+        lstatSync: () => ({
+          isDirectory: () => true,
+          isSymbolicLink: () => false,
+          uid,
+        }),
+        chmodSync() {},
+      }),
+    };
+    vm.runInNewContext(
+      applyLinuxBrowserUseSocketDirectoryPatch(producerFixture),
+      producerContext,
+    );
+
+    assert.equal(
+      producerContext.globalThis.producerSocketDirectory,
+      globalThis.clientSocketDirectory,
+    );
+  } finally {
+    delete globalThis.nodeRepl;
+    delete globalThis.clientSocketDirectory;
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
 
 test("Linux socket discovery uses the bridge override then a deterministic UID path", async () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-user-socket-dir-"));

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -946,6 +946,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "browser-use-node-repl-approval",
     "linux-bundled-plugin-reconcile-stale-snapshot",
     "linux-bundled-plugin-copy-permissions",
+    "linux-browser-use-socket-directory",
     "linux-browser-use-route-liveness",
     "linux-chrome-extension-status",
     "linux-notification-actions",

--- a/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
+++ b/scripts/patches/core/all-linux/main-process/browser-integrations/patch.js
@@ -10,6 +10,7 @@ const {
   applyLinuxBundledPluginCopyPermissionsPatch,
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
+  applyLinuxBrowserUseSocketDirectoryPatch,
   applyLinuxChromeExtensionStatusPatch,
 } = require("../../../../impl/main-process/browser.js");
 const { applyLinuxChromePluginAutoInstallPatch } = require("../../../../impl/chrome-plugin.js");
@@ -52,6 +53,13 @@ module.exports = [
     order: 165,
     ciPolicy: "optional",
     apply: applyLinuxBundledPluginCopyPermissionsPatch,
+  }),
+  mainBundlePatch({
+    id: "linux-browser-use-socket-directory",
+    phase: "main-bundle",
+    order: 168,
+    ciPolicy: "optional",
+    apply: applyLinuxBrowserUseSocketDirectoryPatch,
   }),
   mainBundlePatch({
     id: "linux-browser-use-route-liveness",

--- a/scripts/patches/impl/main-process/browser.js
+++ b/scripts/patches/impl/main-process/browser.js
@@ -371,6 +371,64 @@ function applyLinuxBrowserUseRouteLivenessPatch(currentSource) {
   return currentSource.replace(original, replacement);
 }
 
+function applyLinuxBrowserUseSocketDirectoryPatch(currentSource) {
+  const helperName = "codexLinuxBrowserUseSocketDir";
+  const socketModeMarker = "/*codexLinuxBrowserUseSocketMode*/";
+  const hasHelper = currentSource.includes(`function ${helperName}(`);
+  const hasSocketModePatch = currentSource.includes(socketModeMarker);
+  if (hasHelper && hasSocketModePatch) {
+    return currentSource;
+  }
+  if (hasHelper || hasSocketModePatch) {
+    console.warn(
+      "WARN: Browser Use socket directory patch is only partially present — leaving main bundle unchanged",
+    );
+    return currentSource;
+  }
+
+  const socketDirectoryPattern =
+    /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)=>\2===`win32`\?(`(?:\\.|[^`\\])*codex-browser-use`):`\/tmp\/codex-browser-use`/g;
+  const socketDirectoryMatches = [...currentSource.matchAll(socketDirectoryPattern)];
+  const socketListenPattern =
+    /this\.server\.listen\(this\.pipePath,\(\)=>\{this\.server\.off\(`error`,([A-Za-z_$][\w$]*)\),([A-Za-z_$][\w$]*)\(\)\}\)/g;
+  const socketListenMatches = [...currentSource.matchAll(socketListenPattern)];
+  if (socketDirectoryMatches.length !== 1 || socketListenMatches.length !== 1) {
+    if (currentSource.includes("codex-browser-use")) {
+      console.warn(
+        `WARN: Expected one Browser Use socket directory and listener, found ${socketDirectoryMatches.length}/${socketListenMatches.length} — skipping Linux IAB socket alignment patch`,
+      );
+    }
+    return currentSource;
+  }
+
+  const [directoryTarget, resolverName, platformName, windowsSocket] =
+    socketDirectoryMatches[0];
+  const [listenTarget, errorHandlerName, resolveName] = socketListenMatches[0];
+  const helper =
+    `function ${helperName}(){let e=process.env.CODEX_BROWSER_USE_SOCKET_DIR,t=typeof e===\`string\`&&e.length>0?e:null,n=typeof process.getuid===\`function\`?process.getuid():null;` +
+    `if(t==null){if(!Number.isInteger(n)||n<0)throw Error(\`Browser Use cannot resolve a per-user Linux socket directory\`);t=\`/tmp/codex-browser-use-\${n}\`}` +
+    `let r=require(\`node:fs\`);r.mkdirSync(t,{recursive:!0,mode:448});let i=r.lstatSync(t);` +
+    `if(i.isSymbolicLink()||!i.isDirectory())throw Error(\`Browser Use socket directory is not a directory\`);` +
+    `if(Number.isInteger(n)&&i.uid!==n)throw Error(\`Browser Use socket directory is not owned by the current user\`);` +
+    `r.chmodSync(t,448);return t}`;
+  const directoryReplacement = `${resolverName}=${platformName}=>${platformName}===\`win32\`?${windowsSocket}:${helperName}()`;
+  const listenReplacement =
+    `this.server.listen(this.pipePath,()=>{if(process.platform===\`linux\`)try{require(\`node:fs\`).chmodSync(this.pipePath,384)}catch(e){this.server.off(\`error\`,${errorHandlerName}),this.server.close(()=>{}),${errorHandlerName}(e);return}${socketModeMarker}` +
+    `this.server.off(\`error\`,${errorHandlerName}),${resolveName}()})`;
+
+  let patchedSource = currentSource.replace(directoryTarget, directoryReplacement);
+  patchedSource = patchedSource.replace(listenTarget, listenReplacement);
+  const strictDirective = '"use strict";';
+  const helperInsertionIndex = patchedSource.startsWith(strictDirective)
+    ? strictDirective.length
+    : 0;
+  return (
+    patchedSource.slice(0, helperInsertionIndex) +
+    helper +
+    patchedSource.slice(helperInsertionIndex)
+  );
+}
+
 function applyLinuxChromeExtensionStatusPatch(currentSource) {
   if (currentSource.includes("codexLinuxChromeProfileRoots")) {
     return currentSource;
@@ -517,5 +575,6 @@ module.exports = {
   applyLinuxBundledPluginReconcileStaleSnapshotPatch,
   applyLinuxExternalOpenEnvPatch,
   applyLinuxBrowserUseRouteLivenessPatch,
+  applyLinuxBrowserUseSocketDirectoryPatch,
   applyLinuxChromeExtensionStatusPatch,
 };

--- a/scripts/patches/impl/main-process/browser.test.js
+++ b/scripts/patches/impl/main-process/browser.test.js
@@ -3,11 +3,84 @@
 
 const assert = require("node:assert/strict");
 const test = require("node:test");
+const vm = require("node:vm");
 
 const {
+  applyLinuxBrowserUseSocketDirectoryPatch,
   applyLinuxChromeExtensionStatusPatch,
   applyLinuxExternalOpenEnvPatch,
 } = require("./browser.js");
+
+const browserUseSocketFixture =
+  '"use strict";' +
+  'var zt=e=>e===`win32`?`\\\\\\\\.\\\\pipe\\\\codex-browser-use`:`/tmp/codex-browser-use`;' +
+  'var Sd=class{server;pipePath;async start(){await new Promise((e,t)=>{this.server.once(`error`,t),this.server.listen(this.pipePath,()=>{this.server.off(`error`,t),e()})})}};' +
+  'globalThis.socketDirectory=zt(`linux`);';
+
+function evaluateBrowserUseSocketPatch({ env = {}, metadataUid = 1000 } = {}) {
+  const operations = [];
+  const fs = {
+    mkdirSync: (target, options) => operations.push(["mkdir", target, options]),
+    lstatSync: (target) => ({
+      isDirectory: () => true,
+      isSymbolicLink: () => false,
+      uid: metadataUid,
+      target,
+    }),
+    chmodSync: (target, mode) => operations.push(["chmod", target, mode]),
+  };
+  const context = {
+    globalThis: {},
+    process: { env, getuid: () => 1000, platform: "linux" },
+    require: (specifier) => {
+      assert.equal(specifier, "node:fs");
+      return fs;
+    },
+  };
+  vm.runInNewContext(
+    applyLinuxBrowserUseSocketDirectoryPatch(browserUseSocketFixture),
+    context,
+  );
+  return { context, operations };
+}
+
+test("Linux IAB producer uses the same deterministic per-user socket directory as Browser clients", () => {
+  const { context, operations } = evaluateBrowserUseSocketPatch();
+
+  assert.equal(context.globalThis.socketDirectory, "/tmp/codex-browser-use-1000");
+  assert.equal(operations[0][0], "mkdir");
+  assert.equal(operations[0][1], "/tmp/codex-browser-use-1000");
+  assert.equal(operations[0][2].recursive, true);
+  assert.equal(operations[0][2].mode, 0o700);
+  assert.deepEqual(operations[1], ["chmod", "/tmp/codex-browser-use-1000", 0o700]);
+});
+
+test("Linux IAB producer honors the explicit shared socket directory override", () => {
+  const { context } = evaluateBrowserUseSocketPatch({
+    env: { CODEX_BROWSER_USE_SOCKET_DIR: "/custom/browser-use" },
+  });
+
+  assert.equal(context.globalThis.socketDirectory, "/custom/browser-use");
+});
+
+test("Linux IAB producer rejects a socket directory owned by another user", () => {
+  assert.throws(
+    () => evaluateBrowserUseSocketPatch({ metadataUid: 2000 }),
+    /not owned by the current user/,
+  );
+});
+
+test("Linux IAB socket alignment patch hardens the directory and socket modes", () => {
+  const patched = applyLinuxBrowserUseSocketDirectoryPatch(browserUseSocketFixture);
+
+  assert.match(patched, /mkdirSync\(t,\{recursive:!0,mode:448\}\)/);
+  assert.match(patched, /chmodSync\(t,448\)/);
+  assert.match(patched, /chmodSync\(this\.pipePath,384\)/);
+  assert.match(patched, /this\.server\.close\(\(\)=>\{\}\)/);
+  assert.match(patched, /t\(e\);return/);
+  assert.match(patched, /codexLinuxBrowserUseSocketMode/);
+  assert.equal(applyLinuxBrowserUseSocketDirectoryPatch(patched), patched);
+});
 
 test("Linux Chrome extension opener searches Chrome Beta and Unstable commands", () => {
   const source =


### PR DESCRIPTION
## Summary

- align the packaged Electron IAB server with the deterministic UID-scoped Linux socket directory already used by the staged Browser and Chrome clients
- preserve `CODEX_BROWSER_USE_SOCKET_DIR` as the explicit cross-process override
- fail closed for invalid or foreign-owned directories, normalize the directory to `0700`, and normalize the listening socket to `0600`
- add regression coverage that executes the producer and staged-client resolvers independently and requires them to select the same path

## Root cause

The per-user socket work in #1016 moved the staged consumers to `/tmp/codex-browser-use-$UID`, but the packaged Electron main process still created IAB sockets under the legacy global `/tmp/codex-browser-use` directory. The server could be healthy and listening while `agent.browsers.list()` returned no IAB browser because the consumers searched a different directory.

This follow-up patches the actual IAB producer instead of adding a legacy consumer fallback, so the multi-user isolation from #1016 remains intact.

## Validation

- `node --test scripts/lib/patch-browser-client-iab-socket-scope.test.js scripts/patches/impl/main-process/browser.test.js` — 15/15 passed
- `node --test scripts/patch-linux-window-ui.test.js` — 374/374 passed
- `bash tests/scripts_smoke.sh` — passed
- rebuilt a transactional candidate from the latest upstream DMG `26.715.21425` (`ff459150991612007549270d2d28c5e78cec6bd6ac200a7ada5ed6c031369b87`); the new descriptor applied to the current main-bundle shape and the candidate was accepted with unrelated optional-patch warnings
- launched the candidate side by side and confirmed the real Electron process created `/tmp/codex-browser-use-$UID` as `0700` with its listening socket as `0600`
- end-to-end validation selected `Codex In-app Browser` through `agent.browsers.list()`, opened an IAB tab, and navigated successfully to `https://example.com`

## Scope and risk

The Windows named-pipe path is unchanged. The change is limited to the Linux main-process producer patch and its regression tests; it does not restore the global socket directory or weaken the existing ownership boundary.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream-drift compatibility workaround; it was validated against the latest `CODEX.DMG` only.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. Local validation is complete; GitHub CI is pending.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
