### PR TITLE
Fix shared app-server socket DMG drift

### DIFF
--- a/linux-features/shared-app-server-socket/patch.js
+++ b/linux-features/shared-app-server-socket/patch.js
@@ -3,7 +3,11 @@
 const IDENT = "[A-Za-z_$][\\w$]*";
 
 function findTransportSymbols(source) {
-  const classMatch = source.match(new RegExp(`var (${IDENT})=class\\{kind=\\\`websocket\\\``));
+  const classMatch = source.match(
+    new RegExp(
+      `var (${IDENT})=class\\{options;kind=\\\`websocket\\\`;logger=${IDENT}\\.${IDENT}\\(\\\`AppServerTransportSshWebsocket\\\`\\)`,
+    ),
+  );
   const selectionLogIndex = source.indexOf("selected app-server transport");
   if (classMatch == null || selectionLogIndex < 0 || classMatch.index >= selectionLogIndex) return null;
 
@@ -65,7 +69,7 @@ function applySharedAppServerSocketPatch(source) {
   }
   const factorySource = source.slice(factoryStart, factoryEnd);
   const localFallbackPattern = new RegExp(
-    `(if\\(${symbols.namespace}\\.(${IDENT})\\(e\\.hostConfig\\)\\)return [^;]+;)(let (${IDENT})=(${IDENT})\\(e\\.hostConfig\\);return \\4\\?)`,
+    `(if\\(${symbols.namespace}\\.(${IDENT})\\(e\\.hostConfig\\)\\)return new (${IDENT})\\(\\{hostConfig:e\\.hostConfig,repoRoot:e\\.repoRoot,resourcesPath:e\\.resourcesPath,defaultOriginator:e\\.defaultOriginator\\}\\);)(?=let (${IDENT})=(${IDENT})\\(e\\.hostConfig\\);if\\(\\4\\)\\{)`,
   );
   const localFallbackMatch = factorySource.match(localFallbackPattern);
   if (localFallbackMatch == null) {
@@ -77,7 +81,8 @@ function applySharedAppServerSocketPatch(source) {
 
   const patchedFactory = factorySource.replace(
     localFallbackPattern,
-    `$1if(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET&&e.hostConfig.kind===\`local\`)return new CodexLinuxSharedAppServerSocketTransport(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET);$3`,
+    (match) =>
+      `${match}if(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET&&e.hostConfig.kind===\`local\`)return new CodexLinuxSharedAppServerSocketTransport(process.env.CODEX_LINUX_APP_SERVER_BRIDGE_SOCKET);`,
   );
   return source.slice(0, factoryStart) + classSource + patchedFactory + source.slice(factoryEnd);
 }

--- a/linux-features/shared-app-server-socket/test.js
+++ b/linux-features/shared-app-server-socket/test.js
@@ -175,13 +175,14 @@ async function closeServer(server) {
 
 function syntheticBundle() {
   return [
-    "var Ky=class{kind=`websocket`;proxyStreams=new Set;supportsReconnect(){return!0}",
+    "var Ky=class{options;kind=`websocket`;logger=r.i(`AppServerTransportSshWebsocket`);proxyStreams=new Set;supportsReconnect(){return!0}",
     "async connect(){let t={current:null},r=new n.zn(Fy,{perMessageDeflate:!1,createConnection:()=>",
     "(t.current=this.createSshProxyStream(),t.current)});return n.Ln(r,{onPongTimeout:()=>r.terminate()}),new n.Rn(r)}};",
     "function n6(e){let t=Jy(e.hostConfig);if(t)return Z.info(`selected app-server transport`),new Ky(t);",
     "if(e.transportKind===`remote-control`)return new Remote(e);",
-    "if(n.io(e.hostConfig))return new Wsl(e);",
-    "let r=r6(e.hostConfig);return r?new n.Fn({websocketUrl:r}):new n.Nn(e)}function afterFactory(){}",
+    "if(n.io(e.hostConfig))return new Wsl({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator});",
+    "let r=r6(e.hostConfig);if(r){e.desktopAuthAppServerClient;let t=p8(e.hostConfig,r);return new n.Fn({hostConfig:e.hostConfig,websocketUrl:r,getWebsocketProtocols:void 0,...t==null?{}:{socksProxyUrl:t}})}",
+    "return new n.Nn({hostConfig:e.hostConfig,repoRoot:e.repoRoot,resourcesPath:e.resourcesPath,defaultOriginator:e.defaultOriginator})}function afterFactory(){}",
   ].join("");
 }
 
@@ -241,6 +242,22 @@ test("patch leaves unsupported bundle shapes unchanged with a warning", () => {
     console.warn = originalWarn;
   }
   assert.match(warnings.join("\n"), /shared app-server socket/i);
+});
+
+test("patch rejects the previous SSH transport class shape", () => {
+  const source = syntheticBundle().replace(
+    "class{options;kind=`websocket`;logger=r.i(`AppServerTransportSshWebsocket`);",
+    "class{kind=`websocket`;",
+  );
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    assert.equal(applySharedAppServerSocketPatch(source), source);
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.match(warnings.join("\n"), /SSH WebSocket transport/);
 });
 
 test("descriptor is optional and targets the main bundle", () => {


### PR DESCRIPTION
## Summary

- update the shared app-server socket detector for the current upstream SSH WebSocket transport class
- match the current local transport factory's WebSocket fallback block
- keep the patch fail-soft, idempotent, and latest-DMG-only
- add regression coverage that rejects the previous bundle shape

## Root cause

The current DMG added fields before the SSH transport's `kind` marker and changed the local transport factory from a ternary fallback to an `if (websocketUrl)` block. The feature descriptor therefore skipped, and enabled-feature acceptance rejected the candidate.

## User impact

Native bootstrap and updater rebuilds can accept the current DMG when `shared-app-server-socket` is enabled. The feature's runtime behavior is unchanged.

## Validation

- `node --test linux-features/shared-app-server-socket/test.js` — 24 passed
- real current-DMG main bundle — first pass changed, second pass byte-identical, one transport injected
- `node --check` passed for the feature sources and patched current bundle
- current-DMG transactional rebuild — `accepted_with_warnings`; `shared-app-server-socket` applied once with no enabled-feature blockers

## Limitations

The rebuild retains unrelated optional core drift warnings already present for the current DMG.