### PR TITLE
Fix latest-DMG Arch bootstrap failures

### DIFF
--- a/linux-features/project-group-last-updated-sort/patch.js
+++ b/linux-features/project-group-last-updated-sort/patch.js
@@ -1,14 +1,14 @@
 "use strict";
 
 const currentGroupSorter =
-  "function Fe({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return ue(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
+  "function h2o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return iZi(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}";
 const patchedGroupSorter =
-  "function Fe({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:ue(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
+  "function h2o({groups:e,items:t,projectOrder:n,sortMode:codexLinuxProjectSortMode}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return((codexLinuxRecencySortedGroups)=>codexLinuxProjectSortMode===`updated_at`?codexLinuxRecencySortedGroups:iZi(codexLinuxRecencySortedGroups,n))(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e))}";
 
 const currentGroupSorterCall =
-  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER)})";
+  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER)})";
 const patchedGroupSorterCall =
-  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER),sortMode:t(C).projectSortMode})";
+  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER),sortMode:t(Ez).projectSortMode})";
 
 function countOccurrences(source, needle) {
   return source.split(needle).length - 1;
@@ -52,8 +52,7 @@ const descriptors = [
     phase: "webview-asset",
     order: 20_900,
     ciPolicy: "optional",
-    pattern:
-      /^app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~[A-Za-z0-9_-]+\.js$/,
+    pattern: /^app-initial-[A-Za-z0-9_-]+\.js$/,
     missingDescription: "project group sort webview bundle",
     skipDescription: "project group Last updated sorting feature patch",
     apply: applyProjectGroupLastUpdatedSortPatch,

--- a/linux-features/project-group-last-updated-sort/test.js
+++ b/linux-features/project-group-last-updated-sort/test.js
@@ -18,13 +18,13 @@ const {
 } = require("./patch.js");
 
 const currentProjectSource = [
-  "function ue(e,t){let n=new Map(t.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(n.get(e.projectId)??2**53-1)-(n.get(t.projectId)??2**53-1))}",
-  "function Re(e,t){let n=e.projectUpdatedAt??0;for(let r of e.threadKeys)n=Math.max(n,t.get(r)??0);return n}",
-  "function Fe({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return ue(e.map((e,t)=>({group:e,index:t,recencyAt:Re(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
+  "function iZi(e,t){let n=new Map(t.map((e,t)=>[e,t]));return[...e].sort((e,t)=>(n.get(e.projectId)??2**53-1)-(n.get(t.projectId)??2**53-1))}",
+  "function y2o(e,t){let n=e.projectUpdatedAt??0;for(let r of e.threadKeys)n=Math.max(n,t.get(r)??0);return n}",
+  "function h2o({groups:e,items:t,projectOrder:n}){let r=new Map(t.map(e=>[e.task.key,e.recencyAt]));return iZi(e.map((e,t)=>({group:e,index:t,recencyAt:y2o(e,r)})).sort((e,t)=>t.recencyAt-e.recencyAt||e.index-t.index).map(({group:e})=>e),n)}",
   "const prioritySortId=`sidebarElectron.sortMenu.priority`;",
   "const updatedSortId=`sidebarElectron.sortMenu.updated`;",
   "const manualSortId=`sidebarElectron.sortMenu.manual`;",
-  "T=Fe({groups:Pe({groups:S,items:c}),items:c,projectOrder:f(t,o.PROJECT_ORDER)});",
+  "T=h2o({groups:m2o({groups:C,items:s}),items:s,projectOrder:ap(t,zl.PROJECT_ORDER)});",
 ].join("");
 
 function captureWarns(fn) {
@@ -70,7 +70,7 @@ function withFeatureConfig(enabled, fn) {
 function evaluateGroupSorter(source) {
   const context = {};
   const sorterSource = source.slice(0, source.indexOf("const prioritySortId"));
-  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=Fe`, context);
+  vm.runInNewContext(`${sorterSource};globalThis.sortProjectGroups=h2o`, context);
   return context.sortProjectGroups;
 }
 
@@ -154,15 +154,15 @@ test("patch passes the selected project sort mode into the group sorter", () => 
   const patched = applyPatchTwice(currentProjectSource);
   assert.ok(
     patched.includes(
-      "projectOrder:f(t,o.PROJECT_ORDER),sortMode:t(C).projectSortMode",
+      "projectOrder:ap(t,zl.PROJECT_ORDER),sortMode:t(Ez).projectSortMode",
     ),
   );
 });
 
 test("drift leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "function Fe({groups:e,items:t,projectOrder:n})",
-    "function Fe({groups:e,items:t,projectOrder:n,unknown:o})",
+    "function h2o({groups:e,items:t,projectOrder:n})",
+    "function h2o({groups:e,items:t,projectOrder:n,unknown:o})",
   );
   const { value, warnings } = captureWarns(() =>
     applyProjectGroupLastUpdatedSortPatch(source),
@@ -175,7 +175,7 @@ test("drift leaves the asset byte-identical", () => {
 
 test("missing current call site leaves the asset byte-identical", () => {
   const source = currentProjectSource.replace(
-    "projectOrder:f(t,o.PROJECT_ORDER)",
+    "projectOrder:ap(t,zl.PROJECT_ORDER)",
     "projectOrder:unknownProjectOrder",
   );
   const { value, warnings } = captureWarns(() =>
@@ -208,7 +208,7 @@ test("descriptor targets and patches only the current project sidebar chunk", ()
     const assetsDir = path.join(tempDir, "webview", "assets");
     const assetPath = path.join(
       assetsDir,
-      "app-initial~app-main~onboarding-page~projects-index-page~quick-chat-window-page~codex-micro~iqsnin5k-demo.js",
+      "app-initial-BHB6SClA.js",
     );
     fs.mkdirSync(assetsDir, { recursive: true });
     fs.writeFileSync(assetPath, currentProjectSource);

--- a/packaging/linux/PKGBUILD.template
+++ b/packaging/linux/PKGBUILD.template
@@ -51,5 +51,5 @@ source=()
 sha256sums=()
 
 package() {
-    cp -a "__STAGING_DIR__/." "${pkgdir}/"
+    cp -a --no-preserve=ownership "__STAGING_DIR__/." "${pkgdir}/"
 }

--- a/tests/scripts_smoke.sh
+++ b/tests/scripts_smoke.sh
@@ -1429,6 +1429,7 @@ SCRIPT
     assert_contains "$capture_dir/PKGBUILD" "pkgver=2026.03.24.120000+manual"
     assert_contains "$capture_dir/PKGBUILD" "pkgrel=1"
     assert_contains "$capture_dir/PKGBUILD" "ampersand&tmp"
+    assert_contains "$capture_dir/PKGBUILD" "cp -a --no-preserve=ownership"
     assert_not_contains "$capture_dir/PKGBUILD" "__STAGING_DIR__"
     assert_contains "$capture_dir/PKGBUILD" "install=codex-desktop.install"
     assert_occurrence_count "$capture_dir/PKGBUILD" "'polkit'" "1"


### PR DESCRIPTION
## Summary

- retarget the opt-in project-group Last updated sort feature to the current `app-initial` bundle and minified symbols
- keep the patch fail-soft and idempotent while passing the current project sort mode at the updated call site
- prevent pacman fakeroot builds from preserving user ownership when copying the staged payload

## User-visible behavior

`make bootstrap-native` can accept the current upstream DMG when `project-group-last-updated-sort` is enabled and can finish the Arch package build without `cp: failed to preserve ownership` errors.

## Validation

- `node --test linux-features/project-group-last-updated-sort/test.js`
- shell syntax checks for installer, package builders, launcher template, and `scripts/lib/*.sh`
- `bash tests/scripts_smoke.sh`
- `./scripts/build-pacman.sh`
- local upstream acceptance for ChatGPT `26.721.81911`: `accepted`, zero blockers