### PR TITLE
Add opt-in Codex Micro Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ workarounds.
 | Linux AppShots | Opt-in | `appshots` | [Docs](linux-features/appshots/README.md) |
 | Authenticated proxy | Opt-in | `authenticated-proxy` | [Docs](linux-features/authenticated-proxy/README.md) |
 | Wrapper updater button | Opt-in | `codex-wrapper-updater` | [Docs](linux-features/codex-wrapper-updater/README.md) |
+| Codex Micro (USB-C / Bluetooth LE) | Opt-in | `codex-micro` | [Docs](linux-features/codex-micro/README.md) |
 | Conversation mode | Opt-in | `conversation-mode` | [Docs](linux-features/conversation-mode/README.md) |
 | Copilot reasoning effort defaults | Opt-in | `copilot-reasoning-effort` | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | Directory-only working-tree watch | Opt-in | `directory-only-working-tree-watch` | [Docs](linux-features/directory-only-working-tree-watch/README.md) |

--- a/docs/linux-features-architecture.md
+++ b/docs/linux-features-architecture.md
@@ -66,8 +66,9 @@ The build pipeline loads enabled features in these phases:
    `codex-app/`.
 3. Legacy staging: optional `stage.sh` hooks run for features that still need
    custom install-time logic.
-4. Native packaging: optional package hooks can mutate the `.deb`, `.rpm`, or
-   pacman staging root.
+4. Native packaging: declarative package resources and dependencies are added
+   to `.deb`, `.rpm`, or pacman payloads, then optional package hooks can mutate
+   the staging root.
 5. Runtime: the launcher consumes staged environment files, prelaunch hooks,
    Electron args, and cold-start hooks.
 
@@ -88,7 +89,8 @@ manifest and must clean up any feature-owned files themselves.
 
 `entrypoints` declares optional feature code hooks. Feature patching uses only
 `patchDescriptors`; features that only stage resources, runtime hooks, package
-hooks, or `stageHook` are still valid without any patch entrypoint.
+resources, package dependencies, package hooks, or `stageHook` are still valid
+without any patch entrypoint.
 
 ```json
 {
@@ -188,6 +190,17 @@ such as Codex skills: stage the source file with `resources` under
 `$CODEX_LINUX_FEATURES_DIR/<feature-id>/...` to `$CODEX_HOME/skills/...` in a
 `runtimeHooks.prelaunch` script. Do not write user-home files from `stage.sh`;
 install, package, and updater rebuilds may run outside the real user's session.
+
+## Declarative Native Package Staging
+
+`packageResources` copies feature-owned files outside the app directory into
+`.deb`, RPM, or pacman payloads. Each entry uses `source`, `target`, `mode`, and
+an optional `formats` list. Sources must remain inside the feature directory,
+targets must remain inside the package root, and modes use quoted octal strings.
+
+`packageDependencies` maps each native package format to its additional runtime
+dependencies. Resources and dependencies are validated and included only when
+their feature is enabled.
 
 ## Package Hooks
 

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -205,6 +205,7 @@ The Home Manager and NixOS modules accept these feature IDs through
 | Feature ID | Purpose |
 | --- | --- |
 | `appshots` | Linux AppShots capture integration |
+| `codex-micro` | Work Louder Codex Micro USB and Bluetooth HID integration |
 | `directory-only-working-tree-watch` | Bounded directory-only working-tree watches |
 | `frameless-titlebar` | Hide app-provided titlebar controls for compositor-managed decorations |
 | `mcp-helper-reaper` | Cleanup for stale configured MCP helper processes |
@@ -217,6 +218,10 @@ The list is validated during module evaluation, then deduplicated and sorted so
 equivalent configurations produce the same derivation. Features that are not in
 this Nix allowlist remain available through the regular opt-in feature flow but
 cannot be selected from a pure flake configuration.
+
+When `codex-micro` is selected, the NixOS module installs its udev rule through
+`services.udev.packages`. Home Manager and direct flake installs require that
+rule to be installed separately; see the feature README.
 
 ## Home Manager / NixOS Module
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,18 @@
           hash = "sha256-ghAJ+cGDAFDYlK755hkGywpTeyAAstm77ZmF//HV4NA=";
         };
 
+        codexMicroNodeHidArchive = pkgs.fetchurl {
+          name = "node-hid-3.3.0.tgz";
+          url = "https://registry.npmjs.org/node-hid/-/node-hid-3.3.0.tgz";
+          hash = "sha512-j+dFgJLRAE0nufQKXk3IfS6T6YuHhCgMvz4TrG0sgtb6DSCdYpfJ1etcdmeCmPQjUgO+yo32ktVrRliNs/+fmg==";
+        };
+
+        codexMicroUdevRules = pkgs.runCommand "codex-micro-udev-rules" { } ''
+          install -Dm0644 \
+            ${sourceRoot}/linux-features/codex-micro/resources/70-codex-micro.rules \
+            "$out/lib/udev/rules.d/70-codex-micro.rules"
+        '';
+
         browserUseNodeReplRuntime = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-primary-runtime/26.426.12240/codex-primary-runtime-linux-x64-26.426.12240.tar.xz";
           hash = "sha256-21Yk6276NrZuxvbdBIjO+5ZuSWNoYqq2IJpDNsHKkMQ=";
@@ -345,6 +357,12 @@
           stdenv.cc.cc.lib
           zlib
         ]);
+        codexMicroRuntimeLibPath = pkgs.lib.makeLibraryPath (with pkgs; [
+          systemd
+          libusb1
+          stdenv.cc.cc.lib
+          glibc
+        ]);
         gsettingsSchemaPackages = with pkgs; [
           gsettings-desktop-schemas
           gtk3
@@ -511,6 +529,7 @@ PY
             else
               normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
           effectiveLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
+          codexMicroEnabled = builtins.elem "codex-micro" effectiveLinuxFeatureIds;
         in
         pkgs.stdenv.mkDerivation {
           pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi; linuxFeatureIds = effectiveLinuxFeatureIds; }}-payload";
@@ -533,6 +552,13 @@ PY
             pkgs.python3
             pkgs.unzip
             pkgs.util-linux
+          ] ++ pkgs.lib.optionals codexMicroEnabled [
+            pkgs.pkg-config
+          ];
+
+          buildInputs = pkgs.lib.optionals codexMicroEnabled [
+            pkgs.systemd
+            pkgs.libusb1
           ];
 
           dontConfigure = true;
@@ -563,6 +589,11 @@ PY
             export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfigFile effectiveLinuxFeaturesConfig}"
             export CODEX_ELECTRON_ZIP_SOURCE="${electronZip}"
             export CODEX_NATIVE_MODULES_SOURCE="${codexNativeModules}"
+            ${pkgs.lib.optionalString codexMicroEnabled ''
+            export CODEX_MICRO_NODE_HID_ARCHIVE="${codexMicroNodeHidArchive}"
+            export CODEX_ELECTRON_VERSION="${electronVersion}"
+            export CODEX_MICRO_REQUIRE_PREBUILD=1
+            ''}
             ${pkgs.lib.optionalString (browserUseNodeRepl != null) ''
             export CODEX_LINUX_NODE_REPL_SOURCE="${browserUseNodeRepl}/bin/node_repl"
             ''}
@@ -611,6 +642,7 @@ PY
             else
               normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
           normalizedLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
+          codexMicroEnabled = builtins.elem "codex-micro" normalizedLinuxFeatureIds;
           featureArgs = {
             inherit enableComputerUseUi;
             linuxFeatureIds = normalizedLinuxFeatureIds;
@@ -657,6 +689,31 @@ PY
               --ordering "$TMPDIR/app.asar.ordering" \
               --unpack "{*.node,*.so,*.dylib}"
             rm -rf "$resources_dir/app-extracted"
+
+            ${pkgs.lib.optionalString codexMicroEnabled ''
+            codex_micro_node_count=0
+            while IFS= read -r codex_micro_node; do
+              codex_micro_node_count=$((codex_micro_node_count + 1))
+              patchelf --set-rpath "${codexMicroRuntimeLibPath}" "$codex_micro_node"
+              actual_rpath="$(patchelf --print-rpath "$codex_micro_node")"
+              if [ "$actual_rpath" != "${codexMicroRuntimeLibPath}" ]; then
+                echo "codex-micro node-hid RPATH verification failed: $actual_rpath" >&2
+                exit 1
+              fi
+            done < <(
+              find "$resources_dir/app.asar.unpacked" -type f \
+                -path '*/node-hid/prebuilds/HID_hidraw-linux-*/node-napi-v4.node' \
+                -print
+            )
+            if [ "$codex_micro_node_count" -ne 1 ]; then
+              echo "expected exactly one codex-micro node-hid Linux binding, found $codex_micro_node_count" >&2
+              exit 1
+            fi
+
+            install -Dm0644 \
+              "${codexMicroUdevRules}/lib/udev/rules.d/70-codex-micro.rules" \
+              "$out/lib/udev/rules.d/70-codex-micro.rules"
+            ''}
 
             for node_repl_binary in \
               "$resources_dir/node_repl" \
@@ -789,6 +846,7 @@ PY
           codex-desktop-computer-use-ui = codexDesktopComputerUseUi;
           codex-desktop-remote-mobile-control = codexDesktopRemoteMobileControl;
           codex-desktop-computer-use-ui-remote-mobile-control = codexDesktopComputerUseUiRemoteMobileControl;
+          codex-micro-udev-rules = codexMicroUdevRules;
           installer = installer;
         };
 

--- a/linux-features/README.md
+++ b/linux-features/README.md
@@ -88,7 +88,8 @@ Each feature directory must include:
 - `README.md` — what it does, how to test it, and known risks
 - optional `patch.js` — descriptor patches when `feature.json` uses
   `entrypoints.patchDescriptors`
-- optional declarative `resources`, `runtimeHooks`, and `packageHooks`
+- optional declarative `resources`, `runtimeHooks`, `packageResources`,
+  `packageDependencies`, and `packageHooks`
 - optional `stage.sh` — legacy install/build staging hook
 - optional `test.js` — self-contained tests for the feature
 
@@ -126,7 +127,13 @@ or other user-home artifact, stage the source with `resources` and copy it from
 Avoid writing user-home files from `stage.sh`, because install/package/update
 rebuilds may run outside the real user's session.
 
-`packageHooks` run during native package staging and receive `PACKAGE_FORMAT`,
+`packageResources` stage feature-owned files outside the app directory for
+native packages. `packageDependencies` adds per-format runtime dependencies.
+Both apply only while their feature is enabled; see the architecture document
+for the field contract.
+
+`packageHooks` run after declarative native package resources are staged and
+receive `PACKAGE_FORMAT`,
 `PACKAGE_ROOT`, `PACKAGE_NAME`, `PACKAGE_VERSION`, and `APP_DIR`.
 
 Feature patching uses only `entrypoints.patchDescriptors`. Descriptor modules

--- a/linux-features/codex-micro/README.md
+++ b/linux-features/codex-micro/README.md
@@ -1,0 +1,70 @@
+# Codex Micro
+
+This default-off feature enables the OpenAI x Work Louder Codex Micro over USB
+and Bluetooth on Linux. It reuses the service and device kit bundled with the
+upstream app; it does not reimplement the device protocol.
+
+## Enable
+
+Add the feature to the gitignored `linux-features/features.json`:
+
+```json
+{
+  "enabled": ["codex-micro"]
+}
+```
+
+Then rebuild or package the app through the normal project workflow. Do not run
+the app as root.
+
+Debian, RPM, pacman, and NixOS packages install the included udev rule. Replug
+the USB cable or reconnect Bluetooth after the first install. Source builds,
+AppImage, Home Manager, and direct `nix build` installs cannot change host udev
+policy; install the tracked rule once on those systems:
+
+```bash
+sudo install -Dm0644 \
+  linux-features/codex-micro/resources/70-codex-micro.rules \
+  /etc/udev/rules.d/70-codex-micro.rules
+sudo udevadm control --reload-rules
+```
+
+The packaged AppImage copy is under
+`.codex-linux/features/codex-micro/70-codex-micro.rules`.
+
+## Bluetooth
+
+Pair the Micro through the desktop Bluetooth settings before opening Codex.
+Channel selection and pairing mode are device operations; see the
+[Work Louder setup guide](https://worklouder.cc/micro-setup).
+
+## Implementation notes
+
+The upstream app currently includes `node-hid` 3.3.0 with only its macOS native
+binding. This feature verifies that exact package and stages the matching x64
+or arm64 Linux binding. Package builds also provide its `libudev` and `libusb`
+runtime dependencies.
+
+The udev rules are limited to the observed Work Louder VID/PID `303a:8360`, the
+USB HID interface used by the device, and the corresponding Bluetooth HID bus
+identity. They grant the active desktop user access through `uaccess` and do
+not make HID devices world-writable.
+
+Upstream package drift, a mismatched native artifact, or an unsupported
+architecture causes the enabled feature to reject candidate promotion. Nix
+builds require the pinned prebuilt binding; other builds can fall back to an
+Electron source build when the supported prebuild is unavailable.
+
+## Verify
+
+After connecting the device, confirm that the Codex Micro settings surface
+reports it as connected and test the buttons, dial, joystick, and lighting.
+For permission failures, identify the matching `/dev/hidraw*` node with
+`udevadm info` and confirm that the logged-in user has read/write access.
+
+Run the automated checks with:
+
+```bash
+node --test linux-features/codex-micro/test.js
+node --test scripts/lib/linux-features.test.js
+```

--- a/linux-features/codex-micro/feature.json
+++ b/linux-features/codex-micro/feature.json
@@ -1,0 +1,50 @@
+{
+  "id": "codex-micro",
+  "title": "Codex Micro hardware support",
+  "description": "Adds the verified Linux node-hid binding and narrow USB-C/Bluetooth udev policy needed by the upstream Work Louder Codex Micro service.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "resources": [
+    {
+      "source": "resources/70-codex-micro.rules",
+      "target": ".codex-linux/features/codex-micro/70-codex-micro.rules",
+      "mode": "0644"
+    }
+  ],
+  "packageResources": [
+    {
+      "source": "resources/70-codex-micro.rules",
+      "target": "usr/lib/udev/rules.d/70-codex-micro.rules",
+      "mode": "0644",
+      "formats": [
+        "deb",
+        "rpm",
+        "pacman"
+      ]
+    },
+    {
+      "source": "resources/codex-micro-udev.hook",
+      "target": "usr/share/libalpm/hooks/codex-micro-udev.hook",
+      "mode": "0644",
+      "formats": [
+        "pacman"
+      ]
+    }
+  ],
+  "packageDependencies": {
+    "deb": [
+      "libudev1",
+      "libusb-1.0-0"
+    ],
+    "rpm": [
+      "libudev.so.1%{codex_elf_suffix}",
+      "libusb-1.0.so.0%{codex_elf_suffix}"
+    ],
+    "pacman": [
+      "libusb",
+      "systemd-libs"
+    ]
+  }
+}

--- a/linux-features/codex-micro/native-artifacts.json
+++ b/linux-features/codex-micro/native-artifacts.json
@@ -1,0 +1,27 @@
+{
+  "name": "node-hid",
+  "version": "3.3.0",
+  "license": "(MIT OR X11)",
+  "integrity": "sha512-j+dFgJLRAE0nufQKXk3IfS6T6YuHhCgMvz4TrG0sgtb6DSCdYpfJ1etcdmeCmPQjUgO+yo32ktVrRliNs/+fmg==",
+  "shasum": "2b00639e8bb9fc96592e8366fda7ae380826a7ee",
+  "loaderContract": {
+    "main": "./nodehid.js",
+    "napiVersions": [
+      4
+    ],
+    "files": {
+      "nodehid.js": "84053a6ea19b238e61368f5220a9a8af96b27e752569f14d63dba2127a37988b",
+      "binding-options.js": "e7c820107f3b6571ca1505a5ffbe17511088336e4c410ec718ea9ec200c6b1e6"
+    }
+  },
+  "prebuilds": {
+    "x64": {
+      "path": "prebuilds/HID_hidraw-linux-x64/node-napi-v4.node",
+      "sha256": "6c7f3b3fcc238a74e7e3237b50b2ff05181e94862b1963e8074ff8fc75885021"
+    },
+    "arm64": {
+      "path": "prebuilds/HID_hidraw-linux-arm64/node-napi-v4.node",
+      "sha256": "06ea97f377e2246a1e9bf3770186727e72ff3c166579d9c259c6d32a07aeaa60"
+    }
+  }
+}

--- a/linux-features/codex-micro/native-binding.js
+++ b/linux-features/codex-micro/native-binding.js
@@ -1,0 +1,670 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const SUPPORTED_ARCHITECTURES = new Set(["x64", "arm64"]);
+const SOURCE_BUILD_TOOLCHAIN_DIR = path.join(__dirname, "source-build");
+const SOURCE_BUILD_DEPENDENCIES = Object.freeze({
+  "@electron/rebuild": "4.0.4",
+  "node-addon-api": "3.2.1",
+  "pkg-prebuilds": "1.0.0",
+});
+
+function readPackageMetadata(packageDir, label) {
+  const packagePath = path.join(packageDir, "package.json");
+  if (!fs.existsSync(packagePath)) {
+    throw new Error(`${label} package.json is missing: ${packagePath}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  } catch (error) {
+    throw new Error(`${label} package.json is unreadable: ${error.message}`);
+  }
+}
+
+function requirePackageDirectory(packageDir, expectedName, label) {
+  if (!fs.statSync(packageDir, { throwIfNoEntry: false })?.isDirectory()) {
+    throw new Error(`${label} package is missing: ${packageDir}`);
+  }
+  const metadata = readPackageMetadata(packageDir, label);
+  if (metadata.name !== expectedName) {
+    throw new Error(`${label} package identity mismatch: expected ${expectedName}, got ${metadata.name ?? "unknown"}`);
+  }
+  return metadata;
+}
+
+function discoverBundledNodeHid(extractedDir) {
+  const deviceKitDir = path.join(
+    path.resolve(extractedDir),
+    "node_modules",
+    "@worklouder",
+    "device-kit-oai",
+  );
+  requirePackageDirectory(deviceKitDir, "@worklouder/device-kit-oai", "Work Louder device-kit-oai");
+
+  const workLouderKitDir = path.join(
+    deviceKitDir,
+    "node_modules",
+    "@worklouder",
+    "wl-device-kit",
+  );
+  requirePackageDirectory(workLouderKitDir, "@worklouder/wl-device-kit", "Work Louder wl-device-kit");
+
+  const nodeHidDir = path.join(workLouderKitDir, "node_modules", "node-hid");
+  const nodeHid = requirePackageDirectory(nodeHidDir, "node-hid", "Work Louder nested node-hid");
+  return {
+    deviceKitDir,
+    workLouderKitDir,
+    nodeHidDir,
+    packageMetadata: nodeHid,
+    name: nodeHid.name,
+    version: nodeHid.version,
+    license: nodeHid.license,
+  };
+}
+
+function normalizeArchitecture(arch) {
+  if (!SUPPORTED_ARCHITECTURES.has(arch)) {
+    throw new Error(`Unsupported Codex Micro native binding architecture: ${String(arch)}`);
+  }
+  return arch;
+}
+
+function selectPrebuild(artifactManifest, arch) {
+  normalizeArchitecture(arch);
+  return artifactManifest?.prebuilds?.[arch] ?? null;
+}
+
+function inspectElf(contents) {
+  if (!Buffer.isBuffer(contents) || contents.length < 20 || !contents.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+    throw new Error("Native binding is not an ELF binary");
+  }
+  if (contents[4] !== 2) {
+    throw new Error(`Unsupported ELF class ${contents[4]}; expected a 64-bit ELF binary`);
+  }
+  if (contents[5] !== 1) {
+    throw new Error(`Unsupported ELF encoding ${contents[5]}; expected little-endian`);
+  }
+  const machine = contents.readUInt16LE(18);
+  const arch = machine === 62 ? "x64" : machine === 183 ? "arm64" : null;
+  if (arch == null) {
+    throw new Error(`Unsupported ELF machine ${machine}`);
+  }
+  return { arch, machine };
+}
+
+function digest(contents, algorithm, encoding) {
+  return crypto.createHash(algorithm).update(contents).digest(encoding);
+}
+
+function integrityFor(contents) {
+  return `sha512-${digest(contents, "sha512", "base64")}`;
+}
+
+function equalStringMaps(left, right) {
+  if (left == null || right == null || typeof left !== "object" || typeof right !== "object") {
+    return false;
+  }
+  const leftEntries = Object.entries(left).sort(([a], [b]) => a.localeCompare(b));
+  const rightEntries = Object.entries(right).sort(([a], [b]) => a.localeCompare(b));
+  return JSON.stringify(leftEntries) === JSON.stringify(rightEntries)
+    && leftEntries.every(([, value]) => typeof value === "string");
+}
+
+function loadSourceBuildToolchain(toolchainDir = SOURCE_BUILD_TOOLCHAIN_DIR) {
+  const root = path.resolve(toolchainDir);
+  const packageJsonPath = path.join(root, "package.json");
+  const packageLockPath = path.join(root, "package-lock.json");
+  for (const filePath of [packageJsonPath, packageLockPath]) {
+    const stat = fs.lstatSync(filePath, { throwIfNoEntry: false });
+    if (!stat?.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Codex Micro source-build toolchain file is missing or unsafe: ${filePath}`);
+    }
+  }
+
+  const packageRaw = fs.readFileSync(packageJsonPath);
+  const lockRaw = fs.readFileSync(packageLockPath);
+  let manifest;
+  let lock;
+  try {
+    manifest = JSON.parse(packageRaw.toString("utf8"));
+    lock = JSON.parse(lockRaw.toString("utf8"));
+  } catch (error) {
+    throw new Error(`Codex Micro source-build toolchain JSON is invalid: ${error.message}`);
+  }
+
+  if (manifest.private !== true || !equalStringMaps(manifest.dependencies, SOURCE_BUILD_DEPENDENCIES)) {
+    throw new Error("Codex Micro source-build package.json dependencies do not match the pinned toolchain");
+  }
+  if (lock.lockfileVersion !== 3 || lock.packages == null || typeof lock.packages !== "object") {
+    throw new Error("Codex Micro source-build package-lock.json must use lockfileVersion 3");
+  }
+  const lockRoot = lock.packages[""];
+  if (
+    lock.name !== manifest.name
+    || lock.version !== manifest.version
+    || lockRoot?.name !== manifest.name
+    || lockRoot?.version !== manifest.version
+    || !equalStringMaps(lockRoot?.dependencies, SOURCE_BUILD_DEPENDENCIES)
+  ) {
+    throw new Error("Codex Micro source-build package-lock root does not match package.json");
+  }
+
+  const exactVersion = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+  const registryArtifact = /^https:\/\/registry\.npmjs\.org\//;
+  const sha512Integrity = /^sha512-[A-Za-z0-9+/]+={0,2}$/;
+  for (const [packagePath, entry] of Object.entries(lock.packages)) {
+    if (packagePath === "" || entry?.link === true) {
+      continue;
+    }
+    if (
+      entry == null
+      || typeof entry !== "object"
+      || !exactVersion.test(entry.version ?? "")
+      || !registryArtifact.test(entry.resolved ?? "")
+      || !sha512Integrity.test(entry.integrity ?? "")
+    ) {
+      throw new Error(`Codex Micro source-build lock entry is not integrity-pinned: ${packagePath}`);
+    }
+  }
+
+  return {
+    packageJsonPath,
+    packageLockPath,
+    lockSha256: digest(lockRaw, "sha256", "hex"),
+  };
+}
+
+function validateArtifactManifest(artifactManifest) {
+  if (artifactManifest == null || typeof artifactManifest !== "object" || Array.isArray(artifactManifest)) {
+    throw new Error("Codex Micro node-hid artifact manifest is invalid");
+  }
+  for (const key of ["name", "version", "license", "integrity", "shasum"]) {
+    if (typeof artifactManifest[key] !== "string" || artifactManifest[key].length === 0) {
+      throw new Error(`Codex Micro node-hid artifact manifest is missing ${key}`);
+    }
+  }
+  const loaderContract = artifactManifest.loaderContract;
+  if (
+    loaderContract == null
+    || typeof loaderContract !== "object"
+    || Array.isArray(loaderContract)
+    || typeof loaderContract.main !== "string"
+    || loaderContract.main.length === 0
+    || !Array.isArray(loaderContract.napiVersions)
+    || loaderContract.napiVersions.length === 0
+    || !loaderContract.napiVersions.every(Number.isSafeInteger)
+    || loaderContract.files == null
+    || typeof loaderContract.files !== "object"
+    || Array.isArray(loaderContract.files)
+    || Object.keys(loaderContract.files).length === 0
+  ) {
+    throw new Error("Codex Micro node-hid loader contract is invalid");
+  }
+  for (const [relativePath, sha256] of Object.entries(loaderContract.files)) {
+    if (
+      path.isAbsolute(relativePath)
+      || relativePath.split(/[\\/]+/).includes("..")
+      || typeof sha256 !== "string"
+      || !/^[0-9a-f]{64}$/.test(sha256)
+    ) {
+      throw new Error(`Codex Micro node-hid loader contract file is invalid: ${relativePath}`);
+    }
+  }
+}
+
+function validateBundledPackage(discovered, artifactManifest) {
+  if (discovered.name !== artifactManifest.name) {
+    throw new Error(`Bundled node-hid identity mismatch: expected ${artifactManifest.name}, got ${discovered.name}`);
+  }
+  if (discovered.version !== artifactManifest.version) {
+    throw new Error(`Bundled node-hid version mismatch: expected ${artifactManifest.version}, got ${discovered.version}`);
+  }
+  if (discovered.license !== artifactManifest.license) {
+    throw new Error(`Bundled node-hid license mismatch: expected ${artifactManifest.license}, got ${discovered.license}`);
+  }
+  const loaderContract = artifactManifest.loaderContract;
+  if (discovered.packageMetadata.main !== loaderContract.main) {
+    throw new Error(
+      `Bundled node-hid loader entrypoint mismatch: expected ${loaderContract.main}, got ${discovered.packageMetadata.main ?? "unknown"}`,
+    );
+  }
+  if (
+    JSON.stringify(discovered.packageMetadata.binary?.napi_versions)
+    !== JSON.stringify(loaderContract.napiVersions)
+  ) {
+    throw new Error(
+      `Bundled node-hid N-API contract mismatch: expected ${JSON.stringify(loaderContract.napiVersions)}, got ${JSON.stringify(discovered.packageMetadata.binary?.napi_versions ?? null)}`,
+    );
+  }
+  for (const [relativePath, expectedSha256] of Object.entries(loaderContract.files)) {
+    const filePath = path.join(discovered.nodeHidDir, relativePath);
+    const stat = fs.lstatSync(filePath, { throwIfNoEntry: false });
+    if (!stat?.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Bundled node-hid loader contract file is missing or unsafe: ${relativePath}`);
+    }
+    const actualSha256 = digest(fs.readFileSync(filePath), "sha256", "hex");
+    if (actualSha256 !== expectedSha256) {
+      throw new Error(
+        `Bundled node-hid loader contract hash mismatch for ${relativePath}: expected ${expectedSha256}, got ${actualSha256}`,
+      );
+    }
+  }
+}
+
+function validateMaterializedPackage(materialized, artifactManifest) {
+  if (materialized == null || typeof materialized !== "object") {
+    throw new Error("node-hid materializer returned no package");
+  }
+  if (materialized.integrity !== artifactManifest.integrity) {
+    throw new Error(`node-hid artifact integrity mismatch: expected ${artifactManifest.integrity}, got ${materialized.integrity ?? "unknown"}`);
+  }
+  const metadata = readPackageMetadata(materialized.packageDir, "Materialized node-hid");
+  if (metadata.name !== artifactManifest.name) {
+    throw new Error(`node-hid artifact identity mismatch: expected ${artifactManifest.name}, got ${metadata.name ?? "unknown"}`);
+  }
+  if (metadata.version !== artifactManifest.version) {
+    throw new Error(`node-hid artifact version mismatch: expected ${artifactManifest.version}, got ${metadata.version ?? "unknown"}`);
+  }
+  if (metadata.license !== artifactManifest.license) {
+    throw new Error(`node-hid artifact license mismatch: expected ${artifactManifest.license}, got ${metadata.license ?? "unknown"}`);
+  }
+  return metadata;
+}
+
+function validateBinding(contents, expectedArch, expectedSha256 = null) {
+  if (expectedSha256 != null) {
+    const actualSha256 = digest(contents, "sha256", "hex");
+    if (actualSha256 !== expectedSha256) {
+      throw new Error(`node-hid native binding SHA-256 mismatch: expected ${expectedSha256}, got ${actualSha256}`);
+    }
+  }
+  const elf = inspectElf(contents);
+  if (elf.arch !== expectedArch) {
+    throw new Error(`node-hid native binding ELF architecture ${elf.arch} does not match ${expectedArch}`);
+  }
+  return elf;
+}
+
+function atomicWriteBinding(targetPath, contents) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const temporaryPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.codex-micro-${process.pid}`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, contents, { mode: 0o755 });
+    fs.renameSync(temporaryPath, targetPath);
+    fs.chmodSync(targetPath, 0o755);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function sourceBuildProvenancePath(targetPath) {
+  return `${targetPath}.codex-micro.json`;
+}
+
+function atomicWriteJson(targetPath, value) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const temporaryPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.${process.pid}`,
+  );
+  try {
+    fs.writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o644 });
+    fs.renameSync(temporaryPath, targetPath);
+    fs.chmodSync(targetPath, 0o644);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function validatedSourceBuildProvenance(targetPath, expected) {
+  const provenancePath = sourceBuildProvenancePath(targetPath);
+  const targetStat = fs.lstatSync(targetPath, { throwIfNoEntry: false });
+  const provenanceStat = fs.lstatSync(provenancePath, { throwIfNoEntry: false });
+  if (!targetStat?.isFile() || !provenanceStat?.isFile() || provenanceStat.size > 16 * 1024) {
+    return null;
+  }
+
+  let provenance;
+  try {
+    provenance = JSON.parse(fs.readFileSync(provenancePath, "utf8"));
+  } catch {
+    return null;
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (provenance?.[key] !== value) {
+      return null;
+    }
+  }
+
+  const contents = fs.readFileSync(targetPath);
+  try {
+    validateBinding(contents, expected.arch, provenance.sha256);
+  } catch {
+    return null;
+  }
+  return { contents, provenancePath };
+}
+
+function run(command, args, options = {}) {
+  try {
+    return childProcess.execFileSync(command, args, {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      ...options,
+    });
+  } catch (error) {
+    const stderr = typeof error?.stderr === "string" ? error.stderr.trim() : "";
+    const failure = stderr || error?.code || error?.message || "unknown error";
+    const detail = failure ? `: ${failure}` : "";
+    throw new Error(`${command} ${args.join(" ")} failed${detail}`);
+  }
+}
+
+async function defaultMaterializePackage(request) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-micro-node-hid-"));
+  try {
+    const archiveOverride = process.env.CODEX_MICRO_NODE_HID_ARCHIVE?.trim();
+    let archivePath;
+    if (archiveOverride) {
+      archivePath = path.resolve(archiveOverride);
+      if (!fs.statSync(archivePath, { throwIfNoEntry: false })?.isFile()) {
+        throw new Error(`CODEX_MICRO_NODE_HID_ARCHIVE is not a file: ${archivePath}`);
+      }
+    } else {
+      const packOutput = run(
+        "npm",
+        [
+          "pack",
+          `${request.name}@${request.version}`,
+          "--ignore-scripts",
+          "--json",
+          "--pack-destination",
+          temporaryRoot,
+        ],
+        { env: { ...process.env, npm_config_ignore_scripts: "true" } },
+      );
+      let packResult;
+      try {
+        [packResult] = JSON.parse(packOutput);
+      } catch (error) {
+        throw new Error(`Could not parse npm pack output: ${error.message}`);
+      }
+      archivePath = path.join(temporaryRoot, packResult.filename);
+    }
+
+    const archive = fs.readFileSync(archivePath);
+    const actualIntegrity = integrityFor(archive);
+    if (actualIntegrity !== request.integrity) {
+      throw new Error(`node-hid archive integrity mismatch: expected ${request.integrity}, got ${actualIntegrity}`);
+    }
+
+    const extractRoot = path.join(temporaryRoot, "extracted");
+    fs.mkdirSync(extractRoot);
+    run("tar", ["-xzf", archivePath, "-C", extractRoot]);
+    const packageDir = path.join(extractRoot, "package");
+    if (!fs.statSync(packageDir, { throwIfNoEntry: false })?.isDirectory()) {
+      throw new Error("node-hid archive did not contain package/");
+    }
+    return {
+      packageDir,
+      integrity: actualIntegrity,
+      cleanup: () => fs.rmSync(temporaryRoot, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function defaultBuildFromSource(request) {
+  if (!request.electronVersion) {
+    throw new Error("CODEX_ELECTRON_VERSION is required to build node-hid from source");
+  }
+  const execute = request.execute ?? run;
+  if (process.platform === "linux") {
+    try {
+      execute("pkg-config", ["--exists", "libudev", "libusb-1.0"]);
+    } catch {
+      throw new Error(
+        "node-hid source build requires pkg-config plus the libudev and libusb development packages; see linux-features/codex-micro/README.md",
+      );
+    }
+  }
+  const sourceBuildToolchain = request.sourceBuildToolchain
+    ?? loadSourceBuildToolchain(request.sourceBuildToolchainDir);
+  const buildRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-micro-node-hid-build-"));
+  try {
+    fs.copyFileSync(sourceBuildToolchain.packageJsonPath, path.join(buildRoot, "package.json"));
+    fs.copyFileSync(sourceBuildToolchain.packageLockPath, path.join(buildRoot, "package-lock.json"));
+    execute(
+      "npm",
+      [
+        "ci",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+      ],
+      { cwd: buildRoot, env: { ...process.env, npm_config_ignore_scripts: "true" } },
+    );
+    const moduleDir = path.join(buildRoot, "node_modules", request.name);
+    fs.cpSync(request.packageDir, moduleDir, { recursive: true, force: true });
+    const rebuildCli = path.join(buildRoot, "node_modules", "@electron", "rebuild", "lib", "cli.js");
+    const distUrl = process.env.CODEX_ELECTRON_HEADERS_URL?.trim()
+      || process.env.npm_config_disturl?.trim()
+      || process.env.NPM_CONFIG_DISTURL?.trim()
+      || "https://artifacts.electronjs.org/headers/dist";
+    execute(
+      process.execPath,
+      [
+        rebuildCli,
+        "-v",
+        request.electronVersion,
+        "--arch",
+        request.arch,
+        "--force",
+        "--which-module",
+        request.name,
+        "--only",
+        request.name,
+        "--build-from-source",
+        "--dist-url",
+        distUrl,
+      ],
+      {
+        cwd: buildRoot,
+        env: {
+          ...process.env,
+          npm_config_disturl: distUrl,
+          NPM_CONFIG_DISTURL: distUrl,
+        },
+      },
+    );
+    const bindingPath = path.join(moduleDir, "build", "Release", "HID_hidraw.node");
+    if (!fs.statSync(bindingPath, { throwIfNoEntry: false })?.isFile()) {
+      throw new Error(`node-hid source build did not produce ${bindingPath}`);
+    }
+    const retainedRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-micro-built-binding-"));
+    const retainedBinding = path.join(retainedRoot, "HID_hidraw.node");
+    fs.copyFileSync(bindingPath, retainedBinding);
+    return {
+      bindingPath: retainedBinding,
+      cleanup: () => fs.rmSync(retainedRoot, { recursive: true, force: true }),
+    };
+  } finally {
+    fs.rmSync(buildRoot, { recursive: true, force: true });
+  }
+}
+
+async function stageCodexMicroNativeBinding(options) {
+  const {
+    extractedDir,
+    artifactManifest,
+    materializePackage = defaultMaterializePackage,
+    buildFromSource = defaultBuildFromSource,
+  } = options;
+  const arch = normalizeArchitecture(options.arch);
+  validateArtifactManifest(artifactManifest);
+  const discovered = discoverBundledNodeHid(extractedDir);
+  validateBundledPackage(discovered, artifactManifest);
+
+  const prebuild = selectPrebuild(artifactManifest, arch);
+  const targetRelativePath = prebuild?.path
+    ?? path.join("prebuilds", `HID_hidraw-linux-${arch}`, "node-napi-v4.node");
+  const targetPath = path.join(discovered.nodeHidDir, targetRelativePath);
+  if (prebuild != null && fs.statSync(targetPath, { throwIfNoEntry: false })?.isFile()) {
+    const existing = fs.readFileSync(targetPath);
+    if (digest(existing, "sha256", "hex") === prebuild.sha256) {
+      validateBinding(existing, arch, prebuild.sha256);
+      return {
+        changed: false,
+        alreadyApplied: true,
+        version: artifactManifest.version,
+        targetPath,
+        source: "existing",
+        integrity: artifactManifest.integrity,
+      };
+    }
+  }
+  let sourceBuildToolchain = null;
+  if (prebuild == null) {
+    if (options.requirePrebuild === true) {
+      throw new Error(`A verified node-hid prebuild is required for ${arch} in this build environment`);
+    }
+    sourceBuildToolchain = loadSourceBuildToolchain(options.sourceBuildToolchainDir);
+    const existing = validatedSourceBuildProvenance(targetPath, {
+      schemaVersion: 2,
+      name: artifactManifest.name,
+      version: artifactManifest.version,
+      integrity: artifactManifest.integrity,
+      electronVersion: options.electronVersion,
+      arch,
+      targetRelativePath,
+      sourceBuildLockSha256: sourceBuildToolchain.lockSha256,
+    });
+    if (existing != null) {
+      return {
+        changed: false,
+        alreadyApplied: true,
+        version: artifactManifest.version,
+        targetPath,
+        source: "existing-source-build",
+        integrity: artifactManifest.integrity,
+      };
+    }
+  }
+
+  let materialized;
+  let built;
+  try {
+    materialized = await materializePackage({
+      name: artifactManifest.name,
+      version: artifactManifest.version,
+      integrity: artifactManifest.integrity,
+    });
+    validateMaterializedPackage(materialized, artifactManifest);
+
+    let contents;
+    let source;
+    if (prebuild != null) {
+      const sourcePath = path.join(materialized.packageDir, prebuild.path);
+      if (!fs.statSync(sourcePath, { throwIfNoEntry: false })?.isFile()) {
+        throw new Error(`Verified node-hid prebuild is missing: ${prebuild.path}`);
+      }
+      contents = fs.readFileSync(sourcePath);
+      validateBinding(contents, arch, prebuild.sha256);
+      source = "prebuild";
+    } else {
+      built = await buildFromSource({
+        packageDir: materialized.packageDir,
+        name: artifactManifest.name,
+        version: artifactManifest.version,
+        arch,
+        electronVersion: options.electronVersion,
+        targetRelativePath,
+        sourceBuildToolchain,
+      });
+      if (!fs.statSync(built?.bindingPath, { throwIfNoEntry: false })?.isFile()) {
+        throw new Error("node-hid source build returned no native binding");
+      }
+      contents = fs.readFileSync(built.bindingPath);
+      validateBinding(contents, arch);
+      source = "source-build";
+    }
+
+    atomicWriteBinding(targetPath, contents);
+    const provenancePath = sourceBuildProvenancePath(targetPath);
+    if (source === "source-build") {
+      atomicWriteJson(provenancePath, {
+        schemaVersion: 2,
+        name: artifactManifest.name,
+        version: artifactManifest.version,
+        integrity: artifactManifest.integrity,
+        electronVersion: options.electronVersion,
+        arch,
+        targetRelativePath,
+        sourceBuildLockSha256: sourceBuildToolchain.lockSha256,
+        sha256: digest(contents, "sha256", "hex"),
+      });
+    } else {
+      fs.rmSync(provenancePath, { force: true });
+    }
+    return {
+      changed: true,
+      alreadyApplied: false,
+      version: artifactManifest.version,
+      targetPath,
+      source,
+      integrity: artifactManifest.integrity,
+    };
+  } finally {
+    built?.cleanup?.();
+    materialized?.cleanup?.();
+  }
+}
+
+function currentArtifactManifest() {
+  return JSON.parse(fs.readFileSync(path.join(__dirname, "native-artifacts.json"), "utf8"));
+}
+
+async function main() {
+  if (process.argv[2] !== "--stage" || !process.argv[3]) {
+    console.error("Usage: native-binding.js --stage <extracted-app-dir>");
+    process.exitCode = 1;
+    return;
+  }
+  const arch = process.arch;
+  const result = await stageCodexMicroNativeBinding({
+    extractedDir: process.argv[3],
+    arch,
+    electronVersion: process.env.CODEX_ELECTRON_VERSION?.trim(),
+    requirePrebuild: process.env.CODEX_MICRO_REQUIRE_PREBUILD === "1",
+    artifactManifest: currentArtifactManifest(),
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`ERROR: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  defaultBuildFromSource,
+  defaultMaterializePackage,
+  discoverBundledNodeHid,
+  inspectElf,
+  loadSourceBuildToolchain,
+  selectPrebuild,
+  stageCodexMicroNativeBinding,
+};

--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -1,0 +1,128 @@
+"use strict";
+
+const childProcess = require("node:child_process");
+const path = require("node:path");
+
+const {
+  extractedAppPatch,
+  webviewAssetPatch,
+} = require("../../scripts/patches/descriptor.js");
+
+const CODEX_MICRO_GATE_ID = "3207467860";
+const CODEX_MICRO_GATE_MARKER = "codexLinuxCodexMicroGateOverride";
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exportedFeatureGateHook(source) {
+  const exportStart = source.lastIndexOf("export{");
+  const exportEnd = exportStart < 0 ? -1 : source.indexOf("}", exportStart);
+  if (exportStart < 0 || exportEnd < 0) {
+    return null;
+  }
+
+  const exportBlock = source.slice(exportStart, exportEnd + 1);
+  const candidates = new RegExp(
+    `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{return ` +
+      `(${JS_IDENT})\\(\\),(${JS_IDENT})\\((${JS_IDENT}),\\2\\)\\}`,
+    "g",
+  );
+  const exportedCandidates = [];
+  for (const match of source.matchAll(candidates)) {
+    const hookName = match[1];
+    const exportedAsGateHook = new RegExp(
+      `(?:\\{|,)${escapeRegExp(hookName)} as ${JS_IDENT}(?:,|\\})`,
+    );
+    if (exportedAsGateHook.test(exportBlock)) {
+      exportedCandidates.push({
+        source: match[0],
+        hookName,
+        argumentName: match[2],
+        contextHookName: match[3],
+        atomReadName: match[4],
+        gateAtomName: match[5],
+      });
+    }
+  }
+  return exportedCandidates.length === 1 ? exportedCandidates[0] : null;
+}
+
+function matchesCodexMicroFeatureGateContract(source) {
+  if (typeof source !== "string") {
+    return false;
+  }
+  if (source.includes(CODEX_MICRO_GATE_MARKER)) {
+    return true;
+  }
+  return source.includes("useFeatureGate hook failed to find a valid StatsigClient") &&
+    exportedFeatureGateHook(source) != null;
+}
+
+function applyCodexMicroFeatureGatePatch(source) {
+  if (typeof source !== "string" || source.includes(CODEX_MICRO_GATE_MARKER)) {
+    return source;
+  }
+
+  const hook = exportedFeatureGateHook(source);
+  if (hook == null) {
+    if (source.includes("useFeatureGate hook failed to find a valid StatsigClient")) {
+      console.warn(
+        "WARN: Could not find the current exported feature-gate hook - " +
+          "skipping Codex Micro gate override",
+      );
+    }
+    return source;
+  }
+
+  const replacement =
+    `function ${hook.hookName}(${hook.argumentName}){return ` +
+    `${hook.contextHookName}(),${hook.atomReadName}(${hook.gateAtomName},${hook.argumentName})||` +
+    `${hook.argumentName}===\`${CODEX_MICRO_GATE_ID}\`/*${CODEX_MICRO_GATE_MARKER}*/}`;
+  return source.replace(hook.source, replacement);
+}
+
+function stageNativeBinding(extractedDir) {
+  const helper = path.join(__dirname, "native-binding.js");
+  const output = childProcess.execFileSync(process.execPath, [helper, "--stage", extractedDir], {
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return JSON.parse(output);
+}
+
+module.exports = {
+  CODEX_MICRO_GATE_ID,
+  CODEX_MICRO_GATE_MARKER,
+  applyCodexMicroFeatureGatePatch,
+  exportedFeatureGateHook,
+  matchesCodexMicroFeatureGateContract,
+  descriptors: [
+    webviewAssetPatch({
+      id: "webview-feature-gate",
+      order: 28_990,
+      ciPolicy: "opt-in",
+      pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
+      assetMatch: matchesCodexMicroFeatureGateContract,
+      missingDescription: "current shared feature-gate webview bundle",
+      skipDescription: "Codex Micro feature-gate override",
+      apply: applyCodexMicroFeatureGatePatch,
+    }),
+    extractedAppPatch({
+      id: "linux-node-hid-binding",
+      phase: "extracted-app:post-webview",
+      order: 29_000,
+      ciPolicy: "opt-in",
+      targetSummary: "current Work Louder node-hid 3.3.0 nested dependency",
+      apply: (extractedDir) => stageNativeBinding(extractedDir),
+      status: (result) => ({
+        status: result?.changed ? "applied" : result?.alreadyApplied ? "already-applied" : "skipped-optional",
+        reason: result == null
+          ? "node-hid binding staging returned no result"
+          : `${result.source} node-hid ${result.version}`,
+      }),
+    }),
+  ],
+};

--- a/linux-features/codex-micro/resources/70-codex-micro.rules
+++ b/linux-features/codex-micro/resources/70-codex-micro.rules
@@ -1,0 +1,4 @@
+# OpenAI x Work Louder Codex Micro vendor HID channel (interface 00 only).
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_VENDOR_ID}=="303a", ENV{ID_MODEL_ID}=="8360", ENV{ID_USB_INTERFACE_NUM}=="00", TAG+="uaccess", MODE="0660"
+# BlueZ exposes the same vendor HID channel through UHID on Bluetooth bus 0005.
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", KERNELS=="0005:303A:8360.*", TAG+="uaccess", MODE="0660"

--- a/linux-features/codex-micro/resources/codex-micro-udev.hook
+++ b/linux-features/codex-micro/resources/codex-micro-udev.hook
@@ -1,0 +1,9 @@
+[Trigger]
+Operation = Remove
+Type = Path
+Target = usr/lib/udev/rules.d/70-codex-micro.rules
+
+[Action]
+Description = Reloading udev rules after removing Codex Micro access policy
+When = PostTransaction
+Exec = /bin/sh -c "if command -v udevadm >/dev/null 2>&1; then udevadm control --reload-rules >/dev/null 2>&1 || true; fi"

--- a/linux-features/codex-micro/source-build/package-lock.json
+++ b/linux-features/codex-micro/source-build/package-lock.json
@@ -1,0 +1,614 @@
+{
+  "name": "codex-micro-node-hid-source-toolchain",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-micro-node-hid-source-toolchain",
+      "version": "0.0.0",
+      "dependencies": {
+        "@electron/rebuild": "4.0.4",
+        "node-addon-api": "3.2.1",
+        "pkg-prebuilds": "1.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-prebuilds": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-prebuilds/-/pkg-prebuilds-1.0.0.tgz",
+      "integrity": "sha512-D9wlkXZCmjxj2kBHTw3fGSyjoahr33breGBoJcoezpi7ouYS59DJVOHMZ+dgqacSrZiJo4qtkXxLQTE+BqXJmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "pkg-prebuilds-copy": "bin/copy.mjs",
+        "pkg-prebuilds-verify": "bin/verify.mjs"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/linux-features/codex-micro/source-build/package.json
+++ b/linux-features/codex-micro/source-build/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "codex-micro-node-hid-source-toolchain",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@electron/rebuild": "4.0.4",
+    "node-addon-api": "3.2.1",
+    "pkg-prebuilds": "1.0.0"
+  }
+}

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -1,0 +1,1095 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  defaultBuildFromSource,
+  discoverBundledNodeHid,
+  inspectElf,
+  loadSourceBuildToolchain,
+  selectPrebuild,
+  stageCodexMicroNativeBinding,
+} = require("./native-binding.js");
+const {
+  CODEX_MICRO_GATE_ID,
+  CODEX_MICRO_GATE_MARKER,
+  applyCodexMicroFeatureGatePatch,
+  descriptors,
+  exportedFeatureGateHook,
+  matchesCodexMicroFeatureGateContract,
+} = require("./patch.js");
+const {
+  enabledLinuxFeaturePackageDependencies,
+  enabledLinuxFeaturePackageFiles,
+  loadLinuxFeaturePatchDescriptors,
+  stageEnabledLinuxFeaturePackageResources,
+} = require("../../scripts/lib/linux-features.js");
+
+const NODE_HID_INTEGRITY =
+  "sha512-j+dFgJLRAE0nufQKXk3IfS6T6YuHhCgMvz4TrG0sgtb6DSCdYpfJ1etcdmeCmPQjUgO+yo32ktVrRliNs/+fmg==";
+const FIXTURE_NODE_HID_LOADER =
+  "module.exports = require('pkg-prebuilds')(__dirname); // bundled loader\n";
+const FIXTURE_NODE_HID_OPTIONS =
+  "module.exports = { name: 'HID', tags: ['backend'] }; // bundled options\n";
+const CURRENT_ARTIFACT = Object.freeze({
+  name: "node-hid",
+  version: "3.3.0",
+  license: "(MIT OR X11)",
+  integrity: NODE_HID_INTEGRITY,
+  shasum: "2b00639e8bb9fc96592e8366fda7ae380826a7ee",
+  loaderContract: Object.freeze({
+    main: "./nodehid.js",
+    napiVersions: Object.freeze([4]),
+    files: Object.freeze({
+      "nodehid.js": "84053a6ea19b238e61368f5220a9a8af96b27e752569f14d63dba2127a37988b",
+      "binding-options.js": "e7c820107f3b6571ca1505a5ffbe17511088336e4c410ec718ea9ec200c6b1e6",
+    }),
+  }),
+  prebuilds: Object.freeze({
+    x64: Object.freeze({
+      path: "prebuilds/HID_hidraw-linux-x64/node-napi-v4.node",
+      sha256: "6c7f3b3fcc238a74e7e3237b50b2ff05181e94862b1963e8074ff8fc75885021",
+    }),
+    arm64: Object.freeze({
+      path: "prebuilds/HID_hidraw-linux-arm64/node-napi-v4.node",
+      sha256: "06ea97f377e2246a1e9bf3770186727e72ff3c166579d9c259c6d32a07aeaa60",
+    }),
+  }),
+});
+
+function currentFeatureGateFixture() {
+  return [
+    "const warning=`useFeatureGate hook failed to find a valid StatsigClient`;",
+    "function Lh(){return zh().isLoading}",
+    "function Rh(e){return bnt(),Bo(Fh,e)}",
+    "function zh(){return bnt(),client()}",
+    "export{zh as c,Lh as flt,Rh as rlt};",
+  ].join("");
+}
+
+test("Codex Micro locally enables only its upstream feature gate", () => {
+  const source = currentFeatureGateFixture();
+  const hook = exportedFeatureGateHook(source);
+
+  assert.deepEqual(hook, {
+    source: "function Rh(e){return bnt(),Bo(Fh,e)}",
+    hookName: "Rh",
+    argumentName: "e",
+    contextHookName: "bnt",
+    atomReadName: "Bo",
+    gateAtomName: "Fh",
+  });
+  assert.equal(matchesCodexMicroFeatureGateContract(source), true);
+
+  const patched = applyCodexMicroFeatureGatePatch(source);
+  assert.match(
+    patched,
+    new RegExp(
+      `function Rh\\(e\\)\\{return bnt\\(\\),Bo\\(Fh,e\\)\\|\\|` +
+        `e===\\\`${CODEX_MICRO_GATE_ID}\\\`/\\*${CODEX_MICRO_GATE_MARKER}\\*/\\}`,
+    ),
+  );
+  assert.equal(applyCodexMicroFeatureGatePatch(patched), patched);
+  assert.equal(matchesCodexMicroFeatureGateContract(patched), true);
+  assert.doesNotMatch(patched, /e===`[^`]+`\|\|/);
+});
+
+test("Codex Micro gate patch rejects a lookalike hook that is not the shared gate export", () => {
+  const source = currentFeatureGateFixture().replace(",Rh as rlt", "");
+
+  assert.equal(exportedFeatureGateHook(source), null);
+  assert.equal(matchesCodexMicroFeatureGateContract(source), false);
+  assert.equal(applyCodexMicroFeatureGatePatch(source), source);
+});
+
+test("Codex Micro gate patch targets only the current app-initial bundle shape", () => {
+  const descriptor = descriptors.find(({ id }) => id === "webview-feature-gate");
+
+  assert.ok(descriptor);
+  assert.equal(descriptor.pattern.test("app-initial-BTphDPeq.js"), true);
+  assert.equal(
+    descriptor.pattern.test(
+      "app-initial~avatarOverlayCompositionSurface~artifact-tab-content.electron~notebook-preview-old.js",
+    ),
+    false,
+  );
+});
+
+test("the shipped native artifact manifest matches the focused-test contract", () => {
+  const shipped = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "native-artifacts.json"),
+    "utf8",
+  ));
+  assert.deepEqual(shipped, CURRENT_ARTIFACT);
+});
+
+test("the source-build toolchain is fully integrity-pinned", () => {
+  const toolchain = loadSourceBuildToolchain();
+  const manifest = JSON.parse(fs.readFileSync(toolchain.packageJsonPath, "utf8"));
+  const lock = JSON.parse(fs.readFileSync(toolchain.packageLockPath, "utf8"));
+
+  assert.deepEqual(manifest.dependencies, {
+    "@electron/rebuild": "4.0.4",
+    "node-addon-api": "3.2.1",
+    "pkg-prebuilds": "1.0.0",
+  });
+  assert.deepEqual(lock.packages[""].dependencies, manifest.dependencies);
+  assert.match(toolchain.lockSha256, /^[0-9a-f]{64}$/);
+});
+
+test("the source-build toolchain rejects an unpinned transitive artifact", (t) => {
+  const root = tempDirectory(t, "codex-micro-unpinned-toolchain-");
+  const toolchainDir = path.join(root, "source-build");
+  fs.cpSync(path.join(__dirname, "source-build"), toolchainDir, { recursive: true });
+  const lockPath = path.join(toolchainDir, "package-lock.json");
+  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  delete lock.packages["node_modules/@electron/rebuild"].integrity;
+  writeJson(lockPath, lock);
+
+  assert.throws(
+    () => loadSourceBuildToolchain(toolchainDir),
+    /lock entry is not integrity-pinned.*@electron\/rebuild/i,
+  );
+});
+
+const DEVICE_KIT_RELATIVE = path.join(
+  "node_modules",
+  "@worklouder",
+  "device-kit-oai",
+);
+const WORK_LOUDER_KIT_RELATIVE = path.join(
+  DEVICE_KIT_RELATIVE,
+  "node_modules",
+  "@worklouder",
+  "wl-device-kit",
+);
+const NODE_HID_RELATIVE = path.join(
+  WORK_LOUDER_KIT_RELATIVE,
+  "node_modules",
+  "node-hid",
+);
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFile(filePath, contents, mode) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, mode == null ? undefined : { mode });
+}
+
+function tempDirectory(t, prefix) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function sha256(contents) {
+  return crypto.createHash("sha256").update(contents).digest("hex");
+}
+
+function makeElf(arch, marker = arch) {
+  const machines = { x64: 62, arm64: 183 };
+  const machine = machines[arch];
+  if (machine == null) {
+    throw new Error(`Unsupported ELF fixture architecture: ${arch}`);
+  }
+
+  const contents = Buffer.alloc(128);
+  contents.set([0x7f, 0x45, 0x4c, 0x46], 0);
+  contents[4] = 2; // ELFCLASS64
+  contents[5] = 1; // ELFDATA2LSB
+  contents[6] = 1; // EV_CURRENT
+  contents.writeUInt16LE(3, 16); // ET_DYN
+  contents.writeUInt16LE(machine, 18);
+  contents.writeUInt32LE(1, 20);
+  contents.write(marker, 64, "utf8");
+  return contents;
+}
+
+function bindingRelativePath(arch) {
+  return path.join(
+    "prebuilds",
+    `HID_hidraw-linux-${arch}`,
+    "node-napi-v4.node",
+  );
+}
+
+function createBundledFixture(t, options = {}) {
+  const root = tempDirectory(t, "codex-micro-bundled-");
+  const extractedDir = path.join(root, "app-extracted");
+  const deviceKitDir = path.join(extractedDir, DEVICE_KIT_RELATIVE);
+  const workLouderKitDir = path.join(extractedDir, WORK_LOUDER_KIT_RELATIVE);
+  const nodeHidDir = path.join(extractedDir, NODE_HID_RELATIVE);
+
+  fs.mkdirSync(extractedDir, { recursive: true });
+  if (options.includeDeviceKit !== false) {
+    writeJson(path.join(deviceKitDir, "package.json"), {
+      name: "@worklouder/device-kit-oai",
+      version: "0.4.0",
+      dependencies: { "@worklouder/wl-device-kit": "0.12.0" },
+    });
+    writeFile(path.join(deviceKitDir, "dist/index.js"), "device-kit-oai bundled bytes\n");
+  }
+  if (options.includeDeviceKit !== false && options.includeWorkLouderKit !== false) {
+    writeJson(path.join(workLouderKitDir, "package.json"), {
+      name: "@worklouder/wl-device-kit",
+      version: "0.12.0",
+      dependencies: { "node-hid": options.bundledVersion ?? "3.3.0" },
+    });
+    writeFile(path.join(workLouderKitDir, "dist/index.js"), "wl-device-kit bundled bytes\n");
+  }
+  if (
+    options.includeDeviceKit !== false &&
+    options.includeWorkLouderKit !== false &&
+    options.includeNodeHid !== false
+  ) {
+    writeJson(path.join(nodeHidDir, "package.json"), {
+      name: "node-hid",
+      version: options.bundledVersion ?? "3.3.0",
+      license: "(MIT OR X11)",
+      main: "./nodehid.js",
+      binary: { napi_versions: [4] },
+    });
+    writeFile(path.join(nodeHidDir, "nodehid.js"), FIXTURE_NODE_HID_LOADER);
+    writeFile(path.join(nodeHidDir, "binding-options.js"), FIXTURE_NODE_HID_OPTIONS);
+    writeFile(
+      path.join(nodeHidDir, "prebuilds/HID-darwin-arm64/node-napi-v4.node"),
+      "bundled Mach-O bytes",
+    );
+  }
+
+  // Neither a hoisted package nor a node-hid nested at the wrong Work Louder
+  // level is the dependency used by the current codex-micro service.
+  writeJson(path.join(extractedDir, "node_modules/node-hid/package.json"), {
+    name: "node-hid",
+    version: "99.0.0",
+  });
+  if (options.includeDeviceKit !== false) {
+    writeJson(path.join(deviceKitDir, "node_modules/node-hid/package.json"), {
+      name: "node-hid",
+      version: "98.0.0",
+    });
+  }
+
+  return {
+    extractedDir,
+    deviceKitDir,
+    workLouderKitDir,
+    nodeHidDir,
+  };
+}
+
+function fixtureArtifact(binaries = {}) {
+  const x64 = binaries.x64 ?? makeElf("x64", "fixture-x64");
+  const arm64 = binaries.arm64 ?? makeElf("arm64", "fixture-arm64");
+  return {
+    ...CURRENT_ARTIFACT,
+    loaderContract: {
+      main: "./nodehid.js",
+      napiVersions: [4],
+      files: {
+        "nodehid.js": sha256(FIXTURE_NODE_HID_LOADER),
+        "binding-options.js": sha256(FIXTURE_NODE_HID_OPTIONS),
+      },
+    },
+    prebuilds: {
+      x64: {
+        path: CURRENT_ARTIFACT.prebuilds.x64.path,
+        sha256: sha256(x64),
+      },
+      arm64: {
+        path: CURRENT_ARTIFACT.prebuilds.arm64.path,
+        sha256: sha256(arm64),
+      },
+    },
+  };
+}
+
+function createMaterializedPackage(t, options = {}) {
+  const packageDir = path.join(
+    tempDirectory(t, "codex-micro-node-hid-artifact-"),
+    "package",
+  );
+  const packageMetadata = {
+    name: "node-hid",
+    version: "3.3.0",
+    license: "(MIT OR X11)",
+    main: "nodehid.js",
+    scripts: { install: "this must never be run" },
+    ...options.packageMetadata,
+  };
+  writeJson(path.join(packageDir, "package.json"), packageMetadata);
+  writeFile(path.join(packageDir, "nodehid.js"), "throw new Error('artifact JS must not be copied');\n");
+  writeFile(path.join(packageDir, "README.md"), "artifact documentation must not be copied\n");
+  writeFile(path.join(packageDir, "src/hid.cc"), "artifact source must not be copied\n");
+
+  for (const [arch, binary] of Object.entries(options.binaries ?? {})) {
+    writeFile(path.join(packageDir, bindingRelativePath(arch)), binary, 0o755);
+  }
+  return packageDir;
+}
+
+function bundledSnapshots(fixture) {
+  return new Map(
+    [
+      "package.json",
+      "nodehid.js",
+      "binding-options.js",
+      "prebuilds/HID-darwin-arm64/node-napi-v4.node",
+    ].map((relativePath) => [
+      relativePath,
+      fs.readFileSync(path.join(fixture.nodeHidDir, relativePath)),
+    ]),
+  );
+}
+
+function assertBundledSnapshots(fixture, snapshots) {
+  for (const [relativePath, expected] of snapshots) {
+    assert.deepEqual(
+      fs.readFileSync(path.join(fixture.nodeHidDir, relativePath)),
+      expected,
+      `${relativePath} changed`,
+    );
+  }
+}
+
+async function assertStageRejects(options, expected) {
+  await assert.rejects(
+    async () => stageCodexMicroNativeBinding(options),
+    expected,
+  );
+}
+
+test("discovers only the current nested Work Louder node-hid package", (t) => {
+  const fixture = createBundledFixture(t);
+
+  const discovered = discoverBundledNodeHid(fixture.extractedDir);
+
+  assert.equal(discovered.deviceKitDir, fixture.deviceKitDir);
+  assert.equal(discovered.workLouderKitDir, fixture.workLouderKitDir);
+  assert.equal(discovered.nodeHidDir, fixture.nodeHidDir);
+  assert.equal(discovered.name, "node-hid");
+  assert.equal(discovered.version, "3.3.0");
+  assert.equal(discovered.license, "(MIT OR X11)");
+});
+
+test("missing Work Louder packages are reported as upstream drift", (t) => {
+  const missingOuter = createBundledFixture(t, { includeDeviceKit: false });
+  assert.throws(
+    () => discoverBundledNodeHid(missingOuter.extractedDir),
+    /Work Louder.*device-kit-oai|device-kit-oai.*missing/i,
+  );
+
+  const missingNested = createBundledFixture(t, { includeWorkLouderKit: false });
+  assert.throws(
+    () => discoverBundledNodeHid(missingNested.extractedDir),
+    /Work Louder.*wl-device-kit|wl-device-kit.*missing/i,
+  );
+});
+
+test("missing nested node-hid is reported without accepting a hoisted decoy", (t) => {
+  const fixture = createBundledFixture(t, { includeNodeHid: false });
+
+  assert.throws(
+    () => discoverBundledNodeHid(fixture.extractedDir),
+    /nested node-hid|node-hid.*missing/i,
+  );
+});
+
+test("same-version node-hid loader drift rejects candidate staging", async (t) => {
+  const fixture = createBundledFixture(t);
+  writeFile(
+    path.join(fixture.nodeHidDir, "nodehid.js"),
+    "module.exports = require('./unexpected-loader');\n",
+  );
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      artifactManifest: fixtureArtifact(),
+      materializePackage: async () => {
+        throw new Error("loader drift must fail before materialization");
+      },
+    },
+    /loader contract hash mismatch.*nodehid\.js/i,
+  );
+});
+
+test("same-version node-hid N-API metadata drift rejects candidate staging", async (t) => {
+  const fixture = createBundledFixture(t);
+  const packagePath = path.join(fixture.nodeHidDir, "package.json");
+  const metadata = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  metadata.binary.napi_versions = [5];
+  writeJson(packagePath, metadata);
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      artifactManifest: fixtureArtifact(),
+      materializePackage: async () => {
+        throw new Error("N-API drift must fail before materialization");
+      },
+    },
+    /N-API contract mismatch/i,
+  );
+});
+
+test("selects the exact node-hid 3.3.0 hidraw prebuild for x64", () => {
+  const selected = selectPrebuild(CURRENT_ARTIFACT, "x64");
+
+  assert.equal(selected.path, "prebuilds/HID_hidraw-linux-x64/node-napi-v4.node");
+  assert.equal(
+    selected.sha256,
+    "6c7f3b3fcc238a74e7e3237b50b2ff05181e94862b1963e8074ff8fc75885021",
+  );
+});
+
+test("selects the exact node-hid 3.3.0 hidraw prebuild for arm64", () => {
+  const selected = selectPrebuild(CURRENT_ARTIFACT, "arm64");
+
+  assert.equal(selected.path, "prebuilds/HID_hidraw-linux-arm64/node-napi-v4.node");
+  assert.equal(
+    selected.sha256,
+    "06ea97f377e2246a1e9bf3770186727e72ff3c166579d9c259c6d32a07aeaa60",
+  );
+});
+
+test("prebuild selection distinguishes unavailable artifacts from unsupported architectures", () => {
+  const unavailable = { ...CURRENT_ARTIFACT, prebuilds: { arm64: CURRENT_ARTIFACT.prebuilds.arm64 } };
+
+  assert.equal(selectPrebuild(unavailable, "x64"), null);
+  assert.throws(
+    () => selectPrebuild(CURRENT_ARTIFACT, "riscv64"),
+    /unsupported.*architecture.*riscv64/i,
+  );
+});
+
+for (const arch of ["x64", "arm64"]) {
+  test(`stages the verified ${arch} prebuild at the nested loader path`, async (t) => {
+    const binary = makeElf(arch, `stage-${arch}`);
+    const artifactManifest = fixtureArtifact({ [arch]: binary });
+    const fixture = createBundledFixture(t);
+    const packageDir = createMaterializedPackage(t, { binaries: { [arch]: binary } });
+    const materializeCalls = [];
+    let buildCalls = 0;
+
+    const result = await stageCodexMicroNativeBinding({
+      extractedDir: fixture.extractedDir,
+      arch,
+      electronVersion: "42.1.0",
+      artifactManifest,
+      materializePackage: async (request) => {
+        materializeCalls.push(request);
+        return { packageDir, integrity: NODE_HID_INTEGRITY };
+      },
+      buildFromSource: async () => {
+        buildCalls += 1;
+        throw new Error("source build should not run when a prebuild exists");
+      },
+    });
+
+    const targetPath = path.join(fixture.nodeHidDir, bindingRelativePath(arch));
+    assert.deepEqual(materializeCalls, [
+      { name: "node-hid", version: "3.3.0", integrity: NODE_HID_INTEGRITY },
+    ]);
+    assert.equal(buildCalls, 0);
+    assert.deepEqual(fs.readFileSync(targetPath), binary);
+    assert.equal(result.changed, true);
+    assert.equal(result.alreadyApplied, false);
+    assert.equal(result.version, "3.3.0");
+    assert.equal(result.targetPath, targetPath);
+    assert.equal(result.source, "prebuild");
+    assert.equal(result.integrity, NODE_HID_INTEGRITY);
+  });
+}
+
+test("copies only the selected native subtree and preserves bundled JS byte-for-byte", async (t) => {
+  const binary = makeElf("x64", "native-only");
+  const artifactManifest = fixtureArtifact({ x64: binary });
+  const fixture = createBundledFixture(t);
+  const snapshots = bundledSnapshots(fixture);
+  const packageDir = createMaterializedPackage(t, {
+    binaries: {
+      x64: binary,
+      arm64: makeElf("arm64", "must-not-copy-arm64"),
+    },
+  });
+
+  await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    electronVersion: "42.1.0",
+    artifactManifest,
+    materializePackage: async () => ({ packageDir, integrity: NODE_HID_INTEGRITY }),
+    buildFromSource: async () => {
+      throw new Error("unexpected source build");
+    },
+  });
+
+  assertBundledSnapshots(fixture, snapshots);
+  assert.equal(fs.existsSync(path.join(fixture.nodeHidDir, "README.md")), false);
+  assert.equal(fs.existsSync(path.join(fixture.nodeHidDir, "src/hid.cc")), false);
+  assert.equal(
+    fs.existsSync(path.join(fixture.nodeHidDir, bindingRelativePath("arm64"))),
+    false,
+  );
+  assert.deepEqual(
+    fs.readFileSync(path.join(fixture.nodeHidDir, bindingRelativePath("x64"))),
+    binary,
+  );
+});
+
+test("a hash-valid existing binding is idempotent and performs no fetch or build", async (t) => {
+  const binary = makeElf("x64", "already-correct");
+  const artifactManifest = fixtureArtifact({ x64: binary });
+  const fixture = createBundledFixture(t);
+  const targetPath = path.join(fixture.nodeHidDir, bindingRelativePath("x64"));
+  writeFile(targetPath, binary, 0o755);
+  const snapshots = bundledSnapshots(fixture);
+
+  const result = await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    electronVersion: "42.1.0",
+    artifactManifest,
+    materializePackage: async () => {
+      throw new Error("correct existing binding must not fetch");
+    },
+    buildFromSource: async () => {
+      throw new Error("correct existing binding must not build");
+    },
+  });
+
+  assert.equal(result.changed, false);
+  assert.equal(result.alreadyApplied, true);
+  assert.equal(result.version, "3.3.0");
+  assert.equal(result.targetPath, targetPath);
+  assert.equal(result.source, "existing");
+  assert.equal(result.integrity, NODE_HID_INTEGRITY);
+  assert.deepEqual(fs.readFileSync(targetPath), binary);
+  assertBundledSnapshots(fixture, snapshots);
+});
+
+test("an unavailable prebuild invokes the injected Electron source-build fallback", async (t) => {
+  const binary = makeElf("x64", "source-build");
+  const artifactManifest = fixtureArtifact();
+  delete artifactManifest.prebuilds.x64;
+  const fixture = createBundledFixture(t);
+  const toolchainDir = path.join(tempDirectory(t, "codex-micro-source-toolchain-"), "source-build");
+  fs.cpSync(path.join(__dirname, "source-build"), toolchainDir, { recursive: true });
+  const packageDir = createMaterializedPackage(t);
+  const buildRoot = tempDirectory(t, "codex-micro-source-build-");
+  const builtBindingPath = path.join(buildRoot, "build/Release/HID_hidraw.node");
+  writeFile(builtBindingPath, binary, 0o755);
+  const buildCalls = [];
+
+  const result = await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    electronVersion: "42.1.0",
+    sourceBuildToolchainDir: toolchainDir,
+    artifactManifest,
+    materializePackage: async () => ({ packageDir, integrity: NODE_HID_INTEGRITY }),
+    buildFromSource: async (request) => {
+      buildCalls.push(request);
+      return { bindingPath: builtBindingPath };
+    },
+  });
+
+  assert.equal(buildCalls.length, 1);
+  assert.equal(buildCalls[0].packageDir, packageDir);
+  assert.equal(buildCalls[0].name, "node-hid");
+  assert.equal(buildCalls[0].version, "3.3.0");
+  assert.equal(buildCalls[0].arch, "x64");
+  assert.equal(buildCalls[0].electronVersion, "42.1.0");
+  assert.equal(buildCalls[0].targetRelativePath, bindingRelativePath("x64"));
+
+  const targetPath = path.join(fixture.nodeHidDir, bindingRelativePath("x64"));
+  assert.deepEqual(fs.readFileSync(targetPath), binary);
+  assert.equal(result.changed, true);
+  assert.equal(result.alreadyApplied, false);
+  assert.equal(result.targetPath, targetPath);
+  assert.equal(result.source, "source-build");
+  assert.equal(result.integrity, NODE_HID_INTEGRITY);
+
+  let materializeCalls = 0;
+  let repeatedBuildCalls = 0;
+  const repeated = await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    electronVersion: "42.1.0",
+    sourceBuildToolchainDir: toolchainDir,
+    artifactManifest,
+    materializePackage: async () => {
+      materializeCalls += 1;
+      throw new Error("valid source-build provenance must avoid materialization");
+    },
+    buildFromSource: async () => {
+      repeatedBuildCalls += 1;
+      throw new Error("valid source-build provenance must avoid recompilation");
+    },
+  });
+  assert.equal(materializeCalls, 0);
+  assert.equal(repeatedBuildCalls, 0);
+  assert.equal(repeated.changed, false);
+  assert.equal(repeated.alreadyApplied, true);
+  assert.equal(repeated.source, "existing-source-build");
+
+  fs.appendFileSync(path.join(toolchainDir, "package-lock.json"), "\n");
+  let lockChangeMaterializeCalls = 0;
+  let lockChangeBuildCalls = 0;
+  const rebuilt = await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    electronVersion: "42.1.0",
+    sourceBuildToolchainDir: toolchainDir,
+    artifactManifest,
+    materializePackage: async () => {
+      lockChangeMaterializeCalls += 1;
+      return { packageDir, integrity: NODE_HID_INTEGRITY };
+    },
+    buildFromSource: async () => {
+      lockChangeBuildCalls += 1;
+      return { bindingPath: builtBindingPath };
+    },
+  });
+  assert.equal(lockChangeMaterializeCalls, 1);
+  assert.equal(lockChangeBuildCalls, 1);
+  assert.equal(rebuilt.changed, true);
+  assert.equal(rebuilt.source, "source-build");
+});
+
+test("prebuild-only environments fail before a source fallback can fetch or compile", async (t) => {
+  const artifactManifest = fixtureArtifact();
+  delete artifactManifest.prebuilds.x64;
+  const fixture = createBundledFixture(t);
+  let materializeCalls = 0;
+  let buildCalls = 0;
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      requirePrebuild: true,
+      artifactManifest,
+      materializePackage: async () => {
+        materializeCalls += 1;
+      },
+      buildFromSource: async () => {
+        buildCalls += 1;
+      },
+    },
+    /verified node-hid prebuild is required.*x64/i,
+  );
+  assert.equal(materializeCalls, 0);
+  assert.equal(buildCalls, 0);
+});
+
+test("the default source builder seeds Electron rebuild with the verified node-hid package", async (t) => {
+  const root = tempDirectory(t, "codex-micro-default-source-build-");
+  const packageDir = path.join(root, "materialized", "package");
+  const binary = makeElf("x64", "default-source-builder");
+  fs.mkdirSync(packageDir, { recursive: true });
+  writeJson(path.join(packageDir, "package.json"), {
+    name: "node-hid",
+    version: "3.3.0",
+    license: "(MIT OR X11)",
+    gypfile: true,
+  });
+  writeFile(path.join(packageDir, "binding.gyp"), "{}\n");
+  const calls = [];
+  const execute = (command, args, options) => {
+    calls.push({ command, args: [...args], cwd: options?.cwd });
+    if (command === "pkg-config") {
+      assert.deepEqual(args, ["--exists", "libudev", "libusb-1.0"]);
+      return "";
+    }
+    if (command === "npm") {
+      assert.ok(fs.existsSync(path.join(options.cwd, "package.json")));
+      assert.ok(fs.existsSync(path.join(options.cwd, "package-lock.json")));
+      const cli = path.join(options.cwd, "node_modules", "@electron", "rebuild", "lib", "cli.js");
+      writeFile(cli, "// deterministic electron-rebuild fixture\n");
+      return "";
+    }
+
+    const value = (flag) => {
+      const index = args.indexOf(flag);
+      return index < 0 ? null : args[index + 1];
+    };
+    assert.equal(command, process.execPath);
+    assert.equal(value("--which-module"), "node-hid");
+    assert.equal(value("--only"), "node-hid");
+    assert.ok(args.includes("--build-from-source"));
+    assert.equal(value("-v"), "42.3.0");
+    assert.equal(value("--arch"), "x64");
+    const moduleDir = path.join(options.cwd, "node_modules", "node-hid");
+    assert.ok(fs.existsSync(path.join(moduleDir, "package.json")));
+    assert.ok(fs.existsSync(path.join(moduleDir, "binding.gyp")));
+    writeFile(path.join(moduleDir, "build", "Release", "HID_hidraw.node"), binary, 0o755);
+    return "";
+  };
+
+  let built;
+  built = await defaultBuildFromSource({
+    packageDir,
+    name: "node-hid",
+    version: "3.3.0",
+    arch: "x64",
+    electronVersion: "42.3.0",
+    execute,
+  });
+
+  t.after(() => built?.cleanup?.());
+  assert.deepEqual(fs.readFileSync(built.bindingPath), binary);
+  assert.equal(calls.length, 3);
+  const npmArgs = calls[1].args;
+  assert.deepEqual(npmArgs, ["ci", "--ignore-scripts", "--no-audit", "--no-fund"]);
+  assert.ok(!npmArgs.some((arg) => arg.startsWith("electron@")));
+});
+
+test("the default source builder explains missing native development prerequisites before npm", async (t) => {
+  const root = tempDirectory(t, "codex-micro-source-prerequisites-");
+  const packageDir = path.join(root, "package");
+  writeJson(path.join(packageDir, "package.json"), {
+    name: "node-hid",
+    version: "3.3.0",
+    license: "(MIT OR X11)",
+  });
+  const calls = [];
+
+  await assert.rejects(
+    defaultBuildFromSource({
+      packageDir,
+      name: "node-hid",
+      version: "3.3.0",
+      arch: "x64",
+      electronVersion: "42.3.0",
+      execute: (command) => {
+        calls.push(command);
+        throw new Error("pkg-config unavailable");
+      },
+    }),
+    /pkg-config.*libudev.*libusb.*development packages/i,
+  );
+  assert.deepEqual(calls, ["pkg-config"]);
+});
+
+test("unsupported staging architectures fail before package materialization", async (t) => {
+  const fixture = createBundledFixture(t);
+  let materializeCalls = 0;
+  let buildCalls = 0;
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "riscv64",
+      electronVersion: "42.1.0",
+      artifactManifest: fixtureArtifact(),
+      materializePackage: async () => {
+        materializeCalls += 1;
+      },
+      buildFromSource: async () => {
+        buildCalls += 1;
+      },
+    },
+    /unsupported.*architecture.*riscv64/i,
+  );
+
+  assert.equal(materializeCalls, 0);
+  assert.equal(buildCalls, 0);
+});
+
+test("bundled node-hid version drift fails before fetch and never falls back", async (t) => {
+  const fixture = createBundledFixture(t, { bundledVersion: "3.2.0" });
+  let materializeCalls = 0;
+  let buildCalls = 0;
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      artifactManifest: fixtureArtifact(),
+      materializePackage: async () => {
+        materializeCalls += 1;
+      },
+      buildFromSource: async () => {
+        buildCalls += 1;
+      },
+    },
+    /node-hid.*version.*3\.3\.0.*3\.2\.0|expected.*3\.3\.0.*got.*3\.2\.0/i,
+  );
+
+  assert.equal(materializeCalls, 0);
+  assert.equal(buildCalls, 0);
+});
+
+for (const scenario of [
+  {
+    label: "package identity",
+    packageMetadata: { name: "not-node-hid" },
+    integrity: NODE_HID_INTEGRITY,
+    expected: /node-hid.*identity|identity.*node-hid/i,
+  },
+  {
+    label: "package version",
+    packageMetadata: { version: "3.3.1" },
+    integrity: NODE_HID_INTEGRITY,
+    expected: /version.*3\.3\.0.*3\.3\.1|expected.*3\.3\.0.*got.*3\.3\.1/i,
+  },
+  {
+    label: "package license",
+    packageMetadata: { license: "UNLICENSED" },
+    integrity: NODE_HID_INTEGRITY,
+    expected: /license.*MIT OR X11|expected.*MIT OR X11.*UNLICENSED/i,
+  },
+  {
+    label: "package integrity",
+    packageMetadata: {},
+    integrity: "sha512-unverified",
+    expected: /integrity/i,
+  },
+]) {
+  test(`rejects a materialized node-hid artifact with the wrong ${scenario.label}`, async (t) => {
+    const binary = makeElf("x64", `wrong-${scenario.label}`);
+    const artifactManifest = fixtureArtifact({ x64: binary });
+    const fixture = createBundledFixture(t);
+    const packageDir = createMaterializedPackage(t, {
+      packageMetadata: scenario.packageMetadata,
+      binaries: { x64: binary },
+    });
+    let buildCalls = 0;
+
+    await assertStageRejects(
+      {
+        extractedDir: fixture.extractedDir,
+        arch: "x64",
+        electronVersion: "42.1.0",
+        artifactManifest,
+        materializePackage: async () => ({
+          packageDir,
+          integrity: scenario.integrity,
+        }),
+        buildFromSource: async () => {
+          buildCalls += 1;
+        },
+      },
+      scenario.expected,
+    );
+
+    assert.equal(buildCalls, 0, "metadata drift must not trigger a source build");
+    assert.equal(
+      fs.existsSync(path.join(fixture.nodeHidDir, bindingRelativePath("x64"))),
+      false,
+    );
+  });
+}
+
+test("inspectElf identifies the supported 64-bit little-endian machines", () => {
+  assert.equal(inspectElf(makeElf("x64")).arch, "x64");
+  assert.equal(inspectElf(makeElf("arm64")).arch, "arm64");
+});
+
+test("inspectElf rejects non-ELF, 32-bit, big-endian, and unknown-machine binaries", () => {
+  assert.throws(() => inspectElf(Buffer.from("not an ELF")), /ELF/i);
+
+  const elf32 = makeElf("x64");
+  elf32[4] = 1;
+  assert.throws(() => inspectElf(elf32), /64-bit|ELF class/i);
+
+  const bigEndian = makeElf("x64");
+  bigEndian[5] = 2;
+  assert.throws(() => inspectElf(bigEndian), /little-endian|ELF encoding/i);
+
+  const unknownMachine = makeElf("x64");
+  unknownMachine.writeUInt16LE(243, 18);
+  assert.throws(() => inspectElf(unknownMachine), /unsupported.*ELF machine|machine.*243/i);
+});
+
+test("rejects a hash-valid prebuild whose ELF architecture is wrong", async (t) => {
+  const arm64Binary = makeElf("arm64", "arm64-under-x64-path");
+  const artifactManifest = fixtureArtifact();
+  artifactManifest.prebuilds.x64.sha256 = sha256(arm64Binary);
+  const fixture = createBundledFixture(t);
+  const packageDir = createMaterializedPackage(t, { binaries: { x64: arm64Binary } });
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      artifactManifest,
+      materializePackage: async () => ({ packageDir, integrity: NODE_HID_INTEGRITY }),
+      buildFromSource: async () => {
+        throw new Error("wrong architecture must not fall back");
+      },
+    },
+    /ELF.*arm64.*x64|architecture.*arm64.*x64/i,
+  );
+
+  assert.equal(
+    fs.existsSync(path.join(fixture.nodeHidDir, bindingRelativePath("x64"))),
+    false,
+  );
+});
+
+test("rejects a same-architecture prebuild whose SHA-256 does not match", async (t) => {
+  const binary = makeElf("x64", "tampered-prebuild");
+  const artifactManifest = fixtureArtifact({ x64: makeElf("x64", "expected-prebuild") });
+  const fixture = createBundledFixture(t);
+  const packageDir = createMaterializedPackage(t, { binaries: { x64: binary } });
+
+  await assertStageRejects(
+    {
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      electronVersion: "42.1.0",
+      artifactManifest,
+      materializePackage: async () => ({ packageDir, integrity: NODE_HID_INTEGRITY }),
+      buildFromSource: async () => {
+        throw new Error("hash mismatch must not fall back");
+      },
+    },
+    /SHA-256|sha256|hash.*mismatch/i,
+  );
+
+  assert.equal(
+    fs.existsSync(path.join(fixture.nodeHidDir, bindingRelativePath("x64"))),
+    false,
+  );
+});
+
+test("udev policy has narrow USB and Bluetooth Codex Micro hidraw rules", () => {
+  const rulePath = path.join(__dirname, "resources", "70-codex-micro.rules");
+  const source = fs.readFileSync(rulePath, "utf8");
+  const activeRules = source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+  assert.equal(activeRules.length, 2, "udev policy must contain exactly two active rules");
+  const [usbRule, bluetoothRule] = activeRules;
+  for (const rule of activeRules) {
+    assert.match(rule, /(?:^|,\s*)SUBSYSTEM=="hidraw"(?:,|$)/);
+    assert.match(rule, /KERNEL=="hidraw\*"/);
+    assert.match(rule, /TAG\+="uaccess"/);
+    assert.match(rule, /MODE="0660"/);
+  }
+
+  assert.match(usbRule, /ENV\{ID_VENDOR_ID\}=="303a"/i);
+  assert.match(usbRule, /ENV\{ID_MODEL_ID\}=="8360"/i);
+  assert.match(usbRule, /ENV\{ID_USB_INTERFACE_NUM\}=="00"/);
+  assert.doesNotMatch(usbRule, /KERNELS=="0005:/);
+
+  assert.match(bluetoothRule, /KERNELS=="0005:303A:8360\.\*"/);
+  assert.doesNotMatch(bluetoothRule, /ID_USB_INTERFACE_NUM/);
+  assert.doesNotMatch(bluetoothRule, /HID_UNIQ|[0-9A-F]{2}(?::[0-9A-F]{2}){5}/i);
+
+  assert.doesNotMatch(source, /MODE="0666"/);
+  assert.doesNotMatch(source, /SUBSYSTEM=="usb"/);
+});
+
+test("pacman removal hook reloads only after the feature-owned rule is removed", () => {
+  const hookPath = path.join(__dirname, "resources", "codex-micro-udev.hook");
+  const source = fs.readFileSync(hookPath, "utf8");
+
+  assert.match(source, /^\[Trigger\]$/m);
+  assert.match(source, /^Operation = Remove$/m);
+  assert.doesNotMatch(source, /^Operation = (?:Install|Upgrade)$/m);
+  assert.match(source, /^Type = Path$/m);
+  assert.match(source, /^Target = usr\/lib\/udev\/rules\.d\/70-codex-micro\.rules$/m);
+  assert.doesNotMatch(source, /^Target = .*[*?!]/m);
+  assert.match(source, /^\[Action\]$/m);
+  assert.match(source, /^When = PostTransaction$/m);
+  assert.match(source, /^Exec = \/bin\/sh -c ".*command -v udevadm.*--reload-rules.*\|\| true.*"$/m);
+});
+
+test("disabled codex-micro performs no patch or native package work", (t) => {
+  const root = tempDirectory(t, "codex-micro-disabled-config-");
+  const configPath = path.join(root, "features.json");
+  writeJson(configPath, { enabled: [] });
+  const frameworkOptions = {
+    featuresRoot: path.resolve(__dirname, ".."),
+    featuresConfigPath: configPath,
+  };
+
+  assert.deepEqual(loadLinuxFeaturePatchDescriptors(frameworkOptions), []);
+  for (const packageFormat of ["deb", "rpm", "pacman"]) {
+    const options = { ...frameworkOptions, packageFormat };
+    assert.deepEqual(enabledLinuxFeaturePackageDependencies(options), []);
+    assert.deepEqual(enabledLinuxFeaturePackageFiles(options), []);
+  }
+});
+
+test("native package formats stage the exact rule and feature-only dependencies", (t) => {
+  const root = tempDirectory(t, "codex-micro-package-resources-");
+  const configPath = path.join(root, "features.json");
+  writeJson(configPath, { enabled: ["codex-micro"] });
+  const expectedDependencies = {
+    deb: ["libudev1", "libusb-1.0-0"],
+    rpm: [
+      "libudev.so.1%{codex_elf_suffix}",
+      "libusb-1.0.so.0%{codex_elf_suffix}",
+    ],
+    pacman: ["libusb", "systemd-libs"],
+  };
+  const expectedRule = fs.readFileSync(
+    path.join(__dirname, "resources", "70-codex-micro.rules"),
+  );
+  const expectedPacmanHook = fs.readFileSync(
+    path.join(__dirname, "resources", "codex-micro-udev.hook"),
+  );
+
+  for (const packageFormat of ["deb", "rpm", "pacman"]) {
+    const packageRoot = path.join(root, packageFormat);
+    const options = {
+      featuresRoot: path.resolve(__dirname, ".."),
+      featuresConfigPath: configPath,
+      packageFormat,
+    };
+    const plan = stageEnabledLinuxFeaturePackageResources(packageRoot, options);
+    const target = path.join(
+      packageRoot,
+      "usr",
+      "lib",
+      "udev",
+      "rules.d",
+      "70-codex-micro.rules",
+    );
+
+    assert.deepEqual(plan.dependencies, expectedDependencies[packageFormat]);
+    assert.deepEqual(enabledLinuxFeaturePackageDependencies(options), expectedDependencies[packageFormat]);
+    const expectedFiles = ["/usr/lib/udev/rules.d/70-codex-micro.rules"];
+    if (packageFormat === "pacman") {
+      expectedFiles.push("/usr/share/libalpm/hooks/codex-micro-udev.hook");
+    }
+    assert.deepEqual(enabledLinuxFeaturePackageFiles(options), expectedFiles);
+    assert.deepEqual(fs.readFileSync(target), expectedRule);
+    assert.equal(fs.statSync(target).mode & 0o777, 0o644);
+    if (packageFormat === "pacman") {
+      const hookTarget = path.join(
+        packageRoot,
+        "usr",
+        "share",
+        "libalpm",
+        "hooks",
+        "codex-micro-udev.hook",
+      );
+      assert.deepEqual(fs.readFileSync(hookTarget), expectedPacmanHook);
+      assert.equal(fs.statSync(hookTarget).mode & 0o777, 0o644);
+    }
+  }
+});

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -13,6 +13,7 @@ let
   testFeatureIds = [
     "persistent-status-panel"
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -24,9 +25,11 @@ let
     "remote-control-ui"
     "ui-tweaks"
     "appshots"
+    "codex-micro"
   ];
   normalizedTestFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -42,6 +45,7 @@ let
   watchdogFeatureIds = (builtins.fromJSON (builtins.readFile ../scripts/ci/watchdog-linux-features.json)).enabled;
   normalizedWatchdogFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -84,6 +88,10 @@ let
               type = lib.types.attrsOf lib.types.anything;
               default = { };
             };
+            services.udev.packages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [ ];
+            };
           };
           config = {
             home.homeDirectory = "/home/tester";
@@ -117,6 +125,10 @@ let
               type = lib.types.attrsOf lib.types.anything;
               default = { };
             };
+            services.udev.packages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [ ];
+            };
           };
           config.programs.codexDesktopLinux = moduleConfig;
         })
@@ -129,6 +141,14 @@ let
     builtins.head (evalNixOS moduleConfig).config.environment.systemPackages;
 
   defaultConfig = { enable = true; };
+  codexMicroConfig = {
+    enable = true;
+    linuxFeatures = [ "codex-micro" ];
+  };
+  disabledCodexMicroConfig = {
+    enable = false;
+    linuxFeatures = [ "codex-micro" ];
+  };
   legacyRemoteConfig = {
     enable = true;
     remoteMobileControl.enable = true;
@@ -144,11 +164,15 @@ let
     enableComputerUseUi = true;
     linuxFeatureIds = normalizedTestFeatureIds;
   };
+  expectedCodexMicro = packages.codex-desktop.override {
+    linuxFeatureIds = [ "codex-micro" ];
+  };
   reorderedCombined = packages.codex-desktop.override {
     enableComputerUseUi = true;
     linuxFeatureIds = [
       "remote-mobile-control"
       "frameless-titlebar"
+      "codex-micro"
       "codex-wrapper-updater"
       "directory-only-working-tree-watch"
       "global-dictation"
@@ -160,13 +184,22 @@ let
       "ui-tweaks"
       "appshots"
       "appshots"
+      "codex-micro"
     ];
   };
+
+  homeDefault = evalHomeManager defaultConfig;
+  nixosDefault = evalNixOS defaultConfig;
+  homeCodexMicro = evalHomeManager codexMicroConfig;
+  nixosCodexMicro = evalNixOS codexMicroConfig;
+  homeDisabledCodexMicro = evalHomeManager disabledCodexMicroConfig;
+  nixosDisabledCodexMicro = evalNixOS disabledCodexMicroConfig;
 
   customPackage = pkgs.runCommand "codex-desktop-custom-test-package" { } ''
     mkdir -p "$out"
   '';
   customConfig = combinedConfig // { package = customPackage; };
+  nixosCustom = evalNixOS customConfig;
   remoteControlConfig = {
     enable = true;
     package = customPackage;
@@ -290,6 +323,15 @@ let
   ) contextEnvironmentFiles;
 in
 assert lib.assertMsg
+  (lib.elem "codex-micro" (linuxFeatures.normalize linuxFeatures.supportedFeatureIds))
+  "codex-micro is missing from the normalized Nix-supported feature list";
+assert lib.assertMsg
+  (linuxFeatures.normalize [ "codex-micro" "appshots" "codex-micro" ] == [
+    "appshots"
+    "codex-micro"
+  ])
+  "codex-micro was not accepted, sorted, and deduplicated";
+assert lib.assertMsg
   (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
   "Nix Linux feature IDs must be sorted and deduplicated";
 assert lib.assertMsg
@@ -301,6 +343,39 @@ assert lib.assertMsg
 assert lib.assertMsg
   ((nixosPackage defaultConfig).drvPath == packages.codex-desktop.drvPath)
   "the NixOS default package changed";
+assert lib.assertMsg
+  ((homePackage codexMicroConfig).drvPath == expectedCodexMicro.drvPath)
+  "Home Manager did not select the codex-micro package";
+assert lib.assertMsg
+  ((nixosPackage codexMicroConfig).drvPath == expectedCodexMicro.drvPath)
+  "NixOS did not select the codex-micro package";
+assert lib.assertMsg
+  (expectedCodexMicro.drvPath != packages.codex-desktop.drvPath)
+  "enabling codex-micro did not change the selected package";
+assert lib.assertMsg
+  (builtins.length nixosCodexMicro.config.services.udev.packages == 1)
+  "NixOS did not install the codex-micro udev-rules package";
+assert lib.assertMsg
+  (homeCodexMicro.config.services.udev.packages == [ ])
+  "Home Manager claimed system-wide codex-micro udev installation";
+assert lib.assertMsg
+  (homeDefault.config.services.udev.packages == [ ])
+  "the Home Manager default unexpectedly installs codex-micro udev rules";
+assert lib.assertMsg
+  (nixosDefault.config.services.udev.packages == [ ])
+  "the NixOS default unexpectedly installs codex-micro udev rules";
+assert lib.assertMsg
+  (homeDisabledCodexMicro.config.home.packages == [ ])
+  "disabled Home Manager unexpectedly selected the codex-micro package";
+assert lib.assertMsg
+  (nixosDisabledCodexMicro.config.environment.systemPackages == [ ])
+  "disabled NixOS unexpectedly selected the codex-micro package";
+assert lib.assertMsg
+  (homeDisabledCodexMicro.config.services.udev.packages == [ ])
+  "disabled Home Manager unexpectedly installs codex-micro udev rules";
+assert lib.assertMsg
+  (nixosDisabledCodexMicro.config.services.udev.packages == [ ])
+  "disabled NixOS unexpectedly installs codex-micro udev rules";
 assert lib.assertMsg
   ((homePackage legacyRemoteConfig).drvPath == packages.codex-desktop-remote-mobile-control.drvPath)
   "the Home Manager remoteMobileControl shorthand changed";
@@ -322,6 +397,9 @@ assert lib.assertMsg
 assert lib.assertMsg
   ((nixosPackage customConfig).drvPath == customPackage.drvPath)
   "the NixOS custom package override lost precedence";
+assert lib.assertMsg
+  (nixosCustom.config.services.udev.packages == [ ])
+  "the NixOS custom package override unexpectedly inherited codex-micro udev policy";
 assert lib.assertMsg (!invalidBuilder.success) "the package builder accepted an unsupported feature";
 assert lib.assertMsg
   shallowRepositoryWatchBuilder.success

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -2,6 +2,7 @@
 let
   supportedFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -23,6 +23,10 @@ let
     inherit cfg flakePackages lib;
   };
   basePackage = packageSelection.package;
+  codexMicroEnabled =
+    cfg.package == null
+    && lib.elem "codex-micro" packageSelection.normalizedFeatureIds;
+  codexMicroUdevRules = flakePackages.codex-micro-udev-rules;
   codexCliPackage =
     if cfg.cliPackage != null then
       cfg.cliPackage
@@ -272,6 +276,10 @@ in
 
     environment.systemPackages = [
       desktopPackage
+    ];
+
+    services.udev.packages = lib.optionals codexMicroEnabled [
+      codexMicroUdevRules
     ];
 
     environment.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -37,6 +37,7 @@ depends=(
     'nspr'
     'nss'
     'pango'
+__LINUX_FEATURE_DEPENDENCIES__
 )
 optdepends=(
     'nodejs>=22.22.0: optional override for the bundled managed Node.js runtime'

--- a/packaging/linux/codex-desktop.spec
+++ b/packaging/linux/codex-desktop.spec
@@ -22,7 +22,7 @@ Requires:       libdrm.so.2%{codex_elf_suffix}, libnspr4.so%{codex_elf_suffix}, 
 Requires:       libpango-1.0.so.0%{codex_elf_suffix}, libstdc++.so.6%{codex_elf_suffix}, libX11.so.6%{codex_elf_suffix}
 Requires:       libxcb.so.1%{codex_elf_suffix}, libXcomposite.so.1%{codex_elf_suffix}, libXdamage.so.1%{codex_elf_suffix}
 Requires:       libXext.so.6%{codex_elf_suffix}, libXfixes.so.3%{codex_elf_suffix}, libxkbcommon.so.0%{codex_elf_suffix}
-Requires:       libXrandr.so.2%{codex_elf_suffix}, libgbm.so.1%{codex_elf_suffix}
+Requires:       libXrandr.so.2%{codex_elf_suffix}, libgbm.so.1%{codex_elf_suffix}__LINUX_FEATURE_DEPENDENCY_SUFFIX__
 Recommends:     zenity, kdialog
 
 %description
@@ -50,6 +50,7 @@ cp -a "__RPM_STAGING_DIR__/." "%{buildroot}/"
 %endif
 /usr/share/applications/__PACKAGE_NAME__.desktop
 /usr/share/icons/hicolor/256x256/apps/__PACKAGE_NAME__.png
+__LINUX_FEATURE_FILES__
 %if __PACKAGE_WITH_UPDATER__
 /usr/share/polkit-1/actions/com.github.ilysenko.codex-desktop-linux.update.policy
 %endif
@@ -63,6 +64,7 @@ if [ -f "$DESKTOP_ENTRY_DOCTOR" ]; then
     . "$DESKTOP_ENTRY_DOCTOR"
     codex_desktop_repair_system_package_shadow_entries __PACKAGE_NAME__ || true
 fi
+__LINUX_FEATURE_UDEV_POST__
 
 %if __PACKAGE_WITH_UPDATER__
 SERVICE_HELPER=/opt/__PACKAGE_NAME__/update-builder/packaging/linux/codex-update-manager-user-service.sh
@@ -106,7 +108,10 @@ if [ -f "$SERVICE_HELPER" ]; then
     . "$SERVICE_HELPER"
     codex_reload_user_managers || true
 fi
+__LINUX_FEATURE_UDEV_POSTUN_BODY__
 %endif
+
+__LINUX_FEATURE_UDEV_POSTUN_SECTION__
 
 %changelog
 * Thu Jan 01 2026 ChatGPT Desktop for Linux Maintainers <maintainers@codex-desktop-linux>

--- a/packaging/linux/control
+++ b/packaging/linux/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: __ARCH__
 Maintainer: ChatGPT Desktop for Linux Maintainers
-Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, xdg-utils, libasound2t64 | libasound2, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2
+Depends: build-essential, curl, dpkg, p7zip-full, pkexec | policykit-1, polkitd | policykit-1, python3, unzip, xdg-utils, libasound2t64 | libasound2, libatk-bridge2.0-0, libatk1.0-0, libc6, libcairo2, libcups2t64 | libcups2, libdbus-1-3, libdrm2, libgbm1, libglib2.0-0t64 | libglib2.0-0, libgtk-3-0t64 | libgtk-3.0-0, libnspr4, libnss3, libpango-1.0-0, libstdc++6, libx11-6, libx11-xcb1, libxcb-dri3-0, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2__LINUX_FEATURE_DEPENDENCY_SUFFIX__
 Recommends: zenity, kdialog
 Description: ChatGPT Desktop for Linux
  Community-built Linux package for ChatGPT Desktop generated from the macOS DMG.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -78,15 +78,21 @@ main() {
     stage_common_package_files "$PKG_ROOT"
     stage_optional_update_builder_bundle "$PKG_ROOT"
     write_launcher_stub "$PKG_ROOT"
+    stage_linux_feature_package_resources "$PKG_ROOT" "deb"
     run_linux_feature_package_hooks "$PKG_ROOT" "deb"
     normalize_package_payload_permissions "$PKG_ROOT"
     restore_linux_feature_payload_permissions "$PKG_ROOT"
+    restore_linux_feature_package_resource_permissions "$PKG_ROOT" "deb"
 
     sed \
         -e "s/__PACKAGE_NAME__/$PACKAGE_NAME/g" \
         -e "s/__VERSION__/$PACKAGE_VERSION/g" \
         -e "s/__ARCH__/$arch/g" \
         "$CONTROL_TEMPLATE" > "$PKG_ROOT/DEBIAN/control"
+    replace_literal_file_token \
+        "$PKG_ROOT/DEBIAN/control" \
+        "__LINUX_FEATURE_DEPENDENCY_SUFFIX__" \
+        "$(linux_feature_package_dependency_suffix deb)"
     if ! package_with_updater_enabled; then
         sed -i \
             -e 's/pkexec | policykit-1, //g' \
@@ -110,6 +116,14 @@ CONTROL
     else
         write_no_updater_deb_postinst "$PKG_ROOT/DEBIAN/postinst"
         write_no_updater_deb_prerm "$PKG_ROOT/DEBIAN/prerm"
+    fi
+    if linux_feature_package_has_udev_rules deb; then
+        inject_udev_reload_before_exit "$PKG_ROOT/DEBIAN/postinst"
+        if [ -f "$PKG_ROOT/DEBIAN/postrm" ]; then
+            inject_udev_reload_before_exit "$PKG_ROOT/DEBIAN/postrm"
+        else
+            write_udev_reload_script "$PKG_ROOT/DEBIAN/postrm"
+        fi
     fi
 
     mkdir -p "$DIST_DIR"

--- a/scripts/build-pacman.sh
+++ b/scripts/build-pacman.sh
@@ -123,9 +123,11 @@ main() {
 	stage_common_package_files "$staging_root"
 	stage_optional_update_builder_bundle "$staging_root"
 	write_launcher_stub "$staging_root"
+	stage_linux_feature_package_resources "$staging_root" "pacman"
 	run_linux_feature_package_hooks "$staging_root" "pacman"
 	normalize_package_payload_permissions "$staging_root"
 	restore_linux_feature_payload_permissions "$staging_root"
+	restore_linux_feature_package_resource_permissions "$staging_root" "pacman"
 
 	local package_name
 	local pacman_pkgver
@@ -145,6 +147,16 @@ main() {
 		-e "s|__STAGING_DIR__|$staging_dir|g" \
 		-e "s/__ARCH__/$arch_replacement/g" \
 		"$PKGBUILD_TEMPLATE" >"$build_root/PKGBUILD"
+	local feature_dependency_lines=""
+	local feature_dependency
+	while IFS= read -r feature_dependency; do
+		[ -n "$feature_dependency" ] || continue
+		feature_dependency_lines+="    '$feature_dependency'"$'\n'
+	done < <(linux_feature_package_dependencies pacman)
+	replace_literal_file_token \
+		"$build_root/PKGBUILD" \
+		"__LINUX_FEATURE_DEPENDENCIES__" \
+		"$feature_dependency_lines"
 	if package_with_updater_enabled; then
 		sed -e "s|/opt/codex-desktop|/opt/$PACKAGE_NAME|g" \
 			-e "s|codex_desktop_repair_system_package_shadow_entries codex-desktop|codex_desktop_repair_system_package_shadow_entries $PACKAGE_NAME|g" \
@@ -154,6 +166,9 @@ main() {
 		sed -i \
 			-e "/'polkit'/d" \
 			"$build_root/PKGBUILD"
+	fi
+	if linux_feature_package_has_udev_rules pacman; then
+		enable_pacman_udev_reload_hooks "$build_root/${PACKAGE_NAME}.install"
 	fi
 
 	mkdir -p "$DIST_DIR"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -101,9 +101,11 @@ main() {
 exec /opt/$PACKAGE_NAME/start.sh "\$@"
 SCRIPT
     chmod 0755 "$staging_root/usr/bin/$PACKAGE_NAME"
+    stage_linux_feature_package_resources "$staging_root" "rpm"
     run_linux_feature_package_hooks "$staging_root" "rpm"
     normalize_package_payload_permissions "$staging_root"
     restore_linux_feature_payload_permissions "$staging_root"
+    restore_linux_feature_package_resource_permissions "$staging_root" "rpm"
 
     local spec_file="$build_root/codex-desktop.spec"
     sed \
@@ -114,6 +116,32 @@ SCRIPT
         -e "s/__ARCH__/$arch/g" \
         -e "s/__PACKAGE_WITH_UPDATER__/$(package_with_updater_enabled && echo 1 || echo 0)/g" \
         "$SPEC_TEMPLATE" > "$spec_file"
+    replace_literal_file_token \
+        "$spec_file" \
+        "__LINUX_FEATURE_DEPENDENCY_SUFFIX__" \
+        "$(linux_feature_package_dependency_suffix rpm)"
+    replace_literal_file_token \
+        "$spec_file" \
+        "__LINUX_FEATURE_FILES__" \
+        "$(linux_feature_package_files rpm)"
+    if linux_feature_package_has_udev_rules rpm; then
+        replace_literal_file_token \
+            "$spec_file" \
+            "__LINUX_FEATURE_UDEV_POST__" \
+            $'if command -v udevadm >/dev/null 2>&1; then\n    udevadm control --reload-rules >/dev/null 2>&1 || true\nfi'
+        local udev_reload_body=$'if command -v udevadm >/dev/null 2>&1; then\n    udevadm control --reload-rules >/dev/null 2>&1 || true\nfi'
+        if package_with_updater_enabled; then
+            replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_BODY__" "$udev_reload_body"
+            replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_SECTION__" ""
+        else
+            replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_BODY__" ""
+            replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_SECTION__" $'%postun\n'"$udev_reload_body"
+        fi
+    else
+        replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POST__" ""
+        replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_BODY__" ""
+        replace_literal_file_token "$spec_file" "__LINUX_FEATURE_UDEV_POSTUN_SECTION__" ""
+    fi
 
     local rpmbuild_dir="$build_root/rpmbuild"
     mkdir -p \

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -217,6 +217,7 @@ test("Nix hash refresh accepts a validated focused output override", () => {
 
   assert.deepEqual(watchdogProfile.enabled, [
     "appshots",
+    "codex-micro",
     "codex-wrapper-updater",
     "directory-only-working-tree-watch",
     "frameless-titlebar",

--- a/scripts/ci/watchdog-linux-features.json
+++ b/scripts/ci/watchdog-linux-features.json
@@ -1,6 +1,7 @@
 {
   "enabled": [
     "appshots",
+    "codex-micro",
     "codex-wrapper-updater",
     "directory-only-working-tree-watch",
     "frameless-titlebar",

--- a/scripts/lib/asar-patch.sh
+++ b/scripts/lib/asar-patch.sh
@@ -96,7 +96,9 @@ patch_asar() {
     else
         warn "Critical patch enforcement disabled (CODEX_ENFORCE_CRITICAL_PATCHES=0)"
     fi
-    node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" "${patch_args[@]}" "$WORK_DIR/app-extracted"
+    CODEX_ELECTRON_VERSION="$ELECTRON_VERSION" \
+        CODEX_ELECTRON_HEADERS_URL="$ELECTRON_HEADERS_URL" \
+        node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" "${patch_args[@]}" "$WORK_DIR/app-extracted"
     CODEX_PATCH_REPORT_RESOLVED="$patch_report_json"
     print_patch_report_summary "$patch_report_json"
 
@@ -132,7 +134,9 @@ inspect_rebuild_candidate() {
         cp -r "$resources_dir/app.asar.unpacked/"* "$inspect_dir/" 2>/dev/null || true
     fi
 
-    node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" --report-json "$patch_report" "$inspect_dir"
+    CODEX_ELECTRON_VERSION="$ELECTRON_VERSION" \
+        CODEX_ELECTRON_HEADERS_URL="$ELECTRON_HEADERS_URL" \
+        node "$SCRIPT_DIR/scripts/patch-linux-window-ui.js" --report-json "$patch_report" "$inspect_dir"
     write_rebuild_report_json "$rebuild_report" "$dmg_path" "$ELECTRON_VERSION" "$patch_report" ""
 
     info "Patch report: $patch_report"

--- a/scripts/lib/linux-features.js
+++ b/scripts/lib/linux-features.js
@@ -25,6 +25,10 @@ const RUNTIME_HOOK_DIRS = {
   afterExit: { dir: "after-exit.d", executable: true },
 };
 const STAGED_FEATURE_MANIFEST_RELATIVE_PATH = ".codex-linux/linux-features-staged.json";
+const SUPPORTED_PACKAGE_FORMATS = new Set(["deb", "rpm", "pacman"]);
+const PACKAGE_DEPENDENCY_PATTERN = /^[A-Za-z0-9][A-Za-z0-9+._:@()=<>~\/-]*$/;
+const RPM_ELF_DEPENDENCY_SUFFIX = "%{codex_elf_suffix}";
+const PACKAGE_PATH_COMPONENT_PATTERN = /^(?!-)(?!\.\.?$)[A-Za-z0-9._+@:-]+$/;
 
 function defaultLinuxFeaturesRoot() {
   return path.resolve(__dirname, "..", "..", "linux-features");
@@ -739,10 +743,12 @@ function installRelativeDirectoryExists(installDir, relativePath, label) {
   }
 }
 
-function copyInstallFile(installDir, source, target, mode) {
-  assertNoSymbolicLinks(source, "Linux feature source");
-  assertInstallParentInside(installDir, target, "Linux feature target");
-  assertNoSymbolicLinksIfPresent(target, "Linux feature target");
+function copyInstallFile(installDir, source, target, mode, labels = {}) {
+  const sourceLabel = labels.source ?? "Linux feature source";
+  const targetLabel = labels.target ?? "Linux feature target";
+  assertNoSymbolicLinks(source, sourceLabel);
+  assertInstallParentInside(installDir, target, targetLabel);
+  assertNoSymbolicLinksIfPresent(target, targetLabel);
   fs.mkdirSync(path.dirname(target), { recursive: true });
   fs.cpSync(source, target, { recursive: true, force: true });
   if (mode != null) {
@@ -901,6 +907,228 @@ function enabledLinuxFeaturePackageHooks(options = {}) {
   return hooks;
 }
 
+function normalizePackageFormat(value, label = "package format") {
+  if (typeof value !== "string" || !SUPPORTED_PACKAGE_FORMATS.has(value)) {
+    throw new Error(`Unsupported ${label} '${String(value)}'`);
+  }
+  return value;
+}
+
+function normalizePackageFormats(value, featureId, label) {
+  if (value == null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`Linux feature '${featureId}' ${label} formats must be an array`);
+  }
+  const formats = [];
+  for (const rawFormat of value) {
+    const format = normalizePackageFormat(rawFormat, `package format for Linux feature '${featureId}'`);
+    if (!formats.includes(format)) {
+      formats.push(format);
+    }
+  }
+  return formats.sort();
+}
+
+function normalizePackageTarget(value, featureId) {
+  const label = `Linux feature '${featureId}' package resource target`;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a relative path inside the package root`);
+  }
+  const parts = relativePathParts(value);
+  if (path.isAbsolute(value) || parts.includes("..")) {
+    throw new Error(`${label} must stay inside the package root`);
+  }
+  if (parts.length === 0) {
+    throw new Error(`${label} must not target the package root`);
+  }
+  for (const part of parts) {
+    if (!PACKAGE_PATH_COMPONENT_PATTERN.test(part)) {
+      throw new Error(`${label} contains an unsafe package path component: ${JSON.stringify(part)}`);
+    }
+  }
+  return parts.join("/");
+}
+
+function assertNoSymbolicLinkAncestors(root, target, label) {
+  const relative = path.relative(root, target);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${label} must stay inside the feature directory`);
+  }
+  let current = root;
+  for (const part of relativePathParts(relative)) {
+    current = path.join(current, part);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${label} must not contain symbolic links`);
+    }
+  }
+}
+
+function normalizePackageDependencies(feature) {
+  const value = feature.manifest.packageDependencies;
+  if (value == null) {
+    return new Map();
+  }
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Linux feature '${feature.id}' packageDependencies must be an object`);
+  }
+
+  const dependencies = new Map();
+  for (const [rawFormat, entries] of Object.entries(value)) {
+    const format = normalizePackageFormat(
+      rawFormat,
+      `package format in Linux feature '${feature.id}' packageDependencies`,
+    );
+    if (!Array.isArray(entries)) {
+      throw new Error(`Linux feature '${feature.id}' dependencies for ${format} must be an array`);
+    }
+    const normalized = [];
+    for (const entry of entries) {
+      const dependencyToken = typeof entry === "string"
+        && format === "rpm"
+        && entry.endsWith(RPM_ELF_DEPENDENCY_SUFFIX)
+        ? entry.slice(0, -RPM_ELF_DEPENDENCY_SUFFIX.length)
+        : entry;
+      if (
+        typeof entry !== "string"
+        || !PACKAGE_DEPENDENCY_PATTERN.test(dependencyToken)
+      ) {
+        throw new Error(`Linux feature '${feature.id}' has invalid ${format} package dependency '${String(entry)}'`);
+      }
+      if (!normalized.includes(entry)) {
+        normalized.push(entry);
+      }
+    }
+    dependencies.set(format, normalized.sort());
+  }
+  return dependencies;
+}
+
+function enabledLinuxFeaturePackagePlan(options = {}) {
+  const packageFormat = normalizePackageFormat(options.packageFormat);
+  const resources = [];
+  const dependencies = [];
+  const targetOwners = new Map();
+
+  for (const feature of loadEnabledLinuxFeatures(options)) {
+    const featureDependencies = normalizePackageDependencies(feature);
+    dependencies.push(...(featureDependencies.get(packageFormat) ?? []));
+
+    const entries = feature.manifest.packageResources;
+    if (entries == null) {
+      continue;
+    }
+    if (!Array.isArray(entries)) {
+      throw new Error(`Linux feature '${feature.id}' packageResources must be an array`);
+    }
+    for (const [index, entry] of entries.entries()) {
+      if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(`Linux feature '${feature.id}' package resource ${index + 1} must be an object`);
+      }
+      const source = resolveFeatureRelativePath(
+        feature,
+        entry.source ?? entry.path,
+        `package resource ${index + 1}`,
+      );
+      assertNoSymbolicLinkAncestors(
+        feature.dir,
+        source,
+        `Linux feature '${feature.id}' package resource ${index + 1}`,
+      );
+      const target = normalizePackageTarget(entry.target, feature.id);
+      const formats = normalizePackageFormats(entry.formats, feature.id, `package resource ${index + 1}`);
+      if (formats.length > 0 && !formats.includes(packageFormat)) {
+        continue;
+      }
+      if (
+        packageFormat === "deb"
+        && (target === "DEBIAN" || target.startsWith("DEBIAN/"))
+      ) {
+        throw new Error(
+          `Linux feature '${feature.id}' package resource target '${target}' uses the reserved Debian control namespace`,
+        );
+      }
+      for (const [existingTarget, previousOwner] of targetOwners) {
+        const duplicate = target === existingTarget;
+        const overlap = duplicate
+          || target.startsWith(`${existingTarget}/`)
+          || existingTarget.startsWith(`${target}/`);
+        if (overlap) {
+          const kind = duplicate ? "Duplicate" : "Overlapping";
+          throw new Error(
+            `${kind} Linux feature package target '${target}': feature '${feature.id}' conflicts with '${existingTarget}' from ${previousOwner}`,
+          );
+        }
+      }
+      targetOwners.set(target, `feature '${feature.id}'`);
+      resources.push({
+        id: feature.id,
+        source,
+        target,
+        mode: parseFileMode(entry.mode, 0o644),
+        formats,
+        index,
+      });
+    }
+  }
+
+  resources.sort((left, right) => left.target.localeCompare(right.target));
+  return {
+    resources,
+    dependencies: [...new Set(dependencies)].sort(),
+  };
+}
+
+function enabledLinuxFeaturePackageDependencies(options = {}) {
+  return enabledLinuxFeaturePackagePlan(options).dependencies;
+}
+
+function enabledLinuxFeaturePackageFiles(options = {}) {
+  return enabledLinuxFeaturePackagePlan(options).resources.map((resource) => `/${resource.target}`);
+}
+
+function enabledLinuxFeaturePackageResourceMetadata(options = {}) {
+  return enabledLinuxFeaturePackagePlan(options).resources.map((resource) => ({
+    target: resource.target,
+    mode: modeString(resource.mode),
+  }));
+}
+
+function stageEnabledLinuxFeaturePackageResources(packageRoot, options = {}) {
+  const installDir = path.resolve(packageRoot);
+  const plan = enabledLinuxFeaturePackagePlan(options);
+  fs.mkdirSync(installDir, { recursive: true });
+  for (const resource of plan.resources) {
+    const targetPath = path.join(installDir, resource.target);
+    if (fs.lstatSync(targetPath, { throwIfNoEntry: false }) != null) {
+      throw new Error(
+        `Linux feature package target conflicts with existing package payload: ${resource.target}`,
+      );
+    }
+    try {
+      copyInstallFile(
+        installDir,
+        resource.source,
+        targetPath,
+        resource.mode,
+        {
+          source: "Linux feature package source",
+          target: "Linux feature package target",
+        },
+      );
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("inside the install directory")) {
+        throw new Error(error.message.replace("inside the install directory", "inside the package root"));
+      }
+      throw error;
+    }
+    console.error(`Staged Linux feature package resource: ${resource.id} -> ${resource.target}`);
+  }
+  return plan;
+}
+
 function featuresJsonSummary(options = {}) {
   return discoverLinuxFeatureManifests(options).map((feature) => ({
     id: feature.id,
@@ -939,6 +1167,35 @@ function main() {
     }
     return;
   }
+  if (command === "--stage-package-resources") {
+    const packageFormat = process.argv[3] ?? "";
+    const packageRoot = process.argv[4] ?? process.env.PACKAGE_ROOT;
+    if (!packageRoot) {
+      console.error("Usage: linux-features.js --stage-package-resources <format> <package-root>");
+      process.exit(1);
+    }
+    stageEnabledLinuxFeaturePackageResources(packageRoot, { packageFormat });
+    return;
+  }
+  if (command === "--package-dependencies") {
+    const packageFormat = process.argv[3] ?? "";
+    for (const dependency of enabledLinuxFeaturePackageDependencies({ packageFormat })) {
+      process.stdout.write(`${dependency}\n`);
+    }
+    return;
+  }
+  if (command === "--package-files") {
+    const packageFormat = process.argv[3] ?? "";
+    for (const file of enabledLinuxFeaturePackageFiles({ packageFormat })) {
+      process.stdout.write(`${file}\n`);
+    }
+    return;
+  }
+  if (command === "--package-resources-json") {
+    const packageFormat = process.argv[3] ?? "";
+    process.stdout.write(`${JSON.stringify(enabledLinuxFeaturePackageResourceMetadata({ packageFormat }), null, 2)}\n`);
+    return;
+  }
   if (command === "--stage-install") {
     const appDir = process.argv[3] ?? process.env.INSTALL_DIR;
     if (!appDir) {
@@ -971,7 +1228,7 @@ function main() {
     process.stdout.write(`${linuxFeaturesRoot()}\n`);
     return;
   }
-  console.error("Usage: linux-features.js --enabled | --features-json | --features-root | --stage-install <install-dir> | --staged-files-json <install-dir> | --stage-hooks | --cleanup-hooks | --package-hooks <format>");
+  console.error("Usage: linux-features.js --enabled | --features-json | --features-root | --stage-install <install-dir> | --staged-files-json <install-dir> | --stage-hooks | --cleanup-hooks | --package-hooks <format> | --stage-package-resources <format> <package-root> | --package-dependencies <format> | --package-files <format> | --package-resources-json <format>");
   process.exit(1);
 }
 
@@ -990,7 +1247,11 @@ module.exports = {
   enabledLinuxFeaturesConfig,
   enabledLinuxFeatureIds,
   enabledLinuxFeatureInstallPlan,
+  enabledLinuxFeaturePackageDependencies,
+  enabledLinuxFeaturePackageFiles,
+  enabledLinuxFeaturePackageResourceMetadata,
   enabledLinuxFeaturePackageHooks,
+  enabledLinuxFeaturePackagePlan,
   enabledLinuxFeatureStageHooks,
   featuresJsonSummary,
   loadEnabledLinuxFeatures,
@@ -1000,5 +1261,6 @@ module.exports = {
   linuxFeaturesRoot,
   resolveFeatureEntrypoint,
   stageEnabledLinuxFeatureInstall,
+  stageEnabledLinuxFeaturePackageResources,
   stagedLinuxFeatureFiles,
 };

--- a/scripts/lib/linux-features.test.js
+++ b/scripts/lib/linux-features.test.js
@@ -8,7 +8,12 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  enabledLinuxFeaturePackageDependencies,
+  enabledLinuxFeaturePackageFiles,
+  enabledLinuxFeaturePackagePlan,
+  enabledLinuxFeaturePackageResourceMetadata,
   loadLinuxFeaturePatchDescriptors,
+  stageEnabledLinuxFeaturePackageResources,
   stageEnabledLinuxFeatureInstall,
 } = require("./linux-features.js");
 
@@ -352,4 +357,396 @@ test("Linux feature staging does not clean legacy hooks through symlinked hook d
     /must (stay inside the install directory|not contain symbolic links)/,
   );
   assert.equal(fs.readFileSync(path.join(outside, "unsafe-link-old-hook.sh"), "utf8"), "outside\n");
+});
+
+test("disabled Linux features do not add package resources or dependencies", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-disabled-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      {
+        source: "70-unsafe-link.rules",
+        target: "usr/lib/udev/rules.d/70-unsafe-link.rules",
+        mode: "0644",
+        formats: ["deb", "rpm", "pacman"],
+      },
+    ],
+    packageDependencies: {
+      deb: ["libudev1"],
+      rpm: ["systemd-udev"],
+      pacman: ["systemd-libs"],
+    },
+  });
+  fs.writeFileSync(path.join(featureDir, "70-unsafe-link.rules"), "SUBSYSTEM==\"hidraw\"\n");
+  fs.writeFileSync(path.join(featuresRoot, "features.json"), '{"enabled":[]}\n');
+
+  const options = { featuresRoot, packageFormat: "deb" };
+  assert.deepEqual(enabledLinuxFeaturePackagePlan(options), {
+    resources: [],
+    dependencies: [],
+  });
+  assert.deepEqual(enabledLinuxFeaturePackageDependencies(options), []);
+  assert.deepEqual(enabledLinuxFeaturePackageFiles(options), []);
+
+  const packageRoot = path.join(root, "package-root");
+  fs.mkdirSync(packageRoot);
+  fs.writeFileSync(path.join(packageRoot, "sentinel"), "preserved\n");
+  assert.deepEqual(stageEnabledLinuxFeaturePackageResources(packageRoot, options), {
+    resources: [],
+    dependencies: [],
+  });
+  assert.deepEqual(fs.readdirSync(packageRoot), ["sentinel"]);
+});
+
+test("enabled Linux features stage package resources with exact modes and reject payload collisions", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-stage-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const target = "usr/lib/udev/rules.d/70-unsafe-link.rules";
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      {
+        source: "70-unsafe-link.rules",
+        target,
+        mode: "0640",
+        formats: ["deb", "rpm"],
+      },
+    ],
+    packageDependencies: {
+      deb: ["libudev1"],
+      rpm: ["systemd-udev"],
+      pacman: ["systemd-libs"],
+    },
+  });
+  const rule = 'SUBSYSTEM=="hidraw", TAG+="uaccess"\n';
+  fs.writeFileSync(path.join(featureDir, "70-unsafe-link.rules"), rule);
+
+  const options = { featuresRoot, packageFormat: "deb" };
+  const plan = enabledLinuxFeaturePackagePlan(options);
+  assert.deepEqual(plan.dependencies, ["libudev1"]);
+  assert.equal(plan.resources.length, 1);
+  assert.equal(plan.resources[0].id, "unsafe-link");
+  assert.equal(plan.resources[0].target, target);
+  assert.equal(plan.resources[0].mode, 0o640);
+  assert.deepEqual(plan.resources[0].formats, ["deb", "rpm"]);
+  assert.deepEqual(enabledLinuxFeaturePackageResourceMetadata(options), [
+    { target, mode: "0640" },
+  ]);
+
+  const packageRoot = path.join(root, "package-root");
+  assert.deepEqual(stageEnabledLinuxFeaturePackageResources(packageRoot, options), plan);
+  const stagedTarget = path.join(packageRoot, target);
+  assert.equal(fs.readFileSync(stagedTarget, "utf8"), rule);
+  assert.equal(fs.statSync(stagedTarget).mode & 0o777, 0o640);
+
+  fs.writeFileSync(stagedTarget, "tampered\n");
+  fs.chmodSync(stagedTarget, 0o777);
+  assert.throws(
+    () => stageEnabledLinuxFeaturePackageResources(packageRoot, options),
+    /conflicts with existing package payload/i,
+  );
+  assert.equal(fs.readFileSync(stagedTarget, "utf8"), "tampered\n");
+  assert.equal(fs.statSync(stagedTarget).mode & 0o777, 0o777);
+});
+
+test("Linux feature package dependencies and files are sorted, deduplicated, and format-specific", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-lists-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      {
+        source: "90-last.rules",
+        target: "usr/lib/udev/rules.d/90-last.rules",
+        formats: ["rpm", "deb", "deb"],
+      },
+      {
+        source: "70-first.rules",
+        target: "etc/udev/rules.d/70-first.rules",
+        formats: ["deb"],
+      },
+      {
+        source: "80-shared.rules",
+        target: "usr/lib/udev/rules.d/80-shared.rules",
+      },
+    ],
+    packageDependencies: {
+      deb: ["zlib1g", "libudev1", "zlib1g"],
+      rpm: ["zlib", "systemd-udev", "zlib"],
+      pacman: ["zlib", "systemd-libs", "zlib"],
+    },
+  });
+  for (const name of ["90-last.rules", "70-first.rules", "80-shared.rules"]) {
+    fs.writeFileSync(path.join(featureDir, name), `${name}\n`);
+  }
+
+  const debOptions = { featuresRoot, packageFormat: "deb" };
+  assert.deepEqual(enabledLinuxFeaturePackageDependencies(debOptions), ["libudev1", "zlib1g"]);
+  assert.deepEqual(enabledLinuxFeaturePackageFiles(debOptions), [
+    "/etc/udev/rules.d/70-first.rules",
+    "/usr/lib/udev/rules.d/80-shared.rules",
+    "/usr/lib/udev/rules.d/90-last.rules",
+  ]);
+  assert.deepEqual(
+    enabledLinuxFeaturePackagePlan(debOptions).resources.map((resource) => resource.target),
+    [
+      "etc/udev/rules.d/70-first.rules",
+      "usr/lib/udev/rules.d/80-shared.rules",
+      "usr/lib/udev/rules.d/90-last.rules",
+    ],
+  );
+
+  const rpmOptions = { featuresRoot, packageFormat: "rpm" };
+  assert.deepEqual(enabledLinuxFeaturePackageDependencies(rpmOptions), ["systemd-udev", "zlib"]);
+  assert.deepEqual(enabledLinuxFeaturePackageFiles(rpmOptions), [
+    "/usr/lib/udev/rules.d/80-shared.rules",
+    "/usr/lib/udev/rules.d/90-last.rules",
+  ]);
+
+  const pacmanOptions = { featuresRoot, packageFormat: "pacman" };
+  assert.deepEqual(enabledLinuxFeaturePackageDependencies(pacmanOptions), ["systemd-libs", "zlib"]);
+  assert.deepEqual(enabledLinuxFeaturePackageFiles(pacmanOptions), [
+    "/usr/lib/udev/rules.d/80-shared.rules",
+  ]);
+});
+
+test("Linux feature package resources reject traversal and package-root targets", () => {
+  const cases = [
+    { target: ".", error: /must not target the package root/i },
+    { target: "./", error: /must not target the package root/i },
+    { target: "../escape.rules", error: /must stay inside the package root/i },
+    { target: "usr/lib/udev/../../escape.rules", error: /must stay inside the package root/i },
+    { target: "DEBIAN", error: /reserved Debian control namespace/i },
+    { target: "DEBIAN/preinst", error: /reserved Debian control namespace/i },
+    { target: "usr/lib/udev/rules.d/bad\npath.rules", error: /unsafe package path component/i },
+    { target: "usr/%{_libdir}/bad.rules", error: /unsafe package path component/i },
+    { target: "usr/lib/udev/rules.d/*.rules", error: /unsafe package path component/i },
+    { target: "usr/lib/udev/rules.d/-bad.rules", error: /unsafe package path component/i },
+  ];
+
+  for (const { target, error } of cases) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-target-"));
+    try {
+      const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+        id: "unsafe-link",
+        title: "Unsafe Link",
+        packageResources: [{ source: "payload.rules", target, mode: "0644", formats: ["deb"] }],
+      });
+      fs.writeFileSync(path.join(featureDir, "payload.rules"), "payload\n");
+
+      assert.throws(
+        () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "deb" }),
+        error,
+        target,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("Linux feature package resources reject ancestor and descendant target overlaps", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-overlap-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      { source: "tree", target: "usr/share/unsafe-link", mode: "0644", formats: ["deb"] },
+      { source: "child.txt", target: "usr/share/unsafe-link/child.txt", mode: "0644", formats: ["deb"] },
+    ],
+  });
+  fs.mkdirSync(path.join(featureDir, "tree"));
+  fs.writeFileSync(path.join(featureDir, "tree", "payload.txt"), "tree\n");
+  fs.writeFileSync(path.join(featureDir, "child.txt"), "child\n");
+
+  assert.throws(
+    () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "deb" }),
+    /overlapping Linux feature package target/i,
+  );
+});
+
+test("Linux feature package staging rejects symlinked resource sources", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-source-link-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside.rules");
+  const target = "usr/lib/udev/rules.d/70-unsafe-link.rules";
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      { source: "payload-link.rules", target, mode: "0644", formats: ["deb"] },
+    ],
+  });
+  fs.writeFileSync(outside, "outside\n");
+  fs.symlinkSync(outside, path.join(featureDir, "payload-link.rules"));
+
+  const packageRoot = path.join(root, "package-root");
+  assert.throws(
+    () => stageEnabledLinuxFeaturePackageResources(packageRoot, { featuresRoot, packageFormat: "deb" }),
+    /must not contain symbolic links/i,
+  );
+  assert.equal(fs.existsSync(path.join(packageRoot, target)), false);
+});
+
+test("Linux feature package staging rejects symlinked source ancestors", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-source-ancestor-link-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const target = "usr/lib/udev/rules.d/70-unsafe-link.rules";
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      { source: "linked/payload.rules", target, mode: "0644", formats: ["deb"] },
+    ],
+  });
+  fs.mkdirSync(outside);
+  fs.writeFileSync(path.join(outside, "payload.rules"), "outside\n");
+  fs.symlinkSync(outside, path.join(featureDir, "linked"), "junction");
+
+  assert.throws(
+    () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "deb" }),
+    /must not contain symbolic links/i,
+  );
+});
+
+test("Linux feature package staging rejects symlinked target parents", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-target-link-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const outside = path.join(root, "outside");
+  const packageRoot = path.join(root, "package-root");
+  const target = "usr/lib/udev/rules.d/70-unsafe-link.rules";
+  const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+    id: "unsafe-link",
+    title: "Unsafe Link",
+    packageResources: [
+      { source: "payload.rules", target, mode: "0644", formats: ["deb"] },
+    ],
+  });
+  fs.writeFileSync(path.join(featureDir, "payload.rules"), "payload\n");
+  fs.mkdirSync(path.join(packageRoot, "usr", "lib", "udev"), { recursive: true });
+  fs.mkdirSync(outside);
+  fs.symlinkSync(outside, path.join(packageRoot, "usr", "lib", "udev", "rules.d"), "junction");
+
+  assert.throws(
+    () => stageEnabledLinuxFeaturePackageResources(packageRoot, { featuresRoot, packageFormat: "deb" }),
+    /must (stay inside the package root|not contain symbolic links)/i,
+  );
+  assert.equal(fs.existsSync(path.join(outside, "70-unsafe-link.rules")), false);
+});
+
+test("Linux feature package resources reject invalid modes and formats", () => {
+  const invalidResources = [
+    {
+      resource: {
+        source: "payload.rules",
+        target: "usr/lib/udev/rules.d/payload.rules",
+        mode: 644,
+        formats: ["deb"],
+      },
+      error: /file mode must be a quoted octal string/i,
+    },
+    {
+      resource: {
+        source: "payload.rules",
+        target: "usr/lib/udev/rules.d/payload.rules",
+        mode: "0899",
+        formats: ["deb"],
+      },
+      error: /file mode must be a quoted octal string/i,
+    },
+    {
+      resource: {
+        source: "payload.rules",
+        target: "usr/lib/udev/rules.d/payload.rules",
+        mode: "0644",
+        formats: ["deb", "appimage"],
+      },
+      error: /unsupported package format.*appimage/i,
+    },
+    {
+      resource: {
+        source: "payload.rules",
+        target: "usr/lib/udev/rules.d/payload.rules",
+        mode: "0644",
+        formats: "deb",
+      },
+      error: /formats must be an array/i,
+    },
+  ];
+
+  for (const { resource, error } of invalidResources) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-invalid-resource-"));
+    try {
+      const { featureDir, featuresRoot } = makeFeatureRoot(root, {
+        id: "unsafe-link",
+        title: "Unsafe Link",
+        packageResources: [resource],
+      });
+      fs.writeFileSync(path.join(featureDir, "payload.rules"), "payload\n");
+      assert.throws(
+        () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "deb" }),
+        error,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-invalid-format-"));
+  try {
+    const { featuresRoot } = makeFeatureRoot(root, {
+      id: "unsafe-link",
+      title: "Unsafe Link",
+    });
+    assert.throws(
+      () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "appimage" }),
+      /unsupported package format.*appimage/i,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Linux feature package dependencies reject unsafe tokens and unsupported formats", () => {
+  const invalidDependencies = [
+    { packageDependencies: { deb: ["libudev1;curl"] }, error: /invalid.*dependency/i },
+    { packageDependencies: { deb: [""] }, error: /invalid.*dependency/i },
+    { packageDependencies: { deb: "libudev1" }, error: /dependencies.*array/i },
+    { packageDependencies: { appimage: ["libudev1"] }, error: /unsupported package format.*appimage/i },
+    { packageDependencies: { rpm: ["libudev.so.1%(id)"] }, error: /invalid.*dependency/i },
+    { packageDependencies: { rpm: ["libudev.so.1%{_libdir}"] }, error: /invalid.*dependency/i },
+    {
+      packageDependencies: { rpm: ["libudev.so.1%{codex_elf_suffix}%(id)"] },
+      error: /invalid.*dependency/i,
+    },
+  ];
+
+  for (const { packageDependencies, error } of invalidDependencies) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-feature-package-invalid-dependency-"));
+    try {
+      const { featuresRoot } = makeFeatureRoot(root, {
+        id: "unsafe-link",
+        title: "Unsafe Link",
+        packageDependencies,
+      });
+      assert.throws(
+        () => enabledLinuxFeaturePackagePlan({ featuresRoot, packageFormat: "deb" }),
+        error,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
 });

--- a/scripts/lib/package-common.sh
+++ b/scripts/lib/package-common.sh
@@ -165,6 +165,152 @@ run_linux_feature_package_hooks() {
     done <<< "$hooks_output"
 }
 
+stage_linux_feature_package_resources() {
+    local staging_root="$1"
+    local package_format="$2"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+
+    [ -d "$staging_root" ] || error "Missing package staging root: $staging_root"
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+    node_bin="$(package_node_binary)"
+    "$node_bin" "$helper" --stage-package-resources "$package_format" "$staging_root"
+}
+
+linux_feature_package_dependencies() {
+    local package_format="$1"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+    node_bin="$(package_node_binary)"
+    "$node_bin" "$helper" --package-dependencies "$package_format"
+}
+
+linux_feature_package_files() {
+    local package_format="$1"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+    node_bin="$(package_node_binary)"
+    "$node_bin" "$helper" --package-files "$package_format"
+}
+
+linux_feature_package_dependency_suffix() {
+    local package_format="$1"
+    local dependency
+    local suffix=""
+
+    while IFS= read -r dependency; do
+        [ -n "$dependency" ] || continue
+        suffix+=", $dependency"
+    done < <(linux_feature_package_dependencies "$package_format")
+    printf '%s' "$suffix"
+}
+
+linux_feature_package_has_udev_rules() {
+    local package_format="$1"
+    local package_file
+    local has_udev_rules=1
+
+    while IFS= read -r package_file; do
+        case "$package_file" in
+            /usr/lib/udev/rules.d/*.rules|/etc/udev/rules.d/*.rules)
+                has_udev_rules=0
+                ;;
+        esac
+    done < <(linux_feature_package_files "$package_format")
+    return "$has_udev_rules"
+}
+
+replace_literal_file_token() {
+    local target="$1"
+    local token="$2"
+    local replacement="$3"
+    local node_bin
+
+    node_bin="$(package_node_binary)"
+    "$node_bin" - "$target" "$token" "$replacement" <<'NODE'
+const fs = require("node:fs");
+const [target, token, replacement] = process.argv.slice(2);
+const source = fs.readFileSync(target, "utf8");
+if (!source.includes(token)) {
+  throw new Error(`Template token not found in ${target}: ${token}`);
+}
+fs.writeFileSync(target, source.split(token).join(replacement));
+NODE
+}
+
+inject_udev_reload_before_exit() {
+    local target="$1"
+    local node_bin
+
+    node_bin="$(package_node_binary)"
+    "$node_bin" - "$target" <<'NODE'
+const fs = require("node:fs");
+const target = process.argv[2];
+const marker = "\nexit 0\n";
+const block = [
+  "",
+  "if command -v udevadm >/dev/null 2>&1; then",
+  "    udevadm control --reload-rules >/dev/null 2>&1 || true",
+  "fi",
+].join("\n");
+const source = fs.readFileSync(target, "utf8");
+const index = source.lastIndexOf(marker);
+if (index < 0) throw new Error(`Final exit marker not found in ${target}`);
+fs.writeFileSync(target, `${source.slice(0, index)}${block}${source.slice(index)}`);
+NODE
+}
+
+write_udev_reload_script() {
+    local target="$1"
+    cat > "$target" <<'SCRIPT'
+#!/bin/sh
+set -eu
+
+if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules >/dev/null 2>&1 || true
+fi
+
+exit 0
+SCRIPT
+    chmod 0755 "$target"
+}
+
+enable_pacman_udev_reload_hooks() {
+    local target="$1"
+    local node_bin
+
+    node_bin="$(package_node_binary)"
+    "$node_bin" - "$target" <<'NODE'
+const fs = require("node:fs");
+const target = process.argv[2];
+let source = fs.readFileSync(target, "utf8");
+const helper = [
+  "codex_desktop_reload_udev_rules() {",
+  "    if command -v udevadm >/dev/null 2>&1; then",
+  "        udevadm control --reload-rules >/dev/null 2>&1 || true",
+  "    fi",
+  "}",
+  "",
+].join("\n");
+source = `${helper}${source}`;
+for (const hook of ["post_install", "post_upgrade", "post_remove"]) {
+  const marker = `${hook}() {\n`;
+  if (source.includes(marker)) {
+    source = source.replace(marker, `${marker}    codex_desktop_reload_udev_rules\n`);
+  } else if (hook === "post_remove") {
+    source += `\npost_remove() {\n    codex_desktop_reload_udev_rules\n}\n`;
+  } else {
+    throw new Error(`${hook} hook not found in ${target}`);
+  }
+}
+fs.writeFileSync(target, source);
+NODE
+}
+
 render_desktop_entry() {
     local target="$1"
     local package_name
@@ -926,6 +1072,120 @@ for (const entry of entries) {
 NODE
     then
         error "Failed to restore Linux feature staged file permissions"
+    fi
+}
+
+restore_linux_feature_package_resource_permissions() {
+    local root="$1"
+    local package_format="$2"
+    local helper="$REPO_DIR/scripts/lib/linux-features.js"
+    local node_bin
+    local resources_json
+
+    [ -d "$root" ] || error "Missing package root: $root"
+    [ -f "$helper" ] || error "Missing Linux features helper: $helper"
+
+    node_bin="$(package_node_binary)"
+    if ! resources_json="$("$node_bin" "$helper" --package-resources-json "$package_format")"; then
+        error "Failed to read Linux feature package resource metadata"
+    fi
+
+    if ! "$node_bin" - "$root" "$resources_json" <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [packageRoot, rawJson] = process.argv.slice(2);
+const resolvedPackageRoot = path.resolve(packageRoot);
+const packageRootStat = fs.lstatSync(resolvedPackageRoot);
+if (packageRootStat.isSymbolicLink()) {
+  throw new Error(`Linux feature package root must not be a symbolic link: ${resolvedPackageRoot}`);
+}
+const realPackageRoot = fs.realpathSync(resolvedPackageRoot);
+const entries = JSON.parse(rawJson);
+if (!Array.isArray(entries)) {
+  throw new Error("Linux feature package resource metadata must be an array");
+}
+
+function staysInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === ""
+    || (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+function resolveTarget(target) {
+  if (typeof target !== "string" || target.length === 0) {
+    throw new Error("Linux feature package resource target must be a relative path");
+  }
+  const parts = target.split(/[\\/]+/).filter(Boolean);
+  if (path.isAbsolute(target) || parts.includes("..")) {
+    throw new Error(`Unsafe Linux feature package resource target: ${target}`);
+  }
+  const resolved = path.resolve(resolvedPackageRoot, ...parts);
+  const relative = path.relative(resolvedPackageRoot, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Unsafe Linux feature package resource target: ${target}`);
+  }
+
+  let current = resolvedPackageRoot;
+  for (const part of parts) {
+    current = path.join(current, part);
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        return resolved;
+      }
+      throw error;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Linux feature package resource must not contain symbolic links: ${target}`);
+    }
+  }
+  const realTarget = fs.realpathSync(resolved);
+  if (!staysInside(realPackageRoot, realTarget)) {
+    throw new Error(`Linux feature package resource must stay inside the package root: ${target}`);
+  }
+  return resolved;
+}
+
+function chmodRecursive(target, mode) {
+  const stat = fs.lstatSync(target);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Linux feature package resource must not be a symbolic link: ${target}`);
+  }
+  const targetMode = stat.isDirectory()
+    ? mode
+      | ((mode & 0o400) ? 0o100 : 0)
+      | ((mode & 0o040) ? 0o010 : 0)
+      | ((mode & 0o004) ? 0o001 : 0)
+    : mode;
+  fs.chmodSync(target, targetMode);
+  if (stat.isDirectory()) {
+    for (const name of fs.readdirSync(target)) {
+      chmodRecursive(path.join(target, name), mode);
+    }
+  }
+}
+
+for (const entry of entries) {
+  if (entry == null || typeof entry !== "object") {
+    throw new Error("Linux feature package resource entry must be an object");
+  }
+  if (typeof entry.mode !== "string" || !/^[0-7]{3,4}$/.test(entry.mode)) {
+    throw new Error(`Invalid Linux feature package resource mode for ${entry.target}: ${entry.mode}`);
+  }
+  const target = resolveTarget(entry.target);
+  if (!fs.existsSync(target)) {
+    throw new Error(`Linux feature package resource is missing from payload: ${entry.target}`);
+  }
+  chmodRecursive(target, Number.parseInt(entry.mode, 8));
+}
+NODE
+    then
+        error "Failed to restore Linux feature package resource permissions"
     fi
 }
 

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -444,6 +444,10 @@ test_package_payload_permission_normalization() {
     local root="$TMP_DIR/package-permissions"
     local app_root="$root/opt/codex-desktop"
     local private_file="$app_root/.codex-linux/features/private/secret.txt"
+    local features_root="$TMP_DIR/package-permissions-features"
+    local feature_dir="$features_root/private-package"
+    local feature_config="$features_root/features.json"
+    local package_resource="$root/usr/share/private-package/secret.txt"
 
     mkdir -p "$app_root/content/webview" "$root/usr/bin" "$(dirname "$private_file")"
     printf '%s\n' "#!$BASH_BIN" 'echo start' > "$app_root/start.sh"
@@ -468,10 +472,37 @@ JSON
     chmod 0700 "$app_root/start.sh" "$root/usr/bin/codex-desktop"
     chmod 0600 "$app_root/content/webview/index.html" "$private_file"
 
+    mkdir -p "$feature_dir"
+    printf '%s\n' '# Private package resource' > "$feature_dir/README.md"
+    printf '%s\n' 'package secret' > "$feature_dir/secret.txt"
+    cat > "$feature_dir/feature.json" <<'JSON'
+{
+  "id": "private-package",
+  "packageResources": [
+    {
+      "source": "secret.txt",
+      "target": "usr/share/private-package/secret.txt",
+      "mode": "0640",
+      "formats": ["deb"]
+    }
+  ]
+}
+JSON
+    printf '%s\n' '{"enabled":[]}' > "$features_root/features.example.json"
+    printf '%s\n' '{"enabled":["private-package"]}' > "$feature_config"
+
     # shellcheck disable=SC1091
     source "$REPO_DIR/scripts/lib/package-common.sh"
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
+    PACKAGE_NAME="codex-desktop" \
+        stage_linux_feature_package_resources "$root" "deb"
     normalize_package_payload_permissions "$root"
     PACKAGE_NAME="codex-desktop" restore_linux_feature_payload_permissions "$root"
+    CODEX_LINUX_FEATURES_ROOT="$features_root" \
+    CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
+    PACKAGE_NAME="codex-desktop" \
+        restore_linux_feature_package_resource_permissions "$root" "deb"
 
     assert_mode "$app_root" "755"
     assert_mode "$app_root/content/webview" "755"
@@ -479,6 +510,31 @@ JSON
     assert_mode "$root/usr/bin/codex-desktop" "755"
     assert_mode "$app_root/content/webview/index.html" "644"
     assert_mode "$private_file" "600"
+    assert_mode "$package_resource" "640"
+
+    local attack_root="$TMP_DIR/package-permissions-symlink-attack"
+    local external_root="$TMP_DIR/package-permissions-external"
+    local external_file="$external_root/private-package/secret.txt"
+    local attack_log="$TMP_DIR/package-permissions-symlink-attack.log"
+    mkdir -p "$attack_root/usr" "$(dirname "$external_file")"
+    printf '%s\n' 'external secret' > "$external_file"
+    chmod 0600 "$external_file"
+    ln -s "$external_root" "$attack_root/usr/share"
+
+    set +e
+    (
+        CODEX_LINUX_FEATURES_ROOT="$features_root" \
+        CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
+        PACKAGE_NAME="codex-desktop" \
+            restore_linux_feature_package_resource_permissions "$attack_root" "deb"
+    ) >"$attack_log" 2>&1
+    local attack_rc=$?
+    set -e
+
+    [ "$attack_rc" -ne 0 ] \
+        || fail "package resource permission restoration followed a symlinked target ancestor"
+    assert_contains "$attack_log" "must not contain symbolic links"
+    assert_mode "$external_file" "600"
 }
 
 test_deb_builder_smoke() {
@@ -490,11 +546,13 @@ test_deb_builder_smoke() {
     local pkg_root="$workspace/deb-root"
     local updater_bin="$workspace/codex-update-manager"
     local capture_dir="$workspace/capture"
+    local feature_config="$workspace/features.json"
 
     mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
+    printf '%s\n' '{"enabled":["codex-micro"]}' > "$feature_config"
     chmod +x "$updater_bin"
 
     cat > "$bin_dir/dpkg" <<'SCRIPT'
@@ -525,6 +583,7 @@ SCRIPT
     PKG_ROOT_OVERRIDE="$pkg_root" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     CAPTURE_DIR="$capture_dir" \
+    CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
     MAX_BUILD_THREADS=6 \
     PACKAGE_VERSION="2026.03.24.120000+deadbeef" \
@@ -573,7 +632,10 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/scripts/patches/core/package/deb/README.md"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/README.md"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/example-feature/feature.json"
-    assert_file_not_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/features.json"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/features.json"
+    assert_contains "$pkg_root/opt/codex-desktop/update-builder/linux-features/features.json" "codex-micro"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/codex-micro/source-build/package.json"
+    assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/linux-features/codex-micro/source-build/package-lock.json"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/node-runtime/bin/node"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/Cargo.toml"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/CHANGELOG.md"
@@ -596,6 +658,15 @@ SCRIPT
     assert_file_exists "$pkg_root/opt/codex-desktop/.codex-linux/codex-desktop-entry-doctor.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/update-builder/packaging/linux/codex-desktop-entry-doctor.sh"
     assert_file_exists "$pkg_root/opt/codex-desktop/resources/node-runtime/bin/node"
+    assert_file_exists "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules"
+    assert_mode "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules" "644"
+    assert_contains "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules" 'ENV{ID_VENDOR_ID}=="303a"'
+    assert_contains "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules" 'ENV{ID_MODEL_ID}=="8360"'
+    assert_contains "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules" 'ENV{ID_USB_INTERFACE_NUM}=="00"'
+    assert_contains "$pkg_root/usr/lib/udev/rules.d/70-codex-micro.rules" 'KERNELS=="0005:303A:8360.*"'
+    assert_contains "$pkg_root/DEBIAN/control" "libudev1, libusb-1.0-0"
+    assert_contains "$pkg_root/DEBIAN/postinst" "udevadm control --reload-rules"
+    assert_contains "$pkg_root/DEBIAN/postrm" "udevadm control --reload-rules"
 }
 
 test_deb_builder_rebuilds_deleted_updater_source() {
@@ -1113,6 +1184,8 @@ test_rpm_builder_smoke() {
     local dist_dir="$workspace/dist"
     local updater_bin="$workspace/codex-update-manager"
     local capture_dir="$workspace/capture"
+    local enabled_feature_config="$workspace/features-enabled.json"
+    local disabled_feature_config="$workspace/features-disabled.json"
 
     mkdir -p "$workspace" "$dist_dir" "$capture_dir"
     make_stub_bin_dir "$bin_dir"
@@ -1121,6 +1194,8 @@ test_rpm_builder_smoke() {
     chmod 0700 "$app_dir/start.sh"
     chmod 0600 "$app_dir/content/webview/index.html"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$updater_bin"
+    printf '%s\n' '{"enabled":["codex-micro"]}' > "$enabled_feature_config"
+    printf '%s\n' '{"enabled":[]}' > "$disabled_feature_config"
     chmod +x "$updater_bin"
 
     cat > "$bin_dir/rpmbuild" <<'SCRIPT'
@@ -1160,6 +1235,7 @@ SCRIPT
 
     PATH="$bin_dir:$PATH" \
     CAPTURE_DIR="$capture_dir" \
+    CODEX_LINUX_FEATURES_CONFIG="$enabled_feature_config" \
     APP_DIR_OVERRIDE="$app_dir" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
@@ -1169,12 +1245,19 @@ SCRIPT
     assert_file_exists "$dist_dir/codex-desktop-2026.03.24.120000-deadbeef.x86_64.rpm"
     [ "$(cat "$capture_dir/rpm-binary-payload")" = "" ] \
         || fail "Expected default RPM binary payload to use tool default"
+    assert_file_exists "$capture_dir/staging/usr/lib/udev/rules.d/70-codex-micro.rules"
+    assert_mode "$capture_dir/staging/usr/lib/udev/rules.d/70-codex-micro.rules" "644"
+    assert_contains "$capture_dir/codex-desktop.spec" 'libudev.so.1%{codex_elf_suffix}'
+    assert_contains "$capture_dir/codex-desktop.spec" 'libusb-1.0.so.0%{codex_elf_suffix}'
+    assert_contains "$capture_dir/codex-desktop.spec" '/usr/lib/udev/rules.d/70-codex-micro.rules'
+    assert_contains "$capture_dir/codex-desktop.spec" 'udevadm control --reload-rules'
 
     rm -rf "$dist_dir" "$capture_dir"
     mkdir -p "$dist_dir" "$capture_dir"
 
     PATH="$bin_dir:$PATH" \
     CAPTURE_DIR="$capture_dir" \
+    CODEX_LINUX_FEATURES_CONFIG="$disabled_feature_config" \
     APP_DIR_OVERRIDE="$app_dir" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     PACKAGE_WITH_UPDATER=0 \
@@ -1209,6 +1292,7 @@ SCRIPT
 
     PATH="$bin_dir:$PATH" \
     CAPTURE_DIR="$capture_dir" \
+    CODEX_LINUX_FEATURES_CONFIG="$disabled_feature_config" \
     APP_DIR_OVERRIDE="$app_dir" \
     DIST_DIR_OVERRIDE="$dist_dir" \
     UPDATER_BINARY_SOURCE="$updater_bin" \
@@ -1234,17 +1318,25 @@ test_pacman_builder_without_updater_transition_hook() {
     local capture_dir="$workspace/capture"
     local ampersand_tmpdir="$workspace/ampersand&tmp"
     local base_makepkg_conf="$workspace/base-makepkg.conf"
+    local feature_config="$workspace/features.json"
+    local disabled_feature_config="$workspace/features-disabled.json"
 
     mkdir -p "$workspace" "$dist_dir" "$capture_dir" "$ampersand_tmpdir"
     make_stub_bin_dir "$bin_dir"
     make_fake_app "$app_dir"
     printf 'MAKEFLAGS="-j12"\n' > "$base_makepkg_conf"
+    printf '%s\n' '{"enabled":["codex-micro"]}' > "$feature_config"
+    printf '%s\n' '{"enabled":[]}' > "$disabled_feature_config"
 
     cat > "$bin_dir/makepkg" <<'SCRIPT'
 #!/usr/bin/env bash
 set -euo pipefail
 cp PKGBUILD "$CAPTURE_DIR/PKGBUILD"
 cp codex-desktop.install "$CAPTURE_DIR/codex-desktop.install"
+staging_dir="$(sed -n 's|.*cp -a "\(.*\)/\.".*|\1|p' PKGBUILD | head -n 1)"
+if [ -n "$staging_dir" ] && [ -d "$staging_dir" ]; then
+    cp -a "$staging_dir" "$CAPTURE_DIR/staging"
+fi
 printf '%s\n' "${MAKEPKG_CONF:-}" > "$CAPTURE_DIR/makepkg-conf-path"
 if [ -n "${MAKEPKG_CONF:-}" ]; then
     cp "$MAKEPKG_CONF" "$CAPTURE_DIR/makepkg.conf"
@@ -1269,6 +1361,7 @@ SCRIPT
         TMPDIR="$ampersand_tmpdir" \
         PATH="$bin_dir:$PATH" \
         CAPTURE_DIR="$capture_dir" \
+        CODEX_LINUX_FEATURES_CONFIG="$feature_config" \
         APP_DIR_OVERRIDE="$app_dir" \
         DIST_DIR_OVERRIDE="$dist_dir" \
         MAKEPKG_CONF="$base_makepkg_conf" \
@@ -1300,6 +1393,34 @@ SCRIPT
     assert_contains "$capture_dir/codex-desktop.install" "pre_remove"
     assert_contains "$capture_dir/codex-desktop.install" "codex-no-updater-transition-cleanup.sh"
     assert_not_contains "$capture_dir/codex-desktop.install" "update-builder"
+    assert_contains "$capture_dir/PKGBUILD" "'libusb'"
+    assert_contains "$capture_dir/PKGBUILD" "'systemd-libs'"
+    assert_contains "$capture_dir/codex-desktop.install" "udevadm control --reload-rules"
+    assert_file_exists "$capture_dir/staging/usr/lib/udev/rules.d/70-codex-micro.rules"
+    assert_mode "$capture_dir/staging/usr/lib/udev/rules.d/70-codex-micro.rules" "644"
+    assert_file_exists "$capture_dir/staging/usr/share/libalpm/hooks/codex-micro-udev.hook"
+    assert_mode "$capture_dir/staging/usr/share/libalpm/hooks/codex-micro-udev.hook" "644"
+    assert_contains "$capture_dir/staging/usr/share/libalpm/hooks/codex-micro-udev.hook" "Operation = Remove"
+
+    rm -rf "$dist_dir" "$capture_dir"
+    mkdir -p "$dist_dir" "$capture_dir"
+    package_path="$(
+        TMPDIR="$ampersand_tmpdir" \
+        PATH="$bin_dir:$PATH" \
+        CAPTURE_DIR="$capture_dir" \
+        CODEX_LINUX_FEATURES_CONFIG="$disabled_feature_config" \
+        APP_DIR_OVERRIDE="$app_dir" \
+        DIST_DIR_OVERRIDE="$dist_dir" \
+        MAKEPKG_CONF="$base_makepkg_conf" \
+        PACKAGE_WITH_UPDATER=0 \
+        PACKAGE_VERSION="2026.03.24.120000+disabled" \
+        bash "$REPO_DIR/scripts/build-pacman.sh"
+    )"
+
+    assert_file_exists "$package_path"
+    assert_file_not_exists "$capture_dir/staging/usr/lib/udev/rules.d/70-codex-micro.rules"
+    assert_file_not_exists "$capture_dir/staging/usr/share/libalpm/hooks/codex-micro-udev.hook"
+    assert_not_contains "$capture_dir/codex-desktop.install" "udevadm control --reload-rules"
 }
 
 test_appimage_builder_smoke() {


### PR DESCRIPTION
## Summary

- Add a default-off `codex-micro` Linux feature that reuses the Codex Micro
  service and controls already bundled with the upstream desktop app.
- Verify and stage the matching Linux x64 or arm64 `node-hid@3.3.0` binding.
- Install narrowly scoped USB and Bluetooth hidraw access rules for native
  packages, with corresponding Nix/NixOS support.
- Leave disabled builds and unrelated HID devices unchanged.

The upstream app contains the Work Louder integration but not the Linux native
binding expected by its nested `node-hid` loader. Linux also requires udev
permission for the device's vendor hidraw collection. This feature supplies
those Linux-specific pieces without emulating the device or reimplementing its
protocol.

Refs #631

## Validation

- `node --test linux-features/codex-micro/test.js scripts/lib/linux-features.test.js scripts/ci/upstream-dmg-acceptance.test.js`
- JavaScript syntax checks for the feature and feature-framework files
- Shell syntax checks for the installer, launcher template, shared helpers, and
  package builders
- `git diff --check`
- Debian, RPM, pacman, and AppImage smoke paths, including feature-disabled
  packages, permissions, dependencies, udev reload behavior, and symlink-escape
  checks
- Accepted side-by-side app build using the latest upstream desktop
  `26.721.30844` / Electron `42.3.0`; both Codex Micro patches applied and the
  acceptance verdict was `accepted_with_warnings` with no feature blockers
- Built and installed Debian package from desktop `26.715.72359`
- Physical USB and Bluetooth verification of input, Codex status, and lighting
  on desktop `26.715.72359`

Nix is unavailable on the validation host, so `nix flake check` was not run
locally. `bash tests/scripts_smoke.sh` reaches and passes every affected package
phase, then exits at the final unrelated launcher validation; the same exit
reproduces from a clean current `origin/main` archive.

## Checklist

- [ ] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [ ] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [ ] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
