### PR TITLE
[codex] Keep separated Linux header actions right-aligned

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -2802,12 +2802,17 @@ test("updates every Linux zoom titlebar overlay refresh call site", () => {
   );
 });
 
-test("adds a right-side safe area for Linux window controls in application menu chrome", () => {
-  const source = [
-    "var l=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+c,right:0}),modern:Object.freeze({left:76+c,right:0})}),applicationMenu:Object.freeze({left:0,right:0})});",
-    "var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
+function windowControlsSafeAreaFixture(firstInset = 0, secondInset = 0) {
+  return [
+    `var l=Object.freeze({default:Object.freeze({left:0,right:0}),mac:Object.freeze({legacy:Object.freeze({left:66+c,right:0}),modern:Object.freeze({left:76+c,right:0})}),applicationMenu:Object.freeze({left:0,right:${firstInset}})});`,
+    `var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:${secondInset}})});`,
+    "function ol({isHeaderEdgeScroll:e,isApplicationMenuBarEnabled:t}){return (0,gl.jsxs)(ue.header,{className:a(`app-header`,t?`top-toolbar-sm`:`top-0`),children:[(0,gl.jsx)(sl,{entries:m,fitWidth:n,slotWidth:t?c:o,side:`start`}),(0,gl.jsx)(sl,{entries:h,fitWidth:r,slotWidth:u,side:`end`})]})}",
     "function sl({entries:e,fitWidth:t,side:n,slotWidth:r}){let i=e.some(({align:e})=>e===`end`),o=a({\"ps-[max(var(--spacing-token-safe-header-left),0.5rem)]\":n===`start`,\"pe-2\":n===`start`&&i||n===`end`}),s=vr(e=>{let{width:n}=sr(e);t.set(n)});return jsx(o)}",
   ].join("");
+}
+
+test("uses the Linux window-controls safe area only when the app header shares the titlebar", () => {
+  const source = windowControlsSafeAreaFixture();
 
   const patched = applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source);
 
@@ -2821,17 +2826,38 @@ test("adds a right-side safe area for Linux window controls in application menu 
   );
   assert.match(
     patched,
-    /"pe-2":n===`start`&&i,"pe-\(--spacing-token-safe-header-right\)":n===`end`/,
+    /codexLinuxUseWindowControlsSafeArea:!t,side:`end`/,
   );
-  assert.doesNotMatch(patched, /"pe-2":n===`start`&&i\|\|n===`end`/);
+  assert.match(
+    patched,
+    /function sl\(\{entries:e,fitWidth:t,side:n,slotWidth:r,codexLinuxUseWindowControlsSafeArea\}\)/,
+  );
+  assert.match(
+    patched,
+    /"pe-2":n===`start`&&i\|\|n===`end`&&!codexLinuxUseWindowControlsSafeArea,"pe-\(--spacing-token-safe-header-right\)":n===`end`&&codexLinuxUseWindowControlsSafeArea/,
+  );
+  assert.doesNotMatch(patched, /"pe-2":n===`start`&&i\|\|n===`end`(?=[,}])/);
+
+  const classRulesSource = patched.match(
+    /o=a\((\{[^{}]*codexLinuxUseWindowControlsSafeArea[^{}]*\})\),s=vr/,
+  )?.[1];
+  assert.ok(classRulesSource);
+  const resolveClassRules = (side, hasEndEntries, useWindowControlsSafeArea) =>
+    vm.runInNewContext(`(${classRulesSource})`, {
+      n: side,
+      i: hasEndEntries,
+      codexLinuxUseWindowControlsSafeArea: useWindowControlsSafeArea,
+    });
+  const separateRowClasses = resolveClassRules("end", true, false);
+  assert.equal(separateRowClasses["pe-2"], true);
+  assert.equal(separateRowClasses["pe-(--spacing-token-safe-header-right)"], false);
+  const overlaidTitlebarClasses = resolveClassRules("end", true, true);
+  assert.equal(overlaidTitlebarClasses["pe-2"], false);
+  assert.equal(overlaidTitlebarClasses["pe-(--spacing-token-safe-header-right)"], true);
 });
 
 test("patches remaining Linux window controls safe areas when another copy is already patched", () => {
-  const source = [
-    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:138})});",
-    "var m=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
-    "function sl({entries:e,fitWidth:t,side:n,slotWidth:r}){let i=e.some(({align:e})=>e===`end`),o=a({\"ps-[max(var(--spacing-token-safe-header-left),0.5rem)]\":n===`start`,\"pe-2\":n===`start`&&i||n===`end`}),s=vr(e=>{let{width:n}=sr(e);t.set(n)});return jsx(o)}",
-  ].join("");
+  const source = windowControlsSafeAreaFixture(138, 0);
 
   const patched = applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source);
 
@@ -2845,21 +2871,36 @@ test("patches remaining Linux window controls safe areas when another copy is al
   );
   assert.match(
     patched,
-    /"pe-2":n===`start`&&i,"pe-\(--spacing-token-safe-header-right\)":n===`end`/,
+    /codexLinuxUseWindowControlsSafeArea:!t,side:`end`/,
   );
 });
 
 test("patches remaining Linux header safe-area padding when the menu inset is already patched", () => {
-  const source =
-    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:138})});function sl({entries:e,fitWidth:t,side:n,slotWidth:r}){let i=e.some(({align:e})=>e===`end`),o=a({\"ps-[max(var(--spacing-token-safe-header-left),0.5rem)]\":n===`start`,\"pe-2\":n===`start`&&i||n===`end`}),s=vr(e=>{let{width:n}=sr(e);t.set(n)});return jsx(o)}";
+  const source = windowControlsSafeAreaFixture(138, 138);
 
   const patched = applyPatchTwice(applyLinuxWindowControlsSafeAreaPatch, source);
 
   assert.match(
     patched,
-    /"pe-2":n===`start`&&i,"pe-\(--spacing-token-safe-header-right\)":n===`end`/,
+    /"pe-2":n===`start`&&i\|\|n===`end`&&!codexLinuxUseWindowControlsSafeArea,"pe-\(--spacing-token-safe-header-right\)":n===`end`&&codexLinuxUseWindowControlsSafeArea/,
   );
-  assert.doesNotMatch(patched, /"pe-2":n===`start`&&i\|\|n===`end`/);
+  assert.doesNotMatch(patched, /"pe-2":n===`start`&&i\|\|n===`end`(?=[,}])/);
+});
+
+test("warns when the Linux window-controls safe area cannot follow the current header layout", () => {
+  const source = [
+    "var l=Object.freeze({applicationMenu:Object.freeze({left:0,right:0})});",
+    "function ol({isHeaderEdgeScroll:e,isApplicationMenuBarEnabled:t}){return jsx(`drifted-header`)}",
+  ].join("");
+
+  const { value, warnings } = captureWarns(() =>
+    applyLinuxWindowControlsSafeAreaPatch(source),
+  );
+
+  assert.match(value, /applicationMenu:Object\.freeze\(\{left:0,right:138\}\)/);
+  assert.deepEqual(warnings, [
+    "WARN: Could not connect the Linux window controls safe area to the current app header layout",
+  ]);
 });
 
 test("keeps tooltips out of the Linux window controls titlebar area", () => {

--- a/scripts/patches/impl/webview/index.js
+++ b/scripts/patches/impl/webview/index.js
@@ -16,6 +16,7 @@ const LINUX_SAFE_MONOSPACE_FONT_STACK =
   "\"Noto Sans Mono\", \"DejaVu Sans Mono\", \"Liberation Mono\", \"Ubuntu Mono\", ui-monospace, \"SFMono-Regular\", \"SF Mono\", Menlo, Consolas, monospace";
 const LINUX_TOOLTIP_COLLISION_PADDING_TOP = 44;
 const LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT = 138;
+const LINUX_WINDOW_CONTROLS_SAFE_AREA_PROP = "codexLinuxUseWindowControlsSafeArea";
 
 function applyLinuxSafeMonospaceFontStackPatch(currentSource) {
   const safeLinuxMonoFontPattern =
@@ -141,35 +142,118 @@ function applyLinuxOpaqueWindowsDefaultPatch(currentSource) {
   return currentSource;
 }
 
+function applyLinuxHeaderSlotSafeAreaPatch(currentSource) {
+  const prop = LINUX_WINDOW_CONTROLS_SAFE_AREA_PROP;
+  const alreadyPatched =
+    currentSource.includes(`${prop}:!`) &&
+    currentSource.includes(`,${prop}}){`) &&
+    currentSource.includes(`&&!${prop},"pe-(--spacing-token-safe-header-right)":`) &&
+    currentSource.includes(`&&${prop}`);
+  if (alreadyPatched) {
+    return currentSource;
+  }
+  if (currentSource.includes(prop)) {
+    return null;
+  }
+
+  const headerMatch = currentSource.match(
+    /function [A-Za-z_$][\w$]*\(\{isHeaderEdgeScroll:[A-Za-z_$][\w$]*,isApplicationMenuBarEnabled:([A-Za-z_$][\w$]*)\}\)\{/u,
+  );
+  if (headerMatch == null) {
+    return null;
+  }
+  const headerOpenBrace = headerMatch.index + headerMatch[0].length - 1;
+  const headerCloseBrace = findMatchingBrace(currentSource, headerOpenBrace);
+  if (headerCloseBrace === -1) {
+    return null;
+  }
+  const headerSource = currentSource.slice(headerMatch.index, headerCloseBrace + 1);
+  const endSlotPattern = /(slotWidth:[A-Za-z_$][\w$]*),side:`end`/gu;
+  const endSlotMatches = [...headerSource.matchAll(endSlotPattern)];
+  if (endSlotMatches.length !== 1) {
+    return null;
+  }
+
+  const slotMatches = [...currentSource.matchAll(
+    /function [A-Za-z_$][\w$]*\(\{entries:[A-Za-z_$][\w$]*,fitWidth:[A-Za-z_$][\w$]*,side:([A-Za-z_$][\w$]*),slotWidth:[A-Za-z_$][\w$]*\}\)\{/gu,
+  )];
+  if (slotMatches.length !== 1) {
+    return null;
+  }
+  const slotMatch = slotMatches[0];
+  const slotOpenBrace = slotMatch.index + slotMatch[0].length - 1;
+  const slotCloseBrace = findMatchingBrace(currentSource, slotOpenBrace);
+  if (slotCloseBrace === -1) {
+    return null;
+  }
+  const slotSource = currentSource.slice(slotMatch.index, slotCloseBrace + 1);
+  const sideAlias = slotMatch[1];
+  const paddingPattern = new RegExp(
+    `"pe-2":${escapeRegExp(sideAlias)}===\`start\`&&([A-Za-z_$][\\w$]*)\\|\\|${escapeRegExp(sideAlias)}===\`end\``,
+    "u",
+  );
+  const paddingMatch = slotSource.match(paddingPattern);
+  if (paddingMatch == null) {
+    return null;
+  }
+
+  const menuEnabledAlias = headerMatch[1];
+  const hasEndEntriesAlias = paddingMatch[1];
+  const patchedHeaderSource = headerSource.replace(
+    endSlotPattern,
+    `$1,${prop}:!${menuEnabledAlias},side:\`end\``,
+  );
+  const patchedSlotSource = slotSource
+    .replace(
+      slotMatch[0],
+      slotMatch[0].replace("}){", `,${prop}}){`),
+    )
+    .replace(
+      paddingPattern,
+      `"pe-2":${sideAlias}===\`start\`&&${hasEndEntriesAlias}||${sideAlias}===\`end\`&&!${prop},"pe-(--spacing-token-safe-header-right)":${sideAlias}===\`end\`&&${prop}`,
+    );
+
+  return currentSource
+    .replace(headerSource, patchedHeaderSource)
+    .replace(slotSource, patchedSlotSource);
+}
+
 function applyLinuxWindowControlsSafeAreaPatch(currentSource) {
   const currentInset = `applicationMenu:Object.freeze({left:0,right:${LINUX_WINDOW_CONTROLS_SAFE_AREA_RIGHT}})`;
   const defaultInset = "applicationMenu:Object.freeze({left:0,right:0})";
-  const currentHeaderSlotPadding =
-    '"pe-2":n===`start`&&i,"pe-(--spacing-token-safe-header-right)":n===`end`';
-  const defaultHeaderSlotPadding = '"pe-2":n===`start`&&i||n===`end`';
 
   let patchedSource = currentSource;
   if (patchedSource.includes(defaultInset)) {
     patchedSource = patchedSource.split(defaultInset).join(currentInset);
   }
 
-  if (patchedSource.includes(defaultHeaderSlotPadding)) {
-    patchedSource = patchedSource.split(defaultHeaderSlotPadding).join(currentHeaderSlotPadding);
+  let warnedHeaderSlotDrift = false;
+  const headerSlotSource = applyLinuxHeaderSlotSafeAreaPatch(patchedSource);
+  if (headerSlotSource != null) {
+    patchedSource = headerSlotSource;
+  } else if (currentSource.includes("isApplicationMenuBarEnabled")) {
+    console.warn(
+      "WARN: Could not connect the Linux window controls safe area to the current app header layout",
+    );
+    warnedHeaderSlotDrift = true;
   }
 
   if (
     patchedSource !== currentSource ||
     (
       patchedSource.includes(currentInset) &&
-      patchedSource.includes(currentHeaderSlotPadding)
+      patchedSource.includes(LINUX_WINDOW_CONTROLS_SAFE_AREA_PROP)
     )
   ) {
     return patchedSource;
   }
 
   if (
-    currentSource.includes("applicationMenu:Object.freeze({left:0,right:") ||
-    currentSource.includes("spacing-token-safe-header-right")
+    !warnedHeaderSlotDrift &&
+    (
+      currentSource.includes("applicationMenu:Object.freeze({left:0,right:") ||
+      currentSource.includes("spacing-token-safe-header-right")
+    )
   ) {
     console.warn(
       "WARN: Could not find Linux window controls safe-area insertion point — skipping safe-area patch",


### PR DESCRIPTION
## Summary

- keep the 138px right safe area when the app header shares the native titlebar row
- restore the normal `pe-2` alignment when the application-menu layout moves the app header below the titlebar
- keep the patch fail-soft on upstream drift and cover both layout modes with runtime class-rule tests

## Root cause

#1071 correctly reserved the native window-controls footprint, but the current app shell positions the main header at `top-toolbar-sm` when the application menu is enabled. The right slot still consumed the titlebar safe area even though it was vertically below the controls.

This does not revert #1071: the application-menu/titlebar row retains the 138px inset, and an app header overlaid on the titlebar continues to use the safe-area padding.

Fixes #1074

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` (395 passed)
- `bash tests/scripts_smoke.sh`
- `TMPDIR=/tmp make build-app` against ChatGPT 26.715.31925 (`accepted_with_warnings`; required patch validation passed)
- `./scripts/build-appimage.sh`
