### PR TITLE
Add per-connection SSH command wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ workarounds.
 | Read Aloud MCP | Opt-in | `read-aloud-mcp` | [Docs](linux-features/read-aloud-mcp/README.md) |
 | Remote Control UI gates | Opt-in | `remote-control-ui` | [Docs](linux-features/remote-control-ui/README.md) |
 | Experimental Remote Mobile Control | Opt-in | `remote-mobile-control` | [Docs](linux-features/remote-mobile-control/README.md) |
+| SSH command wrapper | Opt-in | `ssh-command-wrapper` | [Docs](linux-features/ssh-command-wrapper/README.md) |
 | Thorium Chrome Plugin Support | Opt-in | `thorium-chrome-plugin` | [Docs](linux-features/thorium-chrome-plugin/README.md) |
 | UI tweaks | Opt-in | `ui-tweaks` | [Docs](linux-features/ui-tweaks/README.md) |
 | X11/EWMH Computer Use adapter | Opt-in | `x11-ewmh-computer-use` | [Docs](linux-features/x11-ewmh-computer-use/README.md) |

--- a/linux-features/ssh-command-wrapper/README.md
+++ b/linux-features/ssh-command-wrapper/README.md
@@ -1,0 +1,59 @@
+# SSH Command Wrapper
+
+This opt-in feature adds a **Remote command wrapper** field to each saved SSH
+connection in **Settings → Connections → SSH**. Codex appends its generated
+remote command as the wrapper's final argument and runs the result on the
+configured SSH host.
+
+For a connection that should route Codex operations through a specific target
+host, configure:
+
+```text
+ssh -T target-host --
+```
+
+Codex still opens the configured outer connection, but every remote probe,
+installation command, and app-server proxy is then routed through
+`target-host`.
+The wrapper is also part of the SSH startup-gate identity, so connections with
+different wrappers do not share startup sequencing.
+
+The field accepts POSIX-style argv text, including single quotes, double
+quotes, and backslash escaping. It is deliberately not a shell-snippet field:
+unquoted shell operators (`;`, `&`, `|`, `<`, and `>`) and newlines are
+rejected. The limit is 4096 input characters and 64 arguments. Wrapper
+failures use the existing SSH connection error path and abort setup.
+
+An empty wrapper leaves upstream SSH behavior unchanged. Saved discovered
+aliases and manually entered hosts both support wrappers.
+
+## Enable
+
+Add the feature id to the gitignored `linux-features/features.json`, then
+rebuild the app:
+
+```json
+{
+  "enabled": [
+    "ssh-command-wrapper"
+  ]
+}
+```
+
+```bash
+./install.sh ./Codex.dmg
+```
+
+## Test
+
+```bash
+node --test linux-features/ssh-command-wrapper/test.js
+```
+
+## Risks
+
+The feature patches current upstream minified main-process and settings
+bundles. Upstream UI or SSH transport changes can cause the optional patch to
+be skipped with a warning until its bundle needles are updated. A configured
+wrapper can run any executable available on the outer remote host, so only use
+values you trust.

--- a/linux-features/ssh-command-wrapper/feature.json
+++ b/linux-features/ssh-command-wrapper/feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "ssh-command-wrapper",
+  "title": "SSH Command Wrapper",
+  "description": "Adds a per-connection argv wrapper for routing Codex SSH operations through another remote command.",
+  "defaultEnabled": false,
+  "entrypoints": {
+    "patchDescriptors": "./patch.js"
+  }
+}

--- a/linux-features/ssh-command-wrapper/patch.js
+++ b/linux-features/ssh-command-wrapper/patch.js
@@ -1,0 +1,315 @@
+"use strict";
+
+const MAX_WRAPPER_TEXT_LENGTH = 4096;
+const MAX_WRAPPER_ARGS = 64;
+const WRAPPER_PROPERTY = "codexLinuxSshCommandWrapper";
+const WRAPPER_TEXT_PROPERTY = "codexLinuxSshCommandWrapperText";
+const MAIN_MARKER = "function codexLinuxSshCommandWrapperArgs(";
+const WEBVIEW_MARKER = "function codexLinuxParseSshCommandWrapper(";
+
+function wrapperError(message) {
+  const error = new Error(message);
+  error.code = "invalidSshCommandWrapper";
+  return error;
+}
+
+function parseCommandWrapper(input) {
+  if (typeof input !== "string") {
+    throw wrapperError("Remote command wrapper must be text");
+  }
+  if (input.length > MAX_WRAPPER_TEXT_LENGTH) {
+    throw wrapperError(`Remote command wrapper must be at most ${MAX_WRAPPER_TEXT_LENGTH} characters`);
+  }
+  if (input.includes("\0") || /[\r\n]/u.test(input)) {
+    throw wrapperError("Remote command wrapper cannot contain NUL or newlines");
+  }
+
+  const args = [];
+  let value = "";
+  let quote = null;
+  let started = false;
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index];
+    if (quote === "'") {
+      if (char === "'") quote = null;
+      else value += char;
+      started = true;
+      continue;
+    }
+    if (quote === '"') {
+      if (char === '"') {
+        quote = null;
+      } else if (char === "\\") {
+        index += 1;
+        if (index >= input.length) throw wrapperError("Remote command wrapper has a trailing escape");
+        const escaped = input[index];
+        value += '$`"\\'.includes(escaped) ? escaped : `\\${escaped}`;
+      } else {
+        value += char;
+      }
+      started = true;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      started = true;
+      continue;
+    }
+    if (char === "\\") {
+      index += 1;
+      if (index >= input.length) throw wrapperError("Remote command wrapper has a trailing escape");
+      value += input[index];
+      started = true;
+      continue;
+    }
+    if (/\s/u.test(char)) {
+      if (started) {
+        args.push(value);
+        value = "";
+        started = false;
+        if (args.length > MAX_WRAPPER_ARGS) {
+          throw wrapperError(`Remote command wrapper must have at most ${MAX_WRAPPER_ARGS} arguments`);
+        }
+      }
+      continue;
+    }
+    if (/[;&|<>]/u.test(char)) {
+      throw wrapperError(`Remote command wrapper contains an unquoted shell operator: ${char}`);
+    }
+    value += char;
+    started = true;
+  }
+  if (quote != null) throw wrapperError("Remote command wrapper has an unterminated quote");
+  if (started) args.push(value);
+  if (args.length > MAX_WRAPPER_ARGS) {
+    throw wrapperError(`Remote command wrapper must have at most ${MAX_WRAPPER_ARGS} arguments`);
+  }
+  if (args.length > 0 && args[0].length === 0) {
+    throw wrapperError("Remote command wrapper executable cannot be empty");
+  }
+  return args;
+}
+
+function quoteShellArg(value) {
+  if (typeof value !== "string" || value.length === 0) return "''";
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/u.test(value)) return value;
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function formatCommandWrapper(args) {
+  const valid = validateCommandWrapperArgs(args);
+  return valid.map(quoteShellArg).join(" ");
+}
+
+function validateCommandWrapperArgs(value) {
+  if (value == null) return [];
+  if (!Array.isArray(value) || value.length > MAX_WRAPPER_ARGS) {
+    throw wrapperError("Remote command wrapper argv is invalid");
+  }
+  let totalLength = 0;
+  const result = value.map((arg) => {
+    if (typeof arg !== "string" || /[\0\r\n]/u.test(arg)) {
+      throw wrapperError("Remote command wrapper argv is invalid");
+    }
+    totalLength += arg.length;
+    return arg;
+  });
+  if (totalLength > MAX_WRAPPER_TEXT_LENGTH) {
+    throw wrapperError("Remote command wrapper argv is too long");
+  }
+  if (result.length > 0 && result[0].length === 0) {
+    throw wrapperError("Remote command wrapper executable cannot be empty");
+  }
+  return result;
+}
+
+function wrapRemoteCommand(command, args) {
+  const valid = validateCommandWrapperArgs(args);
+  if (valid.length === 0) return command;
+  return `exec ${valid.map(quoteShellArg).join(" ")} ${quoteShellArg(command)}`;
+}
+
+function replaceRequired(source, needle, replacement, label) {
+  if (!source.includes(needle)) {
+    console.warn(`WARN: Could not find ${label} - skipping SSH command-wrapper patch`);
+    return null;
+  }
+  return source.replace(needle, replacement);
+}
+
+function mainHelperSource() {
+  return [
+    "function codexLinuxSshCommandWrapperArgs(e){if(e==null)return[];if(!Array.isArray(e)||e.length>64)throw Error(`Invalid SSH remote command wrapper`);let t=0,n=e.map(e=>{if(typeof e!=`string`||/[\\0\\r\\n]/u.test(e))throw Error(`Invalid SSH remote command wrapper`);if(t+=e.length,t>4096)throw Error(`Invalid SSH remote command wrapper`);return e});if(n.length>0&&n[0].length===0)throw Error(`Invalid SSH remote command wrapper`);return n}",
+    "function codexLinuxSshCommandWrapperQuote(e){return e.length>0&&/^[A-Za-z0-9_@%+=:,./-]+$/u.test(e)?e:`'${e.replaceAll(`'`,`'\\\\''`)}'`}",
+    "function codexLinuxSshWrapRemoteCommand(e,t){let n=codexLinuxSshCommandWrapperArgs(t);return n.length===0?e:`exec ${n.map(codexLinuxSshCommandWrapperQuote).join(` `)} ${codexLinuxSshCommandWrapperQuote(e)}`}",
+  ].join("");
+}
+
+function applyMainBundlePatch(source) {
+  if (source.includes(MAIN_MARKER)) return source;
+
+  let patched = source;
+  const helperNeedle = "function Gx(";
+  const helperIndex = patched.indexOf(helperNeedle);
+  if (helperIndex < 0) {
+    console.warn("WARN: Could not find SSH login-shell helper - skipping SSH command-wrapper patch");
+    return source;
+  }
+  patched = `${patched.slice(0, helperIndex)}${mainHelperSource()}${patched.slice(helperIndex)}`;
+
+  const replacements = [
+    [
+      "Gx(e,s)]",
+      `codexLinuxSshWrapRemoteCommand(Gx(e,s),this.options.sshConnection.${WRAPPER_PROPERTY})]`,
+      "SSH management command",
+    ],
+    [
+      "Gx(t,i)]",
+      `codexLinuxSshWrapRemoteCommand(Gx(t,i),this.options.sshConnection.${WRAPPER_PROPERTY})]`,
+      "SSH app-server proxy command",
+    ],
+    [
+      "return t?{sshConnection:{alias:t.sshAlias,host:t.sshHost,port:t.sshPort,identity:t.identity}}:null",
+      `return t?{sshConnection:{alias:t.sshAlias,host:t.sshHost,port:t.sshPort,identity:t.identity,${WRAPPER_PROPERTY}:t.${WRAPPER_PROPERTY}}}:null`,
+      "SSH transport host mapping",
+    ],
+    [
+      "function Wre(e){let t=e.alias?.trim();return t?`alias:${t}`:[`direct`,e.host,String(e.port??``),e.identity?.trim()??``].join(`",
+      `function Wre(e){let t=e.alias?.trim(),n=JSON.stringify(codexLinuxSshCommandWrapperArgs(e.${WRAPPER_PROPERTY}));return t?\`alias:\${t}:\${n}\`:[\`direct\`,e.host,String(e.port??\`\`),e.identity?.trim()??\`\`,n].join(\``,
+      "SSH startup-gate identity",
+    ],
+    [
+      "displayName:e.displayName,autoConnect:!1})",
+      `displayName:e.displayName,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY},autoConnect:!1})`,
+      "saved alias runtime mapping",
+    ],
+    [
+      "sshPort:e.sshPort,identity:e.identity}]),...t.filter",
+      `sshPort:e.sshPort,identity:e.identity,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY}}]),...t.filter`,
+      "saved hostname runtime mapping",
+    ],
+    [
+      "sshPort:e.sshPort,identity:e.identity}:{hostId:e.hostId,connectionAnalyticsId:e.connectionAnalyticsId,displayName:e.displayName,source:`discovered`,alias:e.alias,hostname:null,sshPort:null,identity:null}",
+      `sshPort:e.sshPort,identity:e.identity,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY}}:{hostId:e.hostId,connectionAnalyticsId:e.connectionAnalyticsId,displayName:e.displayName,source:\`discovered\`,alias:e.alias,hostname:null,sshPort:null,identity:null,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY}}`,
+      "current saved connection normalization",
+    ],
+    [
+      "sshPort:t.sshPort,identity:t.identity}:{hostId:t.hostId,connectionAnalyticsId:t.connectionAnalyticsId,displayName:t.displayName,source:`discovered`,alias:n,hostname:null,sshPort:null,identity:null}",
+      `sshPort:t.sshPort,identity:t.identity,${WRAPPER_PROPERTY}:t.${WRAPPER_PROPERTY}}:{hostId:t.hostId,connectionAnalyticsId:t.connectionAnalyticsId,displayName:t.displayName,source:\`discovered\`,alias:n,hostname:null,sshPort:null,identity:null,${WRAPPER_PROPERTY}:t.${WRAPPER_PROPERTY}}`,
+      "legacy saved connection normalization",
+    ],
+    [
+      "identity:e.identity}};return e.homeDir",
+      `identity:e.identity,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY}}};return e.homeDir`,
+      "SSH host metadata",
+    ],
+    [
+      "var O$=n.mu({sshAlias:n._u().nullable(),sshHost:n._u(),sshPort:n.pu().nullable(),identity:n._u().nullable()});",
+      `var O$=n.mu({sshAlias:n._u().nullable(),sshHost:n._u(),sshPort:n.pu().nullable(),identity:n._u().nullable(),${WRAPPER_PROPERTY}:n.ou(n._u()).optional()});`,
+      "SSH host metadata schema",
+    ],
+    [
+      "sshPort:e.sshPort,identity:e.identity,codexCliCommand:[]",
+      `sshPort:e.sshPort,identity:e.identity,${WRAPPER_PROPERTY}:e.${WRAPPER_PROPERTY},codexCliCommand:[]`,
+      "SSH host configuration",
+    ],
+  ];
+
+  for (const [needle, replacement, label] of replacements) {
+    const next = replaceRequired(patched, needle, replacement, label);
+    if (next == null) return source;
+    patched = next;
+  }
+  return patched;
+}
+
+function webviewHelperSource() {
+  return [
+    "function codexLinuxParseSshCommandWrapper(e){if(typeof e!=`string`||e.length>4096||/[\\0\\r\\n]/u.test(e))throw Error(`invalid`);let t=[],n=``,r=null,i=!1;for(let a=0;a<e.length;a++){let o=e[a];if(r===`'`){o===`'`?r=null:n+=o,i=!0;continue}if(r===`\\\"`){if(o===`\\\"`)r=null;else if(o===`\\\\`){if(++a>=e.length)throw Error(`invalid`);let t=e[a];n+=`$\\\\\\\"`.includes(t)?t:`\\\\${t}`}else n+=o;i=!0;continue}if(o===`'`||o===`\\\"`){r=o,i=!0;continue}if(o===`\\\\`){if(++a>=e.length)throw Error(`invalid`);n+=e[a],i=!0;continue}if(/\\s/u.test(o)){if(i&&(t.push(n),n=``,i=!1,t.length>64))throw Error(`invalid`);continue}if(/[;&|<>]/u.test(o))throw Error(`invalid`);n+=o,i=!0}if(r!=null)throw Error(`invalid`);if(i&&t.push(n),t.length>64||t.length>0&&t[0].length===0)throw Error(`invalid`);return t}",
+    "function codexLinuxFormatSshCommandWrapper(e){return Array.isArray(e)?e.map(e=>typeof e==`string`&&e.length>0&&/^[A-Za-z0-9_@%+=:,./-]+$/u.test(e)?e:`'${String(e??``).replaceAll(`'`,`'\\\\''`)}'`).join(` `):``}",
+  ].join("");
+}
+
+function applyWebviewPatch(source) {
+  if (source.includes(WEBVIEW_MARKER)) return source;
+  if (!source.includes("function Pi(){return{displayName:") || !source.includes("function Bi(e){")) {
+    console.warn("WARN: Could not find remote-connections settings editor - skipping SSH command-wrapper patch");
+    return source;
+  }
+
+  let patched = source.replace("function Pi(){", `${webviewHelperSource()}function Pi(){`);
+  const replacements = [
+    [
+      "authMode:`none`,identity:``}}",
+      `authMode:\`none\`,identity:\`\`,${WRAPPER_TEXT_PROPERTY}:\`\`}}`,
+      "new connection draft",
+    ],
+    [
+      "authMode:e.identity==null?`none`:`identity`,identity:e.identity??``}}",
+      `authMode:e.identity==null?\`none\`:\`identity\`,identity:e.identity??\`\`,${WRAPPER_TEXT_PROPERTY}:codexLinuxFormatSshCommandWrapper(e.${WRAPPER_PROPERTY})}}`,
+      "saved connection draft",
+    ],
+    [
+      "identity:e.authMode===`identity`?e.identity.trim():null}:{hostId:",
+      `identity:e.authMode===\`identity\`?e.identity.trim():null,${WRAPPER_PROPERTY}:codexLinuxParseSshCommandWrapper(e.${WRAPPER_TEXT_PROPERTY})}:{hostId:`,
+      "hostname connection save",
+    ],
+    [
+      "sshPort:null,identity:null}}function Li(",
+      `sshPort:null,identity:null,${WRAPPER_PROPERTY}:codexLinuxParseSshCommandWrapper(e.${WRAPPER_TEXT_PROPERTY})}}function Li(`,
+      "alias connection save",
+    ],
+    [
+      "let r=[],i=e.displayName.trim();",
+      `let r=[],i=e.displayName.trim();try{codexLinuxParseSshCommandWrapper(e.${WRAPPER_TEXT_PROPERTY})}catch{r.push(\`invalidSshCommandWrapper\`)}`,
+      "wrapper validation",
+    ],
+    [
+      "children:[D,k,A]",
+      `children:[D,k,A,(0,q.jsx)(_.Field,{name:\`${WRAPPER_TEXT_PROPERTY}\`,children:e=>(0,q.jsx)(Wi,{label:(0,q.jsxs)(q.Fragment,{children:[(0,q.jsx)(U,{id:\`settings.remoteConnections.dialog.field.commandWrapper\`,defaultMessage:\`Remote command wrapper\`,description:\`Label for the optional SSH remote command wrapper field\`}),\` \`,(0,q.jsx)(\`span\`,{className:\`font-normal text-token-text-secondary\`,children:(0,q.jsx)(U,{id:\`settings.remoteConnections.dialog.field.commandWrapper.optional\`,defaultMessage:\`(optional)\`,description:\`Marker for the optional SSH remote command wrapper field\`})})]}),description:(0,q.jsx)(U,{id:\`settings.remoteConnections.dialog.field.commandWrapper.description\`,defaultMessage:\`Runs every Codex SSH operation through this argv command and appends the generated remote command as its final argument.\`,description:\`Description for the SSH remote command wrapper field\`}),placeholder:\`ssh -T target-host --\`,value:e.state.value,onChange:e.handleChange,onBlur:e.handleBlur,disabled:l})})]`,
+      "wrapper settings field",
+    ],
+    [
+      "function Gi(e){switch(e){",
+      "function Gi(e){switch(e){case`invalidSshCommandWrapper`:return(0,q.jsx)(U,{id:`settings.remoteConnections.dialog.field.commandWrapper.error`,defaultMessage:`Enter a valid command (quotes and escapes are supported; shell operators are not)`,description:`Error for an invalid SSH remote command wrapper`});",
+      "wrapper validation message",
+    ],
+  ];
+  for (const [needle, replacement, label] of replacements) {
+    const next = replaceRequired(patched, needle, replacement, label);
+    if (next == null) return source;
+    patched = next;
+  }
+  return patched;
+}
+
+module.exports = {
+  MAX_WRAPPER_ARGS,
+  MAX_WRAPPER_TEXT_LENGTH,
+  applyMainBundlePatch,
+  applyWebviewPatch,
+  formatCommandWrapper,
+  parseCommandWrapper,
+  quoteShellArg,
+  validateCommandWrapperArgs,
+  wrapRemoteCommand,
+  descriptors: [
+    {
+      id: "main-bundle-ssh-command-wrapper",
+      phase: "main-bundle",
+      order: 20700,
+      ciPolicy: "opt-in",
+      apply: applyMainBundlePatch,
+    },
+    {
+      id: "webview-ssh-command-wrapper-settings",
+      phase: "webview-asset",
+      order: 20710,
+      ciPolicy: "opt-in",
+      pattern: /^remote-connections-settings-[^.]+\.js$/u,
+      missingDescription: "remote-connections settings webview bundle",
+      skipDescription: "SSH command-wrapper settings patch",
+      apply: applyWebviewPatch,
+    },
+  ],
+};

--- a/linux-features/ssh-command-wrapper/test.js
+++ b/linux-features/ssh-command-wrapper/test.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  loadLinuxFeaturePatchDescriptors,
+} = require("../../scripts/lib/linux-features.js");
+const {
+  MAX_WRAPPER_ARGS,
+  applyMainBundlePatch,
+  applyWebviewPatch,
+  descriptors,
+  formatCommandWrapper,
+  parseCommandWrapper,
+  validateCommandWrapperArgs,
+  wrapRemoteCommand,
+} = require("./patch.js");
+
+const mainFixture = [
+  "function Gx(e,t){return e+t}",
+  "function management(){return[...x,Gx(e,s)]}",
+  "function proxy(){return[...x,Gx(t,i)]}",
+  "function uS(e){let t=Hre(e);return t?{sshConnection:{alias:t.sshAlias,host:t.sshHost,port:t.sshPort,identity:t.identity}}:null}",
+  "function Wre(e){let t=e.alias?.trim();return t?`alias:${t}`:[`direct`,e.host,String(e.port??``),e.identity?.trim()??``].join(`:",
+  "aliasLoad.then(t=>t==null?null:{...t,hostId:e.hostId,connectionAnalyticsId:e.connectionAnalyticsId,displayName:e.displayName,autoConnect:!1})",
+  "let direct=[{hostId:e.hostId,sshPort:e.sshPort,identity:e.identity}]),...t.filter",
+  "let current=e.alias==null?{hostId:e.hostId,connectionAnalyticsId:e.connectionAnalyticsId,displayName:e.displayName,source:`codex-managed`,alias:null,hostname:e.hostname,sshPort:e.sshPort,identity:e.identity}:{hostId:e.hostId,connectionAnalyticsId:e.connectionAnalyticsId,displayName:e.displayName,source:`discovered`,alias:e.alias,hostname:null,sshPort:null,identity:null}",
+  "let legacy=n==null?{hostId:t.hostId,connectionAnalyticsId:t.connectionAnalyticsId,displayName:t.displayName,source:`codex-managed`,alias:null,hostname:t.sshHost,sshPort:t.sshPort,identity:t.identity}:{hostId:t.hostId,connectionAnalyticsId:t.connectionAnalyticsId,displayName:t.displayName,source:`discovered`,alias:n,hostname:null,sshPort:null,identity:null}",
+  "let host={metadata:{identity:e.identity}};return e.homeDir",
+  "var O$=n.mu({sshAlias:n._u().nullable(),sshHost:n._u(),sshPort:n.pu().nullable(),identity:n._u().nullable()});",
+  "let config={sshPort:e.sshPort,identity:e.identity,codexCliCommand:[]}",
+].join(";");
+
+const webviewFixture = [
+  "function Pi(){return{displayName:``,targetKind:`hostname`,sshHost:``,sshPort:``,authMode:`none`,identity:``}}",
+  "function Fi(e){return{authMode:e.identity==null?`none`:`identity`,identity:e.identity??``}}",
+  "function Ii(e){return e.targetKind===`hostname`?{identity:e.authMode===`identity`?e.identity.trim():null}:{hostId:x,sshPort:null,identity:null}}",
+  "function Li(e){let r=[],i=e.displayName.trim();return r}",
+  "function Bi(e){let _,q,U,Wi,l,D,k,A,j;j=(0,q.jsx)(x,{children:(0,q.jsxs)(`div`,{children:[D,k,A]})});return j}",
+  "function Gi(e){switch(e){case`other`:return null}}",
+].join("");
+
+function withFeatureConfig(enabled, callback) {
+  const originalConfig = process.env.CODEX_LINUX_FEATURES_CONFIG;
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ssh-command-wrapper-feature-"));
+  process.env.CODEX_LINUX_FEATURES_CONFIG = path.join(tempDir, "features.json");
+  fs.writeFileSync(process.env.CODEX_LINUX_FEATURES_CONFIG, `${JSON.stringify({ enabled })}\n`);
+  try {
+    return callback(path.resolve(__dirname, ".."));
+  } finally {
+    if (originalConfig == null) delete process.env.CODEX_LINUX_FEATURES_CONFIG;
+    else process.env.CODEX_LINUX_FEATURES_CONFIG = originalConfig;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+test("parses argv text without invoking a shell", () => {
+  assert.deepEqual(parseCommandWrapper("ssh -T target-host --"), ["ssh", "-T", "target-host", "--"]);
+  assert.deepEqual(parseCommandWrapper("env 'NAME=hello world' command\\ name \"\""), [
+    "env",
+    "NAME=hello world",
+    "command name",
+    "",
+  ]);
+  assert.deepEqual(parseCommandWrapper('command "a\\q" "a\\$b"'), ["command", "a\\q", "a$b"]);
+  assert.deepEqual(parseCommandWrapper(""), []);
+  assert.deepEqual(parseCommandWrapper("   \t "), []);
+});
+
+test("rejects snippets and malformed or oversized argv", () => {
+  for (const value of [
+    "ssh target-host; echo unsafe",
+    "ssh target-host | tee log",
+    "ssh target-host\nwhoami",
+    "ssh 'target-host",
+    "ssh target-host\\",
+    "'' -T target-host",
+    `ssh ${"x".repeat(4096)}`,
+  ]) {
+    assert.throws(() => parseCommandWrapper(value), { code: "invalidSshCommandWrapper" });
+  }
+  assert.throws(
+    () => parseCommandWrapper(Array.from({ length: MAX_WRAPPER_ARGS + 1 }, () => "x").join(" ")),
+    { code: "invalidSshCommandWrapper" },
+  );
+});
+
+test("round trips quoted argv and preserves an empty wrapper", () => {
+  const args = ["ssh", "-T", "login node", "--", "apostrophe's", ""];
+  assert.deepEqual(parseCommandWrapper(formatCommandWrapper(args)), args);
+  assert.equal(wrapRemoteCommand("sh -c 'echo ok'", []), "sh -c 'echo ok'");
+  assert.equal(
+    wrapRemoteCommand("sh -c 'echo ok'", ["ssh", "-T", "target-host", "--"]),
+    "exec ssh -T target-host -- 'sh -c '\\''echo ok'\\'''",
+  );
+});
+
+test("validates persisted argv independently of the editor", () => {
+  assert.deepEqual(validateCommandWrapperArgs(null), []);
+  assert.deepEqual(validateCommandWrapperArgs(["ssh", "-T"]), ["ssh", "-T"]);
+  assert.throws(() => validateCommandWrapperArgs("ssh -T"), { code: "invalidSshCommandWrapper" });
+  assert.throws(() => validateCommandWrapperArgs(["ssh\nwhoami"]), {
+    code: "invalidSshCommandWrapper",
+  });
+});
+
+test("patches all main-process transport and persistence paths idempotently", () => {
+  const patched = applyMainBundlePatch(mainFixture);
+  assert.notEqual(patched, mainFixture);
+  assert.equal(applyMainBundlePatch(patched), patched);
+  assert.match(patched, /codexLinuxSshWrapRemoteCommand\(Gx\(e,s\)/u);
+  assert.match(patched, /codexLinuxSshWrapRemoteCommand\(Gx\(t,i\)/u);
+  assert.match(patched, /codexLinuxSshCommandWrapperArgs\(e\.codexLinuxSshCommandWrapper\)/u);
+  assert.ok(patched.split("codexLinuxSshCommandWrapper").length > 10);
+});
+
+test("main-process patch fails soft and byte-identical on drift", () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = (message) => warnings.push(String(message));
+  try {
+    assert.equal(applyMainBundlePatch("function Gx(){}"), "function Gx(){}");
+  } finally {
+    console.warn = originalWarn;
+  }
+  assert.ok(warnings.length > 0);
+});
+
+test("patches the SSH connection editor for manual hosts and aliases", () => {
+  const patched = applyWebviewPatch(webviewFixture);
+  assert.notEqual(patched, webviewFixture);
+  assert.equal(applyWebviewPatch(patched), patched);
+  assert.match(patched, /Remote command wrapper/u);
+  assert.match(patched, /ssh -T target-host --/u);
+  assert.match(patched, /invalidSshCommandWrapper/u);
+  assert.match(patched, /codexLinuxSshCommandWrapper:codexLinuxParseSshCommandWrapper/u);
+});
+
+test("exports opt-in main and settings descriptors", () => {
+  assert.deepEqual(
+    descriptors.map(({ phase, ciPolicy }) => [phase, ciPolicy]),
+    [
+      ["main-bundle", "opt-in"],
+      ["webview-asset", "opt-in"],
+    ],
+  );
+  assert.equal(
+    descriptors[1].pattern.test("remote-connections-settings-current.js"),
+    true,
+  );
+});
+
+test("feature stays disabled until explicitly enabled", () => {
+  withFeatureConfig([], (featuresRoot) => {
+    assert.deepEqual(loadLinuxFeaturePatchDescriptors({ featuresRoot }), []);
+  });
+  withFeatureConfig(["ssh-command-wrapper"], (featuresRoot) => {
+    assert.deepEqual(
+      loadLinuxFeaturePatchDescriptors({ featuresRoot }).map(({ id }) => id),
+      [
+        "feature:ssh-command-wrapper:main-bundle-ssh-command-wrapper",
+        "feature:ssh-command-wrapper:webview-ssh-command-wrapper-settings",
+      ],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `ssh-command-wrapper` Linux feature that allows each saved SSH connection to define an argv-based remote command wrapper in **Settings -> Connections -> SSH**.

I often work with HPC clusters that route incoming SSH sessions to randomly selected login nodes without allowing a specific node to be chosen before connecting. This can cause multiple Codex app-server processes to run concurrently on different login nodes. Because these nodes share a filesystem, the redundant processes are wasteful and can race or conflict with one another.

This feature lets me route all Codex remote operations through a consistent login node so only one app-server environment is used. More generally, it allows any saved SSH connection to route Codex operations through a user-specified argv command.

Codex appends its generated remote command as the wrapper’s final argument. For example:

```text
ssh -T target-host --
```

The feature:

- Supports saved SSH aliases and manually configured hosts.
- Applies to remote probes, installation commands, and the app-server proxy.
- Persists the wrapper as an argv array rather than a shell snippet.
- Supports POSIX-style quoting and escaping while rejecting unquoted shell operators, newlines, malformed quoting, and oversized input.
- Includes the wrapper in the SSH startup-gate identity.
- Preserves upstream behavior when no wrapper is configured.
- Remains disabled by default.

No issue is currently linked.

## Validation

Passed:

- `node --test linux-features/ssh-command-wrapper/test.js`
  - 9/9 focused tests passed.
- `node --test scripts/patch-linux-window-ui.test.js`
  - 387/387 tests passed.
- `git diff --check`
- Latest upstream DMG rebuild and acceptance:
  - App version: `26.721.41059`
  - Both feature descriptors applied.
  - No acceptance warnings or blockers.
- Verified the final patch against pristine JavaScript extracted from the latest upstream DMG:
  - Main-process and webview bundles have valid syntax.
  - The generic `ssh -T target-host --` placeholder is present.
  - Both patches are idempotent.
  - The feature composes with the `remote-mobile-control` patches.
- Manual end-to-end test:
  - Configured an SSH connection with `ssh -T login1 --`.
  - Connected through Codex and ran `hostname` from the remote task.
  - Confirmed the app-server was running on `login1`.

Broader local validation encountered two reproducible environment-dependent failures unrelated to this change:

- `node --test linux-features/*/test.js`
  - 816/817 tests passed.
  - The `shared-app-server-socket` integration test failed because the locally installed Codex app-server exited before creating its test socket.
- `bash tests/scripts_smoke.sh`
  - Reached launcher CLI-resolution validation, then failed because this environment resolved `/usr/bin/codex` instead of the test’s expected Linuxbrew installation.

Known risk: this optional feature patches the current upstream minified SSH transport and settings bundles. Future upstream bundle drift may cause the fail-soft descriptors to skip until their current-DMG needles are updated.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area. *(Not applicable: this is a new opt-in feature, validated against only the latest DMG.)*
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass. *(Tests were added and run locally; awaiting GitHub CI.)*
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.