### PR TITLE
Stop inheriting multi-launch requests

### DIFF
--- a/docs/build-and-packaging.md
+++ b/docs/build-and-packaging.md
@@ -140,6 +140,10 @@ CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh --new-instance
 CODEX_MULTI_LAUNCH=1 CODEX_MULTI_LAUNCH_PORT_RANGE=5175-5199 ./codex-app/start.sh
 ```
 
+`CODEX_MULTI_LAUNCH=1` applies only to that launcher invocation. The launcher
+does not forward it into Electron, so a normal launch from an app descendant
+does not recursively create another side-by-side instance.
+
 ## Package Formats
 
 After `make build-app` or `make build-app-fresh`, build a package from

--- a/launcher/start.sh.template
+++ b/launcher/start.sh.template
@@ -112,6 +112,13 @@ MULTI_LAUNCH_ACTIVE=0
 CODEX_LINUX_INSTANCE_ID=""
 LAUNCHER_ARGS=()
 
+# Multi-launch requests are one launcher invocation wide. Keep the public
+# compatibility flag long enough to parse this invocation, but do not leak it
+# into Electron or descendants where it would turn later normal launches into
+# additional side-by-side instances.
+CODEX_MULTI_LAUNCH_REQUEST="${CODEX_MULTI_LAUNCH:-}"
+unset CODEX_MULTI_LAUNCH
+
 # Internal marker consumed by patched Electron bundles; never trust inheritance.
 unset CODEX_LINUX_MULTI_LAUNCH
 
@@ -197,7 +204,7 @@ parse_launcher_args() {
     local passthrough=0
 
     LAUNCHER_ARGS=()
-    if early_truthy_env_value "${CODEX_MULTI_LAUNCH:-}"; then
+    if early_truthy_env_value "$CODEX_MULTI_LAUNCH_REQUEST"; then
         MULTI_LAUNCH_REQUESTED=1
     fi
 
@@ -350,7 +357,7 @@ Environment:
   CODEX_FORCE_RENDERER_ACCESSIBILITY=auto|0|1
                               Override --force-renderer-accessibility; auto forces it only when assistive
                               technology is detected and never under WSLg or native wayland-gpu
-  CODEX_MULTI_LAUNCH=1        Treat normal launches like --new-instance
+  CODEX_MULTI_LAUNCH=1        Treat this launcher invocation like --new-instance
   CODEX_MULTI_LAUNCH_PORT_RANGE=START-END
                               Port allocation range for --new-instance (default: CODEX_WEBVIEW_PORT through +4)
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -5392,6 +5392,16 @@ if 'configure_multi_launch_instance "$@"' not in source:
     raise SystemExit("launcher must configure multi-launch before deriving WEBVIEW_ORIGIN")
 if 'unset CODEX_LINUX_MULTI_LAUNCH' not in source.split('parse_launcher_args() {', 1)[0]:
     raise SystemExit("launcher must clear inherited internal multi-launch markers before parsing args")
+multi_launch_prefix = source.split('parse_launcher_args() {', 1)[0]
+multi_launch_capture = 'CODEX_MULTI_LAUNCH_REQUEST="${CODEX_MULTI_LAUNCH:-}"'
+if multi_launch_capture not in multi_launch_prefix:
+    raise SystemExit("launcher must capture the public multi-launch request for the current invocation")
+if multi_launch_prefix.index(multi_launch_capture) > multi_launch_prefix.index("unset CODEX_MULTI_LAUNCH"):
+    raise SystemExit("launcher must capture the public multi-launch request before clearing it")
+if 'early_truthy_env_value "$CODEX_MULTI_LAUNCH_REQUEST"' not in source.split("parse_launcher_args() {", 1)[1].split("configure_multi_launch_instance() {", 1)[0]:
+    raise SystemExit("launcher must parse multi-launch from the one-shot request snapshot")
+if "unset CODEX_MULTI_LAUNCH" not in multi_launch_prefix:
+    raise SystemExit("launcher must not leak the public multi-launch request into Electron descendants")
 if '$((CODEX_LINUX_WEBVIEW_PORT + 4))' not in source:
     raise SystemExit("multi-launch default range must cap the default at five ports")
 if '( trap - EXIT\n      exec 3<>/dev/tcp/127.0.0.1/"$CODEX_LINUX_WEBVIEW_PORT" || exit 1\n      exec 3>&- 3<&-\n      exit 0 )' not in webview_probe_body:


### PR DESCRIPTION
Fixes #1134.

## What

- Capture the public `CODEX_MULTI_LAUNCH` request for the current launcher invocation.
- Unset the public flag before Electron and its descendants are spawned.
- Continue exporting the internal `CODEX_LINUX_MULTI_LAUNCH=1` identity marker for an actual side-by-side instance.
- Clarify the one-invocation scope in launcher help and build documentation.

## Why

The packaged **New Window** action sets `CODEX_MULTI_LAUNCH=1` and passes `--new-instance`. The launcher previously forwarded the public flag into Electron. A later normal launcher call from any app descendant inherited the flag and silently became another side-by-side launch, allocating another port and process tree. Repeating that path could leave multiple tray-hidden instances and block updates waiting for all app processes to exit.

The public flag is a launcher request, not durable app identity. The existing internal `CODEX_LINUX_MULTI_LAUNCH` variable already carries the app-visible identity and is deliberately cleared before each launcher argument parse.

## Impact

- Explicit `--new-instance` still works.
- One-shot `CODEX_MULTI_LAUNCH=1` still works.
- The requested side-by-side Electron process still receives `CODEX_LINUX_MULTI_LAUNCH=1`.
- Normal descendant launches no longer recursively opt into additional instances.
- Tray close/minimize behavior is unchanged.

## Checks

- `bash -n launcher/start.sh.template`
- `bash -n tests/scripts_smoke.sh`
- isolated `test_launcher_template_sanity`
- `git diff --check`
- local packaged end-to-end verification:
  - public `CODEX_MULTI_LAUNCH` absent from the spawned webview environment;
  - internal `CODEX_LINUX_MULTI_LAUNCH=1` retained;
  - tray-enabled X hid the same Electron PID;
  - launch action restored the same PID/window;
  - explicit Quit stopped Electron and webview and released the allocated port.
