### PR TITLE
Fix packaged wrapper update detection

### DIFF
--- a/docs/updater.md
+++ b/docs/updater.md
@@ -245,6 +245,9 @@ enable_wrapper_updates = true
 
 in `~/.config/codex-update-manager/config.toml`.
 
-This is intended for git-checkout/dev update-builder installs. Frozen
-native-package builders without a `.git` directory report no wrapper candidate
-and receive wrapper changes through normal package upgrades.
+This remains opt-in. Git-checkout/dev builders inspect their configured remote
+without changing the working tree. Frozen native-package builders prepare a
+managed checkout under `~/.cache/codex-update-manager/wrapper-src`, using the
+remote recorded in the package's source metadata, and inspect updates there.
+The installed bundle is not modified until the user applies a detected wrapper
+update through the optional `codex-wrapper-updater` feature.

--- a/linux-features/codex-wrapper-updater/README.md
+++ b/linux-features/codex-wrapper-updater/README.md
@@ -69,8 +69,9 @@ features the rebuild stages.
     ahead of the tracked remote, so updating would be a downgrade; the update
     action is suppressed and the apply path refuses.
 - "Ahead of upstream" is decided by fetching the tracked branch and checking
-  whether the candidate descends from the installed commit. Offline or
-  non-git/frozen bundles clear stale candidates and show no update action.
+  whether the candidate descends from the installed commit. Offline checks
+  clear stale candidates and show no update action. Frozen packaged bundles use
+  a managed checkout under the updater cache for detection.
 
 ## Why this is a Linux feature
 
@@ -160,6 +161,16 @@ remote/branch and records the result in:
 ```text
 ~/.local/state/codex-update-manager/state.json
 ```
+
+For frozen native-package builders, detection clones or refreshes the remote
+recorded in packaged source metadata under:
+
+```text
+~/.cache/codex-update-manager/wrapper-src
+```
+
+This managed checkout preserves commit history for the no-downgrade ancestry
+check and never mutates the installed `/opt/codex-desktop/update-builder` copy.
 
 The webview button is shown only when this state contains a non-empty
 `candidate_wrapper_commit`.

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -534,8 +534,9 @@ async fn run_check_now(
 
 /// Detects a newer wrapper release and records it into state. Returns
 /// `Ok(true)` when an update was found and recorded. No-ops (returning
-/// `Ok(false)`) when wrapper tracking is disabled, the builder bundle is not a
-/// git checkout, or no newer commit is available. Never mutates the checkout.
+/// `Ok(false)`) when wrapper tracking is disabled or no newer commit is
+/// available. Frozen packaged builders use a managed checkout under the updater
+/// cache; the installed bundle and any user checkout remain untouched.
 fn detect_and_record_wrapper_update(
     config: &RuntimeConfig,
     state: &mut PersistedState,
@@ -556,8 +557,28 @@ fn detect_and_record_wrapper_update(
 
     use wrapper::WrapperDetectionState::*;
 
+    let detection_root = if wrapper::is_git_checkout(&config.builder_bundle_root) {
+        config.builder_bundle_root.clone()
+    } else {
+        match wrapper_apply::ensure_wrapper_source(config, paths, None) {
+            Ok(source) => source,
+            Err(error) => {
+                warn!(
+                    ?error,
+                    "could not prepare managed wrapper source for detection"
+                );
+                let original_state = state.clone();
+                state.installed_wrapper_version = installed.version;
+                state.installed_wrapper_commit = Some(installed.commit);
+                state.clear_wrapper_update_candidate();
+                persist_if_changed(paths, state, &original_state)?;
+                return Ok(false);
+            }
+        }
+    };
+
     let detection = match wrapper::detect_state_from_bundle_root(
-        &config.builder_bundle_root,
+        &detection_root,
         &installed,
         &config.wrapper_remote,
         &config.wrapper_branch,
@@ -1983,6 +2004,7 @@ fn notify_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
     use wiremock::{
         matchers::{method, path},
         Mock, MockServer, ResponseTemplate,
@@ -2014,6 +2036,56 @@ mod tests {
             wrapper_branch: "main".to_string(),
             generated_artifact_cleanup: Default::default(),
         }
+    }
+
+    fn test_git(repo: &std::path::Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args(args)
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    fn init_wrapper_remote(repo: &std::path::Path) -> (String, String) {
+        std::fs::create_dir_all(repo.join("updater")).unwrap();
+        test_git(repo, &["init", "-q", "-b", "main"]);
+        std::fs::write(
+            repo.join("updater/Cargo.toml"),
+            "[package]\nname = \"codex-update-manager\"\nversion = \"0.8.1\"\n",
+        )
+        .unwrap();
+        std::fs::write(repo.join("CHANGELOG.md"), "# Changelog\n").unwrap();
+        test_git(repo, &["add", "-A"]);
+        test_git(repo, &["commit", "-q", "-m", "initial wrapper"]);
+        let installed_commit = test_git(repo, &["rev-parse", "HEAD"]);
+
+        std::fs::write(
+            repo.join("updater/Cargo.toml"),
+            "[package]\nname = \"codex-update-manager\"\nversion = \"0.10.1\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            repo.join("CHANGELOG.md"),
+            "# Changelog\n\n## [0.10.1] - 2026-07-17\n\n### Fixed\n\n- Packaged detection.\n",
+        )
+        .unwrap();
+        test_git(repo, &["add", "-A"]);
+        test_git(repo, &["commit", "-q", "-m", "advance wrapper"]);
+        let candidate_commit = test_git(repo, &["rev-parse", "HEAD"]);
+        (installed_commit, candidate_commit)
     }
 
     fn write_installed_build_info(config: &RuntimeConfig, sha256: &str) -> Result<()> {
@@ -2184,6 +2256,51 @@ mod tests {
         assert_eq!(persisted.candidate_wrapper_commit, None);
         assert_eq!(persisted.wrapper_changelog, None);
         assert_eq!(persisted.wrapper_dev_mode, None);
+        Ok(())
+    }
+
+    #[test]
+    fn packaged_builder_detects_wrapper_update_from_managed_checkout() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let remote = temp.path().join("remote");
+        let (installed_commit, candidate_commit) = init_wrapper_remote(&remote);
+
+        let mut config = test_config(temp.path());
+        config.enable_wrapper_updates = true;
+        std::fs::create_dir_all(config.builder_bundle_root.join(".codex-linux"))?;
+        std::fs::write(
+            config
+                .builder_bundle_root
+                .join(".codex-linux/source-info.json"),
+            format!(
+                r#"{{
+  "commit": "{installed_commit}",
+  "version": "0.8.1",
+  "remote": "file://{}",
+  "provenance": "packaged-update-builder"
+}}
+"#,
+                remote.canonicalize()?.display()
+            ),
+        )?;
+
+        let mut state = PersistedState::new(true);
+        let found = detect_and_record_wrapper_update(&config, &mut state, &paths)?;
+
+        assert!(found);
+        assert_eq!(
+            state.installed_wrapper_commit.as_deref(),
+            Some(installed_commit.as_str())
+        );
+        assert_eq!(
+            state.candidate_wrapper_commit.as_deref(),
+            Some(candidate_commit.as_str())
+        );
+        assert_eq!(state.candidate_wrapper_version.as_deref(), Some("0.10.1"));
+        assert!(paths.cache_dir.join("wrapper-src/.git").is_dir());
+        assert!(!paths.cache_dir.join("wrapper-src/.git/shallow").exists());
         Ok(())
     }
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -2261,6 +2261,7 @@ mod tests {
 
     #[test]
     fn packaged_builder_detects_wrapper_update_from_managed_checkout() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
         let temp = tempfile::tempdir()?;
         let paths = test_paths(temp.path());
         paths.ensure_dirs()?;

--- a/updater/src/wrapper.rs
+++ b/updater/src/wrapper.rs
@@ -9,9 +9,9 @@
 //! read. The actual rebuild reuses the existing DMG rebuild path against the
 //! refreshed checkout.
 //!
-//! When the builder bundle is a frozen packaged copy (no `.git`), the wrapper
-//! axis degrades gracefully: detection reports "not a git checkout" and the
-//! caller leaves wrapper updates to a normal package upgrade.
+//! When the builder bundle is a frozen packaged copy (no `.git`), callers can
+//! prepare a managed checkout using the trusted remote recorded in packaged
+//! source metadata, then run the same detection against that checkout.
 
 use anyhow::Result;
 use serde_json::Value;
@@ -276,6 +276,21 @@ fn origin_url(repo: &Path) -> Option<String> {
     git_capture(repo, &["remote", "get-url", "origin"])
 }
 
+fn metadata_remote(bundle_root: &Path) -> Option<String> {
+    ["source-info.json", "build-info.json"]
+        .into_iter()
+        .map(|name| bundle_root.join(".codex-linux").join(name))
+        .find_map(|path| {
+            let content = std::fs::read_to_string(path).ok()?;
+            let value = serde_json::from_str::<Value>(&content).ok()?;
+            let source = metadata_source(&value)?;
+            string_field(source, "remote")
+                .map(str::trim)
+                .filter(|remote| !remote.is_empty())
+                .map(str::to_string)
+        })
+}
+
 /// Resolves the configured wrapper remote into either an explicit URL/name or
 /// the builder checkout's origin URL.
 pub fn resolve_remote(config_remote: &str, bundle_root: &Path) -> String {
@@ -283,7 +298,9 @@ pub fn resolve_remote(config_remote: &str, bundle_root: &Path) -> String {
     if !trimmed.is_empty() {
         return trimmed.to_string();
     }
-    origin_url(bundle_root).unwrap_or_else(|| "origin".to_string())
+    origin_url(bundle_root)
+        .or_else(|| metadata_remote(bundle_root))
+        .unwrap_or_else(|| "origin".to_string())
 }
 
 /// Queries the remote head commit for `branch` via `git ls-remote`.

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -435,16 +435,13 @@ pub(crate) fn ensure_wrapper_source(
     let dest = paths.cache_dir.join("wrapper-src");
 
     if dest.join(".git").is_dir() {
-        run_git(&[
-            "-C",
-            &dest.to_string_lossy(),
-            "fetch",
-            "--depth",
-            "1",
-            "--quiet",
-            &remote,
-            branch,
-        ])?;
+        let dest_text = dest.to_string_lossy().into_owned();
+        let mut fetch_args = vec!["-C", dest_text.as_str(), "fetch"];
+        if dest.join(".git/shallow").is_file() {
+            fetch_args.push("--unshallow");
+        }
+        fetch_args.extend(["--quiet", &remote, branch]);
+        run_git(&fetch_args)?;
         run_git(&[
             "-C",
             &dest.to_string_lossy(),
@@ -460,8 +457,7 @@ pub(crate) fn ensure_wrapper_source(
         let _ = std::fs::remove_dir_all(&dest);
         run_git(&[
             "clone",
-            "--depth",
-            "1",
+            "--filter=blob:none",
             "--branch",
             branch,
             "--single-branch",


### PR DESCRIPTION
## Summary

- resolve the wrapper remote from packaged source metadata when the frozen update-builder has no Git checkout
- create or refresh a managed full-history wrapper checkout so ancestry and no-downgrade checks remain authoritative
- use that managed checkout for opt-in packaged wrapper detection while preserving stale-candidate cleanup on offline/fetch failures
- document the managed checkout behavior for updater and feature users

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-update-manager`
- `env -u CODEX_CLI_PATH -u NVM_DIR cargo test -p codex-update-manager wrapper -- --test-threads=1` (24 passed)
- isolated live `check-wrapper --json` against the installed frozen `/opt/codex-desktop/update-builder`; resolved the packaged GitHub remote, created a non-shallow managed checkout, and reported installed wrapper `b24e5ff / 0.10.1` aligned
