### PR TITLE
Add Suggested Prompts to UI Tweaks

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -18,6 +18,7 @@ Enable it in the local, gitignored feature config:
 | Tweak | Patch module | What it does | Settings |
 | --- | --- | --- | --- |
 | `appearance.dockIcon` | `patches/dock-icon.js` | Exposes the upstream Appearance setting and search result for switching Linux windows, the system tray, and supported launchers between the official ChatGPT and Codex icons. | `tweaks.appearance.dockIcon.enabled` |
+| `home.suggestedPrompts` | `patches/suggested-prompts.js` | Exposes the upstream Suggested Prompts setting and enables generated project-aware cards on Home. | `tweaks.home.suggestedPrompts.enabled` |
 | `modelPicker.showModelsByDefault` | `patches/model-picker-model-list.js` | Opens the advanced picker by default and shows model choices inline instead of hiding them behind the compact Power slider and a nested Model submenu. | `tweaks.modelPicker.showModelsByDefault.enabled` |
 | `reasoning.keepEffortLabelsEnglish` | `patches/reasoning-effort-labels.js` | Keeps reasoning effort values in English in the Simplified Chinese UI while leaving the surrounding interface translated. | `tweaks.reasoning.keepEffortLabelsEnglish.enabled` |
 | `sidebar.projectName` | `patches/sidebar-project-name.js` | Styles project names in the left sidebar project list. It does not style `Projects` / `Chats` section headings and does not style chat rows. | `tweaks.sidebar.projectName.enabled`, `tweaks.sidebar.projectName.style` |
@@ -91,6 +92,43 @@ Config keys:
   a prelaunch hook also removes a marker-owned user-local launcher and its
   managed icon files. Unmanaged or symlinked desktop artifacts are preserved.
 
+### `home.suggestedPrompts`
+
+Exposes the upstream Suggested Prompts row in General Settings and enables the
+existing generated-suggestion path on Home. Suggestions are generated from the
+selected project and connected apps by the upstream implementation. Selecting a
+card fills the composer with its proposed next action.
+
+The patch continues to call the upstream rollout and account-eligibility
+functions for diagnostics, then honors the explicit Linux opt-in. It also keeps
+the upstream setting as the user's runtime on/off control after the feature is
+built into the app.
+
+This tweak is independently disabled by default:
+
+```json
+{
+  "enabled": ["ui-tweaks"],
+  "settings": {
+    "ui-tweaks": {
+      "tweaks": {
+        "home": {
+          "suggestedPrompts": {
+            "enabled": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Config keys:
+
+- `enabled`: `true` applies the four current-DMG Suggested Prompts descriptors.
+  `false` leaves the upstream Settings and Home behavior unchanged while other
+  UI tweaks remain independently configurable.
+
 ### `modelPicker.showModelsByDefault`
 
 Makes the detailed model list the default Codex composer picker view. The model
@@ -155,8 +193,9 @@ The patches are fail-soft. If upstream bundle markers drift, the feature writes
 a `WARN` message and leaves the asset unchanged. The patch report exposes that
 warning, and acceptance rejects a candidate when the enabled feature has drifted.
 Missing Dock icon resources also warn, remove only the Dock icon payload, and do
-not abort staging. Invalid style values warn and fall back to the default bold
-style.
+not abort staging. Suggested Prompts validates every current insertion point
+before changing an asset and leaves mixed or drifted input byte-identical.
+Invalid style values warn and fall back to the default bold style.
 
 ## Adding Tweaks
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -21,6 +21,11 @@
         "enabled": false
       }
     },
+    "home": {
+      "suggestedPrompts": {
+        "enabled": false
+      }
+    },
     "modelPicker": {
       "showModelsByDefault": {
         "enabled": true

--- a/linux-features/ui-tweaks/patch.js
+++ b/linux-features/ui-tweaks/patch.js
@@ -4,6 +4,7 @@ const sidebarProjectName = require("./patches/sidebar-project-name.js");
 const modelPickerModelList = require("./patches/model-picker-model-list.js");
 const reasoningEffortLabels = require("./patches/reasoning-effort-labels.js");
 const dockIcon = require("./patches/dock-icon.js");
+const suggestedPrompts = require("./patches/suggested-prompts.js");
 
 function patchesFrom(...modules) {
   return modules.flatMap((moduleExports) =>
@@ -17,5 +18,6 @@ module.exports = {
     modelPickerModelList,
     reasoningEffortLabels,
     dockIcon,
+    suggestedPrompts,
   ),
 };

--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -1,0 +1,243 @@
+"use strict";
+
+const APP_PAGE_ASSET_PATTERN =
+  /^app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-Ccxu2qV_\.js$/;
+const GENERAL_SETTINGS_ASSET_PATTERN = /^general-settings-Boi5S8Wz\.js$/;
+const HOME_CONTENT_ASSET_PATTERN = /^home-ambient-suggestions-content-DNeFqrrf\.js$/;
+const FEATURE_GATE_ID = "2425897452";
+const RUNTIME_MARKER = "codexLinuxUiTweaksSuggestedPromptsEnabled";
+const APP_PAGE_ELIGIBILITY_MARKER = "codexLinuxUiTweaksSuggestedPromptsAppPageEligible";
+const HOME_CONTENT_SOURCE_MARKER = "codexLinuxSuggestedPromptsGeneratedSource";
+const MAIN_ELIGIBILITY_MARKER = "codexLinuxUiTweaksSuggestedPromptsMainEnabled";
+const SETTINGS_ELIGIBILITY_MARKER = "codexLinuxUiTweaksSuggestedPromptsSettingsEligible";
+
+function suggestedPromptsConfig(context) {
+  const defaults = context?.feature?.manifest?.tweaks?.home?.suggestedPrompts;
+  const settings = context?.feature?.settings?.tweaks?.home?.suggestedPrompts;
+  return {
+    ...(defaults != null && typeof defaults === "object" && !Array.isArray(defaults) ? defaults : {}),
+    ...(settings != null && typeof settings === "object" && !Array.isArray(settings) ? settings : {}),
+  };
+}
+
+function suggestedPromptsEnabled(context) {
+  return suggestedPromptsConfig(context).enabled === true;
+}
+
+function gateAssignmentPattern() {
+  return /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`2425897452`\)/gu;
+}
+
+function appPageEligibilityPattern() {
+  return /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)&&([A-Za-z_$][\w$]*)(?=,[\s\S]{0,500}?generatedSuggestionsEnabled:\1)/gu;
+}
+
+function mainEligibilityPattern() {
+  return /return\{enabled:([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\.account\),staleTimeMs:\1\.([A-Za-z_$][\w$]*)\(\3\.account\)\}/gu;
+}
+
+function settingsEligibilityPattern() {
+  return /if\(!([A-Za-z_$][\w$]*)\(\{authMethod:([A-Za-z_$][\w$]*),email:([A-Za-z_$][\w$]*)\?\.email\?\?([A-Za-z_$][\w$]*),plan:\3\?\.plan\?\?([A-Za-z_$][\w$]*)\}\)\)return null;/gu;
+}
+
+function homeContentSourcePattern() {
+  return /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)===`curated`(?=,[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*\.email\),[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\(\{canUsePersonalizedSuggestions:[A-Za-z_$][\w$]*,generatedSuggestionsEnabled:[A-Za-z_$][\w$]*,hasGeneratedSuggestionsReadSettled:[A-Za-z_$][\w$]*,shouldUseCuratedNewChatPageSuggestions:\1\}\))/gu;
+}
+
+function matchCount(source, pattern) {
+  return [...source.matchAll(pattern)].length;
+}
+
+function warn(target) {
+  console.warn(`WARN: Could not find current Suggested Prompts ${target} contract - skipping ui-tweaks patch`);
+}
+
+function rolloutMarkerCount(source) {
+  return source.split(RUNTIME_MARKER).length - 1;
+}
+
+function replaceRolloutGates(source) {
+  return source.replace(
+    gateAssignmentPattern(),
+    (_match, targetName, gateName) =>
+      `${targetName}=(${gateName}(\`${FEATURE_GATE_ID}\`),function ${RUNTIME_MARKER}(){return!0}())`,
+  );
+}
+
+function applySuggestedPromptsAppPagePatch(source) {
+  try {
+    const rolloutMarkers = typeof source === "string" ? rolloutMarkerCount(source) : 0;
+    const eligibilityMarkers = typeof source === "string"
+      ? source.split(APP_PAGE_ELIGIBILITY_MARKER).length - 1
+      : 0;
+    const cleanRollouts = typeof source === "string" ? matchCount(source, gateAssignmentPattern()) : 0;
+    const cleanEligibility = typeof source === "string"
+      ? matchCount(source, appPageEligibilityPattern())
+      : 0;
+    if (rolloutMarkers === 2 && eligibilityMarkers === 1 && cleanRollouts === 0 && cleanEligibility === 0) {
+      return source;
+    }
+    if (rolloutMarkers !== 0 || eligibilityMarkers !== 0 || cleanRollouts !== 2 || cleanEligibility !== 1) {
+      warn("app page");
+      return source;
+    }
+
+    return replaceRolloutGates(source).replace(
+      appPageEligibilityPattern(),
+      (_match, enabledName, rolloutName, eligibilityName) =>
+        `${enabledName}=${rolloutName}&&(${eligibilityName}||function ${APP_PAGE_ELIGIBILITY_MARKER}(){return!0}())`,
+    );
+  } catch (error) {
+    console.warn(
+      `WARN: Unexpected Suggested Prompts app page patch error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return source;
+  }
+}
+
+function applySuggestedPromptsMainPatch(source) {
+  try {
+    const markerMatches = typeof source === "string"
+      ? source.split(MAIN_ELIGIBILITY_MARKER).length - 1
+      : 0;
+    const cleanMatches = typeof source === "string" ? matchCount(source, mainEligibilityPattern()) : 0;
+    if (markerMatches === 1 && cleanMatches === 0) {
+      return source;
+    }
+    if (markerMatches !== 0 || cleanMatches !== 1) {
+      warn("main process");
+      return source;
+    }
+
+    return source.replace(
+      mainEligibilityPattern(),
+      (_match, namespace, enabledMethod, accountName, staleMethod) =>
+        `return{enabled:(${namespace}.${enabledMethod}(${accountName}.account),function ${MAIN_ELIGIBILITY_MARKER}(){return!0}()),staleTimeMs:${namespace}.${staleMethod}(${accountName}.account)}`,
+    );
+  } catch (error) {
+    console.warn(
+      `WARN: Unexpected Suggested Prompts main process patch error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return source;
+  }
+}
+
+function applySuggestedPromptsHomeContentPatch(source) {
+  try {
+    const markerMatches = typeof source === "string"
+      ? source.split(HOME_CONTENT_SOURCE_MARKER).length - 1
+      : 0;
+    const cleanMatches = typeof source === "string" ? matchCount(source, homeContentSourcePattern()) : 0;
+    if (markerMatches === 1 && cleanMatches === 0) {
+      return source;
+    }
+    if (markerMatches !== 0 || cleanMatches !== 1) {
+      warn("Home generated-source");
+      return source;
+    }
+
+    return source.replace(
+      homeContentSourcePattern(),
+      (_match, sourceFlag, debugOverride) =>
+        `${sourceFlag}=(${debugOverride}===\`curated\`,function ${HOME_CONTENT_SOURCE_MARKER}(){return!1}())`,
+    );
+  } catch (error) {
+    console.warn(
+      `WARN: Unexpected Suggested Prompts Home content patch error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return source;
+  }
+}
+
+function applySuggestedPromptsSettingsPatch(source) {
+  try {
+    const rolloutMarkers = typeof source === "string" ? rolloutMarkerCount(source) : 0;
+    const eligibilityMarkers = typeof source === "string"
+      ? source.split(SETTINGS_ELIGIBILITY_MARKER).length - 1
+      : 0;
+    const cleanRollouts = typeof source === "string" ? matchCount(source, gateAssignmentPattern()) : 0;
+    const cleanEligibility = typeof source === "string"
+      ? matchCount(source, settingsEligibilityPattern())
+      : 0;
+    if (rolloutMarkers === 1 && eligibilityMarkers === 1 && cleanRollouts === 0 && cleanEligibility === 0) {
+      return source;
+    }
+    if (rolloutMarkers !== 0 || eligibilityMarkers !== 0 || cleanRollouts !== 1 || cleanEligibility !== 1) {
+      warn("settings");
+      return source;
+    }
+
+    return replaceRolloutGates(source).replace(
+      settingsEligibilityPattern(),
+      (_match, eligibilityName, authMethod, accountInfo, email, plan) =>
+        `if(!(${eligibilityName}({authMethod:${authMethod},email:${accountInfo}?.email??${email},plan:${accountInfo}?.plan??${plan}})||function ${SETTINGS_ELIGIBILITY_MARKER}(){return!0}()))return null;`,
+    );
+  } catch (error) {
+    console.warn(
+      `WARN: Unexpected Suggested Prompts settings patch error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return source;
+  }
+}
+
+const descriptors = [
+  {
+    id: "home-suggested-prompts-main-process",
+    phase: "main-bundle",
+    order: 20_970,
+    ciPolicy: "optional",
+    enabled: suggestedPromptsEnabled,
+    apply: applySuggestedPromptsMainPatch,
+  },
+  {
+    id: "home-suggested-prompts-app-page",
+    phase: "webview-asset",
+    order: 20_980,
+    ciPolicy: "optional",
+    enabled: suggestedPromptsEnabled,
+    pattern: APP_PAGE_ASSET_PATTERN,
+    missingDescription: "current Suggested Prompts app page bundle",
+    skipDescription: "ui-tweaks Suggested Prompts app page patch",
+    apply: applySuggestedPromptsAppPagePatch,
+  },
+  {
+    id: "home-suggested-prompts-settings-row",
+    phase: "webview-asset",
+    order: 20_990,
+    ciPolicy: "optional",
+    enabled: suggestedPromptsEnabled,
+    pattern: GENERAL_SETTINGS_ASSET_PATTERN,
+    missingDescription: "current Suggested Prompts General settings bundle",
+    skipDescription: "ui-tweaks Suggested Prompts settings row patch",
+    apply: applySuggestedPromptsSettingsPatch,
+  },
+  {
+    id: "home-suggested-prompts-content",
+    phase: "webview-asset",
+    order: 21_000,
+    ciPolicy: "optional",
+    enabled: suggestedPromptsEnabled,
+    pattern: HOME_CONTENT_ASSET_PATTERN,
+    missingDescription: "current Suggested Prompts Home content bundle",
+    skipDescription: "ui-tweaks Suggested Prompts generated-source patch",
+    apply: applySuggestedPromptsHomeContentPatch,
+  },
+];
+
+module.exports = {
+  APP_PAGE_ASSET_PATTERN,
+  APP_PAGE_ELIGIBILITY_MARKER,
+  GENERAL_SETTINGS_ASSET_PATTERN,
+  HOME_CONTENT_ASSET_PATTERN,
+  HOME_CONTENT_SOURCE_MARKER,
+  MAIN_ELIGIBILITY_MARKER,
+  RUNTIME_MARKER,
+  SETTINGS_ELIGIBILITY_MARKER,
+  applySuggestedPromptsAppPagePatch,
+  applySuggestedPromptsHomeContentPatch,
+  applySuggestedPromptsMainPatch,
+  applySuggestedPromptsSettingsPatch,
+  descriptors,
+  suggestedPromptsConfig,
+  suggestedPromptsEnabled,
+};

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  APP_PAGE_ASSET_PATTERN,
+  APP_PAGE_ELIGIBILITY_MARKER,
+  GENERAL_SETTINGS_ASSET_PATTERN,
+  HOME_CONTENT_ASSET_PATTERN,
+  HOME_CONTENT_SOURCE_MARKER,
+  MAIN_ELIGIBILITY_MARKER,
+  RUNTIME_MARKER,
+  SETTINGS_ELIGIBILITY_MARKER,
+  applySuggestedPromptsAppPagePatch,
+  applySuggestedPromptsHomeContentPatch,
+  applySuggestedPromptsMainPatch,
+  applySuggestedPromptsSettingsPatch,
+  descriptors,
+  suggestedPromptsEnabled,
+} = require("./patches/suggested-prompts.js");
+
+function captureWarnings(callback) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.map(String).join(" "));
+  try {
+    return { value: callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function settingsFixture() {
+  return [
+    "function ki(){let e=(0,Q.c)(31),t=xe(`1372061905`),n=xe(`2425897452`),r=xe(ft),i;",
+    "return n?(0,$.jsx)(H,{electron:!0,children:(0,$.jsx)(ci,{})}):null}",
+    "function ci(){let e=(0,li.c)(12),t=n(m),r=R(),{authMethod:i,email:a,planAtLogin:o}=We(),",
+    "s=i===`chatgpt`,l,{data:d}=N(`account-info`,{queryConfig:{enabled:s}}),f=u(b.enabled);",
+    "if(!M({authMethod:i,email:d?.email??a,plan:d?.plan??o}))return null;return row()}",
+  ].join("");
+}
+
+function appPageFixture() {
+  return [
+    "function home(){let we=es(`2425897452`),Te=es(`1857002365`),",
+    "ke=ln({authMethod:_,email:j?.email??v,plan:be}),Ae=we&&ke,je=N?null:B;",
+    "return jsx(bF,{generatedSuggestionsEnabled:Ae,projectRoot:je})}",
+    "function sync(){let n=es(`2425897452`),r=es(`1304276663`);",
+    "dispatchMessage(`electron-desktop-features-changed`,{ambientSuggestions:n,appshotsEnabled:r})}",
+  ].join("");
+}
+
+function mainFixture() {
+  return [
+    "function nt(e){return Xe().ambientSuggestions&&e.getEffective(n.oa.enabled.key)===!0}",
+    "async function rt({appServerConnection:e,settingsStore:t}){",
+    "if(!nt(t))return{enabled:!1,staleTimeMs:n.ml(null)};let r=await e.getAccount();",
+    "return{enabled:n.pl(r.account),staleTimeMs:n.ml(r.account)}}",
+  ].join("");
+}
+
+function homeContentFixture() {
+  return [
+    "function ua({generatedSuggestionsEnabled:i,projectRoot:l}){",
+    "let Ee=d(b.enabled)===!0,De=a(jn),Oe=a(fn),Me=i&&l!=null,",
+    "Ne=De==null&&Me&&Ee,{data:Pe,isLoading:Fe}=rr({enabled:Ne}),",
+    "ze=Ne&&(Fe||Le&&P)?null:ir({debugOverride:De,experimentEligible:Le,personalized:Re}),",
+    "z=ze===`curated`,Be=ln(ye.email),Ve=ar({canUsePersonalizedSuggestions:Ee,",
+    "generatedSuggestionsEnabled:Me,hasGeneratedSuggestionsReadSettled:x,",
+    "shouldUseCuratedNewChatPageSuggestions:z});return Ve}",
+  ].join("");
+}
+
+function featureContext({ defaultEnabled = false, override } = {}) {
+  return {
+    feature: {
+      manifest: {
+        tweaks: { home: { suggestedPrompts: { enabled: defaultEnabled } } },
+      },
+      settings: override == null
+        ? {}
+        : { tweaks: { home: { suggestedPrompts: { enabled: override } } } },
+    },
+  };
+}
+
+test("Suggested Prompts stays disabled unless its nested UI tweak is enabled", () => {
+  assert.equal(suggestedPromptsEnabled(featureContext()), false);
+  assert.equal(suggestedPromptsEnabled(featureContext({ override: true })), true);
+  assert.equal(suggestedPromptsEnabled(featureContext({ defaultEnabled: true, override: false })), false);
+  assert.equal(descriptors.every((descriptor) => descriptor.enabled(featureContext()) === false), true);
+  assert.equal(
+    descriptors.every((descriptor) => descriptor.enabled(featureContext({ override: true })) === true),
+    true,
+  );
+});
+
+test("settings patch exposes the upstream row while preserving eligibility diagnostics", () => {
+  const source = settingsFixture();
+  const patched = applySuggestedPromptsSettingsPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(new RegExp(RUNTIME_MARKER, "g")) || []).length, 1);
+  assert.equal((patched.match(new RegExp(SETTINGS_ELIGIBILITY_MARKER, "g")) || []).length, 1);
+  assert.match(patched, /xe\(`2425897452`\)/);
+  assert.match(
+    patched,
+    /if\(!\(M\(\{authMethod:i,email:d\?\.email\?\?a,plan:d\?\.plan\?\?o\}\)\|\|function codexLinuxUiTweaksSuggestedPromptsSettingsEligible\(\)\{return!0\}\(\)\)\)return null/,
+  );
+  assert.equal(applySuggestedPromptsSettingsPatch(patched), patched);
+});
+
+test("app page patch enables Home generation and desktop availability gates atomically", () => {
+  const source = appPageFixture();
+  const patched = applySuggestedPromptsAppPagePatch(source);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(new RegExp(RUNTIME_MARKER, "g")) || []).length, 2);
+  assert.equal((patched.match(new RegExp(APP_PAGE_ELIGIBILITY_MARKER, "g")) || []).length, 1);
+  assert.equal((patched.match(/es\(`2425897452`\)/g) || []).length, 2);
+  assert.match(
+    patched,
+    /Ae=we&&\(ke\|\|function codexLinuxUiTweaksSuggestedPromptsAppPageEligible\(\)\{return!0\}\(\)\)/,
+  );
+  assert.match(patched, /ambientSuggestions:n/);
+  assert.equal(applySuggestedPromptsAppPagePatch(patched), patched);
+});
+
+test("main patch enables refresh while preserving the upstream account call", () => {
+  const source = mainFixture();
+  const patched = applySuggestedPromptsMainPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(new RegExp(MAIN_ELIGIBILITY_MARKER, "g")) || []).length, 1);
+  assert.match(patched, /n\.pl\(r\.account\)/);
+  assert.match(patched, /staleTimeMs:n\.ml\(r\.account\)/);
+  assert.equal(applySuggestedPromptsMainPatch(patched), patched);
+});
+
+test("Home content renders generated suggestions instead of selecting curated cards", () => {
+  const source = homeContentFixture();
+  const patched = applySuggestedPromptsHomeContentPatch(source);
+
+  assert.notEqual(patched, source);
+  assert.equal((patched.match(new RegExp(HOME_CONTENT_SOURCE_MARKER, "g")) || []).length, 1);
+  assert.match(patched, /ze===`curated`/);
+  assert.match(patched, /function codexLinuxSuggestedPromptsGeneratedSource\(\)\{return!1\}/);
+  assert.equal(applySuggestedPromptsHomeContentPatch(patched), patched);
+});
+
+test("multi-point patches reject mixed and drifted contracts byte-identically", () => {
+  const cleanAppPage = appPageFixture();
+  const patchedAppPage = applySuggestedPromptsAppPagePatch(cleanAppPage);
+  const firstMarker = patchedAppPage.indexOf(RUNTIME_MARKER);
+  const mixedAppPage = `${patchedAppPage.slice(0, firstMarker)}missingMarker${patchedAppPage.slice(firstMarker + RUNTIME_MARKER.length)}`;
+  const mixedResult = captureWarnings(() => applySuggestedPromptsAppPagePatch(mixedAppPage));
+  assert.equal(mixedResult.value, mixedAppPage);
+  assert.match(mixedResult.warnings.join("\n"), /current Suggested Prompts app page contract/);
+
+  const driftedSettings = settingsFixture().replace(
+    "n=xe(`2425897452`)",
+    "n=xe(`replacement-rollout`)",
+  );
+  const settingsResult = captureWarnings(() => applySuggestedPromptsSettingsPatch(driftedSettings));
+  assert.equal(settingsResult.value, driftedSettings);
+  assert.match(settingsResult.warnings.join("\n"), /current Suggested Prompts settings contract/);
+
+  const driftedHome = homeContentFixture().replace(
+    "z=ze===`curated`",
+    "z=selectSuggestionSource(ze)",
+  );
+  const homeResult = captureWarnings(() => applySuggestedPromptsHomeContentPatch(driftedHome));
+  assert.equal(homeResult.value, driftedHome);
+  assert.match(homeResult.warnings.join("\n"), /current Suggested Prompts Home generated-source contract/);
+});
+
+test("unrecognized contracts warn instead of reporting false already-applied", () => {
+  const cases = [
+    [applySuggestedPromptsMainPatch, "main process"],
+    [applySuggestedPromptsAppPagePatch, "app page"],
+    [applySuggestedPromptsSettingsPatch, "settings"],
+    [applySuggestedPromptsHomeContentPatch, "Home generated-source"],
+  ];
+
+  for (const [apply, target] of cases) {
+    const source = `function drifted${target.replaceAll(/[^A-Za-z]/g, "")}(){return null}`;
+    const result = captureWarnings(() => apply(source));
+    assert.equal(result.value, source);
+    assert.match(result.warnings.join("\n"), new RegExp(`current Suggested Prompts ${target} contract`));
+  }
+});
+
+test("Suggested Prompts descriptors target only current-DMG active assets", () => {
+  assert.match("general-settings-Boi5S8Wz.js", GENERAL_SETTINGS_ASSET_PATTERN);
+  assert.doesNotMatch("general-settings-B8bUS3xL.js", GENERAL_SETTINGS_ASSET_PATTERN);
+  assert.doesNotMatch("general-settings-DMO9G9gL.js", GENERAL_SETTINGS_ASSET_PATTERN);
+
+  assert.match(
+    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-Ccxu2qV_.js",
+    APP_PAGE_ASSET_PATTERN,
+  );
+  assert.doesNotMatch(
+    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-3B_QTMVW.js",
+    APP_PAGE_ASSET_PATTERN,
+  );
+  assert.doesNotMatch("app-initial~app-main~page-CtzZUdyW.js", APP_PAGE_ASSET_PATTERN);
+
+  assert.match("home-ambient-suggestions-content-DNeFqrrf.js", HOME_CONTENT_ASSET_PATTERN);
+  assert.doesNotMatch("home-ambient-suggestions-content-BnjCpFM8.js", HOME_CONTENT_ASSET_PATTERN);
+  assert.doesNotMatch("home-ambient-suggestions-content-BIOXM98x.js", HOME_CONTENT_ASSET_PATTERN);
+});

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -8,6 +8,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 require("./dock-icon.test.js");
+require("./suggested-prompts.test.js");
 
 const {
   discoverLinuxFeatureManifests,
@@ -178,6 +179,10 @@ test("ui-tweaks is discoverable and disabled until listed in features.json", () 
         ["feature:ui-tweaks:appearance-dock-icon-main-process", "main-bundle", "optional"],
         ["feature:ui-tweaks:appearance-dock-icon-settings-row", "webview-asset", "optional"],
         ["feature:ui-tweaks:appearance-dock-icon-settings-search", "webview-asset", "optional"],
+        ["feature:ui-tweaks:home-suggested-prompts-main-process", "main-bundle", "optional"],
+        ["feature:ui-tweaks:home-suggested-prompts-app-page", "webview-asset", "optional"],
+        ["feature:ui-tweaks:home-suggested-prompts-settings-row", "webview-asset", "optional"],
+        ["feature:ui-tweaks:home-suggested-prompts-content", "webview-asset", "optional"],
       ],
     );
   } finally {


### PR DESCRIPTION
## Summary

- add a default-off `ui-tweaks.home.suggestedPrompts` option
- expose the upstream Suggested Prompts row in General Settings
- enable the existing generated, project-aware suggestion path on Home while preserving upstream rollout and account checks for diagnostics
- keep the upstream Settings toggle as the runtime on/off control

The maintainer [approved the one-tweak-at-a-time direction](https://github.com/ilysenko/codex-desktop-linux/issues/1038#issuecomment-5010933211). Dock icon selection landed separately in #1078; this PR implements the remaining Suggested Prompts tweak.

Closes #1038

## Current DMG contract

Validated against:

- repository base: `3bc05c523ff4ae8a653b3864e3810ff68ecd305e`
- ChatGPT Desktop: `26.715.31925`
- Electron: `42.3.0`
- DMG SHA-256: `c602b7909606a88dcce596d91a54428dc3b5305a3f11ef8c3060d9fedc3a1396`
- DMG ETag: `0x8DEE48DA130A277`
- DMG size: `618650132` bytes

The tweak uses four current-DMG-only descriptors:

- main-process refresh eligibility in `main-DvTOqeoA.js`
- Home and desktop availability gates in the current app page chunk
- the General Settings row in `general-settings-Boi5S8Wz.js`
- generated suggestion selection in `home-ambient-suggestions-content-DNeFqrrf.js`

Each asset validates all of its insertion points before writing. Complete markers prove `already-applied`; missing, mixed, or drifted contracts warn and leave the asset byte-identical. No older chunk hashes or compatibility fallbacks are retained.

## Configuration

```json
{
  "enabled": ["ui-tweaks"],
  "settings": {
    "ui-tweaks": {
      "tweaks": {
        "home": {
          "suggestedPrompts": {
            "enabled": true
          }
        }
      }
    }
  }
}
```

## Runtime validation

Built and launched as an isolated side-by-side identity on KDE Plasma Wayland:

- General Settings rendered the native Suggested Prompts row and enabled switch
- Home rendered a generated project-aware suggestion card
- selecting the card populated the composer with the generated prompt
- the setting remained enabled after restart and suggestions returned
- no error boundary or feature-related launcher error appeared
- a full second patch pass was byte-stable; all four descriptors reported `already-applied`

## Validation

- `node --test linux-features/ui-tweaks/test.js` (53 passed)
- `node --test linux-features/*/test.js` (757 passed, 1 opt-in integration test skipped)
- `node --test scripts/patch-linux-window-ui.test.js` (381 passed)
- `bash tests/scripts_smoke.sh`
- `node scripts/ci/validate-patch-report.js ...` with all four descriptors required as applied
- `node --check` on all four generated current-DMG assets
- isolated current-DMG build and Debian package build
- packaged update-builder preserved the complete nested feature configuration and Suggested Prompts source
- `git diff --check`

The build report contained eight pre-existing optional core drift warnings unrelated to this feature; every Suggested Prompts descriptor applied without warnings.
