### PR TITLE
Fix UI Tweaks sidebar project row overflow

### DIFF
--- a/linux-features/ui-tweaks/README.md
+++ b/linux-features/ui-tweaks/README.md
@@ -170,7 +170,7 @@ Tracked default in `feature.json`:
     "sidebar": {
       "projectName": {
         "enabled": true,
-        "style": "font-weight: 700 !important; padding-top: 0.25rem;"
+        "style": "font-weight: 700 !important;"
       }
     }
   }
@@ -184,8 +184,8 @@ Config keys:
 - `style`: CSS declaration list inserted into the project-name rule, such as
   `font-weight: 800 !important; color: red;`. It is not arbitrary CSS; unsafe
   syntax that could escape the scoped rule warns and falls back to the default.
-  The default is `font-weight: 700 !important; padding-top: 0.25rem;`, so
-  project names are bold with a small top offset and no color is forced.
+  The default is `font-weight: 700 !important;`, so project names are bold
+  without changing the fixed row geometry or forcing a color.
 
 ## Drift Behavior
 

--- a/linux-features/ui-tweaks/feature.json
+++ b/linux-features/ui-tweaks/feature.json
@@ -39,7 +39,7 @@
     "sidebar": {
       "projectName": {
         "enabled": true,
-        "style": "font-weight: 700 !important; padding-top: 0.25rem;"
+        "style": "font-weight: 700 !important;"
       }
     }
   }

--- a/linux-features/ui-tweaks/patches/sidebar-project-name.js
+++ b/linux-features/ui-tweaks/patches/sidebar-project-name.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important; padding-top: 0.25rem;";
+const DEFAULT_PROJECT_NAME_STYLE = "font-weight: 700 !important;";
 const PROJECTS_SIDEBAR_ASSET_PATTERN =
   /^app-initial~notebook-preview-panel~app-main~pull-request-route~projects-index-page~cloud-en~lpx9dmpy-[^.]+\.js$/;
 const PROJECT_NAME_SELECTOR = ".group\\/folder-row .text-fade-truncate.pr-1";

--- a/linux-features/ui-tweaks/test.js
+++ b/linux-features/ui-tweaks/test.js
@@ -504,17 +504,18 @@ test("feature manifest defaults reach descriptor context through the feature loa
     const [descriptor] = loadLinuxFeaturePatchDescriptors({ featuresRoot });
     const patched = descriptor.apply(projectBundleFixture(), {});
 
-    assert.match(patched, /font-weight: 700 !important; padding-top: 0.25rem;/);
+    assert.match(patched, /font-weight: 700 !important;/);
+    assert.doesNotMatch(patched, /padding-top/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });
 
-test("default project name style is bold with top padding and no forced color", () => {
+test("default project name style is bold without changing fixed row geometry", () => {
   const featureJson = JSON.parse(fs.readFileSync(path.join(__dirname, "feature.json"), "utf8"));
   assert.equal(featureJson.tweaks.sidebar.projectName.style, DEFAULT_PROJECT_NAME_STYLE);
   assert.match(DEFAULT_PROJECT_NAME_STYLE, /font-weight:\s*700\s*!important/);
-  assert.match(DEFAULT_PROJECT_NAME_STYLE, /padding-top:\s*0\.25rem/);
+  assert.doesNotMatch(DEFAULT_PROJECT_NAME_STYLE, /(?:padding|margin|height)/i);
   assert.doesNotMatch(DEFAULT_PROJECT_NAME_STYLE, /color/i);
   assert.doesNotMatch(sidebarProjectNameCss(DEFAULT_PROJECT_NAME_STYLE), /#000|black/i);
 });
@@ -573,7 +574,8 @@ test("invalid feature settings warn and fall back to defaults", () => {
     const patched = descriptors[0].apply(projectBundleFixture(), {});
 
     assert.match(warnings.join("\n"), /WARN: Linux feature 'ui-tweaks' settings/);
-    assert.match(patched, /font-weight: 700 !important; padding-top: 0.25rem;/);
+    assert.match(patched, /font-weight: 700 !important;/);
+    assert.doesNotMatch(patched, /padding-top/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
@@ -638,7 +640,8 @@ test("invalid and empty styles warn and fall back without throwing", () => {
     );
 
     assert.match(value, new RegExp(STYLE_ID));
-    assert.match(value, /font-weight: 700 !important; padding-top: 0.25rem;/);
+    assert.match(value, /font-weight: 700 !important;/);
+    assert.doesNotMatch(value, /padding-top/);
     assert.equal(warnings.length, 1);
     assert.match(warnings[0], /^WARN: ui-tweaks sidebar project name style/);
   }
@@ -663,7 +666,8 @@ test("unsafe styles warn, stay scoped, and fall back to the default", () => {
   );
 
   assert.match(value, new RegExp(STYLE_ID));
-  assert.match(value, /font-weight: 700 !important; padding-top: 0.25rem;/);
+  assert.match(value, /font-weight: 700 !important;/);
+  assert.doesNotMatch(value, /padding-top/);
   assert.doesNotMatch(value, /body\{display:none\}/);
   assert.equal(value.includes(unsafeStyle), false);
   assert.equal(warnings.length, 1);


### PR DESCRIPTION
## Summary

- remove the layout-changing top padding from the tracked `ui-tweaks.sidebar.projectName` default
- keep project names bold without making fixed-height project rows vertically scrollable
- update manifest, runtime fallback, documentation, and regression coverage together

## Problem

With `ui-tweaks` enabled, the tracked sidebar project-name style adds `padding-top: 0.25rem` to the title inside a fixed-height project row. The upstream row also has `overflow-x-hidden`, which computes to `overflow-y: auto` in Chromium. The extra vertical box size therefore makes every project row scroll by 2 px and Linux Chromium renders native up/down scrollbar steppers at the right edge.

Those steppers look like project-order controls but only scroll the row's 2 px overflow. Project ordering remains the upstream drag-and-drop interaction.

On the current renderer asset, temporarily restoring the previous tracked CSS produced the same result for all five visible project rows:

| Style | `clientHeight` | `scrollHeight` | title padding | Result |
| --- | ---: | ---: | ---: | --- |
| previous default | 30 px | 32 px | 4 px | native scrollbar steppers visible |
| this change | 30 px | 30 px | 0 px | no row overflow or steppers |

Both states retained `font-weight: 700`. The comparison was performed in the same running renderer and the corrected CSS was restored immediately afterward.

## Fix

The default declaration becomes:

```css
font-weight: 700 !important;
```

The feature remains disabled by default. Explicit user-provided declaration lists remain supported; this change only corrects the repository-owned default and its invalid-setting fallback.

Regression coverage now requires the tracked default to remain bold without `padding`, `margin`, or `height` declarations, and verifies that manifest defaults plus invalid/unsafe fallbacks do not inject the previous top padding.

## Current upstream identity

- repository base: `c370485373c135c2bbf370138555b8042cf7c11d`
- branch head: `bcf0fb40f4c0aa624c855adbf60714743516b343`
- ChatGPT Desktop: `26.715.72359`
- Electron: `42.3.0`
- DMG SHA-256: `05a76850a5a035bb3e7e3c0b61b7cb0f359c2509e8ec1ed4810526a6bc751abe`
- DMG size: `618752284` bytes
- HTTP fingerprint: `etag=0x8DEE7D259F0CEBB|last_modified=Wed, 22 Jul 2026 09:19:37 GMT|content_length=618752284`
- active asset: `app-initial~notebook-preview-panel~app-main~pull-request-route~projects-index-page~cloud-en~lpx9dmpy-CP_V9_i3.js`
- environment: Ubuntu 25.10, KDE Plasma, Wayland

## Validation

The isolated profile enabled only `ui-tweaks.sidebar.projectName`; Dock icon, Suggested Prompts, model picker, and English reasoning labels were explicitly disabled.

- focused sidebar/default/fallback tests: `7/7`
- complete `ui-tweaks` suite: `55/55`
- all Linux Feature tests: `777/777`
- core patcher suite: `390/390`
- `bash tests/scripts_smoke.sh`
- `node --check` on the source patch and selected generated asset
- `git diff --check`
- isolated current-DMG candidate: `accepted_with_warnings`, zero blockers
- sidebar descriptor first pass: `applied`
- sidebar descriptor second pass: `already-applied`
- selected asset stayed byte-identical on the second pass: `2533369eab50085c8c1f0d17cdcce579f6f09ad8230cbaf14ad26a1e1b534cbf`
- runtime at `1548x936` and `760x800`: five project rows measured `30/30`, title weight `700`, padding `0`, and no scrollbar steppers
- drag-and-drop sensor activated for a project row, emitted the upstream DnD live-region event, then canceled with `Escape`; project order remained unchanged
- cold restart retained the corrected CSS and `30/30` row geometry
- CDP Runtime/Log capture reported no renderer exceptions during the tested flow

The acceptance warning is unrelated optional core drift in `linux-computer-use-host-platform`; the enabled sidebar descriptor applied without warnings.

## Scope

This changes only the tracked sidebar project-name default inside `ui-tweaks` and its tests/documentation. It does not change the patch engine, semantic asset selection from #1113, project ordering, other UI Tweaks, committed feature enablement, updater behavior, or the installed daily-driver app.
