### PR TITLE
Retarget Suggested Prompts to the current desktop bundles

### DIFF
--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -1,9 +1,9 @@
 "use strict";
 
 const APP_PAGE_ASSET_PATTERN =
-  /^app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-Ccxu2qV_\.js$/;
-const GENERAL_SETTINGS_ASSET_PATTERN = /^general-settings-Boi5S8Wz\.js$/;
-const HOME_CONTENT_ASSET_PATTERN = /^home-ambient-suggestions-content-DNeFqrrf\.js$/;
+  /^app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-CrEakH0Y\.js$/;
+const GENERAL_SETTINGS_ASSET_PATTERN = /^general-settings-CsA3Lt9Z\.js$/;
+const HOME_CONTENT_ASSET_PATTERN = /^home-ambient-suggestions-content-C01Mwmkt\.js$/;
 const FEATURE_GATE_ID = "2425897452";
 const RUNTIME_MARKER = "codexLinuxUiTweaksSuggestedPromptsEnabled";
 const APP_PAGE_ELIGIBILITY_MARKER = "codexLinuxUiTweaksSuggestedPromptsAppPageEligible";

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -193,21 +193,19 @@ test("unrecognized contracts warn instead of reporting false already-applied", (
 });
 
 test("Suggested Prompts descriptors target only current-DMG active assets", () => {
-  assert.match("general-settings-Boi5S8Wz.js", GENERAL_SETTINGS_ASSET_PATTERN);
+  assert.match("general-settings-CsA3Lt9Z.js", GENERAL_SETTINGS_ASSET_PATTERN);
+  assert.doesNotMatch("general-settings-Boi5S8Wz.js", GENERAL_SETTINGS_ASSET_PATTERN);
   assert.doesNotMatch("general-settings-B8bUS3xL.js", GENERAL_SETTINGS_ASSET_PATTERN);
-  assert.doesNotMatch("general-settings-DMO9G9gL.js", GENERAL_SETTINGS_ASSET_PATTERN);
 
   assert.match(
-    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-Ccxu2qV_.js",
+    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-CrEakH0Y.js",
     APP_PAGE_ASSET_PATTERN,
   );
   assert.doesNotMatch(
-    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-3B_QTMVW.js",
+    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-Ccxu2qV_.js",
     APP_PAGE_ASSET_PATTERN,
   );
-  assert.doesNotMatch("app-initial~app-main~page-CtzZUdyW.js", APP_PAGE_ASSET_PATTERN);
 
-  assert.match("home-ambient-suggestions-content-DNeFqrrf.js", HOME_CONTENT_ASSET_PATTERN);
-  assert.doesNotMatch("home-ambient-suggestions-content-BnjCpFM8.js", HOME_CONTENT_ASSET_PATTERN);
-  assert.doesNotMatch("home-ambient-suggestions-content-BIOXM98x.js", HOME_CONTENT_ASSET_PATTERN);
+  assert.match("home-ambient-suggestions-content-C01Mwmkt.js", HOME_CONTENT_ASSET_PATTERN);
+  assert.doesNotMatch("home-ambient-suggestions-content-DNeFqrrf.js", HOME_CONTENT_ASSET_PATTERN);
 });


### PR DESCRIPTION
## Summary

- retarget the Suggested Prompts app-page descriptor to the current active bundle
- retarget the General Settings row and Home content descriptors to their current assets
- remove the prior-DMG hashes from source and fixtures without adding broad matchers or compatibility fallbacks

## Context

This maintains the default-off Suggested Prompts tweak introduced in #1083 after the maintainer approved the one-tweak-at-a-time direction in #1038.

While isolating the opt-in configuration from the GNOME/X11 tray report in #1100, the current acceptance gate rejected the Suggested Prompts profile: the main-process descriptor still applied, but all three webview descriptors were `skipped-optional`. The minified contracts remain valid in the current artifact; only the owning asset names changed.

This PR is independent of the GNOME/X11 tray issue; #1100 remains unresolved.

## Current upstream identity

- repository base: `157ea148c704755351fe62868b3ff685b917c602` (merge of #1101)
- branch head: `afec3035497738c39ee864389ef1a49466d24063`
- ChatGPT Desktop: `26.715.52143`
- Electron: `42.3.0`
- DMG SHA-256: `3e5055c185b68369d3cee4f24b45eec30d11b4f0c848c0c7fe550103135fc5e5`
- DMG size: `618693003` bytes
- runtime: Ubuntu 25.10, KDE Plasma, Wayland

## Current-DMG contract

The existing atomic patch functions now target:

- app page: `app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-CrEakH0Y.js`
- General Settings: `general-settings-CsA3Lt9Z.js`
- Home content: `home-ambient-suggestions-content-C01Mwmkt.js`

The previous `Ccxu2qV_`, `Boi5S8Wz`, and `DNeFqrrf` assets are removed from the descriptors, and regression coverage asserts that those old filenames no longer match. Existing complete markers continue to prove idempotency; missing or mixed insertion points warn and leave the asset byte-identical.

## Runtime validation

The isolated Suggested Prompts identity was exercised on the current DMG with only this nested tweak enabled:

- General Settings row and Settings search result are visible
- the runtime toggle removes and restores cards without duplication
- project changes generate project-specific suggestions
- selecting a card populates the composer without submitting
- ChatGPT removes Codex project cards while retaining its own Home suggestions; returning to Codex restores them
- a 760x800 window stays within the viewport
- the setting, selected project, and cards survive a cold restart
- a console reload produced no runtime, console, or log errors
- the post-rebase side-by-side smoke rendered a generated `codex-desktop-linux` card

## Validation

- `node --test linux-features/ui-tweaks/suggested-prompts.test.js linux-features/ui-tweaks/test.js scripts/patch-linux-window-ui.test.js` (`463/463`)
- isolated current-DMG rebuild: `accepted_with_warnings`, all four Suggested Prompts descriptors `applied`, zero feature blockers
- patch-report validation requiring all four descriptors as `applied`
- complete second patch pass: all four descriptors `already-applied` and all four owning assets byte-stable
- `node --check` on the current generated main, app-page, General Settings, and Home content assets
- update-builder staging preserves the complete nested Suggested Prompts configuration without obsolete standalone feature ids
- synthetic missing and mixed insertion-point tests leave source byte-identical
- `git diff --check`

The acceptance warnings are pre-existing optional core drift; no Suggested Prompts descriptor warns or skips.

## Scope

This changes only the Suggested Prompts descriptor filenames and their focused fixtures. It does not alter core patching, updater behavior, committed feature defaults, Dock Icon, or the GNOME/X11 tray lifecycle.
