### PR TITLE
Add project group Last updated sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ workarounds.
 | Open Target Discovery | Opt-in | `open-target-discovery` | [Docs](linux-features/open-target-discovery/README.md) |
 | Persistent status panel | Opt-in | `persistent-status-panel` | [Docs](linux-features/persistent-status-panel/README.md) |
 | Pet overlay | Opt-in | `pet-overlay` | [Docs](linux-features/pet-overlay/README.md) |
+| Project group Last updated sorting | Opt-in | `project-group-last-updated-sort` | [Docs](linux-features/project-group-last-updated-sort/README.md) |
 | Project task Created sorting | Opt-in | `project-task-sort` | [Docs](linux-features/project-task-sort/README.md) |
 | Read Aloud button | Opt-in | `read-aloud` | [Docs](linux-features/read-aloud/README.md) |
 | Read Aloud MCP | Opt-in | `read-aloud-mcp` | [Docs](linux-features/read-aloud-mcp/README.md) |

--- a/linux-features/project-group-last-updated-sort/README.md
+++ b/linux-features/project-group-last-updated-sort/README.md
@@ -1,0 +1,32 @@
+# Project Group Last Updated Sorting
+
+Optional current-DMG patch for the Projects sidebar.
+
+Upstream applies `Last updated` to task rows inside each project, but it then
+reapplies the saved manual project order to the project groups themselves. A
+complete saved order therefore leaves every project header fixed even when a
+different project has the newest task.
+
+This feature makes `Last updated` sort both project groups and their task rows
+by recency. `Priority` and `Manual order` keep upstream's saved project-group
+ordering behavior.
+
+The feature is disabled by default because it intentionally changes upstream
+sidebar semantics. Enable it in `linux-features/features.json`:
+
+```json
+{
+  "enabled": [
+    "project-group-last-updated-sort"
+  ]
+}
+```
+
+Run the feature tests with:
+
+```bash
+node --test linux-features/project-group-last-updated-sort/test.js
+```
+
+The patch targets only the current upstream Projects sidebar chunk. Upstream
+bundle drift leaves the asset unchanged and reports an optional patch warning.

--- a/linux-features/project-group-last-updated-sort/feature.json
+++ b/linux-features/project-group-last-updated-sort/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "project-group-last-updated-sort",
+  "title": "Project Group Last Updated Sorting",
+  "description": "Makes Last updated reorder project groups as well as their tasks in the Projects sidebar.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/project-group-last-updated-sort/patch.js
+++ b/linux-features/project-group-last-updated-sort/patch.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const currentGroupSorter =
+  "function Fe({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return ue(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
+const patchedGroupSorter =
+  "function Fe({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:ue(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
+
+const currentGroupSorterCall =
+  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER)})";
+const patchedGroupSorterCall =
+  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER),sortMode:t(C).projectSortMode})";
+
+function countOccurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+function applyProjectGroupLastUpdatedSortPatch(source) {
+  const currentSorterCount = countOccurrences(source, currentGroupSorter);
+  const patchedSorterCount = countOccurrences(source, patchedGroupSorter);
+  const currentCallCount = countOccurrences(source, currentGroupSorterCall);
+  const patchedCallCount = countOccurrences(source, patchedGroupSorterCall);
+
+  if (
+    patchedSorterCount === 1 &&
+    patchedCallCount === 1 &&
+    currentSorterCount === 0 &&
+    currentCallCount === 0
+  ) {
+    return source;
+  }
+
+  if (
+    currentSorterCount !== 1 ||
+    patchedSorterCount !== 0 ||
+    currentCallCount !== 1 ||
+    patchedCallCount !== 0
+  ) {
+    console.warn(
+      "WARN: Could not find current project group sorting insertion points - skipping project group Last updated sort feature patch",
+    );
+    return source;
+  }
+
+  return source
+    .replace(currentGroupSorter, patchedGroupSorter)
+    .replace(currentGroupSorterCall, patchedGroupSorterCall);
+}
+
+const descriptors = [
+  {
+    id: "last-updated-project-groups",
+    phase: "webview-asset",
+    order: 20_900,
+    ciPolicy: "optional",
+    pattern:
+      /^app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~[A-Za-z0-9_-]+\.js$/,
+    missingDescription: "project group sort webview bundle",
+    skipDescription: "project group Last updated sorting feature patch",
+    apply: applyProjectGroupLastUpdatedSortPatch,
+  },
+];
+
+module.exports = {
+  applyProjectGroupLastUpdatedSortPatch,
+  descriptors,
+};

--- a/linux-features/project-group-last-updated-sort/test.js
+++ b/linux-features/project-group-last-updated-sort/test.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const { patchAssetFiles } = require("../../scripts/patches/lib/assets.js");
+const {
+  applyProjectGroupLastUpdatedSortPatch,
+  descriptors,
+} = require("./patch.js");
+
+const currentProjectSource = [
+  "function ue(e,t){let n=new Map(t.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(n.get(e.projectId)??2**53-1)-(n.get(t.projectId)??2**53-1))}",
+  "function Re(e,t){let n=e.projectUpdatedAt??0;for(let r of e.threadKeys)n=Math.max(n,t.get(r)??0);return n}",
+  "function Fe({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return ue(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
+  "const prioritySortId=`sidebarElectron.sortMenu.priority`;",
+  "const updatedSortId=`sidebarElectron.sortMenu.updated`;",
+  "const manualSortId=`sidebarElectron.sortMenu.manual`;",
+  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER)});",
+].join("");
+
+function captureWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(message);
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function applyPatchTwice(source) {
+  const patched = applyProjectGroupLastUpdatedSortPatch(source);
+  const { value: secondPass, warnings } = captureWarns(() =>
+    applyProjectGroupLastUpdatedSortPatch(patched),
+  );
+  assert.equal(secondPass, patched);
+  assert.deepEqual(warnings, []);
+  return patched;
+}
+
+function withFeatureConfig(enabled, fn) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "project-group-last-updated-sort-"),
+  );
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  try {
+    fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, JSON.stringify({ enabled }));
+    return fn();
+  } finally {
+    if (originalConfig == null) {
+      delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    } else {
+      process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function evaluateGroupSorter(source) {
+  const context = {};
+  const sorterSource = source.slice(0, source.indexOf("const prioritySortId"));
+  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=Fe`, context);
+  return context.sortProjectGroups;
+}
+
+test("feature is disabled until selected", () => {
+  const featuresRoot = path.resolve(__dirname, "..");
+  withFeatureConfig([], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot }).some(
+        (descriptor) =>
+          descriptor.id ===
+          "feature:project-group-last-updated-sort:last-updated-project-groups",
+      ),
+      false,
+    );
+  });
+  withFeatureConfig(["project-group-last-updated-sort"], () => {
+    assert.equal(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot }).some(
+        (descriptor) =>
+          descriptor.id ===
+          "feature:project-group-last-updated-sort:last-updated-project-groups",
+      ),
+      true,
+    );
+  });
+});
+
+test("Last updated sorts project groups by their newest task", () => {
+  const patched = applyPatchTwice(currentProjectSource);
+  const sortProjectGroups = evaluateGroupSorter(patched);
+  const groups = [
+    { projectId: "nix", threadKeys: ["nix-task"] },
+    { projectId: "delta", threadKeys: ["delta-task"] },
+    { projectId: "multi", threadKeys: ["multi-task"] },
+    { projectId: "chezmoi", threadKeys: ["chezmoi-task"] },
+    { projectId: "tapas", threadKeys: ["tapas-task"] },
+  ];
+  const items = [
+    { task: { key: "nix-task" }, recencyAt: 1 },
+    { task: { key: "delta-task" }, recencyAt: 2 },
+    { task: { key: "multi-task" }, recencyAt: 3 },
+    { task: { key: "chezmoi-task" }, recencyAt: 4 },
+    { task: { key: "tapas-task" }, recencyAt: 5 },
+  ];
+  const projectOrder = ["nix", "delta", "multi", "chezmoi", "tapas"];
+
+  assert.deepEqual(
+    Array.from(
+      sortProjectGroups({ groups, items, projectOrder, sortMode: "updated_at" }),
+      (group) => group.projectId,
+    ),
+    ["tapas", "chezmoi", "multi", "delta", "nix"],
+  );
+});
+
+test("non-updated modes preserve the upstream saved project order", () => {
+  const patched = applyPatchTwice(currentProjectSource);
+  const sortProjectGroups = evaluateGroupSorter(patched);
+  const groups = [
+    { projectId: "newer", threadKeys: ["newer-task"] },
+    { projectId: "older", threadKeys: ["older-task"] },
+  ];
+  const items = [
+    { task: { key: "newer-task" }, recencyAt: 2 },
+    { task: { key: "older-task" }, recencyAt: 1 },
+  ];
+  const projectOrder = ["older", "newer"];
+
+  for (const sortMode of ["manual", "priority"]) {
+    assert.deepEqual(
+      Array.from(
+        sortProjectGroups({ groups, items, projectOrder, sortMode }),
+        (group) => group.projectId,
+      ),
+      ["older", "newer"],
+    );
+  }
+});
+
+test("patch passes the selected project sort mode into the group sorter", () => {
+  const patched = applyPatchTwice(currentProjectSource);
+  assert.ok(
+    patched.includes(
+      "projectOrder:f(t,o.PROJECT_ORDER),sortMode:t(C).projectSortMode",
+    ),
+  );
+});
+
+test("drift leaves the asset byte-identical", () => {
+  const source = currentProjectSource.replace(
+    "function Fe({groups:e,items:t,projectOrder:n})",
+    "function Fe({groups:e,items:t,projectOrder:n,unknown:o})",
+  );
+  const { value, warnings } = captureWarns(() =>
+    applyProjectGroupLastUpdatedSortPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project group sorting insertion points/);
+});
+
+test("missing current call site leaves the asset byte-identical", () => {
+  const source = currentProjectSource.replace(
+    "projectOrder:f(t,o.PROJECT_ORDER)",
+    "projectOrder:unknownProjectOrder",
+  );
+  const { value, warnings } = captureWarns(() =>
+    applyProjectGroupLastUpdatedSortPatch(source),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project group sorting insertion points/);
+});
+
+test("mixed patched and clean helpers are rejected byte-identically", () => {
+  const mixed = `${applyProjectGroupLastUpdatedSortPatch(
+    currentProjectSource,
+  )}${currentProjectSource}`;
+  const { value, warnings } = captureWarns(() =>
+    applyProjectGroupLastUpdatedSortPatch(mixed),
+  );
+
+  assert.equal(value, mixed);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /project group sorting insertion points/);
+});
+
+test("descriptor targets and patches only the current project sidebar chunk", () => {
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "project-group-last-updated-sort-assets-"),
+  );
+  try {
+    const assetsDir = path.join(tempDir, "webview", "assets");
+    const assetPath = path.join(
+      assetsDir,
+      "app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~iqsnin5k-demo.js",
+    );
+    fs.mkdirSync(assetsDir, { recursive: true });
+    fs.writeFileSync(assetPath, currentProjectSource);
+
+    const result = patchAssetFiles(
+      tempDir,
+      descriptors[0].pattern,
+      descriptors[0].apply,
+      "missing",
+    );
+
+    assert.deepEqual(result, { matched: 1, changed: 1 });
+    assert.notEqual(fs.readFileSync(assetPath, "utf8"), currentProjectSource);
+    assert.equal(
+      descriptors[0].pattern.test(
+        "app-initial~app-main~projects-index-page~remote-conversation-page-old.js",
+      ),
+      false,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add an opt-in `project-group-last-updated-sort` Linux feature
- make Last updated reorder project groups as well as task rows
- preserve upstream Priority and Manual order behavior
- keep the feature disabled by default

## Root cause

Upstream first computes project-group recency, then reapplies the persisted project order. When that saved order contains every project, it fixes the project headers in place even though task rows are sorted by Last updated.

## User-visible behavior

With `project-group-last-updated-sort` enabled, Last updated sorts unpinned project groups by the newest project/task activity. Priority and Manual order continue to use the upstream saved project order.

## Validation

- `node --test linux-features/project-group-last-updated-sort/test.js` — 8 passed
- `node --test --test-reporter=dot linux-features/*/test.js` — 607 passed, 1 unrelated sandbox-only failure because the Thorium cleanup test could not write `~/.codex/hooks.json`
- current-DMG rebuild with `project-group-last-updated-sort` enabled — feature descriptor applied once
- real bundle patch — first pass changed, second pass idempotent, `node --check` passed

## Limitations

The isolated current-DMG candidate reached the feature patch successfully, then promotion remained inconclusive because a disabled cleanup hook attempted to write `~/.codex/hooks.json` under sandbox restrictions. Existing optional core drift warnings are unchanged.