### PR TITLE
feat: keep thread history visible across model providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 
+- An opt-in `cross-provider-thread-history` Linux feature keeps local Recent,
+  Projects, archive, and lookup lists visible after the active model provider
+  changes. It requests an explicit unfiltered provider list and binds cold
+  resume to the active provider without rewriting persisted thread provenance
+  or authentication state.
 - A shared upstream DMG acceptance profile now produces the same structured
   decision for local installs, updater rebuilds, and scheduled CI. Scheduled
   rejections create one fingerprinted drift issue and supersede issues for

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ workarounds.
 | Wrapper updater button | Opt-in | `codex-wrapper-updater` | [Docs](linux-features/codex-wrapper-updater/README.md) |
 | Conversation mode | Opt-in | `conversation-mode` | [Docs](linux-features/conversation-mode/README.md) |
 | Copilot reasoning effort defaults | Opt-in | `copilot-reasoning-effort` | [Docs](linux-features/copilot-reasoning-effort/README.md) |
+| Cross-provider thread history | Opt-in | `cross-provider-thread-history` | [Docs](linux-features/cross-provider-thread-history/README.md) |
 | Directory-only working-tree watch | Opt-in | `directory-only-working-tree-watch` | [Docs](linux-features/directory-only-working-tree-watch/README.md) |
 | Example Linux Feature | Developer example | `example-feature` | [Docs](linux-features/example-feature/README.md) |
 | Frameless titlebar | Opt-in | `frameless-titlebar` | [Docs](linux-features/frameless-titlebar/README.md) |

--- a/linux-features/cross-provider-thread-history/README.md
+++ b/linux-features/cross-provider-thread-history/README.md
@@ -1,0 +1,68 @@
+# Cross-Provider Thread History
+
+This feature is disabled by default. Enable it when one Desktop installation
+uses more than one Codex model provider and locally stored threads disappear
+from Recent or Projects after the active provider changes.
+
+```json
+{
+  "enabled": [
+    "cross-provider-thread-history"
+  ]
+}
+```
+
+Codex app-server treats an omitted or `null` `modelProviders` field on ordinary
+`thread/list` calls as “the currently configured provider.” An explicit empty
+array means “do not filter by provider.” The upstream Desktop webview currently
+sends `modelProviders: null` from its recent, archived, lookup, and related
+thread enumeration paths. This feature changes those thread-enumeration
+parameters to explicit empty arrays.
+
+The feature does not rewrite SQLite rows, JSONL session files, provider
+metadata, authentication state, project assignments, or thread contents. It
+also does not bypass host, workspace, `sourceKinds`, archive, recent-limit, or
+relation filters.
+
+When Desktop cold-resumes a visible thread, the feature explicitly prefers the
+special provider selected by Desktop (for example, Copilot), then the current
+`model_provider` from Codex config, and finally Codex's normal default. The
+stored thread keeps its original `modelProvider` as provenance, while new turns
+are routed through the provider that is active when the thread is reopened.
+Provider choice is sticky for a running thread, so reopen the thread after
+changing `model_provider`. If the thread has already been loaded by the current
+app-server process, fully restart Desktop first; app-server intentionally
+rejoins loaded threads instead of rebinding them in place.
+
+## ChatGPT account plus a custom provider
+
+Do not replace the global ChatGPT login with API-key login when ChatGPT account
+features such as Remote Control must remain available. Keep the custom
+credential inside its exact provider table instead:
+
+```toml
+model_provider = "custom"
+
+[model_providers.custom]
+name = "Custom"
+base_url = "https://example.invalid/v1"
+wire_api = "responses"
+requires_openai_auth = true
+experimental_bearer_token = "<custom-provider-token>"
+```
+
+Then use the normal ChatGPT browser login (`codex login`). In this arrangement,
+the provider-scoped bearer token authenticates only custom-provider model
+requests; the global ChatGPT login remains the account identity used by
+subscription features and Remote Control. Set `model_provider` to the desired
+provider, restart Desktop, and reopen an existing thread to switch its
+continuation route. No login/logout cycle is required.
+
+Never commit a real token, `~/.codex/config.toml`, `~/.codex/auth.json`, or
+Remote Control device keys to this repository.
+
+## Test
+
+```bash
+node --test linux-features/cross-provider-thread-history/test.js
+```

--- a/linux-features/cross-provider-thread-history/feature.json
+++ b/linux-features/cross-provider-thread-history/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "cross-provider-thread-history",
+  "title": "Cross-Provider Thread History",
+  "description": "Keeps local threads visible across model providers and resumes them through the currently active provider.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/cross-provider-thread-history/patch.js
+++ b/linux-features/cross-provider-thread-history/patch.js
@@ -1,0 +1,296 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PATCH_MARKER = "codexLinuxCrossProviderThreadHistory";
+const ACTIVE_RESUME_PROVIDER_MARKER = "codexLinuxActiveResumeProvider";
+const CURRENT_LIST_ALL = "listAllThreads({modelProviders:null";
+const COMPLIANT_LIST_ALL = "listAllThreads({modelProviders:[]";
+const PATCHED_PROVIDER_FILTER = `modelProviders:[]/*${PATCH_MARKER}*/`;
+const CURRENT_RESUME_PROVIDER_PATTERN =
+  /(`thread\/resume`,\{[^{}]{0,1600}?model:null,modelProvider:)([A-Za-z_$][\w$]*)(\.modelProvider)(,serviceTier:\2\.serviceTier)/g;
+const COMPLIANT_RESUME_PROVIDER_PATTERN = new RegExp(
+  "(`thread/resume`,\\{[^{}]{0,1600}?model:null,modelProvider:)" +
+    "([A-Za-z_$][\\w$]*)(\\.modelProvider\\?\\?\\2\\.config\\?\\.model_provider" +
+    `\\?\\?null/\\*${ACTIVE_RESUME_PROVIDER_MARKER}\\*/)` +
+    "(,serviceTier:\\2\\.serviceTier)",
+  "g",
+);
+const DIRECT_THREAD_LIST_PREFIX = "`thread/list`,\\{[^{}]{0,800}?";
+const RECENT_THREAD_PARAMS_PREFIX =
+  "async listRecentThreads\\([^)]*\\)\\{let [A-Za-z_$][\\w$]*=\\{[^{}]{0,800}?";
+const THREAD_ENUMERATION_PREFIXES = [
+  DIRECT_THREAD_LIST_PREFIX,
+  RECENT_THREAD_PARAMS_PREFIX,
+];
+const THREAD_HISTORY_TARGETS = [
+  {
+    id: "manager",
+    pattern:
+      /^app-initial~artifact-tab-content\.electron~notebook-preview-panel~app-main~business-checkout~oxnpxkxc-[^.]+\.js$/,
+    expectedEnumerationCount: 5,
+    expectedResumeCount: 1,
+    surface: "thread manager",
+  },
+  {
+    id: "resolver",
+    pattern:
+      /^app-initial~artifact-tab-content\.electron~notebook-preview-panel~app-main~pull-request-rout~jvsvjxtt-[^.]+\.js$/,
+    expectedEnumerationCount: 2,
+    expectedResumeCount: 0,
+    surface: "cross-host thread resolver",
+  },
+  {
+    id: "subagent",
+    pattern:
+      /^app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~k4644ppc-[^.]+\.js$/,
+    expectedEnumerationCount: 1,
+    expectedResumeCount: 0,
+    surface: "subagent thread enumeration",
+  },
+];
+
+function countOccurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+function countMatches(source, pattern) {
+  return Array.from(source.matchAll(pattern)).length;
+}
+
+function providerFilterPattern(prefixPattern, providerPattern, capturePrefix = false) {
+  const prefix = capturePrefix
+    ? `(${prefixPattern})`
+    : prefixPattern;
+  return new RegExp(`${prefix}${providerPattern}`, "g");
+}
+
+function countThreadEnumerationFilters(source, listAllNeedle, providerPattern) {
+  return THREAD_ENUMERATION_PREFIXES.reduce(
+    (total, prefix) =>
+      total + countMatches(source, providerFilterPattern(prefix, providerPattern)),
+    countOccurrences(source, listAllNeedle),
+  );
+}
+
+function threadEnumerationCounts(source) {
+  return {
+    currentEnumeration: countThreadEnumerationFilters(
+      source,
+      CURRENT_LIST_ALL,
+      "modelProviders:null",
+    ),
+    compliantEnumeration: countThreadEnumerationFilters(
+      source,
+      COMPLIANT_LIST_ALL,
+      "modelProviders:\\[\\]",
+    ),
+  };
+}
+
+function matchesThreadHistoryState(counts, target, state) {
+  const current = state === "current";
+  return (
+    counts.currentEnumeration ===
+      (current ? target.expectedEnumerationCount : 0) &&
+    counts.compliantEnumeration ===
+      (current ? 0 : target.expectedEnumerationCount) &&
+    counts.currentResume === (current ? target.expectedResumeCount : 0) &&
+    counts.compliantResume === (current ? 0 : target.expectedResumeCount)
+  );
+}
+
+function classifyThreadHistoryState(counts, target) {
+  if (matchesThreadHistoryState(counts, target, "current")) {
+    return "current";
+  }
+  if (matchesThreadHistoryState(counts, target, "compliant")) {
+    return "compliant";
+  }
+  return "invalid";
+}
+
+function threadHistoryCounts(source) {
+  return {
+    ...threadEnumerationCounts(source),
+    currentResume: countMatches(source, CURRENT_RESUME_PROVIDER_PATTERN),
+    compliantResume: countMatches(source, COMPLIANT_RESUME_PROVIDER_PATTERN),
+  };
+}
+
+function applyCrossProviderThreadHistoryPatch(
+  source,
+  { expectedEnumerationCount, expectedResumeCount = 0, surface },
+) {
+  const target = { expectedEnumerationCount, expectedResumeCount };
+  const counts = threadHistoryCounts(source);
+
+  if (matchesThreadHistoryState(counts, target, "compliant")) {
+    return source;
+  }
+
+  if (!matchesThreadHistoryState(counts, target, "current")) {
+    console.warn(
+      `WARN: Could not verify ${surface} provider filter ` +
+        `(current=${counts.currentEnumeration}, ` +
+        `compliant=${counts.compliantEnumeration}, ` +
+        `expected=${expectedEnumerationCount}) - or resume provider ` +
+        `(current=${counts.currentResume}, compliant=${counts.compliantResume}, ` +
+        `expected=${expectedResumeCount}) - ` +
+        "skipping cross-provider thread history patch",
+    );
+    return source;
+  }
+
+  let patched = source
+    .replaceAll(
+      CURRENT_LIST_ALL,
+      `listAllThreads({${PATCHED_PROVIDER_FILTER}`,
+    );
+  for (const prefix of THREAD_ENUMERATION_PREFIXES) {
+    patched = patched.replace(
+      providerFilterPattern(prefix, "modelProviders:null", true),
+      `$1${PATCHED_PROVIDER_FILTER}`,
+    );
+  }
+  patched = patched.replace(
+    CURRENT_RESUME_PROVIDER_PATTERN,
+    `$1$2.modelProvider??$2.config?.model_provider??null/*${ACTIVE_RESUME_PROVIDER_MARKER}*/$4`,
+  );
+  return patched;
+}
+
+function skipCrossProviderThreadHistoryPatch(reason) {
+  console.warn(`WARN: ${reason} - skipping cross-provider thread history patch`);
+  return { matched: false, changed: 0, reason };
+}
+
+function resolveThreadHistoryAssets(extractedDir) {
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(assetsDir)) {
+    return {
+      error: `missing webview assets directory ${assetsDir}`,
+      assets: [],
+    };
+  }
+
+  const candidates = fs.readdirSync(assetsDir);
+  const assets = [];
+  for (const target of THREAD_HISTORY_TARGETS) {
+    const matches = candidates.filter((candidate) => target.pattern.test(candidate));
+    if (matches.length !== 1) {
+      return {
+        error:
+          `expected exactly one ${target.surface} bundle, found ${matches.length}`,
+        assets: [],
+      };
+    }
+    const filePath = path.join(assetsDir, matches[0]);
+    assets.push({
+      ...target,
+      filePath,
+      source: fs.readFileSync(filePath, "utf8"),
+    });
+  }
+  return { error: null, assets };
+}
+
+function applyCrossProviderThreadHistoryAssets(extractedDir) {
+  const resolved = resolveThreadHistoryAssets(extractedDir);
+  if (resolved.error != null) {
+    return skipCrossProviderThreadHistoryPatch(resolved.error);
+  }
+
+  const inspected = resolved.assets.map((asset) => {
+    const counts = threadHistoryCounts(asset.source);
+    const state = classifyThreadHistoryState(counts, asset);
+    return { ...asset, counts, state };
+  });
+  const invalid = inspected.find((asset) => asset.state === "invalid");
+  if (invalid != null) {
+    return skipCrossProviderThreadHistoryPatch(
+      `could not verify ${invalid.surface} provider filter ` +
+        `(current=${invalid.counts.currentEnumeration}, ` +
+        `compliant=${invalid.counts.compliantEnumeration}, ` +
+        `expected=${invalid.expectedEnumerationCount}) or resume provider ` +
+        `(current=${invalid.counts.currentResume}, ` +
+        `compliant=${invalid.counts.compliantResume}, ` +
+        `expected=${invalid.expectedResumeCount})`,
+    );
+  }
+
+  const states = new Set(inspected.map((asset) => asset.state));
+  if (states.size !== 1) {
+    return skipCrossProviderThreadHistoryPatch(
+      `inconsistent cross-bundle provider filter state (${inspected
+        .map((asset) => `${asset.id}=${asset.state}`)
+        .join(", ")})`,
+    );
+  }
+  if (states.has("compliant")) {
+    return { matched: true, changed: 0 };
+  }
+
+  const patches = inspected.map((asset) => {
+    const patchedSource = applyCrossProviderThreadHistoryPatch(asset.source, asset);
+    const patchedCounts = threadHistoryCounts(patchedSource);
+    if (
+      patchedSource === asset.source ||
+      !matchesThreadHistoryState(patchedCounts, asset, "compliant")
+    ) {
+      throw new Error(
+        `cross-provider thread history postcondition failed for ${asset.surface}`,
+      );
+    }
+    return { ...asset, patchedSource };
+  });
+
+  const written = [];
+  try {
+    for (const patch of patches) {
+      written.push(patch);
+      fs.writeFileSync(patch.filePath, patch.patchedSource, "utf8");
+    }
+  } catch (error) {
+    const rollbackErrors = [];
+    for (const patch of written.reverse()) {
+      try {
+        fs.writeFileSync(patch.filePath, patch.source, "utf8");
+      } catch (rollbackError) {
+        rollbackErrors.push(
+          rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+        );
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      throw new Error(
+        `cross-provider thread history write failed and rollback was incomplete: ${rollbackErrors.join("; ")}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  return { matched: true, changed: patches.length };
+}
+
+const descriptors = [
+  {
+    id: "all-provider-thread-history",
+    phase: "extracted-app:post-webview",
+    order: 20_850,
+    ciPolicy: "optional",
+    apply: applyCrossProviderThreadHistoryAssets,
+  },
+];
+
+module.exports = {
+  ACTIVE_RESUME_PROVIDER_MARKER,
+  THREAD_HISTORY_TARGETS,
+  applyCrossProviderThreadHistoryAssets,
+  applyCrossProviderThreadHistoryPatch,
+  descriptors,
+  resolveThreadHistoryAssets,
+  threadHistoryCounts,
+  threadEnumerationCounts,
+};

--- a/linux-features/cross-provider-thread-history/test.js
+++ b/linux-features/cross-provider-thread-history/test.js
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  applyExtractedAppPatchDescriptors,
+  normalizePatchDescriptors,
+} = require("../../scripts/patches/engine.js");
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const { createPatchReport } = require("../../scripts/lib/patch-report.js");
+const {
+  ACTIVE_RESUME_PROVIDER_MARKER,
+  THREAD_HISTORY_TARGETS,
+  applyCrossProviderThreadHistoryAssets,
+  applyCrossProviderThreadHistoryPatch,
+  descriptors,
+  threadHistoryCounts,
+} = require("./patch.js");
+
+const currentThreadHistorySource = [
+  "async listRecentThreads({limit:e}){return(await this.sendRequest(`thread/list`,{archived:!1,cursor:null,limit:e,modelProviders:null,sortKey:`updated_at`,useStateDbOnly:!0},{priority:`background`,source:`thread_list`})).data}",
+  "async listArchivedThreads(){return this.listAllThreads({modelProviders:null,archived:!0})}",
+  "async listRecentThreads({cursor:e,limit:t,background:n=!1}){let r={limit:t,cursor:e,sortKey:this.recentConversationSortKey,modelProviders:null,archived:!1,sourceKinds:ie,useStateDbOnly:!0},i=await this.requestClient.sendRequest(`thread/list`,r);return i}",
+  "const listActiveThreads=()=>e.listAllThreads({modelProviders:null});",
+  "let r=await this.threadStore.listAllThreads({modelProviders:null,sourceKinds:j});",
+  "let P=await e.buildNewConversationParams(M,N,x[0]??`/`,k,k.approvalsReviewer,{mode:l?.mode,skipDynamicTools:!0,threadId:t}),F=e.sendRequest(`thread/resume`,{threadId:t,history:null,path:l?.rolloutPath??null,model:null,modelProvider:P.modelProvider,serviceTier:P.serviceTier,cwd:P.cwd})",
+].join("");
+
+const resolverSource =
+  "let[r,i]=await Promise.all([e.listAllThreads({modelProviders:null}),e.listAllThreads({modelProviders:null,archived:!0})]);";
+const subagentSource =
+  "let d=await r(`thread/list`,{limit:200,cursor:n,modelProviders:null,archived:!1,parentThreadId:e});";
+
+const patchOptions = {
+  expectedEnumerationCount: 5,
+  expectedResumeCount: 1,
+  surface: "recent-thread",
+};
+const fixtureAssets = new Map([
+  [
+    "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~oxnpxkxc-fixture.js",
+    currentThreadHistorySource,
+  ],
+  [
+    "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~pull-request-rout~jvsvjxtt-fixture.js",
+    resolverSource,
+  ],
+  [
+    "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~k4644ppc-fixture.js",
+    subagentSource,
+  ],
+]);
+
+function captureWarns(fn) {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (message) => warnings.push(message);
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+function withTempDir(callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cross-provider-thread-history-"));
+  try {
+    return callback(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function withFeatureConfig(enabled, callback) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  return withTempDir((tempDir) => {
+    const configPath = path.join(tempDir, "features.json");
+    fs.writeFileSync(configPath, `${JSON.stringify({ enabled })}\n`);
+    process.env.CODEX_LINUX_FEATURES_CONFIG = configPath;
+    try {
+      return callback(path.resolve(__dirname, ".."));
+    } finally {
+      if (originalConfig == null) {
+        delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+      } else {
+        process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+      }
+    }
+  });
+}
+
+function writeFixtureAssets(extractedDir, sources = fixtureAssets) {
+  const assetsDir = path.join(extractedDir, "webview", "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  for (const [assetName, source] of sources) {
+    fs.writeFileSync(path.join(assetsDir, assetName), source);
+  }
+  return assetsDir;
+}
+
+test("feature stays disabled until selected", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+
+  withFeatureConfig(["cross-provider-thread-history"], (featuresRoot) => {
+    const loaded = loadLinuxFeaturePatchDescriptors({ featuresRoot });
+    assert.deepEqual(
+      loaded.map((descriptor) => [descriptor.id, descriptor.phase, descriptor.ciPolicy]),
+      [
+        [
+          "feature:cross-provider-thread-history:all-provider-thread-history",
+          "extracted-app:post-webview",
+          "optional",
+        ],
+      ],
+    );
+  });
+});
+
+test("thread enumeration requests use an explicit empty provider filter", () => {
+  const patched = applyCrossProviderThreadHistoryPatch(
+    currentThreadHistorySource,
+    patchOptions,
+  );
+
+  assert.notEqual(patched, currentThreadHistorySource);
+  assert.equal(patched.includes("modelProviders:null"), false);
+  assert.equal(
+    patched.match(/modelProviders:\[\]\/\*codexLinuxCrossProviderThreadHistory\*\//g)?.length,
+    5,
+  );
+  assert.equal(applyCrossProviderThreadHistoryPatch(patched, patchOptions), patched);
+});
+
+test("thread resume explicitly prefers the active configured provider", () => {
+  const patched = applyCrossProviderThreadHistoryPatch(
+    currentThreadHistorySource,
+    patchOptions,
+  );
+
+  assert.equal(
+    patched.includes("modelProvider:P.modelProvider,serviceTier:P.serviceTier"),
+    false,
+  );
+  assert.match(
+    patched,
+    new RegExp(
+      `modelProvider:P\\.modelProvider\\?\\?P\\.config\\?\\.model_provider` +
+        `\\?\\?null/\\*${ACTIVE_RESUME_PROVIDER_MARKER}\\*/` +
+        `,serviceTier:P\\.serviceTier`,
+    ),
+  );
+  assert.deepEqual(threadHistoryCounts(patched), {
+    currentEnumeration: 0,
+    compliantEnumeration: 5,
+    currentResume: 0,
+    compliantResume: 1,
+  });
+});
+
+test("resume hardening preserves explicit special-provider overrides", () => {
+  const patched = applyCrossProviderThreadHistoryPatch(
+    currentThreadHistorySource,
+    patchOptions,
+  );
+
+  assert.match(
+    patched,
+    /modelProvider:P\.modelProvider\?\?P\.config\?\.model_provider/,
+  );
+  assert.equal(
+    patched.includes("modelProvider:P.config?.model_provider??P.modelProvider"),
+    false,
+  );
+});
+
+test("explicit provider filters and unrelated null values remain unchanged", () => {
+  const source = [
+    "await sendRequest(`thread/list`,{modelProviders:[`custom`]});",
+    "await sendRequest(`thread/list`,{modelProviders:[]});",
+    "const unrelated={modelProviders:null};",
+  ].join("");
+
+  assert.equal(
+    applyCrossProviderThreadHistoryPatch(source, {
+      expectedEnumerationCount: 1,
+      expectedResumeCount: 0,
+      surface: "explicit-filter fixture",
+    }),
+    source,
+  );
+});
+
+test("an upstream empty provider filter is already compliant", () => {
+  const source = currentThreadHistorySource
+    .replaceAll("modelProviders:null", "modelProviders:[]")
+    .replace(
+      "modelProvider:P.modelProvider,serviceTier:P.serviceTier",
+      `modelProvider:P.modelProvider??P.config?.model_provider??null/*${ACTIVE_RESUME_PROVIDER_MARKER}*/,serviceTier:P.serviceTier`,
+    );
+  const { value, warnings } = captureWarns(() =>
+    applyCrossProviderThreadHistoryPatch(source, patchOptions),
+  );
+
+  assert.equal(value, source);
+  assert.deepEqual(warnings, []);
+});
+
+test("a drifted recent-thread provider expression fails soft with a warning", () => {
+  const source = currentThreadHistorySource.replaceAll(
+    "modelProviders:null",
+    "modelProviders:currentProvider",
+  );
+  const { value, warnings } = captureWarns(() =>
+    applyCrossProviderThreadHistoryPatch(source, patchOptions),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /recent-thread provider filter/);
+});
+
+test("a partially patched bundle is rejected byte-identically", () => {
+  const source = currentThreadHistorySource.replace(
+    "modelProviders:null",
+    "modelProviders:[]/*codexLinuxCrossProviderThreadHistory*/",
+  );
+  const { value, warnings } = captureWarns(() =>
+    applyCrossProviderThreadHistoryPatch(source, patchOptions),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /current=4, compliant=1, expected=5/);
+});
+
+test("a drifted resume provider expression rejects the whole feature", () => {
+  const source = currentThreadHistorySource.replace(
+    "modelProvider:P.modelProvider,serviceTier:P.serviceTier",
+    "modelProvider:storedThread.modelProvider,serviceTier:P.serviceTier",
+  );
+  const { value, warnings } = captureWarns(() =>
+    applyCrossProviderThreadHistoryPatch(source, patchOptions),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /resume provider/);
+});
+
+test("enabled descriptor patches matching extracted webview assets", () => {
+  withFeatureConfig(["cross-provider-thread-history"], (featuresRoot) => {
+    withTempDir((extractedDir) => {
+      const assetsDir = writeFixtureAssets(extractedDir);
+      const loaded = normalizePatchDescriptors(
+        loadLinuxFeaturePatchDescriptors({ featuresRoot }),
+      );
+      const firstReport = createPatchReport();
+
+      applyExtractedAppPatchDescriptors(
+        extractedDir,
+        loaded,
+        {},
+        firstReport,
+        "extracted-app:post-webview",
+      );
+
+      let markerCount = 0;
+      for (const assetName of fixtureAssets.keys()) {
+        const patched = fs.readFileSync(path.join(assetsDir, assetName), "utf8");
+        assert.equal(patched.includes("modelProviders:null"), false);
+        assert.match(patched, /codexLinuxCrossProviderThreadHistory/);
+        markerCount += patched.match(/codexLinuxCrossProviderThreadHistory/g)?.length ?? 0;
+      }
+      assert.equal(markerCount, 8);
+      assert.equal(firstReport.patches[0].status, "applied");
+
+      const secondReport = createPatchReport();
+      applyExtractedAppPatchDescriptors(
+        extractedDir,
+        loaded,
+        {},
+        secondReport,
+        "extracted-app:post-webview",
+      );
+      assert.equal(secondReport.patches[0].status, "already-applied");
+    });
+  });
+});
+
+test("a cross-bundle mixed state is rejected before any asset is written", () => {
+  withTempDir((extractedDir) => {
+    const mixed = new Map(fixtureAssets);
+    const managerName = Array.from(mixed.keys())[0];
+    mixed.set(
+      managerName,
+      applyCrossProviderThreadHistoryPatch(mixed.get(managerName), patchOptions),
+    );
+    const assetsDir = writeFixtureAssets(extractedDir, mixed);
+    const before = new Map(
+      Array.from(mixed.keys(), (assetName) => [
+        assetName,
+        fs.readFileSync(path.join(assetsDir, assetName)),
+      ]),
+    );
+
+    const { value: result, warnings } = captureWarns(() =>
+      applyCrossProviderThreadHistoryAssets(extractedDir),
+    );
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /inconsistent cross-bundle provider filter state/);
+    assert.equal(warnings.length, 1);
+    for (const [assetName, original] of before) {
+      assert.deepEqual(fs.readFileSync(path.join(assetsDir, assetName)), original);
+    }
+  });
+});
+
+test("one drifted bundle prevents writes to every bundle", () => {
+  withTempDir((extractedDir) => {
+    const drifted = new Map(fixtureAssets);
+    const resolverName = Array.from(drifted.keys())[1];
+    drifted.set(
+      resolverName,
+      drifted.get(resolverName).replace("modelProviders:null", "modelProviders:provider"),
+    );
+    const assetsDir = writeFixtureAssets(extractedDir, drifted);
+    const before = new Map(
+      Array.from(drifted.keys(), (assetName) => [
+        assetName,
+        fs.readFileSync(path.join(assetsDir, assetName)),
+      ]),
+    );
+
+    const { value: result, warnings } = captureWarns(() =>
+      applyCrossProviderThreadHistoryAssets(extractedDir),
+    );
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /could not verify cross-host thread resolver/);
+    assert.equal(warnings.length, 1);
+    for (const [assetName, original] of before) {
+      assert.deepEqual(fs.readFileSync(path.join(assetsDir, assetName)), original);
+    }
+  });
+});
+
+test("a missing target bundle prevents writes to every present bundle", () => {
+  withTempDir((extractedDir) => {
+    const incomplete = new Map(fixtureAssets);
+    incomplete.delete(Array.from(incomplete.keys())[2]);
+    const assetsDir = writeFixtureAssets(extractedDir, incomplete);
+    const before = new Map(
+      Array.from(incomplete.keys(), (assetName) => [
+        assetName,
+        fs.readFileSync(path.join(assetsDir, assetName)),
+      ]),
+    );
+
+    const { value: result, warnings } = captureWarns(() =>
+      applyCrossProviderThreadHistoryAssets(extractedDir),
+    );
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /expected exactly one subagent thread enumeration bundle/);
+    assert.equal(warnings.length, 1);
+    for (const [assetName, original] of before) {
+      assert.deepEqual(fs.readFileSync(path.join(assetsDir, assetName)), original);
+    }
+  });
+});
+
+test("a mid-transaction write failure restores every target asset", () => {
+  withTempDir((extractedDir) => {
+    const assetsDir = writeFixtureAssets(extractedDir);
+    const before = new Map(
+      Array.from(fixtureAssets.keys(), (assetName) => [
+        assetName,
+        fs.readFileSync(path.join(assetsDir, assetName)),
+      ]),
+    );
+    const originalWriteFileSync = fs.writeFileSync;
+    let failureInjected = false;
+    fs.writeFileSync = (filePath, data, ...args) => {
+      if (
+        !failureInjected &&
+        path.basename(filePath).includes("jvsvjxtt") &&
+        String(data).includes("codexLinuxCrossProviderThreadHistory")
+      ) {
+        failureInjected = true;
+        throw new Error("injected cross-provider asset write failure");
+      }
+      return originalWriteFileSync(filePath, data, ...args);
+    };
+
+    const report = createPatchReport();
+    try {
+      applyExtractedAppPatchDescriptors(
+        extractedDir,
+        normalizePatchDescriptors(descriptors),
+        {},
+        report,
+        "extracted-app:post-webview",
+      );
+    } finally {
+      fs.writeFileSync = originalWriteFileSync;
+    }
+
+    assert.equal(failureInjected, true);
+    assert.equal(report.patches[0].status, "skipped-optional");
+    assert.match(report.patches[0].reason, /injected cross-provider asset write failure/);
+    for (const [assetName, original] of before) {
+      assert.deepEqual(fs.readFileSync(path.join(assetsDir, assetName)), original);
+    }
+  });
+});
+
+test("descriptors target the three current thread history bundles", () => {
+  assert.equal(descriptors.length, 1);
+  assert.equal(THREAD_HISTORY_TARGETS.length, 3);
+  assert.equal(
+    THREAD_HISTORY_TARGETS[0].pattern.test(
+      "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~oxnpxkxc-fixture.js",
+    ),
+    true,
+  );
+  assert.equal(
+    THREAD_HISTORY_TARGETS[1].pattern.test(
+      "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~pull-request-rout~jvsvjxtt-fixture.js",
+    ),
+    true,
+  );
+  assert.equal(
+    THREAD_HISTORY_TARGETS[2].pattern.test(
+      "app-initial~app-main~new-thread-panel-page~onboarding-page~appgen-library-page~hotkey-windo~k4644ppc-fixture.js",
+    ),
+    true,
+  );
+  for (const target of THREAD_HISTORY_TARGETS) {
+    assert.equal(target.pattern.test("setting-storage-fixture.js"), false);
+  }
+});

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -14,6 +14,7 @@ let
     "persistent-status-panel"
     "appshots"
     "codex-wrapper-updater"
+    "cross-provider-thread-history"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
     "global-dictation"
@@ -28,6 +29,7 @@ let
   normalizedTestFeatureIds = [
     "appshots"
     "codex-wrapper-updater"
+    "cross-provider-thread-history"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
     "global-dictation"
@@ -43,6 +45,7 @@ let
   normalizedWatchdogFeatureIds = [
     "appshots"
     "codex-wrapper-updater"
+    "cross-provider-thread-history"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
     "global-dictation"
@@ -150,6 +153,7 @@ let
       "remote-mobile-control"
       "frameless-titlebar"
       "codex-wrapper-updater"
+      "cross-provider-thread-history"
       "directory-only-working-tree-watch"
       "global-dictation"
       "persistent-status-panel"

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -3,6 +3,7 @@ let
   supportedFeatureIds = [
     "appshots"
     "codex-wrapper-updater"
+    "cross-provider-thread-history"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
     "global-dictation"

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -218,6 +218,7 @@ test("Nix hash refresh accepts a validated focused output override", () => {
   assert.deepEqual(watchdogProfile.enabled, [
     "appshots",
     "codex-wrapper-updater",
+    "cross-provider-thread-history",
     "directory-only-working-tree-watch",
     "frameless-titlebar",
     "global-dictation",

--- a/scripts/ci/watchdog-linux-features.json
+++ b/scripts/ci/watchdog-linux-features.json
@@ -2,6 +2,7 @@
   "enabled": [
     "appshots",
     "codex-wrapper-updater",
+    "cross-provider-thread-history",
     "directory-only-working-tree-watch",
     "frameless-titlebar",
     "global-dictation",


### PR DESCRIPTION
## Summary

- add a default-off `cross-provider-thread-history` Linux feature that requests `modelProviders: []` for current Recent, Projects, archive, resolver, and subagent enumeration surfaces
- make cold resume select `Desktop special provider ?? current config model_provider ?? Codex default`, while keeping the stored thread provider as provenance; already-loaded threads still require a Desktop restart before rebinding
- document the safe split-auth setup: global ChatGPT login for subscription/Remote Control plus a provider-scoped `experimental_bearer_token` for custom model requests
- register the feature for Nix and the current-DMG watchdog so future upstream chunk drift is caught

This addresses a Linux Desktop failure mode where changing the active provider hid local threads and could later resume a historical thread against the wrong endpoint. No credentials, auth files, or Remote Control device keys are included.

No linked issue; this is based on a directly reproduced user report.

## Validation

- `node --test linux-features/cross-provider-thread-history/test.js` — 15/15 passed
- Node 24 focused feature/acceptance/patcher suite — 426/426 passed
- `bash tests/scripts_smoke.sh` — passed
- latest upstream DMG `26.715.52143` (`3e5055c1…fc5e5`) feature-enabled build — accepted with the existing six unrelated optional core warnings; feature descriptor applied exactly once
- extracted final ASAR — 5/2/1 enumeration markers, one resume marker in the manager bundle, ESM syntax valid
- isolated app-server A/B matrix — cold A→B resume sent only B's scoped dummy token to B while retaining A provenance
- final Debian package — ASAR byte-identical to the validated build; no private-state paths or reported key prefix
- Matt Pocock two-axis final review — Standards: 0 findings; Spec: 0 findings
- full Node 24 suite: 1359 passed, 1 skipped, 2 failures in unchanged `directory-only-working-tree-watch` timing tests; the remaining deterministic failure reproduces byte-for-byte on `origin/main` in a detached worktree

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This does not fix upstream drift; it targets only the latest `CODEX.DMG` and adds no legacy fallback path.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. *(Local validation is complete; hosted required checks are pending.)*
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
