### PR TITLE
Recover stale npm Codex CLI upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Updater-managed npm Codex CLI installs now serialize across daemon, launcher,
+  and status processes. If an interrupted npm upgrade leaves the exact
+  user-owned Arborist retirement directory that blocks every later install
+  with `ENOTEMPTY`, the updater removes only that validated directory and
+  retries once.
 - Concurrent updater entrypoints now serialize state reloads and cache cleanup
   before persisting startup state. A second process can no longer prune an
   active rebuild workspace, while forced checks wait for startup maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   the condition under the shared lock, records crash-durable quarantines, and
   retries npm once per explicit invocation without discarding failed recovery
   state or concurrent updater state. In-flight mutating npm children retain the
-  lock if their updater parent exits abruptly, and late routine CLI checks
-  revalidate both the repair journal and their original CLI state before
-  persisting a result. Missing-CLI preflight also re-resolves a CLI installed
-  while it waited for the lock before consulting npm.
+  lock under a parent-independent bounded supervisor, which terminates their
+  process group and releases the lock if the updater parent exits abruptly.
+  Late routine CLI checks revalidate both the repair journal and their original
+  CLI state before persisting a result. Missing-CLI preflight also re-resolves a
+  CLI installed while it waited for the lock before consulting npm.
 - Concurrent updater entrypoints now serialize state reloads and cache cleanup
   before persisting startup state. A second process can no longer prune an
   active rebuild workspace, while forced checks wait for startup maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   and status processes. If npm reports the exact stale Arborist retirement
   directory failure, automatic paths preserve the working CLI and direct the
   user to read-only diagnostics. The explicit `repair-cli` command revalidates
-  the condition under the shared lock, quarantines the directory, and retries
-  npm once without discarding a failed recovery.
+  the condition under the shared lock, records crash-durable quarantines, and
+  retries npm once per explicit invocation without discarding failed recovery
+  state or concurrent updater state. In-flight mutating npm children retain the
+  lock if their updater parent exits abruptly, and late routine CLI checks
+  revalidate both the repair journal and their original CLI state before
+  persisting a result. Missing-CLI preflight also re-resolves a CLI installed
+  while it waited for the lock before consulting npm.
 - Concurrent updater entrypoints now serialize state reloads and cache cleanup
   before persisting startup state. A second process can no longer prune an
   active rebuild workspace, while forced checks wait for startup maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   user to read-only diagnostics. The explicit `repair-cli` command revalidates
   the condition under the shared lock, records crash-durable quarantines, and
   retries npm once per explicit invocation without discarding failed recovery
-  state or concurrent updater state. In-flight mutating npm children retain the
-  lock under a parent-independent bounded supervisor, which terminates their
-  process group and releases the lock if the updater parent exits abruptly.
+  state or concurrent updater state. A parent-independent bounded supervisor
+  retains the lock while mutating npm children run without inheriting it,
+  terminates their complete process group, and releases the lock if the updater
+  parent exits abruptly or the npm leader leaves a background descendant.
   Late routine CLI checks revalidate both the repair journal and their original
   CLI state before persisting a result. Missing-CLI preflight also re-resolves a
   CLI installed while it waited for the lock before consulting npm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - Updater-managed npm Codex CLI installs now serialize across daemon, launcher,
-  and status processes. If an interrupted npm upgrade leaves the exact
-  user-owned Arborist retirement directory that blocks every later install
-  with `ENOTEMPTY`, the updater removes only that validated directory and
-  retries once.
+  and status processes. If npm reports the exact stale Arborist retirement
+  directory failure, automatic paths preserve the working CLI and direct the
+  user to read-only diagnostics. The explicit `repair-cli` command revalidates
+  the condition under the shared lock, quarantines the directory, and retries
+  npm once without discarding a failed recovery.
 - Concurrent updater entrypoints now serialize state reloads and cache cleanup
   before persisting startup state. A second process can no longer prune an
   active rebuild workspace, while forced checks wait for startup maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
   retries npm once per explicit invocation without discarding failed recovery
   state or concurrent updater state. A parent-independent bounded supervisor
   retains the lock while mutating npm children run without inheriting it,
-  terminates their complete process group, and releases the lock if the updater
-  parent exits abruptly or the npm leader leaves a background descendant.
+  terminates their complete process group, and releases the lock only after
+  cleanup if the updater parent or supervisor exits abruptly or the npm leader
+  leaves a background descendant.
   Late routine CLI checks revalidate both the repair journal and their original
   CLI state before persisting a result. Missing-CLI preflight also re-resolves a
   CLI installed while it waited for the lock before consulting npm.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "codex-update-manager"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -39,11 +39,36 @@ codex-update-manager repair-cli
 ```
 
 `repair-cli` acquires the shared CLI install lock, reloads the dedicated repair
-journal, derives and revalidates the managed npm paths, and records the planned
+journal, derives and revalidates the managed npm paths, and records each planned
 quarantine before moving the stale directory. It then retries npm once with a
-bounded subprocess. The quarantine is preserved and reported after both
-successful and failed repairs. A failed or interrupted repair remains visible
-in later `diagnose` output and can be retried explicitly.
+bounded subprocess. Quarantines are preserved and reported after both
+successful and failed repairs, including when npm recreates the same retirement
+directory during a later explicit retry. A failed or interrupted repair remains
+visible in later `diagnose` output and can be retried explicitly.
+
+Only mutating npm children inherit the CLI install lock descriptor. If the
+updater parent exits abruptly while npm is still running, other updater
+entrypoints continue waiting until that npm process releases the lock. When an
+entrypoint first encounters contention, its PID is recorded in the updater log.
+
+CLI maintenance and the updater lifecycle merge their separately owned fields
+under a shared state lock. Concurrent daemon, status, and launcher processes
+therefore cannot overwrite a newer CLI result with an older full-state
+snapshot. Before routine CLI state writes, the process acquires the CLI install
+lock and reloads the repair journal so a late registry result cannot hide a
+newer actionable repair condition. The final state write also compares the CLI
+fields with the caller's original snapshot; if another CLI writer completed
+while the caller was waiting, the caller reloads that result instead of
+overwriting it. A pending journal overrides only CLI status and error text on
+top of the latest persisted CLI identity. Operations that need both locks
+acquire the CLI install lock first and hold the state lock only for the final
+reload, comparison, merge, and atomic write.
+
+Missing-CLI launcher preflight acquires the install lock before changing state
+or consulting the npm registry. After contention, it reloads the latest
+CLI-owned state and re-resolves both the requested and persisted CLI paths. If
+another entrypoint completed installation or repair while it waited, preflight
+uses that CLI without a second registry lookup or install attempt.
 
 The updater scopes permission hardening to the official standalone installer
 process. New managed releases use the caller's existing umask plus the
@@ -136,6 +161,9 @@ Runtime files:
 ```text
 ~/.config/codex-update-manager/config.toml
 ~/.local/state/codex-update-manager/state.json
+~/.local/state/codex-update-manager/state.lock
+~/.local/state/codex-update-manager/cli-install.lock
+~/.local/state/codex-update-manager/cli-repair.json
 ~/.local/state/codex-update-manager/service.log
 ~/.cache/codex-update-manager/
 ~/.cache/codex-desktop/launcher.log

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -22,6 +22,29 @@ installer instead of being replaced through npm. Homebrew/Linuxbrew installs
 are reused and reported, but the updater does not replace them with an
 npm-managed install.
 
+If an interrupted npm upgrade leaves a stale Arborist retirement directory,
+automatic daemon, status, and launcher paths record the exact condition but do
+not remove it or retry npm. A functional existing Codex CLI remains selected,
+and updater status directs the user to the read-only diagnostic command:
+
+```bash
+codex-update-manager diagnose
+```
+
+The diagnostic output explains the stale npm condition and prints the explicit
+repair command:
+
+```bash
+codex-update-manager repair-cli
+```
+
+`repair-cli` acquires the shared CLI install lock, reloads the dedicated repair
+journal, derives and revalidates the managed npm paths, and records the planned
+quarantine before moving the stale directory. It then retries npm once with a
+bounded subprocess. The quarantine is preserved and reported after both
+successful and failed repairs. A failed or interrupted repair remains visible
+in later `diagnose` output and can be retried explicitly.
+
 The updater scopes permission hardening to the official standalone installer
 process. New managed releases use the caller's existing umask plus the
 group/world write restrictions from `0022`; stricter policies such as `0027`

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -46,12 +46,13 @@ successful and failed repairs, including when npm recreates the same retirement
 directory during a later explicit retry. A failed or interrupted repair remains
 visible in later `diagnose` output and can be retried explicitly.
 
-Mutating npm commands run under an internal bounded supervisor that inherits
-the CLI install lock descriptor and owns the npm process group. If the updater
-parent exits abruptly, the supervisor terminates that process group and
-releases the lock. Its own timeout remains active independently of the updater
-parent. When an entrypoint first encounters contention, its PID is recorded in
-the updater log.
+Mutating npm commands run under an internal bounded supervisor that retains the
+CLI install lock while preventing npm and its descendants from inheriting the
+lock descriptor. The supervisor owns the npm process group and terminates any
+remaining descendants before it exits. If the updater parent exits abruptly,
+the supervisor terminates that process group and releases the lock. Its own
+timeout remains active independently of the updater parent. When an entrypoint
+first encounters contention, its PID is recorded in the updater log.
 
 CLI maintenance and the updater lifecycle merge their separately owned fields
 under a shared state lock. Concurrent daemon, status, and launcher processes

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -46,10 +46,12 @@ successful and failed repairs, including when npm recreates the same retirement
 directory during a later explicit retry. A failed or interrupted repair remains
 visible in later `diagnose` output and can be retried explicitly.
 
-Only mutating npm children inherit the CLI install lock descriptor. If the
-updater parent exits abruptly while npm is still running, other updater
-entrypoints continue waiting until that npm process releases the lock. When an
-entrypoint first encounters contention, its PID is recorded in the updater log.
+Mutating npm commands run under an internal bounded supervisor that inherits
+the CLI install lock descriptor and owns the npm process group. If the updater
+parent exits abruptly, the supervisor terminates that process group and
+releases the lock. Its own timeout remains active independently of the updater
+parent. When an entrypoint first encounters contention, its PID is recorded in
+the updater log.
 
 CLI maintenance and the updater lifecycle merge their separately owned fields
 under a shared state lock. Concurrent daemon, status, and launcher processes

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -48,11 +48,13 @@ visible in later `diagnose` output and can be retried explicitly.
 
 Mutating npm commands run under an internal bounded supervisor that retains the
 CLI install lock while preventing npm and its descendants from inheriting the
-lock descriptor. The supervisor owns the npm process group and terminates any
-remaining descendants before it exits. If the updater parent exits abruptly,
-the supervisor terminates that process group and releases the lock. Its own
-timeout remains active independently of the updater parent. When an entrypoint
-first encounters contention, its PID is recorded in the updater log.
+lock descriptor. The supervisor and npm share one dedicated process group; the
+supervisor terminates remaining npm members before it exits, and the updater
+keeps the supervisor unreaped while applying the same cleanup if the supervisor
+itself fails. If the updater parent exits abruptly, the supervisor cleans the
+group before releasing the lock. Its own timeout remains active independently
+of the updater parent. When an entrypoint first encounters contention, its PID
+is recorded in the updater log.
 
 CLI maintenance and the updater lifecycle merge their separately owned fields
 under a shared state lock. Concurrent daemon, status, and launcher processes

--- a/updater/Cargo.toml
+++ b/updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-update-manager"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 
 [dependencies]

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -55,11 +55,18 @@ pub async fn run(cli: Cli) -> Result<()> {
     if let Commands::RunNpmSupervisor {
         owner_pid,
         timeout_millis,
+        install_lock_fd,
         program,
         args,
     } = &cli.command
     {
-        return codex_cli::run_npm_supervisor(*owner_pid, *timeout_millis, program, args);
+        return codex_cli::run_npm_supervisor(
+            *owner_pid,
+            *timeout_millis,
+            *install_lock_fd,
+            program,
+            args,
+        );
     }
 
     let paths = RuntimePaths::detect()?;

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -52,6 +52,16 @@ const POLKIT_AUTH_AGENT_PROCESS_TOKENS: &[&str] = &[
 
 /// Runs the updater command-line entrypoint.
 pub async fn run(cli: Cli) -> Result<()> {
+    if let Commands::RunNpmSupervisor {
+        owner_pid,
+        timeout_millis,
+        program,
+        args,
+    } = &cli.command
+    {
+        return codex_cli::run_npm_supervisor(*owner_pid, *timeout_millis, program, args);
+    }
+
     let paths = RuntimePaths::detect()?;
     if let Commands::Diagnose { json } = &cli.command {
         return run_diagnose_command(&paths, *json).await;
@@ -109,6 +119,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             print_path,
         } => run_recover_standalone_cli(codex_home, install_dir, print_path),
         Commands::RepairCli => run_repair_cli(&mut state, &paths),
+        Commands::RunNpmSupervisor { .. } => {
+            unreachable!("npm supervisor is handled before runtime writes")
+        }
         Commands::PromptInstallCli {
             cli_path,
             print_path,

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -138,7 +138,7 @@ async fn run_diagnose_command(paths: &RuntimePaths, json: bool) -> Result<()> {
 }
 
 fn persist_state(paths: &RuntimePaths, state: &PersistedState) -> Result<()> {
-    state.save(&paths.state_file)
+    state.save_updater(&paths.state_file)
 }
 
 fn persist_if_changed(
@@ -875,16 +875,22 @@ fn run_recover_standalone_cli(
 
 fn run_repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
     let outcome = codex_cli::repair_cli(state, paths)?;
-    match outcome.quarantine_path {
-        Some(path) => println!(
-            "Codex CLI repaired at version {}. Quarantine preserved at {}",
-            outcome.installed_version,
-            path.display()
-        ),
-        None => println!(
+    if outcome.quarantine_paths.is_empty() {
+        println!(
             "Codex CLI repaired at version {}. The stale npm directory was already absent.",
             outcome.installed_version
-        ),
+        );
+    } else {
+        println!(
+            "Codex CLI repaired at version {}. Quarantines preserved at {}",
+            outcome.installed_version,
+            outcome
+                .quarantine_paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
     }
     Ok(())
 }
@@ -1204,7 +1210,7 @@ async fn run_check_cycle_with_options(
         state.dmg_sha256 = Some(downloaded.sha256.clone());
         state.artifact_paths.dmg_path = Some(downloaded.path.clone());
         state.notified_events.clear();
-        state.save(&paths.state_file)?;
+        state.save_updater(&paths.state_file)?;
 
         maybe_notify(
             state,
@@ -3179,15 +3185,6 @@ mod tests {
                     &config, &mut state, &paths,
                 ))
             }
-            "daemon-startup-maintenance" => {
-                let paths = RuntimePaths::detect()?;
-                let config = RuntimeConfig::load_or_default(&paths)?;
-                let mut state = PersistedState::load_or_default(
-                    &paths.state_file,
-                    effective_auto_install(&config),
-                )?;
-                run_daemon_startup_maintenance(&config, &mut state, &paths)
-            }
             "cli-preflight" => {
                 let cli_path = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_CLI_PATH")
                     .map(PathBuf::from)
@@ -3200,6 +3197,13 @@ mod tests {
                     },
                 }))
             }
+            "cli-preflight-install-missing" => runtime.block_on(run(Cli {
+                command: Commands::CliPreflight {
+                    cli_path: None,
+                    print_path: false,
+                    allow_install_missing: true,
+                },
+            })),
             "cli-status" => runtime.block_on(run(Cli {
                 command: Commands::Status { json: true },
             })),

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -108,6 +108,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             install_dir,
             print_path,
         } => run_recover_standalone_cli(codex_home, install_dir, print_path),
+        Commands::RepairCli => run_repair_cli(&mut state, &paths),
         Commands::PromptInstallCli {
             cli_path,
             print_path,
@@ -868,6 +869,22 @@ fn run_recover_standalone_cli(
     let launch_path = codex_cli::recover_standalone_cli(codex_home, install_dir)?;
     if print_path {
         println!("{}", launch_path.display());
+    }
+    Ok(())
+}
+
+fn run_repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
+    let outcome = codex_cli::repair_cli(state, paths)?;
+    match outcome.quarantine_path {
+        Some(path) => println!(
+            "Codex CLI repaired at version {}. Quarantine preserved at {}",
+            outcome.installed_version,
+            path.display()
+        ),
+        None => println!(
+            "Codex CLI repaired at version {}. The stale npm directory was already absent.",
+            outcome.installed_version
+        ),
     }
     Ok(())
 }
@@ -2182,6 +2199,8 @@ mod tests {
         Mock, MockServer, ResponseTemplate,
     };
 
+    mod cli_repair_process_tests;
+
     fn test_paths(root: &std::path::Path) -> RuntimePaths {
         RuntimePaths {
             config_file: root.join("config/config.toml"),
@@ -3160,6 +3179,36 @@ mod tests {
                     &config, &mut state, &paths,
                 ))
             }
+            "daemon-startup-maintenance" => {
+                let paths = RuntimePaths::detect()?;
+                let config = RuntimeConfig::load_or_default(&paths)?;
+                let mut state = PersistedState::load_or_default(
+                    &paths.state_file,
+                    effective_auto_install(&config),
+                )?;
+                run_daemon_startup_maintenance(&config, &mut state, &paths)
+            }
+            "cli-preflight" => {
+                let cli_path = std::env::var_os("CODEX_UPDATE_MANAGER_TEST_CLI_PATH")
+                    .map(PathBuf::from)
+                    .context("missing process test CLI path")?;
+                runtime.block_on(run(Cli {
+                    command: Commands::CliPreflight {
+                        cli_path: Some(cli_path),
+                        print_path: false,
+                        allow_install_missing: false,
+                    },
+                }))
+            }
+            "cli-status" => runtime.block_on(run(Cli {
+                command: Commands::Status { json: true },
+            })),
+            "repair-cli" => runtime.block_on(run(Cli {
+                command: Commands::RepairCli,
+            })),
+            "diagnose" => runtime.block_on(run(Cli {
+                command: Commands::Diagnose { json: false },
+            })),
             other => anyhow::bail!("Unknown updater process test role {other}"),
         }
     }
@@ -4560,6 +4609,7 @@ mod tests {
             temp.path()
                 .join("cache/workspaces/2026.04.28.082247+abcdef12"),
         );
+        state.save(&paths.state_file)?;
 
         let original_home = std::env::var_os("HOME");
         let original_path = std::env::var_os("PATH");

--- a/updater/src/app.rs
+++ b/updater/src/app.rs
@@ -3011,7 +3011,13 @@ mod tests {
                 root.join("missing-settings.json"),
             )
             .env_remove("CODEX_UPDATE_MANAGER_ASSUME_NO_POLKIT_AGENT")
-            .env("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1");
+            .env("CODEX_UPDATE_MANAGER_ASSUME_POLKIT_AGENT", "1")
+            .env_remove("CODEX_CLI_PATH")
+            .env_remove("FNM_DIR")
+            .env_remove("FNM_MULTISHELL_PATH")
+            .env_remove("HOMEBREW_PREFIX")
+            .env_remove("NVM_DIR")
+            .env_remove("XDG_DATA_HOME");
         command.process_group(0);
     }
 

--- a/updater/src/app/tests/cli_repair_process_tests.rs
+++ b/updater/src/app/tests/cli_repair_process_tests.rs
@@ -36,6 +36,7 @@ struct CliRepairProcessFixture {
     install_release: PathBuf,
     install_overlap: PathBuf,
     owner_dir: PathBuf,
+    view_log: PathBuf,
 }
 
 impl CliRepairProcessFixture {
@@ -52,6 +53,7 @@ impl CliRepairProcessFixture {
             ("NPM_INSTALL_RELEASE", &self.install_release),
             ("NPM_INSTALL_OVERLAP", &self.install_overlap),
             ("NPM_OWNER_DIR", &self.owner_dir),
+            ("NPM_VIEW_LOG", &self.view_log),
         ]
     }
 }
@@ -85,8 +87,13 @@ fn prepare_fixture(root: &Path) -> Result<CliRepairProcessFixture> {
     write_executable(
         &bin_dir.join("npm"),
         r#"#!/bin/sh
-if [ "$1" = "view" ]; then
-  echo '0.42.1'
+	if [ "$1" = "view" ]; then
+	  printf 'view\n' >> "$NPM_VIEW_LOG"
+	  if [ "${NPM_VIEW_RESULT:-success}" = "failure" ]; then
+	    printf 'registry unavailable\n' >&2
+	    exit 43
+	  fi
+	  echo '0.42.1'
   exit 0
 fi
 if [ "$1" = "install" ]; then
@@ -132,83 +139,8 @@ exit 1
         install_release: root.join("npm-install.release"),
         install_overlap: root.join("npm-install.overlap"),
         owner_dir: root.join("npm-install.owner"),
+        view_log: root.join("npm-view.log"),
     })
-}
-
-#[test]
-fn concurrent_cli_preflight_status_and_daemon_serialize_npm_install_subprocesses() -> Result<()> {
-    let _env_guard = crate::test_util::env_lock();
-    let temp = tempfile::tempdir()?;
-    let fixture = prepare_fixture(temp.path())?;
-    let status_lock_waiting = temp.path().join("status-cli-install-lock.waiting");
-    let daemon_lock_waiting = temp.path().join("daemon-cli-install-lock.waiting");
-    let common_env = fixture.env();
-
-    let first = spawn_process_test_child(
-        temp.path(),
-        "cli-preflight",
-        &common_env,
-        &[&fixture.install_release],
-    )?;
-    wait_for_process_test_path(&fixture.install_started, "first npm install")?;
-
-    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
-    persisted.cli_last_check_at = None;
-    persisted.remote_headers_fingerprint = Some("must-survive-cli-race".to_string());
-    persisted.save(&fixture.paths.state_file)?;
-
-    let mut daemon_env = common_env.clone();
-    daemon_env.push((
-        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
-        &daemon_lock_waiting,
-    ));
-    let daemon =
-        spawn_process_test_child(temp.path(), "daemon-startup-maintenance", &daemon_env, &[])?;
-    wait_for_process_test_path(&daemon_lock_waiting, "daemon CLI install lock wait")?;
-
-    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
-    persisted.cli_last_check_at = None;
-    persisted.save(&fixture.paths.state_file)?;
-    let mut status_env = common_env.clone();
-    status_env.push((
-        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
-        &status_lock_waiting,
-    ));
-    let status = spawn_process_test_child(temp.path(), "cli-status", &status_env, &[])?;
-    wait_for_process_test_path(&status_lock_waiting, "status CLI install lock wait")?;
-
-    assert_eq!(
-        std::fs::read_to_string(&fixture.install_log)?
-            .lines()
-            .count(),
-        1
-    );
-    assert!(!fixture.install_overlap.exists());
-
-    std::fs::write(&fixture.install_release, b"continue")?;
-    first.wait()?;
-    status.wait()?;
-    daemon.wait()?;
-
-    assert_eq!(
-        std::fs::read_to_string(&fixture.install_log)?
-            .lines()
-            .count(),
-        1
-    );
-    assert!(!fixture.install_overlap.exists());
-    assert!(fixture.stale_directory.exists());
-    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
-    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_some());
-    assert!(persisted
-        .cli_error_message
-        .as_deref()
-        .is_some_and(|message| message.contains("codex-update-manager diagnose")));
-    assert_eq!(
-        persisted.remote_headers_fingerprint.as_deref(),
-        Some("must-survive-cli-race")
-    );
-    Ok(())
 }
 
 #[test]
@@ -273,6 +205,7 @@ fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<
     crate::npm_cli_repair::write_detected_for_test(&fixture.paths, ".codex-cqYkmGXr")?;
     let mut common_env = fixture.env();
     common_env.push(("NPM_INSTALL_RESULT", Path::new("success")));
+    let lock_waiting = temp.path().join("cli-install-lock.waiting");
 
     let repair = spawn_process_test_child(
         temp.path(),
@@ -282,7 +215,7 @@ fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<
     )?;
     wait_for_process_test_path(&fixture.install_started, "explicit repair npm install")?;
     let quarantine_path = crate::npm_cli_repair::snapshot(&fixture.paths)?
-        .and_then(|snapshot| snapshot.quarantine_path)
+        .and_then(|snapshot| snapshot.quarantine_paths.into_iter().next())
         .context("repair should persist its quarantine before running npm")?;
     assert!(!fixture.stale_directory.exists());
     assert!(quarantine_path.exists());
@@ -290,7 +223,13 @@ fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<
     let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
     persisted.remote_headers_fingerprint = Some("must-survive-explicit-repair".to_string());
     persisted.save(&fixture.paths.state_file)?;
-    spawn_process_test_child(temp.path(), "cli-status", &common_env, &[])?.wait()?;
+    let mut status_env = common_env.clone();
+    status_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
+        &lock_waiting,
+    ));
+    let status = spawn_process_test_child(temp.path(), "cli-status", &status_env, &[])?;
+    wait_for_process_test_path(&lock_waiting, "status wait during explicit repair")?;
 
     assert_eq!(
         std::fs::read_to_string(&fixture.install_log)?
@@ -303,6 +242,7 @@ fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<
 
     std::fs::write(&fixture.install_release, b"continue")?;
     repair.wait()?;
+    status.wait()?;
 
     assert_eq!(
         std::fs::read_to_string(&fixture.install_log)?
@@ -320,6 +260,114 @@ fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<
         persisted.remote_headers_fingerprint.as_deref(),
         Some("must-survive-explicit-repair")
     );
+    Ok(())
+}
+
+#[test]
+fn missing_cli_waiter_uses_the_repair_completed_under_the_lock() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+    let temp = tempfile::tempdir()?;
+    let fixture = prepare_fixture(temp.path())?;
+    std::env::set_var("HOME", temp.path().join("home"));
+    crate::npm_cli_repair::write_detected_for_test(&fixture.paths, ".codex-cqYkmGXr")?;
+    std::fs::remove_file(&fixture.cli_path)?;
+
+    let mut repair_env = fixture.env();
+    repair_env.push(("NPM_INSTALL_RESULT", Path::new("success")));
+    let repair = spawn_process_test_child(
+        temp.path(),
+        "repair-cli",
+        &repair_env,
+        &[&fixture.install_release],
+    )?;
+    wait_for_process_test_path(&fixture.install_started, "explicit repair npm install")?;
+    let views_before_waiter = std::fs::read_to_string(&fixture.view_log)?.lines().count();
+
+    let lock_waiting = temp.path().join("missing-cli-lock.waiting");
+    let mut missing_env = fixture.env();
+    missing_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
+        &lock_waiting,
+    ));
+    missing_env.push(("NPM_VIEW_RESULT", Path::new("failure")));
+    let missing = spawn_process_test_child(
+        temp.path(),
+        "cli-preflight-install-missing",
+        &missing_env,
+        &[],
+    )?;
+    wait_for_process_test_path(&lock_waiting, "missing CLI install lock wait")?;
+
+    std::fs::write(&fixture.install_release, b"continue")?;
+    repair.wait()?;
+    missing.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.view_log)?.lines().count(),
+        views_before_waiter
+    );
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    assert_eq!(persisted.cli_status, CliStatus::UpToDate);
+    assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+    assert_eq!(persisted.cli_error_message, None);
+    Ok(())
+}
+
+#[test]
+fn status_loaded_before_repair_cannot_restore_its_stale_cli_snapshot() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+    let temp = tempfile::tempdir()?;
+    let fixture = prepare_fixture(temp.path())?;
+    std::env::set_var("HOME", temp.path().join("home"));
+    crate::npm_cli_repair::write_detected_for_test(&fixture.paths, ".codex-cqYkmGXr")?;
+
+    let entrypoint_loaded = temp.path().join("entrypoint.loaded");
+    let entrypoint_continue = temp.path().join("entrypoint.continue");
+    let mut status_env = fixture.env();
+    status_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_LOADED",
+        &entrypoint_loaded,
+    ));
+    status_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_ENTRYPOINT_CONTINUE",
+        &entrypoint_continue,
+    ));
+    status_env.push(("NPM_VIEW_RESULT", Path::new("failure")));
+    let status = spawn_process_test_child(
+        temp.path(),
+        "cli-status",
+        &status_env,
+        &[&entrypoint_continue],
+    )?;
+    wait_for_process_test_path(&entrypoint_loaded, "status initial state load")?;
+
+    std::fs::write(&fixture.install_release, b"continue")?;
+    let mut repair_env = fixture.env();
+    repair_env.push(("NPM_INSTALL_RESULT", Path::new("success")));
+    spawn_process_test_child(temp.path(), "repair-cli", &repair_env, &[])?.wait()?;
+    let views_after_repair = std::fs::read_to_string(&fixture.view_log)?.lines().count();
+    assert_eq!(views_after_repair, 1);
+    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_none());
+
+    std::fs::write(&entrypoint_continue, b"continue")?;
+    status.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.view_log)?.lines().count(),
+        views_after_repair
+    );
+    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    assert_eq!(persisted.cli_status, CliStatus::UpToDate);
+    assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+    assert_eq!(persisted.cli_error_message, None);
     Ok(())
 }
 

--- a/updater/src/app/tests/cli_repair_process_tests.rs
+++ b/updater/src/app/tests/cli_repair_process_tests.rs
@@ -1,0 +1,360 @@
+use super::*;
+use std::{
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+};
+
+fn write_executable(path: &Path, contents: &str) -> Result<()> {
+    std::fs::write(path, contents)?;
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+fn secure_tree(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))?;
+    for entry in std::fs::read_dir(path)? {
+        secure_tree(&entry?.path())?;
+    }
+    Ok(())
+}
+
+struct CliRepairProcessFixture {
+    root: PathBuf,
+    paths: RuntimePaths,
+    bin_dir: PathBuf,
+    active_package: PathBuf,
+    stale_directory: PathBuf,
+    cli_path: PathBuf,
+    install_log: PathBuf,
+    install_started: PathBuf,
+    install_release: PathBuf,
+    install_overlap: PathBuf,
+    owner_dir: PathBuf,
+}
+
+impl CliRepairProcessFixture {
+    fn env(&self) -> Vec<(&'static str, &Path)> {
+        vec![
+            ("PATH", &self.bin_dir),
+            ("CODEX_UPDATE_MANAGER_TEST_CLI_PATH", &self.cli_path),
+            ("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", &self.root),
+            ("NPM_ACTIVE_PACKAGE", &self.active_package),
+            ("NPM_RETIREMENT_PATH", &self.stale_directory),
+            ("NPM_MANAGED_CLI", &self.cli_path),
+            ("NPM_INSTALL_LOG", &self.install_log),
+            ("NPM_INSTALL_STARTED", &self.install_started),
+            ("NPM_INSTALL_RELEASE", &self.install_release),
+            ("NPM_INSTALL_OVERLAP", &self.install_overlap),
+            ("NPM_OWNER_DIR", &self.owner_dir),
+        ]
+    }
+}
+
+fn prepare_fixture(root: &Path) -> Result<CliRepairProcessFixture> {
+    let paths = process_test_paths(root);
+    paths.ensure_dirs()?;
+    let home = root.join("home");
+    let bin_dir = root.join("cli-bin");
+    let prefix = home.join(".codex-cli-npm");
+    let managed_bin = prefix.join("bin");
+    let active_package = prefix.join("lib/node_modules/@openai/codex");
+    let stale_directory = prefix
+        .join("lib/node_modules/@openai")
+        .join(".codex-cqYkmGXr");
+    std::fs::create_dir_all(&active_package)?;
+    std::fs::create_dir_all(&stale_directory)?;
+    std::fs::create_dir_all(&bin_dir)?;
+    std::fs::create_dir_all(&managed_bin)?;
+
+    let mut config = test_config(root);
+    config.workspace_root = paths.cache_dir.clone();
+    std::fs::write(&paths.config_file, toml::to_string(&config)?)?;
+
+    let cli_path = managed_bin.join("codex");
+    write_executable(
+        &cli_path,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+    )?;
+    write_executable(&bin_dir.join("node"), "#!/bin/sh\nexit 0\n")?;
+    write_executable(
+        &bin_dir.join("npm"),
+        r#"#!/bin/sh
+if [ "$1" = "view" ]; then
+  echo '0.42.1'
+  exit 0
+fi
+if [ "$1" = "install" ]; then
+  printf '%s\n' "$$" >> "$NPM_INSTALL_LOG"
+  if /bin/mkdir "$NPM_OWNER_DIR" 2>/dev/null; then
+    /bin/touch "$NPM_INSTALL_STARTED"
+    while [ ! -e "$NPM_INSTALL_RELEASE" ]; do
+      /bin/sleep 0.01
+    done
+  else
+    /bin/touch "$NPM_INSTALL_OVERLAP"
+  fi
+  if [ "${NPM_INSTALL_RESULT:-stale}" = "success" ]; then
+    printf '%s\n' '#!/bin/sh' 'echo "codex-cli v0.42.1"' > "$NPM_MANAGED_CLI"
+    /bin/chmod 755 "$NPM_MANAGED_CLI"
+    exit 0
+  fi
+  printf '%s\n' \
+    'npm error code ENOTEMPTY' \
+    'npm error syscall rename' \
+    "npm error path $NPM_ACTIVE_PACKAGE" \
+    "npm error dest $NPM_RETIREMENT_PATH" >&2
+  exit 217
+fi
+exit 1
+"#,
+    )?;
+    secure_tree(&home)?;
+
+    let mut state = PersistedState::new(true);
+    state.cli_path = Some(cli_path.clone());
+    state.cli_install_channel = Some(crate::state::CliInstallChannel::Npm);
+    state.save(&paths.state_file)?;
+    Ok(CliRepairProcessFixture {
+        root: root.to_path_buf(),
+        paths,
+        bin_dir,
+        active_package,
+        stale_directory,
+        cli_path,
+        install_log: root.join("npm-install.log"),
+        install_started: root.join("npm-install.started"),
+        install_release: root.join("npm-install.release"),
+        install_overlap: root.join("npm-install.overlap"),
+        owner_dir: root.join("npm-install.owner"),
+    })
+}
+
+#[test]
+fn concurrent_cli_preflight_status_and_daemon_serialize_npm_install_subprocesses() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let temp = tempfile::tempdir()?;
+    let fixture = prepare_fixture(temp.path())?;
+    let status_lock_waiting = temp.path().join("status-cli-install-lock.waiting");
+    let daemon_lock_waiting = temp.path().join("daemon-cli-install-lock.waiting");
+    let common_env = fixture.env();
+
+    let first = spawn_process_test_child(
+        temp.path(),
+        "cli-preflight",
+        &common_env,
+        &[&fixture.install_release],
+    )?;
+    wait_for_process_test_path(&fixture.install_started, "first npm install")?;
+
+    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    persisted.cli_last_check_at = None;
+    persisted.remote_headers_fingerprint = Some("must-survive-cli-race".to_string());
+    persisted.save(&fixture.paths.state_file)?;
+
+    let mut daemon_env = common_env.clone();
+    daemon_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
+        &daemon_lock_waiting,
+    ));
+    let daemon =
+        spawn_process_test_child(temp.path(), "daemon-startup-maintenance", &daemon_env, &[])?;
+    wait_for_process_test_path(&daemon_lock_waiting, "daemon CLI install lock wait")?;
+
+    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    persisted.cli_last_check_at = None;
+    persisted.save(&fixture.paths.state_file)?;
+    let mut status_env = common_env.clone();
+    status_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
+        &status_lock_waiting,
+    ));
+    let status = spawn_process_test_child(temp.path(), "cli-status", &status_env, &[])?;
+    wait_for_process_test_path(&status_lock_waiting, "status CLI install lock wait")?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    assert!(!fixture.install_overlap.exists());
+
+    std::fs::write(&fixture.install_release, b"continue")?;
+    first.wait()?;
+    status.wait()?;
+    daemon.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    assert!(!fixture.install_overlap.exists());
+    assert!(fixture.stale_directory.exists());
+    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_some());
+    assert!(persisted
+        .cli_error_message
+        .as_deref()
+        .is_some_and(|message| message.contains("codex-update-manager diagnose")));
+    assert_eq!(
+        persisted.remote_headers_fingerprint.as_deref(),
+        Some("must-survive-cli-race")
+    );
+    Ok(())
+}
+
+#[test]
+fn waiting_status_revalidates_successful_cli_install_before_running_npm() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let temp = tempfile::tempdir()?;
+    let fixture = prepare_fixture(temp.path())?;
+    let lock_waiting = temp.path().join("cli-install-lock.waiting");
+    let mut common_env = fixture.env();
+    common_env.push(("NPM_INSTALL_RESULT", Path::new("success")));
+
+    let first = spawn_process_test_child(
+        temp.path(),
+        "cli-preflight",
+        &common_env,
+        &[&fixture.install_release],
+    )?;
+    wait_for_process_test_path(&fixture.install_started, "first successful npm install")?;
+
+    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    persisted.cli_last_check_at = None;
+    persisted.remote_headers_fingerprint = Some("must-survive-success-race".to_string());
+    persisted.save(&fixture.paths.state_file)?;
+
+    let mut second_env = common_env.clone();
+    second_env.push((
+        "CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING",
+        &lock_waiting,
+    ));
+    let second = spawn_process_test_child(temp.path(), "cli-status", &second_env, &[])?;
+    wait_for_process_test_path(&lock_waiting, "status CLI install lock wait")?;
+
+    std::fs::write(&fixture.install_release, b"continue")?;
+    first.wait()?;
+    second.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    assert!(!fixture.install_overlap.exists());
+    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_none());
+    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    assert_eq!(persisted.cli_status, CliStatus::UpToDate);
+    assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+    assert_eq!(
+        persisted.remote_headers_fingerprint.as_deref(),
+        Some("must-survive-success-race")
+    );
+    Ok(())
+}
+
+#[test]
+fn explicit_repair_preserves_concurrent_status_state_and_quarantine() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+    let temp = tempfile::tempdir()?;
+    let fixture = prepare_fixture(temp.path())?;
+    std::env::set_var("HOME", temp.path().join("home"));
+    crate::npm_cli_repair::write_detected_for_test(&fixture.paths, ".codex-cqYkmGXr")?;
+    let mut common_env = fixture.env();
+    common_env.push(("NPM_INSTALL_RESULT", Path::new("success")));
+
+    let repair = spawn_process_test_child(
+        temp.path(),
+        "repair-cli",
+        &common_env,
+        &[&fixture.install_release],
+    )?;
+    wait_for_process_test_path(&fixture.install_started, "explicit repair npm install")?;
+    let quarantine_path = crate::npm_cli_repair::snapshot(&fixture.paths)?
+        .and_then(|snapshot| snapshot.quarantine_path)
+        .context("repair should persist its quarantine before running npm")?;
+    assert!(!fixture.stale_directory.exists());
+    assert!(quarantine_path.exists());
+
+    let mut persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    persisted.remote_headers_fingerprint = Some("must-survive-explicit-repair".to_string());
+    persisted.save(&fixture.paths.state_file)?;
+    spawn_process_test_child(temp.path(), "cli-status", &common_env, &[])?.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    assert!(!fixture.install_overlap.exists());
+    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_some());
+
+    std::fs::write(&fixture.install_release, b"continue")?;
+    repair.wait()?;
+
+    assert_eq!(
+        std::fs::read_to_string(&fixture.install_log)?
+            .lines()
+            .count(),
+        1
+    );
+    assert!(!fixture.install_overlap.exists());
+    assert!(crate::npm_cli_repair::load(&fixture.paths)?.is_none());
+    assert!(quarantine_path.exists());
+    let persisted = PersistedState::load_or_default(&fixture.paths.state_file, true)?;
+    assert_eq!(persisted.cli_status, CliStatus::UpToDate);
+    assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+    assert_eq!(
+        persisted.remote_headers_fingerprint.as_deref(),
+        Some("must-survive-explicit-repair")
+    );
+    Ok(())
+}
+
+#[test]
+fn diagnose_subprocess_is_read_only_and_explains_pending_cli_repair() -> Result<()> {
+    let _env_guard = crate::test_util::env_lock();
+    let absent = tempfile::tempdir()?;
+    let child = spawn_process_test_child(absent.path(), "diagnose", &[], &[])?;
+    child.wait()?;
+    assert!(!absent.path().join("xdg-config").exists());
+    assert!(!absent.path().join("xdg-state").exists());
+    assert!(!absent.path().join("xdg-cache").exists());
+
+    let pending = tempfile::tempdir()?;
+    let paths = process_test_paths(pending.path());
+    std::fs::create_dir_all(&paths.state_dir)?;
+    crate::npm_cli_repair::write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+    let journal_path = paths.state_dir.join("cli-repair.json");
+    let before = std::fs::read(&journal_path)?;
+
+    let mut command = std::process::Command::new(std::env::current_exe()?);
+    configure_process_test_command(&mut command, pending.path(), "diagnose");
+    let output = command.output()?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "diagnose subprocess failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stale npm retirement directory"));
+    assert!(stdout.contains("codex-update-manager repair-cli"));
+    assert_eq!(std::fs::read(journal_path)?, before);
+    assert!(!paths.log_file.exists());
+    assert!(!paths.config_file.exists());
+    assert!(!paths.cache_dir.exists());
+    Ok(())
+}

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -1308,6 +1308,7 @@ fi
 
     #[test]
     fn fake_package_builders_emit_source_info() -> Result<()> {
+        let _env_guard = crate::test_util::env_lock();
         let temp = tempdir()?;
         for (index, output) in [
             FakePackageOutput::Deb,

--- a/updater/src/builder.rs
+++ b/updater/src/builder.rs
@@ -122,13 +122,13 @@ pub async fn build_update_from(
 
     state.status = UpdateStatus::PreparingWorkspace;
     state.artifact_paths.workspace_dir = Some(workspace.workspace_dir.clone());
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
 
     copy_builder_bundle(bundle_source, &workspace.bundle_dir)?;
     stage_git_source_info(bundle_source, &workspace.bundle_dir)?;
 
     state.status = UpdateStatus::PatchingApp;
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
     let feature_config = crate::config::effective_feature_config_path(config);
     let mut install = Command::new(workspace.bundle_dir.join("install.sh"));
     install
@@ -158,7 +158,7 @@ pub async fn build_update_from(
         .context("install.sh failed during local rebuild")?;
 
     state.status = UpdateStatus::BuildingPackage;
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
 
     let build_script = package_build_script(&workspace.bundle_dir);
     let mut package_build = Command::new(&build_script);
@@ -190,7 +190,7 @@ pub async fn build_update_from(
         package_path: Some(package_path.clone()),
         rollback_package_path: state.artifact_paths.rollback_package_path.clone(),
     };
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
     info!(candidate_version, package = %package_path.display(), "local update build ready");
 
     Ok(BuildArtifacts {

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -59,6 +59,8 @@ pub enum Commands {
         owner_pid: u32,
         #[arg(long)]
         timeout_millis: u64,
+        #[arg(long)]
+        install_lock_fd: i32,
         program: PathBuf,
         #[arg(last = true, allow_hyphen_values = true)]
         args: Vec<OsString>,

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -1,7 +1,7 @@
 //! Command-line interface definition for the updater binary.
 
 use clap::{Parser, Subcommand};
-use std::path::PathBuf;
+use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug, Parser)]
 #[command(name = "codex-update-manager")]
@@ -53,6 +53,16 @@ pub enum Commands {
         print_path: bool,
     },
     RepairCli,
+    #[command(hide = true)]
+    RunNpmSupervisor {
+        #[arg(long)]
+        owner_pid: u32,
+        #[arg(long)]
+        timeout_millis: u64,
+        program: PathBuf,
+        #[arg(last = true, allow_hyphen_values = true)]
+        args: Vec<OsString>,
+    },
     PromptInstallCli {
         #[arg(long)]
         cli_path: Option<PathBuf>,

--- a/updater/src/cli.rs
+++ b/updater/src/cli.rs
@@ -52,6 +52,7 @@ pub enum Commands {
         #[arg(long)]
         print_path: bool,
     },
+    RepairCli,
     PromptInstallCli {
         #[arg(long)]
         cli_path: Option<PathBuf>,

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -1792,7 +1792,7 @@ fn terminate_process_group_members(process_group: i32, excluded_pid: i32) {
         }
         thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL.min(deadline - Instant::now()));
     }
-    signal_process_group_members(process_group, excluded_pid, SIGKILL);
+    signal_process_group(process_group, SIGKILL);
 }
 
 fn signal_process_group_members(process_group: i32, excluded_pid: i32, signal: i32) -> bool {
@@ -1832,7 +1832,8 @@ fn process_group_member_pidfds(
     excluded_pid: i32,
 ) -> std::io::Result<Vec<OwnedFd>> {
     let mut members = Vec::new();
-    for entry in fs::read_dir("/proc")?.flatten() {
+    for entry in fs::read_dir("/proc")? {
+        let entry = entry?;
         let Some(pid) = entry
             .file_name()
             .to_str()
@@ -1840,7 +1841,7 @@ fn process_group_member_pidfds(
         else {
             continue;
         };
-        if pid == excluded_pid || process_group_for_pid(pid) != Some(process_group) {
+        if pid == excluded_pid || process_group_for_pid(pid)? != Some(process_group) {
             continue;
         }
         let pidfd = {
@@ -1854,17 +1855,42 @@ fn process_group_member_pidfds(
             }
             unsafe { OwnedFd::from_raw_fd(raw_fd) }
         };
-        if process_group_for_pid(pid) == Some(process_group) {
+        if process_group_for_pid(pid)? == Some(process_group) {
             members.push(pidfd);
         }
     }
     Ok(members)
 }
 
-fn process_group_for_pid(pid: i32) -> Option<i32> {
-    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    let after_name = stat.get(stat.rfind(')')? + 1..)?;
-    after_name.split_whitespace().nth(2)?.parse().ok()
+fn process_group_for_pid(pid: i32) -> std::io::Result<Option<i32>> {
+    let stat = match fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let close = stat.rfind(')').ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("process {pid} stat has no command terminator"),
+        )
+    })?;
+    let process_group = stat
+        .get(close + 1..)
+        .and_then(|fields| fields.split_whitespace().nth(2))
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("process {pid} stat has no process group"),
+            )
+        })?
+        .parse::<i32>()
+        .map_err(|error| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("process {pid} stat has an invalid process group: {error}"),
+            )
+        })?;
+    Ok(Some(process_group))
 }
 
 fn signal_process_group(process_group: i32, signal: i32) {

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -64,13 +64,18 @@ enum CliUpdateOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliRepairOutcome {
     pub installed_version: String,
-    pub quarantine_path: Option<PathBuf>,
+    pub quarantine_paths: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ManagedCliInstall {
     cli_path: PathBuf,
     installed_version: String,
+}
+
+enum OptionalDependencyRepairOutcome {
+    Functional(String),
+    RepairRequired,
 }
 
 pub fn preflight(
@@ -95,16 +100,19 @@ fn preflight_with_version_timeout(
     allow_install_missing: bool,
     version_timeout: StdDuration,
 ) -> Result<PreflightOutcome> {
+    let mut routine_baseline = state.clone();
     let requested_path = explicit_cli_path.as_deref();
     let (selected_cli_path, installed_missing_cli) = match resolve_cli_path(requested_path) {
         Some(path) => (path, false),
-        None if allow_install_missing => match install_missing_cli(state, paths) {
-            Ok(path) => (path, true),
-            Err(error) => {
-                persist_cli_failure(state, paths, &error)?;
-                return Err(error);
+        None if allow_install_missing => {
+            match install_missing_cli(state, paths, &mut routine_baseline, requested_path) {
+                Ok(result) => result,
+                Err(error) => {
+                    persist_cli_failure(state, paths, &error, &mut routine_baseline)?;
+                    return Err(error);
+                }
             }
-        },
+        }
         None => anyhow::bail!("Codex CLI not found in PATH or known install locations"),
     };
     let cli_path = match stable_cli_launch_path(&selected_cli_path) {
@@ -116,7 +124,7 @@ fn preflight_with_version_timeout(
             state.cli_installed_version = None;
             state.cli_package_manager_latest_version = None;
             state.cli_last_verified_at = None;
-            persist_cli_failure(state, paths, &error)?;
+            persist_cli_failure(state, paths, &error, &mut routine_baseline)?;
             return Err(error);
         }
     };
@@ -137,15 +145,33 @@ fn preflight_with_version_timeout(
         Err(probe_error) => {
             let Some(missing_dependency) = missing_platform_optional_dependency(&probe_error)
             else {
-                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
+                persist_new_cli_probe_failure(
+                    installed_missing_cli,
+                    state,
+                    paths,
+                    &probe_error,
+                    &mut routine_baseline,
+                )?;
                 return Err(probe_error);
             };
             if managed_cli.is_some() {
-                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
+                persist_new_cli_probe_failure(
+                    installed_missing_cli,
+                    state,
+                    paths,
+                    &probe_error,
+                    &mut routine_baseline,
+                )?;
                 return Err(probe_error);
             }
             let Some(npm_install) = npm_cli_install(&cli_path, &missing_dependency) else {
-                persist_new_cli_probe_failure(installed_missing_cli, state, paths, &probe_error)?;
+                persist_new_cli_probe_failure(
+                    installed_missing_cli,
+                    state,
+                    paths,
+                    &probe_error,
+                    &mut routine_baseline,
+                )?;
                 return Err(probe_error);
             };
 
@@ -160,25 +186,41 @@ fn preflight_with_version_timeout(
             state.cli_last_verified_at = None;
             state.cli_status = CliStatus::Updating;
             state.cli_error_message = None;
-            persist_state(paths, state)?;
+            if persist_routine_state(paths, state, &mut routine_baseline)? {
+                return Err(anyhow!(
+                    "Codex CLI repair is already pending. Run `codex-update-manager diagnose` for details and repair instructions."
+                ));
+            }
 
-            let repaired_version = repair_npm_optional_dependency(&npm_install, paths)
-                .and_then(|()| {
-                    read_installed_version_bounded(&cli_path, version_timeout)
-                })
-                .with_context(|| {
-                    format!(
-                        "Failed to repair npm-managed Codex CLI at {} after its version probe failed: {probe_error}",
-                        cli_path.display()
-                    )
-                });
+            let repaired_version = match repair_npm_optional_dependency(
+                &npm_install,
+                paths,
+                &cli_path,
+                version_timeout,
+            ) {
+                Ok(OptionalDependencyRepairOutcome::Functional(version)) => Ok(version),
+                Ok(OptionalDependencyRepairOutcome::RepairRequired) => {
+                    set_cli_repair_required(state);
+                    persist_routine_state(paths, state, &mut routine_baseline)?;
+                    return Err(anyhow!(
+                        "Codex CLI repair is already pending. Run `codex-update-manager diagnose` for details and repair instructions."
+                    ));
+                }
+                Err(error) => Err(error),
+            }
+            .with_context(|| {
+                format!(
+                    "Failed to repair npm-managed Codex CLI at {} after its version probe failed: {probe_error}",
+                    cli_path.display()
+                )
+            });
             match repaired_version {
                 Ok(version) => {
                     repaired_npm_install = Some(npm_install);
                     version
                 }
                 Err(error) => {
-                    persist_cli_failure(state, paths, &error)?;
+                    persist_cli_failure(state, paths, &error, &mut routine_baseline)?;
                     return Err(error);
                 }
             }
@@ -199,16 +241,11 @@ fn preflight_with_version_timeout(
         .as_ref()
         .map(|status| status.latest_version.clone());
     state.cli_last_verified_at = Some(Utc::now());
-    persist_state(paths, state)?;
-
-    if matches!(cli_install_kind, CliInstallKind::Npm) && npm_cli_repair::load(paths)?.is_some() {
-        set_cli_repair_required(state);
-        persist_state(paths, state)?;
-        return Ok(preflight_outcome_from_state(
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(preflight_outcome_from_current_state(
+            state,
             cli_path,
             installed_version,
-            state,
-            false,
         ));
     }
 
@@ -228,7 +265,13 @@ fn preflight_with_version_timeout(
             managed_cli.as_ref(),
             package_manager_version_status.as_ref(),
         );
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                cli_path,
+                installed_version,
+            ));
+        }
         return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
@@ -240,7 +283,13 @@ fn preflight_with_version_timeout(
     state.cli_last_check_at = Some(Utc::now());
     state.cli_error_message = None;
     state.cli_status = CliStatus::Checking;
-    persist_state(paths, state)?;
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(preflight_outcome_from_current_state(
+            state,
+            cli_path,
+            installed_version,
+        ));
+    }
 
     let latest_version_result =
         repaired_npm_install
@@ -261,7 +310,13 @@ fn preflight_with_version_timeout(
                 state.cli_error_message = Some(format!(
                     "Could not check the latest {CLI_PACKAGE_NAME} version: {error}"
                 ));
-                persist_state(paths, state)?;
+                if persist_routine_state(paths, state, &mut routine_baseline)? {
+                    return Ok(preflight_outcome_from_current_state(
+                        state,
+                        cli_path,
+                        installed_version,
+                    ));
+                }
                 warn!(?error, "unable to check latest Codex CLI version");
                 return Ok(preflight_outcome_from_state(
                     cli_path,
@@ -286,7 +341,13 @@ fn preflight_with_version_timeout(
     );
 
     if managed_cli.is_some() {
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                cli_path,
+                installed_version,
+            ));
+        }
         return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
@@ -303,7 +364,13 @@ fn preflight_with_version_timeout(
             "This Codex CLI appears to be installed through Homebrew at {}. Update it with Homebrew; ChatGPT Desktop will not replace it with an npm-managed install.",
             cli_path.display()
         ));
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                cli_path,
+                installed_version,
+            ));
+        }
         return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
@@ -320,7 +387,13 @@ fn preflight_with_version_timeout(
             state.cli_error_message = Some(format!(
                 "Could not check the latest {CLI_PACKAGE_NAME} version"
             ));
-            persist_state(paths, state)?;
+            if persist_routine_state(paths, state, &mut routine_baseline)? {
+                return Ok(preflight_outcome_from_current_state(
+                    state,
+                    cli_path,
+                    installed_version,
+                ));
+            }
             return Ok(preflight_outcome_from_state(
                 cli_path,
                 installed_version,
@@ -330,7 +403,13 @@ fn preflight_with_version_timeout(
         }
     };
     if state.cli_status == CliStatus::UpToDate {
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                cli_path,
+                installed_version,
+            ));
+        }
         return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
@@ -339,7 +418,13 @@ fn preflight_with_version_timeout(
         ));
     }
     if repaired {
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                cli_path,
+                installed_version,
+            ));
+        }
         return Ok(preflight_outcome_from_state(
             cli_path,
             installed_version,
@@ -348,32 +433,44 @@ fn preflight_with_version_timeout(
         ));
     }
 
-    persist_state(paths, state)?;
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(preflight_outcome_from_current_state(
+            state,
+            cli_path,
+            installed_version,
+        ));
+    }
     info!(
         installed_version,
         latest_version, "Codex CLI is outdated; attempting prelaunch upgrade"
     );
 
     state.cli_status = CliStatus::Updating;
-    persist_state(paths, state)?;
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(preflight_outcome_from_current_state(
+            state,
+            cli_path,
+            installed_version,
+        ));
+    }
     let managed_install =
         match update_existing_cli(&cli_install_kind, &latest_version, state, paths) {
             Ok(CliUpdateOutcome::Updated(managed_install)) => managed_install,
             Ok(CliUpdateOutcome::RepairRequired) => {
                 set_cli_repair_required(state);
-                persist_state(paths, state)?;
-                return Ok(preflight_outcome_from_state(
+                persist_routine_state(paths, state, &mut routine_baseline)?;
+                return Ok(preflight_outcome_from_current_state(
+                    state,
                     cli_path,
                     installed_version,
-                    state,
-                    false,
                 ));
             }
             Err(error) => {
-                persist_cli_failure(state, paths, &error)?;
+                persist_cli_failure(state, paths, &error, &mut routine_baseline)?;
                 return Err(error);
             }
         };
+    routine_baseline = state.clone();
 
     let (refreshed_path, refreshed_version) = if let Some(managed_install) = managed_install {
         (managed_install.cli_path, managed_install.installed_version)
@@ -398,13 +495,25 @@ fn preflight_with_version_timeout(
         );
         state.cli_status = CliStatus::Failed;
         state.cli_error_message = Some(message.clone());
-        persist_state(paths, state)?;
+        if persist_routine_state(paths, state, &mut routine_baseline)? {
+            return Ok(preflight_outcome_from_current_state(
+                state,
+                refreshed_path,
+                refreshed_version,
+            ));
+        }
         anyhow::bail!(message);
     }
 
     state.cli_status = CliStatus::UpToDate;
     state.cli_error_message = None;
-    persist_state(paths, state)?;
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(preflight_outcome_from_current_state(
+            state,
+            refreshed_path,
+            refreshed_version,
+        ));
+    }
     Ok(preflight_outcome_from_state(
         refreshed_path,
         refreshed_version,
@@ -479,12 +588,13 @@ pub fn refresh_cached_status(state: &mut PersistedState, paths: &RuntimePaths) -
 }
 
 pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Result<()> {
+    let mut routine_baseline = state.clone();
     let requested_path = requested_cli_path(state);
     let selected_cli_path = match resolve_cli_path(requested_path.as_deref()) {
         Some(path) => path,
         None => {
             mark_cli_missing(state);
-            persist_state(paths, state)?;
+            persist_routine_state(paths, state, &mut routine_baseline)?;
             return Ok(());
         }
     };
@@ -501,7 +611,7 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
             state.cli_error_message = Some(format!(
                 "Could not read the installed {CLI_PACKAGE_NAME} version: {error:#}"
             ));
-            persist_state(paths, state)?;
+            persist_routine_state(paths, state, &mut routine_baseline)?;
             warn!(?error, "unable to trust selected Codex CLI");
             return Ok(());
         }
@@ -538,7 +648,7 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
             state.cli_error_message = Some(format!(
                 "Could not read the installed {CLI_PACKAGE_NAME} version: {error}"
             ));
-            persist_state(paths, state)?;
+            persist_routine_state(paths, state, &mut routine_baseline)?;
             warn!(?error, "unable to read installed Codex CLI version");
             return Ok(());
         }
@@ -580,14 +690,16 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
             managed_cli.as_ref(),
             package_manager_version_status.as_ref(),
         );
-        persist_state(paths, state)?;
+        persist_routine_state(paths, state, &mut routine_baseline)?;
         return Ok(());
     }
 
     state.cli_last_check_at = Some(Utc::now());
     state.cli_error_message = None;
     state.cli_status = CliStatus::Checking;
-    persist_state(paths, state)?;
+    if persist_routine_state(paths, state, &mut routine_baseline)? {
+        return Ok(());
+    }
 
     match read_latest_version() {
         Ok(latest_version) => {
@@ -636,7 +748,7 @@ pub fn refresh_status(state: &mut PersistedState, paths: &RuntimePaths) -> Resul
         }
     }
 
-    persist_state(paths, state)
+    persist_routine_state(paths, state, &mut routine_baseline).map(|_| ())
 }
 
 pub fn reconcile_if_present(state: &mut PersistedState, paths: &RuntimePaths) -> Result<bool> {
@@ -650,31 +762,38 @@ pub fn reconcile_if_present(state: &mut PersistedState, paths: &RuntimePaths) ->
 }
 
 fn persist_state(paths: &RuntimePaths, state: &mut PersistedState) -> Result<()> {
-    let mut latest =
-        PersistedState::load_or_default(&paths.state_file, state.auto_install_on_app_exit)?;
-    latest.cli_path = state.cli_path.clone();
-    latest.cli_install_channel = state.cli_install_channel.clone();
-    latest.cli_installed_version = state.cli_installed_version.clone();
-    latest.cli_official_latest_version = state.cli_official_latest_version.clone();
-    latest.cli_package_manager_latest_version = state.cli_package_manager_latest_version.clone();
-    latest.cli_status = state.cli_status.clone();
-    latest.cli_last_check_at = state.cli_last_check_at;
-    latest.cli_last_verified_at = state.cli_last_verified_at;
-    latest.cli_error_message = state.cli_error_message.clone();
-    latest.cli_prompt_dismissed_at = state.cli_prompt_dismissed_at;
-    latest.save(&paths.state_file)?;
-    *state = latest;
-    Ok(())
+    state.save_cli(&paths.state_file)
+}
+
+fn persist_routine_state(
+    paths: &RuntimePaths,
+    state: &mut PersistedState,
+    baseline: &mut PersistedState,
+) -> Result<bool> {
+    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    let repair_pending = npm_cli_repair::load(paths)?.is_some();
+    if repair_pending {
+        set_cli_repair_required(state);
+        state.save_cli_status(&paths.state_file)?;
+        *baseline = state.clone();
+        return Ok(true);
+    }
+    let persisted = state.save_cli_if_unchanged(&paths.state_file, baseline)?;
+    if persisted {
+        *baseline = state.clone();
+    }
+    Ok(!persisted)
 }
 
 fn persist_cli_failure(
     state: &mut PersistedState,
     paths: &RuntimePaths,
     error: &anyhow::Error,
+    baseline: &mut PersistedState,
 ) -> Result<()> {
     state.cli_status = CliStatus::Failed;
     state.cli_error_message = Some(format!("{error:#}"));
-    persist_state(paths, state)
+    persist_routine_state(paths, state, baseline).map(|_| ())
 }
 
 fn set_cli_repair_required(state: &mut PersistedState) {
@@ -690,9 +809,10 @@ fn persist_new_cli_probe_failure(
     state: &mut PersistedState,
     paths: &RuntimePaths,
     error: &anyhow::Error,
+    baseline: &mut PersistedState,
 ) -> Result<()> {
     if installed_missing_cli {
-        persist_cli_failure(state, paths, error)?;
+        persist_cli_failure(state, paths, error, baseline)?;
     }
     Ok(())
 }
@@ -994,6 +1114,22 @@ fn preflight_outcome_from_state(
     }
 }
 
+fn preflight_outcome_from_current_state(
+    state: &PersistedState,
+    fallback_path: PathBuf,
+    fallback_version: String,
+) -> PreflightOutcome {
+    preflight_outcome_from_state(
+        state.cli_path.clone().unwrap_or(fallback_path),
+        state
+            .cli_installed_version
+            .clone()
+            .unwrap_or(fallback_version),
+        state,
+        false,
+    )
+}
+
 fn installed_cli_version_satisfies_latest(installed_version: &str, latest_version: &str) -> bool {
     if installed_version == latest_version {
         return true;
@@ -1090,7 +1226,7 @@ fn read_latest_version_with_npm_bounded(
         OsString::from(CLI_PACKAGE_NAME),
         OsString::from("version"),
     ];
-    let output = run_bounded_command_output(npm, path_env, None, &args, timeout, false)?;
+    let output = run_bounded_command_output(npm, path_env, None, &args, timeout, false, None)?;
 
     parse_latest_version_output(npm, &output)
 }
@@ -1222,14 +1358,32 @@ fn path_is_system_managed_location(path: &Path) -> bool {
             .any(|root| path.starts_with(root))
 }
 
-fn repair_npm_optional_dependency(install: &NpmCliInstall, paths: &RuntimePaths) -> Result<()> {
-    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
-    repair_npm_optional_dependency_with_timeout(install, NPM_REPAIR_INSTALL_TIMEOUT)
+fn repair_npm_optional_dependency(
+    install: &NpmCliInstall,
+    paths: &RuntimePaths,
+    cli_path: &Path,
+    version_timeout: StdDuration,
+) -> Result<OptionalDependencyRepairOutcome> {
+    let install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    if npm_cli_repair::load(paths)?.is_some() {
+        return Ok(OptionalDependencyRepairOutcome::RepairRequired);
+    }
+    if let Ok(version) = read_installed_version_bounded(cli_path, version_timeout) {
+        return Ok(OptionalDependencyRepairOutcome::Functional(version));
+    }
+    repair_npm_optional_dependency_with_timeout(
+        install,
+        NPM_REPAIR_INSTALL_TIMEOUT,
+        Some(&install_lock),
+    )?;
+    read_installed_version_bounded(cli_path, version_timeout)
+        .map(OptionalDependencyRepairOutcome::Functional)
 }
 
 fn repair_npm_optional_dependency_with_timeout(
     install: &NpmCliInstall,
     timeout: StdDuration,
+    install_lock: Option<&npm_cli_repair::InstallLock>,
 ) -> Result<()> {
     let args = [
         OsString::from("install"),
@@ -1242,6 +1396,7 @@ fn repair_npm_optional_dependency_with_timeout(
         &args,
         timeout,
         true,
+        install_lock,
     )?;
 
     anyhow::ensure!(
@@ -1262,7 +1417,7 @@ fn run_bounded_command(
     args: &[OsString],
     timeout: StdDuration,
 ) -> Result<String> {
-    let output = run_bounded_command_output(program, path_env, None, args, timeout, false)?;
+    let output = run_bounded_command_output(program, path_env, None, args, timeout, false, None)?;
     if !output.status.success() {
         anyhow::bail!(
             "{} exited with {}{}",
@@ -1281,6 +1436,7 @@ fn run_bounded_command_output(
     args: &[OsString],
     timeout: StdDuration,
     safe_umask: bool,
+    install_lock: Option<&npm_cli_repair::InstallLock>,
 ) -> Result<Output> {
     let mut command = Command::new(program);
     command
@@ -1294,6 +1450,9 @@ fn run_bounded_command_output(
     }
     if safe_umask {
         apply_safe_child_umask(&mut command);
+    }
+    if let Some(install_lock) = install_lock {
+        install_lock.inherit_with(&mut command);
     }
     command.process_group(0);
 
@@ -2111,20 +2270,35 @@ fn install_latest_cli(
     state: &mut PersistedState,
     paths: &RuntimePaths,
 ) -> Result<CliUpdateOutcome> {
+    let install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    install_latest_cli_locked(latest_version, state, paths, &install_lock)
+}
+
+fn install_latest_cli_locked(
+    latest_version: &str,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    install_lock: &npm_cli_repair::InstallLock,
+) -> Result<CliUpdateOutcome> {
     let (npm, path_env) = npm_program()?;
     let package_spec = format!("{CLI_PACKAGE_NAME}@{latest_version}");
     let local_prefix = npm_cli_repair::managed_prefix();
     prepare_safe_npm_prefix(&local_prefix)?;
-    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
     if npm_cli_repair::load(paths)?.is_some() {
         set_cli_repair_required(state);
-        persist_state(paths, state)?;
+        state.save_cli_status(&paths.state_file)?;
         return Ok(CliUpdateOutcome::RepairRequired);
     }
-    if let Some(install) = current_managed_install(latest_version).ok().flatten() {
-        record_managed_install(state, latest_version, &install);
-        persist_state(paths, state)?;
-        return Ok(CliUpdateOutcome::Updated(Some(install)));
+    match current_managed_install(latest_version) {
+        Ok(Some(install)) => {
+            record_managed_install(state, latest_version, &install);
+            persist_state(paths, state)?;
+            return Ok(CliUpdateOutcome::Updated(Some(install)));
+        }
+        Ok(None) => {}
+        Err(error) => {
+            return Err(error).context("Failed to validate the existing managed Codex CLI");
+        }
     }
     let local_args = vec![
         OsString::from("install"),
@@ -2141,6 +2315,7 @@ fn install_latest_cli(
         &local_args,
         NPM_REPAIR_INSTALL_TIMEOUT,
         true,
+        Some(install_lock),
     )?;
     if first_output.status.success() {
         let install = current_managed_install(latest_version)?.with_context(|| {
@@ -2153,7 +2328,7 @@ fn install_latest_cli(
 
     if npm_cli_repair::detect_and_persist(paths, &local_prefix, &first_output)?.is_some() {
         set_cli_repair_required(state);
-        persist_state(paths, state)?;
+        state.save_cli_status(&paths.state_file)?;
         return Ok(CliUpdateOutcome::RepairRequired);
     }
 
@@ -2195,21 +2370,82 @@ fn prepare_safe_npm_prefix(prefix: &Path) -> Result<()> {
 }
 
 pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<CliRepairOutcome> {
-    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
-    let journal = npm_cli_repair::load(paths)?
+    let install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    let mut journal = npm_cli_repair::load(paths)?
         .context("No Codex CLI repair is pending. Run `codex-update-manager diagnose` first.")?;
-    let (npm, path_env) = npm_program()?;
+    let initial_snapshot = npm_cli_repair::validate_journal(&journal)?;
+    let (npm, path_env) = match npm_program() {
+        Ok(command) => command,
+        Err(error) => {
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &initial_snapshot,
+                &format!("Failed to resolve npm for Codex CLI repair: {error:#}"),
+            ));
+        }
+    };
     let latest_version =
-        read_latest_version_with_npm_bounded(&npm, &path_env, NPM_REPAIR_REGISTRY_TIMEOUT)?;
-    let (mut journal, snapshot) = npm_cli_repair::quarantine(paths, journal)?;
+        match read_latest_version_with_npm_bounded(&npm, &path_env, NPM_REPAIR_REGISTRY_TIMEOUT) {
+            Ok(version) => version,
+            Err(error) => {
+                return Err(cli_repair_failure_error(
+                    state,
+                    paths,
+                    &mut journal,
+                    &initial_snapshot,
+                    &format!("Failed to resolve the latest Codex CLI version: {error:#}"),
+                ));
+            }
+        };
+    let snapshot = match npm_cli_repair::quarantine(paths, &mut journal) {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let fallback_snapshot = npm_cli_repair::journal_snapshot(&journal)
+                .unwrap_or_else(|_| initial_snapshot.clone());
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &fallback_snapshot,
+                &format!("Failed to quarantine the stale npm directory: {error:#}"),
+            ));
+        }
+    };
 
-    if let Some(install) = current_managed_install(&latest_version).ok().flatten() {
-        npm_cli_repair::clear(paths)?;
+    if let Some(install) = match current_managed_install(&latest_version) {
+        Ok(install) => install,
+        Err(error) => {
+            warn!(
+                ?error,
+                "managed Codex CLI probe failed during explicit repair"
+            );
+            None
+        }
+    } {
         record_managed_install(state, &latest_version, &install);
-        persist_state(paths, state)?;
+        if let Err(error) = persist_state(paths, state) {
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &snapshot,
+                &format!("Failed to persist repaired Codex CLI state: {error:#}"),
+            ));
+        }
+        if let Err(error) = npm_cli_repair::clear(paths) {
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &snapshot,
+                &format!("Failed to clear the completed Codex CLI repair journal: {error:#}"),
+            ));
+        }
         return Ok(CliRepairOutcome {
             installed_version: install.installed_version,
-            quarantine_path: snapshot.quarantine_path,
+            quarantine_paths: snapshot.quarantine_paths,
         });
     }
 
@@ -2229,12 +2465,17 @@ pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<Cl
         &args,
         NPM_REPAIR_INSTALL_TIMEOUT,
         true,
+        Some(&install_lock),
     ) {
         Ok(output) => output,
         Err(error) => {
-            let message = format!("{error:#}");
-            let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &message)?;
-            anyhow::bail!("{}", repair_failure_message(&message, &snapshot));
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &snapshot,
+                &format!("{error:#}"),
+            ));
         }
     };
     if !output.status.success() {
@@ -2245,49 +2486,118 @@ pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<Cl
             output.status,
             format_command_output(&output)
         );
-        let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &error)?;
-        anyhow::bail!("{}", repair_failure_message(&error, &snapshot));
+        return Err(cli_repair_failure_error(
+            state,
+            paths,
+            &mut journal,
+            &snapshot,
+            &error,
+        ));
     }
 
-    let Some(install) = current_managed_install(&latest_version)? else {
-        let error = format!(
-            "npm completed but Codex CLI {latest_version} could not be resolved after repair"
-        );
-        let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &error)?;
-        anyhow::bail!("{}", repair_failure_message(&error, &snapshot));
+    let install = match current_managed_install(&latest_version) {
+        Ok(Some(install)) => install,
+        Ok(None) => {
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &snapshot,
+                &format!(
+                    "npm completed but Codex CLI {latest_version} could not be resolved after repair"
+                ),
+            ));
+        }
+        Err(error) => {
+            return Err(cli_repair_failure_error(
+                state,
+                paths,
+                &mut journal,
+                &snapshot,
+                &format!(
+                    "npm completed but the repaired Codex CLI could not be validated: {error:#}"
+                ),
+            ));
+        }
     };
 
-    npm_cli_repair::clear(paths)?;
     record_managed_install(state, &latest_version, &install);
-    persist_state(paths, state)?;
+    if let Err(error) = persist_state(paths, state) {
+        return Err(cli_repair_failure_error(
+            state,
+            paths,
+            &mut journal,
+            &snapshot,
+            &format!("Failed to persist repaired Codex CLI state: {error:#}"),
+        ));
+    }
+    if let Err(error) = npm_cli_repair::clear(paths) {
+        return Err(cli_repair_failure_error(
+            state,
+            paths,
+            &mut journal,
+            &snapshot,
+            &format!("Failed to clear the completed Codex CLI repair journal: {error:#}"),
+        ));
+    }
 
     Ok(CliRepairOutcome {
         installed_version: install.installed_version,
-        quarantine_path: snapshot.quarantine_path,
+        quarantine_paths: snapshot.quarantine_paths,
     })
 }
 
-fn persist_cli_repair_failure(
+fn cli_repair_failure_error(
     state: &mut PersistedState,
     paths: &RuntimePaths,
     journal: &mut npm_cli_repair::RepairJournal,
+    fallback_snapshot: &npm_cli_repair::RepairSnapshot,
     error: &str,
-) -> Result<npm_cli_repair::RepairSnapshot> {
-    let snapshot = npm_cli_repair::record_failure(paths, journal, error)?;
+) -> anyhow::Error {
+    let mut persistence_errors = Vec::new();
+    let snapshot = match npm_cli_repair::record_failure(paths, journal, error) {
+        Ok(snapshot) => snapshot,
+        Err(persist_error) => {
+            persistence_errors.push(format!(
+                "failed to persist the Codex CLI repair journal: {persist_error:#}"
+            ));
+            fallback_snapshot.clone()
+        }
+    };
+    let repair_message = repair_failure_message(error, &snapshot);
     state.cli_status = CliStatus::Failed;
     state.cli_error_message = Some(format!(
         "{} Run `codex-update-manager diagnose` before retrying `codex-update-manager repair-cli`.",
-        repair_failure_message(error, &snapshot)
+        repair_message
     ));
-    persist_state(paths, state)?;
-    Ok(snapshot)
+    if let Err(persist_error) = persist_state(paths, state) {
+        persistence_errors.push(format!(
+            "failed to persist updater CLI failure state: {persist_error:#}"
+        ));
+    }
+    if persistence_errors.is_empty() {
+        anyhow!(repair_message)
+    } else {
+        anyhow!("{repair_message}. {}", persistence_errors.join("; "))
+    }
 }
 
 fn repair_failure_message(error: &str, snapshot: &npm_cli_repair::RepairSnapshot) -> String {
-    match snapshot.quarantine_path.as_deref() {
-        Some(path) => format!("{error}. Quarantine preserved at {}", path.display()),
-        None => format!("{error}. The stale npm directory was already absent"),
+    let mut quarantine_paths = snapshot.quarantine_paths.clone();
+    if let Some(path) = snapshot.planned_quarantine_path.as_ref() {
+        if fs::symlink_metadata(path).is_ok() && !quarantine_paths.iter().any(|item| item == path) {
+            quarantine_paths.push(path.clone());
+        }
     }
+    if quarantine_paths.is_empty() {
+        return format!("{error}. No quarantine was created by this attempt");
+    }
+    let paths = quarantine_paths
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{error}. Quarantines preserved at {paths}")
 }
 
 fn current_managed_install(expected_version: &str) -> Result<Option<ManagedCliInstall>> {
@@ -2324,34 +2634,81 @@ fn record_managed_install(
     state.cli_error_message = None;
 }
 
-fn install_missing_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<PathBuf> {
+fn install_missing_cli(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    baseline: &mut PersistedState,
+    requested_path: Option<&Path>,
+) -> Result<(PathBuf, bool)> {
+    install_missing_cli_with_registry_timeout(
+        state,
+        paths,
+        baseline,
+        requested_path,
+        NPM_REPAIR_REGISTRY_TIMEOUT,
+    )
+}
+
+fn install_missing_cli_with_registry_timeout(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    baseline: &mut PersistedState,
+    requested_path: Option<&Path>,
+    registry_timeout: StdDuration,
+) -> Result<(PathBuf, bool)> {
+    let install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    state.reload_cli(&paths.state_file)?;
+    *baseline = state.clone();
+    let persisted_path = state.cli_path.clone();
+    if let Some(path) =
+        resolve_cli_path(requested_path).or_else(|| resolve_cli_path(persisted_path.as_deref()))
+    {
+        return Ok((path, false));
+    }
+    if npm_cli_repair::load(paths)?.is_some() {
+        set_cli_repair_required(state);
+        state.save_cli_status(&paths.state_file)?;
+        *baseline = state.clone();
+        anyhow::bail!(
+            "Codex CLI installation is blocked by stale npm state. Run `codex-update-manager diagnose` for details and repair instructions."
+        );
+    }
     state.cli_status = CliStatus::Updating;
     persist_state(paths, state)?;
+    *baseline = state.clone();
 
-    let latest_version = read_latest_version()?;
+    let (npm, path_env) = npm_program()?;
+    let latest_version = read_latest_version_with_npm_bounded(&npm, &path_env, registry_timeout)?;
     state.cli_official_latest_version = Some(latest_version.clone());
     state.cli_package_manager_latest_version = None;
     persist_state(paths, state)?;
+    *baseline = state.clone();
 
     info!(
         latest_version,
         "Codex CLI is missing; attempting automatic installation"
     );
-    let managed_install = match install_latest_cli(&latest_version, state, paths)? {
+    let managed_install = match install_latest_cli_locked(
+        &latest_version,
+        state,
+        paths,
+        &install_lock,
+    )? {
         CliUpdateOutcome::Updated(Some(install)) => install,
         CliUpdateOutcome::Updated(None) => {
             anyhow::bail!("Managed npm install did not return a Codex CLI path")
         }
         CliUpdateOutcome::RepairRequired => {
             set_cli_repair_required(state);
-            persist_state(paths, state)?;
+            state.save_cli_status(&paths.state_file)?;
             anyhow::bail!(
                 "Codex CLI installation is blocked by stale npm state. Run `codex-update-manager diagnose` for details and repair instructions."
             );
         }
     };
+    *baseline = state.clone();
 
-    Ok(managed_install.cli_path)
+    Ok((managed_install.cli_path, true))
 }
 
 fn run_command<I, S>(program: &Path, args: I) -> Result<String>
@@ -4679,6 +5036,37 @@ exit 1
     }
 
     #[test]
+    fn pending_explicit_repair_blocks_optional_dependency_npm_mutation() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+        let prefix = temp.path().join("npm-prefix");
+        let fixture = write_npm_cli_install(
+            &prefix,
+            "#!/bin/sh\necho 'Missing optional dependency @openai/codex-linux-x64. Reinstall Codex: npm install -g @openai/codex' >&2\nexit 1\n",
+        )?;
+        let npm_log = temp.path().join("npm.log");
+        write_executable_script(
+            &fixture.npm_program,
+            "#!/bin/sh\necho called > \"$NPM_LOG\"\nexit 0\n",
+        )?;
+        let _restore_env = configure_cli_test_env(temp.path(), [prefix.join("bin")])?;
+        std::env::set_var("NPM_LOG", &npm_log);
+        npm_cli_repair::write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+
+        let mut state = PersistedState::new(true);
+        let error = preflight(&mut state, &paths, Some(fixture.visible_cli), false)
+            .expect_err("pending explicit repair must block automatic npm mutation");
+
+        assert!(error.to_string().contains("codex-update-manager diagnose"));
+        assert_eq!(state.cli_status, CliStatus::UpdateRequired);
+        assert!(!npm_log.exists());
+        assert!(npm_cli_repair::load(&paths)?.is_some());
+        Ok(())
+    }
+
+    #[test]
     fn optional_dependency_repair_match_is_specific_to_linux_platform_packages() {
         let linux_error = anyhow::anyhow!(
             "Error: Missing optional dependency @openai/codex-linux-x64. Reinstall Codex: npm install -g @openai/codex"
@@ -4805,9 +5193,12 @@ exit 1
         };
 
         let started = Instant::now();
-        let error =
-            repair_npm_optional_dependency_with_timeout(&install, StdDuration::from_millis(100))
-                .expect_err("a hanging npm repair must time out");
+        let error = repair_npm_optional_dependency_with_timeout(
+            &install,
+            StdDuration::from_millis(100),
+            None,
+        )
+        .expect_err("a hanging npm repair must time out");
 
         assert!(error.to_string().contains("timed out"));
         assert!(started.elapsed() < StdDuration::from_secs(3));
@@ -4881,6 +5272,139 @@ exit 1
         let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
         assert_eq!(persisted.cli_status, CliStatus::Failed);
         assert_eq!(persisted.cli_error_message, state.cli_error_message);
+        Ok(())
+    }
+
+    #[test]
+    fn pending_repair_blocks_missing_cli_registry_and_install_transitions() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        let npm_log = temp.path().join("npm.log");
+        fs::create_dir_all(&bin_dir)?;
+        write_executable_script(
+            &bin_dir.join("npm"),
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 42\n",
+                npm_log.display()
+            ),
+        )?;
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+        npm_cli_repair::write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+
+        let winner_path = temp.path().join("winner/codex");
+        let mut winner = PersistedState::new(true);
+        winner.cli_path = Some(winner_path.clone());
+        winner.cli_installed_version = Some("0.42.1".to_string());
+        winner.remote_headers_fingerprint = Some("must-survive-pending-repair".to_string());
+        winner.save(&paths.state_file)?;
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(temp.path().join("stale/codex"));
+        state.cli_installed_version = Some("0.42.0".to_string());
+        preflight(&mut state, &paths, None, true)
+            .expect_err("pending repair must block a missing CLI installation");
+
+        assert!(!npm_log.exists());
+        assert_eq!(state.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(state.cli_path.as_deref(), Some(winner_path.as_path()));
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert!(state
+            .cli_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("codex-update-manager diagnose")));
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(persisted.cli_path.as_deref(), Some(winner_path.as_path()));
+        assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(
+            persisted.remote_headers_fingerprint.as_deref(),
+            Some("must-survive-pending-repair")
+        );
+        assert_eq!(persisted.cli_error_message, state.cli_error_message);
+        Ok(())
+    }
+
+    #[test]
+    fn pending_repair_during_cli_update_preserves_newer_cli_identity() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        let npm_log = temp.path().join("npm.log");
+        fs::create_dir_all(&bin_dir)?;
+        write_executable_script(
+            &bin_dir.join("npm"),
+            &format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"{}\"\nexit 42\n",
+                npm_log.display()
+            ),
+        )?;
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+        npm_cli_repair::write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+
+        let winner_path = temp.path().join("winner/codex");
+        let mut winner = PersistedState::new(true);
+        winner.cli_path = Some(winner_path.clone());
+        winner.cli_installed_version = Some("0.42.1".to_string());
+        winner.remote_headers_fingerprint = Some("must-survive-update-repair".to_string());
+        winner.save(&paths.state_file)?;
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(temp.path().join("stale/codex"));
+        state.cli_installed_version = Some("0.42.0".to_string());
+        let outcome = install_latest_cli("0.42.1", &mut state, &paths)?;
+
+        assert!(matches!(outcome, CliUpdateOutcome::RepairRequired));
+        assert!(!npm_log.exists());
+        assert_eq!(state.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(state.cli_path.as_deref(), Some(winner_path.as_path()));
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
+        let persisted = PersistedState::load_or_default(&paths.state_file, true)?;
+        assert_eq!(persisted.cli_path.as_deref(), Some(winner_path.as_path()));
+        assert_eq!(persisted.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(
+            persisted.remote_headers_fingerprint.as_deref(),
+            Some("must-survive-update-repair")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_cli_registry_timeout_releases_the_install_lock() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir_all(&bin_dir)?;
+        write_executable_script(
+            &bin_dir.join("npm"),
+            "#!/bin/sh\nif [ \"$1\" = \"view\" ]; then\n  while :; do sleep 1; done\nfi\nexit 42\n",
+        )?;
+        let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
+
+        let mut state = PersistedState::new(true);
+        let mut baseline = state.clone();
+        let started = Instant::now();
+        let error = install_missing_cli_with_registry_timeout(
+            &mut state,
+            &paths,
+            &mut baseline,
+            None,
+            StdDuration::from_millis(100),
+        )
+        .expect_err("a hanging missing-CLI registry lookup must time out");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
+        let _lock = npm_cli_repair::acquire_install_lock(&paths)?;
         Ok(())
     }
 
@@ -5027,8 +5551,12 @@ exit 1
             "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
             "FAKE_CODEX_PATH",
             "NPM_ACTIVE_PACKAGE",
+            "NPM_INSTALL_RESULT",
             "NPM_INSTALL_LOG",
+            "NPM_MANAGED_CLI",
+            "NPM_MANAGED_CLI_DIR",
             "NPM_RETIREMENT_PATH",
+            "NPM_VIEW_RESULT",
         ]);
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
@@ -5118,7 +5646,8 @@ exit 1
 
         let outcome = repair_cli(&mut state, &paths)?;
         assert_eq!(outcome.installed_version, "0.42.1");
-        assert!(outcome.quarantine_path.as_deref().is_some_and(Path::exists));
+        assert_eq!(outcome.quarantine_paths.len(), 1);
+        assert!(outcome.quarantine_paths[0].exists());
         assert!(!retirement_path.exists());
         assert_eq!(fs::read_to_string(&install_log)?, "attempt\nattempt\n");
         assert_eq!(state.cli_status, CliStatus::UpToDate);
@@ -5139,7 +5668,10 @@ exit 1
             "CODEX_CLI_PATH",
             "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
             "NPM_ACTIVE_PACKAGE",
+            "NPM_INSTALL_RESULT",
             "NPM_INSTALL_LOG",
+            "NPM_MANAGED_CLI",
+            "NPM_MANAGED_CLI_DIR",
             "NPM_RETIREMENT_PATH",
         ]);
         let temp = tempdir()?;
@@ -5152,6 +5684,7 @@ exit 1
         let destination = prefix
             .join("lib/node_modules/@openai")
             .join(".codex-cqYkmGXr");
+        let managed_cli = prefix.join("bin/codex");
         let install_log = temp.path().join("npm-install.log");
         fs::create_dir_all(&source)?;
         fs::create_dir_all(&destination)?;
@@ -5162,11 +5695,22 @@ exit 1
             &bin_dir.join("npm"),
             r#"#!/bin/sh
 if [ "$1" = "view" ]; then
+  if [ "${NPM_VIEW_RESULT:-success}" = "failure" ]; then
+    printf 'registry unavailable\n' >&2
+    exit 43
+  fi
   echo '0.42.1'
   exit 0
 fi
 if [ "$1" = "install" ]; then
   printf 'attempt\n' >> "$NPM_INSTALL_LOG"
+  if [ "${NPM_INSTALL_RESULT:-failure}" = "invalid" ]; then
+    /bin/mkdir -p "$NPM_MANAGED_CLI_DIR"
+    printf '%s\n' '#!/bin/sh' 'exit 1' > "$NPM_MANAGED_CLI"
+    /bin/chmod 755 "$NPM_MANAGED_CLI"
+    exit 0
+  fi
+  /bin/mkdir -p "$NPM_RETIREMENT_PATH"
   printf 'retry failed\n' >&2
   exit 42
 fi
@@ -5185,6 +5729,11 @@ exit 1
         std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
         std::env::set_var("NPM_ACTIVE_PACKAGE", &source);
         std::env::set_var("NPM_INSTALL_LOG", &install_log);
+        std::env::set_var("NPM_MANAGED_CLI", &managed_cli);
+        std::env::set_var(
+            "NPM_MANAGED_CLI_DIR",
+            managed_cli.parent().context("managed CLI has no parent")?,
+        );
         std::env::set_var("NPM_RETIREMENT_PATH", &destination);
 
         let mut state = PersistedState::new(true);
@@ -5199,18 +5748,54 @@ exit 1
         let error = repair_cli(&mut state, &paths).expect_err("the retry failure must be returned");
 
         assert!(format!("{error:#}").contains("retry failed"));
-        assert!(format!("{error:#}").contains("Quarantine preserved"));
-        assert_eq!(fs::read_to_string(install_log)?, "attempt\n");
-        assert!(!destination.exists());
+        assert!(format!("{error:#}").contains("Quarantines preserved"));
+        assert_eq!(fs::read_to_string(&install_log)?, "attempt\n");
+        assert!(destination.exists());
         let repair = npm_cli_repair::snapshot(&paths)?.context("repair should remain pending")?;
-        let quarantine = repair
-            .quarantine_path
-            .context("failed repair should record quarantine")?;
-        assert!(quarantine.exists());
+        assert_eq!(repair.quarantine_paths.len(), 1);
+        assert!(repair.quarantine_paths[0].exists());
         assert!(repair
             .last_error
             .as_deref()
             .is_some_and(|message| message.contains("retry failed")));
+
+        std::env::set_var("NPM_VIEW_RESULT", "failure");
+        let error =
+            repair_cli(&mut state, &paths).expect_err("the registry failure must be returned");
+
+        assert!(format!("{error:#}").contains("registry unavailable"));
+        assert!(format!("{error:#}").contains("Quarantines preserved"));
+        assert_eq!(fs::read_to_string(&install_log)?, "attempt\n");
+        assert!(destination.exists());
+        let repair = npm_cli_repair::snapshot(&paths)?.context("repair should remain pending")?;
+        assert_eq!(repair.quarantine_paths.len(), 1);
+        assert!(repair
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.contains("registry unavailable")));
+        std::env::remove_var("NPM_VIEW_RESULT");
+
+        repair_cli(&mut state, &paths).expect_err("the second retry failure must be returned");
+
+        assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
+        assert!(destination.exists());
+        let repair = npm_cli_repair::snapshot(&paths)?.context("repair should remain pending")?;
+        assert_eq!(repair.quarantine_paths.len(), 2);
+        assert!(repair.quarantine_paths.iter().all(|path| path.exists()));
+
+        std::env::set_var("NPM_INSTALL_RESULT", "invalid");
+        let error =
+            repair_cli(&mut state, &paths).expect_err("an invalid repaired CLI must be reported");
+
+        assert!(format!("{error:#}").contains("could not be validated"));
+        assert!(format!("{error:#}").contains("Quarantines preserved"));
+        assert_eq!(state.cli_status, CliStatus::Failed);
+        let repair = npm_cli_repair::snapshot(&paths)?.context("repair should remain pending")?;
+        assert_eq!(repair.quarantine_paths.len(), 3);
+        assert!(repair
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.contains("could not be validated")));
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -15,7 +15,7 @@ use std::{
     ffi::{OsStr, OsString},
     fs,
     io::{Read, Write},
-    os::fd::RawFd,
+    os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd},
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     os::unix::process::{CommandExt, ExitStatusExt},
     path::{Path, PathBuf},
@@ -1505,24 +1505,55 @@ fn run_bounded_command_output(
     };
 
     loop {
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                return Ok(collect_bounded_output(
-                    status,
-                    process_group,
-                    &stdout_rx,
-                    &stderr_rx,
-                ));
+        if supervised {
+            match child_has_exited_without_reaping(&child) {
+                Ok(true) => {
+                    terminate_process_group_members(process_group, child.id() as i32);
+                    let status = child.wait().with_context(|| {
+                        format!(
+                            "Failed to reap npm supervisor for {} {}",
+                            program.display(),
+                            format_command_args(args)
+                        )
+                    })?;
+                    return Ok(collect_bounded_output(
+                        status,
+                        process_group,
+                        &stdout_rx,
+                        &stderr_rx,
+                    ));
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    terminate_process_group(&mut child, process_group);
+                    let _ = child.wait();
+                    anyhow::bail!(
+                        "Failed while waiting for {} {}: {error}",
+                        program.display(),
+                        format_command_args(args)
+                    );
+                }
             }
-            Ok(None) => {}
-            Err(error) => {
-                terminate_process_group(&mut child, process_group);
-                let _ = child.wait();
-                anyhow::bail!(
-                    "Failed while waiting for {} {}: {error}",
-                    program.display(),
-                    format_command_args(args)
-                );
+        } else {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Ok(collect_bounded_output(
+                        status,
+                        process_group,
+                        &stdout_rx,
+                        &stderr_rx,
+                    ));
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    terminate_process_group(&mut child, process_group);
+                    let _ = child.wait();
+                    anyhow::bail!(
+                        "Failed while waiting for {} {}: {error}",
+                        program.display(),
+                        format_command_args(args)
+                    );
+                }
             }
         }
 
@@ -1573,8 +1604,12 @@ pub(crate) fn run_npm_supervisor(
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .process_group(0);
+        .stderr(Stdio::inherit());
+    if cfg!(test) {
+        // Unit tests invoke the supervisor inside the shared test runner rather
+        // than through the production process-group boundary.
+        command.process_group(0);
+    }
     let supervisor_pid = std::process::id();
     unsafe {
         command.pre_exec(move || {
@@ -1593,13 +1628,18 @@ pub(crate) fn run_npm_supervisor(
     let mut child = command
         .spawn()
         .with_context(|| format!("Failed to spawn supervised npm {}", program.display()))?;
-    let process_group = child.id() as i32;
+    let supervisor_pid = std::process::id() as i32;
+    let process_group = if cfg!(test) {
+        child.id() as i32
+    } else {
+        supervisor_pid
+    };
     let started = Instant::now();
 
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
-                terminate_remaining_process_group(process_group);
+                terminate_process_group_members(process_group, supervisor_pid);
                 if status.success() {
                     return Ok(());
                 }
@@ -1607,7 +1647,8 @@ pub(crate) fn run_npm_supervisor(
             }
             Ok(None) => {}
             Err(error) => {
-                terminate_process_group(&mut child, process_group);
+                terminate_process_group_members(process_group, supervisor_pid);
+                let _ = child.kill();
                 let _ = child.wait();
                 return Err(error).with_context(|| {
                     format!(
@@ -1619,12 +1660,14 @@ pub(crate) fn run_npm_supervisor(
         }
 
         if current_parent_pid() != owner_pid {
-            terminate_process_group(&mut child, process_group);
+            terminate_process_group_members(process_group, supervisor_pid);
+            let _ = child.kill();
             let _ = child.wait();
             anyhow::bail!("updater parent exited while npm was running");
         }
         if started.elapsed() >= timeout {
-            terminate_process_group(&mut child, process_group);
+            terminate_process_group_members(process_group, supervisor_pid);
+            let _ = child.kill();
             let _ = child.wait();
             anyhow::bail!(
                 "{} {} timed out after {} seconds",
@@ -1654,6 +1697,23 @@ fn set_close_on_exec(fd: RawFd) -> Result<()> {
 
 fn current_parent_pid() -> u32 {
     unsafe { libc::getppid() as u32 }
+}
+
+fn child_has_exited_without_reaping(child: &std::process::Child) -> std::io::Result<bool> {
+    let mut info = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
+    let result = unsafe {
+        libc::waitid(
+            libc::P_PID,
+            child.id(),
+            info.as_mut_ptr(),
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+        )
+    };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let info = unsafe { info.assume_init() };
+    Ok(unsafe { info.si_pid() } != 0)
 }
 
 fn exit_with_status(status: ExitStatus) -> ! {
@@ -1720,22 +1780,98 @@ fn terminate_process_group(child: &mut std::process::Child, process_group: i32) 
     let _ = child.kill();
 }
 
-fn terminate_remaining_process_group(process_group: i32) {
-    if signal_process_group_checked(process_group, SIGTERM) {
-        thread::sleep(BOUNDED_COMMAND_TERMINATION_GRACE);
-        signal_process_group(process_group, SIGKILL);
+fn terminate_process_group_members(process_group: i32, excluded_pid: i32) {
+    if !signal_process_group_members(process_group, excluded_pid, SIGTERM) {
+        return;
     }
+
+    let deadline = Instant::now() + BOUNDED_COMMAND_TERMINATION_GRACE;
+    while Instant::now() < deadline {
+        if !process_group_has_members(process_group, excluded_pid) {
+            return;
+        }
+        thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL.min(deadline - Instant::now()));
+    }
+    signal_process_group_members(process_group, excluded_pid, SIGKILL);
 }
 
-fn signal_process_group_checked(process_group: i32, signal: i32) -> bool {
-    unsafe { kill(-process_group, signal) == 0 }
+fn signal_process_group_members(process_group: i32, excluded_pid: i32, signal: i32) -> bool {
+    let members = match process_group_member_pidfds(process_group, excluded_pid) {
+        Ok(members) => members,
+        Err(_) => {
+            signal_process_group(process_group, SIGKILL);
+            return true;
+        }
+    };
+    for member in &members {
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                member.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if result == -1 && std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH) {
+            signal_process_group(process_group, SIGKILL);
+            return true;
+        }
+    }
+    !members.is_empty()
+}
+
+fn process_group_has_members(process_group: i32, excluded_pid: i32) -> bool {
+    process_group_member_pidfds(process_group, excluded_pid)
+        .map(|members| !members.is_empty())
+        .unwrap_or(true)
+}
+
+fn process_group_member_pidfds(
+    process_group: i32,
+    excluded_pid: i32,
+) -> std::io::Result<Vec<OwnedFd>> {
+    let mut members = Vec::new();
+    for entry in fs::read_dir("/proc")?.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<i32>().ok())
+        else {
+            continue;
+        };
+        if pid == excluded_pid || process_group_for_pid(pid) != Some(process_group) {
+            continue;
+        }
+        let pidfd = {
+            let raw_fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as i32 };
+            if raw_fd == -1 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ESRCH) {
+                    continue;
+                }
+                return Err(error);
+            }
+            unsafe { OwnedFd::from_raw_fd(raw_fd) }
+        };
+        if process_group_for_pid(pid) == Some(process_group) {
+            members.push(pidfd);
+        }
+    }
+    Ok(members)
+}
+
+fn process_group_for_pid(pid: i32) -> Option<i32> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_name = stat.get(stat.rfind(')')? + 1..)?;
+    after_name.split_whitespace().nth(2)?.parse().ok()
 }
 
 fn signal_process_group(process_group: i32, signal: i32) {
-    // SAFETY: the process was spawned into a dedicated group whose id is the
-    // child pid. Timeout cleanup signals it before reaping the child; after a
-    // successful parent exit this is called only if a descendant still holds a
-    // captured output pipe open.
+    // SAFETY: callers target a dedicated process group while its leader is
+    // alive or deliberately unreaped. The fail-closed member cleanup path may
+    // also terminate its own supervisor, ensuring the lock cannot be released
+    // while an untracked npm descendant remains.
     unsafe {
         let _ = kill(-process_group, signal);
     }
@@ -5470,6 +5606,21 @@ wait
             "#!/bin/sh\nif [ -e \"/proc/self/fd/$NPM_INSTALL_LOCK_FD\" ]; then\n  printf inherited > \"$NPM_LOCK_INHERITED_MARKER\"\n  exit 88\nfi\nexit 0\n",
         )?;
         let install_lock = fs::File::create(temp.path().join("install.lock"))?;
+        let initial_flags = unsafe { libc::fcntl(install_lock.as_raw_fd(), libc::F_GETFD) };
+        anyhow::ensure!(
+            initial_flags != -1,
+            "failed to inspect the test install lock descriptor"
+        );
+        anyhow::ensure!(
+            unsafe {
+                libc::fcntl(
+                    install_lock.as_raw_fd(),
+                    libc::F_SETFD,
+                    initial_flags & !libc::FD_CLOEXEC,
+                )
+            } != -1,
+            "failed to make the test install lock descriptor inheritable"
+        );
         let _restore_env =
             EnvRestoreGuard::capture(&["NPM_INSTALL_LOCK_FD", "NPM_LOCK_INHERITED_MARKER"]);
         std::env::set_var("NPM_INSTALL_LOCK_FD", install_lock.as_raw_fd().to_string());
@@ -5484,6 +5635,12 @@ wait
         )?;
 
         assert!(!inherited_marker.exists());
+        let final_flags = unsafe { libc::fcntl(install_lock.as_raw_fd(), libc::F_GETFD) };
+        anyhow::ensure!(
+            final_flags != -1,
+            "failed to re-inspect the test install lock descriptor"
+        );
+        assert_ne!(final_flags & libc::FD_CLOEXEC, 0);
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -2424,29 +2424,14 @@ pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<Cl
             None
         }
     } {
-        record_managed_install(state, &latest_version, &install);
-        if let Err(error) = persist_state(paths, state) {
-            return Err(cli_repair_failure_error(
-                state,
-                paths,
-                &mut journal,
-                &snapshot,
-                &format!("Failed to persist repaired Codex CLI state: {error:#}"),
-            ));
-        }
-        if let Err(error) = npm_cli_repair::clear(paths) {
-            return Err(cli_repair_failure_error(
-                state,
-                paths,
-                &mut journal,
-                &snapshot,
-                &format!("Failed to clear the completed Codex CLI repair journal: {error:#}"),
-            ));
-        }
-        return Ok(CliRepairOutcome {
-            installed_version: install.installed_version,
-            quarantine_paths: snapshot.quarantine_paths,
-        });
+        return complete_cli_repair(
+            state,
+            paths,
+            &mut journal,
+            snapshot,
+            &latest_version,
+            install,
+        );
     }
 
     let package_spec = format!("{CLI_PACKAGE_NAME}@{latest_version}");
@@ -2521,12 +2506,30 @@ pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<Cl
         }
     };
 
-    record_managed_install(state, &latest_version, &install);
+    complete_cli_repair(
+        state,
+        paths,
+        &mut journal,
+        snapshot,
+        &latest_version,
+        install,
+    )
+}
+
+fn complete_cli_repair(
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+    journal: &mut npm_cli_repair::RepairJournal,
+    snapshot: npm_cli_repair::RepairSnapshot,
+    latest_version: &str,
+    install: ManagedCliInstall,
+) -> Result<CliRepairOutcome> {
+    record_managed_install(state, latest_version, &install);
     if let Err(error) = persist_state(paths, state) {
         return Err(cli_repair_failure_error(
             state,
             paths,
-            &mut journal,
+            journal,
             &snapshot,
             &format!("Failed to persist repaired Codex CLI state: {error:#}"),
         ));
@@ -2535,7 +2538,7 @@ pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<Cl
         return Err(cli_repair_failure_error(
             state,
             paths,
-            &mut journal,
+            journal,
             &snapshot,
             &format!("Failed to clear the completed Codex CLI repair journal: {error:#}"),
         ));

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -13,7 +13,7 @@ use std::{
     collections::BTreeMap,
     ffi::{OsStr, OsString},
     fs,
-    io::{Read, Write},
+    io::{Read, Seek, SeekFrom, Write},
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     os::unix::process::CommandExt,
     path::{Component, Path, PathBuf},
@@ -31,6 +31,7 @@ const CLI_NOT_INSTALLED_MESSAGE: &str =
 const CLI_VERSION_CHECK_TTL: Duration = Duration::hours(1);
 const NPM_REPAIR_INSTALL_TIMEOUT: StdDuration = StdDuration::from_secs(90);
 const NPM_REPAIR_REGISTRY_TIMEOUT: StdDuration = StdDuration::from_secs(20);
+const CLI_INSTALL_LOCK_TIMEOUT: StdDuration = StdDuration::from_secs(120);
 const CLI_PREFLIGHT_VERSION_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 const BOUNDED_COMMAND_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
 const BOUNDED_COMMAND_TERMINATION_GRACE: StdDuration = StdDuration::from_millis(500);
@@ -143,7 +144,7 @@ fn preflight_with_version_timeout(
             state.cli_error_message = None;
             persist_state(paths, state)?;
 
-            let repaired_version = repair_npm_optional_dependency(&npm_install)
+            let repaired_version = repair_npm_optional_dependency(&npm_install, paths)
                 .and_then(|()| {
                     read_installed_version_bounded(&cli_path, version_timeout)
                 })
@@ -326,7 +327,7 @@ fn preflight_with_version_timeout(
 
     state.cli_status = CliStatus::Updating;
     persist_state(paths, state)?;
-    if let Err(error) = update_existing_cli(&cli_install_kind, &latest_version) {
+    if let Err(error) = update_existing_cli(&cli_install_kind, &latest_version, paths) {
         persist_cli_failure(state, paths, &error)?;
         return Err(error);
     }
@@ -1155,7 +1156,8 @@ fn path_is_system_managed_location(path: &Path) -> bool {
             .any(|root| path.starts_with(root))
 }
 
-fn repair_npm_optional_dependency(install: &NpmCliInstall) -> Result<()> {
+fn repair_npm_optional_dependency(install: &NpmCliInstall, paths: &RuntimePaths) -> Result<()> {
+    let _install_lock = acquire_cli_install_lock(paths)?;
     repair_npm_optional_dependency_with_timeout(install, NPM_REPAIR_INSTALL_TIMEOUT)
 }
 
@@ -1379,13 +1381,17 @@ impl StandaloneCliInstall {
     }
 }
 
-fn update_existing_cli(install_kind: &CliInstallKind, latest_version: &str) -> Result<()> {
+fn update_existing_cli(
+    install_kind: &CliInstallKind,
+    latest_version: &str,
+    paths: &RuntimePaths,
+) -> Result<()> {
     match install_kind {
         CliInstallKind::Standalone(install) => update_standalone_cli(install, latest_version),
         CliInstallKind::Homebrew => {
             anyhow::bail!("Homebrew-managed Codex CLI installs must be updated with Homebrew")
         }
-        CliInstallKind::Npm => install_latest_cli(latest_version),
+        CliInstallKind::Npm => install_latest_cli(latest_version, paths),
     }
 }
 
@@ -2030,11 +2036,12 @@ fn resolved_program_path(path: PathBuf) -> PathBuf {
     fs::canonicalize(&path).unwrap_or(path)
 }
 
-fn install_latest_cli(latest_version: &str) -> Result<()> {
+fn install_latest_cli(latest_version: &str, paths: &RuntimePaths) -> Result<()> {
     let (npm, path_env) = npm_program()?;
     let package_spec = format!("{CLI_PACKAGE_NAME}@{latest_version}");
     let local_prefix = local_npm_prefix();
     prepare_safe_npm_prefix(&local_prefix)?;
+    let _install_lock = acquire_cli_install_lock(paths)?;
     let local_args = vec![
         OsString::from("install"),
         OsString::from("-g"),
@@ -2092,6 +2099,72 @@ fn prepare_safe_npm_prefix(prefix: &Path) -> Result<()> {
             .with_context(|| format!("Failed to secure npm prefix {}", prefix.display()))?;
     }
     Ok(())
+}
+
+#[derive(Debug)]
+struct CliInstallLock {
+    _file: fs::File,
+}
+
+fn acquire_cli_install_lock(paths: &RuntimePaths) -> Result<CliInstallLock> {
+    acquire_cli_install_lock_with_timeout(paths, CLI_INSTALL_LOCK_TIMEOUT)
+}
+
+fn acquire_cli_install_lock_with_timeout(
+    paths: &RuntimePaths,
+    timeout: StdDuration,
+) -> Result<CliInstallLock> {
+    let lock_path = paths.state_dir.join("cli-install.lock");
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&lock_path)
+        .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
+    let euid = unsafe { libc::geteuid() };
+    anyhow::ensure!(
+        metadata.is_file() && metadata.uid() == euid,
+        "CLI install lock {} is not a user-owned regular file",
+        lock_path.display()
+    );
+    if metadata.permissions().mode() & 0o077 != 0 {
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
+    }
+
+    let started = Instant::now();
+    loop {
+        match file.try_lock() {
+            Ok(()) => break,
+            Err(fs::TryLockError::WouldBlock) if started.elapsed() < timeout => {
+                thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL);
+            }
+            Err(fs::TryLockError::WouldBlock) => {
+                anyhow::bail!(
+                    "Timed out waiting for another Codex CLI install after {} ms",
+                    timeout.as_millis()
+                );
+            }
+            Err(fs::TryLockError::Error(error)) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to lock {}", lock_path.display()));
+            }
+        }
+    }
+
+    file.set_len(0)
+        .with_context(|| format!("Failed to truncate {}", lock_path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("Failed to seek {}", lock_path.display()))?;
+    writeln!(file, "{}", std::process::id())
+        .with_context(|| format!("Failed to write {}", lock_path.display()))?;
+    Ok(CliInstallLock { _file: file })
 }
 
 fn recover_stale_npm_retirement_directory(prefix: &Path, output: &Output) -> Result<bool> {
@@ -2212,7 +2285,7 @@ fn install_missing_cli(
         latest_version,
         "Codex CLI is missing; attempting automatic installation"
     );
-    install_latest_cli(&latest_version)?;
+    install_latest_cli(&latest_version, paths)?;
 
     let cli_path = resolve_cli_path(requested_path)
         .or_else(|| resolve_cli_path(None))
@@ -2522,8 +2595,30 @@ mod tests {
         test_util::{env_lock, EnvRestoreGuard},
     };
     use chrono::Utc;
-    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+    use std::{
+        fs,
+        os::unix::{fs::PermissionsExt, process::ExitStatusExt},
+        path::Path,
+    };
     use tempfile::tempdir;
+
+    fn npm_enotempty_output(source: &Path, destination: &Path, legacy_prefix: bool) -> Output {
+        let prefix = if legacy_prefix {
+            "npm ERR!"
+        } else {
+            "npm error"
+        };
+        Output {
+            status: ExitStatus::from_raw(217 << 8),
+            stdout: Vec::new(),
+            stderr: format!(
+                "{prefix} code ENOTEMPTY\n{prefix} syscall rename\n{prefix} path {}\n{prefix} dest {}\n{prefix} errno -39\n",
+                source.display(),
+                destination.display()
+            )
+            .into_bytes(),
+        }
+    }
 
     fn write_executable_script(path: &Path, contents: &str) -> Result<()> {
         let temp_root = std::env::temp_dir();
@@ -4951,6 +5046,183 @@ exit 1
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
         assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
         assert!(!retirement_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn cli_install_lock_serializes_updater_processes() -> Result<()> {
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let first = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))?;
+        let started = Instant::now();
+        let error = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(75))
+            .expect_err("a second updater process must not enter the CLI install boundary");
+
+        assert!(error.to_string().contains("Timed out waiting"));
+        assert!(started.elapsed() >= StdDuration::from_millis(75));
+        assert!(started.elapsed() < StdDuration::from_secs(2));
+
+        drop(first);
+        acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))?;
+        Ok(())
+    }
+
+    #[test]
+    fn cli_install_lock_rejects_symlinks() -> Result<()> {
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+        let target = temp.path().join("must-survive");
+        fs::write(&target, "unchanged\n")?;
+        std::os::unix::fs::symlink(&target, paths.state_dir.join("cli-install.lock"))?;
+
+        let error = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))
+            .expect_err("the CLI install lock must not follow symlinks");
+
+        assert!(format!("{error:#}").contains("Failed to open"));
+        assert_eq!(fs::read_to_string(target)?, "unchanged\n");
+        Ok(())
+    }
+
+    #[test]
+    fn stale_npm_recovery_rejects_untrusted_paths() -> Result<()> {
+        let temp = tempdir()?;
+        let prefix = temp.path().join("prefix");
+        prepare_safe_npm_prefix(&prefix)?;
+        let source = prefix.join("lib/node_modules/@openai/codex");
+        let scope = source.parent().context("test package has no scope")?;
+        fs::create_dir_all(&source)?;
+
+        let outside = temp.path().join(".codex-cqYkmGXr");
+        fs::create_dir_all(&outside)?;
+        assert!(!recover_stale_npm_retirement_directory(
+            &prefix,
+            &npm_enotempty_output(&source, &outside, false),
+        )?);
+        assert!(outside.exists());
+
+        let malformed = scope.join(".codex-not-a-retirement-hash");
+        fs::create_dir_all(&malformed)?;
+        assert!(!recover_stale_npm_retirement_directory(
+            &prefix,
+            &npm_enotempty_output(&source, &malformed, false),
+        )?);
+        assert!(malformed.exists());
+
+        let wrong_source = scope.join("another-package");
+        let valid_name = scope.join(".codex-cqYkmGXr");
+        fs::create_dir_all(&valid_name)?;
+        assert!(!recover_stale_npm_retirement_directory(
+            &prefix,
+            &npm_enotempty_output(&wrong_source, &valid_name, false),
+        )?);
+        assert!(valid_name.exists());
+        fs::remove_dir_all(&valid_name)?;
+
+        let symlink_target = temp.path().join("must-survive");
+        fs::create_dir_all(&symlink_target)?;
+        std::os::unix::fs::symlink(&symlink_target, &valid_name)?;
+        let error = recover_stale_npm_retirement_directory(
+            &prefix,
+            &npm_enotempty_output(&source, &valid_name, false),
+        )
+        .expect_err("a retirement symlink must fail closed");
+        assert!(error.to_string().contains("not a regular directory"));
+        assert!(valid_name.is_symlink());
+        assert!(symlink_target.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn stale_npm_recovery_accepts_legacy_error_prefix() -> Result<()> {
+        let temp = tempdir()?;
+        let prefix = temp.path().join("prefix");
+        prepare_safe_npm_prefix(&prefix)?;
+        let source = prefix.join("lib/node_modules/@openai/codex");
+        let destination = prefix
+            .join("lib/node_modules/@openai")
+            .join(".codex-cqYkmGXr");
+        fs::create_dir_all(&source)?;
+        fs::create_dir_all(&destination)?;
+
+        assert!(recover_stale_npm_retirement_directory(
+            &prefix,
+            &npm_enotempty_output(&source, &destination, true),
+        )?);
+        assert!(!destination.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn stale_npm_recovery_retries_only_once() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "XDG_DATA_HOME",
+            "FNM_DIR",
+            "FNM_MULTISHELL_PATH",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            "NPM_ACTIVE_PACKAGE",
+            "NPM_INSTALL_LOG",
+            "NPM_RETIREMENT_PATH",
+        ]);
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+        let home = temp.path().join("home");
+        let bin_dir = temp.path().join("bin");
+        let prefix = home.join(".codex-cli-npm");
+        let source = prefix.join("lib/node_modules/@openai/codex");
+        let destination = prefix
+            .join("lib/node_modules/@openai")
+            .join(".codex-cqYkmGXr");
+        let install_log = temp.path().join("npm-install.log");
+        fs::create_dir_all(&source)?;
+        fs::create_dir_all(&destination)?;
+        fs::create_dir_all(&bin_dir)?;
+        write_executable_script(
+            &bin_dir.join("npm"),
+            r#"#!/bin/sh
+if [ "$1" = "install" ]; then
+  printf 'attempt\n' >> "$NPM_INSTALL_LOG"
+  if [ -d "$NPM_RETIREMENT_PATH" ]; then
+    printf '%s\n' \
+      'npm error code ENOTEMPTY' \
+      'npm error syscall rename' \
+      "npm error path $NPM_ACTIVE_PACKAGE" \
+      "npm error dest $NPM_RETIREMENT_PATH" >&2
+    exit 217
+  fi
+  printf 'retry failed\n' >&2
+  exit 42
+fi
+exit 1
+"#,
+        )?;
+
+        std::env::set_var("HOME", &home);
+        std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("XDG_DATA_HOME");
+        std::env::remove_var("FNM_DIR");
+        std::env::remove_var("FNM_MULTISHELL_PATH");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+        std::env::set_var("NPM_ACTIVE_PACKAGE", &source);
+        std::env::set_var("NPM_INSTALL_LOG", &install_log);
+        std::env::set_var("NPM_RETIREMENT_PATH", &destination);
+
+        let error = install_latest_cli("0.42.1", &paths)
+            .expect_err("the retry failure must be returned to the caller");
+
+        assert!(format!("{error:#}").contains("retry failed"));
+        assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
+        assert!(!destination.exists());
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -3,6 +3,7 @@
 use crate::{
     cli_management,
     config::RuntimePaths,
+    npm_cli_repair,
     state::{CliInstallChannel, CliStatus, PersistedState},
 };
 use anyhow::{anyhow, Context, Result};
@@ -13,10 +14,10 @@ use std::{
     collections::BTreeMap,
     ffi::{OsStr, OsString},
     fs,
-    io::{Read, Seek, SeekFrom, Write},
+    io::{Read, Write},
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     os::unix::process::CommandExt,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     process::{Command, ExitStatus, Output, Stdio},
     sync::mpsc::{self, Receiver, RecvTimeoutError},
     thread,
@@ -31,7 +32,6 @@ const CLI_NOT_INSTALLED_MESSAGE: &str =
 const CLI_VERSION_CHECK_TTL: Duration = Duration::hours(1);
 const NPM_REPAIR_INSTALL_TIMEOUT: StdDuration = StdDuration::from_secs(90);
 const NPM_REPAIR_REGISTRY_TIMEOUT: StdDuration = StdDuration::from_secs(20);
-const CLI_INSTALL_LOCK_TIMEOUT: StdDuration = StdDuration::from_secs(120);
 const CLI_PREFLIGHT_VERSION_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 const BOUNDED_COMMAND_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
 const BOUNDED_COMMAND_TERMINATION_GRACE: StdDuration = StdDuration::from_millis(500);
@@ -53,6 +53,24 @@ pub struct PreflightOutcome {
     pub official_latest_version: Option<String>,
     pub package_manager_latest_version: Option<String>,
     pub updated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CliUpdateOutcome {
+    Updated(Option<ManagedCliInstall>),
+    RepairRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliRepairOutcome {
+    pub installed_version: String,
+    pub quarantine_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ManagedCliInstall {
+    cli_path: PathBuf,
+    installed_version: String,
 }
 
 pub fn preflight(
@@ -80,7 +98,7 @@ fn preflight_with_version_timeout(
     let requested_path = explicit_cli_path.as_deref();
     let (selected_cli_path, installed_missing_cli) = match resolve_cli_path(requested_path) {
         Some(path) => (path, false),
-        None if allow_install_missing => match install_missing_cli(state, paths, requested_path) {
+        None if allow_install_missing => match install_missing_cli(state, paths) {
             Ok(path) => (path, true),
             Err(error) => {
                 persist_cli_failure(state, paths, &error)?;
@@ -182,6 +200,17 @@ fn preflight_with_version_timeout(
         .map(|status| status.latest_version.clone());
     state.cli_last_verified_at = Some(Utc::now());
     persist_state(paths, state)?;
+
+    if matches!(cli_install_kind, CliInstallKind::Npm) && npm_cli_repair::load(paths)?.is_some() {
+        set_cli_repair_required(state);
+        persist_state(paths, state)?;
+        return Ok(preflight_outcome_from_state(
+            cli_path,
+            installed_version,
+            state,
+            false,
+        ));
+    }
 
     if should_skip_latest_version_check(
         state,
@@ -327,13 +356,28 @@ fn preflight_with_version_timeout(
 
     state.cli_status = CliStatus::Updating;
     persist_state(paths, state)?;
-    if let Err(error) = update_existing_cli(&cli_install_kind, &latest_version, paths) {
-        persist_cli_failure(state, paths, &error)?;
-        return Err(error);
-    }
+    let managed_install =
+        match update_existing_cli(&cli_install_kind, &latest_version, state, paths) {
+            Ok(CliUpdateOutcome::Updated(managed_install)) => managed_install,
+            Ok(CliUpdateOutcome::RepairRequired) => {
+                set_cli_repair_required(state);
+                persist_state(paths, state)?;
+                return Ok(preflight_outcome_from_state(
+                    cli_path,
+                    installed_version,
+                    state,
+                    false,
+                ));
+            }
+            Err(error) => {
+                persist_cli_failure(state, paths, &error)?;
+                return Err(error);
+            }
+        };
 
-    let (refreshed_path, refreshed_version) = if let Some(updated_cli) =
-        resolve_cli_path_with_version(requested_path, &latest_version)
+    let (refreshed_path, refreshed_version) = if let Some(managed_install) = managed_install {
+        (managed_install.cli_path, managed_install.installed_version)
+    } else if let Some(updated_cli) = resolve_cli_path_with_version(requested_path, &latest_version)
     {
         updated_cli
     } else {
@@ -605,8 +649,22 @@ pub fn reconcile_if_present(state: &mut PersistedState, paths: &RuntimePaths) ->
     Ok(preflight(state, paths, requested_path, false)?.updated)
 }
 
-fn persist_state(paths: &RuntimePaths, state: &PersistedState) -> Result<()> {
-    state.save(&paths.state_file)
+fn persist_state(paths: &RuntimePaths, state: &mut PersistedState) -> Result<()> {
+    let mut latest =
+        PersistedState::load_or_default(&paths.state_file, state.auto_install_on_app_exit)?;
+    latest.cli_path = state.cli_path.clone();
+    latest.cli_install_channel = state.cli_install_channel.clone();
+    latest.cli_installed_version = state.cli_installed_version.clone();
+    latest.cli_official_latest_version = state.cli_official_latest_version.clone();
+    latest.cli_package_manager_latest_version = state.cli_package_manager_latest_version.clone();
+    latest.cli_status = state.cli_status.clone();
+    latest.cli_last_check_at = state.cli_last_check_at;
+    latest.cli_last_verified_at = state.cli_last_verified_at;
+    latest.cli_error_message = state.cli_error_message.clone();
+    latest.cli_prompt_dismissed_at = state.cli_prompt_dismissed_at;
+    latest.save(&paths.state_file)?;
+    *state = latest;
+    Ok(())
 }
 
 fn persist_cli_failure(
@@ -617,6 +675,14 @@ fn persist_cli_failure(
     state.cli_status = CliStatus::Failed;
     state.cli_error_message = Some(format!("{error:#}"));
     persist_state(paths, state)
+}
+
+fn set_cli_repair_required(state: &mut PersistedState) {
+    state.cli_status = CliStatus::UpdateRequired;
+    state.cli_error_message = Some(
+        "A stale npm retirement directory is blocking the Codex CLI update. The existing functional CLI remains in use. Run `codex-update-manager diagnose` for details and repair instructions."
+            .to_string(),
+    );
 }
 
 fn persist_new_cli_probe_failure(
@@ -634,7 +700,7 @@ fn persist_new_cli_probe_failure(
 #[cfg(test)]
 fn persist_if_changed(
     paths: &RuntimePaths,
-    state: &PersistedState,
+    state: &mut PersistedState,
     original_state: &PersistedState,
 ) -> Result<()> {
     if state != original_state {
@@ -1157,7 +1223,7 @@ fn path_is_system_managed_location(path: &Path) -> bool {
 }
 
 fn repair_npm_optional_dependency(install: &NpmCliInstall, paths: &RuntimePaths) -> Result<()> {
-    let _install_lock = acquire_cli_install_lock(paths)?;
+    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
     repair_npm_optional_dependency_with_timeout(install, NPM_REPAIR_INSTALL_TIMEOUT)
 }
 
@@ -1384,14 +1450,18 @@ impl StandaloneCliInstall {
 fn update_existing_cli(
     install_kind: &CliInstallKind,
     latest_version: &str,
+    state: &mut PersistedState,
     paths: &RuntimePaths,
-) -> Result<()> {
+) -> Result<CliUpdateOutcome> {
     match install_kind {
-        CliInstallKind::Standalone(install) => update_standalone_cli(install, latest_version),
+        CliInstallKind::Standalone(install) => {
+            update_standalone_cli(install, latest_version)?;
+            Ok(CliUpdateOutcome::Updated(None))
+        }
         CliInstallKind::Homebrew => {
             anyhow::bail!("Homebrew-managed Codex CLI installs must be updated with Homebrew")
         }
-        CliInstallKind::Npm => install_latest_cli(latest_version, paths),
+        CliInstallKind::Npm => install_latest_cli(latest_version, state, paths),
     }
 }
 
@@ -2036,12 +2106,26 @@ fn resolved_program_path(path: PathBuf) -> PathBuf {
     fs::canonicalize(&path).unwrap_or(path)
 }
 
-fn install_latest_cli(latest_version: &str, paths: &RuntimePaths) -> Result<()> {
+fn install_latest_cli(
+    latest_version: &str,
+    state: &mut PersistedState,
+    paths: &RuntimePaths,
+) -> Result<CliUpdateOutcome> {
     let (npm, path_env) = npm_program()?;
     let package_spec = format!("{CLI_PACKAGE_NAME}@{latest_version}");
-    let local_prefix = local_npm_prefix();
+    let local_prefix = npm_cli_repair::managed_prefix();
     prepare_safe_npm_prefix(&local_prefix)?;
-    let _install_lock = acquire_cli_install_lock(paths)?;
+    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    if npm_cli_repair::load(paths)?.is_some() {
+        set_cli_repair_required(state);
+        persist_state(paths, state)?;
+        return Ok(CliUpdateOutcome::RepairRequired);
+    }
+    if let Some(install) = current_managed_install(latest_version).ok().flatten() {
+        record_managed_install(state, latest_version, &install);
+        persist_state(paths, state)?;
+        return Ok(CliUpdateOutcome::Updated(Some(install)));
+    }
     let local_args = vec![
         OsString::from("install"),
         OsString::from("-g"),
@@ -2050,23 +2134,32 @@ fn install_latest_cli(latest_version: &str, paths: &RuntimePaths) -> Result<()> 
         local_prefix.as_os_str().to_os_string(),
         OsString::from(&package_spec),
     ];
-    let first_output = run_npm_command_output(&npm, &path_env, &local_args)?;
+    let first_output = run_bounded_command_output(
+        &npm,
+        &path_env,
+        None,
+        &local_args,
+        NPM_REPAIR_INSTALL_TIMEOUT,
+        true,
+    )?;
     if first_output.status.success() {
-        return Ok(());
+        let install = current_managed_install(latest_version)?.with_context(|| {
+            format!("npm completed but managed Codex CLI {latest_version} could not be resolved")
+        })?;
+        record_managed_install(state, latest_version, &install);
+        persist_state(paths, state)?;
+        return Ok(CliUpdateOutcome::Updated(Some(install)));
     }
 
-    if recover_stale_npm_retirement_directory(&local_prefix, &first_output)? {
-        warn!(
-            prefix = %local_prefix.display(),
-            "retrying Codex CLI install after removing stale npm retirement directory"
-        );
-        let retry_output = run_npm_command_output(&npm, &path_env, &local_args)?;
-        return ensure_npm_command_success(&npm, &local_args, retry_output)
-            .with_context(|| format!("npm install into {} failed", local_prefix.display()));
+    if npm_cli_repair::detect_and_persist(paths, &local_prefix, &first_output)?.is_some() {
+        set_cli_repair_required(state);
+        persist_state(paths, state)?;
+        return Ok(CliUpdateOutcome::RepairRequired);
     }
 
     ensure_npm_command_success(&npm, &local_args, first_output)
-        .with_context(|| format!("npm install into {} failed", local_prefix.display()))
+        .with_context(|| format!("npm install into {} failed", local_prefix.display()))?;
+    unreachable!("failed npm output should have returned an error")
 }
 
 fn prepare_safe_npm_prefix(prefix: &Path) -> Result<()> {
@@ -2101,178 +2194,137 @@ fn prepare_safe_npm_prefix(prefix: &Path) -> Result<()> {
     Ok(())
 }
 
-#[derive(Debug)]
-struct CliInstallLock {
-    _file: fs::File,
-}
+pub fn repair_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<CliRepairOutcome> {
+    let _install_lock = npm_cli_repair::acquire_install_lock(paths)?;
+    let journal = npm_cli_repair::load(paths)?
+        .context("No Codex CLI repair is pending. Run `codex-update-manager diagnose` first.")?;
+    let (npm, path_env) = npm_program()?;
+    let latest_version =
+        read_latest_version_with_npm_bounded(&npm, &path_env, NPM_REPAIR_REGISTRY_TIMEOUT)?;
+    let (mut journal, snapshot) = npm_cli_repair::quarantine(paths, journal)?;
 
-fn acquire_cli_install_lock(paths: &RuntimePaths) -> Result<CliInstallLock> {
-    acquire_cli_install_lock_with_timeout(paths, CLI_INSTALL_LOCK_TIMEOUT)
-}
-
-fn acquire_cli_install_lock_with_timeout(
-    paths: &RuntimePaths,
-    timeout: StdDuration,
-) -> Result<CliInstallLock> {
-    let lock_path = paths.state_dir.join("cli-install.lock");
-    let mut file = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .mode(0o600)
-        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(&lock_path)
-        .with_context(|| format!("Failed to open {}", lock_path.display()))?;
-    let metadata = file
-        .metadata()
-        .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
-    let euid = unsafe { libc::geteuid() };
-    anyhow::ensure!(
-        metadata.is_file() && metadata.uid() == euid,
-        "CLI install lock {} is not a user-owned regular file",
-        lock_path.display()
-    );
-    if metadata.permissions().mode() & 0o077 != 0 {
-        file.set_permissions(fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
+    if let Some(install) = current_managed_install(&latest_version).ok().flatten() {
+        npm_cli_repair::clear(paths)?;
+        record_managed_install(state, &latest_version, &install);
+        persist_state(paths, state)?;
+        return Ok(CliRepairOutcome {
+            installed_version: install.installed_version,
+            quarantine_path: snapshot.quarantine_path,
+        });
     }
 
-    let started = Instant::now();
-    loop {
-        match file.try_lock() {
-            Ok(()) => break,
-            Err(fs::TryLockError::WouldBlock) if started.elapsed() < timeout => {
-                thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL);
-            }
-            Err(fs::TryLockError::WouldBlock) => {
-                anyhow::bail!(
-                    "Timed out waiting for another Codex CLI install after {} ms",
-                    timeout.as_millis()
-                );
-            }
-            Err(fs::TryLockError::Error(error)) => {
-                return Err(error)
-                    .with_context(|| format!("Failed to lock {}", lock_path.display()));
-            }
+    let package_spec = format!("{CLI_PACKAGE_NAME}@{latest_version}");
+    let args = vec![
+        OsString::from("install"),
+        OsString::from("-g"),
+        OsString::from("--include=optional"),
+        OsString::from("--prefix"),
+        npm_cli_repair::managed_prefix().as_os_str().to_os_string(),
+        OsString::from(&package_spec),
+    ];
+    let output = match run_bounded_command_output(
+        &npm,
+        &path_env,
+        None,
+        &args,
+        NPM_REPAIR_INSTALL_TIMEOUT,
+        true,
+    ) {
+        Ok(output) => output,
+        Err(error) => {
+            let message = format!("{error:#}");
+            let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &message)?;
+            anyhow::bail!("{}", repair_failure_message(&message, &snapshot));
         }
-    }
-
-    file.set_len(0)
-        .with_context(|| format!("Failed to truncate {}", lock_path.display()))?;
-    file.seek(SeekFrom::Start(0))
-        .with_context(|| format!("Failed to seek {}", lock_path.display()))?;
-    writeln!(file, "{}", std::process::id())
-        .with_context(|| format!("Failed to write {}", lock_path.display()))?;
-    Ok(CliInstallLock { _file: file })
-}
-
-fn recover_stale_npm_retirement_directory(prefix: &Path, output: &Output) -> Result<bool> {
-    if output.status.success() {
-        return Ok(false);
-    }
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if !stderr.lines().any(|line| line.contains("ENOTEMPTY"))
-        || !stderr.lines().any(|line| line.contains("syscall rename"))
-    {
-        return Ok(false);
-    }
-
-    let Some(source) = npm_error_path_field(&stderr, "path") else {
-        return Ok(false);
     };
-    let Some(destination) = npm_error_path_field(&stderr, "dest") else {
-        return Ok(false);
-    };
-    let expected_source = prefix.join("lib/node_modules/@openai/codex");
-    let expected_parent = expected_source
-        .parent()
-        .context("Managed npm package path has no parent directory")?;
-    if source != expected_source
-        || destination.parent() != Some(expected_parent)
-        || !destination
-            .file_name()
-            .and_then(OsStr::to_str)
-            .is_some_and(is_npm_retirement_directory_name)
-    {
-        return Ok(false);
+    if !output.status.success() {
+        let error = format!(
+            "{} {} failed with {}{}",
+            npm.display(),
+            format_command_args(&args),
+            output.status,
+            format_command_output(&output)
+        );
+        let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &error)?;
+        anyhow::bail!("{}", repair_failure_message(&error, &snapshot));
     }
 
-    validate_managed_npm_directory(prefix, &expected_source)?;
-    validate_managed_npm_directory(prefix, &destination)?;
-    fs::remove_dir_all(&destination).with_context(|| {
-        format!(
-            "Failed to remove stale npm retirement directory {}",
-            destination.display()
-        )
-    })?;
-    Ok(true)
-}
+    let Some(install) = current_managed_install(&latest_version)? else {
+        let error = format!(
+            "npm completed but Codex CLI {latest_version} could not be resolved after repair"
+        );
+        let snapshot = persist_cli_repair_failure(state, paths, &mut journal, &error)?;
+        anyhow::bail!("{}", repair_failure_message(&error, &snapshot));
+    };
 
-fn npm_error_path_field(stderr: &str, field: &str) -> Option<PathBuf> {
-    stderr.lines().find_map(|line| {
-        let payload = line
-            .trim()
-            .strip_prefix("npm error ")
-            .or_else(|| line.trim().strip_prefix("npm ERR! "))?;
-        payload
-            .strip_prefix(field)?
-            .strip_prefix(char::is_whitespace)
-            .filter(|value| !value.is_empty())
-            .map(PathBuf::from)
+    npm_cli_repair::clear(paths)?;
+    record_managed_install(state, &latest_version, &install);
+    persist_state(paths, state)?;
+
+    Ok(CliRepairOutcome {
+        installed_version: install.installed_version,
+        quarantine_path: snapshot.quarantine_path,
     })
 }
 
-fn is_npm_retirement_directory_name(name: &str) -> bool {
-    name.strip_prefix(".codex-").is_some_and(|suffix| {
-        suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())
-    })
-}
-
-fn validate_managed_npm_directory(prefix: &Path, path: &Path) -> Result<()> {
-    let relative = path.strip_prefix(prefix).with_context(|| {
-        format!(
-            "Managed npm path {} is outside {}",
-            path.display(),
-            prefix.display()
-        )
-    })?;
-    anyhow::ensure!(
-        !relative.as_os_str().is_empty(),
-        "Managed npm cleanup cannot target the prefix root"
-    );
-
-    let euid = unsafe { libc::geteuid() };
-    let mut current = prefix.to_path_buf();
-    for component in relative.components() {
-        anyhow::ensure!(
-            matches!(component, Component::Normal(_)),
-            "Managed npm path {} contains an unsafe component",
-            path.display()
-        );
-        current.push(component.as_os_str());
-        let metadata = fs::symlink_metadata(&current)
-            .with_context(|| format!("Failed to inspect managed npm path {}", current.display()))?;
-        anyhow::ensure!(
-            metadata.is_dir() && !metadata.file_type().is_symlink(),
-            "Managed npm path {} is not a regular directory",
-            current.display()
-        );
-        anyhow::ensure!(
-            metadata.uid() == euid,
-            "Managed npm path {} is not owned by the current user",
-            current.display()
-        );
-    }
-    Ok(())
-}
-
-fn install_missing_cli(
+fn persist_cli_repair_failure(
     state: &mut PersistedState,
     paths: &RuntimePaths,
-    requested_path: Option<&Path>,
-) -> Result<PathBuf> {
+    journal: &mut npm_cli_repair::RepairJournal,
+    error: &str,
+) -> Result<npm_cli_repair::RepairSnapshot> {
+    let snapshot = npm_cli_repair::record_failure(paths, journal, error)?;
+    state.cli_status = CliStatus::Failed;
+    state.cli_error_message = Some(format!(
+        "{} Run `codex-update-manager diagnose` before retrying `codex-update-manager repair-cli`.",
+        repair_failure_message(error, &snapshot)
+    ));
+    persist_state(paths, state)?;
+    Ok(snapshot)
+}
+
+fn repair_failure_message(error: &str, snapshot: &npm_cli_repair::RepairSnapshot) -> String {
+    match snapshot.quarantine_path.as_deref() {
+        Some(path) => format!("{error}. Quarantine preserved at {}", path.display()),
+        None => format!("{error}. The stale npm directory was already absent"),
+    }
+}
+
+fn current_managed_install(expected_version: &str) -> Result<Option<ManagedCliInstall>> {
+    let requested_path = npm_cli_repair::managed_cli_path();
+    if !is_executable(&requested_path) {
+        return Ok(None);
+    }
+    let cli_path = canonical_cli_launch_path(&requested_path)?;
+    let installed_version =
+        read_installed_version_bounded(&cli_path, CLI_PREFLIGHT_VERSION_TIMEOUT)?;
+    Ok(
+        installed_cli_version_satisfies_latest(&installed_version, expected_version).then_some(
+            ManagedCliInstall {
+                cli_path,
+                installed_version,
+            },
+        ),
+    )
+}
+
+fn record_managed_install(
+    state: &mut PersistedState,
+    latest_version: &str,
+    install: &ManagedCliInstall,
+) {
+    state.cli_path = Some(install.cli_path.clone());
+    state.cli_install_channel = Some(CliInstallChannel::Npm);
+    state.cli_installed_version = Some(install.installed_version.clone());
+    state.cli_official_latest_version = Some(latest_version.to_string());
+    state.cli_package_manager_latest_version = None;
+    state.cli_status = CliStatus::UpToDate;
+    state.cli_last_check_at = Some(Utc::now());
+    state.cli_last_verified_at = Some(Utc::now());
+    state.cli_error_message = None;
+}
+
+fn install_missing_cli(state: &mut PersistedState, paths: &RuntimePaths) -> Result<PathBuf> {
     state.cli_status = CliStatus::Updating;
     persist_state(paths, state)?;
 
@@ -2285,13 +2337,21 @@ fn install_missing_cli(
         latest_version,
         "Codex CLI is missing; attempting automatic installation"
     );
-    install_latest_cli(&latest_version, paths)?;
+    let managed_install = match install_latest_cli(&latest_version, state, paths)? {
+        CliUpdateOutcome::Updated(Some(install)) => install,
+        CliUpdateOutcome::Updated(None) => {
+            anyhow::bail!("Managed npm install did not return a Codex CLI path")
+        }
+        CliUpdateOutcome::RepairRequired => {
+            set_cli_repair_required(state);
+            persist_state(paths, state)?;
+            anyhow::bail!(
+                "Codex CLI installation is blocked by stale npm state. Run `codex-update-manager diagnose` for details and repair instructions."
+            );
+        }
+    };
 
-    let cli_path = resolve_cli_path(requested_path)
-        .or_else(|| resolve_cli_path(None))
-        .ok_or_else(|| anyhow!("Codex CLI installed but could not be found afterwards"))?;
-
-    Ok(cli_path)
+    Ok(managed_install.cli_path)
 }
 
 fn run_command<I, S>(program: &Path, args: I) -> Result<String>
@@ -2364,22 +2424,6 @@ fn npm_program() -> Result<(PathBuf, OsString)> {
     entries.extend(std::env::split_paths(&fallback).filter(|entry| entry != toolchain_bin));
     let path_env = std::env::join_paths(entries).unwrap_or(fallback);
     Ok((npm, path_env))
-}
-
-fn local_npm_prefix() -> PathBuf {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".codex-cli-npm")
-}
-
-fn run_npm_command_output(npm: &Path, path_env: &OsString, args: &[OsString]) -> Result<Output> {
-    let mut command = Command::new(npm);
-    command.env("PATH", path_env).args(args);
-    apply_safe_child_umask(&mut command);
-    command
-        .output()
-        .with_context(|| format!("Failed to spawn {}", npm.display()))
 }
 
 fn ensure_npm_command_success(npm: &Path, args: &[OsString], output: Output) -> Result<()> {
@@ -2640,6 +2684,18 @@ mod tests {
                 fs::write(&node, "#!/bin/sh\nexec /bin/sh \"$@\"\n")?;
                 fs::set_permissions(node, fs::Permissions::from_mode(0o755))?;
             }
+        }
+        Ok(())
+    }
+
+    fn secure_test_directory_tree(path: &Path) -> Result<()> {
+        let metadata = fs::symlink_metadata(path)?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Ok(());
+        }
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+        for entry in fs::read_dir(path)? {
+            secure_test_directory_tree(&entry?.path())?;
         }
         Ok(())
     }
@@ -4838,14 +4894,19 @@ exit 1
 
         let bin_dir = temp.path().join("bin");
         fs::create_dir_all(&bin_dir)?;
-        let codex_path = bin_dir.join("codex");
+        let managed_codex_path = temp.path().join(".codex-cli-npm/bin/codex");
+        fs::create_dir_all(
+            managed_codex_path
+                .parent()
+                .context("managed CLI should have a parent")?,
+        )?;
         write_executable_script(
             &bin_dir.join("npm"),
             "#!/bin/sh\nif [ \"$1\" = \"view\" ]; then\n  echo '0.42.1'\n  exit 0\nfi\nif [ \"$1\" = \"install\" ]; then\n  printf '%s\\n' '#!/bin/sh' \"echo 'version probe failed' >&2\" 'exit 43' > \"$FAKE_CODEX_PATH\"\n  /bin/chmod 0755 \"$FAKE_CODEX_PATH\"\n  exit 0\nfi\nexit 1\n",
         )?;
 
         let _restore_env = configure_cli_test_env(temp.path(), [bin_dir])?;
-        std::env::set_var("FAKE_CODEX_PATH", &codex_path);
+        std::env::set_var("FAKE_CODEX_PATH", &managed_codex_path);
 
         let mut state = PersistedState::new(true);
         let error = preflight(&mut state, &paths, None, true)
@@ -4885,8 +4946,15 @@ exit 1
     #[test]
     fn reconcile_if_present_upgrades_outdated_cli() -> Result<()> {
         let _env_guard = env_lock();
-        let _restore_fnm_env =
-            EnvRestoreGuard::capture(&["XDG_DATA_HOME", "FNM_DIR", "FNM_MULTISHELL_PATH"]);
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "XDG_DATA_HOME",
+            "FNM_DIR",
+            "FNM_MULTISHELL_PATH",
+            "FAKE_CODEX_PATH",
+        ]);
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
         paths.ensure_dirs()?;
@@ -4895,6 +4963,12 @@ exit 1
         fs::create_dir_all(&bin_dir)?;
 
         let codex_path = bin_dir.join("codex");
+        let managed_codex_path = temp.path().join(".codex-cli-npm/bin/codex");
+        fs::create_dir_all(
+            managed_codex_path
+                .parent()
+                .context("managed CLI should have a parent")?,
+        )?;
         write_executable_script(
             &codex_path,
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
@@ -4903,19 +4977,16 @@ exit 1
         let npm_path = bin_dir.join("npm");
         write_executable_script(
             &npm_path,
-            "#!/bin/sh\nif [ \"$1\" = \"view\" ] && [ \"$2\" = \"@openai/codex\" ] && [ \"$3\" = \"version\" ]; then\n  echo '0.42.1'\n  exit 0\nfi\nif [ \"$1\" = \"install\" ] && [ \"$2\" = \"-g\" ] && [ \"$3\" = \"--include=optional\" ]; then\n  printf '%s\\n' '#!/bin/sh' 'if [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then' \"  echo 'codex-cli v0.42.1'\" '  exit 0' 'fi' 'exit 1' > \"$FAKE_CODEX_PATH\"\n  exit 0\nfi\nexit 1\n",
+            "#!/bin/sh\nif [ \"$1\" = \"view\" ] && [ \"$2\" = \"@openai/codex\" ] && [ \"$3\" = \"version\" ]; then\n  echo '0.42.1'\n  exit 0\nfi\nif [ \"$1\" = \"install\" ] && [ \"$2\" = \"-g\" ] && [ \"$3\" = \"--include=optional\" ]; then\n  printf '%s\\n' '#!/bin/sh' 'if [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then' \"  echo 'codex-cli v0.42.1'\" '  exit 0' 'fi' 'exit 1' > \"$FAKE_CODEX_PATH\"\n  /bin/chmod 0755 \"$FAKE_CODEX_PATH\"\n  exit 0\nfi\nexit 1\n",
         )?;
 
-        let original_home = std::env::var_os("HOME");
-        let original_path = std::env::var_os("PATH");
-        let original_nvm_dir = std::env::var_os("NVM_DIR");
         std::env::set_var("HOME", temp.path());
         std::env::set_var("PATH", std::env::join_paths([bin_dir.clone()])?);
         std::env::remove_var("NVM_DIR");
         std::env::remove_var("XDG_DATA_HOME");
         std::env::remove_var("FNM_DIR");
         std::env::remove_var("FNM_MULTISHELL_PATH");
-        std::env::set_var("FAKE_CODEX_PATH", &codex_path);
+        std::env::set_var("FAKE_CODEX_PATH", &managed_codex_path);
 
         assert_eq!(npm_program()?.0, npm_path);
 
@@ -4929,35 +5000,21 @@ exit 1
 
         let updated = reconcile_if_present(&mut state, &paths)?;
 
-        if let Some(home) = original_home {
-            std::env::set_var("HOME", home);
-        } else {
-            std::env::remove_var("HOME");
-        }
-        if let Some(path) = original_path {
-            std::env::set_var("PATH", path);
-        } else {
-            std::env::remove_var("PATH");
-        }
-        if let Some(nvm_dir) = original_nvm_dir {
-            std::env::set_var("NVM_DIR", nvm_dir);
-        } else {
-            std::env::remove_var("NVM_DIR");
-        }
-        std::env::remove_var("FAKE_CODEX_PATH");
-
         assert!(updated);
-        assert_eq!(state.cli_path.as_deref(), Some(codex_path.as_path()));
+        assert_eq!(
+            state.cli_path.as_deref(),
+            Some(managed_codex_path.as_path())
+        );
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
         assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
         assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
-        assert_eq!(read_installed_version(&codex_path)?, "0.42.1");
+        assert_eq!(read_installed_version(&managed_codex_path)?, "0.42.1");
         Ok(())
     }
 
     #[test]
-    fn reconcile_if_present_recovers_stale_npm_retirement_directory() -> Result<()> {
+    fn reconcile_if_present_detects_stale_npm_without_mutating_it() -> Result<()> {
         let _env_guard = env_lock();
         let _restore_env = EnvRestoreGuard::capture(&[
             "HOME",
@@ -4980,6 +5037,7 @@ exit 1
         let home = temp.path().join("home");
         let bin_dir = temp.path().join("bin");
         let local_prefix = home.join(".codex-cli-npm");
+        let managed_bin = local_prefix.join("bin");
         let active_package = local_prefix.join("lib/node_modules/@openai/codex");
         let retirement_path = local_prefix
             .join("lib/node_modules/@openai")
@@ -4989,9 +5047,11 @@ exit 1
         fs::write(active_package.join("package.json"), "{}\n")?;
         fs::create_dir_all(&retirement_path)?;
         fs::write(retirement_path.join("package.json"), "{}\n")?;
+        secure_test_directory_tree(&local_prefix)?;
         fs::create_dir_all(&bin_dir)?;
+        fs::create_dir_all(&managed_bin)?;
 
-        let codex_path = bin_dir.join("codex");
+        let codex_path = managed_bin.join("codex");
         write_executable_script(
             &codex_path,
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
@@ -5024,7 +5084,7 @@ exit 1
         )?;
 
         std::env::set_var("HOME", &home);
-        std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
+        std::env::set_var("PATH", std::env::join_paths([bin_dir, managed_bin])?);
         std::env::remove_var("NVM_DIR");
         std::env::remove_var("XDG_DATA_HOME");
         std::env::remove_var("FNM_DIR");
@@ -5041,122 +5101,33 @@ exit 1
 
         let updated = reconcile_if_present(&mut state, &paths)?;
 
-        assert!(updated);
-        assert_eq!(state.cli_status, CliStatus::UpToDate);
-        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
-        assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
+        assert!(!updated);
+        assert_eq!(state.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.0"));
+        assert_eq!(fs::read_to_string(&install_log)?, "attempt\n");
+        assert!(retirement_path.exists());
+        assert!(state
+            .cli_error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("codex-update-manager diagnose")));
+
+        let updated = reconcile_if_present(&mut state, &paths)?;
+        assert!(!updated);
+        assert_eq!(fs::read_to_string(&install_log)?, "attempt\n");
+        assert!(retirement_path.exists());
+
+        let outcome = repair_cli(&mut state, &paths)?;
+        assert_eq!(outcome.installed_version, "0.42.1");
+        assert!(outcome.quarantine_path.as_deref().is_some_and(Path::exists));
         assert!(!retirement_path.exists());
+        assert_eq!(fs::read_to_string(&install_log)?, "attempt\nattempt\n");
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert!(npm_cli_repair::load(&paths)?.is_none());
         Ok(())
     }
 
     #[test]
-    fn cli_install_lock_serializes_updater_processes() -> Result<()> {
-        let temp = tempdir()?;
-        let paths = test_runtime_paths(temp.path());
-        paths.ensure_dirs()?;
-
-        let first = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))?;
-        let started = Instant::now();
-        let error = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(75))
-            .expect_err("a second updater process must not enter the CLI install boundary");
-
-        assert!(error.to_string().contains("Timed out waiting"));
-        assert!(started.elapsed() >= StdDuration::from_millis(75));
-        assert!(started.elapsed() < StdDuration::from_secs(2));
-
-        drop(first);
-        acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))?;
-        Ok(())
-    }
-
-    #[test]
-    fn cli_install_lock_rejects_symlinks() -> Result<()> {
-        let temp = tempdir()?;
-        let paths = test_runtime_paths(temp.path());
-        paths.ensure_dirs()?;
-        let target = temp.path().join("must-survive");
-        fs::write(&target, "unchanged\n")?;
-        std::os::unix::fs::symlink(&target, paths.state_dir.join("cli-install.lock"))?;
-
-        let error = acquire_cli_install_lock_with_timeout(&paths, StdDuration::from_millis(100))
-            .expect_err("the CLI install lock must not follow symlinks");
-
-        assert!(format!("{error:#}").contains("Failed to open"));
-        assert_eq!(fs::read_to_string(target)?, "unchanged\n");
-        Ok(())
-    }
-
-    #[test]
-    fn stale_npm_recovery_rejects_untrusted_paths() -> Result<()> {
-        let temp = tempdir()?;
-        let prefix = temp.path().join("prefix");
-        prepare_safe_npm_prefix(&prefix)?;
-        let source = prefix.join("lib/node_modules/@openai/codex");
-        let scope = source.parent().context("test package has no scope")?;
-        fs::create_dir_all(&source)?;
-
-        let outside = temp.path().join(".codex-cqYkmGXr");
-        fs::create_dir_all(&outside)?;
-        assert!(!recover_stale_npm_retirement_directory(
-            &prefix,
-            &npm_enotempty_output(&source, &outside, false),
-        )?);
-        assert!(outside.exists());
-
-        let malformed = scope.join(".codex-not-a-retirement-hash");
-        fs::create_dir_all(&malformed)?;
-        assert!(!recover_stale_npm_retirement_directory(
-            &prefix,
-            &npm_enotempty_output(&source, &malformed, false),
-        )?);
-        assert!(malformed.exists());
-
-        let wrong_source = scope.join("another-package");
-        let valid_name = scope.join(".codex-cqYkmGXr");
-        fs::create_dir_all(&valid_name)?;
-        assert!(!recover_stale_npm_retirement_directory(
-            &prefix,
-            &npm_enotempty_output(&wrong_source, &valid_name, false),
-        )?);
-        assert!(valid_name.exists());
-        fs::remove_dir_all(&valid_name)?;
-
-        let symlink_target = temp.path().join("must-survive");
-        fs::create_dir_all(&symlink_target)?;
-        std::os::unix::fs::symlink(&symlink_target, &valid_name)?;
-        let error = recover_stale_npm_retirement_directory(
-            &prefix,
-            &npm_enotempty_output(&source, &valid_name, false),
-        )
-        .expect_err("a retirement symlink must fail closed");
-        assert!(error.to_string().contains("not a regular directory"));
-        assert!(valid_name.is_symlink());
-        assert!(symlink_target.exists());
-        Ok(())
-    }
-
-    #[test]
-    fn stale_npm_recovery_accepts_legacy_error_prefix() -> Result<()> {
-        let temp = tempdir()?;
-        let prefix = temp.path().join("prefix");
-        prepare_safe_npm_prefix(&prefix)?;
-        let source = prefix.join("lib/node_modules/@openai/codex");
-        let destination = prefix
-            .join("lib/node_modules/@openai")
-            .join(".codex-cqYkmGXr");
-        fs::create_dir_all(&source)?;
-        fs::create_dir_all(&destination)?;
-
-        assert!(recover_stale_npm_retirement_directory(
-            &prefix,
-            &npm_enotempty_output(&source, &destination, true),
-        )?);
-        assert!(!destination.exists());
-        Ok(())
-    }
-
-    #[test]
-    fn stale_npm_recovery_retries_only_once() -> Result<()> {
+    fn explicit_repair_runs_npm_once_and_preserves_failed_quarantine() -> Result<()> {
         let _env_guard = env_lock();
         let _restore_env = EnvRestoreGuard::capture(&[
             "HOME",
@@ -5184,26 +5155,25 @@ exit 1
         let install_log = temp.path().join("npm-install.log");
         fs::create_dir_all(&source)?;
         fs::create_dir_all(&destination)?;
+        secure_test_directory_tree(&prefix)?;
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o755))?;
         fs::create_dir_all(&bin_dir)?;
         write_executable_script(
             &bin_dir.join("npm"),
             r#"#!/bin/sh
+if [ "$1" = "view" ]; then
+  echo '0.42.1'
+  exit 0
+fi
 if [ "$1" = "install" ]; then
   printf 'attempt\n' >> "$NPM_INSTALL_LOG"
-  if [ -d "$NPM_RETIREMENT_PATH" ]; then
-    printf '%s\n' \
-      'npm error code ENOTEMPTY' \
-      'npm error syscall rename' \
-      "npm error path $NPM_ACTIVE_PACKAGE" \
-      "npm error dest $NPM_RETIREMENT_PATH" >&2
-    exit 217
-  fi
   printf 'retry failed\n' >&2
   exit 42
 fi
 exit 1
 "#,
         )?;
+        write_executable_script(&bin_dir.join("node"), "#!/bin/sh\nexit 0\n")?;
 
         std::env::set_var("HOME", &home);
         std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
@@ -5217,17 +5187,35 @@ exit 1
         std::env::set_var("NPM_INSTALL_LOG", &install_log);
         std::env::set_var("NPM_RETIREMENT_PATH", &destination);
 
-        let error = install_latest_cli("0.42.1", &paths)
-            .expect_err("the retry failure must be returned to the caller");
+        let mut state = PersistedState::new(true);
+        state.save(&paths.state_file)?;
+        npm_cli_repair::detect_and_persist(
+            &paths,
+            &prefix,
+            &npm_enotempty_output(&source, &destination, false),
+        )?
+        .context("stale npm output should be detected")?;
+
+        let error = repair_cli(&mut state, &paths).expect_err("the retry failure must be returned");
 
         assert!(format!("{error:#}").contains("retry failed"));
-        assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
+        assert!(format!("{error:#}").contains("Quarantine preserved"));
+        assert_eq!(fs::read_to_string(install_log)?, "attempt\n");
         assert!(!destination.exists());
+        let repair = npm_cli_repair::snapshot(&paths)?.context("repair should remain pending")?;
+        let quarantine = repair
+            .quarantine_path
+            .context("failed repair should record quarantine")?;
+        assert!(quarantine.exists());
+        assert!(repair
+            .last_error
+            .as_deref()
+            .is_some_and(|message| message.contains("retry failed")));
         Ok(())
     }
 
     #[test]
-    fn preflight_accepts_user_prefix_cli_after_system_cli_upgrade() -> Result<()> {
+    fn preflight_switches_system_cli_to_managed_prefix_after_upgrade() -> Result<()> {
         let _env_guard = env_lock();
         let temp = tempdir()?;
         let paths = test_runtime_paths(temp.path());
@@ -5253,6 +5241,12 @@ exit 1
         )?;
 
         let npm_path = npm_bin.join("npm");
+        let managed_codex = home.join(".codex-cli-npm/bin/codex");
+        fs::create_dir_all(
+            managed_codex
+                .parent()
+                .context("managed CLI should have a parent")?,
+        )?;
         write_executable_script(
             &npm_path,
             r#"#!/bin/sh
@@ -5261,6 +5255,8 @@ if [ "$1" = "view" ] && [ "$2" = "@openai/codex" ] && [ "$3" = "version" ]; then
   exit 0
 fi
 if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "--include=optional" ]; then
+  printf '%s\n' '#!/bin/sh' 'echo "codex-cli v0.42.1"' > "$FAKE_CODEX_PATH"
+  /bin/chmod 0755 "$FAKE_CODEX_PATH"
   exit 0
 fi
 exit 1
@@ -5275,6 +5271,7 @@ exit 1
             "FNM_DIR",
             "FNM_MULTISHELL_PATH",
             "CODEX_CLI_PATH",
+            "FAKE_CODEX_PATH",
         ]);
         std::env::set_var("HOME", &home);
         std::env::set_var("PATH", std::env::join_paths([npm_bin, system_bin])?);
@@ -5283,6 +5280,7 @@ exit 1
         std::env::remove_var("FNM_DIR");
         std::env::remove_var("FNM_MULTISHELL_PATH");
         std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("FAKE_CODEX_PATH", &managed_codex);
 
         let mut state = PersistedState::new(true);
         state.cli_path = Some(system_codex.clone());
@@ -5295,9 +5293,9 @@ exit 1
         let outcome = preflight(&mut state, &paths, Some(system_codex.clone()), false)?;
 
         assert!(outcome.updated);
-        assert_eq!(outcome.cli_path, user_codex);
+        assert_eq!(outcome.cli_path, managed_codex);
         assert_eq!(outcome.installed_version, "0.42.1");
-        assert_eq!(state.cli_path.as_deref(), Some(user_codex.as_path()));
+        assert_eq!(state.cli_path.as_deref(), Some(managed_codex.as_path()));
         assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
         assert_eq!(state.cli_official_latest_version.as_deref(), Some("0.42.1"));
         assert_eq!(state.cli_package_manager_latest_version, None);

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -16,7 +16,7 @@ use std::{
     io::{Read, Write},
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     os::unix::process::CommandExt,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::{Command, ExitStatus, Output, Stdio},
     sync::mpsc::{self, Receiver, RecvTimeoutError},
     thread,
@@ -2043,7 +2043,22 @@ fn install_latest_cli(latest_version: &str) -> Result<()> {
         local_prefix.as_os_str().to_os_string(),
         OsString::from(&package_spec),
     ];
-    run_npm_command(&npm, &path_env, &local_args)
+    let first_output = run_npm_command_output(&npm, &path_env, &local_args)?;
+    if first_output.status.success() {
+        return Ok(());
+    }
+
+    if recover_stale_npm_retirement_directory(&local_prefix, &first_output)? {
+        warn!(
+            prefix = %local_prefix.display(),
+            "retrying Codex CLI install after removing stale npm retirement directory"
+        );
+        let retry_output = run_npm_command_output(&npm, &path_env, &local_args)?;
+        return ensure_npm_command_success(&npm, &local_args, retry_output)
+            .with_context(|| format!("npm install into {} failed", local_prefix.display()));
+    }
+
+    ensure_npm_command_success(&npm, &local_args, first_output)
         .with_context(|| format!("npm install into {} failed", local_prefix.display()))
 }
 
@@ -2075,6 +2090,107 @@ fn prepare_safe_npm_prefix(prefix: &Path) -> Result<()> {
     if mode & 0o022 != 0 {
         fs::set_permissions(prefix, fs::Permissions::from_mode(mode & !0o022))
             .with_context(|| format!("Failed to secure npm prefix {}", prefix.display()))?;
+    }
+    Ok(())
+}
+
+fn recover_stale_npm_retirement_directory(prefix: &Path, output: &Output) -> Result<bool> {
+    if output.status.success() {
+        return Ok(false);
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.lines().any(|line| line.contains("ENOTEMPTY"))
+        || !stderr.lines().any(|line| line.contains("syscall rename"))
+    {
+        return Ok(false);
+    }
+
+    let Some(source) = npm_error_path_field(&stderr, "path") else {
+        return Ok(false);
+    };
+    let Some(destination) = npm_error_path_field(&stderr, "dest") else {
+        return Ok(false);
+    };
+    let expected_source = prefix.join("lib/node_modules/@openai/codex");
+    let expected_parent = expected_source
+        .parent()
+        .context("Managed npm package path has no parent directory")?;
+    if source != expected_source
+        || destination.parent() != Some(expected_parent)
+        || !destination
+            .file_name()
+            .and_then(OsStr::to_str)
+            .is_some_and(is_npm_retirement_directory_name)
+    {
+        return Ok(false);
+    }
+
+    validate_managed_npm_directory(prefix, &expected_source)?;
+    validate_managed_npm_directory(prefix, &destination)?;
+    fs::remove_dir_all(&destination).with_context(|| {
+        format!(
+            "Failed to remove stale npm retirement directory {}",
+            destination.display()
+        )
+    })?;
+    Ok(true)
+}
+
+fn npm_error_path_field(stderr: &str, field: &str) -> Option<PathBuf> {
+    stderr.lines().find_map(|line| {
+        let payload = line
+            .trim()
+            .strip_prefix("npm error ")
+            .or_else(|| line.trim().strip_prefix("npm ERR! "))?;
+        payload
+            .strip_prefix(field)?
+            .strip_prefix(char::is_whitespace)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    })
+}
+
+fn is_npm_retirement_directory_name(name: &str) -> bool {
+    name.strip_prefix(".codex-").is_some_and(|suffix| {
+        suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())
+    })
+}
+
+fn validate_managed_npm_directory(prefix: &Path, path: &Path) -> Result<()> {
+    let relative = path.strip_prefix(prefix).with_context(|| {
+        format!(
+            "Managed npm path {} is outside {}",
+            path.display(),
+            prefix.display()
+        )
+    })?;
+    anyhow::ensure!(
+        !relative.as_os_str().is_empty(),
+        "Managed npm cleanup cannot target the prefix root"
+    );
+
+    let euid = unsafe { libc::geteuid() };
+    let mut current = prefix.to_path_buf();
+    for component in relative.components() {
+        anyhow::ensure!(
+            matches!(component, Component::Normal(_)),
+            "Managed npm path {} contains an unsafe component",
+            path.display()
+        );
+        current.push(component.as_os_str());
+        let metadata = fs::symlink_metadata(&current)
+            .with_context(|| format!("Failed to inspect managed npm path {}", current.display()))?;
+        anyhow::ensure!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "Managed npm path {} is not a regular directory",
+            current.display()
+        );
+        anyhow::ensure!(
+            metadata.uid() == euid,
+            "Managed npm path {} is not owned by the current user",
+            current.display()
+        );
     }
     Ok(())
 }
@@ -2184,14 +2300,16 @@ fn local_npm_prefix() -> PathBuf {
         .join(".codex-cli-npm")
 }
 
-fn run_npm_command(npm: &Path, path_env: &OsString, args: &[OsString]) -> Result<()> {
+fn run_npm_command_output(npm: &Path, path_env: &OsString, args: &[OsString]) -> Result<Output> {
     let mut command = Command::new(npm);
     command.env("PATH", path_env).args(args);
     apply_safe_child_umask(&mut command);
-    let output = command
+    command
         .output()
-        .with_context(|| format!("Failed to spawn {}", npm.display()))?;
+        .with_context(|| format!("Failed to spawn {}", npm.display()))
+}
 
+fn ensure_npm_command_success(npm: &Path, args: &[OsString], output: Output) -> Result<()> {
     anyhow::ensure!(
         output.status.success(),
         "{} {} failed with {}{}",
@@ -2200,7 +2318,6 @@ fn run_npm_command(npm: &Path, path_env: &OsString, args: &[OsString]) -> Result
         output.status,
         format_command_output(&output)
     );
-
     Ok(())
 }
 
@@ -4741,6 +4858,99 @@ exit 1
         assert_eq!(state.cli_package_manager_latest_version, None);
         assert_eq!(state.cli_status, CliStatus::UpToDate);
         assert_eq!(read_installed_version(&codex_path)?, "0.42.1");
+        Ok(())
+    }
+
+    #[test]
+    fn reconcile_if_present_recovers_stale_npm_retirement_directory() -> Result<()> {
+        let _env_guard = env_lock();
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "XDG_DATA_HOME",
+            "FNM_DIR",
+            "FNM_MULTISHELL_PATH",
+            "CODEX_CLI_PATH",
+            "CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP",
+            "FAKE_CODEX_PATH",
+            "NPM_ACTIVE_PACKAGE",
+            "NPM_INSTALL_LOG",
+            "NPM_RETIREMENT_PATH",
+        ]);
+        let temp = tempdir()?;
+        let paths = test_runtime_paths(temp.path());
+        paths.ensure_dirs()?;
+
+        let home = temp.path().join("home");
+        let bin_dir = temp.path().join("bin");
+        let local_prefix = home.join(".codex-cli-npm");
+        let active_package = local_prefix.join("lib/node_modules/@openai/codex");
+        let retirement_path = local_prefix
+            .join("lib/node_modules/@openai")
+            .join(".codex-cqYkmGXr");
+        let install_log = temp.path().join("npm-install.log");
+        fs::create_dir_all(&active_package)?;
+        fs::write(active_package.join("package.json"), "{}\n")?;
+        fs::create_dir_all(&retirement_path)?;
+        fs::write(retirement_path.join("package.json"), "{}\n")?;
+        fs::create_dir_all(&bin_dir)?;
+
+        let codex_path = bin_dir.join("codex");
+        write_executable_script(
+            &codex_path,
+            "#!/bin/sh\nif [ \"$1\" = \"--version\" ] || [ \"$1\" = \"version\" ]; then\n  echo 'codex-cli v0.42.0'\n  exit 0\nfi\nexit 1\n",
+        )?;
+        let npm_path = bin_dir.join("npm");
+        write_executable_script(
+            &npm_path,
+            r#"#!/bin/sh
+if [ "$1" = "view" ] && [ "$2" = "@openai/codex" ] && [ "$3" = "version" ]; then
+  echo '0.42.1'
+  exit 0
+fi
+if [ "$1" = "install" ] && [ "$2" = "-g" ] && [ "$3" = "--include=optional" ]; then
+  printf 'attempt\n' >> "$NPM_INSTALL_LOG"
+  if [ -d "$NPM_RETIREMENT_PATH" ]; then
+    printf '%s\n' \
+      'npm error code ENOTEMPTY' \
+      'npm error syscall rename' \
+      "npm error path $NPM_ACTIVE_PACKAGE" \
+      "npm error dest $NPM_RETIREMENT_PATH" \
+      'npm error errno -39' \
+      "npm error ENOTEMPTY: directory not empty, rename '$NPM_ACTIVE_PACKAGE' -> '$NPM_RETIREMENT_PATH'" >&2
+    exit 217
+  fi
+  printf '%s\n' '#!/bin/sh' 'if [ "$1" = "--version" ] || [ "$1" = "version" ]; then' "  echo 'codex-cli v0.42.1'" '  exit 0' 'fi' 'exit 1' > "$FAKE_CODEX_PATH"
+  exit 0
+fi
+exit 1
+"#,
+        )?;
+
+        std::env::set_var("HOME", &home);
+        std::env::set_var("PATH", std::env::join_paths([bin_dir])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("XDG_DATA_HOME");
+        std::env::remove_var("FNM_DIR");
+        std::env::remove_var("FNM_MULTISHELL_PATH");
+        std::env::remove_var("CODEX_CLI_PATH");
+        std::env::set_var("CODEX_UPDATE_MANAGER_SKIP_SYSTEM_CLI_LOOKUP", "1");
+        std::env::set_var("FAKE_CODEX_PATH", &codex_path);
+        std::env::set_var("NPM_ACTIVE_PACKAGE", &active_package);
+        std::env::set_var("NPM_INSTALL_LOG", &install_log);
+        std::env::set_var("NPM_RETIREMENT_PATH", &retirement_path);
+
+        let mut state = PersistedState::new(true);
+        state.cli_path = Some(codex_path.clone());
+
+        let updated = reconcile_if_present(&mut state, &paths)?;
+
+        assert!(updated);
+        assert_eq!(state.cli_status, CliStatus::UpToDate);
+        assert_eq!(state.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(fs::read_to_string(install_log)?, "attempt\nattempt\n");
+        assert!(!retirement_path.exists());
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -15,6 +15,7 @@ use std::{
     ffi::{OsStr, OsString},
     fs,
     io::{Read, Write},
+    os::fd::RawFd,
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
     os::unix::process::{CommandExt, ExitStatusExt},
     path::{Path, PathBuf},
@@ -1450,6 +1451,13 @@ fn run_bounded_command_output(
             .arg(std::process::id().to_string())
             .arg("--timeout-millis")
             .arg(timeout_millis.to_string())
+            .arg("--install-lock-fd")
+            .arg(
+                install_lock
+                    .expect("supervised npm commands require the install lock")
+                    .raw_fd()
+                    .to_string(),
+            )
             .arg(program)
             .arg("--")
             .args(args);
@@ -1540,6 +1548,7 @@ fn run_bounded_command_output(
 pub(crate) fn run_npm_supervisor(
     owner_pid: u32,
     timeout_millis: u64,
+    install_lock_fd: RawFd,
     program: &Path,
     args: &[OsString],
 ) -> Result<()> {
@@ -1557,6 +1566,7 @@ pub(crate) fn run_npm_supervisor(
         current_parent_pid() == owner_pid,
         "npm supervisor owner exited before npm started"
     );
+    set_close_on_exec(install_lock_fd).context("Failed to isolate the CLI install lock")?;
 
     let mut command = Command::new(program);
     command
@@ -1565,6 +1575,21 @@ pub(crate) fn run_npm_supervisor(
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit())
         .process_group(0);
+    let supervisor_pid = std::process::id();
+    unsafe {
+        command.pre_exec(move || {
+            if libc::prctl(libc::PR_SET_PDEATHSIG, SIGKILL) == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::getppid() as u32 != supervisor_pid {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "npm supervisor exited before npm started",
+                ));
+            }
+            Ok(())
+        });
+    }
     let mut child = command
         .spawn()
         .with_context(|| format!("Failed to spawn supervised npm {}", program.display()))?;
@@ -1574,6 +1599,7 @@ pub(crate) fn run_npm_supervisor(
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
+                terminate_remaining_process_group(process_group);
                 if status.success() {
                     return Ok(());
                 }
@@ -1610,6 +1636,20 @@ pub(crate) fn run_npm_supervisor(
 
         thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
     }
+}
+
+fn set_close_on_exec(fd: RawFd) -> Result<()> {
+    anyhow::ensure!(fd >= 0, "npm supervisor install lock descriptor is invalid");
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error())
+            .context("Failed to inspect the inherited install lock descriptor");
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } == -1 {
+        return Err(std::io::Error::last_os_error())
+            .context("Failed to protect the inherited install lock descriptor");
+    }
+    Ok(())
 }
 
 fn current_parent_pid() -> u32 {
@@ -1678,6 +1718,17 @@ fn terminate_process_group(child: &mut std::process::Child, process_group: i32) 
     thread::sleep(BOUNDED_COMMAND_TERMINATION_GRACE);
     signal_process_group(process_group, SIGKILL);
     let _ = child.kill();
+}
+
+fn terminate_remaining_process_group(process_group: i32) {
+    if signal_process_group_checked(process_group, SIGTERM) {
+        thread::sleep(BOUNDED_COMMAND_TERMINATION_GRACE);
+        signal_process_group(process_group, SIGKILL);
+    }
+}
+
+fn signal_process_group_checked(process_group: i32, signal: i32) -> bool {
+    unsafe { kill(-process_group, signal) == 0 }
 }
 
 fn signal_process_group(process_group: i32, signal: i32) {
@@ -2886,6 +2937,13 @@ fn normalize_version_token(token: &str) -> Option<String> {
 
 fn npm_program() -> Result<(PathBuf, OsString)> {
     let npm = find_in_path("npm", &command_path_env()).context("npm was not found in PATH")?;
+    let npm = if npm.is_absolute() {
+        npm
+    } else {
+        std::env::current_dir()
+            .context("Failed to resolve the current directory for npm")?
+            .join(npm)
+    };
     canonical_cli_launch_path(&npm).context("npm executable is not usable")?;
     let toolchain_bin = npm
         .parent()
@@ -3114,10 +3172,27 @@ mod tests {
     use chrono::Utc;
     use std::{
         fs,
+        os::fd::AsRawFd,
         os::unix::{fs::PermissionsExt, process::ExitStatusExt},
         path::Path,
     };
     use tempfile::tempdir;
+
+    struct CurrentDirectoryGuard(PathBuf);
+
+    impl CurrentDirectoryGuard {
+        fn set(path: &Path) -> Result<Self> {
+            let original = std::env::current_dir().context("current test directory")?;
+            std::env::set_current_dir(path).context("set current test directory")?;
+            Ok(Self(original))
+        }
+    }
+
+    impl Drop for CurrentDirectoryGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).expect("restore current test directory");
+        }
+    }
 
     fn npm_enotempty_output(source: &Path, destination: &Path, legacy_prefix: bool) -> Output {
         let prefix = if legacy_prefix {
@@ -5338,11 +5413,13 @@ wait
         )?;
         let _restore_env = EnvRestoreGuard::capture(&["NPM_CHILD_MARKER"]);
         std::env::set_var("NPM_CHILD_MARKER", &child_marker);
+        let install_lock = fs::File::create(temp.path().join("install.lock"))?;
 
         let started = Instant::now();
         let error = run_npm_supervisor(
             current_parent_pid(),
             100,
+            install_lock.as_raw_fd(),
             &npm_program,
             &[OsString::from("install")],
         )
@@ -5366,12 +5443,79 @@ wait
         )?;
         let _restore_env = EnvRestoreGuard::capture(&["NPM_STARTED"]);
         std::env::set_var("NPM_STARTED", &started);
+        let install_lock = fs::File::create(temp.path().join("install.lock"))?;
 
-        let error = run_npm_supervisor(u32::MAX, 100, &npm_program, &[OsString::from("install")])
-            .expect_err("a supervisor with a stale owner must not start npm");
+        let error = run_npm_supervisor(
+            u32::MAX,
+            100,
+            install_lock.as_raw_fd(),
+            &npm_program,
+            &[OsString::from("install")],
+        )
+        .expect_err("a supervisor with a stale owner must not start npm");
 
         assert!(error.to_string().contains("owner exited"));
         assert!(!started.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn npm_supervisor_keeps_the_install_lock_out_of_npm() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let npm_program = temp.path().join("npm");
+        let inherited_marker = temp.path().join("lock-inherited");
+        write_executable_script(
+            &npm_program,
+            "#!/bin/sh\nif [ -e \"/proc/self/fd/$NPM_INSTALL_LOCK_FD\" ]; then\n  printf inherited > \"$NPM_LOCK_INHERITED_MARKER\"\n  exit 88\nfi\nexit 0\n",
+        )?;
+        let install_lock = fs::File::create(temp.path().join("install.lock"))?;
+        let _restore_env =
+            EnvRestoreGuard::capture(&["NPM_INSTALL_LOCK_FD", "NPM_LOCK_INHERITED_MARKER"]);
+        std::env::set_var("NPM_INSTALL_LOCK_FD", install_lock.as_raw_fd().to_string());
+        std::env::set_var("NPM_LOCK_INHERITED_MARKER", &inherited_marker);
+
+        run_npm_supervisor(
+            current_parent_pid(),
+            1_000,
+            install_lock.as_raw_fd(),
+            &npm_program,
+            &[OsString::from("install")],
+        )?;
+
+        assert!(!inherited_marker.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn npm_program_absolutizes_a_relative_path_entry_without_resolving_symlinks() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let path_bin = temp.path().join("path-bin");
+        fs::create_dir_all(&path_bin)?;
+        let real_bin = temp.path().join("real-bin");
+        fs::create_dir_all(&real_bin)?;
+        write_executable_script(&real_bin.join("npm"), "#!/bin/sh\nexit 0\n")?;
+        write_executable_script(&real_bin.join("node"), "#!/bin/sh\nexit 0\n")?;
+        std::os::unix::fs::symlink(real_bin.join("npm"), path_bin.join("npm"))?;
+        std::os::unix::fs::symlink(real_bin.join("node"), path_bin.join("node"))?;
+        let _current_directory = CurrentDirectoryGuard::set(temp.path())?;
+        let _restore_env = EnvRestoreGuard::capture(&[
+            "HOME",
+            "PATH",
+            "NVM_DIR",
+            "XDG_DATA_HOME",
+            "FNM_DIR",
+            "FNM_MULTISHELL_PATH",
+        ]);
+        std::env::set_var("HOME", temp.path());
+        std::env::set_var("PATH", std::env::join_paths([PathBuf::from("path-bin")])?);
+        std::env::remove_var("NVM_DIR");
+        std::env::remove_var("XDG_DATA_HOME");
+        std::env::remove_var("FNM_DIR");
+        std::env::remove_var("FNM_MULTISHELL_PATH");
+
+        assert_eq!(npm_program()?.0, path_bin.join("npm"));
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -16,7 +16,7 @@ use std::{
     fs,
     io::{Read, Write},
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
-    os::unix::process::CommandExt,
+    os::unix::process::{CommandExt, ExitStatusExt},
     path::{Path, PathBuf},
     process::{Command, ExitStatus, Output, Stdio},
     sync::mpsc::{self, Receiver, RecvTimeoutError},
@@ -36,6 +36,7 @@ const CLI_PREFLIGHT_VERSION_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 const BOUNDED_COMMAND_POLL_INTERVAL: StdDuration = StdDuration::from_millis(50);
 const BOUNDED_COMMAND_TERMINATION_GRACE: StdDuration = StdDuration::from_millis(500);
 const BOUNDED_COMMAND_OUTPUT_DRAIN_TIMEOUT: StdDuration = StdDuration::from_secs(1);
+const NPM_SUPERVISOR_EXIT_GRACE: StdDuration = StdDuration::from_secs(2);
 const BOUNDED_COMMAND_OUTPUT_LIMIT: usize = 64 * 1024;
 const SIGTERM: i32 = 15;
 const SIGKILL: i32 = 9;
@@ -1438,10 +1439,28 @@ fn run_bounded_command_output(
     safe_umask: bool,
     install_lock: Option<&npm_cli_repair::InstallLock>,
 ) -> Result<Output> {
-    let mut command = Command::new(program);
+    let supervised = install_lock.is_some() && !cfg!(test);
+    let mut command = if supervised {
+        let timeout_millis = u64::try_from(timeout.as_millis())
+            .context("bounded npm timeout does not fit in milliseconds")?;
+        let mut command = Command::new("/proc/self/exe");
+        command
+            .arg("run-npm-supervisor")
+            .arg("--owner-pid")
+            .arg(std::process::id().to_string())
+            .arg("--timeout-millis")
+            .arg(timeout_millis.to_string())
+            .arg(program)
+            .arg("--")
+            .args(args);
+        command
+    } else {
+        let mut command = Command::new(program);
+        command.args(args);
+        command
+    };
     command
         .env("PATH", path_env)
-        .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -1471,6 +1490,11 @@ fn run_bounded_command_output(
     let stdout_rx = spawn_bounded_output_reader(stdout);
     let stderr_rx = spawn_bounded_output_reader(stderr);
     let started = Instant::now();
+    let parent_timeout = if supervised {
+        timeout.saturating_add(NPM_SUPERVISOR_EXIT_GRACE)
+    } else {
+        timeout
+    };
 
     loop {
         match child.try_wait() {
@@ -1494,11 +1518,88 @@ fn run_bounded_command_output(
             }
         }
 
-        if started.elapsed() >= timeout {
+        if started.elapsed() >= parent_timeout {
             terminate_process_group(&mut child, process_group);
             let _ = child.wait();
             let _ = receive_bounded_output(&stdout_rx, process_group);
             let _ = receive_bounded_output(&stderr_rx, process_group);
+            anyhow::bail!(
+                "{} {} timed out after {} seconds",
+                program.display(),
+                format_command_args(args),
+                parent_timeout.as_secs_f64()
+            );
+        }
+
+        thread::sleep(
+            BOUNDED_COMMAND_POLL_INTERVAL.min(parent_timeout.saturating_sub(started.elapsed())),
+        );
+    }
+}
+
+pub(crate) fn run_npm_supervisor(
+    owner_pid: u32,
+    timeout_millis: u64,
+    program: &Path,
+    args: &[OsString],
+) -> Result<()> {
+    anyhow::ensure!(owner_pid != 0, "npm supervisor owner PID is invalid");
+    anyhow::ensure!(
+        program.is_absolute(),
+        "npm supervisor program must be an absolute path"
+    );
+    let timeout = StdDuration::from_millis(timeout_millis);
+    anyhow::ensure!(
+        !timeout.is_zero(),
+        "npm supervisor timeout must be positive"
+    );
+    anyhow::ensure!(
+        current_parent_pid() == owner_pid,
+        "npm supervisor owner exited before npm started"
+    );
+
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .process_group(0);
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("Failed to spawn supervised npm {}", program.display()))?;
+    let process_group = child.id() as i32;
+    let started = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    return Ok(());
+                }
+                exit_with_status(status);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                terminate_process_group(&mut child, process_group);
+                let _ = child.wait();
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed while waiting for supervised npm {}",
+                        program.display()
+                    )
+                });
+            }
+        }
+
+        if current_parent_pid() != owner_pid {
+            terminate_process_group(&mut child, process_group);
+            let _ = child.wait();
+            anyhow::bail!("updater parent exited while npm was running");
+        }
+        if started.elapsed() >= timeout {
+            terminate_process_group(&mut child, process_group);
+            let _ = child.wait();
             anyhow::bail!(
                 "{} {} timed out after {} seconds",
                 program.display(),
@@ -1509,6 +1610,18 @@ fn run_bounded_command_output(
 
         thread::sleep(BOUNDED_COMMAND_POLL_INTERVAL.min(timeout.saturating_sub(started.elapsed())));
     }
+}
+
+fn current_parent_pid() -> u32 {
+    unsafe { libc::getppid() as u32 }
+}
+
+fn exit_with_status(status: ExitStatus) -> ! {
+    let code = status
+        .code()
+        .or_else(|| status.signal().map(|signal| 128 + signal))
+        .unwrap_or(1);
+    std::process::exit(code);
 }
 
 fn spawn_bounded_output_reader<R>(mut reader: R) -> Receiver<Vec<u8>>
@@ -5207,6 +5320,58 @@ exit 1
         assert!(started.elapsed() < StdDuration::from_secs(3));
         assert!(child_pid.exists(), "the nested npm child must have started");
         assert_eq!(fs::read_to_string(child_marker)?, "terminated");
+        Ok(())
+    }
+
+    #[test]
+    fn npm_supervisor_owns_timeout_and_process_group_cleanup() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let npm_program = temp.path().join("npm");
+        let child_marker = temp.path().join("child-terminated");
+        write_executable_script(
+            &npm_program,
+            r#"#!/bin/sh
+sh -c 'trap '\''printf terminated > "$NPM_CHILD_MARKER"; exit 0'\'' TERM; while :; do sleep 1; done' &
+wait
+"#,
+        )?;
+        let _restore_env = EnvRestoreGuard::capture(&["NPM_CHILD_MARKER"]);
+        std::env::set_var("NPM_CHILD_MARKER", &child_marker);
+
+        let started = Instant::now();
+        let error = run_npm_supervisor(
+            current_parent_pid(),
+            100,
+            &npm_program,
+            &[OsString::from("install")],
+        )
+        .expect_err("the npm supervisor must enforce its own timeout");
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < StdDuration::from_secs(3));
+        assert_eq!(fs::read_to_string(child_marker)?, "terminated");
+        Ok(())
+    }
+
+    #[test]
+    fn npm_supervisor_rejects_a_stale_owner_before_spawning() -> Result<()> {
+        let _env_guard = env_lock();
+        let temp = tempdir()?;
+        let npm_program = temp.path().join("npm");
+        let started = temp.path().join("started");
+        write_executable_script(
+            &npm_program,
+            "#!/bin/sh\nprintf started > \"$NPM_STARTED\"\n",
+        )?;
+        let _restore_env = EnvRestoreGuard::capture(&["NPM_STARTED"]);
+        std::env::set_var("NPM_STARTED", &started);
+
+        let error = run_npm_supervisor(u32::MAX, 100, &npm_program, &[OsString::from("install")])
+            .expect_err("a supervisor with a stale owner must not start npm");
+
+        assert!(error.to_string().contains("owner exited"));
+        assert!(!started.exists());
         Ok(())
     }
 

--- a/updater/src/codex_cli.rs
+++ b/updater/src/codex_cli.rs
@@ -1863,34 +1863,15 @@ fn process_group_member_pidfds(
 }
 
 fn process_group_for_pid(pid: i32) -> std::io::Result<Option<i32>> {
-    let stat = match fs::read_to_string(format!("/proc/{pid}/stat")) {
-        Ok(stat) => stat,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let close = stat.rfind(')').ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("process {pid} stat has no command terminator"),
-        )
-    })?;
-    let process_group = stat
-        .get(close + 1..)
-        .and_then(|fields| fields.split_whitespace().nth(2))
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("process {pid} stat has no process group"),
-            )
-        })?
-        .parse::<i32>()
-        .map_err(|error| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("process {pid} stat has an invalid process group: {error}"),
-            )
-        })?;
-    Ok(Some(process_group))
+    let process_group = unsafe { libc::getpgid(pid) };
+    if process_group >= 0 {
+        return Ok(Some(process_group));
+    }
+    let error = std::io::Error::last_os_error();
+    match error.raw_os_error() {
+        Some(libc::ESRCH | libc::EPERM) => Ok(None),
+        _ => Err(error),
+    }
 }
 
 fn signal_process_group(process_group: i32, signal: i32) {

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     config::{self, RuntimeConfig, RuntimePaths},
-    liveness,
+    liveness, npm_cli_repair,
     state::PersistedState,
 };
 use anyhow::Result;
@@ -40,6 +40,18 @@ struct UpdateDiagnostics {
     last_known_good_version: Option<String>,
     update_error: Option<String>,
     cli_status: String,
+    cli_error: Option<String>,
+    cli_repair: Option<CliRepairDiagnostics>,
+}
+
+#[derive(Debug, Serialize)]
+struct CliRepairDiagnostics {
+    condition: &'static str,
+    detected_at: String,
+    stale_directory: PathBuf,
+    quarantine_path: Option<PathBuf>,
+    last_error: Option<String>,
+    repair_command: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -136,6 +148,7 @@ fn collect_with_webview(
         running_error: running.err().map(|error| error.to_string()),
         pid_file: pid_file_diagnostics(&app_pid_file),
     };
+    let cli_repair = npm_cli_repair::snapshot(paths)?;
     let report_without_warnings = DiagnosticsReport {
         schema: "codex-update-manager/diagnostics/v1",
         ok: false,
@@ -147,6 +160,16 @@ fn collect_with_webview(
             last_known_good_version: state.last_known_good_version.clone(),
             update_error: state.error_message.clone(),
             cli_status: format!("{:?}", state.cli_status),
+            cli_error: state.cli_error_message.clone(),
+            cli_repair: cli_repair.map(|repair| CliRepairDiagnostics {
+                condition:
+                    "A stale npm retirement directory is blocking managed Codex CLI updates.",
+                detected_at: repair.detected_at.to_rfc3339(),
+                stale_directory: repair.stale_directory,
+                quarantine_path: repair.quarantine_path,
+                last_error: repair.last_error,
+                repair_command: "codex-update-manager repair-cli",
+            }),
         },
         app,
         webview: WebviewDiagnostics {
@@ -199,6 +222,26 @@ fn print_text(report: &DiagnosticsReport) {
         report.update.update_error.as_deref().unwrap_or("none")
     );
     println!(
+        "cli: status={} error={}",
+        report.update.cli_status,
+        report.update.cli_error.as_deref().unwrap_or("none")
+    );
+    if let Some(repair) = &report.update.cli_repair {
+        println!(
+            "cli_repair: condition={} stale_directory={} quarantine={} last_error={} command={}",
+            repair.condition,
+            repair.stale_directory.display(),
+            repair
+                .quarantine_path
+                .as_deref()
+                .map(Path::display)
+                .map(|path| path.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            repair.last_error.as_deref().unwrap_or("none"),
+            repair.repair_command
+        );
+    }
+    println!(
         "app: executable={} exists={} running={}",
         report.app.executable_path.display(),
         report.app.executable_exists,
@@ -248,6 +291,11 @@ fn diagnostics_warnings(report: &DiagnosticsReport) -> Vec<String> {
     }
     if report.update.update_error.is_some() {
         warnings.push("updater state has an update error".to_string());
+    }
+    if report.update.cli_repair.is_some() {
+        warnings.push(
+            "Codex CLI requires explicit repair; run codex-update-manager repair-cli".to_string(),
+        );
     }
     if report.app.running && !report.webview.ok {
         warnings.push("app is running but webview did not respond".to_string());
@@ -548,6 +596,8 @@ mod tests {
                 last_known_good_version: None,
                 update_error: None,
                 cli_status: "Unknown".to_string(),
+                cli_error: None,
+                cli_repair: None,
             },
             app: AppDiagnostics {
                 executable_path: config.app_executable_path,

--- a/updater/src/diagnostics.rs
+++ b/updater/src/diagnostics.rs
@@ -48,8 +48,10 @@ struct UpdateDiagnostics {
 struct CliRepairDiagnostics {
     condition: &'static str,
     detected_at: String,
+    phase: &'static str,
     stale_directory: PathBuf,
-    quarantine_path: Option<PathBuf>,
+    quarantine_paths: Vec<PathBuf>,
+    planned_quarantine_path: Option<PathBuf>,
     last_error: Option<String>,
     repair_command: &'static str,
 }
@@ -165,8 +167,14 @@ fn collect_with_webview(
                 condition:
                     "A stale npm retirement directory is blocking managed Codex CLI updates.",
                 detected_at: repair.detected_at.to_rfc3339(),
+                phase: match repair.phase {
+                    npm_cli_repair::RepairPhase::Detected => "detected",
+                    npm_cli_repair::RepairPhase::QuarantinePlanned => "quarantine_planned",
+                    npm_cli_repair::RepairPhase::Quarantined => "quarantined",
+                },
                 stale_directory: repair.stale_directory,
-                quarantine_path: repair.quarantine_path,
+                quarantine_paths: repair.quarantine_paths,
+                planned_quarantine_path: repair.planned_quarantine_path,
                 last_error: repair.last_error,
                 repair_command: "codex-update-manager repair-cli",
             }),
@@ -227,12 +235,24 @@ fn print_text(report: &DiagnosticsReport) {
         report.update.cli_error.as_deref().unwrap_or("none")
     );
     if let Some(repair) = &report.update.cli_repair {
+        let quarantine_paths = repair
+            .quarantine_paths
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(",");
         println!(
-            "cli_repair: condition={} stale_directory={} quarantine={} last_error={} command={}",
+            "cli_repair: condition={} phase={} stale_directory={} quarantines={} planned_quarantine={} last_error={} command={}",
             repair.condition,
+            repair.phase,
             repair.stale_directory.display(),
+            if quarantine_paths.is_empty() {
+                "none"
+            } else {
+                quarantine_paths.as_str()
+            },
             repair
-                .quarantine_path
+                .planned_quarantine_path
                 .as_deref()
                 .map(Path::display)
                 .map(|path| path.to_string())

--- a/updater/src/main.rs
+++ b/updater/src/main.rs
@@ -15,6 +15,7 @@ mod install_rollback;
 mod liveness;
 mod logging;
 mod notify;
+mod npm_cli_repair;
 mod restart;
 mod rollback;
 mod state;

--- a/updater/src/npm_cli_repair.rs
+++ b/updater/src/npm_cli_repair.rs
@@ -68,6 +68,10 @@ pub(crate) struct InstallLock {
 }
 
 impl InstallLock {
+    pub(crate) fn raw_fd(&self) -> std::os::fd::RawFd {
+        self._file.as_raw_fd()
+    }
+
     pub(crate) fn inherit_with(&self, command: &mut Command) {
         let fd = self._file.as_raw_fd();
         unsafe {

--- a/updater/src/npm_cli_repair.rs
+++ b/updater/src/npm_cli_repair.rs
@@ -1,4 +1,7 @@
-use crate::{config::RuntimePaths, state::atomic_write};
+use crate::{
+    config::RuntimePaths,
+    state::{atomic_write, sync_directory},
+};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -6,13 +9,16 @@ use std::{
     ffi::{CString, OsStr},
     fs,
     io::{Seek, SeekFrom, Write},
+    os::fd::AsRawFd,
     os::unix::ffi::OsStrExt,
     os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
+    os::unix::process::CommandExt,
     path::{Component, Path, PathBuf},
-    process::Output,
+    process::{Command, Output},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
+use tracing::info;
 
 const JOURNAL_FILE_NAME: &str = "cli-repair.json";
 const LOCK_FILE_NAME: &str = "cli-install.lock";
@@ -24,28 +30,35 @@ const QUARANTINE_DIRECTORY_NAME: &str = ".codex-linux-quarantine";
 pub(crate) struct RepairJournal {
     detected_at: DateTime<Utc>,
     retirement_name: String,
+    #[serde(default)]
+    quarantine_names: Vec<String>,
     stage: RepairStage,
+    #[serde(default)]
+    last_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "stage", rename_all = "snake_case")]
 enum RepairStage {
     Detected,
-    QuarantinePlanned {
-        quarantine_name: String,
-    },
-    Quarantined {
-        quarantine_name: Option<String>,
-        #[serde(default)]
-        last_error: Option<String>,
-    },
+    QuarantinePlanned { quarantine_name: String },
+    Quarantined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RepairPhase {
+    Detected,
+    QuarantinePlanned,
+    Quarantined,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RepairSnapshot {
     pub(crate) detected_at: DateTime<Utc>,
+    pub(crate) phase: RepairPhase,
     pub(crate) stale_directory: PathBuf,
-    pub(crate) quarantine_path: Option<PathBuf>,
+    pub(crate) quarantine_paths: Vec<PathBuf>,
+    pub(crate) planned_quarantine_path: Option<PathBuf>,
     pub(crate) last_error: Option<String>,
 }
 
@@ -54,8 +67,27 @@ pub(crate) struct InstallLock {
     _file: fs::File,
 }
 
+impl InstallLock {
+    pub(crate) fn inherit_with(&self, command: &mut Command) {
+        let fd = self._file.as_raw_fd();
+        unsafe {
+            command.pre_exec(move || {
+                let flags = libc::fcntl(fd, libc::F_GETFD);
+                if flags == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ManagedNpmLayout {
+    retirement_name: String,
     prefix: PathBuf,
     scope: PathBuf,
     active_package: PathBuf,
@@ -107,10 +139,18 @@ fn acquire_install_lock_with_timeout(
     }
 
     let started = Instant::now();
+    let mut reported_wait = false;
     loop {
         match file.try_lock() {
             Ok(()) => break,
             Err(fs::TryLockError::WouldBlock) if started.elapsed() < timeout => {
+                if !reported_wait {
+                    info!(
+                        "Codex CLI install lock is busy; process {} is waiting",
+                        std::process::id()
+                    );
+                    reported_wait = true;
+                }
                 #[cfg(test)]
                 if let Some(path) =
                     std::env::var_os("CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING")
@@ -209,82 +249,115 @@ fn detect(prefix: &Path, output: &Output) -> Option<RepairJournal> {
     Some(RepairJournal {
         detected_at: Utc::now(),
         retirement_name: retirement_name.to_string(),
+        quarantine_names: Vec::new(),
         stage: RepairStage::Detected,
+        last_error: None,
     })
 }
 
 pub(crate) fn quarantine(
     paths: &RuntimePaths,
-    mut journal: RepairJournal,
-) -> Result<(RepairJournal, RepairSnapshot)> {
+    journal: &mut RepairJournal,
+) -> Result<RepairSnapshot> {
+    validate_journal(journal)?;
+    let layout = ManagedNpmLayout::new(&journal.retirement_name)?;
+
+    if matches!(journal.stage, RepairStage::QuarantinePlanned { .. }) {
+        reconcile_planned_quarantine(paths, &layout, journal)?;
+    }
+
+    if path_exists_without_following(&layout.stale_directory)? {
+        layout.validate_stale_directory()?;
+        layout.ensure_quarantine_root()?;
+        let quarantine_name = layout.allocate_quarantine_name();
+        journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
+        save(paths, journal)?;
+        reconcile_planned_quarantine(paths, &layout, journal)?;
+    } else if matches!(journal.stage, RepairStage::Detected) {
+        journal.stage = RepairStage::Quarantined;
+        save(paths, journal)?;
+    }
+
+    let snapshot = journal.snapshot()?;
+    for path in &snapshot.quarantine_paths {
+        layout.validate_quarantine_path(path)?;
+    }
+    Ok(snapshot)
+}
+
+pub(crate) fn validate_journal(journal: &RepairJournal) -> Result<RepairSnapshot> {
+    let snapshot = journal.snapshot()?;
     let layout = ManagedNpmLayout::new(&journal.retirement_name)?;
     layout.validate_prefix()?;
 
     if matches!(journal.stage, RepairStage::Detected) {
         layout.validate_active_package()?;
-        if !path_exists_without_following(&layout.stale_directory)? {
-            journal.stage = RepairStage::Quarantined {
-                quarantine_name: None,
-                last_error: None,
-            };
-            save(paths, &journal)?;
-            let snapshot = journal.snapshot()?;
-            return Ok((journal, snapshot));
-        }
+    } else {
+        layout.validate_existing_install_target()?;
+    }
+
+    if path_exists_without_following(&layout.stale_directory)? {
         layout.validate_stale_directory()?;
-        layout.ensure_quarantine_root()?;
-        let quarantine_name = layout.allocate_quarantine_name();
-        journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
-        save(paths, &journal)?;
     }
-
-    if let RepairStage::QuarantinePlanned { quarantine_name } = &journal.stage {
-        layout.ensure_quarantine_root()?;
-        let quarantine_path = layout.quarantine_root.join(quarantine_name);
-        let stale_exists = path_exists_without_following(&layout.stale_directory)?;
-        let quarantine_exists = path_exists_without_following(&quarantine_path)?;
-        match (stale_exists, quarantine_exists) {
-            (true, false) => {
-                layout.validate_stale_directory()?;
-                rename_noreplace(&layout.stale_directory, &quarantine_path).with_context(|| {
-                    format!(
-                        "Failed to quarantine stale npm directory {} at {}",
-                        layout.stale_directory.display(),
-                        quarantine_path.display()
-                    )
-                })?;
-            }
-            (false, true) => {}
-            (false, false) => {
-                journal.stage = RepairStage::Quarantined {
-                    quarantine_name: None,
-                    last_error: None,
-                };
-                save(paths, &journal)?;
-                let snapshot = journal.snapshot()?;
-                return Ok((journal, snapshot));
-            }
-            (true, true) => {
-                anyhow::bail!(
-                    "Both stale npm directory {} and planned quarantine {} exist",
-                    layout.stale_directory.display(),
-                    quarantine_path.display()
-                );
-            }
-        }
-        layout.validate_quarantine_path(&quarantine_path)?;
-        journal.stage = RepairStage::Quarantined {
-            quarantine_name: Some(quarantine_name.clone()),
-            last_error: None,
-        };
-        save(paths, &journal)?;
-    }
-
-    let snapshot = journal.snapshot()?;
-    if let Some(path) = snapshot.quarantine_path.as_deref() {
+    for path in &snapshot.quarantine_paths {
         layout.validate_quarantine_path(path)?;
     }
-    Ok((journal, snapshot))
+    if let Some(path) = snapshot.planned_quarantine_path.as_deref() {
+        if path_exists_without_following(path)? {
+            layout.validate_quarantine_path(path)?;
+        }
+    }
+    Ok(snapshot)
+}
+
+pub(crate) fn journal_snapshot(journal: &RepairJournal) -> Result<RepairSnapshot> {
+    journal.snapshot()
+}
+
+fn reconcile_planned_quarantine(
+    paths: &RuntimePaths,
+    layout: &ManagedNpmLayout,
+    journal: &mut RepairJournal,
+) -> Result<()> {
+    let RepairStage::QuarantinePlanned { quarantine_name } = &journal.stage else {
+        return Ok(());
+    };
+    let quarantine_name = quarantine_name.clone();
+    layout.ensure_quarantine_root()?;
+    let quarantine_path = layout.quarantine_path(&quarantine_name)?;
+    let stale_exists = path_exists_without_following(&layout.stale_directory)?;
+    let quarantine_exists = path_exists_without_following(&quarantine_path)?;
+    match (stale_exists, quarantine_exists) {
+        (true, false) => {
+            layout.validate_stale_directory()?;
+            rename_noreplace(&layout.stale_directory, &quarantine_path).with_context(|| {
+                format!(
+                    "Failed to quarantine stale npm directory {} at {}",
+                    layout.stale_directory.display(),
+                    quarantine_path.display()
+                )
+            })?;
+        }
+        (false, true) => {}
+        (true, true) => {
+            layout.validate_stale_directory()?;
+        }
+        (false, false) => {
+            journal.stage = RepairStage::Quarantined;
+            save(paths, journal)?;
+            return Ok(());
+        }
+    }
+    layout.validate_quarantine_path(&quarantine_path)?;
+    if !journal
+        .quarantine_names
+        .iter()
+        .any(|name| name == &quarantine_name)
+    {
+        journal.quarantine_names.push(quarantine_name);
+    }
+    journal.stage = RepairStage::Quarantined;
+    save(paths, journal)
 }
 
 pub(crate) fn record_failure(
@@ -292,16 +365,7 @@ pub(crate) fn record_failure(
     journal: &mut RepairJournal,
     error: &str,
 ) -> Result<RepairSnapshot> {
-    let quarantine_name = match &journal.stage {
-        RepairStage::Quarantined {
-            quarantine_name, ..
-        } => quarantine_name.clone(),
-        _ => anyhow::bail!("Codex CLI repair failed before quarantine completed"),
-    };
-    journal.stage = RepairStage::Quarantined {
-        quarantine_name,
-        last_error: Some(error.to_string()),
-    };
+    journal.last_error = Some(error.to_string());
     save(paths, journal)?;
     journal.snapshot()
 }
@@ -309,7 +373,7 @@ pub(crate) fn record_failure(
 pub(crate) fn clear(paths: &RuntimePaths) -> Result<()> {
     let path = journal_path(paths);
     match fs::remove_file(&path) {
-        Ok(()) => Ok(()),
+        Ok(()) => sync_directory(&paths.state_dir),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error).with_context(|| format!("Failed to remove {}", path.display())),
     }
@@ -335,7 +399,9 @@ pub(crate) fn write_detected_for_test(paths: &RuntimePaths, retirement_name: &st
         &RepairJournal {
             detected_at: Utc::now(),
             retirement_name: retirement_name.to_string(),
+            quarantine_names: Vec::new(),
             stage: RepairStage::Detected,
+            last_error: None,
         },
     )
 }
@@ -343,23 +409,26 @@ pub(crate) fn write_detected_for_test(paths: &RuntimePaths, retirement_name: &st
 impl RepairJournal {
     fn snapshot(&self) -> Result<RepairSnapshot> {
         let layout = ManagedNpmLayout::new(&self.retirement_name)?;
-        let (quarantine_path, last_error) = match &self.stage {
-            RepairStage::Detected | RepairStage::QuarantinePlanned { .. } => (None, None),
-            RepairStage::Quarantined {
-                quarantine_name,
-                last_error,
-            } => (
-                quarantine_name
-                    .as_ref()
-                    .map(|name| layout.quarantine_root.join(name)),
-                last_error.clone(),
+        let (phase, planned_quarantine_path) = match &self.stage {
+            RepairStage::Detected => (RepairPhase::Detected, None),
+            RepairStage::QuarantinePlanned { quarantine_name } => (
+                RepairPhase::QuarantinePlanned,
+                Some(layout.quarantine_path(quarantine_name)?),
             ),
+            RepairStage::Quarantined => (RepairPhase::Quarantined, None),
         };
+        let quarantine_paths = self
+            .quarantine_names
+            .iter()
+            .map(|name| layout.quarantine_path(name))
+            .collect::<Result<Vec<_>>>()?;
         Ok(RepairSnapshot {
             detected_at: self.detected_at,
+            phase,
             stale_directory: layout.stale_directory,
-            quarantine_path,
-            last_error,
+            quarantine_paths,
+            planned_quarantine_path,
+            last_error: self.last_error.clone(),
         })
     }
 }
@@ -373,6 +442,7 @@ impl ManagedNpmLayout {
         let prefix = managed_prefix();
         let scope = prefix.join("lib/node_modules/@openai");
         Ok(Self {
+            retirement_name: retirement_name.to_string(),
             active_package: scope.join("codex"),
             stale_directory: scope.join(retirement_name),
             quarantine_root: scope.join(QUARANTINE_DIRECTORY_NAME),
@@ -394,6 +464,10 @@ impl ManagedNpmLayout {
         validate_managed_directory(&self.prefix, &self.active_package)
     }
 
+    fn validate_existing_install_target(&self) -> Result<()> {
+        validate_existing_managed_path(&self.prefix, &self.active_package)
+    }
+
     fn validate_stale_directory(&self) -> Result<()> {
         validate_managed_directory(&self.prefix, &self.stale_directory)
     }
@@ -412,6 +486,7 @@ impl ManagedNpmLayout {
                             self.quarantine_root.display()
                         )
                     })?;
+                sync_directory(&self.scope)?;
             }
             Err(error) => {
                 return Err(error).with_context(|| {
@@ -432,6 +507,28 @@ impl ManagedNpmLayout {
             path.display()
         );
         validate_managed_directory(&self.prefix, path)
+    }
+
+    fn quarantine_path(&self, name: &str) -> Result<PathBuf> {
+        let mut components = Path::new(name).components();
+        anyhow::ensure!(
+            matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none(),
+            "Persisted npm quarantine name {name} is invalid"
+        );
+        let suffix = name
+            .strip_prefix(&format!("{}.", self.retirement_name))
+            .context("Persisted npm quarantine name does not match the retirement directory")?;
+        let (timestamp, pid) = suffix
+            .split_once('.')
+            .context("Persisted npm quarantine name has an invalid suffix")?;
+        anyhow::ensure!(
+            !timestamp.is_empty()
+                && timestamp.bytes().all(|byte| byte.is_ascii_digit())
+                && !pid.is_empty()
+                && pid.bytes().all(|byte| byte.is_ascii_digit()),
+            "Persisted npm quarantine name {name} has an invalid suffix"
+        );
+        Ok(self.quarantine_root.join(name))
     }
 
     fn allocate_quarantine_name(&self) -> String {
@@ -508,6 +605,40 @@ fn validate_managed_directory(prefix: &Path, path: &Path) -> Result<()> {
     Ok(())
 }
 
+fn validate_existing_managed_path(prefix: &Path, path: &Path) -> Result<()> {
+    let relative = path.strip_prefix(prefix).with_context(|| {
+        format!(
+            "Managed npm path {} is outside {}",
+            path.display(),
+            prefix.display()
+        )
+    })?;
+    anyhow::ensure!(
+        !relative.as_os_str().is_empty(),
+        "Managed npm operation cannot target the prefix root"
+    );
+
+    let mut current = prefix.to_path_buf();
+    for component in relative.components() {
+        anyhow::ensure!(
+            matches!(component, Component::Normal(_)),
+            "Managed npm path {} contains an unsafe component",
+            path.display()
+        );
+        current.push(component.as_os_str());
+        match fs::symlink_metadata(&current) {
+            Ok(_) => validate_owned_directory(&current)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to inspect managed npm path {}", current.display())
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 fn path_exists_without_following(path: &Path) -> Result<bool> {
     match fs::symlink_metadata(path) {
         Ok(_) => Ok(true),
@@ -517,6 +648,8 @@ fn path_exists_without_following(path: &Path) -> Result<bool> {
 }
 
 fn rename_noreplace(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let source_parent = source.parent().map(Path::to_path_buf);
+    let destination_parent = destination.parent().map(Path::to_path_buf);
     let source = CString::new(source.as_os_str().as_bytes())
         .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
     let destination = CString::new(destination.as_os_str().as_bytes())
@@ -531,6 +664,14 @@ fn rename_noreplace(source: &Path, destination: &Path) -> std::io::Result<()> {
         )
     };
     if result == 0 {
+        if let Some(parent) = source_parent.as_deref() {
+            sync_directory(parent).map_err(std::io::Error::other)?;
+        }
+        if destination_parent != source_parent {
+            if let Some(parent) = destination_parent.as_deref() {
+                sync_directory(parent).map_err(std::io::Error::other)?;
+            }
+        }
         Ok(())
     } else {
         Err(std::io::Error::last_os_error())
@@ -694,16 +835,55 @@ mod tests {
         let quarantine_path = layout.quarantine_root.join(&quarantine_name);
         journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
         save(&paths, &journal)?;
-        rename_noreplace(&stale, &quarantine_path)?;
-
-        let (journal, snapshot) = quarantine(&paths, load(&paths)?.context("missing journal")?)?;
-
-        assert!(matches!(journal.stage, RepairStage::Quarantined { .. }));
+        let planned = snapshot(&paths)?.context("planned repair should be visible")?;
+        assert_eq!(planned.phase, RepairPhase::QuarantinePlanned);
         assert_eq!(
-            snapshot.quarantine_path.as_deref(),
+            planned.planned_quarantine_path.as_deref(),
             Some(quarantine_path.as_path())
         );
+        rename_noreplace(&stale, &quarantine_path)?;
+
+        let mut journal = load(&paths)?.context("missing journal")?;
+        let snapshot = quarantine(&paths, &mut journal)?;
+
+        assert!(matches!(journal.stage, RepairStage::Quarantined));
+        assert_eq!(snapshot.quarantine_paths, vec![quarantine_path.clone()]);
         assert!(quarantine_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn planned_quarantine_moves_a_recreated_stale_directory_again() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let active = prefix.join("lib/node_modules/@openai/codex");
+        let stale = prefix.join("lib/node_modules/@openai/.codex-cqYkmGXr");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        let mut journal = detect(&prefix, &output(&active, &stale)).context("missing repair")?;
+        let layout = ManagedNpmLayout::new(&journal.retirement_name)?;
+        layout.ensure_quarantine_root()?;
+        let quarantine_name = layout.allocate_quarantine_name();
+        let first_quarantine = layout.quarantine_root.join(&quarantine_name);
+        fs::create_dir_all(&first_quarantine)?;
+        secure_tree(&first_quarantine)?;
+        journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
+        save(&paths, &journal)?;
+
+        let snapshot = quarantine(&paths, &mut journal)?;
+
+        assert!(matches!(journal.stage, RepairStage::Quarantined));
+        assert_eq!(snapshot.quarantine_paths.len(), 2);
+        assert_eq!(snapshot.quarantine_paths[0], first_quarantine);
+        assert!(snapshot.quarantine_paths.iter().all(|path| path.exists()));
+        assert!(!stale.exists());
         Ok(())
     }
 
@@ -721,17 +901,11 @@ mod tests {
         std::env::set_var("HOME", &home);
         write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
 
-        let (journal, snapshot) =
-            quarantine(&paths, load(&paths)?.context("missing repair journal")?)?;
+        let mut journal = load(&paths)?.context("missing repair journal")?;
+        let snapshot = quarantine(&paths, &mut journal)?;
 
-        assert!(matches!(
-            journal.stage,
-            RepairStage::Quarantined {
-                quarantine_name: None,
-                ..
-            }
-        ));
-        assert_eq!(snapshot.quarantine_path, None);
+        assert!(matches!(journal.stage, RepairStage::Quarantined));
+        assert!(snapshot.quarantine_paths.is_empty());
         Ok(())
     }
 
@@ -754,10 +928,131 @@ mod tests {
         std::env::set_var("HOME", &home);
         write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
 
-        quarantine(&paths, load(&paths)?.context("missing repair journal")?)
-            .expect_err("quarantine must reject a retirement symlink");
+        let mut journal = load(&paths)?.context("missing repair journal")?;
+        quarantine(&paths, &mut journal).expect_err("quarantine must reject a retirement symlink");
 
         assert!(stale.is_symlink());
+        assert!(target.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn planned_quarantine_rejects_an_untrusted_persisted_name_before_rename() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let scope = prefix.join("lib/node_modules/@openai");
+        let active = scope.join("codex");
+        let stale = scope.join(".codex-cqYkmGXr");
+        let escaped = scope.join("escaped");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        let mut journal = detect(&prefix, &output(&active, &stale)).context("missing repair")?;
+        journal.stage = RepairStage::QuarantinePlanned {
+            quarantine_name: "../escaped".to_string(),
+        };
+        save(&paths, &journal)?;
+
+        quarantine(&paths, &mut journal)
+            .expect_err("repair must reject an untrusted persisted quarantine name");
+
+        assert!(stale.exists());
+        assert!(!escaped.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn historical_quarantine_names_are_validated_before_a_new_rename() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let scope = prefix.join("lib/node_modules/@openai");
+        let active = scope.join("codex");
+        let stale = scope.join(".codex-cqYkmGXr");
+        let escaped = scope.join("escaped");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        let mut journal = detect(&prefix, &output(&active, &stale)).context("missing repair")?;
+        journal.quarantine_names.push("../escaped".to_string());
+        journal.stage = RepairStage::Quarantined;
+        save(&paths, &journal)?;
+
+        quarantine(&paths, &mut journal)
+            .expect_err("repair must reject an untrusted historical quarantine name");
+
+        assert!(stale.exists());
+        assert!(!escaped.exists());
+        assert!(!scope.join(QUARANTINE_DIRECTORY_NAME).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn retry_revalidates_a_recreated_active_package() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let scope = home.join(".codex-cli-npm/lib/node_modules/@openai");
+        let active = scope.join("codex");
+        let stale = scope.join(".codex-cqYkmGXr");
+        let target = temp.path().join("must-survive");
+        fs::create_dir_all(&scope)?;
+        fs::create_dir_all(&stale)?;
+        fs::create_dir_all(&target)?;
+        secure_tree(&home)?;
+        std::os::unix::fs::symlink(&target, &active)?;
+        std::env::set_var("HOME", &home);
+        write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+        let mut journal = load(&paths)?.context("missing repair journal")?;
+        journal.stage = RepairStage::Quarantined;
+        save(&paths, &journal)?;
+
+        quarantine(&paths, &mut journal).expect_err("repair retry must reject an active symlink");
+
+        assert!(active.is_symlink());
+        assert!(stale.exists());
+        assert!(target.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn retry_revalidates_existing_install_ancestors() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let modules = home.join(".codex-cli-npm/lib/node_modules");
+        let scope = modules.join("@openai");
+        let target = temp.path().join("must-survive");
+        fs::create_dir_all(&modules)?;
+        fs::create_dir_all(&target)?;
+        secure_tree(&home)?;
+        std::os::unix::fs::symlink(&target, &scope)?;
+        std::env::set_var("HOME", &home);
+        write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+        let mut journal = load(&paths)?.context("missing repair journal")?;
+        journal.stage = RepairStage::Quarantined;
+        save(&paths, &journal)?;
+
+        quarantine(&paths, &mut journal).expect_err("repair retry must reject an ancestor symlink");
+
+        assert!(scope.is_symlink());
         assert!(target.exists());
         Ok(())
     }

--- a/updater/src/npm_cli_repair.rs
+++ b/updater/src/npm_cli_repair.rs
@@ -1,0 +1,785 @@
+use crate::{config::RuntimePaths, state::atomic_write};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::{
+    ffi::{CString, OsStr},
+    fs,
+    io::{Seek, SeekFrom, Write},
+    os::unix::ffi::OsStrExt,
+    os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt},
+    path::{Component, Path, PathBuf},
+    process::Output,
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const JOURNAL_FILE_NAME: &str = "cli-repair.json";
+const LOCK_FILE_NAME: &str = "cli-install.lock";
+const LOCK_TIMEOUT: Duration = Duration::from_secs(120);
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const QUARANTINE_DIRECTORY_NAME: &str = ".codex-linux-quarantine";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct RepairJournal {
+    detected_at: DateTime<Utc>,
+    retirement_name: String,
+    stage: RepairStage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "stage", rename_all = "snake_case")]
+enum RepairStage {
+    Detected,
+    QuarantinePlanned {
+        quarantine_name: String,
+    },
+    Quarantined {
+        quarantine_name: Option<String>,
+        #[serde(default)]
+        last_error: Option<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RepairSnapshot {
+    pub(crate) detected_at: DateTime<Utc>,
+    pub(crate) stale_directory: PathBuf,
+    pub(crate) quarantine_path: Option<PathBuf>,
+    pub(crate) last_error: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct InstallLock {
+    _file: fs::File,
+}
+
+#[derive(Debug, Clone)]
+struct ManagedNpmLayout {
+    prefix: PathBuf,
+    scope: PathBuf,
+    active_package: PathBuf,
+    stale_directory: PathBuf,
+    quarantine_root: PathBuf,
+}
+
+pub(crate) fn managed_prefix() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".codex-cli-npm")
+}
+
+pub(crate) fn managed_cli_path() -> PathBuf {
+    managed_prefix().join("bin/codex")
+}
+
+pub(crate) fn acquire_install_lock(paths: &RuntimePaths) -> Result<InstallLock> {
+    acquire_install_lock_with_timeout(paths, LOCK_TIMEOUT)
+}
+
+fn acquire_install_lock_with_timeout(
+    paths: &RuntimePaths,
+    timeout: Duration,
+) -> Result<InstallLock> {
+    let lock_path = paths.state_dir.join(LOCK_FILE_NAME);
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&lock_path)
+        .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
+    let euid = unsafe { libc::geteuid() };
+    anyhow::ensure!(
+        metadata.is_file() && metadata.uid() == euid,
+        "CLI install lock {} is not a user-owned regular file",
+        lock_path.display()
+    );
+    if metadata.permissions().mode() & 0o077 != 0 {
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
+    }
+
+    let started = Instant::now();
+    loop {
+        match file.try_lock() {
+            Ok(()) => break,
+            Err(fs::TryLockError::WouldBlock) if started.elapsed() < timeout => {
+                #[cfg(test)]
+                if let Some(path) =
+                    std::env::var_os("CODEX_UPDATE_MANAGER_TEST_CLI_INSTALL_LOCK_WAITING")
+                {
+                    let _ = fs::write(path, b"waiting");
+                }
+                thread::sleep(LOCK_POLL_INTERVAL);
+            }
+            Err(fs::TryLockError::WouldBlock) => {
+                anyhow::bail!(
+                    "Timed out waiting for another Codex CLI install after {} ms",
+                    timeout.as_millis()
+                );
+            }
+            Err(fs::TryLockError::Error(error)) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to lock {}", lock_path.display()));
+            }
+        }
+    }
+
+    file.set_len(0)
+        .with_context(|| format!("Failed to truncate {}", lock_path.display()))?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("Failed to seek {}", lock_path.display()))?;
+    writeln!(file, "{}", std::process::id())
+        .with_context(|| format!("Failed to write {}", lock_path.display()))?;
+    Ok(InstallLock { _file: file })
+}
+
+pub(crate) fn load(paths: &RuntimePaths) -> Result<Option<RepairJournal>> {
+    let journal_path = journal_path(paths);
+    let metadata = match fs::symlink_metadata(&journal_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("Failed to inspect {}", journal_path.display()));
+        }
+    };
+    anyhow::ensure!(
+        metadata.is_file()
+            && !metadata.file_type().is_symlink()
+            && metadata.uid() == unsafe { libc::geteuid() }
+            && metadata.permissions().mode() & 0o022 == 0,
+        "Codex CLI repair journal {} is not a secure user-owned file",
+        journal_path.display()
+    );
+    let contents = fs::read_to_string(&journal_path)
+        .with_context(|| format!("Failed to read {}", journal_path.display()))?;
+    serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", journal_path.display()))
+        .map(Some)
+}
+
+pub(crate) fn snapshot(paths: &RuntimePaths) -> Result<Option<RepairSnapshot>> {
+    load(paths)?.map(|journal| journal.snapshot()).transpose()
+}
+
+pub(crate) fn detect_and_persist(
+    paths: &RuntimePaths,
+    prefix: &Path,
+    output: &Output,
+) -> Result<Option<RepairSnapshot>> {
+    let Some(journal) = detect(prefix, output) else {
+        return Ok(None);
+    };
+    save(paths, &journal)?;
+    journal.snapshot().map(Some)
+}
+
+fn detect(prefix: &Path, output: &Output) -> Option<RepairJournal> {
+    if output.status.success() || prefix != managed_prefix() {
+        return None;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.lines().any(|line| line.contains("ENOTEMPTY"))
+        || !stderr.lines().any(|line| line.contains("syscall rename"))
+    {
+        return None;
+    }
+
+    let source = npm_error_path_field(&stderr, "path")?;
+    let destination = npm_error_path_field(&stderr, "dest")?;
+    let expected_source = prefix.join("lib/node_modules/@openai/codex");
+    let expected_parent = expected_source.parent()?;
+    let retirement_name = destination.file_name()?.to_str()?;
+    if source != expected_source
+        || destination.parent() != Some(expected_parent)
+        || !is_retirement_directory_name(retirement_name)
+    {
+        return None;
+    }
+
+    Some(RepairJournal {
+        detected_at: Utc::now(),
+        retirement_name: retirement_name.to_string(),
+        stage: RepairStage::Detected,
+    })
+}
+
+pub(crate) fn quarantine(
+    paths: &RuntimePaths,
+    mut journal: RepairJournal,
+) -> Result<(RepairJournal, RepairSnapshot)> {
+    let layout = ManagedNpmLayout::new(&journal.retirement_name)?;
+    layout.validate_prefix()?;
+
+    if matches!(journal.stage, RepairStage::Detected) {
+        layout.validate_active_package()?;
+        if !path_exists_without_following(&layout.stale_directory)? {
+            journal.stage = RepairStage::Quarantined {
+                quarantine_name: None,
+                last_error: None,
+            };
+            save(paths, &journal)?;
+            let snapshot = journal.snapshot()?;
+            return Ok((journal, snapshot));
+        }
+        layout.validate_stale_directory()?;
+        layout.ensure_quarantine_root()?;
+        let quarantine_name = layout.allocate_quarantine_name();
+        journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
+        save(paths, &journal)?;
+    }
+
+    if let RepairStage::QuarantinePlanned { quarantine_name } = &journal.stage {
+        layout.ensure_quarantine_root()?;
+        let quarantine_path = layout.quarantine_root.join(quarantine_name);
+        let stale_exists = path_exists_without_following(&layout.stale_directory)?;
+        let quarantine_exists = path_exists_without_following(&quarantine_path)?;
+        match (stale_exists, quarantine_exists) {
+            (true, false) => {
+                layout.validate_stale_directory()?;
+                rename_noreplace(&layout.stale_directory, &quarantine_path).with_context(|| {
+                    format!(
+                        "Failed to quarantine stale npm directory {} at {}",
+                        layout.stale_directory.display(),
+                        quarantine_path.display()
+                    )
+                })?;
+            }
+            (false, true) => {}
+            (false, false) => {
+                journal.stage = RepairStage::Quarantined {
+                    quarantine_name: None,
+                    last_error: None,
+                };
+                save(paths, &journal)?;
+                let snapshot = journal.snapshot()?;
+                return Ok((journal, snapshot));
+            }
+            (true, true) => {
+                anyhow::bail!(
+                    "Both stale npm directory {} and planned quarantine {} exist",
+                    layout.stale_directory.display(),
+                    quarantine_path.display()
+                );
+            }
+        }
+        layout.validate_quarantine_path(&quarantine_path)?;
+        journal.stage = RepairStage::Quarantined {
+            quarantine_name: Some(quarantine_name.clone()),
+            last_error: None,
+        };
+        save(paths, &journal)?;
+    }
+
+    let snapshot = journal.snapshot()?;
+    if let Some(path) = snapshot.quarantine_path.as_deref() {
+        layout.validate_quarantine_path(path)?;
+    }
+    Ok((journal, snapshot))
+}
+
+pub(crate) fn record_failure(
+    paths: &RuntimePaths,
+    journal: &mut RepairJournal,
+    error: &str,
+) -> Result<RepairSnapshot> {
+    let quarantine_name = match &journal.stage {
+        RepairStage::Quarantined {
+            quarantine_name, ..
+        } => quarantine_name.clone(),
+        _ => anyhow::bail!("Codex CLI repair failed before quarantine completed"),
+    };
+    journal.stage = RepairStage::Quarantined {
+        quarantine_name,
+        last_error: Some(error.to_string()),
+    };
+    save(paths, journal)?;
+    journal.snapshot()
+}
+
+pub(crate) fn clear(paths: &RuntimePaths) -> Result<()> {
+    let path = journal_path(paths);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("Failed to remove {}", path.display())),
+    }
+}
+
+fn save(paths: &RuntimePaths, journal: &RepairJournal) -> Result<()> {
+    let contents = serde_json::to_vec_pretty(journal)?;
+    atomic_write(&journal_path(paths), &contents)
+}
+
+fn journal_path(paths: &RuntimePaths) -> PathBuf {
+    paths.state_dir.join(JOURNAL_FILE_NAME)
+}
+
+#[cfg(test)]
+pub(crate) fn write_detected_for_test(paths: &RuntimePaths, retirement_name: &str) -> Result<()> {
+    anyhow::ensure!(
+        is_retirement_directory_name(retirement_name),
+        "invalid test retirement name"
+    );
+    save(
+        paths,
+        &RepairJournal {
+            detected_at: Utc::now(),
+            retirement_name: retirement_name.to_string(),
+            stage: RepairStage::Detected,
+        },
+    )
+}
+
+impl RepairJournal {
+    fn snapshot(&self) -> Result<RepairSnapshot> {
+        let layout = ManagedNpmLayout::new(&self.retirement_name)?;
+        let (quarantine_path, last_error) = match &self.stage {
+            RepairStage::Detected | RepairStage::QuarantinePlanned { .. } => (None, None),
+            RepairStage::Quarantined {
+                quarantine_name,
+                last_error,
+            } => (
+                quarantine_name
+                    .as_ref()
+                    .map(|name| layout.quarantine_root.join(name)),
+                last_error.clone(),
+            ),
+        };
+        Ok(RepairSnapshot {
+            detected_at: self.detected_at,
+            stale_directory: layout.stale_directory,
+            quarantine_path,
+            last_error,
+        })
+    }
+}
+
+impl ManagedNpmLayout {
+    fn new(retirement_name: &str) -> Result<Self> {
+        anyhow::ensure!(
+            is_retirement_directory_name(retirement_name),
+            "Invalid npm retirement directory name {retirement_name}"
+        );
+        let prefix = managed_prefix();
+        let scope = prefix.join("lib/node_modules/@openai");
+        Ok(Self {
+            active_package: scope.join("codex"),
+            stale_directory: scope.join(retirement_name),
+            quarantine_root: scope.join(QUARANTINE_DIRECTORY_NAME),
+            prefix,
+            scope,
+        })
+    }
+
+    fn validate_prefix(&self) -> Result<()> {
+        let home = self
+            .prefix
+            .parent()
+            .context("Managed npm prefix has no home directory")?;
+        validate_owned_directory(home)?;
+        validate_owned_directory(&self.prefix)
+    }
+
+    fn validate_active_package(&self) -> Result<()> {
+        validate_managed_directory(&self.prefix, &self.active_package)
+    }
+
+    fn validate_stale_directory(&self) -> Result<()> {
+        validate_managed_directory(&self.prefix, &self.stale_directory)
+    }
+
+    fn ensure_quarantine_root(&self) -> Result<()> {
+        validate_managed_directory(&self.prefix, &self.scope)?;
+        match fs::symlink_metadata(&self.quarantine_root) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::DirBuilder::new()
+                    .mode(0o700)
+                    .create(&self.quarantine_root)
+                    .with_context(|| {
+                        format!(
+                            "Failed to create npm quarantine {}",
+                            self.quarantine_root.display()
+                        )
+                    })?;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to inspect npm quarantine {}",
+                        self.quarantine_root.display()
+                    )
+                });
+            }
+        }
+        validate_managed_directory(&self.prefix, &self.quarantine_root)
+    }
+
+    fn validate_quarantine_path(&self, path: &Path) -> Result<()> {
+        anyhow::ensure!(
+            path.parent() == Some(self.quarantine_root.as_path()),
+            "Persisted npm quarantine path {} is invalid",
+            path.display()
+        );
+        validate_managed_directory(&self.prefix, path)
+    }
+
+    fn allocate_quarantine_name(&self) -> String {
+        let stale_name = self
+            .stale_directory
+            .file_name()
+            .and_then(OsStr::to_str)
+            .expect("validated retirement name should remain UTF-8");
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        format!("{stale_name}.{timestamp}.{}", std::process::id())
+    }
+}
+
+fn npm_error_path_field(stderr: &str, field: &str) -> Option<PathBuf> {
+    stderr.lines().find_map(|line| {
+        let payload = line
+            .trim()
+            .strip_prefix("npm error ")
+            .or_else(|| line.trim().strip_prefix("npm ERR! "))?;
+        payload
+            .strip_prefix(field)?
+            .strip_prefix(char::is_whitespace)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    })
+}
+
+fn is_retirement_directory_name(name: &str) -> bool {
+    name.strip_prefix(".codex-").is_some_and(|suffix| {
+        suffix.len() == 8 && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())
+    })
+}
+
+fn validate_owned_directory(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("Failed to inspect managed npm path {}", path.display()))?;
+    anyhow::ensure!(
+        metadata.is_dir()
+            && !metadata.file_type().is_symlink()
+            && metadata.uid() == unsafe { libc::geteuid() }
+            && metadata.permissions().mode() & 0o022 == 0,
+        "Managed npm path {} is not a secure user-owned directory",
+        path.display()
+    );
+    Ok(())
+}
+
+fn validate_managed_directory(prefix: &Path, path: &Path) -> Result<()> {
+    let relative = path.strip_prefix(prefix).with_context(|| {
+        format!(
+            "Managed npm path {} is outside {}",
+            path.display(),
+            prefix.display()
+        )
+    })?;
+    anyhow::ensure!(
+        !relative.as_os_str().is_empty(),
+        "Managed npm operation cannot target the prefix root"
+    );
+
+    let mut current = prefix.to_path_buf();
+    for component in relative.components() {
+        anyhow::ensure!(
+            matches!(component, Component::Normal(_)),
+            "Managed npm path {} contains an unsafe component",
+            path.display()
+        );
+        current.push(component.as_os_str());
+        validate_owned_directory(&current)?;
+    }
+    Ok(())
+}
+
+fn path_exists_without_following(path: &Path) -> Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| format!("Failed to inspect {}", path.display())),
+    }
+}
+
+fn rename_noreplace(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let source = CString::new(source.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let destination = CString::new(destination.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from_raw_os_error(libc::EINVAL))?;
+    let result = unsafe {
+        libc::renameat2(
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            destination.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{os::unix::fs::PermissionsExt, process::ExitStatus};
+    use tempfile::tempdir;
+
+    fn test_paths(root: &Path) -> RuntimePaths {
+        RuntimePaths {
+            config_file: root.join("config/config.toml"),
+            state_file: root.join("state/state.json"),
+            log_file: root.join("state/service.log"),
+            cache_dir: root.join("cache"),
+            state_dir: root.join("state"),
+            config_dir: root.join("config"),
+        }
+    }
+
+    fn output_with_prefix(source: &Path, destination: &Path, prefix: &str) -> Output {
+        use std::os::unix::process::ExitStatusExt;
+        Output {
+            status: ExitStatus::from_raw(217 << 8),
+            stdout: Vec::new(),
+            stderr: format!(
+                "{prefix} code ENOTEMPTY\n{prefix} syscall rename\n{prefix} path {}\n{prefix} dest {}\n",
+                source.display(),
+                destination.display()
+            )
+            .into_bytes(),
+        }
+    }
+
+    fn output(source: &Path, destination: &Path) -> Output {
+        output_with_prefix(source, destination, "npm error")
+    }
+
+    fn secure_tree(root: &Path) -> Result<()> {
+        let metadata = fs::symlink_metadata(root)?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Ok(());
+        }
+        fs::set_permissions(root, fs::Permissions::from_mode(0o755))?;
+        for entry in fs::read_dir(root)? {
+            secure_tree(&entry?.path())?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn detection_persists_without_mutating_stale_directory() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let active = prefix.join("lib/node_modules/@openai/codex");
+        let stale = prefix.join("lib/node_modules/@openai/.codex-cqYkmGXr");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        std::env::set_var("HOME", &home);
+
+        let snapshot = detect_and_persist(&paths, &prefix, &output(&active, &stale))?
+            .context("stale condition should be detected")?;
+
+        assert_eq!(snapshot.stale_directory, stale);
+        assert!(stale.exists());
+        assert!(journal_path(&paths).exists());
+        Ok(())
+    }
+
+    #[test]
+    fn detection_rejects_untrusted_shapes_without_persisting() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let active = prefix.join("lib/node_modules/@openai/codex");
+        let scope = active.parent().context("test package has no scope")?;
+        let outside = temp.path().join(".codex-cqYkmGXr");
+        let malformed = scope.join(".codex-not-a-retirement-hash");
+        let valid = scope.join(".codex-cqYkmGXr");
+        let wrong_source = scope.join("another-package");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&outside)?;
+        fs::create_dir_all(&malformed)?;
+        fs::create_dir_all(&valid)?;
+        std::env::set_var("HOME", &home);
+
+        assert!(detect_and_persist(&paths, &prefix, &output(&active, &outside))?.is_none());
+        assert!(detect_and_persist(&paths, &prefix, &output(&active, &malformed))?.is_none());
+        assert!(detect_and_persist(&paths, &prefix, &output(&wrong_source, &valid))?.is_none());
+        assert!(detect_and_persist(
+            &paths,
+            &temp.path().join("other-prefix"),
+            &output(&active, &valid)
+        )?
+        .is_none());
+        assert!(!journal_path(&paths).exists());
+        assert!(outside.exists());
+        assert!(malformed.exists());
+        assert!(valid.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn detection_accepts_legacy_npm_error_prefix_without_mutating() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let active = prefix.join("lib/node_modules/@openai/codex");
+        let stale = prefix.join("lib/node_modules/@openai/.codex-cqYkmGXr");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        std::env::set_var("HOME", &home);
+
+        let snapshot = detect_and_persist(
+            &paths,
+            &prefix,
+            &output_with_prefix(&active, &stale, "npm ERR!"),
+        )?
+        .context("legacy npm stderr should be detected")?;
+
+        assert_eq!(snapshot.stale_directory, stale);
+        assert!(stale.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn planned_quarantine_recovers_after_rename_before_stage_commit() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let prefix = home.join(".codex-cli-npm");
+        let active = prefix.join("lib/node_modules/@openai/codex");
+        let stale = prefix.join("lib/node_modules/@openai/.codex-cqYkmGXr");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&stale)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        let mut journal = detect(&prefix, &output(&active, &stale)).context("missing repair")?;
+        let layout = ManagedNpmLayout::new(&journal.retirement_name)?;
+        layout.ensure_quarantine_root()?;
+        let quarantine_name = layout.allocate_quarantine_name();
+        let quarantine_path = layout.quarantine_root.join(&quarantine_name);
+        journal.stage = RepairStage::QuarantinePlanned { quarantine_name };
+        save(&paths, &journal)?;
+        rename_noreplace(&stale, &quarantine_path)?;
+
+        let (journal, snapshot) = quarantine(&paths, load(&paths)?.context("missing journal")?)?;
+
+        assert!(matches!(journal.stage, RepairStage::Quarantined { .. }));
+        assert_eq!(
+            snapshot.quarantine_path.as_deref(),
+            Some(quarantine_path.as_path())
+        );
+        assert!(quarantine_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn quarantine_handles_an_already_absent_stale_directory() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let active = home.join(".codex-cli-npm/lib/node_modules/@openai/codex");
+        fs::create_dir_all(&active)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+
+        let (journal, snapshot) =
+            quarantine(&paths, load(&paths)?.context("missing repair journal")?)?;
+
+        assert!(matches!(
+            journal.stage,
+            RepairStage::Quarantined {
+                quarantine_name: None,
+                ..
+            }
+        ));
+        assert_eq!(snapshot.quarantine_path, None);
+        Ok(())
+    }
+
+    #[test]
+    fn quarantine_rejects_a_stale_directory_symlink() -> Result<()> {
+        let _guard = crate::test_util::env_lock();
+        let _restore_env = crate::test_util::EnvRestoreGuard::capture(&["HOME"]);
+        let temp = tempdir()?;
+        let home = temp.path().join("home");
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let scope = home.join(".codex-cli-npm/lib/node_modules/@openai");
+        let active = scope.join("codex");
+        let stale = scope.join(".codex-cqYkmGXr");
+        let target = temp.path().join("must-survive");
+        fs::create_dir_all(&active)?;
+        fs::create_dir_all(&target)?;
+        std::os::unix::fs::symlink(&target, &stale)?;
+        secure_tree(&home)?;
+        std::env::set_var("HOME", &home);
+        write_detected_for_test(&paths, ".codex-cqYkmGXr")?;
+
+        quarantine(&paths, load(&paths)?.context("missing repair journal")?)
+            .expect_err("quarantine must reject a retirement symlink");
+
+        assert!(stale.is_symlink());
+        assert!(target.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn install_lock_rejects_symlinks_and_times_out() -> Result<()> {
+        let temp = tempdir()?;
+        let paths = test_paths(temp.path());
+        fs::create_dir_all(&paths.state_dir)?;
+        let first = acquire_install_lock_with_timeout(&paths, Duration::from_millis(100))?;
+        let error = acquire_install_lock_with_timeout(&paths, Duration::from_millis(75))
+            .expect_err("second lock must time out");
+        assert!(error.to_string().contains("Timed out waiting"));
+        drop(first);
+
+        fs::remove_file(paths.state_dir.join(LOCK_FILE_NAME))?;
+        let target = temp.path().join("must-survive");
+        fs::write(&target, "unchanged\n")?;
+        std::os::unix::fs::symlink(&target, paths.state_dir.join(LOCK_FILE_NAME))?;
+        acquire_install_lock_with_timeout(&paths, Duration::from_millis(100))
+            .expect_err("lock must reject symlinks");
+        assert_eq!(fs::read_to_string(target)?, "unchanged\n");
+        Ok(())
+    }
+}

--- a/updater/src/rollback.rs
+++ b/updater/src/rollback.rs
@@ -53,7 +53,7 @@ pub async fn run(
             "Rollback package is missing: {}",
             package_path.display()
         ));
-        state.save(&paths.state_file)?;
+        state.save_updater(&paths.state_file)?;
         println!("Rollback package is missing: {}", package_path.display());
         return Ok(());
     }
@@ -71,7 +71,7 @@ async fn trigger_rollback(
 
     state.status = UpdateStatus::Installing;
     state.error_message = None;
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
 
     let _ = notify::send(
         "Rolling back ChatGPT Desktop",
@@ -92,7 +92,7 @@ async fn trigger_rollback(
             blocked_candidate,
             blocked_dmg_sha256,
         );
-        state.save(&paths.state_file)?;
+        state.save_updater(&paths.state_file)?;
         let _ = cache_cleanup::prune_unreferenced_workspaces(&config.workspace_root, state);
         println!(
             "Rolled back ChatGPT Desktop to {}.",
@@ -117,7 +117,7 @@ async fn trigger_rollback(
     }
 
     state.mark_failed(message.clone());
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
     let _ = notify::send(
         "ChatGPT Desktop rollback failed",
         "The previous package could not be installed. Check the updater log for details.",

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -7,11 +7,13 @@ use std::{
     collections::BTreeSet,
     fs::{self, OpenOptions},
     io::Write,
-    os::unix::fs::OpenOptionsExt,
+    os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt},
     path::{Path, PathBuf},
     process,
     time::{SystemTime, UNIX_EPOCH},
 };
+
+const STATE_LOCK_FILE_NAME: &str = "state.lock";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -188,9 +190,60 @@ impl PersistedState {
     }
 
     /// Persists the updater state to JSON on disk.
+    #[cfg(test)]
     pub fn save(&self, path: &Path) -> Result<()> {
-        let content = serde_json::to_string_pretty(self)?;
-        atomic_write(path, content.as_bytes())?;
+        let _lock = StateLock::acquire(path)?;
+        self.save_unlocked(path)
+    }
+
+    pub fn save_updater(&self, path: &Path) -> Result<()> {
+        let _lock = StateLock::acquire(path)?;
+        let mut merged = self.clone();
+        if let Some(latest) = Self::load_if_present(path)? {
+            merged.copy_cli_state_from(&latest);
+        }
+        merged.save_unlocked(path)
+    }
+
+    pub fn save_cli(&mut self, path: &Path) -> Result<()> {
+        let _lock = StateLock::acquire(path)?;
+        let mut merged = Self::load_if_present(path)?
+            .unwrap_or_else(|| Self::new(self.auto_install_on_app_exit));
+        merged.copy_cli_state_from(self);
+        merged.save_unlocked(path)?;
+        *self = merged;
+        Ok(())
+    }
+
+    pub fn reload_cli(&mut self, path: &Path) -> Result<()> {
+        let _lock = StateLock::acquire(path)?;
+        if let Some(latest) = Self::load_if_present(path)? {
+            self.copy_cli_state_from(&latest);
+        }
+        Ok(())
+    }
+
+    pub fn save_cli_if_unchanged(&mut self, path: &Path, expected: &Self) -> Result<bool> {
+        let _lock = StateLock::acquire(path)?;
+        let latest = Self::load_if_present(path)?.unwrap_or_else(|| expected.clone());
+        if !latest.same_cli_state(expected) {
+            *self = latest;
+            return Ok(false);
+        }
+        let mut merged = latest;
+        merged.copy_cli_state_from(self);
+        merged.save_unlocked(path)?;
+        *self = merged;
+        Ok(true)
+    }
+
+    pub fn save_cli_status(&mut self, path: &Path) -> Result<()> {
+        let _lock = StateLock::acquire(path)?;
+        let mut latest = Self::load_if_present(path)?.unwrap_or_else(|| self.clone());
+        latest.cli_status = self.cli_status.clone();
+        latest.cli_error_message = self.cli_error_message.clone();
+        latest.save_unlocked(path)?;
+        *self = latest;
         Ok(())
     }
 
@@ -207,6 +260,45 @@ impl PersistedState {
         self.candidate_wrapper_commit = None;
         self.wrapper_changelog = None;
         self.wrapper_dev_mode = None;
+    }
+
+    fn load_if_present(path: &Path) -> Result<Option<Self>> {
+        match fs::read_to_string(path) {
+            Ok(content) => serde_json::from_str::<Self>(&content)
+                .with_context(|| format!("Failed to parse {}", path.display()))
+                .map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error).with_context(|| format!("Failed to read {}", path.display())),
+        }
+    }
+
+    fn save_unlocked(&self, path: &Path) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)?;
+        atomic_write(path, content.as_bytes())
+    }
+
+    fn copy_cli_state_from(&mut self, source: &Self) {
+        self.cli_path = source.cli_path.clone();
+        self.cli_install_channel = source.cli_install_channel.clone();
+        self.cli_installed_version = source.cli_installed_version.clone();
+        self.cli_official_latest_version = source.cli_official_latest_version.clone();
+        self.cli_package_manager_latest_version = source.cli_package_manager_latest_version.clone();
+        self.cli_status = source.cli_status.clone();
+        self.cli_last_check_at = source.cli_last_check_at;
+        self.cli_last_verified_at = source.cli_last_verified_at;
+        self.cli_error_message = source.cli_error_message.clone();
+    }
+
+    fn same_cli_state(&self, other: &Self) -> bool {
+        self.cli_path == other.cli_path
+            && self.cli_install_channel == other.cli_install_channel
+            && self.cli_installed_version == other.cli_installed_version
+            && self.cli_official_latest_version == other.cli_official_latest_version
+            && self.cli_package_manager_latest_version == other.cli_package_manager_latest_version
+            && self.cli_status == other.cli_status
+            && self.cli_last_check_at == other.cli_last_check_at
+            && self.cli_last_verified_at == other.cli_last_verified_at
+            && self.cli_error_message == other.cli_error_message
     }
 }
 
@@ -246,7 +338,54 @@ pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
             temp_path.display()
         )
     })?;
+    sync_directory(parent)?;
     Ok(())
+}
+
+pub(crate) fn sync_directory(path: &Path) -> Result<()> {
+    fs::File::open(path)
+        .with_context(|| format!("Failed to open directory {}", path.display()))?
+        .sync_all()
+        .with_context(|| format!("Failed to sync directory {}", path.display()))
+}
+
+struct StateLock {
+    _file: fs::File,
+}
+
+impl StateLock {
+    fn acquire(state_path: &Path) -> Result<Self> {
+        let parent = state_path
+            .parent()
+            .with_context(|| format!("{} has no parent directory", state_path.display()))?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+        let lock_path = parent.join(STATE_LOCK_FILE_NAME);
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+            .open(&lock_path)
+            .with_context(|| format!("Failed to open {}", lock_path.display()))?;
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("Failed to inspect {}", lock_path.display()))?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.uid() == unsafe { libc::geteuid() },
+            "Updater state lock {} is not a user-owned regular file",
+            lock_path.display()
+        );
+        if metadata.permissions().mode() & 0o077 != 0 {
+            file.set_permissions(fs::Permissions::from_mode(0o600))
+                .with_context(|| format!("Failed to secure {}", lock_path.display()))?;
+        }
+        file.lock()
+            .with_context(|| format!("Failed to lock {}", lock_path.display()))?;
+        Ok(Self { _file: file })
+    }
 }
 
 fn atomic_temp_path(path: &Path) -> PathBuf {
@@ -303,6 +442,130 @@ mod tests {
         );
         assert!(!loaded.auto_install_on_app_exit);
         assert!(loaded.waiting_for_app_exit_auto_install);
+        Ok(())
+    }
+
+    #[test]
+    fn updater_and_cli_state_transactions_preserve_each_other() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("state.json");
+        PersistedState::new(true).save(&path)?;
+
+        let mut cli = PersistedState::load_or_default(&path, true)?;
+        cli.cli_status = CliStatus::UpToDate;
+        cli.cli_installed_version = Some("0.42.1".to_string());
+
+        let mut updater = PersistedState::load_or_default(&path, true)?;
+        updater.status = UpdateStatus::DownloadingDmg;
+        updater.remote_headers_fingerprint = Some("new-updater-state".to_string());
+        updater.cli_prompt_dismissed_at = Some(Utc::now());
+
+        cli.save_cli(&path)?;
+        updater.save_updater(&path)?;
+
+        let loaded = PersistedState::load_or_default(&path, true)?;
+        assert_eq!(loaded.cli_status, CliStatus::UpToDate);
+        assert_eq!(loaded.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(loaded.status, UpdateStatus::DownloadingDmg);
+        assert_eq!(
+            loaded.remote_headers_fingerprint.as_deref(),
+            Some("new-updater-state")
+        );
+        assert!(loaded.cli_prompt_dismissed_at.is_some());
+
+        let mut later_cli = PersistedState::new(true);
+        later_cli.cli_status = CliStatus::UpdateRequired;
+        later_cli.cli_error_message = Some("repair required".to_string());
+        later_cli.save_cli(&path)?;
+
+        let loaded = PersistedState::load_or_default(&path, true)?;
+        assert_eq!(loaded.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(
+            loaded.remote_headers_fingerprint.as_deref(),
+            Some("new-updater-state")
+        );
+        assert!(loaded.cli_prompt_dismissed_at.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn guarded_cli_state_write_reloads_a_newer_cli_result() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("state.json");
+        PersistedState::new(true).save(&path)?;
+
+        let baseline = PersistedState::load_or_default(&path, true)?;
+        let mut stale = baseline.clone();
+        stale.cli_status = CliStatus::Unknown;
+        stale.cli_installed_version = Some("0.42.0".to_string());
+
+        let mut newer = baseline.clone();
+        newer.cli_status = CliStatus::UpToDate;
+        newer.cli_installed_version = Some("0.42.1".to_string());
+        newer.save_cli(&path)?;
+        newer.remote_headers_fingerprint = Some("must-survive".to_string());
+        newer.save_updater(&path)?;
+
+        assert!(!stale.save_cli_if_unchanged(&path, &baseline)?);
+        assert_eq!(stale.cli_status, CliStatus::UpToDate);
+        assert_eq!(stale.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(
+            stale.remote_headers_fingerprint.as_deref(),
+            Some("must-survive")
+        );
+        let loaded = PersistedState::load_or_default(&path, true)?;
+        assert_eq!(loaded.cli_status, CliStatus::UpToDate);
+        assert_eq!(loaded.cli_installed_version.as_deref(), Some("0.42.1"));
+        Ok(())
+    }
+
+    #[test]
+    fn cli_status_write_preserves_the_latest_cli_identity() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("state.json");
+        let mut latest = PersistedState::new(true);
+        latest.cli_path = Some(PathBuf::from("/new/codex"));
+        latest.cli_installed_version = Some("0.42.1".to_string());
+        latest.cli_official_latest_version = Some("0.42.1".to_string());
+        latest.cli_last_verified_at = Some(Utc::now());
+        latest.cli_status = CliStatus::UpToDate;
+        latest.remote_headers_fingerprint = Some("must-survive".to_string());
+        latest.save(&path)?;
+
+        let mut stale = PersistedState::new(true);
+        stale.cli_path = Some(PathBuf::from("/old/codex"));
+        stale.cli_installed_version = Some("0.42.0".to_string());
+        stale.cli_official_latest_version = None;
+        stale.cli_status = CliStatus::UpdateRequired;
+        stale.cli_error_message = Some("repair required".to_string());
+        stale.save_cli_status(&path)?;
+
+        assert_eq!(stale.cli_path, Some(PathBuf::from("/new/codex")));
+        assert_eq!(stale.cli_installed_version.as_deref(), Some("0.42.1"));
+        assert_eq!(stale.cli_official_latest_version.as_deref(), Some("0.42.1"));
+        assert!(stale.cli_last_verified_at.is_some());
+        assert_eq!(stale.cli_status, CliStatus::UpdateRequired);
+        assert_eq!(stale.cli_error_message.as_deref(), Some("repair required"));
+        assert_eq!(
+            stale.remote_headers_fingerprint.as_deref(),
+            Some("must-survive")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn state_lock_rejects_a_symlink() -> Result<()> {
+        let temp = tempdir()?;
+        let path = temp.path().join("state.json");
+        let target = temp.path().join("must-survive");
+        fs::write(&target, "unchanged\n")?;
+        std::os::unix::fs::symlink(&target, temp.path().join(STATE_LOCK_FILE_NAME))?;
+
+        PersistedState::new(true)
+            .save(&path)
+            .expect_err("state lock must reject symlinks");
+
+        assert_eq!(fs::read_to_string(target)?, "unchanged\n");
         Ok(())
     }
 

--- a/updater/src/state.rs
+++ b/updater/src/state.rs
@@ -7,6 +7,7 @@ use std::{
     collections::BTreeSet,
     fs::{self, OpenOptions},
     io::Write,
+    os::unix::fs::OpenOptionsExt,
     path::{Path, PathBuf},
     process,
     time::{SystemTime, UNIX_EPOCH},
@@ -209,7 +210,7 @@ impl PersistedState {
     }
 }
 
-fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
+pub(crate) fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
     let parent = path
         .parent()
         .with_context(|| format!("{} has no parent directory", path.display()))?;
@@ -219,6 +220,7 @@ fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
     let mut temp_file = OpenOptions::new()
         .write(true)
         .create_new(true)
+        .mode(0o600)
         .open(&temp_path)
         .with_context(|| format!("Failed to create {}", temp_path.display()))?;
 

--- a/updater/src/wrapper_apply.rs
+++ b/updater/src/wrapper_apply.rs
@@ -109,7 +109,7 @@ pub async fn run_apply_wrapper_update(
             state.artifact_paths.package_path = None;
             refresh_installed_wrapper_state(config, state);
             state.clear_wrapper_update_candidate();
-            state.save(&paths.state_file)?;
+            state.save_updater(&paths.state_file)?;
             let _ = notify::send(
                 "ChatGPT Desktop for Linux updated",
                 "The newer Linux wrapper build has been installed.",
@@ -415,7 +415,7 @@ async fn apply_packaged(
     }
 
     state.installed_version = install::installed_package_version();
-    let _ = state.save(&paths.state_file);
+    let _ = state.save_updater(&paths.state_file);
     Ok(())
 }
 
@@ -527,7 +527,7 @@ async fn cached_or_downloaded_dmg(
             .await
             .context("Failed to download upstream DMG for wrapper rebuild")?;
     state.artifact_paths.dmg_path = Some(downloaded.path.clone());
-    state.save(&paths.state_file)?;
+    state.save_updater(&paths.state_file)?;
     Ok(CachedDmg {
         path: downloaded.path,
         _lease: downloaded.lease,

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -96,6 +96,11 @@ fi
 if [ "$1" = "install" ]; then
   printf '%s\n' "$$" >> "$NPM_INSTALL_LOG"
   printf '%s\n' "$PPID" > "$NPM_SUPERVISOR_PID"
+  previous_group="$(/bin/cat "$NPM_BACKGROUND_PROCESS_GROUP" 2>/dev/null || true)"
+  if [ -n "$previous_group" ] && /bin/kill -0 "-$previous_group" 2>/dev/null; then
+    /bin/touch "$NPM_INSTALL_OVERLAP"
+    exit 99
+  fi
   if ! /bin/mkdir "$NPM_INSTALL_OWNER" 2>/dev/null; then
     owner_pid="$(/bin/cat "$NPM_INSTALL_OWNER/pid" 2>/dev/null || true)"
     if [ -n "$owner_pid" ] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
@@ -114,7 +119,7 @@ if [ "$1" = "install" ]; then
        [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant-hang" ]; then
       /bin/sh -c 'trap "exit 0" TERM; while :; do /bin/sleep 1; done' \
         >/dev/null 2>&1 &
-      /bin/ps -o pgid= -p "$$" > "$NPM_BACKGROUND_PROCESS_GROUP"
+      printf '%s\n' "$PPID" > "$NPM_BACKGROUND_PROCESS_GROUP"
       if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant" ]; then
         exit 0
       fi
@@ -253,6 +258,7 @@ exit 1
             .env_remove("FNM_MULTISHELL_PATH")
             .env_remove("HOMEBREW_PREFIX")
             .env_remove("NVM_DIR")
+            .env_remove("XDG_DATA_HOME")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         command

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -97,7 +97,7 @@ if [ "$1" = "install" ]; then
   printf '%s\n' "$$" >> "$NPM_INSTALL_LOG"
   printf '%s\n' "$PPID" > "$NPM_SUPERVISOR_PID"
   previous_group="$(/bin/cat "$NPM_BACKGROUND_PROCESS_GROUP" 2>/dev/null || true)"
-  if [ -n "$previous_group" ] && /bin/kill -0 "-$previous_group" 2>/dev/null; then
+  if [ -n "$previous_group" ] && /bin/kill -0 -- "-$previous_group" 2>/dev/null; then
     /bin/touch "$NPM_INSTALL_OVERLAP"
     exit 99
   fi
@@ -614,6 +614,13 @@ fn killed_npm_supervisor_cleans_descendants_before_lock_release() -> Result<()> 
         wait_for_nonempty_file(&fixture.npm_supervisor_pid, "npm supervisor pid value")?
             .trim()
             .parse::<i32>()?;
+    anyhow::ensure!(
+        Command::new("/bin/kill")
+            .args(["-0", "--", &format!("-{background_process_group}")])
+            .status()?
+            .success(),
+        "overlap oracle did not recognize live npm group {background_process_group}"
+    );
     anyhow::ensure!(
         unsafe { libc::kill(supervisor_pid, libc::SIGKILL) } == 0,
         "failed to kill npm supervisor {supervisor_pid}"

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -476,7 +476,7 @@ fn late_registry_failure_cannot_overwrite_a_completed_repair() -> Result<()> {
 }
 
 #[test]
-fn npm_child_retains_the_install_lock_after_the_updater_parent_dies() -> Result<()> {
+fn orphaned_npm_process_group_is_bounded_and_releases_the_install_lock() -> Result<()> {
     let fixture = Fixture::new()?;
 
     let mut preflight_command = fixture.command();
@@ -485,25 +485,25 @@ fn npm_child_retains_the_install_lock_after_the_updater_parent_dies() -> Result<
         .arg(&fixture.cli_path);
     let mut preflight = ManagedChild::spawn(preflight_command, "cli-preflight")?;
     wait_for_path(&fixture.install_started, "first npm install")?;
+    let orphan_process_group = fs::read_to_string(fixture.install_owner.join("pid"))?
+        .trim()
+        .parse::<i32>()?;
     preflight.kill_parent_only()?;
+    wait_for_process_group_exit(orphan_process_group, "orphaned npm install")?;
+    fs::remove_file(&fixture.install_started)?;
 
     fixture.update_state(expire_cli_registry_check)?;
     let mut status_command = fixture.command();
     status_command.args(["status", "--json"]);
     let mut status = ManagedChild::spawn(status_command, "status")?;
-    wait_for_text(
-        &fixture.log_path(),
-        &format!("process {} is waiting", status.pid()?),
-        "status wait after updater parent death",
-    )?;
+    wait_for_path(&fixture.install_started, "replacement npm install")?;
     status.assert_running()?;
-    assert_eq!(install_count(&fixture.install_log)?, 1);
+    assert_eq!(install_count(&fixture.install_log)?, 2);
     assert!(!fixture.install_overlap.exists());
 
     fs::write(&fixture.install_release, b"continue")?;
     ensure_success("status", &status.wait()?)?;
 
-    assert_eq!(install_count(&fixture.install_log)?, 2);
     assert!(!fixture.install_overlap.exists());
     Ok(())
 }
@@ -555,6 +555,21 @@ fn wait_for_path(path: &Path, description: &str) -> Result<()> {
         thread::sleep(Duration::from_millis(20));
     }
     Ok(())
+}
+
+fn wait_for_process_group_exit(process_group: i32, description: &str) -> Result<()> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        let exists = unsafe { libc::kill(-process_group, 0) } == 0;
+        if !exists {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {description} process group {process_group} to exit"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
 }
 
 fn wait_for_state(fixture: &Fixture, predicate: impl Fn(&Value) -> bool) -> Result<()> {

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -29,6 +29,7 @@ struct Fixture {
     install_release: PathBuf,
     install_overlap: PathBuf,
     install_owner: PathBuf,
+    background_process_group: PathBuf,
     view_started: PathBuf,
     view_release: PathBuf,
 }
@@ -57,6 +58,7 @@ impl Fixture {
         let install_release = root.join("npm-install.release");
         let install_overlap = root.join("npm-install.overlap");
         let install_owner = root.join("npm-install.owner");
+        let background_process_group = root.join("npm-background-process-group");
         let view_started = root.join("npm-view.started");
         let view_release = root.join("npm-view.release");
         let app_executable = root.join("app/electron");
@@ -105,6 +107,12 @@ if [ "$1" = "install" ]; then
     printf '%s\n' "$$" > "$NPM_INSTALL_OWNER/pid"
     trap '/bin/rm -f "$NPM_INSTALL_OWNER/pid"; /bin/rmdir "$NPM_INSTALL_OWNER"' EXIT
     /bin/touch "$NPM_INSTALL_STARTED"
+    if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant" ]; then
+      /bin/sh -c 'trap "exit 0" TERM; while :; do /bin/sleep 1; done' \
+        >/dev/null 2>&1 &
+      printf '%s\n' "$$" > "$NPM_BACKGROUND_PROCESS_GROUP"
+      exit 0
+    fi
     while [ ! -e "$NPM_INSTALL_RELEASE" ]; do
       /bin/sleep 0.01
     done
@@ -175,6 +183,7 @@ exit 1
             install_release,
             install_overlap,
             install_owner,
+            background_process_group,
             view_started,
             view_release,
         };
@@ -226,6 +235,10 @@ exit 1
             .env("NPM_INSTALL_RELEASE", &self.install_release)
             .env("NPM_INSTALL_OVERLAP", &self.install_overlap)
             .env("NPM_INSTALL_OWNER", &self.install_owner)
+            .env(
+                "NPM_BACKGROUND_PROCESS_GROUP",
+                &self.background_process_group,
+            )
             .env("NPM_VIEW_STARTED", &self.view_started)
             .env("NPM_VIEW_RELEASE", &self.view_release)
             .env_remove("FNM_DIR")
@@ -260,6 +273,13 @@ exit 1
 
 impl Drop for Fixture {
     fn drop(&mut self) {
+        if let Ok(process_group) = fs::read_to_string(&self.background_process_group) {
+            if let Ok(process_group) = process_group.trim().parse::<i32>() {
+                unsafe {
+                    libc::kill(-process_group, libc::SIGKILL);
+                }
+            }
+        }
         let pid_path = self.install_owner.join("pid");
         let Ok(pid) = fs::read_to_string(pid_path) else {
             return;
@@ -503,6 +523,46 @@ fn orphaned_npm_process_group_is_bounded_and_releases_the_install_lock() -> Resu
 
     fs::write(&fixture.install_release, b"continue")?;
     ensure_success("status", &status.wait()?)?;
+
+    assert!(!fixture.install_overlap.exists());
+    Ok(())
+}
+
+#[test]
+fn completed_npm_leader_cleans_background_group_and_releases_the_install_lock() -> Result<()> {
+    let fixture = Fixture::new()?;
+    fs::write(&fixture.install_mode, b"background-descendant\n")?;
+
+    let mut first_status_command = fixture.command();
+    first_status_command.args(["status", "--json"]);
+    let first_status = ManagedChild::spawn(first_status_command, "first status")?;
+    wait_for_path(
+        &fixture.background_process_group,
+        "background npm process group",
+    )?;
+    let background_process_group = fs::read_to_string(&fixture.background_process_group)?
+        .trim()
+        .parse::<i32>()?;
+    let first_output = first_status.wait()?;
+    assert!(!first_output.status.success());
+    assert!(String::from_utf8_lossy(&first_output.stderr)
+        .contains("npm completed but managed Codex CLI 0.42.1 could not be resolved"));
+    wait_for_process_group_exit(background_process_group, "background npm descendant")?;
+
+    fs::remove_file(&fixture.install_started)?;
+    fixture.update_state(expire_cli_registry_check)?;
+    fs::write(&fixture.install_mode, b"success\n")?;
+    let mut replacement_status_command = fixture.command();
+    replacement_status_command.args(["status", "--json"]);
+    let mut replacement_status =
+        ManagedChild::spawn(replacement_status_command, "replacement status")?;
+    wait_for_path(&fixture.install_started, "replacement npm install")?;
+    replacement_status.assert_running()?;
+    assert_eq!(install_count(&fixture.install_log)?, 2);
+    assert!(!fixture.install_overlap.exists());
+
+    fs::write(&fixture.install_release, b"continue")?;
+    ensure_success("replacement status", &replacement_status.wait()?)?;
 
     assert!(!fixture.install_overlap.exists());
     Ok(())

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -30,6 +30,7 @@ struct Fixture {
     install_overlap: PathBuf,
     install_owner: PathBuf,
     background_process_group: PathBuf,
+    npm_supervisor_pid: PathBuf,
     view_started: PathBuf,
     view_release: PathBuf,
 }
@@ -59,6 +60,7 @@ impl Fixture {
         let install_overlap = root.join("npm-install.overlap");
         let install_owner = root.join("npm-install.owner");
         let background_process_group = root.join("npm-background-process-group");
+        let npm_supervisor_pid = root.join("npm-supervisor.pid");
         let view_started = root.join("npm-view.started");
         let view_release = root.join("npm-view.release");
         let app_executable = root.join("app/electron");
@@ -93,6 +95,7 @@ impl Fixture {
 fi
 if [ "$1" = "install" ]; then
   printf '%s\n' "$$" >> "$NPM_INSTALL_LOG"
+  printf '%s\n' "$PPID" > "$NPM_SUPERVISOR_PID"
   if ! /bin/mkdir "$NPM_INSTALL_OWNER" 2>/dev/null; then
     owner_pid="$(/bin/cat "$NPM_INSTALL_OWNER/pid" 2>/dev/null || true)"
     if [ -n "$owner_pid" ] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
@@ -107,11 +110,14 @@ if [ "$1" = "install" ]; then
     printf '%s\n' "$$" > "$NPM_INSTALL_OWNER/pid"
     trap '/bin/rm -f "$NPM_INSTALL_OWNER/pid"; /bin/rmdir "$NPM_INSTALL_OWNER"' EXIT
     /bin/touch "$NPM_INSTALL_STARTED"
-    if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant" ]; then
+    if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant" ] ||
+       [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant-hang" ]; then
       /bin/sh -c 'trap "exit 0" TERM; while :; do /bin/sleep 1; done' \
         >/dev/null 2>&1 &
-      printf '%s\n' "$$" > "$NPM_BACKGROUND_PROCESS_GROUP"
-      exit 0
+      /bin/ps -o pgid= -p "$$" > "$NPM_BACKGROUND_PROCESS_GROUP"
+      if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "background-descendant" ]; then
+        exit 0
+      fi
     fi
     while [ ! -e "$NPM_INSTALL_RELEASE" ]; do
       /bin/sleep 0.01
@@ -184,6 +190,7 @@ exit 1
             install_overlap,
             install_owner,
             background_process_group,
+            npm_supervisor_pid,
             view_started,
             view_release,
         };
@@ -239,6 +246,7 @@ exit 1
                 "NPM_BACKGROUND_PROCESS_GROUP",
                 &self.background_process_group,
             )
+            .env("NPM_SUPERVISOR_PID", &self.npm_supervisor_pid)
             .env("NPM_VIEW_STARTED", &self.view_started)
             .env("NPM_VIEW_RELEASE", &self.view_release)
             .env_remove("FNM_DIR")
@@ -505,9 +513,10 @@ fn orphaned_npm_process_group_is_bounded_and_releases_the_install_lock() -> Resu
         .arg(&fixture.cli_path);
     let mut preflight = ManagedChild::spawn(preflight_command, "cli-preflight")?;
     wait_for_path(&fixture.install_started, "first npm install")?;
-    let orphan_process_group = fs::read_to_string(fixture.install_owner.join("pid"))?
-        .trim()
-        .parse::<i32>()?;
+    let orphan_process_group =
+        wait_for_nonempty_file(&fixture.npm_supervisor_pid, "npm supervisor pid")?
+            .trim()
+            .parse::<i32>()?;
     preflight.kill_parent_only()?;
     wait_for_process_group_exit(orphan_process_group, "orphaned npm install")?;
     fs::remove_file(&fixture.install_started)?;
@@ -540,14 +549,18 @@ fn completed_npm_leader_cleans_background_group_and_releases_the_install_lock() 
         &fixture.background_process_group,
         "background npm process group",
     )?;
-    let background_process_group = fs::read_to_string(&fixture.background_process_group)?
-        .trim()
-        .parse::<i32>()?;
+    let background_process_group = wait_for_nonempty_file(
+        &fixture.background_process_group,
+        "background npm process group value",
+    )?
+    .trim()
+    .parse::<i32>()?;
     let first_output = first_status.wait()?;
     assert!(!first_output.status.success());
     assert!(String::from_utf8_lossy(&first_output.stderr)
         .contains("npm completed but managed Codex CLI 0.42.1 could not be resolved"));
     wait_for_process_group_exit(background_process_group, "background npm descendant")?;
+    fs::remove_file(&fixture.background_process_group)?;
 
     fs::remove_file(&fixture.install_started)?;
     fixture.update_state(expire_cli_registry_check)?;
@@ -564,6 +577,62 @@ fn completed_npm_leader_cleans_background_group_and_releases_the_install_lock() 
     fs::write(&fixture.install_release, b"continue")?;
     ensure_success("replacement status", &replacement_status.wait()?)?;
 
+    assert!(!fixture.install_overlap.exists());
+    Ok(())
+}
+
+#[test]
+fn killed_npm_supervisor_cleans_descendants_before_lock_release() -> Result<()> {
+    let fixture = Fixture::new()?;
+    fs::write(&fixture.install_mode, b"background-descendant-hang\n")?;
+
+    let mut preflight_command = fixture.command();
+    preflight_command
+        .args(["cli-preflight", "--cli-path"])
+        .arg(&fixture.cli_path);
+    let preflight = ManagedChild::spawn(preflight_command, "cli-preflight")?;
+    wait_for_path(&fixture.install_started, "first npm install")?;
+    wait_for_path(
+        &fixture.background_process_group,
+        "background npm process group",
+    )?;
+    wait_for_path(&fixture.npm_supervisor_pid, "npm supervisor pid")?;
+
+    let background_process_group = wait_for_nonempty_file(
+        &fixture.background_process_group,
+        "background npm process group value",
+    )?
+    .trim()
+    .parse::<i32>()?;
+    let supervisor_pid =
+        wait_for_nonempty_file(&fixture.npm_supervisor_pid, "npm supervisor pid value")?
+            .trim()
+            .parse::<i32>()?;
+    anyhow::ensure!(
+        unsafe { libc::kill(supervisor_pid, libc::SIGKILL) } == 0,
+        "failed to kill npm supervisor {supervisor_pid}"
+    );
+
+    fs::remove_file(&fixture.install_started)?;
+    fixture.update_state(expire_cli_registry_check)?;
+    fs::write(&fixture.install_mode, b"success\n")?;
+    let mut status_command = fixture.command();
+    status_command.args(["status", "--json"]);
+    let status = ManagedChild::spawn(status_command, "status")?;
+
+    wait_for_process_group_exit(background_process_group, "npm group after supervisor death")?;
+    fs::remove_file(&fixture.background_process_group)?;
+    let first = preflight.wait()?;
+    anyhow::ensure!(
+        !first.status.success(),
+        "cli-preflight unexpectedly succeeded after its npm supervisor was killed"
+    );
+    wait_for_path(&fixture.install_started, "replacement npm install")?;
+    assert_eq!(install_count(&fixture.install_log)?, 2);
+    assert!(!fixture.install_overlap.exists());
+
+    fs::write(&fixture.install_release, b"continue")?;
+    ensure_success("status", &status.wait()?)?;
     assert!(!fixture.install_overlap.exists());
     Ok(())
 }
@@ -615,6 +684,23 @@ fn wait_for_path(path: &Path, description: &str) -> Result<()> {
         thread::sleep(Duration::from_millis(20));
     }
     Ok(())
+}
+
+fn wait_for_nonempty_file(path: &Path, description: &str) -> Result<String> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if let Ok(value) = fs::read_to_string(path) {
+            if !value.trim().is_empty() {
+                return Ok(value);
+            }
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {description} at {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
 }
 
 fn wait_for_process_group_exit(process_group: i32, description: &str) -> Result<()> {

--- a/updater/tests/cli_repair_concurrency.rs
+++ b/updater/tests/cli_repair_concurrency.rs
@@ -1,0 +1,602 @@
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::{
+    fs,
+    os::unix::fs::{symlink, PermissionsExt},
+    path::{Path, PathBuf},
+    process::{Child, Command, Output, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+use tempfile::TempDir;
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+struct Fixture {
+    _temp: TempDir,
+    root: PathBuf,
+    home: PathBuf,
+    config_home: PathBuf,
+    state_home: PathBuf,
+    cache_home: PathBuf,
+    cli_path: PathBuf,
+    active_package: PathBuf,
+    stale_directory: PathBuf,
+    latest_version: PathBuf,
+    install_mode: PathBuf,
+    install_log: PathBuf,
+    install_started: PathBuf,
+    install_release: PathBuf,
+    install_overlap: PathBuf,
+    install_owner: PathBuf,
+    view_started: PathBuf,
+    view_release: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Result<Self> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().to_path_buf();
+        let home = root.join("home");
+        let config_home = root.join("xdg-config");
+        let state_home = root.join("xdg-state");
+        let cache_home = root.join("xdg-cache");
+        let prefix = home.join(".codex-cli-npm");
+        let package_root = prefix.join("lib/node_modules/@openai/codex");
+        let cli_entrypoint = package_root.join("bin/codex.js");
+        let cli_path = prefix.join("bin/codex");
+        let stale_directory = prefix
+            .join("lib/node_modules/@openai")
+            .join(".codex-cqYkmGXr");
+        let npm_path = prefix.join("bin/npm");
+        let node_path = prefix.join("bin/node");
+        let latest_version = root.join("npm-latest-version");
+        let install_mode = root.join("npm-install-mode");
+        let install_log = root.join("npm-install.log");
+        let install_started = root.join("npm-install.started");
+        let install_release = root.join("npm-install.release");
+        let install_overlap = root.join("npm-install.overlap");
+        let install_owner = root.join("npm-install.owner");
+        let view_started = root.join("npm-view.started");
+        let view_release = root.join("npm-view.release");
+        let app_executable = root.join("app/electron");
+
+        fs::create_dir_all(cli_entrypoint.parent().context("CLI entrypoint parent")?)?;
+        fs::create_dir_all(cli_path.parent().context("CLI path parent")?)?;
+        fs::create_dir_all(config_home.join("codex-update-manager"))?;
+        fs::create_dir_all(state_home.join("codex-update-manager"))?;
+        fs::create_dir_all(cache_home.join("codex-update-manager"))?;
+        fs::create_dir_all(app_executable.parent().context("app executable parent")?)?;
+
+        write_executable(&cli_entrypoint, &cli_script("0.42.0"))?;
+        symlink(
+            Path::new("../lib/node_modules/@openai/codex/bin/codex.js"),
+            &cli_path,
+        )?;
+        write_executable(&node_path, "#!/bin/sh\nexit 0\n")?;
+        write_executable(
+            &npm_path,
+            r#"#!/bin/sh
+		if [ "$1" = "view" ]; then
+			  if [ "${NPM_VIEW_MODE:-success}" = "delayed-failure" ]; then
+		    /bin/touch "$NPM_VIEW_STARTED"
+	    while [ ! -e "$NPM_VIEW_RELEASE" ]; do
+	      /bin/sleep 0.01
+	    done
+	    printf 'registry unavailable\n' >&2
+	    exit 43
+	  fi
+	  /bin/cat "$NPM_LATEST_VERSION"
+  exit 0
+fi
+if [ "$1" = "install" ]; then
+  printf '%s\n' "$$" >> "$NPM_INSTALL_LOG"
+  if ! /bin/mkdir "$NPM_INSTALL_OWNER" 2>/dev/null; then
+    owner_pid="$(/bin/cat "$NPM_INSTALL_OWNER/pid" 2>/dev/null || true)"
+    if [ -n "$owner_pid" ] && /bin/kill -0 "$owner_pid" 2>/dev/null; then
+      /bin/touch "$NPM_INSTALL_OVERLAP"
+      exit 99
+    fi
+    /bin/rm -f "$NPM_INSTALL_OWNER/pid"
+    /bin/rmdir "$NPM_INSTALL_OWNER"
+    /bin/mkdir "$NPM_INSTALL_OWNER"
+  fi
+  if [ -d "$NPM_INSTALL_OWNER" ]; then
+    printf '%s\n' "$$" > "$NPM_INSTALL_OWNER/pid"
+    trap '/bin/rm -f "$NPM_INSTALL_OWNER/pid"; /bin/rmdir "$NPM_INSTALL_OWNER"' EXIT
+    /bin/touch "$NPM_INSTALL_STARTED"
+    while [ ! -e "$NPM_INSTALL_RELEASE" ]; do
+      /bin/sleep 0.01
+    done
+  fi
+	  if [ "$(/bin/cat "$NPM_INSTALL_MODE")" = "stale" ]; then
+    /bin/mkdir -p "$NPM_RETIREMENT_PATH"
+    printf '%s\n' \
+      'npm error code ENOTEMPTY' \
+      'npm error syscall rename' \
+      "npm error path $NPM_ACTIVE_PACKAGE" \
+      "npm error dest $NPM_RETIREMENT_PATH" >&2
+	    exit 217
+	  fi
+	  printf '%s\n' '#!/bin/sh' "echo 'codex-cli v0.42.1'" > "$NPM_MANAGED_CLI"
+	  /bin/chmod 755 "$NPM_MANAGED_CLI"
+	  exit 0
+fi
+exit 1
+"#,
+        )?;
+        fs::write(&latest_version, b"0.42.0\n")?;
+        fs::write(&install_mode, b"success\n")?;
+        write_executable(&app_executable, "#!/bin/sh\nexit 0\n")?;
+        fs::write(
+            package_root.join("package.json"),
+            serde_json::to_vec_pretty(&json!({
+                "name": "@openai/codex",
+                "bin": {"codex": "bin/codex.js"},
+                "optionalDependencies": {
+                    "@openai/codex-linux-x64": "0.42.1"
+                }
+            }))?,
+        )?;
+        secure_directory_tree(&home)?;
+
+        let config = format!(
+            "dmg_url = \"http://127.0.0.1:9/Codex.dmg\"\n\
+             initial_check_delay_seconds = 3600\n\
+             check_interval_hours = 24\n\
+             auto_install_on_app_exit = false\n\
+             notifications = false\n\
+             workspace_root = \"{}\"\n\
+             builder_bundle_root = \"{}\"\n\
+             app_executable_path = \"{}\"\n\
+             enable_wrapper_updates = false\n\
+             wrapper_remote = \"\"\n\
+             wrapper_branch = \"main\"\n",
+            toml_path(&cache_home.join("codex-update-manager")),
+            toml_path(&root),
+            toml_path(&app_executable),
+        );
+        fs::write(config_home.join("codex-update-manager/config.toml"), config)?;
+
+        let fixture = Self {
+            _temp: temp,
+            root,
+            home,
+            config_home,
+            state_home,
+            cache_home,
+            cli_path,
+            active_package: package_root,
+            stale_directory,
+            latest_version,
+            install_mode,
+            install_log,
+            install_started,
+            install_release,
+            install_overlap,
+            install_owner,
+            view_started,
+            view_release,
+        };
+        let output = fixture
+            .command()
+            .args(["cli-preflight", "--cli-path"])
+            .arg(&fixture.cli_path)
+            .output()?;
+        ensure_success("fixture CLI preflight", &output)?;
+        fixture.update_state(|state| {
+            state["remote_headers_fingerprint"] = json!("must-survive-cli-race");
+            state["cli_last_check_at"] = Value::Null;
+            state["cli_official_latest_version"] = Value::Null;
+        })?;
+        fs::write(&fixture.latest_version, b"0.42.1\n")?;
+        fs::write(&fixture.install_mode, b"stale\n")?;
+        Ok(fixture)
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_codex-update-manager"));
+        command
+            .env("HOME", &self.home)
+            .env("XDG_CONFIG_HOME", &self.config_home)
+            .env("XDG_STATE_HOME", &self.state_home)
+            .env("XDG_CACHE_HOME", &self.cache_home)
+            .env(
+                "CODEX_LINUX_SETTINGS_FILE",
+                self.root.join("missing-settings.json"),
+            )
+            .env("CODEX_CLI_PATH", &self.cli_path)
+            .env(
+                "PATH",
+                format!(
+                    "{}:/usr/bin:/bin",
+                    self.cli_path
+                        .parent()
+                        .expect("CLI path should have a parent")
+                        .display()
+                ),
+            )
+            .env("NPM_ACTIVE_PACKAGE", &self.active_package)
+            .env("NPM_RETIREMENT_PATH", &self.stale_directory)
+            .env("NPM_LATEST_VERSION", &self.latest_version)
+            .env("NPM_INSTALL_MODE", &self.install_mode)
+            .env("NPM_INSTALL_LOG", &self.install_log)
+            .env("NPM_MANAGED_CLI", &self.cli_path)
+            .env("NPM_INSTALL_STARTED", &self.install_started)
+            .env("NPM_INSTALL_RELEASE", &self.install_release)
+            .env("NPM_INSTALL_OVERLAP", &self.install_overlap)
+            .env("NPM_INSTALL_OWNER", &self.install_owner)
+            .env("NPM_VIEW_STARTED", &self.view_started)
+            .env("NPM_VIEW_RELEASE", &self.view_release)
+            .env_remove("FNM_DIR")
+            .env_remove("FNM_MULTISHELL_PATH")
+            .env_remove("HOMEBREW_PREFIX")
+            .env_remove("NVM_DIR")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        command
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.state_home.join("codex-update-manager/state.json")
+    }
+
+    fn log_path(&self) -> PathBuf {
+        self.state_home.join("codex-update-manager/service.log")
+    }
+
+    fn update_state(&self, update: impl FnOnce(&mut Value)) -> Result<()> {
+        let path = self.state_path();
+        let mut state: Value = serde_json::from_slice(&fs::read(&path)?)?;
+        update(&mut state);
+        fs::write(path, serde_json::to_vec_pretty(&state)?)?;
+        Ok(())
+    }
+
+    fn state(&self) -> Result<Value> {
+        Ok(serde_json::from_slice(&fs::read(self.state_path())?)?)
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let pid_path = self.install_owner.join("pid");
+        let Ok(pid) = fs::read_to_string(pid_path) else {
+            return;
+        };
+        let Ok(pid) = pid.trim().parse::<i32>() else {
+            return;
+        };
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+            libc::kill(pid, libc::SIGKILL);
+        }
+    }
+}
+
+struct ManagedChild {
+    child: Option<Child>,
+    name: &'static str,
+}
+
+impl ManagedChild {
+    fn spawn(mut command: Command, name: &'static str) -> Result<Self> {
+        let child = command
+            .spawn()
+            .with_context(|| format!("failed to spawn {name}"))?;
+        Ok(Self {
+            child: Some(child),
+            name,
+        })
+    }
+
+    fn assert_running(&mut self) -> Result<()> {
+        anyhow::ensure!(
+            self.child
+                .as_mut()
+                .context("child already consumed")?
+                .try_wait()?
+                .is_none(),
+            "{} exited before the install lock was released",
+            self.name
+        );
+        Ok(())
+    }
+
+    fn pid(&self) -> Result<u32> {
+        Ok(self.child.as_ref().context("child already consumed")?.id())
+    }
+
+    fn kill_parent_only(&mut self) -> Result<()> {
+        let child = self.child.as_mut().context("child already consumed")?;
+        child.kill()?;
+        child.wait()?;
+        self.child.take();
+        Ok(())
+    }
+
+    fn wait(mut self) -> Result<Output> {
+        let deadline = Instant::now() + WAIT_TIMEOUT;
+        loop {
+            if self
+                .child
+                .as_mut()
+                .context("child already consumed")?
+                .try_wait()?
+                .is_some()
+            {
+                let child = self.child.take().context("child already consumed")?;
+                return child.wait_with_output().map_err(Into::into);
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "{} did not exit before the timeout",
+                self.name
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn terminate(&mut self) -> Result<()> {
+        let Some(child) = self.child.as_mut() else {
+            return Ok(());
+        };
+        child.kill()?;
+        child.wait()?;
+        self.child.take();
+        Ok(())
+    }
+}
+
+impl Drop for ManagedChild {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+#[test]
+fn actual_cli_preflight_status_and_daemon_share_the_npm_install_lock() -> Result<()> {
+    let fixture = Fixture::new()?;
+
+    let mut preflight_command = fixture.command();
+    preflight_command
+        .args(["cli-preflight", "--cli-path"])
+        .arg(&fixture.cli_path);
+    let mut preflight = ManagedChild::spawn(preflight_command, "cli-preflight")?;
+    wait_for_path(&fixture.install_started, "first npm install")?;
+
+    fixture.update_state(expire_cli_registry_check)?;
+    let mut status_command = fixture.command();
+    status_command.args(["status", "--json"]);
+    let mut status = ManagedChild::spawn(status_command, "status")?;
+    wait_for_text(
+        &fixture.log_path(),
+        &format!("process {} is waiting", status.pid()?),
+        "status install-lock wait",
+    )?;
+    status.assert_running()?;
+
+    fixture.update_state(expire_cli_registry_check)?;
+    let mut daemon_command = fixture.command();
+    daemon_command.arg("daemon");
+    let mut daemon = ManagedChild::spawn(daemon_command, "daemon")?;
+
+    wait_for_text(
+        &fixture.log_path(),
+        &format!("process {} is waiting", daemon.pid()?),
+        "daemon install-lock wait",
+    )?;
+    preflight.assert_running()?;
+    status.assert_running()?;
+    daemon.assert_running()?;
+    assert_eq!(install_count(&fixture.install_log)?, 1);
+    assert!(!fixture.install_overlap.exists());
+
+    fs::write(&fixture.install_release, b"continue")?;
+    ensure_success("cli-preflight", &preflight.wait()?)?;
+    ensure_success("status", &status.wait()?)?;
+    wait_for_state(&fixture, |state| {
+        state["cli_status"] == "update_required" && state["cli_installed_version"] == "0.42.0"
+    })?;
+    daemon.terminate()?;
+
+    assert_eq!(install_count(&fixture.install_log)?, 1);
+    assert!(!fixture.install_overlap.exists());
+    assert!(fixture.stale_directory.exists());
+    assert!(fixture
+        .state_home
+        .join("codex-update-manager/cli-repair.json")
+        .exists());
+    let state = fixture.state()?;
+    assert_eq!(state["remote_headers_fingerprint"], "must-survive-cli-race");
+    assert_eq!(state["cli_status"], "update_required");
+    assert_eq!(state["cli_installed_version"], "0.42.0");
+    assert!(state["cli_error_message"]
+        .as_str()
+        .is_some_and(|message| message.contains("codex-update-manager diagnose")));
+    Ok(())
+}
+
+#[test]
+fn late_registry_failure_cannot_overwrite_a_completed_repair() -> Result<()> {
+    let fixture = Fixture::new()?;
+
+    let mut status_command = fixture.command();
+    status_command
+        .args(["status", "--json"])
+        .env("NPM_VIEW_MODE", "delayed-failure");
+    let status = ManagedChild::spawn(status_command, "delayed status")?;
+    wait_for_path(&fixture.view_started, "delayed npm registry lookup")?;
+
+    fixture.update_state(expire_cli_registry_check)?;
+    fs::write(&fixture.install_release, b"continue")?;
+    let mut preflight_command = fixture.command();
+    preflight_command
+        .args(["cli-preflight", "--cli-path"])
+        .arg(&fixture.cli_path);
+    ensure_success(
+        "stale-detecting cli-preflight",
+        &preflight_command.output()?,
+    )?;
+    wait_for_state(&fixture, |state| {
+        state["cli_status"] == "update_required"
+            && state["cli_error_message"]
+                .as_str()
+                .is_some_and(|message| message.contains("codex-update-manager diagnose"))
+    })?;
+
+    fs::write(&fixture.install_mode, b"success\n")?;
+    let mut repair_command = fixture.command();
+    repair_command.arg("repair-cli");
+    ensure_success("explicit repair", &repair_command.output()?)?;
+    wait_for_state(&fixture, |state| {
+        state["cli_status"] == "up_to_date" && state["cli_installed_version"] == "0.42.1"
+    })?;
+    assert!(!fixture
+        .state_home
+        .join("codex-update-manager/cli-repair.json")
+        .exists());
+
+    fs::write(&fixture.view_release, b"continue")?;
+    ensure_success("delayed status", &status.wait()?)?;
+
+    let state = fixture.state()?;
+    assert_eq!(state["cli_status"], "up_to_date");
+    assert_eq!(state["cli_installed_version"], "0.42.1");
+    assert!(state["cli_error_message"].is_null());
+    assert!(!fixture
+        .state_home
+        .join("codex-update-manager/cli-repair.json")
+        .exists());
+    assert_eq!(install_count(&fixture.install_log)?, 2);
+    Ok(())
+}
+
+#[test]
+fn npm_child_retains_the_install_lock_after_the_updater_parent_dies() -> Result<()> {
+    let fixture = Fixture::new()?;
+
+    let mut preflight_command = fixture.command();
+    preflight_command
+        .args(["cli-preflight", "--cli-path"])
+        .arg(&fixture.cli_path);
+    let mut preflight = ManagedChild::spawn(preflight_command, "cli-preflight")?;
+    wait_for_path(&fixture.install_started, "first npm install")?;
+    preflight.kill_parent_only()?;
+
+    fixture.update_state(expire_cli_registry_check)?;
+    let mut status_command = fixture.command();
+    status_command.args(["status", "--json"]);
+    let mut status = ManagedChild::spawn(status_command, "status")?;
+    wait_for_text(
+        &fixture.log_path(),
+        &format!("process {} is waiting", status.pid()?),
+        "status wait after updater parent death",
+    )?;
+    status.assert_running()?;
+    assert_eq!(install_count(&fixture.install_log)?, 1);
+    assert!(!fixture.install_overlap.exists());
+
+    fs::write(&fixture.install_release, b"continue")?;
+    ensure_success("status", &status.wait()?)?;
+
+    assert_eq!(install_count(&fixture.install_log)?, 2);
+    assert!(!fixture.install_overlap.exists());
+    Ok(())
+}
+
+fn cli_script(version: &str) -> String {
+    format!("#!/bin/sh\necho 'codex-cli v{version}'\n")
+}
+
+fn expire_cli_registry_check(state: &mut Value) {
+    state["cli_last_check_at"] = Value::Null;
+    state["cli_official_latest_version"] = Value::Null;
+}
+
+fn write_executable(path: &Path, contents: &str) -> Result<()> {
+    fs::write(path, contents)?;
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+fn secure_directory_tree(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o755))?;
+    for entry in fs::read_dir(path)? {
+        secure_directory_tree(&entry?.path())?;
+    }
+    Ok(())
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display()
+        .to_string()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn wait_for_path(path: &Path, description: &str) -> Result<()> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    while !path.exists() {
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {description}: {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+    Ok(())
+}
+
+fn wait_for_state(fixture: &Fixture, predicate: impl Fn(&Value) -> bool) -> Result<()> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if fixture.state().is_ok_and(|state| predicate(&state)) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for persisted CLI state"
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn wait_for_text(path: &Path, needle: &str, description: &str) -> Result<()> {
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+    loop {
+        if fs::read_to_string(path).is_ok_and(|contents| contents.contains(needle)) {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out waiting for {description}: {}",
+            path.display()
+        );
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn install_count(path: &Path) -> Result<usize> {
+    Ok(fs::read_to_string(path)?.lines().count())
+}
+
+fn ensure_success(name: &str, output: &Output) -> Result<()> {
+    anyhow::ensure!(
+        output.status.success(),
+        "{name} failed with {}: stdout={} stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- keep daemon reconciliation, `status`, and launcher preflight non-destructive
  when npm reports the exact stale Arborist retirement-directory failure
- preserve a functional existing Codex CLI and direct the user to the existing
  read-only `codex-update-manager diagnose` command
- add an explicit `codex-update-manager repair-cli` flow that revalidates the
  managed npm layout under a shared lock, records a crash-durable quarantine,
  and runs one bounded npm retry per invocation
- serialize CLI-owned and updater-owned state persistence so concurrent
  entrypoints do not overwrite each other's fields or hide a newer repair
  condition with a late registry result
- cover actual `cli-preflight`, `status`, and daemon executables contending for
  the same npm install lock

## Reproduction

Reproduced from current `origin/main` on Ubuntu 25.10, KDE Plasma, Wayland, and
the native Debian package.

The updater-managed CLI was `0.144.6` while npm reported `0.145.0`. An
interrupted npm upgrade had left this Arborist retirement directory:

```text
$HOME/.codex-cli-npm/lib/node_modules/@openai/.codex-cqYkmGXr
```

Every later automatic upgrade attempt failed with:

```text
npm error code ENOTEMPTY
npm error syscall rename
npm error path $HOME/.codex-cli-npm/lib/node_modules/@openai/codex
npm error dest $HOME/.codex-cli-npm/lib/node_modules/@openai/.codex-cqYkmGXr
```

No open or merged issue or pull request covered this stale npm recovery flow
when work began. The existing optional-dependency repair PRs do not address
this Arborist retirement-directory failure.

## Behavior and safety

Automatic paths may perform the normal npm update attempt. If that attempt
reports the exact validated stale-directory condition, they persist a dedicated
repair journal and stop. They do not delete, quarantine, or retry anything. A
functional CLI remains selected, and one actionable message points to:

```bash
codex-update-manager diagnose
```

`diagnose` remains read-only. It reports the stale path, journal phase, planned
or completed quarantines, the last repair error, and the explicit command:

```bash
codex-update-manager repair-cli
```

The explicit repair command:

- acquires the shared CLI install lock before any managed-prefix mutation
- reloads the repair journal and revalidates the prefix, every existing install
  ancestor, active package, stale directory, and persisted quarantine paths
- rejects symlinks, unsafe components, wrong ownership, and group/world-writable
  managed directories
- persists a planned quarantine before using no-replace rename semantics
- fsyncs journal files and affected directories across the rename transition
- runs npm once with existing bounded subprocess and process-group handling
- bounds missing-CLI registry discovery while the shared install lock is held
- reloads CLI state and re-resolves requested and persisted CLI paths after
  lock contention before a missing-CLI flow consults npm
- runs mutating npm under a parent-independent bounded supervisor that inherits
  the install lock, terminates the npm process group if the updater parent exits,
  and retains its own timeout
- commits successful CLI state before clearing the repair journal
- preserves every quarantine and the journal after failure, including when npm
  recreates the same retirement directory during a later explicit retry

The state file now has a separate user-owned lock. CLI maintenance merges only
CLI-owned fields into the latest updater state, while updater writes preserve
the latest CLI-owned fields. Routine CLI writers also acquire the install lock
and reload the repair journal before persisting. They compare the latest CLI
fields with the snapshot originally loaded by that entrypoint and reload a
newer result instead of overwriting it, so a stale registry result cannot hide
either an actionable repair condition or a completed repair. UI prompt state
remains updater-owned.

Other prefixes, package names, malformed retirement names, unrelated npm
failures, and untrusted filesystem shapes remain unchanged. No recursive
deletion is part of this recovery flow.

This changes updater CLI maintenance only. It does not change upstream DMG
patches, Linux Feature descriptors, Browser Use, Computer Use, remote control,
package payload layout, or candidate promotion policy. The installed app and
live managed CLI prefix were not modified during development.

## Validation

- `cargo fmt --all`
- `cargo check -p codex-update-manager`
- `cargo clippy -p codex-update-manager --all-targets -- -D warnings`
- `cargo test -p codex-update-manager` (`312 passed`, plus 3 executable
  integration tests)
- `cargo test -p codex-update-manager --test cli_repair_concurrency
  -- --test-threads=1` (5 serial runs)
- `bash tests/scripts_smoke.sh`
- `./scripts/ci-local.sh pr` (core, Debian, RPM, and pacman passed)
- `git diff --check`

Regression coverage includes:

- automatic detection without filesystem mutation or npm retry
- continued use of the functional existing CLI
- read-only diagnostics on both absent and pending state
- explicit successful and failed repair
- repeated failed repair with multiple preserved quarantines
- crash recovery after the quarantine rename but before the next journal phase
- symlink, path-shape, ownership, and lock-file rejection
- state-field preservation across concurrent CLI and updater writes
- pending repair blocking automatic optional-dependency npm mutation
- actual `cli-preflight`, `status`, and long-running daemon processes contending
  for the npm install lock without overlapping npm
- a delayed failing registry lookup completing after another entrypoint detects
  stale npm state and completes repair without restoring the old CLI snapshot
- a status process paused after its initial state load while repair completes,
  proving load-to-dispatch state cannot overwrite the repaired CLI
- pending repair state blocking missing-CLI registry and install transitions
- bounded missing-CLI registry failure releasing the shared install lock
- a missing-CLI subprocess waiting behind explicit repair and then using the
  completed winner without another registry lookup or install
- pending repair status preserving the latest CLI path, versions, and timestamps
- updater-parent `SIGKILL` without manually releasing fake npm, proving the
  supervisor terminates the orphaned process group, releases the lock, and lets
  a second updater enter npm without overlap

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] This is not an upstream DMG drift fix.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum reasoning effort, addressed all findings, and reran the relevant tests.