### PR TITLE
Fix Cachix after automated Nix refresh merges

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - flake.nix
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -35,6 +36,7 @@ jobs:
       - name: Compare Codex DMG hashes
         id: codex-dmg-hash
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
@@ -46,7 +48,10 @@ jobs:
           previous_flake="$(mktemp)"
           trap 'rm -f "$previous_flake"' EXIT
 
-          if [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            changed=true
+            previous_hash=manual-backfill
+          elif [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
             changed=true
             previous_hash=missing
           else

--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   detect-codex-dmg-hash:
     name: Detect Codex DMG hash change
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.codex-dmg-hash.outputs.changed }}

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -142,7 +142,6 @@ jobs:
               -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
               -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the current upstream DMG." \
               -m "Verified all ChatGPT Desktop Nix package outputs against the refreshed DMG." \
-              -m "[skip ci]" \
               -m "Source-Main-SHA: $EXPECTED_MAIN_SHA" \
               -m "Upstream-DMG-SHA256: $DMG_SHA256"
             git push --force-with-lease origin "$REFRESH_BRANCH"

--- a/.github/workflows/update-codex-hash.yml
+++ b/.github/workflows/update-codex-hash.yml
@@ -138,6 +138,8 @@ jobs:
             git config user.email "actions@github.com"
             git checkout -B "$REFRESH_BRANCH"
             git add "${pin_paths[@]}"
+            # GITHUB_TOKEN already suppresses branch push workflows. Do not add
+            # a skip marker: squash merges copy it to main and suppress Cachix.
             git commit \
               -m "fix(nix): refresh upstream Nix pins${CODEX_VERSION:+ for $CODEX_VERSION}" \
               -m "Refreshed Codex.dmg SRI hash to $CODEX_DMG_HASH and synced codexVersion / electronVersion / native-module pins to the current upstream DMG." \

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -280,4 +280,5 @@ When a merge to `main` changes the pinned `Codex.dmg` hash, the `Populate
 Cachix` workflow builds the default package, feature-specific package variants,
 the watchdog feature check, and `.#installer`. It uploads and garbage-collects
 each output before starting the next one so the hosted runner does not retain
-every large app variant at once.
+every large app variant at once. Maintainers can dispatch the workflow manually
+to backfill the current `main` pin after a skipped or interrupted run.

--- a/scripts/ci/cachix-workflow.test.js
+++ b/scripts/ci/cachix-workflow.test.js
@@ -7,15 +7,26 @@ const workflow = fs.readFileSync(
   path.resolve(__dirname, "../../.github/workflows/cachix.yml"),
   "utf8",
 );
+const updateHashWorkflow = fs.readFileSync(
+  path.resolve(__dirname, "../../.github/workflows/update-codex-hash.yml"),
+  "utf8",
+);
 
-test("Cachix population runs only for an actual Codex DMG hash change", () => {
+test("Cachix automatic population runs only for an actual Codex DMG hash change", () => {
   assert.match(workflow, /paths:\n\s+- flake\.nix/);
   assert.doesNotMatch(workflow, /schedule:/);
-  assert.doesNotMatch(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /id: codex-dmg-hash/);
+  assert.match(workflow, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
   assert.match(workflow, /BEFORE_SHA: \$\{\{ github\.event\.before \}\}/);
+  assert.match(workflow, /if \[ "\$EVENT_NAME" = "workflow_dispatch" \]; then\n\s+changed=true/);
   assert.match(workflow, /read-flake-hash "codexDmg = pkgs\.fetchurl \{" "hash = "/);
   assert.match(workflow, /if: needs\.detect-codex-dmg-hash\.outputs\.changed == 'true'/);
+});
+
+test("Nix refresh commits allow post-merge workflows to run", () => {
+  assert.doesNotMatch(updateHashWorkflow, /\[skip ci\]/);
+  assert.match(updateHashWorkflow, /gh workflow run ci\.yml/);
 });
 
 test("Cachix population pushes each output before collecting the Nix store", () => {

--- a/scripts/ci/cachix-workflow.test.js
+++ b/scripts/ci/cachix-workflow.test.js
@@ -17,6 +17,7 @@ test("Cachix automatic population runs only for an actual Codex DMG hash change"
   assert.doesNotMatch(workflow, /schedule:/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /id: codex-dmg-hash/);
+  assert.match(workflow, /if: github\.event_name != 'workflow_dispatch' \|\| github\.ref == 'refs\/heads\/main'/);
   assert.match(workflow, /EVENT_NAME: \$\{\{ github\.event_name \}\}/);
   assert.match(workflow, /BEFORE_SHA: \$\{\{ github\.event\.before \}\}/);
   assert.match(workflow, /if \[ "\$EVENT_NAME" = "workflow_dispatch" \]; then\n\s+changed=true/);


### PR DESCRIPTION
Summary:
- allow squash-merged Nix refresh commits to trigger post-merge workflows
- add a main-only manual Cachix backfill for skipped runs
- cover both trigger paths with regression tests

Tests/checks run:
- node --test scripts/ci/cachix-workflow.test.js scripts/ci/github-actions-runtime.test.js
- bash scripts/ci/run-node-checks.sh syntax
- bash scripts/ci/run-node-checks.sh tests
- git diff --check

Notes:
- automatic Cachix runs remain limited to main pushes that change flake.nix