### PR TITLE
Version packaged renderer URLs across updates

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -269,7 +269,7 @@ resolve_webview_renderer_url() {
     fi
     if ! index_sha256="$(sha256sum "$webview_index" 2>/dev/null | awk '{print $1}')" ||
        [[ ! "$index_sha256" =~ ^[0-9a-f]{64}$ ]]; then
-        printf '%s\n' "$CODEX_LINUX_APP_DISPLAY_NAME could not fingerprint $webview_index; install coreutils and rebuild the app." >&2
+        launcher_notice "$CODEX_LINUX_APP_DISPLAY_NAME could not fingerprint $webview_index; install coreutils and rebuild the app."
         return 1
     fi
 
@@ -290,7 +290,6 @@ select_webview_renderer_url() {
 
 WEBVIEW_RENDERER_URL=""
 WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE=0
-select_webview_renderer_url || exit 1
 
 mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
 chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
@@ -385,11 +384,6 @@ else
 fi
 
 echo "[$(date -Is)] Starting $CODEX_LINUX_APP_DISPLAY_NAME launcher"
-if [ "$WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE" -eq 1 ]; then
-    echo "External renderer URL override active"
-else
-    echo "Packaged webview renderer URL: $WEBVIEW_RENDERER_URL"
-fi
 if [ "$MULTI_LAUNCH_ACTIVE" -eq 1 ]; then
     echo "Multi-launch instance: id=$CODEX_LINUX_INSTANCE_ID webview_port=$CODEX_LINUX_WEBVIEW_PORT state_dir=$APP_STATE_DIR user_data_dir=$CODEX_ELECTRON_USER_DATA_DIR"
 fi
@@ -4200,6 +4194,12 @@ source_feature_env_files
 if [ "$LAUNCHER_DIAGNOSE_SCALING" -eq 1 ]; then
     print_scaling_diagnostics
     exit 0
+fi
+select_webview_renderer_url || exit 1
+if renderer_url_override_is_active; then
+    echo "External renderer URL override active"
+else
+    echo "Packaged webview renderer URL: $WEBVIEW_RENDERER_URL"
 fi
 register_url_scheme_handlers
 log_phase "initial_launch_state_refresh_start"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -258,11 +258,25 @@ configure_multi_launch_instance() {
 
 configure_multi_launch_instance "$@"
 WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"
-WEBVIEW_RENDERER_URL="$WEBVIEW_ORIGIN/"
-if [ -f "$WEBVIEW_DIR/index.html" ]; then
-    WEBVIEW_INDEX_SHA256="$(sha256sum "$WEBVIEW_DIR/index.html" | awk '{print $1}')"
-    WEBVIEW_RENDERER_URL="${WEBVIEW_ORIGIN}/?v=$WEBVIEW_INDEX_SHA256"
-fi
+
+resolve_webview_renderer_url() {
+    local webview_index="$WEBVIEW_DIR/index.html"
+    local index_sha256
+
+    if [ ! -f "$webview_index" ]; then
+        printf '%s/\n' "$WEBVIEW_ORIGIN"
+        return 0
+    fi
+    if ! index_sha256="$(sha256sum "$webview_index" 2>/dev/null | awk '{print $1}')" ||
+       [[ ! "$index_sha256" =~ ^[0-9a-f]{64}$ ]]; then
+        printf '%s\n' "$CODEX_LINUX_APP_DISPLAY_NAME could not fingerprint $webview_index; install coreutils and rebuild the app." >&2
+        return 1
+    fi
+
+    printf '%s/?v=%s\n' "$WEBVIEW_ORIGIN" "$index_sha256"
+}
+
+WEBVIEW_RENDERER_URL="$(resolve_webview_renderer_url)" || exit 1
 
 mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
 chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
@@ -357,6 +371,7 @@ else
 fi
 
 echo "[$(date -Is)] Starting $CODEX_LINUX_APP_DISPLAY_NAME launcher"
+echo "Packaged webview renderer URL: $WEBVIEW_RENDERER_URL"
 if [ "$MULTI_LAUNCH_ACTIVE" -eq 1 ]; then
     echo "Multi-launch instance: id=$CODEX_LINUX_INSTANCE_ID webview_port=$CODEX_LINUX_WEBVIEW_PORT state_dir=$APP_STATE_DIR user_data_dir=$CODEX_ELECTRON_USER_DATA_DIR"
 fi

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -269,7 +269,6 @@ resolve_webview_renderer_url() {
     fi
     if ! index_sha256="$(sha256sum "$webview_index" 2>/dev/null | awk '{print $1}')" ||
        [[ ! "$index_sha256" =~ ^[0-9a-f]{64}$ ]]; then
-        launcher_notice "$CODEX_LINUX_APP_DISPLAY_NAME could not fingerprint $webview_index; install coreutils and rebuild the app."
         return 1
     fi
 
@@ -285,7 +284,10 @@ select_webview_renderer_url() {
         return 0
     fi
 
-    WEBVIEW_RENDERER_URL="$(resolve_webview_renderer_url)" || return 1
+    if ! WEBVIEW_RENDERER_URL="$(resolve_webview_renderer_url)"; then
+        launcher_notice "$CODEX_LINUX_APP_DISPLAY_NAME could not fingerprint $WEBVIEW_DIR/index.html; install coreutils and rebuild the app."
+        return 1
+    fi
 }
 
 WEBVIEW_RENDERER_URL=""

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -258,6 +258,11 @@ configure_multi_launch_instance() {
 
 configure_multi_launch_instance "$@"
 WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"
+WEBVIEW_RENDERER_URL="$WEBVIEW_ORIGIN/"
+if [ -f "$WEBVIEW_DIR/index.html" ]; then
+    WEBVIEW_INDEX_SHA256="$(sha256sum "$WEBVIEW_DIR/index.html" | awk '{print $1}')"
+    WEBVIEW_RENDERER_URL="${WEBVIEW_ORIGIN}/?v=$WEBVIEW_INDEX_SHA256"
+fi
 
 mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
 chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
@@ -2269,7 +2274,7 @@ running_app_uses_renderer_url_override() {
     allow_override="$(pid_environ_value "$RUNNING_APP_PID" CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE 2>/dev/null || true)"
     truthy_env_value "$allow_override" || return 1
     renderer_url="$(pid_environ_value "$RUNNING_APP_PID" ELECTRON_RENDERER_URL 2>/dev/null || true)"
-    [ -n "$renderer_url" ] && [ "$renderer_url" != "$WEBVIEW_ORIGIN/" ]
+    [ -n "$renderer_url" ] && [ "$renderer_url" != "$WEBVIEW_RENDERER_URL" ]
 }
 
 terminate_stale_electron_with_pidfd() {
@@ -2742,7 +2747,7 @@ adopt_discovered_webview_server() {
 renderer_url_override_is_active() {
     if truthy_env_value "${CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE:-}" &&
        [ -n "${ELECTRON_RENDERER_URL:-}" ] &&
-       [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_ORIGIN/" ]; then
+       [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_RENDERER_URL" ]; then
         return 0
     fi
 
@@ -4210,12 +4215,12 @@ if [ -z "${CODEX_CLI_PATH:-}" ]; then
 fi
 export CHROME_DESKTOP="${CHROME_DESKTOP:-$CODEX_LINUX_APP_ID.desktop}"
 if ! truthy_env_value "${CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE:-}"; then
-    if [ -n "${ELECTRON_RENDERER_URL:-}" ] && [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_ORIGIN/" ]; then
+    if [ -n "${ELECTRON_RENDERER_URL:-}" ] && [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_RENDERER_URL" ]; then
         echo "Ignoring inherited ELECTRON_RENDERER_URL; set CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE=1 to allow overrides"
     fi
-    export ELECTRON_RENDERER_URL="$WEBVIEW_ORIGIN/"
+    export ELECTRON_RENDERER_URL="$WEBVIEW_RENDERER_URL"
 else
-    export ELECTRON_RENDERER_URL="${ELECTRON_RENDERER_URL:-$WEBVIEW_ORIGIN/}"
+    export ELECTRON_RENDERER_URL="${ELECTRON_RENDERER_URL:-$WEBVIEW_RENDERER_URL}"
 fi
 
 if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -276,7 +276,21 @@ resolve_webview_renderer_url() {
     printf '%s/?v=%s\n' "$WEBVIEW_ORIGIN" "$index_sha256"
 }
 
-WEBVIEW_RENDERER_URL="$(resolve_webview_renderer_url)" || exit 1
+select_webview_renderer_url() {
+    WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE=0
+    if early_truthy_env_value "${CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE:-}" &&
+       [ -n "${ELECTRON_RENDERER_URL:-}" ]; then
+        WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE=1
+        WEBVIEW_RENDERER_URL="$ELECTRON_RENDERER_URL"
+        return 0
+    fi
+
+    WEBVIEW_RENDERER_URL="$(resolve_webview_renderer_url)" || return 1
+}
+
+WEBVIEW_RENDERER_URL=""
+WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE=0
+select_webview_renderer_url || exit 1
 
 mkdir -p "$LOG_DIR" "$APP_CONFIG_DIR" "$APP_STATE_DIR" "$LAUNCH_ACTION_RUNTIME_DIR"
 chmod 700 "$LAUNCH_ACTION_RUNTIME_DIR" 2>/dev/null || true
@@ -371,7 +385,11 @@ else
 fi
 
 echo "[$(date -Is)] Starting $CODEX_LINUX_APP_DISPLAY_NAME launcher"
-echo "Packaged webview renderer URL: $WEBVIEW_RENDERER_URL"
+if [ "$WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE" -eq 1 ]; then
+    echo "External renderer URL override active"
+else
+    echo "Packaged webview renderer URL: $WEBVIEW_RENDERER_URL"
+fi
 if [ "$MULTI_LAUNCH_ACTIVE" -eq 1 ]; then
     echo "Multi-launch instance: id=$CODEX_LINUX_INSTANCE_ID webview_port=$CODEX_LINUX_WEBVIEW_PORT state_dir=$APP_STATE_DIR user_data_dir=$CODEX_ELECTRON_USER_DATA_DIR"
 fi
@@ -2289,7 +2307,9 @@ running_app_uses_renderer_url_override() {
     allow_override="$(pid_environ_value "$RUNNING_APP_PID" CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE 2>/dev/null || true)"
     truthy_env_value "$allow_override" || return 1
     renderer_url="$(pid_environ_value "$RUNNING_APP_PID" ELECTRON_RENDERER_URL 2>/dev/null || true)"
-    [ -n "$renderer_url" ] && [ "$renderer_url" != "$WEBVIEW_RENDERER_URL" ]
+    [ -n "$renderer_url" ] || return 1
+    renderer_url_override_is_active && return 0
+    [ "$renderer_url" != "$WEBVIEW_RENDERER_URL" ]
 }
 
 terminate_stale_electron_with_pidfd() {
@@ -2760,13 +2780,7 @@ adopt_discovered_webview_server() {
 }
 
 renderer_url_override_is_active() {
-    if truthy_env_value "${CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE:-}" &&
-       [ -n "${ELECTRON_RENDERER_URL:-}" ] &&
-       [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_RENDERER_URL" ]; then
-        return 0
-    fi
-
-    return 1
+    [ "${WEBVIEW_RENDERER_URL_OVERRIDE_ACTIVE:-0}" -eq 1 ]
 }
 
 require_webview_entrypoint() {
@@ -4229,13 +4243,13 @@ if [ -z "${CODEX_CLI_PATH:-}" ]; then
     log_phase "cli_lookup"
 fi
 export CHROME_DESKTOP="${CHROME_DESKTOP:-$CODEX_LINUX_APP_ID.desktop}"
-if ! truthy_env_value "${CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE:-}"; then
+if ! renderer_url_override_is_active; then
     if [ -n "${ELECTRON_RENDERER_URL:-}" ] && [ "$ELECTRON_RENDERER_URL" != "$WEBVIEW_RENDERER_URL" ]; then
         echo "Ignoring inherited ELECTRON_RENDERER_URL; set CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE=1 to allow overrides"
     fi
     export ELECTRON_RENDERER_URL="$WEBVIEW_RENDERER_URL"
 else
-    export ELECTRON_RENDERER_URL="${ELECTRON_RENDERER_URL:-$WEBVIEW_RENDERER_URL}"
+    export ELECTRON_RENDERER_URL="$WEBVIEW_RENDERER_URL"
 fi
 
 if needs_cold_start && [ -z "$CODEX_CLI_PATH" ]; then

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5018,6 +5018,21 @@ SCRIPT
     assert_file_exists "$electron_marker"
     [ "$(cat "$electron_marker")" = "http://127.0.0.1:9999/" ] \
         || fail "Fingerprint failure should not replace an explicit renderer URL override"
+
+    local feature_renderer_env="$app_dir/.codex-linux/env.d/renderer-url.env"
+    printf '%s\n' \
+        'CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE=1' \
+        'ELECTRON_RENDERER_URL=http://127.0.0.1:9998/' \
+        > "$feature_renderer_env"
+    rm -f "$electron_marker"
+    set +e
+    run_packaged_launcher "$fake_bin:$HOST_TOOL_PATH" > "$fingerprint_error" 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || fail "Feature renderer URL override should bypass packaged fingerprint failure"
+    assert_file_exists "$electron_marker"
+    [ "$(cat "$electron_marker")" = "http://127.0.0.1:9998/" ] \
+        || fail "Feature environment should replace the inherited renderer URL override"
 }
 
 test_launcher_extra_bundled_plugin_cache_rollback() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4949,37 +4949,60 @@ SCRIPT
         || fail "Launcher should preserve explicit renderer URL override"
     assert_contains "$launcher_log" "Skipping packaged webview setup because ELECTRON_RENDERER_URL override is enabled"
 
+    run_packaged_launcher() {
+        local test_path="${1:-$HOST_TOOL_PATH}"
+        timeout 20 env -i \
+            PATH="$test_path" \
+            HOME="$home_dir" \
+            XDG_RUNTIME_DIR="$runtime_dir" \
+            CODEX_CLI_PATH="$TRUE_BIN" \
+            CODEX_WEBVIEW_PORT=45675 \
+            ELECTRON_RENDERER_URL="http://127.0.0.1:9999/" \
+            ELECTRON_MARKER="$electron_marker" \
+            "$app_dir/start.sh"
+    }
+
     printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader">first build</div>' \
         > "$app_dir/content/webview/index.html"
     rm -f "$electron_marker"
-    timeout 20 env -i \
-        PATH="$HOST_TOOL_PATH" \
-        HOME="$home_dir" \
-        XDG_RUNTIME_DIR="$runtime_dir" \
-        CODEX_CLI_PATH="$TRUE_BIN" \
-        CODEX_WEBVIEW_PORT=45675 \
-        ELECTRON_MARKER="$electron_marker" \
-        "$app_dir/start.sh" >/dev/null 2>&1
+    run_packaged_launcher >/dev/null 2>&1
     local first_renderer_url
     first_renderer_url="$(cat "$electron_marker")"
     [[ "$first_renderer_url" =~ ^http://127\.0\.0\.1:45675/\?v=[0-9a-f]{64}$ ]] \
         || fail "Packaged renderer URL should include the webview index content hash"
+    assert_contains "$launcher_log" "Ignoring inherited ELECTRON_RENDERER_URL"
+    assert_contains "$launcher_log" "Packaged webview renderer URL: $first_renderer_url"
+
+    rm -f "$electron_marker"
+    run_packaged_launcher >/dev/null 2>&1
+    [ "$(cat "$electron_marker")" = "$first_renderer_url" ] \
+        || fail "Packaged renderer URL should remain stable while the webview index is unchanged"
 
     printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader">second build</div>' \
         > "$app_dir/content/webview/index.html"
     rm -f "$electron_marker"
-    timeout 20 env -i \
-        PATH="$HOST_TOOL_PATH" \
-        HOME="$home_dir" \
-        XDG_RUNTIME_DIR="$runtime_dir" \
-        CODEX_CLI_PATH="$TRUE_BIN" \
-        CODEX_WEBVIEW_PORT=45675 \
-        ELECTRON_MARKER="$electron_marker" \
-        "$app_dir/start.sh" >/dev/null 2>&1
+    run_packaged_launcher >/dev/null 2>&1
     local second_renderer_url
     second_renderer_url="$(cat "$electron_marker")"
     [ "$first_renderer_url" != "$second_renderer_url" ] \
         || fail "Packaged renderer URL should change when the webview index changes"
+
+    local fake_bin="$workspace/fake-bin"
+    local fingerprint_error="$workspace/fingerprint-error.log"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/sha256sum" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 73
+SCRIPT
+    chmod +x "$fake_bin/sha256sum"
+    rm -f "$electron_marker"
+    set +e
+    run_packaged_launcher "$fake_bin:$HOST_TOOL_PATH" > "$fingerprint_error" 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] || fail "Launcher should fail when the webview fingerprint cannot be calculated"
+    [ ! -e "$electron_marker" ] || fail "Fingerprint failure should stop before Electron"
+    assert_contains "$fingerprint_error" "could not fingerprint"
 }
 
 test_launcher_extra_bundled_plugin_cache_rollback() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4951,12 +4951,17 @@ SCRIPT
 
     run_packaged_launcher() {
         local test_path="${1:-$HOST_TOOL_PATH}"
+        local -a renderer_override_env=()
+        if [ -n "${2:-}" ]; then
+            renderer_override_env+=(CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE="$2")
+        fi
         timeout 20 env -i \
             PATH="$test_path" \
             HOME="$home_dir" \
             XDG_RUNTIME_DIR="$runtime_dir" \
             CODEX_CLI_PATH="$TRUE_BIN" \
             CODEX_WEBVIEW_PORT=45675 \
+            "${renderer_override_env[@]}" \
             ELECTRON_RENDERER_URL="http://127.0.0.1:9999/" \
             ELECTRON_MARKER="$electron_marker" \
             "$app_dir/start.sh"
@@ -5003,6 +5008,16 @@ SCRIPT
     [ "$rc" -ne 0 ] || fail "Launcher should fail when the webview fingerprint cannot be calculated"
     [ ! -e "$electron_marker" ] || fail "Fingerprint failure should stop before Electron"
     assert_contains "$fingerprint_error" "could not fingerprint"
+
+    rm -f "$electron_marker"
+    set +e
+    run_packaged_launcher "$fake_bin:$HOST_TOOL_PATH" 1 > "$fingerprint_error" 2>&1
+    rc=$?
+    set -e
+    [ "$rc" -eq 0 ] || fail "Explicit renderer URL override should bypass packaged fingerprint failure"
+    assert_file_exists "$electron_marker"
+    [ "$(cat "$electron_marker")" = "http://127.0.0.1:9999/" ] \
+        || fail "Fingerprint failure should not replace an explicit renderer URL override"
 }
 
 test_launcher_extra_bundled_plugin_cache_rollback() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5008,6 +5008,7 @@ SCRIPT
     [ "$rc" -ne 0 ] || fail "Launcher should fail when the webview fingerprint cannot be calculated"
     [ ! -e "$electron_marker" ] || fail "Fingerprint failure should stop before Electron"
     assert_contains "$fingerprint_error" "could not fingerprint"
+    assert_contains "$launcher_log" "could not fingerprint"
 
     rm -f "$electron_marker"
     set +e

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -4871,7 +4871,7 @@ test_launcher_rejects_missing_webview_entrypoint() {
     local home_dir="$workspace/home"
     local runtime_dir="$workspace/runtime"
     local electron_marker="$workspace/electron-called"
-    local launcher_log="$home_dir/.cache/codex-desktop/launcher.log"
+    local launcher_log="$home_dir/.cache/codex-renderer-url-test/launcher.log"
 
     mkdir -p \
         "$app_dir/.codex-linux/cold-start.d" \
@@ -4892,7 +4892,7 @@ test_launcher_rejects_missing_webview_entrypoint() {
         printf '%s\n' \
             '#!/usr/bin/env bash' \
             'set -Eeuo pipefail' \
-            'CODEX_LINUX_APP_ID=codex-desktop' \
+            'CODEX_LINUX_APP_ID=codex-renderer-url-test' \
             'CODEX_LINUX_APP_DISPLAY_NAME="Codex Desktop"' \
             'CODEX_LINUX_WEBVIEW_PORT="${CODEX_WEBVIEW_PORT:-5175}"'
         cat "$REPO_DIR/launcher/start.sh.template"
@@ -4948,6 +4948,38 @@ SCRIPT
     [ "$(cat "$electron_marker")" = "http://127.0.0.1:9999/" ] \
         || fail "Launcher should preserve explicit renderer URL override"
     assert_contains "$launcher_log" "Skipping packaged webview setup because ELECTRON_RENDERER_URL override is enabled"
+
+    printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader">first build</div>' \
+        > "$app_dir/content/webview/index.html"
+    rm -f "$electron_marker"
+    timeout 20 env -i \
+        PATH="$HOST_TOOL_PATH" \
+        HOME="$home_dir" \
+        XDG_RUNTIME_DIR="$runtime_dir" \
+        CODEX_CLI_PATH="$TRUE_BIN" \
+        CODEX_WEBVIEW_PORT=45675 \
+        ELECTRON_MARKER="$electron_marker" \
+        "$app_dir/start.sh" >/dev/null 2>&1
+    local first_renderer_url
+    first_renderer_url="$(cat "$electron_marker")"
+    [[ "$first_renderer_url" =~ ^http://127\.0\.0\.1:45675/\?v=[0-9a-f]{64}$ ]] \
+        || fail "Packaged renderer URL should include the webview index content hash"
+
+    printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader">second build</div>' \
+        > "$app_dir/content/webview/index.html"
+    rm -f "$electron_marker"
+    timeout 20 env -i \
+        PATH="$HOST_TOOL_PATH" \
+        HOME="$home_dir" \
+        XDG_RUNTIME_DIR="$runtime_dir" \
+        CODEX_CLI_PATH="$TRUE_BIN" \
+        CODEX_WEBVIEW_PORT=45675 \
+        ELECTRON_MARKER="$electron_marker" \
+        "$app_dir/start.sh" >/dev/null 2>&1
+    local second_renderer_url
+    second_renderer_url="$(cat "$electron_marker")"
+    [ "$first_renderer_url" != "$second_renderer_url" ] \
+        || fail "Packaged renderer URL should change when the webview index changes"
 }
 
 test_launcher_extra_bundled_plugin_cache_rollback() {
@@ -6067,7 +6099,7 @@ EOF
     assert_not_contains "$REPO_DIR/install.sh" "pkill -f \"http.server 5175\""
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_WEBVIEW_PORT"
     assert_contains "$REPO_DIR/launcher/start.sh.template" "CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE"
-    assert_contains "$REPO_DIR/launcher/start.sh.template" 'export ELECTRON_RENDERER_URL="$WEBVIEW_ORIGIN/"'
+    assert_contains "$REPO_DIR/launcher/start.sh.template" 'export ELECTRON_RENDERER_URL="$WEBVIEW_RENDERER_URL"'
     assert_contains "$REPO_DIR/launcher/start.sh.template" '--app-id="$CODEX_LINUX_APP_ID"'
     assert_contains "$REPO_DIR/scripts/lib/process-detection.sh" "CODEX_APP_ID"
     assert_contains "$REPO_DIR/launcher/start.sh.template" 'ELECTRON_OZONE_HINT="auto"'
@@ -6984,7 +7016,7 @@ test_side_by_side_launcher_identity() {
     assert_contains "$app_dir/start.sh" 'export CODEX_HOME CODEX_LINUX_APP_ID CODEX_LINUX_APP_DISPLAY_NAME CODEX_LINUX_WEBVIEW_PORT CODEX_LINUX_SETTINGS_FILE CODEX_LINUX_FEATURES_DIR'
     assert_contains "$app_dir/start.sh" 'WEBVIEW_ORIGIN="http://127.0.0.1:$CODEX_LINUX_WEBVIEW_PORT"'
     assert_contains "$app_dir/start.sh" "CODEX_LINUX_ALLOW_RENDERER_URL_OVERRIDE"
-    assert_contains "$app_dir/start.sh" 'export ELECTRON_RENDERER_URL="$WEBVIEW_ORIGIN/"'
+    assert_contains "$app_dir/start.sh" 'export ELECTRON_RENDERER_URL="$WEBVIEW_RENDERER_URL"'
     assert_contains "$app_dir/start.sh" "resolve_script_dir"
     assert_contains "$app_dir/start.sh" "configure_side_by_side_app_env"
     assert_contains "$app_dir/start.sh" 'XDG_CONFIG_HOME="${CODEX_XDG_CONFIG_HOME:-$APP_STATE_DIR/xdg-config}"'


### PR DESCRIPTION
## Summary

- version the packaged renderer URL with the SHA-256 of `content/webview/index.html`
- keep explicit renderer URL overrides and missing-entrypoint failure behavior unchanged
- cover stable and changed renderer fingerprints plus fingerprint failure in the launcher smoke harness

## Problem

After the native updater replaced a working package and relaunched the app, the new webview server received requests for hashed chunks that existed only in the previous DMG. Threads and Settings opened the generic `Oops, an error has occurred` boundary until the Electron cache was moved aside.

The launcher already serves all webview responses with `Cache-Control: no-store`, following #164. PR #940 also established that Chromium/Electron module reuse can survive those headers for stable module URLs. The packaged renderer entrypoint still used the same `http://127.0.0.1:5175/` URL across DMG revisions, allowing an old module graph to be restored after an updater-driven restart.

The launcher now derives `ELECTRON_RENDERER_URL` as `http://127.0.0.1:<port>/?v=<index-sha256>`. A changed webview entrypoint therefore receives a new navigation/cache key without deleting cookies, sessions, settings, or the user's Electron profile.

## Reproduction evidence

- previous DMG SHA-256: `3e5055c185b68369d3cee4f24b45eec30d11b4f0c848c0c7fe550103135fc5e5`
- updated DMG SHA-256: `447f3bf318ba01822371db1ec01c1b9553224e7f8cb5ae577e17da441aaa3a30`
- remote fingerprint: `etag=0x8DEE6ED04CFB50F|last_modified=Tue, 21 Jul 2026 05:57:59 GMT|content_length=618781423`
- upstream app: `26.715.61943`
- Electron: `42.3.0`
- package path: updater-built Debian package on Ubuntu 25.10, KDE Plasma, Wayland
- repository base: `8e8cad33d6d040e3723ddc1c9b434a3aae186a25`

The failing launch requested removed previous-build assets including:

```text
/assets/settings-route-state-BtPsWPDu.js
/assets/settings-page-BOdFN1v1.js
/assets/thread-user-message-navigation-rail-CDkyA6AP.js
```

The installed package contained the corresponding current assets under different hashes. Moving the Electron HTTP/code caches aside and cold-starting the same installed package restored threads and Settings.

## Validation

- `bash tests/scripts_smoke.sh`
- `bash -n launcher/start.sh.template tests/scripts_smoke.sh`
- `git diff --check`
- GitHub CI: Rust and Smoke Tests, Debian, RPM, Pacman, and Nix builds passed
- current-DMG isolated build: `accepted_with_warnings`, patch report `61 applied`, `18 already-applied`, `7 skipped-optional`, `1 skipped-target`, no enabled Linux features and no blockers
- generated app identity: DMG SHA-256 `447f3bf3...`, app `26.715.61943`, Electron `42.3.0`, source commit `bd23313`
- side-by-side Electron runtime with isolated app id, ports, config, state, cache, and user-data directory
- initial launch opened Settings and an existing task successfully
- cold restart with the same isolated profile reused the same renderer fingerprint and reopened Settings successfully
- current Settings and task chunks returned HTTP 200; no HTTP 404, old asset hash request, dynamic-import failure, or fatal error-boundary controls were observed

## Scope

This PR addresses renderer asset graph invalidation only. Updater wrapper provenance being recorded as unknown in updater-built packages is a separate issue.
