### PR TITLE
HEROX-1165: Fix current DMG optional feature patch drift

### DIFF
--- a/linux-features/agent-workspace/patch.js
+++ b/linux-features/agent-workspace/patch.js
@@ -1839,7 +1839,7 @@ function inferRuntimeDependenciesFromSettingsSource(source) {
 function inferRuntimeDependenciesFromSettingsAssets(assetsDir) {
   const candidates = fs
     .readdirSync(assetsDir)
-    .filter((name) => /^settings-page-.*\.js$/.test(name) || /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name))
+    .filter((name) => /^settings-page-[^.]+\.js$/.test(name))
     .sort();
   for (const candidate of candidates) {
     const dependencies = inferRuntimeDependenciesFromSettingsSource(
@@ -1909,19 +1909,41 @@ function isAgentWorkspaceSettingsRouteBundleSource(currentSource) {
   );
 }
 
-function isAgentWorkspaceSettingsNavigationBundleSource(currentSource) {
-  return (
-    /[A-Za-z_$][\w$]*=\{[^;]*"local-environments":[A-Za-z_$][\w$]*,[^;]*worktrees:/.test(currentSource) &&
-    currentSource.includes("slugs:[`") &&
-    currentSource.includes("`local-environments`") &&
-    currentSource.includes("`worktrees`")
-  );
-}
-
 const CURRENT_SETTINGS_CATALOG_SLUGS = "local-environments.worktrees.environments";
 const PATCHED_SETTINGS_CATALOG_SLUGS = "local-environments.agent-workspaces.worktrees.environments";
 const CURRENT_SETTINGS_CATALOG_ITEMS = "{slug:`local-environments`},{slug:`worktrees`}";
 const PATCHED_SETTINGS_CATALOG_ITEMS = "{slug:`local-environments`},{slug:`agent-workspaces`},{slug:`worktrees`}";
+const CURRENT_SETTINGS_NAVIGATION_SLUGS = "local-environments.worktrees.browser-use";
+const PATCHED_SETTINGS_NAVIGATION_SLUGS = "local-environments.agent-workspaces.worktrees.browser-use";
+const CURRENT_SETTINGS_NAVIGATION_GROUP = "`local-environments`,`environments`,`worktrees`";
+const PATCHED_SETTINGS_NAVIGATION_GROUP =
+  "`local-environments`,`agent-workspaces`,`environments`,`worktrees`";
+const CURRENT_SETTINGS_VISIBILITY_CASES =
+  "case`worktrees`:case`local-environments`:case`environments`:return";
+const PATCHED_SETTINGS_VISIBILITY_CASES =
+  "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return";
+const CURRENT_SETTINGS_ICON_PATTERN =
+  /"local-environments":([A-Za-z_$][\w$]*),worktrees:([A-Za-z_$][\w$]*)/;
+const PATCHED_SETTINGS_ICON_PATTERN =
+  /"local-environments":([A-Za-z_$][\w$]*),"agent-workspaces":([A-Za-z_$][\w$]*),worktrees:([A-Za-z_$][\w$]*)/;
+
+function isAgentWorkspaceSettingsNavigationBundleSource(currentSource) {
+  return (
+    (currentSource.includes(CURRENT_SETTINGS_NAVIGATION_SLUGS) ||
+      currentSource.includes(PATCHED_SETTINGS_NAVIGATION_SLUGS)) &&
+    (currentSource.includes(CURRENT_SETTINGS_NAVIGATION_GROUP) ||
+      currentSource.includes(PATCHED_SETTINGS_NAVIGATION_GROUP))
+  );
+}
+
+function isAgentWorkspaceSettingsVisibilityBundleSource(currentSource) {
+  return (
+    (CURRENT_SETTINGS_ICON_PATTERN.test(currentSource) ||
+      PATCHED_SETTINGS_ICON_PATTERN.test(currentSource)) &&
+    (currentSource.includes(CURRENT_SETTINGS_VISIBILITY_CASES) ||
+      currentSource.includes(PATCHED_SETTINGS_VISIBILITY_CASES))
+  );
+}
 
 function isAgentWorkspaceSettingsCatalogBundleSource(currentSource) {
   return (
@@ -1950,50 +1972,6 @@ function applyAgentWorkspaceSettingsCatalogPatch(currentSource) {
   return currentSource
     .replace(CURRENT_SETTINGS_CATALOG_SLUGS, PATCHED_SETTINGS_CATALOG_SLUGS)
     .replace(CURRENT_SETTINGS_CATALOG_ITEMS, PATCHED_SETTINGS_CATALOG_ITEMS);
-}
-
-function addAgentWorkspaceToSettingsSlugLists(currentSource) {
-  return currentSource
-    .replaceAll(
-      "`local-environments`,`worktrees`",
-      "`local-environments`,`agent-workspaces`,`worktrees`",
-    )
-    .replaceAll(
-      "`local-environments`,`environments`,`worktrees`",
-      "`local-environments`,`agent-workspaces`,`environments`,`worktrees`",
-    );
-}
-
-function addAgentWorkspaceVisibilityCases(currentSource) {
-  let patchedSource = currentSource;
-  const replacements = [[
-    "case`worktrees`:case`local-environments`:case`environments`:return",
-    "case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return",
-  ]];
-
-  for (const [needle, replacement] of replacements) {
-    if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
-      patchedSource = patchedSource.replace(needle, replacement);
-    }
-  }
-
-  return patchedSource;
-}
-
-function addAgentWorkspaceLoadingCases(currentSource) {
-  let patchedSource = currentSource;
-  const replacements = [[
-    "case`local-environments`:case`worktrees`:case`environments`:",
-    "case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`:",
-  ]];
-
-  for (const [needle, replacement] of replacements) {
-    if (!patchedSource.includes(replacement) && patchedSource.includes(needle)) {
-      patchedSource = patchedSource.replace(needle, replacement);
-    }
-  }
-
-  return patchedSource;
 }
 
 function applyAgentWorkspaceSettingsSharedPatch(currentSource) {
@@ -2047,34 +2025,45 @@ function applyAgentWorkspaceSettingsIndexPatch(currentSource) {
 
 function applyAgentWorkspaceSettingsPagePatch(currentSource) {
   let patchedSource = currentSource;
+  let matched = false;
 
-  // Reuse an existing icon alias instead of injecting a new minified-scope
-  // symbol. Upstream can wrap the icon map in initializer closures, and a
-  // dangling injected symbol breaks the whole Settings route.
-  const agentWorkspaceIcon = patchedSource.match(/"local-environments":([A-Za-z_$][\w$]*)/)?.[1] ?? null;
-
-  if (agentWorkspaceIcon != null) {
-    patchedSource = patchedSource.replace(
-      new RegExp(`"${SETTINGS_SLUG}":[A-Za-z_$][\\w$]*`),
-      `"${SETTINGS_SLUG}":${agentWorkspaceIcon}`,
-    );
+  if (isAgentWorkspaceSettingsNavigationBundleSource(patchedSource)) {
+    matched = true;
+    const slugsPatched = patchedSource.includes(PATCHED_SETTINGS_NAVIGATION_SLUGS);
+    const groupPatched = patchedSource.includes(PATCHED_SETTINGS_NAVIGATION_GROUP);
+    if (slugsPatched !== groupPatched) {
+      throw new Error("agent workspace settings navigation is partially patched");
+    }
+    if (!slugsPatched) {
+      patchedSource = patchedSource
+        .replace(CURRENT_SETTINGS_NAVIGATION_SLUGS, PATCHED_SETTINGS_NAVIGATION_SLUGS)
+        .replace(CURRENT_SETTINGS_NAVIGATION_GROUP, PATCHED_SETTINGS_NAVIGATION_GROUP);
+    }
   }
 
-  if (
-    !new RegExp(`[,{]"${SETTINGS_SLUG}":[A-Za-z_$][\\w$]*,worktrees`).test(patchedSource) &&
-    /"local-environments":([A-Za-z_$][\w$]*),worktrees:/.test(patchedSource)
-  ) {
-    patchedSource = patchedSource.replace(
-      /"local-environments":([A-Za-z_$][\w$]*),worktrees:/,
-      `"local-environments":$1,"${SETTINGS_SLUG}":${agentWorkspaceIcon ?? "$1"},worktrees:`,
-    );
+  if (isAgentWorkspaceSettingsVisibilityBundleSource(patchedSource)) {
+    matched = true;
+    const iconMatch = patchedSource.match(PATCHED_SETTINGS_ICON_PATTERN);
+    if (iconMatch != null && iconMatch[1] !== iconMatch[2]) {
+      throw new Error("agent workspace settings visibility has an unexpected icon");
+    }
+    const iconPatched = iconMatch != null && iconMatch[1] === iconMatch[2];
+    const casesPatched = patchedSource.includes(PATCHED_SETTINGS_VISIBILITY_CASES);
+    if (iconPatched !== casesPatched) {
+      throw new Error("agent workspace settings visibility is partially patched");
+    }
+    if (!iconPatched) {
+      patchedSource = patchedSource
+        .replace(
+          CURRENT_SETTINGS_ICON_PATTERN,
+          (_match, localEnvironmentsIcon, worktreesIcon) =>
+            `"local-environments":${localEnvironmentsIcon},"${SETTINGS_SLUG}":${localEnvironmentsIcon},worktrees:${worktreesIcon}`,
+        )
+        .replace(CURRENT_SETTINGS_VISIBILITY_CASES, PATCHED_SETTINGS_VISIBILITY_CASES);
+    }
   }
 
-  patchedSource = addAgentWorkspaceToSettingsSlugLists(patchedSource);
-  patchedSource = addAgentWorkspaceVisibilityCases(patchedSource);
-  patchedSource = addAgentWorkspaceLoadingCases(patchedSource);
-
-  if (!patchedSource.includes(`\`${SETTINGS_SLUG}\``)) {
+  if (!matched) {
     throw new Error("could not add agent workspace settings navigation");
   }
 
@@ -2090,13 +2079,15 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   const candidates = fs
     .readdirSync(assetsDir)
     .filter((name) =>
-      /^app-initial~app-main~.*\.js$/.test(name) ||
-      /(?:^|~)settings-page(?:[-~].*)?\.js$/.test(name)
+      /^app-initial-[^.]+\.js$/.test(name) ||
+      /^settings-page-[^.]+\.js$/.test(name) ||
+      /^use-visible-settings-sections-[^.]+\.js$/.test(name)
     )
     .sort();
   let metadataMatched = false;
   let routeMatched = false;
   let navigationMatched = false;
+  let visibilityMatched = false;
   let catalogMatched = false;
   const patches = [];
 
@@ -2116,6 +2107,10 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
       navigationMatched = true;
       patchedSource = applyAgentWorkspaceSettingsPagePatch(patchedSource);
     }
+    if (isAgentWorkspaceSettingsVisibilityBundleSource(currentSource)) {
+      visibilityMatched = true;
+      patchedSource = applyAgentWorkspaceSettingsPagePatch(patchedSource);
+    }
     if (isAgentWorkspaceSettingsCatalogBundleSource(currentSource)) {
       catalogMatched = true;
       patchedSource = applyAgentWorkspaceSettingsCatalogPatch(patchedSource);
@@ -2133,6 +2128,9 @@ function collectAgentWorkspaceRouteAndNavigationPatches(extractedDir) {
   }
   if (!navigationMatched) {
     throw new Error("could not find webview settings navigation bundle");
+  }
+  if (!visibilityMatched) {
+    throw new Error("could not find webview settings visibility bundle");
   }
   if (!catalogMatched) {
     throw new Error("could not find current webview settings catalog bundle");

--- a/linux-features/agent-workspace/test.js
+++ b/linux-features/agent-workspace/test.js
@@ -27,6 +27,7 @@ const {
   SETTINGS_PERMISSIONS_KEY,
   SETTINGS_SLUG,
   applyAgentWorkspaceMainBridgePatch,
+  applyAgentWorkspaceSettingsCatalogPatch,
   applyAgentWorkspaceSettingsIndexPatch,
   applyAgentWorkspaceSettingsPagePatch,
   applyAgentWorkspaceSettingsSharedPatch,
@@ -138,26 +139,47 @@ function buildBridgeHarness({ env = {}, globalState = new Map(), execFile, spawn
   return { handlers: host.handlers(), execCalls, spawnCalls };
 }
 
-function syntheticSettingsShared() {
+function syntheticCurrentSettingsMetadata() {
   return [
     "var c=r({",
     '"general-settings":{id:`settings.nav.general-settings`,defaultMessage:`General`,description:`Title for general settings section`},',
     '"local-environments":{id:`settings.nav.local-environments`,defaultMessage:`Environments`,description:`Title for environments settings section`},',
     "worktrees:{id:`settings.nav.worktrees`,defaultMessage:`Worktrees`,description:`Title for worktrees settings section`}",
     "});",
-    "function m(e){let t=(0,u.c)(3),{slug:r}=e;switch(r){",
-    "case`general-settings`:{return (0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`})}",
-    "case`local-environments`:{return (0,d.jsx)(n,{id:`settings.section.local-environments`,defaultMessage:`Environments`})}",
-    "case`worktrees`:{return (0,d.jsx)(n,{id:`settings.section.worktrees`,defaultMessage:`Worktrees`})}",
+    "function m(e){let t=(0,u.c)(30),{slug:r}=e;switch(r){",
+    "case`general-settings`:{let e;return t[0]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.general-settings`,defaultMessage:`General`}),t[0]=e):e=t[0],e}",
+    "case`local-environments`:{let e;return t[21]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.local-environments`,defaultMessage:`Environments`}),t[21]=e):e=t[21],e}",
+    "case`worktrees`:{let e;return t[22]===Symbol.for(`react.memo_cache_sentinel`)?(e=(0,d.jsx)(n,{id:`settings.section.worktrees`,defaultMessage:`Worktrees`}),t[22]=e):e=t[22],e}",
     "}}",
   ].join("");
 }
 
-function syntheticCurrentAppMainRouteRegistry() {
+function syntheticCurrentAppInitialBundle() {
   return [
     "function render(e){return currentRouteMap[e.slug]}",
     'var currentRouteMap={"general-settings":BN(async()=>(await Y(async()=>{let{GeneralSettings:e}=await import(`./general-settings-TbWU8D8b.js`);return{GeneralSettings:e}},__vite__mapDeps([1,2]),import.meta.url)).GeneralSettings),',
     'import:BN(async()=>(await Y(async()=>{let{ImportSettings:e}=await import(`./import-settings-DmsueF_s.js`);return{ImportSettings:e}},__vite__mapDeps([3]),import.meta.url)).ImportSettings)};',
+    syntheticCurrentSettingsMetadata(),
+    syntheticCurrentSettingsCatalog(),
+  ].join("");
+}
+
+function syntheticCurrentSettingsNavigation() {
+  return [
+    'import{s as __toESM}from"./chunk-test.js";',
+    'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
+    'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
+    'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
+    "var nn=`general-settings.linux-desktop.import.profile.appearance.voice.chronicle.appshots.agent.personalization.pets.usage.debug.keyboard-shortcuts.codex-micro.mcp-settings.hooks-settings.connections.cloud-settings.cloud-environments.code-review.git-settings.local-environments.worktrees.browser-use.computer-use.data-controls`.split(`.`);",
+    "var rn=[{key:`personal`,slugs:[`general-settings`,`linux-desktop`]},{key:`coding`,slugs:[`hooks-settings`,`connections`,`cloud-settings`,`cloud-environments`,`code-review`,`git-settings`,`local-environments`,`environments`,`worktrees`]}];",
+  ].join("");
+}
+
+function syntheticCurrentSettingsVisibility() {
+  return [
+    "var H=e=>e,F=e=>e;",
+    'var it={"linux-desktop":H,"general-settings":H,"local-environments":H,worktrees:F,environments:H,"mcp-settings":H,connections:H};',
+    "function visible(S){switch(S.slug){case`computer-use`:return!0;case`browser-use`:return!0;case`appearance`:return!0;case`pets`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;case`linux-desktop`:case`general-settings`:case`agent`:case`personalization`:return!0;}}",
   ].join("");
 }
 
@@ -216,30 +238,15 @@ function rewriteSettingsAssetsWithConsolidatedCurrentLayout(assetsDir) {
   );
   fs.writeFileSync(
     path.join(assetsDir, "settings-page-test.js"),
-    [
-      'import{s as __toESM}from"./chunk-test.js";',
-      'import{r as ReactFactory,j as jsxFactory}from"./runtime-test.js";',
-      'var React=__toESM(ReactFactory(),1),$=jsxFactory();',
-      'function RuntimeProbe(){let [value]=(0,React.useState)(0);return (0,$.jsx)("span",{children:value})}',
-      "var Z=$,S=e=>(0,Z.jsxs)(`svg`,{children:[]}),ln=S,F=S;",
-      'var Hn={"linux-desktop":S,"general-settings":S,"local-environments":ln,worktrees:F,environments:ln,"mcp-settings":S,connections:S};',
-      "var Wn=[`general-settings`,`linux-desktop`,`local-environments`,`worktrees`,`data-controls`],Gn=[{key:`personal`,slugs:[`general-settings`,`linux-desktop`]},{key:`coding`,slugs:[`local-environments`,`environments`,`worktrees`]}];",
-      "function visible(S){switch(S.slug){case`computer-use`:return!0;case`browser-use`:return!0;case`appearance`:return!0;case`pets`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;case`linux-desktop`:case`general-settings`:case`agent`:case`personalization`:return!0;}}",
-      "function load(S){let T=!1;switch(S.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:case`connections`:T=!1;break}return T}",
-      "var lr=[`profile`,`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`local-environments`,`worktrees`,`data-controls`];",
-    ].join(""),
+    syntheticCurrentSettingsNavigation(),
   );
   fs.writeFileSync(
-    path.join(assetsDir, "app-initial~app-main~messages-test.js"),
-    syntheticSettingsShared(),
+    path.join(assetsDir, "app-initial-test.js"),
+    syntheticCurrentAppInitialBundle(),
   );
   fs.writeFileSync(
-    path.join(assetsDir, "app-initial~app-main~automations-page-test.js"),
-    syntheticCurrentAppMainRouteRegistry(),
-  );
-  fs.writeFileSync(
-    path.join(assetsDir, "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js"),
-    syntheticCurrentSettingsCatalog(),
+    path.join(assetsDir, "use-visible-settings-sections-test.js"),
+    syntheticCurrentSettingsVisibility(),
   );
 }
 
@@ -1588,31 +1595,45 @@ test("generated settings UI auto-opens the GPUI viewer after approved workspace 
 });
 
 test("settings asset patches add navigation, route, visibility, and title", () => {
-  const shared = applyAgentWorkspaceSettingsSharedPatch(syntheticSettingsShared());
+  const shared = applyAgentWorkspaceSettingsSharedPatch(syntheticCurrentAppInitialBundle());
   assert.match(shared, new RegExp(`settings\\.nav\\.${SETTINGS_SLUG}`));
   assert.match(shared, new RegExp(`settings\\.section\\.${SETTINGS_SLUG}`));
   assert.equal(applyAgentWorkspaceSettingsSharedPatch(shared), shared);
 
-  const currentAppMain = applyAgentWorkspaceSettingsIndexPatch(syntheticCurrentAppMainRouteRegistry());
+  const currentAppMain = applyAgentWorkspaceSettingsIndexPatch(shared);
   assert.match(
     currentAppMain,
     /"agent-workspaces":BN\(async\(\)=>\(await Y\(async\(\)=>\{let\{default:e\}=await import\(`\.\/agent-workspaces-linux\.js`\);return\{default:e\}\},\[\],import\.meta\.url\)\)\.default\),"general-settings":/,
   );
   assert.equal(applyAgentWorkspaceSettingsIndexPatch(currentAppMain), currentAppMain);
 
-  const settingsPage = applyAgentWorkspaceSettingsPagePatch(
-    [
-      'var Hn={"linux-desktop":S,"general-settings":S,"local-environments":ln,worktrees:F,environments:ln,"mcp-settings":S,connections:S};',
-      "var Wn=[`general-settings`,`linux-desktop`,`local-environments`,`worktrees`,`data-controls`],Gn=[{key:`coding`,slugs:[`local-environments`,`environments`,`worktrees`]}];",
-      "function visible(S){switch(S.slug){case`pets`:case`git-settings`:case`worktrees`:case`local-environments`:case`environments`:return!0;case`data-controls`:return!0;}}",
-      "function load(S){switch(S.slug){case`local-environments`:case`worktrees`:case`environments`:case`mcp-settings`:return!1}}",
-    ].join(""),
+  const catalog = applyAgentWorkspaceSettingsCatalogPatch(currentAppMain);
+  assert.match(catalog, /local-environments\.agent-workspaces\.worktrees/);
+  assert.match(catalog, /\{slug:`local-environments`\},\{slug:`agent-workspaces`\},\{slug:`worktrees`\}/);
+  assert.equal(applyAgentWorkspaceSettingsCatalogPatch(catalog), catalog);
+
+  const settingsNavigation = applyAgentWorkspaceSettingsPagePatch(
+    syntheticCurrentSettingsNavigation(),
   );
-  assert.match(settingsPage, new RegExp(`"local-environments":ln,"${SETTINGS_SLUG}":ln,worktrees`));
-  assert.match(settingsPage, /`local-environments`,`agent-workspaces`,`worktrees`/);
-  assert.match(settingsPage, /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
-  assert.match(settingsPage, /case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`/);
-  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsPage), settingsPage);
+  assert.match(settingsNavigation, /local-environments\.agent-workspaces\.worktrees\.browser-use/);
+  assert.match(
+    settingsNavigation,
+    /`local-environments`,`agent-workspaces`,`environments`,`worktrees`/,
+  );
+  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsNavigation), settingsNavigation);
+
+  const settingsVisibility = applyAgentWorkspaceSettingsPagePatch(
+    syntheticCurrentSettingsVisibility(),
+  );
+  assert.match(
+    settingsVisibility,
+    new RegExp(`"local-environments":H,"${SETTINGS_SLUG}":H,worktrees:F`),
+  );
+  assert.match(
+    settingsVisibility,
+    /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/,
+  );
+  assert.equal(applyAgentWorkspaceSettingsPagePatch(settingsVisibility), settingsVisibility);
 });
 
 test("agent-workspace feature participates in ASAR patching and reports", () => {
@@ -1632,8 +1653,9 @@ test("agent-workspace feature participates in ASAR patching and reports", () => 
         assert.ok(fs.existsSync(path.join(assetsDir, SETTINGS_ASSET)));
         assert.match(fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8"), /AgentWorkspacesSettings/);
         assert.match(fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8"), /agent-workspaces/);
-        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~messages-test.js"), "utf8"), /Agent Workspaces/);
-        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+        assert.match(fs.readFileSync(path.join(assetsDir, "use-visible-settings-sections-test.js"), "utf8"), /agent-workspaces/);
+        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8"), /Agent Workspaces/);
+        assert.match(fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
         assert.equal(
           fs.readFileSync(path.join(assetsDir, "local-conversation-thread-test.js"), "utf8"),
           staleConversationMonitorBundle(),
@@ -1672,7 +1694,7 @@ test("agent-workspace settings resolve latest upstream request API asset", () =>
     const settingsSource = fs.readFileSync(path.join(assetsDir, SETTINGS_ASSET), "utf8");
     assert.match(settingsSource, /import\{l as __post\}from"\.\/setting-storage-test\.js"/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }
@@ -1698,7 +1720,7 @@ test("agent-workspace settings infer runtime dependencies from bundled settings 
     assert.match(settingsSource, /function SettingsPage/);
     assert.match(settingsSource, /AgentWorkspacesSettings/);
     assert.match(fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8"), /agent-workspaces/);
-    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
+    assert.match(fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8"), new RegExp(SETTINGS_ASSET));
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
   }
@@ -1721,27 +1743,29 @@ test("agent-workspace settings patch supports consolidated current settings bund
     assert.match(settingsSource, /function SettingsPage/);
 
     const settingsPageSource = fs.readFileSync(path.join(assetsDir, "settings-page-test.js"), "utf8");
-    assert.match(settingsPageSource, /"local-environments":ln,"agent-workspaces":ln,worktrees:F/);
-    assert.match(settingsPageSource, /`local-environments`,`agent-workspaces`,`worktrees`/);
-    assert.match(settingsPageSource, /slugs:\[`local-environments`,`agent-workspaces`,`environments`,`worktrees`\]/);
-    assert.match(settingsPageSource, /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/);
-    assert.match(settingsPageSource, /case`local-environments`:case`agent-workspaces`:case`worktrees`:case`environments`/);
-    assert.match(settingsPageSource, /lr=\[`profile`,`agent`,`personalization`,`mcp-settings`,`hooks-settings`,`local-environments`,`agent-workspaces`,`worktrees`,`data-controls`\]/);
+    assert.match(settingsPageSource, /local-environments\.agent-workspaces\.worktrees\.browser-use/);
+    assert.match(
+      settingsPageSource,
+      /`local-environments`,`agent-workspaces`,`environments`,`worktrees`/,
+    );
 
-    const sharedSource = fs.readFileSync(path.join(assetsDir, "app-initial~app-main~messages-test.js"), "utf8");
-    assert.match(sharedSource, /settings\.nav\.agent-workspaces/);
-    assert.match(sharedSource, /settings\.section\.agent-workspaces/);
-
-    const routeSource = fs.readFileSync(path.join(assetsDir, "app-initial~app-main~automations-page-test.js"), "utf8");
-    assert.match(routeSource, new RegExp(SETTINGS_ASSET));
-    assert.match(routeSource, /"agent-workspaces":BN\(async\(\)=>\(await Y\(/);
-
-    const catalogSource = fs.readFileSync(
-      path.join(assetsDir, "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js"),
+    const visibilitySource = fs.readFileSync(
+      path.join(assetsDir, "use-visible-settings-sections-test.js"),
       "utf8",
     );
-    assert.match(catalogSource, /local-environments\.agent-workspaces\.worktrees/);
-    assert.match(catalogSource, /\{slug:`local-environments`\},\{slug:`agent-workspaces`\},\{slug:`worktrees`\}/);
+    assert.match(visibilitySource, /"local-environments":H,"agent-workspaces":H,worktrees:F/);
+    assert.match(
+      visibilitySource,
+      /case`worktrees`:case`local-environments`:case`agent-workspaces`:case`environments`:return!0/,
+    );
+
+    const appInitialSource = fs.readFileSync(path.join(assetsDir, "app-initial-test.js"), "utf8");
+    assert.match(appInitialSource, /settings\.nav\.agent-workspaces/);
+    assert.match(appInitialSource, /settings\.section\.agent-workspaces/);
+    assert.match(appInitialSource, new RegExp(SETTINGS_ASSET));
+    assert.match(appInitialSource, /"agent-workspaces":BN\(async\(\)=>\(await Y\(/);
+    assert.match(appInitialSource, /local-environments\.agent-workspaces\.worktrees/);
+    assert.match(appInitialSource, /\{slug:`local-environments`\},\{slug:`agent-workspaces`\},\{slug:`worktrees`\}/);
     assert.equal(patchAgentWorkspaceSettingsAssets(tempApp).changed, 0);
   } finally {
     fs.rmSync(tempApp, { recursive: true, force: true });
@@ -1754,7 +1778,7 @@ test("agent-workspace settings patch rejects a partially patched current catalog
     const { assetsDir } = writeSyntheticExtractedApp(tempApp);
     const catalogPath = path.join(
       assetsDir,
-      "app-initial~app-main~hotkey-window-thread-page~keyboard-shortcuts-settings~thread-app-shell~current-test.js",
+      "app-initial-test.js",
     );
     fs.writeFileSync(
       catalogPath,

--- a/linux-features/conversation-mode/patch.js
+++ b/linux-features/conversation-mode/patch.js
@@ -2,10 +2,7 @@
 
 const HANDLER_NAME = "linux-read-aloud";
 const RUNTIME_VERSION = "conversation-mode-v26";
-const CURRENT_DICTATION_ASSET_PATTERN =
-  /^app-initial~app-main~onboarding-page-[A-Za-z0-9_-]+\.js$/;
-const CURRENT_COMPOSER_ASSET_PATTERN =
-  /^app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-[^.]+\.js$/;
+const CURRENT_APP_INITIAL_ASSET_PATTERN = /^app-initial-[A-Za-z0-9_-]+\.js$/;
 
 function warn(message, patchName) {
   console.warn(`WARN: ${message} - skipping ${patchName}`);
@@ -124,7 +121,10 @@ function objectPropVar(objectSource, name, fallback) {
 }
 
 function currentComposerBinding(source) {
-  const propsPattern = new RegExp(`function ${JS_IDENT}\\(\\{([^{}]*voiceControls:${JS_IDENT}[^{}]*)\\}\\)\\{`, "g");
+  const propsPattern = new RegExp(
+    `\\{([^{}]*voiceControls:${JS_IDENT}[^{}]*)\\}=${JS_IDENT}(?:,|;)`,
+    "g",
+  );
   for (const propsMatch of source.matchAll(propsPattern)) {
     const propsObject = propsMatch[1];
     const voiceControlsVar = objectPropVar(propsObject, "voiceControls", null);
@@ -136,7 +136,7 @@ function currentComposerBinding(source) {
       continue;
     }
     const functionBodyStart = propsMatch.index + propsMatch[0].length;
-    const composerPrefix = source.slice(functionBodyStart, functionBodyStart + 5000);
+    const composerPrefix = source.slice(functionBodyStart, functionBodyStart + 25000);
     const conversationId =
       composerPrefix.match(new RegExp(`conversationId:(${JS_IDENT}),hostId:${JS_IDENT}`))?.[1] ?? null;
     if (conversationId == null) {
@@ -259,9 +259,10 @@ function applyDictationEndpointPatch(source) {
     return source;
   }
 
-  const micConstraintsPattern = /([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\{channelCount:1\}\)/u;
+  const micConstraintsPattern =
+    /stream:([A-Za-z_$][\w$]*)\(\{channelCount:1\}\)\.then\(/u;
   const cleanupPattern =
-    /([A-Za-z_$][\w$]*)&&\(\1\.ondataavailable=null,\1\.onstop=null\),([A-Za-z_$][\w$]*)\.current=null,([A-Za-z_$][\w$]*)\(\);/u;
+    /([A-Za-z_$][\w$]*)&&\(\1\.ondataavailable=null,\1\.onstop=null\),([A-Za-z_$][\w$]*)\.current=null,([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*)\(\),/u;
   const actionRef = source.match(/let [A-Za-z_$][\w$]*=([A-Za-z_$][\w$]*)\.current\?\?`insert`/)?.[1] ?? null;
   const recorderPattern =
     /let ([A-Za-z_$][\w$]*)=new MediaRecorder\(([A-Za-z_$][\w$]*)\);if\(([A-Za-z_$][\w$]*)\.current=\1,([A-Za-z_$][\w$]*)\.current=\[\],\1\.ondataavailable=([A-Za-z_$][\w$]*)=>\{\5\.data\.size>0&&\4\.current\.push\(\5\.data\)\},\1\.onstop=\(\)=>\{([A-Za-z_$][\w$]*)\(\)\},\1\.start\(\),([A-Za-z_$][\w$]*)\(!0\)/u;
@@ -281,11 +282,11 @@ function applyDictationEndpointPatch(source) {
 
   let patched = source.replace(
     micConstraintsPattern,
-    "$1=await $2({channelCount:1,echoCancellation:!0,noiseSuppression:!0,autoGainControl:!0})",
+    "stream:$1({channelCount:1,echoCancellation:!0,noiseSuppression:!0,autoGainControl:!0}).then(",
   );
   patched = patched.replace(
     cleanupPattern,
-    "$1?.codexLinuxConversationCleanup?.(),$1&&($1.ondataavailable=null,$1.onstop=null),$2.current=null,$3();",
+    "$1?.codexLinuxConversationCleanup?.(),$1&&($1.ondataavailable=null,$1.onstop=null),$2.current=null,$3(),$4(),",
   );
   patched = patched.replace(
     recorderPattern,
@@ -360,7 +361,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20690,
       ciPolicy: "optional",
-      pattern: CURRENT_DICTATION_ASSET_PATTERN,
+      pattern: CURRENT_APP_INITIAL_ASSET_PATTERN,
       missingDescription: "current primary dictation bundle",
       skipDescription: "conversation mode dictation endpoint patch",
       apply: applyDictationEndpointPatch,
@@ -370,7 +371,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20700,
       ciPolicy: "optional",
-      pattern: CURRENT_COMPOSER_ASSET_PATTERN,
+      pattern: CURRENT_APP_INITIAL_ASSET_PATTERN,
       missingDescription: "current primary composer bundle",
       skipDescription: "conversation mode composer control patch",
       apply: applyComposerPatch,
@@ -380,7 +381,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20710,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~onboarding-page-[A-Za-z0-9_-]+\.js$/,
+      pattern: CURRENT_APP_INITIAL_ASSET_PATTERN,
       missingDescription: "current primary thread assistant bundle",
       skipDescription: "conversation mode assistant observer patch",
       apply: applyAssistantRenderPatch,

--- a/linux-features/conversation-mode/test.js
+++ b/linux-features/conversation-mode/test.js
@@ -88,19 +88,18 @@ const mainBundleSource =
 const explicitButtonMainBundleSource =
   "function codexLinuxReadAloudHandle(e={}){return e.action===`config`?codexLinuxReadAloudConfig():e.action===`setup`?codexLinuxReadAloudSetup(e):e.action===`stop`?codexLinuxReadAloudStop():e.action===`speak`&&e.source===`button`?codexLinuxReadAloudSpeak(e.text,{requireEnabled:!1}):codexLinuxReadAloudReport({spoken:!1,reason:`not-explicit`})}var h={handlers:{\"linux-read-aloud\":async(e)=>codexLinuxReadAloudHandle(e),\"native-desktop-apps\":async()=>({apps:[]})}};";
 
-const currentComposerAsset =
-  "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-current.js";
-const currentDictationAsset =
-  "app-initial~app-main~onboarding-page-current.js";
+const currentAppInitialAsset = "app-initial-current.js";
+const currentComposerAsset = currentAppInitialAsset;
+const currentDictationAsset = currentAppInitialAsset;
 
 const dictationSource =
-  "function Lke({onTranscriptInsert:i,onTranscriptSend:a}){let h={current:null},g={current:null},y={current:[]},b={current:null};let P=async({action:t,handlers:r})=>{let a=`hello`;a.length>0&&(df.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:a}),t===`send`?r.onTranscriptSend(a):r.onTranscriptInsert(a))},F=async()=>{let e=b.current??`insert`,r=h.current,i=y.current;y.current=[],r&&(r.ondataavailable=null,r.onstop=null),h.current=null,A();await P({action:e,audio:i,handlers:{onTranscriptInsert:i,onTranscriptSend:a}})},L=e=>{b.current=e;let t=h.current;t.state!==`inactive`&&t.stop()};return{startDictation:async()=>{let e=await _Oe({channelCount:1});let t=new MediaRecorder(e);if(h.current=t,y.current=[],t.ondataavailable=e=>{e.data.size>0&&y.current.push(e.data)},t.onstop=()=>{F()},t.start(),u(!0),b.current!=null){t.stop();return}},stopDictation:L}}";
+  "function Sit({onTranscriptInsert:i,onTranscriptSend:a}){let h={current:null},g={current:null},y={current:[]},b={current:null};let P=async({action:t,handlers:r})=>{let a=`hello`;a.length>0&&(df.getInstance().dispatchMessage(`global-dictation-record-history-item`,{text:a}),t===`send`?r.onTranscriptSend(a):r.onTranscriptInsert(a))},F=async()=>{let e=b.current??`insert`,r=h.current,i=y.current;y.current=[],r&&(r.ondataavailable=null,r.onstop=null),h.current=null,j(),Q(),u(!1);await P({action:e,audio:i,handlers:{onTranscriptInsert:i,onTranscriptSend:a}})},L=e=>{b.current=e;let t=h.current;t.state!==`inactive`&&t.stop()};return{startDictation:async()=>{let e=Cit(),g.current=e;let t=await e.stream;let n=new MediaRecorder(t);if(h.current=n,y.current=[],n.ondataavailable=e=>{e.data.size>0&&y.current.push(e.data)},n.onstop=()=>{F()},n.start(),u(!0),b.current!=null){n.stop();return}},stopDictation:L}}function Cit(){let e=!1,t=null,n=()=>{e=!0,t?.getTracks().forEach(e=>{e.stop()}),t=null};return{dispose:n,stream:Knt({channelCount:1}).then(r=>(t=r,e&&n(),r))}}";
 
 const currentComposerControlSource =
-  "function Vka({isResponseInProgress:x,onStop:T,submitBlockReason:E,voiceControls:A}){let j=Nn(Bk);let M=RZ(),N=Rk(j),P=LEa(j.value,t),{canRetryDictation:B,dictationShortcutLabel:V,isDictating:U,isDictationButtonVisible:W,isDictationSupported:G,isTranscribing:ee,isVoiceFooterVisible:te,recordingDurationMs:ne,retryDictation:K,startDictation:re,stopDictation:ie,restrictedSession:ae,waveformCanvasRef:oe}=A;let je=(0,x7.jsx)(_ka,{conversationId:N,hostId:g,cwdOverride:_}),ke=(0,x7.jsx)(Twe,{isTranscribing:ee,recordingDurationMs:ne,waveformCanvasRef:oe,stopDictation:ie}),Ae=(0,x7.jsx)(Ewe,{isVisible:W,disabled:!G||ae.thread.phase!==`inactive`,isTranscribing:ee,canRetryDictation:B,shortcutLabel:V,retryDictation:K,startDictation:re,stopDictation:ie});return Ae}";
+  "function Vka(e){let{isResponseInProgress:x,onStop:T,submitBlockReason:E,voiceControls:A}=e,j=Nn(Bk),M=RZ(),N=Rk(j),P=LEa(j.value,t),{canRetryDictation:B,dictationShortcutLabel:V,isDictating:U,isDictationButtonVisible:W,isDictationSupported:G,isTranscribing:ee,isVoiceFooterVisible:te,recordingDurationMs:ne,retryDictation:K,startDictation:re,stopDictation:ie,realtimeSession:ae,waveformCanvasRef:oe}=A;let je=(0,x7.jsx)(_ka,{conversationId:N,hostId:g,cwdOverride:_}),ke=(0,x7.jsx)(Twe,{isTranscribing:ee,recordingDurationMs:ne,waveformCanvasRef:oe,stopDictation:ie});let Ae=(0,x7.jsx)(Ewe,{isVisible:W,disabled:!G,isTranscribing:ee,canRetryDictation:B,shortcutLabel:V,retryDictation:K,startDictation:re,stopDictation:ie});return Ae}";
 
 const assistantRenderSource =
-  "return (0,$.jsx)(Ov,{item:n,alwaysShowActions:M,assistantCopyText:p,turnId:m,after:g,conversationId:o,cwd:u,renderCodeBlocksAsWritingBlocks:V})";
+  "return (0,t8.jsx)(K6c,{item:n,alwaysShowActions:re,assistantCopyText:b,turnId:x,processTargets:S,autoReviewStats:A,hookStats:j,threadDetailLevel:p,after:T,conversationId:d,cwd:g,renderCodeBlocksAsWritingBlocks:we})";
 
 const conversationGlobals = [
   "codexLinuxConversationAvailable",
@@ -121,42 +120,32 @@ test("dictation endpoint descriptor targets the current dictation bundle", () =>
   const descriptor = featurePatches.find((patch) => patch.id === "dictation-endpoint");
   assert.ok(descriptor);
   assert.equal(descriptor.pattern.test(currentDictationAsset), true);
-  assert.equal(descriptor.pattern.test(currentComposerAsset), false);
-  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-BUwCKIcU.js"), true);
-  assert.equal(
-    descriptor.pattern.test(
-      "app-initial~app-main~onboarding-page~debug-window-page~debug-modal-jrWqnMas.js",
-    ),
-    false,
-  );
+  assert.equal(descriptor.pattern.test("app-initial-BHB6SClA.js"), true);
+  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-BUwCKIcU.js"), false);
   assert.equal(descriptor.pattern.test("use-dictation-BUwCKIcU.js"), false);
   assert.equal(descriptor.pattern.test("use-dictation-hotkey-BUwCKIcU.js"), false);
 });
 
-test("composer descriptor targets only the current primary app bundle", () => {
+test("composer descriptor targets the current app-initial bundle", () => {
   const descriptor = featurePatches.find((patch) => patch.id === "composer-control");
   assert.ok(descriptor);
   assert.equal(descriptor.pattern.test(currentComposerAsset), true);
+  assert.equal(descriptor.pattern.test("app-initial-BHB6SClA.js"), true);
   assert.equal(descriptor.pattern.test("app-initial~app-main~page-hSvsQcNf.js"), false);
   assert.equal(descriptor.pattern.test("composer-old.js"), false);
 });
 
-test("current DMG co-locates dictation and assistant ownership apart from the composer", () => {
+test("current DMG co-locates dictation, composer, and assistant ownership", () => {
   const dictation = featurePatches.find((patch) => patch.id === "dictation-endpoint");
   const composer = featurePatches.find((patch) => patch.id === "composer-control");
   const assistant = featurePatches.find((patch) => patch.id === "assistant-observer");
-  const dictationAsset = "app-initial~app-main~onboarding-page-CIkoyvFz.js";
-  const composerAsset =
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~iufn7mg3-DRU9Ekz0.js";
-  const adjacentComposerAsset =
-    "app-initial~app-main~new-thread-panel-page~appgen-library-page~hotkey-window-thread-page~ho~lhgjoyjn-CMTECkzu.js";
+  const asset = "app-initial-BHB6SClA.js";
 
-  assert.equal(dictation.pattern.test(dictationAsset), true);
-  assert.equal(dictation.pattern.test(composerAsset), false);
-  assert.equal(assistant.pattern.test(dictationAsset), true);
-  assert.equal(composer.pattern.test(composerAsset), true);
-  assert.equal(composer.pattern.test(dictationAsset), false);
-  assert.equal(composer.pattern.test(adjacentComposerAsset), false);
+  assert.equal(dictation.pattern.test(asset), true);
+  assert.equal(composer.pattern.test(asset), true);
+  assert.equal(assistant.pattern.test(asset), true);
+  assert.equal(dictation.pattern.test("onboarding-page-Bv4pLarm.js"), false);
+  assert.equal(composer.pattern.test("new-thread-panel-page-Xl0DC1bk.js"), false);
 });
 
 function fetchBodies(events) {
@@ -2037,7 +2026,7 @@ test("dictation endpoint patch adds VAD stop-on-silence and send action", () => 
   assert.match(patched, /codexLinuxConversationShouldSendTranscript/);
   assert.match(patched, /t!==`discard`/);
   assert.match(patched, /t===`send`\?r\.onTranscriptSend\(a\):r\.onTranscriptInsert\(a\)/);
-  assert.match(patched, /stop:\(\)=>\{b\.current=`send`;t\.state!==`inactive`&&t\.stop\(\)\}/);
+  assert.match(patched, /stop:\(\)=>\{b\.current=`send`;n\.state!==`inactive`&&n\.stop\(\)\}/);
 });
 
 test("dictation endpoint patch fails soft and atomically when the current recorder contract drifts", () => {
@@ -2131,7 +2120,7 @@ test("composer control preserves the current async startDictation contract", asy
       return originalResult;
     },
     stopDictation() {},
-    restrictedSession: { thread: { phase: "inactive" } },
+    realtimeSession: {},
     waveformCanvasRef: {},
   };
   const render = () => context.renderCurrentComposer({
@@ -2193,8 +2182,8 @@ test("composer patch ignores adjacent composer chunks", () => {
 
 test("assistant render patch observes assistant text for automatic speech", () => {
   const patched = twice(applyAssistantRenderPatch, assistantRenderSource);
-  assert.match(patched, /codexLinuxConversationAssistant\?\.\(n,p,o,m,typeof c!="undefined"\?c:null\)/);
-  assert.match(patched, /\$\.Fragment/);
+  assert.match(patched, /codexLinuxConversationAssistant\?\.\(n,b,d,x,typeof c!="undefined"\?c:null\)/);
+  assert.match(patched, /t8\.Fragment/);
 });
 
 test("assistant render patch preserves the current JSX runtime alias", () => {
@@ -2209,7 +2198,8 @@ test("assistant render patch preserves the current JSX runtime alias", () => {
 test("assistant observer targets only the current primary thread bundle", () => {
   const descriptor = featurePatches.find((patch) => patch.id === "assistant-observer");
   assert.ok(descriptor);
-  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-D4eTO0KG.js"), true);
+  assert.equal(descriptor.pattern.test("app-initial-BHB6SClA.js"), true);
+  assert.equal(descriptor.pattern.test("app-initial~app-main~onboarding-page-D4eTO0KG.js"), false);
   assert.equal(descriptor.pattern.test("local-conversation-turn-old.js"), false);
   assert.equal(descriptor.pattern.test("local-conversation-thread-old.js"), false);
   assert.equal(descriptor.pattern.test("index-old.js"), false);
@@ -2220,7 +2210,7 @@ test("current assistant observer drift is reported as skipped instead of already
   try {
     const assetsDir = path.join(root, "webview", "assets");
     fs.mkdirSync(assetsDir, { recursive: true });
-    const assetPath = path.join(assetsDir, "app-initial~app-main~onboarding-page-current.js");
+    const assetPath = path.join(assetsDir, currentAppInitialAsset);
     const drifted = "console.log(`current assistant renderer drifted`);";
     fs.writeFileSync(assetPath, drifted);
     const descriptor = featurePatches.find((patch) => patch.id === "assistant-observer");
@@ -2253,9 +2243,8 @@ test("conversation mode patches matching app assets and records report entries",
         fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
         fs.writeFileSync(
           path.join(assetsDir, currentDictationAsset),
-          `${dictationSource};${assistantRenderSource}`,
+          `${dictationSource};${currentComposerControlSource};${assistantRenderSource}`,
         );
-        fs.writeFileSync(path.join(assetsDir, currentComposerAsset), currentComposerControlSource);
 
         const report = createPatchReport();
         const { warnings } = captureWarns(() => patchExtractedApp(tempApp, { report }));
@@ -2272,7 +2261,7 @@ test("conversation mode patches matching app assets and records report entries",
           /codexLinuxConversationEndpoint/,
         );
         assert.match(
-          fs.readFileSync(path.join(assetsDir, currentComposerAsset), "utf8"),
+          fs.readFileSync(path.join(assetsDir, currentAppInitialAsset), "utf8"),
           /codexLinuxConversationToggle/,
         );
         assert.match(

--- a/linux-features/read-aloud/patch.js
+++ b/linux-features/read-aloud/patch.js
@@ -793,7 +793,7 @@ module.exports = {
       phase: "webview-asset",
       order: 20620,
       ciPolicy: "optional",
-      pattern: /^app-initial~app-main~onboarding-page-[A-Za-z0-9_-]+\.js$/,
+      pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
       missingDescription: "current primary thread assistant bundle",
       skipDescription: "read aloud assistant runtime patch",
       apply: applyWebviewPatch,

--- a/linux-features/read-aloud/test.js
+++ b/linux-features/read-aloud/test.js
@@ -1000,12 +1000,12 @@ test("assistant render patch preserves the current JSX runtime alias", () => {
 });
 
 test("assistant render patch covers the current shared assistant message call", () => {
-  const source = "return (0,DX.jsx)(Jft,{item:n,alwaysShowActions:V,assistantCopyText:_,turnId:v,processTargets:b,hookStats:D,threadDetailLevel:u,completedThreadGoal:O,after:C,electronAfter:w,conversationId:l,cwd:p,hostId:m,reportEntityType:h,markdownMediaCacheKey:e,projectlessOutputDirectory:q,forceCodeBlockWordWrap:ie,hasArtifacts:J,onAddSelectedTextToChat:r,onFileLinkOpen:E,onFork:F,renderCodeBlocksAsWritingBlocks:ie,showActionRow:H,showTimestampWithoutActions:U,showProcessBadges:i})";
+  const source = "return (0,t8.jsx)(K6c,{item:n,alwaysShowActions:re,assistantCopyText:b,turnId:x,processTargets:S,autoReviewStats:A,hookStats:j,threadDetailLevel:p,completedThreadGoal:M,after:T,electronAfter:E,conversationId:d,getVisualizeTurnTriggerType:f,cwd:g,hostId:_,reportEntityType:v,markdownMediaCacheKey:e,projectlessOutputDirectory:de,forceCodeBlockWordWrap:we,hasArtifacts:fe,onAddResponseTextAnnotation:r,onFileLinkOpen:k,onFork:B,renderCodeBlocksAsWritingBlocks:we,showActionRow:ie,showTimestampWithoutActions:ae,timestampHoverOnly:oe,showProcessBadges:i,allowCopyWhileStreaming:q})";
   const patched = twice(applyAssistantRenderPatch, source);
 
-  assert.match(patched, /DX\.Fragment/);
-  assert.match(patched, /\(0,DX\.jsx\)\("button"/);
-  assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(n,_,l,e\.currentTarget\)/);
+  assert.match(patched, /t8\.Fragment/);
+  assert.match(patched, /\(0,t8\.jsx\)\("button"/);
+  assert.match(patched, /globalThis\.codexLinuxReadAloudClick\?\.\(n,b,d,e\.currentTarget\)/);
 });
 
 test("assistant runtime descriptor targets current shared assistant bundles", () => {
@@ -1013,7 +1013,7 @@ test("assistant runtime descriptor targets current shared assistant bundles", ()
   assert.ok(descriptor);
   assert.equal(
     descriptor.pattern.test(
-      "app-initial~app-main~onboarding-page-zcfEkMl-.js",
+      "app-initial-BHB6SClA.js",
     ),
     true,
   );
@@ -1021,6 +1021,7 @@ test("assistant runtime descriptor targets current shared assistant bundles", ()
     "index-current.js",
     "local-conversation-thread-current.js",
     "local-conversation-turn-current.js",
+    "app-initial~app-main~onboarding-page-zcfEkMl-.js",
     "app-initial~app-main~onboarding-page~hotkey-window-thread-page~editor-diff-page~thread-app-~current.js",
   ]) {
     assert.equal(descriptor.pattern.test(legacyName), false, legacyName);
@@ -1034,7 +1035,7 @@ test("assistant runtime descriptor fails soft and atomically when the current re
     fs.mkdirSync(assetsDir, { recursive: true });
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~onboarding-page-zcfEkMl-.js",
+      "app-initial-BHB6SClA.js",
     );
     const source = "console.log(`assistant render contract moved`);";
     fs.writeFileSync(assetPath, source);
@@ -1062,7 +1063,7 @@ test("assistant runtime descriptor reports applied then already-applied for the 
     fs.mkdirSync(assetsDir, { recursive: true });
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~onboarding-page-zcfEkMl-.js",
+      "app-initial-BHB6SClA.js",
     );
     fs.writeFileSync(
       assetPath,


### PR DESCRIPTION
## Summary

- retarget Read Aloud and Conversation Mode descriptors to the current `app-initial-<hash>.js` bundle
- update Conversation Mode dictation cleanup/stream and composer binding matchers for the current upstream contract
- split Agent Workspace settings wiring across the current app-initial, settings-page, and visible-settings bundles
- remove obsolete legacy bundle matchers and add current-shape regression fixtures

Fixes #1165

## Tests/checks

- `node --test linux-features/read-aloud/test.js` (59/59)
- `node --test linux-features/conversation-mode/test.js` (56/56)
- `node --test linux-features/agent-workspace/test.js` (32/32)
- `bash tests/scripts_smoke.sh`
- fresh `./install.sh --fresh` rebuild from upstream DMG 26.721.41059 (`ae864e2def7db56d0bb77a876a5cbe4e4c2f554ccc654cec921b946892583c0a`), acceptance verdict `accepted`
- `scripts/ci/validate-patch-report.js` and syntax checks for the generated launcher and patched webview modules

## Notes

- The optional features remain disabled by default.
- Broad local Node suites retain two unrelated baseline/environment failures that reproduce on clean `origin/main`: the live app-server socket test and bundled-plugin ancestor trust test.