### PR TITLE
Fix Linux desktop settings navigation grouping

### DIFF
--- a/scripts/patch-linux-window-ui.test.js
+++ b/scripts/patch-linux-window-ui.test.js
@@ -46,6 +46,7 @@ const {
   linuxDesktopSettingsAsset,
   applyLinuxDesktopSettingsIconPatch,
   applyLinuxDesktopSettingsIndexPatch,
+  applyLinuxDesktopSettingsNavigationGroupPatch,
   applyLinuxShortcutPhysicalKeyFallbackPatch,
   applyLinuxDesktopSettingsSectionsPatch,
   applyLinuxDesktopSettingsSharedPatch,
@@ -1768,6 +1769,14 @@ function createModernNativeKeyboardShortcutsSettingsFixture() {
     ].join(""),
   );
   writeAsset(
+    "settings-page-A.js",
+    [
+      "var nn=`general-settings.import.profile.appearance.voice.agent.personalization.pets.keyboard-shortcuts.usage.debug`.split(`.`),",
+      "rn=[{key:`personal`,heading:d({id:`settings.nav.heading.personal`,defaultMessage:`Personal`,description:`Heading for personal settings in the settings navigation`}),",
+      "slugs:[`general-settings`,`import`,`profile`,`appearance`,`voice`,`agent`,`personalization`,`pets`,`keyboard-shortcuts`,`usage`,`debug`]}];",
+    ].join(""),
+  );
+  writeAsset(
     "use-visible-settings-sections-A.js",
     [
       'var Hn={"general-settings":wt,import:it,profile:pt,"keyboard-shortcuts":xn};',
@@ -1872,7 +1881,7 @@ function createSplitRouteNativeKeyboardShortcutsSettingsFixture({
     "settings-page-A.js",
     [
       "var Wn=[`general-settings`,`import`,`profile`,`keyboard-shortcuts`];",
-      "var Qn=[{key:`app`,slugs:[`general-settings`,`import`,`profile`,`keyboard-shortcuts`]}];",
+      "var Qn=[{key:`personal`,heading:d({id:`settings.nav.heading.personal`,defaultMessage:`Personal`,description:`Heading for personal settings in the settings navigation`}),slugs:[`general-settings`,`import`,`profile`,`keyboard-shortcuts`]}];",
       "function loading(H){let W=!1;if(H)bb0:switch(H.slug){case`appearance`:case`general-settings`:case`agent`:case`git-settings`:case`data-controls`:case`personalization`:W=!1;break bb0;case`keyboard-shortcuts`:W=!1;break bb0}return W}",
     ].join(""),
   );
@@ -6380,6 +6389,14 @@ test("adds Linux desktop settings in the current monolithic app bundle", () => {
       routeChunkSource,
       /"linux-desktop":Ya\(async\(\)=>\(await Pr\(async\(\)=>\{let\{LinuxDesktopSettings:e\}=await import\(`\.\/linux-desktop-settings-linux\.js\?v=[a-f0-9]{12}`\);return\{LinuxDesktopSettings:e\}\},\[\],import\.meta\.url\)\)\.LinuxDesktopSettings\),"general-settings":/,
     );
+    const settingsPageSource = fs.readFileSync(
+      path.join(assetsDir, "settings-page-A.js"),
+      "utf8",
+    );
+    assert.match(
+      settingsPageSource,
+      /slugs:\[`general-settings`,`linux-desktop`,`import`,`profile`,`keyboard-shortcuts`\]/,
+    );
 
     const secondResult = patchKeybindsSettingsAssets(extractedDir);
     assert.equal(secondResult.matched, true);
@@ -6471,6 +6488,62 @@ test("adds Linux desktop section to current native Keyboard Shortcuts sections b
 
   assert.match(patched, /e=\[`general-settings`,`linux-desktop`,`profile`,`keyboard-shortcuts`/);
   assert.match(patched, /r=\[\{slug:`general-settings`\},\{slug:`linux-desktop`\},\{slug:`profile`\}/);
+});
+
+test("adds Linux desktop to the current personal settings navigation group", () => {
+  const source = [
+    "var nn=`general-settings.import.profile.appearance.keyboard-shortcuts`.split(`.`),",
+    "rn=[{key:`personal`,heading:d({id:`settings.nav.heading.personal`,defaultMessage:`Personal`,description:`Heading for personal settings in the settings navigation`}),",
+    "slugs:[`general-settings`,`import`,`profile`,`appearance`,`keyboard-shortcuts`]}];",
+  ].join("");
+
+  const patched = applyPatchTwice(applyLinuxDesktopSettingsNavigationGroupPatch, source);
+
+  assert.match(
+    patched,
+    /slugs:\[`general-settings`,`linux-desktop`,`import`,`profile`,`appearance`,`keyboard-shortcuts`\]/,
+  );
+});
+
+test("rejects ambiguous current personal settings navigation groups", () => {
+  const group =
+    "{key:`personal`,heading:d({id:`settings.nav.heading.personal`,defaultMessage:`Personal`,description:`Heading for personal settings in the settings navigation`}),slugs:[`general-settings`,`appearance`]}";
+
+  assert.throws(
+    () => applyLinuxDesktopSettingsNavigationGroupPatch(`[${group},${group}]`),
+    /expected exactly one current personal settings navigation group \(found 2, 0 already patched\)/,
+  );
+});
+
+test("skips Linux desktop settings when the current navigation group asset drifts", () => {
+  const { extractedDir, assetsDir } = createSplitRouteNativeKeyboardShortcutsSettingsFixture();
+  try {
+    const settingsPagePath = path.join(assetsDir, "settings-page-A.js");
+    fs.writeFileSync(
+      settingsPagePath,
+      fs.readFileSync(settingsPagePath, "utf8").replace(
+        "id:`settings.nav.heading.personal`",
+        "id:`settings.nav.heading.primary`",
+      ),
+      "utf8",
+    );
+
+    const { value: result, warnings } = captureWarns(() => patchKeybindsSettingsAssets(extractedDir));
+
+    assert.equal(result.matched, false);
+    assert.equal(result.changed, 0);
+    assert.match(result.reason, /exactly one current settings navigation group asset \(found 0\)/);
+    assert.ok(warnings.some((warning) => warning.includes(result.reason)));
+    assert.equal(fs.existsSync(path.join(assetsDir, linuxDesktopSettingsAsset)), false);
+
+    const report = createPatchReport();
+    captureWarns(() => patchExtractedApp(extractedDir, { report }));
+    const reportEntry = report.patches.find((patch) => patch.name === "keybinds-settings");
+    assert.equal(reportEntry.status, "skipped-optional");
+    assert.match(reportEntry.reason, /exactly one current settings navigation group asset \(found 0\)/);
+  } finally {
+    fs.rmSync(extractedDir, { recursive: true, force: true });
+  }
 });
 
 test("skips Linux desktop settings when the current visibility asset drifts", () => {

--- a/scripts/patches/impl/keybinds-settings.js
+++ b/scripts/patches/impl/keybinds-settings.js
@@ -632,6 +632,38 @@ function collectLinuxDesktopVisibilityPatch(extractedDir) {
   }];
 }
 
+function collectLinuxDesktopNavigationGroupPatch(extractedDir) {
+  const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
+  if (!fs.existsSync(webviewAssetsDir)) {
+    throw new Error(`Required Keybinds settings patch failed: missing webview assets directory ${webviewAssetsDir}`);
+  }
+
+  const candidates = fs
+    .readdirSync(webviewAssetsDir)
+    .filter((name) => /^settings-page-[^.]+\.js$/.test(name))
+    .sort()
+    .filter((name) => {
+      const source = fs.readFileSync(path.join(webviewAssetsDir, name), "utf8");
+      return source.includes("id:`settings.nav.heading.personal`");
+    });
+
+  if (candidates.length !== 1) {
+    throw new Error(
+      `Required Keybinds settings patch failed: could not find exactly one current settings navigation group asset (found ${candidates.length})`,
+    );
+  }
+
+  const [candidate] = candidates;
+  const filePath = path.join(webviewAssetsDir, candidate);
+  const currentSource = fs.readFileSync(filePath, "utf8");
+  return [{
+    filePath,
+    currentSource,
+    patchedSource: applyLinuxDesktopSettingsNavigationGroupPatch(currentSource),
+    patchFn: applyLinuxDesktopSettingsNavigationGroupPatch,
+  }];
+}
+
 function collectLinuxDesktopIconMapPatches(extractedDir) {
   const webviewAssetsDir = path.join(extractedDir, "webview", "assets");
   if (!fs.existsSync(webviewAssetsDir)) {
@@ -801,6 +833,7 @@ function patchKeybindsSettingsAssets(extractedDir) {
         isSettingsSectionsMetadataBundleSource,
         applyLinuxDesktopSettingsSectionsPatch,
       ),
+      ...collectLinuxDesktopNavigationGroupPatch(extractedDir),
       ...collectLinuxDesktopVisibilityPatch(extractedDir),
       ...collectOptionalMatchingAssetPatches(
         extractedDir,
@@ -918,6 +951,29 @@ function applyLinuxDesktopSettingsSectionsPatch(currentSource) {
   }
 
   return patchedSource;
+}
+
+function applyLinuxDesktopSettingsNavigationGroupPatch(currentSource) {
+  const unpatchedGroupPattern =
+    /(\{key:`personal`,heading:[^;]{0,1200}?id:`settings\.nav\.heading\.personal`[^;]{0,1200}?slugs:\[`general-settings`,)(?!`linux-desktop`,)/g;
+  const patchedGroupPattern =
+    /\{key:`personal`,heading:[^;]{0,1200}?id:`settings\.nav\.heading\.personal`[^;]{0,1200}?slugs:\[`general-settings`,`linux-desktop`,/g;
+  const unpatchedCount = currentSource.match(unpatchedGroupPattern)?.length ?? 0;
+  const patchedCount = currentSource.match(patchedGroupPattern)?.length ?? 0;
+
+  if (unpatchedCount === 0 && patchedCount === 1) {
+    return currentSource;
+  }
+  if (unpatchedCount !== 1 || patchedCount !== 0) {
+    throw new Error(
+      `Required Keybinds settings patch failed: expected exactly one current personal settings navigation group (found ${unpatchedCount}, ${patchedCount} already patched)`,
+    );
+  }
+
+  return currentSource.replace(
+    unpatchedGroupPattern,
+    "$1`linux-desktop`,",
+  );
 }
 
 // Inserts a new `titleForSection` switch case after the upstream
@@ -1217,6 +1273,7 @@ module.exports = {
   applyKeybindsSettingsSharedPatch,
   applyLinuxDesktopSettingsIndexPatch,
   applyLinuxDesktopSettingsIconPatch,
+  applyLinuxDesktopSettingsNavigationGroupPatch,
   applyLinuxDesktopSettingsRoutePatch,
   applyLinuxDesktopSettingsSectionsPatch,
   applyLinuxDesktopSettingsSharedPatch,

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -9130,6 +9130,9 @@ JS
     cat > "$extracted/webview/assets/use-visible-settings-sections-test.js" <<'JS'
 var Xge={"general-settings":xh,"keyboard-shortcuts":ks,appearance:Pf,agent:gU};function n_e(){let e=e=>{switch(e.slug){case`general-settings`:case`agent`:case`personalization`:return!0;case`keyboard-shortcuts`:return!0}}}
 JS
+    cat > "$extracted/webview/assets/settings-page-test.js" <<'JS'
+var nn=`general-settings.import.profile.appearance.keyboard-shortcuts`.split(`.`),rn=[{key:`personal`,heading:d({id:`settings.nav.heading.personal`,defaultMessage:`Personal`,description:`Heading for personal settings in the settings navigation`}),slugs:[`general-settings`,`import`,`profile`,`appearance`,`keyboard-shortcuts`]}];
+JS
     cat > "$extracted/webview/assets/app-initial-BTphDPeq.js" <<'JS'
 import{n as routeModule,s as routeToESM}from"./rolldown-runtime-test.js";import{I as routeJsxFactory,R as routeReactFactory}from"./shared-runtime-test.js";function Z(e){let r=(0,RouteReact.lazy)(e);function SettingsRouteWrapper(){let t=(0,RouteReact.useState)(null);return (0,RouteJsx.jsx)(r,{children:t})}return SettingsRouteWrapper}var RouteReact,RouteJsx;routeModule(()=>{RouteReact=routeToESM(routeReactFactory(),1),RouteJsx=routeJsxFactory()})();var c_e={"general-settings":Z(async()=>(await s(async()=>{let{GeneralSettings:e}=await import(`./general-settings-DZbwMmWz.js`);return{GeneralSettings:e}},[],import.meta.url)).GeneralSettings),"keyboard-shortcuts":Z(async()=>(await s(async()=>{let{KeyboardShortcutsSettings:e}=await import(`./keyboard-shortcuts-settings-test.js`);return{KeyboardShortcutsSettings:e}},[],import.meta.url)).KeyboardShortcutsSettings)};export{Z};
 JS
@@ -9161,6 +9164,7 @@ JS
     assert_contains "$extracted/webview/assets/settings-shared-test.js" "settings.section.linux-desktop"
     assert_contains "$extracted/webview/assets/use-visible-settings-sections-test.js" '"linux-desktop":xh,"general-settings":xh'
     assert_contains "$extracted/webview/assets/use-visible-settings-sections-test.js" 'case`linux-desktop`:return!0;case`general-settings`'
+    assert_contains "$extracted/webview/assets/settings-page-test.js" 'slugs:\[`general-settings`,`linux-desktop`,`import`'
     assert_contains "$extracted/webview/assets/app-initial-BTphDPeq.js" "linux-desktop-settings-linux.js?v="
     assert_contains "$extracted/webview/assets/app-initial-BTphDPeq.js" 'export{Z,'
     assert_contains "$extracted/webview/assets/app-initial-BTphDPeq.js" 'RouteReact as codexLinuxReact,RouteJsx as codexLinuxJsx'
@@ -9174,6 +9178,7 @@ JS
     assert_occurrence_count "$extracted/webview/assets/settings-shared-test.js" "settings.section.linux-desktop" '1'
     assert_occurrence_count "$extracted/webview/assets/use-visible-settings-sections-test.js" '"linux-desktop"' '1'
     assert_occurrence_count "$extracted/webview/assets/use-visible-settings-sections-test.js" 'case`linux-desktop`' '1'
+    assert_occurrence_count "$extracted/webview/assets/settings-page-test.js" '`linux-desktop`' '1'
     assert_occurrence_count "$extracted/webview/assets/app-initial-BTphDPeq.js" "linux-desktop-settings-linux.js" '1'
 }
 


### PR DESCRIPTION
## Summary

Fixes #1168.

The current upstream settings UI keeps sidebar group membership in the explicit `slugs` arrays inside `settings-page-*.js`. The existing Linux desktop settings patch registered the route, section metadata, visibility, and icon, but did not add `linux-desktop` to the Personal navigation group.

This change:

- locates exactly one current `settings-page-*.js` asset using the semantic `settings.nav.heading.personal` marker;
- inserts `linux-desktop` immediately after `general-settings` in the Personal group;
- keeps the patch idempotent and fails soft without partial writes when the contract is missing or ambiguous;
- adds focused current-contract, ambiguity, drift, idempotence, and smoke coverage.

Source-of-truth files changed:

- `scripts/patches/impl/keybinds-settings.js`
- `scripts/patch-linux-window-ui.test.js`
- `tests/scripts_smoke.sh`

The change targets only the latest supported DMG contract. It does not add legacy fallback paths or modify generated artifacts.

## Validation

- `node --test scripts/patch-linux-window-ui.test.js` — 401/401 passed
- `bash tests/scripts_smoke.sh` — passed
- Targeted Linux desktop settings tests — 18/18 passed
- `git diff --check` — passed
- `node --check scripts/patches/impl/keybinds-settings.js` — passed
- `bash -n tests/scripts_smoke.sh` — passed
- Current-DMG transactional candidate build — `accepted`
  - ChatGPT Desktop `26.721.41059`
  - DMG SHA-256 `ae864e2def7db56d0bb77a876a5cbe4e4c2f554ccc654cec921b946892583c0a`
  - enabled feature: `codex-wrapper-updater`
- `node scripts/ci/validate-patch-report.js codex-app-next/.codex-linux/patch-report.json` — passed

Local current-DMG validation used Deepin 25, DDE, X11, and the `.deb` target. The patch itself is package- and desktop-neutral core Linux compatibility glue. The candidate was validated but not installed.

## Checklist

- [x] This pull request is ready for review and is no longer a draft.
- [x] I followed [CONTRIBUTING.md](https://github.com/ilysenko/codex-desktop-linux/blob/main/CONTRIBUTING.md), kept the change focused, edited source files rather than generated output, and removed unrelated changes.
- [x] If this fixes upstream drift, it targets only the latest `CODEX.DMG` and removes obsolete fallback code and tests from the affected area.
- [x] I added or updated relevant tests, ran the validation listed above, and confirmed that required CI checks pass.
- [x] I reviewed the final diff with my coding agent using maximum available reasoning effort, addressed all findings, and reran the relevant tests.
