### PR TITLE
Fix Chrome app-server proxy inheritance on Linux

### DIFF
--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -973,7 +973,10 @@ write_chrome_native_host_launcher() {
         'run_proxy_probe() {' \
         '    local output_file timeout_file probe_pid watchdog_pid rc=0 use_process_group=0' \
         '    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-probe.XXXXXX")" || return 1' \
-        '    timeout_file="$output_file.timeout"' \
+        '    timeout_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-timeout.XXXXXX")" || {' \
+        '        rm -f -- "$output_file"' \
+        '        return 1' \
+        '    }' \
         '    if command -v setsid >/dev/null 2>&1; then' \
         '        setsid "$@" >"$output_file" 2>/dev/null &' \
         '        use_process_group=1' \
@@ -983,7 +986,7 @@ write_chrome_native_host_launcher() {
         '    probe_pid=$!' \
         '    (' \
         '        sleep 0.5' \
-        '        : > "$timeout_file"' \
+        '        printf 1 > "$timeout_file"' \
         '        if kill -0 "$probe_pid" 2>/dev/null; then' \
         '            if [ "$use_process_group" -eq 1 ]; then' \
         '                kill -TERM -- "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true' \
@@ -998,7 +1001,7 @@ write_chrome_native_host_launcher() {
         '    ) >/dev/null 2>&1 &' \
         '    watchdog_pid=$!' \
         '    wait "$probe_pid" || rc=$?' \
-        '    if [ -e "$timeout_file" ]; then' \
+        '    if [ -s "$timeout_file" ]; then' \
         '        wait "$watchdog_pid" 2>/dev/null || true' \
         '    else' \
         '        kill "$watchdog_pid" 2>/dev/null || true' \

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -958,6 +958,84 @@ chrome_extension_host_arch() {
     esac
 }
 
+write_chrome_native_host_launcher() {
+    local cache_root="$1"
+    local launcher_path="$cache_root/native-host"
+    local tmp_path="$launcher_path.tmp.$$"
+
+    if [ -x "$launcher_path" ] && \
+        grep -q '^CODEX_CHROME_NATIVE_HOST_LAUNCHER_V1=1$' "$launcher_path" 2>/dev/null && \
+        ! path_has_unsafe_write "$launcher_path"; then
+        printf '%s\n' "$launcher_path"
+        return 0
+    fi
+
+    make_path_owner_trusted "$cache_root" || return 1
+    if ! (umask 0077; printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -euo pipefail' \
+        'CODEX_CHROME_NATIVE_HOST_LAUNCHER_V1=1' \
+        'cache_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"' \
+        'while IFS="=" read -r name value; do' \
+        '    case "$name" in' \
+        '        HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|http_proxy|https_proxy|all_proxy)' \
+        '            if [ -z "${!name+x}" ]; then' \
+        '                export "$name=$value"' \
+        '            fi' \
+        '            ;;' \
+        '    esac' \
+        'done < <(systemctl --user show-environment 2>/dev/null || true)' \
+        'copy_proxy_pair() {' \
+        '    local upper_name="$1" lower_name="$2"' \
+        '    if [ -z "${!upper_name+x}" ] && [ -n "${!lower_name+x}" ]; then' \
+        '        export "$upper_name=${!lower_name}"' \
+        '    elif [ -z "${!lower_name+x}" ] && [ -n "${!upper_name+x}" ]; then' \
+        '        export "$lower_name=${!upper_name}"' \
+        '    fi' \
+        '}' \
+        'read_gnome_proxy_value() {' \
+        '    local schema="$1" key="$2" value' \
+        '    value="$(gsettings get "$schema" "$key" 2>/dev/null)" || return 1' \
+        '    value="$(printf "%s" "$value" | tr -d "\047")"' \
+        '    printf "%s\\n" "$value"' \
+        '}' \
+        'set_gnome_proxy_pair() {' \
+        '    local upper_name="$1" lower_name="$2" schema="$3" scheme="$4"' \
+        '    local host port value' \
+        '    [ -z "${!upper_name+x}" ] && [ -z "${!lower_name+x}" ] || return 0' \
+        '    host="$(read_gnome_proxy_value "$schema" host)" || return 0' \
+        '    port="$(read_gnome_proxy_value "$schema" port)" || return 0' \
+        '    [ -n "$host" ] || return 0' \
+        '    case "$port" in ""|*[!0-9]*) return 0 ;; esac' \
+        '    [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 0' \
+        '    value="$scheme://$host:$port"' \
+        '    [ "$scheme" != socks5 ] || value="$value/"' \
+        '    export "$upper_name=$value" "$lower_name=$value"' \
+        '}' \
+        'copy_proxy_pair HTTP_PROXY http_proxy' \
+        'copy_proxy_pair HTTPS_PROXY https_proxy' \
+        'copy_proxy_pair ALL_PROXY all_proxy' \
+        'gnome_proxy_mode="$(read_gnome_proxy_value org.gnome.system.proxy mode 2>/dev/null || true)"' \
+        'if [ "$gnome_proxy_mode" = manual ]; then' \
+        '    set_gnome_proxy_pair HTTP_PROXY http_proxy org.gnome.system.proxy.http http' \
+        '    set_gnome_proxy_pair HTTPS_PROXY https_proxy org.gnome.system.proxy.https http' \
+        '    set_gnome_proxy_pair ALL_PROXY all_proxy org.gnome.system.proxy.socks socks5' \
+        'fi' \
+        'case "$(uname -m)" in' \
+        '    x86_64) extension_arch=x64 ;;' \
+        '    aarch64|arm64) extension_arch=arm64 ;;' \
+        '    *) exit 1 ;;' \
+        'esac' \
+        'host_path="$cache_root/latest/extension-host/linux/$extension_arch/extension-host"' \
+        'exec "$host_path" "$@"' > "$tmp_path"); then
+        rm -f "$tmp_path"
+        return 1
+    fi
+    chmod 0755 "$tmp_path" || return 1
+    mv -f "$tmp_path" "$launcher_path" || return 1
+    printf '%s\n' "$launcher_path"
+}
+
 write_chrome_native_host_manifests() {
     local host_path="$1"
     local plugin_dir="$2"
@@ -1194,8 +1272,8 @@ sync_chrome_bundled_plugin_cache() {
     mkdir -p "$marketplace_plugins_dir" "$marketplace_root/plugins"
     replace_symlink "$cache_root/latest" "$marketplace_plugin_link"
 
-    host_path="$cache_root/latest/extension-host/linux/$extension_arch/extension-host"
-    [ -x "$host_path" ] || return 0
+    [ -x "$cache_root/latest/extension-host/linux/$extension_arch/extension-host" ] || return 0
+    host_path="$(write_chrome_native_host_launcher "$cache_root")" || return 0
     write_chrome_native_host_manifests "$host_path" "$cache_root/latest" || \
         echo "Chrome native host manifest sync failed; continuing with existing browser manifests."
 }

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -971,16 +971,19 @@ write_chrome_native_host_launcher() {
         'CODEX_CHROME_NATIVE_HOST_LAUNCHER_V2=1' \
         'cache_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"' \
         'run_proxy_probe() {' \
-        '    local probe_pid watchdog_pid rc=0 use_process_group=0' \
+        '    local output_file timeout_file probe_pid watchdog_pid rc=0 use_process_group=0' \
+        '    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-probe.XXXXXX")" || return 1' \
+        '    timeout_file="$output_file.timeout"' \
         '    if command -v setsid >/dev/null 2>&1; then' \
-        '        setsid "$@" &' \
+        '        setsid "$@" >"$output_file" 2>/dev/null &' \
         '        use_process_group=1' \
         '    else' \
-        '        "$@" &' \
+        '        "$@" >"$output_file" 2>/dev/null &' \
         '    fi' \
         '    probe_pid=$!' \
         '    (' \
         '        sleep 0.5' \
+        '        : > "$timeout_file"' \
         '        if kill -0 "$probe_pid" 2>/dev/null; then' \
         '            if [ "$use_process_group" -eq 1 ]; then' \
         '                kill -TERM -- "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true' \
@@ -995,8 +998,16 @@ write_chrome_native_host_launcher() {
         '    ) >/dev/null 2>&1 &' \
         '    watchdog_pid=$!' \
         '    wait "$probe_pid" || rc=$?' \
-        '    kill "$watchdog_pid" 2>/dev/null || true' \
-        '    wait "$watchdog_pid" 2>/dev/null || true' \
+        '    if [ -e "$timeout_file" ]; then' \
+        '        wait "$watchdog_pid" 2>/dev/null || true' \
+        '    else' \
+        '        kill "$watchdog_pid" 2>/dev/null || true' \
+        '        wait "$watchdog_pid" 2>/dev/null || true' \
+        '    fi' \
+        '    if [ "$rc" -eq 0 ]; then' \
+        '        cat "$output_file"' \
+        '    fi' \
+        '    rm -f -- "$output_file" "$timeout_file"' \
         '    return "$rc"' \
         '}' \
         'while IFS="=" read -r name value; do' \

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -973,6 +973,7 @@ write_chrome_native_host_launcher() {
         'run_proxy_probe() {' \
         '    local output_file timeout_file probe_pid watchdog_pid rc=0 self_pid' \
         '    command -v setsid >/dev/null 2>&1 || return 1' \
+        '    [ -r /proc/self/stat ] || return 1' \
         '    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-probe.XXXXXX")" || return 1' \
         '    timeout_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-timeout.XXXXXX")" || {' \
         '        rm -f -- "$output_file"' \
@@ -1011,13 +1012,20 @@ write_chrome_native_host_launcher() {
         '    rm -f -- "$output_file" "$timeout_file"' \
         '    return "$rc"' \
         '}' \
+        'http_proxy_inherited=0' \
+        'https_proxy_inherited=0' \
+        'all_proxy_inherited=0' \
+        'no_proxy_inherited=0' \
+        '[ -z "${HTTP_PROXY+x}" ] && [ -z "${http_proxy+x}" ] || http_proxy_inherited=1' \
+        '[ -z "${HTTPS_PROXY+x}" ] && [ -z "${https_proxy+x}" ] || https_proxy_inherited=1' \
+        '[ -z "${ALL_PROXY+x}" ] && [ -z "${all_proxy+x}" ] || all_proxy_inherited=1' \
+        '[ -z "${NO_PROXY+x}" ] && [ -z "${no_proxy+x}" ] || no_proxy_inherited=1' \
         'while IFS="=" read -r name value; do' \
         '    case "$name" in' \
-        '        HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|http_proxy|https_proxy|all_proxy|no_proxy)' \
-        '            if [ -z "${!name+x}" ]; then' \
-        '                export "$name=$value"' \
-        '            fi' \
-        '            ;;' \
+        '        HTTP_PROXY|http_proxy) [ "$http_proxy_inherited" -eq 1 ] || export "$name=$value" ;;' \
+        '        HTTPS_PROXY|https_proxy) [ "$https_proxy_inherited" -eq 1 ] || export "$name=$value" ;;' \
+        '        ALL_PROXY|all_proxy) [ "$all_proxy_inherited" -eq 1 ] || export "$name=$value" ;;' \
+        '        NO_PROXY|no_proxy) [ "$no_proxy_inherited" -eq 1 ] || export "$name=$value" ;;' \
         '    esac' \
         'done < <(run_proxy_probe systemctl --user show-environment 2>/dev/null || true)' \
         'copy_proxy_pair() {' \
@@ -1064,6 +1072,7 @@ write_chrome_native_host_launcher() {
         '    [ -n "$host" ] || return 0' \
         '    case "$port" in ""|*[!0-9]*) return 0 ;; esac' \
         '    [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 0' \
+        '    case "$host" in \[*\]) ;; *:*) host="[$host]" ;; esac' \
         '    value="$scheme://$host:$port"' \
         '    [ "$scheme" != socks5 ] || value="$value/"' \
         '    export "$upper_name=$value" "$lower_name=$value"' \
@@ -1101,6 +1110,9 @@ write_chrome_native_host_launcher() {
         'exec "$host_path" "$@"' > "$tmp_path"; then
         rm -f -- "$tmp_path"
         return 1
+    fi
+    if [ -d "$launcher_path" ] && [ ! -L "$launcher_path" ]; then
+        remove_tree_if_exists "$launcher_path"
     fi
     if ! chmod 0755 "$tmp_path" || ! mv -fT -- "$tmp_path" "$launcher_path"; then
         rm -f -- "$tmp_path"

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -961,30 +961,53 @@ chrome_extension_host_arch() {
 write_chrome_native_host_launcher() {
     local cache_root="$1"
     local launcher_path="$cache_root/native-host"
-    local tmp_path="$launcher_path.tmp.$$"
-
-    if [ -x "$launcher_path" ] && \
-        grep -q '^CODEX_CHROME_NATIVE_HOST_LAUNCHER_V1=1$' "$launcher_path" 2>/dev/null && \
-        ! path_has_unsafe_write "$launcher_path"; then
-        printf '%s\n' "$launcher_path"
-        return 0
-    fi
+    local tmp_path
 
     make_path_owner_trusted "$cache_root" || return 1
-    if ! (umask 0077; printf '%s\n' \
+    tmp_path="$(mktemp "$cache_root/.native-host.tmp.XXXXXX")" || return 1
+    if ! printf '%s\n' \
         '#!/usr/bin/env bash' \
         'set -euo pipefail' \
-        'CODEX_CHROME_NATIVE_HOST_LAUNCHER_V1=1' \
+        'CODEX_CHROME_NATIVE_HOST_LAUNCHER_V2=1' \
         'cache_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"' \
+        'run_proxy_probe() {' \
+        '    local probe_pid watchdog_pid rc=0 use_process_group=0' \
+        '    if command -v setsid >/dev/null 2>&1; then' \
+        '        setsid "$@" &' \
+        '        use_process_group=1' \
+        '    else' \
+        '        "$@" &' \
+        '    fi' \
+        '    probe_pid=$!' \
+        '    (' \
+        '        sleep 0.5' \
+        '        if kill -0 "$probe_pid" 2>/dev/null; then' \
+        '            if [ "$use_process_group" -eq 1 ]; then' \
+        '                kill -TERM -- "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true' \
+        '                sleep 0.1' \
+        '                kill -KILL -- "-$probe_pid" 2>/dev/null || kill -KILL "$probe_pid" 2>/dev/null || true' \
+        '            else' \
+        '                kill -TERM "$probe_pid" 2>/dev/null || true' \
+        '                sleep 0.1' \
+        '                kill -KILL "$probe_pid" 2>/dev/null || true' \
+        '            fi' \
+        '        fi' \
+        '    ) >/dev/null 2>&1 &' \
+        '    watchdog_pid=$!' \
+        '    wait "$probe_pid" || rc=$?' \
+        '    kill "$watchdog_pid" 2>/dev/null || true' \
+        '    wait "$watchdog_pid" 2>/dev/null || true' \
+        '    return "$rc"' \
+        '}' \
         'while IFS="=" read -r name value; do' \
         '    case "$name" in' \
-        '        HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|http_proxy|https_proxy|all_proxy)' \
+        '        HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY|http_proxy|https_proxy|all_proxy|no_proxy)' \
         '            if [ -z "${!name+x}" ]; then' \
         '                export "$name=$value"' \
         '            fi' \
         '            ;;' \
         '    esac' \
-        'done < <(systemctl --user show-environment 2>/dev/null || true)' \
+        'done < <(run_proxy_probe systemctl --user show-environment 2>/dev/null || true)' \
         'copy_proxy_pair() {' \
         '    local upper_name="$1" lower_name="$2"' \
         '    if [ -z "${!upper_name+x}" ] && [ -n "${!lower_name+x}" ]; then' \
@@ -993,10 +1016,31 @@ write_chrome_native_host_launcher() {
         '        export "$lower_name=${!upper_name}"' \
         '    fi' \
         '}' \
+        'copy_proxy_family() {' \
+        '    local source_upper="$1" source_lower="$2" target_upper="$3" target_lower="$4" value' \
+        '    [ -z "${!target_upper+x}" ] && [ -z "${!target_lower+x}" ] || return 0' \
+        '    if [ -n "${!source_upper+x}" ]; then' \
+        '        value="${!source_upper}"' \
+        '    elif [ -n "${!source_lower+x}" ]; then' \
+        '        value="${!source_lower}"' \
+        '    else' \
+        '        return 0' \
+        '    fi' \
+        '    export "$target_upper=$value" "$target_lower=$value"' \
+        '}' \
         'read_gnome_proxy_value() {' \
         '    local schema="$1" key="$2" value' \
-        '    value="$(gsettings get "$schema" "$key" 2>/dev/null)" || return 1' \
+        '    value="$(run_proxy_probe gsettings get "$schema" "$key" 2>/dev/null)" || return 1' \
         '    value="$(printf "%s" "$value" | tr -d "\047")"' \
+        '    printf "%s\\n" "$value"' \
+        '}' \
+        'read_gnome_proxy_ignore_hosts() {' \
+        '    local value' \
+        '    value="$(run_proxy_probe gsettings get org.gnome.system.proxy ignore-hosts 2>/dev/null)" || return 1' \
+        '    value="${value#@as }"' \
+        '    value="${value#[}"' \
+        '    value="${value%]}"' \
+        '    value="$(printf "%s" "$value" | tr -d "\047" | sed "s/, */,/g")"' \
         '    printf "%s\\n" "$value"' \
         '}' \
         'set_gnome_proxy_pair() {' \
@@ -1012,14 +1056,29 @@ write_chrome_native_host_launcher() {
         '    [ "$scheme" != socks5 ] || value="$value/"' \
         '    export "$upper_name=$value" "$lower_name=$value"' \
         '}' \
+        'set_gnome_no_proxy_pair() {' \
+        '    local value' \
+        '    [ -z "${NO_PROXY+x}" ] && [ -z "${no_proxy+x}" ] || return 0' \
+        '    value="$(read_gnome_proxy_ignore_hosts)" || return 0' \
+        '    [ -n "$value" ] || return 0' \
+        '    export "NO_PROXY=$value" "no_proxy=$value"' \
+        '}' \
         'copy_proxy_pair HTTP_PROXY http_proxy' \
         'copy_proxy_pair HTTPS_PROXY https_proxy' \
         'copy_proxy_pair ALL_PROXY all_proxy' \
+        'copy_proxy_pair NO_PROXY no_proxy' \
         'gnome_proxy_mode="$(read_gnome_proxy_value org.gnome.system.proxy mode 2>/dev/null || true)"' \
         'if [ "$gnome_proxy_mode" = manual ]; then' \
         '    set_gnome_proxy_pair HTTP_PROXY http_proxy org.gnome.system.proxy.http http' \
-        '    set_gnome_proxy_pair HTTPS_PROXY https_proxy org.gnome.system.proxy.https http' \
-        '    set_gnome_proxy_pair ALL_PROXY all_proxy org.gnome.system.proxy.socks socks5' \
+        '    gnome_use_same_proxy="$(read_gnome_proxy_value org.gnome.system.proxy use-same-proxy 2>/dev/null || true)"' \
+        '    if [ "$gnome_use_same_proxy" = true ]; then' \
+        '        copy_proxy_family HTTP_PROXY http_proxy HTTPS_PROXY https_proxy' \
+        '        copy_proxy_family HTTP_PROXY http_proxy ALL_PROXY all_proxy' \
+        '    else' \
+        '        set_gnome_proxy_pair HTTPS_PROXY https_proxy org.gnome.system.proxy.https http' \
+        '        set_gnome_proxy_pair ALL_PROXY all_proxy org.gnome.system.proxy.socks socks5' \
+        '    fi' \
+        '    set_gnome_no_proxy_pair' \
         'fi' \
         'case "$(uname -m)" in' \
         '    x86_64) extension_arch=x64 ;;' \
@@ -1027,12 +1086,14 @@ write_chrome_native_host_launcher() {
         '    *) exit 1 ;;' \
         'esac' \
         'host_path="$cache_root/latest/extension-host/linux/$extension_arch/extension-host"' \
-        'exec "$host_path" "$@"' > "$tmp_path"); then
-        rm -f "$tmp_path"
+        'exec "$host_path" "$@"' > "$tmp_path"; then
+        rm -f -- "$tmp_path"
         return 1
     fi
-    chmod 0755 "$tmp_path" || return 1
-    mv -f "$tmp_path" "$launcher_path" || return 1
+    if ! chmod 0755 "$tmp_path" || ! mv -fT -- "$tmp_path" "$launcher_path"; then
+        rm -f -- "$tmp_path"
+        return 1
+    fi
     printf '%s\n' "$launcher_path"
 }
 

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -971,38 +971,36 @@ write_chrome_native_host_launcher() {
         'CODEX_CHROME_NATIVE_HOST_LAUNCHER_V2=1' \
         'cache_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"' \
         'run_proxy_probe() {' \
-        '    local output_file timeout_file probe_pid watchdog_pid rc=0 use_process_group=0' \
+        '    local output_file timeout_file probe_pid watchdog_pid rc=0 self_pid' \
+        '    command -v setsid >/dev/null 2>&1 || return 1' \
         '    output_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-probe.XXXXXX")" || return 1' \
         '    timeout_file="$(mktemp "${TMPDIR:-/tmp}/codex-chrome-proxy-timeout.XXXXXX")" || {' \
         '        rm -f -- "$output_file"' \
         '        return 1' \
         '    }' \
-        '    if command -v setsid >/dev/null 2>&1; then' \
-        '        setsid "$@" >"$output_file" 2>/dev/null &' \
-        '        use_process_group=1' \
-        '    else' \
-        '        "$@" >"$output_file" 2>/dev/null &' \
-        '    fi' \
+        '    self_pid=${BASHPID:-$$}' \
+        '    setsid "$@" >"$output_file" 2>/dev/null &' \
         '    probe_pid=$!' \
         '    (' \
         '        sleep 0.5' \
+        '        [ -r "/proc/$probe_pid/stat" ] || exit 0' \
+        '        local stat_line rest' \
+        '        stat_line=$(< "/proc/$probe_pid/stat") || exit 0' \
+        '        rest=${stat_line##*) }' \
+        '        set -- $rest' \
+        '        [ "${2:-}" = "$self_pid" ] || exit 0' \
         '        printf 1 > "$timeout_file"' \
         '        if kill -0 "$probe_pid" 2>/dev/null; then' \
-        '            if [ "$use_process_group" -eq 1 ]; then' \
-        '                kill -TERM -- "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true' \
-        '                sleep 0.1' \
-        '                kill -KILL -- "-$probe_pid" 2>/dev/null || kill -KILL "$probe_pid" 2>/dev/null || true' \
-        '            else' \
-        '                kill -TERM "$probe_pid" 2>/dev/null || true' \
-        '                sleep 0.1' \
-        '                kill -KILL "$probe_pid" 2>/dev/null || true' \
-        '            fi' \
+        '            kill -TERM -- "-$probe_pid" 2>/dev/null || kill -TERM "$probe_pid" 2>/dev/null || true' \
+        '            sleep 0.1' \
+        '            kill -KILL -- "-$probe_pid" 2>/dev/null || kill -KILL "$probe_pid" 2>/dev/null || true' \
         '        fi' \
         '    ) >/dev/null 2>&1 &' \
         '    watchdog_pid=$!' \
         '    wait "$probe_pid" || rc=$?' \
         '    if [ -s "$timeout_file" ]; then' \
         '        wait "$watchdog_pid" 2>/dev/null || true' \
+        '        rc=124' \
         '    else' \
         '        kill "$watchdog_pid" 2>/dev/null || true' \
         '        wait "$watchdog_pid" 2>/dev/null || true' \

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6473,6 +6473,16 @@ if grep -q PRESEEDED_PAYLOAD "$cache_root/native-host"; then
   exit 1
 fi
 
+rm -f "$cache_root/native-host"
+mkdir "$cache_root/native-host"
+printf '%s\n' PRESEEDED_DIRECTORY_PAYLOAD > "$cache_root/native-host/payload"
+native_host_path="$(write_chrome_native_host_launcher "$cache_root")"
+test -f "$native_host_path"
+if grep -q PRESEEDED_DIRECTORY_PAYLOAD "$native_host_path"; then
+  echo "Chrome native host launcher retained a pre-seeded directory" >&2
+  exit 1
+fi
+
 native_host_path="$(cat "$root/native-host-path")"
 stub_bin="$root/stub-bin"
 mkdir -p "$stub_bin"
@@ -6512,6 +6522,37 @@ test "$proxy_output" = "$(printf '%s\n' \
   'socks5://127.0.0.1:7897/' \
   'localhost,127.0.0.0/8' \
   'localhost,127.0.0.0/8')"
+
+cat > "$stub_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' \
+  'HTTP_PROXY=http://manager.invalid:8080' \
+  'http_proxy=http://stale.invalid:8080' \
+  'HTTPS_PROXY=http://127.0.0.1:7897' \
+  'ALL_PROXY=socks5://127.0.0.1:7897/' \
+  'NO_PROXY=localhost'
+STUB
+cat > "$stub_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+
+proxy_output="$(env -u HTTPS_PROXY -u ALL_PROXY -u NO_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy -u no_proxy \
+  HTTP_PROXY=http://inherited.example:3128 \
+  STUB_UNAME_MACHINE=x86_64 \
+  PATH="$stub_bin:$PATH" "$native_host_path")"
+test "$proxy_output" = "$(printf '%s\n' \
+  'ARCH=x64' \
+  'http://inherited.example:3128' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/' \
+  'http://inherited.example:3128' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/' \
+  'localhost' \
+  'localhost')"
 
 cat > "$stub_bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
@@ -6557,9 +6598,9 @@ case "$2:$3" in
   org.gnome.system.proxy:ignore-hosts) printf "['example.internal']\n" ;;
   org.gnome.system.proxy.http:host) printf "'192.0.2.10'\n" ;;
   org.gnome.system.proxy.http:port) printf '8080\n' ;;
-  org.gnome.system.proxy.https:host) printf "'192.0.2.11'\n" ;;
+  org.gnome.system.proxy.https:host) printf "'2001:db8::11'\n" ;;
   org.gnome.system.proxy.https:port) printf '8443\n' ;;
-  org.gnome.system.proxy.socks:host) printf "'192.0.2.12'\n" ;;
+  org.gnome.system.proxy.socks:host) printf "'::1'\n" ;;
   org.gnome.system.proxy.socks:port) printf '1080\n' ;;
   *) exit 1 ;;
 esac
@@ -6573,11 +6614,11 @@ proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
 test "$proxy_output" = "$(printf '%s\n' \
   'ARCH=x64' \
   'http://192.0.2.10:8080' \
-  'http://192.0.2.11:8443' \
-  'socks5://192.0.2.12:1080/' \
+  'http://[2001:db8::11]:8443' \
+  'socks5://[::1]:1080/' \
   'http://192.0.2.10:8080' \
-  'http://192.0.2.11:8443' \
-  'socks5://192.0.2.12:1080/' \
+  'http://[2001:db8::11]:8443' \
+  'socks5://[::1]:1080/' \
   'example.internal' \
   'example.internal')"
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6583,6 +6583,7 @@ test "$proxy_output" = "$(printf '%s\n' \
 
 cat > "$stub_bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
+printf '%s\n' 'HTTP_PROXY=http://partial.invalid:9999'
 trap 'exit 0' TERM
 (
   trap '' TERM
@@ -6599,21 +6600,48 @@ chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
 
 probe_child_pid_file="$root/probe-child-pid"
 started_at="$(date +%s)"
-env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
   -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
   PROBE_CHILD_PID_FILE="$probe_child_pid_file" \
   STUB_UNAME_MACHINE=aarch64 \
-  PATH="$stub_bin:$PATH" "$native_host_path" >/dev/null
+  PATH="$stub_bin:$PATH" "$native_host_path")"
 elapsed="$(( $(date +%s) - started_at ))"
 if [ "$elapsed" -ge 4 ]; then
   echo "Chrome native host proxy probes exceeded their fail-soft deadline" >&2
   exit 1
 fi
+test "$proxy_output" = 'ARCH=arm64'
 probe_child_pid="$(cat "$probe_child_pid_file")"
 if kill -0 "$probe_child_pid" 2>/dev/null; then
   echo "Chrome native host proxy watchdog left a TERM-resistant child running" >&2
   exit 1
 fi
+
+no_setsid_bin="$root/no-setsid-bin"
+mkdir -p "$no_setsid_bin"
+ln -s "$(type -P bash)" "$no_setsid_bin/bash"
+ln -s "$(type -P dirname)" "$no_setsid_bin/dirname"
+cat > "$no_setsid_bin/uname" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' x86_64
+STUB
+cat > "$no_setsid_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' called > "${PROBE_CALLED_FILE:?}"
+STUB
+cat > "$no_setsid_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' called > "${PROBE_CALLED_FILE:?}"
+STUB
+chmod 0755 "$no_setsid_bin/uname" "$no_setsid_bin/systemctl" "$no_setsid_bin/gsettings"
+
+probe_called_file="$root/probe-called-without-setsid"
+proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  PROBE_CALLED_FILE="$probe_called_file" \
+  PATH="$no_setsid_bin" "$native_host_path")"
+test "$proxy_output" = 'ARCH=x64'
+test ! -e "$probe_called_file"
 '''
 )
 PY

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6408,13 +6408,20 @@ mkdir -p \
 printf '%s\n' '{"name":"chrome","version":"26.test"}' > "$source_plugin/.codex-plugin/plugin.json"
 cat > "$source_plugin/extension-host/linux/x64/extension-host" <<'HOST'
 #!/usr/bin/env bash
+printf '%s\n' ARCH=x64
 printf '%s\n' \
   "${HTTP_PROXY-}" "${HTTPS_PROXY-}" "${ALL_PROXY-}" \
   "${http_proxy-}" "${https_proxy-}" "${all_proxy-}" \
   "${NO_PROXY-}" "${no_proxy-}"
 HOST
-cp "$source_plugin/extension-host/linux/x64/extension-host" \
-  "$source_plugin/extension-host/linux/arm64/extension-host"
+cat > "$source_plugin/extension-host/linux/arm64/extension-host" <<'HOST'
+#!/usr/bin/env bash
+printf '%s\n' ARCH=arm64
+printf '%s\n' \
+  "${HTTP_PROXY-}" "${HTTPS_PROXY-}" "${ALL_PROXY-}" \
+  "${http_proxy-}" "${https_proxy-}" "${all_proxy-}" \
+  "${NO_PROXY-}" "${no_proxy-}"
+HOST
 printf '%s\n' trusted-client > "$source_plugin/scripts/browser-client.mjs"
 printf '%s\n' trusted-manifest > "$source_plugin/scripts/installManifest.mjs"
 printf '%s\n' trusted-module > "$source_plugin/scripts/node_modules/classic-level.mjs"
@@ -6469,6 +6476,10 @@ fi
 native_host_path="$(cat "$root/native-host-path")"
 stub_bin="$root/stub-bin"
 mkdir -p "$stub_bin"
+cat > "$stub_bin/uname" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${STUB_UNAME_MACHINE:-x86_64}"
+STUB
 cat > "$stub_bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' \
@@ -6485,12 +6496,14 @@ cat > "$stub_bin/gsettings" <<'STUB'
 #!/usr/bin/env bash
 exit 1
 STUB
-chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+chmod 0755 "$stub_bin/uname" "$stub_bin/systemctl" "$stub_bin/gsettings"
 
 proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
   -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  STUB_UNAME_MACHINE=x86_64 \
   PATH="$stub_bin:$PATH" "$native_host_path")"
 test "$proxy_output" = "$(printf '%s\n' \
+  'ARCH=x64' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
   'socks5://127.0.0.1:7897/' \
@@ -6519,8 +6532,10 @@ chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
 
 proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
   -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  STUB_UNAME_MACHINE=aarch64 \
   PATH="$stub_bin:$PATH" "$native_host_path")"
 test "$proxy_output" = "$(printf '%s\n' \
+  'ARCH=arm64' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
@@ -6532,7 +6547,49 @@ test "$proxy_output" = "$(printf '%s\n' \
 
 cat > "$stub_bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
-sleep 5
+exit 0
+STUB
+cat > "$stub_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+case "$2:$3" in
+  org.gnome.system.proxy:mode) printf "'manual'\n" ;;
+  org.gnome.system.proxy:use-same-proxy) printf 'false\n' ;;
+  org.gnome.system.proxy:ignore-hosts) printf "['example.internal']\n" ;;
+  org.gnome.system.proxy.http:host) printf "'192.0.2.10'\n" ;;
+  org.gnome.system.proxy.http:port) printf '8080\n' ;;
+  org.gnome.system.proxy.https:host) printf "'192.0.2.11'\n" ;;
+  org.gnome.system.proxy.https:port) printf '8443\n' ;;
+  org.gnome.system.proxy.socks:host) printf "'192.0.2.12'\n" ;;
+  org.gnome.system.proxy.socks:port) printf '1080\n' ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+
+proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  STUB_UNAME_MACHINE=x86_64 \
+  PATH="$stub_bin:$PATH" "$native_host_path")"
+test "$proxy_output" = "$(printf '%s\n' \
+  'ARCH=x64' \
+  'http://192.0.2.10:8080' \
+  'http://192.0.2.11:8443' \
+  'socks5://192.0.2.12:1080/' \
+  'http://192.0.2.10:8080' \
+  'http://192.0.2.11:8443' \
+  'socks5://192.0.2.12:1080/' \
+  'example.internal' \
+  'example.internal')"
+
+cat > "$stub_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+trap 'exit 0' TERM
+(
+  trap '' TERM
+  printf '%s\n' "$BASHPID" > "${PROBE_CHILD_PID_FILE:?}"
+  exec sleep 5
+) &
+wait
 STUB
 cat > "$stub_bin/gsettings" <<'STUB'
 #!/usr/bin/env bash
@@ -6540,13 +6597,21 @@ sleep 5
 STUB
 chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
 
+probe_child_pid_file="$root/probe-child-pid"
 started_at="$(date +%s)"
 env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
   -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  PROBE_CHILD_PID_FILE="$probe_child_pid_file" \
+  STUB_UNAME_MACHINE=aarch64 \
   PATH="$stub_bin:$PATH" "$native_host_path" >/dev/null
 elapsed="$(( $(date +%s) - started_at ))"
 if [ "$elapsed" -ge 4 ]; then
   echo "Chrome native host proxy probes exceeded their fail-soft deadline" >&2
+  exit 1
+fi
+probe_child_pid="$(cat "$probe_child_pid_file")"
+if kill -0 "$probe_child_pid" 2>/dev/null; then
+  echo "Chrome native host proxy watchdog left a TERM-resistant child running" >&2
   exit 1
 fi
 '''

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6359,6 +6359,13 @@ for name in (
         raise SystemExit(f"missing {name}")
     helpers.append(match.group(0))
 
+native_launcher = re.search(
+    r"write_chrome_native_host_launcher\(\) \{[\s\S]*?\n\}\n",
+    launcher,
+)
+if native_launcher is not None:
+    helpers.append(native_launcher.group(0))
+
 sync_match = re.search(
     r"sync_chrome_bundled_plugin_cache\(\) \{[\s\S]*?\n\}\n\nsync_computer_use_bundled_plugin_cache\(\)",
     launcher,
@@ -6387,7 +6394,7 @@ cache_plugin="$cache_root/26.test"
 chrome_extension_host_arch() { printf '%s\n' x64; }
 bundled_plugin_version() { printf '%s\n' 26.test; }
 replace_symlink() { ln -sfnT "$1" "$2"; }
-write_chrome_native_host_manifests() { :; }
+write_chrome_native_host_manifests() { printf '%s\n' "$1" > "$root/native-host-path"; }
 
 mkdir -p \
   "$source_plugin/.codex-plugin" \
@@ -6397,7 +6404,12 @@ mkdir -p \
   "$cache_plugin/extension-host/linux/x64" \
   "$cache_plugin/scripts/node_modules"
 printf '%s\n' '{"name":"chrome","version":"26.test"}' > "$source_plugin/.codex-plugin/plugin.json"
-printf '%s\n' trusted-host > "$source_plugin/extension-host/linux/x64/extension-host"
+cat > "$source_plugin/extension-host/linux/x64/extension-host" <<'HOST'
+#!/usr/bin/env bash
+printf '%s\n' \
+  "${HTTP_PROXY-}" "${HTTPS_PROXY-}" "${ALL_PROXY-}" \
+  "${http_proxy-}" "${https_proxy-}" "${all_proxy-}"
+HOST
 printf '%s\n' trusted-client > "$source_plugin/scripts/browser-client.mjs"
 printf '%s\n' trusted-manifest > "$source_plugin/scripts/installManifest.mjs"
 printf '%s\n' trusted-module > "$source_plugin/scripts/node_modules/classic-level.mjs"
@@ -6433,6 +6445,62 @@ if find "$cache_plugin" ! -type l -perm /022 -print -quit | grep -q .; then
 fi
 test -L "$cache_root/latest"
 test "$(readlink "$cache_root/latest")" = 26.test
+
+native_host_path="$(cat "$root/native-host-path")"
+stub_bin="$root/stub-bin"
+mkdir -p "$stub_bin"
+cat > "$stub_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' \
+  'HTTP_PROXY=http://127.0.0.1:7897' \
+  'HTTPS_PROXY=http://127.0.0.1:7897' \
+  'ALL_PROXY=socks5://127.0.0.1:7897/' \
+  'http_proxy=http://127.0.0.1:7897' \
+  'https_proxy=http://127.0.0.1:7897' \
+  'all_proxy=socks5://127.0.0.1:7897/'
+STUB
+cat > "$stub_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+
+proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy \
+  PATH="$stub_bin:$PATH" "$native_host_path")"
+test "$proxy_output" = "$(printf '%s\n' \
+  'http://127.0.0.1:7897' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/' \
+  'http://127.0.0.1:7897' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/')"
+
+cat > "$stub_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+cat > "$stub_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+case "$2:$3" in
+  org.gnome.system.proxy:mode) printf "'manual'\n" ;;
+  org.gnome.system.proxy.http:host|org.gnome.system.proxy.https:host|org.gnome.system.proxy.socks:host) printf "'127.0.0.1'\n" ;;
+  org.gnome.system.proxy.http:port|org.gnome.system.proxy.https:port|org.gnome.system.proxy.socks:port) printf '7897\n' ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+
+proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy \
+  PATH="$stub_bin:$PATH" "$native_host_path")"
+test "$proxy_output" = "$(printf '%s\n' \
+  'http://127.0.0.1:7897' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/' \
+  'http://127.0.0.1:7897' \
+  'http://127.0.0.1:7897' \
+  'socks5://127.0.0.1:7897/')"
 '''
 )
 PY

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -6353,6 +6353,7 @@ for name in (
     "path_has_unsafe_write",
     "tree_has_unsafe_write",
     "remove_tree_if_exists",
+    "chrome_extension_host_arch",
 ):
     match = re.search(rf"{name}\(\) \{{[\s\S]*?\n\}}\n", launcher)
     if match is None:
@@ -6391,7 +6392,6 @@ source_plugin="$SCRIPT_DIR/resources/plugins/openai-bundled/plugins/chrome"
 cache_root="$CODEX_HOME/plugins/cache/openai-bundled/chrome"
 cache_plugin="$cache_root/26.test"
 
-chrome_extension_host_arch() { printf '%s\n' x64; }
 bundled_plugin_version() { printf '%s\n' 26.test; }
 replace_symlink() { ln -sfnT "$1" "$2"; }
 write_chrome_native_host_manifests() { printf '%s\n' "$1" > "$root/native-host-path"; }
@@ -6399,23 +6399,38 @@ write_chrome_native_host_manifests() { printf '%s\n' "$1" > "$root/native-host-p
 mkdir -p \
   "$source_plugin/.codex-plugin" \
   "$source_plugin/extension-host/linux/x64" \
+  "$source_plugin/extension-host/linux/arm64" \
   "$source_plugin/scripts/node_modules" \
   "$cache_plugin/.codex-plugin" \
   "$cache_plugin/extension-host/linux/x64" \
+  "$cache_plugin/extension-host/linux/arm64" \
   "$cache_plugin/scripts/node_modules"
 printf '%s\n' '{"name":"chrome","version":"26.test"}' > "$source_plugin/.codex-plugin/plugin.json"
 cat > "$source_plugin/extension-host/linux/x64/extension-host" <<'HOST'
 #!/usr/bin/env bash
 printf '%s\n' \
   "${HTTP_PROXY-}" "${HTTPS_PROXY-}" "${ALL_PROXY-}" \
-  "${http_proxy-}" "${https_proxy-}" "${all_proxy-}"
+  "${http_proxy-}" "${https_proxy-}" "${all_proxy-}" \
+  "${NO_PROXY-}" "${no_proxy-}"
 HOST
+cp "$source_plugin/extension-host/linux/x64/extension-host" \
+  "$source_plugin/extension-host/linux/arm64/extension-host"
 printf '%s\n' trusted-client > "$source_plugin/scripts/browser-client.mjs"
 printf '%s\n' trusted-manifest > "$source_plugin/scripts/installManifest.mjs"
 printf '%s\n' trusted-module > "$source_plugin/scripts/node_modules/classic-level.mjs"
-chmod +x "$source_plugin/extension-host/linux/x64/extension-host"
+chmod +x \
+  "$source_plugin/extension-host/linux/x64/extension-host" \
+  "$source_plugin/extension-host/linux/arm64/extension-host"
 cp -R "$source_plugin/." "$cache_plugin/"
 printf '%s\n' tampered-module > "$cache_plugin/scripts/node_modules/classic-level.mjs"
+printf '%s\n' untouched > "$root/predictable-temp-target"
+ln -s "$root/predictable-temp-target" "$cache_root/native-host.tmp.$$"
+cat > "$cache_root/native-host" <<'HOST'
+#!/usr/bin/env bash
+CODEX_CHROME_NATIVE_HOST_LAUNCHER_V1=1
+printf '%s\n' PRESEEDED_PAYLOAD
+HOST
+chmod 0755 "$cache_root/native-host"
 
 # Simulate a cache and relevant ancestor created under umask 0002. The four
 # files used by the old partial comparison still match, while an imported
@@ -6445,6 +6460,11 @@ if find "$cache_plugin" ! -type l -perm /022 -print -quit | grep -q .; then
 fi
 test -L "$cache_root/latest"
 test "$(readlink "$cache_root/latest")" = 26.test
+grep -qx untouched "$root/predictable-temp-target"
+if grep -q PRESEEDED_PAYLOAD "$cache_root/native-host"; then
+  echo "Chrome native host launcher retained a pre-seeded executable" >&2
+  exit 1
+fi
 
 native_host_path="$(cat "$root/native-host-path")"
 stub_bin="$root/stub-bin"
@@ -6457,7 +6477,9 @@ printf '%s\n' \
   'ALL_PROXY=socks5://127.0.0.1:7897/' \
   'http_proxy=http://127.0.0.1:7897' \
   'https_proxy=http://127.0.0.1:7897' \
-  'all_proxy=socks5://127.0.0.1:7897/'
+  'all_proxy=socks5://127.0.0.1:7897/' \
+  'NO_PROXY=localhost,127.0.0.0/8' \
+  'no_proxy=localhost,127.0.0.0/8'
 STUB
 cat > "$stub_bin/gsettings" <<'STUB'
 #!/usr/bin/env bash
@@ -6466,7 +6488,7 @@ STUB
 chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
 
 proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
-  -u http_proxy -u https_proxy -u all_proxy \
+  -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
   PATH="$stub_bin:$PATH" "$native_host_path")"
 test "$proxy_output" = "$(printf '%s\n' \
   'http://127.0.0.1:7897' \
@@ -6474,7 +6496,9 @@ test "$proxy_output" = "$(printf '%s\n' \
   'socks5://127.0.0.1:7897/' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
-  'socks5://127.0.0.1:7897/')"
+  'socks5://127.0.0.1:7897/' \
+  'localhost,127.0.0.0/8' \
+  'localhost,127.0.0.0/8')"
 
 cat > "$stub_bin/systemctl" <<'STUB'
 #!/usr/bin/env bash
@@ -6484,23 +6508,47 @@ cat > "$stub_bin/gsettings" <<'STUB'
 #!/usr/bin/env bash
 case "$2:$3" in
   org.gnome.system.proxy:mode) printf "'manual'\n" ;;
-  org.gnome.system.proxy.http:host|org.gnome.system.proxy.https:host|org.gnome.system.proxy.socks:host) printf "'127.0.0.1'\n" ;;
-  org.gnome.system.proxy.http:port|org.gnome.system.proxy.https:port|org.gnome.system.proxy.socks:port) printf '7897\n' ;;
+  org.gnome.system.proxy:use-same-proxy) printf 'true\n' ;;
+  org.gnome.system.proxy:ignore-hosts) printf "['localhost', '127.0.0.0/8']\n" ;;
+  org.gnome.system.proxy.http:host) printf "'127.0.0.1'\n" ;;
+  org.gnome.system.proxy.http:port) printf '7897\n' ;;
   *) exit 1 ;;
 esac
 STUB
 chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
 
 proxy_output="$(env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
-  -u http_proxy -u https_proxy -u all_proxy \
+  -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
   PATH="$stub_bin:$PATH" "$native_host_path")"
 test "$proxy_output" = "$(printf '%s\n' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
-  'socks5://127.0.0.1:7897/' \
   'http://127.0.0.1:7897' \
   'http://127.0.0.1:7897' \
-  'socks5://127.0.0.1:7897/')"
+  'http://127.0.0.1:7897' \
+  'http://127.0.0.1:7897' \
+  'localhost,127.0.0.0/8' \
+  'localhost,127.0.0.0/8')"
+
+cat > "$stub_bin/systemctl" <<'STUB'
+#!/usr/bin/env bash
+sleep 5
+STUB
+cat > "$stub_bin/gsettings" <<'STUB'
+#!/usr/bin/env bash
+sleep 5
+STUB
+chmod 0755 "$stub_bin/systemctl" "$stub_bin/gsettings"
+
+started_at="$(date +%s)"
+env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY \
+  -u http_proxy -u https_proxy -u all_proxy -u NO_PROXY -u no_proxy \
+  PATH="$stub_bin:$PATH" "$native_host_path" >/dev/null
+elapsed="$(( $(date +%s) - started_at ))"
+if [ "$elapsed" -ge 4 ]; then
+  echo "Chrome native host proxy probes exceeded their fail-soft deadline" >&2
+  exit 1
+fi
 '''
 )
 PY


### PR DESCRIPTION
## Summary

- route the Linux Chrome native-host manifests through an owner-trusted launcher in the managed Chrome plugin cache
- recover `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and their lowercase variants from the systemd user environment without overriding inherited values
- fall back to GNOME manual proxy settings when GUI-launched Chrome has no exported proxy environment
- keep native-host arguments and the managed `latest` extension-host target unchanged

Chrome starts native messaging hosts outside the desktop launcher environment. On proxied Linux desktops this allowed the side panel to start, but its Codex app-server attempted a direct connection and remained stuck in `Thinking`. The generated native-host launcher restores the user-session proxy environment before executing the bundled extension host.

This stays separate from the bundled-plugin trust/materialization fix in #1105: it does not bless or rewrite plugin source trees and only changes the manifest target used after the existing cache trust checks pass.

## Validation

- RED: `bash tests/scripts_smoke.sh` exited 1 after Chrome cache sync because the direct extension-host received no proxy variables
- GREEN: `bash tests/scripts_smoke.sh` — `All script smoke tests passed`
- `node --test scripts/patch-linux-window-ui.test.js scripts/lib/linux-features.test.js scripts/patches/descriptor.test.js scripts/patches/runner.test.js linux-features/*/test.js` — 1200 passed, 0 failed
- `bash -n install.sh scripts/lib/*.sh launcher/start.sh.template scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh tests/scripts_smoke.sh`
- `node --check scripts/patches/impl/main-process/browser.js`
- `git diff --check origin/main...HEAD`
- live environment: Ubuntu 24.04, GNOME/X11, `.deb`, Desktop 26.715.71837; Chrome side-panel replies resumed after restart with the native host using the GNOME proxy

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.