### PR TITLE
Preserve updater build source provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Updater rebuild workspaces now retain the Git identity of the wrapper source
+  after `.git` is stripped, so installed build metadata and packaged
+  update-builder metadata report the wrapper commit instead of `unknown`.
 - V2 pets now look toward the live pointer position after successful Linux
   Computer Use click, scroll, and drag actions, then return to their normal
   animation. The bridge is isolated per app instance and fails softly when its

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -346,22 +346,50 @@ fn sanitize_git_remote(remote: Option<String>) -> Option<String> {
         || Path::new(&value).is_absolute()
         || value.starts_with("./")
         || value.starts_with("../")
+        || value.starts_with('~')
+        || value.contains('\\')
     {
         return None;
     }
 
     if let Ok(mut url) = reqwest::Url::parse(&value) {
-        if url.scheme() == "file" {
+        if !matches!(url.scheme(), "http" | "https" | "ssh" | "git") || url.host_str().is_none() {
             return None;
         }
-        if matches!(url.scheme(), "http" | "https") {
-            url.set_username("").ok()?;
-            url.set_password(None).ok()?;
-            return Some(url.to_string());
-        }
+        url.set_username("").ok()?;
+        url.set_password(None).ok()?;
+        url.set_query(None);
+        url.set_fragment(None);
+        return Some(url.to_string());
     }
 
-    Some(value)
+    sanitize_scp_like_git_remote(&value)
+}
+
+fn sanitize_scp_like_git_remote(remote: &str) -> Option<String> {
+    if remote.contains("::")
+        || remote.chars().any(char::is_whitespace)
+        || remote.contains(['?', '#'])
+    {
+        return None;
+    }
+
+    let host_start = remote.rfind('@').map_or(0, |index| index + 1);
+    let separator = host_start + remote[host_start..].find(':')?;
+    let authority = &remote[..separator];
+    let path = &remote[separator + 1..];
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if host.is_empty()
+        || host.contains(['/', '\\', ':'])
+        || path.is_empty()
+        || path.starts_with(['/', '.', '~'])
+    {
+        return None;
+    }
+
+    Some(format!("{host}:{path}"))
 }
 
 fn stage_git_source_info(source_root: &Path, destination_root: &Path) -> Result<()> {
@@ -1215,6 +1243,43 @@ fi
             "{\"commit\":\"packaged\"}\n"
         );
         Ok(())
+    }
+
+    #[test]
+    fn sanitizes_credential_bearing_network_remotes() {
+        assert_eq!(
+            sanitize_git_remote(Some(
+                "ssh://builder:secret-token@github.com/example/codex-desktop-linux.git".to_string()
+            )),
+            Some("ssh://github.com/example/codex-desktop-linux.git".to_string())
+        );
+        assert_eq!(
+            sanitize_git_remote(Some(
+                "private-user@github.com:example/codex-desktop-linux.git".to_string()
+            )),
+            Some("github.com:example/codex-desktop-linux.git".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_local_and_custom_git_remotes() {
+        for remote in [
+            "/home/builder/private/codex-desktop-linux",
+            "./private/codex-desktop-linux",
+            "../private/codex-desktop-linux",
+            "~/private/codex-desktop-linux",
+            "private/codex-desktop-linux",
+            "file:///home/builder/private/codex-desktop-linux",
+            "C:\\Users\\builder\\private\\codex-desktop-linux",
+            "ext::ssh -i /home/builder/.ssh/private_key github.com %S",
+            "custom://builder:secret@internal.example/private/repo.git",
+        ] {
+            assert_eq!(
+                sanitize_git_remote(Some(remote.to_string())),
+                None,
+                "remote should be rejected: {remote}"
+            );
+        }
     }
 
     #[test]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -785,6 +785,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop_${PACKAGE_VERSION}_amd64.deb"
             FakePackageOutput::Rpm => {
                 r#"set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
+cp .codex-linux/source-info.json "${DIST_DIR_OVERRIDE}/package-source-info.json"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop-${PACKAGE_VERSION}.x86_64.rpm"
 "#
             }
@@ -792,6 +793,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${PACKAGE_VERSION}.x86_64.rpm"
                 r#"set -euo pipefail
 VER="${PACKAGE_VERSION%%+*}"
 mkdir -p "${DIST_DIR_OVERRIDE}"
+cp .codex-linux/source-info.json "${DIST_DIR_OVERRIDE}/package-source-info.json"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
 "#
             }
@@ -1280,6 +1282,40 @@ fi
                 "remote should be rejected: {remote}"
             );
         }
+    }
+
+    #[test]
+    fn fake_package_builders_emit_source_info() -> Result<()> {
+        let temp = tempdir()?;
+        for (index, output) in [
+            FakePackageOutput::Deb,
+            FakePackageOutput::Rpm,
+            FakePackageOutput::Pacman,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let bundle_root = temp.path().join(format!("bundle-{index}"));
+            let source_info = bundle_root.join(".codex-linux/source-info.json");
+            let script_path = bundle_root.join("build-package.sh");
+            let dist_dir = bundle_root.join("dist");
+            fs::create_dir_all(source_info.parent().unwrap())?;
+            fs::write(&source_info, "{\"commit\":\"test-commit\"}\n")?;
+            write_fake_build_script(&script_path, output)?;
+
+            let status = StdCommand::new(&script_path)
+                .current_dir(&bundle_root)
+                .env("DIST_DIR_OVERRIDE", &dist_dir)
+                .env("PACKAGE_VERSION", "2026.07.22+test")
+                .status()?;
+
+            assert!(status.success(), "fake package builder {index} failed");
+            assert_eq!(
+                fs::read_to_string(dist_dir.join("package-source-info.json"))?,
+                "{\"commit\":\"test-commit\"}\n"
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -6,10 +6,12 @@ use crate::{
     state::{ArtifactPaths, PersistedState, UpdateStatus},
 };
 use anyhow::{Context, Result};
+use serde::Serialize;
 use std::{
     ffi::OsString,
     fs,
     path::{Component, Path, PathBuf},
+    process::Command as StdCommand,
 };
 use tokio::process::Command;
 use tracing::info;
@@ -123,6 +125,7 @@ pub async fn build_update_from(
     state.save(&paths.state_file)?;
 
     copy_builder_bundle(bundle_source, &workspace.bundle_dir)?;
+    stage_git_source_info(bundle_source, &workspace.bundle_dir)?;
 
     state.status = UpdateStatus::PatchingApp;
     state.save(&paths.state_file)?;
@@ -268,6 +271,114 @@ fn copy_builder_bundle(source_root: &Path, destination_root: &Path) -> Result<()
         )?;
     }
 
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct GitSourceInfo {
+    commit: String,
+    short_commit: String,
+    branch: Option<String>,
+    remote: Option<String>,
+    describe: Option<String>,
+    dirty: Option<bool>,
+    provenance: &'static str,
+}
+
+impl GitSourceInfo {
+    fn capture(source_root: &Path) -> Option<Self> {
+        let top_level = git_capture(source_root, &["rev-parse", "--show-toplevel"])?;
+        let source_root = fs::canonicalize(source_root).ok()?;
+        let top_level = fs::canonicalize(top_level).ok()?;
+        if source_root != top_level {
+            return None;
+        }
+
+        let commit = git_capture(source_root.as_path(), &["rev-parse", "HEAD"])?;
+        let status = git_capture(
+            source_root.as_path(),
+            &["status", "--porcelain", "--untracked-files=normal"],
+        );
+        Some(Self {
+            short_commit: commit.chars().take(12).collect(),
+            commit,
+            branch: non_empty(git_capture(
+                source_root.as_path(),
+                &["branch", "--show-current"],
+            )),
+            remote: sanitize_git_remote(non_empty(git_capture(
+                source_root.as_path(),
+                &["remote", "get-url", "origin"],
+            ))),
+            describe: non_empty(git_capture(
+                source_root.as_path(),
+                &["describe", "--always", "--dirty", "--tags"],
+            )),
+            dirty: status.map(|value| !value.trim().is_empty()),
+            provenance: "git",
+        })
+    }
+}
+
+fn git_capture(repo: &Path, args: &[&str]) -> Option<String> {
+    let output = StdCommand::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+}
+
+fn non_empty(value: Option<String>) -> Option<String> {
+    value.filter(|item| !item.is_empty())
+}
+
+fn sanitize_git_remote(remote: Option<String>) -> Option<String> {
+    let value = remote?.trim().to_string();
+    if value.is_empty()
+        || Path::new(&value).is_absolute()
+        || value.starts_with("./")
+        || value.starts_with("../")
+    {
+        return None;
+    }
+
+    if let Ok(mut url) = reqwest::Url::parse(&value) {
+        if url.scheme() == "file" {
+            return None;
+        }
+        if matches!(url.scheme(), "http" | "https") {
+            url.set_username("").ok()?;
+            url.set_password(None).ok()?;
+            return Some(url.to_string());
+        }
+    }
+
+    Some(value)
+}
+
+fn stage_git_source_info(source_root: &Path, destination_root: &Path) -> Result<()> {
+    let Some(source_info) = GitSourceInfo::capture(source_root) else {
+        return Ok(());
+    };
+    let info_path = destination_root.join(".codex-linux/source-info.json");
+    let info_dir = info_path
+        .parent()
+        .context("Source info path has no parent directory")?;
+    fs::create_dir_all(info_dir)
+        .with_context(|| format!("Failed to create {}", info_dir.display()))?;
+    fs::write(
+        &info_path,
+        format!("{}\n", serde_json::to_string_pretty(&source_info)?),
+    )
+    .with_context(|| format!("Failed to write {}", info_path.display()))?;
     Ok(())
 }
 
@@ -583,11 +694,63 @@ mod tests {
         Ok(format!("#!{}\n{body}", host_tool("bash")?.display()))
     }
 
+    fn install_fake_git(root: &Path, top_level: &Path, dirty: bool) -> Result<()> {
+        let bin_dir = root.join("fake-git-bin");
+        let git_path = bin_dir.join("git");
+        fs::create_dir_all(&bin_dir)?;
+        fs::write(
+            &git_path,
+            host_bash_script(
+                r#"set -euo pipefail
+if [ "$1" != "-C" ]; then
+  exit 2
+fi
+shift 2
+case "$*" in
+  "rev-parse --show-toplevel") printf '%s\n' "$FAKE_GIT_TOP_LEVEL" ;;
+  "rev-parse HEAD") printf '%s\n' "$FAKE_GIT_COMMIT" ;;
+  "status --porcelain --untracked-files=normal") printf '%s' "$FAKE_GIT_STATUS" ;;
+  "branch --show-current") printf 'main\n' ;;
+  "remote get-url origin") printf 'https://builder:secret-token@github.com/example/codex-desktop-linux.git\n' ;;
+  "describe --always --dirty --tags") printf '%s\n' "$FAKE_GIT_DESCRIBE" ;;
+  *) exit 1 ;;
+esac
+"#,
+            )?,
+        )?;
+        fs::set_permissions(&git_path, fs::Permissions::from_mode(0o755))?;
+
+        let mut path_entries = vec![bin_dir];
+        path_entries.extend(std::env::split_paths(
+            &std::env::var_os("PATH").unwrap_or_default(),
+        ));
+        std::env::set_var("PATH", std::env::join_paths(path_entries)?);
+        std::env::set_var("FAKE_GIT_TOP_LEVEL", top_level);
+        std::env::set_var(
+            "FAKE_GIT_COMMIT",
+            "0123456789abcdef0123456789abcdef01234567",
+        );
+        std::env::set_var(
+            "FAKE_GIT_DESCRIBE",
+            if dirty { "v0.10.2-dirty" } else { "v0.10.2" },
+        );
+        std::env::set_var(
+            "FAKE_GIT_STATUS",
+            if dirty {
+                " M updater/src/builder.rs\n"
+            } else {
+                ""
+            },
+        );
+        Ok(())
+    }
+
     fn write_fake_build_script(path: &Path, output: FakePackageOutput) -> Result<()> {
         let script_body = match output {
             FakePackageOutput::Deb => {
                 r#"set -euo pipefail
 mkdir -p "${DIST_DIR_OVERRIDE}"
+cp .codex-linux/source-info.json "${DIST_DIR_OVERRIDE}/package-source-info.json"
 touch "${DIST_DIR_OVERRIDE}/codex-desktop_${PACKAGE_VERSION}_amd64.deb"
 "#
             }
@@ -728,6 +891,13 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
     #[test]
     fn builds_update_with_fake_bundle() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "PATH",
+            "FAKE_GIT_TOP_LEVEL",
+            "FAKE_GIT_COMMIT",
+            "FAKE_GIT_DESCRIBE",
+            "FAKE_GIT_STATUS",
+        ]);
         let runtime = tokio::runtime::Runtime::new()?;
         let temp = tempdir()?;
         let bundle_root = temp.path().join("bundle");
@@ -737,15 +907,10 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
         fs::create_dir_all(bundle_root.join("launcher"))?;
         fs::create_dir_all(bundle_root.join("packaging/linux"))?;
         fs::create_dir_all(bundle_root.join("assets"))?;
-        fs::create_dir_all(bundle_root.join(".codex-linux"))?;
         write_fake_computer_use_bundle(&bundle_root)?;
         write_fake_linux_features_bundle(&bundle_root)?;
         write_fake_patch_bundle(&bundle_root)?;
         fs::write(bundle_root.join("CHANGELOG.md"), b"# Changelog\n")?;
-        fs::write(
-            bundle_root.join(".codex-linux/source-info.json"),
-            b"{\"commit\":\"0123456789012345678901234567890123456789\",\"version\":\"0.8.1\"}\n",
-        )?;
         fs::write(
             bundle_root.join("launcher/start.sh.template"),
             b"# fake launcher template\n",
@@ -811,6 +976,7 @@ touch "${DIST_DIR_OVERRIDE}/codex-desktop-${VER}-1-x86_64.pkg.tar.zst"
 mkdir -p "${CODEX_INSTALL_DIR}"
 echo launcher > "${CODEX_INSTALL_DIR}/start.sh"
 chmod +x "${CODEX_INSTALL_DIR}/start.sh"
+cp .codex-linux/source-info.json "${CODEX_INSTALL_DIR}/app-source-info.json"
 if [ -n "${CODEX_PATCH_REPORT_JSON:-}" ]; then
   mkdir -p "$(dirname "$CODEX_PATCH_REPORT_JSON")"
   printf '{"patches":[]}\n' > "${CODEX_PATCH_REPORT_JSON}"
@@ -863,6 +1029,10 @@ fi
             bundle_root.join("scripts/lib/node-runtime.sh"),
             b"#!/bin/bash\n",
         )?;
+        fs::create_dir_all(bundle_root.join(".git"))?;
+        install_fake_git(temp.path(), &bundle_root, false)?;
+        let expected_commit = "0123456789abcdef0123456789abcdef01234567";
+        let expected_describe = "v0.10.2";
         let paths = RuntimePaths {
             config_file: temp.path().join("config/config.toml"),
             state_file: state_root.join("state.json"),
@@ -917,10 +1087,24 @@ fi
             .workspace_dir
             .join("builder/CHANGELOG.md")
             .exists());
-        assert!(artifacts
-            .workspace_dir
-            .join("builder/.codex-linux/source-info.json")
-            .exists());
+        assert!(!artifacts.workspace_dir.join("builder/.git").exists());
+        for relative_path in [
+            "codex-app/app-source-info.json",
+            "dist/package-source-info.json",
+        ] {
+            let source_info: serde_json::Value =
+                serde_json::from_slice(&fs::read(artifacts.workspace_dir.join(relative_path))?)?;
+            assert_eq!(source_info["commit"], expected_commit);
+            assert_eq!(source_info["shortCommit"], &expected_commit[..12]);
+            assert_eq!(source_info["branch"], "main");
+            assert_eq!(
+                source_info["remote"],
+                "https://github.com/example/codex-desktop-linux.git"
+            );
+            assert_eq!(source_info["describe"], expected_describe);
+            assert_eq!(source_info["dirty"], false);
+            assert_eq!(source_info["provenance"], "git");
+        }
         assert!(artifacts
             .workspace_dir
             .join("builder/launcher/cli-launch-path.py")
@@ -950,6 +1134,85 @@ fi
             is_native_package_file(&artifacts.package_path),
             "expected a native package (.deb, .rpm, or .pkg.tar.zst), got {}",
             artifacts.package_path.display()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stages_dirty_git_source_identity() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "PATH",
+            "FAKE_GIT_TOP_LEVEL",
+            "FAKE_GIT_COMMIT",
+            "FAKE_GIT_DESCRIBE",
+            "FAKE_GIT_STATUS",
+        ]);
+        let temp = tempdir()?;
+        let source_root = temp.path().join("source");
+        let destination_root = temp.path().join("destination");
+        fs::create_dir_all(&source_root)?;
+        install_fake_git(temp.path(), &source_root, true)?;
+
+        stage_git_source_info(&source_root, &destination_root)?;
+
+        let source_info: serde_json::Value = serde_json::from_slice(&fs::read(
+            destination_root.join(".codex-linux/source-info.json"),
+        )?)?;
+        assert_eq!(
+            source_info["commit"],
+            "0123456789abcdef0123456789abcdef01234567"
+        );
+        assert_eq!(source_info["dirty"], true);
+        assert_eq!(source_info["describe"], "v0.10.2-dirty");
+        assert_eq!(
+            source_info["remote"],
+            "https://github.com/example/codex-desktop-linux.git"
+        );
+        assert_eq!(source_info["provenance"], "git");
+        Ok(())
+    }
+
+    #[test]
+    fn source_identity_does_not_leak_from_parent_checkout() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "PATH",
+            "FAKE_GIT_TOP_LEVEL",
+            "FAKE_GIT_COMMIT",
+            "FAKE_GIT_DESCRIBE",
+            "FAKE_GIT_STATUS",
+        ]);
+        let temp = tempdir()?;
+        let parent_root = temp.path().join("parent");
+        let source_root = parent_root.join("nested-builder");
+        let destination_root = temp.path().join("destination");
+        fs::create_dir_all(&source_root)?;
+        install_fake_git(temp.path(), &parent_root, false)?;
+
+        stage_git_source_info(&source_root, &destination_root)?;
+
+        assert!(!destination_root
+            .join(".codex-linux/source-info.json")
+            .exists());
+        Ok(())
+    }
+
+    #[test]
+    fn no_git_source_leaves_packaged_metadata_unchanged() -> Result<()> {
+        let temp = tempdir()?;
+        let source_root = temp.path().join("source");
+        let destination_root = temp.path().join("destination");
+        let source_info = destination_root.join(".codex-linux/source-info.json");
+        fs::create_dir_all(&source_root)?;
+        fs::create_dir_all(source_info.parent().unwrap())?;
+        fs::write(&source_info, "{\"commit\":\"packaged\"}\n")?;
+
+        stage_git_source_info(&source_root, &destination_root)?;
+
+        assert_eq!(
+            fs::read_to_string(source_info)?,
+            "{\"commit\":\"packaged\"}\n"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Capture the wrapper source Git identity before the updater copies the builder into its no-Git workspace.
- Stage that identity through the existing `.codex-linux/source-info.json` contract so generated app build info and packaged update-builder metadata retain the same wrapper commit.
- Preserve packaged metadata for no-Git sources, reject identity inherited from a parent checkout, retain dirty state, and sanitize supported network remotes.
- Strip credentials from HTTP(S), SSH, and SCP-like remotes; omit local paths and custom transports from installed metadata.
- Verify the same provenance handoff through fake Debian, RPM, and pacman package builders.
- Bump `codex-update-manager` to `0.10.2`.

This addresses the reproducible state where an updater-built package contained `source.commit=null` and `source.provenance=unknown`, leaving `installed_wrapper_commit` unavailable even though the updater candidate checkout had a known wrapper commit.

The change does not alter wrapper update discovery/comparison or current-DMG patch targeting. Related discussions in #1001 and #1049 focused on those separate detection mechanisms.

## Reproduction Identity

- App version: `26.715.70719`
- Electron: `42.3.0`
- SHA-256: `95c66f30ad0ee946cfec2b83c50e68744700be5da76898c5de484a755000f4a3`
- Size: `618776575` bytes
- HTTP fingerprint: `etag=0x8DEE74C91EAF288|last_modified=Tue, 21 Jul 2026 17:21:58 GMT|content_length=618776575`

That exact DMG reproduced the missing wrapper provenance. The candidate was not promoted because an unrelated enabled feature drifted, so this PR makes no claim to fix that feature drift or the acceptance verdict.

The branch is rebased onto current `main` at `aa1b7b8`, which pins upstream app `26.715.72359` with Electron `42.3.0` in #1128. The provenance transport is independent of DMG bundle shape.

## Validation

- `cargo test -p codex-update-manager` (275 passed)
- `cargo check -p codex-update-manager`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `CI_CACHE_DIR=/tmp/codex-desktop-linux-ci TMPDIR=/tmp ./scripts/ci-local.sh pr`
  - core: updater, Node/patch, and script smoke suites passed
  - Debian, RPM, and pacman package jobs passed
  - no-updater variants passed
- `git diff --check origin/main...HEAD`

The focused regression tests cover credential-bearing SSH and SCP-like remotes, local/custom remote rejection, and metadata output from all three fake native package builders.

No daily-driver installation or runtime replacement was performed. The change is confined to updater builder metadata transport and is covered by the full package matrix.

## Checklist

- [x] This pull request is ready for review.
- [x] I followed `CONTRIBUTING.md` and kept the change focused.
- [x] The reproduction identity and current-main base are documented above.
- [x] I reviewed the final diff and validation results.
- [x] Tests cover clean, dirty, nested-checkout, no-Git packaged-metadata, remote privacy, cross-format package output, and complete updater-build paths.
