### PR TITLE
Temporarily mitigate sidebar scroll fade regression

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -178,6 +178,7 @@ const {
   applyLinuxOpaqueWindowsDefaultPatch,
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyLinuxSidebarScrollFadePerformancePatch,
   applyLinuxSkillsListDedupePatch,
   applyLinuxThreadSidePanelNativeTooltipPatch,
   applyLinuxTooltipWindowControlsCollisionPatch,
@@ -978,6 +979,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-window-controls-safe-area",
     "linux-tooltip-window-controls-collision",
     "linux-thread-side-panel-native-tooltip",
+    "linux-sidebar-scroll-fade-performance-mitigation",
     "linux-fast-mode-model-guard",
     "linux-safe-monospace-font-stack",
     "subagent-nickname-metadata-shape",
@@ -1124,6 +1126,9 @@ test("optional webview descriptors follow the current upstream chunk split", () 
   const tooltipCollision = descriptors.find(
     (descriptor) => descriptor.id === "linux-tooltip-window-controls-collision",
   );
+  const sidebarScrollFade = descriptors.find(
+    (descriptor) => descriptor.id === "linux-sidebar-scroll-fade-performance-mitigation",
+  );
 
   assert.ok(automationUpdate);
   assert.equal(
@@ -1146,6 +1151,14 @@ test("optional webview descriptors follow the current upstream chunk split", () 
   assert.equal(
     tooltipCollision.pattern.test(
       "app-initial~app-main~onboarding-page~hotkey-window-thread-page~quick-chat-window-page~chatg~legacy.js",
+    ),
+    false,
+  );
+  assert.ok(sidebarScrollFade);
+  assert.equal(sidebarScrollFade.pattern.test("app-DdRwcpIN.css"), true);
+  assert.equal(
+    sidebarScrollFade.pattern.test(
+      "app-initial~app-main~projects-index-page-C6cWVbB-.css",
     ),
     false,
   );
@@ -2855,6 +2868,41 @@ test("removes native title tooltip from the thread side panel toolbar action", (
   assert.match(patched, /"aria-label":i/);
   assert.match(patched, /tooltipContent:i/);
   assert.doesNotMatch(patched, /title:i/);
+});
+
+test("replaces the current sidebar scroll-linked fade with a static temporary fade", () => {
+  const source = [
+    "@property --top-fade{syntax:`<length>`;inherits:false;initial-value:0}",
+    "@property --bottom-fade{syntax:`<length>`;inherits:false;initial-value:0}",
+    "@keyframes edge-fade{0%{--top-fade:0;--bottom-fade:var(--edge-fade-distance,1rem)}to{--top-fade:var(--edge-fade-distance,1rem);--bottom-fade:0}}",
+    ".vertical-scroll-fade-mask{-webkit-mask:linear-gradient(to bottom,transparent,#000 var(--top-fade) calc(100% - var(--bottom-fade)),transparent);mask:linear-gradient(to bottom,transparent,#000 var(--top-fade) calc(100% - var(--bottom-fade)),transparent);animation-name:edge-fade;animation-timing-function:linear;animation-fill-mode:both;animation-timeline:scroll(self y)}",
+  ].join("");
+
+  const { value: patched, warnings } = captureWarns(() =>
+    applyPatchTwice(applyLinuxSidebarScrollFadePerformancePatch, source),
+  );
+
+  assert.deepEqual(warnings, []);
+  assert.match(
+    patched,
+    /codex-linux-issue-1048-temporary-scroll-fade-mitigation/,
+  );
+  assert.match(
+    patched,
+    /\.vertical-scroll-fade-mask\{--top-fade:var\(--edge-fade-distance,1rem\);--bottom-fade:var\(--edge-fade-distance,1rem\);animation:none!important;animation-timeline:auto!important\}$/,
+  );
+});
+
+test("reports drift when the temporary sidebar scroll fade mitigation no longer matches", () => {
+  const source = ".vertical-scroll-fade-mask{overflow:auto}";
+  const { value: patched, warnings } = captureWarns(() =>
+    applyLinuxSidebarScrollFadePerformancePatch(source),
+  );
+
+  assert.equal(patched, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find sidebar scroll fade animation — skipping temporary Linux scroll performance mitigation",
+  ]);
 });
 
 test("removes the Linux menu next to Windows removeMenu calls", () => {

--- a/scripts/patches/core/all-linux/webview/sidebar-scroll-fade/patch.js
+++ b/scripts/patches/core/all-linux/webview/sidebar-scroll-fade/patch.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const {
+  webviewAssetPatch,
+} = require("../../../../descriptor.js");
+const {
+  applyLinuxSidebarScrollFadePerformancePatch,
+} = require("../../../../impl/webview/index.js");
+
+module.exports = webviewAssetPatch({
+  id: "linux-sidebar-scroll-fade-performance-mitigation",
+  phase: "webview-asset",
+  order: 1070,
+  ciPolicy: "optional",
+  pattern: /^app-(?!initial~)[^.]+\.css$/,
+  missingDescription: "main webview stylesheet",
+  skipDescription: "temporary Linux sidebar scroll performance mitigation",
+  apply: applyLinuxSidebarScrollFadePerformancePatch,
+});

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -16,6 +16,33 @@ const LINUX_SAFE_MONOSPACE_FONT_STACK =
   "\"Noto Sans Mono\", \"DejaVu Sans Mono\", \"Liberation Mono\", \"Ubuntu Mono\", ui-monospace, \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace";
 const LINUX_TOOLTIP_COLLISION_PADDING_TOP = 44;
 const LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT = 138;
+const LINUX_SCROLL_FADE_MITIGATION_MARKER =
+  "codex-linux-issue-1048-temporary-scroll-fade-mitigation";
+
+function applyLinuxSidebarScrollFadePerformancePatch(currentSource) {
+  if (currentSource.includes(LINUX_SCROLL_FADE_MITIGATION_MARKER)) {
+    return currentSource;
+  }
+
+  const scrollFadeSelector = ".vertical-scroll-fade-mask{";
+  const scrollFadeAnimation = "animation-name:edge-fade;";
+  const scrollFadeTimeline = "animation-timeline:scroll(self y)";
+  if (
+    currentSource.includes(scrollFadeSelector) &&
+    currentSource.includes(scrollFadeAnimation) &&
+    currentSource.includes(scrollFadeTimeline)
+  ) {
+    // Temporary mitigation for https://github.com/ilysenko/codex-desktop-linux/issues/1048.
+    // Keep a static fade at both edges while avoiding the expensive scroll-linked
+    // custom-property animation seen with the current upstream Electron build.
+    return `${currentSource}/* ${LINUX_SCROLL_FADE_MITIGATION_MARKER} */.vertical-scroll-fade-mask{--top-fade:var(--edge-fade-distance,1rem);--bottom-fade:var(--edge-fade-distance,1rem);animation:none!important;animation-timeline:auto!important}`;
+  }
+
+  console.warn(
+    "WARN: Could not find sidebar scroll fade animation — skipping temporary Linux scroll performance mitigation",
+  );
+  return currentSource;
+}
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -2324,6 +2351,7 @@ module.exports = {
   applyLinuxWindowControlsSafeAreaPatch,
   applyLinuxSafeMonospaceFontStackPatch,
   applyLinuxSettingsSearchVisibilityPatch,
+  applyLinuxSidebarScrollFadePerformancePatch,
   applyLinuxFastModeModelGuardPatch,
   applyLinuxSkillsListDedupePatch,
   applyLocalEnvironmentActionModalDraftPatch,


### PR DESCRIPTION
## Summary

- add an optional current-DMG webview patch for the sidebar scroll regression reported in #1048
- replace the scroll-linked `edge-fade` animation with a static top-and-bottom fade
- keep the patch idempotent and fail-soft when the current upstream CSS shape drifts
- add descriptor, current-bundle, idempotency, and drift coverage

Related to #1048.

## Status: prospective temporary workaround

This is intentionally presented as a prospective, somewhat hacky mitigation rather than a definitive upstream fix. It disables one visual animation globally wherever the upstream `.vertical-scroll-fade-mask` utility is used. The static mask remains, but its fade no longer tracks the exact scroll position.

The descriptor is optional and carries an issue-specific temporary marker so it can be removed cleanly if a future upstream or Electron release resolves the regression.

## Evidence and rationale

A same-machine comparison showed a clear regression between upstream 26.707 / Electron 42.1 and upstream 26.715 / Electron 42.3:

| Build | Mean frame | Median | p95 |
| --- | ---: | ---: | ---: |
| 26.707 | 8.0 ms | 4.2 ms | 29.1 ms |
| 26.715 | 23.7 ms | 17.5 ms | 59.8 ms |

On 26.715, disabling the scroll-linked animation in a live renderer reduced measured style recalculation time from 1.78s to 0.05s and overall task time from 2.76s to 1.05s during the same scrolling workload. This patch preserves a static fade while removing that scroll-linked custom-property animation.

This evidence localizes the expensive behavior to the new upstream/Electron combination, but does not establish whether the ultimate bug is in Chromium, Electron, or the upstream CSS/runtime interaction.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` — 377 passed
- `node --test scripts/patches/descriptor.test.js scripts/patches/runner.test.js` — 3 passed
- applied idempotently to the exact 26.715 `app-DdRwcpIN.css` bundle
- verified in the live 26.715 renderer that `animation-name` becomes `none`, `animation-timeline` becomes `auto`, and the existing 40px fade remains
- `git diff --check`

`bash tests/scripts_smoke.sh` passed the packaging and earlier launcher sections, then stopped at the launcher CLI-resolution fixture because it hard-codes `/usr/bin:/bin` while this NixOS host provides Bash at `/run/current-system/sw/bin/bash`. This failure is unrelated to the patch.

## Autonomy disclosure

The investigation, diagnosis, proposed mitigation, implementation, validation, commit, and pull-request text were produced autonomously by OpenAI Codex at the request of @colonelpanic8. The human request specified the desired outcome and disclosure, but did not author or direct the implementation details.
