### PR TITLE
Fix upstream DMG drift

### DIFF
--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -61,7 +61,7 @@ const REMOTE_CONTROL_APP_MAIN_PAGE_ASSET_PATTERN =
 const REMOTE_CONTROL_VISIBILITY_ASSET_PATTERN =
   /^app-initial~avatarOverlayCompositionSurface~notebook-preview-panel~app-main~appgen-settings~el5fc9d5-[^.]+\.js$/u;
 const REMOTE_CONTROL_LOAD_GATE_ASSET_PATTERN =
-  /^app-initial~artifact-tab-content\.electron~notebook-preview-panel~app-main~business-checkout~hm0a50up-[^.]+\.js$/u;
+  /^app-initial~artifact-tab-content\.electron~notebook-preview-panel~app-main~business-checkout~k87y25tw-[^.]+\.js$/u;
 const REMOTE_MOBILE_ACTIVE_STATUS_ASSET_PATTERN =
   /^app-initial~notebook-preview-panel~app-main~pull-request-route~projects-index-page~cloud-en~lpx9dmpy-[^.]+\.js$/u;
 const REMOTE_CONTROL_LINUX_COPY_REPLACEMENTS = [

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -65,9 +65,9 @@ const CURRENT_APP_MAIN_PAGE_ASSET =
 const CURRENT_REMOTE_CONNECTIONS_VISIBILITY_ASSET =
   "app-initial~avatarOverlayCompositionSurface~notebook-preview-panel~app-main~appgen-settings~el5fc9d5-test.js";
 const CURRENT_REMOTE_LOAD_GATE_ASSET =
-  "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~hm0a50up-test.js";
+  "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~k87y25tw-test.js";
 const OLD_REMOTE_LOAD_GATE_ASSET =
-  "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~d7o11fcp-test.js";
+  "app-initial~artifact-tab-content.electron~notebook-preview-panel~app-main~business-checkout~hm0a50up-test.js";
 const OLD_REMOTE_CONVERSATION_STATUS_ASSET =
   "app-initial~app-main~projects-index-page~remote-conversation-page-test.js";
 const CURRENT_REMOTE_CONVERSATION_STATUS_ASSET =


### PR DESCRIPTION
<!-- upstream-dmg-sha256:95c66f30ad0ee946cfec2b83c50e68744700be5da76898c5de484a755000f4a3 -->

## Summary
- repair Linux compatibility drift for the current upstream DMG
- remove obsolete compatibility paths replaced by the current DMG shape

## Validation
- exact current-DMG acceptance recorded by watchdog v2
- GitHub CI must pass, including Nix Package Builds
