### PR TITLE
test(launcher): add resident window-reopen behavior harness

### DIFF
--- a/tests/launcher_window_reopen_behavior.sh
+++ b/tests/launcher_window_reopen_behavior.sh
@@ -307,7 +307,8 @@ PY
     cat "$REPO_DIR/launcher/start.sh.template"
 } > "$APP_DIR/start.sh"
 chmod +x "$APP_DIR/start.sh"
-if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
+if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ] \
+    && [ "${CODEX_TEST_MUTATION_CONTROL_ONLY:-0}" != "1" ]; then
     python3 - "$APP_DIR/start.sh" <<'PY'
 import sys
 
@@ -401,10 +402,29 @@ SOCKET_PID=$!
 wait_for "controlled handoff socket" test -S "$SOCKET_PATH"
 
 if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
-    printf '%s\n' '{"codex-linux-warm-start-enabled":false}' \
-        > "$HOME_DIR/.config/codex-desktop/settings.json"
     "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1 &
     SECOND_LAUNCHER_PID=$!
+    if [ "${CODEX_TEST_MUTATION_CONTROL_ONLY:-0}" = "1" ]; then
+        set +e
+        wait "$SECOND_LAUNCHER_PID"
+        rc=$?
+        set -e
+        SECOND_LAUNCHER_PID=""
+        [ "$rc" -eq 0 ] \
+            || fail "mutation control launcher invocation failed (status $rc)"
+        wait_for "mutation control handoff acknowledgement" handoff_was_recorded
+        HANDOFF_STATUS="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$HANDOFF_RESULT")"
+        FINAL_ELECTRON_PID="$(read_live_app_pid)"
+        [ "$FINAL_ELECTRON_PID" = "$FIRST_ELECTRON_PID" ] \
+            || fail "mutation control changed the healthy resident PID"
+        [ "$(count_test_main_processes)" -eq 1 ] \
+            || fail "mutation control did not preserve exactly one controlled Electron process"
+        [ "$HANDOFF_STATUS" = "acknowledged" ] \
+            || fail "mutation control handoff was not acknowledged"
+        record_result "mutation-control-preserved"
+        printf '%s\n' 'launcher window-reopen behavior mutation control passed'
+        exit 0
+    fi
     wait_for "unconditional resident replacement regression" resident_policy_regressed
     mutation_detected
 fi

--- a/tests/launcher_window_reopen_behavior.sh
+++ b/tests/launcher_window_reopen_behavior.sh
@@ -3,6 +3,54 @@ set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MUTATION_DETECTED_EXIT=86
+PIDFD_UNAVAILABLE_EXIT=77
+
+pidfd_cleanup_probe() {
+    [ "${CODEX_TEST_FORCE_NO_PIDFD:-0}" != "1" ] || return "$PIDFD_UNAVAILABLE_EXIT"
+    python3 - <<'PY'
+import errno
+import os
+import signal
+import sys
+
+if not hasattr(os, "pidfd_open") or not hasattr(signal, "pidfd_send_signal"):
+    raise SystemExit(77)
+
+try:
+    pidfd = os.pidfd_open(os.getpid(), 0)
+except OSError as error:
+    if error.errno in {errno.EACCES, errno.EINVAL, errno.ENOSYS, errno.EPERM}:
+        raise SystemExit(77)
+    print(f"pidfd capability probe failed: {error}", file=sys.stderr)
+    raise SystemExit(1)
+
+try:
+    signal.pidfd_send_signal(pidfd, 0, None, 0)
+except OSError as error:
+    if error.errno in {errno.EACCES, errno.EINVAL, errno.ENOSYS, errno.EPERM}:
+        raise SystemExit(77)
+    print(f"pidfd signal probe failed: {error}", file=sys.stderr)
+    raise SystemExit(1)
+finally:
+    os.close(pidfd)
+PY
+}
+
+set +e
+pidfd_cleanup_probe
+pidfd_probe_status=$?
+set -e
+if [ "$pidfd_probe_status" -eq "$PIDFD_UNAVAILABLE_EXIT" ]; then
+    printf '%s\n' '{"outcome":"skipped","reason":"pidfd-cleanup-unavailable"}'
+    printf '%s\n' 'launcher window-reopen behavior test skipped: pidfd cleanup unavailable'
+    exit "$PIDFD_UNAVAILABLE_EXIT"
+fi
+if [ "$pidfd_probe_status" -ne 0 ]; then
+    printf '%s\n' 'launcher window-reopen behavior test failed: pidfd capability probe failed' >&2
+    exit 1
+fi
+
 TMP_DIR="$(mktemp -d)"
 APP_DIR="$TMP_DIR/app"
 HOME_DIR="$TMP_DIR/home"
@@ -10,7 +58,6 @@ RUNTIME_DIR="$TMP_DIR/runtime"
 STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
 SOCKET_PATH="$RUNTIME_DIR/codex-desktop/launch-action.sock"
 HANDOFF_RESULT="$TMP_DIR/handoff.json"
-WINDOW_STATE="$TMP_DIR/window-state"
 FIRST_LOG="$TMP_DIR/first-launch.log"
 SECOND_LOG="$TMP_DIR/second-launch.log"
 APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
@@ -50,13 +97,12 @@ record_result() {
     marker_pid="$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)"
     main_process_count="$(count_test_main_processes)"
 
-    printf '{"outcome":"%s","initialPid":"%s","finalPid":"%s","mainProcessCount":%s,"handoff":"%s","windowState":"%s","markerPid":"%s","webviewMarkerPresent":%s,"socketPresent":%s,"timedOut":%s,"userVisibleError":%s}\n' \
+    printf '{"outcome":"%s","initialPid":"%s","finalPid":"%s","mainProcessCount":%s,"handoff":"%s","markerPid":"%s","webviewMarkerPresent":%s,"socketPresent":%s,"timedOut":%s,"userVisibleError":%s}\n' \
         "$outcome" \
         "$FIRST_ELECTRON_PID" \
         "$FINAL_ELECTRON_PID" \
         "$main_process_count" \
         "$HANDOFF_STATUS" \
-        "$(cat "$WINDOW_STATE" 2>/dev/null || printf unknown)" \
         "$marker_pid" \
         "$([ -s "$STATE_DIR/webview.pid" ] && printf true || printf false)" \
         "$([ -S "$SOCKET_PATH" ] && printf true || printf false)" \
@@ -70,7 +116,7 @@ stop_owned_process_bounded() {
     local expected="$3"
 
     [[ "$pid" =~ ^[0-9]+$ ]] || return 0
-    python3 - "$pid" "$match_mode" "$expected" <<'PY' || true
+    python3 - "$pid" "$match_mode" "$expected" <<'PY'
 import os
 import select
 import signal
@@ -81,15 +127,21 @@ match_mode = sys.argv[2]
 expected = sys.argv[3]
 
 try:
-    pidfd = os.pidfd_open(pid)
-except (ProcessLookupError, PermissionError):
+    pidfd = os.pidfd_open(pid, 0)
+except ProcessLookupError:
     raise SystemExit(0)
+except OSError as error:
+    print(f"failed to open pidfd for {pid}: {error}", file=sys.stderr)
+    raise SystemExit(1)
 
 try:
     try:
         raw_cmdline = open(f"/proc/{pid}/cmdline", "rb").read()
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError:
         raise SystemExit(0)
+    except OSError as error:
+        print(f"failed to read process identity for {pid}: {error}", file=sys.stderr)
+        raise SystemExit(1)
     argv = [part.decode(errors="surrogateescape") for part in raw_cmdline.split(b"\0") if part]
     matches = bool(argv) and (
         (match_mode == "arg0" and argv[0] == expected)
@@ -98,28 +150,40 @@ try:
     if not matches:
         raise SystemExit(0)
 
-    signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+    try:
+        signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+    except ProcessLookupError:
+        raise SystemExit(0)
     poller = select.poll()
     poller.register(pidfd, select.POLLIN)
     if not poller.poll(1000):
-        signal.pidfd_send_signal(pidfd, signal.SIGKILL)
-        poller.poll(1000)
+        try:
+            signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+        except ProcessLookupError:
+            raise SystemExit(0)
+        if not poller.poll(1000):
+            print(f"process {pid} did not exit after bounded TERM/KILL", file=sys.stderr)
+            raise SystemExit(1)
 finally:
     os.close(pidfd)
 PY
 }
 
 cleanup() {
+    local original_status=$?
+    local cleanup_failed=0
     local cmdline
     local pid
     local webview_pid
 
+    trap - EXIT
+    set +e
     webview_pid="$(cat "$STATE_DIR/webview.pid" 2>/dev/null || true)"
-    stop_owned_process_bounded "$LAUNCHER_PID" argv "$APP_DIR/start.sh"
-    stop_owned_process_bounded "$SECOND_LAUNCHER_PID" argv "$APP_DIR/start.sh"
-    stop_owned_process_bounded "$SOCKET_PID" argv "$SOCKET_PATH"
-    stop_owned_process_bounded "$webview_pid" argv "$APP_DIR/.codex-linux/webview-server.py"
-    stop_owned_process_bounded "$DECOY_PID" arg0 "$TMP_DIR/decoy-electron"
+    stop_owned_process_bounded "$LAUNCHER_PID" argv "$APP_DIR/start.sh" || cleanup_failed=1
+    stop_owned_process_bounded "$SECOND_LAUNCHER_PID" argv "$APP_DIR/start.sh" || cleanup_failed=1
+    stop_owned_process_bounded "$SOCKET_PID" argv "$SOCKET_PATH" || cleanup_failed=1
+    stop_owned_process_bounded "$webview_pid" argv "$APP_DIR/.codex-linux/webview-server.py" || cleanup_failed=1
+    stop_owned_process_bounded "$DECOY_PID" arg0 "$TMP_DIR/decoy-electron" || cleanup_failed=1
     for cmdline in /proc/[0-9]*/cmdline; do
         [ -r "$cmdline" ] || continue
         pid="${cmdline#/proc/}"
@@ -128,13 +192,18 @@ cleanup() {
         if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
             IFS= read -r -d '' revalidated_arg0 < "$cmdline" 2>/dev/null || true
             if [ "${revalidated_arg0:-}" = "$APP_DIR/electron" ]; then
-                stop_owned_process_bounded "$pid" arg0 "$APP_DIR/electron"
+                stop_owned_process_bounded "$pid" arg0 "$APP_DIR/electron" || cleanup_failed=1
             fi
         fi
         arg0=""
         revalidated_arg0=""
     done
-    rm -rf "$TMP_DIR"
+    rm -rf "$TMP_DIR" || cleanup_failed=1
+    if [ "$cleanup_failed" -ne 0 ]; then
+        printf '%s\n' 'launcher window-reopen behavior cleanup failed' >&2
+        exit 1
+    fi
+    exit "$original_status"
 }
 trap cleanup EXIT
 
@@ -152,6 +221,13 @@ fail() {
     printf '%s\n' '--- app launcher log ---' >&2
     sed -n '1,300p' "$APP_LOG" >&2 2>/dev/null || true
     exit 1
+}
+
+mutation_detected() {
+    FINAL_ELECTRON_PID="$(read_live_app_pid 2>/dev/null || true)"
+    printf '%s\n' 'launcher window-reopen behavior mutation detected: healthy resident replacement' >&2
+    record_result "resident-replacement-detected" >&2
+    exit "$MUTATION_DETECTED_EXIT"
 }
 
 wait_for() {
@@ -213,8 +289,6 @@ mkdir -p \
 
 printf '%s\n' '{"codex-linux-warm-start-enabled":true}' \
     > "$HOME_DIR/.config/codex-desktop/settings.json"
-printf '%s\n' "visible-unfocused" > "$WINDOW_STATE"
-
 PORT="$(python3 - <<'PY'
 import socket
 with socket.socket() as sock:
@@ -297,13 +371,13 @@ wait_for "first Electron marker" pid_file_is_live
 wait_for "first launcher lock release" launcher_lock_is_available
 FIRST_ELECTRON_PID="$(read_live_app_pid)"
 
-python3 - "$SOCKET_PATH" "$HANDOFF_RESULT" "$WINDOW_STATE" <<'PY' &
+python3 - "$SOCKET_PATH" "$HANDOFF_RESULT" <<'PY' &
 import json
 import os
 import socket
 import sys
 
-socket_path, result_path, window_state_path = sys.argv[1:]
+socket_path, result_path = sys.argv[1:]
 os.makedirs(os.path.dirname(socket_path), exist_ok=True)
 try:
     os.unlink(socket_path)
@@ -319,8 +393,6 @@ with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
         client.settimeout(2)
         payload = client.recv(65536)
         request = json.loads(payload.decode("utf-8").strip())
-        with open(window_state_path, "w", encoding="utf-8") as window_state:
-            window_state.write("visible-focused\n")
         with open(result_path, "w", encoding="utf-8") as result:
             json.dump({"argv": request.get("argv", []), "status": "acknowledged"}, result)
         client.sendall(b"ok\n")
@@ -334,8 +406,7 @@ if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
     "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1 &
     SECOND_LAUNCHER_PID=$!
     wait_for "unconditional resident replacement regression" resident_policy_regressed
-    FINAL_ELECTRON_PID="$(read_live_app_pid 2>/dev/null || true)"
-    fail "warm-start-disabled launch replaced or duplicated a healthy resident"
+    mutation_detected
 fi
 
 set +e
@@ -361,8 +432,6 @@ kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
     || fail "runtime marker no longer identifies the healthy resident"
 [ "$HANDOFF_STATUS" = "acknowledged" ] \
     || fail "controlled resident did not acknowledge the reopen handoff"
-[ "$(cat "$WINDOW_STATE")" = "visible-focused" ] \
-    || fail "controlled primary window did not become visible and focused"
 python3 - "$HANDOFF_RESULT" <<'PY' \
     || fail "reopen handoff did not preserve the --new-chat argument"
 import json

--- a/tests/launcher_window_reopen_behavior.sh
+++ b/tests/launcher_window_reopen_behavior.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+APP_DIR="$TMP_DIR/app"
+HOME_DIR="$TMP_DIR/home"
+RUNTIME_DIR="$TMP_DIR/runtime"
+STATE_DIR="$HOME_DIR/.local/state/codex-desktop"
+SOCKET_PATH="$RUNTIME_DIR/codex-desktop/launch-action.sock"
+HANDOFF_RESULT="$TMP_DIR/handoff.json"
+WINDOW_STATE="$TMP_DIR/window-state"
+FIRST_LOG="$TMP_DIR/first-launch.log"
+SECOND_LOG="$TMP_DIR/second-launch.log"
+APP_LOG="$HOME_DIR/.cache/codex-desktop/launcher.log"
+LAUNCHER_PID=""
+SECOND_LAUNCHER_PID=""
+SOCKET_PID=""
+DECOY_PID=""
+FIRST_ELECTRON_PID=""
+FINAL_ELECTRON_PID=""
+HANDOFF_STATUS="not-attempted"
+TIMEOUT_STATUS="false"
+ERROR_STATUS="false"
+
+count_test_main_processes() {
+    local count=0
+    local cmdline
+    local pid
+
+    for cmdline in /proc/[0-9]*/cmdline; do
+        [ -r "$cmdline" ] || continue
+        pid="${cmdline#/proc/}"
+        pid="${pid%/cmdline}"
+        IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
+        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
+            count=$((count + 1))
+        fi
+        arg0=""
+    done
+    printf '%s\n' "$count"
+}
+
+record_result() {
+    local outcome="$1"
+    local main_process_count
+    local marker_pid=""
+
+    marker_pid="$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)"
+    main_process_count="$(count_test_main_processes)"
+
+    printf '{"outcome":"%s","initialPid":"%s","finalPid":"%s","mainProcessCount":%s,"handoff":"%s","windowState":"%s","markerPid":"%s","webviewMarkerPresent":%s,"socketPresent":%s,"timedOut":%s,"userVisibleError":%s}\n' \
+        "$outcome" \
+        "$FIRST_ELECTRON_PID" \
+        "$FINAL_ELECTRON_PID" \
+        "$main_process_count" \
+        "$HANDOFF_STATUS" \
+        "$(cat "$WINDOW_STATE" 2>/dev/null || printf unknown)" \
+        "$marker_pid" \
+        "$([ -s "$STATE_DIR/webview.pid" ] && printf true || printf false)" \
+        "$([ -S "$SOCKET_PATH" ] && printf true || printf false)" \
+        "$TIMEOUT_STATUS" \
+        "$ERROR_STATUS"
+}
+
+stop_owned_process_bounded() {
+    local pid="$1"
+    local match_mode="$2"
+    local expected="$3"
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 0
+    python3 - "$pid" "$match_mode" "$expected" <<'PY' || true
+import os
+import select
+import signal
+import sys
+
+pid = int(sys.argv[1])
+match_mode = sys.argv[2]
+expected = sys.argv[3]
+
+try:
+    pidfd = os.pidfd_open(pid)
+except (ProcessLookupError, PermissionError):
+    raise SystemExit(0)
+
+try:
+    try:
+        raw_cmdline = open(f"/proc/{pid}/cmdline", "rb").read()
+    except (FileNotFoundError, PermissionError):
+        raise SystemExit(0)
+    argv = [part.decode(errors="surrogateescape") for part in raw_cmdline.split(b"\0") if part]
+    matches = bool(argv) and (
+        (match_mode == "arg0" and argv[0] == expected)
+        or (match_mode == "argv" and expected in argv)
+    )
+    if not matches:
+        raise SystemExit(0)
+
+    signal.pidfd_send_signal(pidfd, signal.SIGTERM)
+    poller = select.poll()
+    poller.register(pidfd, select.POLLIN)
+    if not poller.poll(1000):
+        signal.pidfd_send_signal(pidfd, signal.SIGKILL)
+        poller.poll(1000)
+finally:
+    os.close(pidfd)
+PY
+}
+
+cleanup() {
+    local cmdline
+    local pid
+    local webview_pid
+
+    webview_pid="$(cat "$STATE_DIR/webview.pid" 2>/dev/null || true)"
+    stop_owned_process_bounded "$LAUNCHER_PID" argv "$APP_DIR/start.sh"
+    stop_owned_process_bounded "$SECOND_LAUNCHER_PID" argv "$APP_DIR/start.sh"
+    stop_owned_process_bounded "$SOCKET_PID" argv "$SOCKET_PATH"
+    stop_owned_process_bounded "$webview_pid" argv "$APP_DIR/.codex-linux/webview-server.py"
+    stop_owned_process_bounded "$DECOY_PID" arg0 "$TMP_DIR/decoy-electron"
+    for cmdline in /proc/[0-9]*/cmdline; do
+        [ -r "$cmdline" ] || continue
+        pid="${cmdline#/proc/}"
+        pid="${pid%/cmdline}"
+        IFS= read -r -d '' arg0 < "$cmdline" 2>/dev/null || true
+        if [ "${arg0:-}" = "$APP_DIR/electron" ]; then
+            IFS= read -r -d '' revalidated_arg0 < "$cmdline" 2>/dev/null || true
+            if [ "${revalidated_arg0:-}" = "$APP_DIR/electron" ]; then
+                stop_owned_process_bounded "$pid" arg0 "$APP_DIR/electron"
+            fi
+        fi
+        arg0=""
+        revalidated_arg0=""
+    done
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    local message="$*"
+    if grep -Eqi 'notify-send|zenity|could not safely|failed to' "$SECOND_LOG" "$APP_LOG" 2>/dev/null; then
+        ERROR_STATUS="true"
+    fi
+    printf 'launcher window-reopen behavior test failed: %s\n' "$message" >&2
+    record_result "failed" >&2
+    printf '%s\n' '--- first launch ---' >&2
+    sed -n '1,200p' "$FIRST_LOG" >&2 2>/dev/null || true
+    printf '%s\n' '--- second launch ---' >&2
+    sed -n '1,240p' "$SECOND_LOG" >&2 2>/dev/null || true
+    printf '%s\n' '--- app launcher log ---' >&2
+    sed -n '1,300p' "$APP_LOG" >&2 2>/dev/null || true
+    exit 1
+}
+
+wait_for() {
+    local description="$1"
+    shift
+    local attempt
+
+    for attempt in $(seq 1 100); do
+        "$@" && return 0
+        sleep 0.05
+    done
+    TIMEOUT_STATUS="true"
+    fail "timed out waiting for $description"
+}
+
+read_live_app_pid() {
+    local pid
+
+    pid="$(cat "$STATE_DIR/app.pid" 2>/dev/null || true)"
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    printf '%s\n' "$pid"
+}
+
+pid_file_is_live() {
+    read_live_app_pid >/dev/null
+}
+
+handoff_was_recorded() {
+    [ -s "$HANDOFF_RESULT" ]
+}
+
+launcher_lock_is_available() {
+    flock -n "$STATE_DIR/launcher.lock" true
+}
+
+resident_policy_regressed() {
+    local marker_pid
+
+    marker_pid="$(read_live_app_pid 2>/dev/null || true)"
+    if [ -n "$marker_pid" ] && [ "$marker_pid" != "$FIRST_ELECTRON_PID" ]; then
+        return 0
+    fi
+    [ "$(count_test_main_processes)" -ne 1 ]
+}
+
+mkdir -p \
+    "$APP_DIR/.codex-linux/cold-start.d" \
+    "$APP_DIR/.codex-linux/env.d" \
+    "$APP_DIR/.codex-linux/features" \
+    "$APP_DIR/.codex-linux/prelaunch.d" \
+    "$APP_DIR/.codex-linux/electron-args.d" \
+    "$APP_DIR/.codex-linux/launcher.d" \
+    "$APP_DIR/.codex-linux/after-exit.d" \
+    "$APP_DIR/content/webview" \
+    "$APP_DIR/resources/node-runtime/bin" \
+    "$HOME_DIR/.config/codex-desktop" \
+    "$RUNTIME_DIR/codex-desktop"
+
+printf '%s\n' '{"codex-linux-warm-start-enabled":true}' \
+    > "$HOME_DIR/.config/codex-desktop/settings.json"
+printf '%s\n' "visible-unfocused" > "$WINDOW_STATE"
+
+PORT="$(python3 - <<'PY'
+import socket
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+
+{
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -Eeuo pipefail' \
+        'CODEX_LINUX_APP_ID=codex-desktop' \
+        'CODEX_LINUX_APP_DISPLAY_NAME="ChatGPT Desktop"' \
+        'CODEX_LINUX_WEBVIEW_PORT="${CODEX_WEBVIEW_PORT:-5175}"'
+    cat "$REPO_DIR/launcher/start.sh.template"
+} > "$APP_DIR/start.sh"
+chmod +x "$APP_DIR/start.sh"
+if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
+    python3 - "$APP_DIR/start.sh" <<'PY'
+import sys
+
+path = sys.argv[1]
+source = open(path, encoding="utf-8").read()
+needle = "\nprepare_launch_state_under_lock\n"
+mutation = r'''
+prepare_launch_state_under_lock
+if running_app_is_active; then
+    controlled_resident_pid="$RUNNING_APP_PID"
+    kill "$controlled_resident_pid"
+    for _ in $(seq 1 100); do
+        kill -0 "$controlled_resident_pid" 2>/dev/null || break
+        sleep 0.05
+    done
+    rm -f "$APP_PID_FILE" "$LAUNCH_ACTION_SOCKET"
+    refresh_launch_state_quick
+fi
+'''
+if source.count(needle) != 1:
+    raise SystemExit("unable to install controlled resident-replacement mutation")
+open(path, "w", encoding="utf-8").write(source.replace(needle, "\n" + mutation, 1))
+PY
+fi
+cp "$REPO_DIR/launcher/webview-server.py" "$APP_DIR/.codex-linux/webview-server.py"
+cp "$REPO_DIR/launcher/cli-launch-path.py" "$APP_DIR/.codex-linux/cli-launch-path.py"
+ln -s "$(command -v node)" "$APP_DIR/resources/node-runtime/bin/node"
+printf '%s\n' '<!doctype html><title>Codex</title><div id="startup-loader"></div>' \
+    > "$APP_DIR/content/webview/index.html"
+
+g++ -x c++ -O2 -o "$APP_DIR/electron" - <<'CPP'
+#include <csignal>
+#include <unistd.h>
+
+static volatile sig_atomic_t running = 1;
+static void stop(int) { running = 0; }
+
+int main() {
+    std::signal(SIGTERM, stop);
+    std::signal(SIGINT, stop);
+    while (running) pause();
+    return 0;
+}
+CPP
+cp "$APP_DIR/electron" "$TMP_DIR/decoy-electron"
+"$TMP_DIR/decoy-electron" --app-id=codex-desktop &
+DECOY_PID=$!
+
+COMMON_ENV=(
+    env -i
+    "PATH=$PATH"
+    "HOME=$HOME_DIR"
+    "XDG_RUNTIME_DIR=$RUNTIME_DIR"
+    "CODEX_CLI_PATH=$(command -v true)"
+    "CODEX_WEBVIEW_PORT=$PORT"
+)
+
+"${COMMON_ENV[@]}" "$APP_DIR/start.sh" > "$FIRST_LOG" 2>&1 &
+LAUNCHER_PID=$!
+wait_for "first Electron marker" pid_file_is_live
+wait_for "first launcher lock release" launcher_lock_is_available
+FIRST_ELECTRON_PID="$(read_live_app_pid)"
+
+python3 - "$SOCKET_PATH" "$HANDOFF_RESULT" "$WINDOW_STATE" <<'PY' &
+import json
+import os
+import socket
+import sys
+
+socket_path, result_path, window_state_path = sys.argv[1:]
+os.makedirs(os.path.dirname(socket_path), exist_ok=True)
+try:
+    os.unlink(socket_path)
+except FileNotFoundError:
+    pass
+
+with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+    server.bind(socket_path)
+    server.listen()
+    server.settimeout(10)
+    client, _ = server.accept()
+    with client:
+        client.settimeout(2)
+        payload = client.recv(65536)
+        request = json.loads(payload.decode("utf-8").strip())
+        with open(window_state_path, "w", encoding="utf-8") as window_state:
+            window_state.write("visible-focused\n")
+        with open(result_path, "w", encoding="utf-8") as result:
+            json.dump({"argv": request.get("argv", []), "status": "acknowledged"}, result)
+        client.sendall(b"ok\n")
+PY
+SOCKET_PID=$!
+wait_for "controlled handoff socket" test -S "$SOCKET_PATH"
+
+if [ "${CODEX_TEST_FORCE_RESIDENT_REPLACEMENT:-0}" = "1" ]; then
+    printf '%s\n' '{"codex-linux-warm-start-enabled":false}' \
+        > "$HOME_DIR/.config/codex-desktop/settings.json"
+    "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1 &
+    SECOND_LAUNCHER_PID=$!
+    wait_for "unconditional resident replacement regression" resident_policy_regressed
+    FINAL_ELECTRON_PID="$(read_live_app_pid 2>/dev/null || true)"
+    fail "warm-start-disabled launch replaced or duplicated a healthy resident"
+fi
+
+set +e
+timeout 8s "${COMMON_ENV[@]}" "$APP_DIR/start.sh" --new-chat > "$SECOND_LOG" 2>&1
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    if [ "$rc" -eq 124 ]; then
+        TIMEOUT_STATUS="true"
+    fi
+    fail "second launcher invocation did not complete successfully (status $rc)"
+fi
+
+wait_for "reopen handoff acknowledgement" handoff_was_recorded
+HANDOFF_STATUS="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$HANDOFF_RESULT")"
+FINAL_ELECTRON_PID="$(read_live_app_pid)"
+
+[ "$FINAL_ELECTRON_PID" = "$FIRST_ELECTRON_PID" ] \
+    || fail "healthy resident PID changed from $FIRST_ELECTRON_PID to $FINAL_ELECTRON_PID"
+kill -0 "$FIRST_ELECTRON_PID" 2>/dev/null \
+    || fail "healthy resident Electron did not survive reopen handoff"
+[ "$(cat "$STATE_DIR/app.pid")" = "$FIRST_ELECTRON_PID" ] \
+    || fail "runtime marker no longer identifies the healthy resident"
+[ "$HANDOFF_STATUS" = "acknowledged" ] \
+    || fail "controlled resident did not acknowledge the reopen handoff"
+[ "$(cat "$WINDOW_STATE")" = "visible-focused" ] \
+    || fail "controlled primary window did not become visible and focused"
+python3 - "$HANDOFF_RESULT" <<'PY' \
+    || fail "reopen handoff did not preserve the --new-chat argument"
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as result:
+    assert json.load(result)["argv"] == ["--new-chat"]
+PY
+[ "$(count_test_main_processes)" -eq 1 ] \
+    || fail "reopen handoff left more than one controlled Electron process"
+[ -s "$STATE_DIR/webview.pid" ] \
+    || fail "webview runtime marker disappeared during reopen handoff"
+kill -0 "$DECOY_PID" 2>/dev/null \
+    || fail "launcher signalled a decoy process outside the isolated app identity"
+if grep -Eqi 'notify-send|zenity|could not safely|failed to' "$SECOND_LOG" "$APP_LOG" 2>/dev/null; then
+    ERROR_STATUS="true"
+    fail "reopen handoff emitted a user-visible error"
+fi
+
+record_result "preserved"
+printf '%s\n' "launcher window-reopen behavior test passed"

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -10565,6 +10565,15 @@ test_launcher_warm_start_recovery() {
         bash "$REPO_DIR/tests/launcher_warm_start_recovery.sh"
 }
 
+test_launcher_window_reopen_behavior() {
+    info "Checking healthy resident window-reopen behavior"
+    bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh"
+    if CODEX_TEST_FORCE_RESIDENT_REPLACEMENT=1 \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh"; then
+        fail "Window-reopen behavior harness did not detect resident replacement"
+    fi
+}
+
 test_notification_actions_bridge_accepts_prebuilt_binary() {
     local workspace="$TMP_DIR/notification-actions-bridge"
     local source_binary="$workspace/prebuilt/codex-notification-actions-linux"
@@ -10712,6 +10721,7 @@ main() {
     test_launcher_marketplace_metadata_atomic_staging
     test_launcher_template_sanity
     test_launcher_warm_start_recovery
+    test_launcher_window_reopen_behavior
     test_launcher_cli_resolution_policy
     test_webview_server_cache_policy
     test_process_detection_helper_cmdline_shapes

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -10566,12 +10566,91 @@ test_launcher_warm_start_recovery() {
 }
 
 test_launcher_window_reopen_behavior() {
-    info "Checking healthy resident window-reopen behavior"
-    bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh"
-    if CODEX_TEST_FORCE_RESIDENT_REPLACEMENT=1 \
-        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh"; then
-        fail "Window-reopen behavior harness did not detect resident replacement"
+    local nominal_log="$TMP_DIR/launcher-window-reopen-nominal.log"
+    local mutation_log="$TMP_DIR/launcher-window-reopen-mutation.log"
+    local no_pidfd_log="$TMP_DIR/launcher-window-reopen-no-pidfd.log"
+    local no_pidfd_tmp="$TMP_DIR/launcher-window-reopen-no-pidfd-missing"
+    local probe_failure_bin="$TMP_DIR/launcher-window-reopen-probe-failure-bin"
+    local probe_failure_log="$TMP_DIR/launcher-window-reopen-probe-failure.log"
+    local status
+
+    info "Checking healthy resident reopen handoff behavior"
+    set +e
+    bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$nominal_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -eq 77 ]; then
+        if ! grep -Fxq \
+            'launcher window-reopen behavior test skipped: pidfd cleanup unavailable' \
+            "$nominal_log" \
+            || ! grep -Fq '"reason":"pidfd-cleanup-unavailable"' "$nominal_log"; then
+            cat "$nominal_log" >&2
+            fail "Window-reopen behavior harness returned an invalid pidfd skip result"
+        fi
+        cat "$nominal_log"
+        return 0
     fi
+    if [ "$status" -ne 0 ] \
+        || ! grep -Fxq 'launcher window-reopen behavior test passed' "$nominal_log" \
+        || ! grep -Fq '"outcome":"preserved"' "$nominal_log"; then
+        cat "$nominal_log" >&2
+        fail "Window-reopen behavior harness nominal run failed (status $status)"
+    fi
+    cat "$nominal_log"
+
+    set +e
+    CODEX_TEST_FORCE_RESIDENT_REPLACEMENT=1 \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$mutation_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -ne 86 ] \
+        || ! grep -Fxq \
+            'launcher window-reopen behavior mutation detected: healthy resident replacement' \
+            "$mutation_log" \
+        || ! grep -Fq '"outcome":"resident-replacement-detected"' "$mutation_log"; then
+        cat "$mutation_log" >&2
+        fail "Window-reopen behavior harness did not report the expected resident-replacement regression (status $status)"
+    fi
+
+    rm -rf "$no_pidfd_tmp"
+    set +e
+    CODEX_TEST_FORCE_NO_PIDFD=1 TMPDIR="$no_pidfd_tmp" \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$no_pidfd_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -ne 77 ] \
+        || ! grep -Fxq \
+            'launcher window-reopen behavior test skipped: pidfd cleanup unavailable' \
+            "$no_pidfd_log" \
+        || ! grep -Fq '"reason":"pidfd-cleanup-unavailable"' "$no_pidfd_log"; then
+        cat "$no_pidfd_log" >&2
+        fail "Window-reopen behavior harness did not report the expected safe no-pidfd skip (status $status)"
+    fi
+    [ ! -e "$no_pidfd_tmp" ] \
+        || fail "Window-reopen behavior harness created a workspace before the pidfd capability gate"
+
+    mkdir -p "$probe_failure_bin"
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 9' > "$probe_failure_bin/python3"
+    chmod +x "$probe_failure_bin/python3"
+    set +e
+    PATH="$probe_failure_bin:$PATH" TMPDIR="$no_pidfd_tmp" \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$probe_failure_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -ne 1 ] \
+        || ! grep -Fxq \
+            'launcher window-reopen behavior test failed: pidfd capability probe failed' \
+            "$probe_failure_log" \
+        || grep -Fq 'pidfd-cleanup-unavailable' "$probe_failure_log"; then
+        cat "$probe_failure_log" >&2
+        fail "Window-reopen behavior harness misclassified a pidfd probe setup failure (status $status)"
+    fi
+    [ ! -e "$no_pidfd_tmp" ] \
+        || fail "Window-reopen behavior harness created a workspace after a pidfd probe failure"
 }
 
 test_notification_actions_bridge_accepts_prebuilt_binary() {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -10568,6 +10568,7 @@ test_launcher_warm_start_recovery() {
 test_launcher_window_reopen_behavior() {
     local nominal_log="$TMP_DIR/launcher-window-reopen-nominal.log"
     local mutation_log="$TMP_DIR/launcher-window-reopen-mutation.log"
+    local mutation_control_log="$TMP_DIR/launcher-window-reopen-mutation-control.log"
     local no_pidfd_log="$TMP_DIR/launcher-window-reopen-no-pidfd.log"
     local no_pidfd_tmp="$TMP_DIR/launcher-window-reopen-no-pidfd-missing"
     local probe_failure_bin="$TMP_DIR/launcher-window-reopen-probe-failure-bin"
@@ -10612,6 +10613,23 @@ test_launcher_window_reopen_behavior() {
         || ! grep -Fq '"outcome":"resident-replacement-detected"' "$mutation_log"; then
         cat "$mutation_log" >&2
         fail "Window-reopen behavior harness did not report the expected resident-replacement regression (status $status)"
+    fi
+
+    set +e
+    CODEX_TEST_FORCE_RESIDENT_REPLACEMENT=1 \
+        CODEX_TEST_MUTATION_CONTROL_ONLY=1 \
+        bash "$REPO_DIR/tests/launcher_window_reopen_behavior.sh" \
+        > "$mutation_control_log" 2>&1
+    status=$?
+    set -e
+    if [ "$status" -ne 0 ] \
+        || ! grep -Fxq \
+            'launcher window-reopen behavior mutation control passed' \
+            "$mutation_control_log" \
+        || ! grep -Fq '"outcome":"mutation-control-preserved"' "$mutation_control_log" \
+        || grep -Fq 'resident-replacement-detected' "$mutation_control_log"; then
+        cat "$mutation_control_log" >&2
+        fail "Window-reopen behavior harness mutation control failed (status $status)"
     fi
 
     rm -rf "$no_pidfd_tmp"


### PR DESCRIPTION
## Summary

Add an isolated launcher harness for the healthy resident reopen handoff contract.

The harness builds a controlled fake Desktop runtime with its own Electron identity, packaged webview, runtime markers, Unix handoff socket, and observable process state. It verifies that reopening a healthy resident:

- forwards `--new-chat` through the launcher IPC handoff;
- preserves the resident PID and keeps exactly one controlled Electron main process;
- retains the runtime markers;
- leaves a same-app-id decoy process untouched; and
- emits no user-visible error.

Mutation mode now has a dedicated, machine-checkable result: the injected resident-replacement regression must exit with status `86` and emit `resident-replacement-detected`. Setup failures, timeouts, probe failures, and unrelated non-zero exits remain ordinary test failures. A paired control runs the same mutation path without installing the source mutation and must preserve the resident without emitting exit `86` or the mutation sentinel.

The harness also checks pidfd cleanup capability before creating its workspace or starting any fixture process. Unsupported hosts exit with the explicit status `77`; unexpected probe failures remain hard failures. Cleanup revalidates process identity before signalling and fails the test if bounded TERM/KILL cleanup cannot complete.

The previous synthetic focus state has been removed. This test covers launcher IPC and resident preservation only; it does not claim to exercise the production window-focus receiver.

This is a test-only change and does not modify production launcher behavior.

## Validation

- `bash -n tests/launcher_window_reopen_behavior.sh tests/scripts_smoke.sh`
- `git diff --check`
- Nominal harness: resident PID preserved, one controlled main process, `--new-chat` acknowledged, markers retained, decoy untouched, no user-visible error
- Mutation harness: dedicated exit `86` and `resident-replacement-detected` outcome
- No-mutation control: same mutation path preserves the resident and cannot emit exit `86` or the mutation sentinel
- No-pidfd path: dedicated exit `77` before workspace creation or process spawn
- Probe setup failure: hard failure, not a mutation result or unsupported-host skip
- Full repository CI passed on `0f1648a66786fe0fa8e0fb24aca14ae600765a9b`: Rust formatting, Clippy, checks and tests, script smoke tests, Debian, RPM, Pacman, and Nix validation

The existing ephemeral-port selection can still fail safely if another process claims the selected port before the fixture binds it; that produces a test failure rather than a false pass.

## Checklist

- [x] This pull request is ready for maintainer review.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, and edited source tests rather than generated output.
- [x] This is not an upstream-drift fix and adds no compatibility fallback.
- [x] The requested regression, unsupported-host, cleanup, and scope corrections are covered by tests.
- [x] The complete repository CI matrix passes on the current head.
