### PR TITLE
chore(nix): update tar to 7.5.22

### DIFF
--- a/nix/native-modules/package-lock.json
+++ b/nix/native-modules/package-lock.json
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",


### PR DESCRIPTION
## Summary

Refresh `tar` in `nix/native-modules/package-lock.json` from 7.5.20 to 7.5.22.

GitHub published [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m) for `tar <= 7.5.20`. The dependency is transitive through `node-gyp` in the Nix native-module build toolchain; there is no confirmed packaged-runtime exposure.

The direct Electron and native-module dependency versions remain unchanged. The existing `undici` versions also remain unchanged and are not reported by the current audit.

## Validation

- `npm ci --ignore-scripts`
- `npm audit --package-lock-only --omit=dev` — 0 vulnerabilities
- `npm ls tar undici --all`
- repeated `npm audit fix --package-lock-only --ignore-scripts` — byte-identical lockfile
- `git diff --check`

`nix flake check --no-update-lock-file` was not run because `nix` is not installed in this environment.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
