### PR TITLE
fix(lifecycle): prevent windowless warm-start survivors

### DIFF
--- a/docs/windowless-warm-start-fix-report.md
+++ b/docs/windowless-warm-start-fix-report.md
@@ -1,0 +1,127 @@
+# Windowless Warm-Start Fix
+
+## Status
+
+The Linux explicit-quit path now guarantees bounded cleanup followed by process
+exit. A later desktop launch no longer attaches to a surviving Electron process
+that has no window or launch-action socket.
+
+The change is confined to the existing main-process lifecycle patch and its
+regression coverage. Launcher handoff behavior is unchanged.
+
+## Failure
+
+Choosing **Quit** from the application menu could remove the last window and
+partially dispose the main-process application context without terminating the
+Electron process. A later launch then lost the Electron single-instance lock to
+that process. The surviving process could not present a window because the
+services needed by its launch handler had already been disposed.
+
+The warm-start handoff exposed the failure but did not cause it. Reopening a
+window or extending the launch-action socket lifetime after teardown begins
+would route work into a partially destroyed application context.
+
+## Root Cause
+
+The current upstream main bundle has one targeted lifecycle `will-quit` handler
+with two cleanup branches:
+
+- a reduced branch stops Codex Micro and flushes tracing;
+- a full branch also flushes global state and settings.
+
+Both branches call `preventDefault()`, run lifecycle disposers, wait with
+`Promise.allSettled()`, dispose the application context and shared disposable
+collection, and then call `app.quit()` again.
+
+That sequence was not total:
+
+- a synchronous lifecycle-disposer or drain-setup exception could occur before
+  the promise continuation was installed;
+- a stalled drain had no deadline;
+- a context or shared-disposable failure could skip the terminal action;
+- rejected `Promise.allSettled()` members were not observable;
+- the final `app.quit()` could re-enter Electron before the first quit attempt
+  had finished unwinding.
+
+Electron 42.3.0 sets `is_quitting_` before notifying `will-quit`. When the event
+is prevented, Electron clears the flag only after the observer returns. Its
+event bridge performs a microtask checkpoint while returning from JavaScript,
+so a synchronously settled cleanup continuation can call `app.quit()` while the
+flag is still set; `Browser::Quit()` then returns immediately. This is an
+ordering race, not a claim that preventing `will-quit` leaves the flag set
+permanently.
+
+Relevant upstream behavior:
+
+- [`Browser::Quit()` and `Browser::NotifyAndShutdown()`](https://github.com/electron/electron/blob/v42.3.0/shell/browser/browser.cc)
+- [event-emission microtask scope](https://github.com/electron/electron/blob/v42.3.0/shell/common/gin_helper/event_emitter_caller.cc)
+- [`app.exit()` lifecycle contract](https://www.electronjs.org/docs/latest/api/app#appexitexitcode)
+
+## Fix
+
+`applyLinuxWillQuitDrainTimeoutPatch()` semantically locates the single current
+upstream handler. It verifies that both drain branches share the expected
+event, lifecycle managers, drain functions, and finalizer before changing the
+bundle.
+
+On Linux, both branches now pass a cleanup factory to one bounded helper:
+
+1. `Promise.resolve().then(factory)` contains synchronous disposer and drain
+   setup exceptions.
+2. `Promise.race()` limits the drain to three seconds.
+3. Rejected `Promise.allSettled()` results and deadline expiry are logged.
+4. Context disposal remains bounded by the upstream five-second limit and
+   cannot suppress shared-disposable cleanup.
+5. Shared-disposable failure is logged and cannot suppress `app.exit(0)`.
+
+`app.exit(0)` is deliberate. The patched path has already run the available
+bounded cleanup, and Electron documents `app.exit()` as bypassing
+`before-quit` and `will-quit`. It therefore terminates without re-entering the
+graceful-quit sequence that produced the windowless survivor.
+
+Non-Linux behavior remains on the upstream cleanup and `app.quit()` path.
+
+The helper has no separate once-only state. A single `Promise.race()`
+continuation invokes the Linux finalizer, and a promise settles only once.
+
+## Drift And Idempotence
+
+This repository supports only the latest upstream DMG. The patch does not retain
+the obsolete lifecycle matcher.
+
+An unchanged source is considered already patched only when the generated
+markers and the scoped Linux `app.exit(0)` postcondition are present. Otherwise
+the current handler must resolve to exactly one semantic target. Zero or
+multiple targets emit a warning; because this descriptor is
+`required-upstream`, the patch report records `failed-required` and candidate
+promotion is rejected.
+
+This prevents an unrelated `app.exit(0)`, a previous non-exiting finalizer, or
+an upstream anchor rename from being mistaken for a successful application.
+
+## Validation
+
+Automated regression coverage exercises:
+
+- both current upstream drain branches;
+- synchronous lifecycle-disposer and drain-setup failures;
+- asynchronous drain rejection and deadline expiry;
+- context-disposal and shared-disposable failures;
+- Linux forced exit and unchanged non-Linux graceful quit;
+- late drain settlement after the deadline;
+- exact idempotence and scoped postcondition detection;
+- missing, renamed, malformed, and ambiguous current-upstream targets.
+
+The complete patcher suite, script smoke suite, syntax checks, and
+`git diff --check` must pass on the final source.
+
+The manual exit-path gate used a packaged Arch Linux build under
+Hyprland/Wayland. Ten consecutive top-bar **Quit** and relaunch cycles each
+reached zero primary processes, zero packaged helper processes, no
+launch-action socket, and no compositor window before the next launch. An
+eleventh launch opened a healthy window after the tenth exit.
+
+The manual A/B witness also distinguished the terminal operation: the
+cleanup-factory build ending in `app.quit()` left the primary process alive and
+windowless, while the otherwise equivalent `app.exit(0)` build completed all
+ten cycles.

--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -1389,8 +1389,106 @@ function beforeQuitConfirmationBundleFixture() {
 
 function willQuitDrainBundleFixture() {
   return [
-    "n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([u.flush(),p.flush()]).finally(()=>{d(),f.dispose(),n.app.quit()})}});",
+    "l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});",
   ].join("");
+}
+
+async function runPatchedLinuxWillQuit(options = {}) {
+  const patched = applyLinuxWillQuitDrainTimeoutPatch(willQuitDrainBundleFixture());
+  const state = {
+    exitCalls: 0,
+    exitCodes: [],
+    handler: null,
+    handlerError: null,
+    lifecycleDisposeCalls: 0,
+    preventDefaultCalls: 0,
+    quitCalls: 0,
+    warnings: [],
+  };
+  let resolveQuit;
+  const quitPromise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Linux will-quit handler did not terminate the app")),
+      250,
+    );
+    resolveQuit = () => {
+      clearTimeout(timeout);
+      resolve();
+    };
+  });
+  const lifecycleManager = {
+    dispose() {
+      state.lifecycleDisposeCalls += 1;
+      if (state.lifecycleDisposeCalls === options.lifecycleDisposeThrowsAt) {
+        throw new Error("lifecycle disposer failed");
+      }
+    },
+  };
+  const context = {
+    N5: 5,
+    U5: options.contextDispose ?? (() => Promise.resolve()),
+    c: lifecycleManager,
+    codexLinuxExplicitQuitDrainTimeoutMs: options.timeoutMs ?? 5,
+    codexLinuxIsQuitInProgress: () => true,
+    console: {
+      warn(...args) {
+        state.warnings.push(args.map(String).join(" "));
+      },
+    },
+    d: { flush: options.globalStateFlush ?? (() => Promise.resolve()) },
+    f: { flush: options.settingsFlush ?? (() => Promise.resolve()) },
+    g: { dispose: options.disposablesDispose ?? (() => {}) },
+    h: {},
+    l: {
+      app: {
+        exit(exitCode) {
+          state.exitCalls += 1;
+          state.exitCodes.push(exitCode);
+          resolveQuit();
+        },
+        on(eventName, handler) {
+          assert.equal(eventName, "will-quit");
+          state.handler = handler;
+        },
+        quit() {
+          state.quitCalls += 1;
+          resolveQuit();
+        },
+      },
+    },
+    m: options.flushTracing ?? (() => Promise.resolve()),
+    p: options.stopCodexMicro ?? (() => Promise.resolve()),
+    process: { platform: options.platform ?? "linux" },
+    Promise,
+    r: {
+      shouldSkipDrainBeforeQuit() {
+        return options.shouldSkipDrain === true;
+      },
+    },
+    setTimeout,
+    u: lifecycleManager,
+    v: false,
+    y: false,
+  };
+  if (options.omitQuitStateHelper === true) {
+    delete context.codexLinuxIsQuitInProgress;
+  }
+
+  vm.runInNewContext(patched, context);
+  assert.equal(typeof state.handler, "function");
+  try {
+    state.handler({
+      preventDefault() {
+        state.preventDefaultCalls += 1;
+      },
+    });
+  } catch (error) {
+    state.handlerError = error;
+  }
+  await quitPromise;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(state.handlerError, null);
+  return state;
 }
 
 function computerUseGateBundleFixture() {
@@ -2640,7 +2738,7 @@ test("bypasses the upstream before-quit confirmation after a Linux explicit quit
   );
 });
 
-test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
+test("adds a bounded will-quit drain fallback on Linux", () => {
   const source = `${currentMainBundlePrefix}${willQuitDrainBundleFixture()}`;
   const patched = applyPatchTwice(
     applyLinuxWillQuitDrainTimeoutPatch,
@@ -2648,11 +2746,253 @@ test("adds a bounded will-quit drain fallback for Linux explicit quit", () => {
   );
 
   assert.match(patched, /codexLinuxExplicitQuitDrainTimeoutMs=3e3/);
-  assert.match(patched, /\(\(\)=>\{let codexLinuxFinalizeQuit=\(\)=>\{d\(\),f\.dispose\(\),n\.app\.quit\(\)\},codexLinuxDrainPromise=Promise\.all\(\[u\.flush\(\),p\.flush\(\)\]\);/);
-  assert.match(patched, /if\(process\.platform===`linux`&&\(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress\(\)\)\)\{Promise\.race\(\[codexLinuxDrainPromise,new Promise\(e=>setTimeout\(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`\?codexLinuxExplicitQuitDrainTimeoutMs:3e3\)\)\]\)\.finally\(codexLinuxFinalizeQuit\);return\}/);
+  assert.match(
+    patched,
+    /codexLinuxLogQuitDrainResults=e=>\{for\(let t of e\)if\(t\.status===`rejected`\)try\{console\.warn\(`WARN: Linux quit drain cleanup failed`,t\.reason\)\}catch\{\};return e\}/,
+  );
+  assert.doesNotMatch(patched, /codexLinuxQuitFinalized/);
+  assert.match(
+    patched,
+    /Promise\.resolve\(\)\.then\(\(\)=>U5\(h,N5\)\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit context cleanup failed`,e\)\}catch\{\}\}\)/,
+  );
+  assert.match(
+    patched,
+    /try\{g\.dispose\(\)\}catch\(e\)\{try\{console\.warn\(`WARN: Linux quit disposables cleanup failed`,e\)\}catch\{\}\}finally\{l\.app\.exit\(0\)\}/,
+  );
+  assert.match(
+    patched,
+    /Promise\.race\(\[Promise\.resolve\(\)\.then\(e\)\.then\(codexLinuxLogQuitDrainResults\),new Promise\(\(_,e\)=>setTimeout\(\(\)=>e\(Error\(`Linux quit drain timed out`\)\),typeof codexLinuxExplicitQuitDrainTimeoutMs===`number`\?codexLinuxExplicitQuitDrainTimeoutMs:3e3\)\)\]\)\.catch\(e=>\{try\{console\.warn\(`WARN: Linux quit drain cleanup failed`,e\)\}catch\{\}\}\)\.then\(codexLinuxFinalizeQuit\)/,
+  );
+  assert.match(
+    patched,
+    /codexLinuxRunQuitDrain=e=>\{if\(process\.platform===`linux`\)\{/,
+  );
+  assert.equal(
+    (patched.match(/codexLinuxRunQuitDrain\(\(\)=>\{/g) ?? []).length,
+    2,
+  );
+  assert.equal(
+    (patched.match(/\.then\(codexLinuxLogQuitDrainResults\)/g) ?? []).length,
+    1,
+  );
   assert.doesNotMatch(patched, /\\`number\\`/);
-  assert.match(patched, /codexLinuxDrainPromise\.finally\(codexLinuxFinalizeQuit\)\}\)\(\)/);
+  assert.match(patched, /e\(\)\.then\(t\)\}/);
+  assert.doesNotMatch(patched, /Promise\.allSettled\([^;]+\.then\(t\)/);
   assert.doesNotThrow(() => new Function(patched));
+});
+
+test("Linux will-quit reaches app.exit exactly once when a disposer throws", async () => {
+  const state = await runPatchedLinuxWillQuit({
+    disposablesDispose() {
+      throw new Error("disposer failed");
+    },
+  });
+
+  assert.equal(state.preventDefaultCalls, 1);
+  assert.equal(state.lifecycleDisposeCalls, 2);
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit disposables cleanup failed Error: disposer failed",
+  ]);
+});
+
+test("Linux will-quit reaches app.exit after the drain deadline", async () => {
+  let resolveGlobalState;
+  const stalledGlobalState = new Promise((resolve) => {
+    resolveGlobalState = resolve;
+  });
+  const state = await runPatchedLinuxWillQuit({
+    globalStateFlush: () => stalledGlobalState,
+    timeoutMs: 5,
+  });
+
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit drain cleanup failed Error: Linux quit drain timed out",
+  ]);
+  resolveGlobalState();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(state.exitCalls, 1);
+  assert.equal(state.quitCalls, 0);
+});
+
+test("Linux will-quit logs rejected asynchronous drain work before exit", async () => {
+  const state = await runPatchedLinuxWillQuit({
+    globalStateFlush: () => Promise.reject(new Error("global-state flush rejected")),
+  });
+
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit drain cleanup failed Error: global-state flush rejected",
+  ]);
+});
+
+test("Linux will-quit reaches app.exit when pre-drain disposal throws synchronously", async () => {
+  const state = await runPatchedLinuxWillQuit({
+    lifecycleDisposeThrowsAt: 1,
+  });
+
+  assert.equal(state.preventDefaultCalls, 1);
+  assert.equal(state.lifecycleDisposeCalls, 1);
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit drain cleanup failed Error: lifecycle disposer failed",
+  ]);
+});
+
+test("Linux will-quit reaches app.exit when drain setup throws synchronously", async () => {
+  const state = await runPatchedLinuxWillQuit({
+    globalStateFlush() {
+      throw new Error("global-state flush failed");
+    },
+  });
+
+  assert.equal(state.preventDefaultCalls, 1);
+  assert.equal(state.lifecycleDisposeCalls, 2);
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit drain cleanup failed Error: global-state flush failed",
+  ]);
+});
+
+test("Linux will-quit reaches app.exit when the quit-state helper is outside its scope", async () => {
+  let resolveGlobalState;
+  const stalledGlobalState = new Promise((resolve) => {
+    resolveGlobalState = resolve;
+  });
+  const state = await runPatchedLinuxWillQuit({
+    globalStateFlush: () => stalledGlobalState,
+    omitQuitStateHelper: true,
+    timeoutMs: 5,
+  });
+
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  resolveGlobalState();
+});
+
+test("Linux will-quit continues cleanup when bounded context disposal rejects", async () => {
+  let disposablesCalls = 0;
+  const state = await runPatchedLinuxWillQuit({
+    contextDispose: () => Promise.reject(new Error("context failed")),
+    disposablesDispose() {
+      disposablesCalls += 1;
+    },
+  });
+
+  assert.equal(disposablesCalls, 1);
+  assert.equal(state.exitCalls, 1);
+  assert.deepEqual(state.exitCodes, [0]);
+  assert.equal(state.quitCalls, 0);
+  assert.deepEqual(state.warnings, [
+    "WARN: Linux quit context cleanup failed Error: context failed",
+  ]);
+});
+
+test("non-Linux will-quit preserves the upstream drain path", async () => {
+  let resolveGlobalState;
+  let quitReached = false;
+  const stalledGlobalState = new Promise((resolve) => {
+    resolveGlobalState = resolve;
+  });
+  const run = runPatchedLinuxWillQuit({
+    globalStateFlush: () => stalledGlobalState,
+    platform: "darwin",
+    settingsFlush: () => Promise.reject(new Error("non-Linux rejected member")),
+    timeoutMs: 5,
+  }).then((state) => {
+    quitReached = true;
+    return state;
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  assert.equal(quitReached, false);
+  resolveGlobalState();
+
+  const state = await run;
+  assert.equal(state.exitCalls, 0);
+  assert.equal(state.quitCalls, 1);
+  assert.deepEqual(state.warnings, []);
+});
+
+test("current will-quit drift fails the required lifecycle patch", () => {
+  const source = willQuitDrainBundleFixture().replace(
+    "U5(h,N5)",
+    "U5(h,N5,unexpected)",
+  );
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, source);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+  ]);
+  assert.equal(report.patches[0]?.status, "failed-required");
+  assert.equal(report.patches[0]?.reason, warnings[0]);
+});
+
+test("missing, renamed, or ambiguous will-quit targets fail the required lifecycle patch", () => {
+  const sources = [
+    willQuitDrainBundleFixture().replace(
+      "shouldSkipDrainBeforeQuit()",
+      "skipDrainBeforeQuit()",
+    ),
+    "l.app.on(`ready`,()=>{})",
+    `${willQuitDrainBundleFixture()}${willQuitDrainBundleFixture()}`,
+  ];
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+
+  for (const source of sources) {
+    const report = createPatchReport();
+    const { value: result, warnings } = captureWarns(() =>
+      applyMainBundlePatchDescriptors(source, [descriptor], {}, report),
+    );
+
+    assert.equal(result.patchedSource, source);
+    assert.deepEqual(warnings, [
+      "WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+    ]);
+    assert.equal(report.patches[0]?.status, "failed-required");
+    assert.equal(report.patches[0]?.reason, warnings[0]);
+  }
+});
+
+test("a non-exiting Linux finalizer is not accepted as already applied", () => {
+  const previousBrokenPatch = applyLinuxWillQuitDrainTimeoutPatch(
+    willQuitDrainBundleFixture(),
+  ).replace("l.app.exit(0)", "l.app.quit()") + "finally{z.app.exit(0)}";
+  const descriptor = corePatchDescriptors().find(
+    (candidate) => candidate.id === "linux-explicit-quit-drain-timeout",
+  );
+  const report = createPatchReport();
+  const { value: result, warnings } = captureWarns(() =>
+    applyMainBundlePatchDescriptors(previousBrokenPatch, [descriptor], {}, report),
+  );
+
+  assert.equal(result.patchedSource, previousBrokenPatch);
+  assert.deepEqual(warnings, [
+    "WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch",
+  ]);
+  assert.equal(report.patches[0]?.status, "failed-required");
+  assert.equal(report.patches[0]?.reason, warnings[0]);
 });
 
 test("marks Linux quit-in-progress for the tray quit path", () => {

--- a/scripts/patches/impl/main-process/quit-lifecycle.js
+++ b/scripts/patches/impl/main-process/quit-lifecycle.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const {
+  findMatchingBrace,
+} = require("../../lib/minified-js.js");
+
 function applyLinuxQuitGuardPatch(currentSource) {
   if (currentSource.includes("codexLinuxExplicitQuitApproved=!1")) {
     return currentSource;
@@ -27,33 +31,141 @@ function linuxExplicitQuitExpression() {
   return "typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),";
 }
 
-function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
-  let patchedSource = currentSource;
-
-  const explicitQuitDrainGuard =
-    "process.platform===`linux`&&(typeof codexLinuxIsQuitInProgress===`function`&&codexLinuxIsQuitInProgress())";
-  let patchedAny = false;
-
-  const drainRegex =
-    /Promise\.all\(\[([A-Za-z_$][\w$]*)\.flush\(\),([A-Za-z_$][\w$]*)\.flush\(\)\]\)\.finally\(\(\)=>\{([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\.dispose\(\),([A-Za-z_$][\w$]*)\.app\.quit\(\)\}\)/g;
-  patchedSource = patchedSource.replace(
-    drainRegex,
-    (_match, firstDrainVar, secondDrainVar, flushDisposeVar, disposablesVar, electronVar) => {
-      patchedAny = true;
-      return `(()=>{let codexLinuxFinalizeQuit=()=>{${flushDisposeVar}(),${disposablesVar}.dispose(),${electronVar}.app.quit()},codexLinuxDrainPromise=Promise.all([${firstDrainVar}.flush(),${secondDrainVar}.flush()]);if(${explicitQuitDrainGuard}){Promise.race([codexLinuxDrainPromise,new Promise(e=>setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).finally(codexLinuxFinalizeQuit);return}codexLinuxDrainPromise.finally(codexLinuxFinalizeQuit)})()`;
-    },
-  );
-
-  if (
-    !patchedAny &&
-    !patchedSource.includes("codexLinuxDrainPromise=Promise.all(") &&
-    patchedSource.includes("n.app.on(`will-quit`,") &&
-    patchedSource.includes(".flush()")
-  ) {
-    console.warn("WARN: Could not find will-quit drain sequence — skipping Linux explicit quit drain timeout patch");
+function parseCurrentWillQuitDrainBody(body, eventVar, listenerElectronVar) {
+  const identifier = "[A-Za-z_$][\\w$]*";
+  const outerMatch = body.match(new RegExp(
+    `^if\\((?<quitting>${identifier})=!0,(?<draining>${identifier})\\)return;let (?<upstreamFinalize>${identifier})=\\(\\)=>\\{(?<finalizer>[^;]+)\\};if\\((?<quitController>${identifier})\\.shouldSkipDrainBeforeQuit\\(\\)\\)\\{(?<reduced>[^;]+);return\\}(?<full>.+)$`,
+  ));
+  if (outerMatch?.groups == null) {
+    return null;
   }
 
-  return patchedSource;
+  const finalizerMatch = outerMatch.groups.finalizer.match(new RegExp(
+    `^(?<contextDispose>${identifier})\\((?<contextArg>${identifier}),(?<contextTimeout>${identifier})\\)\\.then\\(\\(\\)=>\\{(?<disposables>${identifier})\\.dispose\\(\\),(?<electron>${identifier})\\.app\\.quit\\(\\)\\}\\)$`,
+  ));
+  const reducedMatch = outerMatch.groups.reduced.match(new RegExp(
+    `^(?<event>${identifier})\\.preventDefault\\(\\),(?<draining>${identifier})=!0,(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\),Promise\\.allSettled\\(\\[(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\.then\\((?<finalize>${identifier})\\)$`,
+  ));
+  const fullMatch = outerMatch.groups.full.match(new RegExp(
+    `^(?<event>${identifier})\\.preventDefault\\(\\),(?<draining>${identifier})=!0,(?<hotkey>${identifier})\\.dispose\\(\\),(?<dictation>${identifier})\\.dispose\\(\\),Promise\\.allSettled\\(\\[(?<globalState>${identifier})\\.flush\\(\\),(?<settings>${identifier})\\.flush\\(\\),(?<stop>${identifier})\\(\\),(?<trace>${identifier})\\(\\)\\]\\)\\.then\\((?<finalize>${identifier})\\)$`,
+  ));
+  if (finalizerMatch?.groups == null || reducedMatch?.groups == null || fullMatch?.groups == null) {
+    return null;
+  }
+
+  const outer = outerMatch.groups;
+  const finalizer = finalizerMatch.groups;
+  const reduced = reducedMatch.groups;
+  const full = fullMatch.groups;
+  if (
+    finalizer.electron !== listenerElectronVar ||
+    reduced.event !== eventVar ||
+    full.event !== eventVar ||
+    reduced.draining !== outer.draining ||
+    full.draining !== outer.draining ||
+    reduced.hotkey !== full.hotkey ||
+    reduced.dictation !== full.dictation ||
+    reduced.stop !== full.stop ||
+    reduced.trace !== full.trace ||
+    reduced.finalize !== outer.upstreamFinalize ||
+    full.finalize !== outer.upstreamFinalize
+  ) {
+    return null;
+  }
+
+  return { outer, finalizer, reduced, full };
+}
+
+function currentWillQuitDrainCandidates(currentSource) {
+  const listenerNeedle = ".app.on(`will-quit`,";
+  const candidates = [];
+  let searchFrom = 0;
+
+  while (searchFrom < currentSource.length) {
+    const listenerIndex = currentSource.indexOf(listenerNeedle, searchFrom);
+    if (listenerIndex === -1) {
+      break;
+    }
+    searchFrom = listenerIndex + listenerNeedle.length;
+
+    const electronMatch = currentSource
+      .slice(Math.max(0, listenerIndex - 100), listenerIndex)
+      .match(/([A-Za-z_$][\w$]*)$/);
+    const handlerPrefix = currentSource.slice(searchFrom, searchFrom + 100);
+    const handlerMatch = handlerPrefix.match(/^([A-Za-z_$][\w$]*)=>\{/);
+    if (electronMatch == null || handlerMatch == null) {
+      continue;
+    }
+
+    const openBrace = searchFrom + handlerMatch[0].length - 1;
+    const closeBrace = findMatchingBrace(currentSource, openBrace);
+    if (closeBrace === -1) {
+      continue;
+    }
+    const body = currentSource.slice(openBrace + 1, closeBrace);
+    const shape = parseCurrentWillQuitDrainBody(body, handlerMatch[1], electronMatch[1]);
+    if (shape != null) {
+      candidates.push({ body, openBrace, closeBrace, shape });
+    }
+  }
+
+  return candidates;
+}
+
+function applyLinuxWillQuitDrainTimeoutPatch(currentSource) {
+  const linuxQuitDrainGuard = "process.platform===`linux`";
+  const appliedMarkers = [
+    "codexLinuxLogQuitDrainResults=e=>{",
+    "codexLinuxFinalizeQuit=()=>{",
+    "codexLinuxRunQuitDrain=e=>{if(process.platform===`linux`){Promise.race([Promise.resolve().then(e)",
+    "Linux quit drain timed out",
+    "WARN: Linux quit drain cleanup failed",
+    "WARN: Linux quit context cleanup failed",
+    "WARN: Linux quit disposables cleanup failed",
+  ];
+  const appliedFinalizerStart = currentSource.indexOf(appliedMarkers[0]);
+  const appliedFinalizerEnd = currentSource.indexOf(
+    ",codexLinuxRunQuitDrain=",
+    appliedFinalizerStart,
+  );
+  const hasAppliedFinalizerPostcondition =
+    appliedFinalizerStart !== -1 &&
+    appliedFinalizerEnd > appliedFinalizerStart &&
+    /finally\{[A-Za-z_$][\w$]*\.app\.exit\(0\)\}/.test(
+      currentSource.slice(appliedFinalizerStart, appliedFinalizerEnd),
+    );
+  if (
+    appliedMarkers.every((marker) => currentSource.includes(marker)) &&
+    hasAppliedFinalizerPostcondition
+  ) {
+    return currentSource;
+  }
+
+  const candidates = currentWillQuitDrainCandidates(currentSource);
+  if (candidates.length !== 1) {
+    console.warn("WARN: Could not uniquely match current will-quit drain sequence — skipping Linux explicit quit drain timeout patch");
+    return currentSource;
+  }
+
+  const candidate = candidates[0];
+  const { outer, finalizer, reduced, full } = candidate.shape;
+  const originalFinalizer = `${outer.upstreamFinalize}=()=>{${outer.finalizer}}`;
+  const linuxFinalizer =
+    `codexLinuxLogQuitDrainResults=e=>{for(let t of e)if(t.status===\`rejected\`)try{console.warn(\`WARN: Linux quit drain cleanup failed\`,t.reason)}catch{};return e},codexLinuxFinalizeQuit=()=>{Promise.resolve().then(()=>${finalizer.contextDispose}(${finalizer.contextArg},${finalizer.contextTimeout})).catch(e=>{try{console.warn(\`WARN: Linux quit context cleanup failed\`,e)}catch{}}).then(()=>{try{${finalizer.disposables}.dispose()}catch(e){try{console.warn(\`WARN: Linux quit disposables cleanup failed\`,e)}catch{}}finally{${finalizer.electron}.app.exit(0)}})},codexLinuxRunQuitDrain=e=>{if(${linuxQuitDrainGuard}){Promise.race([Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults),new Promise((_,e)=>setTimeout(()=>e(Error(\`Linux quit drain timed out\`)),typeof codexLinuxExplicitQuitDrainTimeoutMs===\`number\`?codexLinuxExplicitQuitDrainTimeoutMs:3e3))]).catch(e=>{try{console.warn(\`WARN: Linux quit drain cleanup failed\`,e)}catch{}}).then(codexLinuxFinalizeQuit);return}e().then(${outer.upstreamFinalize})}`;
+  let patchedBody = candidate.body.replace(
+    `let ${originalFinalizer};`,
+    `let ${originalFinalizer},${linuxFinalizer};`,
+  );
+  patchedBody = patchedBody.replace(
+    `${reduced.hotkey}.dispose(),${reduced.dictation}.dispose(),Promise.allSettled([${reduced.stop}(),${reduced.trace}()]).then(${outer.upstreamFinalize})`,
+    `codexLinuxRunQuitDrain(()=>{${reduced.hotkey}.dispose(),${reduced.dictation}.dispose();return Promise.allSettled([${reduced.stop}(),${reduced.trace}()])})`,
+  );
+  patchedBody = patchedBody.replace(
+    `${full.hotkey}.dispose(),${full.dictation}.dispose(),Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()]).then(${outer.upstreamFinalize})`,
+    `codexLinuxRunQuitDrain(()=>{${full.hotkey}.dispose(),${full.dictation}.dispose();return Promise.allSettled([${full.globalState}.flush(),${full.settings}.flush(),${full.stop}(),${full.trace}()])})`,
+  );
+
+  return `${currentSource.slice(0, candidate.openBrace + 1)}${patchedBody}${currentSource.slice(candidate.closeBrace)}`;
 }
 
 function applyLinuxExplicitQuitPromptBypassPatch(currentSource) {

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -8980,7 +8980,7 @@ const x={o:e=>e};let s=require(`node:url`),n=require(`electron`);n=x.o(n);let l=
 var pb=class{getNativeTrayMenuItems(){return[{label:this.systemQuitMenuItemLabel,click:()=>{n.app.quit()}}]}};
 function qB(r,o){if(o.type===`quit-app`){n.app.quit();return}return o}
 n.app.on(`before-quit`,o=>{let s=BI(),c=t.sr().some(e=>e.status===`ACTIVE`);if(e||i.canQuitWithoutPrompt()||r||!s&&!c){g=!0,a.markAppQuitting();return}let l=n.app.getName();if(n.dialog.showMessageBoxSync({type:`warning`,buttons:[`Quit`,`Cancel`],defaultId:0,cancelId:1,noLink:!0,title:`Quit ${l}?`,message:`Quit ${l}?`,detail:vB({hasInProgressLocalConversation:s,hasEnabledAutomations:c})})!==0){o.preventDefault();return}i.markQuitApproved(),g=!0,a.markAppQuitting()});
-n.app.on(`will-quit`,e=>{if(g=!0,!h){if(i.shouldSkipDrainBeforeQuit()){mB({hotkeyWindowLifecycleManager:c,globalDictationLifecycleManager:l,flushAndDisposeContexts:d,disposables:f});return}e.preventDefault(),h=!0,c.dispose(),l.dispose(),Promise.all([u.flush(),p.flush()]).finally(()=>{d(),f.dispose(),n.app.quit()})}});
+l.app.on(`will-quit`,e=>{if(y=!0,v)return;let t=()=>{U5(h,N5).then(()=>{g.dispose(),l.app.quit()})};if(r.shouldSkipDrainBeforeQuit()){e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([p(),m()]).then(t);return}e.preventDefault(),v=!0,c.dispose(),u.dispose(),Promise.allSettled([d.flush(),f.flush(),p(),m()]).then(t)});
 JS
 )"
     make_fake_extracted_asar "$extracted" "$bundle_body"
@@ -8992,9 +8992,18 @@ JS
     assert_contains "$extracted/.vite/build/main-test.js" 'if(o.type===`quit-app`){typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),n.app.quit();return}'
     assert_contains "$extracted/.vite/build/main-test.js" 'if((typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt())||e||i.canQuitWithoutPrompt()||r||!s&&!c){process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),g=!0,a.markAppQuitting();return}'
     assert_contains "$extracted/.vite/build/main-test.js" 'process.platform===`linux`&&typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress(),i.markQuitApproved(),g=!0,a.markAppQuitting()'
-    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{d(),f.dispose(),n.app.quit()},codexLinuxDrainPromise=Promise.all('
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxLogQuitDrainResults=e=>{'
+    assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{'
+    assert_not_contains "$extracted/.vite/build/main-test.js" 'codexLinuxQuitFinalized'
+    assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit drain cleanup failed'
+    assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit context cleanup failed'
+    assert_contains "$extracted/.vite/build/main-test.js" 'WARN: Linux quit disposables cleanup failed'
+    assert_contains "$extracted/.vite/build/main-test.js" 'finally{l.app.exit(0)}'
+    assert_not_contains "$extracted/.vite/build/main-test.js" 'finally{l.app.quit()}'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitDrain(()=>{' '2'
+    assert_contains "$extracted/.vite/build/main-test.js" 'Promise.resolve().then(e).then(codexLinuxLogQuitDrainResults),new Promise'
     assert_contains "$extracted/.vite/build/main-test.js" 'codexLinuxExplicitQuitDrainTimeoutMs'
-    assert_contains "$extracted/.vite/build/main-test.js" 'setTimeout(e,typeof codexLinuxExplicitQuitDrainTimeoutMs'
+    assert_contains "$extracted/.vite/build/main-test.js" 'setTimeout(()=>e(Error(`Linux quit drain timed out`)),typeof codexLinuxExplicitQuitDrainTimeoutMs'
     assert_not_contains "$extracted/.vite/build/main-test.js" '\`number\`'
     assert_not_contains "$output_log" 'WARN: Could not find tray quit menu handler'
     assert_not_contains "$output_log" 'WARN: Could not find quit-app IPC handler'
@@ -9098,7 +9107,9 @@ NODE
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxShouldBypassQuitPrompt=()=>codexLinuxExplicitQuitApproved===!0' '1'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'typeof codexLinuxPrepareForExplicitQuit===`function`?codexLinuxPrepareForExplicitQuit():typeof codexLinuxMarkQuitInProgress===`function`&&codexLinuxMarkQuitInProgress()' '2'
     assert_occurrence_count "$extracted/.vite/build/main-test.js" 'typeof codexLinuxShouldBypassQuitPrompt===`function`&&codexLinuxShouldBypassQuitPrompt()' '1'
-    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxDrainPromise=Promise.all(' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxLogQuitDrainResults=e=>{' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxFinalizeQuit=()=>{' '1'
+    assert_occurrence_count "$extracted/.vite/build/main-test.js" 'codexLinuxRunQuitDrain(()=>{' '2'
 }
 
 test_keybinds_settings_tab_patch_smoke() {


### PR DESCRIPTION
## Summary

Fix Linux explicit Quit leaving an Electron process alive after its window and main-process services have already been disposed.

The current upstream `will-quit` handler prevents the initial quit, drains lifecycle work, disposes the application context, and calls `app.quit()` again. When cleanup settles during Electron's event-emission microtask checkpoint, that second call can occur before the original quit has finished unwinding. Electron ignores the re-entrant quit, leaving a windowless process holding the single-instance lock.

This change:

- contains synchronous cleanup failures and bounds the Linux drain to three seconds;
- preserves the existing bounded application-context cleanup;
- logs rejected cleanup work without allowing it to suppress termination;
- finishes the Linux explicit-quit path with `app.exit(0)`, after cleanup, instead of re-entering `app.quit()`;
- leaves the upstream non-Linux path and launcher handoff behavior unchanged;
- adds semantic matching, drift, idempotence, failure-path, and platform regression coverage.

This is complementary to #1147. Healthy resident instances must still retain their PID and accept reopen handoffs. This PR changes only explicit Quit after teardown has begun; the #1147 resident-reopen harness continues to pass.

Source-of-truth files:

- `scripts/patches/impl/main-process/quit-lifecycle.js`
- `scripts/patch-linux-window-ui.test.js`
- `tests/scripts_smoke.sh`
- `docs/windowless-warm-start-fix-report.md`

No existing issue is linked. The failure was reproduced while investigating packaged Linux warm-start behavior.

## Validation

Automated:

- `node --test scripts/patch-linux-window-ui.test.js` — 398/398 passed
- `bash tests/scripts_smoke.sh` — passed, including the #1147 healthy-resident reopen harness
- `bash -n install.sh launcher/start.sh.template scripts/lib/*.sh scripts/build-deb.sh scripts/build-rpm.sh scripts/build-pacman.sh scripts/build-appimage.sh`
- `git diff --check origin/main...HEAD`

Manual packaged-app validation on Arch Linux with Hyprland/Wayland:

- An equivalent build retaining the final `app.quit()` reproduced the surviving windowless primary process.
- The `app.exit(0)` build completed ten consecutive Quit/relaunch cycles.
- Every cycle reached zero primary processes, zero packaged helper processes, no launch-action socket, and no compositor window before relaunch.
- An eleventh launch opened a healthy window after the tenth exit.

Manual reproduction has not been repeated on other distributions, desktop environments, or X11. The affected lifecycle patch is shared by Linux package formats, but this PR does not claim universal reproduction across Linux environments.

The intentional tradeoff is that cleanup still running after the bounded deadline cannot delay explicit termination indefinitely.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.
