### PR TITLE
Preserve acceptance source provenance on early failures

### DIFF
--- a/scripts/ci/upstream-dmg-acceptance.test.js
+++ b/scripts/ci/upstream-dmg-acceptance.test.js
@@ -149,6 +149,31 @@ test("a structured rejection wins over incomplete checks", () => withFixture(({ 
   assert.equal(decision.verdict, "rejected");
 }));
 
+test("preserves packaged builder source metadata when a build fails before build info", () => withFixture(({ root, dmg }) => {
+  const commit = "a".repeat(40);
+  writeJson(root, ".codex-linux/source-info.json", {
+    commit,
+    shortCommit: commit.slice(0, 12),
+    version: "0.10.1",
+    branch: "main",
+    remote: "https://github.com/ilysenko/codex-desktop-linux.git",
+    provenance: "packaged-update-builder",
+  });
+  const core = requiredCoreReport();
+  core.patches[0].status = "failed-required";
+  core.patches[0].reason = "current upstream contract did not match";
+
+  const decision = evaluate(root, dmg, {
+    core,
+    buildStatus: "failure",
+  });
+
+  assert.equal(decision.verdict, "rejected");
+  assert.equal(decision.source?.commit, commit);
+  assert.equal(decision.source?.version, "0.10.1");
+  assert.equal(decision.source?.provenance, "packaged-update-builder");
+}));
+
 test("HTTP identity requires an ETag or Last-Modified plus Content-Length", () => {
   assert.equal(httpIdentity({ contentLength: 42 }), null);
   assert.equal(httpIdentity({ lastModified: "today" }), null);

--- a/scripts/lib/upstream-dmg-acceptance.js
+++ b/scripts/lib/upstream-dmg-acceptance.js
@@ -4,7 +4,7 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const { sourceInfoFromGit } = require("./build-info.js");
+const { sourceInfo } = require("./build-info.js");
 const { enabledFeatureFailuresFromReport, optionalDriftFromReport } = require("./patch-report.js");
 const { readPatchReport, validatePatchReport } = require("./patch-validation.js");
 const { UPSTREAM_DMG_RELEASE_PROFILE } = require("./upstream-dmg-release-profile.js");
@@ -172,7 +172,8 @@ function evaluateUpstreamDmg(options) {
       : warnings.length > 0
         ? "accepted_with_warnings"
         : "accepted";
-  const source = buildInfo?.source ?? sourceInfoFromGit(options.repoRoot ?? process.cwd()) ?? null;
+  const discoveredSource = sourceInfo(options.repoRoot ?? process.cwd());
+  const source = buildInfo?.source ?? (discoveredSource.commit == null ? null : discoveredSource);
 
   return {
     schemaVersion: 1,


### PR DESCRIPTION
## Summary

- preserve staged packaged-builder source metadata in upstream DMG acceptance decisions when a build fails before app build info exists
- keep the existing null fallback when no source commit can be resolved
- add regression coverage for a rejected non-Git packaged workspace

Refs #1155.

## Tests

- `node --test scripts/ci/upstream-dmg-acceptance.test.js`
- `node --test scripts/ci/upstream-dmg-issue.test.js`
- `node --check scripts/lib/upstream-dmg-acceptance.js`
- `git diff --check`

## Notes

This is diagnostic-only: it does not change patch targeting, acceptance verdicts, or updater installation behavior.