### PR TITLE
Make reasoning label drift handling atomic

### DIFF
--- a/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
+++ b/linux-features/ui-tweaks/patches/reasoning-effort-labels.js
@@ -13,7 +13,7 @@ const ENGLISH_REASONING_LABELS = Object.freeze({
 });
 
 function warn(message) {
-  console.warn(`WARN: ${message} - skipping missing ui-tweaks reasoning label markers`);
+  console.warn(`WARN: ${message} - skipping ui-tweaks reasoning label patch`);
 }
 
 function reasoningLabelConfig(context) {
@@ -43,24 +43,40 @@ function applyEnglishReasoningLabels(source, context = {}) {
       return source;
     }
 
-    let patched = source;
     const missingKeys = [];
+    const replacements = [];
+    let appliedKeyCount = 0;
     for (const [key, label] of Object.entries(ENGLISH_REASONING_LABELS)) {
       const replacement = `"${key}":\`${label}\``;
-      if (patched.includes(replacement)) {
+      if (source.includes(replacement)) {
+        appliedKeyCount += 1;
         continue;
       }
 
       const pattern = new RegExp(`"${escapeRegExp(key)}":\\\`[^\\\`]*\\\``);
-      if (!pattern.test(patched)) {
+      if (!pattern.test(source)) {
         missingKeys.push(key);
         continue;
       }
-      patched = patched.replace(pattern, replacement);
+      replacements.push([pattern, replacement]);
     }
 
     if (missingKeys.length > 0 && context.warnOnMissingMarkers === true) {
       warn(`Could not find ${missingKeys.join(", ")}`);
+    }
+    if (missingKeys.length > 0) {
+      return source;
+    }
+    if (appliedKeyCount > 0 && replacements.length > 0) {
+      if (context.warnOnMissingMarkers === true) {
+        warn("Found mixed applied and untranslated reasoning label markers");
+      }
+      return source;
+    }
+
+    let patched = source;
+    for (const [pattern, replacement] of replacements) {
+      patched = patched.replace(pattern, replacement);
     }
     return patched;
   } catch (error) {

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -391,6 +391,34 @@ test("reasoning effort labels stay in English in the Simplified Chinese locale",
   assert.doesNotMatch("zh-TW-rBlCyjlT.js", ZH_CN_LOCALE_ASSET_PATTERN);
 });
 
+test("reasoning effort label drift warns and leaves the asset unchanged", () => {
+  const source = simplifiedChineseLocaleFixture().replace(
+    '"composer.mode.local.reasoning.ultra.label":`极高`',
+    '"composer.mode.local.reasoning.ultra.missing":`极高`',
+  );
+  const { value, warnings } = withCapturedWarns(() =>
+    applyEnglishReasoningLabels(source, { warnOnMissingMarkers: true }),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /composer\.mode\.local\.reasoning\.ultra\.label/);
+});
+
+test("mixed reasoning effort label markers warn and remain byte-identical", () => {
+  const source = simplifiedChineseLocaleFixture().replace(
+    '"composer.mode.local.reasoning.medium.label":`中`',
+    '"composer.mode.local.reasoning.medium.label":`Medium`',
+  );
+  const { value, warnings } = withCapturedWarns(() =>
+    applyEnglishReasoningLabels(source, { warnOnMissingMarkers: true }),
+  );
+
+  assert.equal(value, source);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /mixed applied and untranslated reasoning label markers/i);
+});
+
 test("English reasoning effort labels can be disabled", () => {
   const source = simplifiedChineseLocaleFixture();
   const context = {


### PR DESCRIPTION
## Summary

- preflight all eight current Simplified Chinese reasoning-label keys before changing the locale asset
- reject mixed English/untranslated marker states without completing a partial patch
- add regression coverage proving missing and mixed contracts remain byte-identical

## Context

The post-#1102 UI Tweaks current-DMG matrix found an atomicity gap in `reasoning.keepEffortLabelsEnglish`. When one current label key was missing, the patch warned about that key after already replacing the labels it had found. `patchAssetFiles()` writes the returned source, so the candidate contained a partially modified locale asset and reported the descriptor as `applied-with-warnings`. Acceptance still protected the installed app, but the feature patch itself was not atomic.

This change gathers every replacement before writing any of them. A clean untranslated asset applies all eight labels, a complete English asset remains idempotent, and missing or mixed markers now warn once and return the original source. The drift report therefore becomes `skipped-optional` with byte-identical asset contents.

## Current upstream identity

- repository base: `54c11eca98a51fece5c520c1c30b601ae166beae` (merge of #1102)
- branch head: `7c4fdea`
- ChatGPT Desktop: `26.715.52143`
- Electron: `42.3.0`
- DMG SHA-256: `3e5055c185b68369d3cee4f24b45eec30d11b4f0c848c0c7fe550103135fc5e5`
- DMG size: `618693003` bytes
- runtime: Ubuntu 25.10, KDE Plasma, Wayland

## Current-DMG validation

- isolated build with only English Reasoning Labels enabled: `accepted_with_warnings`, zero feature blockers
- first pass: `feature:ui-tweaks:reasoning-effort-labels-english` is `applied`
- second complete patch pass: descriptor is `already-applied`; `zh-CN-DacW0uyu.js` stays byte-identical at `a2cc30652036fd65bc7f42639714f526c816f19763e1d703b630d37983c5e3e5`
- synthetic missing-key drift: one warning, source byte-identical
- synthetic mixed-marker drift: one warning, source byte-identical
- generated locale asset passes `node --check`
- runtime in Simplified Chinese keeps the surrounding UI translated while showing `Low`, `Medium`, `High`, `XHigh`, `Max`, and `Ultra`
- the labels persist across a cold restart; the isolated profile was restored to `Auto detect` after QA

## Tests

- `node --test linux-features/ui-tweaks/test.js scripts/patch-linux-window-ui.test.js` (`457/457`)
- all other Linux Feature modules excluding the two independently rerun modules (`632/632`)
- `node --test linux-features/shared-app-server-socket/test.js` (`24/24`)
- `bash tests/scripts_smoke.sh`
- first- and second-pass `scripts/ci/validate-patch-report.js` checks
- `node --check` on source, test, and generated current asset
- `git diff --check`

The monolithic Linux Feature run produced five `directory-only-working-tree-watch` timing/resource failures and one parallel socket-permission failure. The same five watcher failures reproduce unchanged on the clean pre-branch baseline, while the socket module passes `24/24` in isolation. The focused suite, the other 632 feature tests, and smoke all pass.

## Scope

This changes only the feature-local English reasoning-label patch and its tests. It does not alter the patch engine, other UI Tweaks, committed feature defaults, or updater behavior.
