### PR TITLE
Fix enabled feature drift on the current DMG

### DIFF
--- a/docs/record-and-replay-linux.md
+++ b/docs/record-and-replay-linux.md
@@ -50,8 +50,8 @@ The workflow is:
 
 The important compatibility point is the contract: the bundled plugin launches
 an `event-stream` MCP server and the durable output is a Codex skill. The
-official macOS bundle supplies that server through
-`SkyComputerUseClient event-stream mcp`; the Linux feature supplies
+current macOS bundle supplies that server through
+`computer-use-client-launcher event-stream mcp`; the Linux feature supplies
 `SkyLinuxComputerUseClient event-stream mcp`, backed by the Rust
 `codex-record-replay-linux` backend.
 

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -22,12 +22,18 @@ function hasRecordReplayPluginGate(source) {
   const pluginGateArray = findBundledPluginGateArray(source);
   const target = pluginGateArray?.text ?? source;
   return new RegExp(
-    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},(?:isEnabled|isAvailable):`,
+    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},isAvailable:`,
   ).test(target);
 }
 
-function buildRecordReplayDescriptor(availabilityProp) {
-  return `{installWhenMissing:!0,name:\`${RECORD_REPLAY_PLUGIN_NAME}\`,${availabilityProp}:({platform:e})=>e===\`linux\`}`;
+function hasObsoleteRecordReplayPluginGate(source) {
+  return new RegExp(
+    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},isEnabled:`,
+  ).test(source);
+}
+
+function buildRecordReplayDescriptor() {
+  return `{installWhenMissing:!0,name:\`${RECORD_REPLAY_PLUGIN_NAME}\`,isAvailable:({platform:e})=>e===\`linux\`}`;
 }
 
 function findMatchingBracket(source, openIndex) {
@@ -60,7 +66,7 @@ function findBundledPluginGateArray(source) {
     const closeIndex = findMatchingBracket(source, openIndex);
     if (closeIndex !== -1 && markerIndex < closeIndex) {
       const text = source.slice(openIndex + 1, closeIndex);
-      if (text.includes("installWhenMissing") && text.includes("name:") && /(?:isEnabled|isAvailable):/.test(text)) {
+      if (text.includes("installWhenMissing") && text.includes("name:") && text.includes("isAvailable:")) {
         return { start: openIndex + 1, end: closeIndex, text };
       }
     }
@@ -71,7 +77,7 @@ function findBundledPluginGateArray(source) {
 
 function findAlwaysOnBundledDescriptor(pluginGateArray) {
   const pluginNameExpression = "(?:[A-Za-z_$][\\w$]*(?:\\.[A-Za-z_$][\\w$]*)?|`[^`]+`|\"[^\"]+\"|'[^']+')";
-  const regex = new RegExp(String.raw`\{name:(${pluginNameExpression}),(isEnabled|isAvailable):\(\)=>!0\}`, "g");
+  const regex = new RegExp(String.raw`\{name:(${pluginNameExpression}),isAvailable:\(\)=>!0\}`, "g");
   let lastMatch = null;
   for (const match of pluginGateArray.text.matchAll(regex)) lastMatch = match;
   return lastMatch;
@@ -81,6 +87,9 @@ function applyRecordReplayPluginGatePatch(currentSource) {
   if (hasRecordReplayPluginGate(currentSource)) {
     return currentSource;
   }
+  if (hasObsoleteRecordReplayPluginGate(currentSource)) {
+    throw new Error("Optional Record & Replay plugin gate patch drift: obsolete isEnabled availability contract");
+  }
   const pluginGateArray = findBundledPluginGateArray(currentSource);
   if (pluginGateArray == null) {
     throw new Error("Optional Record & Replay plugin gate patch drift: could not find expected upstream .computerUse plugin descriptor array");
@@ -89,9 +98,8 @@ function applyRecordReplayPluginGatePatch(currentSource) {
   if (match == null) {
     throw new Error("Optional Record & Replay plugin gate patch drift: could not find bundled plugin descriptor insertion point");
   }
-  const [_descriptor, _pluginName, availabilityProp] = match;
   const insertionIndex = pluginGateArray.start + match.index;
-  return `${currentSource.slice(0, insertionIndex)}${buildRecordReplayDescriptor(availabilityProp)},${currentSource.slice(insertionIndex)}`;
+  return `${currentSource.slice(0, insertionIndex)}${buildRecordReplayDescriptor()},${currentSource.slice(insertionIndex)}`;
 }
 
 function recordReplayBridgeSource({ childProcessVar, fsVar, pathVar }) {
@@ -149,55 +157,16 @@ async function codexLinuxChronicleEnsureSidecarRunning(e){let t=await codexLinux
 async function codexLinuxChronicleToggleSidecar(){let e=await codexLinuxRecordReplayRun(["skysight","status"],5000),t=e?.json&&typeof e.json==="object"?e.json:null,n=String(t?.state||""),r=t?.is_running===!0||t?.isRunning===!0,a=t?.paused===!0||t?.is_paused===!0||t?.isPaused===!0||n==="paused";if(n==="running"&&r&&!a)return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","pause"],10000));if(r&&a)return codexLinuxChronicleEnsureSidecarRunning(!0);return codexLinuxChronicleControlStateFromSkysight(await codexLinuxRecordReplayRun(["skysight","start","--summary-agent","enabled"],15000))}`;
 }
 
-function upgradeRecordReplayBridgeSource(currentSource) {
-  const patchName = "Record & Replay main bridge patch";
-  let patchedSource = currentSource;
-  const childProcessVar = requireName(currentSource, "node:child_process");
-  if (!patchedSource.includes("function codexLinuxChronicleControlStateFromSkysight")) {
-    if (childProcessVar == null) {
-      warn("Could not find Node child_process alias for Chronicle bridge upgrade", patchName);
-    } else {
-      patchedSource = `${recordReplayChronicleHelperSource({ childProcessVar })}\n${patchedSource}`;
-    }
-  }
-
-  if (!patchedSource.includes('"linux-record-replay-speech-context-active":async')) {
-    const browserTraceNeedle = `"linux-record-replay-browser-trace":async`;
-    if (!patchedSource.includes(browserTraceNeedle)) {
-      warn("Could not find active speech-context bridge upgrade point", patchName);
-    } else {
-      patchedSource = patchedSource.replace(
-        browserTraceNeedle,
-        `${recordReplayActiveSpeechContextBridgeHandler()},${browserTraceNeedle}`,
-      );
-    }
-  }
-
-  const hasChronicleHelpers = patchedSource.includes("function codexLinuxChronicleControlStateFromSkysight");
-  if (!patchedSource.includes('"chronicle-permissions":async')) {
-    const doctorNeedle = `"linux-record-replay-doctor":async`;
-    if (!patchedSource.includes(doctorNeedle)) {
-      warn("Could not find Chronicle bridge upgrade point", patchName);
-    } else if (!hasChronicleHelpers) {
-      warn("Could not install Chronicle bridge handlers without helper functions", patchName);
-    } else {
-      patchedSource = patchedSource.replace(
-        doctorNeedle,
-        `${recordReplayBridgeSource({ childProcessVar, fsVar: "fs", pathVar: "path" }).split(`,"linux-record-replay-doctor":async`)[0]},${doctorNeedle}`,
-      );
-    }
-  }
-
-  return patchedSource;
-}
-
 function recordReplayChronicleTrayControlPattern() {
   return /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
 }
 
-function hasRecordReplayChronicleTrayCallbacks(source) {
-  return source.includes("getChronicleSidecarControlState:()=>")
-    && source.includes("toggleChronicleSidecar:async()=>");
+function hasCompleteRecordReplayMainBridgePatch(source) {
+  return source.includes("function codexLinuxChronicleControlStateFromSkysight")
+    && source.includes('"chronicle-permissions":async')
+    && source.includes('"linux-record-replay-doctor":async')
+    && source.includes('"linux-record-replay-speech-context-active":async')
+    && source.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()");
 }
 
 function applyRecordReplayChronicleTrayPatch(currentSource) {
@@ -228,19 +197,18 @@ function applyRecordReplayChronicleTrayPatch(currentSource) {
 
 function applyRecordReplayMainBridgePatch(currentSource) {
   const patchName = "Record & Replay main bridge patch";
-  if (
-    hasRecordReplayChronicleTrayCallbacks(currentSource)
-    && !currentSource.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()")
-    && !recordReplayChronicleTrayControlPattern().test(currentSource)
-  ) {
+  if (currentSource.includes('"linux-record-replay-doctor":async')) {
+    if (!hasCompleteRecordReplayMainBridgePatch(currentSource)) {
+      warn("Found incomplete Record & Replay main bridge patch", patchName);
+    }
+    return currentSource;
+  }
+  if (!recordReplayChronicleTrayControlPattern().test(currentSource)) {
     warn("Could not find Chronicle tray control callbacks", patchName);
     return currentSource;
   }
-  let patchedSource = currentSource;
-  if (currentSource.includes('"linux-record-replay-doctor":async')) {
-    return applyRecordReplayChronicleTrayPatch(upgradeRecordReplayBridgeSource(currentSource));
-  }
 
+  let patchedSource = currentSource;
   const childProcessVar = requireName(currentSource, "node:child_process");
   const fsVar = requireName(currentSource, "node:fs");
   const pathVar = requireName(currentSource, "node:path");

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -191,14 +191,22 @@ function upgradeRecordReplayBridgeSource(currentSource) {
   return patchedSource;
 }
 
+function recordReplayChronicleTrayControlPattern() {
+  return /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
+}
+
+function hasRecordReplayChronicleTrayCallbacks(source) {
+  return source.includes("getChronicleSidecarControlState:()=>")
+    && source.includes("toggleChronicleSidecar:async()=>");
+}
+
 function applyRecordReplayChronicleTrayPatch(currentSource) {
   const patchName = "Record & Replay Chronicle tray bridge patch";
   if (currentSource.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()")) {
     return currentSource;
   }
 
-  const trayControlPattern =
-    /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?([A-Za-z_$][\w$]*)),toggleChronicleSidecar:async\(\)=>\{let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \3==null\?\2:\3\.getChronicleSidecarControlState\(\)\.running\?\3\.pauseChronicleSidecar\(\):\3\.resumeChronicleSidecar\(\)\}/u;
+  const trayControlPattern = recordReplayChronicleTrayControlPattern();
   if (!trayControlPattern.test(currentSource)) {
     warn("Could not find Chronicle tray control callbacks", patchName);
     return currentSource;
@@ -208,17 +216,26 @@ function applyRecordReplayChronicleTrayPatch(currentSource) {
     trayControlPattern,
     (
       _match,
-      upstreamStateExpression,
+      availabilityFunction,
       disabledStateVar,
+      upstreamStateExpression,
       connectionVar,
       connectionExpression,
     ) =>
-      `getChronicleSidecarControlState:()=>process.platform===\`linux\`?codexLinuxChronicleSidecarControlState():${upstreamStateExpression},toggleChronicleSidecar:async()=>{if(process.platform===\`linux\`)return codexLinuxChronicleToggleSidecar();let ${connectionVar}=${connectionExpression};return ${connectionVar}==null?${disabledStateVar}:${connectionVar}.getChronicleSidecarControlState().running?${connectionVar}.pauseChronicleSidecar():${connectionVar}.resumeChronicleSidecar()}`,
+      `getChronicleSidecarControlState:()=>process.platform===\`linux\`?codexLinuxChronicleSidecarControlState():${availabilityFunction}().skysight?${disabledStateVar}:${upstreamStateExpression},toggleChronicleSidecar:async()=>{if(process.platform===\`linux\`)return codexLinuxChronicleToggleSidecar();if(${availabilityFunction}().skysight)return ${disabledStateVar};let ${connectionVar}=${connectionExpression};return ${connectionVar}==null?${disabledStateVar}:${connectionVar}.getChronicleSidecarControlState().running?${connectionVar}.pauseChronicleSidecar():${connectionVar}.resumeChronicleSidecar()}`,
   );
 }
 
 function applyRecordReplayMainBridgePatch(currentSource) {
   const patchName = "Record & Replay main bridge patch";
+  if (
+    hasRecordReplayChronicleTrayCallbacks(currentSource)
+    && !currentSource.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()")
+    && !recordReplayChronicleTrayControlPattern().test(currentSource)
+  ) {
+    warn("Could not find Chronicle tray control callbacks", patchName);
+    return currentSource;
+  }
   let patchedSource = currentSource;
   if (currentSource.includes('"linux-record-replay-doctor":async')) {
     return applyRecordReplayChronicleTrayPatch(upgradeRecordReplayBridgeSource(currentSource));
@@ -301,6 +318,14 @@ function recordReplayActiveSpeechContextExpression(dispatchVar, transcriptVar) {
   return `(()=>{let t=String(${transcriptVar}??"").trim();if(t.length>0){let n="codex-linux-record-replay-global-dictation-"+Date.now()+"-"+Math.random().toString(36).slice(2);${dispatchVar}.dispatchMessage("fetch",{hostId:"local",requestId:n,method:"POST",url:"vscode://codex/linux-record-replay-speech-context-active",body:JSON.stringify({transcript:t,source:"codex-global-dictation"})})}})()`;
 }
 
+function recordReplayConversationTranscriptPattern() {
+  return /([A-Za-z_$][\w$]*)\.length>0&&([A-Za-z_$][\w$]*)!==`discard`&&globalThis\.codexLinuxConversationShouldSendTranscript\?\.\(\1,\2\)!==!1&&\((([A-Za-z_$][\w$]*)\.getInstance\(\)\.dispatchMessage\(`global-dictation-record-history-item`,\{text:\1\}\),\2===`send`\?([A-Za-z_$][\w$]*)\.onTranscriptSend\(\1\):\5\.onTranscriptInsert\(\1\))\)/u;
+}
+
+function recordReplayUpstreamTranscriptPattern() {
+  return /([A-Za-z_$][\w$]*)\.length>0&&\((([A-Za-z_$][\w$]*)\.getInstance\(\)\.dispatchMessage\(`global-dictation-record-history-item`,\{text:\1\}\),([A-Za-z_$][\w$]*)===`send`\?([A-Za-z_$][\w$]*)\.onTranscriptSend\(\1\):\5\.onTranscriptInsert\(\1\))\)/u;
+}
+
 function applyRecordReplayHudPatch(currentSource) {
   if (currentSource.includes("codexLinuxRecordReplayHudVersion=")) {
     return currentSource;
@@ -318,26 +343,7 @@ function applyRecordReplayDictationTranscriptPatch(currentSource) {
     return currentSource;
   }
 
-  const upstreamNeedle =
-    "i.length>0&&(j.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:i}),e===`send`?n.onTranscriptSend(i):n.onTranscriptInsert(i))";
-  if (currentSource.includes(upstreamNeedle)) {
-    return currentSource.replace(
-      upstreamNeedle,
-      `i.length>0&&(${recordReplayTranscriptCaptureExpression("i", "e")},j.getInstance().dispatchMessage(\`global-dictation-record-history-item\`,{text:i}),e===\`send\`?n.onTranscriptSend(i):n.onTranscriptInsert(i))`,
-    );
-  }
-
-  const conversationNeedle =
-    "i.length>0&&e!==`discard`&&globalThis.codexLinuxConversationShouldSendTranscript?.(i,e)!==!1&&(j.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:i}),e===`send`?n.onTranscriptSend(i):n.onTranscriptInsert(i))";
-  if (currentSource.includes(conversationNeedle)) {
-    return currentSource.replace(
-      conversationNeedle,
-      `i.length>0&&e!==\`discard\`&&globalThis.codexLinuxConversationShouldSendTranscript?.(i,e)!==!1&&(${recordReplayTranscriptCaptureExpression("i", "e")},j.getInstance().dispatchMessage(\`global-dictation-record-history-item\`,{text:i}),e===\`send\`?n.onTranscriptSend(i):n.onTranscriptInsert(i))`,
-    );
-  }
-
-  const conversationPattern =
-    /([A-Za-z_$][\w$]*)\.length>0&&([A-Za-z_$][\w$]*)!==`discard`&&globalThis\.codexLinuxConversationShouldSendTranscript\?\.\(\1,\2\)!==!1&&\((([A-Za-z_$][\w$]*)\.getInstance\(\)\.dispatchMessage\(`global-dictation-record-history-item`,\{text:\1\}\),\2===`send`\?([A-Za-z_$][\w$]*)\.onTranscriptSend\(\1\):\5\.onTranscriptInsert\(\1\))\)/u;
+  const conversationPattern = recordReplayConversationTranscriptPattern();
   if (conversationPattern.test(currentSource)) {
     return currentSource.replace(
       conversationPattern,
@@ -346,8 +352,7 @@ function applyRecordReplayDictationTranscriptPatch(currentSource) {
     );
   }
 
-  const upstreamPattern =
-    /([A-Za-z_$][\w$]*)\.length>0&&\((([A-Za-z_$][\w$]*)\.getInstance\(\)\.dispatchMessage\(`global-dictation-record-history-item`,\{text:\1\}\),([A-Za-z_$][\w$]*)===`send`\?([A-Za-z_$][\w$]*)\.onTranscriptSend\(\1\):\5\.onTranscriptInsert\(\1\))\)/u;
+  const upstreamPattern = recordReplayUpstreamTranscriptPattern();
   if (upstreamPattern.test(currentSource)) {
     return currentSource.replace(
       upstreamPattern,
@@ -358,6 +363,17 @@ function applyRecordReplayDictationTranscriptPatch(currentSource) {
 
   warn("Could not find dictation transcript send point", patchName);
   return currentSource;
+}
+
+function hasRecordReplayDictationTranscriptContract(source) {
+  if (typeof source !== "string" || !source.includes("global-dictation-record-history-item")) {
+    return false;
+  }
+  if (source.includes("codexLinuxRecordReplayCaptureTranscript")) {
+    return true;
+  }
+  return recordReplayConversationTranscriptPattern().test(source)
+    || recordReplayUpstreamTranscriptPattern().test(source);
 }
 
 function applyRecordReplayGlobalDictationTranscriptPatch(currentSource) {
@@ -412,8 +428,8 @@ const descriptors = [
     phase: "webview-asset",
     order: 20695,
     ciPolicy: "optional",
-    pattern:
-      /^(?:(?:browser-sidebar-comment-light-dismiss|use-dictation(?!-hotkey))-|app-initial~app-main~.*onboarding-page).*\.js$/,
+    pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
+    assetMatch: hasRecordReplayDictationTranscriptContract,
     missingDescription: "composer dictation bundle",
     skipDescription: "Record & Replay dictation transcript patch",
     apply: applyRecordReplayDictationTranscriptPatch,

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -84,11 +84,11 @@ function findAlwaysOnBundledDescriptor(pluginGateArray) {
 }
 
 function applyRecordReplayPluginGatePatch(currentSource) {
-  if (hasRecordReplayPluginGate(currentSource)) {
-    return currentSource;
-  }
   if (hasObsoleteRecordReplayPluginGate(currentSource)) {
     throw new Error("Optional Record & Replay plugin gate patch drift: obsolete isEnabled availability contract");
+  }
+  if (hasRecordReplayPluginGate(currentSource)) {
+    return currentSource;
   }
   const pluginGateArray = findBundledPluginGateArray(currentSource);
   if (pluginGateArray == null) {
@@ -161,12 +161,21 @@ function recordReplayChronicleTrayControlPattern() {
   return /getChronicleSidecarControlState:\(\)=>([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
 }
 
+function recordReplayChronicleTrayPatchedPattern() {
+  return /getChronicleSidecarControlState:\(\)=>process\.platform===`linux`\?codexLinuxChronicleSidecarControlState\(\):([A-Za-z_$][\w$]*)\(\)\.skysight\?([A-Za-z_$][\w$]*):([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\(`local`\)\?\.getChronicleSidecarControlState\(\)\?\?\2),toggleChronicleSidecar:async\(\)=>\{if\(process\.platform===`linux`\)return codexLinuxChronicleToggleSidecar\(\);if\(\1\(\)\.skysight\)return \2;let ([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*\.appServerConnectionRegistry\.getMaybeConnection\([A-Za-z_$][\w$]*\));return \4==null\?\2:\4\.getChronicleSidecarControlState\(\)\.running\?\4\.pauseChronicleSidecar\(\):\4\.resumeChronicleSidecar\(\)\}/u;
+}
+
 function hasCompleteRecordReplayMainBridgePatch(source) {
-  return source.includes("function codexLinuxChronicleControlStateFromSkysight")
-    && source.includes('"chronicle-permissions":async')
-    && source.includes('"linux-record-replay-doctor":async')
-    && source.includes('"linux-record-replay-speech-context-active":async')
-    && source.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()");
+  const childProcessVar = requireName(source, "node:child_process");
+  const fsVar = requireName(source, "node:fs");
+  const pathVar = requireName(source, "node:path");
+  if (childProcessVar == null || fsVar == null || pathVar == null) {
+    return false;
+  }
+
+  return source.includes(recordReplayHelperSource({ childProcessVar, fsVar, pathVar }))
+    && source.includes(recordReplayBridgeSource({ childProcessVar, fsVar, pathVar }))
+    && recordReplayChronicleTrayPatchedPattern().test(source);
 }
 
 function applyRecordReplayChronicleTrayPatch(currentSource) {

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -18,12 +18,32 @@ function pluginNameExpressionRegex(pluginName) {
   return String.raw`(?:\`${escaped}\`|"${escaped}"|'${escaped}')`;
 }
 
+function recordReplayPluginDescriptorPattern(flags = "") {
+  return new RegExp(
+    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},`,
+    flags,
+  );
+}
+
 function hasRecordReplayPluginGate(source) {
   const pluginGateArray = findBundledPluginGateArray(source);
-  const target = pluginGateArray?.text ?? source;
-  return new RegExp(
-    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},isAvailable:`,
-  ).test(target);
+  if (pluginGateArray == null) {
+    return false;
+  }
+
+  const expectedDescriptor = buildRecordReplayDescriptor();
+  const sourceDescriptorCount = [...source.matchAll(recordReplayPluginDescriptorPattern("g"))].length;
+  const arrayDescriptorCount = [
+    ...pluginGateArray.text.matchAll(recordReplayPluginDescriptorPattern("g")),
+  ].length;
+  return sourceDescriptorCount === 1
+    && arrayDescriptorCount === 1
+    && source.split(expectedDescriptor).length - 1 === 1
+    && pluginGateArray.text.split(expectedDescriptor).length - 1 === 1;
+}
+
+function hasAnyRecordReplayPluginDescriptor(source) {
+  return recordReplayPluginDescriptorPattern().test(source);
 }
 
 function hasObsoleteRecordReplayPluginGate(source) {
@@ -89,6 +109,9 @@ function applyRecordReplayPluginGatePatch(currentSource) {
   }
   if (hasRecordReplayPluginGate(currentSource)) {
     return currentSource;
+  }
+  if (hasAnyRecordReplayPluginDescriptor(currentSource)) {
+    throw new Error("Optional Record & Replay plugin gate patch drift: invalid isAvailable availability contract");
   }
   const pluginGateArray = findBundledPluginGateArray(currentSource);
   if (pluginGateArray == null) {

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -18,9 +18,9 @@ function pluginNameExpressionRegex(pluginName) {
   return String.raw`(?:\`${escaped}\`|"${escaped}"|'${escaped}')`;
 }
 
-function recordReplayPluginDescriptorPattern(flags = "") {
+function recordReplayPluginNamePattern(flags = "") {
   return new RegExp(
-    String.raw`\{(?:[^{}]*,)?installWhenMissing:!0,name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)},`,
+    String.raw`name:${pluginNameExpressionRegex(RECORD_REPLAY_PLUGIN_NAME)}`,
     flags,
   );
 }
@@ -32,18 +32,18 @@ function hasRecordReplayPluginGate(source) {
   }
 
   const expectedDescriptor = buildRecordReplayDescriptor();
-  const sourceDescriptorCount = [...source.matchAll(recordReplayPluginDescriptorPattern("g"))].length;
-  const arrayDescriptorCount = [
-    ...pluginGateArray.text.matchAll(recordReplayPluginDescriptorPattern("g")),
+  const sourceNameCount = [...source.matchAll(recordReplayPluginNamePattern("g"))].length;
+  const arrayNameCount = [
+    ...pluginGateArray.text.matchAll(recordReplayPluginNamePattern("g")),
   ].length;
-  return sourceDescriptorCount === 1
-    && arrayDescriptorCount === 1
+  return sourceNameCount === 1
+    && arrayNameCount === 1
     && source.split(expectedDescriptor).length - 1 === 1
     && pluginGateArray.text.split(expectedDescriptor).length - 1 === 1;
 }
 
-function hasAnyRecordReplayPluginDescriptor(source) {
-  return recordReplayPluginDescriptorPattern().test(source);
+function hasAnyRecordReplayPluginName(source) {
+  return recordReplayPluginNamePattern().test(source);
 }
 
 function hasObsoleteRecordReplayPluginGate(source) {
@@ -110,7 +110,7 @@ function applyRecordReplayPluginGatePatch(currentSource) {
   if (hasRecordReplayPluginGate(currentSource)) {
     return currentSource;
   }
-  if (hasAnyRecordReplayPluginDescriptor(currentSource)) {
+  if (hasAnyRecordReplayPluginName(currentSource)) {
     throw new Error("Optional Record & Replay plugin gate patch drift: invalid isAvailable availability contract");
   }
   const pluginGateArray = findBundledPluginGateArray(currentSource);

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -214,6 +214,12 @@ function hasCompleteRecordReplayMainBridgePatch(source) {
     && regexMatchCount(source, recordReplayChronicleTrayPatchedPattern()) === 1;
 }
 
+function hasAnyRecordReplayMainBridgeArtifact(source) {
+  return source.includes("codexLinuxRecordReplay")
+    || source.includes("codexLinuxChronicle")
+    || source.includes('"linux-record-replay-');
+}
+
 function applyRecordReplayChronicleTrayPatch(currentSource) {
   const patchName = "Record & Replay Chronicle tray bridge patch";
   if (currentSource.includes("process.platform===`linux`?codexLinuxChronicleSidecarControlState()")) {
@@ -242,7 +248,7 @@ function applyRecordReplayChronicleTrayPatch(currentSource) {
 
 function applyRecordReplayMainBridgePatch(currentSource) {
   const patchName = "Record & Replay main bridge patch";
-  if (currentSource.includes('"linux-record-replay-doctor":async')) {
+  if (hasAnyRecordReplayMainBridgeArtifact(currentSource)) {
     if (!hasCompleteRecordReplayMainBridgePatch(currentSource)) {
       warn("Found incomplete Record & Replay main bridge patch", patchName);
     }

--- a/linux-features/record-and-replay/patch.js
+++ b/linux-features/record-and-replay/patch.js
@@ -13,6 +13,15 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function countOccurrences(source, needle) {
+  return source.split(needle).length - 1;
+}
+
+function regexMatchCount(source, pattern) {
+  const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+  return [...source.matchAll(new RegExp(pattern.source, flags))].length;
+}
+
 function pluginNameExpressionRegex(pluginName) {
   const escaped = escapeRegExp(pluginName);
   return String.raw`(?:\`${escaped}\`|"${escaped}"|'${escaped}')`;
@@ -196,9 +205,13 @@ function hasCompleteRecordReplayMainBridgePatch(source) {
     return false;
   }
 
-  return source.includes(recordReplayHelperSource({ childProcessVar, fsVar, pathVar }))
-    && source.includes(recordReplayBridgeSource({ childProcessVar, fsVar, pathVar }))
-    && recordReplayChronicleTrayPatchedPattern().test(source);
+  const helperPayload = recordReplayHelperSource({ childProcessVar, fsVar, pathVar });
+  const bridgePayload = recordReplayBridgeSource({ childProcessVar, fsVar, pathVar });
+  const bridgeInsertion = `${bridgePayload},"get-global-state":async({key:`;
+  return countOccurrences(source, helperPayload) === 1
+    && countOccurrences(source, bridgePayload) === 1
+    && countOccurrences(source, bridgeInsertion) === 1
+    && regexMatchCount(source, recordReplayChronicleTrayPatchedPattern()) === 1;
 }
 
 function applyRecordReplayChronicleTrayPatch(currentSource) {

--- a/linux-features/record-and-replay/stage.sh
+++ b/linux-features/record-and-replay/stage.sh
@@ -110,7 +110,6 @@ stage_record_replay_plugin_base() {
 
     if source_plugin="$(find_upstream_record_replay_plugin)"; then
         cp -R "$source_plugin/." "$target_plugin/"
-        rm -rf "$target_plugin/Codex Computer Use.app"
         find "$target_plugin" \( -name '*:com.apple.*' -o -name '.gitkeep' -o -name '.DS_Store' \) -delete
         echo "Record & Replay plugin base staged from upstream DMG" >&2
         return 0

--- a/linux-features/record-and-replay/stage.sh
+++ b/linux-features/record-and-replay/stage.sh
@@ -96,6 +96,8 @@ find_upstream_record_replay_plugin() {
     [ -f "$candidate/.codex-plugin/plugin.json" ] || return 1
     [ -f "$candidate/.mcp.json" ] || return 1
     [ -d "$candidate/skills/record-and-replay" ] || return 1
+    [ -x "$candidate/bin/computer-use-client-launcher" ] || return 1
+    [ ! -e "$candidate/Codex Computer Use.app" ] && [ ! -L "$candidate/Codex Computer Use.app" ] || return 1
 
     printf '%s\n' "$candidate"
 }

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -804,6 +804,18 @@ test("record-and-replay plugin gate rejects a non-Linux current availability pre
   );
 });
 
+test("record-and-replay plugin gate rejects incomplete descriptor metadata", () => {
+  const source = [
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{name:`record-and-replay`,isAvailable:({platform:e})=>e===`linux`},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  assert.throws(
+    () => applyRecordReplayPluginGatePatch(source),
+    /invalid isAvailable availability contract/,
+  );
+});
+
 test("record-and-replay plugin template matches upstream-shaped plugin UX", () => {
   const plugin = JSON.parse(fs.readFileSync(path.join(featureDir, "plugin-template/.codex-plugin/plugin.json"), "utf8"));
   const mcp = JSON.parse(fs.readFileSync(path.join(featureDir, "plugin-template/.mcp.json"), "utf8"));

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -28,6 +28,17 @@ const {
 
 const featureDir = __dirname;
 
+function captureWarns(fn) {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(" "));
+  try {
+    return { value: fn(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 function repoRoot() {
   return path.resolve(featureDir, "../..");
 }
@@ -200,6 +211,36 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.doesNotMatch(patched, /"--target"/);
   assert.doesNotMatch(patched, /"--target-dir"/);
   assert.doesNotMatch(patched, /"--mode"/);
+});
+
+test("record-and-replay rejects incomplete current bridge variants byte-identically", () => {
+  const source = [
+    'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
+    'var bridge={"get-global-state":async({key:e})=>null};',
+  ].join("");
+  const patched = applyRecordReplayMainBridgePatch(source);
+  const variants = {
+    "legacy tray shape": patched
+      .replace(":tt().skysight?$9:", ":")
+      .replace("if(tt().skysight)return $9;", ""),
+    "missing Linux toggle branch": patched.replace(
+      "if(process.platform===`linux`)return codexLinuxChronicleToggleSidecar();",
+      "",
+    ),
+    "missing current bridge handler": patched.replace(
+      '"linux-record-replay-status":async',
+      '"linux-record-replay-status-missing":async',
+    ),
+  };
+
+  for (const [name, drifted] of Object.entries(variants)) {
+    assert.notEqual(drifted, patched, name);
+    const { value, warnings } = captureWarns(() => applyRecordReplayMainBridgePatch(drifted));
+    assert.equal(value, drifted, name);
+    assert.equal(warnings.length, 1, name);
+    assert.match(warnings[0], /incomplete Record & Replay main bridge patch/, name);
+  }
 });
 
 test("record-and-replay Chronicle helpers map Skysight status into upstream sidecar state", () => {
@@ -718,6 +759,18 @@ test("record-and-replay plugin gate rejects obsolete isEnabled availability cont
   const source = [
     "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
     "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{installWhenMissing:!0,name:`record-and-replay`,isEnabled:({platform:e})=>e===`linux`},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  assert.throws(
+    () => applyRecordReplayPluginGatePatch(source),
+    /obsolete isEnabled availability contract/,
+  );
+});
+
+test("record-and-replay plugin gate rejects mixed current and obsolete availability contracts", () => {
+  const source = [
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{installWhenMissing:!0,name:`record-and-replay`,isAvailable:({platform:e})=>e===`linux`},{installWhenMissing:!0,name:`record-and-replay`,isEnabled:({platform:e})=>e===`linux`},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
   ].join("");
 
   assert.throws(

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -145,6 +145,7 @@ test("record-and-replay bridge patch is idempotent and uses execFile", () => {
   assert.equal(descriptors.length, 5);
   const source = [
     "const cp=require(\"node:child_process\"),fs=require(\"node:fs\"),path=require(\"node:path\");",
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     "var bridge={\"get-global-state\":async({key:e})=>null};",
   ].join("");
 
@@ -416,6 +417,7 @@ test("record-and-replay Chronicle setup probe does not churn start when summary 
 test("record-and-replay generic Skysight start can pass summary agent true or false", async () => {
   const source = [
     "const cp=require(\"node:child_process\"),fs=require(\"node:fs\"),path=require(\"node:path\");",
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     "var bridge={\"get-global-state\":async({key:e})=>null};",
   ].join("");
   const patched = applyRecordReplayMainBridgePatch(source);
@@ -451,22 +453,6 @@ test("record-and-replay rejects partial current Chronicle tray drift byte-identi
   ].join("");
 
   assert.equal(applyRecordReplayMainBridgePatch(source), source);
-});
-
-test("record-and-replay bridge patch upgrades old patched bundles with active speech endpoint", () => {
-  const oldPatched =
-    'var bridge={"linux-record-replay-doctor":async()=>null,"linux-record-replay-speech-context":async()=>null,"linux-record-replay-browser-trace":async()=>null,"get-global-state":async({key:e})=>null};';
-  const patched = applyRecordReplayMainBridgePatch(oldPatched);
-
-  assert.notEqual(patched, oldPatched);
-  assert.equal(applyRecordReplayMainBridgePatch(patched), patched);
-  assert.match(patched, /"linux-record-replay-speech-context-active":async/);
-  assert.match(
-    patched,
-    /"linux-record-replay-speech-context":async\(\)=>null,"linux-record-replay-speech-context-active":async/,
-  );
-  assert.match(patched, /"linux-record-replay-browser-trace":async\(\)=>null/);
-  assert.doesNotMatch(patched, /"chronicle-permissions":async/);
 });
 
 test("record-and-replay docs mention pause resume and Chronicle-compatible resources", () => {
@@ -726,6 +712,18 @@ test("record-and-replay plugin gate is idempotent and linux-only", () => {
   assert.equal(applyRecordReplayPluginGatePatch(patched), patched);
   assert.match(patched, /installWhenMissing:!0,name:`record-and-replay`,isAvailable:\(\{platform:e\}\)=>e===`linux`/);
   assert.match(patched, /name:ft,isAvailable:\(\{features:e,platform:t\}\)=>t===`darwin`&&e\.computerUse/);
+});
+
+test("record-and-replay plugin gate rejects obsolete isEnabled availability contract", () => {
+  const source = [
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{installWhenMissing:!0,name:`record-and-replay`,isEnabled:({platform:e})=>e===`linux`},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  assert.throws(
+    () => applyRecordReplayPluginGatePatch(source),
+    /obsolete isEnabled availability contract/,
+  );
 });
 
 test("record-and-replay plugin template matches upstream-shaped plugin UX", () => {

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -124,8 +124,12 @@ test("record-and-replay patch descriptor loads only when feature is enabled", ()
 test("record-and-replay dictation descriptor tracks moved upstream composer bundle", () => {
   const descriptor = descriptors.find((patch) => patch.id === "record-replay-dictation-transcript");
   assert.ok(descriptor);
-  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-BUwCKIcU.js"), true);
-  assert.equal(descriptor.pattern.test("use-dictation-BUwCKIcU.js"), true);
+  assert.equal(descriptor.pattern.test("app-initial-C-fROkKo.js"), true);
+  assert.equal(descriptor.assetMatch(
+    "let a=i.trim();a.length>0&&(qf.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:a}),t===`send`?r.onTranscriptSend(a):r.onTranscriptInsert(a))",
+  ), true);
+  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-BUwCKIcU.js"), false);
+  assert.equal(descriptor.pattern.test("use-dictation-BUwCKIcU.js"), false);
   assert.equal(descriptor.pattern.test("use-dictation-hotkey-BUwCKIcU.js"), false);
 });
 
@@ -426,7 +430,7 @@ test("record-and-replay generic Skysight start can pass summary agent true or fa
 test("record-and-replay patch wires Linux Chronicle tray controls to Skysight", () => {
   const source = [
     'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
-    "var tray={getChronicleSidecarControlState:()=>ue.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{let e=ue.appServerConnectionRegistry.getMaybeConnection(B);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.pauseChronicleSidecar():e.resumeChronicleSidecar()}};",
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
   const patched = applyRecordReplayMainBridgePatch(source);
@@ -435,7 +439,18 @@ test("record-and-replay patch wires Linux Chronicle tray controls to Skysight", 
   assert.equal(applyRecordReplayMainBridgePatch(patched), patched);
   assert.match(patched, /getChronicleSidecarControlState:\(\)=>process\.platform===`linux`\?codexLinuxChronicleSidecarControlState\(\)/);
   assert.match(patched, /toggleChronicleSidecar:async\(\)=>\{if\(process\.platform===`linux`\)return codexLinuxChronicleToggleSidecar\(\)/);
+  assert.match(patched, /if\(tt\(\)\.skysight\)return \$9/);
   assert.match(patched, /e\.pauseChronicleSidecar\(\):e\.resumeChronicleSidecar\(\)/);
+});
+
+test("record-and-replay rejects partial current Chronicle tray drift byte-identically", () => {
+  const source = [
+    'const cp=require("node:child_process"),fs=require("node:fs"),path=require("node:path");',
+    "var tray={getChronicleSidecarControlState:()=>tt().skysight?$9:Se.appServerConnectionRegistry.getMaybeConnection(`local`)?.getChronicleSidecarControlState()??$9,toggleChronicleSidecar:async()=>{if(tt().skysight)return $9;let e=Se.appServerConnectionRegistry.getMaybeConnection(V);return e==null?$9:e.getChronicleSidecarControlState().running?e.stopChronicleSidecar():e.resumeChronicleSidecar()}};",
+    'var bridge={"get-global-state":async({key:e})=>null};',
+  ].join("");
+
+  assert.equal(applyRecordReplayMainBridgePatch(source), source);
 });
 
 test("record-and-replay bridge patch upgrades old patched bundles with active speech endpoint", () => {

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -254,6 +254,7 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
       `${bridgePayload},"get-global-state":async`,
       `${bridgePayload},${bridgePayload},"get-global-state":async`,
     ),
+    "helper-only partial": `${helperPayload}\n${source}`,
     "duplicate helper payload": `${helperPayload}\n${patched}`,
     "duplicate patched tray": `${patched}${trayStatement}`,
   };
@@ -1048,6 +1049,7 @@ test("record-and-replay stage hook uses the current upstream plugin shell when p
     );
     fs.writeFileSync(path.join(upstreamPlugin, "assets/app-icon.png"), "official-png");
     fs.writeFileSync(path.join(upstreamPlugin, "bin/computer-use-client-launcher"), "#!/bin/sh\nexec false\n");
+    fs.chmodSync(path.join(upstreamPlugin, "bin/computer-use-client-launcher"), 0o755);
     fs.writeFileSync(path.join(upstreamPlugin, "skills/record-and-replay/SKILL.md"), "official mac skill");
     fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
@@ -1087,6 +1089,76 @@ test("record-and-replay stage hook uses the current upstream plugin shell when p
     assert.match(stagedSkill, /event_stream_start/);
     assert.equal(fs.existsSync(path.join(pluginDir, "bin/codex-record-replay-linux")), true);
     assert.equal(fs.existsSync(path.join(pluginDir, "bin/SkyLinuxComputerUseClient")), true);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("record-and-replay stage hook rejects the obsolete nested-app plugin shell", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-record-replay-stage-obsolete-"));
+  try {
+    const installDir = path.join(workspace, "install");
+    const fakeBinary = path.join(workspace, "codex-record-replay-linux");
+    const upstreamPlugin = path.join(
+      workspace,
+      "upstream/ChatGPT.app/Contents/Resources/plugins/openai-bundled/plugins/record-and-replay",
+    );
+    const oldClient = path.join(
+      upstreamPlugin,
+      "Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient",
+    );
+    const marketplace = path.join(installDir, "resources/plugins/openai-bundled/.agents/plugins/marketplace.json");
+    fs.mkdirSync(path.join(upstreamPlugin, ".codex-plugin"), { recursive: true });
+    fs.mkdirSync(path.join(upstreamPlugin, "bin"), { recursive: true });
+    fs.mkdirSync(path.join(upstreamPlugin, "skills/record-and-replay"), { recursive: true });
+    fs.mkdirSync(path.dirname(oldClient), { recursive: true });
+    fs.mkdirSync(path.dirname(marketplace), { recursive: true });
+    fs.writeFileSync(
+      path.join(upstreamPlugin, ".codex-plugin/plugin.json"),
+      JSON.stringify({
+        name: "record-and-replay",
+        version: "1.0.857",
+        mcpServers: "./.mcp.json",
+        skills: "./skills/",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(upstreamPlugin, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          "event-stream": {
+            command:
+              "./Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient",
+            args: ["event-stream", "mcp"],
+            cwd: ".",
+          },
+        },
+      }),
+    );
+    fs.writeFileSync(path.join(upstreamPlugin, "skills/record-and-replay/SKILL.md"), "obsolete mac skill");
+    fs.writeFileSync(path.join(upstreamPlugin, "bin/computer-use-client-launcher"), "#!/bin/sh\nexec false\n");
+    fs.chmodSync(path.join(upstreamPlugin, "bin/computer-use-client-launcher"), 0o755);
+    fs.writeFileSync(oldClient, "mach-o");
+    fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
+    fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
+    fs.chmodSync(fakeBinary, 0o755);
+
+    execFileSync("bash", [path.join(featureDir, "stage.sh")], {
+      cwd: workspace,
+      env: {
+        ...process.env,
+        SCRIPT_DIR: repoRoot(),
+        INSTALL_DIR: installDir,
+        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/ChatGPT.app"),
+        CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
+      },
+      stdio: "pipe",
+    });
+
+    const pluginDir = path.join(installDir, "resources/plugins/openai-bundled/plugins/record-and-replay");
+    const stagedPlugin = JSON.parse(fs.readFileSync(path.join(pluginDir, ".codex-plugin/plugin.json"), "utf8"));
+    assert.equal(stagedPlugin.version, "0.1.0-linux-alpha1");
+    assert.equal(fs.existsSync(path.join(pluginDir, "Codex Computer Use.app")), false);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -22,6 +22,7 @@ const {
   applyRecordReplayPluginGatePatch,
   applyRecordReplayMainBridgePatch,
   descriptors,
+  recordReplayBridgeSource,
   recordReplayHelperSource,
   recordReplayHudRuntimeSource,
 } = require("./patch.js");
@@ -220,6 +221,19 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
     'var bridge={"get-global-state":async({key:e})=>null};',
   ].join("");
   const patched = applyRecordReplayMainBridgePatch(source);
+  const bridgePayload = recordReplayBridgeSource({
+    childProcessVar: "cp",
+    fsVar: "fs",
+    pathVar: "path",
+  });
+  const helperPayload = recordReplayHelperSource({
+    childProcessVar: "cp",
+    fsVar: "fs",
+    pathVar: "path",
+  });
+  const trayStart = patched.indexOf("var tray=");
+  const trayEnd = patched.indexOf(";var bridge=", trayStart);
+  const trayStatement = patched.slice(trayStart, trayEnd + 1);
   const variants = {
     "legacy tray shape": patched
       .replace(":tt().skysight?$9:", ":")
@@ -232,6 +246,16 @@ test("record-and-replay rejects incomplete current bridge variants byte-identica
       '"linux-record-replay-status":async',
       '"linux-record-replay-status-missing":async',
     ),
+    "misplaced bridge payload": `${patched.replace(
+      `${bridgePayload},"get-global-state":async`,
+      '"get-global-state":async',
+    )}var misplaced={${bridgePayload}};`,
+    "duplicate bridge payload": patched.replace(
+      `${bridgePayload},"get-global-state":async`,
+      `${bridgePayload},${bridgePayload},"get-global-state":async`,
+    ),
+    "duplicate helper payload": `${helperPayload}\n${patched}`,
+    "duplicate patched tray": `${patched}${trayStatement}`,
   };
 
   for (const [name, drifted] of Object.entries(variants)) {
@@ -976,26 +1000,26 @@ test("launcher rejects unsafe bundled plugin version path components", () => {
   }
 });
 
-test("record-and-replay stage hook uses upstream plugin shell when present", () => {
+test("record-and-replay stage hook uses the current upstream plugin shell when present", () => {
   const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "codex-record-replay-stage-upstream-"));
   try {
     const installDir = path.join(workspace, "install");
     const fakeBinary = path.join(workspace, "codex-record-replay-linux");
     const upstreamPlugin = path.join(
       workspace,
-      "upstream/Codex.app/Contents/Resources/plugins/openai-bundled/plugins/record-and-replay",
+      "upstream/ChatGPT.app/Contents/Resources/plugins/openai-bundled/plugins/record-and-replay",
     );
     const marketplace = path.join(installDir, "resources/plugins/openai-bundled/.agents/plugins/marketplace.json");
     fs.mkdirSync(path.join(upstreamPlugin, ".codex-plugin"), { recursive: true });
     fs.mkdirSync(path.join(upstreamPlugin, "assets"), { recursive: true });
+    fs.mkdirSync(path.join(upstreamPlugin, "bin"), { recursive: true });
     fs.mkdirSync(path.join(upstreamPlugin, "skills/record-and-replay"), { recursive: true });
-    fs.mkdirSync(path.join(upstreamPlugin, "Codex Computer Use.app/Contents/MacOS"), { recursive: true });
     fs.mkdirSync(path.dirname(marketplace), { recursive: true });
     fs.writeFileSync(
       path.join(upstreamPlugin, ".codex-plugin/plugin.json"),
       JSON.stringify({
         name: "record-and-replay",
-        version: "1.0.857",
+        version: "1.0.1000502",
         description: "Record what I'm doing on my Mac",
         author: { name: "OpenAI" },
         mcpServers: "./.mcp.json",
@@ -1014,16 +1038,17 @@ test("record-and-replay stage hook uses upstream plugin shell when present", () 
       JSON.stringify({
         mcpServers: {
           "event-stream": {
-            command: "./Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient",
+            command: "./bin/computer-use-client-launcher",
             args: ["event-stream", "mcp"],
             cwd: ".",
+            env_vars: ["CODEX_HOME"],
           },
         },
       }),
     );
     fs.writeFileSync(path.join(upstreamPlugin, "assets/app-icon.png"), "official-png");
+    fs.writeFileSync(path.join(upstreamPlugin, "bin/computer-use-client-launcher"), "#!/bin/sh\nexec false\n");
     fs.writeFileSync(path.join(upstreamPlugin, "skills/record-and-replay/SKILL.md"), "official mac skill");
-    fs.writeFileSync(path.join(upstreamPlugin, "Codex Computer Use.app/Contents/MacOS/SkyComputerUseClient"), "mach-o");
     fs.writeFileSync(marketplace, JSON.stringify({ plugins: [] }));
     fs.writeFileSync(fakeBinary, "#!/bin/sh\nprintf '{\"ok\":true}\\n'\n");
     fs.chmodSync(fakeBinary, 0o755);
@@ -1034,7 +1059,7 @@ test("record-and-replay stage hook uses upstream plugin shell when present", () 
         ...process.env,
         SCRIPT_DIR: repoRoot(),
         INSTALL_DIR: installDir,
-        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/Codex.app"),
+        CODEX_UPSTREAM_APP_DIR: path.join(workspace, "upstream/ChatGPT.app"),
         CODEX_RECORD_REPLAY_LINUX_SOURCE: fakeBinary,
       },
       stdio: "pipe",
@@ -1045,9 +1070,9 @@ test("record-and-replay stage hook uses upstream plugin shell when present", () 
     const stagedMcp = JSON.parse(fs.readFileSync(path.join(pluginDir, ".mcp.json"), "utf8"));
     const stagedSkill = fs.readFileSync(path.join(pluginDir, "skills/record-and-replay/SKILL.md"), "utf8");
 
-    assert.equal(fs.existsSync(path.join(pluginDir, "Codex Computer Use.app")), false);
+    assert.equal(fs.readFileSync(path.join(pluginDir, "bin/computer-use-client-launcher"), "utf8"), "#!/bin/sh\nexec false\n");
     assert.equal(fs.readFileSync(path.join(pluginDir, "assets/app-icon.png"), "utf8"), "official-png");
-    assert.equal(stagedPlugin.version, "1.0.857");
+    assert.equal(stagedPlugin.version, "1.0.1000502");
     assert.equal(stagedPlugin.description, "Record what I'm doing on Linux");
     assert.equal(stagedPlugin.interface.shortDescription, "Record what I'm doing on Linux and turn it into a Skill");
     assert.equal(stagedPlugin.interface.logo, "./assets/record-and-replay-plugin-icon.png");

--- a/linux-features/record-and-replay/test.js
+++ b/linux-features/record-and-replay/test.js
@@ -779,6 +779,31 @@ test("record-and-replay plugin gate rejects mixed current and obsolete availabil
   );
 });
 
+test("record-and-replay plugin gate rejects a misplaced current availability contract", () => {
+  const source = [
+    "var misplaced={installWhenMissing:!0,name:`record-and-replay`,isAvailable:({platform:e})=>e===`linux`};",
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  assert.throws(
+    () => applyRecordReplayPluginGatePatch(source),
+    /invalid isAvailable availability contract/,
+  );
+});
+
+test("record-and-replay plugin gate rejects a non-Linux current availability predicate", () => {
+  const source = [
+    "var lt=`browser-use`,ft=`computer-use`,pt=`latex-tectonic`;",
+    "var Kr=[{forceReload:!0,installWhenMissing:!0,name:lt,isAvailable:({features:e})=>e.inAppBrowserUseAllowed},{installWhenMissing:!0,name:`record-and-replay`,isAvailable:()=>!0},{name:ft,isAvailable:({features:e,platform:t})=>t===`darwin`&&e.computerUse,migrate:vr},{name:pt,isAvailable:()=>!0}];",
+  ].join("");
+
+  assert.throws(
+    () => applyRecordReplayPluginGatePatch(source),
+    /invalid isAvailable availability contract/,
+  );
+});
+
 test("record-and-replay plugin template matches upstream-shaped plugin UX", () => {
   const plugin = JSON.parse(fs.readFileSync(path.join(featureDir, "plugin-template/.codex-plugin/plugin.json"), "utf8"));
   const mcp = JSON.parse(fs.readFileSync(path.join(featureDir, "plugin-template/.mcp.json"), "utf8"));

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -28,20 +28,20 @@ const {
 const currentAppInfoSource = [
   "function F_(e,t){return`icon-chatgpt`}",
   "function I_(e){return{dark:`icon-codex-dark-color.png`,light:`icon-codex-light.png`}}",
-  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=z_(`${F_(e,t)}.png`),i=z_(n.dark),a=z_(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
-  "function z_(e){if(e==null)return null;let t=l.app.isPackaged?(0,f.join)(process.resourcesPath,e):null,n=t!=null&&(0,g.existsSync)(t)?t:(0,f.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
+  "function R_(e,t){if(process.platform!==`darwin`||t==null)return null;let n=I_(e),r=wb(`${F_(e,t)}.png`),i=wb(n.dark),a=wb(n.light);return r==null||i==null||a==null?null:{appDefault:r,codexDark:i,codexLight:a}}",
+  "function wb(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null,n=t!=null&&(0,_.existsSync)(t)?t:(0,p.join)(l.app.getAppPath(),`src`,`icons`,e),r=l.nativeImage.createFromPath(n);return r.isEmpty()?null:r.resize({width:128,height:128,quality:`best`}).toDataURL()}",
 ].join("");
 
 const currentRuntimeSource = [
   "function Xie({appBrand:e,buildFlavor:r,settingsStore:p,repoRoot:_,isMacOS:v,onWindowRegistered:C,disposables:w}){",
-  "let T=(0,f.join)(_,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,f.join)(process.resourcesPath,e);return(0,g.existsSync)(t)?t:null},",
-  "D=e=>null,O=e=>E(e)??D(e),k=()=>p.get(n.cc.DOCK_ICON_PREFERENCE)??`app-default`,",
-  "A=()=>O(`${F_(r,e)}.png`),j=I_(r),M=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?j.dark:j.light,",
-  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
-  "P=()=>{if(!v)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})};",
-  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
-  "let F=null,I=new Rie({onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}});",
-  "return{updateDockIcon:P,windowManager:I}}",
+  "let T=(0,p.join)(_,`electron`,`src`,`icons`),E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null},",
+  "D=e=>null,O=e=>E(e)??D(e),k=()=>p.get(n.Fc.DOCK_ICON_PREFERENCE)??`app-default`,",
+  "A=()=>O(`${F_(r,e)}.png`),j=process.platform===`linux`?K5(r,e,T):null,M=I_(r),N=()=>l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?M.dark:M.light,",
+  "P=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.Ml.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?N():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)},",
+  "F=()=>{if(!v)return;let e=k();P(e),koe({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})};",
+  "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}",
+  "let ee=null,I=new Rie({onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}});",
+  "return{updateDockIcon:F,windowManager:I}}",
 ].join("");
 
 const currentTraySource =
@@ -50,7 +50,7 @@ const currentTraySource =
 const currentMainSource = currentAppInfoSource + currentRuntimeSource + currentTraySource;
 
 const currentSettingsSource =
-  "function Xi(){let e=(0,Q.c)(27),t=n(m),r=R(),{platform:a}=Ze(),{data:o}=i(Bn),s=u(y.dockIconPreference),l;e[0]===t?l=e[1]:(l=function(e){c(t,y.dockIconPreference,e)},e[0]=t,e[1]=l);let d=l;if(a!==`macOS`||w.ChatGPT!==`chatgpt`||T.Agent===`prod`)return null;let f=o?.dockIconPreviews;if(f==null)return null;return H(f,d)}";
+  "function oa(){let e=(0,Q.c)(27),t=B(C),n=z(),{platform:r}=_t(),{data:i}=H(Kn),a=V(K.dockIconPreference),o;if(e[0]===t)o=e[1];else{o=function(e){c(t,K.dockIconPreference,e)},e[0]=t,e[1]=o}let s=o;if(r!==`macOS`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null;let c=i?.dockIconPreviews;if(c==null)return null;return W(c,s)}";
 
 const currentSearchSource = applyLinuxSettingsSearchVisibilityPatch([
   "function qn(e){let t=(0,Zn.c)(17),n=re(),r=Bn(e),{data:i}=_(e),a=i?.isSystemBackdropSupported!==!1,o=i?.platform===`darwin`,{data:s}=T(k,e.selectedHostId),c,l=c;if(a){let e;e=e=>e.sectionSlug===`appearance`&&!a?{...e,messages:e.messages.filter(Jn)}:e.sectionSlug===`agent`?{...e,terms:[]}:e,m=r.map(e)}else m=r;return m}",
@@ -187,22 +187,22 @@ test("main patch enables official previews and synchronizes Linux window and tra
   );
   assert.match(
     patched,
-    /onWindowRegistered:e=>\{F\?\.registerWindow\(e\),C\?\.\(e\),process\.platform===`linux`&&setImmediate\(P\)\}/,
+    /onWindowRegistered:e=>\{ee\?\.registerWindow\(e\),C\?\.\(e\),process\.platform===`linux`&&setImmediate\(F\)\}/,
   );
   assert.ok(
-    patched.indexOf("setImmediate(P)") > 0,
+    patched.indexOf("setImmediate(F)") > 0,
   );
 });
 
 test("main patch rejects drift at every current-DMG insertion point byte-identically", () => {
   const insertionPoints = [
     "if(process.platform!==`darwin`||t==null)return null",
-    "function z_(e){if(e==null)return null",
+    "function wb(e){if(e==null)return null",
     "E=e=>{if(!l.app.isPackaged)return null",
-    "N=t=>{if(t===`app-default`",
-    "P=()=>{if(!v)return",
-    "if(v){P();let e=()=>",
-    "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}",
+    "P=t=>{if(t===`app-default`",
+    "F=()=>{if(!v)return",
+    "if(v){F();let e=()=>",
+    "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}",
     "codexLinuxRegisterTray(new l.Tray(t.defaultIcon))",
   ];
 
@@ -223,8 +223,8 @@ test("main patch rejects drift at every current-DMG insertion point byte-identic
 
 test("main patch rejects mixed patched and clean contracts byte-identically", () => {
   const mixed = applyDockIconMainPatch(currentMainSource).replace(
-    "P=()=>{if(!v&&process.platform!==`linux`)return",
-    "P=()=>{if(!v)return",
+    "F=()=>{if(!v&&process.platform!==`linux`)return",
+    "F=()=>{if(!v)return",
   );
   const { value, warnings } = captureWarns(() => applyDockIconMainPatch(mixed));
 
@@ -237,13 +237,13 @@ test("settings patch exposes the native row on Linux", () => {
   const patched = applyDockIconSettingsPatch(currentSettingsSource);
   const secondPass = captureWarns(() => applyDockIconSettingsPatch(patched));
 
-  assert.match(patched, /a!==`macOS`&&a!==`linux`/);
+  assert.match(patched, /r!==`macOS`&&r!==`linux`/);
   assert.equal(secondPass.value, patched);
   assert.deepEqual(secondPass.warnings, []);
 });
 
 test("settings drift remains byte-identical", () => {
-  const drifted = currentSettingsSource.replace("T.Agent===`prod`", "T.Agent!==`prod`");
+  const drifted = currentSettingsSource.replace("oe.Agent===`prod`", "oe.Agent!==`prod`");
   const { value, warnings } = captureWarns(() => applyDockIconSettingsPatch(drifted));
 
   assert.equal(value, drifted);

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -4,29 +4,29 @@ const currentPreviewGate = "if(process.platform!==`darwin`||t==null)return null"
 const patchedPreviewGate =
   "if(process.platform!==`darwin`&&process.platform!==`linux`||t==null)return null";
 const currentAppInfoResource =
-  "function z_(e){if(e==null)return null;let t=l.app.isPackaged?(0,f.join)(process.resourcesPath,e):null";
+  "function wb(e){if(e==null)return null;let t=l.app.isPackaged?(0,p.join)(process.resourcesPath,e):null";
 const patchedAppInfoResource =
-  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,f.join)(process.resourcesPath,`dock-icon`,e):(0,f.join)(process.resourcesPath,e)}function z_(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
+  "function codexLinuxDockIconResourcePath(e){return process.platform===`linux`?(0,p.join)(process.resourcesPath,`dock-icon`,e):(0,p.join)(process.resourcesPath,e)}function wb(e){if(e==null)return null;let t=l.app.isPackaged||process.platform===`linux`?codexLinuxDockIconResourcePath(e):null";
 const currentWindowResource =
-  "E=e=>{if(!l.app.isPackaged)return null;let t=(0,f.join)(process.resourcesPath,e);return(0,g.existsSync)(t)?t:null}";
+  "E=e=>{if(!l.app.isPackaged)return null;let t=(0,p.join)(process.resourcesPath,e);return(0,_.existsSync)(t)?t:null}";
 const patchedWindowResource =
-  "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,g.existsSync)(t)?t:null}";
+  "E=e=>{if(!l.app.isPackaged&&process.platform!==`linux`)return null;let t=codexLinuxDockIconResourcePath(e);return(0,_.existsSync)(t)?t:null}";
 const currentApplyIcon =
-  "N=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
+  "P=t=>{if(t===`app-default`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.Ml.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?N():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);s.isEmpty()||l.app.dock?.setIcon(s)}";
 const patchedApplyIcon =
-  "N=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.rl.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?M():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(g.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
+  "P=function codexLinuxApplyDockIcon(t){if(t===`app-default`&&process.platform!==`linux`&&r!==i.a.Dev&&(l.app.isPackaged||e===n.Ml.ChatGPT)){let e=l.app.dock;e!=null&&Reflect.apply(e.setIcon.bind(e),e,[null]);return}let a=t===`codex-system`?N():null,o=(a==null?null:O(a))??A(),s=o==null?l.nativeImage.createEmpty():l.nativeImage.createFromPath(o);if(s.isEmpty())return;if(process.platform===`linux`){let codexLinuxIconSelection=t===`codex-system`?(l.nativeTheme.shouldUseDarkColorsForSystemIntegratedUI?`codex-dark`:`codex-light`):`chatgpt`;codexLinuxIconSelection===`codex-dark`?s=s.crop({x:34,y:34,width:956,height:956}):codexLinuxIconSelection===`codex-light`&&(s=s.crop({x:13,y:23,width:998,height:998}));globalThis.codexLinuxDockIconImage=s;for(let e of l.BrowserWindow.getAllWindows())e.isDestroyed()||e.setIcon(s);codexLinuxTray!=null&&!codexLinuxTray.isDestroyed()&&codexLinuxTray.setImage(s);let codexLinuxSyncScript=codexLinuxDockIconResourcePath(`sync-desktop-icon.sh`);if(_.existsSync(codexLinuxSyncScript))try{let e=require(`node:child_process`).spawn(codexLinuxSyncScript,[codexLinuxIconSelection],{detached:!0,stdio:[`pipe`,`ignore`,`ignore`]});e.on(`error`,()=>{}),e.stdin.on(`error`,()=>{}),e.stdin.end(s.toPNG()),e.unref()}catch(e){}return}l.app.dock?.setIcon(s)}";
 const currentUpdateGate =
-  "P=()=>{if(!v)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
+  "F=()=>{if(!v)return;let e=k();P(e),koe({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const patchedUpdateGate =
-  "P=()=>{if(!v&&process.platform!==`linux`)return;let e=k();N(e),NZ({preference:e,resourceName:e===`codex-system`?j.light:null}).then(e=>{e&&N(k())})}";
+  "F=()=>{if(!v&&process.platform!==`linux`)return;let e=k();P(e),koe({preference:e,resourceName:e===`codex-system`?M.light:null}).then(e=>{e&&P(k())})}";
 const currentThemeGate =
-  "if(v){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
+  "if(v){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const patchedThemeGate =
-  "if(v||process.platform===`linux`){P();let e=()=>{let e=k();e===`codex-system`&&N(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
+  "if(v||process.platform===`linux`){F();let e=()=>{let e=k();e===`codex-system`&&P(e)};l.nativeTheme.on(`updated`,e),w.add(()=>{l.nativeTheme.off(`updated`,e)})}";
 const currentWindowRegistration =
-  "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e)}";
+  "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e)}";
 const patchedWindowRegistration =
-  "onWindowRegistered:e=>{F?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(P)}";
+  "onWindowRegistered:e=>{ee?.registerWindow(e),C?.(e),process.platform===`linux`&&setImmediate(F)}";
 const currentTrayRegistration =
   "n=codexLinuxRegisterTray(new l.Tray(t.defaultIcon));if(!G9)return";
 const patchedTrayRegistration =
@@ -102,9 +102,9 @@ function applyDockIconMainPatch(source) {
 }
 
 const currentSettingsGate =
-  "if(a!==`macOS`||w.ChatGPT!==`chatgpt`||T.Agent===`prod`)return null";
+  "if(r!==`macOS`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null";
 const patchedSettingsGate =
-  "if(a!==`macOS`&&a!==`linux`||w.ChatGPT!==`chatgpt`||T.Agent===`prod`)return null";
+  "if(r!==`macOS`&&r!==`linux`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null";
 
 function applyDockIconSettingsPatch(source) {
   const currentCount = countOccurrences(source, currentSettingsGate);

--- a/linux-features/ui-tweaks/patches/suggested-prompts.js
+++ b/linux-features/ui-tweaks/patches/suggested-prompts.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const APP_PAGE_ASSET_PATTERN =
-  /^app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-[A-Za-z0-9_-]+\.js$/;
+  /^app-initial-[A-Za-z0-9_-]+\.js$/;
 const GENERAL_SETTINGS_ASSET_PATTERN = /^general-settings-[A-Za-z0-9_-]+\.js$/;
 const HOME_CONTENT_ASSET_PATTERN = /^home-ambient-suggestions-content-[A-Za-z0-9_-]+\.js$/;
 const FEATURE_GATE_ID = "2425897452";

--- a/linux-features/ui-tweaks/suggested-prompts.test.js
+++ b/linux-features/ui-tweaks/suggested-prompts.test.js
@@ -199,7 +199,7 @@ test("Suggested Prompts descriptors select current contracts across renderer has
   assert.equal(descriptors[2].assetMatch("export{settings}"), false);
 
   assert.match(
-    "app-initial~app-main~appgen-settings-page~page~appgen-library-page~appgen-page~appgen-setti~ogh9jurw-HashNext2.js",
+    "app-initial-HashNext2.js",
     APP_PAGE_ASSET_PATTERN,
   );
   assert.equal(descriptors[1].assetMatch(appPageFixture()), true);

--- a/scripts/dev/probe-codex-dmg-record-replay.sh
+++ b/scripts/dev/probe-codex-dmg-record-replay.sh
@@ -67,11 +67,6 @@ command -v node >/dev/null || {
   echo "node is required; run inside the repo devcontainer." >&2
   exit 1
 }
-command -v strings >/dev/null || {
-  echo "strings is required; run inside the repo devcontainer." >&2
-  exit 1
-}
-
 if [[ -z "$work_dir" ]]; then
   work_dir="$(mktemp -d "${TMPDIR:-/tmp}/codex-record-replay-probe.XXXXXX")"
 else
@@ -87,11 +82,11 @@ trap cleanup EXIT
 
 app_resources="ChatGPT Installer/ChatGPT.app/Contents/Resources"
 record_plugin="$app_resources/plugins/openai-bundled/plugins/record-and-replay"
-sky_client="$record_plugin/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient"
+record_replay_launcher="$record_plugin/bin/computer-use-client-launcher"
 
 echo "== DMG resources =="
 7z l "$dmg_path" \
-  | grep -E 'Contents/Resources/(app\.asar|native/sky\.node|codex_chronicle)$|plugins/openai-bundled/plugins/(browser|chrome|computer-use|record-and-replay)(/(\.mcp\.json|\.codex-plugin/plugin\.json|skills/.*/SKILL\.md|Codex Computer Use\.app/Contents/SharedSupport/SkyComputerUseClient\.app/Contents/MacOS/SkyComputerUseClient)|$)' \
+  | grep -E 'Contents/Resources/(app\.asar|native/sky\.node|codex_chronicle)$|plugins/openai-bundled/plugins/(browser|chrome|computer-use|record-and-replay)(/(\.mcp\.json|\.codex-plugin/plugin\.json|skills/.*/SKILL\.md|bin/computer-use-client-launcher)|$)' \
   | sed -n '1,140p'
 
 echo
@@ -103,14 +98,13 @@ echo "== Extracting probe files to $work_dir =="
   "$record_plugin/.mcp.json" \
   "$record_plugin/.codex-plugin/plugin.json" \
   "$record_plugin/skills/*" \
-  "$sky_client" \
+  "$record_replay_launcher" \
   >/dev/null
 
 extracted_resources="$work_dir/$app_resources"
 asar_path="$extracted_resources/app.asar"
 plugin_root="$work_dir/$record_plugin"
-sky_client_path="$work_dir/$sky_client"
-sky_strings_file="$work_dir/skyclient.strings.txt"
+record_replay_launcher_path="$work_dir/$record_replay_launcher"
 asar_contract_json="$work_dir/record-replay-asar-contract.json"
 missing_required=0
 
@@ -133,7 +127,7 @@ require_file "native/sky.node extracted" "$extracted_resources/native/sky.node"
 require_file "codex_chronicle extracted" "$extracted_resources/codex_chronicle"
 require_file "record-and-replay .mcp.json" "$plugin_root/.mcp.json"
 require_file "record-and-replay plugin.json" "$plugin_root/.codex-plugin/plugin.json"
-require_file "SkyComputerUseClient extracted" "$sky_client_path"
+require_file "Record & Replay launcher extracted" "$record_replay_launcher_path"
 
 if (( missing_required )); then
   echo "Required probe artifacts are missing; aborting." >&2
@@ -171,25 +165,20 @@ NODE
 
 echo
 echo "== Native resource file types =="
-file "$extracted_resources/native/sky.node" "$extracted_resources/codex_chronicle" "$sky_client_path"
-
-strings "$sky_client_path" > "$sky_strings_file"
+file "$extracted_resources/native/sky.node" "$extracted_resources/codex_chronicle" "$record_replay_launcher_path"
 
 echo
-echo "== SkyComputerUseClient contract strings =="
-sky_match_patterns='event_stream|skysight_|recording_controls|metadataPath|eventsPath|session\.json|events\.jsonl|Start recording|Stop the active|Start the replay|Stop recording'
-if ! grep -E "$sky_match_patterns" "$sky_strings_file" | sort -u | sed -n '1,200p'; then
-  echo "no contract strings matched"
-fi
+echo "== Record & Replay launcher contract =="
+sed -n '1,160p' "$record_replay_launcher_path"
 
 echo
 echo "== ASAR contract search =="
-node - "$asar_path" "$asar_contract_json" "$sky_strings_file" <<'NODE'
+node - "$asar_path" "$asar_contract_json" "$record_replay_launcher_path" <<'NODE'
 const fs = require("node:fs");
 
 const asarPath = process.argv[2];
 const reportPath = process.argv[3];
-const skyStringsPath = process.argv[4];
+const launcherPath = process.argv[4];
 
 const archive = fs.readFileSync(asarPath);
 const headerSize = archive.readUInt32LE(4);
@@ -222,7 +211,7 @@ walk("", header.files);
 
 const pathNeedles = {
   record_and_replay_path: /record-and-replay/i,
-  sky_client_path: /SkyComputerUseClient\.app\/Contents\/SharedSupport\/SkyComputerUseClient/i,
+  record_replay_launcher_path: /record-and-replay\/bin\/computer-use-client-launcher/i,
   chronicle_path: /codex_chronicle/i,
   computer_use_path: /computer.?use/i,
   event_stream_path: /event[_-]?stream/i,
@@ -277,7 +266,7 @@ const driftContract = {
     contentHits: contentContract.event_stream.count > 0 || contentContract["event.stream"].count > 0,
   },
   sky_computer_use: {
-    pathHits: pathContract.sky_client_path.count > 0 || pathContract.computer_use_path.count > 0,
+    pathHits: pathContract.record_replay_launcher_path.count > 0 || pathContract.computer_use_path.count > 0,
     contentHits: contentContract.SkyComputerUseClient.count > 0 || contentContract.recording_controls.count > 0,
   },
   chronicle: {
@@ -298,12 +287,11 @@ for (const [name, c] of Object.entries(driftContract)) {
   console.log(`  ${name}: ${status[name]} (path=${c.pathHits ? "yes" : "no"}, content=${c.contentHits ? "yes" : "no"})`);
 }
 
-const skyStrings = fs.existsSync(skyStringsPath) ? fs.readFileSync(skyStringsPath, "utf8") : "";
-const skyStringHits = {
-  event_stream: /event_stream/i.test(skyStrings),
-  skysight: /skysight_/i.test(skyStrings),
-  recording_controls: /recording_controls/i.test(skyStrings),
-  metadata_events: /metadataPath|eventsPath|events\.jsonl|session\.json/i.test(skyStrings),
+const launcherSource = fs.existsSync(launcherPath) ? fs.readFileSync(launcherPath, "utf8") : "";
+const launcherContract = {
+  codex_home: /CODEX_HOME/.test(launcherSource),
+  sky_client: /SkyComputerUseClient/.test(launcherSource),
+  forwards_argv: /exec "\$\{client\}" "\$@"/.test(launcherSource),
 };
 
 const contract = {
@@ -312,7 +300,7 @@ const contract = {
   contentContract,
   driftContract,
   asarStatus: status,
-  skyClientStringState: skyStringHits,
+  recordReplayLauncherContract: launcherContract,
 };
 
 console.log("== ASAR contract JSON ==");
@@ -329,16 +317,13 @@ console.log(`event_stream: ${contract.asarStatus.event_stream}`);
 console.log(`sky_computer_use: ${contract.asarStatus.sky_computer_use}`);
 console.log(`chronicle: ${contract.asarStatus.chronicle}`);
 console.log(`record_and_replay: ${contract.asarStatus.record_and_replay}`);
-console.log(`sky_client_strings_event_stream: ${contract.skyClientStringState.event_stream ? "PASS" : "MISSING"}`);
-console.log(`sky_client_strings_skysight: ${contract.skyClientStringState.skysight ? "PASS" : "MISSING"}`);
-console.log(`sky_client_strings_recording_controls: ${contract.skyClientStringState.recording_controls ? "PASS" : "MISSING"}`);
-console.log(`sky_client_strings_metadata_events: ${contract.skyClientStringState.metadata_events ? "PASS" : "MISSING"}`);
+console.log(`record_replay_launcher_codex_home: ${contract.recordReplayLauncherContract.codex_home ? "PASS" : "MISSING"}`);
+console.log(`record_replay_launcher_sky_client: ${contract.recordReplayLauncherContract.sky_client ? "PASS" : "MISSING"}`);
+console.log(`record_replay_launcher_forwards_argv: ${contract.recordReplayLauncherContract.forwards_argv ? "PASS" : "MISSING"}`);
 NODE
 
 if [[ "$keep" -eq 1 ]]; then
   echo
   echo "contract json: $asar_contract_json"
   echo "kept work dir: $work_dir"
-else
-  rm -f "$sky_strings_file"
 fi

--- a/scripts/dev/upstream-dmg-intel.test.js
+++ b/scripts/dev/upstream-dmg-intel.test.js
@@ -324,7 +324,7 @@ function createFixtureApp(root, variant = "baseline") {
     version: "1.0.0",
     mcpServers: {
       "event-stream": {
-        command: "SkyComputerUseClient",
+        command: "./bin/computer-use-client-launcher",
       },
     },
     skills: [{ name: "record-and-replay", path: "skills/record-and-replay/SKILL.md" }],
@@ -332,7 +332,7 @@ function createFixtureApp(root, variant = "baseline") {
   writeJson(path.join(recordPlugin, ".mcp.json"), {
     mcpServers: {
       "event-stream": {
-        command: "SkyComputerUseClient",
+        command: "./bin/computer-use-client-launcher",
         tools:
           variant === "candidate"
             ? ["event_stream_start", "browser_trace", "speech_context", "skysight_snapshot"]

--- a/scripts/dev/upstream-dmg-protected-surfaces.json
+++ b/scripts/dev/upstream-dmg-protected-surfaces.json
@@ -260,7 +260,7 @@
             "event-stream"
           ],
           "mcpCommandPatterns": [
-            "SkyComputerUseClient"
+            "\\./bin/computer-use-client-launcher"
           ],
           "mcpArgs": [
             "event-stream",


### PR DESCRIPTION
<!-- upstream-dmg-sha256:ff6e8ac9985aec44caa305787552e4ea517a7c745aef283bd4cbcab992de64b7 -->

## Summary

- retarget the Dock icon main/settings contracts and the Suggested Prompts app-page asset to the current desktop bundles
- select the Record & Replay dictation asset by its current semantic contract and preserve the new upstream Skysight tray guard outside Linux
- reject partial Chronicle callback drift byte-identically before any bridge mutation

## Why #1113 did not cover this

#1113 made UI Tweaks renderer selection resilient to hash churn inside stable filename families and semantic contracts. DMG 26.721.31836 changed the bundle topology to `app-initial-*` and changed the Dock and Chronicle source contracts, so the existing descriptors correctly failed closed instead of guessing at new shapes.

## Current DMG

- app version: `26.721.31836`
- Electron: `42.3.0`
- size: `593891632` bytes
- SHA-256: `ff6e8ac9985aec44caa305787552e4ea517a7c745aef283bd4cbcab992de64b7`

## Validation

- `node linux-features/record-and-replay/test.js` (32/32)
- `node linux-features/ui-tweaks/dock-icon.test.js` (24/24)
- `node linux-features/ui-tweaks/test.js` (54/54)
- `node scripts/patch-linux-window-ui.test.js` (386/386)
- real extracted DMG: every descriptor for all ten enabled features applied on the first pass; all 17 touched UI Tweaks and Record & Replay descriptors reported already-applied on the second pass
- isolated candidate acceptance: `accepted_with_warnings`, with no feature blockers and only the two existing optional Computer Use core warnings
- Plasma/Wayland side-by-side runtime: home and Settings loaded without the error fallback; Suggested Prompts and both Dock choices rendered
- Dock selection updated the KDE StatusNotifier immediately (`956x956` Codex to `2048x2048` ChatGPT) and remained selected after a cold restart

## Maintenance

I will continue monitoring and maintaining the Dock icon and Suggested Prompts opt-ins as upstream desktop contracts change.