### PR TITLE
Fix updater workspace cleanup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Concurrent updater entrypoints now serialize state reloads and cache cleanup
+  before persisting startup state. A second process can no longer prune an
+  active rebuild workspace, while forced checks wait for startup maintenance
+  instead of returning without checking upstream.
 - Updater rebuild workspaces now retain the Git identity of the wrapper source
   after `.git` is stripped, so installed build metadata and packaged
   update-builder metadata report the wrapper commit instead of `unknown`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Concurrent updater entrypoints now serialize state reloads and cache cleanup
   before persisting startup state. A second process can no longer prune an
   active rebuild workspace, while forced checks wait for startup maintenance
-  instead of returning without checking upstream.
+  instead of returning without checking upstream, and manual ready-package
+  installs cannot race daemon reconciliation into launching the same install
+  twice.
 - Updater rebuild workspaces now retain the Git identity of the wrapper source
   after `.git` is stripped, so installed build metadata and packaged
   update-builder metadata report the wrapper commit instead of `unknown`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -66,6 +66,11 @@ pub async fn run(cli: Cli) -> Result<()> {
     }
     let mut state =
         PersistedState::load_or_default(&paths.state_file, effective_auto_install(&config))?;
+    #[cfg(test)]
+    wait_for_process_test_barrier(
+        "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_LOADED",
+        "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_CONTINUE",
+    )?;
     if !matches!(
         &cli.command,
         Commands::Daemon | Commands::CheckNow { .. } | Commands::InstallReady
@@ -74,6 +79,8 @@ pub async fn run(cli: Cli) -> Result<()> {
         state.installed_version = install::installed_package_version();
         persist_if_changed(&paths, &state, &original_state)?;
     }
+    #[cfg(test)]
+    signal_process_test_marker("CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_PRE_DISPATCH")?;
 
     match cli.command {
         Commands::Daemon => run_daemon(&config, &mut state, &paths).await,
@@ -1357,7 +1364,50 @@ async fn run_install_ready(
         unreachable!("waiting for the updater flow lock always returns a lock");
     };
     reload_state_from_disk(config, state, paths)?;
+    #[cfg(test)]
+    wait_for_process_test_barrier(
+        "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_RELOADED",
+        "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_CONTINUE",
+    )?;
     run_install_ready_locked(config, state, paths).await
+}
+
+#[cfg(test)]
+fn signal_process_test_marker(variable: &str) -> Result<()> {
+    let Some(path) = std::env::var_os(variable).map(PathBuf::from) else {
+        return Ok(());
+    };
+    std::fs::write(&path, b"ready")
+        .with_context(|| format!("Failed to write process test marker {}", path.display()))
+}
+
+#[cfg(test)]
+fn wait_for_process_test_barrier(marker_variable: &str, release_variable: &str) -> Result<()> {
+    let Some(marker_path) = std::env::var_os(marker_variable).map(PathBuf::from) else {
+        return Ok(());
+    };
+    let release_path = std::env::var_os(release_variable)
+        .map(PathBuf::from)
+        .with_context(|| {
+            format!("{release_variable} must be set when {marker_variable} is used")
+        })?;
+    std::fs::write(&marker_path, b"ready").with_context(|| {
+        format!(
+            "Failed to write process test marker {}",
+            marker_path.display()
+        )
+    })?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !release_path.exists() {
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "Timed out waiting for process test release {}",
+            release_path.display()
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    Ok(())
 }
 
 async fn run_install_ready_locked(
@@ -2880,97 +2930,301 @@ mod tests {
         Ok(())
     }
 
+    fn process_test_paths(root: &Path) -> RuntimePaths {
+        let config_dir = root.join("xdg-config/codex-update-manager");
+        let state_dir = root.join("xdg-state/codex-update-manager");
+        RuntimePaths {
+            config_file: config_dir.join("config.toml"),
+            state_file: state_dir.join("state.json"),
+            log_file: state_dir.join("service.log"),
+            cache_dir: root.join("xdg-cache/codex-update-manager"),
+            state_dir,
+            config_dir,
+        }
+    }
+
+    fn configure_process_test_command(
+        command: &mut std::process::Command,
+        root: &Path,
+        role: &str,
+    ) {
+        command
+            .arg("--exact")
+            .arg("app::tests::updater_flow_process_child")
+            .arg("--nocapture")
+            .env("CODEX_UPDATE_MANAGER_TEST_PROCESS_ROLE", role)
+            .env("HOME", root.join("home"))
+            .env("XDG_CONFIG_HOME", root.join("xdg-config"))
+            .env("XDG_STATE_HOME", root.join("xdg-state"))
+            .env("XDG_CACHE_HOME", root.join("xdg-cache"))
+            .env(
+                "CODEX_LINUX_SETTINGS_FILE",
+                root.join("missing-settings.json"),
+            )
+            .env_remove("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT")
+            .env("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1");
+    }
+
+    fn spawn_process_test_child(
+        root: &Path,
+        role: &str,
+        env: &[(&str, &Path)],
+    ) -> Result<std::process::Child> {
+        let mut command = std::process::Command::new(std::env::current_exe()?);
+        configure_process_test_command(&mut command, root, role);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command
+            .spawn()
+            .with_context(|| format!("Failed to spawn updater process test child {role}"))
+    }
+
+    fn wait_for_process_test_path(path: &Path, description: &str) -> Result<()> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !path.exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "Timed out waiting for {description}: {}",
+                path.display()
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        Ok(())
+    }
+
+    fn wait_for_process_test_child(mut child: std::process::Child, role: &str) -> Result<()> {
+        let status = child
+            .wait()
+            .with_context(|| format!("Failed to wait for updater process test child {role}"))?;
+        anyhow::ensure!(
+            status.success(),
+            "Updater process test child {role} exited with {status}"
+        );
+        Ok(())
+    }
+
+    fn prepare_process_install_fixture(root: &Path) -> Result<(RuntimePaths, PathBuf, PathBuf)> {
+        let paths = process_test_paths(root);
+        paths.ensure_dirs()?;
+        std::fs::create_dir_all(root.join("home"))?;
+
+        let mut config = test_config(root);
+        config.workspace_root = paths.cache_dir.clone();
+        std::fs::write(&paths.config_file, toml::to_string(&config)?)?;
+
+        let package_path = root.join("dist/codex.deb");
+        std::fs::create_dir_all(
+            package_path
+                .parent()
+                .expect("package path should have parent"),
+        )?;
+        std::fs::write(&package_path, b"deb")?;
+
+        let mut state = PersistedState::new(true);
+        state.status = UpdateStatus::WaitingForAppExit;
+        state.installed_version = "stale-entrypoint-snapshot".to_string();
+        state.candidate_version = Some("2999.07.24.010203+deadbeef".to_string());
+        state.waiting_for_app_exit_auto_install = true;
+        state.artifact_paths.package_path = Some(package_path);
+        state.save(&paths.state_file)?;
+
+        let install_log = root.join("install.log");
+        let fake_pkexec = root.join("pkexec");
+        std::fs::write(
+            &fake_pkexec,
+            "#!/bin/sh\n\
+             printf 'install\\n' >> \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG\"\n\
+             if [ -n \"${CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED:-}\" ]; then\n\
+               /bin/touch \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED\"\n\
+             fi\n\
+             if [ -n \"${CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE:-}\" ]; then\n\
+               while [ ! -e \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE\" ]; do\n\
+                 /bin/sleep 0.01\n\
+               done\n\
+             fi\n",
+        )?;
+        let mut permissions = std::fs::metadata(&fake_pkexec)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_pkexec, permissions)?;
+        Ok((paths, fake_pkexec, install_log))
+    }
+
     #[test]
-    fn install_ready_and_daemon_reconcile_launch_only_one_install() -> Result<()> {
-        let _env_guard = crate::test_util::env_lock();
-        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
-            "CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT",
-            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
-            "CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG",
-            "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
-        ]);
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()?;
-        runtime.block_on(async {
-            let temp = tempfile::tempdir()?;
-            let paths = test_paths(temp.path());
-            paths.ensure_dirs()?;
-            let config = test_config(temp.path());
-
-            let package_path = temp.path().join("dist/codex.deb");
-            std::fs::create_dir_all(
-                package_path
-                    .parent()
-                    .expect("package path should have parent"),
-            )?;
-            std::fs::write(&package_path, b"deb")?;
-
-            let mut persisted_state = PersistedState::new(true);
-            persisted_state.status = UpdateStatus::WaitingForAppExit;
-            persisted_state.candidate_version = Some("2999.07.24.010203+deadbeef".to_string());
-            persisted_state.waiting_for_app_exit_auto_install = true;
-            persisted_state.artifact_paths.package_path = Some(package_path);
-            persisted_state.save(&paths.state_file)?;
-
-            let fake_pkexec = temp.path().join("pkexec");
-            std::fs::write(
-                &fake_pkexec,
-                "#!/bin/sh\n\
-                 printf 'install\\n' >> \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG\"\n\
-                 /bin/touch \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED\"\n\
-                 /bin/sleep 0.2\n",
-            )?;
-            let mut permissions = std::fs::metadata(&fake_pkexec)?.permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&fake_pkexec, permissions)?;
-
-            let install_log = temp.path().join("install.log");
-            let install_started = temp.path().join("install.started");
-            std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1");
-            std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec);
-            std::env::set_var("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log);
-            std::env::set_var(
-                "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
-                &install_started,
-            );
-
-            let daemon_config = config.clone();
-            let daemon_paths = paths.clone();
-            let daemon = tokio::spawn(async move {
-                let mut state = PersistedState::new(true);
-                reconcile_pending_install_from_disk(&daemon_config, &mut state, &daemon_paths)
-                    .await?;
-                Ok::<_, anyhow::Error>(state)
-            });
-
-            for _ in 0..100 {
-                if install_started.exists() {
-                    break;
-                }
-                time::sleep(Duration::from_millis(10)).await;
+    fn updater_flow_process_child() -> Result<()> {
+        let Some(role) = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_PROCESS_ROLE") else {
+            return Ok(());
+        };
+        let role = role.to_string_lossy();
+        let runtime = tokio::runtime::Runtime::new()?;
+        match role.as_ref() {
+            "install-ready" => runtime.block_on(run(Cli {
+                command: Commands::InstallReady,
+            })),
+            "daemon-reconcile" => {
+                let paths = RuntimePaths::detect()?;
+                let config = RuntimeConfig::load_or_default(&paths)?;
+                let mut state = PersistedState::load_or_default(
+                    &paths.state_file,
+                    effective_auto_install(&config),
+                )?;
+                runtime.block_on(reconcile_pending_install_from_disk(
+                    &config, &mut state, &paths,
+                ))
             }
-            assert!(
-                install_started.exists(),
-                "daemon reconciliation should start the install"
+            other => anyhow::bail!("Unknown updater process test role {other}"),
+        }
+    }
+
+    #[test]
+    fn install_ready_entrypoint_does_not_overwrite_active_install_state() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let entrypoint_loaded = temp.path().join("entrypoint.loaded");
+        let entrypoint_continue = temp.path().join("entrypoint.continue");
+        let pre_dispatch = temp.path().join("entrypoint.pre-dispatch");
+        let install_started = temp.path().join("install.started");
+        let install_release = temp.path().join("install.release");
+
+        let install_ready = spawn_process_test_child(
+            temp.path(),
+            "install-ready",
+            &[
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_LOADED",
+                    &entrypoint_loaded,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_CONTINUE",
+                    &entrypoint_continue,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_PRE_DISPATCH",
+                    &pre_dispatch,
+                ),
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+            ],
+        )?;
+        wait_for_process_test_path(&entrypoint_loaded, "install-ready state load")?;
+
+        let daemon_reconcile = spawn_process_test_child(
+            temp.path(),
+            "daemon-reconcile",
+            &[
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
+                    &install_started,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE",
+                    &install_release,
+                ),
+            ],
+        )?;
+        wait_for_process_test_path(&install_started, "daemon reconciliation install")?;
+
+        std::fs::write(&entrypoint_continue, b"continue")?;
+        wait_for_process_test_path(&pre_dispatch, "install-ready pre-dispatch boundary")?;
+        let state_while_installing = PersistedState::load_or_default(&paths.state_file, true)?;
+
+        std::fs::write(&install_release, b"continue")?;
+        wait_for_process_test_child(daemon_reconcile, "daemon-reconcile")?;
+        wait_for_process_test_child(install_ready, "install-ready")?;
+
+        assert_eq!(state_while_installing.status, UpdateStatus::Installing);
+        let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(final_state.status, UpdateStatus::Installed);
+        assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_install_ready_entrypoints_launch_only_one_install() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let (paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let first_loaded = temp.path().join("first.loaded");
+        let second_loaded = temp.path().join("second.loaded");
+        let entrypoint_continue = temp.path().join("entrypoint.continue");
+        let first_reloaded = temp.path().join("first.reloaded");
+        let second_reloaded = temp.path().join("second.reloaded");
+        let reload_continue = temp.path().join("reload.continue");
+
+        let common_env = [
+            (
+                "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_CONTINUE",
+                entrypoint_continue.as_path(),
+            ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_CONTINUE",
+                reload_continue.as_path(),
+            ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
+                fake_pkexec.as_path(),
+            ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG",
+                install_log.as_path(),
+            ),
+        ];
+        let mut first_env = common_env.to_vec();
+        first_env.extend([
+            (
+                "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_LOADED",
+                first_loaded.as_path(),
+            ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_RELOADED",
+                first_reloaded.as_path(),
+            ),
+        ]);
+        let mut second_env = common_env.to_vec();
+        second_env.extend([
+            (
+                "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_LOADED",
+                second_loaded.as_path(),
+            ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_RELOADED",
+                second_reloaded.as_path(),
+            ),
+        ]);
+
+        let first = spawn_process_test_child(temp.path(), "install-ready", &first_env)?;
+        let second = spawn_process_test_child(temp.path(), "install-ready", &second_env)?;
+        wait_for_process_test_path(&first_loaded, "first install-ready state load")?;
+        wait_for_process_test_path(&second_loaded, "second install-ready state load")?;
+
+        std::fs::write(&entrypoint_continue, b"continue")?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !first_reloaded.exists() && !second_reloaded.exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "Timed out waiting for an install-ready process to reload state"
             );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        let reloads_before_release =
+            usize::from(first_reloaded.exists()) + usize::from(second_reloaded.exists());
 
-            let install_config = config.clone();
-            let install_paths = paths.clone();
-            let install_ready = tokio::spawn(async move {
-                let mut state = PersistedState::new(true);
-                run_install_ready(&install_config, &mut state, &install_paths).await?;
-                Ok::<_, anyhow::Error>(state)
-            });
+        std::fs::write(&reload_continue, b"continue")?;
+        wait_for_process_test_child(first, "first install-ready")?;
+        wait_for_process_test_child(second, "second install-ready")?;
 
-            let daemon_state = daemon.await??;
-            let install_ready_state = install_ready.await??;
-            assert_eq!(daemon_state.status, UpdateStatus::Installed);
-            assert_eq!(install_ready_state.status, UpdateStatus::Installed);
-            assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
-            Ok::<_, anyhow::Error>(())
-        })
+        assert_eq!(
+            reloads_before_release, 1,
+            "only the lock holder may reload state before serialization is released"
+        );
+        let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(final_state.status, UpdateStatus::Installed);
+        assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
+        Ok(())
     }
 
     #[test]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -66,7 +66,10 @@ pub async fn run(cli: Cli) -> Result<()> {
     }
     let mut state =
         PersistedState::load_or_default(&paths.state_file, effective_auto_install(&config))?;
-    if !matches!(&cli.command, Commands::Daemon | Commands::CheckNow { .. }) {
+    if !matches!(
+        &cli.command,
+        Commands::Daemon | Commands::CheckNow { .. } | Commands::InstallReady
+    ) {
         let original_state = state.clone();
         state.installed_version = install::installed_package_version();
         persist_if_changed(&paths, &state, &original_state)?;
@@ -441,7 +444,7 @@ async fn acquire_check_lock(
         }
 
         if !logged_wait {
-            info!("waiting for the active updater flow before forcing an upstream check");
+            info!("waiting for the active updater flow");
             logged_wait = true;
         }
         time::sleep(Duration::from_millis(50)).await;
@@ -1330,7 +1333,14 @@ async fn reconcile_pending_install(
                 return Ok(());
             }
 
-            trigger_install(state, paths, &config.workspace_root, &package_path).await?;
+            trigger_install(
+                state,
+                paths,
+                &config.workspace_root,
+                &package_path,
+                config.notifications,
+            )
+            .await?;
         }
         _ => {}
     }
@@ -1339,6 +1349,18 @@ async fn reconcile_pending_install(
 }
 
 async fn run_install_ready(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let Some(_check_lock) = acquire_check_lock(paths, CheckLockBehavior::Wait).await? else {
+        unreachable!("waiting for the updater flow lock always returns a lock");
+    };
+    reload_state_from_disk(config, state, paths)?;
+    run_install_ready_locked(config, state, paths).await
+}
+
+async fn run_install_ready_locked(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
@@ -1440,7 +1462,14 @@ async fn run_install_ready(
         print_manual_install_required(&package_path);
         return Ok(());
     }
-    trigger_install(state, paths, &config.workspace_root, &package_path).await
+    trigger_install(
+        state,
+        paths,
+        &config.workspace_root,
+        &package_path,
+        config.notifications,
+    )
+    .await
 }
 
 #[derive(Debug, Deserialize)]
@@ -1842,13 +1871,15 @@ async fn trigger_install(
     paths: &RuntimePaths,
     workspace_root: &Path,
     package_path: &Path,
+    notifications: bool,
 ) -> Result<()> {
     state.status = UpdateStatus::Installing;
     state.waiting_for_app_exit_auto_install = false;
     state.error_message = None;
     persist_state(paths, state)?;
 
-    let _ = notify::send(
+    maybe_send_notification(
+        notifications,
         "Installing ChatGPT Desktop update",
         "Applying the locally rebuilt Linux package.",
     );
@@ -1869,7 +1900,7 @@ async fn trigger_install(
         state.notified_events.clear();
         cache_cleanup::normalize_artifact_workspace_dir(workspace_root, state);
         persist_state(paths, state)?;
-        let _ = maybe_notify_installed(state, paths, true);
+        let _ = maybe_notify_installed(state, paths, notifications);
         maybe_prune_workspace_cache(workspace_root, state);
         return Ok(());
     }
@@ -2850,6 +2881,99 @@ mod tests {
     }
 
     #[test]
+    fn install_ready_and_daemon_reconcile_launch_only_one_install() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT",
+            "CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH",
+            "CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG",
+            "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
+        ]);
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()?;
+        runtime.block_on(async {
+            let temp = tempfile::tempdir()?;
+            let paths = test_paths(temp.path());
+            paths.ensure_dirs()?;
+            let config = test_config(temp.path());
+
+            let package_path = temp.path().join("dist/codex.deb");
+            std::fs::create_dir_all(
+                package_path
+                    .parent()
+                    .expect("package path should have parent"),
+            )?;
+            std::fs::write(&package_path, b"deb")?;
+
+            let mut persisted_state = PersistedState::new(true);
+            persisted_state.status = UpdateStatus::WaitingForAppExit;
+            persisted_state.candidate_version = Some("2999.07.24.010203+deadbeef".to_string());
+            persisted_state.waiting_for_app_exit_auto_install = true;
+            persisted_state.artifact_paths.package_path = Some(package_path);
+            persisted_state.save(&paths.state_file)?;
+
+            let fake_pkexec = temp.path().join("pkexec");
+            std::fs::write(
+                &fake_pkexec,
+                "#!/bin/sh\n\
+                 printf 'install\\n' >> \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG\"\n\
+                 /bin/touch \"$CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED\"\n\
+                 /bin/sleep 0.2\n",
+            )?;
+            let mut permissions = std::fs::metadata(&fake_pkexec)?.permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&fake_pkexec, permissions)?;
+
+            let install_log = temp.path().join("install.log");
+            let install_started = temp.path().join("install.started");
+            std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1");
+            std::env::set_var("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec);
+            std::env::set_var("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log);
+            std::env::set_var(
+                "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
+                &install_started,
+            );
+
+            let daemon_config = config.clone();
+            let daemon_paths = paths.clone();
+            let daemon = tokio::spawn(async move {
+                let mut state = PersistedState::new(true);
+                reconcile_pending_install_from_disk(&daemon_config, &mut state, &daemon_paths)
+                    .await?;
+                Ok::<_, anyhow::Error>(state)
+            });
+
+            for _ in 0..100 {
+                if install_started.exists() {
+                    break;
+                }
+                time::sleep(Duration::from_millis(10)).await;
+            }
+            assert!(
+                install_started.exists(),
+                "daemon reconciliation should start the install"
+            );
+
+            let install_config = config.clone();
+            let install_paths = paths.clone();
+            let install_ready = tokio::spawn(async move {
+                let mut state = PersistedState::new(true);
+                run_install_ready(&install_config, &mut state, &install_paths).await?;
+                Ok::<_, anyhow::Error>(state)
+            });
+
+            let daemon_state = daemon.await??;
+            let install_ready_state = install_ready.await??;
+            assert_eq!(daemon_state.status, UpdateStatus::Installed);
+            assert_eq!(install_ready_state.status, UpdateStatus::Installed);
+            assert_eq!(std::fs::read_to_string(&install_log)?.lines().count(), 1);
+            Ok::<_, anyhow::Error>(())
+        })
+    }
+
+    #[test]
     fn daemon_startup_reloads_active_workspace_state_after_locking() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
         let temp = tempfile::tempdir()?;
@@ -3449,7 +3573,7 @@ mod tests {
             .notified_events
             .insert("install_auth_required:2999.03.25.010203+deadbeef".to_string());
 
-        let result = runtime.block_on(run_install_ready(&config, &mut state, &paths));
+        let result = runtime.block_on(run_install_ready_locked(&config, &mut state, &paths));
 
         if let Some(value) = previous_assume_agent {
             std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", value);
@@ -3510,7 +3634,7 @@ mod tests {
         state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(package_path);
 
-        let result = runtime.block_on(run_install_ready(&config, &mut state, &paths));
+        let result = runtime.block_on(run_install_ready_locked(&config, &mut state, &paths));
 
         if let Some(value) = previous_no_agent {
             std::env::set_var("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT", value);
@@ -3561,7 +3685,7 @@ mod tests {
         state.candidate_version = Some("2999.03.25.010203+deadbeef".to_string());
         state.artifact_paths.package_path = Some(temp.path().join("missing/codex.deb"));
 
-        run_install_ready(&config, &mut state, &paths).await?;
+        run_install_ready_locked(&config, &mut state, &paths).await?;
 
         assert_eq!(state.status, UpdateStatus::Failed);
         assert!(state

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -66,9 +66,11 @@ pub async fn run(cli: Cli) -> Result<()> {
     }
     let mut state =
         PersistedState::load_or_default(&paths.state_file, effective_auto_install(&config))?;
-    let original_state = state.clone();
-    state.installed_version = install::installed_package_version();
-    persist_if_changed(&paths, &state, &original_state)?;
+    if !matches!(&cli.command, Commands::Daemon | Commands::CheckNow { .. }) {
+        let original_state = state.clone();
+        state.installed_version = install::installed_package_version();
+        persist_if_changed(&paths, &state, &original_state)?;
+    }
 
     match cli.command {
         Commands::Daemon => run_daemon(&config, &mut state, &paths).await,
@@ -264,6 +266,44 @@ fn maybe_prune_caches(config: &RuntimeConfig, state: &PersistedState) {
     maybe_prune_generated_artifacts(config);
 }
 
+fn run_daemon_startup_maintenance(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<()> {
+    let _check_lock = match try_acquire_check_lock(paths) {
+        Ok(Some(check_lock)) => check_lock,
+        Ok(None) => {
+            info!("skipping updater startup maintenance because another check is already active");
+            return Ok(());
+        }
+        Err(error) => {
+            warn!(
+                ?error,
+                "skipping updater startup maintenance because the check lock is unavailable"
+            );
+            return Ok(());
+        }
+    };
+
+    if let Err(error) = reload_state_from_disk(config, state, paths) {
+        warn!(
+            ?error,
+            "skipping updater startup maintenance because persisted state could not be reloaded"
+        );
+        return Ok(());
+    }
+
+    sync_and_persist(config, state, paths)?;
+    recover_interrupted_install(state, paths)?;
+    complete_current_dmg_update_if_already_installed(config, state, paths)?;
+    codex_cli::reconcile_if_present(state, paths)?;
+    normalize_workspace_dir_and_persist(state, paths)?;
+    maybe_prune_caches(config, state);
+    maybe_notify_cli_missing(state, paths, config.notifications)?;
+    Ok(())
+}
+
 fn clear_wrapper_update_candidate_and_persist(
     state: &mut PersistedState,
     paths: &RuntimePaths,
@@ -350,6 +390,12 @@ struct CheckLock {
     _file: fs::File,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum CheckLockBehavior {
+    SkipIfBusy,
+    Wait,
+}
+
 fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
     let lock_path = paths.state_dir.join("check.lock");
     let mut file = OpenOptions::new()
@@ -363,7 +409,6 @@ fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
     match file.try_lock() {
         Ok(()) => {}
         Err(fs::TryLockError::WouldBlock) => {
-            info!("skipping upstream check because another check is already active");
             return Ok(None);
         }
         Err(fs::TryLockError::Error(error)) => {
@@ -379,6 +424,28 @@ fn try_acquire_check_lock(paths: &RuntimePaths) -> Result<Option<CheckLock>> {
         .with_context(|| format!("Failed to write {}", lock_path.display()))?;
 
     Ok(Some(CheckLock { _file: file }))
+}
+
+async fn acquire_check_lock(
+    paths: &RuntimePaths,
+    behavior: CheckLockBehavior,
+) -> Result<Option<CheckLock>> {
+    let mut logged_wait = false;
+    loop {
+        if let Some(check_lock) = try_acquire_check_lock(paths)? {
+            return Ok(Some(check_lock));
+        }
+
+        if behavior == CheckLockBehavior::SkipIfBusy {
+            return Ok(None);
+        }
+
+        if !logged_wait {
+            info!("waiting for the active updater flow before forcing an upstream check");
+            logged_wait = true;
+        }
+        time::sleep(Duration::from_millis(50)).await;
+    }
 }
 
 fn update_install_is_pending(status: &UpdateStatus) -> bool {
@@ -441,13 +508,7 @@ async fn run_daemon(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
-    sync_and_persist(config, state, paths)?;
-    recover_interrupted_install(state, paths)?;
-    complete_current_dmg_update_if_already_installed(config, state, paths)?;
-    codex_cli::reconcile_if_present(state, paths)?;
-    normalize_workspace_dir_and_persist(state, paths)?;
-    maybe_prune_caches(config, state);
-    maybe_notify_cli_missing(state, paths, config.notifications)?;
+    run_daemon_startup_maintenance(config, state, paths)?;
     if packaged_runtime_removed(config) {
         info!("packaged app files are gone; stopping updater daemon");
         return Ok(());
@@ -508,28 +569,12 @@ async fn run_check_now(
     paths: &RuntimePaths,
     if_stale: bool,
 ) -> Result<()> {
-    sync_and_persist(config, state, paths)?;
-    recover_interrupted_install(state, paths)?;
-    complete_current_dmg_update_if_already_installed(config, state, paths)?;
-    codex_cli::reconcile_if_present(state, paths)?;
-    normalize_workspace_dir_and_persist(state, paths)?;
-    maybe_prune_caches(config, state);
-    maybe_notify_cli_missing(state, paths, config.notifications)?;
-    if if_stale
-        && !update_check_should_retry(&state.status)
-        && upstream_check_is_fresh(config, state)
-    {
-        if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
-            warn!(
-                ?error,
-                "wrapper update detection failed during fresh check-now"
-            );
-        }
-        info!("skipping check-now because the last successful upstream check is still fresh");
-        return reconcile_pending_install(config, state, paths).await;
-    }
-    run_check_cycle(config, state, paths).await?;
-    reconcile_pending_install(config, state, paths).await
+    let lock_behavior = if if_stale {
+        CheckLockBehavior::SkipIfBusy
+    } else {
+        CheckLockBehavior::Wait
+    };
+    run_check_cycle_with_options(config, state, paths, lock_behavior, if_stale, true, true).await
 }
 
 /// Detects a newer wrapper release and records it into state. Returns
@@ -976,15 +1021,62 @@ async fn run_check_cycle_from_disk(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
-    reload_state_from_disk(config, state, paths)?;
-    run_check_cycle(config, state, paths).await
+    run_check_cycle_with_options(
+        config,
+        state,
+        paths,
+        CheckLockBehavior::SkipIfBusy,
+        false,
+        false,
+        false,
+    )
+    .await
 }
 
+#[cfg(test)]
 async fn run_check_cycle(
     config: &RuntimeConfig,
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
+    state.save(&paths.state_file)?;
+    run_check_cycle_with_options(
+        config,
+        state,
+        paths,
+        CheckLockBehavior::SkipIfBusy,
+        false,
+        false,
+        false,
+    )
+    .await
+}
+
+async fn run_check_cycle_with_options(
+    config: &RuntimeConfig,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    lock_behavior: CheckLockBehavior,
+    if_stale: bool,
+    recover_entrypoint_state: bool,
+    reconcile_after_check: bool,
+) -> Result<()> {
+    let Some(_check_lock) = acquire_check_lock(paths, lock_behavior).await? else {
+        info!("skipping upstream check because another check is already active");
+        return Ok(());
+    };
+
+    // Reload only after entering the serialization boundary. Every operation
+    // below can persist the complete state document, so using a snapshot read
+    // before the lock could overwrite an active checker's workspace metadata.
+    reload_state_from_disk(config, state, paths)?;
+    if recover_entrypoint_state {
+        recover_interrupted_install(state, paths)?;
+        complete_current_dmg_update_if_already_installed(config, state, paths)?;
+        normalize_workspace_dir_and_persist(state, paths)?;
+        maybe_notify_cli_missing(state, paths, config.notifications)?;
+    }
+
     // Keep wrapper state fresh even while a DMG package is pending; otherwise
     // `status --json` could keep advertising stale wrapper candidates.
     if let Err(error) = detect_and_record_wrapper_update(config, state, paths) {
@@ -993,6 +1085,10 @@ async fn run_check_cycle(
 
     if update_install_is_pending(&state.status) {
         info!("skipping upstream check because an update is already pending");
+        maybe_prune_caches(config, state);
+        if reconcile_after_check {
+            reconcile_pending_install(config, state, paths).await?;
+        }
         return Ok(());
     }
 
@@ -1003,13 +1099,20 @@ async fn run_check_cycle(
         );
     }
 
-    let Some(_check_lock) = try_acquire_check_lock(paths)? else {
+    if if_stale
+        && !update_check_should_retry(&state.status)
+        && upstream_check_is_fresh(config, state)
+    {
+        info!("skipping check-now because the last successful upstream check is still fresh");
+        maybe_prune_caches(config, state);
+        if reconcile_after_check {
+            reconcile_pending_install(config, state, paths).await?;
+        }
         return Ok(());
-    };
+    }
 
     let client = upstream::http_client()?;
 
-    sync_runtime_state(config, state);
     let retrying_update = prepare_upstream_check(state, paths)?;
 
     let result: Result<()> = async {
@@ -1103,6 +1206,10 @@ async fn run_check_cycle(
         return Err(error);
     }
 
+    if reconcile_after_check {
+        reconcile_pending_install(config, state, paths).await?;
+    }
+
     Ok(())
 }
 
@@ -1111,6 +1218,10 @@ async fn reconcile_pending_install_from_disk(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<()> {
+    let Some(_check_lock) = acquire_check_lock(paths, CheckLockBehavior::SkipIfBusy).await? else {
+        info!("skipping pending install reconciliation because another updater flow is active");
+        return Ok(());
+    };
     reload_state_from_disk(config, state, paths)?;
     reconcile_pending_install(config, state, paths).await
 }
@@ -2285,6 +2396,7 @@ mod tests {
         state.candidate_wrapper_version = Some("0.9.0".to_string());
         state.wrapper_changelog = Some("old changelog".to_string());
         state.wrapper_dev_mode = Some(true);
+        state.save(&paths.state_file)?;
 
         runtime.block_on(run_check_now(&config, &mut state, &paths, true))?;
 
@@ -2600,6 +2712,220 @@ mod tests {
         }
 
         assert!(reacquired_lock.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn forced_check_now_waits_for_startup_maintenance_lock_then_checks_upstream() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let runtime = tokio::runtime::Runtime::new()?;
+        runtime.block_on(async {
+            let server = MockServer::start().await;
+            let body_len = 42;
+            Mock::given(method("HEAD"))
+                .and(path("/Codex.dmg"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("ETag", "\"unchanged\"")
+                        .insert_header("Content-Length", body_len.to_string()),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let temp = tempfile::tempdir()?;
+            let paths = test_paths(temp.path());
+            paths.ensure_dirs()?;
+            let mut config = test_config(temp.path());
+            config.dmg_url = format!("{}/Codex.dmg", server.uri());
+            let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+                "HOME",
+                "PATH",
+                "NVM_DIR",
+                "XDG_CONFIG_HOME",
+                "CODEX_CLI_PATH",
+                "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            ]);
+            std::env::set_var("HOME", temp.path());
+            std::env::set_var("PATH", temp.path().join("missing-bin"));
+            std::env::remove_var("NVM_DIR");
+            std::env::remove_var("XDG_CONFIG_HOME");
+            std::env::remove_var("CODEX_CLI_PATH");
+            std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+
+            let mut persisted_state = PersistedState::new(true);
+            persisted_state.remote_headers_fingerprint = Some(format!(
+                "etag=\"unchanged\"|last_modified=|content_length={body_len}"
+            ));
+            persisted_state.dmg_sha256 = Some("cached-dmg".to_string());
+            persisted_state.last_successful_check_at = Some(Utc::now());
+            persisted_state.save(&paths.state_file)?;
+
+            let active_maintenance =
+                try_acquire_check_lock(&paths)?.expect("startup maintenance should hold the lock");
+            let started = tokio::time::Instant::now();
+            let release_maintenance = async move {
+                time::sleep(Duration::from_millis(100)).await;
+                drop(active_maintenance);
+            };
+            let mut stale_state = PersistedState::new(true);
+            let forced_check = run_check_now(&config, &mut stale_state, &paths, false);
+
+            let (check_result, ()) = tokio::join!(forced_check, release_maintenance);
+            check_result?;
+            server.verify().await;
+
+            assert!(started.elapsed() >= Duration::from_millis(75));
+            assert!(stale_state.last_check_at.is_some());
+            assert_eq!(stale_state.status, UpdateStatus::Idle);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn daemon_startup_does_not_persist_stale_state_or_prune_while_check_is_active() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let workspace = config.workspace_root.join("workspaces/active-build");
+        std::fs::create_dir_all(workspace.join("builder"))?;
+        std::fs::write(workspace.join("builder/install.sh"), b"#!/bin/sh\n")?;
+
+        let mut persisted_state = PersistedState::new(true);
+        persisted_state.status = UpdateStatus::PatchingApp;
+        persisted_state.candidate_version = Some("2999.07.23.010927+05a76850".to_string());
+        persisted_state.artifact_paths.workspace_dir = Some(workspace.clone());
+        persisted_state.save(&paths.state_file)?;
+
+        let _active_check =
+            try_acquire_check_lock(&paths)?.expect("active check should acquire the lock");
+        let mut stale_state = PersistedState::new(true);
+        stale_state.installed_version = "stale-entrypoint-snapshot".to_string();
+
+        run_daemon_startup_maintenance(&config, &mut stale_state, &paths)?;
+
+        let after = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(after.status, UpdateStatus::PatchingApp);
+        assert_eq!(
+            after.candidate_version.as_deref(),
+            Some("2999.07.23.010927+05a76850")
+        );
+        assert_eq!(
+            after.artifact_paths.workspace_dir.as_deref(),
+            Some(workspace.as_path())
+        );
+        assert!(workspace.join("builder/install.sh").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn daemon_reconcile_does_not_persist_stale_state_while_check_is_active() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let workspace = config.workspace_root.join("workspaces/active-build");
+        std::fs::create_dir_all(workspace.join("builder"))?;
+
+        let mut persisted_state = PersistedState::new(true);
+        persisted_state.status = UpdateStatus::BuildingPackage;
+        persisted_state.candidate_version = Some("2999.07.23.010927+05a76850".to_string());
+        persisted_state.artifact_paths.workspace_dir = Some(workspace.clone());
+        persisted_state.save(&paths.state_file)?;
+
+        let _active_check =
+            try_acquire_check_lock(&paths)?.expect("active check should acquire the lock");
+        let mut stale_state = PersistedState::new(true);
+
+        reconcile_pending_install_from_disk(&config, &mut stale_state, &paths).await?;
+
+        let after = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(after.status, UpdateStatus::BuildingPackage);
+        assert_eq!(
+            after.artifact_paths.workspace_dir.as_deref(),
+            Some(workspace.as_path())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_startup_reloads_active_workspace_state_after_locking() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "XDG_CONFIG_HOME",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        std::env::set_var("PATH", temp.path().join("missing-bin"));
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("XDG_CONFIG_HOME");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+
+        let workspace = config.workspace_root.join("workspaces/active-build");
+        std::fs::create_dir_all(workspace.join("builder"))?;
+        std::fs::write(workspace.join("builder/install.sh"), b"#!/bin/sh\n")?;
+
+        let mut persisted_state = PersistedState::new(true);
+        persisted_state.status = UpdateStatus::PatchingApp;
+        persisted_state.artifact_paths.workspace_dir = Some(workspace.clone());
+        persisted_state.save(&paths.state_file)?;
+
+        let mut stale_state = PersistedState::new(true);
+        run_daemon_startup_maintenance(&config, &mut stale_state, &paths)?;
+
+        assert_eq!(stale_state.status, UpdateStatus::PatchingApp);
+        assert_eq!(
+            stale_state.artifact_paths.workspace_dir.as_deref(),
+            Some(workspace.as_path())
+        );
+        assert!(workspace.join("builder/install.sh").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_startup_check_lock_failure_is_fail_soft() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let workspace = config.workspace_root.join("workspaces/unreferenced");
+        std::fs::create_dir_all(workspace.join("builder"))?;
+        std::fs::write(workspace.join("builder/install.sh"), b"#!/bin/sh\n")?;
+        std::fs::create_dir(paths.state_dir.join("check.lock"))?;
+        let mut state = PersistedState::new(true);
+
+        run_daemon_startup_maintenance(&config, &mut state, &paths)?;
+
+        assert!(workspace.join("builder/install.sh").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_startup_state_reload_failure_is_fail_soft() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let paths = test_paths(temp.path());
+        paths.ensure_dirs()?;
+        let config = test_config(temp.path());
+        let workspace = config.workspace_root.join("workspaces/unreferenced");
+        std::fs::create_dir_all(workspace.join("builder"))?;
+        std::fs::write(workspace.join("builder/install.sh"), b"#!/bin/sh\n")?;
+        std::fs::write(&paths.state_file, b"not json")?;
+        let mut state = PersistedState::new(true);
+
+        run_daemon_startup_maintenance(&config, &mut state, &paths)?;
+
+        assert!(workspace.join("builder/install.sh").exists());
+        assert_eq!(std::fs::read(&paths.state_file)?, b"not json");
         Ok(())
     }
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -445,6 +445,8 @@ async fn acquire_check_lock(
         if let Some(check_lock) = try_acquire_check_lock(paths)? {
             return Ok(Some(check_lock));
         }
+        #[cfg(test)]
+        signal_process_test_marker("CODEX_UPDATE_MANAGER_TEST_CHECK_LOCK_BUSY")?;
 
         if behavior == CheckLockBehavior::SkipIfBusy {
             return Ok(None);
@@ -3152,6 +3154,8 @@ mod tests {
         let entrypoint_continue = temp.path().join("entrypoint.continue");
         let first_reloaded = temp.path().join("first.reloaded");
         let second_reloaded = temp.path().join("second.reloaded");
+        let first_lock_busy = temp.path().join("first.lock-busy");
+        let second_lock_busy = temp.path().join("second.lock-busy");
         let reload_continue = temp.path().join("reload.continue");
 
         let common_env = [
@@ -3182,6 +3186,10 @@ mod tests {
                 "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_RELOADED",
                 first_reloaded.as_path(),
             ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_CHECK_LOCK_BUSY",
+                first_lock_busy.as_path(),
+            ),
         ]);
         let mut second_env = common_env.to_vec();
         second_env.extend([
@@ -3193,6 +3201,10 @@ mod tests {
                 "CODEX_UPDATE_MANAGER_TEST_INSTALL_READY_RELOADED",
                 second_reloaded.as_path(),
             ),
+            (
+                "CODEX_UPDATE_MANAGER_TEST_CHECK_LOCK_BUSY",
+                second_lock_busy.as_path(),
+            ),
         ]);
 
         let first = spawn_process_test_child(temp.path(), "install-ready", &first_env)?;
@@ -3202,14 +3214,15 @@ mod tests {
 
         std::fs::write(&entrypoint_continue, b"continue")?;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-        while !first_reloaded.exists() && !second_reloaded.exists() {
+        while !((first_reloaded.exists() && second_lock_busy.exists())
+            || (second_reloaded.exists() && first_lock_busy.exists()))
+        {
             anyhow::ensure!(
                 std::time::Instant::now() < deadline,
-                "Timed out waiting for an install-ready process to reload state"
+                "Timed out waiting for one install-ready process to hold the lock and the other to block"
             );
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        std::thread::sleep(std::time::Duration::from_millis(250));
         let reloads_before_release =
             usize::from(first_reloaded.exists()) + usize::from(second_reloaded.exists());
 

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -2950,6 +2950,8 @@ mod tests {
         root: &Path,
         role: &str,
     ) {
+        use std::os::unix::process::CommandExt;
+
         command
             .arg("--exact")
             .arg("app::tests::updater_flow_process_child")
@@ -2965,21 +2967,116 @@ mod tests {
             )
             .env_remove("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT")
             .env("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1");
+        command.process_group(0);
+    }
+
+    struct ProcessTestChild {
+        child: Option<std::process::Child>,
+        release_paths: Vec<PathBuf>,
+        role: String,
+    }
+
+    impl ProcessTestChild {
+        fn process_group(&self) -> i32 {
+            self.child
+                .as_ref()
+                .expect("process test child should be present")
+                .id() as i32
+        }
+
+        fn wait(mut self) -> Result<()> {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            loop {
+                let status = self
+                    .child
+                    .as_mut()
+                    .expect("process test child should be present")
+                    .try_wait()
+                    .with_context(|| {
+                        format!(
+                            "Failed to wait for updater process test child {}",
+                            self.role
+                        )
+                    })?;
+                if let Some(status) = status {
+                    self.child.take();
+                    anyhow::ensure!(
+                        status.success(),
+                        "Updater process test child {} exited with {status}",
+                        self.role
+                    );
+                    return Ok(());
+                }
+                if std::time::Instant::now() >= deadline {
+                    self.terminate();
+                    anyhow::bail!("Updater process test child {} timed out", self.role);
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+
+        fn terminate(&mut self) {
+            for path in &self.release_paths {
+                let _ = std::fs::write(path, b"cleanup");
+            }
+
+            let Some(child) = self.child.as_mut() else {
+                return;
+            };
+            let process_group = child.id() as i32;
+            // SAFETY: each test child is spawned as the leader of a dedicated
+            // process group, so signaling the negative child pid cannot target
+            // the cargo test runner or an unrelated process.
+            unsafe {
+                let _ = libc::kill(-process_group, libc::SIGTERM);
+            }
+            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+            while std::time::Instant::now() < deadline {
+                if child.try_wait().ok().flatten().is_some() {
+                    self.child.take();
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+
+            // SAFETY: the same dedicated process-group invariant applies.
+            unsafe {
+                let _ = libc::kill(-process_group, libc::SIGKILL);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            self.child.take();
+        }
+    }
+
+    impl Drop for ProcessTestChild {
+        fn drop(&mut self) {
+            self.terminate();
+        }
     }
 
     fn spawn_process_test_child(
         root: &Path,
         role: &str,
         env: &[(&str, &Path)],
-    ) -> Result<std::process::Child> {
+        release_paths: &[&Path],
+    ) -> Result<ProcessTestChild> {
         let mut command = std::process::Command::new(std::env::current_exe()?);
         configure_process_test_command(&mut command, root, role);
         for (key, value) in env {
             command.env(key, value);
         }
-        command
+        let child = command
             .spawn()
-            .with_context(|| format!("Failed to spawn updater process test child {role}"))
+            .with_context(|| format!("Failed to spawn updater process test child {role}"))?;
+        Ok(ProcessTestChild {
+            child: Some(child),
+            release_paths: release_paths
+                .iter()
+                .map(|path| path.to_path_buf())
+                .collect(),
+            role: role.to_string(),
+        })
     }
 
     fn wait_for_process_test_path(path: &Path, description: &str) -> Result<()> {
@@ -2992,17 +3089,6 @@ mod tests {
             );
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
-        Ok(())
-    }
-
-    fn wait_for_process_test_child(mut child: std::process::Child, role: &str) -> Result<()> {
-        let status = child
-            .wait()
-            .with_context(|| format!("Failed to wait for updater process test child {role}"))?;
-        anyhow::ensure!(
-            status.success(),
-            "Updater process test child {role} exited with {status}"
-        );
         Ok(())
     }
 
@@ -3079,6 +3165,47 @@ mod tests {
     }
 
     #[test]
+    fn process_test_child_drop_releases_and_reaps_install_group() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
+        let temp = tempfile::tempdir()?;
+        let (_paths, fake_pkexec, install_log) = prepare_process_install_fixture(temp.path())?;
+        let install_started = temp.path().join("install.started");
+        let install_release = temp.path().join("install.release");
+        let daemon_reconcile = spawn_process_test_child(
+            temp.path(),
+            "daemon-reconcile",
+            &[
+                ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
+                ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_STARTED",
+                    &install_started,
+                ),
+                (
+                    "CODEX_UPDATE_MANAGER_TEST_INSTALL_RELEASE",
+                    &install_release,
+                ),
+            ],
+            &[&install_release],
+        )?;
+        wait_for_process_test_path(&install_started, "blocked daemon reconciliation install")?;
+        let process_group = daemon_reconcile.process_group();
+
+        drop(daemon_reconcile);
+
+        assert!(install_release.exists());
+        // SAFETY: signal 0 only probes the dedicated process group and does not
+        // deliver a signal. Drop must have reaped every process in that group.
+        let probe = unsafe { libc::kill(-process_group, 0) };
+        assert_eq!(probe, -1);
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+        Ok(())
+    }
+
+    #[test]
     fn install_ready_entrypoint_does_not_overwrite_active_install_state() -> Result<()> {
         let _env_guard = crate::test_util::env_lock();
         let temp = tempfile::tempdir()?;
@@ -3108,6 +3235,7 @@ mod tests {
                 ("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH", &fake_pkexec),
                 ("CODEX_UPDATE_MANAGER_TEST_INSTALL_LOG", &install_log),
             ],
+            &[&entrypoint_continue],
         )?;
         wait_for_process_test_path(&entrypoint_loaded, "install-ready state load")?;
 
@@ -3126,6 +3254,7 @@ mod tests {
                     &install_release,
                 ),
             ],
+            &[&install_release],
         )?;
         wait_for_process_test_path(&install_started, "daemon reconciliation install")?;
 
@@ -3134,8 +3263,8 @@ mod tests {
         let state_while_installing = PersistedState::load_or_default(&paths.state_file, true)?;
 
         std::fs::write(&install_release, b"continue")?;
-        wait_for_process_test_child(daemon_reconcile, "daemon-reconcile")?;
-        wait_for_process_test_child(install_ready, "install-ready")?;
+        daemon_reconcile.wait()?;
+        install_ready.wait()?;
 
         assert_eq!(state_while_installing.status, UpdateStatus::Installing);
         let final_state = PersistedState::load_or_default(&paths.state_file, true)?;
@@ -3207,8 +3336,18 @@ mod tests {
             ),
         ]);
 
-        let first = spawn_process_test_child(temp.path(), "install-ready", &first_env)?;
-        let second = spawn_process_test_child(temp.path(), "install-ready", &second_env)?;
+        let first = spawn_process_test_child(
+            temp.path(),
+            "install-ready",
+            &first_env,
+            &[&entrypoint_continue, &reload_continue],
+        )?;
+        let second = spawn_process_test_child(
+            temp.path(),
+            "install-ready",
+            &second_env,
+            &[&entrypoint_continue, &reload_continue],
+        )?;
         wait_for_process_test_path(&first_loaded, "first install-ready state load")?;
         wait_for_process_test_path(&second_loaded, "second install-ready state load")?;
 
@@ -3227,8 +3366,8 @@ mod tests {
             usize::from(first_reloaded.exists()) + usize::from(second_reloaded.exists());
 
         std::fs::write(&reload_continue, b"continue")?;
-        wait_for_process_test_child(first, "first install-ready")?;
-        wait_for_process_test_child(second, "second install-ready")?;
+        first.wait()?;
+        second.wait()?;
 
         assert_eq!(
             reloads_before_release, 1,

--- a/updater/src/install.rs
+++ b/updater/src/install.rs
@@ -260,7 +260,13 @@ pub fn pkexec_command(current_exe: &Path, package_path: &Path) -> Command {
         PackageKind::Deb => "install-deb",
         PackageKind::Pacman => "install-pacman",
     };
-    let mut command = Command::new("pkexec");
+    #[cfg(test)]
+    let pkexec_program = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_PKEXEC_PATH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("pkexec"));
+    #[cfg(not(test))]
+    let pkexec_program = PathBuf::from("pkexec");
+    let mut command = Command::new(pkexec_program);
     command
         .arg("--disable-internal-agent")
         .arg(updater_binary)


### PR DESCRIPTION
## Summary

- serialize daemon startup maintenance, forced checks, periodic checks, reconciliation, state reloads, and cache cleanup under the updater check lock
- make forced `check-now` wait for startup maintenance while stale checks remain non-blocking
- keep daemon startup lock/open/state-reload failures fail-soft
- bump `codex-update-manager` to 0.10.3 and document the fix

## Problem

A second updater process could persist stale state or prune cache workspaces while another process was rebuilding a DMG. The active builder then lost its update-builder, app, or package files and failed late in `install.sh`.

This replaces #1131 and addresses all owner review blockers there.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo check -p codex-update-manager`
- `git diff --check`
- `env -u XDG_CONFIG_HOME cargo test -p codex-update-manager -- --test-threads=1` (281 passed)
- focused forced-check, daemon-startup, reconciliation, and fail-soft regression tests
- GitHub CI: Rust and Smoke Tests, Debian, RPM, Pacman, and Nix builds all passed
- previously built and installed a local `.deb`; the updater recovered the failed candidate to `idle` with no error