### PR TITLE
Fix managed Node launcher shebangs

### DIFF
--- a/scripts/lib/node-runtime.sh
+++ b/scripts/lib/node-runtime.sh
@@ -104,6 +104,33 @@ node_toolchain_compatible() {
         && [ -x "$runtime_dir/bin/npx" ]
 }
 
+# The official Linux Node archives currently ship npm and npx with a
+# `#!/usr/bin/node` shebang.  That makes the managed runtime unexpectedly
+# depend on a system Node installation when a caller executes `npx` directly
+# (as the installer does while patching app.asar).  Keep the launchers inside
+# the managed runtime self-contained by pointing their shebangs at its node
+# binary.  Resolve symlinks first so npm/npx remain symlinks in bin/.
+repair_managed_node_launchers() {
+    local runtime_dir="$1"
+    local node_path="$runtime_dir/bin/node"
+    local launcher
+    local launcher_target
+    local first_line
+
+    [ -x "$node_path" ] || return 1
+    for launcher in "$runtime_dir/bin/npm" "$runtime_dir/bin/npx"; do
+        [ -e "$launcher" ] || continue
+        launcher_target="$(readlink -f "$launcher" 2>/dev/null || true)"
+        [ -n "$launcher_target" ] && [ -f "$launcher_target" ] || continue
+        first_line="$(head -n 1 "$launcher_target" 2>/dev/null || true)"
+        case "$first_line" in
+            '#!'*node)
+                sed -i "1s|^#!.*node$|#!$node_path|" "$launcher_target"
+                ;;
+        esac
+    done
+}
+
 copy_node_runtime() {
     local source_dir="$1"
     local destination_dir="$2"
@@ -121,6 +148,7 @@ copy_node_runtime() {
     cp -a "$source_dir/." "$tmp_dir/"
     rm -rf "$destination_dir"
     mv "$tmp_dir" "$destination_dir"
+    repair_managed_node_launchers "$destination_dir" || return 1
 }
 
 managed_node_archive_url() {
@@ -180,6 +208,7 @@ ensure_managed_node_runtime() {
     local source_dir
 
     if node_toolchain_compatible "$destination_dir"; then
+        repair_managed_node_launchers "$destination_dir" || error "Failed to repair managed Node.js launchers"
         info "Managed Node.js runtime ready: $destination_dir"
         export_managed_node_runtime "$destination_dir"
         return 0

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -3166,6 +3166,53 @@ SCRIPT
     assert_contains "$workspace/output.log" "v22.22.2"
 }
 
+test_managed_node_runtime_repairs_npx_shebang() {
+    info "Checking managed Node.js runtime repairs npm launcher shebangs"
+    local workspace="$TMP_DIR/managed-node-runtime-launchers"
+    local source_dir="$workspace/source"
+    local install_dir="$workspace/install"
+    local output_log="$workspace/output.log"
+
+    mkdir -p "$source_dir/bin" "$source_dir/lib/node_modules/npm/bin" "$install_dir/resources"
+    cat > "$source_dir/bin/node" <<'SCRIPT'
+#!/usr/bin/env bash
+if [ "${1:-}" = "-e" ]; then
+    printf '%s' 'codex-node-runtime-ok:22.22.2'
+else
+    printf 'managed node ran %s\n' "${1:-}"
+fi
+SCRIPT
+    chmod +x "$source_dir/bin/node"
+    for launcher in npm npx; do
+        cat > "$source_dir/lib/node_modules/npm/bin/${launcher}-cli.js" <<'SCRIPT'
+#!/usr/bin/node
+console.log('launcher')
+SCRIPT
+        chmod +x "$source_dir/lib/node_modules/npm/bin/${launcher}-cli.js"
+        ln -s "../lib/node_modules/npm/bin/${launcher}-cli.js" "$source_dir/bin/$launcher"
+    done
+
+    (
+        SCRIPT_DIR="$REPO_DIR"
+        WORK_DIR="$workspace/work"
+        ARCH="x86_64"
+        CODEX_MANAGED_NODE_SOURCE="$source_dir"
+        mkdir -p "$WORK_DIR"
+        info() { echo "[INFO] $*" >&2; }
+        warn() { echo "[WARN] $*" >&2; }
+        error() { echo "[ERROR] $*" >&2; exit 1; }
+        # shellcheck disable=SC1091
+        source "$REPO_DIR/scripts/lib/node-runtime.sh"
+        ensure_managed_node_runtime "$install_dir/resources/node-runtime"
+        head -n 1 "$install_dir/resources/node-runtime/lib/node_modules/npm/bin/npx-cli.js"
+        "$install_dir/resources/node-runtime/bin/npx" --version
+    ) > "$output_log" 2>&1
+
+    assert_contains "$output_log" "#!$install_dir/resources/node-runtime/bin/node"
+    assert_contains "$output_log" "managed node ran"
+    [ -L "$install_dir/resources/node-runtime/bin/npx" ] || fail "Expected npx to remain a symlink"
+}
+
 test_managed_node_runtime_rejects_version_only_stub() {
     info "Checking managed Node.js runtime rejects version-only stubs"
     local workspace="$TMP_DIR/managed-node-runtime-stub"
@@ -7530,6 +7577,7 @@ main() {
     test_installer_keeps_electron_fallback_for_bad_metadata
     test_port_validation_rejects_oversized_numeric_values
     test_managed_node_runtime_source_install
+    test_managed_node_runtime_repairs_npx_shebang
     test_managed_node_runtime_rejects_version_only_stub
     test_better_sqlite3_electron_42_source_patch
     test_v8_nullptr_workaround_skips_when_included_probe_succeeds


### PR DESCRIPTION
## Summary

- Make bundled npm/npx launchers use the managed Node binary.
- Stage the upstream-DMG intelligence helper required by the patch script.
- Add regression coverage for both packaged builder inputs.

## Root cause

Official Node archives ship npm/npx with a `#!/usr/bin/node` shebang. The updater rebuild uses `npx` directly, so Fedora installations without a system Node fail despite including a managed Node runtime. Once that was corrected, the rebuild also exposed that the packaged update-builder omitted `scripts/lib/upstream-dmg-intel.js`, which `patch-linux-window-ui.js` imports.

## Validation

- `bash tests/scripts_smoke.sh`