### PR TITLE
Retarget project task sorting to the current sidebar bundle

### DIFF
--- a/linux-features/project-task-sort/patch.js
+++ b/linux-features/project-task-sort/patch.js
@@ -19,16 +19,6 @@ function applyProjectTaskSortPatch(source) {
     return source;
   }
 
-  if (
-    !source.includes("sidebarElectron.sortMenu.manual") ||
-    !source.includes("sidebarElectron.sortMenu.created")
-  ) {
-    console.warn(
-      "WARN: Could not find current project task sort menu markers - skipping project task sort feature patch",
-    );
-    return source;
-  }
-
   if (unpatchedCount !== 1 || patchedCount !== 0) {
     console.warn(
       "WARN: Could not find current project task creation timestamp insertion point - skipping project task sort feature patch",
@@ -46,7 +36,7 @@ const descriptors = [
     order: 20_900,
     ciPolicy: "optional",
     pattern:
-      /^app-initial~app-main~projects-index-page~remote-conversation-page-[A-Za-z0-9_-]+\.js$/,
+      /^app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~iqsnin5k-Bxmd3ja1\.js$/,
     missingDescription: "project task sort webview bundle",
     skipDescription: "project task creation timestamp feature patch",
     apply: applyProjectTaskSortPatch,

--- a/linux-features/project-task-sort/test.js
+++ b/linux-features/project-task-sort/test.js
@@ -17,11 +17,8 @@ const {
   descriptors,
 } = require("./patch.js");
 
-const currentProjectSource = [
-  "function ms(e,t){switch(e.kind){case`local`:return e.conversation==null?e.pendingWorktree.createdAt:t===`updated_at`?e.conversation.recencyAt??e.conversation.updatedAt:e.conversation.createdAt;case`remote`:return((t===`updated_at`?e.task.updated_at??e.task.created_at:e.task.created_at??e.task.updated_at)??0)*1e3}}",
-  "const manualSortId=`sidebarElectron.sortMenu.manual`;",
-  "const createdSortId=`sidebarElectron.sortMenu.created`;",
-].join("");
+const currentProjectSource =
+  "function xe(e,t){switch(e.kind){case`local`:return e.conversation==null?e.pendingWorktree.createdAt:t===`updated_at`?e.conversation.recencyAt??e.conversation.updatedAt:e.conversation.createdAt;case`remote`:return((t===`updated_at`?e.task.updated_at??e.task.created_at:e.task.created_at??e.task.updated_at)??0)*1e3}}";
 
 function captureWarns(fn) {
   const originalWarn = console.warn;
@@ -89,7 +86,7 @@ test("patch recovers local UUIDv7 creation time", () => {
   );
 
   const context = {};
-  vm.runInNewContext(`${patched};globalThis.timestamp=ms`, context);
+  vm.runInNewContext(`${patched};globalThis.timestamp=xe`, context);
   const older = {
     key: "local:019e0000-0000-7000-8000-000000000001",
     kind: "local",
@@ -138,28 +135,15 @@ test("patch recovers local UUIDv7 creation time", () => {
 });
 
 test("drift leaves the asset byte-identical", () => {
-  const source = [
-    "function ms(e,t){return e.conversation?.createdTimestamp}",
-    "const manualSortId=`sidebarElectron.sortMenu.manual`;",
-    "const createdSortId=`sidebarElectron.sortMenu.created`;",
-  ].join("");
-  const { value, warnings } = captureWarns(() => applyProjectTaskSortPatch(source));
-
-  assert.equal(value, source);
-  assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /project task creation timestamp insertion point/);
-});
-
-test("missing current menu markers leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "const manualSortId=`sidebarElectron.sortMenu.manual`;const createdSortId=`sidebarElectron.sortMenu.created`;",
-    "",
+    "e.pendingWorktree.createdAt",
+    "e.pendingWorktree.createdTimestamp",
   );
   const { value, warnings } = captureWarns(() => applyProjectTaskSortPatch(source));
 
   assert.equal(value, source);
   assert.equal(warnings.length, 1);
-  assert.match(warnings[0], /project task sort menu markers/);
+  assert.match(warnings[0], /project task creation timestamp insertion point/);
 });
 
 test("mixed patched and clean helpers are rejected byte-identically", () => {
@@ -177,7 +161,7 @@ test("descriptor targets and patches the current project chunk", () => {
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~projects-index-page~remote-conversation-page-y7pwA1Hj.js",
+      "app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~iqsnin5k-Bxmd3ja1.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentProjectSource);
@@ -193,7 +177,7 @@ test("descriptor targets and patches the current project chunk", () => {
     assert.notEqual(fs.readFileSync(assetPath, "utf8"), currentProjectSource);
     assert.equal(
       descriptors[0].pattern.test(
-        "app-initial~app-main~projects-index-page~settings-page-y7pwA1Hj.js",
+        "app-initial~app-main~projects-index-page~remote-conversation-page-y7pwA1Hj.js",
       ),
       false,
     );


### PR DESCRIPTION
## Summary

Follow-up maintenance for #915.

The current `26.715.52143` DMG moved the project task timestamp comparator to a new bundle. The feature descriptor matched no assets, while its retained menu-marker check belonged to a different renderer asset. With `project-task-sort` enabled, an isolated current-DMG candidate therefore reported `skipped-optional` feature drift and was rejected.

This change:

- targets the exact current comparator asset;
- removes the obsolete cross-asset menu-marker dependency;
- updates the fixture to the current minified function and filename;
- retains atomic missing-needle and mixed-state rejection with the asset byte-identical.

The user-visible behavior from #915 remains rollout-dependent. This account currently exposes `Priority`, `Last updated`, and `Manual order`, rather than `Created`; the change restores honest current-DMG application and prevents the enabled feature from blocking updater/rebuild candidates because of stale asset ownership.

## Validation

Environment:

- repo base: `d0f5bc6ecef8bc7361993c120b1268eb546eb07f`
- commit: `2a83838`
- DMG SHA-256: `3e5055c185b68369d3cee4f24b45eec30d11b4f0c848c0c7fe550103135fc5e5`
- DMG ETag: unavailable for the cached local artifact
- DMG size: `618693003` bytes
- app: `26.715.52143`
- Electron: `42.3.0`
- KDE Plasma Wayland, isolated `codex-project-sort-qa` identity

Checks:

- pre-fix current-DMG build rejected the enabled feature with `skipped-optional` drift
- `node --test linux-features/project-task-sort/test.js` (5 passed)
- `node --test linux-features/*/test.js` (767 passed)
- `node --test scripts/patch-linux-window-ui.test.js` (402 passed)
- `node --test scripts/lib/linux-features.test.js` (10 passed)
- `bash tests/scripts_smoke.sh`
- `node --check` on the feature source, test, and generated current asset
- `node scripts/ci/validate-patch-report.js` on the isolated build report
- `git diff --check`
- isolated current-DMG build with only `project-task-sort`: `accepted_with_warnings`, zero feature blockers, descriptor `applied`
- complete second pass: descriptor `already-applied`; owning asset SHA-256 remained `b75d86ae34e82fc4f5d5ab349612ca8d6ed2daffc79f4d6478090368dd3f7e83`
- synthetic missing-needle and mixed states warn and remain byte-identical
- runtime side-by-side: current Projects sidebar loaded with five expanded groups; `Priority` to `Last updated` and back worked; console stayed clean; restart and shutdown passed

The isolated build retained seven unrelated optional core warnings already present for this DMG. No generated output is part of the diff.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This upstream-drift fix targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I updated the relevant tests, ran the validation listed above, and confirmed the focused and surrounding checks pass.
- [x] I reviewed the final diff at maximum reasoning effort, addressed the remaining old-DMG fixture, and reran the relevant tests.
