### PR TITLE
Stabilize Dock settings matching across minified aliases

### DIFF
--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -50,7 +50,7 @@ const currentTraySource =
 const currentMainSource = currentAppInfoSource + currentRuntimeSource + currentTraySource;
 
 const currentSettingsSource =
-  "function oa(){let e=(0,Q.c)(27),t=B(C),n=z(),{platform:r}=_t(),{data:i}=H(Kn),a=V(K.dockIconPreference),o;if(e[0]===t)o=e[1];else{o=function(e){c(t,K.dockIconPreference,e)},e[0]=t,e[1]=o}let s=o;if(r!==`macOS`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null;let c=i?.dockIconPreviews;if(c==null)return null;return W(c,s)}";
+  "function oa(){let e=(0,Q.c)(27),t=B(C),n=z(),{platform:r}=_t(),{data:i}=H(Kn),a=V(K.dockIconPreference),o;if(e[0]===t)o=e[1];else{o=function(e){c(t,K.dockIconPreference,e)},e[0]=t,e[1]=o}let s=o;if(r!==`macOS`||un.ChatGPT!==`chatgpt`||yt.Agent===`prod`)return null;let c=i?.dockIconPreviews;if(c==null)return null;return W(c,s)}";
 
 const currentSearchSource = applyLinuxSettingsSearchVisibilityPatch([
   "function qn(e){let t=(0,Zn.c)(17),n=re(),r=Bn(e),{data:i}=_(e),a=i?.isSystemBackdropSupported!==!1,o=i?.platform===`darwin`,{data:s}=T(k,e.selectedHostId),c,l=c;if(a){let e;e=e=>e.sectionSlug===`appearance`&&!a?{...e,messages:e.messages.filter(Jn)}:e.sectionSlug===`agent`?{...e,terms:[]}:e,m=r.map(e)}else m=r;return m}",
@@ -242,13 +242,45 @@ test("settings patch exposes the native row on Linux", () => {
   assert.deepEqual(secondPass.warnings, []);
 });
 
+test("settings patch preserves current minified aliases across renderer churn", () => {
+  const nextAliases = currentSettingsSource.replace(
+    "if(r!==`macOS`||un.ChatGPT!==`chatgpt`||yt.Agent===`prod`)return null",
+    "if(platformAlias!==`macOS`||brandAlias.ChatGPT!==`chatgpt`||buildAlias.Agent===`prod`)return null",
+  );
+  const patched = applyDockIconSettingsPatch(nextAliases);
+  const secondPass = captureWarns(() => applyDockIconSettingsPatch(patched));
+
+  assert.match(
+    patched,
+    /if\(platformAlias!==`macOS`&&platformAlias!==`linux`\|\|brandAlias\.ChatGPT!==`chatgpt`\|\|buildAlias\.Agent===`prod`\)return null/,
+  );
+  assert.equal(secondPass.value, patched);
+  assert.deepEqual(secondPass.warnings, []);
+  assert.equal(descriptors[1].assetMatch(nextAliases), true);
+  assert.equal(descriptors[1].assetMatch(patched), true);
+});
+
 test("settings drift remains byte-identical", () => {
-  const drifted = currentSettingsSource.replace("oe.Agent===`prod`", "oe.Agent!==`prod`");
+  const drifted = currentSettingsSource.replace("yt.Agent===`prod`", "yt.Agent!==`prod`");
   const { value, warnings } = captureWarns(() => applyDockIconSettingsPatch(drifted));
 
   assert.equal(value, drifted);
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /current Dock icon settings contract/);
+});
+
+test("settings duplicate and mixed contracts remain byte-identical", () => {
+  const patched = applyDockIconSettingsPatch(currentSettingsSource);
+  for (const source of [
+    currentSettingsSource + currentSettingsSource,
+    currentSettingsSource + patched,
+  ]) {
+    const { value, warnings } = captureWarns(() => applyDockIconSettingsPatch(source));
+    assert.equal(value, source);
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /current Dock icon settings contract/);
+    assert.equal(descriptors[1].assetMatch(source), false);
+  }
 });
 
 test("search patch restores Dock icon results after the Linux core patch", () => {

--- a/linux-features/ui-tweaks/dock-icon.test.js
+++ b/linux-features/ui-tweaks/dock-icon.test.js
@@ -271,9 +271,13 @@ test("settings drift remains byte-identical", () => {
 
 test("settings duplicate and mixed contracts remain byte-identical", () => {
   const patched = applyDockIconSettingsPatch(currentSettingsSource);
+  const drifted = currentSettingsSource.replace("yt.Agent===`prod`", "yt.Agent!==`prod`");
   for (const source of [
     currentSettingsSource + currentSettingsSource,
     currentSettingsSource + patched,
+    currentSettingsSource + drifted,
+    patched + drifted,
+    patched + patched,
   ]) {
     const { value, warnings } = captureWarns(() => applyDockIconSettingsPatch(source));
     assert.equal(value, source);

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -101,24 +101,48 @@ function applyDockIconMainPatch(source) {
   );
 }
 
-const currentSettingsGate =
-  "if(r!==`macOS`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null";
-const patchedSettingsGate =
-  "if(r!==`macOS`&&r!==`linux`||ke.ChatGPT!==`chatgpt`||oe.Agent===`prod`)return null";
+const currentSettingsGatePattern =
+  /if\(([A-Za-z_$][\w$]*)!==`macOS`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
+const patchedSettingsGatePattern =
+  /if\(([A-Za-z_$][\w$]*)!==`macOS`&&\1!==`linux`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
+
+function settingsGateMatches(source, pattern) {
+  pattern.lastIndex = 0;
+  return [...source.matchAll(pattern)];
+}
+
+function dockIconSettingsContract(source) {
+  const currentMatches = settingsGateMatches(source, currentSettingsGatePattern);
+  const patchedMatches = settingsGateMatches(source, patchedSettingsGatePattern);
+  if (currentMatches.length === 1 && patchedMatches.length === 0) {
+    return "current";
+  }
+  if (currentMatches.length === 0 && patchedMatches.length === 1) {
+    return "patched";
+  }
+  return "drifted";
+}
 
 function applyDockIconSettingsPatch(source) {
-  const currentCount = countOccurrences(source, currentSettingsGate);
-  const patchedCount = countOccurrences(source, patchedSettingsGate);
-  if (currentCount === 0 && patchedCount === 1) {
+  const contract = dockIconSettingsContract(source);
+  if (contract === "patched") {
     return source;
   }
-  if (currentCount !== 1 || patchedCount !== 0) {
+  if (contract !== "current") {
     console.warn(
       "WARN: Could not find the current Dock icon settings contract - skipping Dock icon settings patch",
     );
     return source;
   }
-  return source.replace(currentSettingsGate, patchedSettingsGate);
+  return source.replace(
+    currentSettingsGatePattern,
+    (
+      _match,
+      platformAlias,
+      brandAlias,
+      buildFlavorAlias,
+    ) => `if(${platformAlias}!==\`macOS\`&&${platformAlias}!==\`linux\`||${brandAlias}.ChatGPT!==\`chatgpt\`||${buildFlavorAlias}.Agent===\`prod\`)return null`,
+  );
 }
 
 const currentSearchFilter =
@@ -156,8 +180,7 @@ const descriptors = [
     order: 20_950,
     ciPolicy: "optional",
     pattern: /^general-settings-[A-Za-z0-9_-]+\.js$/,
-    assetMatch: (source) =>
-      hasCompleteSinglePointContract(source, currentSettingsGate, patchedSettingsGate),
+    assetMatch: (source) => dockIconSettingsContract(source) !== "drifted",
     missingDescription: "General settings Dock icon bundle",
     skipDescription: "Dock icon settings row patch",
     enabled: dockIconEnabled,

--- a/linux-features/ui-tweaks/patches/dock-icon.js
+++ b/linux-features/ui-tweaks/patches/dock-icon.js
@@ -105,6 +105,7 @@ const currentSettingsGatePattern =
   /if\(([A-Za-z_$][\w$]*)!==`macOS`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
 const patchedSettingsGatePattern =
   /if\(([A-Za-z_$][\w$]*)!==`macOS`&&\1!==`linux`\|\|([A-Za-z_$][\w$]*)\.ChatGPT!==`chatgpt`\|\|([A-Za-z_$][\w$]*)\.Agent===`prod`\)return null/g;
+const settingsRowAnchorPattern = /\.dockIconPreviews\b/g;
 
 function settingsGateMatches(source, pattern) {
   pattern.lastIndex = 0;
@@ -112,12 +113,24 @@ function settingsGateMatches(source, pattern) {
 }
 
 function dockIconSettingsContract(source) {
+  if (typeof source !== "string") {
+    return "drifted";
+  }
   const currentMatches = settingsGateMatches(source, currentSettingsGatePattern);
   const patchedMatches = settingsGateMatches(source, patchedSettingsGatePattern);
-  if (currentMatches.length === 1 && patchedMatches.length === 0) {
+  const rowAnchors = settingsGateMatches(source, settingsRowAnchorPattern);
+  if (
+    rowAnchors.length === 1 &&
+    currentMatches.length === 1 &&
+    patchedMatches.length === 0
+  ) {
     return "current";
   }
-  if (currentMatches.length === 0 && patchedMatches.length === 1) {
+  if (
+    rowAnchors.length === 1 &&
+    currentMatches.length === 0 &&
+    patchedMatches.length === 1
+  ) {
     return "patched";
   }
   return "drifted";


### PR DESCRIPTION
## Summary

- Match the current Dock icon settings gate by its complete semantic contract instead of fixed minified aliases.
- Preserve the current platform, brand, and build-flavor aliases in the replacement.
- Reject duplicate, mixed, or incomplete contracts byte-identically with the existing warning/skip behavior.
- Cover current aliases, arbitrary alias churn, idempotency, drift, and ambiguous contracts.

## Current DMG

- App: `26.721.41059`
- Electron: `42.3.0`
- SHA-256: `ae864e2def7db56d0bb77a876a5cbe4e4c2f554ccc654cec921b946892583c0a`
- Size: `593861752` bytes
- ETag: `0x8DEE9C4DB44D751`
- Last-Modified: `Fri, 24 Jul 2026 20:48:03 GMT`
- Content-Length: `593861752`

## Reproduction

On current `origin/main` (`c6d76231f0623c3ef0b18c7e9158697c96bdcf9f`) with the user's 10 enabled Linux features, upstream DMG acceptance rejected the candidate with one blocker:

```text
feature:ui-tweaks:appearance-dock-icon-settings-row
Could not find General settings Dock icon bundle
```

The active asset remained `general-settings-D7HslvR1.js` and contained exactly one complete Dock settings contract. Only local minifier aliases had changed to `un.ChatGPT` and `yt.Agent`, so the fixed `ke.ChatGPT` / `oe.Agent` needle reported false drift.

This complements #1113 and #1148: asset discovery was correct, but the final settings gate still encoded unstable local aliases.

## Validation

- `node --check linux-features/ui-tweaks/patches/dock-icon.js`
- `node --test linux-features/ui-tweaks/dock-icon.test.js`: 26/26
- `node --test linux-features/ui-tweaks/test.js linux-features/ui-tweaks/*.test.js`: 90/90
- `node --test scripts/patch-linux-window-ui.test.js`: 398/398
- Real active asset proof: one match, changed on first pass, byte-identical on second pass.
- Exact current-DMG rebuild with all 10 enabled features: `accepted`, zero blockers, zero warnings, all 12 UI Tweaks descriptors applied.
- Affected second pass: all 12 UI Tweaks descriptors reported `already-applied`.
- Side-by-side KDE Plasma/Wayland runtime: Settings opened, Suggested Prompts was active, the Dock icon row rendered, selection changed immediately, persisted after a cold restart, and was restored to the original Codex selection.

I will continue monitoring and maintaining the Dock icon and Suggested Prompts opt-ins as upstream desktop contracts change.
