### PR TITLE
fix(computer-use): support Arch ydotool raw CLI

### DIFF
--- a/computer-use-linux/src/ydotool.rs
+++ b/computer-use-linux/src/ydotool.rs
@@ -1,10 +1,15 @@
 use std::{
-    env, fs,
-    os::unix::net::UnixDatagram,
+    env,
+    ffi::OsStr,
+    fs, io,
+    os::unix::{
+        ffi::OsStrExt,
+        fs::{DirBuilderExt, MetadataExt, PermissionsExt},
+        net::UnixDatagram,
+    },
     path::{Path, PathBuf},
     process::{self, Command, Stdio},
     sync::OnceLock,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,37 +18,95 @@ pub(crate) enum CliGeneration {
     LegacyNamed,
 }
 
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = 107;
+const PROBE_DIRECTORY_ATTEMPTS: usize = 8;
 const UNSUPPORTED_MESSAGE: &str = "unsupported ydotool CLI; Computer Use requires ydotool 1.0.2 or newer with raw key events, wheel movement, stdin typing, and absolute mouse movement";
 
 struct ProbeSocket {
     _socket: UnixDatagram,
+    directory: PathBuf,
     path: PathBuf,
 }
 
 impl ProbeSocket {
-    fn bind() -> Result<Self, String> {
-        let runtime_dir = env::var_os("XDG_RUNTIME_DIR")
-            .ok_or_else(|| "XDG_RUNTIME_DIR is unavailable for safe ydotool probing".to_string())?;
-        let nonce = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|error| format!("failed to create ydotool probe nonce: {error}"))?
-            .as_nanos();
-        let path = PathBuf::from(runtime_dir).join(format!(
-            ".codex-ydotool-probe-{}-{nonce}.socket",
+    fn bind_with(runtime_dir: Option<&OsStr>, temp_dir: &Path) -> Result<Self, String> {
+        let uid = unsafe { libc::geteuid() };
+        let mut failures = Vec::new();
+        for base in probe_socket_bases(runtime_dir, temp_dir) {
+            if let Err(error) = validate_probe_base(&base, uid) {
+                failures.push(format!("{}: {error}", base.display()));
+                continue;
+            }
+            match Self::bind_in(&base) {
+                Ok(socket) => return Ok(socket),
+                Err(error) => failures.push(format!("{}: {error}", base.display())),
+            }
+        }
+
+        let detail = if failures.is_empty() {
+            "no candidate runtime directory was available".to_string()
+        } else {
+            failures.join("; ")
+        };
+        Err(format!(
+            "failed to bind isolated ydotool probe socket: {detail}"
+        ))
+    }
+
+    fn bind_in(base: &Path) -> io::Result<Self> {
+        let sample_path = base.join(format!(
+            ".codex-ydotool-probe-{}-0000000000000000/s",
             process::id()
         ));
-        let socket = UnixDatagram::bind(&path)
-            .map_err(|error| format!("failed to bind isolated ydotool probe socket: {error}"))?;
-        Ok(Self {
-            _socket: socket,
-            path,
-        })
+        if !unix_socket_path_fits(&sample_path) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "probe socket path is too long",
+            ));
+        }
+
+        for _ in 0..PROBE_DIRECTORY_ATTEMPTS {
+            let nonce = random_hex(8)?;
+            let directory = base.join(format!(".codex-ydotool-probe-{}-{nonce}", process::id()));
+            let path = directory.join("s");
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700);
+            match builder.create(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+            if let Err(error) = fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)) {
+                let _ = fs::remove_dir(&directory);
+                return Err(error);
+            }
+            match UnixDatagram::bind(&path) {
+                Ok(socket) => {
+                    return Ok(Self {
+                        _socket: socket,
+                        directory,
+                        path,
+                    });
+                }
+                Err(error) => {
+                    let _ = fs::remove_file(&path);
+                    let _ = fs::remove_dir(&directory);
+                    return Err(error);
+                }
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a unique probe directory",
+        ))
     }
 }
 
 impl Drop for ProbeSocket {
     fn drop(&mut self) {
         let _ = fs::remove_file(&self.path);
+        let _ = fs::remove_dir(&self.directory);
     }
 }
 
@@ -53,9 +116,22 @@ pub(crate) fn ensure_supported() -> Result<String, String> {
 }
 
 fn probe() -> Result<String, String> {
+    let runtime_dir = env::var_os("XDG_RUNTIME_DIR");
+    probe_with(
+        Path::new("ydotool"),
+        runtime_dir.as_deref(),
+        &env::temp_dir(),
+    )
+}
+
+fn probe_with(
+    ydotool_path: &Path,
+    runtime_dir: Option<&OsStr>,
+    temp_dir: &Path,
+) -> Result<String, String> {
     let mut output_text = String::new();
     for argument in ["help", "--help"] {
-        let output = Command::new("ydotool")
+        let output = Command::new(ydotool_path)
             .arg(argument)
             .output()
             .map_err(|error| format!("failed to run ydotool: {error}"))?;
@@ -64,7 +140,8 @@ fn probe() -> Result<String, String> {
         if let Some(generation) = classify_help(&output_text) {
             return match generation {
                 CliGeneration::RawEvents => {
-                    probe_raw_semantics().map(|()| "compatible raw-event CLI detected".to_string())
+                    probe_raw_semantics(ydotool_path, runtime_dir, temp_dir)
+                        .map(|()| "compatible raw-event CLI detected".to_string())
                 }
                 CliGeneration::LegacyNamed => Err(UNSUPPORTED_MESSAGE.to_string()),
             };
@@ -73,14 +150,20 @@ fn probe() -> Result<String, String> {
     Err("unrecognized ydotool CLI; Computer Use requires ydotool 1.0.2 or newer".to_string())
 }
 
-fn probe_raw_semantics() -> Result<(), String> {
-    let socket = ProbeSocket::bind()?;
+fn probe_raw_semantics(
+    ydotool_path: &Path,
+    runtime_dir: Option<&OsStr>,
+    temp_dir: &Path,
+) -> Result<(), String> {
+    let socket = ProbeSocket::bind_with(runtime_dir, temp_dir)?;
     let wheel = run_probe_command(
+        ydotool_path,
         &socket.path,
         &["mousemove", "--wheel", "--", "0", "0"],
         None,
     )?;
     let type_from_stdin = run_probe_command(
+        ydotool_path,
         &socket.path,
         &["type", "--file", "-"],
         Some(Path::new("/proc/self/fd")),
@@ -99,11 +182,12 @@ fn probe_raw_semantics() -> Result<(), String> {
 }
 
 fn run_probe_command(
+    ydotool_path: &Path,
     socket_path: &Path,
     args: &[&str],
     current_dir: Option<&Path>,
 ) -> Result<std::process::Output, String> {
-    let mut command = Command::new("ydotool");
+    let mut command = Command::new(ydotool_path);
     command
         .args(args)
         .env("YDOTOOL_SOCKET", socket_path)
@@ -116,6 +200,55 @@ fn run_probe_command(
     command
         .output()
         .map_err(|error| format!("failed to run ydotool capability probe: {error}"))
+}
+
+fn probe_socket_bases(runtime_dir: Option<&OsStr>, temp_dir: &Path) -> Vec<PathBuf> {
+    let mut bases = Vec::new();
+    if let Some(runtime_dir) = runtime_dir {
+        push_unique_path(&mut bases, PathBuf::from(runtime_dir));
+    }
+    push_unique_path(&mut bases, temp_dir.to_path_buf());
+    push_unique_path(&mut bases, PathBuf::from("/tmp"));
+    bases
+}
+
+fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
+    if !paths.iter().any(|candidate| candidate == &path) {
+        paths.push(path);
+    }
+}
+
+fn validate_probe_base(path: &Path, uid: libc::uid_t) -> Result<(), String> {
+    if !path.is_absolute() {
+        return Err("path is not absolute".to_string());
+    }
+    let metadata = fs::symlink_metadata(path).map_err(|error| error.to_string())?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err("path is not a real directory".to_string());
+    }
+    let mode = metadata.permissions().mode();
+    let user_owned_safe_directory = metadata.uid() == uid && mode & 0o022 == 0;
+    let root_owned_sticky_directory = metadata.uid() == 0 && mode & libc::S_ISVTX != 0;
+    if !user_owned_safe_directory && !root_owned_sticky_directory {
+        return Err("directory is not private or root-owned sticky".to_string());
+    }
+    Ok(())
+}
+
+fn random_hex(byte_count: usize) -> io::Result<String> {
+    let mut bytes = vec![0_u8; byte_count];
+    getrandom::fill(&mut bytes).map_err(io::Error::other)?;
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(byte_count * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    Ok(output)
+}
+
+fn unix_socket_path_fits(path: &Path) -> bool {
+    path.as_os_str().as_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES
 }
 
 fn raw_semantic_probes_succeeded(
@@ -168,6 +301,70 @@ pub(crate) fn cli_error(stderr: &[u8]) -> Option<String> {
 mod tests {
     use super::*;
 
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let path = env::temp_dir().join(format!(
+                "codex-ydotool-{label}-{}-{}",
+                process::id(),
+                random_hex(8).expect("test nonce")
+            ));
+            let mut builder = fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(&path).expect("create test directory");
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("secure test directory");
+            Self(path)
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn fake_supported_ydotool(root: &Path) -> PathBuf {
+        let path = root.join("ydotool");
+        fs::write(
+            &path,
+            r#"#!/bin/sh
+case "$1" in
+  help|--help)
+    printf '%s\n' \
+      'Usage: ydotool <cmd> <args>' \
+      'Available commands:' \
+      '  click' \
+      '  mousemove' \
+      '  type' \
+      '  key' \
+      '  debug'
+    ;;
+  mousemove)
+    test -S "$YDOTOOL_SOCKET" &&
+      test "$2" = '--wheel' &&
+      test "$3" = '--' &&
+      test "$4" = '0' &&
+      test "$5" = '0'
+    ;;
+  type)
+    test -S "$YDOTOOL_SOCKET" &&
+      test "$2" = '--file' &&
+      test "$3" = '-'
+    ;;
+  *)
+    exit 64
+    ;;
+esac
+"#,
+        )
+        .expect("write fake ydotool");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+            .expect("make fake ydotool executable");
+        path
+    }
+
     #[test]
     fn classifies_legacy_named_cli_from_ubuntu_ydotool() {
         let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  type\n  recorder\n  mousemove\n  key\n  click\n";
@@ -187,6 +384,30 @@ mod tests {
         let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  bakers\n";
 
         assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn accepts_supported_raw_cli_without_xdg_runtime_dir() {
+        let root = TestDirectory::new("no-xdg-cli");
+        let ydotool = fake_supported_ydotool(&root.0);
+
+        assert_eq!(
+            probe_with(&ydotool, None, &root.0),
+            Ok("compatible raw-event CLI detected".to_string())
+        );
+        assert_eq!(
+            fs::read_dir(&root.0)
+                .expect("read test directory")
+                .filter_map(Result::ok)
+                .filter(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with(".codex-ydotool-probe-")
+                })
+                .count(),
+            0
+        );
     }
 
     #[test]

--- a/computer-use-linux/src/ydotool.rs
+++ b/computer-use-linux/src/ydotool.rs
@@ -1,4 +1,11 @@
-use std::{process::Command, sync::OnceLock};
+use std::{
+    env, fs,
+    os::unix::net::UnixDatagram,
+    path::{Path, PathBuf},
+    process::{self, Command, Stdio},
+    sync::OnceLock,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CliGeneration {
@@ -6,7 +13,39 @@ pub(crate) enum CliGeneration {
     LegacyNamed,
 }
 
-const UNSUPPORTED_MESSAGE: &str = "unsupported legacy ydotool CLI; Computer Use requires ydotool 1.0 or newer with raw key events and absolute mouse movement";
+const UNSUPPORTED_MESSAGE: &str = "unsupported ydotool CLI; Computer Use requires ydotool 1.0.2 or newer with raw key events, wheel movement, stdin typing, and absolute mouse movement";
+
+struct ProbeSocket {
+    _socket: UnixDatagram,
+    path: PathBuf,
+}
+
+impl ProbeSocket {
+    fn bind() -> Result<Self, String> {
+        let runtime_dir = env::var_os("XDG_RUNTIME_DIR")
+            .ok_or_else(|| "XDG_RUNTIME_DIR is unavailable for safe ydotool probing".to_string())?;
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|error| format!("failed to create ydotool probe nonce: {error}"))?
+            .as_nanos();
+        let path = PathBuf::from(runtime_dir).join(format!(
+            ".codex-ydotool-probe-{}-{nonce}.socket",
+            process::id()
+        ));
+        let socket = UnixDatagram::bind(&path)
+            .map_err(|error| format!("failed to bind isolated ydotool probe socket: {error}"))?;
+        Ok(Self {
+            _socket: socket,
+            path,
+        })
+    }
+}
+
+impl Drop for ProbeSocket {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
 
 pub(crate) fn ensure_supported() -> Result<String, String> {
     static RESULT: OnceLock<Result<String, String>> = OnceLock::new();
@@ -24,12 +63,71 @@ fn probe() -> Result<String, String> {
         output_text.push_str(&String::from_utf8_lossy(&output.stderr));
         if let Some(generation) = classify_help(&output_text) {
             return match generation {
-                CliGeneration::RawEvents => Ok("compatible raw-event CLI detected".to_string()),
+                CliGeneration::RawEvents => {
+                    probe_raw_semantics().map(|()| "compatible raw-event CLI detected".to_string())
+                }
                 CliGeneration::LegacyNamed => Err(UNSUPPORTED_MESSAGE.to_string()),
             };
         }
     }
-    Err("unrecognized ydotool CLI; Computer Use requires ydotool 1.0 or newer".to_string())
+    Err("unrecognized ydotool CLI; Computer Use requires ydotool 1.0.2 or newer".to_string())
+}
+
+fn probe_raw_semantics() -> Result<(), String> {
+    let socket = ProbeSocket::bind()?;
+    let wheel = run_probe_command(
+        &socket.path,
+        &["mousemove", "--wheel", "--", "0", "0"],
+        None,
+    )?;
+    let type_from_stdin = run_probe_command(
+        &socket.path,
+        &["type", "--file", "-"],
+        Some(Path::new("/proc/self/fd")),
+    )?;
+
+    if raw_semantic_probes_succeeded(
+        wheel.status.success(),
+        &wheel.stderr,
+        type_from_stdin.status.success(),
+        &type_from_stdin.stderr,
+    ) {
+        Ok(())
+    } else {
+        Err(UNSUPPORTED_MESSAGE.to_string())
+    }
+}
+
+fn run_probe_command(
+    socket_path: &Path,
+    args: &[&str],
+    current_dir: Option<&Path>,
+) -> Result<std::process::Output, String> {
+    let mut command = Command::new("ydotool");
+    command
+        .args(args)
+        .env("YDOTOOL_SOCKET", socket_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+    command
+        .output()
+        .map_err(|error| format!("failed to run ydotool capability probe: {error}"))
+}
+
+fn raw_semantic_probes_succeeded(
+    wheel_success: bool,
+    wheel_stderr: &[u8],
+    type_success: bool,
+    type_stderr: &[u8],
+) -> bool {
+    wheel_success
+        && cli_error(wheel_stderr).is_none()
+        && type_success
+        && cli_error(type_stderr).is_none()
 }
 
 pub(crate) fn classify_help(help: &str) -> Option<CliGeneration> {
@@ -89,6 +187,31 @@ mod tests {
         let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  bakers\n";
 
         assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn rejects_raw_cli_without_wheel_semantics() {
+        assert!(!raw_semantic_probes_succeeded(
+            true,
+            b"mousemove: unrecognized option '--wheel'\n",
+            true,
+            b"",
+        ));
+    }
+
+    #[test]
+    fn rejects_raw_cli_without_stdin_file_semantics() {
+        assert!(!raw_semantic_probes_succeeded(
+            true,
+            b"",
+            false,
+            b"ydotool: type: error: failed to open -: No such file or directory\n",
+        ));
+    }
+
+    #[test]
+    fn accepts_raw_cli_with_required_semantics() {
+        assert!(raw_semantic_probes_succeeded(true, b"", true, b""));
     }
 
     #[test]

--- a/computer-use-linux/src/ydotool.rs
+++ b/computer-use-linux/src/ydotool.rs
@@ -38,7 +38,11 @@ pub(crate) fn classify_help(help: &str) -> Option<CliGeneration> {
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>();
-    if commands.contains(&"debug") && commands.contains(&"stdin") {
+    let required_raw_commands = ["click", "mousemove", "type", "key", "debug"];
+    if required_raw_commands
+        .iter()
+        .all(|command| commands.contains(command))
+    {
         Some(CliGeneration::RawEvents)
     } else if commands.contains(&"recorder") {
         Some(CliGeneration::LegacyNamed)
@@ -76,6 +80,13 @@ mod tests {
     #[test]
     fn classifies_raw_event_cli_from_current_ydotool() {
         let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  stdin\n";
+
+        assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
+    }
+
+    #[test]
+    fn classifies_arch_1_0_4_cli_as_raw_events() {
+        let help = "Usage: ydotool <cmd> <args>\nAvailable commands:\n  click\n  mousemove\n  type\n  key\n  debug\n  bakers\n";
 
         assert_eq!(classify_help(help), Some(CliGeneration::RawEvents));
     }

--- a/docs/linux-computer-use.md
+++ b/docs/linux-computer-use.md
@@ -17,10 +17,10 @@ It supports:
 
 ## Runtime Dependencies
 
-Install `ydotool` 1.0 or newer when you need the fallback input path. Some
-Debian and Ubuntu releases still package the incompatible pre-1.0 CLI; the
-Computer Use readiness report detects and rejects it instead of sending unsafe
-input commands.
+Install `ydotool` 1.0.2 or newer when you need the fallback input path. Earlier
+releases lack wheel movement or functional stdin typing required by the
+backend. The Computer Use readiness report detects and rejects incompatible
+CLIs instead of sending unsafe input commands.
 
 ```bash
 # Debian / Ubuntu


### PR DESCRIPTION
## Summary

- Recognize the raw-event CLI shape shipped by Arch Linux's `ydotool` 1.0.4 package.
- Verify required wheel and stdin-typing semantics through an isolated datagram socket before enabling the backend, rejecting incomplete `ydotool` 1.0.0 and 1.0.1 releases.
- Preserve capability probing when `XDG_RUNTIME_DIR` is absent by using a validated temporary base and a private, randomly named probe directory.
- Document `ydotool` 1.0.2 as the minimum compatible raw-event release.

The previous command-list fingerprint required a top-level `stdin` command that Arch's current package does not expose, even though the backend-compatible `type --file -` behavior is available. The semantic probes are effect-free: wheel deltas are zero, typing receives empty stdin, and both commands target a private dummy socket rather than the live `ydotoold` socket.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-computer-use-linux`
- `cargo clippy -p codex-computer-use-linux --all-targets -- -D warnings`
- `TMPDIR=/tmp cargo test -p codex-computer-use-linux` (`376` passed)
- `tests/scripts_smoke.sh`
- Live `doctor` probe on Arch Linux with `ydotool 1.0.4-2`: compatible raw-event CLI detected and no readiness blockers
- Final diff reviewed by coding agents, including the no-XDG follow-up's filesystem and Unix-socket handling

The probe uses `XDG_RUNTIME_DIR` when it is safe and otherwise falls back to a validated temporary base. It still fails closed when it cannot allocate a safe isolated socket location or when `/proc/self/fd` is unavailable, leaving the portal fallback available instead of enabling an unverified raw-input backend.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream-drift fix; it changes only the Linux Computer Use helper and its dependency documentation.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required local checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
