### PR TITLE
Retarget Dock icon to the current desktop bundles

### DIFF
--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -26,26 +26,26 @@ const {
 } = require("../../scripts/patches/impl/webview/index.js");
 
 const currentAppInfoSource = [
-  "function fv(e,t,r){return`icon-chatgpt`}",
-  "function pv(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
-  "function hv(e,t){if(process.platform!==`darwin`||t==null)return null;let n=pv(e),r=gv(`${fv(e,t)}.png`),i=gv(n.dark),a=gv(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
-  "function gv(e){if(e==null)return null;let t=c.app.isPackaged?(0,d.join)(process.resourcesPath,e):null,n=t!=null&&(0,h.existsSync)(t)?t:(0,d.join)(c.app.getAppPath(),`src`,`icons`,e),r=c.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
+  "function F_(e,t){return`icon-chatgpt`}",
+  "function I_(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
+  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=z_(`${F_(e,t)}.png`),i=z_(n.dark),a=z_(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
+  "function z_(e){if(e==null)return null;let t=l.app.isPackaged?(0,f.join)(process.resourcesPath,e):null,n=t!=null&&(0,g.existsSync)(t)?t:(0,f.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
 ].join("");
 
 const currentRuntimeSource = [
   "function Xie({appBrand:e,buildFlavor:r,settingsStore:p,repoRoot:_,isMacOS:v,onWindowRegistered:C,disposables:w}){",
-  "let T=(0,d.join)(_,`electron`,`src`,`icons`),E=e=>{if(!c.app.isPackaged)return null;let t=(0,d.join)(process.resourcesPath,e);return(0,h.existsSync)(t)?t:null},",
+  "let T=(0,f.join)(_,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,f.join)(process.resourcesPath,e);return(0,g.existsSync)(t)?t:null},",
   "D=e=>null,O=e=>E(e)??D(e),k=()=>p.get(n.cc.DOCK_ICON_PREFERENCE)??`app-default`,",
-  "A=()=>O(`${fv(r,e)}.png`),j=pv(r),M=()=>c.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?j.dark:j.light,",
-  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(c.app.isPackaged||e===n.rl.ChatGPT)){let e=c.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?c.nativeImage.createEmpty():c.nativeImage.createFromPath(o);s.isEmpty()||c.app.dock?.setIcon(s)},",
-  "P=()=>{if(!v)return;let e=k();N(e),PZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})};",
-  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};c.nativeTheme.on(`updated`,e),w.add(()=>{c.nativeTheme.off(`updated`,e)})}",
+  "A=()=>O(`${F_(r,e)}.png`),j=I_(r),M=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?j.dark:j.light,",
+  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
+  "P=()=>{if(!v)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})};",
+  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
   "let F=null,I=new Rie({onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}});",
   "return{updateDockIcon:P,windowManager:I}}",
 ].join("");
 
 const currentTraySource =
-  "async function fae(e){let t=await pae(e.buildFlavor,e.appBrand,e.repoRoot),n=codexLinuxRegisterTray(new c.Tray(t.defaultIcon));if(!G9)return n.destroy(),null;return n}";
+  "let codexLinuxTray=null,codexLinuxRegisterTray=e=>(codexLinuxTray=e,e);async function dae(e){let t=await fae(e.buildFlavor,e.appBrand,e.repoRoot),n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!G9)return n.destroy(),null;return n}";
 
 const currentMainSource = currentAppInfoSource + currentRuntimeSource + currentTraySource;
 
@@ -168,21 +168,22 @@ test("main patch enables official previews and synchronizes Linux window and tra
   assert.match(patched, /process\.platform!==`darwin`&&process\.platform!==`linux`/);
   assert.match(
     patched,
-    /c\.app\.isPackaged\|\|process\.platform===`linux`\?codexLinuxDockIconResourcePath/,
+    /l\.app\.isPackaged\|\|process\.platform===`linux`\?codexLinuxDockIconResourcePath/,
   );
-  assert.match(patched, /if\(!c\.app\.isPackaged&&process\.platform!==`linux`\)return null/);
+  assert.match(patched, /if\(!l\.app\.isPackaged&&process\.platform!==`linux`\)return null/);
   assert.match(patched, /BrowserWindow\.getAllWindows\(\)/);
   assert.match(patched, /globalThis\.codexLinuxDockIconImage=s/);
-  assert.match(patched, /dae\(\)\?\.tray/);
+  assert.match(patched, /codexLinuxTray!=null&&!codexLinuxTray\.isDestroyed\(\)&&codexLinuxTray\.setImage\(s\)/);
+  assert.doesNotMatch(patched, /dae\(\)\?\.tray/);
   assert.match(patched, /sync-desktop-icon\.sh/);
   assert.match(patched, /crop\(\{x:34,y:34,width:956,height:956\}\)/);
   assert.match(patched, /crop\(\{x:13,y:23,width:998,height:998\}\)/);
-  assert.match(patched, /require\(`node:child_process`\)\.spawn\(f,\[l\]/);
+  assert.match(patched, /require\(`node:child_process`\)\.spawn\(codexLinuxSyncScript,\[codexLinuxIconSelection\]/);
   assert.match(patched, /e\.stdin\.end\(s\.toPNG\(\)\)/);
   assert.match(patched, /codexLinuxDockIconImage\.isEmpty\(\)/);
   assert.match(
     patched,
-    /codexLinuxRegisterTray\(new c\.Tray\(process\.platform===`linux`&&globalThis\.codexLinuxDockIconImage/,
+    /codexLinuxRegisterTray\(new l\.Tray\(process\.platform===`linux`&&globalThis\.codexLinuxDockIconImage/,
   );
   assert.match(
     patched,
@@ -196,13 +197,13 @@ test("main patch enables official previews and synchronizes Linux window and tra
 test("main patch rejects drift at every current-DMG insertion point byte-identically", () => {
   const insertionPoints = [
     "if(process.platform!==`darwin`||t==null)return null",
-    "function gv(e){if(e==null)return null",
-    "E=e=>{if(!c.app.isPackaged)return null",
+    "function z_(e){if(e==null)return null",
+    "E=e=>{if(!l.app.isPackaged)return null",
     "N=t=>{if(t===`app-default`",
     "P=()=>{if(!v)return",
     "if(v){P();let e=()=>",
     "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}",
-    "codexLinuxRegisterTray(new c.Tray(t.defaultIcon))",
+    "codexLinuxRegisterTray(new l.Tray(t.defaultIcon))",
   ];
 
   for (const insertionPoint of insertionPoints) {
@@ -276,8 +277,8 @@ test("descriptor targets the current General settings asset", () => {
   try {
     const assetsDir = path.join(tempDir, "webview", "assets");
     fs.mkdirSync(assetsDir, { recursive: true });
-    const settingsPath = path.join(assetsDir, "general-settings-Boi5S8Wz.js");
-    const searchPath = path.join(assetsDir, "settings-page-SrGKyWwG.js");
+    const settingsPath = path.join(assetsDir, "general-settings-CsA3Lt9Z.js");
+    const searchPath = path.join(assetsDir, "settings-page-BOdFN1v1.js");
     fs.writeFileSync(settingsPath, currentSettingsSource);
     fs.writeFileSync(searchPath, currentSearchSource);
 
@@ -295,10 +296,11 @@ test("descriptor targets the current General settings asset", () => {
       "missing",
     );
     assert.deepEqual(searchResult, { matched: 1, changed: 1 });
-    assert.equal(descriptors[1].pattern.test("general-settings-Boi5S8Wz.js"), true);
-    assert.equal(descriptors[1].pattern.test("general-settings-BMzH5BZ9.js"), false);
+    assert.equal(descriptors[1].pattern.test("general-settings-CsA3Lt9Z.js"), true);
+    assert.equal(descriptors[1].pattern.test("general-settings-Boi5S8Wz.js"), false);
     assert.equal(descriptors[1].pattern.test("general-settings-stale.js"), false);
-    assert.equal(descriptors[2].pattern.test("settings-page-SrGKyWwG.js"), true);
+    assert.equal(descriptors[2].pattern.test("settings-page-BOdFN1v1.js"), true);
+    assert.equal(descriptors[2].pattern.test("settings-page-SrGKyWwG.js"), false);
     assert.equal(descriptors[2].pattern.test("settings-page-stale.js"), false);
     assert.equal(descriptors[1].pattern.test("general-settings-DMO9G9gL.js"), false);
   } finally {

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -4,33 +4,33 @@ const currentPreviewGate = "if(process.platform!==`darwin`||t==null)return null"
 const patchedPreviewGate =
   "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null";
 const currentAppInfoResource =
-  "function gv(e){if(e==null)return null;let t=c.app.isPackaged?(0,d.join)(process.resourcesPath,e):null";
+  "function z_(e){if(e==null)return null;let t=l.app.isPackaged?(0,f.join)(process.resourcesPath,e):null";
 const patchedAppInfoResource =
-  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,d.join)(process.resourcesPath,`dock-icon`,e):(0,d.join)(process.resourcesPath,e)}function gv(e){if(e==null)return null;let t=c.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
+  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,f.join)(process.resourcesPath,`dock-icon`,e):(0,f.join)(process.resourcesPath,e)}function z_(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
 const currentWindowResource =
-  "E=e=>{if(!c.app.isPackaged)return null;let t=(0,d.join)(process.resourcesPath,e);return(0,h.existsSync)(t)?t:null}";
+  "E=e=>{if(!l.app.isPackaged)return null;let t=(0,f.join)(process.resourcesPath,e);return(0,g.existsSync)(t)?t:null}";
 const patchedWindowResource =
-  "E=e=>{if(!c.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,h.existsSync)(t)?t:null}";
+  "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,g.existsSync)(t)?t:null}";
 const currentApplyIcon =
-  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(c.app.isPackaged||e===n.rl.ChatGPT)){let e=c.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?c.nativeImage.createEmpty():c.nativeImage.createFromPath(o);s.isEmpty()||c.app.dock?.setIcon(s)}";
+  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
 const patchedApplyIcon =
-  "N=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&r!==i.a.Dev&&(c.app.isPackaged||e===n.rl.ChatGPT)){let e=c.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?c.nativeImage.createEmpty():c.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let l=t===`codex-system`?(c.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;l===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):l===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of c.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);let u=dae()?.tray;u!=null&&!u.isDestroyed()&&u.setImage(s);let f=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(h.existsSync(f))try{let e=require(`node:child_process`).spawn(f,[l],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}c.app.dock?.setIcon(s)}";
+  "N=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(g.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
 const currentUpdateGate =
-  "P=()=>{if(!v)return;let e=k();N(e),PZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
+  "P=()=>{if(!v)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
 const patchedUpdateGate =
-  "P=()=>{if(!v&&process.platform!==`linux`)return;let e=k();N(e),PZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
+  "P=()=>{if(!v&&process.platform!==`linux`)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
 const currentThemeGate =
-  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};c.nativeTheme.on(`updated`,e),w.add(()=>{c.nativeTheme.off(`updated`,e)})}";
+  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const patchedThemeGate =
-  "if(v||process.platform===`linux`){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};c.nativeTheme.on(`updated`,e),w.add(()=>{c.nativeTheme.off(`updated`,e)})}";
+  "if(v||process.platform===`linux`){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const currentWindowRegistration =
   "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}";
 const patchedWindowRegistration =
   "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(P)}";
 const currentTrayRegistration =
-  "n=codexLinuxRegisterTray(new c.Tray(t.defaultIcon));if(!G9)return";
+  "n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!G9)return";
 const patchedTrayRegistration =
-  "n=codexLinuxRegisterTray(new c.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon));if(!G9)return";
+  "n=codexLinuxRegisterTray(new l.Tray(process.platform===`linux`&&globalThis.codexLinuxDockIconImage&&!globalThis.codexLinuxDockIconImage.isEmpty()?globalThis.codexLinuxDockIconImage:t.defaultIcon));if(!G9)return";
 
 const currentMainContracts = [
   currentPreviewGate,
@@ -146,7 +146,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_950,
     ciPolicy: "optional",
-    pattern: /^general-settings-Boi5S8Wz\.js$/,
+    pattern: /^general-settings-CsA3Lt9Z\.js$/,
     missingDescription: "General settings Dock icon bundle",
     skipDescription: "Dock icon settings row patch",
     enabled: dockIconEnabled,
@@ -157,7 +157,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_960,
     ciPolicy: "optional",
-    pattern: /^settings-page-SrGKyWwG\.js$/,
+    pattern: /^settings-page-BOdFN1v1\.js$/,
     missingDescription: "Settings search bundle",
     skipDescription: "Dock icon settings search patch",
     enabled: dockIconEnabled,


### PR DESCRIPTION
## Summary

- retarget the Dock Icon main-process contract to the current `main-D-AEKvtN.js` aliases
- retarget the Settings row and search descriptors to the active current-DMG assets
- update the tray through the core-registered `codexLinuxTray` instead of calling the current asynchronous tray factory as a getter
- refresh the fixtures and remove the prior-DMG asset names

## Context

This follows the maintainer's invitation to try a focused PR in #1100. A zero-feature build from current `main` registered a working StatusNotifier item on KDE/Wayland, so this PR does not claim to resolve the separate GNOME/X11 report.

The isolated Dock Icon profile exposed a concrete opt-in failure first: the current artifact was rejected because all three Dock descriptors had drifted. Runtime QA then caught that `dae` now owns asynchronous tray creation; calling `dae()?.tray` from the injected icon helper could start it without configuration and prevented reliable tray registration. The current core patch already owns the concrete Electron tray in `codexLinuxTray`, which is the object this feature now updates.

## Current upstream identity

- repo base: `a29387ebc1c76cc51c942d97c5f5c609a81cdccf`
- DMG SHA-256: `3e5055c185b68369d3cee4f24b45eec30d11b4f0c848c0c7fe550103135fc5e5`
- DMG size: `618693003` bytes
- app: `26.715.52143`
- Electron: `42.3.0`
- runtime: Ubuntu 25.10, KDE Plasma, Wayland

## Visible behavior

- Appearance shows the upstream Dock icon row with ChatGPT and Codex choices
- Settings search returns Dock icon
- switching Codex to ChatGPT updates the live window and StatusNotifier icon
- the selected icon survives a cold restart
- closing the window keeps the isolated tray process alive, activating the tray restores the window, and tray Quit exits the app cleanly

## Validation

- `node --test linux-features/ui-tweaks/dock-icon.test.js` (24/24)
- `node --test linux-features/ui-tweaks/test.js` (53/53)
- `node --test scripts/patch-linux-window-ui.test.js` (402/402)
- `node --test linux-features/*/test.js` (766/766 with inherited updater hook variables removed)
- direct first/second pass against `main-D-AEKvtN.js`; byte-stable second pass and `node --check`
- direct second pass against `general-settings-CsA3Lt9Z.js` and `settings-page-BOdFN1v1.js`; one complete marker each
- isolated Dock-only rebuild: `accepted_with_warnings`, all three feature descriptors `applied`, zero feature blockers
- runtime StatusNotifier ownership mapped to the side-by-side Electron PID
- close, SNI `Activate`, and tray `Quit` verified against that exact isolated owner; the daily-driver SNI remained separate
- Codex icon observed as `956x956`; ChatGPT icon observed as `2048x2048`; ChatGPT remained selected after restart
- update-builder staging preserved `ui-tweaks`, the nested Dock toggle, and sibling settings without restoring obsolete standalone IDs
- synthetic insertion-point drift and mixed state remain byte-identical
- unmanaged and symlinked launcher preservation tests pass
- `git diff --check`

`tests/scripts_smoke.sh` progresses through all package formats and stops at the unrelated oversized webview-port diagnostic assertion. All GitHub checks pass, including Rust/smoke, the current upstream DMG build, Nix, and native package builders.

## Scope

The GNOME/X11 zero-feature tray report from #1100 remains outside this opt-in correction. Suggested Prompts drift found on the same artifact will be handled separately.
