### PR TITLE
Fix V2 pet cursor feedback for Linux Computer Use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- V2 pets now look toward the live pointer position after successful Linux
+  Computer Use click, scroll, and drag actions, then return to their normal
+  animation. The bridge is isolated per app instance and fails softly when its
+  private runtime socket is unavailable.
 - The updater daemon now detects that a package upgrade replaced its binary
   on disk and exits with a nonzero status so systemd's `Restart=on-failure`
   relaunches it on the new binary. Previously a running daemon survived every

--- a/computer-use-linux/src/server.rs
+++ b/computer-use-linux/src/server.rs
@@ -31,16 +31,21 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    env,
+    env, fs,
     future::Future,
-    os::unix::net::{UnixDatagram, UnixStream},
-    path::PathBuf,
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{FileTypeExt, MetadataExt},
+        net::{UnixDatagram, UnixStream},
+    },
+    path::{Path, PathBuf},
     process::{Command, Output, Stdio},
     sync::{Arc, Mutex},
     time::Duration,
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    net::UnixStream as TokioUnixStream,
     process::{Child as TokioChild, Command as TokioCommand},
     time::{sleep, timeout},
 };
@@ -52,6 +57,9 @@ const KDE_CLIPBOARD_DBUS_TIMEOUT: Duration = Duration::from_secs(3);
 const KDE_KLIPPER_SERVICE: &str = "org.kde.klipper";
 const KDE_KLIPPER_PATH: &str = "/klipper";
 const KDE_KLIPPER_INTERFACE: &str = "org.kde.klipper.klipper";
+const AVATAR_CURSOR_SOCKET_NAME: &str = "computer-use-cursor.sock";
+const AVATAR_CURSOR_SOCKET_MAX_BYTES: usize = 100;
+const AVATAR_CURSOR_NOTIFY_TIMEOUT: Duration = Duration::from_millis(100);
 
 #[derive(Clone, Default)]
 pub struct ComputerUseLinux {
@@ -650,13 +658,13 @@ impl ComputerUseLinux {
             == Some(true)
         {
             return Json(with_notes(
-                ActionOutput {
+                pointer_action_result(ActionOutput {
                     ok: true,
                     implemented: true,
                     action: "click".to_string(),
                     message: "Action sent through the uinput absolute pointer.".to_string(),
                     received,
-                },
+                }),
                 off_screen_note.clone(),
             ));
         }
@@ -672,13 +680,13 @@ impl ComputerUseLinux {
             {
                 Ok(()) => {
                     return Json(with_notes(
-                        ActionOutput {
+                        pointer_action_result(ActionOutput {
                             ok: true,
                             implemented: true,
                             action: "click".to_string(),
                             message: "Action sent through the remote desktop portal.".to_string(),
                             received,
-                        },
+                        }),
                         off_screen_note.clone(),
                     ));
                 }
@@ -697,14 +705,14 @@ impl ComputerUseLinux {
                 {
                     Ok(()) => {
                         return Json(with_notes(
-                            ActionOutput {
+                            pointer_action_result(ActionOutput {
                                 ok: true,
                                 implemented: true,
                                 action: "click".to_string(),
                                 message: "Action sent through the remote desktop portal."
                                     .to_string(),
                                 received,
-                            },
+                            }),
                             off_screen_note.clone(),
                         ));
                     }
@@ -725,7 +733,7 @@ impl ComputerUseLinux {
         ])
         .await;
         Json(with_notes(
-            action_result("click", result, received),
+            pointer_action_result(action_result("click", result, received)),
             off_screen_note,
         ))
     }
@@ -931,13 +939,13 @@ impl ComputerUseLinux {
             match portal_scroll(&session, target_point, direction, units).await {
                 Ok(()) => {
                     return Json(with_notes(
-                        ActionOutput {
+                        pointer_action_result(ActionOutput {
                             ok: true,
                             implemented: true,
                             action: "scroll".to_string(),
                             message: "Action sent through the remote desktop portal.".to_string(),
                             received,
-                        },
+                        }),
                         off_screen_note.clone(),
                     ));
                 }
@@ -949,14 +957,14 @@ impl ComputerUseLinux {
                     match portal_scroll(&session, target_point, direction, units).await {
                         Ok(()) => {
                             return Json(with_notes(
-                                ActionOutput {
+                                pointer_action_result(ActionOutput {
                                     ok: true,
                                     implemented: true,
                                     action: "scroll".to_string(),
                                     message: "Action sent through the remote desktop portal."
                                         .to_string(),
                                     received,
-                                },
+                                }),
                                 off_screen_note.clone(),
                             ));
                         }
@@ -990,7 +998,7 @@ impl ComputerUseLinux {
         sequence.push(wheel_mousemove_args(dx, dy));
         let result = run_ydotool_sequence(&sequence).await;
         Json(with_notes(
-            action_result("scroll", result, received),
+            pointer_action_result(action_result("scroll", result, received)),
             off_screen_note,
         ))
     }
@@ -1028,13 +1036,13 @@ impl ComputerUseLinux {
             .ok()
             .flatten();
             if dragged == Some(true) {
-                return Json(ActionOutput {
+                return Json(pointer_action_result(ActionOutput {
                     ok: true,
                     implemented: true,
                     action: "drag".to_string(),
                     message: "Action sent through the uinput absolute pointer.".to_string(),
                     received,
-                });
+                }));
             }
         }
         if let Some(session) = self.cached_portal_pointer_session() {
@@ -1048,13 +1056,13 @@ impl ComputerUseLinux {
             .await
             {
                 Ok(()) => {
-                    return Json(ActionOutput {
+                    return Json(pointer_action_result(ActionOutput {
                         ok: true,
                         implemented: true,
                         action: "drag".to_string(),
                         message: "Action sent through the remote desktop portal.".to_string(),
                         received,
-                    });
+                    }));
                 }
                 Err(_) => self.clear_portal_pointer_session(),
             }
@@ -1070,13 +1078,13 @@ impl ComputerUseLinux {
                 .await
                 {
                     Ok(()) => {
-                        return Json(ActionOutput {
+                        return Json(pointer_action_result(ActionOutput {
                             ok: true,
                             implemented: true,
                             action: "drag".to_string(),
                             message: "Action sent through the remote desktop portal.".to_string(),
                             received,
-                        });
+                        }));
                     }
                     Err(_) => self.clear_portal_pointer_session(),
                 },
@@ -1091,7 +1099,9 @@ impl ComputerUseLinux {
             vec!["click".to_string(), "0x80".to_string()],
         ])
         .await;
-        Json(action_result("drag", result, received))
+        Json(pointer_action_result(action_result(
+            "drag", result, received,
+        )))
     }
 
     #[tool(
@@ -3138,6 +3148,166 @@ fn action_result(
     }
 }
 
+fn valid_runtime_component(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn avatar_cursor_identity_from_cmdline(cmdline: &[u8]) -> (Option<String>, Option<String>) {
+    let executable = cmdline.split(|byte| *byte == 0).next().unwrap_or_default();
+    if Path::new(std::ffi::OsStr::from_bytes(executable)).file_name()
+        != Some(std::ffi::OsStr::new("electron"))
+    {
+        return (None, None);
+    }
+    let mut app_id = None;
+    let mut instance_id = None;
+    for argument in cmdline.split(|byte| *byte == 0) {
+        let Ok(argument) = std::str::from_utf8(argument) else {
+            continue;
+        };
+        if let Some(value) = argument.strip_prefix("--app-id=") {
+            if valid_runtime_component(value) {
+                app_id = Some(value.to_string());
+            }
+        }
+        let Some(value) = argument.strip_prefix("--user-data-dir=") else {
+            continue;
+        };
+        let components = Path::new(value)
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .collect::<Vec<_>>();
+        for window in components.windows(3) {
+            if window[0] == "instances"
+                && valid_runtime_component(window[1])
+                && window[2] == "electron-user-data"
+            {
+                instance_id = Some(window[1].to_string());
+            }
+        }
+    }
+    (app_id, instance_id)
+}
+
+fn proc_parent_pid(pid: &str) -> Option<u32> {
+    let status = fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("PPid:")?.trim().parse::<u32>().ok())
+}
+
+fn avatar_cursor_parent_identity() -> (Option<String>, Option<String>) {
+    let mut pid = proc_parent_pid("self");
+    for _ in 0..8 {
+        let Some(current_pid) = pid.filter(|pid| *pid > 1) else {
+            break;
+        };
+        if let Ok(cmdline) = fs::read(format!("/proc/{current_pid}/cmdline")) {
+            let identity = avatar_cursor_identity_from_cmdline(&cmdline);
+            if identity.0.is_some() {
+                return identity;
+            }
+        }
+        pid = proc_parent_pid(&current_pid.to_string());
+    }
+    (None, None)
+}
+
+fn avatar_cursor_socket_path_from(
+    runtime_dir: Option<&str>,
+    app_id: Option<&str>,
+    legacy_app_id: Option<&str>,
+    instance_id: Option<&str>,
+) -> Option<PathBuf> {
+    let runtime_dir = runtime_dir?.trim();
+    let runtime_dir = Path::new(runtime_dir);
+    if !runtime_dir.is_absolute() {
+        return None;
+    }
+
+    let app_id = app_id
+        .or(legacy_app_id)
+        .map(str::trim)
+        .filter(|value| valid_runtime_component(value))
+        .unwrap_or("codex-desktop");
+    let instance_id = instance_id.map(str::trim).filter(|value| !value.is_empty());
+    if instance_id.is_some_and(|value| !valid_runtime_component(value)) {
+        return None;
+    }
+
+    let mut path = runtime_dir.join(app_id);
+    if let Some(instance_id) = instance_id {
+        path.push("instances");
+        path.push(instance_id);
+    }
+    path.push(AVATAR_CURSOR_SOCKET_NAME);
+    (path.as_os_str().as_bytes().len() <= AVATAR_CURSOR_SOCKET_MAX_BYTES).then_some(path)
+}
+
+fn avatar_cursor_socket_path() -> Option<PathBuf> {
+    let runtime_dir = env::var("XDG_RUNTIME_DIR").ok();
+    let app_id = env::var("CODEX_LINUX_APP_ID").ok();
+    let legacy_app_id = env::var("CODEX_APP_ID").ok();
+    let instance_id = env::var("CODEX_LINUX_INSTANCE_ID").ok();
+    let parent_identity = (app_id.is_none() && legacy_app_id.is_none() || instance_id.is_none())
+        .then(avatar_cursor_parent_identity)
+        .unwrap_or_default();
+    avatar_cursor_socket_path_from(
+        runtime_dir.as_deref(),
+        app_id.as_deref().or(parent_identity.0.as_deref()),
+        legacy_app_id.as_deref(),
+        instance_id.as_deref().or(parent_identity.1.as_deref()),
+    )
+}
+
+async fn send_avatar_cursor_signal(path: &Path) -> bool {
+    let Ok(socket_metadata) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    let Some(current_uid) = fs::metadata("/proc/self")
+        .ok()
+        .map(|metadata| metadata.uid())
+    else {
+        return false;
+    };
+    if !socket_metadata.file_type().is_socket()
+        || socket_metadata.uid() != current_uid
+        || socket_metadata.mode() & 0o077 != 0
+    {
+        return false;
+    }
+    let Ok(Ok(mut stream)) =
+        timeout(AVATAR_CURSOR_NOTIFY_TIMEOUT, TokioUnixStream::connect(path)).await
+    else {
+        return false;
+    };
+    matches!(
+        timeout(AVATAR_CURSOR_NOTIFY_TIMEOUT, stream.write_all(b"pointer\n"),).await,
+        Ok(Ok(()))
+    )
+}
+
+fn notify_avatar_cursor() {
+    let Some(path) = avatar_cursor_socket_path() else {
+        return;
+    };
+    tokio::spawn(async move {
+        let _ = send_avatar_cursor_signal(&path).await;
+    });
+}
+
+fn pointer_action_result(output: ActionOutput) -> ActionOutput {
+    if output.ok {
+        notify_avatar_cursor();
+    }
+    output
+}
+
 fn action_result_with_focus(
     action: &str,
     result: std::result::Result<Vec<Output>, String>,
@@ -3836,6 +4006,101 @@ mod tests {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+
+    #[test]
+    fn avatar_cursor_socket_path_is_instance_scoped_and_bounded() {
+        assert_eq!(
+            avatar_cursor_socket_path_from(
+                Some("/run/user/1000"),
+                Some("codex-desktop"),
+                None,
+                Some("secondary"),
+            ),
+            Some(PathBuf::from(
+                "/run/user/1000/codex-desktop/instances/secondary/computer-use-cursor.sock",
+            )),
+        );
+        assert_eq!(
+            avatar_cursor_socket_path_from(Some("relative"), Some("codex-desktop"), None, None,),
+            None,
+        );
+        assert_eq!(
+            avatar_cursor_socket_path_from(
+                Some("/run/user/1000"),
+                Some("codex-desktop"),
+                None,
+                Some("../escape"),
+            ),
+            None,
+        );
+        assert_eq!(
+            avatar_cursor_socket_path_from(
+                Some(&format!("/run/user/1000/{}", "x".repeat(100))),
+                Some("codex-desktop"),
+                None,
+                None,
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn avatar_cursor_identity_uses_electron_app_and_instance_arguments() {
+        assert_eq!(
+            avatar_cursor_identity_from_cmdline(
+                b"/opt/codex/electron\0--app-id=codex-cua-lab\0--user-data-dir=/home/user/.local/state/codex-cua-lab/instances/port-5176/electron-user-data\0",
+            ),
+            (
+                Some("codex-cua-lab".to_string()),
+                Some("port-5176".to_string()),
+            ),
+        );
+        assert_eq!(
+            avatar_cursor_identity_from_cmdline(
+                b"/opt/codex/electron\0--app-id=../escape\0--user-data-dir=/tmp/instances/../electron-user-data\0",
+            ),
+            (None, None),
+        );
+        assert_eq!(
+            avatar_cursor_identity_from_cmdline(b"/bin/bash\0--app-id=codex-desktop\0"),
+            (None, None),
+        );
+        assert_eq!(
+            avatar_cursor_identity_from_cmdline(
+                b"/opt/codex/electron\0--app-id=codex-desktop\0--user-data-dir=/home/instances/alice/.local/state/codex-desktop/electron-user-data\0",
+            ),
+            (Some("codex-desktop".to_string()), None),
+        );
+    }
+
+    #[tokio::test]
+    async fn avatar_cursor_signal_uses_the_private_unix_stream_protocol() {
+        let root = std::env::temp_dir().join(format!(
+            "computer-use-avatar-cursor-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let socket = root.join("cursor.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        std::fs::set_permissions(&socket, std::os::unix::fs::PermissionsExt::from_mode(0o600))
+            .unwrap();
+
+        assert!(send_avatar_cursor_signal(&socket).await);
+        let (mut stream, _) = timeout(Duration::from_secs(1), listener.accept())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut payload = [0_u8; 8];
+        stream.read_exact(&mut payload).await.unwrap();
+        assert_eq!(&payload, b"pointer\n");
+
+        drop(listener);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     fn node(index: u32, bounds: Option<Bounds>) -> AccessibilityNode {

--- a/docs/linux-computer-use.md
+++ b/docs/linux-computer-use.md
@@ -12,6 +12,8 @@ It supports:
   and i3
 - keyboard, text, click, scroll, and drag input through `/dev/uinput`, XDG
   RemoteDesktop portal, or `ydotool`
+- pointer-direction feedback for the built-in V2 pet after successful click,
+  scroll, and drag actions
 
 ## Runtime Dependencies
 

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -130,6 +130,7 @@ const {
   featurePatchDescriptors,
 } = require("./patches/runner.js");
 const {
+  applyMainBundlePatchDescriptors,
   discoverCorePatchDescriptors,
   normalizePatchDescriptors,
 } = require("./patches/engine.js");
@@ -1061,12 +1062,16 @@ test("default core patch descriptors are grouped and unique", () => {
     descriptors.find((descriptor) => descriptor.id === "linux-terminal-user-path")?.ciPolicy,
     "optional",
   );
+  assert.equal(
+    descriptors.find((descriptor) => descriptor.id === "linux-computer-use-avatar-cursor")?.ciPolicy,
+    "optional",
+    "pet cursor feedback drift should warn without blocking install/rebuild",
+  );
   for (const id of [
     "linux-window-options",
     "linux-native-titlebar",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
-    "linux-computer-use-avatar-cursor",
     "linux-tray",
   ]) {
     assert.equal(
@@ -3857,6 +3862,34 @@ test("registers a private Linux Computer Use cursor bridge without changing Darw
     (patched.match(/function codexLinuxRegisterComputerUseCursorHandler/g) ?? []).length,
     1,
   );
+});
+
+test("warns when the upstream Computer Use cursor handler marker is absent", () => {
+  const source = "function unrelatedCursorHandler(){return!0}";
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-computer-use-avatar-cursor",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not find the Computer Use cursor handler marker - skipping Linux avatar cursor bridge patch",
+  ]);
+  assert.deepEqual(report.patches, [
+    {
+      name: "linux-computer-use-avatar-cursor",
+      status: "skipped-optional",
+      reason: warnings[0],
+      phase: "main-bundle",
+      targetSummary: "all-linux",
+      ciPolicy: "optional",
+      sourceKind: "core",
+      warnings,
+    },
+  ]);
 });
 
 test("Linux Computer Use cursor bridge is local, bounded, and returns to idle", async () => {

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -5,6 +5,7 @@ const crypto = require("node:crypto");
 const { spawnSync } = require("node:child_process");
 const { EventEmitter } = require("node:events");
 const fs = require("node:fs");
+const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
@@ -28,6 +29,7 @@ const {
   patchAutomationScheduleAssets,
 } = require("./patches/impl/automation-schedule.js");
 const {
+  applyLinuxComputerUseAvatarCursorBridgePatch,
   COMPUTER_USE_UI_ENV_VAR,
   COMPUTER_USE_UI_SETTINGS_KEY,
   applyLinuxComputerUseFeaturePatch,
@@ -37,6 +39,7 @@ const {
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
   isComputerUseUiEnabled,
+  linuxComputerUseCursorBridgeRuntimeSource,
 } = require("./patches/impl/computer-use.js");
 const {
   keybindsSettingsAsset,
@@ -939,6 +942,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-tray",
     "linux-build-info-tray",
     "linux-single-instance",
+    "linux-computer-use-avatar-cursor",
     "linux-computer-use-ui-feature",
     "linux-computer-use-plugin-gate",
     "linux-computer-use-native-desktop-apps",
@@ -1062,6 +1066,7 @@ test("default core patch descriptors are grouped and unique", () => {
     "linux-native-titlebar",
     "linux-opaque-background",
     "linux-avatar-overlay-mouse-passthrough",
+    "linux-computer-use-avatar-cursor",
     "linux-tray",
   ]) {
     assert.equal(
@@ -1782,6 +1787,7 @@ function currentBootstrapUpdaterBundleWithAppUpdateStateBroadcastFixture() {
 function latestAvatarOverlayBundleFixture() {
   return [
     "let c=require(`electron`),h=require(`node:child_process`);",
+    "function eo(e,{addon:t,electronAppPath:n,platform:r=process.platform,resourcesPath:i=process.resourcesPath}={}){if(r!==`darwin`)return!1;try{return(t??Sa({electronAppPath:n??c.app.getAppPath(),resourcesPath:i})).setRemoteHostedPIPContentComputerUseCursorLocationHandler(e)}catch{return!1}}",
     "var d5=`/avatar-overlay`,of={width:356,height:320},m5={width:112,height:121},y5={width:0,height:0},v5={width:276,height:131};",
     "var fV=class{window=null;layout=null;mascotSize=m5;traySize=null;pointerInteractive=!1;mousePassthroughEnabled=!1;layoutMode=`native`;compositionHost={setOverlayWindow(){},isNativeMaterialAttached(){return!1},getCursorPosition(){return null},performWindowDrag(){return!1},updateMascotRect(){},publishRemoteHostedPIPContentHost(){}};nativePositionController={clear(){}};",
     "startDrag(e,t,n=!1){let r=this.window;if(r==null||r.isDestroyed()||r.webContents.id!==e)return;this.cancelMomentum();let i=this.getLayout(r),a=this.compositionHost.getCursorPosition(),o=t.pointerScreenX!=null?{x:t.pointerScreenX,y:t.pointerScreenY}:c.screen.getCursorScreenPoint();this.dragState=new a5(a==null?`renderer`:`native`,t.pointerWindowX-i.mascot.left,t.pointerWindowY-i.mascot.top,c.screen.getDisplayNearestPoint(o).bounds,n),this.windowServerDragActive=this.layoutMode===`native`&&!n&&this.compositionHost.performWindowDrag(),this.windowServerDragActive||(this.windowServerDragWindowX=null)}",
@@ -3834,6 +3840,183 @@ test("patches the latest avatar overlay class without depending on adjacent meth
   assert.match(patched, /this\.compositionHost\.updateMascotRect\(a\.mascot\)[\s\S]*?process\.platform===`linux`&&this\.applyPointerInteractivityPolicy\(\)\}showWindow/);
   assert.match(patched, /if\(this\.window!==e\)return;let t=this\.presentationVisibility!=null;this\.codexLinuxStopAvatarPassthroughRecovery\(\)/);
   assert.match(patched, /traySize:process\.platform===`linux`&&typeof this\.codexLinuxIsI3Session==`function`/);
+});
+
+test("registers a private Linux Computer Use cursor bridge without changing Darwin", () => {
+  const source = latestAvatarOverlayBundleFixture();
+  const patched = applyPatchTwice(applyLinuxComputerUseAvatarCursorBridgePatch, source);
+
+  assert.match(
+    patched,
+    /if\(r===`linux`\)return codexLinuxRegisterComputerUseCursorHandler\(e\);if\(r!==`darwin`\)return!1/,
+  );
+  assert.match(patched, /Buffer\.byteLength\(i,`utf8`\)<=100/);
+  assert.match(patched, /i\.chmodSync\(n,384\)/);
+  assert.match(patched, /r\.dev===e\.dev&&r\.ino===e\.ino&&r\.isSocket\(\)/);
+  assert.equal(
+    (patched.match(/function codexLinuxRegisterComputerUseCursorHandler/g) ?? []).length,
+    1,
+  );
+});
+
+test("Linux Computer Use cursor bridge is local, bounded, and returns to idle", async () => {
+  const root = fs.mkdtempSync("/tmp/cu-cursor-");
+  const app = new EventEmitter();
+  const cursorEvents = [];
+  const timers = new Map();
+  let nextTimerId = 1;
+  const scheduleTimer = (callback, delay) => {
+    const handle = { id: nextTimerId, unref() {} };
+    nextTimerId += 1;
+    timers.set(handle, { callback, delay });
+    return handle;
+  };
+  const context = {
+    Buffer,
+    clearTimeout(handle) {
+      timers.delete(handle);
+    },
+    process: {
+      env: {
+        XDG_RUNTIME_DIR: root,
+        CODEX_LINUX_APP_ID: "codex-desktop-test",
+        CODEX_LINUX_INSTANCE_ID: "secondary",
+      },
+      getuid: process.getuid.bind(process),
+    },
+    require(name) {
+      if (name === "electron") {
+        return {
+          app,
+          screen: { getCursorScreenPoint: () => ({ x: 321, y: 654 }) },
+        };
+      }
+      return require(name);
+    },
+    setTimeout: scheduleTimer,
+  };
+  vm.runInNewContext(
+    `${linuxComputerUseCursorBridgeRuntimeSource()};globalThis.bridge={path:codexLinuxComputerUseCursorSocketPath,register:codexLinuxRegisterComputerUseCursorHandler}`,
+    context,
+  );
+
+  context.process.env.CODEX_LINUX_INSTANCE_ID = "..";
+  assert.equal(context.bridge.path(), null);
+  context.process.env.CODEX_LINUX_INSTANCE_ID = "secondary";
+
+  assert.equal(context.bridge.register((event) => cursorEvents.push({ ...event })), true);
+  const socketPath = context.bridge.path();
+  for (
+    let attempt = 0;
+    attempt < 50 &&
+      (!fs.existsSync(socketPath) || (fs.statSync(socketPath).mode & 0o777) !== 0o600);
+    attempt += 1
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(fs.existsSync(socketPath), true);
+  assert.equal(fs.statSync(path.dirname(socketPath)).mode & 0o777, 0o700);
+  assert.equal(fs.statSync(socketPath).mode & 0o777, 0o600);
+
+  await new Promise((resolve, reject) => {
+    const client = net.createConnection(socketPath, () => client.end("ignored\n"));
+    client.on("close", resolve);
+    client.on("error", reject);
+  });
+  assert.deepEqual(cursorEvents, []);
+
+  await new Promise((resolve, reject) => {
+    const client = net.createConnection(socketPath, () => client.end("pointer\n"));
+    client.on("close", resolve);
+    client.on("error", reject);
+  });
+  for (let attempt = 0; attempt < 50 && cursorEvents.length === 0; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.deepEqual(cursorEvents[0], { isActive: true, x: 321, y: 654 });
+  assert.equal(timers.size, 1);
+
+  await new Promise((resolve, reject) => {
+    const client = net.createConnection(socketPath, () => client.end("pointer\n"));
+    client.on("close", resolve);
+    client.on("error", reject);
+  });
+  for (let attempt = 0; attempt < 50 && cursorEvents.length < 2; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(timers.size, 1);
+  assert.deepEqual(cursorEvents[1], { isActive: true, x: 321, y: 654 });
+  const [[timerHandle, timer]] = timers.entries();
+  assert.equal(timer.delay, 900);
+  timers.delete(timerHandle);
+  timer.callback();
+  assert.deepEqual(cursorEvents.at(-1), { isActive: false, x: 321, y: 654 });
+
+  app.emit("before-quit");
+  for (let attempt = 0; attempt < 50 && fs.existsSync(socketPath); attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(fs.existsSync(socketPath), false);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("Linux Computer Use cursor bridge refuses to replace a regular file", () => {
+  const root = fs.mkdtempSync("/tmp/cu-cursor-file-");
+  const socketDir = path.join(root, "codex-desktop-test");
+  const socketPath = path.join(socketDir, "computer-use-cursor.sock");
+  fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(socketPath, "preserve");
+  const context = {
+    Buffer,
+    clearTimeout,
+    process: {
+      env: { XDG_RUNTIME_DIR: root, CODEX_LINUX_APP_ID: "codex-desktop-test" },
+      getuid: process.getuid.bind(process),
+    },
+    require(name) {
+      if (name === "electron") {
+        return { app: new EventEmitter(), screen: { getCursorScreenPoint: () => ({ x: 0, y: 0 }) } };
+      }
+      return require(name);
+    },
+    setTimeout,
+  };
+  vm.runInNewContext(
+    `${linuxComputerUseCursorBridgeRuntimeSource()};globalThis.register=codexLinuxRegisterComputerUseCursorHandler`,
+    context,
+  );
+
+  assert.equal(context.register(() => {}), false);
+  assert.equal(fs.readFileSync(socketPath, "utf8"), "preserve");
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("Linux Computer Use cursor bridge rejects an unsafe runtime directory", () => {
+  const root = fs.mkdtempSync("/tmp/cu-cursor-runtime-");
+  fs.chmodSync(root, 0o755);
+  const context = {
+    Buffer,
+    clearTimeout,
+    process: {
+      env: { XDG_RUNTIME_DIR: root, CODEX_LINUX_APP_ID: "codex-desktop-test" },
+      getuid: process.getuid.bind(process),
+    },
+    require(name) {
+      if (name === "electron") {
+        return { app: new EventEmitter(), screen: { getCursorScreenPoint: () => ({ x: 0, y: 0 }) } };
+      }
+      return require(name);
+    },
+    setTimeout,
+  };
+  vm.runInNewContext(
+    `${linuxComputerUseCursorBridgeRuntimeSource()};globalThis.register=codexLinuxRegisterComputerUseCursorHandler`,
+    context,
+  );
+
+  assert.equal(context.register(() => {}), false);
+  assert.equal(fs.existsSync(path.join(root, "codex-desktop-test")), false);
+  fs.rmSync(root, { recursive: true, force: true });
 });
 
 test("scopes avatar overlay method matching away from unrelated earlier classes", () => {

--- a/scripts/patches/core/all-linux/main-process/computer-use/patch.js
+++ b/scripts/patches/core/all-linux/main-process/computer-use/patch.js
@@ -4,12 +4,20 @@ const {
   mainBundlePatch,
 } = require("../../../../descriptor.js");
 const {
+  applyLinuxComputerUseAvatarCursorBridgePatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxNativeDesktopAppsHandlerPatch,
   applyLinuxComputerUsePluginGatePatch,
 } = require("../../../../impl/computer-use.js");
 
 module.exports = [
+  mainBundlePatch({
+    id: "linux-computer-use-avatar-cursor",
+    phase: "main-bundle",
+    order: 125,
+    ciPolicy: "required-upstream",
+    apply: applyLinuxComputerUseAvatarCursorBridgePatch,
+  }),
   mainBundlePatch({
     id: "linux-computer-use-ui-feature",
     phase: "main-bundle",

--- a/scripts/patches/core/all-linux/main-process/computer-use/patch.js
+++ b/scripts/patches/core/all-linux/main-process/computer-use/patch.js
@@ -15,7 +15,7 @@ module.exports = [
     id: "linux-computer-use-avatar-cursor",
     phase: "main-bundle",
     order: 125,
-    ciPolicy: "required-upstream",
+    ciPolicy: "optional",
     apply: applyLinuxComputerUseAvatarCursorBridgePatch,
   }),
   mainBundlePatch({

--- a/scripts/patches/impl/computer-use.js
+++ b/scripts/patches/impl/computer-use.js
@@ -4,11 +4,84 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const {
+  findMatchingBrace,
   requireName,
 } = require("../lib/minified-js.js");
 
 const COMPUTER_USE_UI_ENV_VAR = "CODEX_LINUX_ENABLE_COMPUTER_USE_UI";
 const COMPUTER_USE_UI_SETTINGS_KEY = "codex-linux-computer-use-ui-enabled";
+const COMPUTER_USE_CURSOR_HANDLER_MARKER =
+  "setRemoteHostedPIPContentComputerUseCursorLocationHandler";
+const LINUX_COMPUTER_USE_CURSOR_BRIDGE_MARKER =
+  "codexLinuxRegisterComputerUseCursorHandler";
+
+function linuxComputerUseCursorBridgeRuntimeSource() {
+  return [
+    "function codexLinuxComputerUseCursorComponent(e){return typeof e==`string`&&e!==`.`&&e!==`..`&&/^[A-Za-z0-9._-]+$/.test(e)}function codexLinuxComputerUseCursorSocketPath(){let e=process.env.XDG_RUNTIME_DIR?.trim();if(!e)return null;let t=require(`node:path`);if(!t.isAbsolute(e))return null;let n=(process.env.CODEX_LINUX_APP_ID||process.env.CODEX_APP_ID||`codex-desktop`).trim();codexLinuxComputerUseCursorComponent(n)||(n=`codex-desktop`);let r=process.env.CODEX_LINUX_INSTANCE_ID?.trim()||``;if(r&&!codexLinuxComputerUseCursorComponent(r))return null;let i=r?t.join(e,n,`instances`,r,`computer-use-cursor.sock`):t.join(e,n,`computer-use-cursor.sock`);return Buffer.byteLength(i,`utf8`)<=100?i:null}",
+    "function codexLinuxRegisterComputerUseCursorHandler(e){let t=codexLinuxRegisterComputerUseCursorHandler;t.handler=e;if(t.server!=null)return!0;let n=codexLinuxComputerUseCursorSocketPath();if(n==null)return!1;try{let r=require(`node:path`),i=require(`node:fs`),a=require(`node:net`),o=require(`electron`),s=r.dirname(n),l=typeof process.getuid==`function`?process.getuid():null,u=i.lstatSync(process.env.XDG_RUNTIME_DIR.trim());if(!u.isDirectory()||u.isSymbolicLink()||l!=null&&u.uid!==l||(u.mode&63)!==0)return!1;i.mkdirSync(s,{recursive:!0,mode:448});let c=i.lstatSync(s);if(!c.isDirectory()||c.isSymbolicLink()||l!=null&&c.uid!==l)return!1;i.chmodSync(s,448);if(i.existsSync(n)){let e=i.lstatSync(n);if(!(e.isSocket()||e.isSymbolicLink())||l!=null&&e.uid!==l)return!1;i.unlinkSync(n)}let d=()=>{let e=t.socketIdentity;t.socketIdentity=null;if(e==null)return;try{let r=i.lstatSync(n);r.dev===e.dev&&r.ino===e.ino&&r.isSocket()&&i.unlinkSync(n)}catch{}},p=()=>{t.timer!=null&&(clearTimeout(t.timer),t.timer=null);let e=t.server;t.server=null;try{e?.close()}catch{}d()},m=()=>{try{let e=t.handler;if(typeof e!=`function`)return;let n=o.screen.getCursorScreenPoint();e({isActive:!0,x:n.x,y:n.y}),t.timer!=null&&clearTimeout(t.timer),t.timer=setTimeout(()=>{try{let e=t.handler;typeof e==`function`&&e({isActive:!1,x:n.x,y:n.y})}catch{}finally{t.timer=null}},900),t.timer.unref?.()}catch{}},f=a.createServer(e=>{let t=``,n=!1;e.setEncoding(`utf8`),e.setTimeout(250,()=>e.destroy()),e.on(`error`,()=>{}),e.on(`data`,r=>{if(n)return;t+=r;if(t.length>64){n=!0,e.destroy();return}if(t.includes(`\n`)){n=!0,t.trim()===`pointer`&&m(),e.end()}})});return t.server=f,f.on(`error`,()=>{t.server===f&&(t.server=null),d()}),f.listen(n,()=>{try{i.chmodSync(n,384);let e=i.lstatSync(n);if(!e.isSocket()||l!=null&&e.uid!==l)throw Error(`unsafe cursor socket`);t.socketIdentity={dev:e.dev,ino:e.ino},f.unref()}catch{p()}}),t.cleanupRegistered||(t.cleanupRegistered=!0,o.app.once(`before-quit`,p)),!0}catch{return t.server=null,!1}}",
+  ].join("");
+}
+
+function findComputerUseCursorRegistrationFunction(source) {
+  const markerIndex = source.indexOf(COMPUTER_USE_CURSOR_HANDLER_MARKER);
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const functionRegex = /function ([A-Za-z_$][\w$]*)\(([^)]*)\)\{/g;
+  let candidate = null;
+  let match;
+  while ((match = functionRegex.exec(source)) != null && match.index < markerIndex) {
+    const openIndex = match.index + match[0].length - 1;
+    const closeIndex = findMatchingBrace(source, openIndex);
+    if (closeIndex >= markerIndex) {
+      candidate = {
+        match,
+        start: match.index,
+        end: closeIndex + 1,
+        text: source.slice(match.index, closeIndex + 1),
+      };
+    }
+  }
+  return candidate;
+}
+
+function applyLinuxComputerUseAvatarCursorBridgePatch(currentSource) {
+  if (currentSource.includes(LINUX_COMPUTER_USE_CURSOR_BRIDGE_MARKER)) {
+    return currentSource;
+  }
+
+  const registration = findComputerUseCursorRegistrationFunction(currentSource);
+  const handlerVar = registration?.match[2].match(/^\s*([A-Za-z_$][\w$]*)\s*,/)?.[1] ?? null;
+  const platformVar = registration?.match[2].match(
+    /platform:([A-Za-z_$][\w$]*)=process\.platform/,
+  )?.[1] ?? null;
+  if (registration == null || handlerVar == null || platformVar == null) {
+    if (currentSource.includes(COMPUTER_USE_CURSOR_HANDLER_MARKER)) {
+      console.warn(
+        "WARN: Could not identify the Computer Use cursor registration function - skipping Linux avatar cursor bridge patch",
+      );
+    }
+    return currentSource;
+  }
+
+  const darwinGuard = `if(${platformVar}!==\`darwin\`)return!1;`;
+  if (!registration.text.includes(darwinGuard)) {
+    console.warn(
+      "WARN: Computer Use cursor registration no longer has the expected Darwin guard - skipping Linux avatar cursor bridge patch",
+    );
+    return currentSource;
+  }
+
+  const patchedRegistration = registration.text.replace(
+    darwinGuard,
+    `if(${platformVar}===\`linux\`)return codexLinuxRegisterComputerUseCursorHandler(${handlerVar});${darwinGuard}`,
+  );
+  return currentSource.slice(0, registration.start) +
+    linuxComputerUseCursorBridgeRuntimeSource() +
+    patchedRegistration +
+    currentSource.slice(registration.end);
+}
 
 // Computer Use has two postures: the bundled plugin gate is default-on Linux
 // platform glue; the visible UI gates remain opt-in because they bypass rollout
@@ -697,6 +770,7 @@ function applyLinuxNativeDesktopAppsHandlerPatch(currentSource) {
 module.exports = {
   COMPUTER_USE_UI_ENV_VAR,
   COMPUTER_USE_UI_SETTINGS_KEY,
+  applyLinuxComputerUseAvatarCursorBridgePatch,
   applyLinuxComputerUseFeaturePatch,
   applyLinuxComputerUseHostPlatformPatch,
   applyLinuxComputerUseInstallFlowPatch,
@@ -704,4 +778,5 @@ module.exports = {
   applyLinuxComputerUsePluginGatePatch,
   applyLinuxComputerUseRendererAvailabilityPatch,
   isComputerUseUiEnabled,
+  linuxComputerUseCursorBridgeRuntimeSource,
 };

--- a/scripts/patches/impl/computer-use.js
+++ b/scripts/patches/impl/computer-use.js
@@ -57,11 +57,10 @@ function applyLinuxComputerUseAvatarCursorBridgePatch(currentSource) {
     /platform:([A-Za-z_$][\w$]*)=process\.platform/,
   )?.[1] ?? null;
   if (registration == null || handlerVar == null || platformVar == null) {
-    if (currentSource.includes(COMPUTER_USE_CURSOR_HANDLER_MARKER)) {
-      console.warn(
-        "WARN: Could not identify the Computer Use cursor registration function - skipping Linux avatar cursor bridge patch",
-      );
-    }
+    const reason = currentSource.includes(COMPUTER_USE_CURSOR_HANDLER_MARKER)
+      ? "Could not identify the Computer Use cursor registration function"
+      : "Could not find the Computer Use cursor handler marker";
+    console.warn(`WARN: ${reason} - skipping Linux avatar cursor bridge patch`);
     return currentSource;
   }
 


### PR DESCRIPTION
## Summary

- Forward successful Linux Computer Use pointer activity to the existing V2 pet cursor path.
- Keep the bridge local, instance-scoped, bounded, and fail-soft.
- Preserve Darwin behavior and leave non-pointer accessibility actions unchanged.

## Why

The current desktop bundle only registers the Computer Use cursor callback on Darwin. Linux click, scroll, and drag actions therefore never reach the avatar overlay, even though the renderer already supports the V2 look frames.

The Linux backend now sends a small private runtime signal after a pointer action succeeds. The main process reads the actual Electron cursor position and forwards it through the existing avatar event, then returns the pet to its idle animation.

Fixes #1061

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (385 passed)
- `TMPDIR=/tmp cargo test -p codex-computer-use-linux` (151 passed)
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash tests/scripts_smoke.sh`
- `cargo build --release -p codex-computer-use-linux`
- `make inspect-upstream` against ChatGPT Desktop `26.715.31925`
