### PR TITLE
Fix X11 Global Dictation runtime helpers

### DIFF
--- a/linux-features/global-dictation/patch.js
+++ b/linux-features/global-dictation/patch.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const LEGACY_PATCH_MARKER = "codex-linux-global-dictation-v1";
 const PATCH_MARKER = "codex-linux-global-dictation-v2";
 const IDENT = "[A-Za-z_$][\\w$]*";
 
@@ -266,51 +265,9 @@ function helperSource() {
     .join("");
 }
 
-function migrateLegacyLinuxGlobalDictationPatch(source) {
-  let patched = replaceUnique(
-    source,
-    new RegExp(
-      `var codexLinuxGlobalDictationPatch=${escapeRegexLiteral(
-        JSON.stringify(LEGACY_PATCH_MARKER),
-      )};`,
-      "u",
-    ),
-    `var codexLinuxGlobalDictationPatch=${JSON.stringify(
-      PATCH_MARKER,
-    )};${codexLinuxGlobalDictationPasteX11}`,
-    "legacy Linux global dictation marker",
-  );
-  patched = replaceUnique(
-    patched,
-    /function codexLinuxGlobalDictationReleaseWatcher\(accelerator\) \{\n  const helperPath = codexLinuxGlobalDictationNativePath\("global-dictation-release-monitor"\);\n  if \(helperPath == null\) return null;\n  return require\("node:child_process"\)\.spawn\(helperPath, \["--accelerator", accelerator\], \{\n    stdio: "ignore",\n    windowsHide: true,\n  \}\);\n\}/u,
-    String(codexLinuxGlobalDictationReleaseWatcher),
-    "legacy Linux release watcher helper",
-  );
-  patched = replaceUnique(
-    patched,
-    /case`linux`:\{let n=codexLinuxGlobalDictationReleaseWatcher\(e\);if\(n==null\)throw Error\(`Global dictation hotkey release watching is not supported\.`\);return _A\(n,t\)\}/u,
-    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e,t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}",
-    "legacy Linux release watcher branch",
-  );
-  return replaceUnique(
-    patched,
-    /await k7\(`xdotool`,\[`key`,`--clearmodifiers`,`ctrl\+v`\]\)/u,
-    "await codexLinuxGlobalDictationPasteX11()",
-    "legacy Linux X11 paste branch",
-  );
-}
-
 function applyLinuxGlobalDictationMainProcessPatch(source) {
   if (source.includes(PATCH_MARKER)) {
     return source;
-  }
-  if (source.includes(LEGACY_PATCH_MARKER)) {
-    try {
-      return migrateLegacyLinuxGlobalDictationPatch(source);
-    } catch (error) {
-      warn(error instanceof Error ? error.message : String(error));
-      return source;
-    }
   }
   if (!source.includes("Global dictation hotkey release watching is not supported.")) {
     warn("release watcher sentinel was not found");

--- a/linux-features/global-dictation/patch.js
+++ b/linux-features/global-dictation/patch.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const PATCH_MARKER = "codex-linux-global-dictation-v1";
+const LEGACY_PATCH_MARKER = "codex-linux-global-dictation-v1";
+const PATCH_MARKER = "codex-linux-global-dictation-v2";
 const IDENT = "[A-Za-z_$][\\w$]*";
 
 function warn(message) {
@@ -69,6 +70,21 @@ async function codexLinuxGlobalDictationPaste() {
     if (registration.ready()) return registration.paste();
   }
   throw new Error("No ready Wayland global dictation helper is available.");
+}
+
+function codexLinuxGlobalDictationPasteX11() {
+  return new Promise((resolve, reject) => {
+    try {
+      require("node:child_process").execFile(
+        "xdotool",
+        ["key", "--clearmodifiers", "ctrl+v"],
+        { windowsHide: true },
+        (error) => (error ? reject(error) : resolve()),
+      );
+    } catch (error) {
+      reject(error);
+    }
+  });
 }
 
 function codexLinuxGlobalDictationPortalRegistration(accelerator, callbacks) {
@@ -208,13 +224,30 @@ function codexLinuxGlobalDictationPortalRegistration(accelerator, callbacks) {
   return registration;
 }
 
-function codexLinuxGlobalDictationReleaseWatcher(accelerator) {
+function codexLinuxGlobalDictationReleaseWatcher(accelerator, onReleased) {
   const helperPath = codexLinuxGlobalDictationNativePath("global-dictation-release-monitor");
   if (helperPath == null) return null;
-  return require("node:child_process").spawn(helperPath, ["--accelerator", accelerator], {
+  const child = require("node:child_process").spawn(helperPath, ["--accelerator", accelerator], {
     stdio: "ignore",
     windowsHide: true,
   });
+  let finished = false;
+  const finish = (error) => {
+    if (finished) return;
+    finished = true;
+    if (error != null) {
+      console.warn("[linux-global-dictation] Hotkey release watcher failed", error);
+    }
+    onReleased();
+  };
+  child.once("error", finish);
+  child.once("exit", () => finish());
+  return {
+    dispose: () => {
+      finished = true;
+      child.kill();
+    },
+  };
 }
 
 function helperSource() {
@@ -227,14 +260,57 @@ function helperSource() {
     codexLinuxGlobalDictationPaste,
     codexLinuxGlobalDictationPortalRegistration,
     codexLinuxGlobalDictationReleaseWatcher,
+    codexLinuxGlobalDictationPasteX11,
   ]
     .map(String)
     .join("");
 }
 
+function migrateLegacyLinuxGlobalDictationPatch(source) {
+  let patched = replaceUnique(
+    source,
+    new RegExp(
+      `var codexLinuxGlobalDictationPatch=${escapeRegexLiteral(
+        JSON.stringify(LEGACY_PATCH_MARKER),
+      )};`,
+      "u",
+    ),
+    `var codexLinuxGlobalDictationPatch=${JSON.stringify(
+      PATCH_MARKER,
+    )};${codexLinuxGlobalDictationPasteX11}`,
+    "legacy Linux global dictation marker",
+  );
+  patched = replaceUnique(
+    patched,
+    /function codexLinuxGlobalDictationReleaseWatcher\(accelerator\) \{\n  const helperPath = codexLinuxGlobalDictationNativePath\("global-dictation-release-monitor"\);\n  if \(helperPath == null\) return null;\n  return require\("node:child_process"\)\.spawn\(helperPath, \["--accelerator", accelerator\], \{\n    stdio: "ignore",\n    windowsHide: true,\n  \}\);\n\}/u,
+    String(codexLinuxGlobalDictationReleaseWatcher),
+    "legacy Linux release watcher helper",
+  );
+  patched = replaceUnique(
+    patched,
+    /case`linux`:\{let n=codexLinuxGlobalDictationReleaseWatcher\(e\);if\(n==null\)throw Error\(`Global dictation hotkey release watching is not supported\.`\);return _A\(n,t\)\}/u,
+    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e,t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}",
+    "legacy Linux release watcher branch",
+  );
+  return replaceUnique(
+    patched,
+    /await k7\(`xdotool`,\[`key`,`--clearmodifiers`,`ctrl\+v`\]\)/u,
+    "await codexLinuxGlobalDictationPasteX11()",
+    "legacy Linux X11 paste branch",
+  );
+}
+
 function applyLinuxGlobalDictationMainProcessPatch(source) {
   if (source.includes(PATCH_MARKER)) {
     return source;
+  }
+  if (source.includes(LEGACY_PATCH_MARKER)) {
+    try {
+      return migrateLegacyLinuxGlobalDictationPatch(source);
+    } catch (error) {
+      warn(error instanceof Error ? error.message : String(error));
+      return source;
+    }
   }
   if (!source.includes("Global dictation hotkey release watching is not supported.")) {
     warn("release watcher sentinel was not found");
@@ -280,7 +356,7 @@ function applyLinuxGlobalDictationMainProcessPatch(source) {
     patched = replaceUnique(
       patched,
       /case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error\(`Global dictation hotkey release watching is not supported\.`\)/u,
-      "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return _A(n,t)}case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation hotkey release watching is not supported.`)",
+      "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e,t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation hotkey release watching is not supported.`)",
       "Linux release watcher platform branch",
     );
 
@@ -309,7 +385,7 @@ function applyLinuxGlobalDictationMainProcessPatch(source) {
     patched = replaceUnique(
       patched,
       /case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error\(`Global dictation paste is not supported on this OS\.`\)/u,
-      "case`linux`:if(codexLinuxGlobalDictationUsesWayland()){await codexLinuxGlobalDictationPaste();return}await k7(`xdotool`,[`key`,`--clearmodifiers`,`ctrl+v`]);return;case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation paste is not supported on this OS.`)",
+      "case`linux`:if(codexLinuxGlobalDictationUsesWayland()){await codexLinuxGlobalDictationPaste();return}await codexLinuxGlobalDictationPasteX11();return;case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation paste is not supported on this OS.`)",
       "Linux global dictation paste branch",
     );
 

--- a/linux-features/global-dictation/test.js
+++ b/linux-features/global-dictation/test.js
@@ -59,14 +59,47 @@ function mainBundleFixture() {
     "function Kk(e,t){let n=``;e.stdout?.on(`data`,e=>{n+=e.toString(`utf8`);let r=n.indexOf(`\\n`);for(;r!==-1;)t(n.slice(0,r).trim()),n=n.slice(r+1),r=n.indexOf(`\\n`)})}",
     "function eA(e,t,n){if(Rk(e))return Lk(e)?Mk(e,t,n?.bareModifierTrigger):null;let r=oA(e),i=()=>{t.onPressed()},a=c.globalShortcut.register(r,i);return a?process.platform===`darwin`?sA({hotkey:e,onPressed:i,registrationHotkey:r}):{handlesRelease:!1,unregister:()=>{c.globalShortcut.unregister(r)}}:null}",
     "function fA(e){return nA(e)??(Lk(e)||bA(e,process.platform)?null:`Shortcut key is not supported for global dictation.`)}",
-    "function pA(e,t){switch(process.platform){case`darwin`:{let n=Ik(mA(e),t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}case`win32`:{let n=gA(e,process.platform);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return _A((0,h.spawn)(`powershell.exe`,[],{stdio:`ignore`}),t)}case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation hotkey release watching is not supported.`)}}",
+    "function pA(e,t){switch(process.platform){case`darwin`:{let n=Ik(mA(e),t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}case`win32`:{let n=gA(e,process.platform);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return BA((0,h.spawn)(`powershell.exe`,[],{stdio:`ignore`}),t)}case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation hotkey release watching is not supported.`)}}",
     "function mA(e){let t=[];for(let n of e.split(`+`)){let e=uA.get(n.trim().toLowerCase());e!=null&&!t.includes(e)&&t.push(e)}return t}",
-    "function _A(e,t){let n=!1,i=e=>{n||(n=!0,e!=null&&r.r().warning(`Global dictation hotkey release watching failed`,{safe:{},sensitive:{error:e}}),t())};return e.once(`error`,i),e.once(`exit`,()=>i()),{dispose:()=>{n=!0,e.kill()}}}",
+    "function _A(){return [`/unrelated/native/path`]}",
+    "function BA(e,t){let n=!1,i=e=>{n||(n=!0,e!=null&&r.r().warning(`Global dictation hotkey release watching failed`,{safe:{},sensitive:{error:e}}),t())};return e.once(`error`,i),e.once(`exit`,()=>i()),{dispose:()=>{n=!0,e.kill()}}}",
     "function bA(e,t){return t===`darwin`?mA(e).length>0:gA(e,t)!=null}",
-    "var k7=async(...e)=>globalThis.__execFile(...e);async function P7(){switch(process.platform){case`darwin`:return;case`win32`:return;case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation paste is not supported on this OS.`)}}",
+    "function k7(e,t,n){return{x:e.centerX-n.x-t.width/2,y:e.centerY-n.y-t.height/2,...t}}var V7=async(...e)=>globalThis.__upstreamExecFile(...e);async function P7(){switch(process.platform){case`darwin`:await V7(`/usr/bin/osascript`,[]);return;case`win32`:return;case`aix`:case`android`:case`cygwin`:case`freebsd`:case`haiku`:case`linux`:case`netbsd`:case`openbsd`:case`sunos`:throw Error(`Global dictation paste is not supported on this OS.`)}}",
     "var H7=class{registeredHotkey=null;registeredHotkeyRegistration=null;registeredToggleHotkey=null;registeredToggleHotkeyRegistration=null;registerHotkeyOrThrow(e){if(this.registeredHotkey===e)return;let t=this.registeredHotkey,n=eA(e,{onPressed:()=>{this.handleHoldHotkeyPressed()},onReleased:()=>{this.handleHoldHotkeyReleased()}});if(n==null)throw Error(`Unable to register global dictation hotkey: ${e}`);t!=null&&this.registeredHotkeyRegistration?.unregister(),this.registeredHotkey=e,this.registeredHotkeyRegistration=n}unregisterHotkey(){this.registeredHotkey!=null&&(this.registeredHotkeyRegistration?.unregister(),this.registeredHotkey=null,this.registeredHotkeyRegistration=null)}registerToggleHotkeyOrThrow(e){if(this.registeredToggleHotkey===e)return;let t=this.registeredToggleHotkey,n=eA(e,{onPressed:()=>{this.handleToggleHotkeyPressed()}},{bareModifierTrigger:`release`});if(n==null)throw Error(`Unable to register global dictation toggle hotkey: ${e}`);t!=null&&this.registeredToggleHotkeyRegistration?.unregister(),this.registeredToggleHotkey=e,this.registeredToggleHotkeyRegistration=n}unregisterToggleHotkey(){this.registeredToggleHotkey!=null&&(this.registeredToggleHotkeyRegistration?.unregister(),this.registeredToggleHotkey=null,this.registeredToggleHotkeyRegistration=null)}deactivateLifecycle(){this.unregisterHotkey(),this.unregisterToggleHotkey()}handleHoldHotkeyPressed(){}handleHoldHotkeyReleased(){}handleToggleHotkeyPressed(){}};",
     "function W7(){return process.platform===`darwin`||process.platform===`win32`}",
   ].join("");
+}
+
+function legacyPatchedMainBundleFixture() {
+  let legacy = applyLinuxGlobalDictationMainProcessPatch(mainBundleFixture());
+  legacy = legacy.replace(
+    'var codexLinuxGlobalDictationPatch="codex-linux-global-dictation-v2";',
+    'var codexLinuxGlobalDictationPatch="codex-linux-global-dictation-v1";',
+  );
+  legacy = legacy.replace(/function codexLinuxGlobalDictationPasteX11\(\) \{[\s\S]*?\n\}/u, "");
+  legacy = legacy.replace(
+    /function codexLinuxGlobalDictationReleaseWatcher\(accelerator, onReleased\) \{[\s\S]*?\n\}/u,
+    `function codexLinuxGlobalDictationReleaseWatcher(accelerator) {
+  const helperPath = codexLinuxGlobalDictationNativePath("global-dictation-release-monitor");
+  if (helperPath == null) return null;
+  return require("node:child_process").spawn(helperPath, ["--accelerator", accelerator], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+}`,
+  );
+  legacy = legacy.replace(
+    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e,t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}",
+    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return _A(n,t)}",
+  );
+  legacy = legacy.replace(
+    "await codexLinuxGlobalDictationPasteX11()",
+    "await k7(`xdotool`,[`key`,`--clearmodifiers`,`ctrl+v`])",
+  );
+  assert.match(legacy, /codex-linux-global-dictation-v1/);
+  assert.match(legacy, /return _A\(n,t\)/);
+  assert.match(legacy, /await k7\(`xdotool`/);
+  return legacy;
 }
 
 function fakeHelperChild() {
@@ -100,13 +133,19 @@ function waylandPatchContext(children) {
     require(id) {
       if (id === "node:fs") return { accessSync() {}, constants: { X_OK: 1 } };
       if (id === "node:path") return path;
-      if (id === "node:child_process") return { spawn: () => children.shift() };
+      if (id === "node:child_process") {
+        return {
+          spawn: () => children.shift(),
+          execFile: (...args) => context.__execFile(...args),
+        };
+      }
       if (id === "electron") return { app: { getAppPath: () => null }, globalShortcut: {} };
       throw new Error(`unexpected module: ${id}`);
     },
     clearTimeout,
     setTimeout,
-    __execFile: async () => {},
+    __execFile: (_file, _args, _options, callback) => callback(),
+    __upstreamExecFile: async () => {},
   };
   vm.runInNewContext(applyPatchTwice(mainBundleFixture()), context);
   return context;
@@ -193,7 +232,12 @@ test("main patch enables Linux and preserves the other platform gates", () => {
     /function W7\(\)\{return process\.platform===`darwin`\|\|process\.platform===`win32`\|\|process\.platform===`linux`\}/,
   );
   assert.match(patched, /case`linux`:if\(codexLinuxGlobalDictationUsesWayland\(\)\)/);
-  assert.match(patched, /await k7\(`xdotool`,\[`key`,`--clearmodifiers`,`ctrl\+v`\]\)/);
+  assert.match(
+    patched,
+    /await codexLinuxGlobalDictationPasteX11\(\)/,
+  );
+  assert.doesNotMatch(patched, /return _A\(n,t\)/);
+  assert.doesNotMatch(patched, /await k7\(`xdotool`/);
 });
 
 test("main patch handles dollar signs in minified identifiers", () => {
@@ -206,6 +250,39 @@ test("main patch handles dollar signs in minified identifiers", () => {
   assert.match(patched, /function e\$A\(e,t,n\)/);
   assert.match(patched, /e\$A\(e,\{onPressed:/);
   assert.match(patched, /L\$k\(e\)\?`Modifier-only shortcuts/);
+});
+
+test("main patch upgrades the legacy v1 minifier aliases atomically", () => {
+  const legacy = legacyPatchedMainBundleFixture();
+  const migrated = applyLinuxGlobalDictationMainProcessPatch(legacy);
+
+  assert.notEqual(migrated, legacy);
+  assert.match(migrated, /codex-linux-global-dictation-v2/);
+  assert.doesNotMatch(migrated, /codex-linux-global-dictation-v1/);
+  assert.doesNotMatch(migrated, /return _A\(n,t\)/);
+  assert.doesNotMatch(migrated, /await k7\(`xdotool`/);
+  assert.match(migrated, /codexLinuxGlobalDictationReleaseWatcher\(e,t\)/);
+  assert.match(migrated, /await codexLinuxGlobalDictationPasteX11\(\)/);
+  assert.doesNotThrow(() => new vm.Script(migrated));
+  assert.equal(applyLinuxGlobalDictationMainProcessPatch(migrated), migrated);
+});
+
+test("legacy v1 migration fails closed when only part of the old patch is present", () => {
+  const legacy = legacyPatchedMainBundleFixture().replace(
+    "await k7(`xdotool`,[`key`,`--clearmodifiers`,`ctrl+v`])",
+    "await changedPasteHelper()",
+  );
+  const warnings = [];
+  const previousWarn = console.warn;
+  console.warn = (message) => warnings.push(message);
+
+  try {
+    assert.equal(applyLinuxGlobalDictationMainProcessPatch(legacy), legacy);
+  } finally {
+    console.warn = previousWarn;
+  }
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /legacy Linux X11 paste branch matched 0 times/);
 });
 
 test("Wayland registration uses a release-aware portal helper", () => {
@@ -274,12 +351,25 @@ test("X11 paste uses xdotool with fixed arguments", async () => {
   const calls = [];
   const context = waylandPatchContext([]);
   context.process.env = { DISPLAY: ":1", XDG_SESSION_TYPE: "x11" };
-  context.__execFile = async (...args) => calls.push(args);
+  context.__execFile = (file, args, options, callback) => {
+    calls.push([file, args, options]);
+    callback();
+  };
 
   await context.P7();
   assert.deepEqual(JSON.parse(JSON.stringify(calls)), [
-    ["xdotool", ["key", "--clearmodifiers", "ctrl+v"]],
+    ["xdotool", ["key", "--clearmodifiers", "ctrl+v"], { windowsHide: true }],
   ]);
+});
+
+test("X11 paste propagates xdotool failures", async () => {
+  const context = waylandPatchContext([]);
+  context.process.env = { DISPLAY: ":1", XDG_SESSION_TYPE: "x11" };
+  context.__execFile = (_file, _args, _options, callback) => {
+    callback(new Error("xdotool failed"));
+  };
+
+  await assert.rejects(context.P7(), /xdotool failed/);
 });
 
 test("Wayland helper failure is reported once and releases the registration queue", async () => {
@@ -312,12 +402,34 @@ test("Wayland helper failure is reported once and releases the registration queu
 test("X11 hold mode starts the bounded release watcher", () => {
   const patched = applyPatchTwice(mainBundleFixture());
   assert.match(patched, /function codexLinuxGlobalDictationReleaseWatcher\(/);
-  assert.match(patched, /case`linux`:\{let n=codexLinuxGlobalDictationReleaseWatcher\(e\)/);
+  assert.match(patched, /case`linux`:\{let n=codexLinuxGlobalDictationReleaseWatcher\(e,t\)/);
   assert.match(patched, /t===`darwin`\|\|t===`linux`\?mA\(e\)\.length>0/);
   assert.match(
     patched,
     /process\.platform===`linux`&&Lk\(e\)\?`Modifier-only shortcuts are not supported for global dictation on Linux\.`/,
   );
+});
+
+test("X11 hold watcher exposes a disposable and releases once", async () => {
+  const firstChild = fakeHelperChild();
+  const secondChild = fakeHelperChild();
+  const context = waylandPatchContext([firstChild, secondChild]);
+  context.process.env = { DISPLAY: ":1", XDG_SESSION_TYPE: "x11" };
+  let releases = 0;
+
+  const completed = context.pA("Ctrl+Space", () => releases++);
+  assert.equal(typeof completed.dispose, "function");
+  firstChild.emit("exit", 0);
+  firstChild.emit("error", new Error("late error"));
+  await new Promise(setImmediate);
+  assert.equal(releases, 1);
+
+  const cancelled = context.pA("Ctrl+Space", () => releases++);
+  cancelled.dispose();
+  secondChild.emit("exit", 0);
+  await new Promise(setImmediate);
+  assert.equal(secondChild.killed, true);
+  assert.equal(releases, 1);
 });
 
 test("portal failure tears down the existing lifecycle without dropping other platforms", () => {

--- a/linux-features/global-dictation/test.js
+++ b/linux-features/global-dictation/test.js
@@ -70,38 +70,6 @@ function mainBundleFixture() {
   ].join("");
 }
 
-function legacyPatchedMainBundleFixture() {
-  let legacy = applyLinuxGlobalDictationMainProcessPatch(mainBundleFixture());
-  legacy = legacy.replace(
-    'var codexLinuxGlobalDictationPatch="codex-linux-global-dictation-v2";',
-    'var codexLinuxGlobalDictationPatch="codex-linux-global-dictation-v1";',
-  );
-  legacy = legacy.replace(/function codexLinuxGlobalDictationPasteX11\(\) \{[\s\S]*?\n\}/u, "");
-  legacy = legacy.replace(
-    /function codexLinuxGlobalDictationReleaseWatcher\(accelerator, onReleased\) \{[\s\S]*?\n\}/u,
-    `function codexLinuxGlobalDictationReleaseWatcher(accelerator) {
-  const helperPath = codexLinuxGlobalDictationNativePath("global-dictation-release-monitor");
-  if (helperPath == null) return null;
-  return require("node:child_process").spawn(helperPath, ["--accelerator", accelerator], {
-    stdio: "ignore",
-    windowsHide: true,
-  });
-}`,
-  );
-  legacy = legacy.replace(
-    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e,t);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return n}",
-    "case`linux`:{let n=codexLinuxGlobalDictationReleaseWatcher(e);if(n==null)throw Error(`Global dictation hotkey release watching is not supported.`);return _A(n,t)}",
-  );
-  legacy = legacy.replace(
-    "await codexLinuxGlobalDictationPasteX11()",
-    "await k7(`xdotool`,[`key`,`--clearmodifiers`,`ctrl+v`])",
-  );
-  assert.match(legacy, /codex-linux-global-dictation-v1/);
-  assert.match(legacy, /return _A\(n,t\)/);
-  assert.match(legacy, /await k7\(`xdotool`/);
-  return legacy;
-}
-
 function fakeHelperChild() {
   const child = new EventEmitter();
   child.stdin = {
@@ -250,39 +218,6 @@ test("main patch handles dollar signs in minified identifiers", () => {
   assert.match(patched, /function e\$A\(e,t,n\)/);
   assert.match(patched, /e\$A\(e,\{onPressed:/);
   assert.match(patched, /L\$k\(e\)\?`Modifier-only shortcuts/);
-});
-
-test("main patch upgrades the legacy v1 minifier aliases atomically", () => {
-  const legacy = legacyPatchedMainBundleFixture();
-  const migrated = applyLinuxGlobalDictationMainProcessPatch(legacy);
-
-  assert.notEqual(migrated, legacy);
-  assert.match(migrated, /codex-linux-global-dictation-v2/);
-  assert.doesNotMatch(migrated, /codex-linux-global-dictation-v1/);
-  assert.doesNotMatch(migrated, /return _A\(n,t\)/);
-  assert.doesNotMatch(migrated, /await k7\(`xdotool`/);
-  assert.match(migrated, /codexLinuxGlobalDictationReleaseWatcher\(e,t\)/);
-  assert.match(migrated, /await codexLinuxGlobalDictationPasteX11\(\)/);
-  assert.doesNotThrow(() => new vm.Script(migrated));
-  assert.equal(applyLinuxGlobalDictationMainProcessPatch(migrated), migrated);
-});
-
-test("legacy v1 migration fails closed when only part of the old patch is present", () => {
-  const legacy = legacyPatchedMainBundleFixture().replace(
-    "await k7(`xdotool`,[`key`,`--clearmodifiers`,`ctrl+v`])",
-    "await changedPasteHelper()",
-  );
-  const warnings = [];
-  const previousWarn = console.warn;
-  console.warn = (message) => warnings.push(message);
-
-  try {
-    assert.equal(applyLinuxGlobalDictationMainProcessPatch(legacy), legacy);
-  } finally {
-    console.warn = previousWarn;
-  }
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /legacy Linux X11 paste branch matched 0 times/);
 });
 
 test("Wayland registration uses a release-aware portal helper", () => {


### PR DESCRIPTION
## Summary

- stop relying on minified main-bundle aliases for the X11 release watcher and paste path
- return a disposable Linux watcher directly and run the fixed `xdotool` paste command through a Linux-owned helper
- migrate already-patched `v1` bundles to the corrected `v2` shape without accepting partial legacy state

Fixes #1064

## Validation

- `node --test linux-features/global-dictation/test.js`
- `bash scripts/ci/run-node-checks.sh`
- `bash tests/scripts_smoke.sh`
- applied the descriptor to the pinned `26.715.31925` main bundle, including an old-`v1` to `v2` migration replay
