### PR TITLE
Fix frameless titlebar right padding

### DIFF
--- a/linux-features/frameless-titlebar/README.md
+++ b/linux-features/frameless-titlebar/README.md
@@ -39,6 +39,8 @@ For a manual check, enable the feature as above, rebuild, and launch the app:
 - The primary and Quick Chat windows should show no Electron-drawn titlebar
   overlay buttons (minimize/maximize/close in the top-right corner) and no menu
   bar.
+- The rightmost app-header control should retain the standard 8px end padding
+  instead of touching the window edge or an overlay scrollbar.
 - Window move, resize, and close/minimize/maximize should work through your
   compositor's bindings (for example Hyprland's `bindm` mouse binds and
   `killactive`/`fullscreen` dispatchers).

--- a/linux-features/frameless-titlebar/patch.js
+++ b/linux-features/frameless-titlebar/patch.js
@@ -81,6 +81,15 @@ function applyFramelessTitlebarWebviewPatch(currentSource) {
   const recognizedApplicationMenuLayout =
     foundApplicationMenuLayout || patchedSource.includes("applicationMenu:Object.freeze({left:0,right:0})");
 
+  const headerSafeAreaProp = "codexLinuxUseWindowControlsSafeArea";
+  const hasHeaderSafeArea = currentSource.includes(headerSafeAreaProp);
+  patchedSource = patchedSource.replace(
+    new RegExp(`${headerSafeAreaProp}:![A-Za-z_$][\\w$]*,side:\`end\``, "g"),
+    `${headerSafeAreaProp}:!1,side:\`end\``,
+  );
+  const recognizedHeaderSafeArea =
+    !hasHeaderSafeArea || patchedSource.includes(`${headerSafeAreaProp}:!1,side:\`end\``);
+
   const linuxApplicationMenuChrome = "case`win32`:case`linux`:return`application-menu`";
   const linuxNativeChrome = "case`win32`:return`application-menu`;case`linux`:return`native`";
   const foundApplicationMenuChrome = patchedSource.includes(linuxApplicationMenuChrome);
@@ -129,12 +138,16 @@ function applyFramelessTitlebarWebviewPatch(currentSource) {
   if (hasApplicationMenuLayout && !recognizedApplicationMenuBridge) {
     console.warn("WARN: Could not find application menu bridge guard - skipping frameless webview bridge patch");
   }
+  if (hasHeaderSafeArea && !recognizedHeaderSafeArea) {
+    console.warn("WARN: Could not disable the Linux window controls safe area - skipping frameless header padding patch");
+  }
   if (hasApplicationMenuChromeConsumer && !recognizedChromeMapping) {
     console.warn("WARN: Could not find Linux window controls chrome mapping - skipping frameless webview chrome patch");
   }
   if (
     !hasApplicationMenuLayout &&
     !hasApplicationMenuChromeConsumer &&
+    !hasHeaderSafeArea &&
     !recognizedChromeMapping
   ) {
     console.warn("WARN: Could not identify frameless titlebar webview target - skipping frameless webview patch");

--- a/linux-features/frameless-titlebar/test.js
+++ b/linux-features/frameless-titlebar/test.js
@@ -214,6 +214,16 @@ test("frameless-titlebar maps Linux window controls chrome to native webview lay
   assert.doesNotMatch(patchedLayout, /right:138/);
 });
 
+test("frameless-titlebar retains standard end padding after the core safe-area patch", () => {
+  assert.equal(
+    applyPatchTwice(
+      applyFramelessTitlebarWebviewPatch,
+      "jsx(slot,{codexLinuxUseWindowControlsSafeArea:!t,side:`end`})",
+    ),
+    "jsx(slot,{codexLinuxUseWindowControlsSafeArea:!1,side:`end`})",
+  );
+});
+
 test("frameless-titlebar reports each current webview sub-contract drift", () => {
   const source = [
     "var eV=Object.freeze({default:Object.freeze({left:0,right:0}),applicationMenu:Object.freeze({left:0,right:138})});",
@@ -237,4 +247,12 @@ test("frameless-titlebar reports each current webview sub-contract drift", () =>
   assert.deepEqual(captureWarnings(() => applyFramelessTitlebarWebviewPatch(chromeDrift)), [
     "WARN: Could not find Linux window controls chrome mapping - skipping frameless webview chrome patch",
   ]);
+
+  assert.deepEqual(
+    captureWarnings(() =>
+      applyFramelessTitlebarWebviewPatch(
+        "jsx(slot,{codexLinuxUseWindowControlsSafeArea:shouldReserveControls,side:`end`})",
+      )),
+    ["WARN: Could not disable the Linux window controls safe area - skipping frameless header padding patch"],
+  );
 });


### PR DESCRIPTION
Restores the standard 8px right padding for header controls when the opt-in `frameless-titlebar` feature is enabled.

Default titlebar builds are unchanged.

Test: `node --test linux-features/frameless-titlebar/test.js`