### PR TITLE
Fix current Linux open target command lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Open Target Discovery now resolves the selected Linux editor or terminal
+  through the current private open-target command path. Command-path drift is
+  reported before the feature changes the main bundle, so enabled-feature
+  acceptance cannot mistake a partially patched bundle for success.
 - Remote mobile control now patches the current 26.721 dual-gate enablement
   bridge instead of reporting it as already applied. Startup auto-connects the
   environment owned by this Desktop without overwriting saved choices for

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -624,42 +624,15 @@ function findCurrentOpenTargetCommandMatch(source) {
   );
 }
 
-function findPatchedOpenTargetCommandBlock(source) {
-  const marker = "let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand(";
-  const markerIndex = source.indexOf(marker);
-  if (markerIndex === -1) {
-    return null;
-  }
-
-  const methodStart = source.lastIndexOf("async#", markerIndex);
-  const blockStart = methodStart === -1 ? -1 : source.indexOf("{", methodStart);
-  const block = findBalancedBlock(source, blockStart);
-  const signature = source.slice(methodStart, blockStart).match(
-    /^async#[A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\)$/u,
+function findPatchedOpenTargetCommandMatch(source) {
+  return source.match(
+    /async#([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{if\(process\.platform===`linux`\)\{let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand\(this\.settingsStore,\2\);if\(_codexLinuxOpenTargetCommand==null\)throw Error\(`Open target "\$\{\2\}" is not available`\);return _codexLinuxOpenTargetCommand\}let\{command:([A-Za-z_$][\w$]*)\}=await this\.#([A-Za-z_$][\w$]*)\(\)\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.settingsStore,\2\)\}\);if\(\3==null\)throw Error\(`Open target "\$\{\2\}" is not available`\);return \3\}/u,
   );
-  if (block == null || signature == null || block.end <= markerIndex) {
-    return null;
-  }
-
-  const targetVar = signature[1];
-  const linuxCommand =
-    `let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand(this.settingsStore,${targetVar})`;
-  const unavailable =
-    `if(_codexLinuxOpenTargetCommand==null)throw Error(\`Open target "\${${targetVar}}" is not available\`)`;
-  if (
-    !block.text.includes(linuxCommand) ||
-    !block.text.includes(unavailable) ||
-    !block.text.includes("return _codexLinuxOpenTargetCommand") ||
-    !block.text.includes("method:`get-target-command`")
-  ) {
-    return null;
-  }
-  return block;
 }
 
 function applyOpenInTargetCommandPatch(currentSource) {
-  const patchedBlock = findPatchedOpenTargetCommandBlock(currentSource);
-  if (patchedBlock != null) {
+  const patchedMatch = findPatchedOpenTargetCommandMatch(currentSource);
+  if (patchedMatch != null) {
     return currentSource;
   }
   if (currentSource.includes("_codexLinuxOpenTargetCommand")) {
@@ -831,6 +804,20 @@ function applyMainBundlePatch(currentSource) {
   const pathVar = requireName(currentSource, "node:path");
   if (fsVar == null || pathVar == null) {
     warn("Could not find node:fs/node:path dependencies");
+    return currentSource;
+  }
+
+  if (
+    currentSource.includes("get-target-command") &&
+    currentSource.includes("Open in worker unavailable") &&
+    findPatchedOpenTargetCommandMatch(currentSource) == null &&
+    findCurrentOpenTargetCommandMatch(currentSource) == null
+  ) {
+    warn(
+      currentSource.includes("_codexLinuxOpenTargetCommand")
+        ? "Found partially patched open target command lookup"
+        : "Could not find current open target command lookup",
+    );
     return currentSource;
   }
 

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -595,7 +595,6 @@ function applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing = 
       warnOnMissing &&
       (
         currentSource.includes("get-target-command") ||
-        currentSource.includes("getOpenInTargetCommand") ||
         currentSource.includes("allAvailableTargets")
       )
     ) {

--- a/linux-features/open-target-discovery/patch.js
+++ b/linux-features/open-target-discovery/patch.js
@@ -618,30 +618,76 @@ function applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing = 
   return currentSource.slice(0, insertionIndex) + helper + currentSource.slice(insertionIndex);
 }
 
-function applyOpenInTargetCommandPatch(currentSource) {
-  currentSource = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
-  if (currentSource.includes("codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e)")) {
-    return currentSource;
-  }
-  if (!currentSource.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
-    return currentSource;
-  }
-
-  const currentShapeMatch = currentSource.match(
-    /async getOpenInTargetCommand\(e\)\{let\{command:t\}=await this\.getOpenInWorker\(\)\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.getSettingsStore\(\),e\)\}\);if\(t==null\)throw Error\(`Open target "\$\{e\}" is not available`\);return t\}/u,
+function findCurrentOpenTargetCommandMatch(source) {
+  return source.match(
+    /async#([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*)\)\{let\{command:([A-Za-z_$][\w$]*)\}=await this\.#([A-Za-z_$][\w$]*)\(\)\(\{method:`get-target-command`,params:([A-Za-z_$][\w$]*)\(this\.settingsStore,\2\)\}\);if\(\3==null\)throw Error\(`Open target "\$\{\2\}" is not available`\);return \3\}/u,
   );
-  if (currentShapeMatch != null) {
-    const [needle, paramsFn] = currentShapeMatch;
-    return currentSource.replace(
-      needle,
-      `async getOpenInTargetCommand(e){if(process.platform===\`linux\`){let t=await codexLinuxOpenTargetRegistryCommand(this.getSettingsStore(),e);if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}let{command:n}=await this.getOpenInWorker()({method:\`get-target-command\`,params:${paramsFn}(this.getSettingsStore(),e)});if(n==null)throw Error(\`Open target "\${e}" is not available\`);return n}`,
-    );
+}
+
+function findPatchedOpenTargetCommandBlock(source) {
+  const marker = "let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand(";
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex === -1) {
+    return null;
   }
 
-  if (currentSource.includes("getOpenInTargetCommand")) {
-    warn("Could not find getOpenInTargetCommand worker fallback");
+  const methodStart = source.lastIndexOf("async#", markerIndex);
+  const blockStart = methodStart === -1 ? -1 : source.indexOf("{", methodStart);
+  const block = findBalancedBlock(source, blockStart);
+  const signature = source.slice(methodStart, blockStart).match(
+    /^async#[A-Za-z_$][\w$]*\(([A-Za-z_$][\w$]*)\)$/u,
+  );
+  if (block == null || signature == null || block.end <= markerIndex) {
+    return null;
   }
-  return currentSource;
+
+  const targetVar = signature[1];
+  const linuxCommand =
+    `let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand(this.settingsStore,${targetVar})`;
+  const unavailable =
+    `if(_codexLinuxOpenTargetCommand==null)throw Error(\`Open target "\${${targetVar}}" is not available\`)`;
+  if (
+    !block.text.includes(linuxCommand) ||
+    !block.text.includes(unavailable) ||
+    !block.text.includes("return _codexLinuxOpenTargetCommand") ||
+    !block.text.includes("method:`get-target-command`")
+  ) {
+    return null;
+  }
+  return block;
+}
+
+function applyOpenInTargetCommandPatch(currentSource) {
+  const patchedBlock = findPatchedOpenTargetCommandBlock(currentSource);
+  if (patchedBlock != null) {
+    return currentSource;
+  }
+  if (currentSource.includes("_codexLinuxOpenTargetCommand")) {
+    warn("Found partially patched open target command lookup");
+    return currentSource;
+  }
+
+  const currentShapeMatch = findCurrentOpenTargetCommandMatch(currentSource);
+  if (currentShapeMatch == null) {
+    if (
+      currentSource.includes("get-target-command") &&
+      currentSource.includes("Open in worker unavailable")
+    ) {
+      warn("Could not find current open target command lookup");
+    }
+    return currentSource;
+  }
+
+  const sourceWithRegistry = applyOpenInTargetRegistryCommandPatch(currentSource, { warnOnMissing: false });
+  if (!sourceWithRegistry.includes("async function codexLinuxOpenTargetRegistryCommand(")) {
+    return currentSource;
+  }
+
+  const [needle, commandMethod, targetVar, commandVar, workerMethod, paramsFn] = currentShapeMatch;
+  return sourceWithRegistry.replace(
+    needle,
+    `async#${commandMethod}(${targetVar}){if(process.platform===\`linux\`){let _codexLinuxOpenTargetCommand=await codexLinuxOpenTargetRegistryCommand(this.settingsStore,${targetVar});if(_codexLinuxOpenTargetCommand==null)throw Error(\`Open target "\${${targetVar}}" is not available\`);return _codexLinuxOpenTargetCommand}let{command:${commandVar}}=await this.#${workerMethod}()({method:\`get-target-command\`,params:${paramsFn}(this.settingsStore,${targetVar})});if(${commandVar}==null)throw Error(\`Open target "\${${targetVar}}" is not available\`);return ${commandVar}}`,
+  );
 }
 
 function applyOpenInTargetsAvailabilityPatch(currentSource) {

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -51,7 +51,7 @@ const currentAppRegistryFunction =
 const currentAppOpenTargetPrelude =
   `var PN=[],FN=async e=>\`shortcut:\${e}\`,BN=new WeakMap;function RN(e){return e.map(({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a})=>({id:e,label:t,icon:n,kind:r,hidden:i,supportsSsh:a}))}function HN(e){return RN(QN(e))}function UN(e,t){let n=QN(e).find(e=>e.id===t);return n?.configuredCommand==null||n.configuredIcon==null?{target:t}:{target:t,customTarget:{command:n.configuredCommand,icon:n.configuredIcon}}}${currentAppRegistryFunction}async function LN(e,t,{detectedCommand:r,targets:c=PN}={}){let l=c.find(t=>t.id===e);if(!l)throw Error(\`Unknown open target "\${e}"\`);let u=r??await l.detect(FN);if(!u)throw Error(\`Open target "\${e}" is not available\`);return u}var WRONG={};async function unrelated(e){return await e.detect(WRONG)}function zN(){return{error(){},warning(){}}}`;
 const currentAppOpenInCommandBundle =
-  `${currentAppOpenTargetPrelude}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}getSettingsStore(){return this.settingsStore}getOpenInWorker(){return this.requestOpenInWorker}async getOpenInTargetCommand(e){let{command:t}=await this.getOpenInWorker()({method:\`get-target-command\`,params:UN(this.getSettingsStore(),e)});if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}}`;
+  `${currentAppOpenTargetPrelude}class App{constructor(e,t){this.settingsStore=e;this.requestOpenInWorker=t}async openTarget(e){return this.#t(e)}async#t(e){let{command:t}=await this.#n()({method:\`get-target-command\`,params:UN(this.settingsStore,e)});if(t==null)throw Error(\`Open target "\${e}" is not available\`);return t}#n(){if(this.requestOpenInWorker==null)throw Error(\`Open in worker unavailable\`);return this.requestOpenInWorker}}`;
 const currentAppOpenInAvailabilityBundle =
   `${currentAppOpenTargetPrelude}async function WN(e,t){let n=await Promise.all(HN(e).map(async n=>{let r=UN(e,n.id),[i,a]=await Promise.all([t({method:\`get-target-command\`,params:r}).then(e=>e.command).catch(e=>(zN().error(\`Failed to detect open target\`,{safe:{},sensitive:{id:n.id,error:e}}),null)),process.platform===\`win32\`?t({method:\`load-target-icon\`,params:r}).then(e=>e.icon).catch(e=>(zN().warning(\`Failed to resolve open target icon\`,{safe:{},sensitive:{id:n.id,error:e}}),n.icon)):n.icon]);return{command:i,metadata:{...n,icon:a}}}));return{allAvailableTargets:n.flatMap(({command:e,metadata:t})=>e==null?[]:[t.id]),targetMetadata:n.map(({metadata:e})=>e)}}`;
 const currentAppOpenInBridgeBundle =
@@ -1109,11 +1109,12 @@ test("open-target discovery patches current app command lookup through its regis
     },
   );
 
-  assert.equal(await app.getOpenInTargetCommand("linux-desktop-agent"), "main-command");
-  await assert.rejects(() => app.getOpenInTargetCommand("broken"), /not available/);
+  assert.equal(await app.openTarget("linux-desktop-agent"), "main-command");
+  await assert.rejects(() => app.openTarget("broken"), /not available/);
   assert.equal(workerCalls, 0);
   assert.match(patched, /n\.detect\(FN\)/);
   assert.doesNotMatch(patched, /n\.detect\(WRONG\)|n\.detect\(void 0\)/);
+  assert.match(patched, /_codexLinuxOpenTargetCommand/);
 
   const darwinApp = new Function("process", `${patched};return new App(arguments[1],arguments[2]);`)(
     { platform: "darwin" },
@@ -1123,7 +1124,7 @@ test("open-target discovery patches current app command lookup through its regis
       return { command: "worker-command" };
     },
   );
-  assert.equal(await darwinApp.getOpenInTargetCommand("linux-desktop-agent"), "worker-command");
+  assert.equal(await darwinApp.openTarget("linux-desktop-agent"), "worker-command");
   assert.equal(workerCalls, 1);
 });
 
@@ -1454,6 +1455,7 @@ test("open-target discovery participates in feature loading and patch reports", 
             patch.status === "applied",
           ),
         );
+
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });
       }

--- a/linux-features/open-target-discovery/test.js
+++ b/linux-features/open-target-discovery/test.js
@@ -1128,6 +1128,58 @@ test("open-target discovery patches current app command lookup through its regis
   assert.equal(workerCalls, 1);
 });
 
+test("open-target discovery rejects current command lookup drift before changing the main bundle", () => {
+  const source =
+    mainBundlePrefix +
+    fileManagerBundle +
+    terminalOpenTargetBundle +
+    ideOpenTargetsBundle +
+    currentAppOpenInCommandBundle.replace(
+      "params:UN(this.settingsStore,e)",
+      "params:UN(this.otherStore,e)",
+    );
+  const { value, warnings } = captureWarns(() => applyMainBundlePatch(source));
+
+  assert.equal(value, source);
+  assert.ok(warnings.some((warning) => warning.includes("open target command lookup")));
+});
+
+test("open-target discovery rejects a partial current command marker byte-identically", () => {
+  const source =
+    mainBundlePrefix +
+    fileManagerBundle +
+    terminalOpenTargetBundle +
+    ideOpenTargetsBundle +
+    currentAppOpenInCommandBundle.replace(
+      "async#t(e){",
+      "async#t(e){let _codexLinuxOpenTargetCommand=null;",
+    );
+  const { value, warnings } = captureWarns(() => applyMainBundlePatch(source));
+
+  assert.equal(value, source);
+  assert.ok(warnings.some((warning) => warning.includes("partially patched open target command lookup")));
+});
+
+test("open-target discovery rejects a corrupted patched command guard byte-identically", () => {
+  const original =
+    mainBundlePrefix +
+    fileManagerBundle +
+    terminalOpenTargetBundle +
+    ideOpenTargetsBundle +
+    currentAppOpenInCommandBundle;
+  const patched = applyMainBundlePatch(original);
+  const source = patched.replace(
+    "if(process.platform===`linux`){let _codexLinuxOpenTargetCommand=",
+    "if(process.platform===`darwin`){let _codexLinuxOpenTargetCommand=",
+  );
+  assert.notEqual(source, patched);
+
+  const { value, warnings } = captureWarns(() => applyMainBundlePatch(source));
+
+  assert.equal(value, source);
+  assert.ok(warnings.some((warning) => warning.includes("partially patched open target command lookup")));
+});
+
 test("open-target discovery patches current app availability through its registry", async () => {
   let workerCalls = 0;
   const settingsStore = currentAppSettingsStore([
@@ -1440,7 +1492,10 @@ test("open-target discovery participates in feature loading and patch reports", 
         const assetsDir = path.join(tempApp, "webview", "assets");
         fs.mkdirSync(buildDir, { recursive: true });
         fs.mkdirSync(assetsDir, { recursive: true });
-        fs.writeFileSync(path.join(buildDir, "main.js"), openTargetsBundle);
+        fs.writeFileSync(
+          path.join(buildDir, "main.js"),
+          openTargetsBundle + currentAppOpenInCommandBundle,
+        );
         fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
 
         const report = createPatchReport();
@@ -1449,6 +1504,7 @@ test("open-target discovery participates in feature loading and patch reports", 
 
         assert.match(patched, /linux:\{label:`Terminal`/);
         assert.match(patched, /\.\.\.codexLinuxDiscoveredIdeTargets\(\)/);
+        assert.match(patched, /_codexLinuxOpenTargetCommand/);
         assert.ok(
           report.patches.some((patch) =>
             patch.name === "feature:open-target-discovery:main-bundle-open-target-discovery" &&
@@ -1456,6 +1512,47 @@ test("open-target discovery participates in feature loading and patch reports", 
           ),
         );
 
+        const secondReport = createPatchReport();
+        captureWarns(() => patchExtractedApp(tempApp, { report: secondReport }));
+        assert.equal(fs.readFileSync(path.join(buildDir, "main.js"), "utf8"), patched);
+        assert.ok(
+          secondReport.patches.some((patch) =>
+            patch.name === "feature:open-target-discovery:main-bundle-open-target-discovery" &&
+            patch.status === "already-applied",
+          ),
+        );
+      } finally {
+        fs.rmSync(tempApp, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+test("open-target discovery reports current command lookup drift as an enabled feature failure", () => {
+  withTempFeatureConfig(["open-target-discovery"], (root) => {
+    withLinuxFeatureRootEnv(root, () => {
+      const tempApp = fs.mkdtempSync(path.join(os.tmpdir(), "codex-open-target-drift-"));
+      try {
+        const buildDir = path.join(tempApp, ".vite", "build");
+        fs.mkdirSync(buildDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(buildDir, "main.js"),
+          openTargetsBundle +
+            currentAppOpenInCommandBundle.replace(
+              "params:UN(this.settingsStore,e)",
+              "params:UN(this.otherStore,e)",
+            ),
+        );
+        fs.writeFileSync(path.join(tempApp, "package.json"), JSON.stringify({ name: "codex" }));
+
+        const report = createPatchReport();
+        captureWarns(() => patchExtractedApp(tempApp, { report }));
+        const featurePatch = report.patches.find(
+          (patch) => patch.name === "feature:open-target-discovery:main-bundle-open-target-discovery",
+        );
+
+        assert.equal(featurePatch?.status, "skipped-optional");
+        assert.match(featurePatch?.reason ?? "", /open target command lookup/);
       } finally {
         fs.rmSync(tempApp, { recursive: true, force: true });
       }


### PR DESCRIPTION
## Summary

- route the current private open-target command lookup through the feature-owned Linux registry while preserving the upstream worker path outside Linux
- validate the complete current command shape before any main-bundle mutation, including the Linux platform guard, and report missing, partial, or corrupted markers as enabled-feature drift with byte-identical output
- cover current-DMG first pass, second pass, drift rejection, patch-report behavior, and the corrupted-guard regression; update the changelog

## Root cause

The feature patched target detection and availability, but the current `async#t(e)` command lookup still sent `get-target-command` to the worker registry. Linux-only targets were therefore visible in the menu but failed at selection with `Unknown open target`.

## Current upstream

- Base: `origin/main@586c20e802b0`
- ChatGPT Desktop: `26.721.81911`
- Electron: `42.3.0`
- DMG SHA-256: `7b3722e4f5864202b1dd69e6e6062f2f8c4388d215091503c73e1957b4cbf97a`
- DMG size: `593881254`
- ETag: `0x8DEED41E83B4B62`

## Validation

- `node linux-features/open-target-discovery/test.js` (42/42)
- `node --test --test-concurrency=1 linux-features/*/test.js` (833/833 before the final detector-only hardening; the affected feature remains 42/42 afterward)
- `node scripts/patch-linux-window-ui.test.js` (401/401 before the final detector-only hardening)
- `bash tests/scripts_smoke.sh`
- `./scripts/ci-local.sh pr`
- patch-report validation passed for an isolated `open-target-discovery` candidate and the normal 10-feature composition; both acceptance verdicts were `accepted` with zero blockers/warnings and clean Git provenance
- active generated main/webview assets passed `node --check`
- KDE/Wayland side-by-side runtime listed the current targets; selecting Terminal spawned `/usr/bin/x-terminal-emulator` with the project as process and shell cwd, showed no error toast, and remained correct after a cold restart

## Scope

Source changes are limited to the opt-in feature patch/test and the changelog. The daily driver was not modified. Account/server rollout and the upstream worker implementation are unchanged.

Fixes #1170