### PR TITLE
Add opt-in Codex Micro Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,40 @@ jobs:
             echo "- Verified generic feature resource, 0640 mode, and runtime dependency."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Create Codex Micro packaged app fixture
+        env:
+          CODEX_FIXTURE_LINUX_FEATURES_JSON: '["codex-micro"]'
+        run: |
+          set -euo pipefail
+          rm -rf codex-app dist
+          tests/fixtures/create-packaged-app-fixture.sh codex-app
+          printf '%s\n' '{"enabled":["codex-micro"]}' > /tmp/codex-micro-features.json
+
+      - name: Build Codex Micro Debian package
+        env:
+          CODEX_LINUX_FEATURES_CONFIG: /tmp/codex-micro-features.json
+        run: PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-deb.sh
+
+      - name: Inspect Codex Micro Debian package
+        run: |
+          set -euo pipefail
+          deb_file="$(find dist -maxdepth 1 -name 'codex-desktop_*.deb' -print -quit)"
+          test -n "$deb_file"
+          dpkg-deb -c "$deb_file" | tee /tmp/deb-micro-contents.txt >/dev/null
+          dpkg-deb -f "$deb_file" Depends | tee /tmp/deb-micro-depends.txt >/dev/null
+          grep -q './usr/lib/udev/rules.d/70-codex-micro.rules' /tmp/deb-micro-contents.txt
+          grep -q 'libudev1' /tmp/deb-micro-depends.txt
+          grep -q 'libusb-1.0-0' /tmp/deb-micro-depends.txt
+          rule_mode="$(
+            awk '$NF == "./usr/lib/udev/rules.d/70-codex-micro.rules" { print $1 }' \
+              /tmp/deb-micro-contents.txt
+          )"
+          test "$rule_mode" = '-rw-r--r--'
+          {
+            echo "- Codex Micro build: \`$(basename "$deb_file")\`"
+            echo "- Verified udev rule, 0644 mode, and libudev/libusb dependencies."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   nix:
     name: Nix Package Builds
     runs-on: ubuntu-latest
@@ -363,6 +397,41 @@ jobs:
             echo "- Verified generic feature resource, 0640 mode, and runtime dependency."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Create Codex Micro packaged app fixture
+        env:
+          CODEX_FIXTURE_LINUX_FEATURES_JSON: '["codex-micro"]'
+        run: |
+          set -euo pipefail
+          rm -rf codex-app dist
+          tests/fixtures/create-packaged-app-fixture.sh codex-app
+          printf '%s\n' '{"enabled":["codex-micro"]}' > /tmp/codex-micro-features.json
+
+      - name: Build Codex Micro RPM package
+        env:
+          CODEX_LINUX_FEATURES_CONFIG: /tmp/codex-micro-features.json
+        run: PACKAGE_VERSION="$CI_PACKAGE_VERSION" ./scripts/build-rpm.sh
+
+      - name: Inspect Codex Micro RPM package
+        run: |
+          set -euo pipefail
+          rpm_file="$(find dist -maxdepth 1 -name 'codex-desktop-*.rpm' -print -quit)"
+          test -n "$rpm_file"
+          rpm -qlp "$rpm_file" | tee /tmp/rpm-micro-contents.txt >/dev/null
+          rpm -qlvp "$rpm_file" | tee /tmp/rpm-micro-long-contents.txt >/dev/null
+          rpm -qp --requires "$rpm_file" | tee /tmp/rpm-micro-requires.txt >/dev/null
+          grep -q '/usr/lib/udev/rules.d/70-codex-micro.rules' /tmp/rpm-micro-contents.txt
+          grep -q '^libudev\.so\.1' /tmp/rpm-micro-requires.txt
+          grep -q '^libusb-1\.0\.so\.0' /tmp/rpm-micro-requires.txt
+          rule_mode="$(
+            awk '$NF == "/usr/lib/udev/rules.d/70-codex-micro.rules" { print $1 }' \
+              /tmp/rpm-micro-long-contents.txt
+          )"
+          test "$rule_mode" = '-rw-r--r--'
+          {
+            echo "- Codex Micro build: \`$(basename "$rpm_file")\`"
+            echo "- Verified udev rule, 0644 mode, and libudev/libusb dependencies."
+          } >> "$GITHUB_STEP_SUMMARY"
+
   package-pacman:
     name: Build Pacman Package
     runs-on: ubuntu-latest
@@ -426,9 +495,34 @@ jobs:
                 fixture_mode="$(sed -n "1s/ .*//p" /tmp/pacman-feature-long-contents.txt)"
                 test "$fixture_mode" = "-rw-r-----"
                 printf "%s\n" "$(basename "$feature_pkg_file")" > /tmp/pacman-feature-package-name.txt
+
+                rm -rf codex-app dist
+                CODEX_FIXTURE_LINUX_FEATURES_JSON="[\"codex-micro\"]" \
+                  tests/fixtures/create-packaged-app-fixture.sh codex-app
+                printf "%s\n" "{\"enabled\":[\"codex-micro\"]}" \
+                  > /tmp/codex-micro-features.json
+
+                CODEX_LINUX_FEATURES_CONFIG=/tmp/codex-micro-features.json \
+                PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+                  ./scripts/build-pacman.sh
+
+                micro_pkg_file="$(find dist -maxdepth 1 -name "codex-desktop-*.pkg.tar.*" -print -quit)"
+                test -n "$micro_pkg_file"
+                pacman -Qlp "$micro_pkg_file" | tee /tmp/pacman-micro-contents.txt >/dev/null
+                tar -xOf "$micro_pkg_file" .PKGINFO | tee /tmp/pacman-micro-pkginfo.txt >/dev/null
+                tar -tvf "$micro_pkg_file" \
+                  usr/lib/udev/rules.d/70-codex-micro.rules \
+                  | tee /tmp/pacman-micro-long-contents.txt >/dev/null
+                grep -q "usr/lib/udev/rules.d/70-codex-micro.rules" /tmp/pacman-micro-contents.txt
+                grep -q "^depend = libusb$" /tmp/pacman-micro-pkginfo.txt
+                grep -q "^depend = systemd-libs$" /tmp/pacman-micro-pkginfo.txt
+                micro_rule_mode="$(sed -n "1s/ .*//p" /tmp/pacman-micro-long-contents.txt)"
+                test "$micro_rule_mode" = "-rw-r--r--"
+                printf "%s\n" "$(basename "$micro_pkg_file")" > /tmp/pacman-micro-package-name.txt
               '"'"'
               cp /tmp/pacman-package-name.txt /work/.pacman-package-name.txt
               cp /tmp/pacman-feature-package-name.txt /work/.pacman-feature-package-name.txt
+              cp /tmp/pacman-micro-package-name.txt /work/.pacman-micro-package-name.txt
             '
 
       - name: Write pacman validation summary
@@ -436,6 +530,7 @@ jobs:
           set -euo pipefail
           pkg_file="$(cat .pacman-package-name.txt)"
           feature_pkg_file="$(cat .pacman-feature-package-name.txt)"
+          micro_pkg_file="$(cat .pacman-micro-package-name.txt)"
           {
             echo "## Pacman Package Validation"
             echo ""
@@ -443,4 +538,6 @@ jobs:
             echo "- Verified updater binary, user service, update-builder bundle, and packaged runtime helper."
             echo "- Feature-enabled build: \`$feature_pkg_file\`"
             echo "- Verified generic feature resource, 0640 mode, and runtime dependency."
+            echo "- Codex Micro build: \`$micro_pkg_file\`"
+            echo "- Verified udev rule, 0644 mode, and systemd-libs/libusb dependencies."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ workarounds.
 | Linux AppShots | Opt-in | `appshots` | [Docs](linux-features/appshots/README.md) |
 | Authenticated proxy | Opt-in | `authenticated-proxy` | [Docs](linux-features/authenticated-proxy/README.md) |
 | Wrapper updater button | Opt-in | `codex-wrapper-updater` | [Docs](linux-features/codex-wrapper-updater/README.md) |
+| Codex Micro (USB-C / Bluetooth) | Opt-in | `codex-micro` | [Docs](linux-features/codex-micro/README.md) |
 | Conversation mode | Opt-in | `conversation-mode` | [Docs](linux-features/conversation-mode/README.md) |
 | Copilot reasoning effort defaults | Opt-in | `copilot-reasoning-effort` | [Docs](linux-features/copilot-reasoning-effort/README.md) |
 | Directory-only working-tree watch | Opt-in | `directory-only-working-tree-watch` | [Docs](linux-features/directory-only-working-tree-watch/README.md) |

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -205,6 +205,7 @@ The Home Manager and NixOS modules accept these feature IDs through
 | Feature ID | Purpose |
 | --- | --- |
 | `appshots` | Linux AppShots capture integration |
+| `codex-micro` | Work Louder Codex Micro USB and Bluetooth HID integration |
 | `directory-only-working-tree-watch` | Bounded directory-only working-tree watches |
 | `frameless-titlebar` | Hide app-provided titlebar controls for compositor-managed decorations |
 | `mcp-helper-reaper` | Cleanup for stale configured MCP helper processes |
@@ -217,6 +218,11 @@ The list is validated during module evaluation, then deduplicated and sorted so
 equivalent configurations produce the same derivation. Features that are not in
 this Nix allowlist remain available through the regular opt-in feature flow but
 cannot be selected from a pure flake configuration.
+
+When `codex-micro` is selected, the NixOS module installs the feature's udev
+rule automatically. Home Manager and direct flake installs cannot change
+system-wide udev policy; follow the manual rule-installation steps in the
+[Codex Micro feature documentation](../linux-features/codex-micro/README.md).
 
 ## Home Manager / NixOS Module
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,12 @@
           hash = "sha256-ghAJ+cGDAFDYlK755hkGywpTeyAAstm77ZmF//HV4NA=";
         };
 
+        codexMicroNodeHidArchive = pkgs.fetchurl {
+          name = "node-hid-3.3.0.tgz";
+          url = "https://registry.npmjs.org/node-hid/-/node-hid-3.3.0.tgz";
+          hash = "sha512-j+dFgJLRAE0nufQKXk3IfS6T6YuHhCgMvz4TrG0sgtb6DSCdYpfJ1etcdmeCmPQjUgO+yo32ktVrRliNs/+fmg==";
+        };
+
         browserUseNodeReplRuntime = pkgs.fetchurl {
           url = "https://persistent.oaistatic.com/codex-primary-runtime/26.426.12240/codex-primary-runtime-linux-x64-26.426.12240.tar.xz";
           hash = "sha256-21Yk6276NrZuxvbdBIjO+5ZuSWNoYqq2IJpDNsHKkMQ=";
@@ -345,6 +351,12 @@
           stdenv.cc.cc.lib
           zlib
         ]);
+        codexMicroRuntimeLibPath = pkgs.lib.makeLibraryPath (with pkgs; [
+          systemd
+          libusb1
+          stdenv.cc.cc.lib
+          glibc
+        ]);
         gsettingsSchemaPackages = with pkgs; [
           gsettings-desktop-schemas
           gtk3
@@ -511,6 +523,7 @@ PY
             else
               normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
           effectiveLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
+          codexMicroEnabled = builtins.elem "codex-micro" effectiveLinuxFeatureIds;
         in
         pkgs.stdenv.mkDerivation {
           pname = "codex-desktop${packageSuffix { inherit enableComputerUseUi; linuxFeatureIds = effectiveLinuxFeatureIds; }}-payload";
@@ -563,6 +576,9 @@ PY
             export CODEX_LINUX_FEATURES_CONFIG="${linuxFeaturesConfigFile effectiveLinuxFeaturesConfig}"
             export CODEX_ELECTRON_ZIP_SOURCE="${electronZip}"
             export CODEX_NATIVE_MODULES_SOURCE="${codexNativeModules}"
+            ${pkgs.lib.optionalString codexMicroEnabled ''
+            export CODEX_MICRO_NODE_HID_ARCHIVE="${codexMicroNodeHidArchive}"
+            ''}
             ${pkgs.lib.optionalString (browserUseNodeRepl != null) ''
             export CODEX_LINUX_NODE_REPL_SOURCE="${browserUseNodeRepl}/bin/node_repl"
             ''}
@@ -611,6 +627,7 @@ PY
             else
               normalizeLinuxFeaturesConfig linuxFeaturesConfigOverride;
           normalizedLinuxFeatureIds = effectiveLinuxFeaturesConfig.enabled;
+          codexMicroEnabled = builtins.elem "codex-micro" normalizedLinuxFeatureIds;
           featureArgs = {
             inherit enableComputerUseUi;
             linuxFeatureIds = normalizedLinuxFeatureIds;
@@ -657,6 +674,31 @@ PY
               --ordering "$TMPDIR/app.asar.ordering" \
               --unpack "{*.node,*.so,*.dylib}"
             rm -rf "$resources_dir/app-extracted"
+
+            ${pkgs.lib.optionalString codexMicroEnabled ''
+            codex_micro_node_count=0
+            while IFS= read -r codex_micro_node; do
+              codex_micro_node_count=$((codex_micro_node_count + 1))
+              patchelf --set-rpath "${codexMicroRuntimeLibPath}" "$codex_micro_node"
+              actual_rpath="$(patchelf --print-rpath "$codex_micro_node")"
+              if [ "$actual_rpath" != "${codexMicroRuntimeLibPath}" ]; then
+                echo "codex-micro node-hid RPATH verification failed: $actual_rpath" >&2
+                exit 1
+              fi
+            done < <(
+              find "$resources_dir/app.asar.unpacked" -type f \
+                -path '*/node-hid/prebuilds/HID_hidraw-linux-*/node-napi-v4.node' \
+                -print
+            )
+            if [ "$codex_micro_node_count" -ne 1 ]; then
+              echo "expected exactly one codex-micro node-hid Linux binding, found $codex_micro_node_count" >&2
+              exit 1
+            fi
+
+            install -Dm0644 \
+              "$out/opt/codex-desktop/.codex-linux/features/codex-micro/70-codex-micro.rules" \
+              "$out/lib/udev/rules.d/70-codex-micro.rules"
+            ''}
 
             for node_repl_binary in \
               "$resources_dir/node_repl" \

--- a/linux-features/codex-micro/README.md
+++ b/linux-features/codex-micro/README.md
@@ -1,0 +1,107 @@
+# Codex Micro
+
+This opt-in Linux feature enables the Work Louder Codex Micro integration that
+already ships in the upstream Codex desktop app. It does two narrowly scoped
+things:
+
+1. enables the upstream Codex Micro feature gate locally; and
+2. adds the verified `node-hid@3.3.0` Linux prebuild for the current app's
+   nested Work Louder dependency.
+
+The feature is disabled by default.
+
+## Enable
+
+Copy `linux-features/features.example.json` to the gitignored
+`linux-features/features.json`, then add `codex-micro` to `enabled` and rebuild:
+
+```json
+{
+  "enabled": [
+    "codex-micro"
+  ]
+}
+```
+
+```bash
+./install.sh
+```
+
+The feature rejects the build if the current DMG no longer contains the
+expected Codex Micro gate/route or the exact nested `node-hid` loader contract.
+Only the pinned x64 and arm64 prebuilds are supported; there is no source-build
+fallback.
+
+## Runtime libraries
+
+Native packages declare the required `libudev.so.1` and `libusb-1.0.so.0`
+dependencies. For AppImage, source, or user-local installs, install them
+yourself:
+
+```bash
+# Debian / Ubuntu
+sudo apt install libudev1 libusb-1.0-0
+
+# Fedora
+sudo dnf install systemd-libs libusb1
+
+# Arch Linux
+sudo pacman -S systemd-libs libusb
+```
+
+## Device access
+
+Feature-enabled Debian, RPM, and pacman packages install
+`/usr/lib/udev/rules.d/70-codex-micro.rules`. Reload the rules after the first
+install, then reconnect USB or Bluetooth:
+
+```bash
+sudo udevadm control --reload-rules
+```
+
+AppImage, source, Home Manager, and direct flake installs cannot change host
+udev policy. Install the tracked rule once:
+
+```bash
+sudo install -Dm0644 \
+  linux-features/codex-micro/resources/70-codex-micro.rules \
+  /etc/udev/rules.d/70-codex-micro.rules
+sudo udevadm control --reload-rules
+```
+
+The USB rule imports `usb_id` before matching the observed Work Louder
+VID/PID/interface (`303a:8360`, interface `00`). The Bluetooth rule matches the
+same vendor HID channel on the Bluetooth HID bus. Both rules use `uaccess` and
+`0660`; they do not make hidraw devices world-writable.
+
+NixOS installs the rule automatically when the feature is selected through the
+module. Home Manager and direct flake users must use the manual rule procedure
+above.
+
+## Bluetooth
+
+Pair the Micro through the desktop Bluetooth settings before opening Codex.
+Channel selection and pairing mode are device operations; see the Work Louder
+Micro setup guide.
+
+## Verify
+
+With the Micro connected, identify its hidraw node and exercise the actual rule:
+
+```bash
+udevadm info --attribute-walk --name=/dev/hidrawN
+sudo udevadm test "$(udevadm info --query=path --name=/dev/hidrawN)"
+getfacl /dev/hidrawN
+```
+
+The test output must show the Codex Micro rule, imported USB properties for a
+USB connection, the `uaccess` tag, and mode `0660`. Then open
+`Settings -> Codex Micro` and verify connection state, buttons, dial, joystick,
+battery/status reporting, and lighting controls.
+
+Run focused checks with:
+
+```bash
+node --test linux-features/codex-micro/test.js
+node --test scripts/lib/linux-features.test.js
+```

--- a/linux-features/codex-micro/README.md
+++ b/linux-features/codex-micro/README.md
@@ -59,12 +59,52 @@ install, then reconnect USB or Bluetooth:
 sudo udevadm control --reload-rules
 ```
 
-AppImage, source, Home Manager, and direct flake installs cannot change host
-udev policy. Install the tracked rule once:
+AppImage, source, user-local, Home Manager, and direct flake installs cannot
+change host udev policy. Install the copy staged for your install mode once.
+
+For a source build:
 
 ```bash
 sudo install -Dm0644 \
-  linux-features/codex-micro/resources/70-codex-micro.rules \
+  codex-app/.codex-linux/features/codex-micro/70-codex-micro.rules \
+  /etc/udev/rules.d/70-codex-micro.rules
+sudo udevadm control --reload-rules
+```
+
+For a user-local install, use the installed app copy:
+
+```bash
+sudo install -Dm0644 \
+  "$HOME/.local/opt/codex-desktop-linux/codex-app/.codex-linux/features/codex-micro/70-codex-micro.rules" \
+  /etc/udev/rules.d/70-codex-micro.rules
+sudo udevadm control --reload-rules
+```
+
+For an AppImage, extract its staged copy first:
+
+```bash
+codex_appimage="$(readlink -f ./codex-desktop-*.AppImage)"
+codex_extract_dir="$(mktemp -d)"
+trap 'rm -rf "$codex_extract_dir"' EXIT
+(
+  cd "$codex_extract_dir"
+  "$codex_appimage" --appimage-extract >/dev/null
+)
+sudo install -Dm0644 \
+  "$codex_extract_dir/squashfs-root/opt/codex-desktop/.codex-linux/features/codex-micro/70-codex-micro.rules" \
+  /etc/udev/rules.d/70-codex-micro.rules
+sudo udevadm control --reload-rules
+```
+
+For Home Manager or a direct flake package, resolve the selected Nix store
+output from the installed launcher:
+
+```bash
+codex_package_root="$(
+  dirname "$(dirname "$(readlink -f "$(command -v codex-desktop)")")"
+)"
+sudo install -Dm0644 \
+  "$codex_package_root/lib/udev/rules.d/70-codex-micro.rules" \
   /etc/udev/rules.d/70-codex-micro.rules
 sudo udevadm control --reload-rules
 ```
@@ -75,8 +115,7 @@ same vendor HID channel on the Bluetooth HID bus. Both rules use `uaccess` and
 `0660`; they do not make hidraw devices world-writable.
 
 NixOS installs the rule automatically when the feature is selected through the
-module. Home Manager and direct flake users must use the manual rule procedure
-above.
+module. Other install modes require the matching manual procedure above.
 
 ## Bluetooth
 

--- a/linux-features/codex-micro/README.md
+++ b/linux-features/codex-micro/README.md
@@ -52,8 +52,10 @@ sudo pacman -S systemd-libs libusb
 ## Device access
 
 Feature-enabled Debian, RPM, and pacman packages install
-`/usr/lib/udev/rules.d/70-codex-micro.rules`. Reload the rules after the first
-install, then reconnect USB or Bluetooth:
+`/usr/lib/udev/rules.d/70-codex-micro.rules`. Native package scripts do not
+reload the system udev daemon. Reload after the first install and after a
+package rebuild that enables or disables the feature, then reconnect USB or
+Bluetooth:
 
 ```bash
 sudo udevadm control --reload-rules
@@ -116,6 +118,10 @@ same vendor HID channel on the Bluetooth HID bus. Both rules use `uaccess` and
 
 NixOS installs the rule automatically when the feature is selected through the
 module. Other install modes require the matching manual procedure above.
+When disabling a manually installed copy, remove
+`/etc/udev/rules.d/70-codex-micro.rules`, reload the rules, and reconnect the
+device. Removing or disabling a native package build removes its packaged copy,
+but still requires the same reload and reconnect.
 
 ## Bluetooth
 

--- a/linux-features/codex-micro/feature.json
+++ b/linux-features/codex-micro/feature.json
@@ -1,0 +1,42 @@
+{
+  "id": "codex-micro",
+  "title": "Codex Micro hardware support",
+  "description": "Adds the verified Linux node-hid binding and narrow USB-C/Bluetooth hidraw policy required by the upstream Work Louder Codex Micro service.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  },
+  "resources": [
+    {
+      "source": "resources/70-codex-micro.rules",
+      "target": ".codex-linux/features/codex-micro/70-codex-micro.rules",
+      "mode": "0644"
+    }
+  ],
+  "packageResources": [
+    {
+      "source": "resources/70-codex-micro.rules",
+      "target": "usr/lib/udev/rules.d/70-codex-micro.rules",
+      "mode": "0644",
+      "formats": [
+        "deb",
+        "rpm",
+        "pacman"
+      ]
+    }
+  ],
+  "packageDependencies": {
+    "deb": [
+      "libudev1",
+      "libusb-1.0-0"
+    ],
+    "rpm": [
+      "libudev.so.1%{codex_elf_suffix}",
+      "libusb-1.0.so.0%{codex_elf_suffix}"
+    ],
+    "pacman": [
+      "libusb",
+      "systemd-libs"
+    ]
+  }
+}

--- a/linux-features/codex-micro/native-artifacts.json
+++ b/linux-features/codex-micro/native-artifacts.json
@@ -1,0 +1,27 @@
+{
+  "name": "node-hid",
+  "version": "3.3.0",
+  "license": "(MIT OR X11)",
+  "integrity": "sha512-j+dFgJLRAE0nufQKXk3IfS6T6YuHhCgMvz4TrG0sgtb6DSCdYpfJ1etcdmeCmPQjUgO+yo32ktVrRliNs/+fmg==",
+  "shasum": "2b00639e8bb9fc96592e8366fda7ae380826a7ee",
+  "loaderContract": {
+    "main": "./nodehid.js",
+    "napiVersions": [
+      4
+    ],
+    "files": {
+      "nodehid.js": "84053a6ea19b238e61368f5220a9a8af96b27e752569f14d63dba2127a37988b",
+      "binding-options.js": "e7c820107f3b6571ca1505a5ffbe17511088336e4c410ec718ea9ec200c6b1e6"
+    }
+  },
+  "prebuilds": {
+    "x64": {
+      "path": "prebuilds/HID_hidraw-linux-x64/node-napi-v4.node",
+      "sha256": "6c7f3b3fcc238a74e7e3237b50b2ff05181e94862b1963e8074ff8fc75885021"
+    },
+    "arm64": {
+      "path": "prebuilds/HID_hidraw-linux-arm64/node-napi-v4.node",
+      "sha256": "06ea97f377e2246a1e9bf3770186727e72ff3c166579d9c259c6d32a07aeaa60"
+    }
+  }
+}

--- a/linux-features/codex-micro/native-binding.js
+++ b/linux-features/codex-micro/native-binding.js
@@ -52,6 +52,7 @@ function discoverBundledNodeHid(extractedDir) {
     "@worklouder",
     "device-kit-oai",
   );
+  assertNoSymbolicLinkAncestors(extractedRoot, deviceKitDir);
   requirePackageDirectory(deviceKitDir, "@worklouder/device-kit-oai", "Work Louder device-kit-oai");
 
   const workLouderKitDir = path.join(
@@ -60,6 +61,7 @@ function discoverBundledNodeHid(extractedDir) {
     "@worklouder",
     "wl-device-kit",
   );
+  assertNoSymbolicLinkAncestors(extractedRoot, workLouderKitDir);
   requirePackageDirectory(
     workLouderKitDir,
     "@worklouder/wl-device-kit",

--- a/linux-features/codex-micro/native-binding.js
+++ b/linux-features/codex-micro/native-binding.js
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+"use strict";
+
+const childProcess = require("node:child_process");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const SUPPORTED_ARCHITECTURES = new Set(["x64", "arm64"]);
+
+function digest(contents, algorithm, encoding) {
+  return crypto.createHash(algorithm).update(contents).digest(encoding);
+}
+
+function integrityFor(contents) {
+  return `sha512-${digest(contents, "sha512", "base64")}`;
+}
+
+function readPackageMetadata(packageDir, label) {
+  const packagePath = path.join(packageDir, "package.json");
+  const stat = fs.lstatSync(packagePath, { throwIfNoEntry: false });
+  if (!stat?.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`${label} package.json is missing or unsafe: ${packagePath}`);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  } catch (error) {
+    throw new Error(`${label} package.json is unreadable: ${error.message}`);
+  }
+}
+
+function requirePackageDirectory(packageDir, expectedName, label) {
+  const stat = fs.lstatSync(packageDir, { throwIfNoEntry: false });
+  if (!stat?.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`${label} package is missing or unsafe: ${packageDir}`);
+  }
+  const metadata = readPackageMetadata(packageDir, label);
+  if (metadata.name !== expectedName) {
+    throw new Error(
+      `${label} package identity mismatch: expected ${expectedName}, got ${metadata.name ?? "unknown"}`,
+    );
+  }
+  return metadata;
+}
+
+function discoverBundledNodeHid(extractedDir) {
+  const extractedRoot = path.resolve(extractedDir);
+  const deviceKitDir = path.join(
+    extractedRoot,
+    "node_modules",
+    "@worklouder",
+    "device-kit-oai",
+  );
+  requirePackageDirectory(deviceKitDir, "@worklouder/device-kit-oai", "Work Louder device-kit-oai");
+
+  const workLouderKitDir = path.join(
+    deviceKitDir,
+    "node_modules",
+    "@worklouder",
+    "wl-device-kit",
+  );
+  requirePackageDirectory(
+    workLouderKitDir,
+    "@worklouder/wl-device-kit",
+    "Work Louder wl-device-kit",
+  );
+
+  const nodeHidDir = path.join(workLouderKitDir, "node_modules", "node-hid");
+  assertNoSymbolicLinkAncestors(extractedRoot, nodeHidDir);
+  const nodeHid = requirePackageDirectory(
+    nodeHidDir,
+    "node-hid",
+    "Work Louder nested node-hid",
+  );
+  return {
+    deviceKitDir,
+    workLouderKitDir,
+    nodeHidDir,
+    packageMetadata: nodeHid,
+    name: nodeHid.name,
+    version: nodeHid.version,
+    license: nodeHid.license,
+  };
+}
+
+function normalizeArchitecture(arch) {
+  if (!SUPPORTED_ARCHITECTURES.has(arch)) {
+    throw new Error(`Unsupported Codex Micro native binding architecture: ${String(arch)}`);
+  }
+  return arch;
+}
+
+function selectPrebuild(artifactManifest, arch) {
+  normalizeArchitecture(arch);
+  return artifactManifest?.prebuilds?.[arch] ?? null;
+}
+
+function inspectElf(contents) {
+  if (
+    !Buffer.isBuffer(contents)
+    || contents.length < 20
+    || !contents.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))
+  ) {
+    throw new Error("Native binding is not an ELF binary");
+  }
+  if (contents[4] !== 2) {
+    throw new Error(`Unsupported ELF class ${contents[4]}; expected a 64-bit ELF binary`);
+  }
+  if (contents[5] !== 1) {
+    throw new Error(`Unsupported ELF encoding ${contents[5]}; expected little-endian`);
+  }
+  const machine = contents.readUInt16LE(18);
+  const arch = machine === 62 ? "x64" : machine === 183 ? "arm64" : null;
+  if (arch == null) {
+    throw new Error(`Unsupported ELF machine ${machine}`);
+  }
+  return { arch, machine };
+}
+
+function safeRelativeFilePath(value, label) {
+  if (
+    typeof value !== "string"
+    || value.length === 0
+    || path.isAbsolute(value)
+    || value.split(/[\\/]+/).some((part) => part === "" || part === "." || part === "..")
+  ) {
+    throw new Error(`${label} must be a safe relative file path`);
+  }
+  return value;
+}
+
+function validateArtifactManifest(artifactManifest) {
+  if (
+    artifactManifest == null
+    || typeof artifactManifest !== "object"
+    || Array.isArray(artifactManifest)
+  ) {
+    throw new Error("Codex Micro node-hid artifact manifest is invalid");
+  }
+  for (const key of ["name", "version", "license", "integrity", "shasum"]) {
+    if (typeof artifactManifest[key] !== "string" || artifactManifest[key].length === 0) {
+      throw new Error(`Codex Micro node-hid artifact manifest is missing ${key}`);
+    }
+  }
+  if (!/^sha512-[A-Za-z0-9+/]+={0,2}$/.test(artifactManifest.integrity)) {
+    throw new Error("Codex Micro node-hid artifact integrity is invalid");
+  }
+  if (!/^[0-9a-f]{40}$/.test(artifactManifest.shasum)) {
+    throw new Error("Codex Micro node-hid artifact shasum is invalid");
+  }
+
+  const loaderContract = artifactManifest.loaderContract;
+  if (
+    loaderContract == null
+    || typeof loaderContract !== "object"
+    || Array.isArray(loaderContract)
+    || typeof loaderContract.main !== "string"
+    || !Array.isArray(loaderContract.napiVersions)
+    || loaderContract.napiVersions.length === 0
+    || !loaderContract.napiVersions.every(Number.isSafeInteger)
+    || loaderContract.files == null
+    || typeof loaderContract.files !== "object"
+    || Array.isArray(loaderContract.files)
+    || Object.keys(loaderContract.files).length === 0
+  ) {
+    throw new Error("Codex Micro node-hid loader contract is invalid");
+  }
+  for (const [relativePath, sha256] of Object.entries(loaderContract.files)) {
+    safeRelativeFilePath(relativePath, "Codex Micro node-hid loader contract file");
+    if (typeof sha256 !== "string" || !/^[0-9a-f]{64}$/.test(sha256)) {
+      throw new Error(`Codex Micro node-hid loader contract hash is invalid: ${relativePath}`);
+    }
+  }
+
+  for (const arch of SUPPORTED_ARCHITECTURES) {
+    const prebuild = artifactManifest.prebuilds?.[arch];
+    if (prebuild == null || typeof prebuild !== "object" || Array.isArray(prebuild)) {
+      throw new Error(`Codex Micro node-hid artifact manifest is missing the ${arch} prebuild`);
+    }
+    const expectedPath = `prebuilds/HID_hidraw-linux-${arch}/node-napi-v4.node`;
+    if (safeRelativeFilePath(prebuild.path, `Codex Micro ${arch} prebuild path`) !== expectedPath) {
+      throw new Error(`Codex Micro ${arch} prebuild path must be ${expectedPath}`);
+    }
+    if (typeof prebuild.sha256 !== "string" || !/^[0-9a-f]{64}$/.test(prebuild.sha256)) {
+      throw new Error(`Codex Micro ${arch} prebuild SHA-256 is invalid`);
+    }
+  }
+}
+
+function validateBundledPackage(discovered, artifactManifest) {
+  if (discovered.name !== artifactManifest.name) {
+    throw new Error(
+      `Bundled node-hid identity mismatch: expected ${artifactManifest.name}, got ${discovered.name}`,
+    );
+  }
+  if (discovered.version !== artifactManifest.version) {
+    throw new Error(
+      `Bundled node-hid version mismatch: expected ${artifactManifest.version}, got ${discovered.version}`,
+    );
+  }
+  if (discovered.license !== artifactManifest.license) {
+    throw new Error(
+      `Bundled node-hid license mismatch: expected ${artifactManifest.license}, got ${discovered.license}`,
+    );
+  }
+
+  const loaderContract = artifactManifest.loaderContract;
+  if (discovered.packageMetadata.main !== loaderContract.main) {
+    throw new Error(
+      `Bundled node-hid loader entrypoint mismatch: expected ${loaderContract.main}, ` +
+        `got ${discovered.packageMetadata.main ?? "unknown"}`,
+    );
+  }
+  if (
+    JSON.stringify(discovered.packageMetadata.binary?.napi_versions)
+    !== JSON.stringify(loaderContract.napiVersions)
+  ) {
+    throw new Error(
+      `Bundled node-hid N-API contract mismatch: expected ` +
+        `${JSON.stringify(loaderContract.napiVersions)}, got ` +
+        `${JSON.stringify(discovered.packageMetadata.binary?.napi_versions ?? null)}`,
+    );
+  }
+  for (const [relativePath, expectedSha256] of Object.entries(loaderContract.files)) {
+    const filePath = path.join(discovered.nodeHidDir, relativePath);
+    assertNoSymbolicLinkAncestors(discovered.nodeHidDir, filePath);
+    const stat = fs.lstatSync(filePath, { throwIfNoEntry: false });
+    if (!stat?.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`Bundled node-hid loader contract file is missing or unsafe: ${relativePath}`);
+    }
+    const actualSha256 = digest(fs.readFileSync(filePath), "sha256", "hex");
+    if (actualSha256 !== expectedSha256) {
+      throw new Error(
+        `Bundled node-hid loader contract hash mismatch for ${relativePath}: ` +
+          `expected ${expectedSha256}, got ${actualSha256}`,
+      );
+    }
+  }
+}
+
+function validateMaterializedPackage(materialized, artifactManifest) {
+  if (materialized == null || typeof materialized !== "object") {
+    throw new Error("node-hid materializer returned no package");
+  }
+  if (materialized.integrity !== artifactManifest.integrity) {
+    throw new Error(
+      `node-hid artifact integrity mismatch: expected ${artifactManifest.integrity}, ` +
+        `got ${materialized.integrity ?? "unknown"}`,
+    );
+  }
+  if (materialized.shasum !== artifactManifest.shasum) {
+    throw new Error(
+      `node-hid artifact shasum mismatch: expected ${artifactManifest.shasum}, ` +
+        `got ${materialized.shasum ?? "unknown"}`,
+    );
+  }
+  const metadata = readPackageMetadata(materialized.packageDir, "Materialized node-hid");
+  for (const key of ["name", "version", "license"]) {
+    if (metadata[key] !== artifactManifest[key]) {
+      throw new Error(
+        `node-hid artifact ${key} mismatch: expected ${artifactManifest[key]}, ` +
+          `got ${metadata[key] ?? "unknown"}`,
+      );
+    }
+  }
+}
+
+function validateBinding(contents, expectedArch, expectedSha256) {
+  const actualSha256 = digest(contents, "sha256", "hex");
+  if (actualSha256 !== expectedSha256) {
+    throw new Error(
+      `node-hid native binding SHA-256 mismatch: expected ${expectedSha256}, got ${actualSha256}`,
+    );
+  }
+  const elf = inspectElf(contents);
+  if (elf.arch !== expectedArch) {
+    throw new Error(
+      `node-hid native binding ELF architecture ${elf.arch} does not match ${expectedArch}`,
+    );
+  }
+  return elf;
+}
+
+function assertNoSymbolicLinkAncestors(root, target) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedTarget = path.resolve(target);
+  const rootStat = fs.lstatSync(resolvedRoot, { throwIfNoEntry: false });
+  if (!rootStat?.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error(`Codex Micro native binding root must be a safe directory: ${resolvedRoot}`);
+  }
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  if (
+    relative === ""
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)
+  ) {
+    throw new Error(`Codex Micro native binding target must stay inside ${resolvedRoot}`);
+  }
+
+  let current = resolvedRoot;
+  for (const part of relative.split(path.sep)) {
+    current = path.join(current, part);
+    const stat = fs.lstatSync(current, { throwIfNoEntry: false });
+    if (stat?.isSymbolicLink()) {
+      throw new Error(`Codex Micro native binding path must not contain symlinks: ${current}`);
+    }
+  }
+}
+
+function atomicWriteBinding(nodeHidDir, targetPath, contents) {
+  assertNoSymbolicLinkAncestors(nodeHidDir, targetPath);
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  assertNoSymbolicLinkAncestors(nodeHidDir, targetPath);
+  const temporaryPath = path.join(
+    path.dirname(targetPath),
+    `.${path.basename(targetPath)}.codex-micro-${process.pid}-` +
+      crypto.randomBytes(8).toString("hex"),
+  );
+  let temporaryFd;
+  try {
+    const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+    temporaryFd = fs.openSync(
+      temporaryPath,
+      fs.constants.O_WRONLY
+        | fs.constants.O_CREAT
+        | fs.constants.O_EXCL
+        | noFollow,
+      0o755,
+    );
+    fs.writeFileSync(temporaryFd, contents);
+    fs.fchmodSync(temporaryFd, 0o755);
+    fs.closeSync(temporaryFd);
+    temporaryFd = undefined;
+    assertNoSymbolicLinkAncestors(nodeHidDir, targetPath);
+    fs.renameSync(temporaryPath, targetPath);
+  } finally {
+    if (temporaryFd != null) {
+      fs.closeSync(temporaryFd);
+    }
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function run(command, args, options = {}) {
+  try {
+    return childProcess.execFileSync(command, args, {
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      ...options,
+    });
+  } catch (error) {
+    const stderr = typeof error?.stderr === "string" ? error.stderr.trim() : "";
+    const failure = stderr || error?.code || error?.message || "unknown error";
+    throw new Error(`${command} ${args.join(" ")} failed: ${failure}`);
+  }
+}
+
+async function defaultMaterializePackage(request) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "codex-micro-node-hid-"));
+  try {
+    const archiveOverride = process.env.CODEX_MICRO_NODE_HID_ARCHIVE?.trim();
+    let archivePath;
+    if (archiveOverride) {
+      archivePath = path.resolve(archiveOverride);
+      const stat = fs.lstatSync(archivePath, { throwIfNoEntry: false });
+      if (!stat?.isFile() || stat.isSymbolicLink()) {
+        throw new Error(`CODEX_MICRO_NODE_HID_ARCHIVE is not a safe file: ${archivePath}`);
+      }
+    } else {
+      const packOutput = run(
+        "npm",
+        [
+          "pack",
+          `${request.name}@${request.version}`,
+          "--ignore-scripts",
+          "--json",
+          "--pack-destination",
+          temporaryRoot,
+        ],
+        { env: { ...process.env, npm_config_ignore_scripts: "true" } },
+      );
+      let packResult;
+      try {
+        [packResult] = JSON.parse(packOutput);
+      } catch (error) {
+        throw new Error(`Could not parse npm pack output: ${error.message}`);
+      }
+      archivePath = path.join(temporaryRoot, packResult.filename);
+    }
+
+    const archive = fs.readFileSync(archivePath);
+    const integrity = integrityFor(archive);
+    const shasum = digest(archive, "sha1", "hex");
+    if (integrity !== request.integrity || shasum !== request.shasum) {
+      throw new Error(
+        `node-hid archive verification failed: expected ${request.integrity} / ` +
+          `${request.shasum}, got ${integrity} / ${shasum}`,
+      );
+    }
+
+    const extractRoot = path.join(temporaryRoot, "extracted");
+    fs.mkdirSync(extractRoot);
+    run("tar", ["-xzf", archivePath, "-C", extractRoot]);
+    const packageDir = path.join(extractRoot, "package");
+    const stat = fs.lstatSync(packageDir, { throwIfNoEntry: false });
+    if (!stat?.isDirectory() || stat.isSymbolicLink()) {
+      throw new Error("node-hid archive did not contain a safe package/ directory");
+    }
+    return {
+      packageDir,
+      integrity,
+      shasum,
+      cleanup: () => fs.rmSync(temporaryRoot, { recursive: true, force: true }),
+    };
+  } catch (error) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+async function stageCodexMicroNativeBinding(options) {
+  const arch = normalizeArchitecture(options.arch);
+  const artifactManifest = options.artifactManifest;
+  const materializePackage = options.materializePackage ?? defaultMaterializePackage;
+  validateArtifactManifest(artifactManifest);
+
+  const discovered = discoverBundledNodeHid(options.extractedDir);
+  validateBundledPackage(discovered, artifactManifest);
+
+  const prebuild = selectPrebuild(artifactManifest, arch);
+  if (prebuild == null) {
+    throw new Error(`A verified node-hid prebuild is required for ${arch}`);
+  }
+  const targetPath = path.join(discovered.nodeHidDir, prebuild.path);
+  assertNoSymbolicLinkAncestors(path.resolve(options.extractedDir), targetPath);
+  const existingStat = fs.lstatSync(targetPath, { throwIfNoEntry: false });
+  if (existingStat != null) {
+    if (!existingStat.isFile() || existingStat.isSymbolicLink()) {
+      throw new Error(`Existing node-hid native binding is unsafe: ${targetPath}`);
+    }
+    const existing = fs.readFileSync(targetPath);
+    if (digest(existing, "sha256", "hex") === prebuild.sha256) {
+      validateBinding(existing, arch, prebuild.sha256);
+      return {
+        changed: false,
+        alreadyApplied: true,
+        version: artifactManifest.version,
+        targetPath,
+        source: "existing-prebuild",
+        integrity: artifactManifest.integrity,
+      };
+    }
+  }
+
+  let materialized;
+  try {
+    materialized = await materializePackage({
+      name: artifactManifest.name,
+      version: artifactManifest.version,
+      integrity: artifactManifest.integrity,
+      shasum: artifactManifest.shasum,
+    });
+    validateMaterializedPackage(materialized, artifactManifest);
+
+    const sourcePath = path.join(materialized.packageDir, prebuild.path);
+    assertNoSymbolicLinkAncestors(materialized.packageDir, sourcePath);
+    const sourceStat = fs.lstatSync(sourcePath, { throwIfNoEntry: false });
+    if (!sourceStat?.isFile() || sourceStat.isSymbolicLink()) {
+      throw new Error(`Verified node-hid prebuild is missing or unsafe: ${prebuild.path}`);
+    }
+    const contents = fs.readFileSync(sourcePath);
+    validateBinding(contents, arch, prebuild.sha256);
+    atomicWriteBinding(path.resolve(options.extractedDir), targetPath, contents);
+
+    return {
+      changed: true,
+      alreadyApplied: false,
+      version: artifactManifest.version,
+      targetPath,
+      source: "verified-prebuild",
+      integrity: artifactManifest.integrity,
+    };
+  } finally {
+    materialized?.cleanup?.();
+  }
+}
+
+function currentArtifactManifest() {
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, "native-artifacts.json"), "utf8"),
+  );
+}
+
+async function main() {
+  if (process.argv[2] !== "--stage" || !process.argv[3]) {
+    console.error("Usage: native-binding.js --stage <extracted-app-dir>");
+    process.exitCode = 1;
+    return;
+  }
+  const result = await stageCodexMicroNativeBinding({
+    extractedDir: process.argv[3],
+    arch: process.arch,
+    artifactManifest: currentArtifactManifest(),
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`ERROR: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  defaultMaterializePackage,
+  discoverBundledNodeHid,
+  inspectElf,
+  selectPrebuild,
+  stageCodexMicroNativeBinding,
+  validateArtifactManifest,
+};

--- a/linux-features/codex-micro/native-binding.js
+++ b/linux-features/codex-micro/native-binding.js
@@ -443,17 +443,22 @@ async function stageCodexMicroNativeBinding(options) {
       throw new Error(`Existing node-hid native binding is unsafe: ${targetPath}`);
     }
     const existing = fs.readFileSync(targetPath);
-    if (digest(existing, "sha256", "hex") === prebuild.sha256) {
-      validateBinding(existing, arch, prebuild.sha256);
-      return {
-        changed: false,
-        alreadyApplied: true,
-        version: artifactManifest.version,
-        targetPath,
-        source: "existing-prebuild",
-        integrity: artifactManifest.integrity,
-      };
+    const existingSha256 = digest(existing, "sha256", "hex");
+    if (existingSha256 !== prebuild.sha256) {
+      throw new Error(
+        `Existing node-hid native binding hash mismatch: expected ${prebuild.sha256}, ` +
+        `got ${existingSha256}`,
+      );
     }
+    validateBinding(existing, arch, prebuild.sha256);
+    return {
+      changed: false,
+      alreadyApplied: true,
+      version: artifactManifest.version,
+      targetPath,
+      source: "existing-prebuild",
+      integrity: artifactManifest.integrity,
+    };
   }
 
   let materialized;

--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -51,9 +51,10 @@ function exportedFeatureGateHook(source) {
   return exportedCandidates.length === 1 ? exportedCandidates[0] : null;
 }
 
-function hasCodexMicroCallsite(source) {
+function hasCodexMicroCallsite(source, hookName) {
   return typeof source === "string"
-    && source.includes(CODEX_MICRO_GATE_ID)
+    && typeof hookName === "string"
+    && source.includes(`${hookName}(\`${CODEX_MICRO_GATE_ID}\`)`)
     && source.includes(CODEX_MICRO_ROUTE);
 }
 
@@ -64,16 +65,14 @@ function matchesCodexMicroFeatureGateContract(source) {
   if (source.includes(CODEX_MICRO_GATE_MARKER)) {
     return true;
   }
-  return hasCodexMicroCallsite(source)
-    && source.includes(FEATURE_GATE_WARNING)
-    && exportedFeatureGateHook(source) != null;
+  const hook = exportedFeatureGateHook(source);
+  return source.includes(FEATURE_GATE_WARNING)
+    && hook != null
+    && hasCodexMicroCallsite(source, hook.hookName);
 }
 
 function applyCodexMicroFeatureGatePatch(source) {
   if (typeof source !== "string" || source.includes(CODEX_MICRO_GATE_MARKER)) {
-    return source;
-  }
-  if (!hasCodexMicroCallsite(source)) {
     return source;
   }
 
@@ -85,6 +84,9 @@ function applyCodexMicroFeatureGatePatch(source) {
           "skipping Codex Micro gate override",
       );
     }
+    return source;
+  }
+  if (!hasCodexMicroCallsite(source, hook.hookName)) {
     return source;
   }
 

--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -1,0 +1,146 @@
+"use strict";
+
+const childProcess = require("node:child_process");
+const path = require("node:path");
+
+const {
+  extractedAppPatch,
+  webviewAssetPatch,
+} = require("../../scripts/patches/descriptor.js");
+
+const CODEX_MICRO_GATE_ID = "3207467860";
+const CODEX_MICRO_ROUTE = "/settings/codex-micro";
+const CODEX_MICRO_GATE_MARKER = "codexLinuxCodexMicroGateOverride";
+const FEATURE_GATE_WARNING = "useFeatureGate hook failed to find a valid StatsigClient";
+const JS_IDENT = "[A-Za-z_$][\\w$]*";
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function exportedFeatureGateHook(source) {
+  const exportStart = source.lastIndexOf("export{");
+  const exportEnd = exportStart < 0 ? -1 : source.indexOf("}", exportStart);
+  if (exportStart < 0 || exportEnd < 0) {
+    return null;
+  }
+
+  const exportBlock = source.slice(exportStart, exportEnd + 1);
+  const candidates = new RegExp(
+    `function (${JS_IDENT})\\((${JS_IDENT})\\)\\{return ` +
+      `(${JS_IDENT})\\(\\),(${JS_IDENT})\\((${JS_IDENT}),\\2\\)\\}`,
+    "g",
+  );
+  const exportedCandidates = [];
+  for (const match of source.matchAll(candidates)) {
+    const hookName = match[1];
+    const exportedAsGateHook = new RegExp(
+      `(?:\\{|,)${escapeRegExp(hookName)} as ${JS_IDENT}(?:,|\\})`,
+    );
+    if (exportedAsGateHook.test(exportBlock)) {
+      exportedCandidates.push({
+        source: match[0],
+        hookName,
+        argumentName: match[2],
+        contextHookName: match[3],
+        atomReadName: match[4],
+        gateAtomName: match[5],
+      });
+    }
+  }
+  return exportedCandidates.length === 1 ? exportedCandidates[0] : null;
+}
+
+function hasCodexMicroCallsite(source) {
+  return typeof source === "string"
+    && source.includes(CODEX_MICRO_GATE_ID)
+    && source.includes(CODEX_MICRO_ROUTE);
+}
+
+function matchesCodexMicroFeatureGateContract(source) {
+  if (typeof source !== "string") {
+    return false;
+  }
+  if (source.includes(CODEX_MICRO_GATE_MARKER)) {
+    return true;
+  }
+  return hasCodexMicroCallsite(source)
+    && source.includes(FEATURE_GATE_WARNING)
+    && exportedFeatureGateHook(source) != null;
+}
+
+function applyCodexMicroFeatureGatePatch(source) {
+  if (typeof source !== "string" || source.includes(CODEX_MICRO_GATE_MARKER)) {
+    return source;
+  }
+  if (!hasCodexMicroCallsite(source)) {
+    return source;
+  }
+
+  const hook = exportedFeatureGateHook(source);
+  if (hook == null) {
+    if (source.includes(FEATURE_GATE_WARNING)) {
+      console.warn(
+        "WARN: Could not find the current exported feature-gate hook - " +
+          "skipping Codex Micro gate override",
+      );
+    }
+    return source;
+  }
+
+  const replacement =
+    `function ${hook.hookName}(${hook.argumentName}){return ` +
+    `${hook.contextHookName}(),${hook.atomReadName}(${hook.gateAtomName},${hook.argumentName})||` +
+    `${hook.argumentName}===\`${CODEX_MICRO_GATE_ID}\`/*${CODEX_MICRO_GATE_MARKER}*/}`;
+  return source.replace(hook.source, replacement);
+}
+
+function stageNativeBinding(extractedDir) {
+  const helper = path.join(__dirname, "native-binding.js");
+  const output = childProcess.execFileSync(process.execPath, [helper, "--stage", extractedDir], {
+    encoding: "utf8",
+    env: process.env,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return JSON.parse(output);
+}
+
+module.exports = {
+  CODEX_MICRO_GATE_ID,
+  CODEX_MICRO_GATE_MARKER,
+  CODEX_MICRO_ROUTE,
+  applyCodexMicroFeatureGatePatch,
+  exportedFeatureGateHook,
+  hasCodexMicroCallsite,
+  matchesCodexMicroFeatureGateContract,
+  descriptors: [
+    webviewAssetPatch({
+      id: "webview-feature-gate",
+      order: 28_990,
+      ciPolicy: "opt-in",
+      pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
+      assetMatch: matchesCodexMicroFeatureGateContract,
+      missingDescription: "current Codex Micro feature-gate webview bundle",
+      skipDescription: "Codex Micro feature-gate override",
+      apply: applyCodexMicroFeatureGatePatch,
+    }),
+    extractedAppPatch({
+      id: "linux-node-hid-binding",
+      phase: "extracted-app:post-webview",
+      order: 29_000,
+      ciPolicy: "opt-in",
+      targetSummary: "current Work Louder nested node-hid 3.3.0 dependency",
+      apply: (extractedDir) => stageNativeBinding(extractedDir),
+      status: (result) => ({
+        status: result?.changed
+          ? "applied"
+          : result?.alreadyApplied
+            ? "already-applied"
+            : "skipped-optional",
+        reason: result == null
+          ? "node-hid binding staging returned no result"
+          : `${result.source} node-hid ${result.version}`,
+      }),
+    }),
+  ],
+};

--- a/linux-features/codex-micro/patch.js
+++ b/linux-features/codex-micro/patch.js
@@ -52,10 +52,14 @@ function exportedFeatureGateHook(source) {
 }
 
 function hasCodexMicroCallsite(source, hookName) {
-  return typeof source === "string"
-    && typeof hookName === "string"
-    && source.includes(`${hookName}(\`${CODEX_MICRO_GATE_ID}\`)`)
-    && source.includes(CODEX_MICRO_ROUTE);
+  if (typeof source !== "string" || typeof hookName !== "string") {
+    return false;
+  }
+  const gateCall = new RegExp(
+    `(?:^|[^A-Za-z0-9_$.])${escapeRegExp(hookName)}\\(\`${CODEX_MICRO_GATE_ID}\`\\)`,
+  );
+  return gateCall.test(source)
+    && source.includes(`\`${CODEX_MICRO_ROUTE}\``);
 }
 
 function matchesCodexMicroFeatureGateContract(source) {

--- a/linux-features/codex-micro/resources/70-codex-micro.rules
+++ b/linux-features/codex-micro/resources/70-codex-micro.rules
@@ -1,0 +1,5 @@
+# OpenAI x Work Louder Codex Micro vendor HID channel (USB interface 00 only).
+# usb_id must run before its imported properties are matched on a hidraw event.
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", IMPORT{builtin}="usb_id", ENV{ID_VENDOR_ID}=="303a", ENV{ID_MODEL_ID}=="8360", ENV{ID_USB_INTERFACE_NUM}=="00", TAG+="uaccess", MODE="0660"
+# BlueZ exposes the same vendor HID channel through UHID on Bluetooth bus 0005.
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", KERNELS=="0005:303A:8360.*", TAG+="uaccess", MODE="0660"

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -202,7 +202,7 @@ function currentFeatureGateFixture() {
     "const warning=`useFeatureGate hook failed to find a valid StatsigClient`;",
     "function Lh(){return zh().isLoading}",
     "function Rh(e){return bnt(),Bo(Fh,e)}",
-    `const microGate=kh(\`${CODEX_MICRO_GATE_ID}\`);`,
+    `const microGate=Rh(\`${CODEX_MICRO_GATE_ID}\`);`,
     `const microRoute=\`${CODEX_MICRO_ROUTE}\`;`,
     "export{zh as c,Lh as flt,Rh as rlt};",
   ].join("");
@@ -247,6 +247,21 @@ test("both the Codex Micro gate id and route are required", () => {
   const withoutRoute = currentFeatureGateFixture().replace(CODEX_MICRO_ROUTE, "/settings/other");
   assert.equal(matchesCodexMicroFeatureGateContract(withoutGate), false);
   assert.equal(matchesCodexMicroFeatureGateContract(withoutRoute), false);
+});
+
+test("Codex Micro gate drift cannot redirect the patch to an unrelated exported hook", () => {
+  const drifted = [
+    "const warning=`useFeatureGate hook failed to find a valid StatsigClient`;",
+    "function Ah(e){return changedGateShape(e)}",
+    "function Uh(e){return touch(),read(atom,e)}",
+    `const microGate=Ah(\`${CODEX_MICRO_GATE_ID}\`);`,
+    `const microRoute=\`${CODEX_MICRO_ROUTE}\`;`,
+    "export{Ah as gate,Uh as unrelated};",
+  ].join("");
+
+  assert.equal(exportedFeatureGateHook(drifted)?.hookName, "Uh");
+  assert.equal(matchesCodexMicroFeatureGateContract(drifted), false);
+  assert.equal(applyCodexMicroFeatureGatePatch(drifted), drifted);
 });
 
 test("Codex Micro gate patch targets only the current app-initial bundle shape", () => {
@@ -327,6 +342,31 @@ test("an already verified binding is idempotent and performs no package fetch", 
   assert.equal(result.changed, false);
   assert.equal(result.alreadyApplied, true);
   assert.equal(result.source, "existing-prebuild");
+});
+
+test("an unexpected upstream binding fails closed before package materialization", async (t) => {
+  const expectedBinary = makeElf("x64", "expected-binding");
+  const unexpectedBinary = makeElf("x64", "unexpected-upstream-binding");
+  const artifact = fixtureArtifact({ x64: expectedBinary });
+  const fixture = createBundledFixture(t);
+  const targetPath = path.join(fixture.nodeHidDir, bindingRelativePath("x64"));
+  writeFile(targetPath, unexpectedBinary, 0o755);
+  let materializeCalls = 0;
+
+  await assert.rejects(
+    stageCodexMicroNativeBinding({
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      artifactManifest: artifact,
+      materializePackage: async () => {
+        materializeCalls += 1;
+        throw new Error("unexpected upstream bindings must fail before materialization");
+      },
+    }),
+    /existing node-hid native binding hash mismatch/i,
+  );
+  assert.equal(materializeCalls, 0);
+  assert.deepEqual(fs.readFileSync(targetPath), unexpectedBinary);
 });
 
 test("upstream node-hid version or loader drift fails before package materialization", async (t) => {

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -547,21 +547,43 @@ test("the nested discovery path cannot be substituted with a hoisted node-hid", 
   );
 });
 
-test("discovery rejects symlinked ancestors in the bundled dependency chain", (t) => {
-  const fixture = createBundledFixture(t);
-  const scopedModules = path.join(
-    fixture.extractedDir,
-    "node_modules",
-    "@worklouder",
-  );
-  const outside = path.join(path.dirname(fixture.extractedDir), "outside-worklouder");
-  fs.renameSync(scopedModules, outside);
-  fs.symlinkSync(outside, scopedModules, "dir");
+test("discovery rejects symlinked ancestors before reading package metadata", (t) => {
+  for (const scenario of [
+    {
+      label: "device-kit-oai",
+      scopedModules: (fixture) => path.join(
+        fixture.extractedDir,
+        "node_modules",
+        "@worklouder",
+      ),
+      packageName: "device-kit-oai",
+    },
+    {
+      label: "wl-device-kit",
+      scopedModules: (fixture) => path.join(
+        fixture.extractedDir,
+        DEVICE_KIT_RELATIVE,
+        "node_modules",
+        "@worklouder",
+      ),
+      packageName: "wl-device-kit",
+    },
+  ]) {
+    const fixture = createBundledFixture(t);
+    const scopedModules = scenario.scopedModules(fixture);
+    const outside = path.join(
+      path.dirname(fixture.extractedDir),
+      `outside-${scenario.label}`,
+    );
+    fs.renameSync(scopedModules, outside);
+    writeFile(path.join(outside, scenario.packageName, "package.json"), "{");
+    fs.symlinkSync(outside, scopedModules, "dir");
 
-  assert.throws(
-    () => discoverBundledNodeHid(fixture.extractedDir),
-    /path must not contain symlinks/i,
-  );
+    assert.throws(
+      () => discoverBundledNodeHid(fixture.extractedDir),
+      /path must not contain symlinks/i,
+    );
+  }
 });
 
 test("native binding staging rejects valid existing bindings behind symlinked parents", async (t) => {

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -586,6 +586,27 @@ test("discovery rejects symlinked ancestors before reading package metadata", (t
   }
 });
 
+test("discovery rejects symlinked package ancestors before reading metadata", (t) => {
+  const fixture = createBundledFixture(t);
+  const scopedModules = path.join(
+    fixture.extractedDir,
+    "node_modules",
+    "@worklouder",
+  );
+  const outside = path.join(path.dirname(fixture.extractedDir), "outside-worklouder");
+  fs.renameSync(scopedModules, outside);
+  fs.writeFileSync(
+    path.join(outside, "device-kit-oai", "package.json"),
+    "{ metadata outside the extracted tree must not be read",
+  );
+  fs.symlinkSync(outside, scopedModules, "dir");
+
+  assert.throws(
+    () => discoverBundledNodeHid(fixture.extractedDir),
+    /path must not contain symlinks/i,
+  );
+});
+
 test("native binding staging rejects valid existing bindings behind symlinked parents", async (t) => {
   const binary = makeElf("x64", "symlinked-target-parent");
   const artifact = fixtureArtifact({ x64: binary });

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -1,0 +1,596 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  discoverBundledNodeHid,
+  inspectElf,
+  selectPrebuild,
+  stageCodexMicroNativeBinding,
+  validateArtifactManifest,
+} = require("./native-binding.js");
+const {
+  CODEX_MICRO_GATE_ID,
+  CODEX_MICRO_GATE_MARKER,
+  CODEX_MICRO_ROUTE,
+  applyCodexMicroFeatureGatePatch,
+  descriptors,
+  exportedFeatureGateHook,
+  matchesCodexMicroFeatureGateContract,
+} = require("./patch.js");
+const {
+  enabledLinuxFeaturePackageDependencies,
+  enabledLinuxFeaturePackageFiles,
+  loadLinuxFeaturePatchDescriptors,
+  stageEnabledLinuxFeaturePackageResources,
+} = require("../../scripts/lib/linux-features.js");
+
+const DEVICE_KIT_RELATIVE = path.join(
+  "node_modules",
+  "@worklouder",
+  "device-kit-oai",
+);
+const WORK_LOUDER_KIT_RELATIVE = path.join(
+  DEVICE_KIT_RELATIVE,
+  "node_modules",
+  "@worklouder",
+  "wl-device-kit",
+);
+const NODE_HID_RELATIVE = path.join(
+  WORK_LOUDER_KIT_RELATIVE,
+  "node_modules",
+  "node-hid",
+);
+const FIXTURE_NODE_HID_LOADER =
+  "module.exports = require('pkg-prebuilds')(__dirname); // bundled loader\n";
+const FIXTURE_NODE_HID_OPTIONS =
+  "module.exports = { name: 'HID', tags: ['backend'] }; // bundled options\n";
+
+function tempDirectory(t, prefix) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFile(filePath, contents, mode) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents, mode == null ? undefined : { mode });
+}
+
+function sha256(contents) {
+  return crypto.createHash("sha256").update(contents).digest("hex");
+}
+
+function makeElf(arch, marker = arch) {
+  const machines = { x64: 62, arm64: 183 };
+  const machine = machines[arch];
+  if (machine == null) {
+    throw new Error(`Unsupported ELF fixture architecture: ${arch}`);
+  }
+  const contents = Buffer.alloc(128);
+  contents.set([0x7f, 0x45, 0x4c, 0x46], 0);
+  contents[4] = 2;
+  contents[5] = 1;
+  contents[6] = 1;
+  contents.writeUInt16LE(3, 16);
+  contents.writeUInt16LE(machine, 18);
+  contents.writeUInt32LE(1, 20);
+  contents.write(marker, 64, "utf8");
+  return contents;
+}
+
+function bindingRelativePath(arch) {
+  return path.join(
+    "prebuilds",
+    `HID_hidraw-linux-${arch}`,
+    "node-napi-v4.node",
+  );
+}
+
+function shippedArtifact() {
+  return JSON.parse(
+    fs.readFileSync(path.join(__dirname, "native-artifacts.json"), "utf8"),
+  );
+}
+
+function fixtureArtifact(binaries = {}) {
+  const x64 = binaries.x64 ?? makeElf("x64", "fixture-x64");
+  const arm64 = binaries.arm64 ?? makeElf("arm64", "fixture-arm64");
+  return {
+    ...shippedArtifact(),
+    loaderContract: {
+      main: "./nodehid.js",
+      napiVersions: [4],
+      files: {
+        "nodehid.js": sha256(FIXTURE_NODE_HID_LOADER),
+        "binding-options.js": sha256(FIXTURE_NODE_HID_OPTIONS),
+      },
+    },
+    prebuilds: {
+      x64: {
+        path: bindingRelativePath("x64"),
+        sha256: sha256(x64),
+      },
+      arm64: {
+        path: bindingRelativePath("arm64"),
+        sha256: sha256(arm64),
+      },
+    },
+  };
+}
+
+function createBundledFixture(t, options = {}) {
+  const root = tempDirectory(t, "codex-micro-bundled-");
+  const extractedDir = path.join(root, "app-extracted");
+  const deviceKitDir = path.join(extractedDir, DEVICE_KIT_RELATIVE);
+  const workLouderKitDir = path.join(extractedDir, WORK_LOUDER_KIT_RELATIVE);
+  const nodeHidDir = path.join(extractedDir, NODE_HID_RELATIVE);
+
+  writeJson(path.join(deviceKitDir, "package.json"), {
+    name: "@worklouder/device-kit-oai",
+    version: "0.4.0",
+  });
+  writeJson(path.join(workLouderKitDir, "package.json"), {
+    name: "@worklouder/wl-device-kit",
+    version: "0.12.0",
+  });
+  writeJson(path.join(nodeHidDir, "package.json"), {
+    name: "node-hid",
+    version: options.bundledVersion ?? "3.3.0",
+    license: "(MIT OR X11)",
+    main: "./nodehid.js",
+    binary: { napi_versions: [4] },
+  });
+  writeFile(
+    path.join(nodeHidDir, "nodehid.js"),
+    options.loader ?? FIXTURE_NODE_HID_LOADER,
+  );
+  writeFile(
+    path.join(nodeHidDir, "binding-options.js"),
+    FIXTURE_NODE_HID_OPTIONS,
+  );
+  writeFile(
+    path.join(nodeHidDir, "prebuilds/HID-darwin-arm64/node-napi-v4.node"),
+    "bundled Mach-O bytes",
+  );
+
+  return { extractedDir, nodeHidDir };
+}
+
+function createMaterializedPackage(t, options = {}) {
+  const packageDir = path.join(
+    tempDirectory(t, "codex-micro-node-hid-artifact-"),
+    "package",
+  );
+  writeJson(path.join(packageDir, "package.json"), {
+    name: options.name ?? "node-hid",
+    version: options.version ?? "3.3.0",
+    license: options.license ?? "(MIT OR X11)",
+    scripts: { install: "must never execute" },
+  });
+  writeFile(
+    path.join(packageDir, "nodehid.js"),
+    "throw new Error('artifact JavaScript must not be copied');\n",
+  );
+  for (const [arch, binary] of Object.entries(options.binaries ?? {})) {
+    writeFile(path.join(packageDir, bindingRelativePath(arch)), binary, 0o755);
+  }
+  return packageDir;
+}
+
+function materializer(packageDir, artifact, overrides = {}) {
+  return async () => ({
+    packageDir,
+    integrity: overrides.integrity ?? artifact.integrity,
+    shasum: overrides.shasum ?? artifact.shasum,
+  });
+}
+
+function currentFeatureGateFixture() {
+  return [
+    "const warning=`useFeatureGate hook failed to find a valid StatsigClient`;",
+    "function Lh(){return zh().isLoading}",
+    "function Rh(e){return bnt(),Bo(Fh,e)}",
+    `const microGate=kh(\`${CODEX_MICRO_GATE_ID}\`);`,
+    `const microRoute=\`${CODEX_MICRO_ROUTE}\`;`,
+    "export{zh as c,Lh as flt,Rh as rlt};",
+  ].join("");
+}
+
+test("Codex Micro locally enables only its current upstream feature gate", () => {
+  const source = currentFeatureGateFixture();
+  const hook = exportedFeatureGateHook(source);
+  assert.deepEqual(hook, {
+    source: "function Rh(e){return bnt(),Bo(Fh,e)}",
+    hookName: "Rh",
+    argumentName: "e",
+    contextHookName: "bnt",
+    atomReadName: "Bo",
+    gateAtomName: "Fh",
+  });
+  assert.equal(matchesCodexMicroFeatureGateContract(source), true);
+
+  const patched = applyCodexMicroFeatureGatePatch(source);
+  assert.match(
+    patched,
+    new RegExp(
+      `function Rh\\(e\\)\\{return bnt\\(\\),Bo\\(Fh,e\\)\\|\\|` +
+        `e===\\\`${CODEX_MICRO_GATE_ID}\\\`/\\*${CODEX_MICRO_GATE_MARKER}\\*/\\}`,
+    ),
+  );
+  assert.equal(applyCodexMicroFeatureGatePatch(patched), patched);
+  assert.equal(matchesCodexMicroFeatureGateContract(patched), true);
+});
+
+test("generic Statsig hook bundles are not accepted as Codex Micro assets", () => {
+  const generic = currentFeatureGateFixture()
+    .replace(`const microGate=kh(\`${CODEX_MICRO_GATE_ID}\`);`, "")
+    .replace(`const microRoute=\`${CODEX_MICRO_ROUTE}\`;`, "");
+  assert.equal(exportedFeatureGateHook(generic)?.hookName, "Rh");
+  assert.equal(matchesCodexMicroFeatureGateContract(generic), false);
+  assert.equal(applyCodexMicroFeatureGatePatch(generic), generic);
+});
+
+test("both the Codex Micro gate id and route are required", () => {
+  const withoutGate = currentFeatureGateFixture().replace(CODEX_MICRO_GATE_ID, "different-gate");
+  const withoutRoute = currentFeatureGateFixture().replace(CODEX_MICRO_ROUTE, "/settings/other");
+  assert.equal(matchesCodexMicroFeatureGateContract(withoutGate), false);
+  assert.equal(matchesCodexMicroFeatureGateContract(withoutRoute), false);
+});
+
+test("Codex Micro gate patch targets only the current app-initial bundle shape", () => {
+  const descriptor = descriptors.find(({ id }) => id === "webview-feature-gate");
+  assert.ok(descriptor);
+  assert.equal(descriptor.pattern.test("app-initial-C-fROkKo.js"), true);
+  assert.equal(descriptor.pattern.test("app-initial~old-chunk.js"), false);
+});
+
+test("the shipped artifact manifest is prebuild-only and pinned for x64 and arm64", () => {
+  const artifact = shippedArtifact();
+  assert.doesNotThrow(() => validateArtifactManifest(artifact));
+  assert.equal(artifact.name, "node-hid");
+  assert.equal(artifact.version, "3.3.0");
+  assert.deepEqual(Object.keys(artifact.prebuilds).sort(), ["arm64", "x64"]);
+  assert.equal(
+    artifact.prebuilds.x64.sha256,
+    "6c7f3b3fcc238a74e7e3237b50b2ff05181e94862b1963e8074ff8fc75885021",
+  );
+  assert.equal(
+    artifact.prebuilds.arm64.sha256,
+    "06ea97f377e2246a1e9bf3770186727e72ff3c166579d9c259c6d32a07aeaa60",
+  );
+  assert.equal(fs.existsSync(path.join(__dirname, "source-build")), false);
+});
+
+for (const arch of ["x64", "arm64"]) {
+  test(`stages only the verified ${arch} prebuild into the exact nested node-hid`, async (t) => {
+    const binary = makeElf(arch, `${arch}-verified`);
+    const artifact = fixtureArtifact({ [arch]: binary });
+    const fixture = createBundledFixture(t);
+    const packageDir = createMaterializedPackage(t, {
+      binaries: { [arch]: binary },
+    });
+
+    const result = await stageCodexMicroNativeBinding({
+      extractedDir: fixture.extractedDir,
+      arch,
+      artifactManifest: artifact,
+      materializePackage: materializer(packageDir, artifact),
+    });
+    const targetPath = path.join(fixture.nodeHidDir, bindingRelativePath(arch));
+    assert.deepEqual(fs.readFileSync(targetPath), binary);
+    assert.equal(fs.statSync(targetPath).mode & 0o777, 0o755);
+    assert.equal(result.changed, true);
+    assert.equal(result.alreadyApplied, false);
+    assert.equal(result.source, "verified-prebuild");
+    assert.equal(result.targetPath, targetPath);
+    assert.equal(
+      fs.existsSync(path.join(fixture.nodeHidDir, "README.md")),
+      false,
+      "artifact package contents other than the selected native binary must not be copied",
+    );
+  });
+}
+
+test("an already verified binding is idempotent and performs no package fetch", async (t) => {
+  const binary = makeElf("x64", "already-staged");
+  const artifact = fixtureArtifact({ x64: binary });
+  const fixture = createBundledFixture(t);
+  writeFile(
+    path.join(fixture.nodeHidDir, bindingRelativePath("x64")),
+    binary,
+    0o755,
+  );
+  let materializeCalls = 0;
+
+  const result = await stageCodexMicroNativeBinding({
+    extractedDir: fixture.extractedDir,
+    arch: "x64",
+    artifactManifest: artifact,
+    materializePackage: async () => {
+      materializeCalls += 1;
+      throw new Error("verified existing binding must avoid materialization");
+    },
+  });
+  assert.equal(materializeCalls, 0);
+  assert.equal(result.changed, false);
+  assert.equal(result.alreadyApplied, true);
+  assert.equal(result.source, "existing-prebuild");
+});
+
+test("upstream node-hid version or loader drift fails before package materialization", async (t) => {
+  for (const options of [
+    { bundledVersion: "3.3.1", expected: /version mismatch/i },
+    { loader: "module.exports = 'drift';\n", expected: /loader contract hash mismatch/i },
+  ]) {
+    const fixture = createBundledFixture(t, options);
+    let materializeCalls = 0;
+    await assert.rejects(
+      stageCodexMicroNativeBinding({
+        extractedDir: fixture.extractedDir,
+        arch: "x64",
+        artifactManifest: fixtureArtifact(),
+        materializePackage: async () => {
+          materializeCalls += 1;
+        },
+      }),
+      options.expected,
+    );
+    assert.equal(materializeCalls, 0);
+  }
+});
+
+for (const scenario of [
+  {
+    label: "archive integrity",
+    materialized: { integrity: "sha512-unverified" },
+    expected: /integrity mismatch/i,
+  },
+  {
+    label: "archive shasum",
+    materialized: { shasum: "0".repeat(40) },
+    expected: /shasum mismatch/i,
+  },
+  {
+    label: "package identity",
+    metadata: { name: "not-node-hid" },
+    expected: /identity mismatch|artifact name mismatch/i,
+  },
+  {
+    label: "package version",
+    metadata: { version: "3.3.1" },
+    expected: /version mismatch/i,
+  },
+]) {
+  test(`rejects a materialized artifact with wrong ${scenario.label}`, async (t) => {
+    const binary = makeElf("x64", scenario.label);
+    const artifact = fixtureArtifact({ x64: binary });
+    const fixture = createBundledFixture(t);
+    const packageDir = createMaterializedPackage(t, {
+      ...scenario.metadata,
+      binaries: { x64: binary },
+    });
+    await assert.rejects(
+      stageCodexMicroNativeBinding({
+        extractedDir: fixture.extractedDir,
+        arch: "x64",
+        artifactManifest: artifact,
+        materializePackage: materializer(packageDir, artifact, scenario.materialized),
+      }),
+      scenario.expected,
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixture.nodeHidDir, bindingRelativePath("x64"))),
+      false,
+    );
+  });
+}
+
+test("rejects a hash-valid prebuild with the wrong ELF architecture", async (t) => {
+  const arm64Binary = makeElf("arm64", "arm64-under-x64-path");
+  const artifact = fixtureArtifact();
+  artifact.prebuilds.x64.sha256 = sha256(arm64Binary);
+  const fixture = createBundledFixture(t);
+  const packageDir = createMaterializedPackage(t, {
+    binaries: { x64: arm64Binary },
+  });
+  await assert.rejects(
+    stageCodexMicroNativeBinding({
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      artifactManifest: artifact,
+      materializePackage: materializer(packageDir, artifact),
+    }),
+    /ELF architecture arm64 does not match x64/i,
+  );
+});
+
+test("unsupported architectures fail before discovery or materialization", async () => {
+  let materializeCalls = 0;
+  await assert.rejects(
+    stageCodexMicroNativeBinding({
+      extractedDir: "/does/not/matter",
+      arch: "riscv64",
+      artifactManifest: shippedArtifact(),
+      materializePackage: async () => {
+        materializeCalls += 1;
+      },
+    }),
+    /unsupported.*architecture.*riscv64/i,
+  );
+  assert.equal(materializeCalls, 0);
+  assert.throws(() => selectPrebuild(shippedArtifact(), "riscv64"), /unsupported/i);
+});
+
+test("inspectElf accepts only supported 64-bit little-endian machines", () => {
+  assert.equal(inspectElf(makeElf("x64")).arch, "x64");
+  assert.equal(inspectElf(makeElf("arm64")).arch, "arm64");
+  assert.throws(() => inspectElf(Buffer.from("not ELF")), /ELF/i);
+  const elf32 = makeElf("x64");
+  elf32[4] = 1;
+  assert.throws(() => inspectElf(elf32), /64-bit/i);
+  const bigEndian = makeElf("x64");
+  bigEndian[5] = 2;
+  assert.throws(() => inspectElf(bigEndian), /little-endian/i);
+});
+
+test("udev policy imports USB properties before narrow USB and Bluetooth matches", () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, "resources", "70-codex-micro.rules"),
+    "utf8",
+  );
+  const activeRules = source
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+  assert.equal(activeRules.length, 2);
+  const [usbRule, bluetoothRule] = activeRules;
+  for (const rule of activeRules) {
+    assert.match(rule, /SUBSYSTEM=="hidraw"/);
+    assert.match(rule, /KERNEL=="hidraw\*"/);
+    assert.match(rule, /TAG\+="uaccess"/);
+    assert.match(rule, /MODE="0660"/);
+  }
+  assert.match(usbRule, /IMPORT\{builtin\}="usb_id"/);
+  assert.ok(
+    usbRule.indexOf('IMPORT{builtin}="usb_id"')
+      < usbRule.indexOf('ENV{ID_VENDOR_ID}=="303a"'),
+    "usb_id must be imported before its properties are matched",
+  );
+  assert.match(usbRule, /ENV\{ID_MODEL_ID\}=="8360"/);
+  assert.match(usbRule, /ENV\{ID_USB_INTERFACE_NUM\}=="00"/);
+  assert.match(bluetoothRule, /KERNELS=="0005:303A:8360\.\*"/);
+  assert.doesNotMatch(source, /MODE="0666"/);
+  assert.doesNotMatch(source, /SUBSYSTEM=="usb"/);
+});
+
+test("disabled Codex Micro performs no patch or package work", (t) => {
+  const root = tempDirectory(t, "codex-micro-disabled-");
+  const configPath = path.join(root, "features.json");
+  writeJson(configPath, { enabled: [] });
+  const options = {
+    featuresRoot: path.resolve(__dirname, ".."),
+    featuresConfigPath: configPath,
+  };
+  assert.deepEqual(loadLinuxFeaturePatchDescriptors(options), []);
+  for (const packageFormat of ["deb", "rpm", "pacman"]) {
+    assert.deepEqual(
+      enabledLinuxFeaturePackageDependencies({ ...options, packageFormat }),
+      [],
+    );
+    assert.deepEqual(enabledLinuxFeaturePackageFiles({ ...options, packageFormat }), []);
+  }
+});
+
+test("native formats stage the exact rule and feature-only dependencies", (t) => {
+  const root = tempDirectory(t, "codex-micro-packages-");
+  const configPath = path.join(root, "features.json");
+  writeJson(configPath, { enabled: ["codex-micro"] });
+  const expectedDependencies = {
+    deb: ["libudev1", "libusb-1.0-0"],
+    rpm: [
+      "libudev.so.1%{codex_elf_suffix}",
+      "libusb-1.0.so.0%{codex_elf_suffix}",
+    ],
+    pacman: ["libusb", "systemd-libs"],
+  };
+  const expectedRule = fs.readFileSync(
+    path.join(__dirname, "resources", "70-codex-micro.rules"),
+  );
+
+  for (const packageFormat of ["deb", "rpm", "pacman"]) {
+    const packageRoot = path.join(root, packageFormat);
+    const options = {
+      featuresRoot: path.resolve(__dirname, ".."),
+      featuresConfigPath: configPath,
+      packageFormat,
+    };
+    const plan = stageEnabledLinuxFeaturePackageResources(packageRoot, options);
+    const target = path.join(
+      packageRoot,
+      "usr/lib/udev/rules.d/70-codex-micro.rules",
+    );
+    assert.deepEqual(plan.dependencies, expectedDependencies[packageFormat]);
+    assert.deepEqual(
+      enabledLinuxFeaturePackageDependencies(options),
+      expectedDependencies[packageFormat],
+    );
+    assert.deepEqual(
+      enabledLinuxFeaturePackageFiles(options),
+      ["/usr/lib/udev/rules.d/70-codex-micro.rules"],
+    );
+    assert.deepEqual(fs.readFileSync(target), expectedRule);
+    assert.equal(fs.statSync(target).mode & 0o777, 0o644);
+  }
+});
+
+test("the nested discovery path cannot be substituted with a hoisted node-hid", (t) => {
+  const root = tempDirectory(t, "codex-micro-hoisted-");
+  writeJson(path.join(root, "node_modules/node-hid/package.json"), {
+    name: "node-hid",
+    version: "3.3.0",
+  });
+  assert.throws(
+    () => discoverBundledNodeHid(root),
+    /device-kit-oai package is missing/i,
+  );
+});
+
+test("discovery rejects symlinked ancestors in the bundled dependency chain", (t) => {
+  const fixture = createBundledFixture(t);
+  const scopedModules = path.join(
+    fixture.extractedDir,
+    "node_modules",
+    "@worklouder",
+  );
+  const outside = path.join(path.dirname(fixture.extractedDir), "outside-worklouder");
+  fs.renameSync(scopedModules, outside);
+  fs.symlinkSync(outside, scopedModules, "dir");
+
+  assert.throws(
+    () => discoverBundledNodeHid(fixture.extractedDir),
+    /path must not contain symlinks/i,
+  );
+});
+
+test("native binding staging rejects valid existing bindings behind symlinked parents", async (t) => {
+  const binary = makeElf("x64", "symlinked-target-parent");
+  const artifact = fixtureArtifact({ x64: binary });
+  const fixture = createBundledFixture(t);
+  const outside = path.join(path.dirname(fixture.extractedDir), "outside-prebuilds");
+  fs.mkdirSync(outside);
+  writeFile(
+    path.join(outside, "HID_hidraw-linux-x64", "node-napi-v4.node"),
+    binary,
+    0o755,
+  );
+  const prebuildsDir = path.join(fixture.nodeHidDir, "prebuilds");
+  fs.rmSync(prebuildsDir, { recursive: true });
+  fs.symlinkSync(outside, prebuildsDir, "dir");
+
+  let materializeCalls = 0;
+  await assert.rejects(
+    stageCodexMicroNativeBinding({
+      extractedDir: fixture.extractedDir,
+      arch: "x64",
+      artifactManifest: artifact,
+      materializePackage: async () => {
+        materializeCalls += 1;
+        throw new Error("symlinked existing binding must fail before materialization");
+      },
+    }),
+    /path must not contain symlinks/i,
+  );
+  assert.equal(materializeCalls, 0);
+});

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -648,27 +648,6 @@ test("discovery rejects symlinked ancestors before reading package metadata", (t
   }
 });
 
-test("discovery rejects symlinked package ancestors before reading metadata", (t) => {
-  const fixture = createBundledFixture(t);
-  const scopedModules = path.join(
-    fixture.extractedDir,
-    "node_modules",
-    "@worklouder",
-  );
-  const outside = path.join(path.dirname(fixture.extractedDir), "outside-worklouder");
-  fs.renameSync(scopedModules, outside);
-  fs.writeFileSync(
-    path.join(outside, "device-kit-oai", "package.json"),
-    "{ metadata outside the extracted tree must not be read",
-  );
-  fs.symlinkSync(outside, scopedModules, "dir");
-
-  assert.throws(
-    () => discoverBundledNodeHid(fixture.extractedDir),
-    /path must not contain symlinks/i,
-  );
-});
-
 test("native binding staging rejects valid existing bindings behind symlinked parents", async (t) => {
   const binary = makeElf("x64", "symlinked-target-parent");
   const artifact = fixtureArtifact({ x64: binary });

--- a/linux-features/codex-micro/test.js
+++ b/linux-features/codex-micro/test.js
@@ -264,6 +264,28 @@ test("Codex Micro gate drift cannot redirect the patch to an unrelated exported 
   assert.equal(applyCodexMicroFeatureGatePatch(drifted), drifted);
 });
 
+test("Codex Micro hook matching rejects identifier suffix collisions", () => {
+  const drifted = [
+    "const warning=`useFeatureGate hook failed to find a valid StatsigClient`;",
+    "function Rh(e){return changedGateShape(e)}",
+    "function h(e){return touch(),read(atom,e)}",
+    `const microGate=Rh(\`${CODEX_MICRO_GATE_ID}\`);`,
+    `const microRoute=\`${CODEX_MICRO_ROUTE}\`;`,
+    "export{Rh as gate,h as unrelated};",
+  ].join("");
+
+  assert.equal(exportedFeatureGateHook(drifted)?.hookName, "h");
+  assert.equal(matchesCodexMicroFeatureGateContract(drifted), false);
+  assert.equal(applyCodexMicroFeatureGatePatch(drifted), drifted);
+});
+
+test("Codex Micro route matching requires the exact current route literal", () => {
+  const drifted = currentFeatureGateFixture()
+    .replace(CODEX_MICRO_ROUTE, `${CODEX_MICRO_ROUTE}-v2`);
+  assert.equal(matchesCodexMicroFeatureGateContract(drifted), false);
+  assert.equal(applyCodexMicroFeatureGatePatch(drifted), drifted);
+});
+
 test("Codex Micro gate patch targets only the current app-initial bundle shape", () => {
   const descriptor = descriptors.find(({ id }) => id === "webview-feature-gate");
   assert.ok(descriptor);

--- a/nix/linux-features-test.nix
+++ b/nix/linux-features-test.nix
@@ -13,6 +13,7 @@ let
   testFeatureIds = [
     "persistent-status-panel"
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -27,6 +28,7 @@ let
   ];
   normalizedTestFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -42,6 +44,7 @@ let
   watchdogFeatureIds = (builtins.fromJSON (builtins.readFile ../scripts/ci/watchdog-linux-features.json)).enabled;
   normalizedWatchdogFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"
@@ -113,6 +116,10 @@ let
               type = lib.types.attrsOf lib.types.anything;
               default = { };
             };
+            services.udev.packages = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              default = [ ];
+            };
             systemd.user.services = lib.mkOption {
               type = lib.types.attrsOf lib.types.anything;
               default = { };
@@ -129,6 +136,14 @@ let
     builtins.head (evalNixOS moduleConfig).config.environment.systemPackages;
 
   defaultConfig = { enable = true; };
+  codexMicroConfig = {
+    enable = true;
+    linuxFeatures = [ "codex-micro" ];
+  };
+  disabledCodexMicroConfig = {
+    enable = false;
+    linuxFeatures = [ "codex-micro" ];
+  };
   legacyRemoteConfig = {
     enable = true;
     remoteMobileControl.enable = true;
@@ -144,11 +159,15 @@ let
     enableComputerUseUi = true;
     linuxFeatureIds = normalizedTestFeatureIds;
   };
+  expectedCodexMicro = packages.codex-desktop.override {
+    linuxFeatureIds = [ "codex-micro" ];
+  };
   reorderedCombined = packages.codex-desktop.override {
     enableComputerUseUi = true;
     linuxFeatureIds = [
       "remote-mobile-control"
       "frameless-titlebar"
+      "codex-micro"
       "codex-wrapper-updater"
       "directory-only-working-tree-watch"
       "global-dictation"
@@ -160,13 +179,19 @@ let
       "ui-tweaks"
       "appshots"
       "appshots"
+      "codex-micro"
     ];
   };
+
+  nixosDefault = evalNixOS defaultConfig;
+  nixosCodexMicro = evalNixOS codexMicroConfig;
+  nixosDisabledCodexMicro = evalNixOS disabledCodexMicroConfig;
 
   customPackage = pkgs.runCommand "codex-desktop-custom-test-package" { } ''
     mkdir -p "$out"
   '';
   customConfig = combinedConfig // { package = customPackage; };
+  nixosCustom = evalNixOS customConfig;
   remoteControlConfig = {
     enable = true;
     package = customPackage;
@@ -290,6 +315,15 @@ let
   ) contextEnvironmentFiles;
 in
 assert lib.assertMsg
+  (lib.elem "codex-micro" (linuxFeatures.normalize linuxFeatures.supportedFeatureIds))
+  "codex-micro is missing from the normalized Nix-supported feature list";
+assert lib.assertMsg
+  (linuxFeatures.normalize [ "codex-micro" "appshots" "codex-micro" ] == [
+    "appshots"
+    "codex-micro"
+  ])
+  "codex-micro was not accepted, sorted, and deduplicated";
+assert lib.assertMsg
   (linuxFeatures.normalize testFeatureIds == normalizedTestFeatureIds)
   "Nix Linux feature IDs must be sorted and deduplicated";
 assert lib.assertMsg
@@ -301,6 +335,28 @@ assert lib.assertMsg
 assert lib.assertMsg
   ((nixosPackage defaultConfig).drvPath == packages.codex-desktop.drvPath)
   "the NixOS default package changed";
+assert lib.assertMsg
+  ((homePackage codexMicroConfig).drvPath == expectedCodexMicro.drvPath)
+  "Home Manager did not select the codex-micro package";
+assert lib.assertMsg
+  ((nixosPackage codexMicroConfig).drvPath == expectedCodexMicro.drvPath)
+  "NixOS did not select the codex-micro package";
+assert lib.assertMsg
+  (expectedCodexMicro.drvPath != packages.codex-desktop.drvPath)
+  "enabling codex-micro did not change the selected package";
+assert lib.assertMsg
+  (
+    builtins.length nixosCodexMicro.config.services.udev.packages == 1
+    && (builtins.head nixosCodexMicro.config.services.udev.packages).drvPath
+      == expectedCodexMicro.drvPath
+  )
+  "NixOS did not register the codex-micro package as a udev rules source";
+assert lib.assertMsg
+  (nixosDefault.config.services.udev.packages == [ ])
+  "the NixOS default unexpectedly installs codex-micro udev rules";
+assert lib.assertMsg
+  (nixosDisabledCodexMicro.config.services.udev.packages == [ ])
+  "disabled NixOS unexpectedly installs codex-micro udev rules";
 assert lib.assertMsg
   ((homePackage legacyRemoteConfig).drvPath == packages.codex-desktop-remote-mobile-control.drvPath)
   "the Home Manager remoteMobileControl shorthand changed";
@@ -322,6 +378,9 @@ assert lib.assertMsg
 assert lib.assertMsg
   ((nixosPackage customConfig).drvPath == customPackage.drvPath)
   "the NixOS custom package override lost precedence";
+assert lib.assertMsg
+  (nixosCustom.config.services.udev.packages == [ ])
+  "the NixOS custom package override unexpectedly inherited codex-micro udev policy";
 assert lib.assertMsg (!invalidBuilder.success) "the package builder accepted an unsupported feature";
 assert lib.assertMsg
   shallowRepositoryWatchBuilder.success

--- a/nix/linux-features.nix
+++ b/nix/linux-features.nix
@@ -2,6 +2,7 @@
 let
   supportedFeatureIds = [
     "appshots"
+    "codex-micro"
     "codex-wrapper-updater"
     "directory-only-working-tree-watch"
     "frameless-titlebar"

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -23,6 +23,9 @@ let
     inherit cfg flakePackages lib;
   };
   basePackage = packageSelection.package;
+  codexMicroEnabled =
+    cfg.package == null
+    && lib.elem "codex-micro" packageSelection.normalizedFeatureIds;
   codexCliPackage =
     if cfg.cliPackage != null then
       cfg.cliPackage
@@ -272,6 +275,10 @@ in
 
     environment.systemPackages = [
       desktopPackage
+    ];
+
+    services.udev.packages = lib.optionals codexMicroEnabled [
+      basePackage
     ];
 
     environment.sessionVariables = lib.mkIf (remoteCfg.enable && remoteCfg.disableLauncherAutostart) {

--- a/scripts/ci/container-entrypoint.sh
+++ b/scripts/ci/container-entrypoint.sh
@@ -336,12 +336,39 @@ run_deb_job() {
     [ "$deb_feature_mode" = '-rw-r-----' ] \
         || error "Expected Debian fixture mode 0640, got: ${deb_feature_mode:-missing}"
 
+    rm -rf codex-app dist
+    CODEX_FIXTURE_LINUX_FEATURES_JSON='["codex-micro"]' \
+        tests/fixtures/create-packaged-app-fixture.sh codex-app
+    printf '%s\n' '{"enabled":["codex-micro"]}' > /tmp/codex-micro-features.json
+    CARGO_TARGET_DIR="$target_dir" \
+    UPDATER_BINARY_SOURCE="$target_dir/release/codex-update-manager" \
+    CODEX_LINUX_FEATURES_CONFIG=/tmp/codex-micro-features.json \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-deb.sh
+
+    local deb_micro_file
+    local deb_micro_mode
+    deb_micro_file="$(package_file_or_fail 'codex-desktop_*.deb')"
+    dpkg-deb -c "$deb_micro_file" | tee /tmp/deb-micro-contents.txt >/dev/null
+    dpkg-deb -f "$deb_micro_file" Depends | tee /tmp/deb-micro-depends.txt >/dev/null
+    assert_contains_file /tmp/deb-micro-contents.txt './usr/lib/udev/rules.d/70-codex-micro.rules'
+    assert_contains_file /tmp/deb-micro-depends.txt 'libudev1'
+    assert_contains_file /tmp/deb-micro-depends.txt 'libusb-1.0-0'
+    deb_micro_mode="$(
+        awk '$NF == "./usr/lib/udev/rules.d/70-codex-micro.rules" { print $1 }' \
+            /tmp/deb-micro-contents.txt
+    )"
+    [ "$deb_micro_mode" = '-rw-r--r--' ] \
+        || error "Expected Debian Codex Micro rule mode 0644, got: ${deb_micro_mode:-missing}"
+
     append_summary "Debian Package Validation" \
         "Built: \`$(basename "$deb_file")\`" \
         "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
         "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts." \
         "Feature-enabled build: \`$(basename "$deb_feature_file")\`." \
-        "Verified generic feature resource, 0640 mode, and runtime dependency."
+        "Verified generic feature resource, 0640 mode, and runtime dependency." \
+        "Codex Micro build: \`$(basename "$deb_micro_file")\`." \
+        "Verified udev rule, 0644 mode, and libudev/libusb dependencies."
 }
 
 run_rpm_job() {
@@ -420,12 +447,40 @@ run_rpm_job() {
     [ "$rpm_feature_mode" = '-rw-r-----' ] \
         || error "Expected RPM fixture mode 0640, got: ${rpm_feature_mode:-missing}"
 
+    rm -rf codex-app dist
+    CODEX_FIXTURE_LINUX_FEATURES_JSON='["codex-micro"]' \
+        tests/fixtures/create-packaged-app-fixture.sh codex-app
+    printf '%s\n' '{"enabled":["codex-micro"]}' > /tmp/codex-micro-features.json
+    CARGO_TARGET_DIR="$target_dir" \
+    UPDATER_BINARY_SOURCE="$target_dir/release/codex-update-manager" \
+    CODEX_LINUX_FEATURES_CONFIG=/tmp/codex-micro-features.json \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-rpm.sh
+
+    local rpm_micro_file
+    local rpm_micro_mode
+    rpm_micro_file="$(package_file_or_fail 'codex-desktop-*.rpm')"
+    rpm -qlp "$rpm_micro_file" | tee /tmp/rpm-micro-contents.txt >/dev/null
+    rpm -qlvp "$rpm_micro_file" | tee /tmp/rpm-micro-long-contents.txt >/dev/null
+    rpm -qp --requires "$rpm_micro_file" | tee /tmp/rpm-micro-requires.txt >/dev/null
+    assert_contains_file /tmp/rpm-micro-contents.txt '/usr/lib/udev/rules.d/70-codex-micro.rules'
+    assert_contains_file /tmp/rpm-micro-requires.txt '^libudev\.so\.1'
+    assert_contains_file /tmp/rpm-micro-requires.txt '^libusb-1\.0\.so\.0'
+    rpm_micro_mode="$(
+        awk '$NF == "/usr/lib/udev/rules.d/70-codex-micro.rules" { print $1 }' \
+            /tmp/rpm-micro-long-contents.txt
+    )"
+    [ "$rpm_micro_mode" = '-rw-r--r--' ] \
+        || error "Expected RPM Codex Micro rule mode 0644, got: ${rpm_micro_mode:-missing}"
+
     append_summary "RPM Package Validation" \
         "Built: \`$(basename "$rpm_file")\`" \
         "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
         "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts." \
         "Feature-enabled build: \`$(basename "$rpm_feature_file")\`." \
-        "Verified generic feature resource, 0640 mode, and runtime dependency."
+        "Verified generic feature resource, 0640 mode, and runtime dependency." \
+        "Codex Micro build: \`$(basename "$rpm_micro_file")\`." \
+        "Verified udev rule, 0644 mode, and libudev/libusb dependencies."
 }
 
 run_pacman_job() {
@@ -508,12 +563,39 @@ run_pacman_job() {
     [ "$pkg_feature_mode" = '-rw-r-----' ] \
         || error "Expected pacman fixture mode 0640, got: ${pkg_feature_mode:-missing}"
 
+    rm -rf codex-app dist
+    CODEX_FIXTURE_LINUX_FEATURES_JSON='["codex-micro"]' \
+        tests/fixtures/create-packaged-app-fixture.sh codex-app
+    printf '%s\n' '{"enabled":["codex-micro"]}' > /tmp/codex-micro-features.json
+    CARGO_TARGET_DIR="$target_dir" \
+    UPDATER_BINARY_SOURCE="$target_dir/release/codex-update-manager" \
+    CODEX_LINUX_FEATURES_CONFIG=/tmp/codex-micro-features.json \
+    PACKAGE_VERSION="$CI_PACKAGE_VERSION" \
+        ./scripts/build-pacman.sh
+
+    local pkg_micro_file
+    local pkg_micro_mode
+    pkg_micro_file="$(package_file_or_fail 'codex-desktop-*.pkg.tar.*')"
+    pacman -Qlp "$pkg_micro_file" | tee /tmp/pacman-micro-contents.txt >/dev/null
+    tar -xOf "$pkg_micro_file" .PKGINFO | tee /tmp/pacman-micro-pkginfo.txt >/dev/null
+    tar -tvf "$pkg_micro_file" \
+        usr/lib/udev/rules.d/70-codex-micro.rules \
+        | tee /tmp/pacman-micro-long-contents.txt >/dev/null
+    assert_contains_file /tmp/pacman-micro-contents.txt 'usr/lib/udev/rules.d/70-codex-micro.rules'
+    assert_contains_file /tmp/pacman-micro-pkginfo.txt '^depend = libusb$'
+    assert_contains_file /tmp/pacman-micro-pkginfo.txt '^depend = systemd-libs$'
+    pkg_micro_mode="$(awk 'NR == 1 { print $1 }' /tmp/pacman-micro-long-contents.txt)"
+    [ "$pkg_micro_mode" = '-rw-r--r--' ] \
+        || error "Expected pacman Codex Micro rule mode 0644, got: ${pkg_micro_mode:-missing}"
+
     append_summary "Pacman Package Validation" \
         "Built: \`$(basename "$pkg_file")\`" \
         "Verified updater binary, user service, update-builder bundle, and packaged runtime helper." \
         "Verified PACKAGE_WITH_UPDATER=0 omits updater artifacts." \
         "Feature-enabled build: \`$(basename "$pkg_feature_file")\`." \
-        "Verified generic feature resource, 0640 mode, and runtime dependency."
+        "Verified generic feature resource, 0640 mode, and runtime dependency." \
+        "Codex Micro build: \`$(basename "$pkg_micro_file")\`." \
+        "Verified udev rule, 0644 mode, and systemd-libs/libusb dependencies."
 }
 
 run_install_deps_job_as_root() {

--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -217,6 +217,7 @@ test("Nix hash refresh accepts a validated focused output override", () => {
 
   assert.deepEqual(watchdogProfile.enabled, [
     "appshots",
+    "codex-micro",
     "codex-wrapper-updater",
     "directory-only-working-tree-watch",
     "frameless-titlebar",

--- a/scripts/ci/watchdog-linux-features.json
+++ b/scripts/ci/watchdog-linux-features.json
@@ -1,6 +1,7 @@
 {
   "enabled": [
     "appshots",
+    "codex-micro",
     "codex-wrapper-updater",
     "directory-only-working-tree-watch",
     "frameless-titlebar",


### PR DESCRIPTION
## Summary

- Add a default-off `codex-micro` Linux feature on top of the generic package
  framework merged in #1149.
- Reuse the Codex Micro service and UI already bundled in the upstream desktop
  app, while enabling only the exact current feature gate/route contract.
- Stage only the integrity-pinned `node-hid@3.3.0` x64 or arm64 prebuild needed
  by the current nested Work Louder dependency; there is no source-build
  fallback.
- Install a narrow USB/Bluetooth hidraw rule and feature-only runtime
  dependencies in Debian, RPM, and pacman packages, with corresponding NixOS
  integration and documentation for AppImage/source/user-local installs.
- Keep disabled builds unchanged and fail closed if the current DMG, nested
  loader, package artifact, architecture, or package feature snapshot drifts.

This is the focused Stage 2 replacement for closed #1142. It implements the
maintainer-requested split after #1149 and carries forward the review fixes for
the Micro-specific gate contract, self-contained `usb_id` import, package/app
feature-set agreement, real native package builds, and removal of speculative
source compilation.

Refs #631.

## Validation

- `node --check` for all Codex Micro JavaScript sources
- `node --test linux-features/codex-micro/test.js scripts/lib/linux-features.test.js`
  — 50/50 passed
- `tests/scripts_smoke.sh` — passed
- `git diff --check origin/main...HEAD` — passed
- Actual Micro-only Nix build against desktop `26.721.41059` — accepted with
  no blockers or warnings; both feature patches applied; exact udev rule,
  one x64 native binding, Nix RPATH, and Electron native loading verified
- Real feature-enabled Debian, RPM, and pacman package builds with native
  integrity/metadata inspection, exact feature dependencies, exact udev rule
  mode/content, resolved templates, and native binding loading verified
- Required GitHub CI passed: Rust/smoke, current upstream DMG build, Debian,
  RPM, pacman, Nix, and contributor-limit checks
- Ubuntu 26.04 x64 physical USB validation:
  - real `303a:8360` interface `00` discovered through `/dev/hidraw4`
  - installed udev rule exercised with `udevadm test`; `uaccess`, mode `0660`,
    and the current user ACL verified
  - app reported connected USB transport, Codex Micro model, battery/status,
    and no service error
  - settings UI, brightness/lighting writes, dial click, joystick directions,
    and joystick gesture feedback exercised without renderer errors
  - pre-UI host-message capture recorded both encoder directions
    (`ENC_CW`, `ENC_CC`, action `2`)

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests and ran the validation listed above.
- [x] I reviewed the final diff with coding agents at high reasoning effort, addressed all findings, and reran the relevant tests.

All required checks passed; this is ready for maintainer review.
