### PR TITLE
fix(remote-mobile-control): retarget current gate bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Remote mobile control now patches the current 26.721 dual-gate enablement
+  bridge instead of reporting it as already applied. Startup auto-connects the
+  environment owned by this Desktop without overwriting saved choices for
+  other enrolled hosts.
 - Updater-managed npm Codex CLI installs now serialize across daemon, launcher,
   and status processes. If npm reports the exact stale Arborist retirement
   directory failure, automatic paths preserve the working CLI and direct the

--- a/linux-features/remote-mobile-control/README.md
+++ b/linux-features/remote-mobile-control/README.md
@@ -126,7 +126,7 @@ feature descriptor to appear exactly once in this table.
 | `linux-remote-control-status-read-guard` | `shared-boundary` | Sends `remoteControl/status/read` only to the local host, never Remote SSH or remote-control environment hosts. |
 | `linux-remote-control-status-wait` | `shared-boundary` | Gives the selected host a Linux-specific connection convergence window without changing host ownership. |
 | `linux-remote-control-enable-for-host-params` | `shared-boundary` | Uses the current enable/disable RPC parameter contract without choosing which host is targeted. |
-| `linux-remote-control-enablement-bridge` | `shared-boundary` | Loads outbound clients while auto-connecting only the remote-control environment owned by this Desktop. |
+| `linux-remote-control-enablement-bridge` | `shared-boundary` | Loads outbound clients and auto-connects the remote-control environment owned by this Desktop without overwriting saved choices for other hosts. |
 | `linux-remote-mobile-active-status` | `mobile-host` | Derives mobile active state from the local thread runtime. |
 
 Remote SSH behavior is nested inside the shared settings descriptor rather than

--- a/linux-features/remote-mobile-control/patch.js
+++ b/linux-features/remote-mobile-control/patch.js
@@ -1254,9 +1254,15 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
 
   patched = applyLinuxRemoteControlEnableForHostParamsPatch(patched);
 
-  const markerIndex = patched.indexOf("[remote-connections/slingshot-gate-bridge]");
+  const markerIndex = patched.indexOf("[remote-connections/gate-bridge]");
   const enablementIndex = patched.indexOf("set-remote-control-connections-enabled");
   if (markerIndex < 0 || enablementIndex < 0) {
+    if (
+      !patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER) ||
+      !patched.includes(REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER)
+    ) {
+      console.warn("WARN: Could not find current remote-control enablement bridge anchors - skipping Linux remote-control bridge patch");
+    }
     return patched;
   }
   if (Math.abs(markerIndex - enablementIndex) > 4_500) {
@@ -1272,11 +1278,14 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
 
   if (!patched.includes(REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER)) {
     const currentBridgePattern =
-      /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(6\),\{checkGate:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*);\2\[0\]===\4\?\7=\2\[1\]:\(\7=\4\(`1042620455`\),\2\[0\]=\4,\2\[1\]=\7\);let ([A-Za-z_$][\w$]*)=\7,([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return /u;
+      /function ([A-Za-z_$][\w$]*)\(\)\{let ([A-Za-z_$][\w$]*)=\(0,([A-Za-z_$][\w$]*)\.c\)\(6\),\{checkGate:([A-Za-z_$][\w$]*),isLoading:([A-Za-z_$][\w$]*)\}=([A-Za-z_$][\w$]*)\(\),([A-Za-z_$][\w$]*);\2\[0\]===\4\?\7=\2\[1\]:\(\7=\4\(`1042620455`\)\|\|\4\(`2055603567`\),\2\[0\]=\4,\2\[1\]=\7\);let ([A-Za-z_$][\w$]*)=\7,([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*);return /u;
     let patchedRegion = region.replace(
       currentBridgePattern,
-      (_needle, functionName, cacheVar, compilerVar, checkGateVar, isLoadingVar, gateHookVar, gateValueVar, enabledVar, callbackVar, depsVar) =>
-        `function ${functionName}(){let ${cacheVar}=(0,${compilerVar}.c)(6),{checkGate:${checkGateVar},isLoading:${isLoadingVar}}=${gateHookVar}(),${gateValueVar};${cacheVar}[0]===${checkGateVar}?${gateValueVar}=${cacheVar}[1]:(${gateValueVar}=${checkGateVar}(\`1042620455\`),${cacheVar}[0]=${checkGateVar},${cacheVar}[1]=${gateValueVar});let ${enabledVar}=${gateValueVar}||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),${callbackVar},${depsVar};return `,
+      (needle, _functionName, _cacheVar, _compilerVar, _checkGateVar, _isLoadingVar, _gateHookVar, gateValueVar, enabledVar) =>
+        needle.replace(
+          `let ${enabledVar}=${gateValueVar},`,
+          `let ${enabledVar}=${gateValueVar}||/*${REMOTE_CONTROL_ENABLEMENT_BRIDGE_MARKER}*/typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`),`,
+        ),
     );
     if (patchedRegion === region) {
       console.warn("WARN: Could not find remote-control enablement bridge needle - skipping Linux remote-control bridge patch");
@@ -1291,10 +1300,10 @@ function applyLinuxRemoteControlEnablementBridgePatch(source) {
   }
 
   const selfAutoConnectReplacement = (desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>
-    `${desktopHostRequestFn}(\`set-remote-control-connections-enabled\`,{params:{enabled:${enabledVar}}}).then(async e=>{if(${enabledVar}&&typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){let t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null;if(t.length===0)try{let e=await ${desktopHostRequestFn}(\`refresh-remote-control-connections\`,{params:{}});t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=n??e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_refresh_failed\`,{safe:{},sensitive:{error:e}})}if(n==null)try{let e=await ${desktopHostRequestFn}(\`get-global-state\`,{params:{key:\`electron-local-remote-control-installation-id\`}});n=e?.value??e?.state?.value??e?.globalState?.[\`electron-local-remote-control-installation-id\`]??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_identity_failed\`,{safe:{},sensitive:{error:e}})}let r=t.filter(e=>typeof e?.hostId==\`string\`&&e.hostId.startsWith(\`remote-control:\`)),i=new Set(r.filter(e=>n!=null&&(e.installationId??e.installation_id)===n).map(e=>e.hostId));await Promise.all(r.map(e=>${desktopHostRequestFn}(\`set-remote-connection-auto-connect\`,{params:{hostId:e.hostId,autoConnect:i.has(e.hostId)}}).catch(t=>{${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_failed\`,{safe:{autoConnect:i.has(e.hostId)},sensitive:{hostId:e.hostId,error:t}})})))}}/*${REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER}*/).catch(${errorVar}=>{${loggerVar}.warning(\`\${${logPrefixVar}} sync_failed\`,{safe:{enabled:${enabledVar}},sensitive:{error:${errorVar}}})})`;
+    `${desktopHostRequestFn}(\`set-remote-control-connections-enabled\`,{params:{enabled:${enabledVar}}}).then(async e=>{if(${enabledVar}&&typeof navigator!=\`undefined\`&&navigator.userAgent.includes(\`Linux\`)){let t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null;if(t.length===0)try{let e=await ${desktopHostRequestFn}(\`refresh-remote-control-connections\`,{params:{}});t=e?.remoteControlConnections??e?.sharedObjects?.remote_control_connections??e?.connections??[],n=n??e?.sharedObjects?.local_remote_control_installation_id??e?.local_remote_control_installation_id??e?.localRemoteControlInstallationId??e?.installationId??e?.installation_id??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_refresh_failed\`,{safe:{},sensitive:{error:e}})}if(n==null)try{let e=await ${desktopHostRequestFn}(\`get-global-state\`,{params:{key:\`electron-local-remote-control-installation-id\`}});n=e?.value??e?.state?.value??e?.globalState?.[\`electron-local-remote-control-installation-id\`]??null}catch(e){${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_identity_failed\`,{safe:{},sensitive:{error:e}})}let r=t.filter(e=>typeof e?.hostId==\`string\`&&e.hostId.startsWith(\`remote-control:\`)),i=new Set(r.filter(e=>n!=null&&(e.installationId??e.installation_id)===n).map(e=>e.hostId));await Promise.all(r.filter(e=>i.has(e.hostId)).map(e=>${desktopHostRequestFn}(\`set-remote-connection-auto-connect\`,{params:{hostId:e.hostId,autoConnect:!0}}).catch(t=>{${loggerVar}.warning(\`\${${logPrefixVar}} self_auto_connect_failed\`,{safe:{autoConnect:!0},sensitive:{hostId:e.hostId,error:t}})})))}}/*${REMOTE_CONTROL_SELF_AUTO_CONNECT_MARKER}*/).catch(${errorVar}=>{${loggerVar}.warning(\`\${${logPrefixVar}} sync_failed\`,{safe:{enabled:${enabledVar}},sensitive:{error:${errorVar}}})})`;
 
   const selfAutoConnectPattern =
-    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{(?:enabled|slingshotEnabled):\2\},sensitive:\{error:\3\}\}\)\}\)/u;
+    /([A-Za-z_$][\w$]*)\(`set-remote-control-connections-enabled`,\{params:\{enabled:([A-Za-z_$][\w$]*)\}\}\)\.catch\(([A-Za-z_$][\w$]*)=>\{([A-Za-z_$][\w$]*)\.warning\(`\$\{([A-Za-z_$][\w$]*)\} sync_failed`,\{safe:\{remoteControlConnectionsEnabled:\2\},sensitive:\{error:\3\}\}\)\}\)/u;
   const selfAutoConnectRegion = region.replace(
     selfAutoConnectPattern,
     (_needle, desktopHostRequestFn, enabledVar, errorVar, loggerVar, logPrefixVar) =>

--- a/linux-features/remote-mobile-control/test.js
+++ b/linux-features/remote-mobile-control/test.js
@@ -413,8 +413,8 @@ function syntheticAppMainActiveStatusBundle() {
 
 function syntheticAppMainEnablementBridgeBundle() {
   return [
-    "function OF(){let e=(0,Z.c)(6),{checkGate:t,isLoading:n}=sc(),r;e[0]===t?r=e[1]:(r=t(`1042620455`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||$o(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{slingshotEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,Q.useEffect)(a,o),null}",
-    "var DF=`[remote-connections/slingshot-gate-bridge]`;",
+    "function OF(){let e=(0,Z.c)(6),{checkGate:t,isLoading:n}=sc(),r;e[0]===t?r=e[1]:(r=t(`1042620455`)||t(`2055603567`),e[0]=t,e[1]=r);let i=r,a,o;return e[2]!==n||e[3]!==i?(a=()=>{n||$o(`set-remote-control-connections-enabled`,{params:{enabled:i}}).catch(e=>{q.warning(`${DF} sync_failed`,{safe:{remoteControlConnectionsEnabled:i},sensitive:{error:e}})})},o=[n,i],e[2]=n,e[3]=i,e[4]=a,e[5]=o):(a=e[4],o=e[5]),(0,Q.useEffect)(a,o),null}",
+    "var DF=`[remote-connections/gate-bridge]`;",
   ].join("");
 }
 
@@ -2591,7 +2591,8 @@ test("remote mobile feature patch report records feature metadata and partial wa
       );
       fs.appendFileSync(
         path.join(assetsDir, CURRENT_APP_MAIN_PAGE_ASSET),
-        syntheticAppMainFeatureSyncBundle() + syntheticAppMainEnablementBridgeBundle(),
+        syntheticAppMainFeatureSyncBundle() +
+          "function OF(){return $o(`set-remote-control-connections-enabled`,{params:{enabled:true}})}",
       );
       fs.appendFileSync(
         path.join(assetsDir, CURRENT_REMOTE_LOAD_GATE_ASSET),
@@ -2639,6 +2640,19 @@ test("remote mobile feature patch report records feature metadata and partial wa
       assert.equal(settingsPatch.featureId, "remote-mobile-control");
       assert.equal(settingsPatch.status, "applied-with-warnings");
       assert.ok(settingsPatch.warnings.some((warning) => warning.includes("SSH install release needles")));
+
+      const enablementBridgePatch = report.patches.find(
+        (patch) =>
+          patch.name ===
+          "feature:remote-mobile-control:linux-remote-control-enablement-bridge",
+      );
+      assert.equal(enablementBridgePatch.status, "skipped-optional");
+      assert.notEqual(enablementBridgePatch.status, "already-applied");
+      assert.ok(
+        enablementBridgePatch.warnings.some((warning) =>
+          warning.includes("current remote-control enablement bridge anchors"),
+        ),
+      );
 
       assert.equal(
         report.patches.some((patch) => patch.name === "linux-app-server-conversation-hydration"),
@@ -2718,7 +2732,7 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
 
   const calls = [];
   const context = {
-    DF: "[remote-connections/slingshot-gate-bridge]",
+    DF: "[remote-connections/gate-bridge]",
     navigator: { userAgent: "X11; Linux x86_64" },
     q: { warning() {} },
     Q: { useEffect(callback) { callback(); } },
@@ -2738,7 +2752,7 @@ test("Linux remote-control enablement bridge loads remote-control clients on Lin
 
 test("Linux remote-control enablement bridge rejects distant anchors", () => {
   const source = [
-    "var DF=`[remote-connections/slingshot-gate-bridge]`;",
+    "var DF=`[remote-connections/gate-bridge]`;",
     "x".repeat(4_501),
     "function OF(){return $o(`set-remote-control-connections-enabled`,{params:{enabled:true}})}",
   ].join("");
@@ -2748,6 +2762,74 @@ test("Linux remote-control enablement bridge rejects distant anchors", () => {
 
   assert.equal(result, source);
   assert.ok(warnings.some((warning) => warning.includes("anchors are too far apart")));
+});
+
+test("Linux remote-control enablement bridge reports current anchor drift instead of false success", () => {
+  const source =
+    "function OF(){return $o(`set-remote-control-connections-enabled`,{params:{enabled:true}})}";
+  const { result, warnings } = captureWarnings(() =>
+    applyLinuxRemoteControlEnablementBridgePatch(source),
+  );
+
+  assert.equal(result, source);
+  assert.ok(
+    warnings.some((warning) =>
+      warning.includes("current remote-control enablement bridge anchors"),
+    ),
+  );
+});
+
+test("Linux remote-control enablement bridge preserves the current second gate off Linux", () => {
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(
+    syntheticAppMainEnablementBridgeBundle(),
+  );
+  const calls = [];
+  const checkedGates = [];
+  const context = {
+    DF: "[remote-connections/gate-bridge]",
+    navigator: { userAgent: "Macintosh" },
+    q: { warning() {} },
+    Q: { useEffect(callback) { callback(); } },
+    sc: () => ({
+      checkGate(gate) {
+        checkedGates.push(gate);
+        return gate === "2055603567";
+      },
+      isLoading: false,
+    }),
+    Z: { c: () => [] },
+    $o: (method, { params }) => {
+      calls.push({ method, params });
+      return Promise.resolve();
+    },
+  };
+  vm.runInNewContext(`${patched};OF();`, context);
+
+  assert.deepEqual(checkedGates, ["1042620455", "2055603567"]);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].params.enabled, true);
+});
+
+test("Linux remote-control enablement bridge waits for current gates to load", () => {
+  const patched = applyLinuxRemoteControlEnablementBridgePatch(
+    syntheticAppMainEnablementBridgeBundle(),
+  );
+  const calls = [];
+  const context = {
+    DF: "[remote-connections/gate-bridge]",
+    navigator: { userAgent: "X11; Linux x86_64" },
+    q: { warning() {} },
+    Q: { useEffect(callback) { callback(); } },
+    sc: () => ({ checkGate: () => false, isLoading: true }),
+    Z: { c: () => [] },
+    $o: (method, { params }) => {
+      calls.push({ method, params });
+      return Promise.resolve();
+    },
+  };
+  vm.runInNewContext(`${patched};OF();`, context);
+
+  assert.equal(calls.length, 0);
 });
 
 test("Linux remote-control enablement bridge omits params for current host toggle handler", async () => {
@@ -2812,16 +2894,17 @@ test("Linux remote-control enablement bridge warns when host toggle params needl
   assert.ok(warnings.some((warning) => warning.includes("enable-for-host params needle")));
 });
 
-test("Linux remote-control enablement bridge auto-connects only this Desktop host", async () => {
+test("Linux remote-control enablement bridge auto-connects this Desktop host without changing other hosts", async () => {
   const source = syntheticAppMainEnablementBridgeBundle();
   const patched = applyLinuxRemoteControlEnablementBridgePatch(source);
 
   assert.doesNotMatch(patched, /safe:\{[^}]*\bhostId:/);
   assert.match(patched, /sensitive:\{hostId:[^}]+error:/);
+  assert.match(patched, /codexLinuxRemoteControlSelfAutoConnect/);
 
   const calls = [];
   const context = {
-    DF: "[remote-connections/slingshot-gate-bridge]",
+    DF: "[remote-connections/gate-bridge]",
     navigator: { userAgent: "X11; Linux x86_64" },
     Promise,
     q: { warning() {} },
@@ -2838,7 +2921,7 @@ test("Linux remote-control enablement bridge auto-connects only this Desktop hos
         return Promise.resolve({
           remoteControlConnections: [
             { hostId: "remote-control:env_local", installationId: "install_local" },
-            { hostId: "remote-control:env_stale", installationId: "install_stale" },
+            { hostId: "remote-control:env_other", installationId: "install_other" },
           ],
         });
       }
@@ -2851,7 +2934,7 @@ test("Linux remote-control enablement bridge auto-connects only this Desktop hos
   vm.runInNewContext(`${patched};OF();`, context);
   await new Promise((resolve) => setImmediate(resolve));
 
-  assert.equal(calls.length, 4);
+  assert.equal(calls.length, 3);
   assert.equal(calls[0].method, "set-remote-control-connections-enabled");
   assert.equal(calls[0].params.enabled, true);
   assert.equal(calls[1].method, "get-global-state");
@@ -2859,9 +2942,14 @@ test("Linux remote-control enablement bridge auto-connects only this Desktop hos
   assert.equal(calls[2].method, "set-remote-connection-auto-connect");
   assert.equal(calls[2].params.hostId, "remote-control:env_local");
   assert.equal(calls[2].params.autoConnect, true);
-  assert.equal(calls[3].method, "set-remote-connection-auto-connect");
-  assert.equal(calls[3].params.hostId, "remote-control:env_stale");
-  assert.equal(calls[3].params.autoConnect, false);
+  assert.equal(
+    calls.some(
+      ({ method, params }) =>
+        method === "set-remote-connection-auto-connect" &&
+        params.hostId === "remote-control:env_other",
+    ),
+    false,
+  );
 });
 
 test("patched Linux device-key provider can create, sign with, and delete a key", async () => {
@@ -3713,6 +3801,12 @@ test("remote mobile control feature participates in ASAR patching and reports", 
         assert.ok(
           secondReport.patches.some((patch) =>
             patch.name === "feature:remote-mobile-control:linux-remote-terminal-status-recovery" &&
+            patch.status === "already-applied",
+          ),
+        );
+        assert.ok(
+          secondReport.patches.some((patch) =>
+            patch.name === "feature:remote-mobile-control:linux-remote-control-enablement-bridge" &&
             patch.status === "already-applied",
           ),
         );


### PR DESCRIPTION
## Summary

- retarget the opt-in Remote Mobile Control patch from the retired slingshot gate bridge to the current gate bridge and dual-gate contract
- report recognizable current-bundle drift instead of treating it as already patched
- enable auto-connect only for the local Desktop host while preserving saved selections for other hosts
- expand regression coverage and update the feature documentation/changelog

## Validation

- node --test linux-features/remote-mobile-control/test.js (110/110)
- TMPDIR=<private 0700 directory> node --test scripts/patch-linux-window-ui.test.js (401/401)
- built a side-by-side app from Codex Desktop 26.721.81911 and verified Android QR pairing, session listing, thread resume/hydration, and a streamed live turn on Linux with Codex CLI 0.146.0
